### PR TITLE
fix: use localhost/prism-agent:latest as fully-qualified image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ nix build .#prismAgentImage
 # Load it into podman (on Darwin, start the VM first: podman machine start)
 podman load < result
 
-# Run the smoke test (defaults to prism-agent:latest)
+# Run the smoke test (defaults to localhost/prism-agent:latest)
 ./modules/programs/prism/prism/scripts/smoke-test-container.sh
 
 # Or test a specific image
-./modules/programs/prism/prism/scripts/smoke-test-container.sh prism-agent:latest
+./modules/programs/prism/prism/scripts/smoke-test-container.sh localhost/prism-agent:latest
 ```
 
 The script exits `0` if all checks pass and non-zero if any fail. It skips gracefully if `podman` is not in PATH.

--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -295,18 +295,18 @@ in
                     EXPECTED_ID=$(${pkgs.gnutar}/bin/tar -xf ${prismAgentImage} --to-stdout manifest.json 2>/dev/null \
                       | ${pkgs.jq}/bin/jq -r '.[0].Config // empty' 2>/dev/null \
                       | ${pkgs.gnused}/bin/sed 's/\.json$//')
-                    CURRENT_ID=$($PODMAN image inspect prism-agent:latest --format '{{.Id}}' 2>/dev/null || true)
+                    CURRENT_ID=$($PODMAN image inspect localhost/prism-agent:latest --format '{{.Id}}' 2>/dev/null || true)
 
                     if [ -n "$EXPECTED_ID" ] && [ "$CURRENT_ID" = "$EXPECTED_ID" ]; then
-                      echo "prism: prism-agent:latest is up to date ($EXPECTED_ID), skipping load." >&2
+                      echo "prism: localhost/prism-agent:latest is up to date ($EXPECTED_ID), skipping load." >&2
                       exit 0
                     fi
 
-                    echo "prism: loading prism-agent:latest into podman..." >&2
-                    $PODMAN image rm prism-agent:latest 2>/dev/null || true
+                    echo "prism: loading localhost/prism-agent:latest into podman..." >&2
+                    $PODMAN image rm localhost/prism-agent:latest 2>/dev/null || true
                     $PODMAN load < ${prismAgentImage}
                     $PODMAN image prune --force 2>/dev/null || true
-                    echo "prism: prism-agent:latest loaded successfully." >&2
+                    echo "prism: localhost/prism-agent:latest loaded successfully." >&2
                   '';
                 in
                 script;
@@ -372,12 +372,12 @@ in
             echo "podman-machine-start: loading prism-agent image into VM..." >&2
             # Remove the old tag first so it does not become a dangling <none>:<none>
             # after the new image is loaded.
-            "$PODMAN" machine ssh -- podman image rm prism-agent:latest 2>/dev/null || true
+            "$PODMAN" machine ssh -- podman image rm localhost/prism-agent:latest 2>/dev/null || true
             # Stream the image tarball into the VM via podman machine ssh.
             "$PODMAN" machine ssh -- podman load < ${prismAgentImage}
             "$PODMAN" machine ssh -- podman image prune --force 2>/dev/null || true
 
-            echo "podman-machine-start: prism-agent:latest loaded successfully." >&2
+            echo "podman-machine-start: localhost/prism-agent:latest loaded successfully." >&2
           '';
         in
         {

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -30,7 +30,11 @@ const (
 	ContainerPort = 4096
 
 	// Image is the container image name used for all agent containers.
-	Image = "prism-agent:latest"
+	// The localhost/ prefix is required for podman to resolve locally-loaded
+	// images correctly on both Linux and Darwin. Without it, podman falls
+	// through to unqualified-search registries and tries docker.io/library/,
+	// which fails for images that were loaded via `podman load`.
+	Image = "localhost/prism-agent:latest"
 
 	// DefaultHealthCheckTimeout is the maximum time to wait for the container
 	// to become healthy before giving up.
@@ -880,7 +884,7 @@ func IsNoSuchContainerError(output string) bool {
 // CheckAvailability verifies that:
 //  1. podman is on PATH,
 //  2. the podman socket is reachable (podman info succeeds), and
-//  3. the prism-agent:latest image is loaded.
+//  3. the localhost/prism-agent:latest image is loaded.
 //
 // Returns a descriptive error for the first failing check, including a hint to
 // use --host-mode as an escape hatch. Returns nil when all checks pass.

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -910,7 +910,7 @@ func CheckAvailability() error {
 		)
 	}
 
-	// 3. prism-agent:latest image loaded.
+	// 3. localhost/prism-agent:latest image loaded.
 	imagesCtx, imagesCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer imagesCancel()
 	imagesCmd := exec.CommandContext(imagesCtx, "podman", "images", "--quiet", Image)

--- a/modules/programs/prism/prism/internal/integration/container_sqlite_test.go
+++ b/modules/programs/prism/prism/internal/integration/container_sqlite_test.go
@@ -86,15 +86,15 @@ func requirePodman(t *testing.T) string {
 	return bin
 }
 
-// requirePrismAgentImage skips the test if the prism-agent:latest image is not
+// requirePrismAgentImage skips the test if the localhost/prism-agent:latest image is not
 // present locally. The image must be built before container mode can be used;
 // this guard prevents the test from failing with a confusing "pull" error.
 func requirePrismAgentImage(t *testing.T, podmanBin string) {
 	t.Helper()
-	out, err := exec.Command(podmanBin, "image", "inspect", "prism-agent:latest",
+	out, err := exec.Command(podmanBin, "image", "inspect", "localhost/prism-agent:latest",
 		"--format", "{{.ID}}").CombinedOutput()
 	if err != nil || strings.TrimSpace(string(out)) == "" {
-		t.Skip("prism-agent:latest image not found — build the image first to run container concurrency tests")
+		t.Skip("localhost/prism-agent:latest image not found — build the image first to run container concurrency tests")
 	}
 }
 
@@ -175,7 +175,7 @@ func runConcurrentContainers(t *testing.T, podmanBin string, n int) []containerR
 				// start, open its DB, and sit idle. That is sufficient to
 				// exercise startup SQLite contention (see file-level doc comment
 				// for the rationale on why idle startup is the key scenario).
-				"prism-agent:latest",
+				"localhost/prism-agent:latest",
 				"opencode", "serve",
 				"--port", "4096",
 				"--hostname", "0.0.0.0",

--- a/modules/programs/prism/prism/scripts/smoke-test-container.sh
+++ b/modules/programs/prism/prism/scripts/smoke-test-container.sh
@@ -6,7 +6,7 @@
 #   ./scripts/smoke-test-container.sh [image:tag]
 #
 # Arguments:
-#   image:tag  Optional. The container image to test (default: prism-agent:latest).
+#   image:tag  Optional. The container image to test (default: localhost/prism-agent:latest).
 #
 # Requirements:
 #   - podman must be running and the target image must be loaded.
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-IMAGE="${1:-prism-agent:latest}"
+IMAGE="${1:-localhost/prism-agent:latest}"
 
 # ── Preflight: skip gracefully if podman is unavailable ──────────────────────
 


### PR DESCRIPTION
## Summary

- Change the `Image` constant in `container.go` from `prism-agent:latest` to `localhost/prism-agent:latest`
- Update all runtime references to the image name consistently (integration tests, load scripts in `container-image.nix`, smoke-test script)
- `go build ./...` and `go test ./...` pass; nix build succeeds

## Problem

On Darwin, `podman machine ssh -- podman load` stores images with the `localhost/` prefix. Using the unqualified name `prism-agent:latest` in `podman run` causes podman to fall through to unqualified-search registries (`docker.io/library/`), which fails for a locally-loaded image.

The fix uses `localhost/prism-agent:latest` everywhere, which is valid on both Linux and Darwin for locally-loaded images.

Closes #596