### PR TITLE
prism stats: add model breakdown subcommand and make summary all-repos by default

### DIFF
--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -4,17 +4,19 @@ package cmd
 //
 // Usage:
 //
-//	prism stats                   summary table of active sessions for current repo
+//	prism stats                   summary table of all active sessions across all repos
 //	prism stats <session>         per-session detail
-//	prism stats --all             summary table of all active sessions across all repos
+//	prism stats --all             same as no flags (kept for backwards compatibility)
 //	prism stats --days N          historical aggregate over the last N days
+//	prism stats model             per-model performance breakdown over last 7 days
+//	prism stats model --days N    per-model performance breakdown over last N days
 
 import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -52,19 +54,21 @@ var statsCmd = &cobra.Command{
 	Short: "Session metrics and statistics",
 	Long: `Display metrics and statistics for agent sessions.
 
-With no arguments, shows a summary table of active sessions for the current
-repo (use --all for all repos).
+With no arguments, shows a summary table of all active sessions across all repos.
+The --all flag is accepted for backwards compatibility and is a no-op.
 
 With a session name argument, shows detailed per-session metrics including
 token usage, cost, duration, tool breakdown, and turn timing.
 
-Use --days N to show aggregate statistics over the last N days.`,
+Use --days N to show aggregate statistics over the last N days.
+
+Use the 'model' subcommand for a per-provider/model performance breakdown.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStats,
 }
 
 func init() {
-	statsCmd.Flags().Bool("all", false, "Show all active sessions across all repos")
+	statsCmd.Flags().Bool("all", false, "No-op, kept for backwards compatibility (all repos are always shown)")
 	statsCmd.Flags().Int("days", 0, "Show aggregate statistics over the last N days")
 	rootCmd.AddCommand(statsCmd)
 }
@@ -73,8 +77,8 @@ func runStats(cmd *cobra.Command, args []string) error {
 	days, _ := cmd.Flags().GetInt("days")
 	showAll, _ := cmd.Flags().GetBool("all")
 
-	if days > 0 && (len(args) > 0 || showAll) {
-		return fmt.Errorf("--days is mutually exclusive with a session name and --all")
+	if days > 0 && len(args) > 0 {
+		return fmt.Errorf("--days is mutually exclusive with a session name")
 	}
 
 	if days > 0 {
@@ -423,33 +427,16 @@ func renderSessionDetail(m *sessionMetrics) {
 
 // ---------- summary table ----------
 
-func runStatsSummary(showAll bool) error {
+// runStatsSummary shows a summary table of all active sessions across all repos.
+// showAll is accepted for backwards compatibility but is now a no-op.
+func runStatsSummary(_ bool) error {
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats: %w", err)
 	}
 	defer d.Close()
 
-	// Determine repo scope.
-	currentRepo := ""
-	if !showAll {
-		cwd, err := os.Getwd()
-		if err != nil {
-			cwd = os.Getenv("PRISM_SPAWN_PATH")
-		}
-		if cwd != "" {
-			currentRepo = deriveRepo(cwd)
-		}
-	}
-
-	var statuses []db.Status
-	if showAll {
-		statuses, err = d.AllActiveStatus()
-	} else if currentRepo != "" {
-		statuses, err = d.AllActiveStatusForRepo(currentRepo)
-	} else {
-		statuses, err = d.AllActiveStatus()
-	}
+	statuses, err := d.AllActiveStatus()
 	if err != nil {
 		return fmt.Errorf("stats: %w", err)
 	}
@@ -707,4 +694,271 @@ func truncateStr(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// ---------- model performance breakdown ----------
+
+// modelMetrics tracks per-model metrics accumulated across turns.
+type modelMetrics struct {
+	Provider     string
+	Model        string
+	Turns        int
+	Sessions     map[string]struct{} // distinct session IDs
+	DurationsMs  []float64           // durationMs values for P50 (zero values excluded)
+	TokPerSec    []float64           // output tokens/sec per turn (zero-duration turns excluded)
+	InputTokens  int
+	OutputTokens int
+	Cost         float64
+}
+
+// percentileFloat64 returns the p-th percentile of a sorted (or unsorted) slice.
+// vals is sorted in-place. Returns 0 for an empty slice.
+func percentileFloat64(vals []float64, p int) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sort.Float64s(vals)
+	if len(vals) == 1 {
+		return vals[0]
+	}
+	// Nearest-rank method.
+	idx := int(math.Ceil(float64(p)/100.0*float64(len(vals)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(vals) {
+		idx = len(vals) - 1
+	}
+	return vals[idx]
+}
+
+// splitModel splits a "provider/model" string into its two parts.
+// If there is no "/" the whole string is returned as the model name with an
+// empty provider.
+func splitModel(modelID string) (provider, model string) {
+	idx := strings.IndexByte(modelID, '/')
+	if idx < 0 {
+		return "", modelID
+	}
+	return modelID[:idx], modelID[idx+1:]
+}
+
+// collectModelMetrics groups msg_assistant events by provider/model and builds
+// per-model metrics. Turns with durationMs == 0 are excluded from latency and
+// throughput calculations.
+func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
+	metrics := make(map[string]*modelMetrics)
+
+	for _, e := range events {
+		if e.Type != "msg_assistant" {
+			continue
+		}
+
+		var p payload.MsgAssistant
+		if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+			continue
+		}
+		if p.Model == "" {
+			continue
+		}
+
+		provider, model := splitModel(p.Model)
+		key := p.Model // full "provider/model" as map key
+		m, ok := metrics[key]
+		if !ok {
+			m = &modelMetrics{
+				Provider: provider,
+				Model:    model,
+				Sessions: make(map[string]struct{}),
+			}
+			metrics[key] = m
+		}
+
+		m.Turns++
+		m.Sessions[e.SessionName] = struct{}{}
+		m.InputTokens += p.InputTokens
+		m.OutputTokens += p.OutputTokens
+
+		// Cost using the full key (provider/model).
+		if costs, ok := modelCosts[key]; ok {
+			m.Cost += (float64(p.InputTokens)*costs.Input +
+				float64(p.OutputTokens)*costs.Output +
+				float64(p.CacheReadTokens)*costs.CacheRead +
+				float64(p.CacheWriteTokens)*costs.CacheWrite) / 1_000_000
+		}
+
+		// Latency and throughput only for turns with valid duration.
+		if p.DurationMs > 0 {
+			m.DurationsMs = append(m.DurationsMs, float64(p.DurationMs))
+			secs := float64(p.DurationMs) / 1000.0
+			tokPerSec := float64(p.OutputTokens) / secs
+			m.TokPerSec = append(m.TokPerSec, tokPerSec)
+		}
+	}
+
+	return metrics
+}
+
+// formatLatency formats a duration given in milliseconds as "Xs" or "Xm Ys".
+func formatLatency(ms float64) string {
+	secs := int(ms / 1000)
+	if secs < 60 {
+		return fmt.Sprintf("%ds", secs)
+	}
+	mins := secs / 60
+	s := secs % 60
+	return fmt.Sprintf("%dm %ds", mins, s)
+}
+
+var modelCmd = &cobra.Command{
+	Use:   "model",
+	Short: "Per-provider/model performance breakdown",
+	Long: `Show a performance breakdown by provider and model over the specified time window.
+
+By default shows the last 7 days across all repos. Use --days N to change the
+window.
+
+Latency figures (LAT p50) reflect full turn duration (wall-clock time from
+request sent to response received), not time-to-first-token.`,
+	Args: cobra.NoArgs,
+	RunE: runStatsModel,
+}
+
+func init() {
+	modelCmd.Flags().Int("days", 7, "Number of days to include (default 7)")
+	statsCmd.AddCommand(modelCmd)
+}
+
+func runStatsModel(cmd *cobra.Command, _ []string) error {
+	days, _ := cmd.Flags().GetInt("days")
+	if days <= 0 {
+		return fmt.Errorf("--days must be greater than 0")
+	}
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats model: %w", err)
+	}
+	defer d.Close()
+
+	sinceMs := time.Now().Add(-time.Duration(days) * 24 * time.Hour).UnixMilli()
+	events, err := d.EventsSince(sinceMs)
+	if err != nil {
+		return fmt.Errorf("stats model: %w", err)
+	}
+
+	metrics := collectModelMetrics(events)
+
+	if len(metrics) == 0 {
+		fmt.Printf("no model data in the last %d days\n", days)
+		return nil
+	}
+
+	renderModelBreakdown(metrics, days)
+	return nil
+}
+
+func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
+	// Convert to slice for sorting.
+	type modelRow struct {
+		key string
+		m   *modelMetrics
+	}
+	var rows []modelRow
+	for key, m := range metrics {
+		rows = append(rows, modelRow{key, m})
+	}
+
+	// Sort by total cost descending; ties sorted by PROVIDER then MODEL ascending.
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].m.Cost != rows[j].m.Cost {
+			return rows[i].m.Cost > rows[j].m.Cost
+		}
+		if rows[i].m.Provider != rows[j].m.Provider {
+			return rows[i].m.Provider < rows[j].m.Provider
+		}
+		return rows[i].m.Model < rows[j].m.Model
+	})
+
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleHeaderDim := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	fmt.Println(styleHeader.Render(fmt.Sprintf("Model Performance — last %d days", days)))
+	fmt.Println()
+
+	// Column widths.
+	const (
+		wProvider = 18
+		wModel    = 28
+		wTurns    = 6
+		wLat      = 9
+		wTokS     = 10
+		wInput    = 8
+		wOutput   = 8
+		wCost     = 8
+		wSessions = 8
+	)
+
+	// Header row.
+	header := fmt.Sprintf("%-*s  %-*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s",
+		wProvider, "PROVIDER",
+		wModel, "MODEL",
+		wTurns, "TURNS",
+		wLat, "LAT p50",
+		wTokS, "TOK/S p50",
+		wInput, "INPUT",
+		wOutput, "OUTPUT",
+		wCost, "COST",
+		wSessions, "SESSIONS",
+	)
+	fmt.Println(styleHeaderDim.Render(header))
+
+	// Separator.
+	sep := strings.Repeat("─", len(header))
+	fmt.Println(styleDim.Render(sep))
+
+	for _, row := range rows {
+		m := row.m
+
+		// Latency P50.
+		latStr := "-"
+		if len(m.DurationsMs) > 0 {
+			p50ms := percentileFloat64(m.DurationsMs, 50)
+			latStr = formatLatency(p50ms)
+		}
+
+		// Throughput P50.
+		tokStr := "-"
+		if len(m.TokPerSec) > 0 {
+			p50tps := percentileFloat64(m.TokPerSec, 50)
+			tokStr = fmt.Sprintf("%.0f t/s", p50tps)
+		}
+
+		// Cost.
+		costStr := "-"
+		if _, ok := modelCosts[row.key]; ok {
+			costStr = formatCost(m.Cost)
+		}
+
+		provider := m.Provider
+		if provider == "" {
+			provider = "(unknown)"
+		}
+
+		fmt.Printf("%-*s  %-*s  %*d  %*s  %*s  %*s  %*s  %*s  %*d\n",
+			wProvider, provider,
+			wModel, m.Model,
+			wTurns, m.Turns,
+			wLat, latStr,
+			wTokS, tokStr,
+			wInput, formatTokenCount(m.InputTokens),
+			wOutput, formatTokenCount(m.OutputTokens),
+			wCost, costStr,
+			wSessions, len(m.Sessions),
+		)
+	}
+
+	fmt.Println()
+	fmt.Println(styleDim.Render("Note: LAT p50 is full turn duration (request→response), not time-to-first-token."))
 }

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -826,6 +826,7 @@ request sent to response received), not time-to-first-token.`,
 
 func init() {
 	modelCmd.Flags().Int("days", 7, "Number of days to include (default 7)")
+	modelCmd.Flags().Bool("all", false, "No-op, kept for consistency (always cross-repo)")
 	statsCmd.AddCommand(modelCmd)
 }
 

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -508,8 +508,10 @@ func TestRunStatsSession_SubagentInvocations(t *testing.T) {
 }
 
 // TestRunStats_DaysMutuallyExclusive verifies that --days is mutually exclusive
-// with a session name argument and with --all.
+// with a session name argument. --all is now a no-op so --days + --all is
+// allowed.
 func TestRunStats_DaysMutuallyExclusive(t *testing.T) {
+	_ = openStatsTestDB(t)            // needed so openDB() works in runStats
 	statsCmd.Flags().Set("days", "7") //nolint:errcheck
 	defer statsCmd.Flags().Set("days", "0")
 
@@ -522,16 +524,14 @@ func TestRunStats_DaysMutuallyExclusive(t *testing.T) {
 		t.Errorf("expected 'mutually exclusive' in error for --days+session, got: %v", err)
 	}
 
-	// --days + --all should also error.
+	// --days + --all should NOT error (--all is a no-op for backwards compatibility).
 	statsCmd.Flags().Set("all", "true") //nolint:errcheck
 	defer statsCmd.Flags().Set("all", "false")
 
 	err = runStats(statsCmd, nil)
-	if err == nil {
-		t.Fatal("expected error when --days and --all are both provided, got nil")
-	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("expected 'mutually exclusive' in error for --days+--all, got: %v", err)
+	// May return an error from the DB (no events), but must NOT be a "mutually exclusive" error.
+	if err != nil && strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("--days + --all should not produce a 'mutually exclusive' error, got: %v", err)
 	}
 }
 
@@ -569,4 +569,363 @@ func TestCollectMetrics_PreEnrichmentEvents(t *testing.T) {
 	if len(m.TurnDurations) != 0 {
 		t.Errorf("TurnDurations should be empty for pre-enrichment events, got %d", len(m.TurnDurations))
 	}
+}
+
+// --- model breakdown tests ---
+
+// assistantPayloadWithModel creates an assistant payload with a specific model.
+func assistantPayloadWithModel(model string, inputTokens, outputTokens int, durationMs int64) string {
+	return fmt.Sprintf(`{"messageId":"msg-%d","text":"reply","agent":"opencode","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":%d}`,
+		inputTokens, model, inputTokens, outputTokens, durationMs)
+}
+
+// TestRunStatsModel_BasicOutput verifies that the model breakdown produces a
+// table with expected columns and rows.
+func TestRunStatsModel_BasicOutput(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Two turns for github-copilot/claude-sonnet-4.6 in session A.
+	writeStatsEvent(t, d, "testrepo@main", "msg_assistant",
+		assistantPayloadWithModel("github-copilot/claude-sonnet-4.6", 10000, 3000, 22000),
+		base.Add(-1*time.Hour))
+	writeStatsEvent(t, d, "testrepo@main", "msg_assistant",
+		assistantPayloadWithModel("github-copilot/claude-sonnet-4.6", 5000, 1500, 18000),
+		base.Add(-50*time.Minute))
+
+	// One turn for anthropic/claude-sonnet-4-6 in session B.
+	writeStatsEvent(t, d, "testrepo@feature", "msg_assistant",
+		assistantPayloadWithModel("anthropic/claude-sonnet-4-6", 8000, 2000, 18000),
+		base.Add(-30*time.Minute))
+
+	events, err := d.EventsSince(base.Add(-2 * time.Hour).UnixMilli())
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+
+	metrics := collectModelMetrics(events)
+
+	// Should have two distinct providers.
+	if len(metrics) != 2 {
+		t.Errorf("expected 2 model entries, got %d", len(metrics))
+	}
+
+	ghEntry, ok := metrics["github-copilot/claude-sonnet-4.6"]
+	if !ok {
+		t.Fatal("missing github-copilot/claude-sonnet-4.6 entry")
+	}
+	if ghEntry.Turns != 2 {
+		t.Errorf("github-copilot turns = %d, want 2", ghEntry.Turns)
+	}
+	if len(ghEntry.Sessions) != 1 {
+		t.Errorf("github-copilot sessions = %d, want 1", len(ghEntry.Sessions))
+	}
+	if ghEntry.InputTokens != 15000 {
+		t.Errorf("github-copilot input tokens = %d, want 15000", ghEntry.InputTokens)
+	}
+	if ghEntry.OutputTokens != 4500 {
+		t.Errorf("github-copilot output tokens = %d, want 4500", ghEntry.OutputTokens)
+	}
+	if ghEntry.Provider != "github-copilot" {
+		t.Errorf("github-copilot provider = %q, want %q", ghEntry.Provider, "github-copilot")
+	}
+	if ghEntry.Model != "claude-sonnet-4.6" {
+		t.Errorf("github-copilot model = %q, want %q", ghEntry.Model, "claude-sonnet-4.6")
+	}
+
+	// Verify render doesn't panic and contains expected headers.
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	for _, want := range []string{"PROVIDER", "MODEL", "TURNS", "LAT p50", "TOK/S p50", "INPUT", "OUTPUT", "COST", "SESSIONS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing column header %q\ngot:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "github-copilot") {
+		t.Errorf("output missing 'github-copilot'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "anthropic") {
+		t.Errorf("output missing 'anthropic'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsModel_NoData verifies graceful output when no session data exists.
+func TestRunStatsModel_NoData(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsModel(modelCmd, nil); err != nil {
+			t.Errorf("runStatsModel: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no model data") {
+		t.Errorf("output missing 'no model data' for empty DB\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsModel_DaysZeroError verifies that --days 0 returns an error.
+func TestRunStatsModel_DaysZeroError(t *testing.T) {
+	modelCmd.Flags().Set("days", "0") //nolint:errcheck
+	defer modelCmd.Flags().Set("days", "7")
+
+	err := runStatsModel(modelCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for --days 0, got nil")
+	}
+	if !strings.Contains(err.Error(), "--days must be greater than 0") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestRunStatsModel_ZeroDurationExcluded verifies that turns with durationMs==0
+// are excluded from latency/throughput P50 but still count towards token totals.
+func TestRunStatsModel_ZeroDurationExcluded(t *testing.T) {
+	events := []fakeEvent{
+		// Turn 1: has duration.
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 10000},
+		// Turn 2: no duration (zero).
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 2000, outputTokens: 800, durationMs: 0},
+	}
+
+	dbEvents := fakeEventsToDBEvents(events)
+	metrics := collectModelMetrics(dbEvents)
+
+	entry, ok := metrics["anthropic/claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing anthropic/claude-sonnet-4-6 entry")
+	}
+
+	// Both turns count towards token totals.
+	if entry.Turns != 2 {
+		t.Errorf("Turns = %d, want 2", entry.Turns)
+	}
+	if entry.InputTokens != 3000 {
+		t.Errorf("InputTokens = %d, want 3000", entry.InputTokens)
+	}
+	if entry.OutputTokens != 1300 {
+		t.Errorf("OutputTokens = %d, want 1300", entry.OutputTokens)
+	}
+
+	// Only the non-zero duration turn contributes to latency/throughput.
+	if len(entry.DurationsMs) != 1 {
+		t.Errorf("DurationsMs has %d entries, want 1 (zero excluded)", len(entry.DurationsMs))
+	}
+	if len(entry.TokPerSec) != 1 {
+		t.Errorf("TokPerSec has %d entries, want 1 (zero excluded)", len(entry.TokPerSec))
+	}
+}
+
+// TestRunStatsModel_ZeroDurationOnlyModel verifies that a model with only
+// zero-duration turns shows "-" for latency and throughput, not 0 or an error.
+func TestRunStatsModel_ZeroDurationOnlyModel(t *testing.T) {
+	events := []fakeEvent{
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 0},
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 2000, outputTokens: 800, durationMs: 0},
+	}
+
+	dbEvents := fakeEventsToDBEvents(events)
+	metrics := collectModelMetrics(dbEvents)
+
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	// The LAT p50 and TOK/S p50 columns should show "-" not "0s" or "0 t/s".
+	if strings.Contains(out, "0s") {
+		t.Errorf("output should not contain '0s' for zero-duration-only model\ngot:\n%s", out)
+	}
+}
+
+// TestPercentileFloat64 verifies the P50 percentile helper.
+func TestPercentileFloat64(t *testing.T) {
+	cases := []struct {
+		vals []float64
+		p    int
+		want float64
+	}{
+		{nil, 50, 0},
+		{[]float64{10}, 50, 10},
+		{[]float64{1, 2, 3, 4, 5}, 50, 3},
+		{[]float64{5, 3, 1, 4, 2}, 50, 3}, // unsorted input
+		{[]float64{1, 2}, 50, 1},
+		{[]float64{1, 2, 3, 4}, 50, 2},
+		{[]float64{1, 2, 3, 4, 5, 6}, 50, 3},
+	}
+	for _, tc := range cases {
+		got := percentileFloat64(tc.vals, tc.p)
+		if got != tc.want {
+			t.Errorf("percentileFloat64(%v, %d) = %v, want %v", tc.vals, tc.p, got, tc.want)
+		}
+	}
+}
+
+// TestFormatLatency verifies the latency formatting helper.
+func TestFormatLatency(t *testing.T) {
+	cases := []struct {
+		ms   float64
+		want string
+	}{
+		{0, "0s"},
+		{1000, "1s"},
+		{22000, "22s"},
+		{59999, "59s"},
+		{60000, "1m 0s"},
+		{90000, "1m 30s"},
+		{124000, "2m 4s"},
+	}
+	for _, tc := range cases {
+		got := formatLatency(tc.ms)
+		if got != tc.want {
+			t.Errorf("formatLatency(%v) = %q, want %q", tc.ms, got, tc.want)
+		}
+	}
+}
+
+// TestSplitModel verifies provider/model splitting.
+func TestSplitModel(t *testing.T) {
+	cases := []struct {
+		input    string
+		provider string
+		model    string
+	}{
+		{"github-copilot/claude-sonnet-4.6", "github-copilot", "claude-sonnet-4.6"},
+		{"anthropic/claude-sonnet-4-6", "anthropic", "claude-sonnet-4-6"},
+		{"no-slash", "", "no-slash"},
+		{"google/gemini-3-flash-preview", "google", "gemini-3-flash-preview"},
+	}
+	for _, tc := range cases {
+		gotProvider, gotModel := splitModel(tc.input)
+		if gotProvider != tc.provider || gotModel != tc.model {
+			t.Errorf("splitModel(%q) = (%q, %q), want (%q, %q)",
+				tc.input, gotProvider, gotModel, tc.provider, tc.model)
+		}
+	}
+}
+
+// TestRunStatsModel_SortedByCostDescending verifies rows are sorted by cost descending.
+func TestRunStatsModel_SortedByCostDescending(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// anthropic/claude-sonnet-4-6: 100K input @ $3/M = $0.30 + 5K output @ $15/M = $0.075 → ~$0.375
+	writeStatsEvent(t, d, "testrepo@main", "msg_assistant",
+		assistantPayloadWithModel("anthropic/claude-sonnet-4-6", 100000, 5000, 5000),
+		base.Add(-1*time.Hour))
+
+	// google/gemini-3-flash-preview: 1K input @ $0.15/M → very cheap
+	writeStatsEvent(t, d, "testrepo@feature", "msg_assistant",
+		assistantPayloadWithModel("google/gemini-3-flash-preview", 1000, 100, 5000),
+		base.Add(-30*time.Minute))
+
+	events, err := d.EventsSince(base.Add(-2 * time.Hour).UnixMilli())
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+
+	metrics := collectModelMetrics(events)
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	// anthropic should appear before google (higher cost).
+	anthropicPos := strings.Index(out, "anthropic")
+	googlePos := strings.Index(out, "google")
+	if anthropicPos == -1 || googlePos == -1 {
+		t.Fatalf("output missing expected model rows\ngot:\n%s", out)
+	}
+	if anthropicPos > googlePos {
+		t.Errorf("expected 'anthropic' to appear before 'google' (sorted by cost desc)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsModel_LatencyNote verifies the footer note about latency measurement.
+func TestRunStatsModel_LatencyNote(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeStatsEvent(t, d, "testrepo@main", "msg_assistant",
+		assistantPayloadWithModel("anthropic/claude-sonnet-4-6", 1000, 500, 5000),
+		base.Add(-1*time.Hour))
+
+	events, err := d.EventsSince(base.Add(-2 * time.Hour).UnixMilli())
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+
+	metrics := collectModelMetrics(events)
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	if !strings.Contains(out, "turn duration") && !strings.Contains(out, "LAT p50") {
+		t.Errorf("output should contain latency note\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsSummary_ShowsAllRepos verifies that the summary table shows all
+// repos by default (no longer scoped to current repo).
+func TestRunStatsSummary_ShowsAllRepos(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Two active sessions in different repos.
+	if err := d.UpsertStatus("repo-a@main", "repo-a", "/code/repo-a/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus("repo-b@main", "repo-b", "/code/repo-b/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	writeStatsEvent(t, d, "repo-a@main", "msg_assistant",
+		assistantPayloadWithTokens("msg-1", "reply", 1000, 500, 0, 0, 5000, 0),
+		base)
+	writeStatsEvent(t, d, "repo-b@main", "msg_assistant",
+		assistantPayloadWithTokens("msg-2", "reply", 2000, 800, 0, 0, 5000, 0),
+		base.Add(time.Second))
+
+	// showAll=false should still show both repos.
+	out := captureStdout(t, func() {
+		if err := runStatsSummary(false); err != nil {
+			t.Errorf("runStatsSummary: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "repo-a@main") {
+		t.Errorf("output missing 'repo-a@main' — should show all repos\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "repo-b@main") {
+		t.Errorf("output missing 'repo-b@main' — should show all repos\ngot:\n%s", out)
+	}
+}
+
+// --- fakeEvent helpers for unit tests that don't need a real DB ---
+
+// fakeEvent is a minimal representation for building test events.
+type fakeEvent struct {
+	session      string
+	model        string
+	inputTokens  int
+	outputTokens int
+	durationMs   int64
+}
+
+// fakeEventsToDBEvents converts fakeEvents into db.Events for use with
+// collectModelMetrics without requiring a real database.
+func fakeEventsToDBEvents(fakes []fakeEvent) []db.Event {
+	var events []db.Event
+	for i, f := range fakes {
+		payload := fmt.Sprintf(`{"messageId":"msg-%d","text":"reply","agent":"opencode","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":%d}`,
+			i, f.model, f.inputTokens, f.outputTokens, f.durationMs)
+		events = append(events, db.Event{
+			ID:          fmt.Sprintf("id-%d", i),
+			SessionName: f.session,
+			Type:        "msg_assistant",
+			Payload:     payload,
+			CreatedAt:   time.Now(),
+		})
+	}
+	return events
 }

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -575,8 +575,10 @@ func TestCollectMetrics_PreEnrichmentEvents(t *testing.T) {
 
 // assistantPayloadWithModel creates an assistant payload with a specific model.
 func assistantPayloadWithModel(model string, inputTokens, outputTokens int, durationMs int64) string {
-	return fmt.Sprintf(`{"messageId":"msg-%d","text":"reply","agent":"opencode","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":%d}`,
-		inputTokens, model, inputTokens, outputTokens, durationMs)
+	// Use a UUID-like ID based on the model and token values to ensure uniqueness.
+	msgID := fmt.Sprintf("%s-%d-%d-%d", model, inputTokens, outputTokens, durationMs)
+	return fmt.Sprintf(`{"messageId":%q,"text":"reply","agent":"opencode","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":%d}`,
+		msgID, model, inputTokens, outputTokens, durationMs)
 }
 
 // TestRunStatsModel_BasicOutput verifies that the model breakdown produces a
@@ -736,6 +738,9 @@ func TestRunStatsModel_ZeroDurationOnlyModel(t *testing.T) {
 	// The LAT p50 and TOK/S p50 columns should show "-" not "0s" or "0 t/s".
 	if strings.Contains(out, "0s") {
 		t.Errorf("output should not contain '0s' for zero-duration-only model\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "0 t/s") {
+		t.Errorf("output should not contain '0 t/s' for zero-duration-only model\ngot:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `prism stats model` subcommand with a per-provider/model performance breakdown table (PROVIDER, MODEL, TURNS, LAT p50, TOK/S p50, INPUT, OUTPUT, COST, SESSIONS) covering a configurable time window (default 7 days, all repos)
- Change `prism stats` summary table to always show all repos by default; `--all` flag retained as a no-op for backwards compatibility
- Add comprehensive unit tests for all new functionality

## Details

### `prism stats model`

```
prism stats model              # breakdown over last 7 days (default), all repos
prism stats model --days N     # breakdown over last N days, all repos
```

Each row is keyed by the full `provider/model` pair. Turns with `durationMs == 0` are excluded from latency and throughput P50 calculations but still contribute to token totals, cost, and session counts. A footer note clarifies that LAT p50 is full turn duration (request→response), not time-to-first-token. Rows are sorted by total cost descending; ties by PROVIDER then MODEL ascending.

### `prism stats` summary scope change

The summary table now always queries `AllActiveStatus()` regardless of the current working directory. The `--all` flag is accepted but is a no-op, preserving backward compatibility with any scripts or muscle memory that uses it.

Closes #559