### PR TITLE
feat(dashboard): responsive column layout with model column

### DIFF
--- a/modules/programs/prism/prism/cmd/dashboard.go
+++ b/modules/programs/prism/prism/cmd/dashboard.go
@@ -948,9 +948,9 @@ func (m dashModel) View() string {
 	}
 
 	// fixedCore (defined below) is the irreducible column overhead. At widths
-	// below that threshold the column-width math cannot produce a valid layout,
-	// so render a skeleton rather than overflowing rows.
-	const minUsableWidth = 21 // fixedCore = 1+dotW+treePrefixW+2+stateW
+	// below fixedCore+1, the session header word "session" (7 chars) overflows
+	// its 6-char slot when sessionW=0, so render a skeleton instead.
+	const minUsableWidth = 22 // fixedCore+1
 	if m.width < minUsableWidth {
 		return skeletonView(m.width)
 	}


### PR DESCRIPTION
## Summary

- Adds a `model` column (after `type`) showing the model identifier from `agent_status.model_id`
- Implements responsive column dropping in priority order as the terminal narrows: compact stat → drop model → drop stat → drop title → drop type → session + state only
- Session column grows when type is dropped, filling reclaimed space
- Column headers always match the visible columns — no phantom headers for dropped columns
- Title fills all remaining space with no fixed cap
- Session names truncate with `…` at all breakpoints; child tree rows stay aligned with parents

Closes #399