### PR TITLE
fix(container): use pasta network mode for podman 5.x compatibility

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -239,12 +239,12 @@ func (m *Manager) buildRunArgs() []string {
 		"--detach",
 		"--name", m.name,
 
-		// Network: slirp4netns (rootless default on Linux) provides outbound
+		// Network: pasta (rootless default on podman 5.x) provides outbound
 		// NAT via the host's network, but the container cannot reach host
 		// loopback services or other containers directly. Declaring it explicitly
 		// makes the network policy declarative rather than relying on the
 		// podman default — satisfying AC-12.
-		"--network", "slirp4netns",
+		"--network", "pasta",
 
 		// Port — bound to localhost only (AC-6).
 		"--publish", portBinding,

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -274,19 +274,19 @@ func TestBuildRunArgs_ContainerNameSet(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_NetworkSlirp4netns(t *testing.T) {
+func TestBuildRunArgs_NetworkPasta(t *testing.T) {
 	// AC-12: explicit network mode for isolation.
 	m := New(Config{SessionName: "repo@br", AllocatedPort: 14000})
 	args := m.buildRunArgs()
 	found := false
 	for i, arg := range args {
-		if arg == "--network" && i+1 < len(args) && args[i+1] == "slirp4netns" {
+		if arg == "--network" && i+1 < len(args) && args[i+1] == "pasta" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("--network slirp4netns not found in args: %v", args)
+		t.Errorf("--network pasta not found in args: %v", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `slirp4netns` was removed as the rootless network backend in podman 5.x; `pasta` is now the default
- Changes `--network slirp4netns` to `--network pasta` in `buildRunArgs()`
- Updates the comment and test (`TestBuildRunArgs_NetworkPasta`) to match

Closes #486