### PR TITLE
fix: correct pendingPermissions key for permission_denied correlation

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -560,10 +560,11 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree, client }) => 
           writeStateChange(STATE_WAITING);
           writeEvent("permission_ask", { tool: props.permission ?? "unknown", patterns: props.patterns, messageId: props.tool?.messageID });
           // Track this permission so we can correlate a denial in permission.replied.
-          // props.permission.id is the framework request ID that matches
-          // repliedProps.permissionID in the permission.replied handler.
-          if (props.permission?.id) {
-            pendingPermissions.set(props.permission.id, {
+          // props is a PermissionRequest; props.id is the framework request ID that
+          // matches repliedProps.requestID in the permission.replied handler.
+          // props.permission is the permission-type string (e.g. "bash"), not an object.
+          if (props.id) {
+            pendingPermissions.set(props.id, {
               tool: props.permission ?? "unknown",
               messageID: props.tool?.messageID ?? "",
             });
@@ -573,8 +574,8 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree, client }) => 
 
         case "permission.replied": {
           const repliedProps = event.properties as any;
-          const permID: string = repliedProps.permissionID ?? "";
-          const response: string = repliedProps.response ?? "";
+          const permID: string = repliedProps.requestID ?? "";
+          const response: string = repliedProps.reply ?? "";
           if (response === "reject") {
             // Permission was denied — record it so checkin can surface it.
             const pending = pendingPermissions.get(permID);


### PR DESCRIPTION
## Summary

- The `permission.asked` handler was keying `pendingPermissions` on `props.permission?.id`, but per the opencode v2 SDK `PermissionRequest` type, `props.permission` is a **string** (e.g. `"bash"`), not an object. So `props.permission?.id` was always `undefined`, the map was never populated, and `permission_denied` events always showed `tool: "unknown"`.
- Fix: use `props.id` as the map key (the `PermissionRequest.id` field, which is the framework request ID).
- Also fix the `permission.replied` handler to use the correct SDK field names: `repliedProps.requestID` (was `permissionID`) and `repliedProps.reply` (was `response`).
- The `permission_ask` `writeEvent` call (fixed in #411) is untouched — `props.permission` there is correctly used as the string tool name.

## Changes

`modules/programs/prism/opencode/plugins/prism-hooks.ts`:
- `permission.asked` handler: `props.permission?.id` → `props.id`; update comment to clarify the shape
- `permission.replied` handler: `repliedProps.permissionID` → `repliedProps.requestID`; `repliedProps.response` → `repliedProps.reply`

## Testing

Go build and tests pass (`go build ./...` + `go test ./...`). TypeScript plugin has no automated tests — verified by inspection against the SDK `PermissionRequest` and `EventPermissionReplied` type definitions in `@opencode-ai/sdk/dist/v2/gen/types.gen.d.ts`.

Closes #412