### PR TITLE
fix(opencode): always load all provider auth plugins unconditionally

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -18,9 +18,9 @@
       default = "anthropic";
       description = ''
         The LLM provider to use for opencode agents.
-        Switching providers updates the model strings and authentication
-        plugins. All provider config blocks are always present in the
-        generated config to allow manual model overrides mid-session.
+        Switching providers updates the model strings only. All provider
+        auth plugins and config blocks are always present so any provider
+        can be used mid-session.
       '';
     };
   };


### PR DESCRIPTION
## Summary

- `authPlugins` was still keyed off the active provider (`providerPlugins.${provider}`), so when `provider = "github-copilot"` the `opencode-claude-auth@latest` plugin was never loaded
- Combined with the always-present `anthropic = {}` block from #370, opencode errored immediately with "Anthropic API key is missing"
- Fix flattens all `providerPlugins` values into a deduplicated union so all provider auth plugins are always loaded, mirroring the unconditional `providerSettings` approach from #370

Fixes #381.