### PR TITLE
feat(prism): add state line to checkin output

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -69,8 +69,10 @@ func runCheckinSession(session string, height int) error {
 
 	fmt.Printf("%s %s\n\n", styleBold.Render("checkin:"), session)
 	fmt.Printf("state: %s\n\n", styleState.Render(state))
-	fmt.Println(result.Screen)
-	fmt.Println()
+	if result.Screen != "" {
+		fmt.Println(result.Screen)
+		fmt.Println()
+	}
 	fmt.Println(styleDim.Render("── end of screen capture ──"))
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -47,19 +47,7 @@ var listSessionsCmd = &cobra.Command{
 				title = title[:57] + "..."
 			}
 			// Colour the state field.
-			var stateColour string
-			switch state {
-			case "active":
-				stateColour = ColorPurple
-			case "waiting":
-				stateColour = ColorYellow
-			case "finished":
-				stateColour = ColorGreen
-			default:
-				stateColour = ColorSecondary
-			}
-			stateStyled := lipgloss.NewStyle().Foreground(lipgloss.Color(stateColour)).
-				Render(fmt.Sprintf("%-8s", state))
+			stateStyled := stateStyle(state).Render(fmt.Sprintf("%-8s", state))
 
 			// Only bold worktree sessions (project@branch).
 			nameStyle := styleTitle


### PR DESCRIPTION
## Summary

- Adds a `state: <value>` line to `prism checkin` output, sitting between the session header and the screen body
- State is sourced from `tmux.AgentStateOf(session)` at checkin time; empty string maps to `idle`
- Colour-coded to match `list-sessions`: `active`=purple, `waiting`=yellow, `finished`=green, others=dim

## Output format

```
checkin: nixos-config@my-branch

state: active

[screen content...]

── end of screen capture ──
```

## Testing

- `go build ./... && go test ./...` passes
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds