### PR TITLE
feat(karabiner): Right Command + vowel → macron vowels (Te Reo Māori)

### DIFF
--- a/machines/m4mac/files/karabiner.json
+++ b/machines/m4mac/files/karabiner.json
@@ -14,106 +14,8 @@
                   "key_code": "a",
                   "modifiers": {
                     "mandatory": [
-                      "right_command"
-                    ],
-                    "optional": [
-                      "caps_lock"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ā\"'"
-                  }
-                ],
-                "type": "basic"
-              },
-              {
-                "from": {
-                  "key_code": "e",
-                  "modifiers": {
-                    "mandatory": [
-                      "right_command"
-                    ],
-                    "optional": [
-                      "caps_lock"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ē\"'"
-                  }
-                ],
-                "type": "basic"
-              },
-              {
-                "from": {
-                  "key_code": "i",
-                  "modifiers": {
-                    "mandatory": [
-                      "right_command"
-                    ],
-                    "optional": [
-                      "caps_lock"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ī\"'"
-                  }
-                ],
-                "type": "basic"
-              },
-              {
-                "from": {
-                  "key_code": "o",
-                  "modifiers": {
-                    "mandatory": [
-                      "right_command"
-                    ],
-                    "optional": [
-                      "caps_lock"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ō\"'"
-                  }
-                ],
-                "type": "basic"
-              },
-              {
-                "from": {
-                  "key_code": "u",
-                  "modifiers": {
-                    "mandatory": [
-                      "right_command"
-                    ],
-                    "optional": [
-                      "caps_lock"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ū\"'"
-                  }
-                ],
-                "type": "basic"
-              },
-              {
-                "from": {
-                  "key_code": "a",
-                  "modifiers": {
-                    "mandatory": [
                       "right_command",
                       "shift"
-                    ],
-                    "optional": [
-                      "caps_lock"
                     ]
                   }
                 },
@@ -131,9 +33,6 @@
                     "mandatory": [
                       "right_command",
                       "shift"
-                    ],
-                    "optional": [
-                      "caps_lock"
                     ]
                   }
                 },
@@ -151,9 +50,6 @@
                     "mandatory": [
                       "right_command",
                       "shift"
-                    ],
-                    "optional": [
-                      "caps_lock"
                     ]
                   }
                 },
@@ -171,9 +67,6 @@
                     "mandatory": [
                       "right_command",
                       "shift"
-                    ],
-                    "optional": [
-                      "caps_lock"
                     ]
                   }
                 },
@@ -191,15 +84,92 @@
                     "mandatory": [
                       "right_command",
                       "shift"
-                    ],
-                    "optional": [
-                      "caps_lock"
                     ]
                   }
                 },
                 "to": [
                   {
                     "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"Ū\"'"
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "key_code": "a",
+                  "modifiers": {
+                    "mandatory": [
+                      "right_command"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ā\"'"
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "key_code": "e",
+                  "modifiers": {
+                    "mandatory": [
+                      "right_command"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ē\"'"
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "key_code": "i",
+                  "modifiers": {
+                    "mandatory": [
+                      "right_command"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ī\"'"
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "key_code": "o",
+                  "modifiers": {
+                    "mandatory": [
+                      "right_command"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ō\"'"
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "key_code": "u",
+                  "modifiers": {
+                    "mandatory": [
+                      "right_command"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ū\"'"
                   }
                 ],
                 "type": "basic"


### PR DESCRIPTION
## Summary

- Adds a new Karabiner complex modification rule that maps `right_command` + `a/e/i/o/u` to the macron vowels `ā ē ī ō ū`, and `right_command` + `shift` + vowel to their uppercase equivalents `Ā Ē Ī Ō Ū`.
- Mirrors the ergonomic already in place on NixOS/sway via the `nz mao` xkb layout (Right Super as AltGr), giving a consistent muscle-memory experience across both platforms.
- Uses `osascript keystroke` via `shell_command` — the correct Karabiner approach for outputting arbitrary Unicode characters not present on the current keyboard layout.
- Right Command is currently unused (only Left Command is swapped with Left Option), so this repurposes it cleanly with no conflicts.
- New rule is inserted at the top of the `rules` array so it takes priority.