### PR TITLE
fix: dynamically compute dashboard header stats column width

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/header.go
+++ b/modules/programs/prism/prism/internal/dashboard/header.go
@@ -201,8 +201,16 @@ func RenderHeader(d Shared, styleDim, styleIns, styleDel lipgloss.Style) string 
 	stateRendered := styleStatDim.Render(stateLine)
 	sessionCountLine := styleStatLabel.Render(fmt.Sprintf("%d sessions", len(d.Sessions)))
 
-	// Fixed column width — wide enough for worst-case state line (35 chars) + room.
-	const statsW = 37
+	// Dynamically compute statsW from the actual visible widths of all stat
+	// content lines, so that a long state line (e.g. all 5 status categories)
+	// never overflows into the art column.
+	const minStatsW = 20
+	statsW := minStatsW
+	for _, s := range []string{sessionCountLine, stateRendered, changesLine, prRendered} {
+		if w := lipgloss.Width(s); w > statsW {
+			statsW = w
+		}
+	}
 
 	// 7 stat lines matching artHeight, each exactly statsW wide.
 	// Lines 0-1: blank  2: sessions  3: states  4: changes  5: PRs  6: blank


### PR DESCRIPTION
## Summary

- Replaces `const statsW = 37` in `internal/dashboard/header.go` with a dynamically computed value derived from the actual visible widths of the rendered stat lines (session count, state summary, changes, PRs)
- A minimum floor of 20 is kept so narrow-terminal layouts remain sensible
- All downstream uses of `statsW` (`showArt` threshold, `middle` gap, narrow-mode padding) automatically use the correct value

## Why

When 4 or 5 status categories are shown (e.g. `1 active  2 done  1 interrupted  1 idle`), the state summary line exceeds 37 visible characters, causing the art block to render at the wrong horizontal offset (warped/displaced ASCII art prism logo).

Closes #446