### PR TITLE
container: fix /spawn to ignore client repo, substitute ownRepo from session name

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -191,7 +191,11 @@ func TestParseUnixSocketURL_ValidAndInvalid(t *testing.T) {
 
 // TestProxySpawn_SendsCorrectPayload verifies AC-11 for spawn: when
 // PRISM_HOST_API is set and proxySpawn is called, the mock server receives
-// the expected JSON payload.
+// the expected JSON payload. Setting PRISM_BARE_ROOT to a container mount path
+// (e.g. "/prism-git" whose filepath.Base differs from the actual repo name)
+// confirms that the client-side repo derivation defect (issue #616) is no
+// longer exercised: the client does not send a "repo" field at all, and the
+// server substitutes its own repo name.
 func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 	type spawnReq struct {
 		Repo   string `json:"repo"`
@@ -212,16 +216,21 @@ func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 		reqCh <- req
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"session_name":"myrepo@test-branch"}`))
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@test-branch"}`))
 	})
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
-	t.Setenv("PRISM_BARE_ROOT", "/home/user/code/myrepo")
+	// Set PRISM_BARE_ROOT to a container mount path whose filepath.Base
+	// ("prism-git") does not match the actual repo name ("nixos-config").
+	// The client must NOT derive the repo from this value — it should omit
+	// the repo field entirely, leaving the server to substitute ownRepo.
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
 
 	// Build a cobra command with the same flags as spawnCmd.
 	cmd := &cobra.Command{Use: "spawn"}
 	cmd.Flags().String("branch", "", "")
 	cmd.Flags().String("agent", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
 	addPromptFlags(cmd)
 	_ = cmd.Flags().Set("branch", "test-branch")
 	_ = cmd.Flags().Set("agent", "worker")
@@ -233,8 +242,9 @@ func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 
 	select {
 	case req := <-reqCh:
-		if req.Repo != "myrepo" {
-			t.Errorf("repo = %q, want %q", req.Repo, "myrepo")
+		// The client must NOT send a repo field (empty string in decoded struct).
+		if req.Repo != "" {
+			t.Errorf("repo = %q, want empty (client must not send repo; server derives it)", req.Repo)
 		}
 		if req.Branch != "test-branch" {
 			t.Errorf("branch = %q, want %q", req.Branch, "test-branch")

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -198,10 +198,14 @@ func TestParseUnixSocketURL_ValidAndInvalid(t *testing.T) {
 // server substitutes its own repo name.
 func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 	type spawnReq struct {
-		Repo   string `json:"repo"`
-		Branch string `json:"branch"`
-		Prompt string `json:"prompt"`
-		Agent  string `json:"agent"`
+		Repo     string `json:"repo"`
+		Branch   string `json:"branch"`
+		Prompt   string `json:"prompt"`
+		Agent    string `json:"agent"`
+		Profile  string `json:"profile"`
+		Model    string `json:"model"`
+		Variant  string `json:"variant"`
+		HostMode bool   `json:"host_mode"`
 	}
 
 	reqCh := make(chan spawnReq, 1)
@@ -230,11 +234,18 @@ func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 	cmd := &cobra.Command{Use: "spawn"}
 	cmd.Flags().String("branch", "", "")
 	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
 	cmd.Flags().Bool("host-mode", false, "")
 	addPromptFlags(cmd)
 	_ = cmd.Flags().Set("branch", "test-branch")
 	_ = cmd.Flags().Set("agent", "worker")
 	_ = cmd.Flags().Set("prompt", "hello world")
+	_ = cmd.Flags().Set("profile", "gemini-hybrid")
+	_ = cmd.Flags().Set("model", "anthropic/claude-sonnet-4-6")
+	_ = cmd.Flags().Set("variant", "high")
+	_ = cmd.Flags().Set("host-mode", "true")
 
 	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
 		t.Fatalf("proxySpawn: %v", err)
@@ -254,6 +265,18 @@ func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 		}
 		if req.Agent != "worker" {
 			t.Errorf("agent = %q, want %q", req.Agent, "worker")
+		}
+		if req.Profile != "gemini-hybrid" {
+			t.Errorf("profile = %q, want %q", req.Profile, "gemini-hybrid")
+		}
+		if req.Model != "anthropic/claude-sonnet-4-6" {
+			t.Errorf("model = %q, want %q", req.Model, "anthropic/claude-sonnet-4-6")
+		}
+		if req.Variant != "high" {
+			t.Errorf("variant = %q, want %q", req.Variant, "high")
+		}
+		if !req.HostMode {
+			t.Errorf("host_mode = false, want true")
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for request")

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -33,6 +33,11 @@ import (
 // proxySpawn forwards a spawn request to the host-API sidecar when running
 // inside a container (PRISM_HOST_API is set). It reads the same flags as
 // runSpawn and POSTs them to /spawn, then prints the returned session name.
+//
+// The "repo" field is intentionally omitted from the request: the sidecar
+// derives the repo from its own session name, so a client running inside a
+// container where PRISM_BARE_ROOT is a mount-path name (e.g. "/prism-git")
+// does not need to supply the correct repo name. See issue #616.
 func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	branchFlag, _ := cmd.Flags().GetString("branch")
 	agentFlag, _ := cmd.Flags().GetString("agent")
@@ -44,17 +49,10 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	// repo is derived from PRISM_BARE_ROOT (injected by A-2/sidecar).
-	bareRoot := os.Getenv("PRISM_BARE_ROOT")
-	if bareRoot == "" {
-		return fmt.Errorf("PRISM_BARE_ROOT is not set — cannot determine repo name in container mode")
-	}
-	repo := filepath.Base(bareRoot)
 	var resp struct {
 		SessionName string `json:"session_name"`
 	}
 	if err := proxyToHostAPI(apiURL, "/spawn", map[string]any{
-		"repo":      repo,
 		"branch":    branchFlag,
 		"prompt":    promptFlag,
 		"agent":     agentFlag,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1848,7 +1848,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	})
 
 	// POST /spawn
-	// Request:  {"repo":"nixos-config","branch":"my-feature","prompt":"...","agent":"worker","profile":"gemini-hybrid"}
+	// Request:  {"branch":"my-feature","prompt":"...","agent":"worker","profile":"gemini-hybrid","host_mode":false}
+	// The "repo" field is accepted but ignored — the sidecar always substitutes
+	// its own repo (derived from its session name) so that a client sending a
+	// mount-path name (e.g. "prism-git") still spawns into the correct repo
+	// (e.g. "nixos-config"). See issue #616.
 	// Response: {"session_name":"nixos-config@my-feature"} | {"error":"..."}
 	mux.HandleFunc("/spawn", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
@@ -1858,20 +1862,17 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		var req struct {
-			Repo    string `json:"repo"`
-			Branch  string `json:"branch"`
-			Prompt  string `json:"prompt"`
-			Agent   string `json:"agent"`
-			Profile string `json:"profile"`
-			Model   string `json:"model"`
-			Variant string `json:"variant"`
+			Repo     string `json:"repo"` // accepted but ignored — ownRepo is always used
+			Branch   string `json:"branch"`
+			Prompt   string `json:"prompt"`
+			Agent    string `json:"agent"`
+			Profile  string `json:"profile"`
+			Model    string `json:"model"`
+			Variant  string `json:"variant"`
+			HostMode bool   `json:"host_mode"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
-			return
-		}
-		if req.Repo == "" {
-			writeError(w, http.StatusBadRequest, "repo is required")
 			return
 		}
 		if req.Branch == "" {
@@ -1879,15 +1880,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
-		// Own-repo restriction: coordinators may only spawn into their own repo.
+		// Always derive the repo from the sidecar's own session name.
+		// This means a client that sends the wrong repo (e.g. a container
+		// mount-path name instead of the actual repo name) is silently
+		// corrected. The own-repo restriction is enforced implicitly: the
+		// sidecar can only spawn into its own repo.
 		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
-			return
-		}
-		if req.Repo != ownRepo {
-			writeError(w, http.StatusForbidden,
-				fmt.Sprintf("coordinators can only spawn sessions in their own repo (%s), got %q", ownRepo, req.Repo))
 			return
 		}
 
@@ -1907,7 +1907,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.Variant != "" {
 			args = append(args, "--variant", req.Variant)
 		}
-		args = append(args, req.Repo)
+		if req.HostMode {
+			args = append(args, "--host-mode")
+		}
+		args = append(args, ownRepo)
 
 		// Log without the prompt value — it may contain sensitive context.
 		logArgs := []string{"spawn", "--branch", req.Branch}
@@ -1926,7 +1929,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.Variant != "" {
 			logArgs = append(logArgs, "--variant", req.Variant)
 		}
-		logArgs = append(logArgs, req.Repo)
+		if req.HostMode {
+			logArgs = append(logArgs, "--host-mode")
+		}
+		logArgs = append(logArgs, ownRepo)
 		log.Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
 		cmd := exec.Command(prismBinary(), args...)
 		out, err := cmd.CombinedOutput()
@@ -1940,8 +1946,8 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// Parse the session name from the output.
 		sessionName := parseSpawnSessionName(string(out))
 		if sessionName == "" {
-			// Fallback: derive from repo@branch (branch already sanitised by spawn).
-			sessionName = req.Repo + "@" + req.Branch
+			// Fallback: derive from ownRepo@branch (branch already sanitised by spawn).
+			sessionName = ownRepo + "@" + req.Branch
 		}
 		writeJSON(w, http.StatusOK, map[string]string{"session_name": sessionName})
 	})

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -4877,6 +4877,86 @@ echo "session \"${last}@cross-branch\" created"
 	}
 }
 
+// TestHostAPI_Spawn_HostModeForwarded verifies that when a client sends
+// {"host_mode":true}, the sidecar includes "--host-mode" in the args passed to
+// the prism binary. This ensures the HostMode field added in issue #616 is
+// actually forwarded to the spawned process.
+func TestHostAPI_Spawn_HostModeForwarded(t *testing.T) {
+	d := openTestDB(t)
+
+	// Stub that echoes all its arguments to stdout so we can inspect them,
+	// then prints the success line expected by parseSpawnSessionName.
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "ARGS: $*"
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@host-mode-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	// Send host_mode: true — the stub should receive "--host-mode" in its args.
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"host-mode-branch","host_mode":true}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var respBody map[string]string
+	decodeJSONBody(t, rr, &respBody)
+	if respBody["session_name"] != "nixos-config@host-mode-branch" {
+		t.Errorf("session_name = %q, want %q", respBody["session_name"], "nixos-config@host-mode-branch")
+	}
+
+	// The stub echoes "ARGS: ..." on its first line — check that --host-mode
+	// was passed to it.
+	output := rr.Body.String()
+	_ = output // rr.Body is the HTTP response body, not the stub's stdout.
+	// We must check via a different mechanism: use a capturing stub.
+	// Re-run with a stub that writes args to a temp file.
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath2 := filepath.Join(t.TempDir(), "prism-stub2")
+	stubScript2 := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@host-mode-branch\" created"
+`
+	if err := os.WriteFile(stubPath2, []byte(stubScript2), 0o755); err != nil {
+		t.Fatalf("write stub2: %v", err)
+	}
+	cfg2 := cfg
+	cfg2.PrismBinaryPath = stubPath2
+	sc2 := New(cfg2)
+
+	rr2 := doHostAPI(t, sc2, http.MethodPost, "/spawn",
+		`{"branch":"host-mode-branch","host_mode":true}`)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr2.Code, rr2.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "--host-mode") {
+		t.Errorf("captured args %q do not contain --host-mode; host_mode:true was not forwarded", string(capturedArgs))
+	}
+}
+
 func TestHostAPI_Cleanup_CoordinatorCrossRepoForbidden(t *testing.T) {
 	d := openTestDB(t)
 	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -4699,21 +4699,181 @@ func TestHostAPI_Checkin_LastParamParsed(t *testing.T) {
 	}
 }
 
-// ── Bug fix tests: /spawn and /cleanup own-repo restriction ───────────────────
+// ── Bug fix tests: /spawn repo substitution (issue #616) ────────────────────
 
-func TestHostAPI_Spawn_CoordinatorCrossRepoForbidden(t *testing.T) {
+// TestHostAPI_Spawn_ClientRepoIsIgnoredServerUsesOwnRepo verifies the fix for
+// issue #616: when a client sends an arbitrary "repo" value (e.g. a container
+// mount-path name like "prism-git"), the server ignores it and substitutes its
+// own repo derived from its session name ("nixos-config").
+//
+// The test uses a stub binary that echoes a spawn success line containing the
+// repo argument passed to it, so we can verify which repo was used.
+func TestHostAPI_Spawn_ClientRepoIsIgnoredServerUsesOwnRepo(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
-	// Coordinator in myrepo tries to spawn into otherrepo — must be 403.
+
+	// Write a stub that prints a success line with the last argument (the repo).
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// prism spawn ... <repo> — the repo is always the last argument.
+	// The stub prints the success line that parseSpawnSessionName expects.
+	stubScript := `#!/bin/sh
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@test-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	// Client sends "repo":"prism-git" (a container mount-path name).
+	// Server must ignore this and use "nixos-config" (from session name).
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
-		`{"repo":"otherrepo","branch":"new-branch"}`)
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403 for cross-repo spawn", rr.Code)
+		`{"repo":"prism-git","branch":"test-branch"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var respBody map[string]string
+	decodeJSONBody(t, rr, &respBody)
+	// Session name must reflect the actual repo, not the mount-path name.
+	if respBody["session_name"] != "nixos-config@test-branch" {
+		t.Errorf("session_name = %q, want %q (server must use ownRepo, not client-supplied repo)",
+			respBody["session_name"], "nixos-config@test-branch")
+	}
+}
+
+// TestHostAPI_Spawn_EmptyRepoFieldSucceeds verifies AC: a request with an
+// absent or empty "repo" field is accepted (the server derives the repo from
+// its own session name, so the client does not need to supply it).
+func TestHostAPI_Spawn_EmptyRepoFieldSucceeds(t *testing.T) {
+	d := openTestDB(t)
+
+	// Stub that echoes the success line using the repo arg.
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@new-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	// No "repo" field sent at all.
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"branch":"new-branch"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for empty repo field; body = %s", rr.Code, rr.Body.String())
+	}
+	var respBody map[string]string
+	decodeJSONBody(t, rr, &respBody)
+	if respBody["session_name"] != "nixos-config@new-branch" {
+		t.Errorf("session_name = %q, want %q", respBody["session_name"], "nixos-config@new-branch")
+	}
+}
+
+// TestHostAPI_Spawn_EmptyBranchReturns400 verifies AC: a request with a
+// missing or empty "branch" field still returns 400 "branch is required".
+func TestHostAPI_Spawn_EmptyBranchReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"repo":"nixos-config"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for missing branch", rr.Code)
 	}
 	var errResp map[string]string
 	decodeJSONBody(t, rr, &errResp)
-	if !strings.Contains(errResp["error"], "own repo") {
-		t.Errorf("error %q should mention 'own repo'", errResp["error"])
+	if !strings.Contains(errResp["error"], "branch is required") {
+		t.Errorf("error %q should mention 'branch is required'", errResp["error"])
+	}
+}
+
+// TestHostAPI_Spawn_SidecarNoAtSign_Returns500 verifies AC edge case: if the
+// sidecar's own session name contains no "@", /spawn returns 500 with a
+// message indicating the repo cannot be derived, and no spawn is attempted.
+func TestHostAPI_Spawn_SidecarNoAtSign_Returns500(t *testing.T) {
+	d := openTestDB(t)
+	// Session name without "@" — repoFromSession will fail.
+	sc := newSidecarWithRole(t, "no-at-sign", "", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"branch":"some-branch"}`)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 when sidecar session has no '@'", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "cannot derive repo") {
+		t.Errorf("error %q should mention 'cannot derive repo'", errResp["error"])
+	}
+}
+
+// TestHostAPI_Spawn_CoordinatorCrossRepoClientFieldIgnored verifies the
+// security property: a client sending "repo":"otherrepo" does NOT get a 403
+// (the field is ignored). The spawn runs against ownRepo instead, making the
+// own-repo restriction implicit and unforgeable.
+func TestHostAPI_Spawn_CoordinatorCrossRepoClientFieldIgnored(t *testing.T) {
+	d := openTestDB(t)
+
+	// Stub that echoes the repo argument used by the server.
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@cross-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "myrepo@main",
+		Repo:            "myrepo",
+		Worktree:        "/tmp/myrepo@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	// Client sends "repo":"otherrepo" — this should be ignored, not rejected.
+	// The spawn runs with ownRepo ("myrepo"), so session_name must reflect myrepo.
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"repo":"otherrepo","branch":"cross-branch"}`)
+	if rr.Code == http.StatusForbidden {
+		t.Fatalf("status = 403 (Forbidden), but client-supplied repo must be ignored, not rejected")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var respBody map[string]string
+	decodeJSONBody(t, rr, &respBody)
+	// Must use ownRepo ("myrepo"), not the client-supplied "otherrepo".
+	if respBody["session_name"] != "myrepo@cross-branch" {
+		t.Errorf("session_name = %q, want %q (server must use ownRepo, not client-supplied repo)",
+			respBody["session_name"], "myrepo@cross-branch")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -4884,11 +4884,13 @@ echo "session \"${last}@cross-branch\" created"
 func TestHostAPI_Spawn_HostModeForwarded(t *testing.T) {
 	d := openTestDB(t)
 
-	// Stub that echoes all its arguments to stdout so we can inspect them,
-	// then prints the success line expected by parseSpawnSessionName.
+	// Use a stub that writes all its arguments to a temp file so we can
+	// assert that --host-mode was included, then prints the success line
+	// expected by parseSpawnSessionName.
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
 	stubScript := `#!/bin/sh
-echo "ARGS: $*"
+echo "$*" > ` + argsFile + `
 last=""
 for arg; do last="$arg"; done
 echo "session \"${last}@host-mode-branch\" created"
@@ -4909,43 +4911,10 @@ echo "session \"${last}@host-mode-branch\" created"
 	}
 	sc := New(cfg)
 
-	// Send host_mode: true — the stub should receive "--host-mode" in its args.
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
 		`{"branch":"host-mode-branch","host_mode":true}`)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
-	}
-	var respBody map[string]string
-	decodeJSONBody(t, rr, &respBody)
-	if respBody["session_name"] != "nixos-config@host-mode-branch" {
-		t.Errorf("session_name = %q, want %q", respBody["session_name"], "nixos-config@host-mode-branch")
-	}
-
-	// The stub echoes "ARGS: ..." on its first line — check that --host-mode
-	// was passed to it.
-	output := rr.Body.String()
-	_ = output // rr.Body is the HTTP response body, not the stub's stdout.
-	// We must check via a different mechanism: use a capturing stub.
-	// Re-run with a stub that writes args to a temp file.
-	argsFile := filepath.Join(t.TempDir(), "captured-args")
-	stubPath2 := filepath.Join(t.TempDir(), "prism-stub2")
-	stubScript2 := `#!/bin/sh
-echo "$*" > ` + argsFile + `
-last=""
-for arg; do last="$arg"; done
-echo "session \"${last}@host-mode-branch\" created"
-`
-	if err := os.WriteFile(stubPath2, []byte(stubScript2), 0o755); err != nil {
-		t.Fatalf("write stub2: %v", err)
-	}
-	cfg2 := cfg
-	cfg2.PrismBinaryPath = stubPath2
-	sc2 := New(cfg2)
-
-	rr2 := doHostAPI(t, sc2, http.MethodPost, "/spawn",
-		`{"branch":"host-mode-branch","host_mode":true}`)
-	if rr2.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body = %s", rr2.Code, rr2.Body.String())
 	}
 
 	capturedArgs, err := os.ReadFile(argsFile)


### PR DESCRIPTION
## Summary

- **Server-side fix**: The `/spawn` host-API handler now ignores the client-supplied `repo` field and always derives `ownRepo` from the sidecar's own session name via `repoFromSession`. The own-repo restriction is now implicit and unforgeable — no client `repo` value can bypass it.
- **Client-side simplification**: `proxySpawn` no longer reads `PRISM_BARE_ROOT` or derives a repo name; the `repo` field is simply omitted from the request body.
- **`host_mode` forwarding**: Added `HostMode bool` to the server-side request struct so `--host-mode` spawns work correctly end-to-end.
- **`400` guard removed**: The `"repo is required"` check is removed since the server no longer needs the client to supply a repo.

## Problem

Inside a container, `PRISM_BARE_ROOT=/prism-git` is the bind-mount path, not the repo name. `filepath.Base("/prism-git")` → `"prism-git"`, which the sidecar rejected with `"coordinators can only spawn sessions in their own repo (nixos-config), got \"prism-git\""`.

## Tests

New sidecar tests cover all acceptance criteria:
- `TestHostAPI_Spawn_ClientRepoIsIgnoredServerUsesOwnRepo` — verifies the fix: client sends `"prism-git"`, server uses `"nixos-config"`
- `TestHostAPI_Spawn_EmptyRepoFieldSucceeds` — empty/absent `repo` accepted
- `TestHostAPI_Spawn_EmptyBranchReturns400` — `branch` still required
- `TestHostAPI_Spawn_SidecarNoAtSign_Returns500` — edge case: malformed session name returns 500
- `TestHostAPI_Spawn_CoordinatorCrossRepoClientFieldIgnored` — security: client `"repo":"otherrepo"` is ignored, not forbidden; spawn uses ownRepo

Updated `TestProxySpawn_SendsCorrectPayload` sets `PRISM_BARE_ROOT=/prism-git` (mount path) and verifies the client sends no `repo` field.

Closes #616