### PR TITLE
revert: disable container_mode pending pipeline fixes

### DIFF
--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -40,7 +40,8 @@ let
     color_foreground = foreground;
     color_bg0 = bg0;
     kitty_bin = "${pkgs.kitty}/bin/kitty";
-    container_mode = true;
+    # Disabled pending container-mode fixes — see #595, #596, #597
+    container_mode = false;
     sidecar_plugin_path = "${
       config.home-manager.users.${config.nx.username}.xdg.configHome
     }/opencode/plugins/prism-hooks.ts";


### PR DESCRIPTION
## Summary

- Reverts the `container_mode = true` change from PR #584, which prematurely re-enabled container mode
- Sets `container_mode = false` with a comment referencing the tracking issues
- No functional change beyond the flag value — the container pipeline code remains in place

## Context

PR #584 re-enabled container mode, but the container pipeline is not yet fully working. This reverts that setting until issues #595, #596, and #597 are resolved.

Closes #595