### PR TITLE
container: mount hostapi socket parent dir instead of socket file

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -4,7 +4,8 @@ package cmd
 //
 // When PRISM_HOST_API is set, prism commands running inside a container
 // cannot reach tmux directly. Instead they POST their operation to the host
-// sidecar over the Unix socket that A-2 mounts at /var/run/prism-hostapi.sock.
+// sidecar over the Unix socket accessible inside the container at
+// /var/run/prism-host/<sockfilename> (the parent directory is bind-mounted by A-2).
 //
 // The host sidecar (A-1) listens on that socket and executes the real tmux
 // operations on the host side.
@@ -23,7 +24,7 @@ import (
 
 // proxyToHostAPI sends a request to the host-API Unix socket server and returns
 // the parsed response. apiURL is the value of PRISM_HOST_API
-// (e.g. "unix:///var/run/prism-hostapi.sock"). endpoint is the path
+// (e.g. "unix:///var/run/prism-host/nixos-config@main-hostapi.sock"). endpoint is the path
 // (e.g. "/spawn"). body is marshalled to JSON and sent as the request body.
 // On success, response JSON is unmarshalled into respDst (may be nil).
 func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -163,7 +163,7 @@ func TestParseUnixSocketURL_ValidAndInvalid(t *testing.T) {
 		wantErr bool
 		want    string
 	}{
-		{"unix:///var/run/prism-hostapi.sock", false, "/var/run/prism-hostapi.sock"},
+		{"unix:///var/run/prism-host/test-hostapi.sock", false, "/var/run/prism-host/test-hostapi.sock"},
 		{"unix:///tmp/foo.sock", false, "/tmp/foo.sock"},
 		{"http://localhost:1234", true, ""},
 		{"unix://", true, ""},

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -111,9 +111,9 @@ type Config struct {
 	WorktreeGitDir string
 
 	// HostAPISockPath is the absolute host path to the sidecar's host-API Unix socket.
-	// When non-empty, the socket is bind-mounted into the container at
-	// /var/run/prism-hostapi.sock and PRISM_HOST_API is set to
-	// unix:///var/run/prism-hostapi.sock so that prism CLI commands inside
+	// When non-empty, the socket's parent directory is bind-mounted into the container
+	// at /var/run/prism-host and PRISM_HOST_API is set to
+	// unix:///var/run/prism-host/<sockfilename> so that prism CLI commands inside
 	// the container can proxy tmux operations to the host sidecar.
 	HostAPISockPath string
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -601,8 +601,8 @@ func (m *Manager) buildRunArgs() []string {
 	// the nix-daemon socket mount already in use above).
 	if cfg.HostAPISockPath != "" {
 		args = append(args,
-			"--volume", cfg.HostAPISockPath+":/var/run/prism-hostapi.sock:Z",
-			"--env", "PRISM_HOST_API=unix:///var/run/prism-hostapi.sock",
+			"--volume", filepath.Dir(cfg.HostAPISockPath)+":/var/run/prism-host:Z",
+			"--env", "PRISM_HOST_API=unix:///var/run/prism-host/"+filepath.Base(cfg.HostAPISockPath),
 		)
 	}
 

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -496,7 +496,7 @@ func TestBuildRunArgs_NoGitMountsWhenBareRootEmpty(t *testing.T) {
 
 func TestBuildRunArgs_HostAPISockMountAndEnvWhenSet(t *testing.T) {
 	// AC-1, AC-2: when HostAPISockPath is non-empty, buildRunArgs must include
-	// the socket volume mount and the PRISM_HOST_API env var.
+	// the socket directory volume mount and the PRISM_HOST_API env var.
 	m := New(Config{
 		SessionName:     "repo@feat",
 		AllocatedPort:   14000,
@@ -504,12 +504,12 @@ func TestBuildRunArgs_HostAPISockMountAndEnvWhenSet(t *testing.T) {
 	})
 	args := m.buildRunArgs()
 
-	// AC-1: --volume <host-sock>:/var/run/prism-hostapi.sock:Z must be present.
+	// AC-1: --volume <host-dir>:/var/run/prism-host:Z must be present.
 	foundMount := false
 	for i, arg := range args {
 		if arg == "--volume" && i+1 < len(args) {
 			v := args[i+1]
-			if v == "/home/user/.local/state/prism/run/repo@feat-hostapi.sock:/var/run/prism-hostapi.sock:Z" {
+			if v == "/home/user/.local/state/prism/run:/var/run/prism-host:Z" {
 				foundMount = true
 				break
 			}
@@ -519,11 +519,11 @@ func TestBuildRunArgs_HostAPISockMountAndEnvWhenSet(t *testing.T) {
 		t.Errorf("host-API socket volume mount not found in args: %v", args)
 	}
 
-	// AC-2: --env PRISM_HOST_API=unix:///var/run/prism-hostapi.sock must be present.
+	// AC-2: --env PRISM_HOST_API=unix:///var/run/prism-host/<sockfilename> must be present.
 	foundEnv := false
 	for i, arg := range args {
 		if arg == "--env" && i+1 < len(args) {
-			if args[i+1] == "PRISM_HOST_API=unix:///var/run/prism-hostapi.sock" {
+			if args[i+1] == "PRISM_HOST_API=unix:///var/run/prism-host/repo@feat-hostapi.sock" {
 				foundEnv = true
 				break
 			}
@@ -535,7 +535,7 @@ func TestBuildRunArgs_HostAPISockMountAndEnvWhenSet(t *testing.T) {
 }
 
 func TestBuildRunArgs_HostAPISockVolumeBeforeEnv(t *testing.T) {
-	// AC-3: the --volume for the socket must appear before the --env PRISM_HOST_API.
+	// AC-3: the --volume for the socket directory must appear before the --env PRISM_HOST_API.
 	m := New(Config{
 		SessionName:     "repo@feat",
 		AllocatedPort:   14000,
@@ -547,11 +547,11 @@ func TestBuildRunArgs_HostAPISockVolumeBeforeEnv(t *testing.T) {
 	envIdx := -1
 	for i, arg := range args {
 		if arg == "--volume" && i+1 < len(args) &&
-			strings.Contains(args[i+1], "/var/run/prism-hostapi.sock") {
+			strings.Contains(args[i+1], "/var/run/prism-host") {
 			mountIdx = i
 		}
 		if arg == "--env" && i+1 < len(args) &&
-			args[i+1] == "PRISM_HOST_API=unix:///var/run/prism-hostapi.sock" {
+			args[i+1] == "PRISM_HOST_API=unix:///var/run/prism-host/test-hostapi.sock" {
 			envIdx = i
 		}
 	}
@@ -582,7 +582,7 @@ func TestBuildRunArgs_HostAPISockAfterPrismBareRoot(t *testing.T) {
 			bareRootIdx = i
 		}
 		if arg == "--volume" && i+1 < len(args) &&
-			strings.Contains(args[i+1], "/var/run/prism-hostapi.sock") {
+			strings.Contains(args[i+1], "/var/run/prism-host") {
 			hostAPIVolumeIdx = i
 		}
 	}
@@ -609,7 +609,7 @@ func TestBuildRunArgs_NoHostAPISockWhenEmpty(t *testing.T) {
 
 	for i, arg := range args {
 		if arg == "--volume" && i+1 < len(args) {
-			if strings.Contains(args[i+1], "prism-hostapi") {
+			if strings.Contains(args[i+1], "prism-host") {
 				t.Errorf("unexpected host-API socket mount when HostAPISockPath is empty: %q", args[i+1])
 			}
 		}

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -81,7 +81,8 @@ func SidecarPIDPath(sessionName string) (string, error) {
 }
 
 // SidecarHostAPIPath returns the Unix socket path for the session's host-API server.
-// The sidecar creates this socket and the container mounts it at /var/run/prism-hostapi.sock.
+// The sidecar creates this socket; the container mounts its parent directory at
+// /var/run/prism-host and accesses the socket at /var/run/prism-host/<sockfilename>.
 //
 // Socket path: $XDG_STATE_HOME/prism/run/<session>-hostapi.sock
 func SidecarHostAPIPath(sessionName string) (string, error) {


### PR DESCRIPTION
## Summary

- Fixes the chicken-and-egg ordering bug where `podman run` failed with `statfs ... no such file or directory` because the host-API socket file didn't exist at container creation time
- Instead of mounting the socket file directly, `buildRunArgs` now mounts its parent directory (`filepath.Dir(HostAPISockPath)`) at `/var/run/prism-host` inside the container
- The `PRISM_HOST_API` env var is updated to `unix:///var/run/prism-host/<sockfilename>` so the container can find the socket once it is created by the sidecar
- Updates four container tests to assert the new directory-mount format

Closes #611