### PR TITLE
docs(AGENTS): add prism section and split workflow into branch/main subsections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ nixfmt .
 
 ### PR workflow (build agents on branches)
 
-If the change touches prism Go source, run `go build ./...` and `go test ./...` from `modules/programs/prism/prism/` before committing. This is faster than a nix build and catches Go errors early.
+If the change touches prism Go source, run the Go build and tests first — see the [Prism](#prism) section for details.
 
 After committing and before opening a PR, run `nix build .#nixosConfigurations.navi.config.system.build.toplevel` to verify the configuration builds. New files must be `git add`-ed first or nix will not see them.
 
@@ -209,8 +209,6 @@ After merging a PR to main, always run `nix build .#nixosConfigurations.navi.con
 If the change affects system state (packages, services, activation scripts, module options, overlays): run `sudo nixos-rebuild switch --flake .` to apply it.
 
 If the change is limited to non-system files (opencode agents, opencode skills, Go source in prism, documentation): skip the switch — these do not affect the NixOS system.
-
-`nix flake check --all-systems` is slow and covers all defined systems. Do not run it as part of routine commit/deploy work. Reserve it for before major releases or flake input updates.
 
 ### Temporary Testing Changes
 


### PR DESCRIPTION
## Summary

- Add a **Prism** section (after Project Overview) documenting that prism lives in this repo, its directory layout, and the `go build`/`go test` check to run before committing Go changes.
- Replace the single linear "Committing and Deploying Changes" sequence with two role-specific subsections: **PR workflow (build agents on branches)** and **Post-merge workflow (coordinator on main)**.
- Demote `nix flake check --all-systems` from the routine workflow — it is slow and covers all systems; reserve it for major releases and flake input updates.