### PR TITLE
tmux: add Prefix-q kill-session and unbind Prefix-d

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -113,7 +113,7 @@ in
               # close pane without confirmation
               bind-key x kill-pane
               # kill current session with confirmation
-              bind-key q display-popup -E "read -p 'Kill session? (y/N) ' yn; [ \"$$yn\" = 'y' ] && tmux kill-session"
+              bind-key q display-popup -E -w 40% -h 3 -b single "read -p 'Kill session? (y/N) ' yn; [ \"$$yn\" = 'y' ] && tmux kill-session"
               # worktree cleanup: remove worktree + kill session (project@worktree sessions only)
               bind-key W display-popup -E -w 60% -h 40% -b single "${prism} cleanup"
               # easy config reload


### PR DESCRIPTION
## Summary

- **Prefix+q**: displays a confirmation popup (`Kill session? (y/N)`) and runs `tmux kill-session` only if the user types `y`
- **unbind d**: noops the default `detach-client` binding, which gets hit by accident when reaching for `Prefix-D` (dashboard)

Both bindings are placed near the existing `kill-window` / `kill-pane` and `unbind v/b` lines respectively.