### PR TITLE
fix: pin opencode-claude-auth to PR #189 build to fix billing validation

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -363,15 +363,18 @@
         anthropic = [
           # use existing Claude Code credentials (via claude login OAuth)
           # no separate proxy or API key needed
-          "opencode-claude-auth@latest"
+          # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+          # "opencode-claude-auth@latest"
         ];
         anthropic-opus = [
-          "opencode-claude-auth@latest"
+          # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+          # "opencode-claude-auth@latest"
         ];
         # gemini-hybrid uses both Anthropic (Opus primary) and Google (Gemini secondary).
         # Both auth plugins are needed; they are both loaded globally anyway.
         gemini-hybrid = [
-          "opencode-claude-auth@latest"
+          # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+          # "opencode-claude-auth@latest"
         ];
         github-copilot = [ ];
         google = [ ];
@@ -481,7 +484,8 @@
 
       # Plugins for containers: claude-auth only (no gemini-auth noise).
       containerPlugins = [
-        "opencode-claude-auth@latest"
+        # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+        # "opencode-claude-auth@latest"
         "./plugins/prism-hooks"
       ];
 


### PR DESCRIPTION
## Summary

- Pins `opencode-claude-auth` to the compiled output of upstream PR [griffinmartin/opencode-claude-auth#189](https://github.com/griffinmartin/opencode-claude-auth/pull/189) (commit `00ee0c42`) rather than `@latest` from npm
- The PR removes blanket `mcp_` tool name prefixing that causes Anthropic's OAuth billing validation to reject requests with 3+ tools (400 "out of extra usage")
- Compiled JS built from the fork branch and committed as static files under `opencode/plugins/opencode-claude-auth/`, mounted via `xdg.configFile` with `recursive = true` — same pattern as the existing `prism-hooks` plugin

## Revert path

Once the fix lands on npm, revert by:
1. Deleting `modules/programs/prism/opencode/plugins/opencode-claude-auth/`
2. Removing the `xdg.configFile."opencode/plugins/opencode-claude-auth"` entry from `opencode.nix`
3. Changing the three `"./plugins/opencode-claude-auth"` strings back to `"opencode-claude-auth@latest"`