### PR TITLE
cleanup: remove orphaned container via direct podman fallback when sidecar is dead

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -578,21 +578,27 @@ func init() {
 // Called after KillSidecar to handle the case where the sidecar is already dead.
 // For host-mode (non-container) sessions, the podman calls return "no such
 // container" which is silently ignored.
+// Each podman command gets its own independent context so that a slow or
+// hung stop does not consume the budget for the rm --force fallback.
 func removeContainerIfExists(sessionName string) {
 	name := container.NameForSession(sessionName)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 
-	// Stop the container (10s grace period).
-	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", name)
+	// Stop the container (10s grace period). Own context so that a slow stop
+	// cannot starve the rm --force that follows.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer stopCancel()
+	stopCmd := exec.CommandContext(stopCtx, "podman", "stop", "--time", "10", name)
 	if out, err := stopCmd.CombinedOutput(); err != nil {
 		if !container.IsNoSuchContainerError(string(out)) {
 			fmt.Fprintf(os.Stderr, "[prism] stop container %q: %v\n", name, err)
 		}
 	}
 
-	// Force-remove the container.
-	rmCmd := exec.CommandContext(ctx, "podman", "rm", "--force", name)
+	// Force-remove the container. Independent context ensures this always runs
+	// even when podman stop timed out.
+	rmCtx, rmCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer rmCancel()
+	rmCmd := exec.CommandContext(rmCtx, "podman", "rm", "--force", name)
 	if out, err := rmCmd.CombinedOutput(); err != nil {
 		if !container.IsNoSuchContainerError(string(out)) {
 			fmt.Fprintf(os.Stderr, "[prism] rm container %q: %v\n", name, err)

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -144,7 +144,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", m.name)
 	if out, err := stopCmd.CombinedOutput(); err != nil {
 		// Only log if it looks like a real error (not "no such container").
-		if !isNoSuchContainer(string(out)) {
+		if !IsNoSuchContainerError(string(out)) {
 			log.Printf("container: stop existing %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
 		}
 	}
@@ -152,7 +152,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	// Remove the container (ignore errors — may not exist).
 	rmCmd := exec.CommandContext(ctx, "podman", "rm", "--force", m.name)
 	if out, err := rmCmd.CombinedOutput(); err != nil {
-		if !isNoSuchContainer(string(out)) {
+		if !IsNoSuchContainerError(string(out)) {
 			log.Printf("container: rm existing %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
 		}
 	}
@@ -295,12 +295,12 @@ func (m *Manager) Shutdown() {
 	log.Printf("container: shutting down %q", m.name)
 
 	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", m.name)
-	if out, err := stopCmd.CombinedOutput(); err != nil && !isNoSuchContainer(string(out)) {
+	if out, err := stopCmd.CombinedOutput(); err != nil && !IsNoSuchContainerError(string(out)) {
 		log.Printf("container: stop %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
 	}
 
 	rmCmd := exec.CommandContext(ctx, "podman", "rm", "--force", m.name)
-	if out, err := rmCmd.CombinedOutput(); err != nil && !isNoSuchContainer(string(out)) {
+	if out, err := rmCmd.CombinedOutput(); err != nil && !IsNoSuchContainerError(string(out)) {
 		log.Printf("container: rm %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
 	}
 
@@ -603,9 +603,4 @@ func IsNoSuchContainerError(output string) bool {
 		strings.Contains(output, "No such container") ||
 		strings.Contains(output, "Error: no such container") ||
 		strings.Contains(output, "Error response from daemon: No such container")
-}
-
-// isNoSuchContainer is the unexported alias kept for internal use.
-func isNoSuchContainer(output string) bool {
-	return IsNoSuchContainerError(output)
 }

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -683,9 +683,9 @@ func TestIsNoSuchContainer(t *testing.T) {
 		{"", false},
 	}
 	for _, tc := range cases {
-		got := isNoSuchContainer(tc.output)
+		got := IsNoSuchContainerError(tc.output)
 		if got != tc.want {
-			t.Errorf("isNoSuchContainer(%q) = %v, want %v", tc.output, got, tc.want)
+			t.Errorf("IsNoSuchContainerError(%q) = %v, want %v", tc.output, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Exports `container.NameForSession` and `container.IsNoSuchContainerError` from `internal/container/container.go` (the unexported originals now delegate to the exported functions).
- Adds `removeContainerIfExists(sessionName string)` helper in `cmd/cleanup.go` that runs `podman stop --time 10` + `podman rm --force` and cleans up associated temp files for a session's container.
- Calls `removeContainerIfExists` after `KillSidecar` and before `ReleasePort` in all four cleanup paths: `doCleanup`, `headlessCleanup`, `closeSession`, and `headlessCloseSession`.
- All `podman` calls are idempotent — "no such container" responses are silently ignored, making this safe for host-mode sessions.
- A `TODO(#507)` comment marks the hook for host-API socket cleanup pending that dependency.
- Adds unit tests for `NameForSession` covering `@`, `/`, `.` substitutions and parity with `containerName`.

Closes #511