### PR TITLE
fix(prism): disable --continue for new worktrees in spawn and pr

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -60,6 +60,7 @@ var prCmd = &cobra.Command{
 			prompt:   promptFlag,
 			agent:    agentFlag,
 			headless: !attachFlag,
+			fresh:    true,
 		}
 		return ensureAndSwitchSession(worktreePath, bareRoot, opts)
 	},

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -59,6 +59,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		prompt:   promptFlag,
 		agent:    agentFlag,
 		headless: !fromKeybind && !attachFlag,
+		fresh:    true,
 	}
 
 	// Resolve the bare repo root.


### PR DESCRIPTION
## Summary
- Modified `prism spawn` and `prism pr` to set `fresh: true` in `sessionOpts`.
- This ensures that `opencode` starts a new session in the newly created worktree instead of attempting to continue a non-existent one (which leads to a "Session not found" error).

## Testing
- Built the `prism` CLI successfully.
- Verified `buildOpencodeCmd` logic through `go test ./cmd/ -v -run TestBuildOpencodeCmd_UsesAgent`.