### PR TITLE
fix(cleanup): set ended_at in DB on session kill

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -203,6 +203,10 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			_, _ = tmux.SwitchClientCurrent("scratchpad")
 		}
 		_ = tmux.KillSession(m.session)
+		if d, err := openDB(); err == nil {
+			_ = d.SetEnded(m.session)
+			d.Close()
+		}
 
 		return cleanupDoneMsg{}
 	}
@@ -361,6 +365,10 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 
 	fmt.Printf("killing session %s\n", session)
 	_ = tmux.KillSession(session)
+	if d, err := openDB(); err == nil {
+		_ = d.SetEnded(session)
+		d.Close()
+	}
 	fmt.Println("done")
 	return nil
 }


### PR DESCRIPTION
## Summary

- After `tmux.KillSession` in `headlessCleanup`, immediately call `d.SetEnded(session)` so the DB reflects the session as ended.
- After `tmux.KillSession` in `cleanupModel.doCleanup`, do the same.
- This ensures `prism list-sessions` stops showing the session right away rather than waiting for the tmux `session-closed` hook to fire.