### PR TITLE
fix: pass agent window command via new-window to avoid tmux semicolon mangling

### DIFF
--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -37,16 +37,18 @@ func withRestoreConfig(t *testing.T, cfg config.Config) {
 	t.Cleanup(func() { loadRestoreConfig = prev })
 }
 
-// waitForAgentPaneContains polls the agent pane (window 1) for the given
-// session until the substring appears or the deadline is reached. Returns
-// the last captured pane content so the test can produce a useful failure
-// message when the substring is missing.
+// waitForAgentPaneContains polls the agent pane (window 1) start command for
+// the given session until the substring appears or the deadline is reached.
+// The agent window is now created with "new-window ... sh -c <cmd>" so the
+// command is delivered via #{pane_start_command}, not via send-keys echoing in
+// the pane. Returns the last captured pane_start_command value so the test can
+// produce a useful failure message when the substring is missing.
 func waitForAgentPaneContains(t *testing.T, s *cmdTestServer, sessionName, want string) string {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	var paneContent string
 	for time.Now().Before(deadline) {
-		out, err := s.output("capture-pane", "-t", sessionName+":1", "-p")
+		out, err := s.output("display-message", "-t", sessionName+":1", "-p", "#{pane_start_command}")
 		if err == nil {
 			paneContent = out
 			if strings.Contains(paneContent, want) {
@@ -383,11 +385,12 @@ func TestRestoreSession_EmptyWorktree(t *testing.T) {
 }
 
 // TestRestoreSession_OpencodeSessionResumed verifies that when a stored
-// OpencodeSID is present, the opencode launch command sent to the agent window
-// includes the session ID (-s flag).
+// OpencodeSID is present, the opencode launch command delivered to the agent
+// window includes the session ID (-s flag).
 //
-// It captures the actual text typed into the agent pane (window 1) via
-// capture-pane and asserts the session ID appears in the captured output.
+// It reads #{pane_start_command} from the agent window (window 1) — the agent
+// window is now created with "new-window ... sh -c <cmd>" so the command is
+// embedded in the pane's start command, not echoed via send-keys.
 func TestRestoreSession_OpencodeSessionResumed(t *testing.T) {
 	// Uses withCmdServer — must not run in parallel.
 	// Redirect XDG_STATE_HOME so StartSidecar writes its PID file to an
@@ -413,24 +416,15 @@ func TestRestoreSession_OpencodeSessionResumed(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// Poll the agent window (index 1) until the session ID appears in the pane
-	// content. send-keys is asynchronous so we allow up to 3 seconds for the
-	// text to land in the shell's input buffer / history.
-	deadline := time.Now().Add(3 * time.Second)
-	var paneContent string
-	for time.Now().Before(deadline) {
-		out, err := s.output("capture-pane", "-t", sessionName+":1", "-p")
-		if err == nil {
-			paneContent = out
-			if strings.Contains(paneContent, "-s "+sid) {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
+	// Read the pane start command — the agent window is created via
+	// "new-window ... sh -c <cmd>" so the command appears in #{pane_start_command}.
+	paneCmd, err := s.output("display-message", "-t", sessionName+":1", "-p", "#{pane_start_command}")
+	if err != nil {
+		t.Fatalf("display-message pane_start_command: %v", err)
 	}
 
-	if !strings.Contains(paneContent, "-s "+sid) {
-		t.Errorf("agent pane does not contain '-s %s'; captured output:\n%s", sid, paneContent)
+	if !strings.Contains(paneCmd, "-s "+sid) {
+		t.Errorf("agent pane_start_command does not contain '-s %s'; got:\n%s", sid, paneCmd)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -45,8 +45,7 @@ func agentPaneStartCmd(t *testing.T, s *cmdTestServer, sessionName string) strin
 	t.Helper()
 	out, err := s.output("display-message", "-t", sessionName+":1", "-p", "#{pane_start_command}")
 	if err != nil {
-		t.Errorf("display-message pane_start_command for %q: %v", sessionName, err)
-		return ""
+		t.Fatalf("display-message pane_start_command for %q: %v", sessionName, err)
 	}
 	return out
 }

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
@@ -37,27 +36,19 @@ func withRestoreConfig(t *testing.T, cfg config.Config) {
 	t.Cleanup(func() { loadRestoreConfig = prev })
 }
 
-// waitForAgentPaneContains polls the agent pane (window 1) start command for
-// the given session until the substring appears or the deadline is reached.
-// The agent window is now created with "new-window ... sh -c <cmd>" so the
-// command is delivered via #{pane_start_command}, not via send-keys echoing in
-// the pane. Returns the last captured pane_start_command value so the test can
-// produce a useful failure message when the substring is missing.
-func waitForAgentPaneContains(t *testing.T, s *cmdTestServer, sessionName, want string) string {
+// agentPaneStartCmd reads #{pane_start_command} from the agent window (window 1)
+// of the named session. The agent window is created with "new-window ... sh -c
+// <cmd>", so the command is embedded in the pane's start command synchronously
+// at window creation — no polling is required. Returns the start command string
+// so callers can assert substrings.
+func agentPaneStartCmd(t *testing.T, s *cmdTestServer, sessionName string) string {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	var paneContent string
-	for time.Now().Before(deadline) {
-		out, err := s.output("display-message", "-t", sessionName+":1", "-p", "#{pane_start_command}")
-		if err == nil {
-			paneContent = out
-			if strings.Contains(paneContent, want) {
-				return paneContent
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
+	out, err := s.output("display-message", "-t", sessionName+":1", "-p", "#{pane_start_command}")
+	if err != nil {
+		t.Errorf("display-message pane_start_command for %q: %v", sessionName, err)
+		return ""
 	}
-	return paneContent
+	return out
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -525,10 +516,10 @@ func TestRestoreSession_ContainerMode(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// The agent pane must contain "opencode attach http://localhost:", not
-	// "opencode --agent". Port is assigned by AllocatePort so we match the
+	// The agent pane start command must contain "opencode attach http://localhost:",
+	// not "opencode --agent". Port is assigned by AllocatePort so we match the
 	// attach URL prefix rather than a specific port number.
-	pane := waitForAgentPaneContains(t, s, sessionName, "opencode attach http://localhost:")
+	pane := agentPaneStartCmd(t, s, sessionName)
 	if !strings.Contains(pane, "opencode attach http://localhost:") {
 		t.Errorf("agent pane missing 'opencode attach http://localhost:' — captured:\n%s", pane)
 	}
@@ -585,8 +576,8 @@ func TestRestoreSession_HostModeOverride(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// Agent pane must contain "opencode --agent ...", not "opencode attach".
-	pane := waitForAgentPaneContains(t, s, sessionName, "opencode --agent")
+	// Agent pane start command must contain "opencode --agent ...", not "opencode attach".
+	pane := agentPaneStartCmd(t, s, sessionName)
 	if !strings.Contains(pane, "opencode --agent") {
 		t.Errorf("agent pane missing 'opencode --agent' — captured:\n%s", pane)
 	}

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -191,9 +191,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	nvimCmd := NvimCmd(directory)
 	_ = tmux.SendKeys(name+":0", nvimCmd)
 
-	_ = tmux.NewWindow(name, 1, "agent", directory)
-
-	// Start the sidecar before sending the agent window command.
+	// Start the sidecar before creating the agent window.
 	// In container mode the sidecar creates the container; we must start it
 	// before the attach command is queued so readiness signalling works.
 	if opts.Port == 0 {
@@ -215,9 +213,12 @@ func setupFullLayout(name, directory string, opts Opts) error {
 		}
 	}
 
-	// Build and send the agent window command.
+	// Build the agent window command.
 	// In container mode, prepend a readiness wait so the pane blocks until
 	// the sidecar has health-checked the container (AC-18, AC-19, AC-20).
+	// opts.SessionName must be set by the caller before setupFullLayout is
+	// invoked — both ensureAndSwitch and restoreProjectSession do this.
+	// BuildOpencodeCmd uses it to prefix PRISM_SESSION_NAME for the plugin.
 	agentCmd := BuildOpencodeCmd(opts)
 	if opts.ContainerMode && opts.Port != 0 {
 		readyPath, pathErr := SidecarReadyPath(name)
@@ -236,10 +237,12 @@ func setupFullLayout(name, directory string, opts Opts) error {
 			agentCmd = buildReadinessWaitCmd(readyPath, sidPath, agentCmd)
 		}
 	}
-	// opts.SessionName must be set by the caller before setupFullLayout is
-	// invoked — both ensureAndSwitch and restoreProjectSession do this.
-	// BuildOpencodeCmd uses it to prefix PRISM_SESSION_NAME for the plugin.
-	_ = tmux.SendKeys(name+":1", agentCmd)
+
+	// Create the agent window with the command passed directly at window
+	// creation time. This runs the command via "sh -c <cmd>", bypassing
+	// tmux's command parser — semicolons in the readiness-wait script are
+	// delivered verbatim to the shell instead of being consumed by tmux.
+	_ = tmux.NewWindow(name, 1, "agent", directory, agentCmd)
 
 	if !opts.SkipStatusSeed {
 		self, selfErr := os.Executable()
@@ -253,7 +256,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 		}
 	}
 
-	_ = tmux.NewWindow(name, 2, "term", directory)
+	_ = tmux.NewWindow(name, 2, "term", directory, "")
 
 	focusIdx := 1
 	if strings.Contains(directory, "obsidian") {

--- a/modules/programs/prism/prism/internal/tmux/tmux.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux.go
@@ -209,10 +209,18 @@ func RenameWindow(target, name string) error {
 }
 
 // NewWindow creates a new window in a session. name may be empty.
-func NewWindow(session string, idx int, name, dir string) error {
+// When cmd is non-empty, the window starts executing that command immediately
+// via "sh -c <cmd>", bypassing tmux's command parser entirely. This avoids
+// semicolons in the command being treated as tmux command separators (which
+// would happen with SendKeys). Note: when a command is given, the pane exits
+// when the command exits — the user's default shell is NOT started.
+func NewWindow(session string, idx int, name, dir string, cmd string) error {
 	args := []string{"new-window", "-t", fmt.Sprintf("%s:%d", session, idx), "-n", name}
 	if dir != "" {
 		args = append(args, "-c", dir)
+	}
+	if cmd != "" {
+		args = append(args, "sh", "-c", cmd)
 	}
 	_, err := run(args...)
 	return err


### PR DESCRIPTION
## Summary

- `tmux send-keys` treats `;` as a tmux command separator even when passed as a separate OS-level argument, breaking the `if`/`fi` shell structure in the readiness-wait script used in container mode
- Fix: modify `tmux.NewWindow()` to accept an optional shell command; when provided, it is appended as `sh -c <cmd>` to the `new-window` args, going through `exec.Command` → `execvp` and bypassing tmux's command parser entirely
- In `setupFullLayout()`, the agent window command is now passed directly at window creation time instead of via a subsequent `SendKeys()` call; the nvim window (window 0) still uses `SendKeys` as before

## Changes

- `internal/tmux/tmux.go`: Add optional `cmd string` parameter to `NewWindow()`. When non-empty, appends `"sh", "-c", cmd` to the `new-window` args.
- `internal/session/session.go`: Move agent command to `NewWindow()` call, remove `SendKeys` for window 1. Update the "term" window call to pass `""` for the new cmd parameter.
- `cmd/restore_test.go`: Update `waitForAgentPaneContains()` to read `#{pane_start_command}` instead of `capture-pane` content — the command is now embedded in the window's start command rather than echoed as typed text.

## Quality gates

- `go build ./...` ✓
- `go test ./...` — same tests pass/fail as on `main` (pre-existing failures in `cmd` and `internal/tmux` packages are unrelated to this change)
- `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel` ✓