### PR TITLE
fix(spawn): deliver initial prompt via opencode --prompt flag, not bus

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -64,6 +64,14 @@ func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 		// Safety-net fallback: empty agent still yields "build".
 		{sessionOpts{opencodeSession: "ses_abc123"}, "opencode --agent build -s ses_abc123"},
 		{sessionOpts{}, "opencode --agent build"},
+		// Prompt with no special characters.
+		{sessionOpts{agent: "build", prompt: "fix the login bug"}, "opencode --agent build --prompt 'fix the login bug'"},
+		// Prompt containing a single quote — exercises shellQuote escaping.
+		{sessionOpts{agent: "build", prompt: "it's broken"}, "opencode --agent build --prompt 'it'\\''s broken'"},
+		// Prompt with shell metacharacters that are safe inside single quotes.
+		{sessionOpts{agent: "build", prompt: "run `make test` and fix $ERRORS"}, "opencode --agent build --prompt 'run `make test` and fix $ERRORS'"},
+		// Prompt + session ID — both flags present.
+		{sessionOpts{agent: "coordinator", opencodeSession: "ses_abc", prompt: "review pr"}, "opencode --agent coordinator -s ses_abc --prompt 'review pr'"},
 	}
 	for _, tc := range cases {
 		got := buildOpencodeCmd(tc.opts)

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -589,11 +589,11 @@ func ensureAndSwitchSession(path string, projectRoot string, opts sessionOpts) e
 			_ = tmux.NewWindow(sessionName, 1, "agent", directory)
 			_ = tmux.SendKeys(sessionName+":1", buildOpencodeCmd(opts))
 
-			// Seed agent_status before writing the bus message so that
-			// WriteBusMessage finds the row and succeeds. The tmux hook fires
-			// too late (wrong pane path at that point) and cannot be relied
-			// upon here. Call tmux-session-start explicitly now; the hook
-			// remains as a fallback for sessions created outside this path.
+			// Seed agent_status so that post-spawn `prism prompt` bus delivery
+			// finds the row and succeeds. The tmux hook fires too late (wrong
+			// pane path at that point) and cannot be relied upon here; call
+			// tmux-session-start explicitly now. The hook remains as a fallback
+			// for sessions created outside this path.
 			//
 			// Use os.Executable() rather than "prism" so that the correct
 			// binary is found in Nix-managed environments where the store


### PR DESCRIPTION
## Summary

- Pass the initial spawn prompt directly to opencode via `--prompt` flag in `buildOpencodeCmd`, eliminating the race condition where the bus delivery depended on `currentOpencodeSID` being set (which required `session.created` to have fired before `session.idle`)
- Remove the `WriteBusMessage` + `touchBusSentinel` block for the initial spawn prompt from `ensureAndSwitchSession`; the DB row seeding (`prism event tmux-session-start`) is retained as it's still needed for post-spawn `prism prompt` bus delivery
- Also removes the now-unused `time`, `uuid`, and `db` imports from `switch.go`

## How it works

Previously: spawn writes prompt to `bus_messages` → plugin reads on `session.idle` → delivery fails if `session.created` hasn't fired yet (race condition)

Now: `opencode --agent <agent> --prompt <quoted-prompt>` receives the prompt at startup, synchronously, with no timing dependency.

`prism prompt` (post-spawn messaging) continues to use the bus as before — this change only affects the initial prompt at spawn time.