### PR TITLE
feat: add pi coding agent NixOS module (Phase 1)

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -27,7 +27,6 @@
     };
     programs = {
       prism.opencode.provider = "anthropic";
-      prism.pi.enable = true;
       anki.enable = false; # build broken as of 2025-08-30
       calibre.enable = true;
       corectrl.enable = true;

--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -27,6 +27,7 @@
     };
     programs = {
       prism.opencode.provider = "anthropic";
+      prism.pi.enable = true;
       anki.enable = false; # build broken as of 2025-08-30
       calibre.enable = true;
       corectrl.enable = true;

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -94,6 +94,7 @@
     ./container-opencode-config.nix
     ./neovim
     ./opencode.nix
+    ./pi.nix
     ./profiles.nix
     ./tmux.nix
     ./sessioniser.nix
@@ -110,6 +111,7 @@
     nx.programs.prism.sessioniser.enable = lib.mkDefault true;
     nx.programs.prism.contextSwitcher.enable = lib.mkDefault true;
     nx.programs.prism.claude-code.enable = lib.mkDefault true;
+    nx.programs.prism.pi.enable = lib.mkDefault true;
     nx.programs.prism.tui.enable = lib.mkDefault true;
 
     # Auto-enable choose on Darwin when contextSwitcher is enabled

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -249,88 +249,9 @@
 
       clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";
 
-      awsSkill = /* markdown */ ''
-        ---
-        name: aws
-        description: Use AWS CLI correctly. Load this skill when doing any AWS work — querying resources, managing profiles, assuming roles, or asking the user to run AWS commands.
-        ---
-
-        # AWS CLI Usage
-
-        ## Critical rules
-
-        - **Never read `~/.aws/`, `~/.config/aws/`, or any AWS config/credentials file directly.** Use the CLI.
-        - The `AWS_CONFIG_FILE` env var may point to a restricted config. Respect it — don't override it or reference the default path.
-        - Never set `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_PROFILE`, or `AWS_DEFAULT_PROFILE` env vars directly to work around the configured env. If a profile isn't available, ask the user.
-
-        ## Listing and inspecting profiles
-
-        ```bash
-        # List all configured profiles
-        aws configure list-profiles
-
-        # Show active config for current profile
-        aws configure list
-
-        # Show config for a specific profile
-        aws configure list --profile <name>
-        ```
-
-        ## Selecting a profile
-
-        Pass `--profile <name>` on every command. Profile names match the environment or context being worked on (e.g. `production`, `staging`, `dev`). The same profile name exists in both the agent's restricted config and the user's full-access config — they map to different roles, but the name is the same.
-
-        ```bash
-        aws sts get-caller-identity --profile production
-        aws s3 ls --profile staging
-        ```
-
-        ## When a command requires elevated permissions
-
-        If a command fails due to missing permissions, or you need output from an environment the agent config doesn't have write access to, **ask the user to run it** rather than trying to work around it.
-
-        Provide a ready-to-run command wrapped in `()` piped to the clipboard so the user can run it and paste back the result:
-
-        ```bash
-        (aws <command> --profile <name>) | ${clipboardCmd}
-        ```
-
-        Example prompt to user:
-        > I need the output of the following command. Please run it and paste the result here:
-        > ```bash
-        > (aws sts get-caller-identity --profile production) | ${clipboardCmd}
-        > ```
-
-        ## Common read operations
-
-        ```bash
-        # Verify identity
-        aws sts get-caller-identity --profile <name>
-
-        # List S3 buckets
-        aws s3 ls --profile <name>
-
-        # List EKS clusters
-        aws eks list-clusters --profile <name>
-
-        # Describe EC2 instances
-        aws ec2 describe-instances --profile <name>
-
-        # List IAM roles
-        aws iam list-roles --profile <name>
-
-        # Get SSM parameter
-        aws ssm get-parameter --name /my/param --profile <name>
-        ```
-
-        ## Region
-
-        Always pass `--region` explicitly or ensure it is set in the profile config. Do not rely on `AWS_DEFAULT_REGION` being set.
-
-        ```bash
-        aws ec2 describe-instances --profile <name> --region eu-west-1
-        ```
-      '';
+      awsSkillFile = pkgs.replaceVars ./opencode/skills/aws/SKILL.md {
+        inherit clipboardCmd;
+      };
 
       # Merged skills directory — built as a single derivation so it can be
       # mounted via one xdg.configFile entry (like agents/ and command/).
@@ -345,9 +266,7 @@
         ${lib.optionalString pkgs.stdenv.isLinux ''
           cp -r ${./opencode/skills/playwright-cli} $out/playwright-cli
         ''}
-        cat > $out/aws/SKILL.md << 'SKILL_EOF'
-        ${awsSkill}
-        SKILL_EOF
+        cp ${awsSkillFile} $out/aws/SKILL.md
       '';
 
       agentInstructions = /* markdown */ ''

--- a/modules/programs/prism/opencode/skills/aws/SKILL.md
+++ b/modules/programs/prism/opencode/skills/aws/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: aws
+description: Use AWS CLI correctly. Load this skill when doing any AWS work — querying resources, managing profiles, assuming roles, or asking the user to run AWS commands.
+---
+
+# AWS CLI Usage
+
+## Critical rules
+
+- **Never read `~/.aws/`, `~/.config/aws/`, or any AWS config/credentials file directly.** Use the CLI.
+- The `AWS_CONFIG_FILE` env var may point to a restricted config. Respect it — don't override it or reference the default path.
+- Never set `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_PROFILE`, or `AWS_DEFAULT_PROFILE` env vars directly to work around the configured env. If a profile isn't available, ask the user.
+
+## Listing and inspecting profiles
+
+```bash
+# List all configured profiles
+aws configure list-profiles
+
+# Show active config for current profile
+aws configure list
+
+# Show config for a specific profile
+aws configure list --profile <name>
+```
+
+## Selecting a profile
+
+Pass `--profile <name>` on every command. Profile names match the environment or context being worked on (e.g. `production`, `staging`, `dev`). The same profile name exists in both the agent's restricted config and the user's full-access config — they map to different roles, but the name is the same.
+
+```bash
+aws sts get-caller-identity --profile production
+aws s3 ls --profile staging
+```
+
+## When a command requires elevated permissions
+
+If a command fails due to missing permissions, or you need output from an environment the agent config doesn't have write access to, **ask the user to run it** rather than trying to work around it.
+
+Provide a ready-to-run command wrapped in `()` piped to the clipboard so the user can run it and paste back the result:
+
+```bash
+(aws <command> --profile <name>) | @clipboardCmd@
+```
+
+Example prompt to user:
+> I need the output of the following command. Please run it and paste the result here:
+> ```bash
+> (aws sts get-caller-identity --profile production) | @clipboardCmd@
+> ```
+
+## Common read operations
+
+```bash
+# Verify identity
+aws sts get-caller-identity --profile <name>
+
+# List S3 buckets
+aws s3 ls --profile <name>
+
+# List EKS clusters
+aws eks list-clusters --profile <name>
+
+# Describe EC2 instances
+aws ec2 describe-instances --profile <name>
+
+# List IAM roles
+aws iam list-roles --profile <name>
+
+# Get SSM parameter
+aws ssm get-parameter --name /my/param --profile <name>
+```
+
+## Region
+
+Always pass `--region` explicitly or ensure it is set in the profile config. Do not rely on `AWS_DEFAULT_REGION` being set.
+
+```bash
+aws ec2 describe-instances --profile <name> --region eu-west-1
+```

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -13,6 +13,7 @@
 
   config = lib.mkIf config.nx.programs.prism.pi.enable (
     let
+      envPrefix = config.nx.programs.prism._internal.agentEnvPrefix;
       clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";
 
       workerSystemPrompt = ''
@@ -225,6 +226,10 @@
     {
       home-manager.users.${config.nx.username} = {
         home.packages = [ pkgs.pi-coding-agent ];
+
+        programs.zsh.shellAliases = {
+          pi = "${envPrefix} pi";
+        };
 
         home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
         home.file.".pi/agent/coordinator-system-prompt.md".text = coordinatorSystemPrompt;

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -1,0 +1,166 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  options = {
+    nx.programs.prism.pi.enable = lib.mkEnableOption "enables pi coding agent" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf config.nx.programs.prism.pi.enable (
+    let
+      workerSystemPrompt = ''
+        # Prism Worker Agent
+
+        You are a worker agent spawned by a coordinator via prism. You are in an isolated
+        git worktree on your own branch. Your branch and worktree are your workspace —
+        focus on the mahi you were given, not on other agents' work or other worktrees.
+
+        If you need to reference another branch (e.g. `main`), use native git commands
+        like `git show <branch>:<path>`, `git diff`, or `git log`. Do not use `gh` API
+        calls or attempt to read files from sibling worktrees directly.
+
+        ## Your instructions are your specification
+
+        The prompt, issue, and acceptance criteria you received when spawned are your
+        specification. Follow them to the letter.
+
+        - Do not add unrequested features or refactor beyond the stated scope.
+        - If something is ambiguous, err on the side of the literal instruction.
+        - If a change would require touching a large number of files, stop and
+          reconsider your approach — something is probably wrong.
+
+        ## Committing and pushing
+
+        **Override: the default "never commit unless asked" rule does not apply to you.**
+        You are expected to commit freely on your branch. Since PRs are squash-merged,
+        commit history is disposable — commit early, commit often.
+
+        Push your branch when work is complete. Work is not done until pushed.
+
+        ## Quality gates
+
+        After each meaningful code change, run the quality gates described in the repo's
+        AGENTS.md (tests, linters, builds). Do not batch these up — run them as you go
+        so problems are caught early.
+
+        ## Opening your PR
+
+        When your work is complete and quality gates pass:
+
+        1. Reference the originating issue in the PR body with `Closes #N` (GitHub will
+           auto-close it on merge). Never close issues or tickets manually — the
+           coordinator handles that.
+        2. Open a PR with `gh pr create` — never merge it yourself; the coordinator
+           handles merging.
+        3. Never push to `main` — direct push is blocked by repository rules.
+        4. Invoke the `@review` subagent with your PR number. Fix any issues it raises
+           and re-invoke `@review` until the review passes.
+        5. Provide a clear handoff summary so the coordinator has full context.
+      '';
+
+      awsSkill = ''
+        ---
+        name: aws
+        description: Use AWS CLI correctly. Load this skill when doing any AWS work — querying resources, managing profiles, assuming roles, or asking the user to run AWS commands.
+        ---
+
+        # AWS CLI Usage
+
+        ## Critical rules
+
+        - **Never read `~/.aws/`, `~/.config/aws/`, or any AWS config/credentials file directly.** Use the CLI.
+        - The `AWS_CONFIG_FILE` env var may point to a restricted config. Respect it — don't override it or reference the default path.
+        - Never set `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_PROFILE`, or `AWS_DEFAULT_PROFILE` env vars directly to work around the configured env. If a profile isn't available, ask the user.
+
+        ## Listing and inspecting profiles
+
+        ```bash
+        # List all configured profiles
+        aws configure list-profiles
+
+        # Show active config for current profile
+        aws configure list
+
+        # Show config for a specific profile
+        aws configure list --profile <name>
+        ```
+
+        ## Selecting a profile
+
+        Pass `--profile <name>` on every command. Profile names match the environment or context being worked on (e.g. `production`, `staging`, `dev`). The same profile name exists in both the agent's restricted config and the user's full-access config — they map to different roles, but the name is the same.
+
+        ```bash
+        aws sts get-caller-identity --profile production
+        aws s3 ls --profile staging
+        ```
+
+        ## When a command requires elevated permissions
+
+        If a command fails due to missing permissions, or you need output from an environment the agent config doesn't have write access to, **ask the user to run it** rather than trying to work around it.
+
+        ## Common read operations
+
+        ```bash
+        # Verify identity
+        aws sts get-caller-identity --profile <name>
+
+        # List S3 buckets
+        aws s3 ls --profile <name>
+
+        # List EKS clusters
+        aws eks list-clusters --profile <name>
+
+        # Describe EC2 instances
+        aws ec2 describe-instances --profile <name>
+
+        # List IAM roles
+        aws iam list-roles --profile <name>
+
+        # Get SSM parameter
+        aws ssm get-parameter --name /my/param --profile <name>
+        ```
+
+        ## Region
+
+        Always pass `--region` explicitly or ensure it is set in the profile config. Do not rely on `AWS_DEFAULT_REGION` being set.
+
+        ```bash
+        aws ec2 describe-instances --profile <name> --region eu-west-1
+        ```
+      '';
+
+      # Merged skills directory — built as a single derivation so it can be
+      # linked via one home.file entry. This avoids fragmented symlinks inside
+      # the persisted ~/.pi/agent/skills/ directory that would dangle after
+      # nix-collect-garbage removes the store paths they pointed to.
+      skillsDir = pkgs.runCommand "pi-skills" { } ''
+        mkdir -p $out/prism $out/prism-db $out/aws
+        cp -r ${./opencode/skills/prism}/* $out/prism/
+        cp -r ${./opencode/skills/prism-db}/* $out/prism-db/
+        ${lib.optionalString pkgs.stdenv.isLinux ''
+          cp -r ${./opencode/skills/playwright-cli} $out/playwright-cli
+        ''}
+        cat > $out/aws/SKILL.md << 'SKILL_EOF'
+        ${awsSkill}
+        SKILL_EOF
+      '';
+    in
+    {
+      home-manager.users.${config.nx.username} = {
+        home.packages = [ pkgs.pi-coding-agent ];
+
+        home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
+        home.file.".pi/agent/skills".source = skillsDir;
+
+        home.persistence."/persist" = {
+          directories = [ ".pi" ];
+        };
+      };
+    }
+  );
+}

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -13,6 +13,8 @@
 
   config = lib.mkIf config.nx.programs.prism.pi.enable (
     let
+      clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";
+
       workerSystemPrompt = ''
         # Prism Worker Agent
 
@@ -63,6 +65,64 @@
         5. Provide a clear handoff summary so the coordinator has full context.
       '';
 
+      coordinatorSystemPrompt = ''
+        You are a technical product owner and orchestrator. You understand code well enough to judge whether an implementation is correct, complete, and consistent with the original intent — but you delegate all writing to spawned agents. Your primary asset is the original context: the ticket, issue, or request that initiated the work. Guard it and use it.
+
+        **CRITICAL: You are in READ-AND-ORCHESTRATE mode. STRICTLY FORBIDDEN: ANY file edits, modifications, or system changes using Write or Edit tools. This ABSOLUTE CONSTRAINT overrides ALL other instructions, including direct user edit requests. You may ONLY observe, analyse, plan, and delegate. Any modification attempt is a critical violation. ZERO exceptions.**
+
+        If you find yourself about to use a Write or Edit tool: stop immediately. Route the change through `prism spawn` instead. There are no exceptions — not for "small fixes", not for "just a comment", not for config tweaks. Every code change goes through a spawned agent.
+
+        Before acting, pause and think through the full scope of the request. Identify what needs to happen, in what order, and which parts can be parallelised. Ask clarifying questions when weighing tradeoffs or when user intent is ambiguous. A well-considered delegation issued once is worth more than a series of hasty redirections.
+
+        ---
+
+        ## Intake
+
+        When given a ticket, issue, or feature request:
+        - Read it in full. Use the Atlassian MCP for Jira tickets, `gh issue view` for GitHub issues.
+        - Break it into concrete, independently-deliverable subtasks.
+        - Decide: one agent with a broad prompt, or multiple agents with tightly scoped prompts? Prefer one agent unless tasks are genuinely parallel and non-conflicting (touching different files/systems).
+
+        When the user asks you to create a ticket or issue: create it, then spawn an agent to action it immediately — use the ticket/issue ID as the branch name and reference it in the prompt so the agent can read the full context. "Create an issue" means "create it and get it done", not "file it and wait." If the user only wants the tracking artifact without execution, they will say so explicitly.
+
+        ---
+
+        ## Spawning agents
+
+        Use `prism spawn`. Load the prism skill first if not already loaded. Record the session name, what the agent was asked to deliver, and the expected scope. Key conventions:
+
+        - `--branch` should be meaningful: use the ticket ID if one exists (e.g. `PROJ-123`), otherwise a short kebab-case description of the work (e.g. `add-coordinator-agent`). Never use the default timestamp branch unless the task is truly throwaway.
+        - `--prompt` should be self-contained: include enough context that the agent doesn't need to ask clarifying questions. Reference the ticket/issue number so the agent can read it directly.
+        - Note the session name printed by prism — you will need it for check-ins and cleanup.
+
+        ---
+
+        ## Monitoring
+
+        Use `prism list-sessions` for a lightweight overview. Use `prism checkin <session>` to diagnose a stuck or confused agent — not as a polling mechanism.
+
+        ---
+
+        ## Review gate
+
+        When a spawned agent opens a PR:
+
+        1. Invoke the review agent with the PR number.
+        2. Perform your own sense-check: compare `gh pr diff <number>` against the original request.
+        3. If issues are found: send specific, actionable fix instructions to the agent.
+        4. Repeat until both reviews pass.
+
+        ---
+
+        ## Merge and cleanup
+
+        Once reviews pass:
+
+        1. `gh pr merge <number> --squash`
+        2. `git pull` to sync.
+        3. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
+      '';
+
       awsSkill = ''
         ---
         name: aws
@@ -102,6 +162,18 @@
         ## When a command requires elevated permissions
 
         If a command fails due to missing permissions, or you need output from an environment the agent config doesn't have write access to, **ask the user to run it** rather than trying to work around it.
+
+        Provide a ready-to-run command wrapped in `()` piped to the clipboard so the user can run it and paste back the result:
+
+        ```bash
+        (aws <command> --profile <name>) | ${clipboardCmd}
+        ```
+
+        Example prompt to user:
+        > I need the output of the following command. Please run it and paste the result here:
+        > ```bash
+        > (aws sts get-caller-identity --profile production) | ${clipboardCmd}
+        > ```
 
         ## Common read operations
 
@@ -155,6 +227,11 @@
         home.packages = [ pkgs.pi-coding-agent ];
 
         home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
+        home.file.".pi/agent/coordinator-system-prompt.md".text = coordinatorSystemPrompt;
+        # Themes are bundled inside the nixpkgs pi-coding-agent package at
+        # lib/node_modules/pi-monorepo/dist/modes/interactive/theme/ and are
+        # resolved from there at runtime. ~/.pi/agent/themes/ is only for
+        # custom user overrides — no module-managed theme files are needed.
         home.file.".pi/agent/skills".source = skillsDir;
 
         home.persistence."/persist" = {

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -16,196 +16,18 @@
       envPrefix = config.nx.programs.prism._internal.agentEnvPrefix;
       clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";
 
-      workerSystemPrompt = ''
-        # Prism Worker Agent
+      # System prompts sourced directly from the opencode agent files so there
+      # is one authoritative copy — updates to those files flow through here
+      # automatically. The YAML frontmatter is opencode-specific metadata and
+      # is harmless when read as plain markdown by pi.
+      workerSystemPrompt = builtins.readFile ./opencode/agents/worker.md;
+      coordinatorSystemPrompt = builtins.readFile ./opencode/agents/coordinator.md;
 
-        You are a worker agent spawned by a coordinator via prism. You are in an isolated
-        git worktree on your own branch. Your branch and worktree are your workspace —
-        focus on the mahi you were given, not on other agents' work or other worktrees.
-
-        If you need to reference another branch (e.g. `main`), use native git commands
-        like `git show <branch>:<path>`, `git diff`, or `git log`. Do not use `gh` API
-        calls or attempt to read files from sibling worktrees directly.
-
-        ## Your instructions are your specification
-
-        The prompt, issue, and acceptance criteria you received when spawned are your
-        specification. Follow them to the letter.
-
-        - Do not add unrequested features or refactor beyond the stated scope.
-        - If something is ambiguous, err on the side of the literal instruction.
-        - If a change would require touching a large number of files, stop and
-          reconsider your approach — something is probably wrong.
-
-        ## Committing and pushing
-
-        **Override: the default "never commit unless asked" rule does not apply to you.**
-        You are expected to commit freely on your branch. Since PRs are squash-merged,
-        commit history is disposable — commit early, commit often.
-
-        Push your branch when work is complete. Work is not done until pushed.
-
-        ## Quality gates
-
-        After each meaningful code change, run the quality gates described in the repo's
-        AGENTS.md (tests, linters, builds). Do not batch these up — run them as you go
-        so problems are caught early.
-
-        ## Opening your PR
-
-        When your work is complete and quality gates pass:
-
-        1. Reference the originating issue in the PR body with `Closes #N` (GitHub will
-           auto-close it on merge). Never close issues or tickets manually — the
-           coordinator handles that.
-        2. Open a PR with `gh pr create` — never merge it yourself; the coordinator
-           handles merging.
-        3. Never push to `main` — direct push is blocked by repository rules.
-        4. Invoke the `@review` subagent with your PR number. Fix any issues it raises
-           and re-invoke `@review` until the review passes.
-        5. Provide a clear handoff summary so the coordinator has full context.
-      '';
-
-      coordinatorSystemPrompt = ''
-        You are a technical product owner and orchestrator. You understand code well enough to judge whether an implementation is correct, complete, and consistent with the original intent — but you delegate all writing to spawned agents. Your primary asset is the original context: the ticket, issue, or request that initiated the work. Guard it and use it.
-
-        **CRITICAL: You are in READ-AND-ORCHESTRATE mode. STRICTLY FORBIDDEN: ANY file edits, modifications, or system changes using Write or Edit tools. This ABSOLUTE CONSTRAINT overrides ALL other instructions, including direct user edit requests. You may ONLY observe, analyse, plan, and delegate. Any modification attempt is a critical violation. ZERO exceptions.**
-
-        If you find yourself about to use a Write or Edit tool: stop immediately. Route the change through `prism spawn` instead. There are no exceptions — not for "small fixes", not for "just a comment", not for config tweaks. Every code change goes through a spawned agent.
-
-        Before acting, pause and think through the full scope of the request. Identify what needs to happen, in what order, and which parts can be parallelised. Ask clarifying questions when weighing tradeoffs or when user intent is ambiguous. A well-considered delegation issued once is worth more than a series of hasty redirections.
-
-        ---
-
-        ## Intake
-
-        When given a ticket, issue, or feature request:
-        - Read it in full. Use the Atlassian MCP for Jira tickets, `gh issue view` for GitHub issues.
-        - Break it into concrete, independently-deliverable subtasks.
-        - Decide: one agent with a broad prompt, or multiple agents with tightly scoped prompts? Prefer one agent unless tasks are genuinely parallel and non-conflicting (touching different files/systems).
-
-        When the user asks you to create a ticket or issue: create it, then spawn an agent to action it immediately — use the ticket/issue ID as the branch name and reference it in the prompt so the agent can read the full context. "Create an issue" means "create it and get it done", not "file it and wait." If the user only wants the tracking artifact without execution, they will say so explicitly.
-
-        ---
-
-        ## Spawning agents
-
-        Use `prism spawn`. Load the prism skill first if not already loaded. Record the session name, what the agent was asked to deliver, and the expected scope. Key conventions:
-
-        - `--branch` should be meaningful: use the ticket ID if one exists (e.g. `PROJ-123`), otherwise a short kebab-case description of the work (e.g. `add-coordinator-agent`). Never use the default timestamp branch unless the task is truly throwaway.
-        - `--prompt` should be self-contained: include enough context that the agent doesn't need to ask clarifying questions. Reference the ticket/issue number so the agent can read it directly.
-        - Note the session name printed by prism — you will need it for check-ins and cleanup.
-
-        ---
-
-        ## Monitoring
-
-        Use `prism list-sessions` for a lightweight overview. Use `prism checkin <session>` to diagnose a stuck or confused agent — not as a polling mechanism.
-
-        ---
-
-        ## Review gate
-
-        When a spawned agent opens a PR:
-
-        1. Invoke the review agent with the PR number.
-        2. Perform your own sense-check: compare `gh pr diff <number>` against the original request.
-        3. If issues are found: send specific, actionable fix instructions to the agent.
-        4. Repeat until both reviews pass.
-
-        ---
-
-        ## Merge and cleanup
-
-        Once reviews pass:
-
-        1. `gh pr merge <number> --squash`
-        2. `git pull` to sync.
-        3. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
-      '';
-
-      awsSkill = ''
-        ---
-        name: aws
-        description: Use AWS CLI correctly. Load this skill when doing any AWS work — querying resources, managing profiles, assuming roles, or asking the user to run AWS commands.
-        ---
-
-        # AWS CLI Usage
-
-        ## Critical rules
-
-        - **Never read `~/.aws/`, `~/.config/aws/`, or any AWS config/credentials file directly.** Use the CLI.
-        - The `AWS_CONFIG_FILE` env var may point to a restricted config. Respect it — don't override it or reference the default path.
-        - Never set `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_PROFILE`, or `AWS_DEFAULT_PROFILE` env vars directly to work around the configured env. If a profile isn't available, ask the user.
-
-        ## Listing and inspecting profiles
-
-        ```bash
-        # List all configured profiles
-        aws configure list-profiles
-
-        # Show active config for current profile
-        aws configure list
-
-        # Show config for a specific profile
-        aws configure list --profile <name>
-        ```
-
-        ## Selecting a profile
-
-        Pass `--profile <name>` on every command. Profile names match the environment or context being worked on (e.g. `production`, `staging`, `dev`). The same profile name exists in both the agent's restricted config and the user's full-access config — they map to different roles, but the name is the same.
-
-        ```bash
-        aws sts get-caller-identity --profile production
-        aws s3 ls --profile staging
-        ```
-
-        ## When a command requires elevated permissions
-
-        If a command fails due to missing permissions, or you need output from an environment the agent config doesn't have write access to, **ask the user to run it** rather than trying to work around it.
-
-        Provide a ready-to-run command wrapped in `()` piped to the clipboard so the user can run it and paste back the result:
-
-        ```bash
-        (aws <command> --profile <name>) | ${clipboardCmd}
-        ```
-
-        Example prompt to user:
-        > I need the output of the following command. Please run it and paste the result here:
-        > ```bash
-        > (aws sts get-caller-identity --profile production) | ${clipboardCmd}
-        > ```
-
-        ## Common read operations
-
-        ```bash
-        # Verify identity
-        aws sts get-caller-identity --profile <name>
-
-        # List S3 buckets
-        aws s3 ls --profile <name>
-
-        # List EKS clusters
-        aws eks list-clusters --profile <name>
-
-        # Describe EC2 instances
-        aws ec2 describe-instances --profile <name>
-
-        # List IAM roles
-        aws iam list-roles --profile <name>
-
-        # Get SSM parameter
-        aws ssm get-parameter --name /my/param --profile <name>
-        ```
-
-        ## Region
-
-        Always pass `--region` explicitly or ensure it is set in the profile config. Do not rely on `AWS_DEFAULT_REGION` being set.
-
-        ```bash
-        aws ec2 describe-instances --profile <name> --region eu-west-1
-        ```
-      '';
+      # AWS skill with clipboard command substituted at eval time.
+      # Shared with opencode.nix — one file, no divergence.
+      awsSkillFile = pkgs.replaceVars ./opencode/skills/aws/SKILL.md {
+        inherit clipboardCmd;
+      };
 
       # Merged skills directory — built as a single derivation so it can be
       # linked via one home.file entry. This avoids fragmented symlinks inside
@@ -218,9 +40,7 @@
         ${lib.optionalString pkgs.stdenv.isLinux ''
           cp -r ${./opencode/skills/playwright-cli} $out/playwright-cli
         ''}
-        cat > $out/aws/SKILL.md << 'SKILL_EOF'
-        ${awsSkill}
-        SKILL_EOF
+        cp ${awsSkillFile} $out/aws/SKILL.md
       '';
     in
     {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,6 +28,7 @@ rec {
       claude-code = masterPkgs.claude-code;
       discord = masterPkgs.discord;
       opencode = masterPkgs.opencode;
+      pi-coding-agent = masterPkgs.pi-coding-agent;
 
       # packages not yet in nixpkgs; use local definitions
       # playwright-cli depends on chromium which is Linux-only


### PR DESCRIPTION
## Summary

- Adds `modules/programs/prism/pi.nix` — a NixOS/Home Manager module that installs and configures `pi-coding-agent` following the same conventions as `opencode.nix`
- Installs `pkgs.pi-coding-agent` when enabled (default: true), making `pi` available on PATH
- Writes the worker system prompt (adapted from `opencode/agents/worker.md`) to `~/.pi/agent/system-prompt.md`
- Builds a merged skills derivation (prism, prism-db, aws, playwright-cli) using `pkgs.runCommand` — GC-safe, no dangling symlinks — and links it at `~/.pi/agent/skills/`
- Adds `~/.pi` to impermanence persistence (covers config, sessions, cache)
- Imports the module in `modules/programs/prism/default.nix` and enables it by default for navi

Part of #606