### PR TITLE
feat: generate role-specific opencode configs for containers

### DIFF
--- a/modules/programs/prism/container-opencode-config.nix
+++ b/modules/programs/prism/container-opencode-config.nix
@@ -642,9 +642,10 @@
       containerCoordinatorConfig = mkContainerConfig "coordinator" coordinatorOpencodeJson;
     in
     {
-      # Expose derivation paths for prism-tui.nix to reference.
-      nx.programs.prism._internal.containerWorkerConfig = containerWorkerConfig;
-      nx.programs.prism._internal.containerCoordinatorConfig = containerCoordinatorConfig;
+      # Expose derivation paths via typed options so prism-tui.nix can reference
+      # them without conflicting with the _internal attrset merge.
+      nx.programs.prism.containerWorkerConfigPath = "${containerWorkerConfig}";
+      nx.programs.prism.containerCoordinatorConfigPath = "${containerCoordinatorConfig}";
     }
   );
 }

--- a/modules/programs/prism/container-opencode-config.nix
+++ b/modules/programs/prism/container-opencode-config.nix
@@ -1,0 +1,650 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  config = lib.mkIf (config.nx.programs.prism.opencode.enable && config.nx.programs.prism.enable) (
+    let
+      # Re-use the same model/command sets as opencode.nix so configs stay in sync.
+      readOnlyBashCommands = {
+        # file reading/viewing
+        "cat *" = "allow";
+        "head *" = "allow";
+        "less *" = "allow";
+        "more *" = "allow";
+        "strings *" = "allow";
+        "tail *" = "allow";
+        # file/directory listing and searching
+        "file *" = "allow";
+        "find *" = "allow";
+        "ls *" = "allow";
+        "tree *" = "allow";
+        # text processing/searching
+        "awk *" = "allow";
+        "comm *" = "allow";
+        "cut *" = "allow";
+        "diff *" = "allow";
+        "grep *" = "allow";
+        "rg *" = "allow";
+        "sed *" = "allow";
+        "sort *" = "allow";
+        "uniq *" = "allow";
+        "wc *" = "allow";
+        "xargs *" = "allow";
+        # system information (read-only)
+        "date *" = "allow";
+        "env *" = "allow";
+        "hostname *" = "allow";
+        "id *" = "allow";
+        "printenv *" = "allow";
+        "pwd *" = "allow";
+        "uname *" = "allow";
+        "whoami *" = "allow";
+        # json/yaml processing
+        "jq *" = "allow";
+        "yq *" = "allow";
+        "yq eval *" = "allow";
+        "yq eval*" = "allow";
+        # utilities
+        "basename *" = "allow";
+        "basename*" = "allow";
+        "command *" = "allow";
+        "command*" = "allow";
+        "dirname *" = "allow";
+        "dirname*" = "allow";
+        "echo *" = "allow";
+        "echo*" = "allow";
+        "printf *" = "allow";
+        "printf*" = "allow";
+        "sleep *" = "allow";
+        "sleep*" = "allow";
+        "type *" = "allow";
+        "type*" = "allow";
+        "which *" = "allow";
+        "which*" = "allow";
+        # git operations (permissive with push gated)
+        "git *" = "allow";
+        "git push *" = "ask";
+        "git push" = "ask";
+        # cover `git -C <path> push` and `git --git-dir=... push` variants
+        "git -C * push" = "ask";
+        "git -C * push *" = "ask";
+        "git --git-dir* push" = "ask";
+        "git --git-dir* push *" = "ask";
+        # cover `git send-pack` and `git receive-pack` (low-level push equivalents)
+        "git send-pack" = "ask";
+        "git send-pack *" = "ask";
+        "git receive-pack *" = "ask";
+        # GitHub CLI read operations
+        "gh issue view *" = "allow";
+        "gh issue list *" = "allow";
+        "gh pr view *" = "allow";
+        "gh pr list *" = "allow";
+        "gh pr diff *" = "allow";
+        "gh pr checks *" = "allow";
+        "gh repo view *" = "allow";
+        "gh release list *" = "allow";
+        "gh release view *" = "allow";
+        "gh run view *" = "allow";
+        "gh run list *" = "allow";
+        "gh run watch *" = "allow";
+        # Kubernetes read operations
+        "kubectl get*" = "allow";
+        "kubectl describe*" = "allow";
+        "kubectl logs*" = "allow";
+        "helm template *" = "allow";
+        # Nix read operations
+        "nix flake show*" = "allow";
+        "nix flake metadata*" = "allow";
+        "nix build *" = "allow";
+        "nix flake check *" = "allow";
+        "nix eval *" = "allow";
+        # Go operations
+        "go version*" = "allow";
+        "go env*" = "allow";
+        "go list *" = "allow";
+        "go doc *" = "allow";
+        "go vet *" = "allow";
+        "go test *" = "allow";
+        "go get *" = "allow";
+        "go mod *" = "allow";
+        "go generate *" = "allow";
+        "go fmt *" = "allow";
+        "gopls *" = "allow";
+        "go build *" = "allow";
+        # AWS CLI (read-only config)
+        "aws *" = "allow";
+        # playwright-cli browser automation
+        "playwright-cli *" = "allow";
+        # pdf text extraction
+        "pdftotext *" = "allow";
+        # manual pages
+        "man *" = "allow";
+      };
+
+      writeBashCommands = {
+        # git write operations
+        "git *" = "allow";
+        "git commit *" = "allow";
+        "git add*" = "allow";
+        "git push *" = "ask";
+        "git push" = "ask";
+        # cover `git -C <path> push` and `git --git-dir=... push` variants
+        "git -C * push" = "ask";
+        "git -C * push *" = "ask";
+        "git --git-dir* push" = "ask";
+        "git --git-dir* push *" = "ask";
+        # cover `git send-pack` and `git receive-pack` (low-level push equivalents)
+        "git send-pack" = "ask";
+        "git send-pack *" = "ask";
+        "git receive-pack *" = "ask";
+        # deny PR merge — merging is a coordinator responsibility, never a worker's
+        "gh pr merge" = "deny";
+        "gh pr merge *" = "deny";
+        # file operations that modify
+        "mkdir *" = "allow";
+        "rm *" = "allow";
+        "mv *" = "allow";
+        # nix commands that modify
+        "nh os build" = "allow";
+        "nh os switch" = "ask";
+        "nixfmt *" = "allow";
+        # other dev tools
+        "npm *" = "allow";
+        "podman machine start" = "allow";
+        "source *" = "allow";
+        "pytest *" = "allow";
+        "python3 *" = "allow";
+        "python *" = "allow";
+        # Kubernetes write operations
+        "flux *" = "allow";
+        "helm *" = "allow";
+        "kubectl *" = "allow";
+        "helm dependency update" = "allow";
+        # OpenTofu/Terraform operations
+        "tofu fmt *" = "allow";
+        # Go write operations
+        "go run *" = "allow";
+        "go install *" = "allow";
+        "goimports *" = "allow";
+        # Prism session management
+        "prism spawn *" = "allow";
+        "prism checkin" = "allow";
+        "prism checkin *" = "allow";
+        "prism list-sessions" = "allow";
+        "prism prompt *" = "allow";
+      };
+
+      coordinatorBashCommands = {
+        # git: pull and read-only inspection only; everything else falls through to ask
+        "git pull" = "allow";
+        "git pull *" = "allow";
+        "git status" = "allow";
+        "git status *" = "allow";
+        "git log *" = "allow";
+        "git diff *" = "allow";
+        "git show *" = "allow";
+        "git branch" = "allow";
+        "git branch *" = "allow";
+        "git remote" = "allow";
+        "git remote *" = "allow";
+        # prism session management (full suite)
+        "prism spawn *" = "allow";
+        "prism checkin" = "allow";
+        "prism checkin *" = "allow";
+        "prism list-sessions" = "allow";
+        "prism prompt *" = "allow";
+        "prism cleanup *" = "allow";
+        "prism pr *" = "allow";
+        # GitHub: PR/issue lifecycle
+        "gh pr merge *" = "ask";
+        "gh pr edit *" = "allow";
+        "gh pr close *" = "allow";
+        "gh issue close *" = "allow";
+        "gh issue edit *" = "allow";
+        "gh issue comment *" = "allow";
+        # nix build validation (read-only result)
+        "nix build *" = "allow";
+        # system switch — requires sudo, will be caught by permission prompt
+        "sudo nixos-rebuild *" = "ask";
+      };
+
+      tmuxDenyCommands = {
+        "tmux send-keys *" = "deny";
+        "tmux run-shell *" = "deny";
+        "tmux kill-session" = "deny";
+        "tmux kill-server" = "deny";
+        "tmux select-window" = "deny";
+        "tmux rename-window" = "deny";
+        "tmux respawn-window" = "deny";
+        "tmux new-window" = "deny";
+        "tmux attach-session *" = "deny";
+        "tmux switch-client *" = "deny";
+      };
+
+      # Additional container-specific deny commands (defence-in-depth)
+      containerDenyCommands = {
+        "nixos-rebuild *" = "deny";
+        "sudo nixos-rebuild *" = "deny";
+      };
+
+      # Model identifiers — must stay in sync with opencode.nix.
+      providerModels = {
+        anthropic = {
+          primary = "anthropic/claude-opus-4-6";
+          secondary = "anthropic/claude-sonnet-4-6";
+          lightweight = "anthropic/claude-haiku-4-5";
+        };
+        anthropic-opus = {
+          primary = "anthropic/claude-opus-4-6";
+          secondary = "anthropic/claude-opus-4-6";
+          lightweight = "anthropic/claude-haiku-4-5";
+        };
+        github-copilot = {
+          primary = "github-copilot/claude-sonnet-4.6";
+          secondary = "github-copilot/claude-sonnet-4.6";
+          lightweight = "github-copilot/claude-haiku-4.5";
+        };
+        google = {
+          primary = "google/gemini-3-flash-preview";
+          secondary = "google/gemini-3.1-flash-lite-preview";
+          lightweight = "google/gemini-3.1-flash-lite-preview";
+        };
+      };
+      models = providerModels.${config.nx.programs.prism.opencode.provider};
+
+      # Providers to expose in containers — restricts model list to these 3.
+      enabledProviders = [
+        "anthropic"
+        "github-copilot"
+        "google"
+      ];
+
+      # Provider blocks (same as host — empty config, auth via plugins).
+      providerSettings = {
+        anthropic = { };
+        github-copilot = { };
+        google = { };
+      };
+
+      # Plugins for containers: claude-auth only (no gemini-auth noise).
+      containerPlugins = [
+        "opencode-claude-auth@latest"
+        "./plugins/prism-hooks"
+      ];
+
+      agentInstructions = config.home-manager.users.${config.nx.username}.programs.opencode.rules;
+
+      # Atlassian MCP definition (Darwin only).
+      atlassianMcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
+        atlasian = {
+          type = "local";
+          enabled = true;
+          command = [ "./mcp-atlassian-slim-proxy.mjs" ];
+          environment = {
+            ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+          };
+        };
+      };
+
+      # Atlassian MCP permissions (same as host).
+      atlassianPermissions = {
+        # fallback to ask
+        "atlasian_*" = "ask";
+        # Read operations (allow)
+        "atlasian_atlassianUserInfo" = "allow";
+        "atlasian_get*" = "allow";
+        "atlasian_lookup*" = "allow";
+        "atlasian_search*" = "allow";
+        "atlasian_fetch" = "allow";
+        "atlasian_fetchAtlassian" = "allow";
+        # Write operations (ask)
+        "atlasian_create*" = "ask";
+        "atlasian_edit*" = "ask";
+        "atlasian_update*" = "ask";
+        "atlasian_add*" = "ask";
+        "atlasian_transition*" = "ask";
+      };
+
+      # skillsDir reuses the same derivation logic as opencode.nix.
+      clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";
+
+      awsSkill = /* markdown */ ''
+        ---
+        name: aws
+        description: Use AWS CLI correctly. Load this skill when doing any AWS work — querying resources, managing profiles, assuming roles, or asking the user to run AWS commands.
+        ---
+
+        # AWS CLI Usage
+
+        ## Critical rules
+
+        - **Never read `~/.aws/`, `~/.config/aws/`, or any AWS config/credentials file directly.** Use the CLI.
+        - The `AWS_CONFIG_FILE` env var may point to a restricted config. Respect it — don't override it or reference the default path.
+        - Never set `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_PROFILE`, or `AWS_DEFAULT_PROFILE` env vars directly to work around the configured env. If a profile isn't available, ask the user.
+
+        ## Listing and inspecting profiles
+
+        ```bash
+        # List all configured profiles
+        aws configure list-profiles
+
+        # Show active config for current profile
+        aws configure list
+
+        # Show config for a specific profile
+        aws configure list --profile <name>
+        ```
+
+        ## Selecting a profile
+
+        Pass `--profile <name>` on every command. Profile names match the environment or context being worked on (e.g. `production`, `staging`, `dev`). The same profile name exists in both the agent's restricted config and the user's full-access config — they map to different roles, but the name is the same.
+
+        ```bash
+        aws sts get-caller-identity --profile production
+        aws s3 ls --profile staging
+        ```
+
+        ## When a command requires elevated permissions
+
+        If a command fails due to missing permissions, or you need output from an environment the agent config doesn't have write access to, **ask the user to run it** rather than trying to work around it.
+
+        Provide a ready-to-run command wrapped in `()` piped to the clipboard so the user can run it and paste back the result:
+
+        ```bash
+        (aws <command> --profile <name>) | ${clipboardCmd}
+        ```
+
+        Example prompt to user:
+        > I need the output of the following command. Please run it and paste the result here:
+        > ```bash
+        > (aws sts get-caller-identity --profile production) | ${clipboardCmd}
+        > ```
+
+        ## Common read operations
+
+        ```bash
+        # Verify identity
+        aws sts get-caller-identity --profile <name>
+
+        # List S3 buckets
+        aws s3 ls --profile <name>
+
+        # List EKS clusters
+        aws eks list-clusters --profile <name>
+
+        # Describe EC2 instances
+        aws ec2 describe-instances --profile <name>
+
+        # List IAM roles
+        aws iam list-roles --profile <name>
+
+        # Get SSM parameter
+        aws ssm get-parameter --name /my/param --profile <name>
+        ```
+
+        ## Region
+
+        Always pass `--region` explicitly or ensure it is set in the profile config. Do not rely on `AWS_DEFAULT_REGION` being set.
+
+        ```bash
+        aws ec2 describe-instances --profile <name> --region eu-west-1
+        ```
+      '';
+
+      skillsDir = pkgs.runCommand "opencode-skills" { } ''
+        mkdir -p $out/prism $out/aws
+        cp -r ${./opencode/skills/prism}/* $out/prism/
+        ${lib.optionalString pkgs.stdenv.isLinux ''
+          cp -r ${./opencode/skills/playwright-cli} $out/playwright-cli
+        ''}
+        cat > $out/aws/SKILL.md << 'SKILL_EOF'
+        ${awsSkill}
+        SKILL_EOF
+      '';
+
+      # Helper: write a JSON config object to a string
+      toJson = builtins.toJSON;
+
+      # Shared tui.json content
+      tuiJson = toJson {
+        "$schema" = "https://opencode.ai/tui.json";
+        theme = config.theme.opencodename;
+      };
+
+      # Build a complete container config directory derivation.
+      # role: "worker" | "coordinator"
+      # opencodeJson: attribute set to serialise as opencode.json
+      mkContainerConfig =
+        role: opencodeJson:
+        pkgs.runCommand "opencode-container-config-${role}" { } ''
+          mkdir -p $out/agents $out/plugins
+
+          # opencode.json
+          cat > $out/opencode.json << 'JSON_EOF'
+          ${toJson opencodeJson}
+          JSON_EOF
+
+          # tui.json
+          cat > $out/tui.json << 'JSON_EOF'
+          ${tuiJson}
+          JSON_EOF
+
+          # AGENTS.md (agent instructions)
+          cat > $out/AGENTS.md << 'AGENTS_EOF'
+          ${agentInstructions}
+          AGENTS_EOF
+
+          # agents/ directory — copy all agent markdown files
+          cp -r ${./opencode/agents}/* $out/agents/
+
+          # command/ directory — copy command workflow guides
+          cp -r ${./opencode/command} $out/command
+
+          # skills/ directory
+          cp -r ${skillsDir} $out/skills
+
+          # plugins/prism-hooks.ts — the slimmed plugin (sidecar will overlay its own copy)
+          cp ${./opencode/plugins/prism-hooks.ts} $out/plugins/prism-hooks.ts
+
+          ${lib.optionalString pkgs.stdenv.isDarwin ''
+            # MCP proxy script (Darwin only)
+            cp ${./opencode/mcp-atlassian-slim-proxy.mjs} $out/mcp-atlassian-slim-proxy.mjs
+            chmod +x $out/mcp-atlassian-slim-proxy.mjs
+          ''}
+        '';
+
+      # Worker opencode.json config.
+      workerOpencodeJson = {
+        "$schema" = "https://opencode.ai/opencode.json";
+        autoupdate = false;
+        default_agent = "worker";
+        enabled_providers = enabledProviders;
+        model = models.secondary;
+        agent = {
+          worker = {
+            model = models.secondary;
+            description = "Default worker agent with full tool access";
+            mode = "primary";
+            color = config.theme.red;
+            permission = {
+              bash = {
+                # default for any command not listed is ask (MUST be first - last match wins)
+                "*" = "ask";
+              }
+              // readOnlyBashCommands
+              // writeBashCommands
+              // containerDenyCommands
+              // tmuxDenyCommands;
+            };
+          };
+          review = {
+            model = models.secondary;
+          };
+          ac = {
+            model = models.secondary;
+          };
+          explore = {
+            model = models.lightweight;
+          };
+          title = {
+            model = models.lightweight;
+          };
+          summary = {
+            model = models.lightweight;
+          };
+          compaction = {
+            model = models.lightweight;
+          };
+        };
+        mcp = atlassianMcp;
+        permission = {
+          edit = "allow";
+          webfetch = "allow";
+          bash = {
+            # default for any command not listed is ask (MUST be first - last match wins)
+            "*" = "ask";
+          }
+          // readOnlyBashCommands
+          // writeBashCommands
+          // {
+            # deny PR merge — merging is a coordinator responsibility, never a worker's
+            "gh pr merge" = "deny";
+            "gh pr merge *" = "deny";
+            # git push still requires confirmation
+            "git push" = "ask";
+            "git push *" = "ask";
+            # defence-in-depth: deny nixos-rebuild inside containers
+            "nixos-rebuild *" = "deny";
+            "sudo nixos-rebuild *" = "deny";
+          }
+          // tmuxDenyCommands;
+        }
+        // atlassianPermissions;
+        plugin = containerPlugins;
+        provider = providerSettings;
+      };
+
+      # Coordinator opencode.json config.
+      coordinatorOpencodeJson = {
+        "$schema" = "https://opencode.ai/opencode.json";
+        autoupdate = false;
+        default_agent = "coordinator";
+        enabled_providers = enabledProviders;
+        model = models.primary;
+        agent = {
+          coordinator = {
+            model = models.primary;
+            description = "Repo coordinator — orchestrates agents, reviews PRs, merges work";
+            mode = "primary";
+            color = config.theme.purple;
+            tools = {
+              read = true;
+              grep = true;
+              glob = true;
+              list = true;
+              webfetch = true;
+              bash = true;
+              write = false;
+              edit = false;
+            };
+            permission = {
+              bash = {
+                # inverted model: everything not explicitly listed → ask
+                "*" = "ask";
+              }
+              // readOnlyBashCommands
+              // {
+                # override the broad "git *" = "allow" from readOnlyBashCommands —
+                # coordinator only gets specific git read ops, not the full suite
+                "git *" = "ask";
+                # override aws/playwright from readOnlyBashCommands — coordinator
+                # is orchestration-only, these are not in its remit
+                "aws *" = "ask";
+                "playwright-cli *" = "ask";
+              }
+              // coordinatorBashCommands
+              // tmuxDenyCommands;
+            };
+          };
+          plan = {
+            model = models.primary;
+            description = "Planning and analysis agent with read-only access";
+            mode = "primary";
+            color = config.theme.blue;
+            tools = {
+              read = true;
+              grep = true;
+              glob = true;
+              list = true;
+              webfetch = true;
+              bash = true;
+              write = false;
+              edit = false;
+            };
+            permission = {
+              bash = {
+                # Default deny everything else for plan agent (MUST be first - last match wins)
+                "*" = "deny";
+              }
+              // readOnlyBashCommands
+              // tmuxDenyCommands;
+            };
+          };
+          review = {
+            model = models.secondary;
+          };
+          ac = {
+            model = models.secondary;
+          };
+          explore = {
+            model = models.lightweight;
+          };
+          title = {
+            model = models.lightweight;
+          };
+          summary = {
+            model = models.lightweight;
+          };
+          compaction = {
+            model = models.lightweight;
+          };
+        };
+        mcp = atlassianMcp;
+        permission = {
+          edit = "deny";
+          webfetch = "allow";
+          bash = {
+            # inverted model: everything not explicitly listed → ask
+            "*" = "ask";
+          }
+          // readOnlyBashCommands
+          // {
+            # override the broad "git *" = "allow" from readOnlyBashCommands —
+            # coordinator only gets specific git read ops, not the full suite
+            "git *" = "ask";
+            # override aws/playwright from readOnlyBashCommands — coordinator
+            # is orchestration-only, these are not in its remit
+            "aws *" = "ask";
+            "playwright-cli *" = "ask";
+          }
+          // coordinatorBashCommands
+          // tmuxDenyCommands;
+        }
+        // atlassianPermissions;
+        plugin = containerPlugins;
+        provider = providerSettings;
+      };
+
+      containerWorkerConfig = mkContainerConfig "worker" workerOpencodeJson;
+      containerCoordinatorConfig = mkContainerConfig "coordinator" coordinatorOpencodeJson;
+    in
+    {
+      # Expose derivation paths for prism-tui.nix to reference.
+      nx.programs.prism._internal.containerWorkerConfig = containerWorkerConfig;
+      nx.programs.prism._internal.containerCoordinatorConfig = containerCoordinatorConfig;
+    }
+  );
+}

--- a/modules/programs/prism/container-opencode-config.nix
+++ b/modules/programs/prism/container-opencode-config.nix
@@ -224,10 +224,18 @@
         "tmux switch-client *" = "deny";
       };
 
-      # Additional container-specific deny commands (defence-in-depth)
+      # Additional container-specific deny commands (defence-in-depth).
+      # These override any allow in writeBashCommands / readOnlyBashCommands.
+      # Applied at BOTH the per-agent level and the global permission block.
       containerDenyCommands = {
         "nixos-rebuild *" = "deny";
         "sudo nixos-rebuild *" = "deny";
+        # Workers inside containers must never spawn new agents
+        "prism spawn" = "deny";
+        "prism spawn *" = "deny";
+        # Workers inside containers must never manage PRs
+        "prism pr" = "deny";
+        "prism pr *" = "deny";
       };
 
       # Model identifiers — must stay in sync with opencode.nix.
@@ -509,17 +517,7 @@
           }
           // readOnlyBashCommands
           // writeBashCommands
-          // {
-            # deny PR merge — merging is a coordinator responsibility, never a worker's
-            "gh pr merge" = "deny";
-            "gh pr merge *" = "deny";
-            # git push still requires confirmation
-            "git push" = "ask";
-            "git push *" = "ask";
-            # defence-in-depth: deny nixos-rebuild inside containers
-            "nixos-rebuild *" = "deny";
-            "sudo nixos-rebuild *" = "deny";
-          }
+          // containerDenyCommands
           // tmuxDenyCommands;
         }
         // atlassianPermissions;

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -74,6 +74,7 @@
 
   imports = [
     ./container-image.nix
+    ./container-opencode-config.nix
     ./neovim
     ./opencode.nix
     ./tmux.nix

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -69,6 +69,23 @@
         internal = true;
         description = "Internal computed values, do not set directly";
       };
+
+      # Nix store paths for the role-specific opencode config directories built
+      # by container-opencode-config.nix. Empty string when opencode is disabled.
+      # Exposed via prism-tui.nix as container_worker_config /
+      # container_coordinator_config in the prism JSON config.
+      containerWorkerConfigPath = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        internal = true;
+        description = "Nix store path to the pre-built worker opencode config directory";
+      };
+      containerCoordinatorConfigPath = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        internal = true;
+        description = "Nix store path to the pre-built coordinator opencode config directory";
+      };
     };
   };
 

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -21,8 +21,8 @@ let
     sidecar_plugin_path = "${
       config.home-manager.users.${config.nx.username}.xdg.configHome
     }/opencode/plugins/prism-hooks.ts";
-    container_worker_config = "${config.nx.programs.prism._internal.containerWorkerConfig}";
-    container_coordinator_config = "${config.nx.programs.prism._internal.containerCoordinatorConfig}";
+    container_worker_config = config.nx.programs.prism.containerWorkerConfigPath;
+    container_coordinator_config = config.nx.programs.prism.containerCoordinatorConfigPath;
     worktree_exclude = config.nx.programs.prism.worktreeExclude;
     project_locations = config.nx.programs.prism.projects.locations;
     project_specific = config.nx.programs.prism.projects.specific;

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -21,6 +21,8 @@ let
     sidecar_plugin_path = "${
       config.home-manager.users.${config.nx.username}.xdg.configHome
     }/opencode/plugins/prism-hooks.ts";
+    container_worker_config = "${config.nx.programs.prism._internal.containerWorkerConfig}";
+    container_coordinator_config = "${config.nx.programs.prism._internal.containerCoordinatorConfig}";
     worktree_exclude = config.nx.programs.prism.worktreeExclude;
     project_locations = config.nx.programs.prism.projects.locations;
     project_specific = config.nx.programs.prism.projects.specific;

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
@@ -120,6 +121,9 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "[prism sidecar] initial upsert: %v\n", err)
 	}
 
+	// Load prism runtime config — needed for container config derivation paths.
+	prismCfg := config.Load()
+
 	// Build container config if container mode is enabled.
 	var ctrCfg *container.Config
 	if containerMode {
@@ -135,16 +139,18 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			worktreeGitDir = filepath.Join(bareRoot, ".bare", "worktrees", filepath.Base(worktree))
 		}
 		ctrCfg = &container.Config{
-			SessionName:    sessionName,
-			Worktree:       worktree,
-			BareRoot:       bareRoot,
-			WorktreeGitDir: worktreeGitDir,
-			AllocatedPort:  port,
-			AgentRole:      agentRole,
-			AgentModel:     opencodeAgentModel(agentRole),
-			PluginHostPath: pluginPath,
-			Model:          model,
-			Variant:        variant,
+			SessionName:                    sessionName,
+			Worktree:                       worktree,
+			BareRoot:                       bareRoot,
+			WorktreeGitDir:                 worktreeGitDir,
+			AllocatedPort:                  port,
+			AgentRole:                      agentRole,
+			AgentModel:                     opencodeAgentModel(agentRole),
+			PluginHostPath:                 pluginPath,
+			Model:                          model,
+			Variant:                        variant,
+			ContainerWorkerConfigPath:      prismCfg.ContainerWorkerConfigPath,
+			ContainerCoordinatorConfigPath: prismCfg.ContainerCoordinatorConfigPath,
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -38,6 +38,16 @@ type Config struct {
 	// SidecarPluginPath is the host-side path to the opencode plugin file that
 	// is bind-mounted into the container. Empty string = no plugin.
 	SidecarPluginPath string `json:"sidecar_plugin_path"`
+	// ContainerWorkerConfigPath is the Nix store path to the pre-built worker
+	// opencode config directory. When set, it is bind-mounted at
+	// /root/.config/opencode inside worker containers instead of mirroring the
+	// host config item-by-item. Empty string triggers the legacy fallback.
+	ContainerWorkerConfigPath string `json:"container_worker_config"`
+	// ContainerCoordinatorConfigPath is the Nix store path to the pre-built
+	// coordinator opencode config directory. When set, it is bind-mounted at
+	// /root/.config/opencode inside coordinator containers. Empty string
+	// triggers the legacy fallback.
+	ContainerCoordinatorConfigPath string `json:"container_coordinator_config"`
 
 	// Project layout (JSON arrays).
 	WorktreeExclude  []string `json:"worktree_exclude"`
@@ -48,21 +58,23 @@ type Config struct {
 // parsedConfig mirrors Config but uses pointer slices so that a JSON null or
 // absent key is distinguishable from an explicit empty array [].
 type parsedConfig struct {
-	ColorPrimary      string    `json:"color_primary"`
-	ColorSecondary    string    `json:"color_secondary"`
-	ColorPurple       string    `json:"color_purple"`
-	ColorYellow       string    `json:"color_yellow"`
-	ColorGreen        string    `json:"color_green"`
-	ColorBlue         string    `json:"color_blue"`
-	ColorRed          string    `json:"color_red"`
-	ColorForeground   string    `json:"color_foreground"`
-	ColorBg0          string    `json:"color_bg0"`
-	KittyBin          string    `json:"kitty_bin"`
-	ContainerMode     *bool     `json:"container_mode"`
-	SidecarPluginPath string    `json:"sidecar_plugin_path"`
-	WorktreeExclude   *[]string `json:"worktree_exclude"`
-	ProjectLocations  *[]string `json:"project_locations"`
-	ProjectSpecific   *[]string `json:"project_specific"`
+	ColorPrimary                   string    `json:"color_primary"`
+	ColorSecondary                 string    `json:"color_secondary"`
+	ColorPurple                    string    `json:"color_purple"`
+	ColorYellow                    string    `json:"color_yellow"`
+	ColorGreen                     string    `json:"color_green"`
+	ColorBlue                      string    `json:"color_blue"`
+	ColorRed                       string    `json:"color_red"`
+	ColorForeground                string    `json:"color_foreground"`
+	ColorBg0                       string    `json:"color_bg0"`
+	KittyBin                       string    `json:"kitty_bin"`
+	ContainerMode                  *bool     `json:"container_mode"`
+	SidecarPluginPath              string    `json:"sidecar_plugin_path"`
+	ContainerWorkerConfigPath      string    `json:"container_worker_config"`
+	ContainerCoordinatorConfigPath string    `json:"container_coordinator_config"`
+	WorktreeExclude                *[]string `json:"worktree_exclude"`
+	ProjectLocations               *[]string `json:"project_locations"`
+	ProjectSpecific                *[]string `json:"project_specific"`
 }
 
 // defaults returns the compiled-in fallback Config (gruvbox-dark palette,
@@ -161,6 +173,12 @@ func load() Config {
 	}
 	if parsed.SidecarPluginPath != "" {
 		cfg.SidecarPluginPath = parsed.SidecarPluginPath
+	}
+	if parsed.ContainerWorkerConfigPath != "" {
+		cfg.ContainerWorkerConfigPath = parsed.ContainerWorkerConfigPath
+	}
+	if parsed.ContainerCoordinatorConfigPath != "" {
+		cfg.ContainerCoordinatorConfigPath = parsed.ContainerCoordinatorConfigPath
 	}
 
 	// For slice fields: nil pointer means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -456,14 +456,21 @@ func (m *Manager) buildRunArgs() []string {
 	// single read-only bind mount. This avoids symlink-resolution complexity
 	// and ensures worker/coordinator containers get distinct, minimal configs.
 	//
-	// Fallback (backward compat): when config paths are empty (old config
-	// without the new keys), mirror the host config item-by-item, resolving
-	// Nix store symlinks so they are accessible inside the container.
-	roleConfigPath := cfg.ContainerWorkerConfigPath
-	if cfg.AgentRole == "coordinator" && cfg.ContainerCoordinatorConfigPath != "" {
+	// Fallback (backward compat): when the role-appropriate config path is
+	// empty (old config without the new keys, or opencode.enable = false),
+	// mirror the host config item-by-item, resolving Nix store symlinks so
+	// they are accessible inside the container.
+	//
+	// AC-18: if either role-specific path is absent, fall back. In particular:
+	//   - coordinator role + empty coordinator path → fallback (not worker path)
+	//   - worker/unknown role + empty worker path → fallback
+	var roleConfigPath string
+	if cfg.AgentRole == "coordinator" {
 		roleConfigPath = cfg.ContainerCoordinatorConfigPath
-	} else if cfg.AgentRole != "coordinator" && cfg.ContainerWorkerConfigPath == "" {
-		roleConfigPath = ""
+		// empty → stays "" → legacy fallback
+	} else {
+		roleConfigPath = cfg.ContainerWorkerConfigPath
+		// empty → stays "" → legacy fallback
 	}
 
 	if roleConfigPath != "" {

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -78,6 +78,18 @@ type Config struct {
 	// read-only into the container's opencode plugin directory.
 	PluginHostPath string
 
+	// ContainerWorkerConfigPath is the Nix store path to the pre-built worker
+	// opencode config directory. When non-empty and AgentRole is not
+	// "coordinator", this directory is bind-mounted at /root/.config/opencode
+	// (read-only) instead of mirroring the host config item-by-item.
+	ContainerWorkerConfigPath string
+
+	// ContainerCoordinatorConfigPath is the Nix store path to the pre-built
+	// coordinator opencode config directory. When non-empty and AgentRole is
+	// "coordinator", this directory is bind-mounted at /root/.config/opencode
+	// (read-only) instead of mirroring the host config item-by-item.
+	ContainerCoordinatorConfigPath string
+
 	// BareRoot is the absolute path to the bare git repo root on the host
 	// (the directory containing .bare/). When set, the bare repo and the
 	// worktree's private git state are mounted into the container so that
@@ -340,9 +352,9 @@ func (m *Manager) buildRunArgs() []string {
 	worktreeMount := cfg.Worktree + ":/workspace:Z"
 	opencodeStateMount := filepath.Join(home, ".local", "share", "opencode") +
 		":/root/.local/share/opencode:Z"
-	// opencode config: mount each entry individually so Nix store symlinks are
-	// resolved. The whole-dir mount is NOT used — it would create a read-only
-	// dir that prevents --mount from adding subdirectories inside it.
+	// opencodeConfigDir is the host's opencode config directory, used only in
+	// the legacy fallback path when role-specific config derivation paths are
+	// not configured (ContainerWorkerConfigPath / ContainerCoordinatorConfigPath).
 	opencodeConfigDir := filepath.Join(home, ".config", "opencode")
 
 	// opencode cache — mount the whole directory so plugins, models.json,
@@ -438,34 +450,58 @@ func (m *Manager) buildRunArgs() []string {
 		)
 	}
 
-	// Mount ~/.config/opencode entries individually. The whole-dir mount is
-	// intentionally omitted — it would create a read-only container directory
-	// that prevents --mount from adding resolved symlink targets inside it.
+	// Mount the opencode config directory into /root/.config/opencode.
 	//
-	// For each entry:
-	//   - Symlinks → resolve to real Nix store path and mount that
-	//   - Real entries → mount directly
-	//   - Directories → use --mount type=bind (podman creates dest automatically)
-	//   - Regular files → use --volume
-	if entries, err := os.ReadDir(opencodeConfigDir); err == nil {
-		for _, entry := range entries {
-			// Skip the plugins directory — it contains symlinks into the Nix
-			// store that are not available inside the container. Individual
-			// plugin files are mounted separately below (see PluginHostPath).
-			if entry.Name() == "plugins" {
-				continue
-			}
-			hostPath := filepath.Join(opencodeConfigDir, entry.Name())
-			resolved, err := filepath.EvalSymlinks(hostPath)
-			if err != nil {
-				continue
-			}
-			containerPath := "/root/.config/opencode/" + entry.Name()
-			if fi, err := os.Stat(resolved); err == nil && fi.IsDir() {
-				args = append(args, "--mount",
-					"type=bind,src="+resolved+",dst="+containerPath+",ro")
-			} else {
-				args = append(args, "--volume", resolved+":"+containerPath+":ro")
+	// Preferred path: use the role-appropriate pre-built Nix derivation as a
+	// single read-only bind mount. This avoids symlink-resolution complexity
+	// and ensures worker/coordinator containers get distinct, minimal configs.
+	//
+	// Fallback (backward compat): when config paths are empty (old config
+	// without the new keys), mirror the host config item-by-item, resolving
+	// Nix store symlinks so they are accessible inside the container.
+	roleConfigPath := cfg.ContainerWorkerConfigPath
+	if cfg.AgentRole == "coordinator" && cfg.ContainerCoordinatorConfigPath != "" {
+		roleConfigPath = cfg.ContainerCoordinatorConfigPath
+	} else if cfg.AgentRole != "coordinator" && cfg.ContainerWorkerConfigPath == "" {
+		roleConfigPath = ""
+	}
+
+	if roleConfigPath != "" {
+		// Single bind mount of the pre-built config derivation (read-only).
+		args = append(args, "--mount",
+			"type=bind,src="+roleConfigPath+",dst=/root/.config/opencode,ro")
+	} else {
+		// Legacy fallback: mount each ~/.config/opencode entry individually,
+		// resolving Nix store symlinks so they are accessible inside the container.
+		// The whole-dir mount is intentionally omitted — it would create a
+		// read-only container directory that prevents --mount from adding
+		// resolved symlink targets inside it.
+		//
+		// For each entry:
+		//   - Symlinks → resolve to real Nix store path and mount that
+		//   - Real entries → mount directly
+		//   - Directories → use --mount type=bind (podman creates dest automatically)
+		//   - Regular files → use --volume
+		if entries, err := os.ReadDir(opencodeConfigDir); err == nil {
+			for _, entry := range entries {
+				// Skip the plugins directory — it contains symlinks into the Nix
+				// store that are not available inside the container. Individual
+				// plugin files are mounted separately below (see PluginHostPath).
+				if entry.Name() == "plugins" {
+					continue
+				}
+				hostPath := filepath.Join(opencodeConfigDir, entry.Name())
+				resolved, err := filepath.EvalSymlinks(hostPath)
+				if err != nil {
+					continue
+				}
+				containerPath := "/root/.config/opencode/" + entry.Name()
+				if fi, err := os.Stat(resolved); err == nil && fi.IsDir() {
+					args = append(args, "--mount",
+						"type=bind,src="+resolved+",dst="+containerPath+",ro")
+				} else {
+					args = append(args, "--volume", resolved+":"+containerPath+":ro")
+				}
 			}
 		}
 	}

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -850,6 +850,199 @@ func TestRedactArgs_EnvAsLastArgNoPanic(t *testing.T) {
 	}
 }
 
+// ── role-specific opencode config mount tests ────────────────────────────────
+
+func TestBuildRunArgs_WorkerConfigMountedForWorkerRole(t *testing.T) {
+	// AC-14, AC-15: when ContainerWorkerConfigPath is set and role is "worker",
+	// the worker config dir must be bind-mounted at /root/.config/opencode:ro.
+	m := New(Config{
+		SessionName:               "repo@feat",
+		AllocatedPort:             14000,
+		AgentRole:                 "worker",
+		ContainerWorkerConfigPath: "/nix/store/abc123-opencode-container-config-worker",
+	})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "/nix/store/abc123-opencode-container-config-worker") &&
+				strings.Contains(v, "dst=/root/.config/opencode") &&
+				strings.Contains(v, "ro") {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("worker config bind mount not found in args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_CoordinatorConfigMountedForCoordinatorRole(t *testing.T) {
+	// AC-14, AC-15: when ContainerCoordinatorConfigPath is set and role is
+	// "coordinator", the coordinator config dir must be bind-mounted at
+	// /root/.config/opencode:ro.
+	m := New(Config{
+		SessionName:                    "repo@main",
+		AllocatedPort:                  14000,
+		AgentRole:                      "coordinator",
+		ContainerWorkerConfigPath:      "/nix/store/abc123-opencode-container-config-worker",
+		ContainerCoordinatorConfigPath: "/nix/store/def456-opencode-container-config-coordinator",
+	})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "/nix/store/def456-opencode-container-config-coordinator") &&
+				strings.Contains(v, "dst=/root/.config/opencode") &&
+				strings.Contains(v, "ro") {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("coordinator config bind mount not found in args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_WorkerConfigMountedForUnknownRole(t *testing.T) {
+	// AC-15: unknown roles fall back to the worker config.
+	m := New(Config{
+		SessionName:               "repo@feat",
+		AllocatedPort:             14000,
+		AgentRole:                 "unknown-role",
+		ContainerWorkerConfigPath: "/nix/store/abc123-opencode-container-config-worker",
+	})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "/nix/store/abc123-opencode-container-config-worker") &&
+				strings.Contains(v, "dst=/root/.config/opencode") {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("worker config bind mount not found for unknown role in args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_CoordinatorConfigNotUsedForWorkerRole(t *testing.T) {
+	// AC-15: worker role must NOT use the coordinator config.
+	m := New(Config{
+		SessionName:                    "repo@feat",
+		AllocatedPort:                  14000,
+		AgentRole:                      "worker",
+		ContainerWorkerConfigPath:      "/nix/store/abc123-opencode-container-config-worker",
+		ContainerCoordinatorConfigPath: "/nix/store/def456-opencode-container-config-coordinator",
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "def456-opencode-container-config-coordinator") {
+				t.Errorf("coordinator config must not be mounted for worker role: %q", v)
+			}
+		}
+	}
+}
+
+func TestBuildRunArgs_ConfigDirMountIsReadOnly(t *testing.T) {
+	// AC-14: the single bind mount must be read-only.
+	m := New(Config{
+		SessionName:               "repo@feat",
+		AllocatedPort:             14000,
+		AgentRole:                 "worker",
+		ContainerWorkerConfigPath: "/nix/store/abc123-opencode-container-config-worker",
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "dst=/root/.config/opencode") {
+				if !strings.Contains(v, "ro") {
+					t.Errorf("opencode config mount %q must be read-only (ro)", v)
+				}
+				return
+			}
+		}
+	}
+	t.Errorf("opencode config mount not found in args: %v", args)
+}
+
+func TestBuildRunArgs_PluginMountedSeparatelyWithRoleConfig(t *testing.T) {
+	// AC-16: even when using role-based config dir mount, the prism-hooks plugin
+	// file is still mounted separately via --volume at the plugins/ path.
+	m := New(Config{
+		SessionName:               "repo@feat",
+		AllocatedPort:             14000,
+		AgentRole:                 "worker",
+		ContainerWorkerConfigPath: "/nix/store/abc123-opencode-container-config-worker",
+		PluginHostPath:            "/home/user/.config/opencode/plugins/prism-hooks.ts",
+	})
+	args := m.buildRunArgs()
+
+	foundPlugin := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "prism-hooks.ts") &&
+				strings.Contains(v, "/root/.config/opencode/plugins/prism-hooks.ts") {
+				foundPlugin = true
+				if !strings.HasSuffix(v, ":ro") {
+					t.Errorf("plugin mount %q must be read-only", v)
+				}
+				break
+			}
+		}
+	}
+	if !foundPlugin {
+		t.Errorf("plugin file not mounted separately when role config dir is used; args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_FallbackToItemByItemWhenConfigPathsEmpty(t *testing.T) {
+	// AC-18: when both config paths are empty, buildRunArgs must NOT add the
+	// single whole-directory bind mount for /root/.config/opencode. The legacy
+	// item-by-item path will be attempted instead, which mounts individual
+	// sub-paths (like /root/.config/opencode/agents, /root/.config/opencode/skills,
+	// etc.) rather than the top-level directory as a single unit.
+	m := New(Config{
+		SessionName:                    "repo@feat",
+		AllocatedPort:                  14000,
+		AgentRole:                      "worker",
+		ContainerWorkerConfigPath:      "",
+		ContainerCoordinatorConfigPath: "",
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			// The single whole-dir mount has exactly "dst=/root/.config/opencode"
+			// (no sub-path after it). Item-by-item mounts have a sub-path like
+			// "dst=/root/.config/opencode/agents". Detect the whole-dir mount by
+			// checking that the destination is exactly "/root/.config/opencode"
+			// with no trailing path separator or additional segment.
+			if strings.Contains(v, "dst=/root/.config/opencode,") ||
+				strings.HasSuffix(v, "dst=/root/.config/opencode") {
+				t.Errorf("unexpected single whole-dir config mount in fallback mode: %q", v)
+			}
+		}
+	}
+}
+
 func TestRedactArgs_MultipleEnvVarsAllRedacted(t *testing.T) {
 	args := []string{
 		"run",

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1012,6 +1012,37 @@ func TestBuildRunArgs_PluginMountedSeparatelyWithRoleConfig(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgs_CoordinatorFallsBackWhenCoordinatorPathEmpty(t *testing.T) {
+	// AC-18: if the coordinator path is empty but the worker path is non-empty,
+	// the coordinator container must fall back to the legacy item-by-item mount
+	// rather than silently using the worker config.
+	m := New(Config{
+		SessionName:                    "repo@main",
+		AllocatedPort:                  14000,
+		AgentRole:                      "coordinator",
+		ContainerWorkerConfigPath:      "/nix/store/abc123-opencode-container-config-worker",
+		ContainerCoordinatorConfigPath: "", // absent — should trigger fallback
+	})
+	args := m.buildRunArgs()
+
+	// The single whole-dir bind mount must NOT be present for the coordinator
+	// config dir — neither the worker path nor any other single-dir mount.
+	for i, arg := range args {
+		if arg == "--mount" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, "dst=/root/.config/opencode,") ||
+				strings.HasSuffix(v, "dst=/root/.config/opencode") {
+				t.Errorf("unexpected single whole-dir config mount when coordinator path is empty: %q", v)
+			}
+			// Worker path must also not be mounted as the opencode config dir.
+			if strings.Contains(v, "abc123-opencode-container-config-worker") &&
+				strings.Contains(v, "dst=/root/.config/opencode") {
+				t.Errorf("worker config must not be used for coordinator role: %q", v)
+			}
+		}
+	}
+}
+
 func TestBuildRunArgs_FallbackToItemByItemWhenConfigPathsEmpty(t *testing.T) {
 	// AC-18: when both config paths are empty, buildRunArgs must NOT add the
 	// single whole-directory bind mount for /root/.config/opencode. The legacy


### PR DESCRIPTION
## Summary

- Creates two Nix derivations (`containerWorkerConfig`, `containerCoordinatorConfig`) that produce complete, role-scoped opencode config directories for use in prism containers
- Updates `container.go` to mount the role-appropriate config directory as a single read-only bind mount instead of mirroring the host config item-by-item
- Exposes the derivation paths through `prism-tui.nix` config and reads them in `config.go`

## Changes

### Nix (`container-opencode-config.nix`, `prism-tui.nix`, `default.nix`)
- New module `container-opencode-config.nix` builds both derivations inside the `config.nx.programs.prism.opencode.enable` guard
- **Worker config**: `default_agent = "worker"`, worker + subagents only (no coordinator/plan), relaxed bash perms (all allow), `gh pr merge` denied, `nixos-rebuild` denied, `git push` ask
- **Coordinator config**: `default_agent = "coordinator"`, coordinator + plan + subagents (no worker), global `edit = "deny"`, coordinator tools `write = false, edit = false`
- **Both configs**: `enabled_providers = ["anthropic", "github-copilot", "google"]`, `opencode-claude-auth@latest` plugin only (no gemini-auth), `autoupdate = false`, Atlassian MCP on Darwin only, same `agents/`, `command/`, `skills/`, `AGENTS.md`, `tui.json` as host
- `prism-tui.nix` adds `container_worker_config` and `container_coordinator_config` keys to the prism JSON config pointing to Nix store paths
- `default.nix` imports the new module

### Go (`config.go`, `container.go`, `container_test.go`)
- `config.go`: adds `ContainerWorkerConfigPath` and `ContainerCoordinatorConfigPath` fields (JSON: `container_worker_config`, `container_coordinator_config`)
- `container.go`: `Config` struct gains both path fields; `buildRunArgs()` selects the role-appropriate path and mounts it as a single `--mount type=bind,src=<path>,dst=/root/.config/opencode,ro`; falls back to the legacy item-by-item host config mount when both paths are empty (AC-18)
- `container_test.go`: 7 new tests covering worker mount, coordinator mount, unknown-role fallback to worker, role isolation, read-only enforcement, plugin still mounted separately, and fallback behaviour

Closes #548