### PR TITLE
fix: allow closing @main sessions without worktree removal

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -7,6 +7,10 @@ package cmd
 // 3. Confirms with the user (y/n).
 // 4. Optionally offers to delete the git branch.
 // 5. Switches to scratchpad, kills the session, removes the worktree.
+//
+// For default-branch sessions (e.g. repo@main), steps 4-5 skip worktree
+// removal and branch deletion — only the tmux session is closed and the
+// DB status is marked as ended.
 
 import (
 	"fmt"
@@ -267,7 +271,7 @@ func (m cleanupModel) View() string {
 
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup",
-	Short: "Remove the current worktree session (project@branch sessions only)",
+	Short: "Close and clean up a worktree session",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 		sessionFlag, _ := cmd.Flags().GetString("session")
@@ -307,8 +311,23 @@ var cleanupCmd = &cobra.Command{
 		}
 
 		defaultBr := git.DefaultBranchFromBareRoot(bareRoot)
-		if defaultBr != "" && worktreeName == defaultBr {
-			return fmt.Errorf("refusing to remove the default branch worktree '%s'\n  switch to a feature branch session first", worktreeName)
+		isDefaultBranch := defaultBr != "" && worktreeName == defaultBr
+
+		if isDefaultBranch {
+			// Default-branch sessions (e.g. repo@main): close the tmux
+			// session and mark the DB as ended, but keep the worktree
+			// and branch intact.
+			if yesFlag {
+				return headlessCloseSession(session)
+			}
+			// Interactive path: simplified confirmation (no worktree/branch prompts).
+			if os.Getenv("TMUX") == "" {
+				return fmt.Errorf("interactive cleanup requires tmux — use --yes for non-interactive use outside tmux")
+			}
+			if !confirm(fmt.Sprintf("Close session %s? (worktree will be kept)", session)) {
+				return nil
+			}
+			return closeSession(session)
 		}
 
 		// Non-interactive path: --yes skips all prompts and runs headlessly.
@@ -356,6 +375,69 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 
 	// Redirect only clients that are currently attached to the target session.
 	// We must not touch the orchestrator's own client.
+	if clients, err := tmux.ListClients(); err == nil {
+		for _, c := range clients {
+			if sess, err := tmux.ClientSession(c); err == nil && sess == session {
+				_ = tmux.SwitchClient(c, "scratchpad")
+			}
+		}
+	}
+
+	fmt.Printf("killing session %s\n", session)
+	_ = tmux.KillSession(session)
+	if d, err := openDB(); err == nil {
+		_ = d.SetEnded(session)
+		_ = d.PurgeBusMessages(session)
+		d.Close()
+	}
+	fmt.Println("done")
+	return nil
+}
+
+// closeSession redirects attached clients to scratchpad, kills the tmux
+// session, and marks the DB as ended. It does NOT remove the worktree or
+// delete the branch — used for default-branch sessions where the checkout
+// must remain intact.
+func closeSession(session string) error {
+	// Ensure scratchpad exists.
+	if !tmux.HasSession("scratchpad") {
+		home, _ := os.UserHomeDir()
+		_ = tmux.NewSessionDetached("scratchpad", home)
+		_ = tmux.RenameWindow("scratchpad:0", "term")
+	}
+
+	// Switch only this client to scratchpad, then kill the session.
+	client, _ := tmux.CurrentClient()
+	if client == "" {
+		client = tmux.CallerClient()
+	}
+	if client != "" {
+		_ = tmux.SwitchClient(client, "scratchpad")
+	} else {
+		_, _ = tmux.SwitchClientCurrent("scratchpad")
+	}
+	_ = tmux.KillSession(session)
+	if d, err := openDB(); err == nil {
+		_ = d.SetEnded(session)
+		_ = d.PurgeBusMessages(session)
+		d.Close()
+	}
+	return nil
+}
+
+// headlessCloseSession is the non-interactive variant of closeSession — used
+// for default-branch sessions invoked with --yes.
+func headlessCloseSession(session string) error {
+	fmt.Printf("closing session %s (worktree kept)...\n", session)
+
+	// Ensure scratchpad exists.
+	if !tmux.HasSession("scratchpad") {
+		home, _ := os.UserHomeDir()
+		_ = tmux.NewSessionDetached("scratchpad", home)
+		_ = tmux.RenameWindow("scratchpad:0", "term")
+	}
+
+	// Redirect clients attached to the target session.
 	if clients, err := tmux.ListClients(); err == nil {
 		for _, c := range clients {
 			if sess, err := tmux.ClientSession(c); err == nil && sess == session {

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -10,6 +10,9 @@
 //   - clients attached to the target session are redirected to scratchpad
 //   - clients attached to other sessions are unaffected
 //   - the target session is removed
+//
+// TestCleanupYes_DefaultBranch verifies that cleanup of a @main session closes
+// the session but preserves the worktree and branch.
 package cmd
 
 import (
@@ -240,6 +243,111 @@ func TestCleanupYes_RedirectsClientsAndKillsSession(t *testing.T) {
 	// The bystander client should still be on "other".  Poll briefly for
 	// stability rather than reading once.  Guard: only assert if at least one
 	// successful read was obtained.
+	var gotOther string
+	otherDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(otherDeadline) {
+		if sess, err := s.clientSession(clientOther); err == nil {
+			gotOther = sess
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if gotOther != "" && gotOther != "other" {
+		t.Errorf("clientOther session = %q, want %q — unrelated client was incorrectly moved",
+			gotOther, "other")
+	}
+}
+
+// TestCleanupYes_DefaultBranch verifies that the headless (--yes) cleanup of a
+// default-branch session (e.g. myrepo@main) closes the session but preserves
+// the worktree directory and git branch.
+//
+// Layout:
+//   - session "myrepo@main"  ← the target; has an "agent" window at mainWorktreePath
+//   - session "other"        ← a bystander session
+//   - clientTarget attached to "myrepo@main"
+//   - clientOther attached to "other"
+func TestCleanupYes_DefaultBranch(t *testing.T) {
+	// Uses withCmdServer which mutates TmuxBin — must not be parallel.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH — skipping integration test")
+	}
+
+	prismBin := buildPrismBinary(t)
+
+	bareRoot, _, _ := setupMinimalBareRepo(t)
+	// The default branch worktree is at bareRoot/main.
+	mainWorktreePath := filepath.Join(bareRoot, "main")
+
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	targetSession := "myrepo@main"
+
+	// Create the target session rooted at the main worktree.
+	if err := s.run("new-session", "-ds", targetSession, "-c", mainWorktreePath); err != nil {
+		t.Fatalf("new-session %q: %v", targetSession, err)
+	}
+	if err := s.run("rename-window", "-t", targetSession+":0", "agent"); err != nil {
+		t.Fatalf("rename-window agent: %v", err)
+	}
+
+	// Create the bystander session.
+	s.newSession("other")
+
+	// Attach clients.
+	clientTarget := s.attachClientToSession(t, targetSession)
+	clientOther := s.attachClientToSession(t, "other")
+
+	// Invoke cleanup on the default-branch session.
+	cleanupArgs := fmt.Sprintf("%s cleanup --yes --session %s", prismBin, targetSession)
+	runInNewWindow(t, s, "other", "/tmp", cleanupArgs)
+
+	// Poll until the target session disappears.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if !s.hasSession(targetSession) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if s.hasSession(targetSession) {
+		t.Fatalf("session %q still exists after cleanup (timed out)", targetSession)
+	}
+
+	// The worktree directory must still exist.
+	if _, err := os.Stat(mainWorktreePath); err != nil {
+		t.Errorf("worktree directory %q was removed — expected it to be preserved: %v",
+			mainWorktreePath, err)
+	}
+
+	// The git branch "main" must still exist.
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if err := exec.Command("git", "--git-dir", bareDir, "rev-parse", "--verify",
+		"refs/heads/main").Run(); err != nil {
+		t.Errorf("branch 'main' no longer exists — expected it to be preserved: %v", err)
+	}
+
+	// Poll until clientTarget lands on "scratchpad".
+	var gotTarget string
+	targetDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(targetDeadline) {
+		if sess, err := s.clientSession(clientTarget); err == nil {
+			gotTarget = sess
+			if sess == "scratchpad" {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if gotTarget != "" && gotTarget != "scratchpad" {
+		t.Errorf("clientTarget session = %q, want %q — client was not redirected to scratchpad",
+			gotTarget, "scratchpad")
+	}
+	if gotTarget == "" {
+		t.Errorf("clientTarget: could not confirm session after cleanup (all clientSession calls failed)")
+	}
+
+	// The bystander client should still be on "other".
 	var gotOther string
 	otherDeadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(otherDeadline) {


### PR DESCRIPTION
## Summary

- `prism cleanup` on default-branch sessions (e.g. `repo@main`) now closes the session instead of refusing with an error
- Worktree and git branch are preserved — only the tmux session is killed, clients redirected to scratchpad, and DB marked as ended
- Both interactive (simplified confirmation prompt) and headless (`--yes`) paths are supported

Closes #437