### PR TITLE
Stage 4: prism status + list-sessions from DB

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -77,6 +77,19 @@ func runCheckinSession(session string, height int) error {
 	return nil
 }
 
+// filterStatusSessions excludes infrastructure sessions from status counts.
+// Used by checkin (no-arg) until Stage 5 replaces checkin with DB queries.
+func filterStatusSessions(all []tmux.Session) []tmux.Session {
+	var out []tmux.Session
+	for _, s := range all {
+		if s.Name == "scratchpad" || s.Name == "prism-dashboard" {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 func runCheckinNoArg() error {
 	sessions, err := tmux.Sessions()
 	if err != nil {

--- a/modules/programs/prism/prism/cmd/db.go
+++ b/modules/programs/prism/prism/cmd/db.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// dbPath returns the path to prism.db, honouring $XDG_STATE_HOME.
+func dbPath() string {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism", "prism.db")
+}
+
+// openDB opens prism.db, returning it or an error.
+func openDB() (*db.DB, error) {
+	return db.Open(dbPath())
+}

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -23,16 +23,6 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
-// dbPath returns the path to prism.db, honouring $XDG_STATE_HOME.
-func dbPath() string {
-	stateHome := os.Getenv("XDG_STATE_HOME")
-	if stateHome == "" {
-		home, _ := os.UserHomeDir()
-		stateHome = filepath.Join(home, ".local", "state")
-	}
-	return filepath.Join(stateHome, "prism", "prism.db")
-}
-
 // deriveBareRoot walks parent directories from worktree until it finds a
 // directory containing a file named ".bare". Returns the bare root path, or
 // an empty string if none is found.
@@ -62,11 +52,6 @@ func deriveRepo(worktree string) string {
 	name := filepath.Base(bareRoot)
 	name = strings.TrimSuffix(name, ".git")
 	return name
-}
-
-// openDB opens prism.db, returning it or an error.
-func openDB() (*db.DB, error) {
-	return db.Open(dbPath())
 }
 
 var eventCmd = &cobra.Command{

--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -1,30 +1,80 @@
 package cmd
 
-// prism list-sessions — print all agent sessions (excluding infrastructure
-// sessions like scratchpad and prism-dashboard) in a human-readable table.
-// Useful for scripting and as a standalone companion to `prism checkin`.
+// prism list-sessions — print agent sessions (from DB) in a human-readable
+// table. By default shows only sessions for the current repo. Use --all / -A
+// to list sessions across all repos.
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	"github.com/prismatic-koi/prism/internal/tmux"
+	"github.com/prismatic-koi/prism/internal/db"
 )
 
 var listSessionsCmd = &cobra.Command{
 	Use:   "list-sessions",
 	Short: "List agent sessions with their state and title",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sessions, err := tmux.Sessions()
-		if err != nil {
-			return err
-		}
-		sessions = filterStatusSessions(sessions)
+		showAll, _ := cmd.Flags().GetBool("all")
 
-		if len(sessions) == 0 {
+		// Derive currentRepo from the working directory using the same
+		// normalisation as deriveRepo() so the filter matches the repo column
+		// written at session-start time.
+		currentRepo := ""
+		cwd, err := os.Getwd()
+		if err != nil {
+			cwd = os.Getenv("PRISM_SPAWN_PATH")
+		}
+		if cwd != "" {
+			currentRepo = deriveRepo(cwd)
+		}
+
+		// If repo detection failed and --all was not requested, refuse to
+		// silently show all sessions — that would violate the scoped-by-default
+		// contract. Direct the user to --all instead.
+		if !showAll && currentRepo == "" {
+			if cwd == "" {
+				return fmt.Errorf("list-sessions: CWD unavailable and PRISM_SPAWN_PATH not set; use --all to list all sessions")
+			}
+			return fmt.Errorf("list-sessions: %q is not inside a prism worktree; use --all to list all sessions", cwd)
+		}
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("list-sessions: open db: %w", err)
+		}
+		defer d.Close()
+
+		type row struct {
+			name  string
+			state string
+			title string
+		}
+
+		var ss []db.Status
+		if showAll {
+			ss, err = d.AllActiveStatus()
+		} else {
+			ss, err = d.AllActiveStatusForRepo(currentRepo)
+		}
+		if err != nil {
+			return fmt.Errorf("list-sessions: query db: %w", err)
+		}
+
+		var rows []row
+		for _, s := range ss {
+			title := "—"
+			if s.Title != nil && *s.Title != "" {
+				title = *s.Title
+			}
+			rows = append(rows, row{name: s.SessionName, state: s.State, title: title})
+		}
+
+		if len(rows) == 0 {
 			fmt.Println("no agent sessions found")
 			return nil
 		}
@@ -34,29 +84,26 @@ var listSessionsCmd = &cobra.Command{
 		styleTitle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 
 		fmt.Println(styleHeader.Render(fmt.Sprintf("%-40s  %-8s  %s", "SESSION", "STATE", "TITLE")))
-		for _, s := range sessions {
-			state := s.AgentState
+		for _, r := range rows {
+			state := r.state
 			if state == "" {
 				state = "idle"
 			}
-			title := s.AgentTitle
-			if title == "" {
-				title = "—"
-			}
-			if len(title) > 60 {
-				title = title[:57] + "..."
+			title := r.title
+			if runes := []rune(title); len(runes) > 60 {
+				title = string(runes[:57]) + "..."
 			}
 			// Colour the state field.
 			stateStyled := stateStyle(state).Render(fmt.Sprintf("%-8s", state))
 
 			// Only bold worktree sessions (project@branch).
 			nameStyle := styleTitle
-			if strings.Contains(s.Name, "@") {
+			if strings.Contains(r.name, "@") {
 				nameStyle = styleName
 			}
 
 			fmt.Printf("%s  %s  %s\n",
-				nameStyle.Render(fmt.Sprintf("%-40s", s.Name)),
+				nameStyle.Render(fmt.Sprintf("%-40s", r.name)),
 				stateStyled,
 				styleTitle.Render(title),
 			)
@@ -66,5 +113,6 @@ var listSessionsCmd = &cobra.Command{
 }
 
 func init() {
+	listSessionsCmd.Flags().BoolP("all", "A", false, "List all sessions across all repos")
 	rootCmd.AddCommand(listSessionsCmd)
 }

--- a/modules/programs/prism/prism/cmd/status.go
+++ b/modules/programs/prism/prism/cmd/status.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/prismatic-koi/prism/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -21,16 +20,22 @@ suitable for embedding in status-right.`,
 		waitingOnly, _ := cmd.Flags().GetBool("waiting")
 		tmuxFormat, _ := cmd.Flags().GetBool("tmux-format")
 
-		sessions, err := tmux.Sessions()
+		d, err := openDB()
 		if err != nil {
 			// Silently produce no output — status bar should not show errors.
 			return nil
 		}
-		sessions = filterStatusSessions(sessions)
+		defer d.Close()
+
+		statuses, err := d.AllActiveStatus()
+		if err != nil {
+			// Silently produce no output — status bar should not show errors.
+			return nil
+		}
 
 		var nActive, nWaiting, nFinished, nIdle int
-		for _, s := range sessions {
-			switch s.AgentState {
+		for _, s := range statuses {
+			switch s.State {
 			case "active":
 				nActive++
 			case "waiting":
@@ -87,18 +92,6 @@ suitable for embedding in status-right.`,
 		}
 		return nil
 	},
-}
-
-// filterStatusSessions excludes infrastructure sessions from status counts.
-func filterStatusSessions(all []tmux.Session) []tmux.Session {
-	var out []tmux.Session
-	for _, s := range all {
-		if s.Name == "scratchpad" || s.Name == "prism-dashboard" {
-			continue
-		}
-		out = append(out, s)
-	}
-	return out
 }
 
 func init() {

--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildGoModule,
+  git,
   tmux,
   kitty,
   # Theme colours injected so the binary matches the user's active theme.
@@ -48,6 +49,15 @@ buildGoModule {
     "-X github.com/prismatic-koi/prism/internal/tmux.TmuxBin=${tmux}/bin/tmux"
     "-X github.com/prismatic-koi/prism/cmd.LaunchKittyBin=${kitty}/bin/kitty"
   ];
+
+  nativeCheckInputs = [ git ];
+
+  preCheck = ''
+    export GIT_CONFIG_NOSYSTEM=1
+    export HOME=$(mktemp -d)
+    git config --global user.email "test@test.com"
+    git config --global user.name "Test"
+  '';
 
   meta = {
     description = "Prism — tmux-based AI development environment TUI";


### PR DESCRIPTION
## Summary

- Replaces tmux polling in `prism status` and `prism list-sessions` with SQLite DB queries against `agent_status` — transparent swap, no user-visible behaviour change
- Extracts `dbPath()`/`openDB()` from `event.go` into a new shared `cmd/db.go` so both commands can use them without duplication
- Adds `--all` / `-A` flag to `prism list-sessions` for cross-repo listing; default now scopes to current repo via `.bare` marker walk
- Fixes nix build sandbox failure from Stage 3: adds `git` to `nativeCheckInputs` and a `preCheck` hook in `pkgs/prism.nix` so tests calling `git init`/`git commit` pass in the nix sandbox

## Acceptance criteria

- [x] `prism status --waiting --tmux-format` reads from DB, not tmux `@prism_waiting`
- [x] `prism status` (no flags) reads all states from DB and formats correctly
- [x] `prism list-sessions` lists sessions for current repo only, from DB
- [x] `prism list-sessions --all` / `-A` lists all active sessions across all repos
- [x] Output format (column widths, colours, state styling) is unchanged
- [x] `TITLE` column reads from `agent_status.title`, not `@agent_title` tmux option
- [x] Non-project sessions (scratchpad, prism-dashboard) do not appear (they have no DB rows)
- [x] `dbPath()` is in a shared location, not duplicated between files
- [x] `filterStatusSessions` removed from `status.go` (moved to `checkin.go` where it is still used until Stage 5)
- [x] No `tmux.Sessions()` calls remain in `status.go` or `list_sessions.go`
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes