### PR TITLE
battery-notifier: log state transitions and fix mouse statusCmd escapes

### DIFF
--- a/modules/services/battery-notifier.nix
+++ b/modules/services/battery-notifier.nix
@@ -22,7 +22,22 @@ let
         import json
         import os
         import subprocess
+        import sys
         from pathlib import Path
+
+
+        def log_event(device, event, **fields):
+            """Emit a single-line event log to stderr for the systemd journal.
+
+            Every line starts with "device=<name> event=<event>" so multi-device
+            greps (e.g. `journalctl --user -u battery-notifier-* | grep mouse`)
+            reliably pick up all events for a given device. Only called on state
+            transitions and notification events — never on uneventful polls.
+            """
+            parts = [f"device={device}", f"event={event}"]
+            for key, value in fields.items():
+                parts.append(f"{key}={value}")
+            print(" ".join(parts), file=sys.stderr, flush=True)
 
 
         def get_command_output(cmd):
@@ -146,11 +161,25 @@ let
                 state["last_notification"] = "none"
                 state["last_id"] = "0"
                 state["full_notification_done"] = True
+                log_event(
+                    args.name,
+                    "notification_dismissed",
+                    notification="full",
+                    level=level,
+                    status=status,
+                )
 
             if last_notification_type == "low" and level >= args.dismiss_threshold:
                 close_notification(state["last_id"])
                 state["last_notification"] = "none"
                 state["last_id"] = "0"
+                log_event(
+                    args.name,
+                    "notification_dismissed",
+                    notification="low",
+                    level=level,
+                    status=status,
+                )
 
             # Reset full_notification_done flag if battery drops below re-notify threshold
             if is_discharging and level <= args.re_notify_threshold:
@@ -158,7 +187,17 @@ let
 
             # Re-read last notification type in case it was changed by dismissal logic
             last_notification_type = state["last_notification"]
-            status_has_changed = status != state["last_status"]
+            previous_status = state["last_status"]
+            status_has_changed = status != previous_status
+
+            # Log status transitions (but not the very first run where the
+            # previous status is "Unknown" — that isn't a real transition).
+            if status_has_changed and previous_status != "Unknown":
+                log_event(
+                    args.name,
+                    "status_transition",
+                    **{"from": previous_status, "to": status, "level": level},
+                )
 
             # 2. Handle notification creation/update conditions
             if level <= args.low_threshold:
@@ -182,6 +221,13 @@ let
                     new_id = send_notification(id_to_replace, icon, title, body)
                     state["last_notification"] = "low"
                     state["last_id"] = new_id
+                    log_event(
+                        args.name,
+                        "notification_sent",
+                        notification="low",
+                        level=level,
+                        status=status,
+                    )
 
             elif level >= args.full_threshold and is_charging:
                 if last_notification_type != "full" and not state["full_notification_done"]:
@@ -191,6 +237,13 @@ let
                     state["last_notification"] = "full"
                     state["last_id"] = new_id
                     state["full_notification_done"] = True
+                    log_event(
+                        args.name,
+                        "notification_sent",
+                        notification="full",
+                        level=level,
+                        status=status,
+                    )
 
             # 3. Always save the final state
             state["last_status"] = status
@@ -395,7 +448,7 @@ in
         enable = true;
         udevTrigger = false; # The mouse doesn't have a standard udev event
         levelCmd = "${pkgs.polychromatic}/bin/polychromatic-cli -d mouse -k | grep Battery | sed 's/[^0-9]*//g' || echo 100";
-        statusCmd = "if ${pkgs.polychromatic}/bin/polychromatic-cli -d mouse -k | grep -q '\\(charging\\)'; then echo 'Charging'; else echo 'Discharging'; fi";
+        statusCmd = "if ${pkgs.polychromatic}/bin/polychromatic-cli -d mouse -k | grep -q '[(]charging[)]'; then echo 'Charging'; else echo 'Discharging'; fi";
         lowThreshold = 20;
         dismissThreshold = 50;
         ignoreZero = true;


### PR DESCRIPTION
## Summary

- Add concise state-transition and notification logging to the shared
  `battery-notifier` Python script in `modules/services/battery-notifier.nix`
  so `journalctl --user -u battery-notifier-*.service` can actually be used
  to reconstruct charging history. New `log_event` helper emits a single
  line per event to stderr with `device=<name> event=<event> ...` so
  multi-device greps (`| grep mouse`) just work.
- Fix the mouse `statusCmd` escape-sequence warning by rewriting the grep
  pattern from `'\(charging\)'` to `'[(]charging[)]'`. The bracket
  character class matches the same literal `(charging)` text but avoids
  the backslash-escaped parens that systemd's unit parser was warning on
  every service start.

## Events logged (stderr, captured by systemd journal)

- `status_transition` — whenever the reported status changes between polls
  (e.g. `Discharging -> Charging`). Includes `from`, `to`, `level`. Not
  emitted on the very first run where the previous status is `Unknown`.
- `notification_sent` — when a low or full notification fires. Includes
  `notification`, `level`, `status`.
- `notification_dismissed` — when the state machine dismisses a full or
  low notification. Includes `notification`, `level`, `status`.

No log line is emitted on uneventful polls (status unchanged, no
notification event), the `Ignoring 0% reading` skip path is untouched,
and the threshold/notification/state-machine behaviour plus the shape of
the `$XDG_RUNTIME_DIR/battery_notifier_<name>.json` state file are
unchanged.

## Verification

- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`
  succeeds (verified `battery-notifier.drv` — which runs flake8 on the
  script — and `battery-notifier-mouse.service.drv` both build cleanly).
- `nixfmt .` leaves `modules/services/battery-notifier.nix` unchanged
  after the edit.
- Inspected the built mouse unit file and confirmed the rendered
  `--status-cmd` is `... grep -q '[(]charging[)]' ...` with no backslash
  escapes.
- Inspected the built Python binary and confirmed `log_event` is called
  for `status_transition`, `notification_sent` (low and full), and
  `notification_dismissed` (low and full).

Closes #578