### PR TITLE
fix(opencode): handle question.asked/replied events as waiting state

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -70,6 +70,15 @@ export const PrismHooks: Plugin = async ({ $ }) => {
         case "permission.replied":
           await notify("set-active");
           break;
+        // question.asked fires when the agent uses the question tool to ask
+        // the user something — treat identically to a permission wait.
+        case "question.asked":
+          await notify("set-waiting");
+          break;
+        case "question.replied":
+        case "question.rejected":
+          await notify("set-active");
+          break;
         case "session.error":
           await notify("set-error");
           break;


### PR DESCRIPTION
## Problem

The `mcp_question` tool causes the agent to pause and wait for user input, but the `prism-hooks.ts` plugin had no handler for `question.asked`/`question.replied`/`question.rejected` events. This meant the tmux status indicator stayed as **active** while the agent was actually blocked waiting for an answer — identical behaviour to `permission.asked` but silently ignored.

## Root Cause

The opencode SDK emits three question-related events:
- `question.asked` — agent is waiting for the user to answer
- `question.replied` — user answered, agent resumes
- `question.rejected` — user dismissed the question, agent resumes

None of these were handled in the plugin's `event` switch statement.

## Fix

Handle `question.asked` identically to `permission.asked` (`set-waiting`) and `question.replied`/`question.rejected` identically to `permission.replied` (`set-active`).