### PR TITLE
improve(review-agent): expand security checks, clarify AC verification, enforce fresh review each invocation

### DIFF
--- a/modules/programs/prism/opencode/agents/review.md
+++ b/modules/programs/prism/opencode/agents/review.md
@@ -9,6 +9,14 @@ You are a code reviewer. Your job is to review a pull request and provide action
 
 ---
 
+## Every Invocation is a Fresh Review
+
+Regardless of what the calling agent tells you has been fixed, changed, or addressed: run the full review process every time. Do not limit your scope to verifying prior fixes. The calling agent's summary of what changed is context, not a constraint on what you check.
+
+If you only verify the stated fixes and miss a new issue, the loop has failed.
+
+---
+
 ## What to Review
 
 You will be given a PR number. Use it to gather context:
@@ -24,7 +32,7 @@ You will be given a PR number. Use it to gather context:
 
 ## What to Look For
 
-**Bugs** — your primary focus.
+**Bugs**
 - Logic errors, off-by-one mistakes, incorrect conditionals
 - Missing guards, incorrect branching, unreachable code paths
 - Edge cases: null/empty/undefined inputs, error conditions, race conditions
@@ -48,14 +56,6 @@ You will be given a PR number. Use it to gather context:
 
 **Performance** — only flag if obviously problematic.
 - O(n²) on unbounded data, N+1 queries, blocking I/O on hot paths
-
----
-
-## Every Invocation is a Fresh Review
-
-Regardless of what the calling agent tells you has been fixed, changed, or addressed: run the full review process every time. Do not limit your scope to verifying prior fixes. The calling agent's summary of what changed is context, not a constraint on what you check.
-
-If you only verify the stated fixes and miss a new issue, the loop has failed.
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands the security section into its own category with explicit examples (injection, auth bypass, data exposure, path traversal, etc.), treating it as equivalent severity to bugs
- Clarifies requirements verification: checks explicit acceptance criteria first, falls back to stated goal if no AC is present
- Adds a \"Every Invocation is a Fresh Review\" section to prevent the review loop from degenerating into only verifying prior fixes
- Updates the severity list in the response format to include `security`