### PR TITLE
fix: re-enable container_mode with AbandonProcessGroup launchd fix

### DIFF
--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -389,6 +389,11 @@ in
               # agent does not restart on failure — a broken VM should not create
               # a restart loop.
               RunAtLoad = true;
+              # AbandonProcessGroup allows the podman VM processes (vfkit,
+              # gvproxy) to survive after the startup script exits.  Without
+              # this, launchd kills the entire process group on job completion,
+              # tearing down the VM immediately after it starts.
+              AbandonProcessGroup = true;
               # Capture output for debugging; visible via:
               #   tail -f /tmp/podman-machine-start.log
               StandardOutPath = "/tmp/podman-machine-start.log";

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -40,8 +40,7 @@ let
     color_foreground = foreground;
     color_bg0 = bg0;
     kitty_bin = "${pkgs.kitty}/bin/kitty";
-    # Disabled pending container-mode fixes — see #595, #596, #597
-    container_mode = false;
+    container_mode = true;
     sidecar_plugin_path = "${
       config.home-manager.users.${config.nx.username}.xdg.configHome
     }/opencode/plugins/prism-hooks.ts";


### PR DESCRIPTION
## Summary

- Adds `AbandonProcessGroup = true` to the `podman-machine-start` LaunchAgent in `container-image.nix`, with a comment explaining why it is needed (prevents launchd from killing `vfkit`/`gvproxy` child processes when the startup script exits)
- Re-enables `container_mode = true` in `prism-tui.nix` and removes the disabling comment

## Quality gates

- `nixfmt`: both files pass with no changes
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`: ✅ exits 0
- `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel`: fails with pre-existing platform mismatch (`aarch64-darwin` required, running on `x86_64-linux`) — confirmed identical failure on unmodified `main`

Closes #595
Closes #597