### PR TITLE
test(prism): add ConfigContent injection tests for restore and injectContainerConfig

### DIFF
--- a/modules/programs/prism/prism/cmd/inject_container_config_test.go
+++ b/modules/programs/prism/prism/cmd/inject_container_config_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+// Unit tests for the injectContainerConfig helper (switch.go).
+//
+// injectContainerConfig derives the agent role from the worktree path,
+// looks up the role's config blob from the profiles file, and sets
+// opts.ConfigContent. These tests exercise:
+//
+//   - Worker role (non-"main" directory base) receives ContainerWorkerConfig.
+//   - Coordinator role ("main" directory base) receives ContainerCoordinatorConfig.
+//   - An explicit Agent override is respected over the DefaultAgent derivation.
+//   - Empty config blob (role present but no config set) leaves ConfigContent empty
+//     and does not return an error.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// makeInjectTestProfile builds a ProfilesFile with known worker and coordinator
+// blobs for inject tests.
+func makeInjectTestProfile() *config.ProfilesFile {
+	return &config.ProfilesFile{
+		ContainerWorkerConfig:      `{"model":"test-worker-model"}`,
+		ContainerCoordinatorConfig: `{"model":"test-coordinator-model"}`,
+	}
+}
+
+// TestInjectContainerConfig_WorkerRole verifies that a non-"main" worktree
+// directory causes injectContainerConfig to select ContainerWorkerConfig.
+func TestInjectContainerConfig_WorkerRole(t *testing.T) {
+	pf := makeInjectTestProfile()
+	opts := session.Opts{}
+	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+
+	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
+		t.Fatalf("injectContainerConfig: %v", err)
+	}
+
+	if opts.ConfigContent != pf.ContainerWorkerConfig {
+		t.Errorf("ConfigContent = %q, want %q (worker blob)",
+			opts.ConfigContent, pf.ContainerWorkerConfig)
+	}
+}
+
+// TestInjectContainerConfig_CoordinatorRole verifies that a worktree directory
+// named "main" causes injectContainerConfig to select ContainerCoordinatorConfig.
+func TestInjectContainerConfig_CoordinatorRole(t *testing.T) {
+	pf := makeInjectTestProfile()
+	opts := session.Opts{}
+	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "main")
+
+	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
+		t.Fatalf("injectContainerConfig: %v", err)
+	}
+
+	if opts.ConfigContent != pf.ContainerCoordinatorConfig {
+		t.Errorf("ConfigContent = %q, want %q (coordinator blob)",
+			opts.ConfigContent, pf.ContainerCoordinatorConfig)
+	}
+}
+
+// TestInjectContainerConfig_ExplicitAgentOverride verifies that an explicit
+// opts.Agent override is respected: when opts.Agent is "coordinator", the
+// coordinator blob is selected even for a non-"main" directory.
+func TestInjectContainerConfig_ExplicitAgentOverride(t *testing.T) {
+	pf := makeInjectTestProfile()
+	opts := session.Opts{Agent: "coordinator"}
+	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+
+	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
+		t.Fatalf("injectContainerConfig: %v", err)
+	}
+
+	// "coordinator" override must win over DefaultAgent("feature-branch") = "worker".
+	if opts.ConfigContent != pf.ContainerCoordinatorConfig {
+		t.Errorf("ConfigContent = %q, want %q (coordinator blob from explicit override)",
+			opts.ConfigContent, pf.ContainerCoordinatorConfig)
+	}
+}
+
+// TestInjectContainerConfig_EmptyBlobNoError verifies that when the profiles
+// file exists but the relevant role config blob is empty, ConfigContent is left
+// empty and no error is returned.
+func TestInjectContainerConfig_EmptyBlobNoError(t *testing.T) {
+	pf := &config.ProfilesFile{
+		// Both blobs are intentionally empty to simulate a profiles.json that
+		// was generated without container configs.
+		ContainerWorkerConfig:      "",
+		ContainerCoordinatorConfig: "",
+	}
+	opts := session.Opts{}
+	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+
+	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
+		t.Fatalf("injectContainerConfig returned error on empty blob: %v", err)
+	}
+
+	if opts.ConfigContent != "" {
+		t.Errorf("ConfigContent = %q, want empty (no blob for role)", opts.ConfigContent)
+	}
+}

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -26,6 +26,17 @@ import (
 // process-wide config.Load() singleton cache.
 var loadRestoreConfig = func() config.Config { return config.Load() }
 
+// loadRestoreProfiles loads profiles.json for the restore code path.
+// It is a package-level variable so tests can inject a fake profiles file
+// without depending on XDG_CONFIG_HOME or the filesystem.
+var loadRestoreProfiles = func() (*config.ProfilesFile, error) { return config.LoadProfiles() }
+
+// onRestoreSessionCreate is called just before session.Create in
+// restoreProjectSession. In production it is nil (no-op). Tests may set it to
+// capture the session.Opts and assert that ConfigContent is populated correctly.
+// The hook is invoked with a snapshot of opts before Create is called.
+var onRestoreSessionCreate func(opts session.Opts)
+
 var restoreCmd = &cobra.Command{
 	Use:   "restore",
 	Short: "Recreate tmux sessions from prism.db",
@@ -174,7 +185,7 @@ func restoreProjectSession(d *db.DB, s db.Status) error {
 		// Profile load errors are non-fatal for restore: log and skip
 		// config injection so the session is still recreated without it,
 		// rather than aborting the entire restore run.
-		pf, pfErr := config.LoadProfiles()
+		pf, pfErr := loadRestoreProfiles()
 		if pfErr != nil {
 			fmt.Fprintf(os.Stderr, "restore %q: load profiles: %v — skipping config injection\n", s.SessionName, pfErr)
 		} else {
@@ -262,6 +273,13 @@ func restoreProjectSession(d *db.DB, s db.Status) error {
 	// When s.Repo == "", RefreshWorktree and AllocatePort are skipped. The
 	// session is still created with the full layout; it just won't have an
 	// opencode serve port allocated.
+
+	// Invoke the test hook (nil in production) with a snapshot of opts
+	// so tests can assert ConfigContent and other fields without intercepting
+	// session.Create.
+	if onRestoreSessionCreate != nil {
+		onRestoreSessionCreate(opts)
+	}
 
 	if err := session.Create(s.SessionName, directory, opts); err != nil {
 		return fmt.Errorf("create session: %w", err)

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -9,12 +9,14 @@
 //   - Already-existing sessions are skipped (idempotent)
 //   - Sessions with missing/inaccessible worktrees are skipped and marked ended
 //     in the DB, not left as zombies
+//   - Container-mode sessions have ConfigContent populated from profiles.json
 //
 // All tests use an isolated tmux server (cmdTestServer) and an isolated DB
 // (SetTestDBPath) so they do not touch the live environment.
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +36,26 @@ func withRestoreConfig(t *testing.T, cfg config.Config) {
 	prev := loadRestoreConfig
 	loadRestoreConfig = func() config.Config { return cfg }
 	t.Cleanup(func() { loadRestoreConfig = prev })
+}
+
+// withRestoreProfiles overrides loadRestoreProfiles for the duration of the
+// test and restores the previous value on cleanup. Pass nil to simulate a
+// missing or unreadable profiles.json.
+func withRestoreProfiles(t *testing.T, pf *config.ProfilesFile, loadErr error) {
+	t.Helper()
+	prev := loadRestoreProfiles
+	loadRestoreProfiles = func() (*config.ProfilesFile, error) { return pf, loadErr }
+	t.Cleanup(func() { loadRestoreProfiles = prev })
+}
+
+// withCreateSessionHook installs onRestoreSessionCreate for the duration of the
+// test and restores it to nil on cleanup. The hook is called with the opts
+// snapshot just before session.Create is invoked inside restoreProjectSession.
+func withCreateSessionHook(t *testing.T, fn func(opts session.Opts)) {
+	t.Helper()
+	prev := onRestoreSessionCreate
+	onRestoreSessionCreate = fn
+	t.Cleanup(func() { onRestoreSessionCreate = prev })
 }
 
 // agentPaneStartCmd reads #{pane_start_command} from the agent window (window 1)
@@ -649,5 +671,164 @@ func TestRestoreSession_KillsStaleSidecarPID(t *testing.T) {
 	// Sanity: the session should have been created.
 	if !s.hasSession(sessionName) {
 		t.Errorf("session %q was not created", sessionName)
+	}
+}
+
+// fakeProfilesFile returns a *config.ProfilesFile with known worker and
+// coordinator container config blobs for use in container-mode tests.
+func fakeProfilesFile() *config.ProfilesFile {
+	return &config.ProfilesFile{
+		ContainerWorkerConfig:      `{"model":"worker-model"}`,
+		ContainerCoordinatorConfig: `{"model":"coordinator-model"}`,
+	}
+}
+
+// TestRestoreSession_ContainerMode_WorkerConfigContent verifies that when
+// cfg.ContainerMode is true and profiles.json contains a worker config blob,
+// restoreProjectSession populates opts.ConfigContent with the worker blob for
+// a non-main worktree directory (DefaultAgent returns "worker").
+//
+// This is the AC regression guard for restore: ConfigContent must flow from
+// profiles.json through opts into session.Create (and on to StartSidecarWithOpts
+// as --config-content) so the container runs with its role identity locked.
+func TestRestoreSession_ContainerMode_WorkerConfigContent(t *testing.T) {
+	// Uses withCmdServer — must not run in parallel.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	pluginPath := "/fake/plugin/path/prism-hooks.ts"
+	withRestoreConfig(t, config.Config{
+		ContainerMode:     true,
+		SidecarPluginPath: pluginPath,
+	})
+
+	// Inject a fake profiles file so tests do not require a real profiles.json.
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	// Use a non-main worktree directory so DefaultAgent returns "worker".
+	worktreeDir := filepath.Join(t.TempDir(), "feature-branch")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@feature"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+
+	// Capture the opts passed to session.Create via the test hook.
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	if err := restoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	if !s.hasSession(sessionName) {
+		t.Fatalf("session %q was not created", sessionName)
+	}
+
+	// The worker blob must be in ConfigContent.
+	if capturedOpts.ConfigContent != pf.ContainerWorkerConfig {
+		t.Errorf("opts.ConfigContent = %q, want %q (worker blob)",
+			capturedOpts.ConfigContent, pf.ContainerWorkerConfig)
+	}
+}
+
+// TestRestoreSession_ContainerMode_CoordinatorConfigContent verifies that the
+// coordinator blob is selected when the worktree directory is named "main"
+// (DefaultAgent returns "coordinator" for directories whose base is "main").
+func TestRestoreSession_ContainerMode_CoordinatorConfigContent(t *testing.T) {
+	// Uses withCmdServer — must not run in parallel.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	withRestoreConfig(t, config.Config{
+		ContainerMode: true,
+	})
+
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	// "main" as the base name causes DefaultAgent to return "coordinator".
+	worktreeDir := filepath.Join(t.TempDir(), "main")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@main"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	if err := restoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	if !s.hasSession(sessionName) {
+		t.Fatalf("session %q was not created", sessionName)
+	}
+
+	// The coordinator blob must be in ConfigContent.
+	if capturedOpts.ConfigContent != pf.ContainerCoordinatorConfig {
+		t.Errorf("opts.ConfigContent = %q, want %q (coordinator blob)",
+			capturedOpts.ConfigContent, pf.ContainerCoordinatorConfig)
+	}
+}
+
+// TestRestoreSession_ContainerMode_ProfilesError verifies that a profiles.json
+// load error is non-fatal for restore: the session is still created and
+// opts.ConfigContent is left empty (no injection), rather than aborting the
+// entire restore run.
+func TestRestoreSession_ContainerMode_ProfilesError(t *testing.T) {
+	// Uses withCmdServer — must not run in parallel.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	withRestoreConfig(t, config.Config{
+		ContainerMode: true,
+	})
+
+	// Simulate a missing/unreadable profiles.json.
+	withRestoreProfiles(t, nil, fmt.Errorf("profiles: not found"))
+
+	d := openRestoreTestDB(t)
+
+	worktreeDir := t.TempDir()
+	sessionName := "myrepo@profiles-error"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	// restoreSession must NOT return an error — the profiles load failure is
+	// logged to stderr but must not abort the session recreation.
+	if err := restoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession returned error on profiles load failure: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	// The session must still have been created.
+	if !s.hasSession(sessionName) {
+		t.Errorf("session %q was not created despite profiles error (should be non-fatal)", sessionName)
+	}
+
+	// ConfigContent must be empty — no injection when profiles are unavailable.
+	if capturedOpts.ConfigContent != "" {
+		t.Errorf("opts.ConfigContent = %q, want empty (profiles load failed — injection must be skipped)",
+			capturedOpts.ConfigContent)
 	}
 }


### PR DESCRIPTION
## Summary

Adds test coverage for the `OPENCODE_CONFIG_CONTENT` injection work from PR #623, which was merged without tests.

- **`restore.go`**: add `loadRestoreProfiles` hook (mirrors `loadRestoreConfig`) and `onRestoreSessionCreate` hook so tests can intercept opts before `session.Create` without requiring a real tmux server or filesystem setup.
- **`restore_test.go`**: three new container-mode integration tests:
  - `TestRestoreSession_ContainerMode_WorkerConfigContent` — verifies worker blob is set in `opts.ConfigContent` for non-main worktrees.
  - `TestRestoreSession_ContainerMode_CoordinatorConfigContent` — verifies coordinator blob is selected for `main` worktrees.
  - `TestRestoreSession_ContainerMode_ProfilesError` — verifies profile load failure is non-fatal (session still created, `ConfigContent` left empty).
- **`inject_container_config_test.go`**: four unit tests for the `injectContainerConfig` helper in `switch.go` (worker role, coordinator role, explicit agent override, empty blob).

All new unit tests pass. The three restore integration tests skip when tmux is not available — consistent with all other restore tests.

Closes #622 (follow-up test coverage — implementation was in #623)