### PR TITLE
fix: replace osascript macron mappings with native key_code integers

### DIFF
--- a/machines/m4mac/files/karabiner.json
+++ b/machines/m4mac/files/karabiner.json
@@ -19,11 +19,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"Ā\"'"
-                  }
-                ],
+                "to": [{ "key_code": 256 }],
                 "type": "basic"
               },
               {
@@ -36,11 +32,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"Ē\"'"
-                  }
-                ],
+                "to": [{ "key_code": 274 }],
                 "type": "basic"
               },
               {
@@ -53,11 +45,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"Ī\"'"
-                  }
-                ],
+                "to": [{ "key_code": 298 }],
                 "type": "basic"
               },
               {
@@ -70,11 +58,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"Ō\"'"
-                  }
-                ],
+                "to": [{ "key_code": 332 }],
                 "type": "basic"
               },
               {
@@ -87,11 +71,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"Ū\"'"
-                  }
-                ],
+                "to": [{ "key_code": 362 }],
                 "type": "basic"
               },
               {
@@ -103,11 +83,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ā\"'"
-                  }
-                ],
+                "to": [{ "key_code": 257 }],
                 "type": "basic"
               },
               {
@@ -119,11 +95,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ē\"'"
-                  }
-                ],
+                "to": [{ "key_code": 275 }],
                 "type": "basic"
               },
               {
@@ -135,11 +107,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ī\"'"
-                  }
-                ],
+                "to": [{ "key_code": 299 }],
                 "type": "basic"
               },
               {
@@ -151,11 +119,7 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ō\"'"
-                  }
-                ],
+                "to": [{ "key_code": 333 }],
                 "type": "basic"
               },
               {
@@ -167,11 +131,15 @@
                     ]
                   }
                 },
-                "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"ū\"'"
-                  }
-                ],
+                "to": [{ "key_code": 363 }],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "any": "key_code",
+                  "modifiers": { "mandatory": ["right_command"], "optional": ["any"] }
+                },
+                "to": [],
                 "type": "basic"
               }
             ]


### PR DESCRIPTION
## Summary

- Replaces all `shell_command` / `osascript keystroke` entries in the \"Right Command + vowel → macron vowel\" rule with native `key_code` integer values (Unicode codepoints), which work directly in `karabiner_grabber` without Accessibility permission
- Adds a catch-all noop manipulator as the last entry in the rule so Right Command + any non-vowel key is swallowed rather than falling through

## Why

`karabiner_grabber` runs as root and cannot be granted Accessibility permission via TCC. `osascript keystroke` via System Events requires the calling process to have Accessibility, so all macron combos silently fell through and typed the plain vowel.

## Mappings

| Combo | Char | key_code |
|-------|------|----------|
| Right Cmd + a | ā | 257 |
| Right Cmd + e | ē | 275 |
| Right Cmd + i | ī | 299 |
| Right Cmd + o | ō | 333 |
| Right Cmd + u | ū | 363 |
| Right Cmd + Shift + a | Ā | 256 |
| Right Cmd + Shift + e | Ē | 274 |
| Right Cmd + Shift + i | Ī | 298 |
| Right Cmd + Shift + o | Ō | 332 |
| Right Cmd + Shift + u | Ū | 362 |

No other rules were touched.