### PR TITLE
fix(prism): replace undefined agentWindow call in AgentStateOf with GetWindowOption

### DIFF
--- a/modules/programs/prism/prism/internal/tmux/tmux.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux.go
@@ -170,8 +170,11 @@ func HasSession(name string) bool {
 // session. Returns an empty string if the session does not exist or has no
 // agent window.
 func AgentStateOf(name string) string {
-	state, _, _ := agentWindow(name)
-	return state
+	state, err := GetWindowOption(name+":agent", "@agent_state")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(state)
 }
 
 // NewSession creates a new detached session.


### PR DESCRIPTION
## Summary

- `AgentStateOf` was calling `agentWindow(name)` which does not exist anywhere in the codebase, causing a build failure (`undefined: agentWindow`)
- Replaced with `GetWindowOption(name+":agent", "@agent_state")` which reads the `@agent_state` option from the `agent` window of the named session
- Returns empty string on error (matching the original intent) and trims whitespace from the result

## Verification

- `go build ./...` and `go test ./...` pass in `modules/programs/prism/prism/`
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds