### PR TITLE
feat(opencode): add configurable provider option for LLM provider switching

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -349,6 +349,10 @@
       # "primary" is the capable reasoning model used by main agents (build/plan/coordinator).
       # "lightweight" is the cheaper/faster model used by mechanical subagents
       # (explore, title, summary, compaction).
+      #
+      # Note: Anthropic uses hyphens as version separators (e.g. claude-sonnet-4-6),
+      # while GitHub Copilot uses dots (e.g. claude-sonnet-4.6). This is intentional —
+      # the two providers report different identifier formats from `opencode models`.
       providerModels = {
         anthropic = {
           primary = "anthropic/claude-sonnet-4-6";
@@ -555,7 +559,9 @@
                 // writeBashCommands;
               };
               plugin = [
-                # a plugin to use Gemini auth for LLM access
+                # Gemini auth is always loaded — it enables Google Gemini as an
+                # alternative provider regardless of which provider is the primary.
+                # It does not conflict with the provider-specific auth in authPlugins.
                 "opencode-gemini-auth@latest"
                 # tmux window status colours based on agent state
                 "./plugins/prism-hooks"


### PR DESCRIPTION
## Summary

- Adds `nx.programs.prism.opencode.provider` option (enum: `anthropic` | `github-copilot`, default: `anthropic`) to `modules/programs/prism/opencode.nix`
- Replaces all hardcoded `anthropic/claude-*` model strings and the provider block with lookup tables in the `let` binding, driven by the new option
- Switching providers updates model strings (primary + lightweight), auth plugins, and the opencode `provider` block in one place — no scattered edits needed

## How it works

Three lookup tables in the `let` block map provider name → config:

| Table | anthropic | github-copilot |
|---|---|---|
| `providerModels.primary` | `anthropic/claude-sonnet-4-6` | `github-copilot/claude-sonnet-4.6` |
| `providerModels.lightweight` | `anthropic/claude-haiku-4-5` | `github-copilot/claude-haiku-4.5` |
| `providerPlugins` | `["opencode-claude-auth@latest"]` | `[]` |
| `providerConfig` | `{ anthropic = {}; }` | `{ github-copilot = {}; }` |

To switch to GitHub Copilot, set in your machine config:
```nix
nx.programs.prism.opencode.provider = "github-copilot";
```

## Validation

- `nix eval .#nixosConfigurations.navi.config.nx.programs.prism.opencode.provider` → `"anthropic"` ✓
- `nix eval .#nixosConfigurations.navi.config.home-manager.users.ben.programs.opencode.settings.model` → `"anthropic/claude-sonnet-4-6"` ✓
- File parses cleanly with `nixfmt`