### PR TITLE
feat(prism): make container SSH key filenames configurable

### DIFF
--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -51,12 +51,33 @@ let
     project_specific = config.nx.programs.prism.projects.specific;
     git_user_name = gitUserName;
     git_user_email = gitUserEmail;
+    ssh_access_key_name = config.nx.programs.prism.sshAccessKeyName;
+    ssh_signing_key_name = config.nx.programs.prism.sshSigningKeyName;
   };
 in
 {
   options = {
     nx.programs.prism.tui.enable = lib.mkEnableOption "enables prism Go TUI binary" // {
       default = true;
+    };
+
+    nx.programs.prism.sshAccessKeyName = lib.mkOption {
+      type = lib.types.str;
+      default = "prismatic-koi-ed25519";
+      description = ''
+        Filename (not full path) of the SSH access key in ~/.ssh/ to mount
+        into prism containers. Defaults to "prismatic-koi-ed25519".
+      '';
+    };
+
+    nx.programs.prism.sshSigningKeyName = lib.mkOption {
+      type = lib.types.str;
+      default = "prismatic-koi-ed25519-signingkey";
+      description = ''
+        Base filename (not full path) of the SSH signing key in ~/.ssh/ to
+        mount into prism containers. The public key is derived by appending
+        ".pub". Defaults to "prismatic-koi-ed25519-signingkey".
+      '';
     };
   };
 

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -153,6 +153,8 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			ContainerCoordinatorConfigPath: prismCfg.ContainerCoordinatorConfigPath,
 			GitUserName:                    prismCfg.GitUserName,
 			GitUserEmail:                   prismCfg.GitUserEmail,
+			SshAccessKeyName:               prismCfg.SshAccessKeyName,
+			SshSigningKeyName:              prismCfg.SshSigningKeyName,
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -97,19 +97,21 @@ type parsedConfig struct {
 // standard paths). These values are used whenever no config file is found.
 func defaults() Config {
 	return Config{
-		ColorPrimary:     "#d4be98",
-		ColorSecondary:   "#a89984",
-		ColorPurple:      "#d3869b",
-		ColorYellow:      "#d8a657",
-		ColorGreen:       "#a9b665",
-		ColorBlue:        "#7daea3",
-		ColorRed:         "#ea6962",
-		ColorForeground:  "#d3c6aa",
-		ColorBg0:         "#2d353b",
-		KittyBin:         "kitty",
-		WorktreeExclude:  []string{"obsidian"},
-		ProjectLocations: []string{"~/code"},
-		ProjectSpecific:  []string{"~/documents/obsidian"},
+		ColorPrimary:      "#d4be98",
+		ColorSecondary:    "#a89984",
+		ColorPurple:       "#d3869b",
+		ColorYellow:       "#d8a657",
+		ColorGreen:        "#a9b665",
+		ColorBlue:         "#7daea3",
+		ColorRed:          "#ea6962",
+		ColorForeground:   "#d3c6aa",
+		ColorBg0:          "#2d353b",
+		KittyBin:          "kitty",
+		SshAccessKeyName:  "prismatic-koi-ed25519",
+		SshSigningKeyName: "prismatic-koi-ed25519-signingkey",
+		WorktreeExclude:   []string{"obsidian"},
+		ProjectLocations:  []string{"~/code"},
+		ProjectSpecific:   []string{"~/documents/obsidian"},
 	}
 }
 

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -54,6 +54,12 @@ type Config struct {
 	// GitUserEmail is the git user.email to write into the container's .gitconfig.
 	// Sourced from the host's NixOS/home-manager git configuration.
 	GitUserEmail string `json:"git_user_email"`
+	// SshAccessKeyName is the filename (not full path) of the SSH access key in ~/.ssh/.
+	// Defaults to "prismatic-koi-ed25519" if empty.
+	SshAccessKeyName string `json:"ssh_access_key_name"`
+	// SshSigningKeyName is the base filename (not full path) of the SSH signing key in ~/.ssh/.
+	// The public key is derived by appending ".pub". Defaults to "prismatic-koi-ed25519-signingkey" if empty.
+	SshSigningKeyName string `json:"ssh_signing_key_name"`
 
 	// Project layout (JSON arrays).
 	WorktreeExclude  []string `json:"worktree_exclude"`
@@ -80,6 +86,8 @@ type parsedConfig struct {
 	ContainerCoordinatorConfigPath string    `json:"container_coordinator_config"`
 	GitUserName                    string    `json:"git_user_name"`
 	GitUserEmail                   string    `json:"git_user_email"`
+	SshAccessKeyName               string    `json:"ssh_access_key_name"`
+	SshSigningKeyName              string    `json:"ssh_signing_key_name"`
 	WorktreeExclude                *[]string `json:"worktree_exclude"`
 	ProjectLocations               *[]string `json:"project_locations"`
 	ProjectSpecific                *[]string `json:"project_specific"`
@@ -193,6 +201,12 @@ func load() Config {
 	}
 	if parsed.GitUserEmail != "" {
 		cfg.GitUserEmail = parsed.GitUserEmail
+	}
+	if parsed.SshAccessKeyName != "" {
+		cfg.SshAccessKeyName = parsed.SshAccessKeyName
+	}
+	if parsed.SshSigningKeyName != "" {
+		cfg.SshSigningKeyName = parsed.SshSigningKeyName
 	}
 
 	// For slice fields: nil pointer means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/config/config_test.go
+++ b/modules/programs/prism/prism/internal/config/config_test.go
@@ -82,6 +82,48 @@ func TestEmptyArrayClearsDefault(t *testing.T) {
 	}
 }
 
+func TestSshKeyNameDefaults(t *testing.T) {
+	// SshAccessKeyName and SshSigningKeyName have no compiled-in default —
+	// they default to empty string, and the consumer (container.go) applies
+	// the fallback. This test verifies the fields are parsed correctly when set.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{
+		"ssh_access_key_name": "my-access-key",
+		"ssh_signing_key_name": "my-signing-key"
+	}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	if cfg.SshAccessKeyName != "my-access-key" {
+		t.Errorf("SshAccessKeyName: got %q, want %q", cfg.SshAccessKeyName, "my-access-key")
+	}
+	if cfg.SshSigningKeyName != "my-signing-key" {
+		t.Errorf("SshSigningKeyName: got %q, want %q", cfg.SshSigningKeyName, "my-signing-key")
+	}
+}
+
+func TestSshKeyNameAbsentIsEmpty(t *testing.T) {
+	// When ssh_access_key_name and ssh_signing_key_name are absent from the
+	// config file, the fields must be empty string (fallback applied by caller).
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	if cfg.SshAccessKeyName != "" {
+		t.Errorf("SshAccessKeyName: got %q, want empty string for absent key", cfg.SshAccessKeyName)
+	}
+	if cfg.SshSigningKeyName != "" {
+		t.Errorf("SshSigningKeyName: got %q, want empty string for absent key", cfg.SshSigningKeyName)
+	}
+}
+
 func TestMalformedJSON(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.json")

--- a/modules/programs/prism/prism/internal/config/config_test.go
+++ b/modules/programs/prism/prism/internal/config/config_test.go
@@ -83,9 +83,23 @@ func TestEmptyArrayClearsDefault(t *testing.T) {
 }
 
 func TestSshKeyNameDefaults(t *testing.T) {
-	// SshAccessKeyName and SshSigningKeyName have no compiled-in default —
-	// they default to empty string, and the consumer (container.go) applies
-	// the fallback. This test verifies the fields are parsed correctly when set.
+	// When no config file is present, SshAccessKeyName and SshSigningKeyName
+	// should return the compiled-in defaults from defaults().
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	if cfg.SshAccessKeyName != "prismatic-koi-ed25519" {
+		t.Errorf("SshAccessKeyName: got %q, want %q", cfg.SshAccessKeyName, "prismatic-koi-ed25519")
+	}
+	if cfg.SshSigningKeyName != "prismatic-koi-ed25519-signingkey" {
+		t.Errorf("SshSigningKeyName: got %q, want %q", cfg.SshSigningKeyName, "prismatic-koi-ed25519-signingkey")
+	}
+}
+
+func TestSshKeyNameOverriddenFromFile(t *testing.T) {
+	// When ssh_access_key_name and ssh_signing_key_name are set in the config
+	// file, the loaded values should override the compiled-in defaults.
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.json")
 
@@ -109,18 +123,27 @@ func TestSshKeyNameDefaults(t *testing.T) {
 	}
 }
 
-func TestSshKeyNameAbsentIsEmpty(t *testing.T) {
+func TestSshKeyNameAbsentKeepsDefault(t *testing.T) {
 	// When ssh_access_key_name and ssh_signing_key_name are absent from the
-	// config file, the fields must be empty string (fallback applied by caller).
-	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+	// config file, the compiled-in defaults are kept (not empty string).
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// Config file exists but doesn't mention SSH key names.
+	raw := `{"color_primary": "#ff0000"}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
 
 	cfg := config.LoadFresh()
 
-	if cfg.SshAccessKeyName != "" {
-		t.Errorf("SshAccessKeyName: got %q, want empty string for absent key", cfg.SshAccessKeyName)
+	if cfg.SshAccessKeyName != "prismatic-koi-ed25519" {
+		t.Errorf("SshAccessKeyName: got %q, want default %q when absent from config", cfg.SshAccessKeyName, "prismatic-koi-ed25519")
 	}
-	if cfg.SshSigningKeyName != "" {
-		t.Errorf("SshSigningKeyName: got %q, want empty string for absent key", cfg.SshSigningKeyName)
+	if cfg.SshSigningKeyName != "prismatic-koi-ed25519-signingkey" {
+		t.Errorf("SshSigningKeyName: got %q, want default %q when absent from config", cfg.SshSigningKeyName, "prismatic-koi-ed25519-signingkey")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -127,6 +127,15 @@ type Config struct {
 	// GitUserEmail is the git user.email to write into the container's .gitconfig.
 	// When empty, the [user] section is omitted from the generated gitconfig.
 	GitUserEmail string
+
+	// SshAccessKeyName is the filename (not full path) of the SSH access key in
+	// ~/.ssh/. When empty, defaults to "prismatic-koi-ed25519".
+	SshAccessKeyName string
+
+	// SshSigningKeyName is the base filename (not full path) of the SSH signing
+	// key in ~/.ssh/. The public key is derived by appending ".pub". When empty,
+	// defaults to "prismatic-koi-ed25519-signingkey".
+	SshSigningKeyName string
 }
 
 // NameForSession returns the stable podman container name for a session.
@@ -239,8 +248,12 @@ func (m *Manager) writeGitconfig() error {
 	sshDir := filepath.Join(home, ".ssh")
 
 	// Check whether signing keys are resolvable.
-	signingKeyPriv := filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey")
-	signingKeyPub := filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub")
+	signingKeyName := m.cfg.SshSigningKeyName
+	if signingKeyName == "" {
+		signingKeyName = "prismatic-koi-ed25519-signingkey"
+	}
+	signingKeyPriv := filepath.Join(sshDir, signingKeyName)
+	signingKeyPub := filepath.Join(sshDir, signingKeyName+".pub")
 	_, errPriv := filepath.EvalSymlinks(signingKeyPriv)
 	_, errPub := filepath.EvalSymlinks(signingKeyPub)
 	hasSigning := errPriv == nil && errPub == nil
@@ -622,16 +635,19 @@ func (m *Manager) buildRunArgs() []string {
 	// Note: the whole ~/.ssh directory is NOT mounted — only individual files.
 	sshDir := filepath.Join(home, ".ssh")
 
-	// Access key (git push/fetch): prismatic-koi-ed25519 → /root/.ssh/access-key
-	// TODO(#560): expose SSH key filenames as Nix module options.
-	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519")); err == nil {
+	// Access key (git push/fetch): <SshAccessKeyName> → /root/.ssh/access-key
+	accessKeyName := m.cfg.SshAccessKeyName
+	if accessKeyName == "" {
+		accessKeyName = "prismatic-koi-ed25519"
+	}
+	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, accessKeyName)); err == nil {
 		args = append(args, "--volume", resolved+":/root/.ssh/access-key:ro")
 	} else {
 		log.Printf("container: access key not resolvable (%v); SSH push/fetch will not work", err)
 	}
 
-	// Signing key private (commit signing): prismatic-koi-ed25519-signingkey → /root/.ssh/signing-key
-	// Signing key public (gitconfig signingKey): prismatic-koi-ed25519-signingkey.pub → /root/.ssh/signing-key.pub
+	// Signing key private (commit signing): <SshSigningKeyName> → /root/.ssh/signing-key
+	// Signing key public (gitconfig signingKey): <SshSigningKeyName>.pub → /root/.ssh/signing-key.pub
 	//
 	// Note: writeGitconfig (called immediately before buildRunArgs in Create)
 	// also resolves these symlinks to determine hasSigning. The resolutions are
@@ -639,8 +655,12 @@ func (m *Manager) buildRunArgs() []string {
 	// gitconfig file, while this block decides what volumes to mount. Both must
 	// agree for the container to work, and they do because Create() calls them
 	// sequentially with no symlink changes possible between the two calls.
-	signingKeyResolved, errPriv := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey"))
-	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub"))
+	signingKeyName := m.cfg.SshSigningKeyName
+	if signingKeyName == "" {
+		signingKeyName = "prismatic-koi-ed25519-signingkey"
+	}
+	signingKeyResolved, errPriv := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName))
+	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName+".pub"))
 	if errPriv == nil && errPub == nil {
 		args = append(args,
 			"--volume", signingKeyResolved+":/root/.ssh/signing-key:ro",

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1449,6 +1449,87 @@ func TestWriteGitconfig_NoUserSectionWhenIdentityMissing(t *testing.T) {
 
 // ── SSH key name configurability tests ──────────────────────────────────────
 
+func TestBuildRunArgs_CustomAccessKeyName(t *testing.T) {
+	// When SshAccessKeyName is set, buildRunArgs should resolve and mount that
+	// file at /root/.ssh/access-key:ro rather than the hardcoded default.
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	// Create only the custom-named key (not the default name).
+	customKey := sshDir + "/my-custom-access-key"
+	if err := os.WriteFile(customKey, []byte("stub"), 0o600); err != nil {
+		t.Fatalf("WriteFile custom access key: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:      "repo@feat",
+		AllocatedPort:    14000,
+		SshAccessKeyName: "my-custom-access-key",
+	})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.HasSuffix(v, ":/root/.ssh/access-key:ro") {
+				found = true
+				// The source path must be the resolved real path of the custom key.
+				if !strings.Contains(v, customKey) {
+					t.Errorf("access-key mount source %q does not contain custom key path %q", v, customKey)
+				}
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("access-key volume mount at /root/.ssh/access-key:ro not found in args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_FallbackWhenAccessKeyNameEmpty(t *testing.T) {
+	// When SshAccessKeyName is empty, buildRunArgs falls back to the default
+	// name "prismatic-koi-ed25519".
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	// Create the default-named key.
+	defaultKey := sshDir + "/prismatic-koi-ed25519"
+	if err := os.WriteFile(defaultKey, []byte("stub"), 0o600); err != nil {
+		t.Fatalf("WriteFile default access key: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		// SshAccessKeyName intentionally left empty — must fall back to default.
+	})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.HasSuffix(v, ":/root/.ssh/access-key:ro") {
+				found = true
+				if !strings.Contains(v, defaultKey) {
+					t.Errorf("access-key mount source %q does not contain default key path %q", v, defaultKey)
+				}
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("access-key volume mount at /root/.ssh/access-key:ro not found in args with default key: %v", args)
+	}
+}
+
 func TestWriteGitconfig_CustomSigningKeyName(t *testing.T) {
 	// When SshSigningKeyName is set, writeGitconfig should resolve that filename
 	// rather than the hardcoded default.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1446,3 +1446,93 @@ func TestWriteGitconfig_NoUserSectionWhenIdentityMissing(t *testing.T) {
 		})
 	}
 }
+
+// ── SSH key name configurability tests ──────────────────────────────────────
+
+func TestWriteGitconfig_CustomSigningKeyName(t *testing.T) {
+	// When SshSigningKeyName is set, writeGitconfig should resolve that filename
+	// rather than the hardcoded default.
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	// Create files under the custom name, NOT the default name.
+	for _, name := range []string{"my-custom-signingkey", "my-custom-signingkey.pub"} {
+		if err := os.WriteFile(sshDir+"/"+name, []byte("stub"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:       "repo@feat",
+		AllocatedPort:     14000,
+		GitUserName:       "test-user",
+		GitUserEmail:      "test@example.com",
+		SshSigningKeyName: "my-custom-signingkey",
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	// Signing sections must be present because the custom-named keys exist.
+	if !strings.Contains(content, "[commit]") {
+		t.Errorf("gitconfig missing [commit] for custom signing key; content:\n%s", content)
+	}
+	if !strings.Contains(content, "signingKey = /root/.ssh/signing-key.pub") {
+		t.Errorf("gitconfig missing signingKey; content:\n%s", content)
+	}
+}
+
+func TestWriteGitconfig_FallbackWhenSigningKeyNameEmpty(t *testing.T) {
+	// When SshSigningKeyName is empty, writeGitconfig falls back to the
+	// default name "prismatic-koi-ed25519-signingkey".
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	// Only the default-named files exist.
+	for _, name := range []string{"prismatic-koi-ed25519-signingkey", "prismatic-koi-ed25519-signingkey.pub"} {
+		if err := os.WriteFile(sshDir+"/"+name, []byte("stub"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		GitUserName:   "test-user",
+		GitUserEmail:  "test@example.com",
+		// SshSigningKeyName intentionally left empty — must fall back to default.
+	})
+
+	if err := m.writeGitconfig(); err != nil {
+		t.Fatalf("writeGitconfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	// Fallback to default name means signing keys are found and sections present.
+	if !strings.Contains(content, "[commit]") {
+		t.Errorf("gitconfig missing [commit] with default signing key fallback; content:\n%s", content)
+	}
+	if !strings.Contains(content, "signingKey = /root/.ssh/signing-key.pub") {
+		t.Errorf("gitconfig missing signingKey with default signing key fallback; content:\n%s", content)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SshAccessKeyName` and `SshSigningKeyName` fields to `config.go` (JSON tags: `ssh_access_key_name`, `ssh_signing_key_name`)
- Replace hardcoded `prismatic-koi-ed25519` and `prismatic-koi-ed25519-signingkey` literals in `container.go` with config values, falling back to the current defaults when empty
- Wire new fields through `cmd/sidecar.go` from prism config into container config
- Expose `nx.programs.prism.sshAccessKeyName` and `nx.programs.prism.sshSigningKeyName` as `lib.mkOption` strings in `prism-tui.nix` with the current filenames as defaults
- Add tests covering custom key names, empty-field fallback, and config parsing

Existing machines need zero configuration changes — the Nix defaults match the previously hardcoded values, and `container.go` falls back to the same defaults if the config fields are empty.

Closes #560