### PR TITLE
prism: re-enable container_mode

### DIFF
--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -40,7 +40,7 @@ let
     color_foreground = foreground;
     color_bg0 = bg0;
     kitty_bin = "${pkgs.kitty}/bin/kitty";
-    container_mode = false;
+    container_mode = true;
     sidecar_plugin_path = "${
       config.home-manager.users.${config.nx.username}.xdg.configHome
     }/opencode/plugins/prism-hooks.ts";


### PR DESCRIPTION
## Summary

Re-enables container mode for prism worker sessions by setting `container_mode = true` in `modules/programs/prism/prism-tui.nix`.

Closes #551

## Changes

- Single-line change: `container_mode = false` → `container_mode = true`

## Testing

- NixOS build verified: `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes
- AC-3 through AC-9 from the issue are smoke tests that require a running system — the user will perform these manually after merging