### PR TITLE
feat(prism): add '/' fuzzy-filter keybind to dashboard

### DIFF
--- a/modules/programs/prism/prism/cmd/dashboard.go
+++ b/modules/programs/prism/prism/cmd/dashboard.go
@@ -455,7 +455,9 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.BlurMsg:
-		if !m.popup {
+		// Do not deactivate the cursor while the filter is open — the user
+		// must be able to see which session Enter will select at all times.
+		if !m.popup && !m.filterActive {
 			m.cursorActive = false
 		}
 
@@ -467,12 +469,17 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Do not re-read CallerSession() here — it may have changed if another
 		// client opened the dashboard. Use the value captured at init time.
 		if !m.cursorInitialised {
-			// Snap cursor to the current session on first load.
+			// Snap cursor to the current session on first load, but only when
+			// filter mode is not already active — the filter may have been
+			// opened before the first tick arrived, and the snap index into
+			// m.sessions would be silently clamped away by dashRefilter.
 			m.cursorInitialised = true
-			for i, s := range m.sessions {
-				if s.Name == m.currentSession {
-					m.cursor = i
-					break
+			if !m.filterActive {
+				for i, s := range m.sessions {
+					if s.Name == m.currentSession {
+						m.cursor = i
+						break
+					}
 				}
 			}
 		}
@@ -482,7 +489,11 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// In filter mode most keys are consumed by the filter input.
 		if m.filterActive {
 			switch msg.String() {
-			case "esc", "ctrl+c":
+			case "ctrl+c":
+				// Pass ctrl+c through to bubbletea so the TUI can quit.
+				return m, tea.Quit
+
+			case "esc":
 				// Cancel filter: restore full list, deactivate filter.
 				m.filterActive = false
 				m.filterText = ""
@@ -681,6 +692,7 @@ func (m dashModel) View() string {
 	styleIns := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorGreen))
 	styleDel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorRed))
 	styleFg := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorForeground))
+	stylePrompt := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true)
 
 	const stateW = 10
 	const dotW = 2
@@ -844,7 +856,6 @@ func (m dashModel) View() string {
 
 	// Filter prompt or help hint at the bottom.
 	if m.filterActive {
-		stylePrompt := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true)
 		sb.WriteString("\n")
 		sb.WriteString(stylePrompt.Render(" / "))
 		sb.WriteString(m.filterText)

--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -452,6 +452,118 @@ func TestDashFilterCursorStaysActiveOnTimeout(t *testing.T) {
 	}
 }
 
+// TestDashFilterBlurKeepsCursorActive verifies that a BlurMsg does not
+// deactivate the cursor while filter mode is open. Without this guard the
+// selection bar disappears on focus loss but the filter prompt remains, leaving
+// the user unable to see which session Enter will select.
+func TestDashFilterBlurKeepsCursorActive(t *testing.T) {
+	t.Parallel()
+
+	m := dashModel{
+		sessions:     []tmux.Session{{Name: "alpha"}, {Name: "beta"}},
+		displayed:    []tmux.Session{{Name: "alpha"}, {Name: "beta"}},
+		filterActive: true,
+		cursorActive: true,
+		popup:        false, // persistent mode: BlurMsg normally deactivates cursor
+	}
+
+	m2, _ := m.Update(tea.BlurMsg{})
+	dm := m2.(dashModel)
+
+	if !dm.cursorActive {
+		t.Error("cursorActive must remain true when BlurMsg fires during filter mode")
+	}
+}
+
+// TestDashFilterCtrlCQuitsProgram verifies that ctrl+c in filter mode quits
+// the TUI rather than merely dismissing the filter. Previously ctrl+c and esc
+// were handled by the same case, so ctrl+c was consumed without quitting.
+func TestDashFilterCtrlCQuitsProgram(t *testing.T) {
+	t.Parallel()
+
+	m := dashModel{
+		sessions:     []tmux.Session{{Name: "alpha"}},
+		displayed:    []tmux.Session{{Name: "alpha"}},
+		filterActive: true,
+		cursorActive: true,
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c in filter mode should return a non-nil quit command")
+	}
+	// Execute the command to confirm it produces a QuitMsg.
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Errorf("ctrl+c command produced %T, want tea.QuitMsg", msg)
+	}
+}
+
+// TestDashFilterEscCancelsNotQuits verifies that Esc in filter mode cancels
+// the filter (returning to normal mode) without quitting the TUI.
+func TestDashFilterEscCancelsNotQuits(t *testing.T) {
+	t.Parallel()
+
+	m := dashModel{
+		sessions:     []tmux.Session{{Name: "alpha"}, {Name: "beta"}},
+		displayed:    []tmux.Session{{Name: "alpha"}}, // narrowed
+		filterActive: true,
+		filterText:   "al",
+		cursorActive: true,
+	}
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	dm := m2.(dashModel)
+
+	if cmd != nil {
+		t.Error("Esc in filter mode should return nil cmd (no quit)")
+	}
+	if dm.filterActive {
+		t.Error("filterActive should be false after Esc")
+	}
+	if len(dm.displayed) != 2 {
+		t.Errorf("displayed len = %d, want 2 (full list restored)", len(dm.displayed))
+	}
+}
+
+// TestDashFilterSnapSkippedWhenFilterActive verifies that the cursor-snap-to-
+// currentSession logic in sessionsMsg is skipped when filter mode is already
+// active. The snap sets m.cursor to an index in m.sessions; dashRefilter then
+// clamps it against m.displayed which may be a different length, silently
+// placing the cursor on the wrong entry.
+func TestDashFilterSnapSkippedWhenFilterActive(t *testing.T) {
+	t.Parallel()
+
+	// Filter is already active and narrowed to "beta" only.
+	m := dashModel{
+		filterActive:      true,
+		filterText:        "bet",
+		cursorInitialised: false,
+		currentSession:    "alpha", // would snap cursor to index 0 in sessions
+		cursor:            0,
+	}
+	sessions := []tmux.Session{{Name: "alpha"}, {Name: "beta"}}
+	m.sessions = sessions
+	m.displayed = []tmux.Session{{Name: "beta"}} // pre-filtered
+
+	// Deliver a sessionsMsg (the first tick).
+	m2, _ := m.Update(sessionsMsg(sessions))
+	dm := m2.(dashModel)
+
+	if !dm.cursorInitialised {
+		t.Error("cursorInitialised should be true after first sessionsMsg")
+	}
+	// The snap should have been skipped; cursor must still point into the
+	// filtered list (at most index 0 since displayed has one entry).
+	if dm.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 — snap into sessions[] must not run during filter mode", dm.cursor)
+	}
+	// "beta" must still be the first displayed entry.
+	if len(dm.displayed) == 0 || dm.displayed[0].Name != "beta" {
+		t.Errorf("displayed[0] = %v, want {Name:beta}", dm.displayed)
+	}
+}
+
 // TestDashFilterCursorNavigation verifies that j/k move the cursor within the
 // filtered list while filter mode is active.
 func TestDashFilterCursorNavigation(t *testing.T) {


### PR DESCRIPTION
## Summary

- Pressing `/` on the dashboard activates an inline fuzzy-filter mode — an input prompt appears at the bottom of the session list.
- Typing characters narrows the session list in real time, reusing the existing `fuzzyMatch()` function from `cmd/switch.go` (no logic duplication).
- `Enter` on a highlighted match switches to that session (same behaviour as the C-f switcher); `Esc`/`Ctrl-C` cancels and restores the full list.
- `j`/`k` navigate the filtered results while filter mode is active.
- A help line at the bottom of the dashboard now shows available keybinds: `/ filter  ↑↓/jk navigate  enter select  q quit`.

## Implementation details

- Added `filterActive`, `filterText`, and `displayed` fields to `dashModel`. `displayed` is always the source of truth for which sessions the cursor and `Enter` operate on.
- `dashRefilter()` recomputes `displayed` from `sessions` + the active filter, and clamps the cursor. It is called on every session tick (so live session changes still propagate through the filter) and on every filter text change.
- Normal keybinds (`q`, `enter`, `j`, `k`) continue to use `displayed`, so the enter-to-switch path works identically in both normal and filter mode.
- 9 new unit tests cover: activation, narrowing, backspace, Esc cancel, Enter switch, cursor navigation, cursor clamping, View prompt rendering, and the help hint.

## Tests

```
ok  github.com/prismatic-koi/prism/cmd   7.8s
ok  github.com/prismatic-koi/prism/internal/tmux  1.1s
```