### PR TITLE
feat(container-image): add prism binary to prism-agent image

### DIFF
--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -83,7 +83,7 @@ let
           sqlite # prism uses SQLite; agents may query it directly
 
           # Prism CLI — agents need prism spawn, prompt, checkin, etc.
-          (pkgs.callPackage ../../../pkgs/prism.nix { })
+          prism
 
           # Cloud and infrastructure
           awscli2


### PR DESCRIPTION
## Summary

- Adds `prism` to the `buildEnv` paths list in `modules/programs/prism/container-image.nix`
- Uses the bare `prism` name, which resolves via `with pkgs;` to the overlay-provided `pkgs.prism` (consistent with every other package in the list)
- Placed alongside `sqlite` in the dev tools section with a comment explaining why it's there

## Why

Agents running inside prism-agent containers need `prism` on PATH to invoke commands like `prism spawn`, `prism prompt`, `prism checkin`, etc.

## Notes

- `pkgs.prism` is already exposed by the overlay at `overlays/default.nix` — no new package file needed
- `tmux` is a transitive closure dep of `prism` (baked in via ldflag) and is included automatically by `buildLayeredImage`