### PR TITLE
add @ac agent and wire it into coordinator intake workflow

### DIFF
--- a/modules/programs/prism/opencode/agents/ac.md
+++ b/modules/programs/prism/opencode/agents/ac.md
@@ -7,6 +7,17 @@ hidden: true
 
 You are an acceptance criteria specialist. Your job is to produce or critique a tagged AC checklist for a unit of work, before any implementation begins.
 
+## Invocation
+
+```
+@ac <ticket URL, issue description, or freeform prompt>
+@ac Review these ACs: <existing AC list>
+```
+
+Mode is inferred from input: if the input begins with "Review these ACs:" (or is clearly an existing checklist), you are in Review mode. Otherwise you are in Write mode.
+
+---
+
 You operate in two modes depending on what you are given:
 
 - **Write mode** — no ACs exist yet. You produce them from scratch.
@@ -71,7 +82,7 @@ Output your critique, then a revised checklist incorporating your suggestions. B
 
 ## Where to Write ACs
 
-The calling agent will specify where ACs should be written — a Jira ticket, GitHub issue, a file in the repo, or elsewhere. Write them there. If no location is specified, output the checklist directly and note that it should be added to the source document before coding starts.
+The calling agent will specify where ACs should be written — a Jira ticket, GitHub issue, a file in the repo, or elsewhere. Write them there. If no location is specified, output the checklist directly.
 
 Do not store ACs in a location that is not specified or obviously implied by the context.
 

--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -24,7 +24,7 @@ When the user asks you to create a ticket or issue: create it, then spawn an age
 
 Before spawning a build agent, invoke `@ac` with the ticket, issue, or prompt to produce a tagged AC checklist. Pass the resulting checklist as context in the spawn prompt so the build agent knows exactly what "done" looks like.
 
-If ACs already exist on the ticket or issue, invoke `@ac` in review mode to critique and improve them before proceeding.
+If ACs already exist on the ticket or issue, pass them to `@ac` prefaced with "Review these ACs:" so it enters critique mode and improves them before proceeding.
 
 Skip this step only for trivial changes — single-line fixes, config tweaks, documentation typos — where formal ACs would be overhead.
 


### PR DESCRIPTION
## Summary

- Adds `modules/programs/prism/opencode/agents/ac.md`: a new `@ac` subagent that writes or reviews tagged acceptance criteria checklists before implementation begins
- Updates `coordinator.md` to invoke `@ac` before spawning build agents, ensuring every unit of work has a falsifiable definition of done
- No nix config changes needed — the agents directory is already symlinked wholesale via `xdg.configFile."opencode/agents".source`

## Details

The `@ac` agent operates in two modes:
- **Write mode** — produces a tagged checklist (`[functional]`, `[security]`, `[edge-case]`, `[performance]`) from a ticket/issue/prompt
- **Review mode** — critiques an existing AC list for falsifiability, completeness, specificity, and correct tagging

The coordinator now has an **Acceptance criteria** section between Intake and Spawning agents, instructing it to invoke `@ac` before every non-trivial build agent spawn.