### PR TITLE
fix(macron-type): accept plain ASCII vowel arg, map to macron internally

### DIFF
--- a/machines/m4mac/files/karabiner.json
+++ b/machines/m4mac/files/karabiner.json
@@ -19,7 +19,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type Ā" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type A" }],
                 "type": "basic"
               },
               {
@@ -32,7 +32,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type Ē" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type E" }],
                 "type": "basic"
               },
               {
@@ -45,7 +45,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type Ī" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type I" }],
                 "type": "basic"
               },
               {
@@ -58,7 +58,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type Ō" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type O" }],
                 "type": "basic"
               },
               {
@@ -71,7 +71,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type Ū" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type U" }],
                 "type": "basic"
               },
               {
@@ -83,7 +83,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type ā" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type a" }],
                 "type": "basic"
               },
               {
@@ -95,7 +95,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type ē" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type e" }],
                 "type": "basic"
               },
               {
@@ -107,7 +107,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type ī" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type i" }],
                 "type": "basic"
               },
               {
@@ -119,7 +119,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type ō" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type o" }],
                 "type": "basic"
               },
               {
@@ -131,7 +131,7 @@
                     ]
                   }
                 },
-                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type ū" }],
+                "to": [{ "shell_command": "/run/current-system/sw/bin/macron-type u" }],
                 "type": "basic"
               },
               {

--- a/modules/programs/macron-type/main.swift
+++ b/modules/programs/macron-type/main.swift
@@ -1,19 +1,27 @@
 import CoreGraphics
 import Foundation
 
+let macrons: [Character: UniChar] = [
+    "a": 0x0101, // ā
+    "e": 0x0113, // ē
+    "i": 0x012B, // ī
+    "o": 0x014D, // ō
+    "u": 0x016B, // ū
+    "A": 0x0100, // Ā
+    "E": 0x0112, // Ē
+    "I": 0x012A, // Ī
+    "O": 0x014C, // Ō
+    "U": 0x016A, // Ū
+]
+
 guard CommandLine.arguments.count == 2,
-      let scalar = CommandLine.arguments[1].unicodeScalars.first
+      let key = CommandLine.arguments[1].first,
+      let uchar = macrons[key]
 else {
-    fputs("usage: macron-type <character>\n", stderr)
+    fputs("usage: macron-type <a|e|i|o|u|A|E|I|O|U>\n", stderr)
     exit(1)
 }
 
-guard scalar.value <= 0xFFFF else {
-    fputs("error: character must be in the Basic Multilingual Plane (U+0000–U+FFFF)\n", stderr)
-    exit(1)
-}
-
-let uchar = UniChar(scalar.value)
 var keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true)!
 var keyUp   = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)!
 keyDown.keyboardSetUnicodeString(stringLength: 1, unicodeString: [uchar])


### PR DESCRIPTION
## Summary

- `macron-type` now accepts a plain ASCII vowel (`a|e|i|o|u|A|E|I|O|U`) and looks up the corresponding macron codepoint internally via a `[Character: UniChar]` dictionary
- All 10 `shell_command` entries in `karabiner.json` updated to pass plain ASCII (e.g. `macron-type a` instead of `macron-type ā`)
- Avoids potential UTF-8 encoding issues with non-ASCII characters in Karabiner shell command strings

## Build

Darwin build verified: `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel` ✓