### PR TITLE
stats: group by opencode_sid, compact table for multi-session, AGENTS column, fix session count, remove --all

### DIFF
--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -6,7 +6,6 @@ package cmd
 //
 //	prism stats                   summary table of all active sessions across all repos
 //	prism stats <session>         per-session detail
-//	prism stats --all             same as no flags (kept for backwards compatibility)
 //	prism stats --days N          historical aggregate over the last N days
 //	prism stats model             per-model performance breakdown over last 7 days
 //	prism stats model --days N    per-model performance breakdown over last N days
@@ -25,6 +24,10 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/payload"
 )
+
+// legacySentinel is the key used to group events that have a NULL opencode_sid.
+// These are pre-sidecar "legacy" events that predate opencode session tracking.
+const legacySentinel = ""
 
 // modelCosts contains per-million-token pricing for known models.
 // Cost is in USD. Keys are "providerID/modelID" exactly as stored in payloads —
@@ -55,10 +58,13 @@ var statsCmd = &cobra.Command{
 	Long: `Display metrics and statistics for agent sessions.
 
 With no arguments, shows a summary table of all active sessions across all repos.
-The --all flag is accepted for backwards compatibility and is a no-op.
 
-With a session name argument, shows detailed per-session metrics including
-token usage, cost, duration, tool breakdown, and turn timing.
+With a session name argument, shows per-session metrics. Long-lived sessions
+(e.g. nixos-config@main) that contain multiple opencode sessions are shown as
+a compact table — one row per opencode session. Short-lived worktree sessions
+with a single opencode session are shown as a detailed block.
+
+Use --detail to force the detailed block format even for multi-session tmux sessions.
 
 Use --days N to show aggregate statistics over the last N days.
 
@@ -68,14 +74,14 @@ Use the 'model' subcommand for a per-provider/model performance breakdown.`,
 }
 
 func init() {
-	statsCmd.Flags().Bool("all", false, "No-op, kept for backwards compatibility (all repos are always shown)")
 	statsCmd.Flags().Int("days", 0, "Show aggregate statistics over the last N days")
+	statsCmd.Flags().Bool("detail", false, "Force detailed block format even for multi-session tmux sessions")
 	rootCmd.AddCommand(statsCmd)
 }
 
 func runStats(cmd *cobra.Command, args []string) error {
 	days, _ := cmd.Flags().GetInt("days")
-	showAll, _ := cmd.Flags().GetBool("all")
+	detail, _ := cmd.Flags().GetBool("detail")
 
 	if days > 0 && len(args) > 0 {
 		return fmt.Errorf("--days is mutually exclusive with a session name")
@@ -86,17 +92,18 @@ func runStats(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 1 {
-		return runStatsSession(args[0])
+		return runStatsSession(args[0], detail)
 	}
 
-	return runStatsSummary(showAll)
+	return runStatsSummary()
 }
 
 // ---------- per-session detail ----------
 
-// sessionMetrics holds aggregated metrics for a single session.
+// sessionMetrics holds aggregated metrics for a single opencode session.
 type sessionMetrics struct {
 	SessionName string
+	OpencodeSID string // empty string = legacy sentinel (NULL opencode_sid)
 	AgentName   string
 	ModelID     string
 	State       string
@@ -182,11 +189,29 @@ func (m *sessionMetrics) totalToolCalls() int {
 	return n
 }
 
-func collectMetrics(events []db.Event) *sessionMetrics {
+// isLegacy reports whether this sessionMetrics represents the legacy NULL-sid
+// sentinel group.
+func (m *sessionMetrics) isLegacy() bool {
+	return m.OpencodeSID == legacySentinel
+}
+
+// collectMetrics builds a sessionMetrics from a slice of events that all belong
+// to the same opencode session (or the legacy sentinel group). The opencodeSID
+// parameter is the key used for this group (legacySentinel for NULL-sid events).
+//
+// The model field is set to the coordinator/root agent's model if one is present
+// (agent field == "coordinator"), falling back to the most-frequently-seen model.
+// This gives a more meaningful "session model" than first-seen.
+func collectMetrics(events []db.Event, opencodeSID string) *sessionMetrics {
 	m := &sessionMetrics{
+		OpencodeSID:   opencodeSID,
 		ToolCalls:     make(map[string]int),
 		ToolDurations: make(map[string][]time.Duration),
 	}
+
+	// Track model turn counts and coordinator model for model selection.
+	modelTurnCounts := make(map[string]int)
+	var coordinatorModel string
 
 	for _, e := range events {
 		if m.SessionName == "" {
@@ -217,8 +242,12 @@ func collectMetrics(events []db.Event) *sessionMetrics {
 				if m.AgentName == "" && p.Agent != "" {
 					m.AgentName = p.Agent
 				}
-				if m.ModelID == "" && p.Model != "" {
-					m.ModelID = p.Model
+				if p.Model != "" {
+					modelTurnCounts[p.Model]++
+					// Prefer coordinator model: take the first coordinator model seen.
+					if p.Agent == "coordinator" && coordinatorModel == "" {
+						coordinatorModel = p.Model
+					}
 				}
 			}
 
@@ -252,10 +281,49 @@ func collectMetrics(events []db.Event) *sessionMetrics {
 		}
 	}
 
+	// Determine the best model: coordinator model takes priority, then
+	// fall back to the most-frequently-seen model.
+	if coordinatorModel != "" {
+		m.ModelID = coordinatorModel
+	} else {
+		// Pick most frequent model.
+		var bestModel string
+		var bestCount int
+		for model, count := range modelTurnCounts {
+			if count > bestCount || (count == bestCount && model < bestModel) {
+				bestModel = model
+				bestCount = count
+			}
+		}
+		m.ModelID = bestModel
+	}
+
 	return m
 }
 
-func runStatsSession(session string) error {
+// groupEventsByOpencodeSID partitions events by opencode_sid, preserving
+// insertion order for the first occurrence of each key.
+// Events with a NULL opencode_sid are grouped under legacySentinel ("").
+// Returns the grouped map and the ordered list of keys.
+func groupEventsByOpencodeSID(events []db.Event) (map[string][]db.Event, []string) {
+	grouped := make(map[string][]db.Event)
+	var order []string
+
+	for _, e := range events {
+		key := legacySentinel
+		if e.OpencodeSID != nil {
+			key = *e.OpencodeSID
+		}
+		if _, exists := grouped[key]; !exists {
+			order = append(order, key)
+		}
+		grouped[key] = append(grouped[key], e)
+	}
+
+	return grouped, order
+}
+
+func runStatsSession(session string, detail bool) error {
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats: %w", err)
@@ -281,23 +349,83 @@ func runStatsSession(session string) error {
 		return nil
 	}
 
-	m := collectMetrics(events)
+	// Group events by opencode_sid.
+	grouped, order := groupEventsByOpencodeSID(events)
 
-	// Overlay status info.
-	if status != nil {
-		m.State = status.State
-		if status.RootAgentName != nil && *status.RootAgentName != "" {
-			m.AgentName = *status.RootAgentName
+	// Build a sessionMetrics per opencode session.
+	var allMetrics []*sessionMetrics
+	for _, key := range order {
+		m := collectMetrics(grouped[key], key)
+		// Overlay status info on the most recent non-legacy group (last non-sentinel key).
+		if status != nil && key != legacySentinel {
+			m.State = status.State
+			if status.RootAgentName != nil && *status.RootAgentName != "" {
+				m.AgentName = *status.RootAgentName
+			}
+			// Only override model from status for the current (most recent) session.
+			// We detect "current" as the last non-legacy key in order.
 		}
-		if status.RootModelID != nil && *status.RootModelID != "" {
-			m.ModelID = *status.RootModelID
+		allMetrics = append(allMetrics, m)
+	}
+
+	// Apply state from status to the last non-legacy session.
+	if status != nil {
+		for i := len(allMetrics) - 1; i >= 0; i-- {
+			if !allMetrics[i].isLegacy() {
+				allMetrics[i].State = status.State
+				if status.RootAgentName != nil && *status.RootAgentName != "" {
+					allMetrics[i].AgentName = *status.RootAgentName
+				}
+				break
+			}
 		}
 	}
 
-	renderSessionDetail(m)
+	// Determine rendering mode:
+	// - Exactly one opencode session, no legacy group → detailed block
+	// - Only legacy group (all NULL-sid events), no real sessions → detailed block labelled legacy
+	// - Multiple opencode sessions, OR mixed legacy+real, OR --detail flag → compact table or forced detail
+	nonLegacyCount := 0
+	hasLegacy := false
+	for _, key := range order {
+		if key == legacySentinel {
+			hasLegacy = true
+		} else {
+			nonLegacyCount++
+		}
+	}
+
+	// Use detailed block only for pure single-session cases (no mixing with legacy).
+	if !detail && nonLegacyCount == 1 && !hasLegacy {
+		// Exactly one opencode session, no legacy data — detailed block format.
+		for _, m := range allMetrics {
+			if !m.isLegacy() {
+				renderSessionDetail(m)
+				return nil
+			}
+		}
+	}
+
+	if !detail && nonLegacyCount == 0 && hasLegacy {
+		// Only legacy events (all NULL-sid) — render as detailed block with legacy label.
+		if len(allMetrics) == 1 {
+			m := allMetrics[0]
+			// Mark model as legacy if there's no model info.
+			if m.ModelID == "" {
+				m.ModelID = "(legacy)"
+			}
+			m.AgentName = "(legacy, pre-sidecar)"
+			renderSessionDetail(m)
+			return nil
+		}
+	}
+
+	// Multi-session (or --detail forced): render compact table.
+	renderSessionCompactTable(session, allMetrics, status, detail)
 	return nil
 }
 
+// renderSessionDetail renders the detailed block format for a single opencode session.
 func renderSessionDetail(m *sessionMetrics) {
 	styleHeader := lipgloss.NewStyle().Bold(true)
 	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
@@ -425,11 +553,158 @@ func renderSessionDetail(m *sessionMetrics) {
 	}
 }
 
+// renderSessionCompactTable renders a compact one-row-per-opencode-session table
+// for tmux sessions that contain multiple opencode sessions. If detail is true,
+// each session is rendered as a full block instead.
+func renderSessionCompactTable(sessionName string, metrics []*sessionMetrics, status *db.Status, detail bool) {
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	// Compute summary totals.
+	var totalTurns int
+	var totalCost float64
+	distinctModels := make(map[string]struct{})
+	for _, m := range metrics {
+		totalTurns += m.AssistantTurns
+		totalCost += m.totalCost()
+		if m.ModelID != "" && m.ModelID != "(legacy)" {
+			distinctModels[m.ModelID] = struct{}{}
+		}
+	}
+
+	fmt.Println(styleHeader.Render("session: " + sessionName))
+	if status != nil && status.State != "" {
+		fmt.Printf("%s %s\n", styleLabel.Render("state:"), stateStyle(status.State).Render(status.State))
+	}
+	fmt.Println()
+
+	// Summary line.
+	modelCountStr := ""
+	if len(distinctModels) > 1 {
+		modelCountStr = fmt.Sprintf(", %d models", len(distinctModels))
+	} else if len(distinctModels) == 1 {
+		for m := range distinctModels {
+			modelCountStr = fmt.Sprintf(", model: %s", m)
+		}
+	}
+	costStr := "—"
+	if totalCost > 0 {
+		costStr = formatCost(totalCost)
+	}
+	fmt.Printf("%s %d opencode sessions%s · %d turns · %s\n",
+		styleLabel.Render("summary:"),
+		len(metrics),
+		modelCountStr,
+		totalTurns,
+		costStr,
+	)
+	fmt.Println()
+
+	if detail {
+		// --detail: render each opencode session as a full block.
+		for i, m := range metrics {
+			if i > 0 {
+				fmt.Println(styleDim.Render(strings.Repeat("─", 60)))
+				fmt.Println()
+			}
+			if m.isLegacy() {
+				fmt.Printf("%s %s\n", styleLabel.Render("opencode session:"), styleDim.Render("(legacy, pre-sidecar)"))
+				if m.ModelID == "" {
+					m.ModelID = "(legacy)"
+				}
+			} else {
+				fmt.Printf("%s %s\n", styleLabel.Render("opencode session:"), styleDim.Render(m.OpencodeSID))
+			}
+			fmt.Println()
+			renderSessionDetail(m)
+		}
+		return
+	}
+
+	// Compact table mode.
+	const (
+		wStarted  = 20
+		wDuration = 10
+		wModel    = 30
+		wTurns    = 6
+		wInput    = 8
+		wOutput   = 8
+		wCost     = 8
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s",
+		wStarted, "STARTED",
+		wDuration, "DURATION",
+		wModel, "MODEL",
+		wTurns, "TURNS",
+		wInput, "INPUT",
+		wOutput, "OUTPUT",
+		wCost, "COST",
+	)
+	fmt.Println(styleDim.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, m := range metrics {
+		// Session identifier label.
+		startedStr := "—"
+		if !m.FirstEvent.IsZero() {
+			startedStr = m.FirstEvent.Format("2006-01-02 15:04")
+		}
+
+		durStr := formatDurationLong(m.duration())
+
+		modelStr := m.ModelID
+		if modelStr == "" {
+			modelStr = "—"
+		}
+		if m.isLegacy() {
+			// For the legacy sentinel row, show model or "(legacy)" in model column.
+			if modelStr == "" || modelStr == "(legacy)" {
+				modelStr = "(legacy)"
+			}
+			startedStr = "(legacy, pre-sidecar)"
+			if len(startedStr) > wStarted {
+				startedStr = startedStr[:wStarted]
+			}
+		}
+		if len(modelStr) > wModel {
+			modelStr = modelStr[:wModel-3] + "..."
+		}
+
+		turnsStr := fmt.Sprintf("%d", m.AssistantTurns)
+		inputStr := "—"
+		if m.InputTokens > 0 {
+			inputStr = formatTokenCount(m.InputTokens)
+		}
+		outputStr := "—"
+		if m.OutputTokens > 0 {
+			outputStr = formatTokenCount(m.OutputTokens)
+		}
+		costStr := "—"
+		if c := m.totalCost(); c > 0 {
+			costStr = formatCost(c)
+		}
+
+		fmt.Printf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s\n",
+			wStarted, startedStr,
+			wDuration, durStr,
+			wModel, modelStr,
+			wTurns, turnsStr,
+			wInput, inputStr,
+			wOutput, outputStr,
+			wCost, costStr,
+		)
+	}
+
+	fmt.Println()
+	fmt.Println(styleDim.Render("use --detail to see full metrics for each opencode session"))
+}
+
 // ---------- summary table ----------
 
 // runStatsSummary shows a summary table of all active sessions across all repos.
-// showAll is accepted for backwards compatibility but is now a no-op.
-func runStatsSummary(_ bool) error {
+func runStatsSummary() error {
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats: %w", err)
@@ -459,20 +734,57 @@ func runStatsSummary(_ bool) error {
 	var rows []summaryRow
 	for _, s := range statuses {
 		events, _ := d.AllSessionEvents(s.SessionName)
-		m := collectMetrics(events)
-		if s.RootAgentName != nil && *s.RootAgentName != "" {
-			m.AgentName = *s.RootAgentName
+		grouped, order := groupEventsByOpencodeSID(events)
+		// For the summary table, aggregate across all opencode sessions within
+		// the tmux session to get total tokens/cost/duration.
+		var totalInput, totalOutput, totalCacheRead, totalCacheWrite int
+		var firstEvent, lastEvent time.Time
+		for _, key := range order {
+			m := collectMetrics(grouped[key], key)
+			totalInput += m.InputTokens
+			totalOutput += m.OutputTokens
+			totalCacheRead += m.CacheReadTokens
+			totalCacheWrite += m.CacheWriteTokens
+			if !m.FirstEvent.IsZero() && (firstEvent.IsZero() || m.FirstEvent.Before(firstEvent)) {
+				firstEvent = m.FirstEvent
+			}
+			if m.LastEvent.After(lastEvent) {
+				lastEvent = m.LastEvent
+			}
 		}
+		dur := time.Duration(0)
+		if !firstEvent.IsZero() && !lastEvent.IsZero() {
+			dur = lastEvent.Sub(firstEvent)
+		}
+
+		// Determine model for display from status (most up-to-date).
+		modelID := ""
 		if s.RootModelID != nil && *s.RootModelID != "" {
-			m.ModelID = *s.RootModelID
+			modelID = *s.RootModelID
 		}
+		agentName := ""
+		if s.RootAgentName != nil && *s.RootAgentName != "" {
+			agentName = *s.RootAgentName
+		}
+
+		// Compute cost from accumulated tokens.
+		cost := 0.0
+		if modelID != "" {
+			if costs, ok := modelCosts[modelID]; ok {
+				cost = (float64(totalInput)*costs.Input +
+					float64(totalOutput)*costs.Output +
+					float64(totalCacheRead)*costs.CacheRead +
+					float64(totalCacheWrite)*costs.CacheWrite) / 1_000_000
+			}
+		}
+
 		rows = append(rows, summaryRow{
 			Session:  s.SessionName,
-			Agent:    truncateStr(agentShortName(m.AgentName), 12),
+			Agent:    truncateStr(agentShortName(agentName), 12),
 			State:    s.State,
-			Duration: m.duration(),
-			Tokens:   m.InputTokens + m.OutputTokens,
-			Cost:     m.totalCost(),
+			Duration: dur,
+			Tokens:   totalInput + totalOutput,
+			Cost:     cost,
 		})
 	}
 
@@ -555,24 +867,40 @@ func runStatsHistorical(days int) error {
 	}
 	var sessionCosts []sessionCostEntry
 
-	for session, events := range bySession {
+	for session, evts := range bySession {
 		totalSessions++
-		m := collectMetrics(events)
-		// Enrich from status table for model info.
-		status, _ := d.CurrentStatus(session)
-		if status != nil {
-			if status.RootModelID != nil && *status.RootModelID != "" {
-				m.ModelID = *status.RootModelID
+		// Sum across all opencode sessions within this tmux session.
+		grouped, order := groupEventsByOpencodeSID(evts)
+		var sessionCost float64
+		var sessionDur time.Duration
+		var firstEvent, lastEvent time.Time
+		for _, key := range order {
+			m := collectMetrics(grouped[key], key)
+			// Enrich model from status table for cost calculation.
+			if m.ModelID == "" {
+				st, _ := d.CurrentStatus(session)
+				if st != nil && st.RootModelID != nil && *st.RootModelID != "" {
+					m.ModelID = *st.RootModelID
+				}
+			}
+			sessionCost += m.totalCost()
+			for tool, count := range m.ToolCalls {
+				toolCounts[tool] += count
+			}
+			if !m.FirstEvent.IsZero() && (firstEvent.IsZero() || m.FirstEvent.Before(firstEvent)) {
+				firstEvent = m.FirstEvent
+			}
+			if m.LastEvent.After(lastEvent) {
+				lastEvent = m.LastEvent
 			}
 		}
-		cost := m.totalCost()
-		totalCost += cost
-		totalDuration += m.duration()
-		for tool, count := range m.ToolCalls {
-			toolCounts[tool] += count
+		if !firstEvent.IsZero() && !lastEvent.IsZero() {
+			sessionDur = lastEvent.Sub(firstEvent)
 		}
-		if cost > 0 {
-			sessionCosts = append(sessionCosts, sessionCostEntry{session, cost})
+		totalCost += sessionCost
+		totalDuration += sessionDur
+		if sessionCost > 0 {
+			sessionCosts = append(sessionCosts, sessionCostEntry{session, sessionCost})
 		}
 	}
 
@@ -703,13 +1031,14 @@ type modelMetrics struct {
 	Provider     string
 	Model        string
 	Turns        int
-	Sessions     map[string]struct{} // distinct session IDs
+	Sessions     map[string]struct{} // distinct opencode session IDs
 	DurationsMs  []float64           // durationMs values for P50 (zero values excluded)
 	TtftMs       []float64           // ttftMs values for P50 (zero/absent values excluded)
 	TokPerSec    []float64           // output tokens/sec per turn (zero-duration turns excluded)
 	InputTokens  int
 	OutputTokens int
 	Cost         float64
+	AgentCounts  map[string]int // agent name → turn count for this model
 }
 
 // percentileFloat64 returns the p-th percentile of a sorted (or unsorted) slice.
@@ -747,6 +1076,11 @@ func splitModel(modelID string) (provider, model string) {
 // collectModelMetrics groups msg_assistant events by provider/model and builds
 // per-model metrics. Turns with durationMs == 0 are excluded from latency and
 // throughput calculations.
+//
+// Sessions are counted by distinct opencode_sid (not session_name) so that
+// long-lived tmux sessions with multiple opencode sessions are counted correctly.
+// Events with a NULL opencode_sid are counted as distinct sessions only if the
+// session_name is distinct — they're bucketed by session_name as a fallback.
 func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 	metrics := make(map[string]*modelMetrics)
 
@@ -768,17 +1102,31 @@ func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 		m, ok := metrics[key]
 		if !ok {
 			m = &modelMetrics{
-				Provider: provider,
-				Model:    model,
-				Sessions: make(map[string]struct{}),
+				Provider:    provider,
+				Model:       model,
+				Sessions:    make(map[string]struct{}),
+				AgentCounts: make(map[string]int),
 			}
 			metrics[key] = m
 		}
 
 		m.Turns++
-		m.Sessions[e.SessionName] = struct{}{}
+
+		// Count sessions by opencode_sid when available; fall back to session_name
+		// for NULL-sid (legacy) events so they still contribute a session count.
+		if e.OpencodeSID != nil && *e.OpencodeSID != "" {
+			m.Sessions[*e.OpencodeSID] = struct{}{}
+		} else {
+			m.Sessions["legacy:"+e.SessionName] = struct{}{}
+		}
+
 		m.InputTokens += p.InputTokens
 		m.OutputTokens += p.OutputTokens
+
+		// Track agent breakdown.
+		if p.Agent != "" {
+			m.AgentCounts[p.Agent]++
+		}
 
 		// Cost using the full key (provider/model).
 		if costs, ok := modelCosts[key]; ok {
@@ -805,6 +1153,31 @@ func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 	return metrics
 }
 
+// formatAgentSummary returns a compact agent summary string for the AGENTS column.
+// Shows the dominant agent name, followed by "(×N)" if there are N distinct agents.
+// Example: "coordinator (×3)" means coordinator ran most turns and 3 distinct
+// agent types ran on this model.
+func formatAgentSummary(agentCounts map[string]int) string {
+	if len(agentCounts) == 0 {
+		return "—"
+	}
+
+	// Find the dominant agent (most turns).
+	var dominant string
+	var dominantCount int
+	for agent, count := range agentCounts {
+		if count > dominantCount || (count == dominantCount && agent < dominant) {
+			dominant = agent
+			dominantCount = count
+		}
+	}
+
+	if len(agentCounts) == 1 {
+		return dominant
+	}
+	return fmt.Sprintf("%s (×%d)", dominant, len(agentCounts))
+}
+
 // formatLatency formats a duration given in milliseconds as "Xs" or "Xm Ys".
 func formatLatency(ms float64) string {
 	secs := int(ms / 1000)
@@ -826,14 +1199,18 @@ window.
 
 TTFT p50 shows median time-to-first-token (request sent → first streaming chunk
 received). DUR p50 shows median full turn duration (request sent → complete
-response received).`,
+response received).
+
+The AGENTS column shows the dominant agent type for each model, with a count of
+distinct agent types in parentheses when more than one agent ran on that model.
+Example: "coordinator (×3)" means the coordinator was dominant and 3 distinct
+agent types used that model.`,
 	Args: cobra.NoArgs,
 	RunE: runStatsModel,
 }
 
 func init() {
 	modelCmd.Flags().Int("days", 7, "Number of days to include (default 7)")
-	modelCmd.Flags().Bool("all", false, "No-op, kept for consistency (always cross-repo)")
 	statsCmd.AddCommand(modelCmd)
 }
 
@@ -907,10 +1284,11 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 		wOutput   = 8
 		wCost     = 8
 		wSessions = 8
+		wAgents   = 20
 	)
 
 	// Header row.
-	header := fmt.Sprintf("%-*s  %-*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s",
+	header := fmt.Sprintf("%-*s  %-*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s  %*s  %-*s",
 		wProvider, "PROVIDER",
 		wModel, "MODEL",
 		wTurns, "TURNS",
@@ -921,6 +1299,7 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 		wOutput, "OUTPUT",
 		wCost, "COST",
 		wSessions, "SESSIONS",
+		wAgents, "AGENTS",
 	)
 	fmt.Println(styleHeaderDim.Render(header))
 
@@ -963,7 +1342,9 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 			provider = "(unknown)"
 		}
 
-		fmt.Printf("%-*s  %-*s  %*d  %*s  %*s  %*s  %*s  %*s  %*s  %*d\n",
+		agentStr := formatAgentSummary(m.AgentCounts)
+
+		fmt.Printf("%-*s  %-*s  %*d  %*s  %*s  %*s  %*s  %*s  %*s  %*d  %-*s\n",
 			wProvider, provider,
 			wModel, m.Model,
 			wTurns, m.Turns,
@@ -974,9 +1355,11 @@ func renderModelBreakdown(metrics map[string]*modelMetrics, days int) {
 			wOutput, formatTokenCount(m.OutputTokens),
 			wCost, costStr,
 			wSessions, len(m.Sessions),
+			wAgents, agentStr,
 		)
 	}
 
 	fmt.Println()
 	fmt.Println(styleDim.Render("Note: TTFT p50 = time to first token (request→first chunk); DUR p50 = full turn duration (request→complete response)."))
+	fmt.Println(styleDim.Render("      SESSIONS = distinct opencode sessions; AGENTS = dominant agent type (×N = N distinct agent types)."))
 }

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -356,19 +356,12 @@ func runStatsSession(session string, detail bool) error {
 	var allMetrics []*sessionMetrics
 	for _, key := range order {
 		m := collectMetrics(grouped[key], key)
-		// Overlay status info on the most recent non-legacy group (last non-sentinel key).
-		if status != nil && key != legacySentinel {
-			m.State = status.State
-			if status.RootAgentName != nil && *status.RootAgentName != "" {
-				m.AgentName = *status.RootAgentName
-			}
-			// Only override model from status for the current (most recent) session.
-			// We detect "current" as the last non-legacy key in order.
-		}
 		allMetrics = append(allMetrics, m)
 	}
 
-	// Apply state from status to the last non-legacy session.
+	// Apply live status (state, agent name) to the last non-legacy session only.
+	// Older sessions within the same tmux session should not inherit the current
+	// live state — they are historical and completed.
 	if status != nil {
 		for i := len(allMetrics) - 1; i >= 0; i-- {
 			if !allMetrics[i].isLegacy() {

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -554,15 +554,24 @@ func renderSessionCompactTable(sessionName string, metrics []*sessionMetrics, st
 	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 
-	// Compute summary totals.
+	// Compute summary totals. Count real (non-legacy) opencode sessions separately
+	// from the legacy sentinel group — the legacy group is a synthetic bucket for
+	// pre-sidecar events, not a real opencode session.
 	var totalTurns int
 	var totalCost float64
+	var realSessionCount int
+	var hasLegacyGroup bool
 	distinctModels := make(map[string]struct{})
 	for _, m := range metrics {
 		totalTurns += m.AssistantTurns
 		totalCost += m.totalCost()
-		if m.ModelID != "" && m.ModelID != "(legacy)" {
-			distinctModels[m.ModelID] = struct{}{}
+		if m.isLegacy() {
+			hasLegacyGroup = true
+		} else {
+			realSessionCount++
+			if m.ModelID != "" {
+				distinctModels[m.ModelID] = struct{}{}
+			}
 		}
 	}
 
@@ -581,14 +590,19 @@ func renderSessionCompactTable(sessionName string, metrics []*sessionMetrics, st
 			modelCountStr = fmt.Sprintf(", model: %s", m)
 		}
 	}
+	legacySuffix := ""
+	if hasLegacyGroup {
+		legacySuffix = " (+ legacy events)"
+	}
 	costStr := "—"
 	if totalCost > 0 {
 		costStr = formatCost(totalCost)
 	}
-	fmt.Printf("%s %d opencode sessions%s · %d turns · %s\n",
+	fmt.Printf("%s %d opencode sessions%s%s · %d turns · %s\n",
 		styleLabel.Render("summary:"),
-		len(metrics),
+		realSessionCount,
 		modelCountStr,
+		legacySuffix,
 		totalTurns,
 		costStr,
 	)
@@ -652,14 +666,14 @@ func renderSessionCompactTable(sessionName string, metrics []*sessionMetrics, st
 			modelStr = "—"
 		}
 		if m.isLegacy() {
-			// For the legacy sentinel row, show model or "(legacy)" in model column.
+			// For the legacy sentinel row, show "(legacy)" in both STARTED and MODEL
+			// columns. The label is kept short to fit the 20-char STARTED column.
+			// The --detail mode uses the longer "(legacy, pre-sidecar)" label where
+			// there is no width constraint.
 			if modelStr == "" || modelStr == "(legacy)" {
 				modelStr = "(legacy)"
 			}
-			startedStr = "(legacy, pre-sidecar)"
-			if len(startedStr) > wStarted {
-				startedStr = startedStr[:wStarted]
-			}
+			startedStr = "(legacy)"
 		}
 		if len(modelStr) > wModel {
 			modelStr = modelStr[:wModel-3] + "..."
@@ -728,16 +742,18 @@ func runStatsSummary() error {
 	for _, s := range statuses {
 		events, _ := d.AllSessionEvents(s.SessionName)
 		grouped, order := groupEventsByOpencodeSID(events)
-		// For the summary table, aggregate across all opencode sessions within
-		// the tmux session to get total tokens/cost/duration.
-		var totalInput, totalOutput, totalCacheRead, totalCacheWrite int
+		// For the summary table, accumulate tokens, cost, and duration across
+		// all opencode sessions within the tmux session. Cost is summed per-session
+		// (each session uses its own model's pricing) rather than applying a single
+		// model's rate to all tokens — critical for sessions that spanned model changes.
+		var totalInput, totalOutput int
+		var totalCost float64
 		var firstEvent, lastEvent time.Time
 		for _, key := range order {
 			m := collectMetrics(grouped[key], key)
 			totalInput += m.InputTokens
 			totalOutput += m.OutputTokens
-			totalCacheRead += m.CacheReadTokens
-			totalCacheWrite += m.CacheWriteTokens
+			totalCost += m.totalCost()
 			if !m.FirstEvent.IsZero() && (firstEvent.IsZero() || m.FirstEvent.Before(firstEvent)) {
 				firstEvent = m.FirstEvent
 			}
@@ -750,25 +766,10 @@ func runStatsSummary() error {
 			dur = lastEvent.Sub(firstEvent)
 		}
 
-		// Determine model for display from status (most up-to-date).
-		modelID := ""
-		if s.RootModelID != nil && *s.RootModelID != "" {
-			modelID = *s.RootModelID
-		}
+		// Determine agent name for display from status (most up-to-date).
 		agentName := ""
 		if s.RootAgentName != nil && *s.RootAgentName != "" {
 			agentName = *s.RootAgentName
-		}
-
-		// Compute cost from accumulated tokens.
-		cost := 0.0
-		if modelID != "" {
-			if costs, ok := modelCosts[modelID]; ok {
-				cost = (float64(totalInput)*costs.Input +
-					float64(totalOutput)*costs.Output +
-					float64(totalCacheRead)*costs.CacheRead +
-					float64(totalCacheWrite)*costs.CacheWrite) / 1_000_000
-			}
 		}
 
 		rows = append(rows, summaryRow{
@@ -777,7 +778,7 @@ func runStatsSummary() error {
 			State:    s.State,
 			Duration: dur,
 			Tokens:   totalInput + totalOutput,
-			Cost:     cost,
+			Cost:     totalCost,
 		})
 	}
 

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -670,7 +670,9 @@ func renderSessionCompactTable(sessionName string, metrics []*sessionMetrics, st
 			// columns. The label is kept short to fit the 20-char STARTED column.
 			// The --detail mode uses the longer "(legacy, pre-sidecar)" label where
 			// there is no width constraint.
-			if modelStr == "" || modelStr == "(legacy)" {
+			// Note: modelStr may be "—" here (assigned above when m.ModelID == ""),
+			// so we also check for "—" to catch the no-model-data case.
+			if modelStr == "—" || modelStr == "" || modelStr == "(legacy)" {
 				modelStr = "(legacy)"
 			}
 			startedStr = "(legacy)"
@@ -865,17 +867,17 @@ func runStatsHistorical(days int) error {
 		totalSessions++
 		// Sum across all opencode sessions within this tmux session.
 		grouped, order := groupEventsByOpencodeSID(evts)
+		// Hoist status lookup outside the inner loop to avoid N+1 queries when
+		// multiple opencode SID groups have no model data.
+		st, _ := d.CurrentStatus(session)
 		var sessionCost float64
 		var sessionDur time.Duration
 		var firstEvent, lastEvent time.Time
 		for _, key := range order {
 			m := collectMetrics(grouped[key], key)
 			// Enrich model from status table for cost calculation.
-			if m.ModelID == "" {
-				st, _ := d.CurrentStatus(session)
-				if st != nil && st.RootModelID != nil && *st.RootModelID != "" {
-					m.ModelID = *st.RootModelID
-				}
+			if m.ModelID == "" && st != nil && st.RootModelID != nil && *st.RootModelID != "" {
+				m.ModelID = *st.RootModelID
 			}
 			sessionCost += m.totalCost()
 			for tool, count := range m.ToolCalls {

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -45,6 +45,24 @@ func writeStatsEvent(t *testing.T, d *db.DB, session, typ, payload string, ts ti
 	}
 }
 
+// writeStatsEventWithSID writes an event with an explicit opencode_sid.
+func writeStatsEventWithSID(t *testing.T, d *db.DB, session, sid, typ, payload string, ts time.Time) {
+	t.Helper()
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: session,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		OpencodeSID: &sid,
+		Type:        typ,
+		Payload:     payload,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
 func assistantPayloadWithTokens(msgID, text string, inputTokens, outputTokens, cacheRead, cacheWrite int, durationMs int64, contextPct float64) string {
 	return fmt.Sprintf(`{"messageId":%q,"text":%q,"agent":"opencode","model":"anthropic/claude-sonnet-4-6","inputTokens":%d,"outputTokens":%d,"cacheReadTokens":%d,"cacheWriteTokens":%d,"durationMs":%d,"contextWindowPct":%f}`,
 		msgID, text, inputTokens, outputTokens, cacheRead, cacheWrite, durationMs, contextPct)
@@ -53,6 +71,12 @@ func assistantPayloadWithTokens(msgID, text string, inputTokens, outputTokens, c
 func toolCallPayloadWithDuration(msgID, tool, args string, durationMs int64) string {
 	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"args":%q,"durationMs":%d}`,
 		msgID, tool, args, durationMs)
+}
+
+// assistantPayloadWithAgentModel creates an assistant payload with explicit agent and model fields.
+func assistantPayloadWithAgentModel(msgID, agent, model string, inputTokens, outputTokens int) string {
+	return fmt.Sprintf(`{"messageId":%q,"text":"reply","agent":%q,"model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":5000}`,
+		msgID, agent, model, inputTokens, outputTokens)
 }
 
 // --- per-session detail tests ---
@@ -77,7 +101,7 @@ func TestRunStatsSession_TokenTotals(t *testing.T) {
 		base.Add(10*time.Second))
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -107,7 +131,7 @@ func TestRunStatsSession_CostEstimate(t *testing.T) {
 		base)
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -136,7 +160,7 @@ func TestRunStatsSession_TurnDurations(t *testing.T) {
 		base.Add(20*time.Second))
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -171,7 +195,7 @@ func TestRunStatsSession_ToolBreakdown(t *testing.T) {
 		base.Add(2*time.Second))
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -203,7 +227,7 @@ func TestRunStatsSession_PeakContext(t *testing.T) {
 		base.Add(10*time.Second))
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -230,7 +254,7 @@ func TestRunStatsSession_Compactions(t *testing.T) {
 	writeStatsEvent(t, d, session, "compaction", `{"note":"compaction complete"}`, base.Add(10*time.Second))
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -250,7 +274,7 @@ func TestRunStatsSession_NoData(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -264,12 +288,337 @@ func TestRunStatsSession_NoData(t *testing.T) {
 func TestRunStatsSession_NotFound(t *testing.T) {
 	_ = openStatsTestDB(t)
 
-	err := runStatsSession("nonexistent@main")
+	err := runStatsSession("nonexistent@main", false)
 	if err == nil {
 		t.Error("expected error for nonexistent session, got nil")
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention 'not found'\ngot: %v", err)
+	}
+}
+
+// TestRunStatsSession_MultipleOpencodeSessions verifies that a tmux session
+// with multiple opencode sessions renders a compact table.
+func TestRunStatsSession_MultipleOpencodeSessions(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@main"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	sid1 := "ses_aaa111"
+	sid2 := "ses_bbb222"
+
+	// Session 1: coordinator on sonnet.
+	writeStatsEventWithSID(t, d, session, sid1, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-1", "coordinator", "anthropic/claude-sonnet-4-6", 1000, 500),
+		base)
+	writeStatsEventWithSID(t, d, session, sid1, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-2", "coordinator", "anthropic/claude-sonnet-4-6", 2000, 800),
+		base.Add(10*time.Second))
+
+	// Session 2: coordinator on opus.
+	writeStatsEventWithSID(t, d, session, sid2, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-3", "coordinator", "anthropic/claude-opus-4-6", 5000, 2000),
+		base.Add(1*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// Should show compact table with summary row.
+	if !strings.Contains(out, "summary:") {
+		t.Errorf("output missing 'summary:' line for multi-session\ngot:\n%s", out)
+	}
+	// Should show both models.
+	if !strings.Contains(out, "claude-sonnet-4-6") {
+		t.Errorf("output missing 'claude-sonnet-4-6'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "claude-opus-4-6") {
+		t.Errorf("output missing 'claude-opus-4-6'\ngot:\n%s", out)
+	}
+	// Should show compact table headers.
+	if !strings.Contains(out, "STARTED") {
+		t.Errorf("output missing 'STARTED' column header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "DURATION") {
+		t.Errorf("output missing 'DURATION' column header\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsSession_SingleSessionUnchanged verifies that a tmux session with
+// exactly one opencode session renders the pre-existing detailed block format.
+func TestRunStatsSession_SingleSessionUnchanged(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@feature"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/feature", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	sid := "ses_single123"
+	writeStatsEventWithSID(t, d, session, sid, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-1", "coordinator", "anthropic/claude-sonnet-4-6", 1000, 500),
+		base)
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// Should show detailed block, not compact table.
+	if strings.Contains(out, "summary:") {
+		t.Errorf("single session should NOT show 'summary:' compact table header\ngot:\n%s", out)
+	}
+	// Should show detailed block headers.
+	if !strings.Contains(out, "Token Usage") {
+		t.Errorf("output missing 'Token Usage' for single session detailed block\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "Turns") {
+		t.Errorf("output missing 'Turns' for single session detailed block\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsSession_NullSidLegacySentinel verifies that events with NULL
+// opencode_sid are grouped under the legacy sentinel and displayed as "(legacy)".
+func TestRunStatsSession_NullSidLegacySentinel(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@main"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Write events with NULL opencode_sid (no SID — uses writeStatsEvent which doesn't set SID).
+	writeStatsEvent(t, d, session, "msg_assistant",
+		`{"messageId":"msg-old","text":"old reply","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":500,"outputTokens":200,"durationMs":3000}`,
+		base)
+	writeStatsEvent(t, d, session, "msg_assistant",
+		`{"messageId":"msg-old2","text":"old reply 2","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":400,"outputTokens":150,"durationMs":2000}`,
+		base.Add(10*time.Second))
+
+	// Also write events with a real SID so we have 2 groups.
+	sid := "ses_real456"
+	writeStatsEventWithSID(t, d, session, sid, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-new", "coordinator", "anthropic/claude-sonnet-4-6", 1000, 500),
+		base.Add(1*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// Should show compact table (2 groups: legacy + real session).
+	if !strings.Contains(out, "summary:") {
+		t.Errorf("output missing 'summary:' for multi-group session\ngot:\n%s", out)
+	}
+	// Legacy row should be labelled.
+	if !strings.Contains(out, "legacy") {
+		t.Errorf("output missing 'legacy' label for NULL-sid group\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsSession_AllNullSidSingleLegacy verifies that a session where ALL
+// events have NULL opencode_sid renders as a detailed block labelled "(legacy)".
+func TestRunStatsSession_AllNullSidSingleLegacy(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@old"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/old", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// All events have NULL opencode_sid.
+	writeStatsEvent(t, d, session, "msg_assistant",
+		`{"messageId":"msg-1","text":"reply","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":500,"outputTokens":200,"durationMs":3000}`,
+		base)
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// All-legacy session: should render as detailed block (not compact table).
+	if strings.Contains(out, "STARTED") {
+		t.Errorf("all-legacy session should use detailed block, not compact table\ngot:\n%s", out)
+	}
+	// Should show legacy label.
+	if !strings.Contains(out, "legacy") {
+		t.Errorf("all-legacy session should show 'legacy' label\ngot:\n%s", out)
+	}
+	// Should show Token Usage block (detailed format).
+	if !strings.Contains(out, "Token Usage") {
+		t.Errorf("all-legacy session should show 'Token Usage' in detailed block\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsSession_DetailFlag verifies that --detail forces detailed block
+// format even for multi-session tmux sessions.
+func TestRunStatsSession_DetailFlag(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@main"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	sid1 := "ses_aaa111"
+	sid2 := "ses_bbb222"
+
+	writeStatsEventWithSID(t, d, session, sid1, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-1", "coordinator", "anthropic/claude-sonnet-4-6", 1000, 500),
+		base)
+	writeStatsEventWithSID(t, d, session, sid2, "msg_assistant",
+		assistantPayloadWithAgentModel("msg-2", "coordinator", "anthropic/claude-opus-4-6", 5000, 2000),
+		base.Add(1*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, true); err != nil { // detail=true
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// With --detail, should show detailed block format for each session.
+	if !strings.Contains(out, "Token Usage") {
+		t.Errorf("--detail flag should show 'Token Usage' in block format\ngot:\n%s", out)
+	}
+	// Should still show the summary line at top.
+	if !strings.Contains(out, "summary:") {
+		t.Errorf("--detail flag should still show 'summary:' header\ngot:\n%s", out)
+	}
+}
+
+// TestGroupEventsByOpencodeSID verifies event grouping by opencode_sid.
+func TestGroupEventsByOpencodeSID(t *testing.T) {
+	sid1 := "ses_aaa"
+	sid2 := "ses_bbb"
+
+	events := []db.Event{
+		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid1, Payload: `{}`, CreatedAt: time.Now()},
+		{ID: "2", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid2, Payload: `{}`, CreatedAt: time.Now()},
+		{ID: "3", SessionName: "s", Type: "msg_assistant", OpencodeSID: nil, Payload: `{}`, CreatedAt: time.Now()},   // NULL → sentinel
+		{ID: "4", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid1, Payload: `{}`, CreatedAt: time.Now()}, // same as id=1
+	}
+
+	grouped, order := groupEventsByOpencodeSID(events)
+
+	if len(order) != 3 {
+		t.Errorf("expected 3 groups (sid1, sid2, sentinel), got %d: %v", len(order), order)
+	}
+	if len(grouped[sid1]) != 2 {
+		t.Errorf("sid1 group should have 2 events, got %d", len(grouped[sid1]))
+	}
+	if len(grouped[sid2]) != 1 {
+		t.Errorf("sid2 group should have 1 event, got %d", len(grouped[sid2]))
+	}
+	if len(grouped[legacySentinel]) != 1 {
+		t.Errorf("legacy sentinel group should have 1 event, got %d", len(grouped[legacySentinel]))
+	}
+	// Order should be: sid1 first (first seen), then sid2, then sentinel.
+	if order[0] != sid1 {
+		t.Errorf("first group should be %q, got %q", sid1, order[0])
+	}
+	if order[1] != sid2 {
+		t.Errorf("second group should be %q, got %q", sid2, order[1])
+	}
+	if order[2] != legacySentinel {
+		t.Errorf("third group should be legacySentinel %q, got %q", legacySentinel, order[2])
+	}
+}
+
+// TestCollectMetrics_CoordinatorModelPreferred verifies that the coordinator
+// agent's model is preferred over the most-frequent model.
+func TestCollectMetrics_CoordinatorModelPreferred(t *testing.T) {
+	// 3 turns on opus (build/review), 1 turn on sonnet (coordinator).
+	// Coordinator model should win despite being less frequent.
+	events := []db.Event{
+		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"build","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+		{ID: "2", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"review","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+		{ID: "3", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"build","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+		{ID: "4", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+	}
+
+	m := collectMetrics(events, "ses_abc")
+
+	if m.ModelID != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("expected coordinator model 'anthropic/claude-sonnet-4-6', got %q", m.ModelID)
+	}
+	if m.AssistantTurns != 4 {
+		t.Errorf("expected 4 assistant turns, got %d", m.AssistantTurns)
+	}
+}
+
+// TestCollectMetrics_FallbackToMostFrequent verifies that when no coordinator
+// turn exists, the most-frequent model is used.
+func TestCollectMetrics_FallbackToMostFrequent(t *testing.T) {
+	events := []db.Event{
+		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"build","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+		{ID: "2", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"review","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+		{ID: "3", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+			Payload: `{"agent":"explore","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+	}
+
+	m := collectMetrics(events, "ses_abc")
+
+	// opus appears 2 times, sonnet 1 time — opus should win.
+	if m.ModelID != "anthropic/claude-opus-4-6" {
+		t.Errorf("expected most-frequent model 'anthropic/claude-opus-4-6', got %q", m.ModelID)
+	}
+}
+
+// TestCollectMetrics_NullSidLegacy verifies that the legacy sentinel is set
+// correctly for NULL-sid events.
+func TestCollectMetrics_NullSidLegacy(t *testing.T) {
+	events := []db.Event{
+		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: nil,
+			Payload: `{"agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
+	}
+
+	m := collectMetrics(events, legacySentinel)
+
+	if !m.isLegacy() {
+		t.Errorf("expected m.isLegacy() == true for legacySentinel key")
+	}
+	if m.OpencodeSID != legacySentinel {
+		t.Errorf("OpencodeSID should be legacySentinel %q, got %q", legacySentinel, m.OpencodeSID)
+	}
+}
+
+// TestRunStatsSession_ZeroEvents verifies that a zero-event tmux session renders
+// without panic.
+func TestRunStatsSession_ZeroEvents(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@empty"
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/empty", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no metrics data") {
+		t.Errorf("zero-event session should show 'no metrics data'\ngot:\n%s", out)
 	}
 }
 
@@ -293,7 +642,7 @@ func TestRunStatsSummary_ActiveSessions(t *testing.T) {
 		base)
 
 	out := captureStdout(t, func() {
-		if err := runStatsSummary(true); err != nil {
+		if err := runStatsSummary(); err != nil {
 			t.Errorf("runStatsSummary: %v", err)
 		}
 	})
@@ -314,7 +663,7 @@ func TestRunStatsSummary_NoSessions(t *testing.T) {
 	_ = openStatsTestDB(t)
 
 	out := captureStdout(t, func() {
-		if err := runStatsSummary(true); err != nil {
+		if err := runStatsSummary(); err != nil {
 			t.Errorf("runStatsSummary: %v", err)
 		}
 	})
@@ -491,7 +840,7 @@ func TestRunStatsSession_SubagentInvocations(t *testing.T) {
 		base.Add(50*time.Second))
 
 	out := captureStdout(t, func() {
-		if err := runStatsSession(session); err != nil {
+		if err := runStatsSession(session, false); err != nil {
 			t.Errorf("runStatsSession: %v", err)
 		}
 	})
@@ -508,8 +857,7 @@ func TestRunStatsSession_SubagentInvocations(t *testing.T) {
 }
 
 // TestRunStats_DaysMutuallyExclusive verifies that --days is mutually exclusive
-// with a session name argument. --all is now a no-op so --days + --all is
-// allowed.
+// with a session name argument.
 func TestRunStats_DaysMutuallyExclusive(t *testing.T) {
 	_ = openStatsTestDB(t)            // needed so openDB() works in runStats
 	statsCmd.Flags().Set("days", "7") //nolint:errcheck
@@ -523,15 +871,23 @@ func TestRunStats_DaysMutuallyExclusive(t *testing.T) {
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("expected 'mutually exclusive' in error for --days+session, got: %v", err)
 	}
+}
 
-	// --days + --all should NOT error (--all is a no-op for backwards compatibility).
-	statsCmd.Flags().Set("all", "true") //nolint:errcheck
-	defer statsCmd.Flags().Set("all", "false")
+// TestRunStats_AllFlagRemoved verifies that --all is no longer a registered flag
+// on statsCmd (passing it should result in an error/unknown flag).
+func TestRunStats_AllFlagRemoved(t *testing.T) {
+	f := statsCmd.Flags().Lookup("all")
+	if f != nil {
+		t.Error("statsCmd should NOT have an --all flag (it was removed), but it is still registered")
+	}
+}
 
-	err = runStats(statsCmd, nil)
-	// May return an error from the DB (no events), but must NOT be a "mutually exclusive" error.
-	if err != nil && strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("--days + --all should not produce a 'mutually exclusive' error, got: %v", err)
+// TestRunStatsModel_AllFlagRemoved verifies that --all is no longer a registered
+// flag on modelCmd.
+func TestRunStatsModel_AllFlagRemoved(t *testing.T) {
+	f := modelCmd.Flags().Lookup("all")
+	if f != nil {
+		t.Error("modelCmd should NOT have an --all flag (it was removed), but it is still registered")
 	}
 }
 
@@ -555,7 +911,7 @@ func TestCollectMetrics_PreEnrichmentEvents(t *testing.T) {
 		t.Fatalf("AllSessionEvents: %v", err)
 	}
 
-	m := collectMetrics(events)
+	m := collectMetrics(events, legacySentinel)
 
 	if m.AssistantTurns != 1 {
 		t.Errorf("AssistantTurns = %d, want 1", m.AssistantTurns)
@@ -619,9 +975,6 @@ func TestRunStatsModel_BasicOutput(t *testing.T) {
 	if ghEntry.Turns != 2 {
 		t.Errorf("github-copilot turns = %d, want 2", ghEntry.Turns)
 	}
-	if len(ghEntry.Sessions) != 1 {
-		t.Errorf("github-copilot sessions = %d, want 1", len(ghEntry.Sessions))
-	}
 	if ghEntry.InputTokens != 15000 {
 		t.Errorf("github-copilot input tokens = %d, want 15000", ghEntry.InputTokens)
 	}
@@ -640,7 +993,7 @@ func TestRunStatsModel_BasicOutput(t *testing.T) {
 		renderModelBreakdown(metrics, 7)
 	})
 
-	for _, want := range []string{"PROVIDER", "MODEL", "TURNS", "TTFT p50", "DUR p50", "TOK/S p50", "INPUT", "OUTPUT", "COST", "SESSIONS"} {
+	for _, want := range []string{"PROVIDER", "MODEL", "TURNS", "TTFT p50", "DUR p50", "TOK/S p50", "INPUT", "OUTPUT", "COST", "SESSIONS", "AGENTS"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing column header %q\ngot:\n%s", want, out)
 		}
@@ -650,6 +1003,69 @@ func TestRunStatsModel_BasicOutput(t *testing.T) {
 	}
 	if !strings.Contains(out, "anthropic") {
 		t.Errorf("output missing 'anthropic'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsModel_SessionCountByOpencodeSID verifies that sessions are counted
+// by opencode_sid (not session_name) so that multi-session tmux sessions are
+// counted correctly.
+func TestRunStatsModel_SessionCountByOpencodeSID(t *testing.T) {
+	sid1 := "ses_opencode_aaa"
+	sid2 := "ses_opencode_bbb"
+	sid3 := "ses_opencode_ccc"
+
+	// Three distinct opencode sessions all within the same tmux session "repo@main",
+	// all using the same model.
+	events := []db.Event{
+		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: &sid1,
+			Payload:   `{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+		{ID: "2", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: &sid2,
+			Payload:   `{"messageId":"m2","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+		{ID: "3", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: &sid3,
+			Payload:   `{"messageId":"m3","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+	}
+
+	metrics := collectModelMetrics(events)
+	entry, ok := metrics["anthropic/claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing entry for anthropic/claude-sonnet-4-6")
+	}
+
+	// Should count 3 sessions (one per opencode_sid), NOT 1 (session_name).
+	if len(entry.Sessions) != 3 {
+		t.Errorf("expected 3 distinct opencode sessions, got %d", len(entry.Sessions))
+	}
+}
+
+// TestRunStatsModel_NullSidFallbackSessionName verifies that NULL opencode_sid
+// events fall back to counting by session_name as a legacy bucket.
+func TestRunStatsModel_NullSidFallbackSessionName(t *testing.T) {
+	// Two different sessions, both with NULL opencode_sid, same model.
+	events := []db.Event{
+		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: nil,
+			Payload:   `{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,
+			CreatedAt: time.Now()},
+		{ID: "2", SessionName: "repo@feature", Type: "msg_assistant", OpencodeSID: nil,
+			Payload:   `{"messageId":"m2","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,
+			CreatedAt: time.Now()},
+		// Same session_name as first but different event — should NOT add another session count.
+		{ID: "3", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: nil,
+			Payload:   `{"messageId":"m3","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,
+			CreatedAt: time.Now()},
+	}
+
+	metrics := collectModelMetrics(events)
+	entry, ok := metrics["anthropic/claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing entry for anthropic/claude-sonnet-4-6")
+	}
+
+	// Should count 2 distinct sessions (repo@main and repo@feature), not 3.
+	if len(entry.Sessions) != 2 {
+		t.Errorf("expected 2 distinct legacy sessions, got %d: %v", len(entry.Sessions), entry.Sessions)
 	}
 }
 
@@ -891,9 +1307,8 @@ func TestRunStatsSummary_ShowsAllRepos(t *testing.T) {
 		assistantPayloadWithTokens("msg-2", "reply", 2000, 800, 0, 0, 5000, 0),
 		base.Add(time.Second))
 
-	// showAll=false should still show both repos.
 	out := captureStdout(t, func() {
-		if err := runStatsSummary(false); err != nil {
+		if err := runStatsSummary(); err != nil {
 			t.Errorf("runStatsSummary: %v", err)
 		}
 	})
@@ -903,6 +1318,64 @@ func TestRunStatsSummary_ShowsAllRepos(t *testing.T) {
 	}
 	if !strings.Contains(out, "repo-b@main") {
 		t.Errorf("output missing 'repo-b@main' — should show all repos\ngot:\n%s", out)
+	}
+}
+
+// TestFormatAgentSummary verifies the agent summary formatting helper.
+func TestFormatAgentSummary(t *testing.T) {
+	cases := []struct {
+		agentCounts map[string]int
+		want        string
+	}{
+		{nil, "—"},
+		{map[string]int{}, "—"},
+		{map[string]int{"coordinator": 10}, "coordinator"},
+		{map[string]int{"coordinator": 10, "build": 5}, "coordinator (×2)"},
+		{map[string]int{"coordinator": 5, "build": 10, "review": 3}, "build (×3)"},
+	}
+	for _, tc := range cases {
+		got := formatAgentSummary(tc.agentCounts)
+		if got != tc.want {
+			t.Errorf("formatAgentSummary(%v) = %q, want %q", tc.agentCounts, got, tc.want)
+		}
+	}
+}
+
+// TestRenderModelBreakdown_AgentsColumn verifies that the AGENTS column appears
+// in the model breakdown table with correct values.
+func TestRenderModelBreakdown_AgentsColumn(t *testing.T) {
+	// Two models: sonnet used by coordinator+review, haiku used only by explore.
+	events := []db.Event{
+		{ID: "1", SessionName: "s1", Type: "msg_assistant",
+			Payload:   `{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+		{ID: "2", SessionName: "s1", Type: "msg_assistant",
+			Payload:   `{"messageId":"m2","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+		{ID: "3", SessionName: "s1", Type: "msg_assistant",
+			Payload:   `{"messageId":"m3","text":"r","agent":"review","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+		{ID: "4", SessionName: "s1", Type: "msg_assistant",
+			Payload:   `{"messageId":"m4","text":"r","agent":"explore","model":"anthropic/claude-haiku-4-5","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
+			CreatedAt: time.Now()},
+	}
+
+	metrics := collectModelMetrics(events)
+	out := captureStdout(t, func() {
+		renderModelBreakdown(metrics, 7)
+	})
+
+	// AGENTS column header must appear.
+	if !strings.Contains(out, "AGENTS") {
+		t.Errorf("output missing 'AGENTS' column header\ngot:\n%s", out)
+	}
+	// Sonnet: coordinator dominant, 2 agent types → "coordinator (×2)"
+	if !strings.Contains(out, "coordinator (×2)") {
+		t.Errorf("output missing 'coordinator (×2)' for sonnet\ngot:\n%s", out)
+	}
+	// Haiku: only explore → "explore"
+	if !strings.Contains(out, "explore") {
+		t.Errorf("output missing 'explore' agent for haiku\ngot:\n%s", out)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -1321,6 +1321,135 @@ func TestRunStatsSummary_ShowsAllRepos(t *testing.T) {
 	}
 }
 
+// TestRunStatsSummary_MultiModelCost verifies that the summary table sums cost
+// per opencode session (each with its own model pricing) rather than applying
+// a single live model's rate to all accumulated tokens. This is critical for
+// long-lived tmux sessions that span multiple model changes.
+func TestRunStatsSummary_MultiModelCost(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+	const session = "testrepo@main"
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	sid1 := "ses_cheap111"
+	sid2 := "ses_expensive222"
+
+	// Session 1: haiku — 100K input @ $0.80/M = $0.08
+	writeStatsEventWithSID(t, d, session, sid1, "msg_assistant",
+		`{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-haiku-4-5","inputTokens":100000,"outputTokens":0,"durationMs":5000}`,
+		base)
+
+	// Session 2: opus — 100K input @ $15.00/M = $1.50
+	writeStatsEventWithSID(t, d, session, sid2, "msg_assistant",
+		`{"messageId":"m2","text":"r","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":100000,"outputTokens":0,"durationMs":5000}`,
+		base.Add(1*time.Hour))
+
+	// Expected: $0.08 (haiku) + $1.50 (opus) = ~$1.58
+	// Wrong (single-model bug): applying opus rate to all 200K tokens = $3.00
+	out := captureStdout(t, func() {
+		if err := runStatsSummary(); err != nil {
+			t.Errorf("runStatsSummary: %v", err)
+		}
+	})
+
+	// The cost shown should be ~$1.58, not ~$3.00.
+	if !strings.Contains(out, "~$1.58") {
+		t.Errorf("summary cost should be ~$1.58 (per-session pricing), got:\n%s", out)
+	}
+	if strings.Contains(out, "~$3.00") {
+		t.Errorf("summary cost must NOT be ~$3.00 (single-model-all-tokens bug)\ngot:\n%s", out)
+	}
+}
+
+// TestRenderSessionCompactTable_LegacyLabelFits verifies that the legacy row
+// label in the compact table fits within the STARTED column without truncation,
+// and never produces the malformed "(legacy, pre-sidecar" artefact.
+func TestRenderSessionCompactTable_LegacyLabelFits(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@main"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Legacy events (NULL sid).
+	writeStatsEvent(t, d, session, "msg_assistant",
+		`{"messageId":"old1","text":"r","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50,"durationMs":3000}`,
+		base)
+
+	// Real session alongside legacy — triggers compact table with legacy row.
+	sid := "ses_real999"
+	writeStatsEventWithSID(t, d, session, sid, "msg_assistant",
+		assistantPayloadWithAgentModel("new1", "coordinator", "anthropic/claude-sonnet-4-6", 500, 200),
+		base.Add(1*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// The compact table must show "(legacy)" — the full word with closing paren.
+	if !strings.Contains(out, "(legacy)") {
+		t.Errorf("compact table should contain '(legacy)' label\ngot:\n%s", out)
+	}
+	// Must NOT contain the truncated artefact "(legacy, pre-sidecar" (missing close paren).
+	if strings.Contains(out, "(legacy, pre-sidecar") {
+		t.Errorf("compact table must NOT contain truncated '(legacy, pre-sidecar' artefact\ngot:\n%s", out)
+	}
+}
+
+// TestRenderSessionCompactTable_SummaryExcludesLegacy verifies that the summary
+// line counts only real opencode sessions, not the legacy sentinel group, and
+// appends "(+ legacy events)" when legacy data is present.
+func TestRenderSessionCompactTable_SummaryExcludesLegacy(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "testrepo@main"
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Legacy events (NULL sid) — should NOT count as an opencode session.
+	writeStatsEvent(t, d, session, "msg_assistant",
+		`{"messageId":"old1","text":"r","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50,"durationMs":3000}`,
+		base)
+
+	// Two real opencode sessions.
+	sid1 := "ses_aaa"
+	sid2 := "ses_bbb"
+	writeStatsEventWithSID(t, d, session, sid1, "msg_assistant",
+		assistantPayloadWithAgentModel("new1", "coordinator", "anthropic/claude-sonnet-4-6", 500, 200),
+		base.Add(1*time.Hour))
+	writeStatsEventWithSID(t, d, session, sid2, "msg_assistant",
+		assistantPayloadWithAgentModel("new2", "coordinator", "anthropic/claude-sonnet-4-6", 500, 200),
+		base.Add(2*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsSession(session, false); err != nil {
+			t.Errorf("runStatsSession: %v", err)
+		}
+	})
+
+	// Summary should say "2 opencode sessions" (not "3").
+	if !strings.Contains(out, "2 opencode sessions") {
+		t.Errorf("summary should say '2 opencode sessions' (excluding legacy), got:\n%s", out)
+	}
+	// Should also mention legacy events.
+	if !strings.Contains(out, "legacy events") {
+		t.Errorf("summary should mention '+ legacy events' when legacy data present\ngot:\n%s", out)
+	}
+	// Must NOT say "3 opencode sessions".
+	if strings.Contains(out, "3 opencode sessions") {
+		t.Errorf("summary must NOT count legacy sentinel as an opencode session\ngot:\n%s", out)
+	}
+}
+
 // TestFormatAgentSummary verifies the agent summary formatting helper.
 func TestFormatAgentSummary(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

- **AC-1/AC-2/AC-3/AC-4/AC-5**: `prism stats <session>` now groups events by `opencode_sid` within the tmux session. Multi-session sessions get a compact table; single-session sessions keep the existing detailed block. `--detail` forces detailed block. NULL-sid events are grouped under `(legacy, pre-sidecar)` sentinel.
- **AC-6**: `collectModelMetrics` session count fixed: uses `e.OpencodeSID` instead of `e.SessionName`. NULL-sid events fall back to `"legacy:"+session_name` as distinct legacy buckets.
- **AC-7/AC-8**: `--all` flag removed from both `statsCmd` and `modelCmd`; docstrings updated.
- **AC-20**: `AGENTS` column added to `prism stats model` showing dominant agent type with distinct-agent count (e.g. `coordinator (×3)`).

## Key design decisions

- Model for a session row = coordinator agent's model (if present), else most-frequent model
- Mixed legacy+real sessions always show compact table (legacy block is not hidden)
- All-legacy sessions (all NULL-sid) → detailed block labelled `(legacy, pre-sidecar)`
- Live status (state, agent name) applied only to the most-recent non-legacy session in the compact table
- `--detail` flag (not `--verbose` or `--expand`) chosen as most idiomatic

## Test coverage added

- `TestGroupEventsByOpencodeSID` — grouping logic, key ordering, sentinel
- `TestCollectMetrics_CoordinatorModelPreferred` — coordinator model wins over frequency
- `TestCollectMetrics_FallbackToMostFrequent` — no coordinator → most-frequent wins  
- `TestCollectMetrics_NullSidLegacy` — legacy sentinel assignment
- `TestRunStatsSession_MultipleOpencodeSessions` — compact table rendered for >1 session
- `TestRunStatsSession_SingleSessionUnchanged` — detailed block for exactly 1 session
- `TestRunStatsSession_NullSidLegacySentinel` — mixed legacy+real → compact table
- `TestRunStatsSession_AllNullSidSingleLegacy` — all-legacy → detailed block with label
- `TestRunStatsSession_DetailFlag` — `--detail` forces block format
- `TestRunStatsSession_ZeroEvents` — no panic on zero events
- `TestRunStatsModel_SessionCountByOpencodeSID` — 3 opencode sessions counted as 3
- `TestRunStatsModel_NullSidFallbackSessionName` — 2 NULL-sid sessions counted correctly
- `TestRunStats_AllFlagRemoved` / `TestRunStatsModel_AllFlagRemoved` — --all is gone
- `TestFormatAgentSummary` — AGENTS column helper
- `TestRenderModelBreakdown_AgentsColumn` — AGENTS column in rendered output