### PR TITLE
docs(agents): document global opencode AGENTS.md source location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ For example:
 - opencode configuration → `modules/programs/prism/opencode.nix`
 - Custom opencode agents → `modules/programs/prism/opencode/agents/`
 - opencode skills → `modules/programs/prism/opencode/skills/`
+- Global opencode agent instructions (`~/.config/opencode/AGENTS.md`) → `modules/programs/prism/opencode.nix` (the `agentInstructions` string, rendered via `programs.opencode.rules`) — **never edit the file at `~/.config` directly, it is overwritten on every switch**
 
 If you need to understand how something is configured, `grep` or `glob` within the working directory before reaching outside it.
 


### PR DESCRIPTION
## Summary

- Adds a bullet to the "Application Configuration Lives in This Repo" example list clarifying that `~/.config/opencode/AGENTS.md` is generated from `modules/programs/prism/opencode.nix` and should never be edited directly.