### PR TITLE
prism: default agent to coordinator for main worktree

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -5,26 +5,14 @@ import (
 	"testing"
 )
 
-// resolveAgent mirrors the agent-defaulting logic in ensureAndSwitchSession so
-// it can be tested independently of the tmux plumbing.
-func resolveAgent(directory, explicitAgent string) string {
-	if explicitAgent != "" {
-		return explicitAgent
-	}
-	if filepath.Base(directory) == "main" {
-		return "coordinator"
-	}
-	return "build"
-}
-
-func TestResolveAgent_DefaultsToCoordinatorForMain(t *testing.T) {
-	got := resolveAgent("/home/user/repos/project/main", "")
+func TestDefaultAgent_CoordinatorForMain(t *testing.T) {
+	got := defaultAgent("/home/user/repos/project/main", "")
 	if got != "coordinator" {
-		t.Errorf("resolveAgent(%q, %q) = %q, want %q", "/home/user/repos/project/main", "", got, "coordinator")
+		t.Errorf("defaultAgent(%q, %q) = %q, want %q", "/home/user/repos/project/main", "", got, "coordinator")
 	}
 }
 
-func TestResolveAgent_DefaultsToBuildForNonMain(t *testing.T) {
+func TestDefaultAgent_BuildForNonMain(t *testing.T) {
 	cases := []string{
 		"/home/user/repos/project/feature-foo",
 		"/home/user/repos/project/maintain",
@@ -35,15 +23,15 @@ func TestResolveAgent_DefaultsToBuildForNonMain(t *testing.T) {
 	}
 	for _, dir := range cases {
 		t.Run(filepath.Base(dir), func(t *testing.T) {
-			got := resolveAgent(dir, "")
+			got := defaultAgent(dir, "")
 			if got != "build" {
-				t.Errorf("resolveAgent(%q, %q) = %q, want %q", dir, "", got, "build")
+				t.Errorf("defaultAgent(%q, %q) = %q, want %q", dir, "", got, "build")
 			}
 		})
 	}
 }
 
-func TestResolveAgent_ExplicitAgentOverridesDefault(t *testing.T) {
+func TestDefaultAgent_ExplicitOverridesDefault(t *testing.T) {
 	cases := []struct {
 		dir   string
 		agent string
@@ -53,9 +41,9 @@ func TestResolveAgent_ExplicitAgentOverridesDefault(t *testing.T) {
 		{"/home/user/repos/project/main", "build"},
 	}
 	for _, tc := range cases {
-		got := resolveAgent(tc.dir, tc.agent)
+		got := defaultAgent(tc.dir, tc.agent)
 		if got != tc.agent {
-			t.Errorf("resolveAgent(%q, %q) = %q, want %q", tc.dir, tc.agent, got, tc.agent)
+			t.Errorf("defaultAgent(%q, %q) = %q, want %q", tc.dir, tc.agent, got, tc.agent)
 		}
 	}
 }

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -10,7 +10,7 @@ package cmd
 //	--repo <name>         target repo by folder name under ~/code (or full path)
 //	--prompt <text>       pass an initial prompt to opencode on launch
 //	--prompt-file <path>  read the initial prompt from a file
-//	--agent <name>        opencode agent to use (default: build)
+//	--agent <name>        opencode agent to use (default: "coordinator" on main, "build" otherwise)
 //	--attach              switch the current tmux client to the new session
 
 import (
@@ -65,7 +65,7 @@ var prCmd = &cobra.Command{
 func init() {
 	prCmd.Flags().String("repo", "", "Target repo name under ~/code, or full path")
 	addPromptFlags(prCmd)
-	prCmd.Flags().String("agent", "", "Opencode agent to use (default: build)")
+	prCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main, "build" otherwise)`)
 	prCmd.Flags().Bool("attach", false, "Switch the current tmux client to the new session")
 	rootCmd.AddCommand(prCmd)
 }

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -10,7 +10,7 @@ package cmd
 //	--pr <number>         check out the branch for a given PR number
 //	--prompt <text>       pass an initial prompt to opencode on launch
 //	--prompt-file <path>  read the initial prompt from a file
-//	--agent <name>        opencode agent to use (default: build)
+//	--agent <name>        opencode agent to use (default: "coordinator" on main, "build" otherwise)
 
 import (
 	"fmt"
@@ -35,7 +35,7 @@ func init() {
 	spawnCmd.Flags().String("repo", "", "Target repo name under ~/code, or full path")
 	spawnCmd.Flags().String("pr", "", "PR number — check out its branch")
 	addPromptFlags(spawnCmd)
-	spawnCmd.Flags().String("agent", "", "Opencode agent to use (default: build)")
+	spawnCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main, "build" otherwise)`)
 	spawnCmd.Flags().Bool("attach", false, "Switch the current tmux client to the new session")
 	rootCmd.AddCommand(spawnCmd)
 }

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -477,6 +477,22 @@ func sessionNameFor(dir, projectRoot string) string {
 	return strings.ReplaceAll(filepath.Base(dir), ".", "_")
 }
 
+// defaultAgent returns the agent to use for the given directory.
+// If explicit is non-empty it is returned unchanged.
+// Otherwise "coordinator" is returned for the "main" worktree and "build" for
+// everything else (including the scratchpad, which resolves to the home dir).
+// Only an exact match on "main" triggers coordinator — case variants and
+// substrings (e.g. "Main", "maintain") resolve to "build".
+func defaultAgent(directory, explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if filepath.Base(directory) == "main" {
+		return "coordinator"
+	}
+	return "build"
+}
+
 func ensureAndSwitchSession(path string, projectRoot string, opts sessionOpts) error {
 	var sessionName string
 	var directory string
@@ -490,15 +506,8 @@ func ensureAndSwitchSession(path string, projectRoot string, opts sessionOpts) e
 		sessionName = sessionNameFor(directory, projectRoot)
 	}
 
-	// Default agent based on worktree name: coordinator for "main", build otherwise.
-	// An explicit opts.agent value is never overridden.
-	if opts.agent == "" {
-		if filepath.Base(directory) == "main" {
-			opts.agent = "coordinator"
-		} else {
-			opts.agent = "build"
-		}
-	}
+	// Default agent based on worktree name; an explicit value is never overridden.
+	opts.agent = defaultAgent(directory, opts.agent)
 
 	if !tmux.HasSession(sessionName) {
 		if err := tmux.NewSessionDetached(sessionName, directory); err != nil {


### PR DESCRIPTION
## Summary

- \`ensureAndSwitchSession\` now resolves the default agent based on the worktree name before calling \`buildOpencodeCmd\`: \`coordinator\` when \`filepath.Base(directory) == \"main\"\`, \`build\` for everything else.
- An explicit \`--agent\` flag is never overridden.
- The fix lives in \`ensureAndSwitchSession\` (not \`spawn.go\`) so it covers all code paths: \`spawn\`, the interactive \`switch\` picker, \`handleBareRepo\`, \`restore\`, etc.
- The scratchpad pseudo-path (\`[scratchpad]\`) resolves \`directory\` to the home dir, so \`filepath.Base\` won't be \`\"main\"\` — naturally excluded.
- Agent defaulting extracted into a standalone \`defaultAgent(directory, explicit)\` helper so tests call the production function directly.

## Tests added

\`cmd/agent_default_test.go\`:
- \`TestDefaultAgent_CoordinatorForMain\` — exact \`main\` match
- \`TestDefaultAgent_BuildForNonMain\` — case variants (\`MAIN\`, \`Main\`), substrings (\`maintain\`, \`main-branch\`), home dir
- \`TestDefaultAgent_ExplicitOverridesDefault\` — explicit agent always wins
- \`TestBuildOpencodeCmd_UsesAgent\` — command string correctness including empty-agent safety-net fallback

Fixes the bug where \`prism launch\`/\`prism spawn\`/\`prism switch\` always defaulted to \`--agent build\` even on the \`main\` worktree.