### PR TITLE
container: add host-API proxy endpoints with role-based permissions

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -674,7 +674,7 @@ func renderProxiedCheckin(raw []byte, verbose bool) error {
 	inlineByMsgID := make(map[string][]inlineEvent)
 	for _, e := range resp.Events {
 		switch e.Type {
-		case "tool_call", "tool_result", "permission_ask", "permission_denied":
+		case "tool_call", "tool_result", "permission_ask", "permission_denied", "thinking":
 			msgID := extractMessageID(e.Payload)
 			if msgID != "" {
 				inlineByMsgID[msgID] = append(inlineByMsgID[msgID], inlineEvent{e.Type, e.Payload})
@@ -763,6 +763,13 @@ func renderProxiedCheckin(raw []byte, verbose bool) error {
 				continue
 			}
 			renderChildEvent("permission_denied", e.Payload, verbose, "")
+
+		case "thinking":
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" && assistantMsgIDs[msgID] {
+				continue
+			}
+			renderChildEvent("thinking", e.Payload, verbose, "")
 
 		default:
 			fmt.Printf("[%s] %s: %s\n", ts, e.Type, e.Payload)

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -95,6 +95,13 @@ func runCheckin(cmd *cobra.Command, args []string) error {
 // a secondary query keyed by messageId. msg_user events within the time window
 // of the fetched assistant turns are also included.
 func runCheckinSession(session string, limit int, before, after *string, types []string, verbose bool) error {
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		raw, err := proxyCheckin(apiURL, session, limit, before, after, types, verbose)
+		if err != nil {
+			return err
+		}
+		return renderProxiedCheckin(raw, verbose)
+	}
 	// When --types is explicitly set, use the old raw-event query path.
 	// The new assistant-turn-centric path only applies to the default view.
 	if len(types) > 0 {
@@ -620,6 +627,144 @@ func renderCheckinEventsRaw(session string, d *db.DB, events []db.Event, verbose
 
 		default:
 			// state_change, compaction, error, etc.
+			fmt.Printf("[%s] %s: %s\n", ts, e.Type, e.Payload)
+		}
+	}
+
+	fmt.Println("── end of event log ──")
+	return nil
+}
+
+// renderProxiedCheckin renders checkin output from the raw JSON returned by the
+// host-API /checkin endpoint. The JSON has the shape:
+//
+//	{"session":"<name>", "state":"<state>", "events":[...db.Event...]}
+//
+// It follows the same rendering logic as runCheckinSession but works from
+// pre-fetched events rather than the local DB.
+func renderProxiedCheckin(raw []byte, verbose bool) error {
+	var resp struct {
+		Session string     `json:"session"`
+		State   string     `json:"state"`
+		Events  []db.Event `json:"events"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("checkin proxy: unmarshal response: %w", err)
+	}
+
+	state := resp.State
+	if state == "" {
+		state = "idle"
+	}
+
+	fmt.Printf("checkin: %s\n\n", resp.Session)
+	fmt.Printf("state: %s\n\n", state)
+
+	if len(resp.Events) == 0 {
+		fmt.Println("── end of event log ──")
+		return nil
+	}
+
+	// Use the raw-event renderer for simplicity — the sidecar returns raw events.
+	// Build a map for inline children keyed by messageId.
+	type inlineEvent struct {
+		eventType string
+		payload   string
+	}
+	inlineByMsgID := make(map[string][]inlineEvent)
+	for _, e := range resp.Events {
+		switch e.Type {
+		case "tool_call", "tool_result", "permission_ask", "permission_denied":
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" {
+				inlineByMsgID[msgID] = append(inlineByMsgID[msgID], inlineEvent{e.Type, e.Payload})
+			}
+		}
+	}
+
+	assistantMsgIDs := make(map[string]bool)
+	for _, e := range resp.Events {
+		if e.Type == "msg_assistant" {
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" {
+				assistantMsgIDs[msgID] = true
+			}
+		}
+	}
+
+	for _, e := range resp.Events {
+		ts := e.CreatedAt.Local().Format("2006-01-02 15:04:05")
+
+		switch e.Type {
+		case "msg_user":
+			var up payload.MsgUser
+			if err := json.Unmarshal([]byte(e.Payload), &up); err != nil {
+				up.Text = e.Payload
+			}
+			text := up.Text
+			if text == "" {
+				text = "(no text)"
+			}
+			label := turnLabel(up.Agent, up.Model)
+			if label != "" {
+				fmt.Printf("[%s] user  [%s]\n%s\n\n", ts, label, text)
+			} else {
+				fmt.Printf("[%s] user\n%s\n\n", ts, text)
+			}
+
+		case "msg_assistant":
+			var ap payload.MsgAssistant
+			if err := json.Unmarshal([]byte(e.Payload), &ap); err != nil {
+				ap.Text = e.Payload
+			}
+			text := ap.Text
+			if text == "" {
+				text = "(no text)"
+			}
+			label := turnLabel(ap.Agent, ap.Model)
+			if label != "" {
+				fmt.Printf("[%s] assistant  [%s]\n%s\n", ts, label, text)
+			} else {
+				fmt.Printf("[%s] assistant\n%s\n", ts, text)
+			}
+
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" {
+				for _, ie := range inlineByMsgID[msgID] {
+					renderChildEvent(ie.eventType, ie.payload, verbose, "")
+				}
+			}
+			fmt.Println()
+
+		case "tool_call":
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" && assistantMsgIDs[msgID] {
+				continue
+			}
+			renderChildEvent("tool_call", e.Payload, verbose, "")
+
+		case "tool_result":
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" && assistantMsgIDs[msgID] {
+				continue
+			}
+			renderChildEvent("tool_result", e.Payload, verbose, "")
+
+		case "permission_ask":
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" && assistantMsgIDs[msgID] {
+				continue
+			}
+			renderChildEvent("permission_ask", e.Payload, verbose, "")
+
+		case "permission_denied":
+			msgID := extractMessageID(e.Payload)
+			if msgID != "" && assistantMsgIDs[msgID] {
+				continue
+			}
+			renderChildEvent("permission_denied", e.Payload, verbose, "")
+
+		default:
 			fmt.Printf("[%s] %s: %s\n", ts, e.Type, e.Payload)
 		}
 	}

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -44,8 +44,12 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 // openCheckinTestDB opens a temp DB and registers t.Cleanup to close it.
+// It also unsets PRISM_HOST_API for the duration of the test so that
+// runCheckinSession and renderCheckinTurns use the local DB path, not the proxy.
 func openCheckinTestDB(t *testing.T) *db.DB {
 	t.Helper()
+	// Ensure the host-API proxy is not active for these unit tests.
+	t.Setenv("PRISM_HOST_API", "")
 	path := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(path)
 	if err != nil {

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -18,22 +18,16 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
 
-// proxyToHostAPI sends a request to the host-API Unix socket server and returns
-// the parsed response. apiURL is the value of PRISM_HOST_API
-// (e.g. "unix:///var/run/prism-host/nixos-config@main-hostapi.sock"). endpoint is the path
-// (e.g. "/spawn"). body is marshalled to JSON and sent as the request body.
-// On success, response JSON is unmarshalled into respDst (may be nil).
-func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
-	sockPath, err := parseUnixSocketURL(apiURL)
-	if err != nil {
-		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
-	}
-
-	client := &http.Client{
+// newHostAPIClient returns an *http.Client that dials sockPath over a Unix
+// socket. Both proxyToHostAPI and proxyGetFromHostAPI share this client to
+// avoid duplicating the transport configuration.
+func newHostAPIClient(sockPath string) *http.Client {
+	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				d := &net.Dialer{Timeout: 5 * time.Second}
@@ -46,6 +40,49 @@ func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
 		},
 		Timeout: 60 * time.Second,
 	}
+}
+
+// readHostAPIResponse reads the response body and returns an error if the
+// status code is >= 400, surfacing the JSON "error" field when present.
+// On success (status < 400), it unmarshals into respDst when non-nil.
+func readHostAPIResponse(endpoint string, resp *http.Response, respDst any) error {
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("host-API %s: read response: %w", endpoint, err)
+	}
+
+	if resp.StatusCode >= 400 {
+		// Try to extract an "error" field from the JSON response.
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil && errResp.Error != "" {
+			return fmt.Errorf("host-API %s: %s", endpoint, errResp.Error)
+		}
+		return fmt.Errorf("host-API %s: HTTP %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	if respDst != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, respDst); err != nil {
+			return fmt.Errorf("host-API %s: unmarshal response: %w", endpoint, err)
+		}
+	}
+	return nil
+}
+
+// proxyToHostAPI sends a request to the host-API Unix socket server and returns
+// the parsed response. apiURL is the value of PRISM_HOST_API
+// (e.g. "unix:///var/run/prism-host/nixos-config@main-hostapi.sock"). endpoint is the path
+// (e.g. "/spawn"). body is marshalled to JSON and sent as the request body.
+// On success, response JSON is unmarshalled into respDst (may be nil).
+func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
+	sockPath, err := parseUnixSocketURL(apiURL)
+	if err != nil {
+		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
+	}
+
+	client := newHostAPIClient(sockPath)
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -64,73 +101,33 @@ func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("proxyToHostAPI: read response: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		// Try to extract an "error" field from the JSON response.
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil && errResp.Error != "" {
-			return fmt.Errorf("host-API %s: %s", endpoint, errResp.Error)
-		}
-		return fmt.Errorf("host-API %s: HTTP %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
-	}
-
-	if respDst != nil && len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, respDst); err != nil {
-			return fmt.Errorf("proxyToHostAPI: unmarshal response: %w", err)
-		}
-	}
-
-	return nil
+	return readHostAPIResponse(endpoint, resp, respDst)
 }
 
 // proxyGetFromHostAPI sends a GET request to the host-API Unix socket server
 // with optional query parameters and returns the parsed response. apiURL is the
 // value of PRISM_HOST_API. endpoint is the path (e.g. "/list-sessions").
-// params are appended as URL query parameters. On success, response JSON is
-// unmarshalled into respDst (may be nil).
+// params are appended as properly-encoded URL query parameters. On success,
+// response JSON is unmarshalled into respDst (may be nil).
 func proxyGetFromHostAPI(apiURL, endpoint string, params map[string]string, respDst any) error {
 	sockPath, err := parseUnixSocketURL(apiURL)
 	if err != nil {
 		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
 	}
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				d := &net.Dialer{Timeout: 5 * time.Second}
-				conn, dialErr := d.DialContext(ctx, "unix", sockPath)
-				if dialErr != nil {
-					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
-				}
-				return conn, nil
-			},
-		},
-		Timeout: 60 * time.Second,
-	}
+	client := newHostAPIClient(sockPath)
 
-	// Build URL with query parameters.
+	// Build URL with properly percent-encoded query parameters.
 	rawURL := "http://prism-hostapi" + endpoint
 	if len(params) > 0 {
-		first := true
+		q := url.Values{}
 		for k, v := range params {
-			if v == "" {
-				continue
+			if v != "" {
+				q.Set(k, v)
 			}
-			if first {
-				rawURL += "?"
-				first = false
-			} else {
-				rawURL += "&"
-			}
-			rawURL += k + "=" + v
+		}
+		if len(q) > 0 {
+			rawURL += "?" + q.Encode()
 		}
 	}
 
@@ -143,31 +140,7 @@ func proxyGetFromHostAPI(apiURL, endpoint string, params map[string]string, resp
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("proxyGetFromHostAPI: read response: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		// Try to extract an "error" field from the JSON response.
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil && errResp.Error != "" {
-			return fmt.Errorf("host-API %s: %s", endpoint, errResp.Error)
-		}
-		return fmt.Errorf("host-API %s: HTTP %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
-	}
-
-	if respDst != nil && len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, respDst); err != nil {
-			return fmt.Errorf("proxyGetFromHostAPI: unmarshal response: %w", err)
-		}
-	}
-
-	return nil
+	return readHostAPIResponse(endpoint, resp, respDst)
 }
 
 // proxyListSessions proxies a list-sessions request to the host-API sidecar.

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -91,6 +91,134 @@ func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
 	return nil
 }
 
+// proxyGetFromHostAPI sends a GET request to the host-API Unix socket server
+// with optional query parameters and returns the parsed response. apiURL is the
+// value of PRISM_HOST_API. endpoint is the path (e.g. "/list-sessions").
+// params are appended as URL query parameters. On success, response JSON is
+// unmarshalled into respDst (may be nil).
+func proxyGetFromHostAPI(apiURL, endpoint string, params map[string]string, respDst any) error {
+	sockPath, err := parseUnixSocketURL(apiURL)
+	if err != nil {
+		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				d := &net.Dialer{Timeout: 5 * time.Second}
+				conn, dialErr := d.DialContext(ctx, "unix", sockPath)
+				if dialErr != nil {
+					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
+				}
+				return conn, nil
+			},
+		},
+		Timeout: 60 * time.Second,
+	}
+
+	// Build URL with query parameters.
+	rawURL := "http://prism-hostapi" + endpoint
+	if len(params) > 0 {
+		first := true
+		for k, v := range params {
+			if v == "" {
+				continue
+			}
+			if first {
+				rawURL += "?"
+				first = false
+			} else {
+				rawURL += "&"
+			}
+			rawURL += k + "=" + v
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("proxyGetFromHostAPI: build request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("proxyGetFromHostAPI: read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		// Try to extract an "error" field from the JSON response.
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil && errResp.Error != "" {
+			return fmt.Errorf("host-API %s: %s", endpoint, errResp.Error)
+		}
+		return fmt.Errorf("host-API %s: HTTP %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	if respDst != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, respDst); err != nil {
+			return fmt.Errorf("proxyGetFromHostAPI: unmarshal response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// proxyListSessions proxies a list-sessions request to the host-API sidecar.
+// apiURL is the value of PRISM_HOST_API. showAll controls whether the all=true
+// query parameter is sent. Returns the raw JSON output for the caller to render.
+func proxyListSessions(apiURL string, showAll bool) ([]byte, error) {
+	params := map[string]string{}
+	if showAll {
+		params["all"] = "true"
+	}
+	var raw json.RawMessage
+	if err := proxyGetFromHostAPI(apiURL, "/list-sessions", params, &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// proxyCheckin proxies a checkin request to the host-API sidecar.
+// apiURL is the value of PRISM_HOST_API. Returns a struct with the session
+// state and raw events JSON.
+func proxyCheckin(apiURL, session string, limit int, before, after *string, types []string, _ bool) ([]byte, error) {
+	params := map[string]string{
+		"session": session,
+		"last":    fmt.Sprintf("%d", limit),
+	}
+	if before != nil {
+		params["before"] = *before
+	}
+	if after != nil {
+		params["from"] = *after
+	}
+	if len(types) > 0 {
+		params["types"] = strings.Join(types, ",")
+	}
+	var raw json.RawMessage
+	if err := proxyGetFromHostAPI(apiURL, "/checkin", params, &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// proxyPrompt proxies a prompt delivery request to the host-API sidecar.
+// apiURL is the value of PRISM_HOST_API.
+func proxyPrompt(apiURL, session, prompt string, urgent bool) error {
+	return proxyToHostAPI(apiURL, "/prompt", map[string]any{
+		"session": session,
+		"prompt":  prompt,
+		"urgent":  urgent,
+	}, nil)
+}
+
 // parseUnixSocketURL extracts the filesystem path from a unix:///path URL.
 // Returns an error for malformed values (not starting with "unix://").
 func parseUnixSocketURL(apiURL string) (string, error) {

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -416,3 +416,200 @@ func TestProxyToHostAPI_NotCalledWhenEnvUnset(t *testing.T) {
 
 	_ = srv // keep compiler happy
 }
+
+// ── proxyGetFromHostAPI unit tests ────────────────────────────────────────────
+
+// TestProxyGetFromHostAPI_SendsGETWithQueryParams verifies that
+// proxyGetFromHostAPI sends a GET request with the correct query parameters.
+func TestProxyGetFromHostAPI_SendsGETWithQueryParams(t *testing.T) {
+	var capturedMethod string
+	var capturedPath string
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	var got []any
+	err := proxyGetFromHostAPI(srv.apiURL(), "/list-sessions",
+		map[string]string{"all": "true"}, &got)
+	if err != nil {
+		t.Fatalf("proxyGetFromHostAPI: %v", err)
+	}
+
+	if capturedMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", capturedMethod)
+	}
+	if capturedPath != "/list-sessions" {
+		t.Errorf("path = %q, want /list-sessions", capturedPath)
+	}
+	if capturedQuery != "all=true" {
+		t.Errorf("query = %q, want all=true", capturedQuery)
+	}
+}
+
+// TestProxyGetFromHostAPI_Returns403AsError verifies that a 403 response from
+// the server is surfaced as an error with the error message.
+func TestProxyGetFromHostAPI_Returns403AsError(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"workers cannot list sessions across all repos"}`))
+	})
+
+	err := proxyGetFromHostAPI(srv.apiURL(), "/list-sessions",
+		map[string]string{"all": "true"}, nil)
+	if err == nil {
+		t.Fatal("expected non-nil error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "workers cannot list") {
+		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}
+
+// ── proxyListSessions unit tests ──────────────────────────────────────────────
+
+// TestProxyListSessions_SendsGetRequest verifies that proxyListSessions sends
+// a GET /list-sessions request (no all param by default).
+func TestProxyListSessions_SendsGetRequest(t *testing.T) {
+	var capturedPath string
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"SessionName":"myrepo@main","State":"active"}]`))
+	})
+
+	raw, err := proxyListSessions(srv.apiURL(), false)
+	if err != nil {
+		t.Fatalf("proxyListSessions: %v", err)
+	}
+	if capturedPath != "/list-sessions" {
+		t.Errorf("path = %q, want /list-sessions", capturedPath)
+	}
+	if capturedQuery != "" {
+		t.Errorf("query = %q, want empty (all=false)", capturedQuery)
+	}
+	if len(raw) == 0 {
+		t.Error("expected non-empty raw response")
+	}
+}
+
+// TestProxyListSessions_SendsAllParam verifies that showAll=true adds all=true.
+func TestProxyListSessions_SendsAllParam(t *testing.T) {
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	_, err := proxyListSessions(srv.apiURL(), true)
+	if err != nil {
+		t.Fatalf("proxyListSessions: %v", err)
+	}
+	if capturedQuery != "all=true" {
+		t.Errorf("query = %q, want all=true", capturedQuery)
+	}
+}
+
+// ── proxyCheckin unit tests ───────────────────────────────────────────────────
+
+// TestProxyCheckin_SendsCorrectQueryParams verifies that proxyCheckin sends the
+// correct GET /checkin request with session and last params.
+func TestProxyCheckin_SendsCorrectQueryParams(t *testing.T) {
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session":"myrepo@main","state":"active","events":[]}`))
+	})
+
+	raw, err := proxyCheckin(srv.apiURL(), "myrepo@main", 5, nil, nil, nil, false)
+	if err != nil {
+		t.Fatalf("proxyCheckin: %v", err)
+	}
+	if !strings.Contains(capturedQuery, "session=myrepo%40main") &&
+		!strings.Contains(capturedQuery, "session=myrepo@main") {
+		t.Errorf("query %q does not contain session param", capturedQuery)
+	}
+	if !strings.Contains(capturedQuery, "last=5") {
+		t.Errorf("query %q does not contain last=5", capturedQuery)
+	}
+	if len(raw) == 0 {
+		t.Error("expected non-empty raw response")
+	}
+}
+
+// ── proxyPrompt unit tests ────────────────────────────────────────────────────
+
+// TestProxyPrompt_SendsCorrectPayload verifies that proxyPrompt POSTs to
+// /prompt with the correct JSON body.
+func TestProxyPrompt_SendsCorrectPayload(t *testing.T) {
+	type promptReq struct {
+		Session string `json:"session"`
+		Prompt  string `json:"prompt"`
+		Urgent  bool   `json:"urgent"`
+	}
+
+	reqCh := make(chan promptReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/prompt" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req promptReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	if err := proxyPrompt(srv.apiURL(), "myrepo@main", "do the thing", false); err != nil {
+		t.Fatalf("proxyPrompt: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Session != "myrepo@main" {
+			t.Errorf("session = %q, want myrepo@main", req.Session)
+		}
+		if req.Prompt != "do the thing" {
+			t.Errorf("prompt = %q, want 'do the thing'", req.Prompt)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// TestProxyPrompt_Returns403AsError verifies that a 403 from the server
+// (e.g. worker trying wrong target) is surfaced as an error.
+func TestProxyPrompt_Returns403AsError(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"workers can only prompt their own coordinator"}`))
+	})
+
+	err := proxyPrompt(srv.apiURL(), "otherrepo@main", "hello", false)
+	if err == nil {
+		t.Fatal("expected non-nil error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "workers can only prompt") {
+		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -541,9 +541,9 @@ func TestProxyCheckin_SendsCorrectQueryParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxyCheckin: %v", err)
 	}
-	if !strings.Contains(capturedQuery, "session=myrepo%40main") &&
-		!strings.Contains(capturedQuery, "session=myrepo@main") {
-		t.Errorf("query %q does not contain session param", capturedQuery)
+	// url.Values.Encode() percent-encodes the "@" as "%40".
+	if !strings.Contains(capturedQuery, "session=myrepo%40main") {
+		t.Errorf("query %q does not contain properly encoded session param (want session=myrepo%%40main)", capturedQuery)
 	}
 	if !strings.Contains(capturedQuery, "last=5") {
 		t.Errorf("query %q does not contain last=5", capturedQuery)

--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -55,13 +55,6 @@ var listSessionsCmd = &cobra.Command{
 		}
 		defer d.Close()
 
-		type row struct {
-			name  string
-			state string
-			port  string
-			title string
-		}
-
 		var ss []db.Status
 		if showAll {
 			ss, err = d.AllActiveStatus()
@@ -72,66 +65,7 @@ var listSessionsCmd = &cobra.Command{
 			return fmt.Errorf("list-sessions: query db: %w", err)
 		}
 
-		var rows []row
-		for _, s := range ss {
-			title := "—"
-			if s.Title != nil && *s.Title != "" {
-				title = *s.Title
-			}
-			port := ""
-			if s.OpencodePort != nil {
-				port = fmt.Sprintf("%d", *s.OpencodePort)
-			}
-			rows = append(rows, row{name: s.SessionName, state: s.State, port: port, title: title})
-		}
-
-		// Sort rows alphabetically by session name for stable, predictable output.
-		for i := 1; i < len(rows); i++ {
-			key := rows[i]
-			j := i - 1
-			for j >= 0 && rows[j].name > key.name {
-				rows[j+1] = rows[j]
-				j--
-			}
-			rows[j+1] = key
-		}
-
-		if len(rows) == 0 {
-			fmt.Println("no agent sessions found")
-			return nil
-		}
-
-		styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
-		styleName := lipgloss.NewStyle().Bold(true)
-		styleTitle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
-
-		fmt.Println(styleHeader.Render(fmt.Sprintf("%-40s  %-8s  %-6s  %s", "SESSION", "STATE", "PORT", "TITLE")))
-		for _, r := range rows {
-			state := r.state
-			if state == "" {
-				state = string(agent.StateIdle)
-			}
-			title := r.title
-			if runes := []rune(title); len(runes) > 60 {
-				title = string(runes[:57]) + "..."
-			}
-			// Colour the state field.
-			stateStyled := stateStyle(state).Render(fmt.Sprintf("%-8s", state))
-
-			// Only bold worktree sessions (project@branch).
-			nameStyle := styleTitle
-			if strings.Contains(r.name, "@") {
-				nameStyle = styleName
-			}
-
-			fmt.Printf("%s  %s  %s  %s\n",
-				nameStyle.Render(fmt.Sprintf("%-40s", r.name)),
-				stateStyled,
-				styleTitle.Render(fmt.Sprintf("%-6s", r.port)),
-				styleTitle.Render(title),
-			)
-		}
-		return nil
+		return renderSessionTable(ss)
 	},
 }
 
@@ -140,19 +74,10 @@ func init() {
 	rootCmd.AddCommand(listSessionsCmd)
 }
 
-// proxyListSessionsAndRender proxies a list-sessions request to the host-API
-// sidecar and renders the result as a session table.
-func proxyListSessionsAndRender(apiURL string, showAll bool) error {
-	raw, err := proxyListSessions(apiURL, showAll)
-	if err != nil {
-		return err
-	}
-
-	var ss []db.Status
-	if err := json.Unmarshal(raw, &ss); err != nil {
-		return fmt.Errorf("list-sessions proxy: unmarshal response: %w", err)
-	}
-
+// renderSessionTable renders a []db.Status as a sorted SESSION/STATE/PORT/TITLE
+// table to stdout. Both the direct DB path and the host-API proxy path use
+// this shared renderer.
+func renderSessionTable(ss []db.Status) error {
 	type row struct {
 		name  string
 		state string
@@ -203,11 +128,15 @@ func proxyListSessionsAndRender(apiURL string, showAll bool) error {
 		if runes := []rune(title); len(runes) > 60 {
 			title = string(runes[:57]) + "..."
 		}
+		// Colour the state field.
 		stateStyled := stateStyle(state).Render(fmt.Sprintf("%-8s", state))
+
+		// Only bold worktree sessions (project@branch).
 		nameStyle := styleTitle
 		if strings.Contains(r.name, "@") {
 			nameStyle = styleName
 		}
+
 		fmt.Printf("%s  %s  %s  %s\n",
 			nameStyle.Render(fmt.Sprintf("%-40s", r.name)),
 			stateStyled,
@@ -216,4 +145,20 @@ func proxyListSessionsAndRender(apiURL string, showAll bool) error {
 		)
 	}
 	return nil
+}
+
+// proxyListSessionsAndRender proxies a list-sessions request to the host-API
+// sidecar and renders the result as a session table.
+func proxyListSessionsAndRender(apiURL string, showAll bool) error {
+	raw, err := proxyListSessions(apiURL, showAll)
+	if err != nil {
+		return err
+	}
+
+	var ss []db.Status
+	if err := json.Unmarshal(raw, &ss); err != nil {
+		return fmt.Errorf("list-sessions proxy: unmarshal response: %w", err)
+	}
+
+	return renderSessionTable(ss)
 }

--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -5,6 +5,7 @@ package cmd
 // to list sessions across all repos.
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -21,6 +22,10 @@ var listSessionsCmd = &cobra.Command{
 	Short: "List agent sessions with their state and title",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		showAll, _ := cmd.Flags().GetBool("all")
+
+		if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+			return proxyListSessionsAndRender(apiURL, showAll)
+		}
 
 		// Derive currentRepo from the working directory using the same
 		// normalisation as deriveRepo() so the filter matches the repo column
@@ -133,4 +138,82 @@ var listSessionsCmd = &cobra.Command{
 func init() {
 	listSessionsCmd.Flags().BoolP("all", "A", false, "List all sessions across all repos")
 	rootCmd.AddCommand(listSessionsCmd)
+}
+
+// proxyListSessionsAndRender proxies a list-sessions request to the host-API
+// sidecar and renders the result as a session table.
+func proxyListSessionsAndRender(apiURL string, showAll bool) error {
+	raw, err := proxyListSessions(apiURL, showAll)
+	if err != nil {
+		return err
+	}
+
+	var ss []db.Status
+	if err := json.Unmarshal(raw, &ss); err != nil {
+		return fmt.Errorf("list-sessions proxy: unmarshal response: %w", err)
+	}
+
+	type row struct {
+		name  string
+		state string
+		port  string
+		title string
+	}
+
+	var rows []row
+	for _, s := range ss {
+		title := "—"
+		if s.Title != nil && *s.Title != "" {
+			title = *s.Title
+		}
+		port := ""
+		if s.OpencodePort != nil {
+			port = fmt.Sprintf("%d", *s.OpencodePort)
+		}
+		rows = append(rows, row{name: s.SessionName, state: s.State, port: port, title: title})
+	}
+
+	// Sort rows alphabetically by session name for stable, predictable output.
+	for i := 1; i < len(rows); i++ {
+		key := rows[i]
+		j := i - 1
+		for j >= 0 && rows[j].name > key.name {
+			rows[j+1] = rows[j]
+			j--
+		}
+		rows[j+1] = key
+	}
+
+	if len(rows) == 0 {
+		fmt.Println("no agent sessions found")
+		return nil
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleName := lipgloss.NewStyle().Bold(true)
+	styleTitle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	fmt.Println(styleHeader.Render(fmt.Sprintf("%-40s  %-8s  %-6s  %s", "SESSION", "STATE", "PORT", "TITLE")))
+	for _, r := range rows {
+		state := r.state
+		if state == "" {
+			state = string(agent.StateIdle)
+		}
+		title := r.title
+		if runes := []rune(title); len(runes) > 60 {
+			title = string(runes[:57]) + "..."
+		}
+		stateStyled := stateStyle(state).Render(fmt.Sprintf("%-8s", state))
+		nameStyle := styleTitle
+		if strings.Contains(r.name, "@") {
+			nameStyle = styleName
+		}
+		fmt.Printf("%s  %s  %s  %s\n",
+			nameStyle.Render(fmt.Sprintf("%-40s", r.name)),
+			stateStyled,
+			styleTitle.Render(fmt.Sprintf("%-6s", r.port)),
+			styleTitle.Render(title),
+		)
+	}
+	return nil
 }

--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -62,7 +62,12 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	}
 
 	// --urgent is accepted but ignored (HTTP delivery is instant).
-	_ = cmd.Flags().Lookup("urgent")
+	urgentFlag, _ := cmd.Flags().GetBool("urgent")
+	_ = urgentFlag
+
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return proxyPrompt(apiURL, sessionName, promptText, urgentFlag)
+	}
 
 	// Open DB.
 	database, err := openDB()

--- a/modules/programs/prism/prism/cmd/prompt_test.go
+++ b/modules/programs/prism/prism/cmd/prompt_test.go
@@ -14,9 +14,12 @@ import (
 )
 
 // openPromptTestDB opens a temp DB, registers cleanup, and overrides the
-// package-level testDBPath so openDB() uses it.
+// package-level testDBPath so openDB() uses it. It also unsets PRISM_HOST_API
+// so runPrompt uses the local DB path, not the host-API proxy.
 func openPromptTestDB(t *testing.T) *db.DB {
 	t.Helper()
+	// Ensure the host-API proxy is not active for these unit tests.
+	t.Setenv("PRISM_HOST_API", "")
 	path := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(path)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -114,6 +114,10 @@ type Config struct {
 	// container readiness. This is the mechanism for prompt delivery in container
 	// mode, where the TUI runs "opencode attach" and cannot accept --prompt (#487).
 	InitialPrompt string
+	// PrismBinaryPath, when non-empty, overrides the path to the prism binary
+	// used by the host-API handler to delegate operations (/spawn, /cleanup,
+	// /prompt). Used in tests to inject a stub binary.
+	PrismBinaryPath string
 }
 
 // Sidecar is the core event processor. It consumes SSE events from the
@@ -1461,14 +1465,52 @@ func marshalTruncated(v any, maxLen int) string {
 
 // ── host-API handler ─────────────────────────────────────────────────────────
 
+// parseInt parses a decimal integer from s. Returns an error for non-numeric
+// or empty strings.
+func parseInt(s string) (int, error) {
+	n := 0
+	if len(s) == 0 {
+		return 0, fmt.Errorf("empty string")
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("non-numeric character %q", c)
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
+}
+
+// repoFromSession extracts the repo prefix from a session name (e.g.
+// "nixos-config" from "nixos-config@main"). Returns an error when the session
+// name contains no "@" — this indicates a misconfigured or non-worktree session.
+func repoFromSession(sessionName string) (string, error) {
+	idx := strings.Index(sessionName, "@")
+	if idx < 0 {
+		return "", fmt.Errorf("session name %q contains no '@' — cannot derive repo", sessionName)
+	}
+	return sessionName[:idx], nil
+}
+
+// isCoordinator returns true when the session name ends with "@main", which is
+// the convention for coordinator sessions in the prism model.
+func isCoordinator(sessionName string) bool {
+	return strings.HasSuffix(sessionName, "@main")
+}
+
 // hostAPIHandler returns an http.Handler that exposes host-side tmux operations
 // to agents running inside the container via a Unix socket. Routes:
 //
-//	POST /spawn   — spawn a new worktree session
-//	POST /cleanup — clean up an existing session
-//	POST /switch  — switch the tmux client to a session
+//	POST /spawn        — spawn a new worktree session
+//	POST /cleanup      — clean up an existing session
+//	POST /switch       — switch the tmux client to a session
+//	GET  /list-sessions — list active sessions (role-scoped)
+//	GET  /checkin      — return conversation history for a session (coordinator only)
+//	POST /prompt       — deliver a prompt to a target session (role-scoped)
 //
-// AC-11: returns HTTP 400 for malformed JSON, HTTP 405 for non-POST methods.
+// Role-based permissions are enforced based on s.cfg.AgentRole and
+// s.cfg.SessionName. Workers have restricted access; coordinators have broader
+// access. All denied requests return HTTP 403 with a structured JSON error.
 func (s *Sidecar) hostAPIHandler() http.Handler {
 	mux := http.NewServeMux()
 
@@ -1499,10 +1541,35 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		return true
 	}
 
+	// requireGet writes a 405 and returns false if the method is not GET.
+	// Returns true when the method is GET (caller should proceed).
+	requireGet := func(w http.ResponseWriter, r *http.Request) bool {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return false
+		}
+		return true
+	}
+
+	// requireCoordinator checks that the calling sidecar's AgentRole is
+	// "coordinator". Returns false and writes HTTP 403 if not.
+	requireCoordinator := func(w http.ResponseWriter, operation string) bool {
+		if s.cfg.AgentRole != "coordinator" {
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("workers cannot perform %s", operation))
+			return false
+		}
+		return true
+	}
+
 	// prismBinary returns the path to the prism binary (this process).
 	// Uses os.Executable() — consistent with StartSidecarWithOpts — to get
 	// the absolute path at binary launch time, avoiding CWD-relative resolution.
+	// When Config.PrismBinaryPath is set (e.g. in tests), it is used instead.
 	prismBinary := func() string {
+		if s.cfg.PrismBinaryPath != "" {
+			return s.cfg.PrismBinaryPath
+		}
 		self, err := os.Executable()
 		if err != nil {
 			return os.Args[0]
@@ -1510,11 +1577,216 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		return self
 	}
 
+	// GET /list-sessions
+	// Query param: all=true (optional, coordinator only)
+	// Response: JSON array of session status objects
+	mux.HandleFunc("/list-sessions", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+
+		showAll := r.URL.Query().Get("all") == "true"
+
+		// Workers cannot use all=true.
+		if showAll && s.cfg.AgentRole != "coordinator" {
+			writeError(w, http.StatusForbidden, "workers cannot list sessions across all repos (all=true requires coordinator role)")
+			return
+		}
+
+		var (
+			sessions []db.Status
+			err      error
+		)
+		if showAll {
+			sessions, err = s.cfg.DB.AllActiveStatus()
+		} else {
+			// Scope to own repo by default.
+			ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+			if repoErr != nil {
+				writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+				return
+			}
+			sessions, err = s.cfg.DB.AllActiveStatusForRepo(ownRepo)
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+			return
+		}
+
+		// Return empty array rather than null when no sessions found.
+		if sessions == nil {
+			sessions = []db.Status{}
+		}
+		writeJSON(w, http.StatusOK, sessions)
+	})
+
+	// GET /checkin
+	// Query params: session (required), last (default 10), types (optional),
+	//               from (optional cursor), before (optional cursor)
+	// Permission: coordinator only; own repo sessions or cross-repo @main sessions.
+	mux.HandleFunc("/checkin", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "checkin") {
+			return
+		}
+
+		q := r.URL.Query()
+		targetSession := q.Get("session")
+		if targetSession == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+
+		// Permission check: coordinator can access own-repo sessions and
+		// any cross-repo coordinator (@main) session.
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		if repoErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+			return
+		}
+		targetRepo, targetRepoErr := repoFromSession(targetSession)
+		if targetRepoErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			return
+		}
+		crossRepo := targetRepo != ownRepo
+		if crossRepo && !isCoordinator(targetSession) {
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("cross-repo checkin can only target coordinators (<repo>@main), got %q", targetSession))
+			return
+		}
+
+		// Parse limit (default 10).
+		limit := 10
+		if lastStr := q.Get("last"); lastStr != "" {
+			if n, parseErr := parseInt(lastStr); parseErr == nil && n > 0 {
+				limit = n
+			}
+		}
+
+		// Parse optional cursor params.
+		var afterPtr, beforePtr *string
+		if fromStr := q.Get("from"); fromStr != "" {
+			afterPtr = &fromStr
+		}
+		if beforeStr := q.Get("before"); beforeStr != "" {
+			beforePtr = &beforeStr
+		}
+
+		// Parse optional types filter.
+		var types []string
+		if typesStr := q.Get("types"); typesStr != "" {
+			for _, t := range strings.Split(typesStr, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					types = append(types, t)
+				}
+			}
+		}
+
+		// Fetch events.
+		events, err := s.cfg.DB.QueryEvents(targetSession, limit, beforePtr, afterPtr, types)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+			return
+		}
+
+		// Fetch session state.
+		status, statusErr := s.cfg.DB.CurrentStatus(targetSession)
+		var state string
+		if statusErr == nil && status != nil {
+			state = status.State
+		}
+
+		// Ensure empty arrays rather than null.
+		if events == nil {
+			events = []db.Event{}
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"session": targetSession,
+			"state":   state,
+			"events":  events,
+		})
+	})
+
+	// POST /prompt
+	// Request:  {"session":"<target>", "prompt":"<text>", "urgent": false}
+	// Permission: worker → own coordinator (@main) only;
+	//             coordinator → own repo any session, cross-repo coordinator only.
+	mux.HandleFunc("/prompt", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+
+		var req struct {
+			Session string `json:"session"`
+			Prompt  string `json:"prompt"`
+			Urgent  bool   `json:"urgent"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Session == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		if repoErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+			return
+		}
+
+		targetRepo, targetRepoErr := repoFromSession(req.Session)
+		if targetRepoErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			return
+		}
+		crossRepo := targetRepo != ownRepo
+
+		if s.cfg.AgentRole == "coordinator" {
+			// Coordinator: own repo any session allowed; cross-repo only @main.
+			if crossRepo && !isCoordinator(req.Session) {
+				writeError(w, http.StatusForbidden,
+					fmt.Sprintf("cross-repo prompts can only target coordinators (<repo>@main), got %q", req.Session))
+				return
+			}
+		} else {
+			// Worker: only own coordinator (@main) allowed.
+			ownCoordinator := ownRepo + "@main"
+			if req.Session != ownCoordinator {
+				writeError(w, http.StatusForbidden,
+					fmt.Sprintf("workers can only prompt their own coordinator (%s), got %q", ownCoordinator, req.Session))
+				return
+			}
+		}
+
+		// Deliver via prism prompt on the host.
+		args := []string{"prompt", req.Session, "--prompt", req.Prompt}
+		log.Printf("sidecar: host-API /prompt: prism prompt %s <omitted>", req.Session)
+		cmd := exec.Command(prismBinary(), args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Printf("sidecar: host-API /prompt: %v: %s", err, out)
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("prompt delivery failed: %v", err))
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{})
+	})
+
 	// POST /spawn
 	// Request:  {"repo":"nixos-config","branch":"my-feature","prompt":"...","agent":"worker","profile":"gemini-hybrid"}
 	// Response: {"session_name":"nixos-config@my-feature"} | {"error":"..."}
 	mux.HandleFunc("/spawn", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "spawn") {
 			return
 		}
 		var req struct {
@@ -1599,6 +1871,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// Response: {} | {"error":"..."}
 	mux.HandleFunc("/cleanup", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "cleanup") {
 			return
 		}
 		var req struct {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1466,6 +1466,19 @@ func marshalTruncated(v any, maxLen int) string {
 
 // ── host-API handler ─────────────────────────────────────────────────────────
 
+// extractMessageIDFromPayload returns the "messageId" field from a raw event
+// payload JSON string. Returns an empty string when the field is absent or the
+// JSON cannot be parsed. Used by the /checkin handler's turn-centric logic.
+func extractMessageIDFromPayload(raw string) string {
+	var p struct {
+		MessageID string `json:"messageId"`
+	}
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return ""
+	}
+	return p.MessageID
+}
+
 // repoFromSession extracts the repo prefix from a session name (e.g.
 // "nixos-config" from "nixos-config@main"). Returns an error when the session
 // name contains no "@" — this indicates a misconfigured or non-worktree session.
@@ -1671,18 +1684,84 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			}
 		}
 
-		// Fetch events.
-		events, err := s.cfg.DB.QueryEvents(targetSession, limit, beforePtr, afterPtr, types)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
-			return
-		}
-
 		// Fetch session state.
 		status, statusErr := s.cfg.DB.CurrentStatus(targetSession)
 		var state string
 		if statusErr == nil && status != nil {
 			state = status.State
+		}
+
+		var events []db.Event
+		if len(types) > 0 {
+			// Explicit --types: return raw events with the type filter, same as
+			// the runCheckinSessionRaw path in the CLI.
+			var err error
+			events, err = s.cfg.DB.QueryEvents(targetSession, limit, beforePtr, afterPtr, types)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+				return
+			}
+		} else {
+			// Default (no --types): replicate the assistant-turn-centric logic from
+			// runCheckinSession / renderCheckinTurns so that --last N means N
+			// assistant turns, not N raw events.
+
+			// Primary query: fetch last N msg_assistant events.
+			assistantEvents, err := s.cfg.DB.QueryEvents(targetSession, limit, beforePtr, afterPtr, []string{"msg_assistant"})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+				return
+			}
+
+			if len(assistantEvents) > 0 {
+				// Collect all messageIds from the assistant events.
+				messageIDs := make([]string, 0, len(assistantEvents))
+				for _, e := range assistantEvents {
+					msgID := extractMessageIDFromPayload(e.Payload)
+					if msgID != "" {
+						messageIDs = append(messageIDs, msgID)
+					}
+				}
+
+				// Secondary query: fetch tool calls, results, permission events, and
+				// thinking events that share a messageId with one of the assistant events.
+				childTypes := []string{"tool_call", "tool_result", "permission_ask", "permission_denied", "thinking"}
+				childEvents, _ := s.cfg.DB.QueryEventsByMessageIDs(targetSession, messageIDs, childTypes)
+
+				// Determine the time window for msg_user events.
+				earliest := assistantEvents[0].CreatedAt
+				latest := assistantEvents[len(assistantEvents)-1].CreatedAt
+				for _, ae := range assistantEvents {
+					if ae.CreatedAt.Before(earliest) {
+						earliest = ae.CreatedAt
+					}
+					if ae.CreatedAt.After(latest) {
+						latest = ae.CreatedAt
+					}
+				}
+
+				// Fetch msg_user events and filter to the time window.
+				allUserEvents, _ := s.cfg.DB.QueryEvents(targetSession, 0, nil, nil, []string{"msg_user"})
+				var userEvents []db.Event
+				for _, ue := range allUserEvents {
+					if !ue.CreatedAt.Before(earliest) && !ue.CreatedAt.After(latest) {
+						userEvents = append(userEvents, ue)
+					}
+				}
+
+				// Merge all into a single sorted timeline (insertion sort, ASC).
+				merged := make([]db.Event, 0, len(assistantEvents)+len(childEvents)+len(userEvents))
+				merged = append(merged, assistantEvents...)
+				merged = append(merged, childEvents...)
+				merged = append(merged, userEvents...)
+				for i := 1; i < len(merged); i++ {
+					for j := i; j > 0 && merged[j].CreatedAt.Before(merged[j-1].CreatedAt); j-- {
+						merged[j], merged[j-1] = merged[j-1], merged[j]
+					}
+				}
+				events = merged
+			}
+			// If no assistant events exist, events stays nil → returned as [].
 		}
 
 		// Ensure empty arrays rather than null.
@@ -1800,6 +1879,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
+		// Own-repo restriction: coordinators may only spawn into their own repo.
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		if repoErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+			return
+		}
+		if req.Repo != ownRepo {
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("coordinators can only spawn sessions in their own repo (%s), got %q", ownRepo, req.Repo))
+			return
+		}
+
 		args := []string{"spawn", "--branch", req.Branch}
 		if req.Prompt != "" {
 			args = append(args, "--prompt", req.Prompt)
@@ -1875,6 +1966,23 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Session == "" {
 			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+
+		// Own-repo restriction: coordinators may only clean up sessions in their own repo.
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		if repoErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+			return
+		}
+		targetRepo, targetRepoErr := repoFromSession(req.Session)
+		if targetRepoErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			return
+		}
+		if targetRepo != ownRepo {
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("coordinators can only clean up sessions in their own repo (%s), got %q", ownRepo, req.Session))
 			return
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1465,22 +1466,6 @@ func marshalTruncated(v any, maxLen int) string {
 
 // ── host-API handler ─────────────────────────────────────────────────────────
 
-// parseInt parses a decimal integer from s. Returns an error for non-numeric
-// or empty strings.
-func parseInt(s string) (int, error) {
-	n := 0
-	if len(s) == 0 {
-		return 0, fmt.Errorf("empty string")
-	}
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, fmt.Errorf("non-numeric character %q", c)
-		}
-		n = n*10 + int(c-'0')
-	}
-	return n, nil
-}
-
 // repoFromSession extracts the repo prefix from a session name (e.g.
 // "nixos-config" from "nixos-config@main"). Returns an error when the session
 // name contains no "@" — this indicates a misconfigured or non-worktree session.
@@ -1661,7 +1646,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// Parse limit (default 10).
 		limit := 10
 		if lastStr := q.Get("last"); lastStr != "" {
-			if n, parseErr := parseInt(lastStr); parseErr == nil && n > 0 {
+			if n, parseErr := strconv.Atoi(lastStr); parseErr == nil && n > 0 {
 				limit = n
 			}
 		}
@@ -1732,6 +1717,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Session == "" {
 			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+		if req.Prompt == "" {
+			writeError(w, http.StatusBadRequest, "prompt is required")
 			return
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -4135,5 +4136,520 @@ func TestTtft_NoTimeStart(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected msg_assistant event to be written")
+	}
+}
+
+// ── Host-API handler tests ────────────────────────────────────────────────────
+//
+// These tests exercise the hostAPIHandler() method directly, without starting
+// a real Unix socket server. They use httptest.NewRecorder to capture responses.
+
+// newHostAPIRequest builds an http.Request for the hostAPIHandler tests.
+func newHostAPIRequest(t *testing.T, method, path, body string) *http.Request {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, "http://prism-hostapi"+path, bodyReader)
+	if err != nil {
+		t.Fatalf("newHostAPIRequest: %v", err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req
+}
+
+// doHostAPI sends a request to the hostAPIHandler and returns the response recorder.
+func doHostAPI(t *testing.T, sc *Sidecar, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := sc.hostAPIHandler()
+	req := newHostAPIRequest(t, method, path, body)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// decodeJSONBody decodes the response recorder body into v.
+func decodeJSONBody(t *testing.T, rr *httptest.ResponseRecorder, v any) {
+	t.Helper()
+	if err := json.Unmarshal(rr.Body.Bytes(), v); err != nil {
+		t.Fatalf("unmarshal response JSON %q: %v", rr.Body.String(), err)
+	}
+}
+
+// newSidecarWithRole creates a Sidecar with the given session name, role, and DB.
+func newSidecarWithRole(t *testing.T, sessionName, repo, role string, d *db.DB) *Sidecar {
+	t.Helper()
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/tmp/" + sessionName,
+		OpencodeURL: "http://localhost:14000",
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   role,
+	}
+	return New(cfg)
+}
+
+// newSidecarWithRoleAndBinary creates a Sidecar that uses a stub binary for
+// host-API shell-out operations (spawn, cleanup, prompt). This avoids
+// blocking on the real prism binary in unit tests.
+// The stub binary is written to a temp file that exits immediately with code 1
+// (so the operation "fails" with a 500, not hangs or produces misleading output).
+func newSidecarWithRoleAndBinary(t *testing.T, sessionName, repo, role string, d *db.DB) *Sidecar {
+	t.Helper()
+	// Write a minimal shell script that exits immediately with failure.
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := "#!/bin/sh\nexit 1\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     sessionName,
+		Repo:            repo,
+		Worktree:        "/tmp/" + sessionName,
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       role,
+		PrismBinaryPath: stubPath,
+	}
+	return New(cfg)
+}
+
+// ── /list-sessions ────────────────────────────────────────────────────────────
+
+func TestHostAPI_ListSessions_WorkerOwnRepo(t *testing.T) {
+	d := openTestDB(t)
+	// Seed two sessions: one in "myrepo" and one in "otherrepo".
+	_ = d.UpsertStatus("myrepo@feature", "myrepo", "/wt1", "active", nil, nil)
+	_ = d.UpsertStatus("otherrepo@main", "otherrepo", "/wt2", "active", nil, nil)
+
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/list-sessions", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var sessions []map[string]any
+	decodeJSONBody(t, rr, &sessions)
+
+	// Only myrepo sessions should appear.
+	for _, s := range sessions {
+		name, _ := s["SessionName"].(string)
+		if strings.HasPrefix(name, "otherrepo") {
+			t.Errorf("worker got cross-repo session %q in list-sessions", name)
+		}
+	}
+	// myrepo@feature must be present.
+	found := false
+	for _, s := range sessions {
+		if s["SessionName"] == "myrepo@feature" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("myrepo@feature not found in list-sessions response")
+	}
+}
+
+func TestHostAPI_ListSessions_WorkerAllForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/list-sessions?all=true", "")
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+func TestHostAPI_ListSessions_CoordinatorOwnRepo(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("myrepo@main", "myrepo", "/wt1", "active", nil, nil)
+	_ = d.UpsertStatus("otherrepo@main", "otherrepo", "/wt2", "active", nil, nil)
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/list-sessions", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var sessions []map[string]any
+	decodeJSONBody(t, rr, &sessions)
+
+	// Default should only show own repo.
+	for _, s := range sessions {
+		name, _ := s["SessionName"].(string)
+		if strings.HasPrefix(name, "otherrepo") {
+			t.Errorf("coordinator got cross-repo session %q in default list-sessions", name)
+		}
+	}
+}
+
+func TestHostAPI_ListSessions_CoordinatorAll(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("myrepo@main", "myrepo", "/wt1", "active", nil, nil)
+	_ = d.UpsertStatus("otherrepo@main", "otherrepo", "/wt2", "active", nil, nil)
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/list-sessions?all=true", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var sessions []map[string]any
+	decodeJSONBody(t, rr, &sessions)
+
+	foundMyRepo := false
+	foundOtherRepo := false
+	for _, s := range sessions {
+		name, _ := s["SessionName"].(string)
+		if name == "myrepo@main" {
+			foundMyRepo = true
+		}
+		if name == "otherrepo@main" {
+			foundOtherRepo = true
+		}
+	}
+	if !foundMyRepo {
+		t.Error("myrepo@main not found in all list-sessions")
+	}
+	if !foundOtherRepo {
+		t.Error("otherrepo@main not found in all list-sessions")
+	}
+}
+
+// ── /checkin ──────────────────────────────────────────────────────────────────
+
+func TestHostAPI_Checkin_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@main", "")
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+func TestHostAPI_Checkin_MissingSession(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin", "")
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestHostAPI_Checkin_CoordinatorOwnRepo(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("myrepo@feature", "myrepo", "/wt", "active", nil, nil)
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@feature", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var body map[string]any
+	decodeJSONBody(t, rr, &body)
+	if body["session"] != "myrepo@feature" {
+		t.Errorf("session = %v, want myrepo@feature", body["session"])
+	}
+}
+
+func TestHostAPI_Checkin_CoordinatorCrossRepoCoordinator(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("otherrepo@main", "otherrepo", "/wt", "active", nil, nil)
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=otherrepo@main", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestHostAPI_Checkin_CoordinatorCrossRepoNonCoordinatorForbidden(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("otherrepo@feature", "otherrepo", "/wt", "active", nil, nil)
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=otherrepo@feature", "")
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "cross-repo") {
+		t.Errorf("error %q should mention cross-repo", errResp["error"])
+	}
+}
+
+// ── /prompt ───────────────────────────────────────────────────────────────────
+
+func TestHostAPI_Prompt_MissingSession(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt", `{"prompt":"hello"}`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestHostAPI_Prompt_WorkerOwnCoordinatorAllowed(t *testing.T) {
+	// Use a stub binary so the test doesn't block waiting for the real prism binary.
+	// The stub exits with code 1 (delivery fails → 500), but the permission check
+	// (not 403) is what matters here.
+	d := openTestDB(t)
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+	// "myrepo@main" is the expected own coordinator for "myrepo@feature".
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@main","prompt":"hello"}`)
+
+	// Permission check should pass (not 403). The stub binary exits with code 1,
+	// so the actual delivery fails with 500, but the role check allows it through.
+	if rr.Code == http.StatusForbidden {
+		var errResp map[string]string
+		decodeJSONBody(t, rr, &errResp)
+		t.Fatalf("got unexpected 403: %s", errResp["error"])
+	}
+	// Should be 500 (stub binary failed), not 403.
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (stub binary failure, not permission error)", rr.Code)
+	}
+}
+
+func TestHostAPI_Prompt_WorkerWrongTargetForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{"own feature branch", "myrepo@other-feature"},
+		{"cross-repo coordinator", "otherrepo@main"},
+		{"cross-repo feature", "otherrepo@feature"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+				fmt.Sprintf(`{"session":%q,"prompt":"hello"}`, tc.target))
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403 for target %q", rr.Code, tc.target)
+			}
+		})
+	}
+}
+
+func TestHostAPI_Prompt_CoordinatorOwnRepoAnySession(t *testing.T) {
+	d := openTestDB(t)
+	// Use stub binary so the test doesn't block.
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	// Coordinator prompting own feature branch: should pass permission check.
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@feature","prompt":"hello"}`)
+	// Permission allowed (not 403). Stub binary fails → 500.
+	if rr.Code == http.StatusForbidden {
+		var errResp map[string]string
+		decodeJSONBody(t, rr, &errResp)
+		t.Fatalf("got unexpected 403: %s", errResp["error"])
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (stub binary failure)", rr.Code)
+	}
+}
+
+func TestHostAPI_Prompt_CoordinatorCrossRepoCoordinatorAllowed(t *testing.T) {
+	d := openTestDB(t)
+	// Use stub binary so the test doesn't block.
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"otherrepo@main","prompt":"hello"}`)
+	// Permission allowed (not 403). Stub binary fails → 500.
+	if rr.Code == http.StatusForbidden {
+		var errResp map[string]string
+		decodeJSONBody(t, rr, &errResp)
+		t.Fatalf("got unexpected 403: %s", errResp["error"])
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (stub binary failure)", rr.Code)
+	}
+}
+
+func TestHostAPI_Prompt_CoordinatorCrossRepoNonCoordinatorForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"otherrepo@feature","prompt":"hello"}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "cross-repo") {
+		t.Errorf("error %q should mention cross-repo", errResp["error"])
+	}
+}
+
+// ── /spawn and /cleanup role enforcement ──────────────────────────────────────
+
+func TestHostAPI_Spawn_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"repo":"myrepo","branch":"new-branch"}`)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+func TestHostAPI_Cleanup_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/cleanup",
+		`{"session":"myrepo@feature","yes":true}`)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+func TestHostAPI_SessionNameNoAt_NoCheckinPanic(t *testing.T) {
+	d := openTestDB(t)
+	// Session name without "@" — edge case for repoFromSession.
+	sc := newSidecarWithRole(t, "no-at-sign", "", "coordinator", d)
+	// The sidecar's own session has no "@", which will fail repoFromSession.
+	// The handler should return 500 (internal error deriving repo), not panic.
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@main", "")
+	if rr.Code == 0 {
+		t.Fatal("got zero status — possible panic")
+	}
+	// Should be 500 (cannot derive repo from sidecar's own session name).
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for no-@ session name", rr.Code)
+	}
+}
+
+func TestHostAPI_Prompt_InvalidTargetNoAt(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	// Target session has no "@" — should return 400.
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"nosession","prompt":"hello"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for no-@ target session", rr.Code)
+	}
+}
+
+func TestHostAPI_RepoFromSession(t *testing.T) {
+	tests := []struct {
+		session string
+		want    string
+		wantErr bool
+	}{
+		{"myrepo@main", "myrepo", false},
+		{"nixos-config@feature/foo", "nixos-config", false},
+		{"norepo", "", true},
+		{"", "", true},
+	}
+	for _, tc := range tests {
+		got, err := repoFromSession(tc.session)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("repoFromSession(%q): expected error, got nil", tc.session)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("repoFromSession(%q): unexpected error: %v", tc.session, err)
+			}
+			if got != tc.want {
+				t.Errorf("repoFromSession(%q) = %q, want %q", tc.session, got, tc.want)
+			}
+		}
+	}
+}
+
+func TestHostAPI_IsCoordinator(t *testing.T) {
+	tests := []struct {
+		session string
+		want    bool
+	}{
+		{"myrepo@main", true},
+		{"myrepo@feature", false},
+		{"myrepo@main-old", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := isCoordinator(tc.session)
+		if got != tc.want {
+			t.Errorf("isCoordinator(%q) = %v, want %v", tc.session, got, tc.want)
+		}
+	}
+}
+
+func TestHostAPI_ListSessions_WrongMethod(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/list-sessions", `{}`)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestHostAPI_Checkin_WrongMethod(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/checkin?session=myrepo@main", `{}`)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestHostAPI_Prompt_WrongMethod(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/prompt", "")
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -4653,3 +4653,48 @@ func TestHostAPI_Prompt_WrongMethod(t *testing.T) {
 		t.Fatalf("status = %d, want 405", rr.Code)
 	}
 }
+
+func TestHostAPI_Prompt_EmptyPromptReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	// Session is set but prompt is empty string.
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@feature","prompt":""}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for empty prompt", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "prompt is required") {
+		t.Errorf("error %q should mention 'prompt is required'", errResp["error"])
+	}
+}
+
+func TestHostAPI_Checkin_LastParamParsed(t *testing.T) {
+	d := openTestDB(t)
+	// Seed several assistant events at distinct timestamps.
+	base := time.Now().Truncate(time.Second)
+	for i := 0; i < 5; i++ {
+		_ = d.WriteEvent(db.Event{
+			ID:          fmt.Sprintf("evt-%d", i),
+			SessionName: "myrepo@feature",
+			Repo:        "myrepo",
+			Worktree:    "/wt",
+			Type:        "msg_assistant",
+			Payload:     fmt.Sprintf(`{"messageId":"msg-%d","text":"turn %d"}`, i, i),
+			CreatedAt:   base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@feature&last=2", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var body map[string]any
+	decodeJSONBody(t, rr, &body)
+	events, _ := body["events"].([]any)
+	if len(events) > 2 {
+		t.Errorf("got %d events with last=2, want at most 2", len(events))
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -4698,3 +4698,111 @@ func TestHostAPI_Checkin_LastParamParsed(t *testing.T) {
 		t.Errorf("got %d events with last=2, want at most 2", len(events))
 	}
 }
+
+// ── Bug fix tests: /spawn and /cleanup own-repo restriction ───────────────────
+
+func TestHostAPI_Spawn_CoordinatorCrossRepoForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	// Coordinator in myrepo tries to spawn into otherrepo — must be 403.
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"repo":"otherrepo","branch":"new-branch"}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for cross-repo spawn", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "own repo") {
+		t.Errorf("error %q should mention 'own repo'", errResp["error"])
+	}
+}
+
+func TestHostAPI_Cleanup_CoordinatorCrossRepoForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	// Coordinator in myrepo tries to clean up otherrepo@feature — must be 403.
+	rr := doHostAPI(t, sc, http.MethodPost, "/cleanup",
+		`{"session":"otherrepo@feature","yes":true}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for cross-repo cleanup", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "own repo") {
+		t.Errorf("error %q should mention 'own repo'", errResp["error"])
+	}
+}
+
+// ── Bug fix test: /checkin default returns turn-centric events, not raw ───────
+
+func TestHostAPI_Checkin_DefaultReturnsAssistantTurnsNotRawEvents(t *testing.T) {
+	d := openTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Seed: msg_user, msg_assistant (with messageId), tool_call (same messageId).
+	_ = d.WriteEvent(db.Event{
+		ID:          "u1",
+		SessionName: "myrepo@feature",
+		Repo:        "myrepo",
+		Worktree:    "/wt",
+		Type:        "msg_user",
+		Payload:     `{"messageId":"umsg1","text":"do something"}`,
+		CreatedAt:   base,
+	})
+	_ = d.WriteEvent(db.Event{
+		ID:          "a1",
+		SessionName: "myrepo@feature",
+		Repo:        "myrepo",
+		Worktree:    "/wt",
+		Type:        "msg_assistant",
+		Payload:     `{"messageId":"amsg1","text":"doing it"}`,
+		CreatedAt:   base.Add(time.Second),
+	})
+	_ = d.WriteEvent(db.Event{
+		ID:          "tc1",
+		SessionName: "myrepo@feature",
+		Repo:        "myrepo",
+		Worktree:    "/wt",
+		Type:        "tool_call",
+		Payload:     `{"messageId":"amsg1","tool":"bash","args":"ls"}`,
+		CreatedAt:   base.Add(2 * time.Second),
+	})
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	// last=1 with no types: should return 1 assistant turn's full context
+	// (the assistant event + its child tool_call + the user event in window).
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@feature&last=1", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var body map[string]any
+	decodeJSONBody(t, rr, &body)
+	events, _ := body["events"].([]any)
+
+	// We expect 3 events: msg_user (in window), msg_assistant, tool_call.
+	// NOT just 1 raw event.
+	if len(events) < 2 {
+		t.Errorf("got %d events, want at least 2 (turn-centric: assistant + child tool_call)", len(events))
+	}
+
+	// Verify the tool_call is present (child of the assistant turn).
+	foundToolCall := false
+	foundAssistant := false
+	for _, ev := range events {
+		evMap, _ := ev.(map[string]any)
+		switch evMap["Type"] {
+		case "tool_call":
+			foundToolCall = true
+		case "msg_assistant":
+			foundAssistant = true
+		}
+	}
+	if !foundAssistant {
+		t.Error("msg_assistant event not found in response")
+	}
+	if !foundToolCall {
+		t.Error("tool_call child event not found in response (turn-centric query should include it)")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -4694,8 +4694,8 @@ func TestHostAPI_Checkin_LastParamParsed(t *testing.T) {
 	var body map[string]any
 	decodeJSONBody(t, rr, &body)
 	events, _ := body["events"].([]any)
-	if len(events) > 2 {
-		t.Errorf("got %d events with last=2, want at most 2", len(events))
+	if len(events) != 2 {
+		t.Errorf("got %d events with last=2, want exactly 2", len(events))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `GET /list-sessions`, `GET /checkin`, and `POST /prompt` endpoints to the host-API Unix socket handler, enabling prism commands inside containers to proxy read operations and prompt delivery through the sidecar
- Enforces role-based permissions server-side: workers get read-only access scoped to their own repo, coordinators get broader access with cross-repo restrictions limited to coordinator sessions (`@main`)
- Adds `PRISM_HOST_API` proxy detection to `prism checkin`, `prism list-sessions`, and `prism prompt` commands, following the same pattern used by `spawn`, `cleanup`, and `switch`

## Changes

**Sidecar (`internal/sidecar/sidecar.go`)**:
- Added `repoFromSession()` and `isCoordinator()` helpers
- `GET /list-sessions` — workers: own repo only; coordinators: own repo by default, all repos with `?all=true`
- `GET /checkin` — coordinators only; own repo sessions + cross-repo `@main` sessions
- `POST /prompt` — workers: own coordinator only; coordinators: own repo any session, cross-repo `@main` only
- Added `requireCoordinator` guard to `/spawn` and `/cleanup` to make worker denial explicit
- Added `Config.PrismBinaryPath` for test injection of stub binary

**CLI (`cmd/`)**:
- `hostapi.go`: added `proxyGetFromHostAPI` GET helper, `proxyListSessions`, `proxyCheckin`, `proxyPrompt` functions
- `checkin.go`: proxy detection + `renderProxiedCheckin` renderer for raw JSON from host API
- `list_sessions.go`: proxy detection + `proxyListSessionsAndRender`
- `prompt.go`: proxy detection via `proxyPrompt`

**Tests**:
- 30 new sidecar tests covering all permission rules, edge cases (no `@` in session name, missing params, wrong HTTP method)
- 8 new CLI proxy tests for `proxyGetFromHostAPI`, `proxyListSessions`, `proxyCheckin`, `proxyPrompt`
- Updated `openCheckinTestDB` and `openPromptTestDB` to unset `PRISM_HOST_API` (prevents ambient env var from affecting pre-existing unit tests)

Closes #614