### PR TITLE
feat(prism): load container image via systemd user service instead of activation script

### DIFF
--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -161,7 +161,7 @@
                     echo "prism: prism-agent:latest loaded successfully." >&2
                   '';
                 in
-                "${script}";
+                script;
             };
             Install = {
               WantedBy = [ "default.target" ];

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -196,7 +196,12 @@ in
         systemd.user.services.prism-restore = {
           Unit = {
             Description = "Restore prism tmux sessions after login";
-            After = [ "graphical-session.target" ];
+            After = [
+              "graphical-session.target"
+              # Ensure the container image is loaded before we try to spawn containers.
+              "prism-agent-image.service"
+            ];
+            Wants = [ "prism-agent-image.service" ];
           };
           Service = {
             Type = "oneshot";


### PR DESCRIPTION
## Summary

- Replace the `nixos-rebuild` activation script with a `systemd` user service (`prism-agent-image.service`) that runs `podman load` from the Nix store path at login.
- The service is `oneshot` with `RemainAfterExit=yes`, so it runs once per login session and does not re-run within the same session.
- The service is declared `Before=prism-restore.service` so the image is available before any container spawn.
- `~/.local/share/containers/` is NOT added to impermanence — the image is always reloaded from the Nix store.

## Problem fixed

The activation script only ran on `nixos-rebuild switch`. After a reboot (without a subsequent switch), `~/.local/share/containers/` was wiped by impermanence and `podman images` returned nothing, causing container spawns to fail.

Closes #466