### PR TITLE
feat(m4mac): switch opencode provider from google to github-copilot

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -24,7 +24,7 @@ in
   # Module configuration using nx namespace (matching NixOS pattern)
   nx = {
     programs = {
-      prism.opencode.provider = "google";
+      prism.opencode.provider = "github-copilot";
       # Disable programs that default to enabled but aren't needed/available on Darwin
       podman.enable = false;
       dragon-drop.enable = false;


### PR DESCRIPTION
## Summary

- Changes `prism.opencode.provider` from `"google"` to `"github-copilot"` in the m4mac machine configuration
- Makes GitHub Copilot the permanent opencode provider for m4mac, replacing Gemini