### PR TITLE
add @retro subagent and prism-db skill for session retrospective analysis

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -339,8 +339,9 @@
       # symlinks dangle after nix-collect-garbage removes the store paths
       # they pointed to.
       skillsDir = pkgs.runCommand "opencode-skills" { } ''
-        mkdir -p $out/prism $out/aws
+        mkdir -p $out/prism $out/prism-db $out/aws
         cp -r ${./opencode/skills/prism}/* $out/prism/
+        cp -r ${./opencode/skills/prism-db}/* $out/prism-db/
         ${lib.optionalString pkgs.stdenv.isLinux ''
           cp -r ${./opencode/skills/playwright-cli} $out/playwright-cli
         ''}
@@ -449,6 +450,7 @@
         github-copilot = { };
         google = { };
       };
+      hmUser = config.home-manager.users.${config.nx.username};
     in
     lib.mkMerge [
       # Common configuration for both platforms
@@ -578,6 +580,42 @@
                 summary = {
                 };
                 compaction = {
+                };
+                retro = {
+                  description = "Analyses agent sessions for quality patterns and improvement opportunities";
+                  mode = "subagent";
+                  tools = {
+                    read = true;
+                    grep = true;
+                    glob = true;
+                    list = true;
+                    bash = true;
+                    # No write/edit tools — retro is read-only
+                    write = false;
+                    edit = false;
+                    patch = false;
+                    webfetch = false;
+                  };
+                  permission = {
+                    bash = {
+                      # Default deny (MUST be first - last match wins)
+                      "*" = "deny";
+                    }
+                    // readOnlyBashCommands
+                    // {
+                      # Prism read-only commands
+                      "prism stats" = "allow";
+                      "prism stats *" = "allow";
+                      "prism checkin" = "allow";
+                      "prism checkin *" = "allow";
+                      "prism list-sessions" = "allow";
+                      # SQLite read-only access to prism DB — the ?mode=ro flag enforces
+                      # read-only at the SQLite engine level, rejecting all write operations.
+                      # The path is baked in at Nix eval time via hmUser.xdg.stateHome.
+                      "sqlite3 file:${hmUser.xdg.stateHome}/prism/prism.db?mode=ro *" = "allow";
+                    }
+                    // tmuxDenyCommands;
+                  };
                 };
               };
               mcp = {

--- a/modules/programs/prism/opencode/agents/retro.md
+++ b/modules/programs/prism/opencode/agents/retro.md
@@ -1,0 +1,166 @@
+---
+name: retro
+description: Analyses agent sessions for quality patterns and improvement opportunities. Invoke for periodic retrospectives or to diagnose a specific session that went badly.
+mode: subagent
+hidden: true
+---
+
+You are a session retrospective analyst. Your job is to examine prism agent session data and produce actionable analysis — identifying what went wrong, why, and what should change.
+
+**First: load the `prism-db` skill** before doing any analysis. It contains the database schema, event types, query patterns, and read-only access instructions you need.
+
+---
+
+## Two modes
+
+Your mode is determined by the invocation:
+
+- **Broad sweep** — no session name provided, or asked to "review the last N days". Scan recent sessions for anomalies, drill into the worst ones, synthesise cross-session patterns.
+- **Targeted** — a specific session name is provided. Analyse that session in depth: what happened, where it went wrong, why, and what would have helped.
+
+---
+
+## Broad sweep mode
+
+### Step 1: Quantitative overview
+
+Run `prism stats --days 7` to get an overview of recent session activity.
+
+### Step 2: Identify anomalous sessions
+
+Query the database to surface sessions worth drilling into. Look for all of:
+
+- Sessions with ≥2 compactions (context pressure — agent is burning through its window)
+- Sessions with high tool-call repetition (potential doom loops — same tool+args called 3+ times)
+- Sessions with errors (`type = 'error'`)
+- Sessions with permission denials (`type = 'permission_denied'`)
+- Sessions with disproportionate token usage relative to turns (high input tokens per turn suggests excessive context re-reading)
+- Sessions that ended without opening a PR (check `agent_status.state` and last events — did the session finish its stated goal?)
+
+Use the example queries in the `prism-db` skill as starting points. Adapt them as needed.
+
+### Step 3: Drill into the top 3–5 most interesting sessions
+
+For each anomalous session:
+
+1. Run `prism checkin <session> --last 20` to get conversation flow
+2. Query `tool_call` events for patterns and repetition
+3. Look at how the session ended (last 5–10 events)
+4. Note whether the session achieved its stated goal
+
+### Step 4: Synthesise and report
+
+Structure your output as:
+
+---
+
+**Broad Sweep: Last 7 Days**
+
+**Overview** _(from `prism stats --days 7`)_
+[key numbers: sessions, turns, tokens, models used]
+
+**Anomalous sessions**
+For each session worth noting:
+- `<session-name>` — [one sentence describing what was anomalous and what went wrong]
+  - Classification: session-specific incident OR cross-session pattern
+  - Root cause: [what actually caused the problem]
+
+**Cross-session patterns**
+[Themes that appear across multiple sessions — e.g. "Workers consistently fail on nix build errors without retrying with --show-trace", "Gemini workers take 3× more turns than Sonnet workers on similar edit tasks"]
+
+If there are no cross-session patterns, say so explicitly.
+
+**Recommendations**
+Concrete, actionable changes. Each recommendation must reference a specific mechanism:
+- "Add a bash permission for X in opencode.nix"
+- "Add this rule to the worker prompt in worker.md: ..."
+- "Create a `prism-db` skill section for ..."
+- "File an issue to implement ..."
+- "Consider switching model Z to Y for edit-heavy tasks based on the data"
+
+---
+
+**Edge case:** If there are no sessions in the target window, output: "No sessions found in the last 7 days. The database may be empty or the window may need adjusting."
+
+---
+
+## Targeted mode
+
+You have been given a specific session name. Analyse it fully.
+
+### Step 1: Metrics
+
+Run `prism stats <session>` for quantitative summary.
+
+### Step 2: Full conversation
+
+Run `prism checkin <session> --verbose` to get the complete conversation with full tool args and results.
+
+### Step 3: Database queries
+
+Query the database for:
+- Tool call frequency and timing
+- Errors and their timing relative to other events
+- Permission asks and denials
+- Compaction events and their position in the timeline
+- Token usage per turn (watch for turns with unusually high input tokens)
+
+### Step 4: Analysis
+
+Structure your output as:
+
+---
+
+**Session Analysis: `<session-name>`**
+
+**What happened**
+Narrative reconstruction of the session from start to finish. Be specific — name the files touched, the errors encountered, the decisions made. "The agent spent 12 turns trying to fix a nix build error by repeatedly editing the same module" is more useful than "the agent had trouble with nix."
+
+**Where it went wrong**
+Identify the turning point(s). At what point did the session start struggling? What was the trigger?
+
+**Root causes**
+Be direct. Name the actual causes:
+- Bad prompt / unclear specification
+- Missing context (what information would have helped?)
+- Wrong model for the task
+- Tool misuse (using the wrong tool repeatedly)
+- Permission gap (needed a bash command that wasn't allowed)
+- Scope too large (task was too broad for one session)
+- Compaction pressure (context window exhausted, losing important state)
+- Doom loop (repeated same failing action without changing approach)
+
+**What would have helped**
+Answer: "If I were the agent in this session, what information or instruction would have prevented this problem?"
+- A specific skill loaded at the start?
+- A different permission set?
+- A different prompt phrasing?
+- Breaking the task into smaller sessions?
+- A different model?
+
+**Token efficiency**
+Was the token spend reasonable for what was achieved? High input tokens per turn signals excessive re-reading of context. Many compactions signal the task was too large.
+
+**Recommendations**
+Concrete, actionable changes with specific mechanism references (skill, permission rule, prompt change, issue). Be direct — if the agent wasted 20 turns doing the wrong thing, say so and say what instruction would have prevented it.
+
+---
+
+**Edge case:** If the session name is not found in the database, output: "Session `<name>` not found. Use `prism list-sessions` or query `agent_status` to see available sessions."
+
+---
+
+## Analysis principles
+
+**Be analytical, not diplomatic.** "The agent wasted 40 turns editing the wrong file" is more useful than "the agent encountered some challenges with file identification."
+
+**Distinguish incidents from patterns.** A single bad session is less interesting than a pattern that repeats. Always explicitly label each identified problem as either a session-specific incident or a cross-session pattern.
+
+**Analysis dimensions to always consider:**
+- **Token efficiency** — was the token spend proportionate to the value delivered?
+- **Trajectory directness** — did the agent go straight to the solution, or meander?
+- **Error recovery** — when the agent hit an error, did it adapt or repeat the same approach?
+- **Tool selection** — did the agent use the right tools? Did it over-rely on bash when dedicated tools existed?
+- **Scope discipline** — did the agent stay within the stated scope, or drift into unrequested changes?
+
+**Recommendations must be actionable.** "Be more careful" is not a recommendation. "Add this rule to worker.md: 'When a nix build fails, always add --show-trace to the next attempt'" is a recommendation.

--- a/modules/programs/prism/opencode/skills/prism-db/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism-db/SKILL.md
@@ -20,10 +20,12 @@ On NixOS, `XDG_STATE_HOME` is set to `$HOME/.local/state`. The database path is 
 **All access MUST use SQLite read-only mode:**
 
 ```bash
-sqlite3 "file:~/.local/state/prism/prism.db?mode=ro" "<query>"
+sqlite3 "file:$HOME/.local/state/prism/prism.db?mode=ro" "<query>"
 ```
 
 The `?mode=ro` flag enforces read-only access at the SQLite engine level. `INSERT`, `UPDATE`, `DELETE`, `DROP`, and all other write operations will be rejected with "attempt to write a readonly database". This is a safety requirement, not a suggestion.
+
+**Important:** Use `$HOME` (shell-expanded) rather than `~` in the URI. SQLite does not expand `~` in `file:` URIs, so a literal `~` causes "unable to open database file". The permission system also expects an absolute path — `$HOME` expands correctly; `~` does not match the permission pattern and will be denied.
 
 ## Schema
 

--- a/modules/programs/prism/opencode/skills/prism-db/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism-db/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: prism-db
+description: Query the prism SQLite database. Load this skill when you need to analyse agent sessions, review session metrics, debug agent behaviour, or access the prism event log.
+---
+
+# Prism Database
+
+The prism SQLite database records every agent interaction: tool calls, messages, token counts, timing metrics, errors, permission events, and state changes across all sessions.
+
+## Database location
+
+```
+~/.local/state/prism/prism.db
+```
+
+On NixOS, `XDG_STATE_HOME` is set to `$HOME/.local/state`. The database path is always `$XDG_STATE_HOME/prism/prism.db`.
+
+## Access — read-only URI required
+
+**All access MUST use SQLite read-only mode:**
+
+```bash
+sqlite3 "file:~/.local/state/prism/prism.db?mode=ro" "<query>"
+```
+
+The `?mode=ro` flag enforces read-only access at the SQLite engine level. `INSERT`, `UPDATE`, `DELETE`, `DROP`, and all other write operations will be rejected with "attempt to write a readonly database". This is a safety requirement, not a suggestion.
+
+## Schema
+
+```sql
+-- Immutable event log: every agent interaction is recorded here.
+CREATE TABLE agent_events (
+  id           TEXT PRIMARY KEY,
+  session_name TEXT NOT NULL,    -- e.g. "nixos-config@fix-login"
+  repo         TEXT NOT NULL,    -- e.g. "nixos-config"
+  worktree     TEXT NOT NULL,    -- filesystem path to the worktree
+  opencode_sid TEXT,             -- opencode session ID (NULL for legacy events)
+  type         TEXT NOT NULL,    -- one of the 11 event types below
+  payload      TEXT NOT NULL,    -- JSON, structure depends on type
+  created_at   INTEGER NOT NULL  -- unix milliseconds
+);
+CREATE INDEX idx_events_session ON agent_events(session_name, created_at DESC);
+CREATE INDEX idx_events_repo    ON agent_events(repo, type, created_at DESC);
+
+-- Current state of each tmux session (one row per session).
+CREATE TABLE agent_status (
+  session_name    TEXT PRIMARY KEY,
+  repo            TEXT NOT NULL,
+  worktree        TEXT NOT NULL,
+  state           TEXT NOT NULL,    -- "active", "waiting", "idle", "finished", etc.
+  title           TEXT,             -- task title/description
+  opencode_sid    TEXT,
+  agent_name      TEXT,             -- current agent (may change during session)
+  model_id        TEXT,             -- current model
+  root_agent_name TEXT,             -- agent at session start (stable)
+  root_model_id   TEXT,             -- model at session start (stable)
+  opencode_port   INTEGER,
+  host_mode       INTEGER NOT NULL DEFAULT 0,
+  last_seen       INTEGER NOT NULL, -- unix milliseconds
+  ended_at        INTEGER           -- unix milliseconds, NULL if still running
+);
+
+-- Inter-session message bus.
+CREATE TABLE bus_messages (
+  id           TEXT PRIMARY KEY,
+  from_session TEXT NOT NULL,
+  to_session   TEXT NOT NULL,
+  repo         TEXT NOT NULL,
+  text         TEXT NOT NULL,
+  urgency      TEXT NOT NULL DEFAULT 'normal',
+  sent_at      INTEGER NOT NULL,   -- unix milliseconds
+  delivered_at INTEGER              -- unix milliseconds, NULL if pending
+);
+
+CREATE TABLE schema_version (
+  version INTEGER NOT NULL
+);
+```
+
+## Event types and payload structures
+
+All payloads are JSON. Field names are camelCase.
+
+| Type | Description | Key payload fields |
+|------|-------------|--------------------|
+| `msg_user` | User/prompt message | `messageId` (TEXT), `text` (TEXT), `agent` (TEXT), `model` (TEXT) |
+| `msg_assistant` | Assistant response | `messageId` (TEXT), `text` (TEXT), `agent` (TEXT), `model` (TEXT), `inputTokens` (INTEGER), `outputTokens` (INTEGER), `cacheReadTokens` (INTEGER), `cacheWriteTokens` (INTEGER), `durationMs` (INTEGER), `ttftMs` (INTEGER), `contextWindowPct` (REAL) |
+| `tool_call` | Tool invocation | `tool` (TEXT), `args` (TEXT — JSON string), `messageId` (TEXT), `durationMs` (INTEGER) |
+| `tool_result` | Tool output | `tool` (TEXT), `result` (TEXT), `messageId` (TEXT) |
+| `permission_ask` | Permission prompt shown | `tool` (TEXT), `patterns` (TEXT), `messageId` (TEXT) |
+| `permission_denied` | Permission denied | `tool` (TEXT), `messageId` (TEXT) |
+| `thinking` | Extended thinking output | `text` (TEXT), `messageId` (TEXT) |
+| `state_change` | Agent state transition | `state` (TEXT) |
+| `compaction` | Context compaction occurred | `note` (TEXT) |
+| `error` | Error event | `note` (TEXT) |
+| `subagent_start` | Subagent invoked | `agent` (TEXT), `description` (TEXT), `messageId` (TEXT) |
+| `subagent_end` | Subagent completed | `agent` (TEXT), `durationMs` (INTEGER), `messageId` (TEXT) |
+
+## Timestamps
+
+All timestamps in the database are **unix milliseconds** (not seconds).
+
+- Human-readable output: `datetime(created_at/1000, 'unixepoch', 'localtime')`
+- Comparison against current time: `strftime('%s','now') * 1000`
+
+Example:
+
+```sql
+-- Events in the last 7 days
+WHERE created_at > (strftime('%s','now','-7 days') * 1000)
+```
+
+## Example queries
+
+### List all sessions in the last 7 days
+
+```sql
+SELECT session_name, state, title, root_agent_name, root_model_id,
+       datetime(last_seen/1000, 'unixepoch', 'localtime') as last_active,
+       CASE WHEN ended_at IS NOT NULL
+            THEN datetime(ended_at/1000, 'unixepoch', 'localtime')
+            ELSE 'running' END as ended
+FROM agent_status
+WHERE last_seen > (strftime('%s','now','-7 days') * 1000)
+ORDER BY last_seen DESC;
+```
+
+### Session summary metrics (tokens, cost, duration, tool calls)
+
+```sql
+SELECT
+  COUNT(CASE WHEN type='msg_assistant' THEN 1 END) as turns,
+  SUM(CASE WHEN type='msg_assistant' THEN json_extract(payload,'$.inputTokens') END) as input_tokens,
+  SUM(CASE WHEN type='msg_assistant' THEN json_extract(payload,'$.outputTokens') END) as output_tokens,
+  COUNT(CASE WHEN type='tool_call' THEN 1 END) as tool_calls,
+  COUNT(CASE WHEN type='compaction' THEN 1 END) as compactions,
+  COUNT(CASE WHEN type='error' THEN 1 END) as errors,
+  MIN(created_at) as first_event_ms,
+  MAX(created_at) as last_event_ms
+FROM agent_events
+WHERE session_name = '<session>';
+```
+
+### Tool call frequency for a session
+
+```sql
+SELECT json_extract(payload,'$.tool') as tool, COUNT(*) as count,
+       AVG(json_extract(payload,'$.durationMs')) as avg_duration_ms
+FROM agent_events
+WHERE session_name = '<session>' AND type = 'tool_call'
+GROUP BY tool ORDER BY count DESC;
+```
+
+### Detect potential doom loops (same tool+args repeated)
+
+```sql
+SELECT json_extract(payload,'$.tool') as tool,
+       json_extract(payload,'$.args') as args,
+       COUNT(*) as repetitions
+FROM agent_events
+WHERE session_name = '<session>' AND type = 'tool_call'
+GROUP BY tool, args
+HAVING COUNT(*) >= 3
+ORDER BY repetitions DESC;
+```
+
+### Find sessions with high compaction count (context pressure indicator)
+
+```sql
+SELECT session_name, COUNT(*) as compactions
+FROM agent_events
+WHERE type = 'compaction'
+  AND created_at > (strftime('%s','now','-7 days') * 1000)
+GROUP BY session_name
+HAVING COUNT(*) >= 2
+ORDER BY compactions DESC;
+```
+
+### Find sessions with permission denials
+
+```sql
+SELECT session_name,
+       json_extract(payload,'$.tool') as tool,
+       COUNT(*) as denials
+FROM agent_events
+WHERE type = 'permission_denied'
+  AND created_at > (strftime('%s','now','-7 days') * 1000)
+GROUP BY session_name, tool
+ORDER BY denials DESC;
+```
+
+### Get conversation flow for a session (drill-down)
+
+```sql
+SELECT type,
+       datetime(created_at/1000, 'unixepoch', 'localtime') as time,
+       CASE
+         WHEN type = 'msg_user' THEN substr(json_extract(payload,'$.text'), 1, 200)
+         WHEN type = 'msg_assistant' THEN substr(json_extract(payload,'$.text'), 1, 200)
+         WHEN type = 'tool_call' THEN json_extract(payload,'$.tool') || ': ' || substr(json_extract(payload,'$.args'), 1, 150)
+         WHEN type = 'error' THEN json_extract(payload,'$.note')
+         WHEN type = 'compaction' THEN json_extract(payload,'$.note')
+         WHEN type = 'state_change' THEN json_extract(payload,'$.state')
+         ELSE payload
+       END as summary
+FROM agent_events
+WHERE session_name = '<session>'
+ORDER BY created_at;
+```
+
+## CLI alternatives
+
+These commands are often faster than raw SQL for common tasks:
+
+| Command | What it does |
+|---------|--------------|
+| `prism stats` | Summary table of all active sessions |
+| `prism stats <session>` | Detailed metrics for one session |
+| `prism stats --days N` | Historical aggregate over N days |
+| `prism stats model --days N` | Per-model performance breakdown |
+| `prism checkin <session>` | Reconstructed conversation history with tool calls inline |
+| `prism checkin <session> --last N` | Last N turns only |
+| `prism checkin <session> --verbose` | Full tool args/results without truncation |
+| `prism list-sessions` | All active sessions with state |

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -36,6 +36,7 @@
             "worker"
             "review"
             "ac"
+            "retro"
           ];
           lightweight = [
             "explore"


### PR DESCRIPTION
## Summary

- Adds a `prism-db` skill documenting the prism SQLite schema, all 11 event types with payload fields, timestamp format, example queries, and CLI alternatives — available to all agents
- Adds a `@retro` subagent that analyses agent sessions in broad sweep mode (last N days: identify anomalies, drill into worst sessions, synthesise cross-session patterns) or targeted mode (specific session: narrative reconstruction, root cause analysis, actionable recommendations)
- Configures the `retro` agent in `opencode.nix` with strict read-only permissions: default-deny bash, whitelist of read-only commands, prism stats/checkin, and `sqlite3` locked to the prism DB path with `?mode=ro` enforced at the SQLite engine level

Closes #592