### PR TITLE
forgecode: wire up zsh `:` prefix integration and p10k segment

### DIFF
--- a/modules/programs/files/p10k.zsh
+++ b/modules/programs/files/p10k.zsh
@@ -79,6 +79,7 @@
     gcloud                  # google cloud cli account and project (https://cloud.google.com/)
     google_app_cred         # google application credentials (https://cloud.google.com/docs/authentication/production)
     toolbox                 # toolbox name (https://github.com/containers/toolbox)
+    forge                   # forgecode active agent / model / cost (custom segment)
     context                 # user@hostname
     nordvpn                 # nordvpn connection status, linux only (https://nordvpn.com/)
     ranger                  # ranger shell (https://github.com/ranger/ranger)

--- a/modules/programs/prism/files/forgecode-init.zsh
+++ b/modules/programs/prism/files/forgecode-init.zsh
@@ -1,0 +1,145 @@
+# forgecode zsh integration
+# Loaded from modules/programs/prism/forgecode.nix via initContent at order 1100
+# (after base zsh init at 1000).
+#
+# Concurrency model:
+#   - Plugin content cache: shared across all shells on this host, keyed on
+#     forge binary path + version. Safe because the content is deterministic
+#     per forge binary (forge embeds its shell plugin via include_dir! and
+#     emits the same bytes on every invocation for a given build).
+#   - rprompt cache: per-shell, keyed on a unique shell-session ID
+#     (_FORGE_SHELL_ID), so N concurrent shells don't stomp on each other's
+#     prompt state.
+#
+# CONTAINER NOTE (future work): If ~/ is bind-mounted into containers, host
+# shells and container shells share the same cache dir. The shell-session ID
+# (PID + microsecond timestamp) prevents filename collisions in practice but
+# does NOT protect against PID-namespace aliasing in edge cases. When
+# container support is wired up, extend _FORGE_SHELL_ID to include a namespace
+# identifier (e.g. from /proc/self/cgroup, /run/.containerenv, or a
+# FORGE_RPROMPT_NAMESPACE env var injected by the container runtime). See the
+# forgecode.nix module for related notes on the ~/forge/ state directory
+# itself.
+#
+# Note on registration with p10k: the `forge` segment is appended to
+# POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS statically in
+# modules/programs/files/p10k.zsh, NOT from this file. home-manager sources
+# p10k plugins in a separate section of .zshrc that runs AFTER all initContent
+# blocks, so at the moment this file executes the right-prompt array does not
+# yet exist. Function definitions (prompt_forge / instant_prompt_forge) made
+# here persist across that later section, so p10k picks them up correctly
+# when it finally renders.
+
+zmodload zsh/datetime 2>/dev/null
+zmodload zsh/stat     2>/dev/null
+
+# ---- section 1: cached plugin loader ----
+# Hash-keyed cache of `forge zsh plugin` output. Shared across all shells on
+# this host since the content is deterministic per forge binary.
+_forge_plugin_init() {
+  [[ -n "$_FORGE_PLUGIN_LOADED" ]] && return 0
+
+  local forge_bin cache_dir plugin_cache key_file current_key
+  forge_bin=${FORGE_BIN:-forge}
+  command -v "$forge_bin" >/dev/null 2>&1 || return 0
+
+  cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/forgecode"
+  plugin_cache="$cache_dir/plugin.zsh"
+  key_file="$cache_dir/plugin.key"
+
+  # Key: resolved absolute path + version. Nix store path changes on every
+  # forgecode bump, so this automatically invalidates the cache.
+  current_key="$(readlink -f "$(command -v "$forge_bin")"):$("$forge_bin" --version 2>/dev/null)"
+
+  if [[ ! -f "$plugin_cache" || ! -f "$key_file" || "$(<"$key_file")" != "$current_key" ]]; then
+    mkdir -p "$cache_dir"
+    "$forge_bin" zsh plugin > "$plugin_cache" 2>/dev/null || return 1
+    printf '%s\n' "$current_key" > "$key_file"
+  fi
+
+  source "$plugin_cache"
+  typeset -g _FORGE_PLUGIN_LOADED=1
+}
+_forge_plugin_init
+
+# ---- section 2: per-shell rprompt cache ----
+# Generate a unique ID for this shell session. PID + microsecond timestamp is
+# collision-free on a single PID namespace.
+# CONTAINER NOTE: this line must be revisited when container support lands —
+# PID namespaces alias host PIDs and EPOCHREALTIME shares wall-clock across
+# bind-mounted cache dirs, so collisions are possible between a host shell
+# and a container shell forked at the same microsecond. See the file header.
+typeset -g _FORGE_SHELL_ID="${_FORGE_SHELL_ID:-$$-${EPOCHREALTIME//./}}"
+# CONTAINER NOTE: this cache path is shared host/container when ~/.cache is
+# bind-mounted. Revisit alongside _FORGE_SHELL_ID when container support lands.
+typeset -g _FORGE_RPROMPT_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/forgecode/rprompt.${_FORGE_SHELL_ID}.txt"
+typeset -gi _FORGE_RPROMPT_TTL=2
+
+# Startup sweep: remove any rprompt cache files older than 24h. Protects
+# against cache-dir bloat if shells die without running zshexit hooks. Runs
+# in a detached subshell so it never blocks shell startup.
+{
+  local _forge_sweep_dir="${XDG_CACHE_HOME:-$HOME/.cache}/forgecode"
+  [[ -d "$_forge_sweep_dir" ]] && find "$_forge_sweep_dir" -maxdepth 1 -name 'rprompt.*.txt' -mtime +1 -delete 2>/dev/null
+} &!
+
+# Async refresh on every precmd if the cache is stale. Non-blocking — the
+# background subshell detaches and writes atomically via mv.
+_forge_rprompt_refresh_if_stale() {
+  command -v "${FORGE_BIN:-forge}" >/dev/null 2>&1 || return 0
+
+  [[ -d "${_FORGE_RPROMPT_CACHE:h}" ]] || mkdir -p "${_FORGE_RPROMPT_CACHE:h}"
+
+  if [[ -f "$_FORGE_RPROMPT_CACHE" ]]; then
+    local -i age mtime
+    mtime=$(zstat +mtime "$_FORGE_RPROMPT_CACHE" 2>/dev/null || echo 0)
+    age=$(( EPOCHSECONDS - mtime ))
+    (( age < _FORGE_RPROMPT_TTL )) && return 0
+  fi
+
+  {
+    local tmp="${_FORGE_RPROMPT_CACHE}.tmp"
+    _FORGE_ACTIVE_AGENT=$_FORGE_ACTIVE_AGENT \
+    _FORGE_CONVERSATION_ID=$_FORGE_CONVERSATION_ID \
+      "${FORGE_BIN:-forge}" zsh rprompt > "$tmp" 2>/dev/null \
+      && mv -f "$tmp" "$_FORGE_RPROMPT_CACHE" \
+      || rm -f "$tmp"
+  } &!
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _forge_rprompt_refresh_if_stale
+
+# On shell exit, clean up our per-shell cache file.
+_forge_rprompt_cleanup() {
+  [[ -f "$_FORGE_RPROMPT_CACHE" ]] && rm -f "$_FORGE_RPROMPT_CACHE"
+}
+add-zsh-hook zshexit _forge_rprompt_cleanup
+
+# ---- section 3: p10k custom segment ----
+# Reads the per-shell cache (sync, zero-cost) and emits it to p10k. forge's
+# output already contains zsh color escapes so we pass it through verbatim.
+#
+# Returns silently if the cache is missing, empty, or unreadable — this makes
+# the very first prompt (before any forge interaction has populated the cache)
+# invisible rather than showing a broken segment.
+function prompt_forge() {
+  [[ -r "$_FORGE_RPROMPT_CACHE" && -s "$_FORGE_RPROMPT_CACHE" ]] || return 0
+  local content
+  content="$(<"$_FORGE_RPROMPT_CACHE")" 2>/dev/null || return 0
+  [[ -z "$content" ]] && return 0
+  p10k segment -t "${content}%f"
+}
+
+# p10k runs instant_prompt_* functions during instant-prompt replay. With
+# POWERLEVEL9K_INSTANT_PROMPT=verbose (see p10k.zsh), any custom segment
+# without a matching instant_prompt_* function prints a warning on every new
+# shell. prompt_forge is a pure synchronous file read with no external state,
+# so it is safe to call during instant-prompt replay.
+function instant_prompt_forge() {
+  prompt_forge
+}
+
+# Needed for p10k instant prompt compatibility — declares the segment has no
+# dynamic classes, which allows p10k to cache the rendered output.
+typeset -g POWERLEVEL9K_FORGE_CLASSES=()

--- a/modules/programs/prism/files/forgecode-init.zsh
+++ b/modules/programs/prism/files/forgecode-init.zsh
@@ -21,14 +21,16 @@
 # forgecode.nix module for related notes on the ~/forge/ state directory
 # itself.
 #
-# Note on registration with p10k: the `forge` segment is appended to
-# POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS statically in
-# modules/programs/files/p10k.zsh, NOT from this file. home-manager sources
-# p10k plugins in a separate section of .zshrc that runs AFTER all initContent
-# blocks, so at the moment this file executes the right-prompt array does not
-# yet exist. Function definitions (prompt_forge / instant_prompt_forge) made
-# here persist across that later section, so p10k picks them up correctly
-# when it finally renders.
+# Note on registration with p10k: the `forge` segment is registered
+# statically in modules/programs/files/p10k.zsh rather than appended from
+# this init script. While home-manager sources p10k plugins before
+# initContent (so POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS is already populated
+# when this file runs), keeping the registration in p10k.zsh makes the
+# segment's position explicit and reviewable in the diff, with no
+# dependency on runtime array mutation. Function definitions
+# (prompt_forge / instant_prompt_forge) made here are available by the
+# time p10k renders the first prompt because the full .zshrc completes
+# before any prompt is drawn.
 
 zmodload zsh/datetime 2>/dev/null
 zmodload zsh/stat     2>/dev/null

--- a/modules/programs/prism/forgecode.nix
+++ b/modules/programs/prism/forgecode.nix
@@ -21,11 +21,11 @@
 
       # Order 1100 runs after the base zsh init (order 1000) so we can safely
       # reference the forge binary, XDG dirs, and any zsh hooks set up earlier.
-      # Note: p10k itself is sourced by home-manager as a plugin (see
-      # modules/programs/zsh.nix), not via initContent — so POWERLEVEL9K_* arrays
-      # are not yet populated at this point. The `forge` segment is therefore
-      # appended to POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS directly in
-      # modules/programs/files/p10k.zsh, not from this init script.
+      # Note: p10k plugins are sourced before initContent in the generated
+      # .zshrc, so POWERLEVEL9K_* arrays are already populated at this point.
+      # Nevertheless, the `forge` segment is registered statically in
+      # modules/programs/files/p10k.zsh rather than appended here — this keeps
+      # its position explicit and reviewable in the diff.
       programs.zsh.initContent = lib.mkOrder 1100 (builtins.readFile ./files/forgecode-init.zsh);
 
       # Persist all forgecode state — credentials, config, conversation history,

--- a/modules/programs/prism/forgecode.nix
+++ b/modules/programs/prism/forgecode.nix
@@ -12,9 +12,35 @@
   };
   config = lib.mkIf config.nx.programs.prism.forgecode.enable {
     home-manager.users.${config.nx.username} = {
-      home.packages = lib.optional (pkgs.forgecode != null) pkgs.forgecode;
+      home.packages = lib.optional (pkgs.forgecode != null) pkgs.forgecode ++ [
+        # fzf powers forgecode's @file tab-completion and :conversation picker.
+        pkgs.fzf
+        # fd is used by forgecode's fast file listing path.
+        pkgs.fd
+      ];
+
+      # Order 1100 runs after the base zsh init (order 1000) so we can safely
+      # reference the forge binary, XDG dirs, and any zsh hooks set up earlier.
+      # Note: p10k itself is sourced by home-manager as a plugin (see
+      # modules/programs/zsh.nix), not via initContent — so POWERLEVEL9K_* arrays
+      # are not yet populated at this point. The `forge` segment is therefore
+      # appended to POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS directly in
+      # modules/programs/files/p10k.zsh, not from this init script.
+      programs.zsh.initContent = lib.mkOrder 1100 (builtins.readFile ./files/forgecode-init.zsh);
+
       # Persist all forgecode state — credentials, config, conversation history,
       # snapshots, cache, etc. all live under ~/forge/ (the base_path).
+      #
+      # CONTAINER NOTE (future work): if forgecode is eventually run inside
+      # containers that bind-mount ~/ from the host, both host and container
+      # shells will share this state directory. forgecode's conversation store
+      # (SQLite WAL, per-conversation UUIDs) handles concurrent reads and writes
+      # across different conversation IDs safely via a connection pool with a
+      # 30s busy timeout. The risk is same-conversation-ID races: two shells
+      # that deliberately resume the same conversation can lose updates
+      # (last-write-wins, not corruption). When container support lands, either
+      # enforce per-shell conversation isolation or give each container its own
+      # volume for ~/forge/ to fully isolate state from the host.
       home.persistence."/persist" = {
         directories = [
           "forge"

--- a/pkgs/forgecode.nix
+++ b/pkgs/forgecode.nix
@@ -7,16 +7,16 @@
 }:
 
 let
-  version = "2.4.1";
+  version = "2.9.9";
 
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/antinomyhq/forgecode/releases/download/v${version}/forge-x86_64-unknown-linux-gnu";
-      hash = "sha256-PZUZrjhHtgLoN127iYsbLceSO75DPWjnBRyiNiIFPCw=";
+      hash = "sha256-P95V3bXqOlqGpxCDzZ2q7yIIwqecSktTrPaSjXWDIhk=";
     };
     "aarch64-darwin" = {
       url = "https://github.com/antinomyhq/forgecode/releases/download/v${version}/forge-aarch64-apple-darwin";
-      hash = "sha256-E7/tjwGKwd06x9vy0bRbMjz9I596/eufmDWOqbMwHAI=";
+      hash = "sha256-KeAZTzLdrjKvOWjJl1EKp6vLgUKhYhtdSPQbgB6izsU=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bumps `forgecode` from v2.4.1 → v2.9.9 and wires up the zsh integration that makes the `:<space><prompt>` routing work, plus a powerlevel10k custom segment for the forge live-state HUD.

- **Version bump** (`pkgs/forgecode.nix`): v2.4.1 → v2.9.9, with both `x86_64-linux` and `aarch64-darwin` hashes refetched via `nix-prefetch-url`. Upstream asset filenames (`forge-x86_64-unknown-linux-gnu`, `forge-aarch64-apple-darwin`) are unchanged between releases — verified via `gh release view v2.9.9 --repo antinomyhq/forgecode`.
- **Module changes** (`modules/programs/prism/forgecode.nix`):
  - Adds `pkgs.fzf` and `pkgs.fd` to `home.packages` (needed for forge's `@file` tab-completion and fast file listing).
  - Adds `programs.zsh.initContent = lib.mkOrder 1100 (builtins.readFile ./files/forgecode-init.zsh)`.
  - Adds a multi-line comment near `home.persistence` documenting the container-future implications of bind-mounting `~/forge/` (SQLite WAL concurrency, same-conversation-ID race risk).
- **New init script** (`modules/programs/prism/files/forgecode-init.zsh`):
  - Cached plugin loader for `forge zsh plugin`, keyed on resolved binary path + `--version` so Nix store path changes auto-invalidate.
  - Per-shell rprompt cache at `~/.cache/forgecode/rprompt.${_FORGE_SHELL_ID}.txt` (PID + `EPOCHREALTIME`), with a 24h startup sweep for orphans.
  - Async `precmd` refresh with 2s TTL, writes to `${cache}.tmp` and `mv -f`s atomically on success.
  - `zshexit` hook cleans up the shell's own cache file on normal exit.
  - `prompt_forge` + `instant_prompt_forge` p10k segment functions; returns silently if the cache is missing/empty/unreadable so first-prompt-before-any-forge-interaction is invisible.
  - `instant_prompt_forge` is defined so p10k's verbose instant-prompt mode doesn't warn on every new shell.
  - Plugin load and refresh are guarded against `forge` being missing from `PATH` so a broken activation never breaks shell startup.
  - Container-future risk points (shell-ID generation, cache path) are flagged inline with `CONTAINER NOTE` comments.
- **p10k config edit** (`modules/programs/files/p10k.zsh`): `forge` is appended to `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS` statically (before `context`), not from the init script. The init script does NOT try to append at runtime — doing it statically in `p10k.zsh` keeps the segment's position explicit and reviewable in the diff, and avoids any coupling to home-manager's plugin/initContent ordering.

## Verification

- `nixfmt --check` clean on touched `.nix` files.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds on the branch.
- Inspected the generated `hm_.localsharezsh.zshrc` derivation — the full init script is embedded in the expected position, after the base `initContent` (order 1000) block and before `zsh-syntax-highlighting` is sourced.
- Functional verification (opening new shells, exercising `:` dispatch, observing the segment) is left to the user post-activation per repo conventions (branch work is build-only).

Closes #582