### PR TITLE
fix: refresh root_model_id on each assistant message to fix stale model in coordinator notifications

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -317,7 +317,7 @@ ON CONFLICT(session_name) DO UPDATE SET
 // current session's model to replace a stale value from a prior session.
 //
 // It is a no-op when no row exists for sessionName (returns nil).
-// Called by the sidecar when the first completed assistant message of a session
+// Called by the sidecar when a completed assistant message from the root agent
 // reveals the current model, so that coordinator notifications always reflect
 // the live model configuration.
 func (d *DB) UpdateRootModelID(sessionName, modelID string) error {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -683,8 +683,12 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 		// coordinator notifications always reflect the live model
 		// configuration (AC-1, AC-2, AC-3). Only write when model is
 		// non-empty to avoid overwriting an existing value with nothing
-		// (AC-5).
-		if model != "" {
+		// (AC-5). Only write for root-agent messages: if a root agent is
+		// known and this message is from a subagent (different name), skip
+		// the update so the root agent's model is not overwritten by a
+		// subagent's model.
+		isRootAgent := s.rootAgent == "" || agentName == "" || agentName == s.rootAgent
+		if model != "" && isRootAgent {
 			if err := s.cfg.DB.UpdateRootModelID(s.cfg.SessionName, model); err != nil {
 				log.Printf("sidecar: UpdateRootModelID failed: %v", err)
 			}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2101,14 +2101,18 @@ func TestOnReady_CalledWhenNotShuttingDown(t *testing.T) {
 }
 
 // TestMessageUpdated_AssistantWritesRootModelID verifies AC-6: after the first
-// completed assistant message, root_model_id in the DB reflects that message's
-// model.
+// completed assistant message from the root agent, root_model_id in the DB
+// reflects that message's model. A subagent message that follows must not
+// overwrite root_model_id.
 func TestMessageUpdated_AssistantWritesRootModelID(t *testing.T) {
 	sc, _ := newTestSidecar(t)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
-	// Accumulate text for the assistant message.
+	// Establish root agent via a user message.
+	sendEvents(sc, makeUserMessage("msg-user-ac6", "root-agent", "Hello"))
+
+	// Accumulate text for the root-agent assistant message.
 	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
 		"part": map[string]any{
 			"type":      "text",
@@ -2117,14 +2121,14 @@ func TestMessageUpdated_AssistantWritesRootModelID(t *testing.T) {
 		},
 	}))
 
-	// Complete the assistant message with a known model.
+	// Complete the root-agent assistant message with a known model.
 	created := 1000.0
 	completed := 2000.0
 	sc.HandleEvent(makeSSE("message.updated", map[string]any{
 		"info": map[string]any{
 			"id":         "msg-asst-ac6",
 			"role":       "assistant",
-			"agent":      "worker",
+			"agent":      "root-agent",
 			"providerID": "github-copilot",
 			"modelID":    "claude-sonnet-4.6",
 			"time": map[string]*float64{
@@ -2148,6 +2152,37 @@ func TestMessageUpdated_AssistantWritesRootModelID(t *testing.T) {
 	if *status.RootModelID != want {
 		t.Errorf("RootModelID = %q, want %q", *status.RootModelID, want)
 	}
+
+	// Now fire a subagent assistant message with a different model. It must NOT
+	// overwrite root_model_id.
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-asst-subagent",
+			"text":      "Subagent response.",
+		},
+	}))
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":         "msg-asst-subagent",
+			"role":       "assistant",
+			"agent":      "subagent",
+			"providerID": "openai",
+			"modelID":    "gpt-4o",
+			"time": map[string]*float64{
+				"created":   &created,
+				"completed": &completed,
+			},
+		},
+	}))
+
+	status, err = sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after subagent: %v", err)
+	}
+	if status.RootModelID == nil || *status.RootModelID != want {
+		t.Errorf("RootModelID after subagent message = %v, want %q (subagent must not overwrite root model)", status.RootModelID, want)
+	}
 }
 
 // TestMessageUpdated_SecondSessionUpdatesRootModelID verifies AC-7: when a
@@ -2158,7 +2193,9 @@ func TestMessageUpdated_SecondSessionUpdatesRootModelID(t *testing.T) {
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
-	// First session: assistant message with old model.
+	// First session: establish root agent via user message, then assistant message with old model.
+	sendEvents(sc, makeUserMessage("msg-user-s1", "root-agent", "Session 1 prompt"))
+
 	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
 		"part": map[string]any{
 			"type":      "text",
@@ -2172,7 +2209,7 @@ func TestMessageUpdated_SecondSessionUpdatesRootModelID(t *testing.T) {
 		"info": map[string]any{
 			"id":         "msg-asst-session1",
 			"role":       "assistant",
-			"agent":      "worker",
+			"agent":      "root-agent",
 			"providerID": "anthropic",
 			"modelID":    "claude-opus-4",
 			"time": map[string]*float64{
@@ -2192,7 +2229,7 @@ func TestMessageUpdated_SecondSessionUpdatesRootModelID(t *testing.T) {
 	}
 
 	// Second session: assistant message with a new (different) model — simulates
-	// a configuration change between sessions.
+	// a configuration change between sessions. root_model_id must be updated.
 	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
 		"part": map[string]any{
 			"type":      "text",
@@ -2204,7 +2241,7 @@ func TestMessageUpdated_SecondSessionUpdatesRootModelID(t *testing.T) {
 		"info": map[string]any{
 			"id":         "msg-asst-session2",
 			"role":       "assistant",
-			"agent":      "worker",
+			"agent":      "root-agent",
 			"providerID": "github-copilot",
 			"modelID":    "claude-sonnet-4.6",
 			"time": map[string]*float64{


### PR DESCRIPTION
## Summary

- Adds `UpdateRootModelID()` to `internal/db/db.go` — an unconditional `UPDATE` (no COALESCE guard) that allows the current session's model to overwrite any stale value from a prior session.
- Modifies `handleMessageUpdated` in `internal/sidecar/sidecar.go` to call `UpdateRootModelID()` whenever a completed assistant message carries a non-empty model name.
- Adds unit tests `TestMessageUpdated_AssistantWritesRootModelID` (AC-6) and `TestMessageUpdated_SecondSessionUpdatesRootModelID` (AC-7) to `sidecar_test.go`.

## Root cause addressed

`root_model_id` was protected by a `COALESCE` guard in `UpsertStatusWithRootAgent()` so it was never overwritten once set. The sidecar also never called any method to update `root_model_id`. When the configured model changed between sessions, coordinator notifications continued showing the old model indefinitely.

## Acceptance criteria

- [x] AC-1: first completed assistant message writes model name to `root_model_id`
- [x] AC-2: if model changed since last session, `root_model_id` is updated to the new value
- [x] AC-3: coordinator notifications reflect the current session's model
- [x] AC-4: existing `model_id` per-message tracking is unchanged
- [x] AC-5: empty model name does not overwrite an existing `root_model_id`
- [x] AC-6: unit test — after first assistant message, `root_model_id` reflects that message's model
- [x] AC-7: unit test — second session with different model correctly updates `root_model_id`

Closes #484