### PR TITLE
fix: isolate tmux and DB in tests to prevent live environment pollution

### DIFF
--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -58,7 +58,10 @@ func newCmdTestServer(t *testing.T) *cmdTestServer {
 func withCmdServer(t *testing.T, s *cmdTestServer) {
 	t.Helper()
 	wrapperPath := t.TempDir() + "/tmux"
-	script := "#!/bin/sh\nexec " + s.bin + " -L " + s.socket + " \"$@\"\n"
+	// -f /dev/null suppresses the user's tmux.conf so no hooks fire against the
+	// live DB when the package-level tmux.* functions create sessions on this
+	// isolated server.
+	script := "#!/bin/sh\nexec " + s.bin + " -L " + s.socket + " -f /dev/null \"$@\"\n"
 	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write tmux wrapper: %v", err)
 	}
@@ -89,7 +92,9 @@ func scriptCmdArgs(cmd string) []string {
 }
 
 func (s *cmdTestServer) run(args ...string) error {
-	cmd := exec.Command(s.bin, append([]string{"-L", s.socket}, args...)...)
+	// -f /dev/null suppresses the user's tmux.conf so no hooks (e.g.
+	// session-created → prism event tmux-session-start) fire against the live DB.
+	cmd := exec.Command(s.bin, append([]string{"-L", s.socket, "-f", "/dev/null"}, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("tmux %v: %w\n%s", args, err, out)
@@ -98,7 +103,8 @@ func (s *cmdTestServer) run(args ...string) error {
 }
 
 func (s *cmdTestServer) output(args ...string) (string, error) {
-	cmd := exec.Command(s.bin, append([]string{"-L", s.socket}, args...)...)
+	// -f /dev/null suppresses the user's tmux.conf so no hooks fire.
+	cmd := exec.Command(s.bin, append([]string{"-L", s.socket, "-f", "/dev/null"}, args...)...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("tmux %v: %w", args, err)
@@ -131,7 +137,7 @@ func (s *cmdTestServer) attachClientToSession(t *testing.T, targetSession string
 			beforeSet[c] = true
 		}
 	}
-	cmd := exec.Command("script", scriptCmdArgs(s.bin+" -L "+s.socket+" attach-session -t "+targetSession)...)
+	cmd := exec.Command("script", scriptCmdArgs(s.bin+" -L "+s.socket+" -f /dev/null attach-session -t "+targetSession)...)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("attach client to %q: %v", targetSession, err)
 	}

--- a/modules/programs/prism/prism/cmd/db.go
+++ b/modules/programs/prism/prism/cmd/db.go
@@ -7,8 +7,19 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
+// testDBPath overrides dbPath() during tests. Set via SetTestDBPath.
+var testDBPath string
+
+// SetTestDBPath overrides the DB path used by openDB. Only for use in tests.
+// Call t.Cleanup(func() { SetTestDBPath("") }) to restore after each test.
+func SetTestDBPath(p string) { testDBPath = p }
+
 // dbPath returns the path to prism.db, honouring $XDG_STATE_HOME.
+// During tests, testDBPath (set via SetTestDBPath) takes precedence.
 func dbPath() string {
+	if testDBPath != "" {
+		return testDBPath
+	}
 	stateHome := os.Getenv("XDG_STATE_HOME")
 	if stateHome == "" {
 		home, _ := os.UserHomeDir()

--- a/modules/programs/prism/prism/internal/tmux/harness_test.go
+++ b/modules/programs/prism/prism/internal/tmux/harness_test.go
@@ -72,8 +72,10 @@ func randHex(n int) string {
 }
 
 // run executes a tmux command against this server's socket.
+// -f /dev/null suppresses the user's tmux.conf so no hooks (e.g.
+// session-created → prism event tmux-session-start) fire against the live DB.
 func (s *server) run(args ...string) error {
-	cmd := exec.Command(s.bin, append([]string{"-L", s.socket}, args...)...)
+	cmd := exec.Command(s.bin, append([]string{"-L", s.socket, "-f", "/dev/null"}, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("tmux %v: %w\n%s", args, err, out)
@@ -82,8 +84,9 @@ func (s *server) run(args ...string) error {
 }
 
 // output executes a tmux command and returns trimmed stdout.
+// -f /dev/null suppresses the user's tmux.conf so no hooks fire.
 func (s *server) output(args ...string) (string, error) {
-	cmd := exec.Command(s.bin, append([]string{"-L", s.socket}, args...)...)
+	cmd := exec.Command(s.bin, append([]string{"-L", s.socket, "-f", "/dev/null"}, args...)...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("tmux %v: %w", args, err)
@@ -188,7 +191,7 @@ func (s *server) attachClientToSession(t *testing.T, targetSession string) strin
 		}
 	}
 
-	cmd := exec.Command("script", scriptArgs(s.bin+" -L "+s.socket+" attach-session -t "+targetSession)...)
+	cmd := exec.Command("script", scriptArgs(s.bin+" -L "+s.socket+" -f /dev/null attach-session -t "+targetSession)...)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("attach client to %q: %v", targetSession, err)
 	}
@@ -235,7 +238,10 @@ func withServer(t *testing.T, s *server) {
 
 	orig := tmux.TmuxBin
 	wrapperPath := t.TempDir() + "/tmux"
-	script := "#!/bin/sh\nexec " + s.bin + " -L " + s.socket + " \"$@\"\n"
+	// -f /dev/null suppresses the user's tmux.conf so no hooks fire against the
+	// live DB when the package-level tmux.* functions create sessions on this
+	// isolated server.
+	script := "#!/bin/sh\nexec " + s.bin + " -L " + s.socket + " -f /dev/null \"$@\"\n"
 	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write tmux wrapper: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Pass `-f /dev/null` to all isolated test tmux servers (in `internal/tmux/harness_test.go` and `cmd/dashboard_test.go`) so the user's `tmux.conf` is not loaded by the test server. This prevents `session-created` hooks (which call `prism event tmux-session-start`) from firing against the live `prism.db` when tests create sessions on their isolated servers.
- Add `SetTestDBPath` / `testDBPath` to `cmd/db.go` so future in-process tests exercising `openDB()` commands (`status`, `list-sessions`) can redirect writes to a temp DB instead of the live `~/.local/state/prism/prism.db`.

## Root cause

Isolated test tmux servers were started without a config override, so they loaded the user's `~/.config/tmux/tmux.conf`. That config defines a `session-created` hook that invokes `prism event tmux-session-start`, which calls `openDB()` and writes rows for every test session into the live `prism.db`. Passing `-f /dev/null` at server startup suppresses config loading entirely, so no hooks fire.

## Testing

`go build ./...` and `go test ./...` both pass cleanly.