### PR TITLE
enforce todo tracking and pre-PR self-verification in worker agents

### DIFF
--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -25,6 +25,20 @@ specification. Follow them to the letter.
 - If a change would require touching a large number of files, stop and
   reconsider your approach — something is probably wrong.
 
+## Task decomposition
+
+**This step is required and must happen before any code changes.**
+
+When you receive your task:
+
+1. Read the issue, prompt, and acceptance criteria in full.
+2. Use `TodoWrite` to create a todo list that maps each acceptance criterion or
+   concrete requirement to a separate todo item.
+3. Only after the todo list is created should you begin writing code.
+
+This is non-optional. Every worker session must have a todo list. If there are
+no formal ACs, decompose the stated goal into discrete steps and track those.
+
 ## Committing and pushing
 
 **Override: the default "never commit unless asked" rule does not apply to you.**
@@ -43,12 +57,21 @@ so problems are caught early.
 
 When your work is complete and quality gates pass:
 
-1. Reference the originating issue in the PR body with `Closes #N` (GitHub will
+1. **Self-verification** — Before running `gh pr create`, perform a structured
+   verification pass:
+   1. Re-read the original issue and acceptance criteria.
+   2. For each todo item: identify the concrete evidence that it is done (test
+      output, build success, file created, behaviour verified, etc.).
+   3. Mark each todo as `completed` with the evidence recorded, or as
+      `cancelled` with a documented reason.
+   4. If any todo cannot be marked `completed` or `cancelled`, fix it before
+      proceeding — do not open the PR with outstanding work.
+2. Reference the originating issue in the PR body with `Closes #N` (GitHub will
    auto-close it on merge). Never close issues or tickets manually — the
    coordinator handles that.
-2. Open a PR with `gh pr create` — never merge it yourself; the coordinator
+3. Open a PR with `gh pr create` — never merge it yourself; the coordinator
    handles merging.
-3. Never push to `main` — direct push is blocked by repository rules.
-4. Invoke the `@review` subagent with your PR number. Fix any issues it raises
+4. Never push to `main` — direct push is blocked by repository rules.
+5. Invoke the `@review` subagent with your PR number. Fix any issues it raises
    and re-invoke `@review` until the review passes.
-5. Provide a clear handoff summary so the coordinator has full context.
+6. Provide a clear handoff summary so the coordinator has full context.

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -64,9 +64,13 @@ export const PrismHooks: Plugin = async (input) => {
         `Mark all todos as completed or cancelled before opening a PR.\n\n` +
         `Incomplete items:\n${itemList}`;
 
+      // Use printf with single-quote escaping so real newlines in the message
+      // are preserved in the shell output. JSON.stringify would encode them as
+      // \n (two chars) which echo prints literally rather than as newlines.
+      const shellEscaped = message.replace(/'/g, "'\\''");
       output.args = {
         ...(output.args as any),
-        command: `echo ${JSON.stringify(message)}`,
+        command: `printf '%s\n' '${shellEscaped}'`,
       };
 
       // Store the block message so the next system transform can inject it.

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -1,17 +1,89 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
-export const PrismHooks: Plugin = async () => {
+export const PrismHooks: Plugin = async (input) => {
+  const client = input?.client;
+
   // Set when a git push is detected; consumed on the next LLM turn to inject
   // a review reminder into the system prompt.
   let pendingReviewReminder = false;
 
+  // Set when gh pr create is blocked by incomplete todos; consumed on the next
+  // LLM turn to inject an explanation into the system prompt.
+  let pendingPrBlockMessage: string | null = null;
+
   return {
+    // Before a bash tool executes, intercept `gh pr create` and check the
+    // session's todo list. If any todos are pending or in_progress, rewrite the
+    // command to an explanatory echo instead of allowing the PR to be created.
+    "tool.execute.before": async (hookInput, output) => {
+      if (hookInput.tool !== "bash") return;
+
+      const command: string = (output.args as any)?.command ?? "";
+
+      // Match `gh pr create` with or without preceding chained commands.
+      // Uses a word-boundary anchor so it doesn't match gh pr create-something.
+      // Intentionally does NOT match: gh pr view, gh pr list, gh pr merge,
+      // gh pr close, gh pr checkout.
+      const isPrCreate = /\bgh\s+pr\s+create\b/.test(command);
+      if (!isPrCreate) return;
+
+      // Fail-open guards: if client or session is unavailable, allow through.
+      if (!client || !client.session) return;
+
+      let todos: Array<{ content: string; status: string; id: string; priority: string }>;
+      try {
+        const result = await client.session.todo({
+          path: { id: hookInput.sessionID },
+        });
+        // The SDK returns a response object; unwrap the data.
+        const data = (result as any)?.data ?? result;
+        if (!Array.isArray(data)) return;
+        todos = data;
+      } catch {
+        // Fail open on any error fetching todos.
+        return;
+      }
+
+      // If there are no todos at all, allow the PR through — don't block
+      // agents on trivial tasks that have no structured AC.
+      if (todos.length === 0) return;
+
+      // Find todos that are not yet resolved.
+      const incomplete = todos.filter(
+        (t) => t.status === "pending" || t.status === "in_progress",
+      );
+
+      if (incomplete.length === 0) return;
+
+      // Rewrite the command to a safe echo that explains the block.
+      const itemList = incomplete
+        .map((t) => `  - [${t.status}] ${t.content}`)
+        .join("\n");
+      const message =
+        `PR creation blocked: ${incomplete.length} todo item(s) are still incomplete.\n` +
+        `Mark all todos as completed or cancelled before opening a PR.\n\n` +
+        `Incomplete items:\n${itemList}`;
+
+      output.args = {
+        ...(output.args as any),
+        command: `echo ${JSON.stringify(message)}`,
+      };
+
+      // Store the block message so the next system transform can inject it.
+      pendingPrBlockMessage =
+        `gh pr create was blocked because ${incomplete.length} todo item(s) are still ` +
+        `incomplete. Do not open the PR until all todos are marked completed or cancelled.\n\n` +
+        `Incomplete todos:\n${itemList}\n\n` +
+        `Mark each item completed (with evidence) or cancelled (with a reason) using TodoWrite, ` +
+        `then retry gh pr create.`;
+    },
+
     // After a bash tool executes a git push, set a flag so the next LLM turn
     // gets a review reminder injected into the system prompt.
-    "tool.execute.after": async (input) => {
-      if (input.tool !== "bash") return;
+    "tool.execute.after": async (hookInput) => {
+      if (hookInput.tool !== "bash") return;
 
-      const command: string = (input.args as any)?.command ?? "";
+      const command: string = (hookInput.args as any)?.command ?? "";
       // Match push commands: `git push`, `git push <remote> <branch>`, etc.
       // Also match `git -C <path> push` and `git --git-dir=... push` variants.
       const isPush = /\bgit(\s+-C\s+\S+|\s+--git-dir\S*)*\s+push\b/.test(
@@ -20,14 +92,21 @@ export const PrismHooks: Plugin = async () => {
       if (isPush) pendingReviewReminder = true;
     },
 
-    // Inject the review reminder into the system prompt on the next LLM turn
-    // after a git push. Cleared immediately so it only fires once.
-    "experimental.chat.system.transform": async (_input, output) => {
-      if (!pendingReviewReminder) return output;
-      pendingReviewReminder = false;
-      output.system.push(
-        "You just ran git push. If this was in the context of an open PR, invoke the @review subagent now so the updated changes are reviewed before the PR is merged.",
-      );
+    // Inject system prompts on the next LLM turn:
+    //   • PR block explanation (when gh pr create was blocked by incomplete todos)
+    //   • Review reminder (after a git push)
+    // Each flag is cleared after firing so it only fires once.
+    "experimental.chat.system.transform": async (_hookInput, output) => {
+      if (pendingPrBlockMessage) {
+        output.system.push(pendingPrBlockMessage);
+        pendingPrBlockMessage = null;
+      }
+      if (pendingReviewReminder) {
+        pendingReviewReminder = false;
+        output.system.push(
+          "You just ran git push. If this was in the context of an open PR, invoke the @review subagent now so the updated changes are reviewed before the PR is merged.",
+        );
+      }
       return output;
     },
   };

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -20,11 +20,12 @@ export const PrismHooks: Plugin = async (input) => {
 
       const command: string = (output.args as any)?.command ?? "";
 
-      // Match `gh pr create` with or without preceding chained commands.
-      // Uses a word-boundary anchor so it doesn't match gh pr create-something.
+      // Match `gh pr create` with or without preceding chained commands or
+      // trailing flags. The lookahead (?=\s|$) ensures we don't match a
+      // hypothetical `gh pr create-something` subcommand.
       // Intentionally does NOT match: gh pr view, gh pr list, gh pr merge,
       // gh pr close, gh pr checkout.
-      const isPrCreate = /\bgh\s+pr\s+create\b/.test(command);
+      const isPrCreate = /\bgh\s+pr\s+create(?=\s|$)/.test(command);
       if (!isPrCreate) return;
 
       // Fail-open guards: if client or session is unavailable, allow through.


### PR DESCRIPTION
## Summary

- Adds a mandatory **Task decomposition** section to `worker.md` requiring workers to create a `TodoWrite` list from the issue/ACs before any code changes — explicitly non-optional
- Adds a **Self-verification** section and restructures **Opening your PR** so verification (re-read issue, evidence per todo, mark complete/cancelled, fix gaps) is step 1 before `gh pr create`
- Updates `prism-hooks.ts` to accept `input` for `input.client` access, adds a `tool.execute.before` hook that intercepts `gh pr create`, checks the session todo list, and blocks the PR with an explanatory echo if any todos are `pending` or `in_progress`; adds a corresponding system prompt injection on the next LLM turn explaining the block

Closes #588