### PR TITLE
fix(cleanup): allow running outside tmux and with dead sessions via DB fallback

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -267,7 +267,8 @@ var cleanupCmd = &cobra.Command{
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 		sessionFlag, _ := cmd.Flags().GetString("session")
 
-		if os.Getenv("TMUX") == "" {
+		// Only require tmux when we need to auto-detect the current session.
+		if sessionFlag == "" && os.Getenv("TMUX") == "" {
 			return fmt.Errorf("not running inside tmux — invoke via the tmux binding (prefix+W)")
 		}
 
@@ -292,7 +293,7 @@ var cleanupCmd = &cobra.Command{
 		// Find worktree path from agent window.
 		worktreePath := worktreePathFromSession(session)
 		if worktreePath == "" {
-			return fmt.Errorf("could not determine worktree path from session windows")
+			return fmt.Errorf("could not determine worktree path for session %q (not found in tmux windows or DB)", session)
 		}
 
 		bareRoot := git.BareRoot(worktreePath)
@@ -308,6 +309,11 @@ var cleanupCmd = &cobra.Command{
 		// Non-interactive path: --yes skips all prompts and runs headlessly.
 		if yesFlag {
 			return headlessCleanup(session, worktreeName, worktreePath, bareRoot)
+		}
+
+		// Interactive TUI requires tmux (bubbletea needs a real TTY).
+		if os.Getenv("TMUX") == "" {
+			return fmt.Errorf("interactive cleanup requires tmux — use --yes for non-interactive use outside tmux")
 		}
 
 		m := newCleanupModel(session, worktreeName, worktreePath, bareRoot, defaultBr)
@@ -378,26 +384,46 @@ func (w cleanupWrapper) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func worktreePathFromSession(session string) string {
+	// Try tmux first (works when the session is still alive).
 	out, err := tmux.ListWindows(session)
+	if err == nil && out != "" {
+		// Prefer agent window, fall back to term.
+		term := ""
+		for _, line := range strings.Split(out, "\n") {
+			parts := strings.SplitN(line, "|", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			name, path := parts[0], parts[1]
+			if name == "agent" {
+				return path
+			}
+			if name == "term" {
+				term = path
+			}
+		}
+		if term != "" {
+			return term
+		}
+	}
+	// Fall back to DB (works when the session no longer exists in tmux).
+	d, err := openDB()
 	if err != nil {
 		return ""
 	}
-	// Prefer agent window, fall back to term.
-	term := ""
-	for _, line := range strings.Split(out, "\n") {
-		parts := strings.SplitN(line, "|", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		name, path := parts[0], parts[1]
-		if name == "agent" {
-			return path
-		}
-		if name == "term" {
-			term = path
+	defer d.Close()
+	status, err := d.CurrentStatus(session)
+	if err != nil || status == nil {
+		return ""
+	}
+	// Only return the DB path if it still exists on disk; a stale path would
+	// produce a confusing git error later rather than a clear "not found" here.
+	if status.Worktree != "" {
+		if _, statErr := os.Stat(status.Worktree); statErr == nil {
+			return status.Worktree
 		}
 	}
-	return term
+	return ""
 }
 
 func init() {

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -19,7 +19,68 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
 )
+
+// TestWorktreePathFromSession_DBFallback verifies that worktreePathFromSession
+// falls back to the DB when tmux has no record of the session (dead session).
+//
+// It seeds a temp DB with a status row containing a real filesystem path, then
+// calls worktreePathFromSession with a session name that does not exist in tmux.
+// The function should return the DB-stored path when it exists on disk, and ""
+// when it does not.
+func TestWorktreePathFromSession_DBFallback(t *testing.T) {
+	// Create a real directory to act as the worktree path.
+	existingPath := t.TempDir()
+	nonExistentPath := filepath.Join(t.TempDir(), "gone")
+
+	// Seed a temp DB.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	sessionDead := "myrepo@dead-branch"
+	sessionStale := "myrepo@stale-branch"
+
+	if err := d.UpsertStatus(sessionDead, "myrepo", existingPath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus dead: %v", err)
+	}
+	if err := d.UpsertStatus(sessionStale, "myrepo", nonExistentPath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus stale: %v", err)
+	}
+	d.Close()
+
+	// Point openDB at the temp DB for this test.
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Neither session exists in tmux (no TMUX env, no server), so the tmux
+	// path always returns "" — the function must fall back to the DB.
+
+	t.Run("existing path returned from DB", func(t *testing.T) {
+		got := worktreePathFromSession(sessionDead)
+		if got != existingPath {
+			t.Errorf("got %q, want %q", got, existingPath)
+		}
+	})
+
+	t.Run("stale path (not on disk) returns empty", func(t *testing.T) {
+		got := worktreePathFromSession(sessionStale)
+		if got != "" {
+			t.Errorf("got %q, want empty string (path does not exist)", got)
+		}
+	})
+
+	t.Run("unknown session returns empty", func(t *testing.T) {
+		got := worktreePathFromSession("myrepo@unknown")
+		if got != "" {
+			t.Errorf("got %q, want empty string (no DB row)", got)
+		}
+	})
+}
 
 // setupMinimalBareRepo creates a minimal bare+worktree git repository layout
 // under baseDir with the following structure:


### PR DESCRIPTION
## Summary

- **Bug 1 (TMUX guard):** The `prism cleanup` command previously required being inside tmux unconditionally. The guard is now only enforced when `--session` is not provided (i.e. when auto-detecting the current session is needed). With `--yes --session <name>`, the command can now run from outside tmux.

- **Bug 2 (dead session path lookup):** `worktreePathFromSession` previously called `tmux.ListWindows` only, which fails when the target session no longer exists in tmux (e.g. after a `prism restart`). It now falls back to `db.CurrentStatus` when tmux returns nothing, so cleanup still works for already-killed sessions as long as the worktree directory exists on disk.