### PR TITLE
container: disable coordinator, build, and plan agents in worker container config

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -509,6 +509,15 @@
           title = { };
           summary = { };
           compaction = { };
+          coordinator = {
+            disable = true;
+          };
+          build = {
+            disable = true;
+          };
+          plan = {
+            disable = true;
+          };
         };
         permission = {
           edit = "allow";


### PR DESCRIPTION
## Summary

- Adds `coordinator = { disable = true; }`, `build = { disable = true; }`, and `plan = { disable = true; }` to the `agent` attrset of `workerContainerOpencodeJson` in `modules/programs/prism/opencode.nix`
- Prevents users/agents in worker containers from switching to the coordinator, build, or plan roles via the UI, enforcing the role-locking design from #619
- No changes to `coordinatorContainerOpencodeJson`, host `programs.opencode.settings`, or any Go source

Closes #625