### PR TITLE
Stage 2: Plugin writes to DB

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -205,7 +205,7 @@ export const PrismHooks: Plugin = async ({ $, worktree }) => {
         case "session.updated": {
           const info = event.properties.info;
           if (info.title) await setTitle(info.title);
-          if (info.time.compacting != null) {
+          if (info.time?.compacting != null) {
             compacting = true;
             await notify("set-compacting");
             // DB
@@ -289,15 +289,25 @@ export const PrismHooks: Plugin = async ({ $, worktree }) => {
           writeEvent("error", { note: "session error" });
           break;
 
-        case "session.compacted":
+        case "session.compacted": {
           // Compaction done — agent returns to idle.
           compacting = false;
           await notify("set-finished");
           // DB
+          let prevStateCompact: string | null = null;
+          if (db && sessionName && getStatus) {
+            try {
+              const row = getStatus.get(sessionName) as { state: string } | undefined;
+              prevStateCompact = row?.state ?? null;
+            } catch (e) { console.error("[prism-hooks] getStatus failed:", e); }
+          }
           upsertAgentStatus("finished");
           writeEvent("compaction", { note: "compaction complete" });
-          notifyCoordinator(`Agent ${sessionName} context was compacted — check in to verify current state`);
+          if (prevStateCompact === "active" || prevStateCompact === "compacting") {
+            notifyCoordinator(`Agent ${sessionName} context was compacted — check in to verify current state`);
+          }
           break;
+        }
 
         case "message.updated": {
           const info = event.properties.info as any;
@@ -319,7 +329,8 @@ export const PrismHooks: Plugin = async ({ $, worktree }) => {
             const result = String(part.state.output ?? "").slice(0, 500);
             writeEvent("tool_call",   { tool: part.tool, args,   messageId: part.messageID });
             writeEvent("tool_result", { tool: part.tool, result, messageId: part.messageID });
-          } else if (part.type === "reasoning") {
+          } else if (part.type === "reasoning" && part.time?.end != null) {
+            // Only write when the reasoning block is complete to avoid one row per token.
             writeEvent("thinking", { text: String(part.text ?? "").slice(0, 500), messageId: part.messageID });
           }
           break;


### PR DESCRIPTION
## Summary

- Extends `prism-hooks.ts` to write all opencode session events to `prism.db` via `bun:sqlite` in parallel with existing `prism notify` calls
- Adds `deriveSessionName()` which walks up from `worktree` to find the `.bare` marker, then derives `repo@branch` via `git symbolic-ref`
- Opens DB at plugin startup with `{ create: false }` — gracefully degrades if `prism.db` is absent or session is not in a prism worktree
- Splits the combined `session.created`/`session.updated` case and adds correct DB semantics for each (created→active, updated with compaction→compacting, updated without→metadata-only update)
- Handles `message.updated` (msg_user/msg_assistant) and `message.part.updated` (tool_call, tool_result, thinking) as new event cases
- Notifies the local coordinator via `bus_messages` on `session.idle` (when prev state was `active`) and on `session.compacted`
- All DB writes wrapped in try/catch; all existing `prism notify` calls untouched

## Acceptance Criteria

All ACs from the Stage 2 spec are met. `go build ./...` and `go test ./...` pass with no changes to Go code.