### PR TITLE
deny gh pr merge for worker agents

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -163,6 +163,9 @@
         "git send-pack" = "ask";
         "git send-pack *" = "ask";
         "git receive-pack *" = "ask";
+        # deny PR merge — merging is a coordinator responsibility, never a worker's
+        "gh pr merge" = "deny";
+        "gh pr merge *" = "deny";
         # file operations that modify
         "mkdir *" = "allow";
         "rm *" = "allow";
@@ -637,6 +640,11 @@
                 }
                 // readOnlyBashCommands
                 // writeBashCommands
+                // {
+                  # deny PR merge — merging is a coordinator responsibility, never a worker's
+                  "gh pr merge" = "deny";
+                  "gh pr merge *" = "deny";
+                }
                 // tmuxDenyCommands;
               };
               plugin = [


### PR DESCRIPTION
## Summary

- Adds `"gh pr merge" = "deny"` and `"gh pr merge *" = "deny"` to `writeBashCommands` (worker agent scoped permissions)
- Adds the same two deny rules to the global `permission.bash` fallback block
- The coordinator's `"gh pr merge *" = "ask"` in `coordinatorBashCommands` is **not changed** — coordinator should be prompted, not denied

## Acceptance criteria

- [x] [functional] `gh pr merge` and `gh pr merge *` are set to `deny` in `writeBashCommands`
- [x] [functional] `gh pr merge` and `gh pr merge *` are set to `deny` in the global `permission.bash` block
- [x] [functional] The coordinator agent's permissions are NOT changed — it still has `"gh pr merge *" = "ask"` in `coordinatorBashCommands`
- [x] [functional] No other permission rules are modified
- [x] [build] `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes