### PR TITLE
fix(opencode): always include all provider configs, provider option controls default only

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -26,7 +26,6 @@
       wallpaper.variant = "enso-6colour";
     };
     programs = {
-      # prism.opencode.provider = "anthropic";
       prism.opencode.provider = "github-copilot";
       prism.forgecode.enable = true;
       anki.enable = false; # build broken as of 2025-08-30

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -18,8 +18,9 @@
       default = "anthropic";
       description = ''
         The LLM provider to use for opencode agents.
-        Switching providers updates the model strings, provider block,
-        and authentication plugins automatically.
+        Switching providers updates the model strings and authentication
+        plugins. All provider config blocks are always present in the
+        generated config to allow manual model overrides mid-session.
       '';
     };
   };


### PR DESCRIPTION
## Summary

- Replace the single-provider `providerSettings` attrset (which only included the active provider's block) with a static attrset containing all three provider blocks (`anthropic`, `github-copilot`, `google`) unconditionally.
- Remove the now-unused `providerConfig` binding.
- The `provider` option continues to drive `providerModels` (model strings per tier) and `authPlugins` (which auth plugin to load).

## Why

Previously, setting `provider = "github-copilot"` would produce a config with only `{ "provider": { "github-copilot": {} } }`, making it impossible to manually switch to an Anthropic or Google model mid-session — opencode had no credentials or config for those providers.

Closes #369