### PR TITLE
fix(plugin): deduplicate events and filter empty user messages

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -89,6 +89,12 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree }) => {
   // Track which messageIds have already been written to avoid duplicate events.
   // message.updated fires multiple times per message (once per partial update)
   // so without this guard each message would produce several DB rows.
+  //
+  // This Set grows with the number of messages in a session but is never
+  // pruned — entries need to persist for the plugin lifetime to guard against
+  // late re-fires of message.updated after the text map has been cleared.
+  // Sessions are short-lived (restarted regularly), so unbounded growth within
+  // a session is acceptable; the tradeoff is intentional.
   const writtenMessageIds = new Set<string>();
 
   // Track the last state_change value written so we only emit an event when
@@ -190,8 +196,8 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree }) => {
 
   function writeStateChange(state: string, opencodeSid?: string | null): void {
     if (state === lastWrittenState) return; // deduplicate same-state transitions
-    lastWrittenState = state;
     writeEvent("state_change", { state }, opencodeSid);
+    lastWrittenState = state;
   }
 
   function upsertAgentStatus(state: string, title?: string | null, opencodeSid?: string | null): void {


### PR DESCRIPTION
## Summary

- **Fix 1 & 2 — Deduplicate msg_user / msg_assistant by messageId**: adds a `writtenMessageIds` Set so each message produces exactly one DB row even though `message.updated` fires multiple times per message (once per partial update in opencode 1.3.10).
- **Fix 2 — Filter empty user messages**: skips `msg_user` writes when there is no accumulated text — these are either opencode's internal tool-result messages (which have `role: "user"` but no text parts) or early fires before text has arrived.
- **Fix 3 & 4 — Deduplicate state_change events**: introduces `writeStateChange()` with a `lastWrittenState` guard so a `state_change` event is only written when the state actually transitions. Fixes the 4+ `state_change` rows per turn caused by `session.status busy` firing once per tool call.

All changes are TypeScript-only, within the plugin function body. No Nix build required.