### PR TITLE
fix: prevent --continue leaking to spawned agent sessions

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -465,8 +465,26 @@
               playwright-cli
             ];
           programs.zsh.shellAliases = {
-            # set environment variables for opencode
-            opencode = "${envPrefix} opencode";
+            # set environment variables for opencode and manage sessions/--continue
+            opencode = ''
+              if [[ -n "$TMUX" ]]; then
+                S=$(tmux display-message -p '#S')
+                if [[ "$S" == *"@"* ]]; then
+                  wt=''${S#*@}
+                  if [[ "$wt" == "main" ]]; then
+                    ${envPrefix} opencode --continue "$@"
+                  else
+                    ${envPrefix} opencode --session "$S" "$@"
+                  fi
+                elif [[ "$S" == "scratchpad" ]]; then
+                  ${envPrefix} opencode --continue "$@"
+                else
+                  ${envPrefix} opencode "$@"
+                fi
+              else
+                ${envPrefix} opencode "$@"
+              fi
+            '';
           };
           programs.neovim.initLua =
             lib.mkAfter

--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -50,21 +50,23 @@ func TestDefaultAgent_ExplicitOverridesDefault(t *testing.T) {
 
 func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 	cases := []struct {
-		opts sessionOpts
-		want string
+		opts        sessionOpts
+		sessionName string
+		directory   string
+		want        string
 	}{
-		{sessionOpts{agent: "coordinator"}, "opencode --agent coordinator --continue"},
-		{sessionOpts{agent: "build"}, "opencode --agent build --continue"},
-		{sessionOpts{agent: "custom"}, "opencode --agent custom --continue"},
+		{sessionOpts{agent: "coordinator"}, "nixos-config@main", "/home/user/repos/nixos-config/main", "opencode --agent coordinator --continue"},
+		{sessionOpts{agent: "build"}, "nixos-config@feature-foo", "/home/user/repos/nixos-config/feature-foo", "opencode --agent build --session nixos-config@feature-foo"},
+		{sessionOpts{agent: "custom"}, "nixos-config@custom", "/home/user/repos/nixos-config/custom", "opencode --agent custom --session nixos-config@custom"},
 		// Safety-net fallback: empty agent still yields "build".
-		{sessionOpts{}, "opencode --agent build --continue"},
+		{sessionOpts{}, "nixos-config@main", "/home/user/repos/nixos-config/main", "opencode --agent build --continue"},
 		// Fresh start
-		{sessionOpts{agent: "build", fresh: true}, "opencode --agent build"},
+		{sessionOpts{agent: "build", fresh: true}, "nixos-config@main", "/home/user/repos/nixos-config/main", "opencode --agent build --session nixos-config@main"},
 	}
 	for _, tc := range cases {
-		got := buildOpencodeCmd(tc.opts)
+		got := buildOpencodeCmd(tc.opts, tc.sessionName, tc.directory)
 		if got != tc.want {
-			t.Errorf("buildOpencodeCmd(%+v) = %q, want %q", tc.opts, got, tc.want)
+			t.Errorf("buildOpencodeCmd(%+v, %q, %q) = %q, want %q", tc.opts, tc.sessionName, tc.directory, got, tc.want)
 		}
 	}
 }

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -451,7 +451,7 @@ type sessionOpts struct {
 // See: https://github.com/anomalyco/opencode/issues/8850
 //
 //	https://github.com/anomalyco/opencode/issues/14349
-func buildOpencodeCmd(opts sessionOpts) string {
+func buildOpencodeCmd(opts sessionOpts, sessionName, directory string) string {
 	agent := opts.agent
 	if agent == "" {
 		// Fallback safety net; ensureAndSwitchSession always sets opts.agent
@@ -459,8 +459,11 @@ func buildOpencodeCmd(opts sessionOpts) string {
 		agent = "build"
 	}
 	cmd := "opencode --agent " + agent
-	if !opts.fresh {
+	isMain := filepath.Base(directory) == "main"
+	if isMain && !opts.fresh {
 		cmd += " --continue"
+	} else {
+		cmd += " --session " + sessionName
 	}
 	return cmd
 }
@@ -549,7 +552,7 @@ func ensureAndSwitchSession(path string, projectRoot string, opts sessionOpts) e
 
 			// Window 1: agent.
 			_ = tmux.NewWindow(sessionName, 1, "agent", directory)
-			_ = tmux.SendKeys(sessionName+":1", buildOpencodeCmd(opts))
+			_ = tmux.SendKeys(sessionName+":1", buildOpencodeCmd(opts, sessionName, directory))
 			// Work around opencode bug where --prompt is ignored on TUI launch.
 			// Instead, send the prompt as keystrokes once opencode signals that
 			// it is ready (i.e. @agent_state == "finished" on the agent window).


### PR DESCRIPTION
## Summary
- Prevents `--continue` from leaking into spawned agent sessions, which was causing context leakage and incorrect agent defaults.
- Updated `buildOpencodeCmd` to use `--session <session>` instead of `--continue` for non-main branches.
- Created an intelligent `opencode` shell alias wrapper that detects tmux session context to choose between `--continue` and `--session`.

## Changes
- `modules/programs/prism/prism/cmd/switch.go`: Updated `buildOpencodeCmd` signature and logic to differentiate between `main` branch (coordinator) and feature worktrees.
- `modules/programs/prism/prism/cmd/agent_default_test.go`: Updated test cases to verify the new `--session` / `--continue` logic.
- `modules/programs/prism/opencode.nix`: Updated `opencode` zsh alias to an intelligent wrapper script.

## Verification
- Ran `go test ./modules/programs/prism/prism/cmd/` — all `BuildOpencodeCmd` tests passed.
- Configuration syntax checked.