### PR TITLE
fix(prism): record interrupted sessions correctly on Ctrl-C

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -229,6 +229,41 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree, client }) => 
   // Helpers (closed over db, sessionName, worktree)
   const repo = sessionName ? sessionName.split("@")[0]! : "";
 
+  // Register signal handlers so that a Ctrl-C (SIGINT) or termination
+  // (SIGTERM) immediately writes "interrupted" and cancels the idle debounce
+  // timer.  Without this, opencode catches the signal first and fires
+  // session.idle, which starts the 2-second debounce.  The debounce fires
+  // "finished" before the tmux pane-died hook can write "interrupted", leaving
+  // the session recorded as finished even though it was interrupted.
+  //
+  // The Bun SQLite run() call is synchronous at the C level, so the write
+  // completes before control returns to opencode's own signal handler.  Layer 2
+  // (pane-died with --exit-code) is the safety net for cases where the write
+  // cannot complete in time (SIGKILL, crash).
+  //
+  // The pane-died hook and the idle timer callback both already guard against
+  // clobbering "interrupted", so it is safe for multiple paths to write it.
+  function handleShutdownSignal(): void {
+    if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
+    // Write interrupted unless the session is already in a terminal state.
+    // Notably, we also write when lastWrittenState === null (plugin never saw
+    // a session event — interrupted before session.created fired): the
+    // pane-died fallback relies on a DB row existing, but the plugin can still
+    // write one here via upsertAgentStatus.
+    if (
+      lastWrittenState !== STATE_FINISHED &&
+      lastWrittenState !== STATE_DELETED &&
+      lastWrittenState !== STATE_INTERRUPTED
+    ) {
+      upsertAgentStatus(STATE_INTERRUPTED);
+      writeStateChange(STATE_INTERRUPTED);
+    }
+    // Do not call process.exit() here — let opencode's own signal handling
+    // proceed normally.  We only need to ensure the DB write happens first.
+  }
+  process.on("SIGINT", handleShutdownSignal);
+  process.on("SIGTERM", handleShutdownSignal);
+
   function writeEvent(type: string, payload: unknown, opencodeSid?: string | null): void {
     if (!db || !sessionName || !insertEvent) return;
     try {

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -126,10 +126,14 @@ var eventStateChangeCmd = &cobra.Command{
 
 // --- pane-died ---
 //
-// Called by the tmux pane-died hook when the opencode pane exits. If the
+// Called by the tmux pane-exited hook when the opencode pane exits. If the
 // session is currently in an active (non-terminal) state, this transitions it
-// to "interrupted". Sessions already in finished, interrupted, or deleted state
-// are left unchanged — this guards against stale hook fires after a clean exit.
+// to "interrupted". Sessions already in interrupted or deleted state are left
+// unchanged — this guards against stale hook fires after a clean exit.
+//
+// When exitCode is non-zero (signal-based exit or crash), "finished" is also
+// overridden with "interrupted" — a non-zero exit means the process did not
+// complete cleanly regardless of what the plugin wrote to the DB before dying.
 
 var eventPaneDiedCmd = &cobra.Command{
 	Use:   "pane-died",
@@ -137,6 +141,7 @@ var eventPaneDiedCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		session, _ := cmd.Flags().GetString("session")
 		window, _ := cmd.Flags().GetString("window")
+		exitCode, _ := cmd.Flags().GetInt("exit-code")
 
 		// Only the agent window exit is meaningful — exits from term, edit,
 		// or any other window should not mark the session as interrupted.
@@ -160,13 +165,26 @@ var eventPaneDiedCmd = &cobra.Command{
 			return nil
 		}
 
-		// Transition to interrupted only if not already in a terminal state.
-		updated, err := d.UpsertStatusIfNotTerminal(session, string(agent.StateInterrupted))
+		var updated bool
+		if exitCode != 0 {
+			// Non-zero exit: the process was killed or crashed.  Override even
+			// a prior "finished" state — the session was not completed cleanly.
+			// This is the primary fix for the race where the plugin writes
+			// "finished" via the idle debounce before the pane-died hook fires.
+			updated, err = d.UpsertStatusInterruptedOverrideFinished(session)
+		} else {
+			// Clean exit (exit code 0): only transition if not already in a
+			// terminal state.  A zero exit after "finished" means the session
+			// completed cleanly; leave "finished" intact.
+			updated, err = d.UpsertStatusIfNotTerminal(session, string(agent.StateInterrupted))
+		}
 		if err != nil {
 			return fmt.Errorf("event pane-died: %w", err)
 		}
 		if !updated {
-			// Already finished / interrupted / deleted — nothing to do.
+			// No update applied.
+			// exitCode == 0 path: session was already finished/interrupted/deleted.
+			// exitCode != 0 path: session was already interrupted/deleted or ended_at is set.
 			return nil
 		}
 
@@ -413,6 +431,7 @@ func init() {
 	// pane-died flags
 	eventPaneDiedCmd.Flags().String("session", "", "tmux session name")
 	eventPaneDiedCmd.Flags().String("window", "", "tmux window name")
+	eventPaneDiedCmd.Flags().Int("exit-code", 0, "pane exit code (#{pane_dead_status}); non-zero overrides finished→interrupted")
 	_ = eventPaneDiedCmd.MarkFlagRequired("session")
 	_ = eventPaneDiedCmd.MarkFlagRequired("window")
 

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -251,6 +251,37 @@ WHERE session_name = ?
 	return n > 0, nil
 }
 
+// UpsertStatusInterruptedOverrideFinished transitions the session to
+// "interrupted", allowing it to override a "finished" state in addition to the
+// active states that UpsertStatusIfNotTerminal covers.  This is used by the
+// pane-died hook when the pane exited with a non-zero exit code: a non-zero
+// exit means the process was killed or crashed, so even a prior "finished" that
+// the plugin wrote should be corrected to "interrupted".
+//
+// "deleted" is still left intact — a deleted session should not be resurrected.
+// "interrupted" is also left alone to avoid a no-op double-write.
+//
+// Returns (true, nil) if the update was applied, (false, nil) if the row did
+// not exist, was already interrupted or deleted, or has ended_at set.
+func (d *DB) UpsertStatusInterruptedOverrideFinished(sessionName string) (bool, error) {
+	now := time.Now().UnixMilli()
+	const q = `
+UPDATE agent_status
+SET state = 'interrupted', last_seen = ?
+WHERE session_name = ?
+  AND ended_at IS NULL
+  AND state NOT IN ('interrupted', 'deleted')`
+	res, err := d.conn.Exec(q, now, sessionName)
+	if err != nil {
+		return false, fmt.Errorf("db: upsert status interrupted override finished: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("db: upsert status interrupted override finished: rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
 // SetEnded marks the session as ended by setting ended_at to now.
 func (d *DB) SetEnded(sessionName string) error {
 	now := time.Now().UnixMilli()

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -410,6 +410,91 @@ func TestUpsertStatusIfNotTerminal(t *testing.T) {
 	}
 }
 
+// TestUpsertStatusInterruptedOverrideFinished verifies that the method
+// overrides "finished" with "interrupted" (unlike UpsertStatusIfNotTerminal
+// which treats "finished" as a terminal no-op).
+func TestUpsertStatusInterruptedOverrideFinished(t *testing.T) {
+	d := openTestDB(t)
+
+	// Should update a non-terminal state (active → interrupted).
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	updated, err := d.UpsertStatusInterruptedOverrideFinished("repo@main")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (active): %v", err)
+	}
+	if !updated {
+		t.Error("UpsertStatusInterruptedOverrideFinished (active): got updated=false, want true")
+	}
+	s, _ := d.CurrentStatus("repo@main")
+	if s.State != "interrupted" {
+		t.Errorf("State after active update: got %q, want \"interrupted\"", s.State)
+	}
+
+	// Key difference from UpsertStatusIfNotTerminal: "finished" should be
+	// overridden (this is the fix for the pane-died / idle-debounce race).
+	if err := d.UpsertStatus("repo@feat", "repo", "/code/repo/feat", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (finished): %v", err)
+	}
+	updated2, err := d.UpsertStatusInterruptedOverrideFinished("repo@feat")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (finished): %v", err)
+	}
+	if !updated2 {
+		t.Error("UpsertStatusInterruptedOverrideFinished (finished): got updated=false, want true (override)")
+	}
+	sf, _ := d.CurrentStatus("repo@feat")
+	if sf.State != "interrupted" {
+		t.Errorf("State after finished override: got %q, want \"interrupted\"", sf.State)
+	}
+
+	// "interrupted" should be a no-op (already in target state).
+	updated3, err := d.UpsertStatusInterruptedOverrideFinished("repo@main")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (interrupted): %v", err)
+	}
+	if updated3 {
+		t.Error("UpsertStatusInterruptedOverrideFinished (interrupted): got updated=true, want false (no-op)")
+	}
+
+	// "deleted" should be a no-op — do not resurrect deleted sessions.
+	if err := d.UpsertStatus("repo@old", "repo", "/code/repo/old", "deleted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (deleted): %v", err)
+	}
+	updated4, err := d.UpsertStatusInterruptedOverrideFinished("repo@old")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (deleted): %v", err)
+	}
+	if updated4 {
+		t.Error("UpsertStatusInterruptedOverrideFinished (deleted): got updated=true, want false (no-op)")
+	}
+
+	// Sessions with ended_at set should be a no-op.
+	if err := d.UpsertStatus("repo@ended", "repo", "/code/repo/ended", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (ended): %v", err)
+	}
+	if err := d.SetEnded("repo@ended"); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+	updated5, err := d.UpsertStatusInterruptedOverrideFinished("repo@ended")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (ended): %v", err)
+	}
+	if updated5 {
+		t.Error("UpsertStatusInterruptedOverrideFinished (ended): got updated=true, want false (no-op)")
+	}
+
+	// Non-existent session should be a no-op.
+	updated6, err := d.UpsertStatusInterruptedOverrideFinished("repo@nonexistent")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (nonexistent): %v", err)
+	}
+	if updated6 {
+		t.Error("UpsertStatusInterruptedOverrideFinished (nonexistent): got updated=true, want false (no-op)")
+	}
+}
+
 // TestAllActiveStatusForRepo verifies that AllActiveStatusForRepo filters by repo.
 func TestAllActiveStatusForRepo(t *testing.T) {
 	d := openTestDB(t)

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -177,7 +177,9 @@ in
               # Only the agent window exit is relevant; prism event pane-died
               # ignores exits from other windows (term, edit) and is a no-op for
               # non-project sessions and sessions already in a terminal state.
-              set-hook -g pane-exited "run-shell '${prism} event pane-died --session #{session_name} --window #{window_name}'"
+              # #{pane_dead_status} is passed so pane-died can override a prior
+              # "finished" state when the exit was non-zero (signal/crash).
+              set-hook -g pane-exited "run-shell '${prism} event pane-died --session #{session_name} --window #{window_name} --exit-code #{pane_dead_status}'"
 
               # Remove HM session vars guard from tmux environment so new shells
               # re-evaluate $(cat ...) substitutions for secrets like GITHUB_TOKEN


### PR DESCRIPTION
## Summary

Fixes #386.

When a user hits Ctrl-C in an opencode session, the session was recorded as `finished` instead of `interrupted`. The root cause was a race: opencode catches SIGINT, fires `session.idle`, which starts a 2-second debounce timer that writes `finished` — and by the time the tmux `pane-died` hook fires with `interrupted`, the state is already terminal and `UpsertStatusIfNotTerminal` refuses to override it.

## Fix — three layers

**1. Plugin (`prism-hooks.ts`) — primary fix**

Register SIGINT/SIGTERM handlers that immediately:
- Cancel the idle debounce timer (so it never writes `finished`)
- Write `state=interrupted` to the DB synchronously

This fires before opencode's own shutdown path, so the correct state is in the DB before any `session.idle` event can produce `finished`.

**2. `pane-died` + `db.go` — fallback for non-catchable kills**

Added `UpsertStatusInterruptedOverrideFinished` — like `UpsertStatusIfNotTerminal` but also overrides a prior `finished` state (while still leaving `deleted` and `interrupted` alone).

`pane-died` now accepts `--exit-code`. When the exit code is non-zero, it uses the new method, correcting `finished → interrupted` even if the plugin couldn't catch the signal (SIGKILL, crash, etc.).

**3. `tmux.nix`**

Pass `#{pane_dead_status}` to `pane-died` so the exit code is available at the hook layer.

## Tests

- Added `TestUpsertStatusInterruptedOverrideFinished` covering: active→interrupted, **finished→interrupted** (the key new case), interrupted no-op, deleted no-op, ended no-op, nonexistent no-op.
- All existing tests pass: `go build ./... && go test ./...` ✓