### PR TITLE
Switch navi opencode provider from anthropic-opus to anthropic

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -26,7 +26,7 @@
       wallpaper.variant = "enso-6colour";
     };
     programs = {
-      prism.opencode.provider = "anthropic-opus";
+      prism.opencode.provider = "anthropic";
       prism.forgecode.enable = true;
       anki.enable = false; # build broken as of 2025-08-30
       calibre.enable = true;


### PR DESCRIPTION
## Summary

- Changes `prism.opencode.provider` on navi from `"anthropic-opus"` to `"anthropic"`