### PR TITLE
container: fix config mounts — allowlist instead of denylist

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -595,41 +595,47 @@ func (m *Manager) buildRunArgs() []string {
 		)
 	}
 
-	// Mount the host opencode config directory item-by-item into
-	// /root/.config/opencode so that agents/, skills/, command/, tui.json,
-	// plugins/, and other assets are available inside the container.
+	// Mount an explicit allowlist of host opencode config entries into
+	// /root/.config/opencode inside the container.
 	//
-	// opencode.json is intentionally skipped — agent identity and permissions
-	// are set authoritatively via OPENCODE_CONFIG_CONTENT (injected below),
-	// which takes precedence at level 6 over any on-disk opencode.json.
+	// An allowlist (not a denylist) is used deliberately: the bun runtime
+	// inside the container writes to package.json and related files at
+	// request time, so mounting those read-only causes EROFS errors and
+	// HTTP 500 responses that break the health check. Only mount what the
+	// container actually needs.
 	//
-	// For each entry:
+	// Excluded intentionally:
+	//   - opencode.json  — superseded by OPENCODE_CONFIG_CONTENT env var
+	//   - plugins/       — mounted separately via PluginHostPath
+	//   - package.json, bun.lock, package-lock.json, node_modules/ — bun
+	//                      ecosystem files the container manages itself
+	//
+	// For each entry that exists on the host:
 	//   - Symlinks → resolve to real Nix store path and mount that
-	//   - Real entries → mount directly
 	//   - Directories → use --mount type=bind (podman creates dest automatically)
 	//   - Regular files → use --volume
-	if entries, err := os.ReadDir(opencodeConfigDir); err == nil {
-		for _, entry := range entries {
-			// Skip plugins — mounted separately via PluginHostPath.
-			if entry.Name() == "plugins" {
-				continue
-			}
-			// Skip opencode.json — superseded by OPENCODE_CONFIG_CONTENT.
-			if entry.Name() == "opencode.json" {
-				continue
-			}
-			hostPath := filepath.Join(opencodeConfigDir, entry.Name())
-			resolved, err := filepath.EvalSymlinks(hostPath)
-			if err != nil {
-				continue
-			}
-			containerPath := "/root/.config/opencode/" + entry.Name()
-			if fi, err := os.Stat(resolved); err == nil && fi.IsDir() {
-				args = append(args, "--mount",
-					"type=bind,src="+resolved+",dst="+containerPath+",ro")
-			} else {
-				args = append(args, "--volume", resolved+":"+containerPath+":ro")
-			}
+	configAllowlist := []string{
+		"AGENTS.md",
+		"agents",
+		"skills",
+		"command",
+		"tui.json",
+		".gitignore",
+		"mcp-atlassian-slim-proxy.mjs",
+	}
+	for _, name := range configAllowlist {
+		hostPath := filepath.Join(opencodeConfigDir, name)
+		resolved, err := filepath.EvalSymlinks(hostPath)
+		if err != nil {
+			// Entry does not exist or symlink is dangling — skip silently.
+			continue
+		}
+		containerPath := "/root/.config/opencode/" + name
+		if fi, err := os.Stat(resolved); err == nil && fi.IsDir() {
+			args = append(args, "--mount",
+				"type=bind,src="+resolved+",dst="+containerPath+",ro")
+		} else {
+			args = append(args, "--volume", resolved+":"+containerPath+":ro")
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1023,6 +1023,106 @@ func TestBuildRunArgs_PluginMountedSeparately(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
+	// Verifies that the config mount block uses an explicit allowlist:
+	// - Allowlisted entries present on disk ARE mounted read-only.
+	// - Bun ecosystem files (package.json, bun.lock, node_modules/) are NOT mounted.
+	// - opencode.json is NOT mounted even when present on disk.
+	//
+	// Previous tests (TestBuildRunArgs_OpencodeJsonSkippedInItemByItemMount,
+	// TestBuildRunArgs_NoSingleWholeDirConfigMount) ran against an empty home dir,
+	// so filepath.EvalSymlinks always failed and the config block produced zero
+	// mount args — the allowlist was never actually exercised. This test populates
+	// the config dir so the allowlist logic is fully covered.
+
+	fakeHome := t.TempDir()
+	configDir := filepath.Join(fakeHome, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll configDir: %v", err)
+	}
+
+	// Allowlisted files/dirs that should be mounted.
+	allowlisted := []struct {
+		name  string
+		isDir bool
+	}{
+		{"AGENTS.md", false},
+		{"tui.json", false},
+		{"mcp-atlassian-slim-proxy.mjs", false},
+		{"agents", true},
+	}
+	for _, e := range allowlisted {
+		p := filepath.Join(configDir, e.name)
+		if e.isDir {
+			if err := os.MkdirAll(p, 0o755); err != nil {
+				t.Fatalf("MkdirAll %s: %v", e.name, err)
+			}
+		} else {
+			if err := os.WriteFile(p, []byte("stub"), 0o644); err != nil {
+				t.Fatalf("WriteFile %s: %v", e.name, err)
+			}
+		}
+	}
+
+	// Files that must NOT be mounted.
+	excluded := []string{"package.json", "bun.lock", "opencode.json"}
+	for _, name := range excluded {
+		if err := os.WriteFile(filepath.Join(configDir, name), []byte("stub"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+	// node_modules/ as a directory must also not be mounted.
+	if err := os.MkdirAll(filepath.Join(configDir, "node_modules"), 0o755); err != nil {
+		t.Fatalf("MkdirAll node_modules: %v", err)
+	}
+
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentRole:     "worker",
+	})
+	args := m.buildRunArgs()
+
+	// Collect all mount/volume values for inspection.
+	var mountValues []string
+	for i, arg := range args {
+		if (arg == "--volume" || arg == "--mount") && i+1 < len(args) {
+			mountValues = append(mountValues, args[i+1])
+		}
+	}
+
+	// Assert allowlisted entries ARE present (as :ro mounts).
+	for _, e := range allowlisted {
+		found := false
+		containerPath := "/root/.config/opencode/" + e.name
+		for _, v := range mountValues {
+			if strings.Contains(v, containerPath) {
+				if !strings.Contains(v, ":ro") && !strings.Contains(v, ",ro") {
+					t.Errorf("mount for %q is not read-only: %q", e.name, v)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("allowlisted entry %q was not mounted; mount values: %v", e.name, mountValues)
+		}
+	}
+
+	// Assert excluded entries are NOT present.
+	excluded = append(excluded, "node_modules")
+	for _, name := range excluded {
+		containerPath := "/root/.config/opencode/" + name
+		for _, v := range mountValues {
+			if strings.Contains(v, containerPath) {
+				t.Errorf("excluded entry %q must not be mounted, but found: %q", name, v)
+			}
+		}
+	}
+}
+
 func TestRedactArgs_MultipleEnvVarsAllRedacted(t *testing.T) {
 	args := []string{
 		"run",

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1025,8 +1025,9 @@ func TestBuildRunArgs_PluginMountedSeparately(t *testing.T) {
 
 func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 	// Verifies that the config mount block uses an explicit allowlist:
-	// - Allowlisted entries present on disk ARE mounted read-only.
-	// - Bun ecosystem files (package.json, bun.lock, node_modules/) are NOT mounted.
+	// - All 7 allowlisted entries present on disk ARE mounted read-only.
+	// - Bun ecosystem files (package.json, bun.lock, package-lock.json,
+	//   node_modules/) are NOT mounted.
 	// - opencode.json is NOT mounted even when present on disk.
 	//
 	// Previous tests (TestBuildRunArgs_OpencodeJsonSkippedInItemByItemMount,
@@ -1041,7 +1042,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		t.Fatalf("MkdirAll configDir: %v", err)
 	}
 
-	// Allowlisted files/dirs that should be mounted.
+	// Allowlisted files/dirs that should be mounted (all 7 entries from configAllowlist).
 	allowlisted := []struct {
 		name  string
 		isDir bool
@@ -1049,7 +1050,10 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		{"AGENTS.md", false},
 		{"tui.json", false},
 		{"mcp-atlassian-slim-proxy.mjs", false},
+		{".gitignore", false},
 		{"agents", true},
+		{"skills", true},
+		{"command", true},
 	}
 	for _, e := range allowlisted {
 		p := filepath.Join(configDir, e.name)
@@ -1064,8 +1068,8 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		}
 	}
 
-	// Files that must NOT be mounted.
-	excluded := []string{"package.json", "bun.lock", "opencode.json"}
+	// Files that must NOT be mounted — bun ecosystem files and opencode.json.
+	excluded := []string{"package.json", "bun.lock", "package-lock.json", "opencode.json"}
 	for _, name := range excluded {
 		if err := os.WriteFile(filepath.Join(configDir, name), []byte("stub"), 0o644); err != nil {
 			t.Fatalf("WriteFile %s: %v", name, err)
@@ -1112,7 +1116,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 	}
 
 	// Assert excluded entries are NOT present.
-	excluded = append(excluded, "node_modules")
+	excluded = append(excluded, "node_modules") // dir also covered
 	for _, name := range excluded {
 		containerPath := "/root/.config/opencode/" + name
 		for _, v := range mountValues {


### PR DESCRIPTION
## Summary

Fixes a critical regression introduced in #619 where `buildRunArgs()` used an `os.ReadDir` denylist loop to mount every entry from `~/.config/opencode/` read-only into the container. This included `package.json` and other bun ecosystem files, which the bun runtime tries to write to at request time — causing EROFS errors, HTTP 500 responses, health check timeouts, and completely broken container spawns.

## Fix

Replaces the denylist loop with an explicit **allowlist** of config entries the container actually needs:

- `AGENTS.md`
- `agents/` (directory)
- `skills/` (directory)
- `command/` (directory)
- `tui.json`
- `.gitignore`
- `mcp-atlassian-slim-proxy.mjs`

Entries intentionally excluded:
- `package.json`, `bun.lock`, `package-lock.json`, `node_modules/` — bun manages these itself inside the container
- `opencode.json` — superseded by `OPENCODE_CONFIG_CONTENT` env var (was already excluded)
- `plugins/` — mounted separately via `PluginHostPath` (was already excluded)

The symlink resolution logic and directory-vs-file mount strategy (`--mount type=bind` vs `--volume`) are unchanged. Entries absent from the host are silently skipped.

Closes #620