### PR TITLE
rename controller agent to coordinator, add intake guidance, set as default agent

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -179,9 +179,9 @@
         "prism prompt *" = "allow";
       };
 
-      # Bash commands for the controller agent — inverted model: ask by default,
+      # Bash commands for the coordinator agent — inverted model: ask by default,
       # only specific read/orchestration ops allowed without prompting.
-      controllerBashCommands = {
+      coordinatorBashCommands = {
         # git: pull and read-only inspection only; everything else falls through to ask
         "git pull" = "allow";
         "git pull *" = "allow";
@@ -411,8 +411,8 @@
                     // readOnlyBashCommands;
                   };
                 };
-                controller = {
-                  description = "Repo controller — orchestrates agents, reviews PRs, merges work";
+                coordinator = {
+                  description = "Repo coordinator — orchestrates agents, reviews PRs, merges work";
                   mode = "primary";
                   color = config.theme.purple;
                   tools = {
@@ -433,14 +433,14 @@
                     // readOnlyBashCommands
                     // {
                       # override the broad "git *" = "allow" from readOnlyBashCommands —
-                      # controller only gets specific git read ops, not the full suite
+                      # coordinator only gets specific git read ops, not the full suite
                       "git *" = "ask";
-                      # override aws/playwright from readOnlyBashCommands — controller
+                      # override aws/playwright from readOnlyBashCommands — coordinator
                       # is orchestration-only, these are not in its remit
                       "aws *" = "ask";
                       "playwright-cli *" = "ask";
                     }
-                    // controllerBashCommands;
+                    // coordinatorBashCommands;
                   };
                 };
                 # Lightweight built-in subagents — use a cheaper/faster model since these

--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -1,6 +1,6 @@
 ---
-name: controller
-description: Repo controller — orchestrates agents, reviews PRs, and merges completed work.
+name: coordinator
+description: Repo coordinator — orchestrates agents, reviews PRs, and merges completed work.
 mode: primary
 hidden: false
 ---
@@ -16,13 +16,15 @@ When given a ticket, issue, or feature request:
 - Break it into concrete, independently-deliverable subtasks.
 - Decide: one agent with a broad prompt, or multiple agents with tightly scoped prompts? Prefer one agent unless tasks are genuinely parallel and non-conflicting (touching different files/systems).
 
+When the user asks you to create a ticket or issue: create it, then spawn an agent to action it immediately — use the ticket/issue ID as the branch name and reference it in the prompt so the agent can read the full context. "Create an issue" means "create it and get it done", not "file it and wait." If the user only wants the tracking artifact without execution, they will say so explicitly.
+
 ---
 
 ## Spawning agents
 
 Use `prism spawn`. Load the prism skill first if not already loaded. Record the session name, what the agent was asked to deliver, and the expected scope. Key conventions:
 
-- `--branch` should be meaningful: use the ticket ID if one exists (e.g. `PROJ-123`), otherwise a short kebab-case description of the work (e.g. `add-controller-agent`). Never use the default timestamp branch unless the task is truly throwaway.
+- `--branch` should be meaningful: use the ticket ID if one exists (e.g. `PROJ-123`), otherwise a short kebab-case description of the work (e.g. `add-coordinator-agent`). Never use the default timestamp branch unless the task is truly throwaway.
 - `--prompt` should be self-contained: include enough context that the agent doesn't need to ask clarifying questions. Reference the ticket/issue number so the agent can read it directly.
 - Note the session name printed by prism — you will need it for check-ins and cleanup.
 

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -5,6 +5,9 @@
   // the remote will reject anything that hasn't gone through a PR. This reduces
   // friction for the build agent when landing work.
   "$schema": "https://opencode.ai/config.json",
+  // Use coordinator as default agent for interactive sessions in this repo.
+  // (prism spawn already defaults spawned agents to "build" via its own --agent flag.)
+  "default_agent": "coordinator",
   // Agent-scoped permissions are merged with the global config and take precedence
   // (per opencode docs: "Agent permissions are merged with the global config, and
   // agent rules take precedence"). Overriding within `agent.build` is therefore


### PR DESCRIPTION
## Summary

- **Rename controller → coordinator**: `controller.md` renamed to `coordinator.md` with updated frontmatter (`name`, `description`). `controllerBashCommands` variable and `controller = {` config block in `opencode.nix` renamed to `coordinator`/`coordinatorBashCommands` throughout, including inline comments.

- **Add intake guidance**: New paragraph added at the end of the Intake bullet list in `coordinator.md`: when the user asks to create a ticket/issue, create it and immediately spawn an agent to action it — "create an issue" means get it done, not just file it. Explicit opt-out for users who only want the tracking artifact.

- **Set coordinator as default agent**: `"default_agent": "coordinator"` added to project-level `opencode.jsonc`. This applies to interactive sessions in this repo only — `prism spawn` still defaults spawned agents to `build` via its own `--agent` flag, so spawned workflows are unaffected.

## Files changed

- `modules/programs/prism/opencode/agents/controller.md` → `coordinator.md`
- `modules/programs/prism/opencode.nix`
- `opencode.jsonc`