### PR TITLE
feat(prism): restore sessions on restart

### DIFF
--- a/modules/programs/prism/prism/cmd/restart.go
+++ b/modules/programs/prism/prism/cmd/restart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -29,7 +30,15 @@ func runRestart(_ *cobra.Command, _ []string) error {
 	// 2. Kill tmux server
 	_, _ = tmux.Run("kill-server")
 
-	// 3. Re-exec
+	// Wait for server to die (kill-server is async).
+	time.Sleep(500 * time.Millisecond)
+
+	// 3. Restore sessions
+	if err := Restore(false); err != nil {
+		return fmt.Errorf("failed to restore sessions: %w", err)
+	}
+
+	// 4. Re-exec
 	executable, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("could not determine executable path: %w", err)

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -37,7 +37,10 @@ func init() {
 
 func runRestore(cmd *cobra.Command, _ []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	return Restore(dryRun)
+}
 
+func Restore(dryRun bool) error {
 	saved, err := loadSessions()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
Implement automatic session restore during prism restart by extracting the Restore function from restore.go and calling it in restart.go after killing the tmux server.