### PR TITLE
fix(prism): relax tmux-session-start guard to allow non-worktree sessions

### DIFF
--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -167,7 +167,9 @@ var eventPaneDiedCmd = &cobra.Command{
 			return fmt.Errorf("event pane-died: current status: %w", err)
 		}
 		if s == nil {
-			// No DB record — non-project session; exit silently.
+			// No DB record for this session — exit silently. This can happen
+			// for races (session ended before the hook wrote a row) or for
+			// genuinely untracked sessions.
 			return nil
 		}
 
@@ -302,7 +304,9 @@ var eventTmuxSessionEndCmd = &cobra.Command{
 			return fmt.Errorf("event tmux-session-end: current status: %w", err)
 		}
 		if s == nil {
-			// No DB record for this session — it was a non-project session; exit 0 silently.
+			// No DB record for this session — exit 0 silently. This can happen
+			// for races (session ended before the hook wrote a row) or for
+			// genuinely untracked sessions.
 			return nil
 		}
 

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -219,11 +219,17 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 		session, _ := cmd.Flags().GetString("session")
 		worktree, _ := cmd.Flags().GetString("worktree")
 
-		// If no .bare marker is found, exit 0 silently — this is a non-project
-		// session (scratchpad, prism-dashboard, etc.).
 		repo := deriveRepo(worktree)
 		if repo == "" {
-			return nil
+			// Non-worktree session: skip only the meta-sessions (scratchpad and
+			// prism-dashboard) that must not appear in agent_status. All other
+			// non-worktree sessions (e.g. "obsidian") are legitimate user
+			// sessions and get a row with repo="" — consistent with the port
+			// allocation path in switch.go:allocatePortForSession.
+			if session == "scratchpad" || session == "prism-dashboard" {
+				return nil
+			}
+			// Fall through: UpsertStatus will be called with repo="" below.
 		}
 
 		d, err := openDB()

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -170,3 +170,168 @@ func TestEventTmuxSessionEnd_EmptySession(t *testing.T) {
 		}
 	}
 }
+
+// TestEventTmuxSessionStart_NonWorktreeSession verifies that a non-worktree
+// session (like "obsidian") gets an agent_status row with repo="", state="idle",
+// and ended_at=NULL when tmux-session-start fires.
+//
+// AC-7: new test for the non-worktree session path.
+func TestEventTmuxSessionStart_NonWorktreeSession(t *testing.T) {
+	// Does not need a live tmux server — no tmux calls in this path.
+	const session = "obsidian"
+
+	// Use a temp dir as the worktree: no .bare marker present.
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "tmux-session-start",
+		"--session", session,
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error %v, want nil", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected agent_status row for obsidian, got nil")
+	}
+	if status.Repo != "" {
+		t.Errorf("repo = %q, want empty string", status.Repo)
+	}
+	if status.State != "idle" {
+		t.Errorf("state = %q, want \"idle\"", status.State)
+	}
+	if status.EndedAt != nil {
+		t.Errorf("ended_at = %v, want NULL", *status.EndedAt)
+	}
+}
+
+// TestEventTmuxSessionStart_SkipsMetaSessions verifies that "scratchpad" and
+// "prism-dashboard" are still silently skipped and do NOT produce an
+// agent_status row.
+//
+// AC-8: meta-sessions must not appear in agent_status.
+func TestEventTmuxSessionStart_SkipsMetaSessions(t *testing.T) {
+	worktree := t.TempDir()
+
+	for _, session := range []string{"scratchpad", "prism-dashboard"} {
+		t.Run(session, func(t *testing.T) {
+			dbFile := filepath.Join(t.TempDir(), "prism.db")
+			d, err := db.Open(dbFile)
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			d.Close()
+
+			SetTestDBPath(dbFile)
+			t.Cleanup(func() { SetTestDBPath("") })
+
+			rootCmd.SetArgs([]string{
+				"event", "tmux-session-start",
+				"--session", session,
+				"--worktree", worktree,
+			})
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute returned error %v, want nil (silent skip)", err)
+			}
+
+			d2, err := db.Open(dbFile)
+			if err != nil {
+				t.Fatalf("re-open db: %v", err)
+			}
+			defer d2.Close()
+
+			status, err := d2.CurrentStatus(session)
+			if err != nil {
+				t.Fatalf("CurrentStatus: %v", err)
+			}
+			if status != nil {
+				t.Errorf("session %q: expected no agent_status row, got one (state=%q)", session, status.State)
+			}
+		})
+	}
+}
+
+// TestEventTmuxSessionStart_NonWorktreeSession_ClearsEnded verifies that when
+// an agent_status row already exists for a non-worktree session with ended_at
+// set, a new tmux-session-start call clears ended_at (making the session
+// visible to AllActiveStatus again).
+//
+// AC-9: regression protection for PR #475 — ClearEnded must fire for obsidian.
+func TestEventTmuxSessionStart_NonWorktreeSession_ClearsEnded(t *testing.T) {
+	const session = "obsidian"
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Pre-seed a row with ended_at set (simulating a cleanup cycle).
+	if err := d.UpsertStatus(session, "", worktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetEnded(session); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	// Verify pre-condition: ended_at is set.
+	pre, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus (pre): %v", err)
+	}
+	if pre == nil || pre.EndedAt == nil {
+		t.Fatal("pre-condition failed: ended_at should be set after SetEnded")
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "tmux-session-start",
+		"--session", session,
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error %v, want nil", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus (post): %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected agent_status row after tmux-session-start, got nil")
+	}
+	if status.EndedAt != nil {
+		t.Errorf("ended_at = %v, want NULL — ClearEnded did not fire", *status.EndedAt)
+	}
+}

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -232,10 +232,9 @@ func TestEventTmuxSessionStart_NonWorktreeSession(t *testing.T) {
 //
 // AC-8: meta-sessions must not appear in agent_status.
 func TestEventTmuxSessionStart_SkipsMetaSessions(t *testing.T) {
-	worktree := t.TempDir()
-
 	for _, session := range []string{"scratchpad", "prism-dashboard"} {
 		t.Run(session, func(t *testing.T) {
+			worktree := t.TempDir()
 			dbFile := filepath.Join(t.TempDir(), "prism.db")
 			d, err := db.Open(dbFile)
 			if err != nil {

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -91,15 +91,17 @@ func restoreSession(d *db.DB, s db.Status) error {
 
 	switch s.SessionName {
 	case "prism-dashboard":
-		// Defensive guard — prism-dashboard is a non-project session and is
-		// never written to agent_status by prism event tmux-session-start (which
-		// exits silently when no .bare marker is found). This case cannot fire in
-		// practice under normal operation.
+		// Defensive guard — prism-dashboard is an internal meta-session
+		// explicitly skipped by name in cmd/event.go:tmux-session-start and
+		// will never appear in agent_status under normal operation. This case
+		// is retained as a safety net.
 		return nil
 
 	case "scratchpad":
-		// Defensive guard — same reasoning as prism-dashboard above: scratchpad
-		// has no .bare ancestor and will never appear in agent_status.
+		// Defensive guard — scratchpad is an internal meta-session explicitly
+		// skipped by name in cmd/event.go:tmux-session-start and will never
+		// appear in agent_status under normal operation. This case is retained
+		// as a safety net.
 		return ensureAndSwitch("[scratchpad]", "", session.Opts{Headless: true})
 
 	default:


### PR DESCRIPTION
## Summary

- The `tmux-session-start` handler in `cmd/event.go` had a too-broad guard that silently returned for any session where `deriveRepo` returned an empty string (no `.bare` marker). This blocked legitimate non-worktree sessions like `obsidian` from being tracked.
- Replace the guard with an explicit name-based check: only `scratchpad` and `prism-dashboard` are skipped. All other non-worktree sessions fall through to `UpsertStatus` (with `repo=""`) and `ClearEnded`.
- Add three new tests: `TestEventTmuxSessionStart_NonWorktreeSession`, `TestEventTmuxSessionStart_SkipsMetaSessions`, and `TestEventTmuxSessionStart_NonWorktreeSession_ClearsEnded`.

## Changes

- `modules/programs/prism/prism/cmd/event.go` — relax the guard in `tmux-session-start`
- `modules/programs/prism/prism/cmd/event_test.go` — three new tests (AC-7, AC-8, AC-9)

## Testing

- `go build ./...` ✅
- `go test ./...` ✅ (all 14 packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #573