### PR TITLE
feat(prism): add SSE client library for opencode event stream

### DIFF
--- a/modules/programs/prism/prism/internal/sse/client.go
+++ b/modules/programs/prism/prism/internal/sse/client.go
@@ -1,0 +1,247 @@
+// Package sse provides a client for consuming Server-Sent Events (SSE) streams.
+//
+// The client connects to an HTTP endpoint, parses event: and data: fields per
+// the SSE specification, and delivers parsed events via a Go channel. It
+// automatically reconnects on connection loss with exponential backoff.
+package sse
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Event represents a single SSE event parsed from the stream.
+type Event struct {
+	// Type is the event type from the SSE "event:" field.
+	// Defaults to "message" when the server omits the event field.
+	Type string
+
+	// Data is the event payload from the SSE "data:" field.
+	// Multiple consecutive data: lines are concatenated with newlines.
+	Data string
+}
+
+// Client consumes a Server-Sent Events stream and delivers parsed events on a
+// channel. It reconnects automatically when the connection drops and respects
+// context cancellation for clean shutdown.
+type Client struct {
+	// HTTPClient is the HTTP client used for requests. If nil, http.DefaultClient
+	// is used.
+	HTTPClient *http.Client
+
+	// BufferSize is the capacity of the event channel. If the consumer falls
+	// behind by this many events, new events are dropped with a log warning.
+	// Defaults to 64 if zero.
+	BufferSize int
+
+	// InitialRetryDelay is the base delay before the first reconnection attempt.
+	// Subsequent attempts double the delay up to MaxRetryDelay.
+	// Defaults to 1s if zero.
+	InitialRetryDelay time.Duration
+
+	// MaxRetryDelay caps the exponential backoff. Defaults to 30s if zero.
+	MaxRetryDelay time.Duration
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (c *Client) bufferSize() int {
+	if c.BufferSize > 0 {
+		return c.BufferSize
+	}
+	return 64
+}
+
+func (c *Client) initialRetryDelay() time.Duration {
+	if c.InitialRetryDelay > 0 {
+		return c.InitialRetryDelay
+	}
+	return 1 * time.Second
+}
+
+func (c *Client) maxRetryDelay() time.Duration {
+	if c.MaxRetryDelay > 0 {
+		return c.MaxRetryDelay
+	}
+	return 30 * time.Second
+}
+
+// Connect starts consuming the SSE stream at url. It returns a channel of
+// parsed events and an error if the initial connection fails. The channel is
+// closed when ctx is cancelled.
+//
+// On connection loss the client automatically reconnects with exponential
+// backoff (1s, 2s, 4s, … capped at 30s). The backoff resets after a successful
+// connection.
+func (c *Client) Connect(ctx context.Context, url string) (<-chan Event, error) {
+	ch := make(chan Event, c.bufferSize())
+
+	// Validate the initial connection so callers get an immediate error for
+	// obviously wrong URLs. We pass the body off to the read loop.
+	resp, err := c.doRequest(ctx, url)
+	if err != nil {
+		close(ch)
+		return ch, fmt.Errorf("sse: initial connection failed: %w", err)
+	}
+
+	go c.readLoop(ctx, url, resp, ch)
+
+	return ch, nil
+}
+
+// doRequest performs a single SSE connection attempt.
+func (c *Client) doRequest(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+// readLoop reads events from the response body, reconnecting on failure.
+// It closes ch when ctx is done.
+func (c *Client) readLoop(ctx context.Context, url string, resp *http.Response, ch chan<- Event) {
+	defer close(ch)
+
+	for {
+		c.consumeStream(ctx, resp, ch)
+		resp.Body.Close()
+
+		// If the context is done, stop reconnecting.
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Reconnect with exponential backoff.
+		resp = c.reconnect(ctx, url)
+		if resp == nil {
+			// Context cancelled during reconnection.
+			return
+		}
+	}
+}
+
+// reconnect attempts to re-establish the SSE connection with exponential
+// backoff. Returns nil if ctx is cancelled before a connection is established.
+func (c *Client) reconnect(ctx context.Context, url string) *http.Response {
+	delay := c.initialRetryDelay()
+	maxDelay := c.maxRetryDelay()
+
+	for {
+		log.Printf("sse: reconnecting in %v", delay)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(delay):
+		}
+
+		resp, err := c.doRequest(ctx, url)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.Printf("sse: reconnection failed: %v", err)
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			continue
+		}
+
+		return resp
+	}
+}
+
+// consumeStream reads from a single response body until EOF or error.
+func (c *Client) consumeStream(ctx context.Context, resp *http.Response, ch chan<- Event) {
+	scanner := bufio.NewScanner(resp.Body)
+
+	var eventType string
+	var dataLines []string
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+
+		line := scanner.Text()
+
+		// An empty line signals the end of an event.
+		if line == "" {
+			if len(dataLines) > 0 {
+				evt := Event{
+					Type: eventType,
+					Data: strings.Join(dataLines, "\n"),
+				}
+				if evt.Type == "" {
+					evt.Type = "message"
+				}
+				c.send(ch, evt)
+			}
+			eventType = ""
+			dataLines = nil
+			continue
+		}
+
+		// Comment lines start with ':' — silently ignore.
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// Parse "field: value" or "field:value" (space after colon is optional).
+		field, value, _ := strings.Cut(line, ":")
+		// Per SSE spec: if the line contains a colon, the value is everything
+		// after the first colon. If a single space follows the colon, it is
+		// stripped.
+		if len(value) > 0 && value[0] == ' ' {
+			value = value[1:]
+		}
+
+		switch field {
+		case "event":
+			eventType = value
+		case "data":
+			dataLines = append(dataLines, value)
+		case "id", "retry":
+			// Recognised but not needed for our use case — ignore.
+		default:
+			// Unknown fields are ignored per spec.
+		}
+	}
+
+	// If the stream ended with accumulated data but no trailing blank line,
+	// we discard it. This matches the SSE spec: an event is only dispatched
+	// when an empty line is encountered.
+}
+
+// send delivers an event to the channel, dropping it with a log warning if the
+// buffer is full.
+func (c *Client) send(ch chan<- Event, evt Event) {
+	select {
+	case ch <- evt:
+	default:
+		log.Printf("sse: buffer full, dropping event type=%q", evt.Type)
+	}
+}

--- a/modules/programs/prism/prism/internal/sse/client_test.go
+++ b/modules/programs/prism/prism/internal/sse/client_test.go
@@ -1,0 +1,441 @@
+package sse
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sseServer creates an httptest.Server that writes the given SSE payload and
+// then blocks until the client disconnects. This prevents the client from
+// seeing a connection close and attempting to reconnect during tests that don't
+// exercise reconnection.
+func sseServer(payload string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprint(w, payload)
+		flusher.Flush()
+
+		// Block until the client disconnects to avoid triggering reconnection.
+		<-r.Context().Done()
+	}))
+}
+
+// collectEvents reads up to n events from ch, with a timeout per event.
+func collectEvents(t *testing.T, ch <-chan Event, n int) []Event {
+	t.Helper()
+	var events []Event
+	for range n {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, evt)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for event (got %d of %d)", len(events), n)
+		}
+	}
+	return events
+}
+
+func TestParseSimpleEvent(t *testing.T) {
+	srv := sseServer("event: greeting\ndata: hello\n\n")
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != "greeting" {
+		t.Errorf("Type = %q, want %q", events[0].Type, "greeting")
+	}
+	if events[0].Data != "hello" {
+		t.Errorf("Data = %q, want %q", events[0].Data, "hello")
+	}
+}
+
+func TestMultipleEvents(t *testing.T) {
+	payload := strings.Join([]string{
+		"event: first",
+		"data: one",
+		"",
+		"event: second",
+		"data: two",
+		"",
+		"",
+	}, "\n")
+
+	srv := sseServer(payload)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 2)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != "first" || events[0].Data != "one" {
+		t.Errorf("event[0] = %+v", events[0])
+	}
+	if events[1].Type != "second" || events[1].Data != "two" {
+		t.Errorf("event[1] = %+v", events[1])
+	}
+}
+
+func TestMultiLineData(t *testing.T) {
+	payload := "event: multi\ndata: line1\ndata: line2\ndata: line3\n\n"
+
+	srv := sseServer(payload)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	want := "line1\nline2\nline3"
+	if events[0].Data != want {
+		t.Errorf("Data = %q, want %q", events[0].Data, want)
+	}
+}
+
+func TestDefaultEventType(t *testing.T) {
+	// No "event:" field — should default to "message".
+	srv := sseServer("data: no-type\n\n")
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != "message" {
+		t.Errorf("Type = %q, want %q", events[0].Type, "message")
+	}
+}
+
+func TestCommentsIgnored(t *testing.T) {
+	payload := ": this is a comment\nevent: real\ndata: value\n: another comment\n\n"
+
+	srv := sseServer(payload)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != "real" || events[0].Data != "value" {
+		t.Errorf("event = %+v", events[0])
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	// Server that blocks until the request context is done.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if ok {
+			flusher.Flush()
+		}
+
+		// Block until the client disconnects.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &Client{}
+
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Cancel the context and verify the channel closes.
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after cancel, but got an event")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("channel was not closed within timeout after cancel")
+	}
+}
+
+func TestReconnection(t *testing.T) {
+	var mu sync.Mutex
+	attempt := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		current := attempt
+		attempt++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+
+		// First connection: send one event then close.
+		// Second connection: send another event then close.
+		evt := fmt.Sprintf("event: attempt\ndata: %d\n\n", current)
+		fmt.Fprint(w, evt)
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := &Client{
+		InitialRetryDelay: 50 * time.Millisecond,
+		MaxRetryDelay:     200 * time.Millisecond,
+	}
+
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// We should get events from at least 2 connections.
+	events := collectEvents(t, ch, 2)
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events across reconnections, got %d", len(events))
+	}
+	if events[0].Data != "0" {
+		t.Errorf("first event data = %q, want %q", events[0].Data, "0")
+	}
+	if events[1].Data != "1" {
+		t.Errorf("second event data = %q, want %q", events[1].Data, "1")
+	}
+}
+
+func TestMidEventDisconnect(t *testing.T) {
+	// Server sends an incomplete event (no trailing blank line) then closes.
+	// Followed by a proper event on reconnect.
+	var mu sync.Mutex
+	attempt := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		current := attempt
+		attempt++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+
+		if current == 0 {
+			// Incomplete event — no trailing empty line.
+			fmt.Fprint(w, "event: broken\ndata: partial")
+			flusher.Flush()
+			return
+		}
+
+		// Complete event on second connection.
+		fmt.Fprint(w, "event: recovered\ndata: complete\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := &Client{
+		InitialRetryDelay: 50 * time.Millisecond,
+		MaxRetryDelay:     200 * time.Millisecond,
+	}
+
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// The incomplete event should be discarded; we should only get the
+	// recovered event from the second connection.
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != "recovered" {
+		t.Errorf("Type = %q, want %q", events[0].Type, "recovered")
+	}
+}
+
+func TestBufferDropsEvents(t *testing.T) {
+	// Generate more events than the buffer can hold.
+	var lines []string
+	for i := range 10 {
+		lines = append(lines, fmt.Sprintf("event: flood\ndata: %d\n", i))
+	}
+	payload := strings.Join(lines, "\n") + "\n"
+
+	srv := sseServer(payload)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{
+		BufferSize: 2, // Tiny buffer to force drops.
+	}
+
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Give the producer time to fill and overflow the buffer.
+	time.Sleep(200 * time.Millisecond)
+
+	// Drain whatever made it through.
+	var got int
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			got++
+		case <-time.After(500 * time.Millisecond):
+			goto done
+		}
+	}
+done:
+
+	// We should have gotten some events but not necessarily all 10.
+	if got == 0 {
+		t.Error("expected at least some events to be delivered")
+	}
+	// The key assertion is that the client did not panic or deadlock.
+}
+
+func TestInitialConnectionError(t *testing.T) {
+	ctx := context.Background()
+	client := &Client{}
+
+	// Connect to a URL that will refuse connections.
+	_, err := client.Connect(ctx, "http://127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected error for bad URL, got nil")
+	}
+}
+
+func TestDataWithColonNoSpace(t *testing.T) {
+	// "data:value" (no space after colon) should still parse correctly.
+	srv := sseServer("data:hello\n\n")
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Data != "hello" {
+		t.Errorf("Data = %q, want %q", events[0].Data, "hello")
+	}
+}
+
+func TestServerConnectedEvent(t *testing.T) {
+	// Simulate opencode's initial server.connected event.
+	srv := sseServer("event: server.connected\ndata: {\"version\":\"1.0\"}\n\n")
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &Client{}
+	ch, err := client.Connect(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	events := collectEvents(t, ch, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != "server.connected" {
+		t.Errorf("Type = %q, want %q", events[0].Type, "server.connected")
+	}
+	if events[0].Data != `{"version":"1.0"}` {
+		t.Errorf("Data = %q", events[0].Data)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/sse/` package with a `Client` type that connects to HTTP SSE endpoints, parses `event:` and `data:` fields per the SSE specification, and delivers parsed events via a Go channel
- Supports automatic reconnection with exponential backoff (1s, 2s, 4s, capped at 30s), context cancellation for clean shutdown, bounded buffer (default 64) with drop-on-overflow logging, and all SSE edge cases (comments, multi-line data, empty event type defaulting to "message")
- Includes 12 unit tests using `httptest.Server` covering: event parsing, multi-line data, comment filtering, reconnection, mid-event disconnect, buffer overflow, context cancellation, and the `server.connected` event

Closes #430