### PR TITLE
phase 2: git identity, signing, and simplified SSH keys in containers

### DIFF
--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -12,14 +12,20 @@ let
   gitUserName =
     let
       names = lib.concatMap (
-        inc: lib.optional (inc.contents ? user && inc.contents.user ? name) inc.contents.user.name
+        inc:
+        lib.optional (
+          inc ? contents && inc.contents ? user && inc.contents.user ? name
+        ) inc.contents.user.name
       ) gitCfg.includes;
     in
     if names != [ ] then builtins.head names else "";
   gitUserEmail =
     let
       emails = lib.concatMap (
-        inc: lib.optional (inc.contents ? user && inc.contents.user ? email) inc.contents.user.email
+        inc:
+        lib.optional (
+          inc ? contents && inc.contents ? user && inc.contents.user ? email
+        ) inc.contents.user.email
       ) gitCfg.includes;
     in
     if emails != [ ] then builtins.head emails else "";

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -6,6 +6,23 @@
 }:
 with config.theme;
 let
+  gitCfg = config.home-manager.users.${config.nx.username}.programs.git;
+  # Extract the first includes entry that has user.name and user.email set.
+  # This mirrors the values defined in modules/programs/git.nix.
+  gitUserName =
+    let
+      names = lib.concatMap (
+        inc: lib.optional (inc.contents ? user && inc.contents.user ? name) inc.contents.user.name
+      ) gitCfg.includes;
+    in
+    if names != [ ] then builtins.head names else "";
+  gitUserEmail =
+    let
+      emails = lib.concatMap (
+        inc: lib.optional (inc.contents ? user && inc.contents.user ? email) inc.contents.user.email
+      ) gitCfg.includes;
+    in
+    if emails != [ ] then builtins.head emails else "";
   prismConfig = {
     color_primary = primary;
     color_secondary = secondary;
@@ -26,6 +43,8 @@ let
     worktree_exclude = config.nx.programs.prism.worktreeExclude;
     project_locations = config.nx.programs.prism.projects.locations;
     project_specific = config.nx.programs.prism.projects.specific;
+    git_user_name = gitUserName;
+    git_user_email = gitUserEmail;
   };
 in
 {

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -151,6 +151,8 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			Variant:                        variant,
 			ContainerWorkerConfigPath:      prismCfg.ContainerWorkerConfigPath,
 			ContainerCoordinatorConfigPath: prismCfg.ContainerCoordinatorConfigPath,
+			GitUserName:                    prismCfg.GitUserName,
+			GitUserEmail:                   prismCfg.GitUserEmail,
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -48,6 +48,12 @@ type Config struct {
 	// /root/.config/opencode inside coordinator containers. Empty string
 	// triggers the legacy fallback.
 	ContainerCoordinatorConfigPath string `json:"container_coordinator_config"`
+	// GitUserName is the git user.name to write into the container's .gitconfig.
+	// Sourced from the host's NixOS/home-manager git configuration.
+	GitUserName string `json:"git_user_name"`
+	// GitUserEmail is the git user.email to write into the container's .gitconfig.
+	// Sourced from the host's NixOS/home-manager git configuration.
+	GitUserEmail string `json:"git_user_email"`
 
 	// Project layout (JSON arrays).
 	WorktreeExclude  []string `json:"worktree_exclude"`
@@ -72,6 +78,8 @@ type parsedConfig struct {
 	SidecarPluginPath              string    `json:"sidecar_plugin_path"`
 	ContainerWorkerConfigPath      string    `json:"container_worker_config"`
 	ContainerCoordinatorConfigPath string    `json:"container_coordinator_config"`
+	GitUserName                    string    `json:"git_user_name"`
+	GitUserEmail                   string    `json:"git_user_email"`
 	WorktreeExclude                *[]string `json:"worktree_exclude"`
 	ProjectLocations               *[]string `json:"project_locations"`
 	ProjectSpecific                *[]string `json:"project_specific"`
@@ -179,6 +187,12 @@ func load() Config {
 	}
 	if parsed.ContainerCoordinatorConfigPath != "" {
 		cfg.ContainerCoordinatorConfigPath = parsed.ContainerCoordinatorConfigPath
+	}
+	if parsed.GitUserName != "" {
+		cfg.GitUserName = parsed.GitUserName
+	}
+	if parsed.GitUserEmail != "" {
+		cfg.GitUserEmail = parsed.GitUserEmail
 	}
 
 	// For slice fields: nil pointer means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -614,6 +614,8 @@ func (m *Manager) buildRunArgs() []string {
 	// Access key (git push/fetch): prismatic-koi-ed25519 → /root/.ssh/access-key
 	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519")); err == nil {
 		args = append(args, "--volume", resolved+":/root/.ssh/access-key:ro")
+	} else {
+		log.Printf("container: access key not resolvable (%v); SSH push/fetch will not work", err)
 	}
 
 	// Signing key private (commit signing): prismatic-koi-ed25519-signingkey → /root/.ssh/signing-key

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -245,7 +245,14 @@ func (m *Manager) writeGitconfig() error {
 	_, errPub := filepath.EvalSymlinks(signingKeyPub)
 	hasSigning := errPriv == nil && errPub == nil
 	if !hasSigning {
-		log.Printf("container: signing keys not resolvable (%v, %v); omitting signing config from gitconfig", errPriv, errPub)
+		// Log each missing key separately so the message is not misleading when
+		// only one of the two is unresolvable.
+		if errPriv != nil {
+			log.Printf("container: signing key (private) not resolvable: %v; omitting signing config from gitconfig", errPriv)
+		}
+		if errPub != nil {
+			log.Printf("container: signing key (public) not resolvable: %v; omitting signing config from gitconfig", errPub)
+		}
 	}
 
 	var sb strings.Builder
@@ -620,6 +627,13 @@ func (m *Manager) buildRunArgs() []string {
 
 	// Signing key private (commit signing): prismatic-koi-ed25519-signingkey → /root/.ssh/signing-key
 	// Signing key public (gitconfig signingKey): prismatic-koi-ed25519-signingkey.pub → /root/.ssh/signing-key.pub
+	//
+	// Note: writeGitconfig (called immediately before buildRunArgs in Create)
+	// also resolves these symlinks to determine hasSigning. The resolutions are
+	// intentionally independent — writeGitconfig decides what to write into the
+	// gitconfig file, while this block decides what volumes to mount. Both must
+	// agree for the container to work, and they do because Create() calls them
+	// sequentially with no symlink changes possible between the two calls.
 	signingKeyResolved, errPriv := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey"))
 	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub"))
 	if errPriv == nil && errPub == nil {

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -119,6 +119,14 @@ type Config struct {
 	// HTTPClient is used for health-check probes. Defaults to a short-timeout
 	// client when nil.
 	HTTPClient *http.Client
+
+	// GitUserName is the git user.name to write into the container's .gitconfig.
+	// When empty, the [user] section is omitted from the generated gitconfig.
+	GitUserName string
+
+	// GitUserEmail is the git user.email to write into the container's .gitconfig.
+	// When empty, the [user] section is omitted from the generated gitconfig.
+	GitUserEmail string
 }
 
 // NameForSession returns the stable podman container name for a session.
@@ -169,6 +177,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.gitdirFilePath())
 	_ = os.Remove(m.worktreeGitdirFilePath())
 	_ = os.Remove(m.sshConfigFilePath())
+	_ = os.Remove(m.gitconfigFilePath())
 	// Stop the container (ignore errors — may not be running).
 	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", m.name)
 	if out, err := stopCmd.CombinedOutput(); err != nil {
@@ -201,6 +210,77 @@ func (m *Manager) gitdirFilePath() string {
 // rejects. We write a simple config that points to the mounted key.
 func (m *Manager) sshConfigFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-ssh-config-"+m.name)
+}
+
+// gitconfigFilePath returns the host path for the temporary .gitconfig
+// written before container start. The container needs a minimal gitconfig
+// for commit identity and SSH signing. Mounted read-only at /root/.gitconfig.
+func (m *Manager) gitconfigFilePath() string {
+	return filepath.Join(os.TempDir(), "prism-gitconfig-"+m.name)
+}
+
+// writeGitconfig generates a minimal .gitconfig for the container and writes
+// it to a temp file. The file is later mounted at /root/.gitconfig:ro.
+//
+// Sections included:
+//   - [user] — only when GitUserName and GitUserEmail are both non-empty;
+//     includes signingKey when the signing public key can be resolved.
+//   - [commit] / [gpg] — only when the signing keys are available.
+//   - [push] — autoSetupRemote = true (always).
+//   - [init] — defaultBranch = main (always).
+//
+// Missing identity → [user] section omitted, warning logged (AC-14).
+// Missing signing keys → signing sections omitted, warning logged (AC-13).
+func (m *Manager) writeGitconfig() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+	sshDir := filepath.Join(home, ".ssh")
+
+	// Check whether signing keys are resolvable.
+	signingKeyPriv := filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey")
+	signingKeyPub := filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub")
+	_, errPriv := filepath.EvalSymlinks(signingKeyPriv)
+	_, errPub := filepath.EvalSymlinks(signingKeyPub)
+	hasSigning := errPriv == nil && errPub == nil
+	if !hasSigning {
+		log.Printf("container: signing keys not resolvable (%v, %v); omitting signing config from gitconfig", errPriv, errPub)
+	}
+
+	var sb strings.Builder
+
+	// [user] section — only when identity is present.
+	if m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
+		sb.WriteString("[user]\n")
+		sb.WriteString("    name = " + m.cfg.GitUserName + "\n")
+		sb.WriteString("    email = " + m.cfg.GitUserEmail + "\n")
+		if hasSigning {
+			sb.WriteString("    signingKey = /root/.ssh/signing-key.pub\n")
+		}
+	} else {
+		log.Printf("container: git identity (name=%q, email=%q) missing; omitting [user] section from gitconfig",
+			m.cfg.GitUserName, m.cfg.GitUserEmail)
+	}
+
+	// [commit] and [gpg] sections — only when signing keys are available.
+	if hasSigning {
+		sb.WriteString("\n[commit]\n")
+		sb.WriteString("    gpgsign = true\n")
+		sb.WriteString("\n[gpg]\n")
+		sb.WriteString("    format = ssh\n")
+	}
+
+	// [push] and [init] — always included.
+	sb.WriteString("\n[push]\n")
+	sb.WriteString("    autoSetupRemote = true\n")
+	sb.WriteString("\n[init]\n")
+	sb.WriteString("    defaultBranch = main\n")
+
+	if err := os.WriteFile(m.gitconfigFilePath(), []byte(sb.String()), 0o644); err != nil {
+		return err
+	}
+	return nil
 }
 
 // worktreeGitdirFilePath returns the host path for the temporary corrected
@@ -250,9 +330,17 @@ func (m *Manager) Create(ctx context.Context) error {
 	// is a nix store symlink with wrong ownership that SSH rejects. This
 	// config only needs to handle GitHub; other SSH hosts are not expected
 	// inside agent containers.
-	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile /root/.ssh/prismatic-koi-ed25519\n  IdentitiesOnly yes\n"
+	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile /root/.ssh/access-key\n  IdentitiesOnly yes\n"
 	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
 		return fmt.Errorf("container: write ssh config: %w", err)
+	}
+
+	// Write a minimal .gitconfig for the container. The host's git config lives
+	// in ~/.config/git/config (managed by home-manager) and is not mounted into
+	// containers. We generate a minimal config with identity, signing, and
+	// convenience settings.
+	if err := m.writeGitconfig(); err != nil {
+		return fmt.Errorf("container: write gitconfig: %w", err)
 	}
 
 	// Build the podman run arguments.
@@ -333,6 +421,12 @@ func (m *Manager) Shutdown() {
 		log.Printf("container: rm %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
 	}
 
+	// Clean up temp files created by Create.
+	_ = os.Remove(m.gitdirFilePath())
+	_ = os.Remove(m.worktreeGitdirFilePath())
+	_ = os.Remove(m.sshConfigFilePath())
+	_ = os.Remove(m.gitconfigFilePath())
+
 	log.Printf("container: %q removed", m.name)
 }
 
@@ -369,9 +463,6 @@ func (m *Manager) buildRunArgs() []string {
 	// read-write so the opencode-claude-auth plugin can write back refreshed
 	// OAuth tokens to .credentials.json inside the container.
 	claudeMount := filepath.Join(home, ".claude") + ":/root/.claude"
-	// SSH keys and config — required for git push/fetch over SSH remotes.
-	// Read-only since agents should not modify the host's SSH config.
-	sshMount := filepath.Join(home, ".ssh") + ":/root/.ssh:ro"
 	// Nix eval cache — pre-populated git cache from the host so flake input
 	// tarballs (nixpkgs, home-manager, etc.) don't need to be re-fetched and
 	// unpacked on every container start. Read-write because nix writes to
@@ -404,8 +495,6 @@ func (m *Manager) buildRunArgs() []string {
 		"--volume", bunCacheMount,
 		// Claude credentials — read-write for auth plugin token refresh.
 		"--volume", claudeMount,
-		// SSH keys and config — git push/fetch over SSH remotes.
-		"--volume", sshMount,
 		// Nix eval cache — flake input tarballs pre-unpacked from the host.
 		"--volume", nixCacheMount,
 
@@ -513,21 +602,41 @@ func (m *Manager) buildRunArgs() []string {
 		}
 	}
 
-	// Mount SSH keys and a generated config for git push/fetch over SSH.
-	// The host's ~/.ssh/ contains sops-nix symlinks to /run/secrets/ssh/ and
-	// a nix store symlink for the config — neither resolves inside the container.
-	// We mount only the keys we need (resolving symlinks to real paths) and
-	// overlay a generated config file with correct permissions.
+	// Mount individual SSH keys and a generated config for git push/fetch and
+	// commit signing over SSH.
+	// The host's ~/.ssh/ contains sops-nix symlinks to /run/secrets/ssh/ and a
+	// nix store symlink for the config — neither resolves inside the container.
+	// We mount only the specific files we need (resolving symlinks to real
+	// paths) and overlay a generated config with correct permissions.
+	// Note: the whole ~/.ssh directory is NOT mounted — only individual files.
 	sshDir := filepath.Join(home, ".ssh")
-	for _, keyName := range []string{"prismatic-koi-ed25519", "known_hosts"} {
-		hostPath := filepath.Join(sshDir, keyName)
-		resolved, err := filepath.EvalSymlinks(hostPath)
-		if err != nil {
-			continue
-		}
-		args = append(args, "--volume", resolved+":/root/.ssh/"+keyName+":ro")
+
+	// Access key (git push/fetch): prismatic-koi-ed25519 → /root/.ssh/access-key
+	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519")); err == nil {
+		args = append(args, "--volume", resolved+":/root/.ssh/access-key:ro")
 	}
+
+	// Signing key private (commit signing): prismatic-koi-ed25519-signingkey → /root/.ssh/signing-key
+	// Signing key public (gitconfig signingKey): prismatic-koi-ed25519-signingkey.pub → /root/.ssh/signing-key.pub
+	signingKeyResolved, errPriv := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey"))
+	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub"))
+	if errPriv == nil && errPub == nil {
+		args = append(args,
+			"--volume", signingKeyResolved+":/root/.ssh/signing-key:ro",
+			"--volume", signingKeyPubResolved+":/root/.ssh/signing-key.pub:ro",
+		)
+	}
+
+	// known_hosts: unchanged
+	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "known_hosts")); err == nil {
+		args = append(args, "--volume", resolved+":/root/.ssh/known_hosts:ro")
+	}
+
+	// Generated SSH config (points to /root/.ssh/access-key).
 	args = append(args, "--volume", m.sshConfigFilePath()+":/root/.ssh/config:ro")
+
+	// Generated .gitconfig (identity, signing, convenience settings).
+	args = append(args, "--volume", m.gitconfigFilePath()+":/root/.gitconfig:ro")
 
 	// Git mounts: when BareRoot is set, mount the bare repo and the
 	// worktree's private git state so that git works inside the container
@@ -636,14 +745,10 @@ func (m *Manager) credentialEnvVars() []string {
 		}
 	}
 
-	// Git author identity — forwarded so git commits inside the container have
-	// proper attribution.
-	for _, k := range []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
-		"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"} {
-		if v := os.Getenv(k); v != "" {
-			vars = append(vars, k+"="+v)
-		}
-	}
+	// Note: GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, and
+	// GIT_COMMITTER_EMAIL are intentionally NOT injected. The container now
+	// has a generated .gitconfig with a [user] section (sourced from prism
+	// config). Env vars override gitconfig and would mask a broken gitconfig.
 
 	// Note: GIT_DIR and GIT_COMMON_DIR are intentionally NOT injected.
 	// Instead, Create() writes a corrected .git pointer file and bind-mounts it

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -270,8 +270,12 @@ func (m *Manager) writeGitconfig() error {
 			m.cfg.GitUserName, m.cfg.GitUserEmail)
 	}
 
-	// [commit] and [gpg] sections — only when signing keys are available.
-	if hasSigning {
+	// [commit] and [gpg] sections — only when signing keys are available AND
+	// identity is present. Without identity the [user] section is omitted, which
+	// means signingKey is never set; writing gpgsign=true in that case would
+	// cause every git commit to fail.
+	// TODO(#558): set gpg.ssh.allowedSignersFile so git verify-commit works inside containers.
+	if hasSigning && m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
 		sb.WriteString("\n[commit]\n")
 		sb.WriteString("    gpgsign = true\n")
 		sb.WriteString("\n[gpg]\n")
@@ -619,6 +623,7 @@ func (m *Manager) buildRunArgs() []string {
 	sshDir := filepath.Join(home, ".ssh")
 
 	// Access key (git push/fetch): prismatic-koi-ed25519 → /root/.ssh/access-key
+	// TODO(#560): expose SSH key filenames as Nix module options.
 	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519")); err == nil {
 		args = append(args, "--volume", resolved+":/root/.ssh/access-key:ro")
 	} else {

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1108,13 +1108,14 @@ func TestRedactArgs_MultipleEnvVarsAllRedacted(t *testing.T) {
 
 // ── SSH key simplification tests (AC-5, AC-9) ────────────────────────────────
 
-func TestBuildRunArgs_SSHConfigUsesAccessKey(t *testing.T) {
-	// AC-9: The generated SSH config must reference /root/.ssh/access-key.
+func TestBuildRunArgs_SSHConfigIsMounted(t *testing.T) {
+	// Verifies that a generated SSH config file is mounted at /root/.ssh/config:ro.
+	// The content of the SSH config (including the IdentityFile = access-key reference
+	// required by AC-9) is tested via the Create() path which writes the config file.
 	m := New(Config{
 		SessionName:   "repo@feat",
 		AllocatedPort: 14000,
 	})
-	// Verify that the SSH config file path is mounted at /root/.ssh/config.
 	args := m.buildRunArgs()
 	found := false
 	for i, arg := range args {
@@ -1231,6 +1232,46 @@ func TestWriteGitconfig_IncludesPushAndInit(t *testing.T) {
 	}
 	if !strings.Contains(content, "defaultBranch = main") {
 		t.Errorf("gitconfig missing defaultBranch; content:\n%s", content)
+	}
+}
+
+func TestWriteGitconfig_NoSigningSectionsWhenKeysUnavailable(t *testing.T) {
+	// AC-13: when signing keys are not resolvable, the generated gitconfig must
+	// NOT contain [commit], [gpg], or signingKey.
+	//
+	// We redirect HOME to a temp dir with no .ssh/ directory so that
+	// filepath.EvalSymlinks cannot find the signing keys, regardless of
+	// what is present on the host running the test.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		GitUserName:   "test-user",
+		GitUserEmail:  "test@example.com",
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	// These sections must be absent when signing keys can't be resolved.
+	if strings.Contains(content, "[commit]") {
+		t.Errorf("gitconfig must not include [commit] when signing keys are absent; content:\n%s", content)
+	}
+	if strings.Contains(content, "[gpg]") {
+		t.Errorf("gitconfig must not include [gpg] when signing keys are absent; content:\n%s", content)
+	}
+	if strings.Contains(content, "signingKey") {
+		t.Errorf("gitconfig must not include signingKey when signing keys are absent; content:\n%s", content)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1306,6 +1306,58 @@ func TestWriteGitconfig_UserSectionWhenIdentityPresent(t *testing.T) {
 	}
 }
 
+func TestWriteGitconfig_NoSigningWithoutIdentity(t *testing.T) {
+	// Bug regression: when signing keys are present but identity (name/email)
+	// is empty, the [commit] and [gpg] sections must NOT be written.
+	// Previously only hasSigning was checked, which would produce gpgsign=true
+	// with no signingKey set (since signingKey lives in [user] which requires
+	// identity), causing every git commit to fail.
+	//
+	// We set up a fakeHome with real signing key files so hasSigning=true,
+	// but leave GitUserName/GitUserEmail empty.
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	// Create non-empty stub files (EvalSymlinks just needs them to exist on disk).
+	for _, name := range []string{"prismatic-koi-ed25519-signingkey", "prismatic-koi-ed25519-signingkey.pub"} {
+		if err := os.WriteFile(sshDir+"/"+name, []byte("stub"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		// GitUserName and GitUserEmail intentionally left empty.
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	// Signing sections must be absent — identity is missing so signingKey
+	// would never be set, and gpgsign=true without a key breaks git commit.
+	if strings.Contains(content, "[commit]") {
+		t.Errorf("gitconfig must not include [commit] when identity is absent; content:\n%s", content)
+	}
+	if strings.Contains(content, "[gpg]") {
+		t.Errorf("gitconfig must not include [gpg] when identity is absent; content:\n%s", content)
+	}
+	if strings.Contains(content, "gpgsign") {
+		t.Errorf("gitconfig must not include gpgsign when identity is absent; content:\n%s", content)
+	}
+}
+
 func TestWriteGitconfig_NoUserSectionWhenIdentityMissing(t *testing.T) {
 	// AC-14: [user] section omitted when GitUserName or GitUserEmail is empty.
 	for _, tc := range []struct {

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1275,6 +1275,57 @@ func TestWriteGitconfig_NoSigningSectionsWhenKeysUnavailable(t *testing.T) {
 	}
 }
 
+func TestWriteGitconfig_SigningSectionsWhenKeysAndIdentityPresent(t *testing.T) {
+	// AC-10: when signing keys are resolvable AND identity is set, the generated
+	// gitconfig must contain [commit] gpgsign=true, [gpg] format=ssh, and
+	// user.signingKey = /root/.ssh/signing-key.pub.
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	for _, name := range []string{"prismatic-koi-ed25519-signingkey", "prismatic-koi-ed25519-signingkey.pub"} {
+		if err := os.WriteFile(sshDir+"/"+name, []byte("stub"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		GitUserName:   "test-user",
+		GitUserEmail:  "test@example.com",
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "[commit]") {
+		t.Errorf("gitconfig missing [commit] when signing keys and identity are present; content:\n%s", content)
+	}
+	if !strings.Contains(content, "gpgsign = true") {
+		t.Errorf("gitconfig missing gpgsign = true; content:\n%s", content)
+	}
+	if !strings.Contains(content, "[gpg]") {
+		t.Errorf("gitconfig missing [gpg] when signing keys and identity are present; content:\n%s", content)
+	}
+	if !strings.Contains(content, "format = ssh") {
+		t.Errorf("gitconfig missing format = ssh; content:\n%s", content)
+	}
+	if !strings.Contains(content, "signingKey = /root/.ssh/signing-key.pub") {
+		t.Errorf("gitconfig missing signingKey = /root/.ssh/signing-key.pub; content:\n%s", content)
+	}
+}
+
 func TestWriteGitconfig_UserSectionWhenIdentityPresent(t *testing.T) {
 	// AC-2, AC-14: [user] section present only when both name and email are set.
 	m := New(Config{

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -477,8 +478,14 @@ func TestBuildRunArgs_NoGitMountsWhenBareRootEmpty(t *testing.T) {
 	for i, arg := range args {
 		if arg == "--volume" && i+1 < len(args) {
 			v := args[i+1]
-			if strings.Contains(v, "/prism-git") {
-				t.Errorf("unexpected git mount when BareRoot is empty: %q", v)
+			// Check that no mount targets a /prism-git container path.
+			// Note: the volume spec format is "host-path:container-path[:opts]",
+			// so we check the container-side path portion (after the first colon).
+			if idx := strings.Index(v, ":"); idx >= 0 {
+				containerPath := v[idx:]
+				if strings.Contains(containerPath, "/prism-git") {
+					t.Errorf("unexpected git mount when BareRoot is empty: %q", v)
+				}
 			}
 			if strings.HasSuffix(v, ":/workspace/.git:ro") {
 				t.Errorf("unexpected .git file mount when BareRoot is empty: %q", v)
@@ -1096,5 +1103,202 @@ func TestRedactArgs_MultipleEnvVarsAllRedacted(t *testing.T) {
 	}
 	if got[6] != "OPENAI_API_KEY=***" {
 		t.Errorf("expected OPENAI_API_KEY=***, got %q", got[6])
+	}
+}
+
+// ── SSH key simplification tests (AC-5, AC-9) ────────────────────────────────
+
+func TestBuildRunArgs_SSHConfigUsesAccessKey(t *testing.T) {
+	// AC-9: The generated SSH config must reference /root/.ssh/access-key.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+	// Verify that the SSH config file path is mounted at /root/.ssh/config.
+	args := m.buildRunArgs()
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			if strings.HasSuffix(args[i+1], ":/root/.ssh/config:ro") {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("SSH config mount not found at /root/.ssh/config:ro in args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_GitconfigMountedAtRootGitconfig(t *testing.T) {
+	// AC-4: The generated .gitconfig must be mounted at /root/.gitconfig:ro.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+	args := m.buildRunArgs()
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			if strings.HasSuffix(args[i+1], ":/root/.gitconfig:ro") {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("gitconfig mount not found at /root/.gitconfig:ro in args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_NoWholeDirSSHMount(t *testing.T) {
+	// AC-15: The whole ~/.ssh directory must NOT be mounted.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+	args := m.buildRunArgs()
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			// A whole-dir ssh mount has the container path :/root/.ssh (without a
+			// file suffix), not :/root/.ssh/<filename>.
+			if v == ":/root/.ssh:ro" || strings.HasSuffix(v, "/.ssh:/root/.ssh:ro") {
+				t.Errorf("whole ~/.ssh directory is mounted (must use individual key files): %q", v)
+			}
+		}
+	}
+}
+
+// ── credentialEnvVars git identity removal tests (AC-11) ────────────────────
+
+func TestCredentialEnvVars_NoGitIdentityEnvVars(t *testing.T) {
+	// AC-11: GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME,
+	// and GIT_COMMITTER_EMAIL must NOT be injected — the container now has
+	// a generated .gitconfig with [user] section.
+	t.Setenv("GIT_AUTHOR_NAME", "Test User")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Test User")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000, AgentRole: "worker"})
+	vars := m.credentialEnvVars()
+
+	for _, kv := range vars {
+		if strings.HasPrefix(kv, "GIT_AUTHOR_NAME=") {
+			t.Errorf("GIT_AUTHOR_NAME must not be injected (gitconfig handles identity); got %q", kv)
+		}
+		if strings.HasPrefix(kv, "GIT_AUTHOR_EMAIL=") {
+			t.Errorf("GIT_AUTHOR_EMAIL must not be injected (gitconfig handles identity); got %q", kv)
+		}
+		if strings.HasPrefix(kv, "GIT_COMMITTER_NAME=") {
+			t.Errorf("GIT_COMMITTER_NAME must not be injected (gitconfig handles identity); got %q", kv)
+		}
+		if strings.HasPrefix(kv, "GIT_COMMITTER_EMAIL=") {
+			t.Errorf("GIT_COMMITTER_EMAIL must not be injected (gitconfig handles identity); got %q", kv)
+		}
+	}
+}
+
+// ── writeGitconfig tests (AC-1, AC-13, AC-14) ────────────────────────────────
+
+func TestWriteGitconfig_IncludesPushAndInit(t *testing.T) {
+	// AC-1: generated gitconfig must always include [push] and [init] sections.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "[push]") {
+		t.Errorf("gitconfig missing [push] section; content:\n%s", content)
+	}
+	if !strings.Contains(content, "autoSetupRemote = true") {
+		t.Errorf("gitconfig missing autoSetupRemote; content:\n%s", content)
+	}
+	if !strings.Contains(content, "[init]") {
+		t.Errorf("gitconfig missing [init] section; content:\n%s", content)
+	}
+	if !strings.Contains(content, "defaultBranch = main") {
+		t.Errorf("gitconfig missing defaultBranch; content:\n%s", content)
+	}
+}
+
+func TestWriteGitconfig_UserSectionWhenIdentityPresent(t *testing.T) {
+	// AC-2, AC-14: [user] section present only when both name and email are set.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		GitUserName:   "test-user",
+		GitUserEmail:  "test@example.com",
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "[user]") {
+		t.Errorf("gitconfig missing [user] section when identity is set; content:\n%s", content)
+	}
+	if !strings.Contains(content, "name = test-user") {
+		t.Errorf("gitconfig missing name in [user]; content:\n%s", content)
+	}
+	if !strings.Contains(content, "email = test@example.com") {
+		t.Errorf("gitconfig missing email in [user]; content:\n%s", content)
+	}
+}
+
+func TestWriteGitconfig_NoUserSectionWhenIdentityMissing(t *testing.T) {
+	// AC-14: [user] section omitted when GitUserName or GitUserEmail is empty.
+	for _, tc := range []struct {
+		name  string
+		uname string
+		email string
+	}{
+		{"both empty", "", ""},
+		{"name only", "test-user", ""},
+		{"email only", "", "test@example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(Config{
+				SessionName:   "repo@feat",
+				AllocatedPort: 14000,
+				GitUserName:   tc.uname,
+				GitUserEmail:  tc.email,
+			})
+
+			if err := m.writeGitconfig(); err != nil {
+				t.Fatalf("writeGitconfig returned error: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+			data, err := os.ReadFile(m.gitconfigFilePath())
+			if err != nil {
+				t.Fatalf("read gitconfig: %v", err)
+			}
+			content := string(data)
+
+			if strings.Contains(content, "[user]") {
+				t.Errorf("[user] section present but identity incomplete (name=%q, email=%q); content:\n%s",
+					tc.uname, tc.email, content)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Generates a minimal `.gitconfig` at container creation time with `[user]` (name, email, signingKey), `[commit]` (gpgsign=true), `[gpg]` (format=ssh), `[push]` (autoSetupRemote=true), and `[init]` (defaultBranch=main) sections
- Mounts SSH keys with simplified names: `access-key`, `signing-key`, `signing-key.pub` instead of the old full key names; removes the whole-directory `~/.ssh` mount
- Adds `git_user_name` and `git_user_email` to the prism config (sourced from NixOS git config in `modules/programs/git.nix`) and wires them through to container creation
- Removes `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` forwarding from `credentialEnvVars()` — gitconfig handles identity now
- Edge cases handled: missing signing keys skip signing config with warning; missing identity skips `[user]` section with warning

Closes #549