### PR TITLE
feat: add local opencode.jsonc allowing build agent to push and create PRs

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -5,6 +5,10 @@
   // the remote will reject anything that hasn't gone through a PR. This reduces
   // friction for the build agent when landing work.
   "$schema": "https://opencode.ai/config.json",
+  // Agent-scoped permissions are merged with the global config and take precedence
+  // (per opencode docs: "Agent permissions are merged with the global config, and
+  // agent rules take precedence"). Overriding within `agent.build` is therefore
+  // sufficient to shadow the global `permission.bash` entries that set push to "ask".
   "agent": {
     "build": {
       "permission": {


### PR DESCRIPTION
## Summary

- Adds a project-level `opencode.jsonc` with a local override for the `build` agent
- Allows `git push` (and variants) and `gh pr create` without prompting
- Branch protection on `main` acts as the safety net — the remote will reject anything that hasn't gone through a PR review, so auto-allowing these operations is low-risk and reduces friction