### PR TITLE
fix: add fd dependency and enable tmux extended-keys for pi

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -45,7 +45,10 @@
     in
     {
       home-manager.users.${config.nx.username} = {
-        home.packages = [ pkgs.pi-coding-agent ];
+        home.packages = with pkgs; [
+          pi-coding-agent
+          fd
+        ];
 
         programs.zsh.shellAliases = {
           pi = "${envPrefix} pi";

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -43,6 +43,7 @@ in
             # tmux
             ''
               # appearance
+              set -g extended-keys on
               set -g status-interval 5
               set -g status-left-length 30
               set -g status-left " [#{session_name}] "


### PR DESCRIPTION
## Summary

- Add `pkgs.fd` to `home.packages` in `pi.nix` — fixes startup error from `fd` missing in PATH
- Add `set -g extended-keys on` to tmux `extraConfig` in `tmux.nix` — suppresses pi TUI warning about modified Enter keys

Part of #606