### PR TITLE
neovim: disable Ruby and Python3 providers to silence deprecation warnings

### DIFF
--- a/modules/programs/prism/neovim/default.nix
+++ b/modules/programs/prism/neovim/default.nix
@@ -33,6 +33,8 @@
         programs.neovim = {
           enable = true;
           defaultEditor = true;
+          withRuby = false;
+          withPython3 = false;
           initLua = lib.mkAfter ''
             vim.opt.runtimepath:append("${maoriSpellDir}")
           '';


### PR DESCRIPTION
## Summary

- Add `withRuby = false;` and `withPython3 = false;` to `programs.neovim` in `modules/programs/prism/neovim/default.nix`
- Silences two home-manager evaluation warnings introduced by upstream default changes for stateVersion 26.05
- Neither provider is used anywhere in the neovim configuration, so disabling them is safe and reduces closure size slightly

Closes #561