### PR TITLE
sidecar: refresh root_model_id on root-agent user messages

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -796,7 +796,7 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 
 		agentName := info.Agent
 		model := ""
-		if info.Model != nil {
+		if info.Model != nil && info.Model.ProviderID != "" && info.Model.ModelID != "" {
 			model = info.Model.ProviderID + "/" + info.Model.ModelID
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -807,6 +807,20 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 			s.rootAgent = agentName
 		}
 
+		// Refresh root_model_id immediately when the user sends a message
+		// with a known model. This captures in-session model picker changes
+		// before any assistant message is produced, so that worker prompts
+		// delivered during the response window read a fresh model value.
+		// Only write for root-agent messages (same gate as the assistant
+		// path below) and only when model is non-empty (AC-1, AC-2, AC-3,
+		// AC-4).
+		isRootAgent := s.rootAgent == "" || agentName == "" || agentName == s.rootAgent
+		if model != "" && isRootAgent {
+			if err := s.cfg.DB.UpdateRootModelID(s.cfg.SessionName, model); err != nil {
+				log.Printf("sidecar: UpdateRootModelID (user msg) failed: %v", err)
+			}
+		}
+
 		s.writeEvent("msg_user", map[string]string{
 			"messageId": info.ID,
 			"text":      text,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2656,6 +2656,78 @@ func TestMessageUpdated_UserMessage_EmptyModel(t *testing.T) {
 	}
 }
 
+// TestMessageUpdated_UserMessage_PartialModel verifies that a user message with
+// an info.Model where either providerID or modelID is empty does NOT write
+// root_model_id (mirrors the both-fields guard on the assistant path).
+func TestMessageUpdated_UserMessage_PartialModel(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Seed a known model via assistant turn so we have something to preserve.
+	sendEvents(sc, makeUserMessage("msg-user-seed2", "root-agent", "Seed message"))
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-asst-seed2",
+			"text":      "Seed reply.",
+		},
+	}))
+	created := 1000.0
+	completed := 2000.0
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":         "msg-asst-seed2",
+			"role":       "assistant",
+			"agent":      "root-agent",
+			"providerID": "anthropic",
+			"modelID":    "claude-opus-4-6",
+			"time": map[string]*float64{
+				"created":   &created,
+				"completed": &completed,
+			},
+		},
+	}))
+
+	want := "anthropic/claude-opus-4-6"
+	status, err := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after seed: %v", err)
+	}
+	if status.RootModelID == nil || *status.RootModelID != want {
+		t.Fatalf("RootModelID after seed = %v, want %q", status.RootModelID, want)
+	}
+
+	// Fire a user message with a partial model (modelID empty). This must NOT
+	// write a malformed "anthropic/" value to root_model_id.
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-user-partial-model",
+			"text":      "Partial model message",
+		},
+	}))
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "msg-user-partial-model",
+			"role":  "user",
+			"agent": "root-agent",
+			"model": map[string]string{
+				"providerID": "anthropic",
+				"modelID":    "", // empty — partial data
+			},
+		},
+	}))
+
+	status, err = sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after partial-model user msg: %v", err)
+	}
+	if status.RootModelID == nil || *status.RootModelID != want {
+		t.Errorf("RootModelID after partial-model user message = %v, want %q (must not write malformed ID)", status.RootModelID, want)
+	}
+}
+
 // ── reconnect recovery timer tests ──────────────────────────────────────────
 
 // TestServerConnected_InitialConnection_NoTimer verifies that server.connected

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2479,6 +2479,183 @@ func TestMessageUpdated_SecondSessionUpdatesRootModelID(t *testing.T) {
 	}
 }
 
+// ── user-message root_model_id tests (AC-7, AC-8, AC-9) ─────────────────────
+
+// TestMessageUpdated_UserMessage_UpdatesRootModelID verifies AC-7: a user
+// message.updated event with info.Model set causes root_model_id to be written
+// to the DB immediately (before any assistant turn), so that worker prompts
+// delivered during the response window read the correct model.
+func TestMessageUpdated_UserMessage_UpdatesRootModelID(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Fire a user message with a model set (simulates user switching model in
+	// the opencode picker and then sending a message).
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-user-model-test",
+			"text":      "Hello with new model",
+		},
+	}))
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "msg-user-model-test",
+			"role":  "user",
+			"agent": "root-agent",
+			"model": map[string]string{
+				"providerID": "anthropic",
+				"modelID":    "claude-opus-4-6",
+			},
+		},
+	}))
+
+	status, err := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("CurrentStatus: got nil status")
+	}
+	if status.RootModelID == nil {
+		t.Fatal("RootModelID: got nil, want non-nil")
+	}
+	want := "anthropic/claude-opus-4-6"
+	if *status.RootModelID != want {
+		t.Errorf("RootModelID = %q, want %q", *status.RootModelID, want)
+	}
+}
+
+// TestMessageUpdated_UserMessage_RootAgentGate verifies AC-8: a user message
+// from a non-root agent does NOT update root_model_id. The root agent's model
+// must not be overwritten by a subagent user message.
+func TestMessageUpdated_UserMessage_RootAgentGate(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Establish root agent via an initial user message (no model).
+	sendEvents(sc, makeUserMessage("msg-user-root-1", "root-agent", "Initial prompt"))
+
+	// Write a known model via a root-agent assistant message.
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-asst-root-1",
+			"text":      "Root agent reply.",
+		},
+	}))
+	created := 1000.0
+	completed := 2000.0
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":         "msg-asst-root-1",
+			"role":       "assistant",
+			"agent":      "root-agent",
+			"providerID": "anthropic",
+			"modelID":    "claude-opus-4-6",
+			"time": map[string]*float64{
+				"created":   &created,
+				"completed": &completed,
+			},
+		},
+	}))
+
+	status, err := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after root assistant: %v", err)
+	}
+	if status.RootModelID == nil || *status.RootModelID != "anthropic/claude-opus-4-6" {
+		t.Fatalf("RootModelID after root assistant message = %v, want %q", status.RootModelID, "anthropic/claude-opus-4-6")
+	}
+
+	// Now fire a subagent user message with a different model. root_model_id
+	// must NOT be overwritten.
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-user-subagent",
+			"text":      "Subagent prompt",
+		},
+	}))
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "msg-user-subagent",
+			"role":  "user",
+			"agent": "review-agent",
+			"model": map[string]string{
+				"providerID": "openai",
+				"modelID":    "gpt-4o",
+			},
+		},
+	}))
+
+	status, err = sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after subagent user msg: %v", err)
+	}
+	want := "anthropic/claude-opus-4-6"
+	if status.RootModelID == nil || *status.RootModelID != want {
+		t.Errorf("RootModelID after subagent user message = %v, want %q (subagent must not overwrite root model)", status.RootModelID, want)
+	}
+}
+
+// TestMessageUpdated_UserMessage_EmptyModel verifies AC-9: a user message with
+// no model (info.Model == nil) does NOT write root_model_id — the existing
+// value is preserved and not cleared.
+func TestMessageUpdated_UserMessage_EmptyModel(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// First, write a known model via a root-agent assistant message.
+	sendEvents(sc, makeUserMessage("msg-user-seed", "root-agent", "Seed message"))
+	sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "text",
+			"messageID": "msg-asst-seed",
+			"text":      "First reply.",
+		},
+	}))
+	created := 1000.0
+	completed := 2000.0
+	sc.HandleEvent(makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":         "msg-asst-seed",
+			"role":       "assistant",
+			"agent":      "root-agent",
+			"providerID": "anthropic",
+			"modelID":    "claude-opus-4-6",
+			"time": map[string]*float64{
+				"created":   &created,
+				"completed": &completed,
+			},
+		},
+	}))
+
+	status, err := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after seed: %v", err)
+	}
+	if status.RootModelID == nil || *status.RootModelID != "anthropic/claude-opus-4-6" {
+		t.Fatalf("RootModelID after seed = %v, want %q", status.RootModelID, "anthropic/claude-opus-4-6")
+	}
+
+	// Now fire a user message with no model field (info.Model == nil). The
+	// root_model_id in the DB must remain unchanged.
+	sendEvents(sc, makeUserMessage("msg-user-no-model", "root-agent", "Follow-up with no model"))
+
+	status, err = sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus after no-model user msg: %v", err)
+	}
+	want := "anthropic/claude-opus-4-6"
+	if status.RootModelID == nil || *status.RootModelID != want {
+		t.Errorf("RootModelID after no-model user message = %v, want %q (must not be cleared)", status.RootModelID, want)
+	}
+}
+
 // ── reconnect recovery timer tests ──────────────────────────────────────────
 
 // TestServerConnected_InitialConnection_NoTimer verifies that server.connected


### PR DESCRIPTION
## Summary

Fixes the bug where `root_model_id` could be stale when a worker delivers a prompt to the coordinator mid-session if the user changed model via the opencode picker.

- Adds a `UpdateRootModelID` call in the `handleMessageUpdated` user-message branch, using the same `isRootAgent` gate as the existing assistant-message path.
- This ensures `root_model_id` is written as soon as the user presses Enter — before any assistant response, so worker notifications during the response window read the correct model.
- Three new tests cover the happy path (AC-7), the subagent gate (AC-8), and the empty-model no-op (AC-9).

## AC-11 investigation: `session.updated` model info

Investigated the opencode 1.4.0 binary and its embedded DB schema. The `session` table columns are:
`id`, `project_id`, `parent_id`, `slug`, `directory`, `title`, `version`, `share_url`, `summary_*`, `revert`, `permission`, `time_created`, `time_updated`, `time_compacting`, `time_archived`, `workspace_id`

**There is no `model` column on the session table.** Model information lives on `message` rows, not session rows. The `session.updated` SSE event reflects session metadata (title, compaction state, archived state, etc.) and does not include model information.

**AC-12 is skipped** — `session.updated` does not carry model info, so no secondary tightening is possible or needed from that event. The narrow window (user changes model in picker but hasn't typed yet) cannot be closed via `session.updated`.

## Changes

- `modules/programs/prism/prism/internal/sidecar/sidecar.go`: add `UpdateRootModelID` call in user-message branch of `handleMessageUpdated`
- `modules/programs/prism/prism/internal/sidecar/sidecar_test.go`: three new tests (`TestMessageUpdated_UserMessage_UpdatesRootModelID`, `TestMessageUpdated_UserMessage_RootAgentGate`, `TestMessageUpdated_UserMessage_EmptyModel`)

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all 14 packages, including 3 new sidecar tests)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #572