### PR TITLE
Add controller agent for orchestrating prism sessions and PRs

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -435,6 +435,10 @@
                       # override the broad "git *" = "allow" from readOnlyBashCommands —
                       # controller only gets specific git read ops, not the full suite
                       "git *" = "ask";
+                      # override aws/playwright from readOnlyBashCommands — controller
+                      # is orchestration-only, these are not in its remit
+                      "aws *" = "ask";
+                      "playwright-cli *" = "ask";
                     }
                     // controllerBashCommands;
                   };

--- a/modules/programs/prism/opencode/agents/controller.md
+++ b/modules/programs/prism/opencode/agents/controller.md
@@ -54,7 +54,7 @@ When a spawned agent opens a PR:
 Once both reviews pass:
 
 1. `gh pr merge <number>` — you will be prompted to confirm.
-2. `git pull` in `@main` to sync with the merged result.
+2. `git pull` to sync with the merged result. (`@main` is the primary prism session — run this in the session where you are working, not in the spawned agent's session.)
 3. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
 
 ---


### PR DESCRIPTION
## Summary

- Adds `modules/programs/prism/opencode/agents/controller.md`: a primary agent that acts as technical product owner — reads tickets, spawns prism sessions, monitors them, gates PR merges on dual review (@review + own sense-check), and runs post-merge build validation. It never edits files directly.
- Adds `controllerBashCommands` attrset to `opencode.nix` with an inverted permission model (ask by default; specific read, git inspection, prism orchestration, and GitHub lifecycle ops allowed); also adds the `controller` agent entry wiring this into opencode with write tools (`write`, `edit`) disabled.

## Permission model

The controller uses an inverted bash permission model: `"*" = "ask"` as the base, then `readOnlyBashCommands` layered on top, then `"git *" = "ask"` to shadow the broad git allow from that set, then `controllerBashCommands` last to carve back specific git read ops and the full prism/gh orchestration suite. `gh pr merge` and `sudo nixos-rebuild` are `ask` rather than `allow`.

## Verification

Build succeeded: `nix build .#nixosConfigurations.navi.config.system.build.toplevel`