### PR TITLE
fix(prism): anchor checkin on assistant turns, not user messages

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -88,13 +88,14 @@ func runCheckin(cmd *cobra.Command, args []string) error {
 // runCheckinSession is the DB-backed path. Falls back to legacy screen-scrape
 // if the DB is unavailable or has no rows for this session.
 //
-// When no explicit types are requested, this uses the message-turn-centric
-// rendering mode: --last N means N user message turns, not N raw events.
+// When no explicit types are requested, this uses the assistant-turn-centric
+// rendering mode: --last N means N assistant turns, not N raw events.
 // For each turn it fetches all associated tool/permission/thinking events via
-// a secondary query keyed by messageId.
+// a secondary query keyed by messageId. msg_user events within the time window
+// of the fetched assistant turns are also included.
 func runCheckinSession(session string, limit int, before, after *string, types []string, verbose bool) error {
 	// When --types is explicitly set, use the old raw-event query path.
-	// The new message-turn-centric path only applies to the default view.
+	// The new assistant-turn-centric path only applies to the default view.
 	if len(types) > 0 {
 		return runCheckinSessionRaw(session, limit, before, after, types, verbose)
 	}
@@ -102,10 +103,20 @@ func runCheckinSession(session string, limit int, before, after *string, types [
 	d, err := openDB()
 	if err == nil {
 		defer d.Close()
-		// Primary query: fetch last N msg_user events to get N conversation turns.
-		userEvents, qerr := d.QueryEvents(session, limit, before, after, []string{"msg_user"})
-		if qerr == nil && len(userEvents) > 0 {
-			return renderCheckinTurns(session, d, userEvents, verbose)
+		// Primary query: fetch last N msg_assistant events to get N assistant turns.
+		assistantEvents, qerr := d.QueryEvents(session, limit, before, after, []string{"msg_assistant"})
+		if qerr == nil && len(assistantEvents) > 0 {
+			return renderCheckinTurns(session, d, assistantEvents, verbose)
+		}
+		// If DB is open but no msg_assistant rows exist, check whether there are
+		// any events at all (e.g. a session with only msg_user). In that case show
+		// just the header+footer rather than falling back to the screen-scrape.
+		if qerr == nil {
+			anyEvents, aerr := d.QueryEvents(session, 1, nil, nil, nil)
+			if aerr == nil && len(anyEvents) > 0 {
+				// Session has events but no assistant turns yet — render header only.
+				return renderCheckinTurns(session, d, nil, verbose)
+			}
 		}
 	}
 
@@ -127,9 +138,15 @@ func runCheckinSessionRaw(session string, limit int, before, after *string, type
 	return runCheckinSessionLegacy(session, 100)
 }
 
-// renderCheckinTurns renders conversation turns using the message-turn-centric
-// approach: one turn = one user message + its assistant reply + child events.
-func renderCheckinTurns(session string, d *db.DB, userEvents []db.Event, verbose bool) error {
+// renderCheckinTurns renders conversation turns using the assistant-turn-centric
+// approach: one turn = one assistant message + its tool/permission/thinking children.
+// msg_user events whose created_at falls within the time window of the fetched
+// assistant turns are also rendered, immediately before the assistant turn that
+// follows them in the timeline.
+//
+// assistantEvents may be nil (session has events but no assistant turns yet);
+// in that case only the header and footer are rendered.
+func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, verbose bool) error {
 	// Fetch state from DB; fall back to tmux if not found.
 	state := ""
 	status, err := d.CurrentStatus(session)
@@ -146,90 +163,131 @@ func renderCheckinTurns(session string, d *db.DB, userEvents []db.Event, verbose
 	fmt.Printf("checkin: %s\n\n", session)
 	fmt.Printf("state: %s\n\n", state)
 
-	// Collect all messageIds from the user events.
-	messageIDs := make([]string, 0, len(userEvents))
-	for _, e := range userEvents {
+	if len(assistantEvents) == 0 {
+		fmt.Println("── end of event log ──")
+		return nil
+	}
+
+	// Collect all messageIds from the assistant events.
+	messageIDs := make([]string, 0, len(assistantEvents))
+	for _, e := range assistantEvents {
 		msgID := extractMessageID(e.Payload)
 		if msgID != "" {
 			messageIDs = append(messageIDs, msgID)
 		}
 	}
 
-	// Secondary query: fetch all related events (assistant reply, tool calls,
-	// tool results, permission events, thinking) for these messageIds.
-	secondaryTypes := []string{"msg_assistant", "tool_call", "tool_result", "permission_ask", "permission_denied", "thinking"}
-	secondary, serr := d.QueryEventsByMessageIDs(session, messageIDs, secondaryTypes)
+	// Secondary query: fetch tool calls, results, permission events, and
+	// thinking events that share a messageId with one of the assistant events.
+	childTypes := []string{"tool_call", "tool_result", "permission_ask", "permission_denied", "thinking"}
+	secondary, serr := d.QueryEventsByMessageIDs(session, messageIDs, childTypes)
 
-	// Organise secondary events by messageId and type.
-	assistantByMsgID := make(map[string]db.Event)
+	// Organise children by messageId.
 	type childEvent struct {
 		eventType string
 		payload   string
 	}
 	childrenByMsgID := make(map[string][]childEvent)
-
 	if serr == nil {
 		for _, e := range secondary {
 			msgID := extractMessageID(e.Payload)
 			if msgID == "" {
 				continue
 			}
-			switch e.Type {
-			case "msg_assistant":
-				assistantByMsgID[msgID] = e
-			case "tool_call", "tool_result", "permission_ask", "permission_denied", "thinking":
-				childrenByMsgID[msgID] = append(childrenByMsgID[msgID], childEvent{e.Type, e.Payload})
-			}
+			childrenByMsgID[msgID] = append(childrenByMsgID[msgID], childEvent{e.Type, e.Payload})
 		}
 	}
 
-	// Render each turn in the order they appeared (userEvents is already ASC).
-	for _, ue := range userEvents {
-		msgID := extractMessageID(ue.Payload)
+	// Determine the time window spanned by the fetched assistant turns so that
+	// we can include msg_user events that fall within it.
+	earliest := assistantEvents[0].CreatedAt
+	latest := assistantEvents[len(assistantEvents)-1].CreatedAt
+	for _, ae := range assistantEvents {
+		if ae.CreatedAt.Before(earliest) {
+			earliest = ae.CreatedAt
+		}
+		if ae.CreatedAt.After(latest) {
+			latest = ae.CreatedAt
+		}
+	}
 
-		// --- User turn header ---
-		var up payload.MsgUser
-		if jerr := json.Unmarshal([]byte(ue.Payload), &up); jerr != nil {
-			up.Text = ue.Payload
+	// Fetch msg_user events within [earliest, latest] (inclusive).
+	// We use QueryEventsByMessageIDs with no messageID filter — instead we do a
+	// plain QueryEvents for msg_user and filter by timestamp in Go.
+	userEventsAll, _ := d.QueryEvents(session, 0, nil, nil, []string{"msg_user"})
+	var userEventsInWindow []db.Event
+	for _, ue := range userEventsAll {
+		if !ue.CreatedAt.Before(earliest) && !ue.CreatedAt.After(latest) {
+			userEventsInWindow = append(userEventsInWindow, ue)
 		}
-		ts := ue.CreatedAt.Local().Format("2006-01-02 15:04:05")
-		label := turnLabel(up.Agent, up.Model)
-		if label != "" {
-			fmt.Printf("[%s] user  [%s]\n", ts, label)
-		} else {
-			fmt.Printf("[%s] user\n", ts)
-		}
-		text := up.Text
-		if text == "" {
-			text = "(no text)"
-		}
-		fmt.Printf("%s\n\n", text)
+	}
 
-		// --- Assistant turn (if present) ---
-		if ae, ok := assistantByMsgID[msgID]; ok {
-			var ap payload.MsgAssistant
-			if jerr := json.Unmarshal([]byte(ae.Payload), &ap); jerr != nil {
-				ap.Text = ae.Payload
+	// Merge assistant events and user events into a single timeline sorted ASC.
+	// assistantEvents is already ASC from QueryEvents; userEventsInWindow is also ASC.
+	type timelineEntry struct {
+		isUser bool
+		event  db.Event
+	}
+	timeline := make([]timelineEntry, 0, len(assistantEvents)+len(userEventsInWindow))
+	for _, ae := range assistantEvents {
+		timeline = append(timeline, timelineEntry{isUser: false, event: ae})
+	}
+	for _, ue := range userEventsInWindow {
+		timeline = append(timeline, timelineEntry{isUser: true, event: ue})
+	}
+	// Sort by created_at ASC (stable, preserving insertion order for ties).
+	for i := 1; i < len(timeline); i++ {
+		for j := i; j > 0 && timeline[j].event.CreatedAt.Before(timeline[j-1].event.CreatedAt); j-- {
+			timeline[j], timeline[j-1] = timeline[j-1], timeline[j]
+		}
+	}
+
+	// Render the merged timeline.
+	for _, entry := range timeline {
+		e := entry.event
+		ts := e.CreatedAt.Local().Format("2006-01-02 15:04:05")
+
+		if entry.isUser {
+			var up payload.MsgUser
+			if jerr := json.Unmarshal([]byte(e.Payload), &up); jerr != nil {
+				up.Text = e.Payload
 			}
-			ats := ae.CreatedAt.Local().Format("2006-01-02 15:04:05")
-			alabel := turnLabel(ap.Agent, ap.Model)
-			if alabel != "" {
-				fmt.Printf("[%s] assistant  [%s]\n", ats, alabel)
+			text := up.Text
+			if text == "" {
+				text = "(no text)"
+			}
+			label := turnLabel(up.Agent, up.Model)
+			if label != "" {
+				fmt.Printf("[%s] user  [%s]\n", ts, label)
 			} else {
-				fmt.Printf("[%s] assistant\n", ats)
+				fmt.Printf("[%s] user\n", ts)
 			}
-			atext := ap.Text
-			if atext == "" {
-				atext = "(no text)"
-			}
-			fmt.Printf("%s\n", atext)
-
-			// Render children (tool calls, results, permissions, thinking).
-			for _, child := range childrenByMsgID[msgID] {
-				renderChildEvent(child.eventType, child.payload, verbose)
-			}
-			fmt.Println()
+			fmt.Printf("%s\n\n", text)
+			continue
 		}
+
+		// Assistant event.
+		var ap payload.MsgAssistant
+		if jerr := json.Unmarshal([]byte(e.Payload), &ap); jerr != nil {
+			ap.Text = e.Payload
+		}
+		alabel := turnLabel(ap.Agent, ap.Model)
+		if alabel != "" {
+			fmt.Printf("[%s] assistant  [%s]\n", ts, alabel)
+		} else {
+			fmt.Printf("[%s] assistant\n", ts)
+		}
+		atext := ap.Text
+		if atext == "" {
+			atext = "(no text)"
+		}
+		fmt.Printf("%s\n", atext)
+
+		msgID := extractMessageID(e.Payload)
+		for _, child := range childrenByMsgID[msgID] {
+			renderChildEvent(child.eventType, child.payload, verbose)
+		}
+		fmt.Println()
 	}
 
 	fmt.Println("── end of event log ──")

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -1,0 +1,619 @@
+package cmd
+
+// Tests for the assistant-anchored renderCheckinTurns path.
+//
+// These tests seed a temp DB with events and invoke renderCheckinTurns (or
+// runCheckinSession via the public DB path) directly, capturing stdout to
+// verify the output.
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// captureStdout redirects os.Stdout to a pipe for the duration of fn,
+// then returns everything that was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+	return buf.String()
+}
+
+// openCheckinTestDB opens a temp DB and registers t.Cleanup to close it.
+func openCheckinTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// writeEvent is a helper that writes a single event, fataling on error.
+func writeEvent(t *testing.T, d *db.DB, id, session, typ, payload string, ts time.Time) db.Event {
+	t.Helper()
+	e := db.Event{
+		ID:          id,
+		SessionName: session,
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        typ,
+		Payload:     payload,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent %s: %v", id, err)
+	}
+	return e
+}
+
+// assistantPayload returns a minimal msg_assistant JSON payload.
+func assistantPayload(msgID, text string) string {
+	return fmt.Sprintf(`{"messageId":%q,"text":%q}`, msgID, text)
+}
+
+// userPayload returns a minimal msg_user JSON payload.
+func userPayload(msgID, text string) string {
+	return fmt.Sprintf(`{"messageId":%q,"text":%q}`, msgID, text)
+}
+
+// toolCallPayload returns a minimal tool_call JSON payload.
+func toolCallPayload(msgID, tool, args string) string {
+	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"args":%q}`, msgID, tool, args)
+}
+
+// toolResultPayload returns a minimal tool_result JSON payload.
+func toolResultPayload(msgID, tool, result string) string {
+	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"result":%q}`, msgID, tool, result)
+}
+
+// permAskPayload returns a minimal permission_ask JSON payload.
+func permAskPayload(msgID, tool string) string {
+	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"patterns":["*"]}`, msgID, tool)
+}
+
+// permDeniedPayload returns a minimal permission_denied JSON payload.
+func permDeniedPayload(msgID, tool string) string {
+	return fmt.Sprintf(`{"messageId":%q,"tool":%q}`, msgID, tool)
+}
+
+// TestRenderCheckinTurns_AllAssistantTurnsShown verifies AC-1:
+// given 1 msg_user and 5 msg_assistant events, all 5 assistant turns appear.
+func TestRenderCheckinTurns_AllAssistantTurnsShown(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// 1 user message.
+	umsgID := uuid.New().String()
+	writeEvent(t, d, uuid.New().String(), session, "msg_user", userPayload(umsgID, "do something"), base)
+
+	// 5 assistant turns on the same user message.
+	assistantEvents := make([]db.Event, 5)
+	for i := range assistantEvents {
+		amsgID := uuid.New().String()
+		assistantEvents[i] = writeEvent(t, d, uuid.New().String(), session,
+			"msg_assistant", assistantPayload(amsgID, fmt.Sprintf("reply %d", i+1)),
+			base.Add(time.Duration(i+1)*time.Second))
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, assistantEvents, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	for i := 1; i <= 5; i++ {
+		want := fmt.Sprintf("reply %d", i)
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "checkin: "+session) {
+		t.Errorf("output missing header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "── end of event log ──") {
+		t.Errorf("output missing footer\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_ToolChildrenIndented verifies AC-2:
+// each assistant turn is followed by its own indented tool_call/tool_result children.
+func TestRenderCheckinTurns_ToolChildrenIndented(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Two distinct assistant turns with different tool calls.
+	msgID1 := "msg-alpha"
+	msgID2 := "msg-beta"
+
+	ae1 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID1, "first assistant"), base.Add(time.Second))
+	ae2 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID2, "second assistant"), base.Add(2*time.Second))
+
+	// Tool events for each.
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID1, "bash", "echo hello"), base.Add(time.Second+100*time.Millisecond))
+	writeEvent(t, d, uuid.New().String(), session, "tool_result",
+		toolResultPayload(msgID1, "bash", "hello"), base.Add(time.Second+200*time.Millisecond))
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID2, "read_file", "main.go"), base.Add(2*time.Second+100*time.Millisecond))
+
+	assistantEvents := []db.Event{ae1, ae2}
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, assistantEvents, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// Both assistant turns present.
+	if !strings.Contains(out, "first assistant") {
+		t.Errorf("missing 'first assistant'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "second assistant") {
+		t.Errorf("missing 'second assistant'\ngot:\n%s", out)
+	}
+
+	// Tool children rendered with indentation.
+	if !strings.Contains(out, "  → bash: echo hello") {
+		t.Errorf("missing indented bash tool_call\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "  → result: hello") {
+		t.Errorf("missing indented tool_result\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "  → read_file: main.go") {
+		t.Errorf("missing indented read_file tool_call\ngot:\n%s", out)
+	}
+
+	// The bash tool should appear before read_file in output (ae1 before ae2).
+	bashPos := strings.Index(out, "  → bash: echo hello")
+	readPos := strings.Index(out, "  → read_file: main.go")
+	if bashPos < 0 || readPos < 0 || bashPos >= readPos {
+		t.Errorf("tool children not in expected order\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_LastN verifies AC-3:
+// passing last=3 returns exactly 3 most-recent assistant turns.
+func TestRenderCheckinTurns_LastN(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	dbPath := d.Path()
+
+	// Write 5 assistant events.
+	for i := 0; i < 5; i++ {
+		msgID := fmt.Sprintf("msg-%d", i)
+		writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+			assistantPayload(msgID, fmt.Sprintf("turn %d", i)), base.Add(time.Duration(i)*time.Second))
+	}
+	d.Close()
+
+	SetTestDBPath(dbPath)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdout(t, func() {
+		if err := runCheckinSession(session, 3, nil, nil, nil, false); err != nil {
+			t.Errorf("runCheckinSession: %v", err)
+		}
+	})
+
+	// Should contain turns 2, 3, 4 (the 3 most-recent) but not 0 or 1.
+	for _, i := range []int{2, 3, 4} {
+		want := fmt.Sprintf("turn %d", i)
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+	for _, i := range []int{0, 1} {
+		notWant := fmt.Sprintf("turn %d", i)
+		if strings.Contains(out, notWant) {
+			t.Errorf("output unexpectedly contains %q (should be outside last-3 window)\ngot:\n%s", notWant, out)
+		}
+	}
+}
+
+// TestRenderCheckinTurns_DefaultLast10 verifies AC-4:
+// no --last flag shows the last 10 assistant turns when >10 exist.
+func TestRenderCheckinTurns_DefaultLast10(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	dbPath := d.Path()
+
+	// Write 15 assistant events with unique, non-overlapping text to avoid
+	// substring false-positives (e.g. "reply-5" does not appear in "reply-15").
+	for i := 0; i < 15; i++ {
+		msgID := fmt.Sprintf("msg-%d", i)
+		writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+			assistantPayload(msgID, fmt.Sprintf("reply-%02d", i)), base.Add(time.Duration(i)*time.Second))
+	}
+	d.Close()
+
+	SetTestDBPath(dbPath)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Default limit is 10: last 10 of 15 are indices 5-14.
+	out := captureStdout(t, func() {
+		if err := runCheckinSession(session, 10, nil, nil, nil, false); err != nil {
+			t.Errorf("runCheckinSession: %v", err)
+		}
+	})
+
+	// Turns 05-14 should be present; 00-04 should not.
+	for i := 5; i < 15; i++ {
+		want := fmt.Sprintf("reply-%02d", i)
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+	for i := 0; i < 5; i++ {
+		notWant := fmt.Sprintf("reply-%02d", i)
+		if strings.Contains(out, notWant) {
+			t.Errorf("output unexpectedly contains %q\ngot:\n%s", notWant, out)
+		}
+	}
+}
+
+// TestRenderCheckinTurns_UserEventsInWindow verifies AC-5 and AC-6:
+// msg_user events within the assistant-turn time window are included;
+// those outside the window are not.
+func TestRenderCheckinTurns_UserEventsInWindow(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Assistant turns at t=10s and t=20s.
+	msgID1 := "msg-1"
+	msgID2 := "msg-2"
+	ae1 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID1, "assistant reply 1"), base.Add(10*time.Second))
+	ae2 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID2, "assistant reply 2"), base.Add(20*time.Second))
+
+	// User message at t=5s — BEFORE window (should NOT appear).
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-early", "early prompt"), base.Add(5*time.Second))
+
+	// User message at t=10s — AT start of window (should appear).
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-atstart", "prompt at start"), base.Add(10*time.Second))
+
+	// User message at t=15s — INSIDE window (should appear).
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-inside", "mid-window prompt"), base.Add(15*time.Second))
+
+	// User message at t=25s — AFTER window (should NOT appear).
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-late", "late prompt"), base.Add(25*time.Second))
+
+	assistantEvents := []db.Event{ae1, ae2}
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, assistantEvents, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// In-window user events should appear.
+	if !strings.Contains(out, "prompt at start") {
+		t.Errorf("output missing in-window user event 'prompt at start'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "mid-window prompt") {
+		t.Errorf("output missing in-window user event 'mid-window prompt'\ngot:\n%s", out)
+	}
+
+	// Out-of-window user events must NOT appear.
+	if strings.Contains(out, "early prompt") {
+		t.Errorf("output unexpectedly contains out-of-window 'early prompt'\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "late prompt") {
+		t.Errorf("output unexpectedly contains out-of-window 'late prompt'\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_StateHeader verifies AC-7:
+// state header is rendered first.
+func TestRenderCheckinTurns_StateHeader(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	msgID := "msg-x"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "hello"), base)
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// Header must come before state.
+	headerPos := strings.Index(out, "checkin: "+session)
+	statePos := strings.Index(out, "state: active")
+	if headerPos < 0 {
+		t.Errorf("missing 'checkin: %s'\ngot:\n%s", session, out)
+	}
+	if statePos < 0 {
+		t.Errorf("missing 'state: active'\ngot:\n%s", out)
+	}
+	if headerPos > statePos {
+		t.Errorf("state line appears before header line\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_MultipleUserTurns verifies AC-8:
+// sessions with multiple user turns each followed by multiple assistant turns
+// render correctly.
+func TestRenderCheckinTurns_MultipleUserTurns(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Turn 1: user prompt at t=0, two assistant replies at t=1 and t=2.
+	u1 := writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-1", "first user prompt"), base)
+	amsgID1a := "amsg-1a"
+	amsgID1b := "amsg-1b"
+	ae1a := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(amsgID1a, "reply 1a"), base.Add(time.Second))
+	ae1b := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(amsgID1b, "reply 1b"), base.Add(2*time.Second))
+
+	// Turn 2: user prompt at t=5, two assistant replies at t=6 and t=7.
+	_ = writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-2", "second user prompt"), base.Add(5*time.Second))
+	amsgID2a := "amsg-2a"
+	amsgID2b := "amsg-2b"
+	ae2a := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(amsgID2a, "reply 2a"), base.Add(6*time.Second))
+	ae2b := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(amsgID2b, "reply 2b"), base.Add(7*time.Second))
+
+	_ = u1
+
+	assistantEvents := []db.Event{ae1a, ae1b, ae2a, ae2b}
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, assistantEvents, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// All four assistant replies present.
+	for _, want := range []string{"reply 1a", "reply 1b", "reply 2a", "reply 2b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+
+	// Both user prompts present (they fall within the window t=1s to t=7s,
+	// or at t=0 which is exactly the window start for the full set).
+	// u1 at t=0 is BEFORE the first assistant turn (t=1s) — outside window.
+	// u2 at t=5s is inside [t=1s, t=7s].
+	if strings.Contains(out, "first user prompt") {
+		// t=0 is before earliest assistant (t=1s) — must NOT be in window.
+		t.Errorf("first user prompt (t=0) unexpectedly in output (it is before the assistant window)\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "second user prompt") {
+		t.Errorf("second user prompt (t=5s) missing from output\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_PermissionEvents verifies AC-9:
+// permission_ask and permission_denied rendered under their assistant turn.
+func TestRenderCheckinTurns_PermissionEvents(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	msgID := "msg-perm"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "asking permission"), base)
+
+	writeEvent(t, d, uuid.New().String(), session, "permission_ask",
+		permAskPayload(msgID, "bash"), base.Add(100*time.Millisecond))
+	writeEvent(t, d, uuid.New().String(), session, "permission_denied",
+		permDeniedPayload(msgID, "bash"), base.Add(200*time.Millisecond))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "⏳ waiting for approval: bash") {
+		t.Errorf("output missing permission_ask\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "❌ denied: bash") {
+		t.Errorf("output missing permission_denied\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_NoToolChildren verifies AC-15:
+// an assistant turn with no tool children renders without indented lines.
+func TestRenderCheckinTurns_NoToolChildren(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	msgID := "msg-plain"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "just a reply, no tools"), base)
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "just a reply, no tools") {
+		t.Errorf("output missing assistant text\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "  →") {
+		t.Errorf("output unexpectedly contains indented tool lines\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_VerboseNoTruncation verifies AC-17:
+// --verbose disables truncation of tool args/results.
+func TestRenderCheckinTurns_VerboseNoTruncation(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	msgID := "msg-verbose"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "verbose test"), base)
+
+	longArgs := strings.Repeat("x", 200)
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID, "bash", longArgs), base.Add(100*time.Millisecond))
+
+	// Non-verbose: should truncate.
+	outTrunc := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns (non-verbose): %v", err)
+		}
+	})
+	if strings.Contains(outTrunc, longArgs) {
+		t.Errorf("non-verbose output should truncate long args but contains full string\ngot:\n%s", outTrunc)
+	}
+	if !strings.Contains(outTrunc, "...") {
+		t.Errorf("non-verbose output should have '...' truncation marker\ngot:\n%s", outTrunc)
+	}
+
+	// Verbose: should NOT truncate.
+	outVerbose := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, true); err != nil {
+			t.Errorf("renderCheckinTurns (verbose): %v", err)
+		}
+	})
+	if !strings.Contains(outVerbose, longArgs) {
+		t.Errorf("verbose output should contain full args string\ngot:\n%s", outVerbose)
+	}
+}
+
+// TestRunCheckinSession_NoAssistantEventsButHasUserEvents verifies AC-14:
+// session with msg_user but zero msg_assistant shows only header + footer, exits 0.
+func TestRunCheckinSession_NoAssistantEventsButHasUserEvents(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	dbPath := d.Path()
+
+	// Write only a msg_user event, no msg_assistant.
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload("umsg-only", "a prompt with no reply yet"), base)
+	d.Close()
+
+	SetTestDBPath(dbPath)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdout(t, func() {
+		if err := runCheckinSession(session, 10, nil, nil, nil, false); err != nil {
+			t.Errorf("runCheckinSession returned unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "checkin: "+session) {
+		t.Errorf("output missing header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "── end of event log ──") {
+		t.Errorf("output missing footer\ngot:\n%s", out)
+	}
+}
+
+// TestRunCheckinSession_TypesRoutesToRaw verifies AC-10:
+// --types routes to the raw event path (runCheckinSessionRaw), not the
+// assistant-anchored path.
+func TestRunCheckinSession_TypesRoutesToRaw(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	dbPath := d.Path()
+
+	msgID := "msg-raw"
+	writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "raw mode reply"), base)
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID, "bash", "ls"), base.Add(100*time.Millisecond))
+	d.Close()
+
+	SetTestDBPath(dbPath)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// --types msg_assistant,tool_call routes to raw path.
+	out := captureStdout(t, func() {
+		if err := runCheckinSession(session, 10, nil, nil, []string{"msg_assistant", "tool_call"}, false); err != nil {
+			t.Errorf("runCheckinSession: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "raw mode reply") {
+		t.Errorf("output missing assistant text in raw mode\ngot:\n%s", out)
+	}
+}
+
+// TestRunCheckinSession_LegacyFallbackNoAssistantNoUser verifies AC-13:
+// when no DB rows exist at all for the session, falls back to legacy
+// (which will error because tmux is unavailable in tests — that's acceptable;
+// we just verify it doesn't panic and the error is from the legacy path).
+func TestRunCheckinSession_LegacyFallbackNoRows(t *testing.T) {
+	d := openCheckinTestDB(t)
+	dbPath := d.Path()
+	d.Close()
+
+	SetTestDBPath(dbPath)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Session "repo@ghost" has no DB rows — should fall through to legacy.
+	err := runCheckinSession("repo@ghost", 10, nil, nil, nil, false)
+	// The legacy path returns an error when tmux is unavailable (no TMUX env
+	// in tests). We just verify the call doesn't panic and the error message
+	// references the session name.
+	if err == nil {
+		t.Error("expected error from legacy path (no tmux in tests), got nil")
+	}
+	if !strings.Contains(err.Error(), "repo@ghost") {
+		t.Errorf("error should mention session name\ngot: %v", err)
+	}
+}


### PR DESCRIPTION
## What was broken

`prism checkin <session>` anchored on `msg_user` events and then tried to fetch associated assistant/tool events via the user `messageId`. In opencode, tool and assistant events share the **assistant** `messageId` — not the user `messageId`. So when an agent worked through multiple assistant turns on a single user prompt, only the first turn was visible.

A session with 1 user message, 5 assistant replies, and 14 tool calls would show just 1 user message and nothing else.

## What the fix does

**`runCheckinSession`** — primary query now fetches `msg_assistant` events instead of `msg_user`. `--last N` means "last N assistant turns".

**`renderCheckinTurns`** — rewritten to anchor on assistant events:
1. Collects `messageId` from each assistant event
2. Secondary query via `QueryEventsByMessageIDs` fetches all `tool_call`, `tool_result`, `permission_ask`, `permission_denied`, and `thinking` children for those IDs
3. Determines the time window spanned by the fetched assistant turns (earliest → latest)
4. Fetches all `msg_user` events and includes those within the window, rendered immediately before the assistant turn that follows them in the timeline
5. Merges everything into a single chronological timeline for rendering

**Edge cases:**
- Session with `msg_user` but no `msg_assistant` rows: renders header + footer only, exits 0 (no screen-scrape fallback)
- Legacy screen-scrape fallback (`runCheckinSessionLegacy`) only triggers when no DB rows exist at all
- `--types` still routes to the raw event path (`runCheckinSessionRaw`) unchanged

## Acceptance criteria coverage

| AC | Description |
|---|---|
| AC-1 | 1 user + 5 assistant events → all 5 assistant turns shown |
| AC-2 | Tool children indented under their assistant turn |
| AC-3 | `--last 3` shows exactly 3 most-recent assistant turns |
| AC-4 | Default shows last 10 assistant turns when >10 exist |
| AC-5/6 | `msg_user` events included/excluded based on time window |
| AC-7 | State header rendered first |
| AC-8 | Multiple user turns each with multiple assistant turns |
| AC-9 | `permission_ask`/`permission_denied` rendered under their assistant turn |
| AC-10 | `--types` routes to raw path unchanged |
| AC-13 | Legacy fallback when no DB rows exist |
| AC-14 | `msg_user`-only session shows header+footer, exits 0 |
| AC-15 | Assistant turn with no tool children renders without indented lines |
| AC-17 | `--verbose` disables truncation |
| AC-18 | `go test ./...` passes |

## Files changed

- `cmd/checkin.go` — `runCheckinSession` and `renderCheckinTurns` rewritten
- `cmd/checkin_test.go` — new file with 14 tests covering the above ACs