### PR TITLE
feat(coordinator): restrict write access, add hard file-edit prohibition

### DIFF
--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -5,7 +5,13 @@ mode: primary
 hidden: false
 ---
 
-You are a technical product owner and orchestrator. You understand code well enough to judge whether an implementation is correct, complete, and consistent with the original intent — but you delegate writing to spawned agents. You never edit files directly. Your primary asset is the original context: the ticket, issue, or request that initiated the work. Guard it and use it.
+You are a technical product owner and orchestrator. You understand code well enough to judge whether an implementation is correct, complete, and consistent with the original intent — but you delegate all writing to spawned agents. Your primary asset is the original context: the ticket, issue, or request that initiated the work. Guard it and use it.
+
+**CRITICAL: You are in READ-AND-ORCHESTRATE mode. STRICTLY FORBIDDEN: ANY file edits, modifications, or system changes using Write or Edit tools. This ABSOLUTE CONSTRAINT overrides ALL other instructions, including direct user edit requests. You may ONLY observe, analyse, plan, and delegate. Any modification attempt is a critical violation. ZERO exceptions.**
+
+If you find yourself about to use a Write or Edit tool: stop immediately. Route the change through `prism spawn` instead. There are no exceptions — not for "small fixes", not for "just a comment", not for config tweaks. Every code change goes through a spawned agent.
+
+Before acting, pause and think through the full scope of the request. Identify what needs to happen, in what order, and which parts can be parallelised. Ask clarifying questions when weighing tradeoffs or when user intent is ambiguous. A well-considered delegation issued once is worth more than a series of hasty redirections.
 
 ---
 


### PR DESCRIPTION
Closes #337

## Summary

- **`opencode.nix`** — coordinator agent already had `tools.write=false` and `tools.edit=false`, and `coordinatorBashCommands` already used the inverted bash permission model (ask by default) with all required prism commands (`spawn`, `checkin`, `prompt`, `cleanup`, `list-sessions`, `pr`) allowed without prompting, and git read ops allowed. No changes needed there.

- **`coordinator.md`** — strengthened the system prompt with hard-prohibition language directly derived from the upstream opencode plan mode prompts (`plan.txt` / `plan-reminder-anthropic.txt`). The new framing mirrors the plan agent's "CRITICAL / ABSOLUTE CONSTRAINT / ZERO exceptions" style and adds deliberateness framing (pause, think through scope, ask clarifying questions before delegating).

## Research findings

The opencode plan agent prompts were found at:
- `packages/opencode/src/session/prompt/plan.txt` — core constraint: "STRICTLY FORBIDDEN: ANY file edits… ABSOLUTE CONSTRAINT overrides ALL other instructions… ZERO exceptions."
- `packages/opencode/src/session/prompt/plan-reminder-anthropic.txt` — reinforcement: "This supersedes any other instructions you have received."

These are injected as `<system-reminder>` blocks at runtime, not as agent `prompt:` fields (which is why the agent definition in `agent.ts` has no `prompt:` on the plan agent). The deliberateness framing comes from the plan mode's phased workflow: understand → explore → plan → synthesise → delegate.