### PR TITLE
fix(prism-hooks): recover state from interrupted/error/finished on session resume

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -565,14 +565,15 @@ export const PrismHooks: Plugin = async ({ $, worktree: _worktree, client }) => 
             // so the session reflects that the agent is running again.
             // "active", "waiting", "compacting" and other states are left alone.
             if (!wasInserted && db && sessionName && getStatus) {
+              let resumedState: string | null = null;
               try {
                 const row = getStatus.get(sessionName) as { state: string } | undefined;
-                const resumedState = row?.state ?? null;
-                if (resumedState === STATE_INTERRUPTED || resumedState === STATE_ERROR || resumedState === STATE_FINISHED) {
-                  upsertAgentStatus(STATE_ACTIVE);
-                  writeStateChange(STATE_ACTIVE, info.id);
-                }
+                resumedState = row?.state ?? null;
               } catch (e) { console.error("[prism-hooks] getStatus (resume recovery) failed:", e); }
+              if (resumedState === STATE_INTERRUPTED || resumedState === STATE_ERROR || resumedState === STATE_FINISHED) {
+                upsertAgentStatus(STATE_ACTIVE, null, info.id);
+                writeStateChange(STATE_ACTIVE, info.id);
+              }
             }
           }
           break;


### PR DESCRIPTION
## Summary

- Adds a step 3 to the `session.updated` handler that reads the current DB state after `updateResumedMetadata`
- If the state is `interrupted`, `error`, or `finished`, transitions back to `active` via `upsertAgentStatus(STATE_ACTIVE)` and `writeStateChange(STATE_ACTIVE)`
- Sessions already in `active`, `waiting`, `compacting`, or other states are left untouched
- Uses the existing `getStatus` prepared statement and follows the same error-handling pattern as other usages in the handler

Closes #444