### PR TITLE
fix(prism-hooks): cancel idle debounce timer on MessageAbortedError

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -604,6 +604,10 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree, client }) => 
           const errorName: string | null = errProps?.error?.name ?? null;
           if (errorName === "MessageAbortedError") {
             // User pressed Escape or Ctrl-C — record as interrupted, not error.
+            // Cancel any pending idle debounce so it cannot fire "finished"
+            // after this write — eliminates the race where session.idle starts
+            // the timer before session.error fires.
+            if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
             upsertAgentStatus(STATE_INTERRUPTED);
             writeStateChange(STATE_INTERRUPTED);
           } else {


### PR DESCRIPTION
## Summary

Fixes #397.

When a tmux `send-keys C-c` interrupts an active opencode session:
- opencode fires `session.idle` → starts the 2-second debounce timer
- opencode fires `session.error` with `MessageAbortedError` → wrote `interrupted` state, but did **not** cancel the timer
- The debounce fired anyway, overwrote `interrupted` with `finished`, and sent a spurious coordinator notification

## Fix

In the `MessageAbortedError` branch of `session.error`, add `if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }` before writing `interrupted` state. This cancels any pending debounce regardless of event ordering (including the inversion case where `session.idle` fires before `session.error`).

The non-`MessageAbortedError` else-branch is untouched, so normal completions, auth errors, and API errors are unaffected.