### PR TITLE
stats: add TTFT p50 column to prism stats model

### DIFF
--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -705,6 +705,7 @@ type modelMetrics struct {
 	Turns        int
 	Sessions     map[string]struct{} // distinct session IDs
 	DurationsMs  []float64           // durationMs values for P50 (zero values excluded)
+	TtftMs       []float64           // ttftMs values for P50 (zero/absent values excluded)
 	TokPerSec    []float64           // output tokens/sec per turn (zero-duration turns excluded)
 	InputTokens  int
 	OutputTokens int
@@ -794,6 +795,11 @@ func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 			tokPerSec := float64(p.OutputTokens) / secs
 			m.TokPerSec = append(m.TokPerSec, tokPerSec)
 		}
+
+		// TTFT only for turns with a non-zero ttftMs value.
+		if p.TtftMs > 0 {
+			m.TtftMs = append(m.TtftMs, float64(p.TtftMs))
+		}
 	}
 
 	return metrics
@@ -818,8 +824,9 @@ var modelCmd = &cobra.Command{
 By default shows the last 7 days across all repos. Use --days N to change the
 window.
 
-Latency figures (LAT p50) reflect full turn duration (wall-clock time from
-request sent to response received), not time-to-first-token.`,
+TTFT p50 shows median time-to-first-token (request sent → first streaming chunk
+received). DUR p50 shows median full turn duration (request sent → complete
+response received).`,
 	Args: cobra.NoArgs,
 	RunE: runStatsModel,
 }
@@ -893,7 +900,8 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 		wProvider = 18
 		wModel    = 28
 		wTurns    = 6
-		wLat      = 9
+		wTtft     = 9
+		wDur      = 9
 		wTokS     = 10
 		wInput    = 8
 		wOutput   = 8
@@ -902,11 +910,12 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 	)
 
 	// Header row.
-	header := fmt.Sprintf("%-*s  %-*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s",
+	header := fmt.Sprintf("%-*s  %-*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s",
 		wProvider, "PROVIDER",
 		wModel, "MODEL",
 		wTurns, "TURNS",
-		wLat, "LAT p50",
+		wTtft, "TTFT p50",
+		wDur, "DUR p50",
 		wTokS, "TOK/S p50",
 		wInput, "INPUT",
 		wOutput, "OUTPUT",
@@ -922,11 +931,18 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 	for _, row := range rows {
 		m := row.m
 
-		// Latency P50.
-		latStr := "-"
+		// TTFT P50.
+		ttftStr := "-"
+		if len(m.TtftMs) > 0 {
+			p50ms := percentileFloat64(m.TtftMs, 50)
+			ttftStr = formatLatency(p50ms)
+		}
+
+		// Full turn duration P50.
+		durStr := "-"
 		if len(m.DurationsMs) > 0 {
 			p50ms := percentileFloat64(m.DurationsMs, 50)
-			latStr = formatLatency(p50ms)
+			durStr = formatLatency(p50ms)
 		}
 
 		// Throughput P50.
@@ -947,11 +963,12 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 			provider = "(unknown)"
 		}
 
-		fmt.Printf("%-*s  %-*s  %*d  %*s  %*s  %*s  %*s  %*s  %*d\n",
+		fmt.Printf("%-*s  %-*s  %*d  %*s  %*s  %*s  %*s  %*s  %*s  %*d\n",
 			wProvider, provider,
 			wModel, m.Model,
 			wTurns, m.Turns,
-			wLat, latStr,
+			wTtft, ttftStr,
+			wDur, durStr,
 			wTokS, tokStr,
 			wInput, formatTokenCount(m.InputTokens),
 			wOutput, formatTokenCount(m.OutputTokens),
@@ -961,5 +978,5 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 	}
 
 	fmt.Println()
-	fmt.Println(styleDim.Render("Note: LAT p50 is full turn duration (request→response), not time-to-first-token."))
+	fmt.Println(styleDim.Render("Note: TTFT p50 = time to first token (request→first chunk); DUR p50 = full turn duration (request→complete response)."))
 }

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -1024,6 +1024,10 @@ func TestRunStatsModel_ZeroTtftShowsDash(t *testing.T) {
 	if !strings.Contains(out, "TTFT p50") {
 		t.Errorf("output missing 'TTFT p50' column header\ngot:\n%s", out)
 	}
+	// The rendered data row should show " - " for the TTFT p50 value.
+	if !strings.Contains(out, " - ") {
+		t.Errorf("expected '-' for TTFT p50 in render output\ngot:\n%s", out)
+	}
 	// The TTFT p50 column should show "-"; check that at least one "-" appears in data rows.
 	// We verify by checking that TtftMs slice is empty (already done above) and that
 	// the render function doesn't panic or show a formatted duration for TTFT.

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -1028,13 +1028,6 @@ func TestRunStatsModel_ZeroTtftShowsDash(t *testing.T) {
 	if !strings.Contains(out, " - ") {
 		t.Errorf("expected '-' for TTFT p50 in render output\ngot:\n%s", out)
 	}
-	// The TTFT p50 column should show "-"; check that at least one "-" appears in data rows.
-	// We verify by checking that TtftMs slice is empty (already done above) and that
-	// the render function doesn't panic or show a formatted duration for TTFT.
-	// Check via the metrics directly: zero TTFT entries means render shows "-".
-	if len(entry.TtftMs) != 0 {
-		t.Errorf("expected no TTFT entries (all zero), got %d — render would not show '-'", len(entry.TtftMs))
-	}
 }
 
 // TestRunStatsModel_TtftAbsentInOldRows verifies that old DB rows without a

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -640,7 +640,7 @@ func TestRunStatsModel_BasicOutput(t *testing.T) {
 		renderModelBreakdown(metrics, 7)
 	})
 
-	for _, want := range []string{"PROVIDER", "MODEL", "TURNS", "LAT p50", "TOK/S p50", "INPUT", "OUTPUT", "COST", "SESSIONS"} {
+	for _, want := range []string{"PROVIDER", "MODEL", "TURNS", "TTFT p50", "DUR p50", "TOK/S p50", "INPUT", "OUTPUT", "COST", "SESSIONS"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing column header %q\ngot:\n%s", want, out)
 		}
@@ -865,7 +865,7 @@ func TestRunStatsModel_LatencyNote(t *testing.T) {
 		renderModelBreakdown(metrics, 7)
 	})
 
-	if !strings.Contains(out, "turn duration") && !strings.Contains(out, "LAT p50") {
+	if !strings.Contains(out, "turn duration") && !strings.Contains(out, "DUR p50") {
 		t.Errorf("output should contain latency note\ngot:\n%s", out)
 	}
 }
@@ -915,6 +915,7 @@ type fakeEvent struct {
 	inputTokens  int
 	outputTokens int
 	durationMs   int64
+	ttftMs       int64
 }
 
 // fakeEventsToDBEvents converts fakeEvents into db.Events for use with
@@ -922,8 +923,8 @@ type fakeEvent struct {
 func fakeEventsToDBEvents(fakes []fakeEvent) []db.Event {
 	var events []db.Event
 	for i, f := range fakes {
-		payload := fmt.Sprintf(`{"messageId":"msg-%d","text":"reply","agent":"opencode","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":%d}`,
-			i, f.model, f.inputTokens, f.outputTokens, f.durationMs)
+		payload := fmt.Sprintf(`{"messageId":"msg-%d","text":"reply","agent":"opencode","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":%d,"ttftMs":%d}`,
+			i, f.model, f.inputTokens, f.outputTokens, f.durationMs, f.ttftMs)
 		events = append(events, db.Event{
 			ID:          fmt.Sprintf("id-%d", i),
 			SessionName: f.session,
@@ -933,4 +934,138 @@ func fakeEventsToDBEvents(fakes []fakeEvent) []db.Event {
 		})
 	}
 	return events
+}
+
+// TestRunStatsModel_TtftP50 verifies that TTFT p50 is calculated only from
+// turns that have a non-zero ttftMs, and that the DUR p50 column still shows
+// full turn duration.
+func TestRunStatsModel_TtftP50(t *testing.T) {
+	events := []fakeEvent{
+		// Turn 1: ttft=2s, duration=10s
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 10000, ttftMs: 2000},
+		// Turn 2: ttft=4s, duration=20s
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 20000, ttftMs: 4000},
+		// Turn 3: no ttft (zero) — should be excluded from TTFT p50
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 15000, ttftMs: 0},
+	}
+
+	dbEvents := fakeEventsToDBEvents(events)
+	metrics := collectModelMetrics(dbEvents)
+
+	entry, ok := metrics["anthropic/claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing anthropic/claude-sonnet-4-6 entry")
+	}
+
+	// All three turns count towards totals.
+	if entry.Turns != 3 {
+		t.Errorf("Turns = %d, want 3", entry.Turns)
+	}
+
+	// Only the two non-zero ttft turns contribute to TtftMs.
+	if len(entry.TtftMs) != 2 {
+		t.Errorf("TtftMs has %d entries, want 2 (zero excluded)", len(entry.TtftMs))
+	}
+
+	// All three non-zero duration turns contribute to DurationsMs.
+	if len(entry.DurationsMs) != 3 {
+		t.Errorf("DurationsMs has %d entries, want 3", len(entry.DurationsMs))
+	}
+
+	// TTFT p50: [2000, 4000] → p50 = 2000 (nearest rank, idx=0 for 2 values at p50)
+	ttftP50 := percentileFloat64(append([]float64{}, entry.TtftMs...), 50)
+	if ttftP50 != 2000 {
+		t.Errorf("TTFT p50 = %v, want 2000", ttftP50)
+	}
+
+	// Render and verify columns appear.
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	if !strings.Contains(out, "TTFT p50") {
+		t.Errorf("output missing 'TTFT p50' column header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "DUR p50") {
+		t.Errorf("output missing 'DUR p50' column header\ngot:\n%s", out)
+	}
+	// "2s" should appear as TTFT p50 value.
+	if !strings.Contains(out, "2s") {
+		t.Errorf("output missing '2s' for TTFT p50\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsModel_ZeroTtftShowsDash verifies that when all turns have
+// ttftMs == 0 (or the field is absent), the TTFT p50 column shows "-".
+func TestRunStatsModel_ZeroTtftShowsDash(t *testing.T) {
+	events := []fakeEvent{
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 10000, ttftMs: 0},
+		{session: "s1", model: "anthropic/claude-sonnet-4-6", inputTokens: 1000, outputTokens: 500, durationMs: 20000, ttftMs: 0},
+	}
+
+	dbEvents := fakeEventsToDBEvents(events)
+	metrics := collectModelMetrics(dbEvents)
+
+	entry, ok := metrics["anthropic/claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing anthropic/claude-sonnet-4-6 entry")
+	}
+
+	if len(entry.TtftMs) != 0 {
+		t.Errorf("TtftMs should be empty when all ttftMs == 0, got %d entries", len(entry.TtftMs))
+	}
+
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	// The TTFT p50 column value should be "-" (a dash), not a duration.
+	// The header "TTFT p50" must still be present.
+	if !strings.Contains(out, "TTFT p50") {
+		t.Errorf("output missing 'TTFT p50' column header\ngot:\n%s", out)
+	}
+	// The TTFT p50 column should show "-"; check that at least one "-" appears in data rows.
+	// We verify by checking that TtftMs slice is empty (already done above) and that
+	// the render function doesn't panic or show a formatted duration for TTFT.
+	// Check via the metrics directly: zero TTFT entries means render shows "-".
+	if len(entry.TtftMs) != 0 {
+		t.Errorf("expected no TTFT entries (all zero), got %d — render would not show '-'", len(entry.TtftMs))
+	}
+}
+
+// TestRunStatsModel_TtftAbsentInOldRows verifies that old DB rows without a
+// ttftMs field degrade gracefully (TTFT p50 shows "-", no error).
+func TestRunStatsModel_TtftAbsentInOldRows(t *testing.T) {
+	// Old-format payloads with no ttftMs field.
+	dbEvents := []db.Event{
+		{
+			ID:          "id-0",
+			SessionName: "s1",
+			Type:        "msg_assistant",
+			Payload:     `{"messageId":"msg-0","text":"reply","agent":"opencode","model":"anthropic/claude-sonnet-4-6","inputTokens":1000,"outputTokens":500,"durationMs":10000}`,
+			CreatedAt:   time.Now(),
+		},
+	}
+
+	metrics := collectModelMetrics(dbEvents)
+
+	entry, ok := metrics["anthropic/claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing anthropic/claude-sonnet-4-6 entry")
+	}
+
+	if len(entry.TtftMs) != 0 {
+		t.Errorf("TtftMs should be empty for old rows without ttftMs field, got %d entries", len(entry.TtftMs))
+	}
+	if entry.Turns != 1 {
+		t.Errorf("Turns = %d, want 1", entry.Turns)
+	}
+
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	if !strings.Contains(out, "TTFT p50") {
+		t.Errorf("output missing 'TTFT p50' column header\ngot:\n%s", out)
+	}
 }

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -38,6 +38,11 @@ type MsgUser struct {
 // measured from time.created to time.completed on the message. Zero means
 // "not available".
 //
+// TtftMs is the time-to-first-token in milliseconds, measured from
+// time.created on the message to the time.start of the first text part
+// received in the stream. Zero means "not available" (non-streaming responses,
+// pre-enrichment rows, or turns where the first-token timestamp was absent).
+//
 // ContextWindowPct is the context window utilization as a percentage (0-100),
 // calculated as (inputTokens / contextWindowSize) * 100. Zero means
 // "not available" (model context window size unknown or inputTokens absent).
@@ -51,6 +56,7 @@ type MsgAssistant struct {
 	CacheReadTokens  int     `json:"cacheReadTokens,omitempty"`
 	CacheWriteTokens int     `json:"cacheWriteTokens,omitempty"`
 	DurationMs       int64   `json:"durationMs,omitempty"`
+	TtftMs           int64   `json:"ttftMs,omitempty"`
 	ContextWindowPct float64 `json:"contextWindowPct,omitempty"`
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -133,11 +133,14 @@ type Sidecar struct {
 	// msgCreatedAtMs tracks the time.created timestamp (ms since epoch) for
 	// in-flight assistant messages. Used to compute TTFT when the first text
 	// part arrives. Keyed by message ID; entries are deleted when the message
-	// is written (same lifecycle as textByMessage).
+	// is written (same lifecycle as textByMessage). Messages abandoned mid-turn
+	// (e.g. opencode interrupted) are not cleaned up; this matches the existing
+	// textByMessage behaviour and is acceptable for short-lived sidecar processes.
 	msgCreatedAtMs map[string]float64
 	// ttftByMessage tracks the computed TTFT (ms) for each assistant message,
 	// set when the first text part with a time.start timestamp arrives.
 	// Zero means "not yet seen" or "unavailable". Keyed by message ID.
+	// Same lifecycle / leak characteristics as msgCreatedAtMs above.
 	ttftByMessage map[string]int64
 	// container is set when running in container mode.
 	// Protected by mu.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -130,6 +130,15 @@ type Sidecar struct {
 	opencodeSID     string
 	writtenMessages map[string]bool // dedup message.updated writes
 	textByMessage   map[string]string
+	// msgCreatedAtMs tracks the time.created timestamp (ms since epoch) for
+	// in-flight assistant messages. Used to compute TTFT when the first text
+	// part arrives. Keyed by message ID; entries are deleted when the message
+	// is written (same lifecycle as textByMessage).
+	msgCreatedAtMs map[string]float64
+	// ttftByMessage tracks the computed TTFT (ms) for each assistant message,
+	// set when the first text part with a time.start timestamp arrives.
+	// Zero means "not yet seen" or "unavailable". Keyed by message ID.
+	ttftByMessage map[string]int64
 	// container is set when running in container mode.
 	// Protected by mu.
 	container *containerMgr
@@ -178,6 +187,8 @@ func New(cfg Config) *Sidecar {
 		cfg:             cfg,
 		writtenMessages: make(map[string]bool),
 		textByMessage:   make(map[string]string),
+		msgCreatedAtMs:  make(map[string]float64),
+		ttftByMessage:   make(map[string]int64),
 	}
 	// Pre-set rootAgent from the configured agent role so that subagent user
 	// messages (which have a non-empty agent field in SSE events) do not
@@ -802,7 +813,24 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 		s.writtenMessages[info.ID] = true
 		delete(s.textByMessage, info.ID)
 
-	} else if info.Role == "assistant" && info.Time != nil && info.Time.Completed != nil {
+	} else if info.Role == "assistant" {
+		// Store time.created for TTFT computation as soon as we see any
+		// assistant message event (whether or not time.completed is set).
+		// This records the request-sent timestamp that we compare against the
+		// first text-part arrival. Only store once (first seen wins) so that
+		// subsequent message.updated events for the same message don't
+		// overwrite the original created time.
+		if info.Time != nil && info.Time.Created != nil {
+			if _, alreadyStored := s.msgCreatedAtMs[info.ID]; !alreadyStored {
+				s.msgCreatedAtMs[info.ID] = *info.Time.Created
+			}
+		}
+
+		if info.Time == nil || info.Time.Completed == nil {
+			// Message not yet complete — nothing more to do.
+			return
+		}
+
 		if s.writtenMessages[info.ID] {
 			return
 		}
@@ -930,9 +958,15 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 			}
 		}
 
+		if ttft, ok := s.ttftByMessage[info.ID]; ok && ttft > 0 {
+			eventPayload["ttftMs"] = ttft
+		}
+
 		s.writeEvent("msg_assistant", eventPayload, nil)
 		s.writtenMessages[info.ID] = true
 		delete(s.textByMessage, info.ID)
+		delete(s.msgCreatedAtMs, info.ID)
+		delete(s.ttftByMessage, info.ID)
 	}
 }
 
@@ -954,7 +988,8 @@ func (s *Sidecar) handleMessagePartUpdated(evt sse.Event) {
 					} `json:"time"`
 				} `json:"state"`
 				Time *struct {
-					End *float64 `json:"end"`
+					Start *float64 `json:"start"`
+					End   *float64 `json:"end"`
 				} `json:"time"`
 			} `json:"part"`
 		} `json:"properties"`
@@ -970,6 +1005,18 @@ func (s *Sidecar) handleMessagePartUpdated(evt sse.Event) {
 	case "text":
 		if part.Text != "" {
 			s.textByMessage[part.MessageID] = part.Text
+		}
+		// Capture TTFT from the first text part with a time.start timestamp.
+		// Only record once per message (first text part wins).
+		if _, alreadyRecorded := s.ttftByMessage[part.MessageID]; !alreadyRecorded {
+			if part.Time != nil && part.Time.Start != nil {
+				if createdAt, ok := s.msgCreatedAtMs[part.MessageID]; ok {
+					ttft := *part.Time.Start - createdAt
+					if ttft > 0 {
+						s.ttftByMessage[part.MessageID] = int64(ttft)
+					}
+				}
+			}
 		}
 
 	case "tool":

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -3710,3 +3710,181 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 		}
 	})
 }
+
+// ── TTFT computation tests ───────────────────────────────────────────────────
+
+// TestTtft_HappyPath verifies that a complete assistant turn with a text part
+// that carries time.start produces a msg_assistant event with the correct
+// ttftMs value: time.start − message.time.created.
+func TestTtft_HappyPath(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	const (
+		msgID     = "msg-ttft-1"
+		createdMs = 1000.0 // request sent
+		startMs   = 1800.0 // first token received → TTFT = 800 ms
+		completed = 5000.0 // response complete → durationMs = 4000 ms
+	)
+
+	// 1. First message.updated: carries time.created but no time.completed —
+	//    the sidecar stores msgCreatedAtMs and returns early.
+	created := float64(createdMs)
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":   msgID,
+			"role": "assistant",
+			"time": map[string]*float64{
+				"created": &created,
+			},
+		},
+	}))
+
+	// 2. message.part.updated: text part with time.start — triggers TTFT computation.
+	start := float64(startMs)
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": msgID,
+			"text":      "Here is the answer...",
+			"time": map[string]*float64{
+				"start": &start,
+			},
+		},
+	}))
+
+	// 3. Final message.updated: carries time.completed — triggers the write.
+	comp := float64(completed)
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":         msgID,
+			"role":       "assistant",
+			"agent":      "worker",
+			"providerID": "anthropic",
+			"modelID":    "claude-4",
+			"tokens": map[string]any{
+				"input":  100,
+				"output": 50,
+			},
+			"time": map[string]*float64{
+				"created":   &created,
+				"completed": &comp,
+			},
+		},
+	}))
+
+	// Find and inspect the msg_assistant event.
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var found bool
+	for _, e := range events {
+		if e.Type != "msg_assistant" {
+			continue
+		}
+		found = true
+		var p map[string]any
+		if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+			t.Fatalf("unmarshal msg_assistant payload: %v", err)
+		}
+
+		// durationMs should be completed − created = 4000.
+		if got, ok := p["durationMs"]; !ok || got != float64(4000) {
+			t.Errorf("durationMs = %v, want 4000", got)
+		}
+
+		// ttftMs should be start − created = 800.
+		if got, ok := p["ttftMs"]; !ok || got != float64(800) {
+			t.Errorf("ttftMs = %v, want 800", got)
+		}
+		break
+	}
+	if !found {
+		t.Error("expected msg_assistant event to be written")
+	}
+}
+
+// TestTtft_NoTimeStart verifies that a complete assistant turn whose text part
+// carries no time.start produces a msg_assistant event without a ttftMs field
+// (omitempty means it is absent when zero).
+func TestTtft_NoTimeStart(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	const (
+		msgID     = "msg-ttft-2"
+		createdMs = 2000.0
+		completed = 7000.0
+	)
+
+	// 1. message.updated: time.created present, no time.completed.
+	created := float64(createdMs)
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":   msgID,
+			"role": "assistant",
+			"time": map[string]*float64{
+				"created": &created,
+			},
+		},
+	}))
+
+	// 2. message.part.updated: text part WITHOUT time.start — no TTFT should be computed.
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": msgID,
+			"text":      "Response without timing info",
+			// deliberately no "time" field
+		},
+	}))
+
+	// 3. Final message.updated: time.completed → triggers write.
+	comp := float64(completed)
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":         msgID,
+			"role":       "assistant",
+			"agent":      "worker",
+			"providerID": "anthropic",
+			"modelID":    "claude-4",
+			"tokens": map[string]any{
+				"input":  100,
+				"output": 50,
+			},
+			"time": map[string]*float64{
+				"created":   &created,
+				"completed": &comp,
+			},
+		},
+	}))
+
+	// Find and inspect the msg_assistant event.
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var found bool
+	for _, e := range events {
+		if e.Type != "msg_assistant" {
+			continue
+		}
+		found = true
+		var p map[string]any
+		if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+			t.Fatalf("unmarshal msg_assistant payload: %v", err)
+		}
+
+		// durationMs should still be present.
+		if _, ok := p["durationMs"]; !ok {
+			t.Error("durationMs should be present")
+		}
+
+		// ttftMs must be absent (omitempty with zero value means the field is
+		// not emitted in JSON).
+		if got, present := p["ttftMs"]; present {
+			t.Errorf("ttftMs should be absent when no time.start was seen, got %v", got)
+		}
+		break
+	}
+	if !found {
+		t.Error("expected msg_assistant event to be written")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds \`TtftMs int64\` field to \`MsgAssistant\` payload struct
- Measures TTFT in the **sidecar** (not the TypeScript plugin): tracks \`message.time.created\` in a \`msgCreatedAtMs\` map; when the first text part with \`time.start\` arrives via \`message.part.updated\`, computes \`ttft = time.start - msgCreatedAt\` and stores in \`ttftByMessage\`
- Adds \`TTFT p50\` column to \`prism stats model\` output (shows \`-\` if no non-zero values)
- Renames \`LAT p50\` → \`DUR p50\` (full turn duration) to clearly distinguish it from TTFT
- Updates footer note: \`TTFT p50 = time to first token (request→first chunk); DUR p50 = full turn duration (request→complete response)\`
- Old DB rows without \`ttftMs\` field degrade gracefully (show \`-\`, no error)
- Adds tests for TTFT p50 calculation, zero-TTFT handling, and absent-field (old row) degradation

## Implementation note: sidecar vs. plugin

Issue #565 AC-1 originally described the TypeScript plugin as the measurement point. After exploring the architecture, the sidecar is the better place: it already processes every SSE event from opencode (including \`message.updated\` with \`time.created\` and \`message.part.updated\` with \`time.start\`), so TTFT can be computed there without any plugin changes. The plugin (\`prism-hooks.ts\`) is minimal and only handles git-push detection; extending it to measure TTFT would require duplicating SSE handling that the sidecar already owns.

Closes #565