### PR TITLE
fix: mount opencode.json as file in containers for plugin path resolution

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -24,19 +24,19 @@
     # Set by opencode.nix and consumed by profiles.nix to embed them into
     # profiles.json under container_worker_config / container_coordinator_config.
     # The Go CLI reads those keys and passes the appropriate blob to the sidecar
-    # as --config-content, which injects it as OPENCODE_CONFIG_CONTENT (precedence
-    # level 6 — above any project-level opencode.jsonc).
+    # as --config-content, which writes it to a temp file and mounts it as
+    # /root/.config/opencode/opencode.json inside the container.
     nx.programs.prism.opencode.containerWorkerConfigJson = lib.mkOption {
       type = lib.types.str;
       default = "";
       internal = true;
-      description = "Serialised opencode.json blob for worker containers (OPENCODE_CONFIG_CONTENT).";
+      description = "Serialised opencode.json blob for worker containers (mounted as config file).";
     };
     nx.programs.prism.opencode.containerCoordinatorConfigJson = lib.mkOption {
       type = lib.types.str;
       default = "";
       internal = true;
-      description = "Serialised opencode.json blob for coordinator containers (OPENCODE_CONFIG_CONTENT).";
+      description = "Serialised opencode.json blob for coordinator containers (mounted as config file).";
     };
   };
   config = lib.mkIf config.nx.programs.prism.opencode.enable (
@@ -363,15 +363,19 @@
         anthropic = [
           # use existing Claude Code credentials (via claude login OAuth)
           # no separate proxy or API key needed
-          "opencode-claude-auth@latest"
+          # "opencode-claude-auth@latest"
+          "./plugins/opencode-claude-auth"
         ];
         anthropic-opus = [
-          "opencode-claude-auth@latest"
+          # "opencode-claude-auth@latest"
+          "./plugins/opencode-claude-auth"
         ];
         # gemini-hybrid uses both Anthropic (Opus primary) and Google (Gemini secondary).
         # Both auth plugins are needed; they are both loaded globally anyway.
         gemini-hybrid = [
-          "opencode-claude-auth@latest"
+          # "opencode-claude-auth@latest"
+          "./plugins/opencode-claude-auth"
+
         ];
         github-copilot = [ ];
         google = [ ];
@@ -480,9 +484,11 @@
       ];
 
       # Plugins for containers: claude-auth only (no gemini-auth noise).
+      # Relative paths resolve from the opencode.json config file location
+      # (/root/.config/opencode/) where the plugins/ directory is mounted.
       containerPlugins = [
-        "opencode-claude-auth@latest"
-        "./plugins/prism-hooks"
+        "./plugins/opencode-claude-auth"
+        "./plugins/prism-hooks.ts"
       ];
 
       # Worker container opencode.json blob.

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -15,8 +15,9 @@ package cmd
 //	--port <n>                allocated host port (required in container mode)
 //	--plugin-path <path>      host path to the prism-hooks.ts plugin; mounted
 //	                          read-only into the container (container mode only)
-//	--config-content <json>   JSON blob for OPENCODE_CONFIG_CONTENT; injected
-//	                          into the container environment (container mode only)
+//	--config-content <json>   JSON blob for the container's opencode.json;
+//	                          written to a temp file and mounted into the
+//	                          container (container mode only)
 //
 // The sidecar connects to <opencode-url>/event and maps opencode SSE events to
 // agent state transitions, writing them to prism.db. It handles idle debounce,
@@ -73,7 +74,7 @@ func init() {
 	sidecarCmd.Flags().Int("port", 0, "Allocated host port (required in container mode)")
 	sidecarCmd.Flags().String("plugin-path", "", "Host path to prism-hooks.ts plugin (container mode only)")
 	sidecarCmd.Flags().String("initial-prompt", "", "Initial prompt to deliver to the agent after container readiness (container mode only)")
-	sidecarCmd.Flags().String("config-content", "", "JSON blob for OPENCODE_CONFIG_CONTENT; injected into container environment (container mode only)")
+	sidecarCmd.Flags().String("config-content", "", "JSON blob for container opencode.json; written to temp file and mounted (container mode only)")
 	_ = sidecarCmd.MarkFlagRequired("session")
 	_ = sidecarCmd.MarkFlagRequired("opencode-url")
 	rootCmd.AddCommand(sidecarCmd)

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -67,19 +67,20 @@ type Config struct {
 	// opencode config and cause "model not supported" errors).
 	AgentModel string
 
-	// ConfigContent is the JSON blob for the OPENCODE_CONFIG_CONTENT environment
-	// variable. When non-empty, it is injected as an env var into the container
-	// so that opencode serve picks up the correct model and variant overrides at
-	// runtime (precedence level 6 in opencode's config merge).
+	// ConfigContent is the JSON blob for the container's opencode.json config
+	// file. When non-empty, it is written to a temp file and bind-mounted into
+	// the container at /root/.config/opencode/opencode.json so that opencode
+	// serve picks up the correct model, variant, and plugin overrides at runtime.
 	//
-	// Previously this was done via --model and --variant flags on opencode serve,
-	// but those flags are not accepted by the serve subcommand. Using
-	// OPENCODE_CONFIG_CONTENT works for both serve and the TUI/attach path.
+	// Using a mounted config file (rather than the OPENCODE_CONFIG_CONTENT env
+	// var) allows plugin paths to be specified as relative paths (e.g.
+	// "./plugins/my-plugin") that resolve correctly relative to the config
+	// file's location inside the container.
 	ConfigContent string
 
-	// PluginHostPath is the absolute path to the prism-hooks plugin file on the
-	// host (e.g. ~/.config/opencode/plugins/prism-hooks.ts). It is mounted
-	// read-only into the container's opencode plugin directory.
+	// PluginHostPath is retained for compatibility but is no longer used by
+	// the container — the entire plugins/ directory is now mounted read-only
+	// via the config allowlist in buildRunArgs.
 	PluginHostPath string
 
 	// BareRoot is the absolute path to the bare git repo root on the host
@@ -184,6 +185,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.sshConfigFilePath())
 	_ = os.Remove(m.gitconfigFilePath())
 	_ = os.Remove(m.allowedSignersFilePath())
+	_ = os.Remove(m.opencodeConfigFilePath())
 	// Stop the container (ignore errors — may not be running).
 	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", m.name)
 	if out, err := stopCmd.CombinedOutput(); err != nil {
@@ -231,6 +233,15 @@ func (m *Manager) gitconfigFilePath() string {
 // git verify-commit to work with SSH signing.
 func (m *Manager) allowedSignersFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-allowed-signers-"+m.name)
+}
+
+// opencodeConfigFilePath returns the host path for the temporary opencode.json
+// config file written before container start. The file is mounted read-only
+// at /root/.config/opencode/opencode.json inside the container so that plugin
+// paths (e.g. "./plugins/my-plugin") resolve correctly relative to the config
+// file location.
+func (m *Manager) opencodeConfigFilePath() string {
+	return filepath.Join(os.TempDir(), "prism-opencode-config-"+m.name)
 }
 
 // writeGitconfig generates a minimal .gitconfig for the container and writes
@@ -397,6 +408,16 @@ func (m *Manager) Create(ctx context.Context) error {
 		return fmt.Errorf("container: write gitconfig: %w", err)
 	}
 
+	// Write the opencode config file for the container. This replaces the
+	// previous OPENCODE_CONFIG_CONTENT env var approach so that relative plugin
+	// paths (e.g. "./plugins/my-plugin") resolve correctly from the config
+	// file's location at /root/.config/opencode/opencode.json.
+	if m.cfg.ConfigContent != "" {
+		if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o644); err != nil {
+			return fmt.Errorf("container: write opencode config: %w", err)
+		}
+	}
+
 	// Build the podman run arguments.
 	args := m.buildRunArgs()
 
@@ -481,6 +502,7 @@ func (m *Manager) Shutdown() {
 	_ = os.Remove(m.sshConfigFilePath())
 	_ = os.Remove(m.gitconfigFilePath())
 	_ = os.Remove(m.allowedSignersFilePath())
+	_ = os.Remove(m.opencodeConfigFilePath())
 
 	log.Printf("container: %q removed", m.name)
 }
@@ -503,8 +525,8 @@ func (m *Manager) buildRunArgs() []string {
 		":/root/.local/share/opencode:Z"
 	// opencodeConfigDir is the host's opencode config directory, mounted
 	// item-by-item so that agents/ files, skills/, etc. are available inside
-	// the container. opencode.json is NOT mounted (it is superseded by
-	// OPENCODE_CONFIG_CONTENT injected via --env below).
+	// the container. opencode.json is NOT mounted from the host — the container
+	// gets its own generated opencode.json via the ConfigContent temp file.
 	opencodeConfigDir := filepath.Join(home, ".config", "opencode")
 
 	// opencode cache — mount the whole directory so plugins, models.json,
@@ -605,8 +627,10 @@ func (m *Manager) buildRunArgs() []string {
 	// container actually needs.
 	//
 	// Excluded intentionally:
-	//   - opencode.json  — superseded by OPENCODE_CONFIG_CONTENT env var
-	//   - plugins/       — mounted separately via PluginHostPath
+	//   - opencode.json  — mounted separately from the ConfigContent temp file
+	//                      (not from the host's opencode.json) so that the
+	//                      container gets the role-specific config with correct
+	//                      relative plugin paths
 	//   - package.json, bun.lock, package-lock.json, node_modules/ — bun
 	//                      ecosystem files the container manages itself
 	//
@@ -617,6 +641,7 @@ func (m *Manager) buildRunArgs() []string {
 	configAllowlist := []string{
 		"AGENTS.md",
 		"agents",
+		"plugins",
 		"skills",
 		"command",
 		"tui.json",
@@ -734,27 +759,18 @@ func (m *Manager) buildRunArgs() []string {
 		)
 	}
 
-	// Plugin mount (AC-5): mount the prism-hooks plugin if a path was provided.
-	if cfg.PluginHostPath != "" {
-		// The container's opencode config is at /root/.config/opencode (from the
-		// opencode config volume). The plugin lives at the same relative path
-		// inside the container.
-		containerPluginPath := "/root/.config/opencode/plugins/" + filepath.Base(cfg.PluginHostPath)
-		args = append(args, "--volume", cfg.PluginHostPath+":"+containerPluginPath+":ro")
-	}
-
 	// Inject credentials as environment variables (AC-10, AC-11).
 	for _, kv := range m.credentialEnvVars() {
 		args = append(args, "--env", kv)
 	}
 
-	// OPENCODE_CONFIG_CONTENT: inject as an env var when set. This overrides
-	// model and variant at runtime (precedence level 6 in opencode's config
-	// merge). Previously --model and --variant were appended to the opencode
-	// serve command, but serve does not accept those flags — env var injection
-	// is the correct and more general approach.
+	// opencode.json: mount the generated config file when ConfigContent is set.
+	// The file is written by Create() to a temp path and mounted read-only at
+	// /root/.config/opencode/opencode.json. This replaces the previous
+	// OPENCODE_CONFIG_CONTENT env var so that relative plugin paths (e.g.
+	// "./plugins/my-plugin") resolve correctly from the config file's directory.
 	if cfg.ConfigContent != "" {
-		args = append(args, "--env", "OPENCODE_CONFIG_CONTENT="+cfg.ConfigContent)
+		args = append(args, "--volume", m.opencodeConfigFilePath()+":/root/.config/opencode/opencode.json:ro")
 	}
 
 	// Image and command: opencode serve on the container port.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -321,49 +321,46 @@ func TestBuildRunArgs_DetachedFlag(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_PluginMount(t *testing.T) {
+func TestBuildRunArgs_PluginDirMountedViaAllowlist(t *testing.T) {
+	// plugins/ is a directory on disk — it should be mounted read-only via
+	// the config allowlist (--mount type=bind,ro), not as a single file.
+	fakeHome := t.TempDir()
+	pluginDir := filepath.Join(fakeHome, ".config", "opencode", "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugins: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "my-plugin.ts"), []byte("stub"), 0o644); err != nil {
+		t.Fatalf("WriteFile my-plugin.ts: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
 	m := New(Config{
-		SessionName:    "repo@feat",
-		AllocatedPort:  14000,
-		PluginHostPath: "/home/user/.config/opencode/plugins/prism-hooks.ts",
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
 	})
 	args := m.buildRunArgs()
 
+	// Must be mounted via --mount type=bind (directory path), read-only.
 	found := false
 	for i, arg := range args {
-		if arg == "--volume" && i+1 < len(args) {
+		if arg == "--mount" && i+1 < len(args) {
 			v := args[i+1]
-			if strings.Contains(v, "prism-hooks.ts") {
+			if strings.Contains(v, "/root/.config/opencode/plugins") && strings.Contains(v, ",ro") {
 				found = true
-				// Must be read-only.
-				if !strings.HasSuffix(v, ":ro") {
-					t.Errorf("plugin mount %q should be read-only (:ro)", v)
-				}
-				// Must map to container plugin dir.
-				if !strings.Contains(v, "/root/.config/opencode/plugins/prism-hooks.ts") {
-					t.Errorf("plugin mount %q should target /root/.config/opencode/plugins/", v)
-				}
 				break
 			}
 		}
 	}
 	if !found {
-		t.Errorf("plugin volume mount not found in args: %v", args)
+		t.Errorf("plugins/ not mounted via --mount type=bind,ro; args: %v", args)
 	}
-}
 
-func TestBuildRunArgs_NoPluginMountWhenEmpty(t *testing.T) {
-	m := New(Config{
-		SessionName:    "repo@feat",
-		AllocatedPort:  14000,
-		PluginHostPath: "",
-	})
-	args := m.buildRunArgs()
-
+	// Must NOT appear as an individual --volume file mount.
 	for i, arg := range args {
 		if arg == "--volume" && i+1 < len(args) {
-			if strings.Contains(args[i+1], "prism-hooks") {
-				t.Errorf("unexpected plugin mount in args when PluginHostPath is empty: %v", args)
+			v := args[i+1]
+			if strings.Contains(v, "plugins/my-plugin.ts") {
+				t.Errorf("plugin should not be mounted as individual file: %q", v)
 			}
 		}
 	}
@@ -950,11 +947,9 @@ func TestRedactArgs_EnvAsLastArgNoPanic(t *testing.T) {
 
 // ── opencode config mount tests ──────────────────────────────────────────────
 
-func TestBuildRunArgs_OpencodeJsonSkippedInItemByItemMount(t *testing.T) {
-	// opencode.json must never be mounted — agent identity and permissions are
-	// set authoritatively via OPENCODE_CONFIG_CONTENT (injected as --env).
-	// Any on-disk opencode.json would be superseded anyway, but skipping the
-	// mount is belt-and-suspenders and avoids polluting the container.
+func TestBuildRunArgs_HostOpencodeJsonNotMountedFromAllowlist(t *testing.T) {
+	// The host's opencode.json must NOT be mounted via the config allowlist.
+	// When ConfigContent is empty, no opencode.json should appear at all.
 	m := New(Config{
 		SessionName:   "repo@feat",
 		AllocatedPort: 14000,
@@ -966,7 +961,57 @@ func TestBuildRunArgs_OpencodeJsonSkippedInItemByItemMount(t *testing.T) {
 		if (arg == "--volume" || arg == "--mount") && i+1 < len(args) {
 			v := args[i+1]
 			if strings.Contains(v, "opencode.json") {
-				t.Errorf("opencode.json must not be mounted into the container, got: %q", v)
+				t.Errorf("opencode.json must not be mounted when ConfigContent is empty, got: %q", v)
+			}
+		}
+	}
+}
+
+func TestBuildRunArgs_OpencodeJsonMountedWhenConfigContentSet(t *testing.T) {
+	// When ConfigContent is set, the generated temp file must be mounted
+	// at /root/.config/opencode/opencode.json:ro.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentRole:     "worker",
+		ConfigContent: `{"model":"anthropic/claude-sonnet-4-6"}`,
+	})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.HasSuffix(v, ":/root/.config/opencode/opencode.json:ro") {
+				found = true
+				// Source must be the temp file path.
+				if !strings.Contains(v, "prism-opencode-config-") {
+					t.Errorf("opencode.json mount source should be temp file, got: %q", v)
+				}
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("opencode.json mount not found when ConfigContent is set; args: %v", args)
+	}
+}
+
+func TestBuildRunArgs_NoConfigContentEnvVar(t *testing.T) {
+	// OPENCODE_CONFIG_CONTENT must NOT be injected as an env var — the config
+	// is now delivered via a mounted opencode.json file.
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentRole:     "worker",
+		ConfigContent: `{"model":"anthropic/claude-sonnet-4-6"}`,
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) {
+			if strings.HasPrefix(args[i+1], "OPENCODE_CONFIG_CONTENT=") {
+				t.Errorf("OPENCODE_CONFIG_CONTENT must not be injected as env var, got: %q", args[i+1])
 			}
 		}
 	}
@@ -994,43 +1039,15 @@ func TestBuildRunArgs_NoSingleWholeDirConfigMount(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_PluginMountedSeparately(t *testing.T) {
-	// The prism-hooks plugin file is mounted separately via --volume.
-	m := New(Config{
-		SessionName:    "repo@feat",
-		AllocatedPort:  14000,
-		AgentRole:      "worker",
-		PluginHostPath: "/home/user/.config/opencode/plugins/prism-hooks.ts",
-	})
-	args := m.buildRunArgs()
-
-	foundPlugin := false
-	for i, arg := range args {
-		if arg == "--volume" && i+1 < len(args) {
-			v := args[i+1]
-			if strings.Contains(v, "prism-hooks.ts") &&
-				strings.Contains(v, "/root/.config/opencode/plugins/prism-hooks.ts") {
-				foundPlugin = true
-				if !strings.HasSuffix(v, ":ro") {
-					t.Errorf("plugin mount %q must be read-only", v)
-				}
-				break
-			}
-		}
-	}
-	if !foundPlugin {
-		t.Errorf("plugin file not mounted separately; args: %v", args)
-	}
-}
-
 func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 	// Verifies that the config mount block uses an explicit allowlist:
-	// - All 7 allowlisted entries present on disk ARE mounted read-only.
+	// - All 8 allowlisted entries present on disk ARE mounted read-only.
 	// - Bun ecosystem files (package.json, bun.lock, package-lock.json,
 	//   node_modules/) are NOT mounted.
-	// - opencode.json is NOT mounted even when present on disk.
+	// - The host's opencode.json is NOT mounted via the allowlist (it is
+	//   delivered separately via the ConfigContent temp file mechanism).
 	//
-	// Previous tests (TestBuildRunArgs_OpencodeJsonSkippedInItemByItemMount,
+	// Previous tests (TestBuildRunArgs_HostOpencodeJsonNotMountedFromAllowlist,
 	// TestBuildRunArgs_NoSingleWholeDirConfigMount) ran against an empty home dir,
 	// so filepath.EvalSymlinks always failed and the config block produced zero
 	// mount args — the allowlist was never actually exercised. This test populates
@@ -1042,7 +1059,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		t.Fatalf("MkdirAll configDir: %v", err)
 	}
 
-	// Allowlisted files/dirs that should be mounted (all 7 entries from configAllowlist).
+	// Allowlisted files/dirs that should be mounted (all 8 entries from configAllowlist).
 	allowlisted := []struct {
 		name  string
 		isDir bool
@@ -1054,6 +1071,7 @@ func TestBuildRunArgs_ConfigMountAllowlist(t *testing.T) {
 		{"agents", true},
 		{"skills", true},
 		{"command", true},
+		{"plugins", true},
 	}
 	for _, e := range allowlisted {
 		p := filepath.Join(configDir, e.name)

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -167,10 +167,10 @@ type StartSidecarOpts struct {
 	// readiness. Passed via --initial-prompt in container mode (#487).
 	// Empty string means no prompt delivery.
 	InitialPrompt string
-	// ConfigContent is the JSON blob for the OPENCODE_CONFIG_CONTENT environment
-	// variable. When non-empty and ContainerMode is true, it is forwarded to
-	// the sidecar via --config-content so the container can inject the correct
-	// model/variant overrides as an env var on podman run.
+	// ConfigContent is the JSON blob for the container's opencode.json config
+	// file. When non-empty and ContainerMode is true, it is forwarded to
+	// the sidecar via --config-content so the container can write it to a
+	// temp file and mount it at /root/.config/opencode/opencode.json.
 	//
 	// In non-container mode, OPENCODE_CONFIG_CONTENT is injected directly by
 	// buildDirectOpencodeCmd (prepended to the opencode shell command) and does


### PR DESCRIPTION
## Summary

- Replaces the `OPENCODE_CONFIG_CONTENT` env var approach with writing a temp file and bind-mounting it at `/root/.config/opencode/opencode.json:ro` inside the container
- Adds `plugins/` to the config directory allowlist so the entire plugins directory is mounted read-only
- Switches all plugin references from npm package names (`opencode-claude-auth@latest`) to relative paths (`./plugins/opencode-claude-auth`, `./plugins/prism-hooks.ts`)
- Cleans up the temp config file on container removal/shutdown

## Context

The `opencode-claude-auth` plugin stopped working via npm. A local clone was placed in `~/.config/opencode/plugins/`, but containers received config via the `OPENCODE_CONFIG_CONTENT` env var (no file on disk), so relative plugin paths couldn't resolve. PR #630 attempted a different fix but caused containers to refuse to start entirely.

This approach writes the config to a real file and mounts it, so `./plugins/...` paths resolve correctly relative to the config file's location inside the container.

Closes #631
Replaces #630