### PR TITLE
fix(sidecar): log response body on non-2xx coordinator notification

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1080,7 +1080,10 @@ func deliverNotificationViaHTTP(port int, opencodeSID string, text string, statu
 		// that the root cause of non-2xx responses is self-diagnosing in logs.
 		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		bodySnippet := strings.TrimSpace(string(bodyBytes))
-		return fmt.Errorf("http status %d: %s", resp.StatusCode, bodySnippet)
+		if bodySnippet != "" {
+			return fmt.Errorf("http status %d: %s", resp.StatusCode, bodySnippet)
+		}
+		return fmt.Errorf("http status %d", resp.StatusCode)
 	}
 
 	return nil

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -1652,11 +1652,18 @@ func TestNotifyCoordinator_WriteBusMessageFallbackOnHTTPFailure(t *testing.T) {
 // body (up to 200 bytes) is included in the returned error, making HTTP 500s
 // from the coordinator self-diagnosing in the sidecar log.
 func TestDeliverNotificationViaHTTP_BodyLogging(t *testing.T) {
+	// Build a 300-byte body where the first 200 bytes are all 'a' and the
+	// last 100 bytes are all 'b'. After truncation at 200, the 'b' region
+	// must not appear in the error.
+	longBody := strings.Repeat("a", 200) + strings.Repeat("b", 100)
+
 	tests := []struct {
-		name       string
-		statusCode int
-		body       string
-		wantInErr  string
+		name          string
+		statusCode    int
+		body          string
+		wantInErr     string
+		wantNotInErr  string
+		exactErrMatch string // if set, error must equal this exactly
 	}{
 		{
 			name:       "500 with body snippet in error",
@@ -1665,10 +1672,21 @@ func TestDeliverNotificationViaHTTP_BodyLogging(t *testing.T) {
 			wantInErr:  `session not found`,
 		},
 		{
-			name:       "body truncated at 200 bytes",
-			statusCode: http.StatusInternalServerError,
-			body:       string(make([]byte, 300)), // 300-byte body
-			wantInErr:  "http status 500",
+			// The body is 300 bytes (200 'a' + 100 'b'); only the first 200
+			// bytes should appear in the error, so 'b' must not be present.
+			name:         "body truncated at 200 bytes",
+			statusCode:   http.StatusInternalServerError,
+			body:         longBody,
+			wantInErr:    strings.Repeat("a", 200),
+			wantNotInErr: "b",
+		},
+		{
+			// Non-2xx with no body: error must be "http status NNN" with no
+			// trailing colon-space.
+			name:          "empty body does not add trailing colon-space",
+			statusCode:    http.StatusBadGateway,
+			body:          "",
+			exactErrMatch: "http status 502",
 		},
 		{
 			name:       "404 with body snippet in error",
@@ -1712,7 +1730,7 @@ func TestDeliverNotificationViaHTTP_BodyLogging(t *testing.T) {
 
 			gotErr := deliverNotificationViaHTTP(srvPort, "test-sid", "notify text", status, srv.Client())
 
-			if tc.wantInErr == "" {
+			if tc.wantInErr == "" && tc.exactErrMatch == "" {
 				if gotErr != nil {
 					t.Errorf("expected no error, got: %v", gotErr)
 				}
@@ -1720,10 +1738,25 @@ func TestDeliverNotificationViaHTTP_BodyLogging(t *testing.T) {
 			}
 
 			if gotErr == nil {
-				t.Fatalf("expected an error containing %q, got nil", tc.wantInErr)
+				want := tc.wantInErr
+				if tc.exactErrMatch != "" {
+					want = tc.exactErrMatch
+				}
+				t.Fatalf("expected an error (want %q), got nil", want)
 			}
+
+			if tc.exactErrMatch != "" {
+				if gotErr.Error() != tc.exactErrMatch {
+					t.Errorf("error = %q, want exactly %q", gotErr.Error(), tc.exactErrMatch)
+				}
+				return
+			}
+
 			if !strings.Contains(gotErr.Error(), tc.wantInErr) {
 				t.Errorf("error = %q, want it to contain %q", gotErr.Error(), tc.wantInErr)
+			}
+			if tc.wantNotInErr != "" && strings.Contains(gotErr.Error(), tc.wantNotInErr) {
+				t.Errorf("error = %q, must NOT contain %q (body was not truncated)", gotErr.Error(), tc.wantNotInErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `deliverNotificationViaHTTP` was silently discarding the HTTP response body on non-2xx status, making the root cause of coordinator notification 500 errors completely opaque in logs
- Now reads up to 200 bytes of the body and includes it in the error string, so future failures are self-diagnosing (e.g. `http status 500: {"error":"session abc123 not found"}`)
- Investigation confirmed the sidecar is a host process — no network issue, no `PRISM_HOST_IP` needed

## Investigation findings (Outcome A)

`StartSidecarWithOpts` launches a native `exec.Command` on the host. The package comment in `container.go` confirms explicitly: *"The sidecar (running on the host) creates a podman container"*. Therefore `localhost` in `deliverNotificationViaHTTP` is the host loopback — networking is not the cause of the 500.

The `PRISM_HOST_IP` solution proposed in #498 is not needed. Findings documented as a comment on #498.

## Changes

- **`internal/sidecar/sidecar.go`**: add `"io"` import; in `deliverNotificationViaHTTP`, read up to 200 bytes of body on non-2xx and include in error
- **`internal/sidecar/sidecar_test.go`**: add `"strings"` import; add `TestDeliverNotificationViaHTTP_BodyLogging` table-driven test covering body snippet in error, truncation, 404, and 200 OK

Closes #510