### PR TITLE
fix: set tmux extended-keys-format to csi-u for pi TUI

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -44,6 +44,7 @@ in
             ''
               # appearance
               set -g extended-keys on
+              set -g extended-keys-format csi-u
               set -g status-interval 5
               set -g status-left-length 30
               set -g status-left " [#{session_name}] "


### PR DESCRIPTION
## Summary

- Adds `set -g extended-keys-format csi-u` immediately after `set -g extended-keys on` in the tmux `extraConfig`
- This ensures tmux encodes extended keys using the CSI u format, which is required for correct key handling in TUI applications (e.g. pi/opencode)

Related to #606