### PR TITLE
fix(macron-type): post events at cgSessionEventTap to bypass Karabiner

### DIFF
--- a/modules/programs/macron-type/main.swift
+++ b/modules/programs/macron-type/main.swift
@@ -18,5 +18,5 @@ var keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true)!
 var keyUp   = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)!
 keyDown.keyboardSetUnicodeString(stringLength: 1, unicodeString: [uchar])
 keyUp.keyboardSetUnicodeString(stringLength: 1,  unicodeString: [uchar])
-keyDown.post(tap: CGEventTapLocation(rawValue: 0)!)
-keyUp.post(tap: CGEventTapLocation(rawValue: 0)!)
+keyDown.post(tap: CGEventTapLocation(rawValue: 1)!)
+keyUp.post(tap: CGEventTapLocation(rawValue: 1)!)


### PR DESCRIPTION
## Summary

- Change `CGEventTapLocation(rawValue: 0)` → `rawValue: 1` in both `keyDown` and `keyUp` post calls in `modules/programs/macron-type/main.swift`
- `rawValue: 0` is `cghidEventTap` (below Karabiner), which causes synthetic events to re-enter Karabiner's pipeline and get dropped
- `rawValue: 1` is `cgSessionEventTap` (above Karabiner), bypassing it entirely so macron characters are delivered correctly