### PR TITLE
fix(sidecar): seed root_agent_name from Config.AgentRole to fix prism prompt delivery

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -192,8 +192,9 @@
         "go run *" = "allow";
         "go install *" = "allow";
         "goimports *" = "allow";
-        # Prism session management
-        "prism spawn *" = "allow";
+        # Prism session management (worker-safe operations only)
+        # Note: prism spawn is intentionally excluded — spawning agents is a
+        # coordinator responsibility. Workers must never spawn new sessions (#557).
         "prism checkin" = "allow";
         "prism checkin *" = "allow";
         "prism list-sessions" = "allow";

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -201,6 +201,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		DB:              d,
 		Clock:           sidecar.RealClock(),
 		AgentRole:       agentRole,
+		AgentModel:      opencodeAgentModel(agentRole),
 		Container:       ctrCfg,
 		HostAPISockPath: hostAPISockPath,
 		OnReady:         onReady,

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -363,10 +363,10 @@ func (d *DB) UpdateRootModelID(sessionName, modelID string) error {
 // root_agent_name and root_model_id are preserved via COALESCE — once set, they
 // are never overwritten.
 //
-// Note: production root-agent tracking is performed by the TypeScript plugin via
-// the setRootAgentModelIfAbsent UPDATE statement on the first msg_user event.
-// This Go method is used in tests and is available for any future Go-side
-// session-creation paths that need to seed root_agent_name at INSERT time.
+// The Go sidecar is the authoritative source of root_agent_name: it calls this
+// method on every state transition when Config.AgentRole is set, seeding the
+// value from the agent role on the initial INSERT and preserving it on subsequent
+// UPDATEs. The TypeScript plugin (prism-hooks.ts) does not write root_agent_name.
 func (d *DB) UpsertStatusWithRootAgent(sessionName, repo, worktree, state string, title *string, opencodeSID *string, agentName *string, modelID *string) error {
 	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusWithRootAgent")
 	now := time.Now().UnixMilli()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1025,6 +1025,28 @@ func (s *Sidecar) currentDBState() agent.AgentState {
 }
 
 func (s *Sidecar) upsertState(state agent.AgentState, title *string, opencodeSID *string) {
+	// When AgentRole is set, use UpsertStatusWithRootAgent so that
+	// root_agent_name is seeded from the configured role on the initial INSERT
+	// and preserved via COALESCE on subsequent UPDATEs. This ensures that
+	// `prism prompt` can always find the correct agent to target (#557).
+	// When AgentRole is empty (legacy sessions), fall back to UpsertStatus so
+	// that root_agent_name is left NULL rather than set to an empty string.
+	if s.cfg.AgentRole != "" {
+		agentRole := s.cfg.AgentRole
+		if err := s.cfg.DB.UpsertStatusWithRootAgent(
+			s.cfg.SessionName,
+			s.cfg.Repo,
+			s.cfg.Worktree,
+			string(state),
+			title,
+			opencodeSID,
+			&agentRole,
+			nil,
+		); err != nil {
+			log.Printf("sidecar: UpsertStatusWithRootAgent failed: %v", err)
+		}
+		return
+	}
 	if err := s.cfg.DB.UpsertStatus(
 		s.cfg.SessionName,
 		s.cfg.Repo,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -84,8 +84,15 @@ type Config struct {
 	// "coordinator"), derived from the --agent-role CLI flag. When non-empty, it
 	// is used to pre-set rootAgent at initialisation time so that subagent user
 	// messages (which have a non-empty agent field) do not accidentally overwrite
-	// rootAgent with a subagent name (#555).
+	// rootAgent with a subagent name (#555). It is also written to
+	// root_agent_name in the DB so that `prism prompt` can target the correct
+	// agent for follow-up messages (#557).
 	AgentRole string
+	// AgentModel is the model identifier for the agent role (e.g.
+	// "anthropic/claude-sonnet-4-6"), read from the opencode config at startup.
+	// When non-empty it is seeded into root_model_id in the DB so that
+	// buildPromptBody can include the model in the prompt_async body (#557).
+	AgentModel string
 	// HTTPClient is the HTTP client used for coordinator notification delivery.
 	// If nil, defaultNotifyHTTPClient is used.
 	HTTPClient *http.Client
@@ -1027,12 +1034,18 @@ func (s *Sidecar) currentDBState() agent.AgentState {
 func (s *Sidecar) upsertState(state agent.AgentState, title *string, opencodeSID *string) {
 	// When AgentRole is set, use UpsertStatusWithRootAgent so that
 	// root_agent_name is seeded from the configured role on the initial INSERT
-	// and preserved via COALESCE on subsequent UPDATEs. This ensures that
-	// `prism prompt` can always find the correct agent to target (#557).
+	// and preserved via COALESCE on subsequent UPDATEs. AgentModel is also
+	// seeded into root_model_id when available, so that buildPromptBody can
+	// include the model in the prompt_async body (#557).
 	// When AgentRole is empty (legacy sessions), fall back to UpsertStatus so
 	// that root_agent_name is left NULL rather than set to an empty string.
 	if s.cfg.AgentRole != "" {
 		agentRole := s.cfg.AgentRole
+		var agentModel *string
+		if s.cfg.AgentModel != "" {
+			m := s.cfg.AgentModel
+			agentModel = &m
+		}
 		if err := s.cfg.DB.UpsertStatusWithRootAgent(
 			s.cfg.SessionName,
 			s.cfg.Repo,
@@ -1041,7 +1054,7 @@ func (s *Sidecar) upsertState(state agent.AgentState, title *string, opencodeSID
 			title,
 			opencodeSID,
 			&agentRole,
-			nil,
+			agentModel,
 		); err != nil {
 			log.Printf("sidecar: UpsertStatusWithRootAgent failed: %v", err)
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -3570,3 +3570,125 @@ func TestSubagentFinish_ToolOnlyFinalTurn_IdlePathStillWorks(t *testing.T) {
 		t.Errorf("state = %q after tool-only idle debounce, want finished", state)
 	}
 }
+
+// TestRootAgentName_SeededFromAgentRole verifies that root_agent_name in the DB
+// is seeded from Config.AgentRole on the first state transition (AC-1, AC-3,
+// AC-4 from #557). It also verifies COALESCE semantics: a subsequent state
+// transition must not overwrite the already-set root_agent_name value.
+func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
+	t.Run("seeded when AgentRole is set", func(t *testing.T) {
+		clk := newTestClock()
+		d := openTestDB(t)
+		cfg := Config{
+			SessionName: "test-repo@main",
+			Repo:        "test-repo",
+			Worktree:    "/tmp/test-worktree",
+			OpencodeURL: "http://localhost:14000",
+			DB:          d,
+			Clock:       clk,
+			AgentRole:   "worker",
+		}
+		sc := New(cfg)
+
+		// Trigger first state transition via session.created.
+		sc.HandleEvent(makeSSE("session.created", map[string]any{
+			"info": map[string]any{
+				"id":    "sid-1",
+				"title": "Test session",
+			},
+		}))
+
+		st, err := d.CurrentStatus(sc.cfg.SessionName)
+		if err != nil {
+			t.Fatalf("CurrentStatus: %v", err)
+		}
+		if st == nil {
+			t.Fatal("expected status row to exist after session.created")
+		}
+		if st.RootAgentName == nil {
+			t.Fatal("root_agent_name is nil, want \"worker\"")
+		}
+		if *st.RootAgentName != "worker" {
+			t.Errorf("root_agent_name = %q, want %q", *st.RootAgentName, "worker")
+		}
+	})
+
+	t.Run("preserved on subsequent state transitions (COALESCE)", func(t *testing.T) {
+		clk := newTestClock()
+		d := openTestDB(t)
+		cfg := Config{
+			SessionName: "test-repo@main",
+			Repo:        "test-repo",
+			Worktree:    "/tmp/test-worktree",
+			OpencodeURL: "http://localhost:14000",
+			DB:          d,
+			Clock:       clk,
+			AgentRole:   "worker",
+		}
+		sc := New(cfg)
+
+		// First transition: session.created → active (seeds root_agent_name).
+		sc.HandleEvent(makeSSE("session.created", map[string]any{
+			"info": map[string]any{
+				"id":    "sid-1",
+				"title": "Test session",
+			},
+		}))
+
+		// Second transition: session.idle → finished (must preserve root_agent_name).
+		sc.HandleEvent(makeSSE("session.idle", map[string]any{}))
+		timer := clk.LastTimer()
+		if timer == nil {
+			t.Fatal("expected idle debounce timer")
+		}
+		timer.Fire()
+
+		st, err := d.CurrentStatus(sc.cfg.SessionName)
+		if err != nil {
+			t.Fatalf("CurrentStatus: %v", err)
+		}
+		if st == nil {
+			t.Fatal("expected status row after finished transition")
+		}
+		if st.RootAgentName == nil {
+			t.Fatal("root_agent_name became nil after subsequent state transition, want preserved")
+		}
+		if *st.RootAgentName != "worker" {
+			t.Errorf("root_agent_name = %q after subsequent transition, want %q", *st.RootAgentName, "worker")
+		}
+	})
+
+	t.Run("remains NULL when AgentRole is empty", func(t *testing.T) {
+		clk := newTestClock()
+		d := openTestDB(t)
+		cfg := Config{
+			SessionName: "test-repo@main",
+			Repo:        "test-repo",
+			Worktree:    "/tmp/test-worktree",
+			OpencodeURL: "http://localhost:14000",
+			DB:          d,
+			Clock:       clk,
+			// AgentRole intentionally left empty to simulate a legacy session.
+		}
+		sc := New(cfg)
+
+		// Trigger state transition.
+		sc.HandleEvent(makeSSE("session.created", map[string]any{
+			"info": map[string]any{
+				"id":    "sid-1",
+				"title": "Legacy session",
+			},
+		}))
+
+		st, err := d.CurrentStatus(sc.cfg.SessionName)
+		if err != nil {
+			t.Fatalf("CurrentStatus: %v", err)
+		}
+		if st == nil {
+			t.Fatal("expected status row to exist after session.created")
+		}
+		if st.RootAgentName != nil {
+			t.Errorf("root_agent_name = %q, want nil for legacy session with empty AgentRole", *st.RootAgentName)
+		}
+	})
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -3571,10 +3571,11 @@ func TestSubagentFinish_ToolOnlyFinalTurn_IdlePathStillWorks(t *testing.T) {
 	}
 }
 
-// TestRootAgentName_SeededFromAgentRole verifies that root_agent_name in the DB
-// is seeded from Config.AgentRole on the first state transition (AC-1, AC-3,
-// AC-4 from #557). It also verifies COALESCE semantics: a subsequent state
-// transition must not overwrite the already-set root_agent_name value.
+// TestRootAgentName_SeededFromAgentRole verifies that root_agent_name and
+// root_model_id in the DB are seeded from Config.AgentRole and Config.AgentModel
+// on the first state transition (AC-1, AC-3, AC-4, AC-5 from #557). It also
+// verifies COALESCE semantics: subsequent state transitions must not overwrite
+// the already-set values.
 func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 	t.Run("seeded when AgentRole is set", func(t *testing.T) {
 		clk := newTestClock()
@@ -3587,6 +3588,7 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			DB:          d,
 			Clock:       clk,
 			AgentRole:   "worker",
+			AgentModel:  "anthropic/claude-sonnet-4-6",
 		}
 		sc := New(cfg)
 
@@ -3611,6 +3613,12 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 		if *st.RootAgentName != "worker" {
 			t.Errorf("root_agent_name = %q, want %q", *st.RootAgentName, "worker")
 		}
+		if st.RootModelID == nil {
+			t.Fatal("root_model_id is nil, want \"anthropic/claude-sonnet-4-6\"")
+		}
+		if *st.RootModelID != "anthropic/claude-sonnet-4-6" {
+			t.Errorf("root_model_id = %q, want %q", *st.RootModelID, "anthropic/claude-sonnet-4-6")
+		}
 	})
 
 	t.Run("preserved on subsequent state transitions (COALESCE)", func(t *testing.T) {
@@ -3624,10 +3632,11 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			DB:          d,
 			Clock:       clk,
 			AgentRole:   "worker",
+			AgentModel:  "anthropic/claude-sonnet-4-6",
 		}
 		sc := New(cfg)
 
-		// First transition: session.created → active (seeds root_agent_name).
+		// First transition: session.created → active (seeds root_agent_name and root_model_id).
 		sc.HandleEvent(makeSSE("session.created", map[string]any{
 			"info": map[string]any{
 				"id":    "sid-1",
@@ -3635,7 +3644,7 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			},
 		}))
 
-		// Second transition: session.idle → finished (must preserve root_agent_name).
+		// Second transition: session.idle → finished (must preserve both values).
 		sc.HandleEvent(makeSSE("session.idle", map[string]any{}))
 		timer := clk.LastTimer()
 		if timer == nil {
@@ -3656,6 +3665,12 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 		if *st.RootAgentName != "worker" {
 			t.Errorf("root_agent_name = %q after subsequent transition, want %q", *st.RootAgentName, "worker")
 		}
+		if st.RootModelID == nil {
+			t.Fatal("root_model_id became nil after subsequent state transition, want preserved")
+		}
+		if *st.RootModelID != "anthropic/claude-sonnet-4-6" {
+			t.Errorf("root_model_id = %q after subsequent transition, want %q", *st.RootModelID, "anthropic/claude-sonnet-4-6")
+		}
 	})
 
 	t.Run("remains NULL when AgentRole is empty", func(t *testing.T) {
@@ -3668,7 +3683,7 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			OpencodeURL: "http://localhost:14000",
 			DB:          d,
 			Clock:       clk,
-			// AgentRole intentionally left empty to simulate a legacy session.
+			// AgentRole and AgentModel intentionally left empty (legacy session).
 		}
 		sc := New(cfg)
 
@@ -3689,6 +3704,9 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 		}
 		if st.RootAgentName != nil {
 			t.Errorf("root_agent_name = %q, want nil for legacy session with empty AgentRole", *st.RootAgentName)
+		}
+		if st.RootModelID != nil {
+			t.Errorf("root_model_id = %q, want nil for legacy session with empty AgentRole", *st.RootModelID)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- The sidecar now calls `UpsertStatusWithRootAgent` (instead of `UpsertStatus`) on every state transition when `Config.AgentRole` is non-empty, seeding `root_agent_name` on the initial INSERT and preserving it via COALESCE on subsequent UPDATEs. This ensures `prism prompt` can always resolve the correct agent to target in its `prompt_async` body.
- Removes `"prism spawn *" = "allow"` from the worker agent's `writeBashCommands` — spawning sessions is a coordinator responsibility, not a worker's.
- Corrects the misleading `db.go` comment that attributed `root_agent_name` writes to the TypeScript plugin (which never implemented them).

## Changed files

- `modules/programs/prism/prism/internal/sidecar/sidecar.go` — `upsertState` now uses `UpsertStatusWithRootAgent` when `AgentRole` is set
- `modules/programs/prism/prism/internal/db/db.go` — corrected misleading comment
- `modules/programs/prism/prism/internal/sidecar/sidecar_test.go` — `TestRootAgentName_SeededFromAgentRole` with three sub-tests
- `modules/programs/prism/opencode.nix` — removed `prism spawn *` from worker `writeBashCommands`

Closes #557