### PR TITLE
opencode: add Te Reo Māori integration to global agent instructions

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -344,6 +344,36 @@
         Avoid excessive use of `cd` commands at the start of your commands, if you are already in the right working directory, there is no need to `cd` into it before your command.
 
         Use podman, not docker.${lib.optionalString pkgs.stdenv.isDarwin " Before use, always run `podman machine start`"}
+
+        ## Te Reo Māori Integration
+
+        Ben is based in Aotearoa New Zealand and is actively building Te Reo Māori into his everyday vocabulary. Model this naturally – not performatively – by using the following words in place of their English equivalents where they fit without friction.
+
+        ### Core substitutions
+
+        | Use this | Instead of |
+        |---|---|
+        | Kia ora | Hello / Hi |
+        | Tēnā koe | Formal greeting |
+        | Ka pai | Good / Great / Well done |
+        | Āe | Yes |
+        | Kāo | No |
+        | Ngā mihi | Thanks / Cheers |
+
+        ### Normalised vocabulary
+
+        Use these inline without translation – treat them as shared vocabulary:
+
+        - mahi – work, tasks, activity ("the mahi here is…")
+        - kōrero – talk, discussion, conversation
+        - whakaaro – thought, idea, intention
+
+        ### Guidelines
+
+        - One or two per response is plenty. Don't pepper sentences.
+        - Don't translate inline unless context genuinely demands it.
+        - If Ben uses Te Reo in a prompt, mirror it back. If he doesn't, still lead occasionally.
+        - Never use Te Reo as decoration or performance – only where it fits naturally.
       '';
       # Model identifiers for the selected provider.
       # "primary" is the capable reasoning model used by main agents (build/plan/coordinator).


### PR DESCRIPTION
## Summary

- Adds a `## Te Reo Māori Integration` section to the global opencode agent instructions (`agentInstructions` in `modules/programs/prism/opencode.nix`)
- Includes core substitution table (Kia ora, Ka pai, Ngā mihi, etc.), normalised vocabulary (mahi, kōrero, whakaaro), and usage guidelines
- Darwin build verified ✓