### PR TITLE
feat(opencode): use claude-haiku for lightweight built-in subagents

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -363,16 +363,16 @@
                 # Lightweight built-in subagents — use a cheaper/faster model since these
                 # do simple, mechanical tasks that don't require deep reasoning.
                 explore = {
-                  model = "anthropic/claude-haiku-4-20250514";
+                  model = "anthropic/claude-haiku-4-5";
                 };
                 title = {
-                  model = "anthropic/claude-haiku-4-20250514";
+                  model = "anthropic/claude-haiku-4-5";
                 };
                 summary = {
-                  model = "anthropic/claude-haiku-4-20250514";
+                  model = "anthropic/claude-haiku-4-5";
                 };
                 compaction = {
-                  model = "anthropic/claude-haiku-4-20250514";
+                  model = "anthropic/claude-haiku-4-5";
                 };
               };
               mcp = {


### PR DESCRIPTION
## Summary

- Assigns `claude-haiku-4-20250514` to the four built-in agents that do simple, mechanical work: `explore`, `title`, `summary`, and `compaction`
- Leaves `build`, `plan`, `general`, and the custom `review` agent on Sonnet (via the global model default) since those require real reasoning

## Rationale

OpenCode's built-in agents break down into two categories:

| Agent | Task | Reasoning needed? |
|-------|------|-------------------|
| `build` | Full development work | Yes — Sonnet |
| `plan` | Analysis & planning | Yes — Sonnet |
| `general` | Complex multi-step tasks | Yes — Sonnet |
| `review` | PR code review | Yes — Sonnet |
| `explore` | Read-only codebase search | No — grep/glob, no reasoning |
| `title` | Generate a short session title | No — trivial text generation |
| `summary` | Summarise a session | No — mechanical summarisation |
| `compaction` | Compact long context | No — mechanical compression |

The last four are invoked frequently and automatically; switching them to Haiku should meaningfully reduce API costs with no quality impact on these lightweight workloads.