### PR TITLE
Stage 1: DB Foundation + prism event command

### DIFF
--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -1,0 +1,358 @@
+package cmd
+
+// prism event — write lifecycle events to prism.db
+//
+// Sub-subcommands:
+//
+//	state-change      --session <name> --state <state> --worktree <path>
+//	tmux-session-start --session <name> --worktree <path>
+//	tmux-session-end  --session <name>
+//	compaction        --session <name>
+//	error             --session <name> --message <text>
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// dbPath returns the path to prism.db, honouring $XDG_STATE_HOME.
+func dbPath() string {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism", "prism.db")
+}
+
+// deriveBareRoot walks parent directories from worktree until it finds a
+// directory containing a file named ".bare". Returns the bare root path, or
+// an empty string if none is found.
+func deriveBareRoot(worktree string) string {
+	p := worktree
+	for {
+		info, err := os.Stat(filepath.Join(p, ".bare"))
+		if err == nil && info.IsDir() {
+			return p
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			break
+		}
+		p = parent
+	}
+	return ""
+}
+
+// deriveRepo returns the repo name from a worktree path by walking up to find
+// the .bare marker. Returns empty string if not found.
+func deriveRepo(worktree string) string {
+	bareRoot := deriveBareRoot(worktree)
+	if bareRoot == "" {
+		return ""
+	}
+	name := filepath.Base(bareRoot)
+	name = strings.TrimSuffix(name, ".git")
+	return name
+}
+
+// openDB opens prism.db, returning it or an error.
+func openDB() (*db.DB, error) {
+	return db.Open(dbPath())
+}
+
+var eventCmd = &cobra.Command{
+	Use:   "event",
+	Short: "Write lifecycle events to prism.db",
+}
+
+// --- state-change ---
+
+var eventStateChangeCmd = &cobra.Command{
+	Use:   "state-change",
+	Short: "Write a state_change event and upsert agent status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		session, _ := cmd.Flags().GetString("session")
+		state, _ := cmd.Flags().GetString("state")
+		worktree, _ := cmd.Flags().GetString("worktree")
+
+		repo := deriveRepo(worktree)
+		if repo == "" {
+			// Not inside a project worktree — exit silently.
+			return nil
+		}
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("event state-change: %w", err)
+		}
+		defer d.Close()
+
+		if err := d.UpsertStatus(session, repo, worktree, state, nil, nil); err != nil {
+			return fmt.Errorf("event state-change: upsert status: %w", err)
+		}
+
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: session,
+			Repo:        repo,
+			Worktree:    worktree,
+			Type:        "state_change",
+			Payload:     fmt.Sprintf(`{"state":%q}`, state),
+			CreatedAt:   time.Now(),
+		}
+		if err := d.WriteEvent(e); err != nil {
+			return fmt.Errorf("event state-change: write event: %w", err)
+		}
+		return nil
+	},
+}
+
+// --- tmux-session-start ---
+
+var eventTmuxSessionStartCmd = &cobra.Command{
+	Use:   "tmux-session-start",
+	Short: "Write a tmux_session_start event and upsert agent status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		session, _ := cmd.Flags().GetString("session")
+		worktree, _ := cmd.Flags().GetString("worktree")
+
+		// If no .bare marker is found, exit 0 silently — this is a non-project
+		// session (scratchpad, prism-dashboard, etc.).
+		repo := deriveRepo(worktree)
+		if repo == "" {
+			return nil
+		}
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("event tmux-session-start: %w", err)
+		}
+		defer d.Close()
+
+		if err := d.UpsertStatus(session, repo, worktree, "idle", nil, nil); err != nil {
+			return fmt.Errorf("event tmux-session-start: upsert status: %w", err)
+		}
+
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: session,
+			Repo:        repo,
+			Worktree:    worktree,
+			Type:        "tmux_session_start",
+			Payload:     `{}`,
+			CreatedAt:   time.Now(),
+		}
+		if err := d.WriteEvent(e); err != nil {
+			return fmt.Errorf("event tmux-session-start: write event: %w", err)
+		}
+
+		// Prune old data once per new session (at most once per tmux server start).
+		if err := d.Prune(90 * 24 * time.Hour); err != nil {
+			// Non-fatal — log but don't fail the command.
+			fmt.Fprintf(os.Stderr, "prism event tmux-session-start: prune: %v\n", err)
+		}
+
+		return nil
+	},
+}
+
+// --- tmux-session-end ---
+
+var eventTmuxSessionEndCmd = &cobra.Command{
+	Use:   "tmux-session-end",
+	Short: "Mark the session as ended and write a tmux_session_end event",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		session, _ := cmd.Flags().GetString("session")
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("event tmux-session-end: %w", err)
+		}
+		defer d.Close()
+
+		// Look up the session's repo and worktree for the event row.
+		s, err := d.CurrentStatus(session)
+		if err != nil {
+			return fmt.Errorf("event tmux-session-end: current status: %w", err)
+		}
+		if s == nil {
+			// No DB record for this session — it was a non-project session; exit 0 silently.
+			return nil
+		}
+
+		if err := d.SetEnded(session); err != nil {
+			return fmt.Errorf("event tmux-session-end: set ended: %w", err)
+		}
+
+		// Delete sentinel file if it exists.
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome == "" {
+			home, _ := os.UserHomeDir()
+			stateHome = filepath.Join(home, ".local", "state")
+		}
+		sentinel := filepath.Join(stateHome, "prism", "bus", session+".signal")
+		_ = os.Remove(sentinel) // ignore error — file may not exist
+
+		// Write the end event using the known repo/worktree from the status row.
+		repo := s.Repo
+		worktree := s.Worktree
+
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: session,
+			Repo:        repo,
+			Worktree:    worktree,
+			Type:        "tmux_session_end",
+			Payload:     `{}`,
+			CreatedAt:   time.Now(),
+		}
+		if err := d.WriteEvent(e); err != nil {
+			return fmt.Errorf("event tmux-session-end: write event: %w", err)
+		}
+
+		return nil
+	},
+}
+
+// --- compaction ---
+
+var eventCompactionCmd = &cobra.Command{
+	Use:   "compaction",
+	Short: "Write a compaction event and upsert state=compacting",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		session, _ := cmd.Flags().GetString("session")
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("event compaction: %w", err)
+		}
+		defer d.Close()
+
+		s, err := d.CurrentStatus(session)
+		if err != nil {
+			return fmt.Errorf("event compaction: current status: %w", err)
+		}
+
+		repo := ""
+		worktree := ""
+		if s != nil {
+			repo = s.Repo
+			worktree = s.Worktree
+		}
+
+		if err := d.UpsertStatus(session, repo, worktree, "compacting", nil, nil); err != nil {
+			return fmt.Errorf("event compaction: upsert status: %w", err)
+		}
+
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: session,
+			Repo:        repo,
+			Worktree:    worktree,
+			Type:        "compaction",
+			Payload:     `{}`,
+			CreatedAt:   time.Now(),
+		}
+		if err := d.WriteEvent(e); err != nil {
+			return fmt.Errorf("event compaction: write event: %w", err)
+		}
+
+		return nil
+	},
+}
+
+// --- error ---
+
+var eventErrorCmd = &cobra.Command{
+	Use:   "error",
+	Short: "Write an error event and upsert state=error",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		session, _ := cmd.Flags().GetString("session")
+		message, _ := cmd.Flags().GetString("message")
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("event error: %w", err)
+		}
+		defer d.Close()
+
+		s, err := d.CurrentStatus(session)
+		if err != nil {
+			return fmt.Errorf("event error: current status: %w", err)
+		}
+
+		repo := ""
+		worktree := ""
+		if s != nil {
+			repo = s.Repo
+			worktree = s.Worktree
+		}
+
+		if err := d.UpsertStatus(session, repo, worktree, "error", nil, nil); err != nil {
+			return fmt.Errorf("event error: upsert status: %w", err)
+		}
+
+		payload := fmt.Sprintf(`{"message":%q}`, message)
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: session,
+			Repo:        repo,
+			Worktree:    worktree,
+			Type:        "error",
+			Payload:     payload,
+			CreatedAt:   time.Now(),
+		}
+		if err := d.WriteEvent(e); err != nil {
+			return fmt.Errorf("event error: write event: %w", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	// state-change flags
+	eventStateChangeCmd.Flags().String("session", "", "tmux session name")
+	eventStateChangeCmd.Flags().String("state", "", "new agent state")
+	eventStateChangeCmd.Flags().String("worktree", "", "worktree path")
+	_ = eventStateChangeCmd.MarkFlagRequired("session")
+	_ = eventStateChangeCmd.MarkFlagRequired("state")
+	_ = eventStateChangeCmd.MarkFlagRequired("worktree")
+
+	// tmux-session-start flags
+	eventTmuxSessionStartCmd.Flags().String("session", "", "tmux session name")
+	eventTmuxSessionStartCmd.Flags().String("worktree", "", "worktree path")
+	_ = eventTmuxSessionStartCmd.MarkFlagRequired("session")
+	_ = eventTmuxSessionStartCmd.MarkFlagRequired("worktree")
+
+	// tmux-session-end flags
+	eventTmuxSessionEndCmd.Flags().String("session", "", "tmux session name")
+	_ = eventTmuxSessionEndCmd.MarkFlagRequired("session")
+
+	// compaction flags
+	eventCompactionCmd.Flags().String("session", "", "tmux session name")
+	_ = eventCompactionCmd.MarkFlagRequired("session")
+
+	// error flags
+	eventErrorCmd.Flags().String("session", "", "tmux session name")
+	eventErrorCmd.Flags().String("message", "", "error message")
+	_ = eventErrorCmd.MarkFlagRequired("session")
+	_ = eventErrorCmd.MarkFlagRequired("message")
+
+	eventCmd.AddCommand(eventStateChangeCmd)
+	eventCmd.AddCommand(eventTmuxSessionStartCmd)
+	eventCmd.AddCommand(eventTmuxSessionEndCmd)
+	eventCmd.AddCommand(eventCompactionCmd)
+	eventCmd.AddCommand(eventErrorCmd)
+
+	rootCmd.AddCommand(eventCmd)
+}

--- a/modules/programs/prism/prism/go.mod
+++ b/modules/programs/prism/prism/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/google/uuid v1.6.0
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/spf13/cobra v1.10.2
 	modernc.org/sqlite v1.48.0
@@ -21,7 +22,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1,0 +1,476 @@
+// Package db provides the prism SQLite database layer.
+//
+// The database is located at $XDG_STATE_HOME/prism/prism.db, falling back to
+// $HOME/.local/state/prism/prism.db. All four tables (agent_events,
+// agent_status, bus_messages, schema_version) are created on Open if they do
+// not already exist.
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite" // register sqlite3 driver
+)
+
+// DB wraps a SQLite connection.
+type DB struct {
+	conn *sql.DB
+	path string
+}
+
+// Path returns the filesystem path of the database file.
+func (d *DB) Path() string { return d.path }
+
+// QueryRow executes a query that returns at most one row. Exposed for testing.
+func (d *DB) QueryRow(query string, args ...any) *sql.Row {
+	return d.conn.QueryRow(query, args...)
+}
+
+// Event represents a row in the agent_events table.
+type Event struct {
+	ID          string
+	SessionName string
+	Repo        string
+	Worktree    string
+	OpencodeSID *string
+	Type        string
+	Payload     string // raw JSON
+	CreatedAt   time.Time
+}
+
+// Status represents a row in the agent_status table.
+type Status struct {
+	SessionName string
+	Repo        string
+	Worktree    string
+	State       string
+	Title       *string
+	OpencodeSID *string
+	LastSeen    time.Time
+	EndedAt     *time.Time
+}
+
+// BusMessage represents a row in the bus_messages table.
+type BusMessage struct {
+	ID          string
+	FromSession string
+	ToSession   string
+	Repo        string
+	Text        string
+	Urgency     string
+	SentAt      time.Time
+	DeliveredAt *time.Time
+}
+
+const schema = `
+CREATE TABLE IF NOT EXISTS agent_events (
+  id           TEXT PRIMARY KEY,
+  session_name TEXT NOT NULL,
+  repo         TEXT NOT NULL,
+  worktree     TEXT NOT NULL,
+  opencode_sid TEXT,
+  type         TEXT NOT NULL,
+  payload      TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_status (
+  session_name TEXT PRIMARY KEY,
+  repo         TEXT NOT NULL,
+  worktree     TEXT NOT NULL,
+  state        TEXT NOT NULL,
+  title        TEXT,
+  opencode_sid TEXT,
+  last_seen    INTEGER NOT NULL,
+  ended_at     INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS bus_messages (
+  id           TEXT PRIMARY KEY,
+  from_session TEXT NOT NULL,
+  to_session   TEXT NOT NULL,
+  repo         TEXT NOT NULL,
+  text         TEXT NOT NULL,
+  urgency      TEXT NOT NULL DEFAULT 'normal',
+  sent_at      INTEGER NOT NULL,
+  delivered_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_bus_pending ON bus_messages(to_session, delivered_at)
+  WHERE delivered_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS schema_version (
+  version INTEGER NOT NULL
+);
+`
+
+// Open opens (or creates) the prism database at path.
+// It creates parent directories as needed, enables WAL mode, runs the full
+// schema, and sets schema_version=1 if the table is empty.
+func Open(path string) (*DB, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("db: create parent dirs: %w", err)
+	}
+
+	conn, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("db: open: %w", err)
+	}
+
+	// Enable WAL mode for better concurrent read/write performance.
+	if _, err := conn.Exec("PRAGMA journal_mode = WAL;"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("db: set WAL mode: %w", err)
+	}
+
+	// Create all tables.
+	if _, err := conn.Exec(schema); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("db: apply schema: %w", err)
+	}
+
+	// Set schema_version=1 if the table is empty.
+	var count int
+	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("db: check schema_version: %w", err)
+	}
+	if count == 0 {
+		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (1)"); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: set schema_version: %w", err)
+		}
+	}
+
+	return &DB{conn: conn, path: path}, nil
+}
+
+// Close closes the underlying database connection.
+func (d *DB) Close() error {
+	return d.conn.Close()
+}
+
+// UpsertStatus inserts or updates the agent_status row for sessionName.
+// repo and worktree are only set on initial insert — they do not change on
+// conflict. title and opencodeSID are updated only when non-nil (COALESCE).
+func (d *DB) UpsertStatus(sessionName, repo, worktree, state string, title *string, opencodeSID *string) error {
+	now := time.Now().UnixMilli()
+	const q = `
+INSERT INTO agent_status (session_name, repo, worktree, state, title, opencode_sid, last_seen)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_name) DO UPDATE SET
+  state        = excluded.state,
+  title        = COALESCE(excluded.title, title),
+  opencode_sid = COALESCE(excluded.opencode_sid, opencode_sid),
+  last_seen    = excluded.last_seen`
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, opencodeSID, now)
+	if err != nil {
+		return fmt.Errorf("db: upsert status: %w", err)
+	}
+	return nil
+}
+
+// SetEnded marks the session as ended by setting ended_at to now.
+func (d *DB) SetEnded(sessionName string) error {
+	now := time.Now().UnixMilli()
+	_, err := d.conn.Exec(
+		"UPDATE agent_status SET ended_at = ? WHERE session_name = ?",
+		now, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("db: set ended: %w", err)
+	}
+	return nil
+}
+
+// WriteEvent inserts an event row into agent_events.
+func (d *DB) WriteEvent(e Event) error {
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now()
+	}
+	createdAt := e.CreatedAt.UnixMilli()
+	const q = `
+INSERT INTO agent_events (id, session_name, repo, worktree, opencode_sid, type, payload, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := d.conn.Exec(q, e.ID, e.SessionName, e.Repo, e.Worktree, e.OpencodeSID, e.Type, e.Payload, createdAt)
+	if err != nil {
+		return fmt.Errorf("db: write event: %w", err)
+	}
+	return nil
+}
+
+// QueryEvents returns up to limit events for the given session, ordered by
+// created_at ASC. before and after are event IDs used for cursor-based
+// pagination — pass nil for open-ended queries. types filters by event type;
+// pass nil to return all types.
+func (d *DB) QueryEvents(sessionName string, limit int, before, after *string, types []string) ([]Event, error) {
+	args := []any{sessionName}
+	var conditions []string
+	conditions = append(conditions, "session_name = ?")
+
+	if after != nil {
+		var afterTS int64
+		err := d.conn.QueryRow(
+			"SELECT created_at FROM agent_events WHERE id = ?", *after,
+		).Scan(&afterTS)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("QueryEvents: cursor event %q not found", *after)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("db: resolve after cursor: %w", err)
+		}
+		conditions = append(conditions, "created_at > ?")
+		args = append(args, afterTS)
+	}
+
+	if before != nil {
+		var beforeTS int64
+		err := d.conn.QueryRow(
+			"SELECT created_at FROM agent_events WHERE id = ?", *before,
+		).Scan(&beforeTS)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("QueryEvents: cursor event %q not found", *before)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("db: resolve before cursor: %w", err)
+		}
+		conditions = append(conditions, "created_at < ?")
+		args = append(args, beforeTS)
+	}
+
+	if len(types) > 0 {
+		placeholders := make([]string, len(types))
+		for i, t := range types {
+			placeholders[i] = "?"
+			args = append(args, t)
+		}
+		conditions = append(conditions, "type IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events"
+	if len(conditions) > 0 {
+		q += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	q += " ORDER BY created_at ASC"
+	if limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		var createdAt int64
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+			return nil, fmt.Errorf("db: scan event: %w", err)
+		}
+		e.CreatedAt = time.UnixMilli(createdAt)
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate events: %w", err)
+	}
+	return events, nil
+}
+
+// CurrentStatus returns the agent_status row for sessionName, or nil if not found.
+func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, opencode_sid, last_seen, ended_at
+FROM agent_status
+WHERE session_name = ?`
+	row := d.conn.QueryRow(q, sessionName)
+	s, err := scanStatus(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: current status: %w", err)
+	}
+	return s, nil
+}
+
+// AllActiveStatus returns all agent_status rows where ended_at IS NULL.
+func (d *DB) AllActiveStatus() ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, opencode_sid, last_seen, ended_at
+FROM agent_status
+WHERE ended_at IS NULL`
+	return d.queryStatuses(q)
+}
+
+// AllActiveStatusForRepo returns all active agent_status rows for repo.
+func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, opencode_sid, last_seen, ended_at
+FROM agent_status
+WHERE ended_at IS NULL AND repo = ?`
+	return d.queryStatuses(q, repo)
+}
+
+// WaitingCount returns the number of active sessions with state='waiting'.
+func (d *DB) WaitingCount() (int, error) {
+	var n int
+	err := d.conn.QueryRow(
+		"SELECT COUNT(*) FROM agent_status WHERE state = 'waiting' AND ended_at IS NULL",
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("db: waiting count: %w", err)
+	}
+	return n, nil
+}
+
+// PendingMessages returns undelivered bus_messages for toSession with the given urgency.
+func (d *DB) PendingMessages(toSession string, urgency string) ([]BusMessage, error) {
+	const q = `
+SELECT id, from_session, to_session, repo, text, urgency, sent_at, delivered_at
+FROM bus_messages
+WHERE to_session = ? AND urgency = ? AND delivered_at IS NULL`
+	rows, err := d.conn.Query(q, toSession, urgency)
+	if err != nil {
+		return nil, fmt.Errorf("db: pending messages: %w", err)
+	}
+	defer rows.Close()
+
+	var msgs []BusMessage
+	for rows.Next() {
+		m, err := scanBusMessage(rows)
+		if err != nil {
+			return nil, fmt.Errorf("db: scan bus message: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate bus messages: %w", err)
+	}
+	return msgs, nil
+}
+
+// MarkDelivered sets delivered_at on the given bus message.
+func (d *DB) MarkDelivered(messageID string) error {
+	now := time.Now().UnixMilli()
+	_, err := d.conn.Exec(
+		"UPDATE bus_messages SET delivered_at = ? WHERE id = ?",
+		now, messageID,
+	)
+	if err != nil {
+		return fmt.Errorf("db: mark delivered: %w", err)
+	}
+	return nil
+}
+
+// WriteBusMessage inserts a new row into bus_messages with delivered_at=NULL.
+func (d *DB) WriteBusMessage(msg BusMessage) error {
+	var sentAt int64
+	if msg.SentAt.IsZero() {
+		sentAt = time.Now().UnixMilli()
+	} else {
+		sentAt = msg.SentAt.UnixMilli()
+	}
+	const q = `
+INSERT INTO bus_messages (id, from_session, to_session, repo, text, urgency, sent_at, delivered_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`
+	_, err := d.conn.Exec(q, msg.ID, msg.FromSession, msg.ToSession, msg.Repo, msg.Text, msg.Urgency, sentAt)
+	if err != nil {
+		return fmt.Errorf("db: write bus message: %w", err)
+	}
+	return nil
+}
+
+// Prune deletes agent_events older than olderThan, and delivered bus_messages
+// older than olderThan. It does NOT delete agent_status rows or undelivered
+// bus_messages.
+func (d *DB) Prune(olderThan time.Duration) error {
+	threshold := time.Now().Add(-olderThan).UnixMilli()
+
+	if _, err := d.conn.Exec(
+		"DELETE FROM agent_events WHERE created_at < ?", threshold,
+	); err != nil {
+		return fmt.Errorf("db: prune agent_events: %w", err)
+	}
+
+	if _, err := d.conn.Exec(
+		"DELETE FROM bus_messages WHERE delivered_at IS NOT NULL AND delivered_at < ?", threshold,
+	); err != nil {
+		return fmt.Errorf("db: prune bus_messages: %w", err)
+	}
+
+	return nil
+}
+
+// queryStatuses is a helper that runs a SELECT on agent_status and scans rows.
+func (d *DB) queryStatuses(q string, args ...any) ([]Status, error) {
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query statuses: %w", err)
+	}
+	defer rows.Close()
+
+	var statuses []Status
+	for rows.Next() {
+		s, err := scanStatus(rows)
+		if err != nil {
+			return nil, fmt.Errorf("db: scan status: %w", err)
+		}
+		statuses = append(statuses, *s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate statuses: %w", err)
+	}
+	return statuses, nil
+}
+
+// scanner abstracts *sql.Row and *sql.Rows for scanStatus.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanStatus(s scanner) (*Status, error) {
+	var st Status
+	var lastSeen int64
+	var endedAt sql.NullInt64
+	err := s.Scan(
+		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
+		&st.Title, &st.OpencodeSID, &lastSeen, &endedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	st.LastSeen = time.UnixMilli(lastSeen)
+	if endedAt.Valid {
+		t := time.UnixMilli(endedAt.Int64)
+		st.EndedAt = &t
+	}
+	return &st, nil
+}
+
+func scanBusMessage(s scanner) (BusMessage, error) {
+	var m BusMessage
+	var sentAt int64
+	var deliveredAt sql.NullInt64
+	err := s.Scan(
+		&m.ID, &m.FromSession, &m.ToSession, &m.Repo, &m.Text, &m.Urgency,
+		&sentAt, &deliveredAt,
+	)
+	if err != nil {
+		return BusMessage{}, err
+	}
+	m.SentAt = time.UnixMilli(sentAt)
+	if deliveredAt.Valid {
+		t := time.UnixMilli(deliveredAt.Int64)
+		m.DeliveredAt = &t
+	}
+	return m, nil
+}

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -1,0 +1,390 @@
+package db_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func strPtr(s string) *string { return &s }
+
+// TestOpen_CreatesSchema verifies that Open creates all required tables.
+func TestOpen_CreatesSchema(t *testing.T) {
+	d := openTestDB(t)
+
+	// Verify all three main tables plus schema_version exist.
+	tables := []string{"agent_events", "agent_status", "bus_messages", "schema_version"}
+	for _, table := range tables {
+		var name string
+		err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name)
+		if err != nil {
+			t.Errorf("table %q not found: %v", table, err)
+		}
+	}
+
+	// Verify schema_version=1.
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 1 {
+		t.Errorf("schema_version: got %d, want 1", version)
+	}
+
+	// Verify WAL mode.
+	var mode string
+	if err := d.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode: got %q, want \"wal\"", mode)
+	}
+
+	// Opening the same path again must succeed without error.
+	path2 := d.Path()
+	d2, err := db.Open(path2)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	d2.Close()
+}
+
+// TestUpsertStatus_Insert verifies that UpsertStatus creates a new row.
+func TestUpsertStatus_Insert(t *testing.T) {
+	d := openTestDB(t)
+
+	err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "idle", nil, nil)
+	if err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil, want a row")
+	}
+	if s.SessionName != "repo@main" {
+		t.Errorf("SessionName: got %q, want %q", s.SessionName, "repo@main")
+	}
+	if s.Repo != "repo" {
+		t.Errorf("Repo: got %q, want %q", s.Repo, "repo")
+	}
+	if s.Worktree != "/code/repo/main" {
+		t.Errorf("Worktree: got %q, want %q", s.Worktree, "/code/repo/main")
+	}
+	if s.State != "idle" {
+		t.Errorf("State: got %q, want %q", s.State, "idle")
+	}
+	if s.EndedAt != nil {
+		t.Errorf("EndedAt: got non-nil, want nil")
+	}
+}
+
+// TestUpsertStatus_Update verifies that upserting the same session twice updates state
+// without creating a duplicate row.
+func TestUpsertStatus_Update(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "idle", nil, nil); err != nil {
+		t.Fatalf("first UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("second UpsertStatus: %v", err)
+	}
+
+	// Must still be only one row.
+	all, err := d.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("row count: got %d, want 1", len(all))
+	}
+	if all[0].State != "active" {
+		t.Errorf("State: got %q, want \"active\"", all[0].State)
+	}
+}
+
+// TestWriteEvent verifies that WriteEvent inserts a row retrievable via QueryEvents.
+func TestWriteEvent(t *testing.T) {
+	d := openTestDB(t)
+
+	id := uuid.New().String()
+	e := db.Event{
+		ID:          id,
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+		CreatedAt:   time.Now(),
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	events, err := d.QueryEvents("repo@main", 10, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count: got %d, want 1", len(events))
+	}
+	got := events[0]
+	if got.ID != id {
+		t.Errorf("ID: got %q, want %q", got.ID, id)
+	}
+	if got.SessionName != "repo@main" {
+		t.Errorf("SessionName: got %q, want %q", got.SessionName, "repo@main")
+	}
+	if got.Type != "state_change" {
+		t.Errorf("Type: got %q, want %q", got.Type, "state_change")
+	}
+	if got.Payload != `{"state":"active"}` {
+		t.Errorf("Payload: got %q, want %q", got.Payload, `{"state":"active"}`)
+	}
+}
+
+// TestSetEnded verifies that SetEnded sets ended_at on the status row.
+func TestSetEnded(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	if err := d.SetEnded("repo@main"); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil")
+	}
+	if s.EndedAt == nil {
+		t.Error("EndedAt: got nil, want non-nil")
+	}
+}
+
+// TestAllActiveStatus_ExcludesEnded verifies that ended sessions are not returned.
+func TestAllActiveStatus_ExcludesEnded(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus live: %v", err)
+	}
+	if err := d.UpsertStatus("repo@feat", "repo", "/code/repo/feat", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus ended: %v", err)
+	}
+	if err := d.SetEnded("repo@feat"); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	all, err := d.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("active count: got %d, want 1", len(all))
+	}
+	if all[0].SessionName != "repo@main" {
+		t.Errorf("SessionName: got %q, want \"repo@main\"", all[0].SessionName)
+	}
+}
+
+// TestWaitingCount verifies that WaitingCount returns the correct count.
+func TestWaitingCount(t *testing.T) {
+	d := openTestDB(t)
+
+	sessions := []struct {
+		name  string
+		state string
+	}{
+		{"repo@s1", "waiting"},
+		{"repo@s2", "waiting"},
+		{"repo@s3", "active"},
+	}
+	for _, s := range sessions {
+		if err := d.UpsertStatus(s.name, "repo", "/code/repo/"+s.name, s.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", s.name, err)
+		}
+	}
+
+	n, err := d.WaitingCount()
+	if err != nil {
+		t.Fatalf("WaitingCount: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("WaitingCount: got %d, want 2", n)
+	}
+}
+
+// TestPrune verifies that old events are deleted and recent ones preserved.
+func TestPrune(t *testing.T) {
+	d := openTestDB(t)
+
+	// Insert an old event (2 days ago) and a recent event (now).
+	oldID := uuid.New().String()
+	newID := uuid.New().String()
+
+	oldEvent := db.Event{
+		ID:          oldID,
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "state_change",
+		Payload:     `{}`,
+		CreatedAt:   time.Now().Add(-48 * time.Hour),
+	}
+	newEvent := db.Event{
+		ID:          newID,
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "state_change",
+		Payload:     `{}`,
+		CreatedAt:   time.Now(),
+	}
+
+	if err := d.WriteEvent(oldEvent); err != nil {
+		t.Fatalf("WriteEvent old: %v", err)
+	}
+	if err := d.WriteEvent(newEvent); err != nil {
+		t.Fatalf("WriteEvent new: %v", err)
+	}
+
+	// Prune with 24h threshold — old event should be deleted, new preserved.
+	if err := d.Prune(24 * time.Hour); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	events, err := d.QueryEvents("repo@main", 100, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count after prune: got %d, want 1", len(events))
+	}
+	if events[0].ID != newID {
+		t.Errorf("remaining event ID: got %q, want %q", events[0].ID, newID)
+	}
+}
+
+// TestUpsertStatus_CoalesceTitle verifies that a subsequent upsert with nil title
+// does not overwrite an existing title (COALESCE behaviour).
+func TestUpsertStatus_CoalesceTitle(t *testing.T) {
+	d := openTestDB(t)
+
+	title := strPtr("my title")
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "idle", title, nil); err != nil {
+		t.Fatalf("first UpsertStatus: %v", err)
+	}
+
+	// Second upsert with nil title must not clobber the existing title.
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("second UpsertStatus: %v", err)
+	}
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s.Title == nil {
+		t.Fatal("Title: got nil, want preserved value")
+	}
+	if *s.Title != "my title" {
+		t.Errorf("Title: got %q, want \"my title\"", *s.Title)
+	}
+}
+
+// TestAllActiveStatusForRepo verifies that AllActiveStatusForRepo filters by repo.
+func TestAllActiveStatusForRepo(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repoA@main", "repoA", "/code/repoA/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus repoA: %v", err)
+	}
+	if err := d.UpsertStatus("repoB@main", "repoB", "/code/repoB/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus repoB: %v", err)
+	}
+
+	results, err := d.AllActiveStatusForRepo("repoA")
+	if err != nil {
+		t.Fatalf("AllActiveStatusForRepo: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("result count: got %d, want 1", len(results))
+	}
+	if results[0].SessionName != "repoA@main" {
+		t.Errorf("SessionName: got %q, want \"repoA@main\"", results[0].SessionName)
+	}
+}
+
+// TestWriteBusMessage_PendingMessages_MarkDelivered tests the full bus message lifecycle.
+func TestWriteBusMessage_PendingMessages_MarkDelivered(t *testing.T) {
+	d := openTestDB(t)
+
+	msgID := uuid.New().String()
+	msg := db.BusMessage{
+		ID:          msgID,
+		FromSession: "repo@feat",
+		ToSession:   "repo@main",
+		Repo:        "repo",
+		Text:        "hello coordinator",
+		Urgency:     "normal",
+		SentAt:      time.Now(),
+	}
+
+	if err := d.WriteBusMessage(msg); err != nil {
+		t.Fatalf("WriteBusMessage: %v", err)
+	}
+
+	// Must appear in pending messages.
+	pending, err := d.PendingMessages("repo@main", "normal")
+	if err != nil {
+		t.Fatalf("PendingMessages: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending count: got %d, want 1", len(pending))
+	}
+	if pending[0].ID != msgID {
+		t.Errorf("message ID: got %q, want %q", pending[0].ID, msgID)
+	}
+	if pending[0].DeliveredAt != nil {
+		t.Error("DeliveredAt: got non-nil, want nil")
+	}
+
+	// Mark delivered.
+	if err := d.MarkDelivered(msgID); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+
+	// Must no longer appear in pending messages.
+	pending2, err := d.PendingMessages("repo@main", "normal")
+	if err != nil {
+		t.Fatalf("PendingMessages after deliver: %v", err)
+	}
+	if len(pending2) != 0 {
+		t.Errorf("pending count after deliver: got %d, want 0", len(pending2))
+	}
+}

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -173,6 +173,13 @@ in
               # (every status-interval seconds). Cheap write; survives sudden shutdowns.
               set-hook -g after-refresh-client "run-shell -b '${prism} save'"
 
+              # --- DB lifecycle hooks ---
+
+              # Write tmux_session_start event when a new session is created.
+              set-hook -g session-created "run-shell '${prism} event tmux-session-start --session #{session_name} --worktree #{pane_current_path}'"
+              # Write tmux_session_end event when a session is closed.
+              set-hook -g session-closed "run-shell '${prism} event tmux-session-end --session #{session_name}'"
+
               # Remove HM session vars guard from tmux environment so new shells
               # re-evaluate $(cat ...) substitutions for secrets like GITHUB_TOKEN
               set-environment -r __HM_SESS_VARS_SOURCED


### PR DESCRIPTION
## Summary

Implements Stage 1 of the Prism DB migration plan: the SQLite database foundation and `prism event` command.

### What's new

- **`internal/db/db.go`** — new `db` package with:
  - `Open` creates `prism.db` with WAL mode, full schema (`agent_events`, `agent_status`, `bus_messages`, `schema_version`), and sets `schema_version=1` on first run
  - `UpsertStatus` uses `INSERT ... ON CONFLICT DO UPDATE SET` with `COALESCE` to avoid clobbering `title`/`opencode_sid`
  - `WriteEvent`, `QueryEvents`, `SetEnded`, `AllActiveStatus`, `AllActiveStatusForRepo`, `WaitingCount`, `WriteBusMessage`, `PendingMessages`, `MarkDelivered`, `Prune`
  - Uses `modernc.org/sqlite` (pure Go, already in `go.mod`)

- **`internal/db/db_test.go`** — 9 tests, all passing:
  `TestOpen_CreatesSchema`, `TestUpsertStatus_Insert`, `TestUpsertStatus_Update`, `TestWriteEvent`, `TestSetEnded`, `TestAllActiveStatus_ExcludesEnded`, `TestWaitingCount`, `TestPrune`, `TestWriteBusMessage_PendingMessages_MarkDelivered`

- **`cmd/event.go`** — new `prism event` command with sub-subcommands:
  - `state-change --session --state --worktree`
  - `tmux-session-start --session --worktree` (walks up to `.bare` to derive repo; exits 0 silently for non-project sessions; calls `Prune(90d)`)
  - `tmux-session-end --session` (calls `SetEnded`, removes sentinel signal file)
  - `compaction --session`
  - `error --session --message`

- **`tmux.nix`** — two new `set-hook -g` entries:
  ```
  set-hook -g session-created "run-shell 'prism event tmux-session-start ...'"
  set-hook -g session-closed  "run-shell 'prism event tmux-session-end ...'"
  ```

### Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all existing + 9 new tests)
- `nixfmt` — no formatting diff

### Non-breaking

No existing commands change behaviour. This is purely additive (Stage 1 per the implementation plan).