### PR TITLE
fix: mount whole plugins/ dir in prism containers

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -363,15 +363,18 @@
         anthropic = [
           # use existing Claude Code credentials (via claude login OAuth)
           # no separate proxy or API key needed
-          "opencode-claude-auth@latest"
+          # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+          # "opencode-claude-auth@latest"
         ];
         anthropic-opus = [
-          "opencode-claude-auth@latest"
+          # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+          # "opencode-claude-auth@latest"
         ];
         # gemini-hybrid uses both Anthropic (Opus primary) and Google (Gemini secondary).
         # Both auth plugins are needed; they are both loaded globally anyway.
         gemini-hybrid = [
-          "opencode-claude-auth@latest"
+          # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+          # "opencode-claude-auth@latest"
         ];
         github-copilot = [ ];
         google = [ ];
@@ -481,7 +484,8 @@
 
       # Plugins for containers: claude-auth only (no gemini-auth noise).
       containerPlugins = [
-        "opencode-claude-auth@latest"
+        # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
+        # "opencode-claude-auth@latest"
         "./plugins/prism-hooks"
       ];
 

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -482,11 +482,15 @@
         "google"
       ];
 
-      # Plugins for containers: claude-auth only (no gemini-auth noise).
+      # Plugins for containers: use absolute paths because the plugin list is
+      # injected via OPENCODE_CONFIG_CONTENT (an env var, not a file on disk).
+      # opencode only resolves relative plugin paths when loading from a file
+      # (isFile=true); env-var config has isFile=false so "./plugins/..." would
+      # be resolved relative to the project working directory and fail to load.
       containerPlugins = [
         # TODO: re-enable once https://github.com/griffinmartin/opencode-claude-auth/pull/191 lands on npm
-        # "opencode-claude-auth@latest"
-        "./plugins/prism-hooks"
+        # "/root/.config/opencode/plugins/opencode-claude-auth"
+        "/root/.config/opencode/plugins/prism-hooks"
       ];
 
       # Worker container opencode.json blob.

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -606,6 +606,10 @@ func (m *Manager) buildRunArgs() []string {
 	//
 	// Excluded intentionally:
 	//   - opencode.json  — superseded by OPENCODE_CONFIG_CONTENT env var
+	//   - plugins/       — mounted separately below as read-write; npm plugin
+	//                      packages (e.g. opencode-claude-auth) write to their
+	//                      own directories at runtime (token refresh etc.) so
+	//                      read-only would cause EROFS errors.
 	//   - package.json, bun.lock, package-lock.json, node_modules/ — bun
 	//                      ecosystem files the container manages itself
 	//
@@ -616,7 +620,6 @@ func (m *Manager) buildRunArgs() []string {
 	configAllowlist := []string{
 		"AGENTS.md",
 		"agents",
-		"plugins",
 		"skills",
 		"command",
 		"tui.json",
@@ -637,6 +640,16 @@ func (m *Manager) buildRunArgs() []string {
 		} else {
 			args = append(args, "--volume", resolved+":"+containerPath+":ro")
 		}
+	}
+
+	// plugins/ — mounted read-write separately from the ro allowlist above.
+	// Plugin packages (e.g. opencode-claude-auth) write back refreshed tokens
+	// and other runtime state into their own directories, so read-only would
+	// cause EROFS errors. Symlinks are resolved so Nix store paths work.
+	pluginsHostPath := filepath.Join(opencodeConfigDir, "plugins")
+	if resolvedPlugins, err := filepath.EvalSymlinks(pluginsHostPath); err == nil {
+		args = append(args, "--mount",
+			"type=bind,src="+resolvedPlugins+",dst=/root/.config/opencode/plugins")
 	}
 
 	// Mount individual SSH keys and a generated config for git push/fetch and

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -606,7 +606,6 @@ func (m *Manager) buildRunArgs() []string {
 	//
 	// Excluded intentionally:
 	//   - opencode.json  — superseded by OPENCODE_CONFIG_CONTENT env var
-	//   - plugins/       — mounted separately via PluginHostPath
 	//   - package.json, bun.lock, package-lock.json, node_modules/ — bun
 	//                      ecosystem files the container manages itself
 	//
@@ -617,6 +616,7 @@ func (m *Manager) buildRunArgs() []string {
 	configAllowlist := []string{
 		"AGENTS.md",
 		"agents",
+		"plugins",
 		"skills",
 		"command",
 		"tui.json",
@@ -732,15 +732,6 @@ func (m *Manager) buildRunArgs() []string {
 			"--volume", gitdirMount,
 			"--volume", wtGitdirMount,
 		)
-	}
-
-	// Plugin mount (AC-5): mount the prism-hooks plugin if a path was provided.
-	if cfg.PluginHostPath != "" {
-		// The container's opencode config is at /root/.config/opencode (from the
-		// opencode config volume). The plugin lives at the same relative path
-		// inside the container.
-		containerPluginPath := "/root/.config/opencode/plugins/" + filepath.Base(cfg.PluginHostPath)
-		args = append(args, "--volume", cfg.PluginHostPath+":"+containerPluginPath+":ro")
 	}
 
 	// Inject credentials as environment variables (AC-10, AC-11).

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -321,51 +321,40 @@ func TestBuildRunArgs_DetachedFlag(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_PluginMount(t *testing.T) {
+func TestBuildRunArgs_PluginsDirMountedViaAllowlist(t *testing.T) {
+	// The plugins/ directory is now mounted via the config allowlist (as a
+	// whole directory), not as an individual file via PluginHostPath.
+	fakeHome := t.TempDir()
+	pluginsDir := filepath.Join(fakeHome, ".config", "opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll pluginsDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginsDir, "prism-hooks.ts"), []byte("stub"), 0o644); err != nil {
+		t.Fatalf("WriteFile prism-hooks.ts: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
 	m := New(Config{
-		SessionName:    "repo@feat",
-		AllocatedPort:  14000,
-		PluginHostPath: "/home/user/.config/opencode/plugins/prism-hooks.ts",
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
 	})
 	args := m.buildRunArgs()
 
 	found := false
 	for i, arg := range args {
-		if arg == "--volume" && i+1 < len(args) {
+		if arg == "--mount" && i+1 < len(args) {
 			v := args[i+1]
-			if strings.Contains(v, "prism-hooks.ts") {
+			if strings.Contains(v, "dst=/root/.config/opencode/plugins") {
 				found = true
-				// Must be read-only.
-				if !strings.HasSuffix(v, ":ro") {
-					t.Errorf("plugin mount %q should be read-only (:ro)", v)
-				}
-				// Must map to container plugin dir.
-				if !strings.Contains(v, "/root/.config/opencode/plugins/prism-hooks.ts") {
-					t.Errorf("plugin mount %q should target /root/.config/opencode/plugins/", v)
+				if !strings.Contains(v, ",ro") {
+					t.Errorf("plugins dir mount %q should be read-only (,ro)", v)
 				}
 				break
 			}
 		}
 	}
 	if !found {
-		t.Errorf("plugin volume mount not found in args: %v", args)
-	}
-}
-
-func TestBuildRunArgs_NoPluginMountWhenEmpty(t *testing.T) {
-	m := New(Config{
-		SessionName:    "repo@feat",
-		AllocatedPort:  14000,
-		PluginHostPath: "",
-	})
-	args := m.buildRunArgs()
-
-	for i, arg := range args {
-		if arg == "--volume" && i+1 < len(args) {
-			if strings.Contains(args[i+1], "prism-hooks") {
-				t.Errorf("unexpected plugin mount in args when PluginHostPath is empty: %v", args)
-			}
-		}
+		t.Errorf("plugins dir not mounted via allowlist; args: %v", args)
 	}
 }
 
@@ -994,38 +983,44 @@ func TestBuildRunArgs_NoSingleWholeDirConfigMount(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_PluginMountedSeparately(t *testing.T) {
-	// The prism-hooks plugin file is mounted separately via --volume.
+func TestBuildRunArgs_PluginsWholeDir(t *testing.T) {
+	// The whole plugins/ directory is mounted via the allowlist when it exists.
+	// PluginHostPath is no longer used for mounting.
+	fakeHome := t.TempDir()
+	pluginsDir := filepath.Join(fakeHome, ".config", "opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll pluginsDir: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
 	m := New(Config{
-		SessionName:    "repo@feat",
-		AllocatedPort:  14000,
-		AgentRole:      "worker",
-		PluginHostPath: "/home/user/.config/opencode/plugins/prism-hooks.ts",
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentRole:     "worker",
 	})
 	args := m.buildRunArgs()
 
-	foundPlugin := false
+	foundDir := false
 	for i, arg := range args {
-		if arg == "--volume" && i+1 < len(args) {
+		if arg == "--mount" && i+1 < len(args) {
 			v := args[i+1]
-			if strings.Contains(v, "prism-hooks.ts") &&
-				strings.Contains(v, "/root/.config/opencode/plugins/prism-hooks.ts") {
-				foundPlugin = true
-				if !strings.HasSuffix(v, ":ro") {
-					t.Errorf("plugin mount %q must be read-only", v)
+			if strings.Contains(v, "dst=/root/.config/opencode/plugins") {
+				foundDir = true
+				if !strings.Contains(v, ",ro") {
+					t.Errorf("plugins dir mount %q must be read-only", v)
 				}
 				break
 			}
 		}
 	}
-	if !foundPlugin {
-		t.Errorf("plugin file not mounted separately; args: %v", args)
+	if !foundDir {
+		t.Errorf("plugins dir not mounted via allowlist; args: %v", args)
 	}
 }
 
 func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 	// Verifies that the config mount block uses an explicit allowlist:
-	// - All 7 allowlisted entries present on disk ARE mounted read-only.
+	// - All 8 allowlisted entries present on disk ARE mounted read-only.
 	// - Bun ecosystem files (package.json, bun.lock, package-lock.json,
 	//   node_modules/) are NOT mounted.
 	// - opencode.json is NOT mounted even when present on disk.
@@ -1042,7 +1037,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		t.Fatalf("MkdirAll configDir: %v", err)
 	}
 
-	// Allowlisted files/dirs that should be mounted (all 7 entries from configAllowlist).
+	// Allowlisted files/dirs that should be mounted (all 8 entries from configAllowlist).
 	allowlisted := []struct {
 		name  string
 		isDir bool
@@ -1052,6 +1047,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		{"mcp-atlassian-slim-proxy.mjs", false},
 		{".gitignore", false},
 		{"agents", true},
+		{"plugins", true},
 		{"skills", true},
 		{"command", true},
 	}

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -322,8 +322,8 @@ func TestBuildRunArgs_DetachedFlag(t *testing.T) {
 }
 
 func TestBuildRunArgs_PluginsDirMountedViaAllowlist(t *testing.T) {
-	// The plugins/ directory is now mounted via the config allowlist (as a
-	// whole directory), not as an individual file via PluginHostPath.
+	// The plugins/ directory is mounted read-write (not via the ro allowlist)
+	// so plugin packages can write back runtime state.
 	fakeHome := t.TempDir()
 	pluginsDir := filepath.Join(fakeHome, ".config", "opencode", "plugins")
 	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
@@ -346,15 +346,16 @@ func TestBuildRunArgs_PluginsDirMountedViaAllowlist(t *testing.T) {
 			v := args[i+1]
 			if strings.Contains(v, "dst=/root/.config/opencode/plugins") {
 				found = true
-				if !strings.Contains(v, ",ro") {
-					t.Errorf("plugins dir mount %q should be read-only (,ro)", v)
+				// Must be read-write — plugin packages write runtime state.
+				if strings.Contains(v, ",ro") {
+					t.Errorf("plugins dir mount %q must be read-write (no ,ro)", v)
 				}
 				break
 			}
 		}
 	}
 	if !found {
-		t.Errorf("plugins dir not mounted via allowlist; args: %v", args)
+		t.Errorf("plugins dir not mounted; args: %v", args)
 	}
 }
 
@@ -984,8 +985,8 @@ func TestBuildRunArgs_NoSingleWholeDirConfigMount(t *testing.T) {
 }
 
 func TestBuildRunArgs_PluginsWholeDir(t *testing.T) {
-	// The whole plugins/ directory is mounted via the allowlist when it exists.
-	// PluginHostPath is no longer used for mounting.
+	// The whole plugins/ directory is mounted read-write (not via the ro
+	// allowlist) so that plugin packages can write back runtime state.
 	fakeHome := t.TempDir()
 	pluginsDir := filepath.Join(fakeHome, ".config", "opencode", "plugins")
 	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
@@ -1006,21 +1007,23 @@ func TestBuildRunArgs_PluginsWholeDir(t *testing.T) {
 			v := args[i+1]
 			if strings.Contains(v, "dst=/root/.config/opencode/plugins") {
 				foundDir = true
-				if !strings.Contains(v, ",ro") {
-					t.Errorf("plugins dir mount %q must be read-only", v)
+				// Must NOT be read-only — plugins write runtime state.
+				if strings.Contains(v, ",ro") {
+					t.Errorf("plugins dir mount %q must be read-write (no ,ro)", v)
 				}
 				break
 			}
 		}
 	}
 	if !foundDir {
-		t.Errorf("plugins dir not mounted via allowlist; args: %v", args)
+		t.Errorf("plugins dir not mounted; args: %v", args)
 	}
 }
 
 func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 	// Verifies that the config mount block uses an explicit allowlist:
-	// - All 8 allowlisted entries present on disk ARE mounted read-only.
+	// - All 7 allowlisted entries present on disk ARE mounted read-only.
+	// - plugins/ is mounted separately as read-write (not in the ro allowlist).
 	// - Bun ecosystem files (package.json, bun.lock, package-lock.json,
 	//   node_modules/) are NOT mounted.
 	// - opencode.json is NOT mounted even when present on disk.
@@ -1037,7 +1040,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		t.Fatalf("MkdirAll configDir: %v", err)
 	}
 
-	// Allowlisted files/dirs that should be mounted (all 8 entries from configAllowlist).
+	// Allowlisted files/dirs that should be mounted read-only (7 entries).
 	allowlisted := []struct {
 		name  string
 		isDir bool
@@ -1047,7 +1050,6 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		{"mcp-atlassian-slim-proxy.mjs", false},
 		{".gitignore", false},
 		{"agents", true},
-		{"plugins", true},
 		{"skills", true},
 		{"command", true},
 	}
@@ -1062,6 +1064,11 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 				t.Fatalf("WriteFile %s: %v", e.name, err)
 			}
 		}
+	}
+
+	// plugins/ should be mounted read-write separately.
+	if err := os.MkdirAll(filepath.Join(configDir, "plugins"), 0o755); err != nil {
+		t.Fatalf("MkdirAll plugins: %v", err)
 	}
 
 	// Files that must NOT be mounted — bun ecosystem files and opencode.json.
@@ -1093,7 +1100,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		}
 	}
 
-	// Assert allowlisted entries ARE present (as :ro mounts).
+	// Assert allowlisted entries ARE present as read-only mounts.
 	for _, e := range allowlisted {
 		found := false
 		containerPath := "/root/.config/opencode/" + e.name
@@ -1109,6 +1116,21 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		if !found {
 			t.Errorf("allowlisted entry %q was not mounted; mount values: %v", e.name, mountValues)
 		}
+	}
+
+	// Assert plugins/ IS mounted and is NOT read-only.
+	foundPlugins := false
+	for _, v := range mountValues {
+		if strings.Contains(v, "/root/.config/opencode/plugins") {
+			foundPlugins = true
+			if strings.Contains(v, ":ro") || strings.Contains(v, ",ro") {
+				t.Errorf("plugins mount %q must be read-write (no :ro/,ro)", v)
+			}
+			break
+		}
+	}
+	if !foundPlugins {
+		t.Errorf("plugins dir not mounted; mount values: %v", mountValues)
 	}
 
 	// Assert excluded entries are NOT present.


### PR DESCRIPTION
## Summary

- Adds `plugins` to the config allowlist in `container.go` so the entire `~/.config/opencode/plugins/` directory is mounted read-only into containers, rather than only the individual `prism-hooks.ts` file
- Removes the now-redundant separate `PluginHostPath` mount block
- Updates tests to reflect the new behaviour

Previously, any plugins beyond `prism-hooks.ts` were silently absent inside containers. Now the whole directory is available.