### PR TITLE
feat(opencode): remind agents to re-review after git push

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -111,11 +111,12 @@ export const PrismHooks: Plugin = async ({ $ }) => {
     // Inject the review reminder into the system prompt on the next LLM turn
     // after a git push. Cleared immediately so it only fires once.
     "experimental.chat.system.transform": async (_input, output) => {
-      if (!pendingReviewReminder) return;
+      if (!pendingReviewReminder) return output;
       pendingReviewReminder = false;
       output.system.push(
         "You just ran git push. If this was in the context of an open PR, invoke the @review subagent now so the updated changes are reviewed before the PR is merged.",
       );
+      return output;
     },
 
     // Fires before the LLM generates the compaction summary.


### PR DESCRIPTION
## Summary

- Adds a `tool.execute.after` hook to `prism-hooks.ts` that detects when the bash tool runs a `git push` command and sets a flag
- Adds an `experimental.chat.system.transform` hook that consumes the flag on the next LLM turn, injecting a reminder into the system prompt to invoke the `@review` subagent if the push was in the context of an open PR
- The reminder fires once per push and is phrased conditionally so it's a no-op on pushes without an associated PR