### PR TITLE
fix(prism): relax state-change guard to track non-worktree sessions

### DIFF
--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -97,11 +97,18 @@ var eventStateChangeCmd = &cobra.Command{
 		state, _ := cmd.Flags().GetString("state")
 		worktree, _ := cmd.Flags().GetString("worktree")
 
-		repo := deriveRepo(worktree)
-		if repo == "" {
-			// Not inside a project worktree — exit silently.
+		// Skip the meta-sessions (scratchpad and prism-dashboard) that must
+		// not appear in agent_status. All other sessions — including
+		// non-worktree sessions like "obsidian" — are tracked. Mirror the
+		// guard used by tmux-session-start so state transitions flow through
+		// for every session that start already wrote a row for.
+		if session == "scratchpad" || session == "prism-dashboard" {
 			return nil
 		}
+
+		// For non-worktree sessions deriveRepo returns "" — that matches the
+		// row tmux-session-start already wrote, so pass it through as-is.
+		repo := deriveRepo(worktree)
 
 		d, err := openDB()
 		if err != nil {

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -11,8 +11,10 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
@@ -268,6 +270,292 @@ func TestEventTmuxSessionStart_SkipsMetaSessions(t *testing.T) {
 				t.Errorf("session %q: expected no agent_status row, got one (state=%q)", session, status.State)
 			}
 		})
+	}
+}
+
+// TestEventStateChange_TracksNonWorktreeSession verifies that firing
+// state-change for a non-worktree session (e.g. "obsidian") writes/updates a
+// row in agent_status with repo="" and the supplied state, and appends a
+// state_change event row to the events table.
+//
+// Regression guard for issue #576: state-change used to silently drop events
+// for any session whose worktree had no .bare ancestor, leaving the dashboard
+// stuck showing the session as "idle".
+func TestEventStateChange_TracksNonWorktreeSession(t *testing.T) {
+	const session = "obsidian"
+
+	// Worktree path with no .bare ancestor — deriveRepo returns "".
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "state-change",
+		"--session", session,
+		"--state", "active",
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error %v, want nil", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected agent_status row for obsidian, got nil")
+	}
+	if status.Repo != "" {
+		t.Errorf("repo = %q, want empty string", status.Repo)
+	}
+	if status.State != "active" {
+		t.Errorf("state = %q, want \"active\"", status.State)
+	}
+
+	events, err := d2.QueryEvents(session, 10, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev.Type != "state_change" {
+		t.Errorf("event type = %q, want \"state_change\"", ev.Type)
+	}
+	if ev.SessionName != session {
+		t.Errorf("event session_name = %q, want %q", ev.SessionName, session)
+	}
+	if ev.Repo != "" {
+		t.Errorf("event repo = %q, want empty string", ev.Repo)
+	}
+	if !strings.Contains(ev.Payload, `"active"`) {
+		t.Errorf("event payload = %q, want payload containing \"active\"", ev.Payload)
+	}
+}
+
+// TestEventStateChange_SkipsMetaSessions verifies that "scratchpad" and
+// "prism-dashboard" state-change invocations return nil without writing an
+// agent_status row or an events row.
+//
+// Regression guard for issue #576 — the precise name-based skip must still
+// exclude meta-sessions even though the broader repo=="" guard is gone.
+func TestEventStateChange_SkipsMetaSessions(t *testing.T) {
+	for _, session := range []string{"scratchpad", "prism-dashboard"} {
+		t.Run(session, func(t *testing.T) {
+			worktree := t.TempDir()
+
+			dbFile := filepath.Join(t.TempDir(), "prism.db")
+			d, err := db.Open(dbFile)
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			d.Close()
+
+			SetTestDBPath(dbFile)
+			t.Cleanup(func() { SetTestDBPath("") })
+
+			rootCmd.SetArgs([]string{
+				"event", "state-change",
+				"--session", session,
+				"--state", "active",
+				"--worktree", worktree,
+			})
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute returned error %v, want nil (silent skip)", err)
+			}
+
+			d2, err := db.Open(dbFile)
+			if err != nil {
+				t.Fatalf("re-open db: %v", err)
+			}
+			defer d2.Close()
+
+			status, err := d2.CurrentStatus(session)
+			if err != nil {
+				t.Fatalf("CurrentStatus: %v", err)
+			}
+			if status != nil {
+				t.Errorf("session %q: expected no agent_status row, got one (state=%q)", session, status.State)
+			}
+
+			events, err := d2.QueryEvents(session, 10, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("QueryEvents: %v", err)
+			}
+			if len(events) != 0 {
+				t.Errorf("session %q: expected 0 events, got %d", session, len(events))
+			}
+		})
+	}
+}
+
+// TestEventStateChange_WorktreeSession verifies the original worktree-backed
+// happy path: a state-change invocation against a path with a .bare ancestor
+// resolves repo via deriveRepo and writes it to both agent_status and the
+// state_change event row.
+//
+// Regression guard for issue #576 — relaxing the guard must not break the
+// existing worktree flow.
+func TestEventStateChange_WorktreeSession(t *testing.T) {
+	const session = "myrepo@main"
+
+	// Build a fake bare repo layout: <tmp>/myrepo/{.bare, worktree}
+	// deriveBareRoot will walk up from the worktree path and find .bare,
+	// yielding repo name "myrepo".
+	root := t.TempDir()
+	bareRoot := filepath.Join(root, "myrepo")
+	worktree := filepath.Join(bareRoot, "main")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(bareRoot, ".bare"), 0o755); err != nil {
+		t.Fatalf("mkdir .bare: %v", err)
+	}
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "state-change",
+		"--session", session,
+		"--state", "active",
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error %v, want nil", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected agent_status row, got nil")
+	}
+	if status.Repo != "myrepo" {
+		t.Errorf("repo = %q, want \"myrepo\"", status.Repo)
+	}
+	if status.State != "active" {
+		t.Errorf("state = %q, want \"active\"", status.State)
+	}
+
+	events, err := d2.QueryEvents(session, 10, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev.Type != "state_change" {
+		t.Errorf("event type = %q, want \"state_change\"", ev.Type)
+	}
+	if ev.Repo != "myrepo" {
+		t.Errorf("event repo = %q, want \"myrepo\"", ev.Repo)
+	}
+	if !strings.Contains(ev.Payload, `"active"`) {
+		t.Errorf("event payload = %q, want payload containing \"active\"", ev.Payload)
+	}
+}
+
+// TestEventStateChange_UpdatesExistingNonWorktreeRow verifies that when
+// tmux-session-start has already created an agent_status row for a
+// non-worktree session, a subsequent state-change for that session updates
+// the existing row's state column rather than inserting a duplicate.
+//
+// This is the primary user-visible bug from issue #576 — the row existed but
+// was never updated, so the dashboard showed "idle" forever.
+func TestEventStateChange_UpdatesExistingNonWorktreeRow(t *testing.T) {
+	const session = "obsidian"
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Simulate the row that tmux-session-start would have written.
+	if err := d.UpsertStatus(session, "", worktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "state-change",
+		"--session", session,
+		"--state", "active",
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error %v, want nil", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	// There should still be exactly one row for this session, with its state
+	// updated from "idle" to "active".
+	statuses, err := d2.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+	count := 0
+	for _, s := range statuses {
+		if s.SessionName == session {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("found %d agent_status rows for %q, want 1", count, session)
+	}
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected agent_status row, got nil")
+	}
+	if status.State != "active" {
+		t.Errorf("state = %q, want \"active\" (row was not updated)", status.State)
+	}
+	if status.Repo != "" {
+		t.Errorf("repo = %q, want empty string", status.Repo)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace the broad `deriveRepo(worktree) == ""` early-exit in the `state-change` handler with the precise name-based skip already used by `tmux-session-start` (only `scratchpad` and `prism-dashboard` are excluded).
- Non-worktree sessions like `obsidian` now have their state transitions persisted instead of being silently dropped — the dashboard no longer shows them as `idle` forever.
- Worktree-backed sessions continue to resolve `repo` via `deriveRepo` exactly as before.

## Tests

Added to `cmd/event_test.go`:

- `TestEventStateChange_TracksNonWorktreeSession` — drives `state-change` for `obsidian` with a worktree path lacking a `.bare` ancestor and asserts the resulting `agent_status` row and `state_change` event both have `repo == ""` and the supplied state.
- `TestEventStateChange_SkipsMetaSessions` — drives `state-change` for both `scratchpad` and `prism-dashboard` and asserts no `agent_status` row and no `events` row are created.
- `TestEventStateChange_WorktreeSession` — regression guard for the worktree-backed happy path, asserting the derived `repo` (`myrepo`) is written to both `agent_status` and the event row.
- `TestEventStateChange_UpdatesExistingNonWorktreeRow` — seeds the `agent_status` row `tmux-session-start` would have written, fires `state-change`, and asserts the existing row is updated in place rather than duplicated.

`go build ./...`, `go test ./...`, and `nix build .#nixosConfigurations.navi.config.system.build.toplevel` all pass.

Closes #576