### PR TITLE
Deny tmux send-keys and other destructive tmux commands

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -238,7 +238,8 @@
         "tmux rename-window" = "deny";
         "tmux respawn-window" = "deny";
         "tmux new-window" = "deny";
-        "tmux *" = "deny";
+        "tmux attach-session *" = "deny";
+        "tmux switch-client *" = "deny";
       };
 
       clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";


### PR DESCRIPTION
## Summary
- Deny `tmux send-keys` for all agents.
- Deny `tmux run-shell` for `plan` and `coordinator` agents.
- Deny other destructive tmux commands (`kill-session`, `kill-server`, `select-window`, `rename-window`, `respawn-window`, `new-window`).