### PR TITLE
docs(prism-skill): add nixos-config note and cross-repo delegation convention

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -119,7 +119,7 @@ When you need to delegate work to a repo you are not the coordinator for, route 
 1. Run `prism list-sessions` and look for `<repo>@main`.
 2. **Found, not in `waiting` state:** send the work request with `prism prompt <repo>@main --prompt '...'`.
 3. **Found, in `waiting` state:** escalate to the user — the coordinator is blocked and expecting human input. The user needs to switch to that session and unblock it directly. Do not attempt to work around the waiting state guard.
-4. **Not found:** there is no coordinator to delegate to. Escalate to the user and ask them to start a `<repo>@main` coordinator session. Note: you also cannot work around this by spawning onto `main` yourself — in the bare+worktree layout prism uses, `main` already has a worktree, so `prism spawn --branch main` will fail with a git error.
+4. **Not found:** there is no coordinator to delegate to. Escalate to the user and ask them to start a `<repo>@main` coordinator session. Note: you also cannot work around this by spawning onto `main` yourself — in the bare+worktree layout prism uses, `main` already has a worktree, so `prism spawn --repo <repo> --branch main` will fail with a git error.
 
 Spawning directly into a feature branch in another repo (bypassing the coordinator) should only happen when you **are** the coordinator for that repo, or when the user explicitly instructs you to.
 


### PR DESCRIPTION
## Summary

- Adds a brief note near the top of `SKILL.md` pointing agents to the `nixos-config` repo as the source of truth for prism changes.
- Adds a new **Delegating work to another repo** section documenting the correct pattern: check for an existing `<repo>@main` coordinator session and route through it via `prism prompt`, rather than spawning a feature branch directly. Covers all three cases (found/not-waiting → prompt; found/waiting → escalate; not found → escalate).
- Updates the existing "Example: delegating work to another repo" section to reference the new convention and clarify that `prism spawn --branch <feature>` is the coordinator's pattern, not something a build agent should do autonomously.