### PR TITLE
fix(plugin): remove create:false from Database constructor (Bun 1.2 compat)

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -101,7 +101,7 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree }) => {
   if (sessionName) {
     try {
       if (fs.existsSync(dbPath)) {
-        db = new Database(dbPath, { create: false });
+        db = new Database(dbPath);
       } else {
         console.warn("[prism-hooks] prism.db not found — DB writes disabled");
       }


### PR DESCRIPTION
## Summary

- Removes `{ create: false }` option from the `new Database(dbPath)` call in `prism-hooks.ts`
- This option was introduced in Bun 1.3 and throws `SQLITE_MISUSE` in Bun 1.2, which is what opencode embeds
- The `fs.existsSync(dbPath)` guard immediately above already prevents opening a missing file, so the option was redundant