### PR TITLE
opencode: container external_directory allow + plan/build agent parity

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -420,6 +420,7 @@
         "gh *" = "allow";
         # Prism — full orchestration suite
         "prism *" = "allow";
+        "sqlite3 *" = "ask";
         # Nix validation
         "nix build *" = "allow";
         # Git read-only operations
@@ -610,6 +611,8 @@
             description = "Implementation agent with full write access";
             mode = "primary";
             color = config.theme.red;
+            # No tools block: all tools enabled by default (unlike coordinator/plan
+            # which explicitly disable write/edit). Full access is intentional here.
             permission = {
               edit = "allow";
               webfetch = "allow";

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -557,8 +557,9 @@
       };
 
       # Coordinator container opencode.json blob.
-      # Write/edit tools disabled; bash is deny-by-default with explicit allowlist
-      # for read + orchestration operations. No tmux deny commands (no tmux in container).
+      # The coordinator and plan agents are read-only (write/edit tools disabled,
+      # deny-by-default bash). The build agent has full write access with an
+      # ask-default bash, matching host worker permissions.
       coordinatorContainerOpencodeJson = {
         "$schema" = "https://opencode.ai/opencode.json";
         autoupdate = false;

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -647,9 +647,8 @@
                 "prism spawn *" = "deny";
                 "prism pr" = "deny";
                 "prism pr *" = "deny";
-                # No tmuxDenyCommands: tmux is not present in the coordinator container,
-                # so those deny entries would be inert. Omission is intentional.
-              };
+              }
+              // tmuxDenyCommands;
             };
           };
           explore = { };

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -529,6 +529,7 @@
           edit = "allow";
           webfetch = "allow";
           bash = containerWorkerBashCommands;
+          external_directory = "allow"; # safe because inside container
         };
         plugin = containerPlugins;
         provider = providerSettings;
@@ -579,7 +580,42 @@
               patch = false;
             };
             permission = {
-              bash = containerCoordinatorBashCommands;
+              bash = {
+                # Default deny everything else for plan agent (MUST be first - last match wins)
+                "*" = "deny";
+              }
+              // readOnlyBashCommands
+              // tmuxDenyCommands;
+            };
+          };
+          build = {
+            mode = "primary";
+            color = config.theme.red;
+            permission = {
+              edit = "allow";
+              webfetch = "allow";
+              # Atlassian MCP permissions
+              # fallback to ask
+              "atlasian_*" = "ask";
+              # Read operations (allow)
+              "atlasian_atlassianUserInfo" = "allow";
+              "atlasian_get*" = "allow";
+              "atlasian_lookup*" = "allow";
+              "atlasian_search*" = "allow";
+              "atlasian_fetch" = "allow";
+              "atlasian_fetchAtlassian" = "allow";
+              # Write operations (ask)
+              "atlasian_create*" = "ask";
+              "atlasian_edit*" = "ask";
+              "atlasian_update*" = "ask";
+              "atlasian_add*" = "ask";
+              "atlasian_transition*" = "ask";
+              bash = {
+                # default for any command not listed is ask (MUST be first - last match wins)
+                "*" = "ask";
+              }
+              // readOnlyBashCommands
+              // writeBashCommands;
             };
           };
           explore = { };
@@ -593,6 +629,7 @@
           edit = "deny";
           webfetch = "allow";
           bash = containerCoordinatorBashCommands;
+          external_directory = "allow"; # safe because inside container
         };
         plugin = containerPlugins;
         provider = providerSettings;

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -420,7 +420,6 @@
         "gh *" = "allow";
         # Prism — full orchestration suite
         "prism *" = "allow";
-        "sqlite3 *" = "allow";
         # Nix validation
         "nix build *" = "allow";
         # Git read-only operations
@@ -526,7 +525,10 @@
             disable = true;
           };
         };
-        mcp = lib.mkIf pkgs.stdenv.isDarwin {
+        # lib.mkIf cannot be used here — this is serialised with builtins.toJSON,
+        # not processed by the module system. Use optionalAttrs so the key is
+        # absent entirely on Linux rather than emitting a malformed _type object.
+        mcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
           atlasian = {
             type = "local";
             enabled = true;
@@ -657,7 +659,10 @@
           summary = { };
           compaction = { };
         };
-        mcp = lib.mkIf pkgs.stdenv.isDarwin {
+        # lib.mkIf cannot be used here — this is serialised with builtins.toJSON,
+        # not processed by the module system. Use optionalAttrs so the key is
+        # absent entirely on Linux rather than emitting a malformed _type object.
+        mcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
           atlasian = {
             type = "local";
             enabled = true;

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -420,7 +420,7 @@
         "gh *" = "allow";
         # Prism — full orchestration suite
         "prism *" = "allow";
-        "sqlite3 *" = "ask";
+        "sqlite3 *" = "allow";
         # Nix validation
         "nix build *" = "allow";
         # Git read-only operations
@@ -640,6 +640,11 @@
                 # already includes these denies — merging is a coordinator responsibility.
                 "gh pr merge" = "deny";
                 "gh pr merge *" = "deny";
+                # Spawning agents is a coordinator responsibility, never a worker's (#557).
+                "prism spawn" = "deny";
+                "prism spawn *" = "deny";
+                "prism pr" = "deny";
+                "prism pr *" = "deny";
                 # No tmuxDenyCommands: tmux is not present in the coordinator container,
                 # so those deny entries would be inert. Omission is intentional.
               };

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -525,9 +525,27 @@
             disable = true;
           };
         };
+        mcp = lib.mkIf pkgs.stdenv.isDarwin {
+          atlasian = {
+            type = "local";
+            enabled = true;
+            command = [ "/root/.config/opencode/mcp-atlassian-slim-proxy.mjs" ];
+            environment = {
+              ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+            };
+          };
+        };
         permission = {
           edit = "allow";
           webfetch = "allow";
+          # Atlassian MCP permissions — workers read freely, no writes
+          "atlasian_*" = "deny";
+          "atlasian_atlassianUserInfo" = "allow";
+          "atlasian_get*" = "allow";
+          "atlasian_lookup*" = "allow";
+          "atlasian_search*" = "allow";
+          "atlasian_fetch" = "allow";
+          "atlasian_fetchAtlassian" = "allow";
           bash = containerWorkerBashCommands;
           external_directory = "allow"; # safe because inside container
         };
@@ -589,22 +607,20 @@
             };
           };
           build = {
+            description = "Implementation agent with full write access";
             mode = "primary";
             color = config.theme.red;
             permission = {
               edit = "allow";
               webfetch = "allow";
-              # Atlassian MCP permissions
-              # fallback to ask
+              # Atlassian MCP permissions — same ask set as host coordinator
               "atlasian_*" = "ask";
-              # Read operations (allow)
               "atlasian_atlassianUserInfo" = "allow";
               "atlasian_get*" = "allow";
               "atlasian_lookup*" = "allow";
               "atlasian_search*" = "allow";
               "atlasian_fetch" = "allow";
               "atlasian_fetchAtlassian" = "allow";
-              # Write operations (ask)
               "atlasian_create*" = "ask";
               "atlasian_edit*" = "ask";
               "atlasian_update*" = "ask";
@@ -615,7 +631,15 @@
                 "*" = "ask";
               }
               // readOnlyBashCommands
-              // writeBashCommands;
+              // writeBashCommands
+              // {
+                # Belt-and-suspenders: explicitly deny PR merge even though writeBashCommands
+                # already includes these denies — merging is a coordinator responsibility.
+                "gh pr merge" = "deny";
+                "gh pr merge *" = "deny";
+                # No tmuxDenyCommands: tmux is not present in the coordinator container,
+                # so those deny entries would be inert. Omission is intentional.
+              };
             };
           };
           explore = { };
@@ -625,9 +649,32 @@
           summary = { };
           compaction = { };
         };
+        mcp = lib.mkIf pkgs.stdenv.isDarwin {
+          atlasian = {
+            type = "local";
+            enabled = true;
+            command = [ "/root/.config/opencode/mcp-atlassian-slim-proxy.mjs" ];
+            environment = {
+              ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+            };
+          };
+        };
         permission = {
           edit = "deny";
           webfetch = "allow";
+          # Atlassian MCP permissions — same ask set as host coordinator
+          "atlasian_*" = "ask";
+          "atlasian_atlassianUserInfo" = "allow";
+          "atlasian_get*" = "allow";
+          "atlasian_lookup*" = "allow";
+          "atlasian_search*" = "allow";
+          "atlasian_fetch" = "allow";
+          "atlasian_fetchAtlassian" = "allow";
+          "atlasian_create*" = "ask";
+          "atlasian_edit*" = "ask";
+          "atlasian_update*" = "ask";
+          "atlasian_add*" = "ask";
+          "atlasian_transition*" = "ask";
           bash = containerCoordinatorBashCommands;
           external_directory = "allow"; # safe because inside container
         };
@@ -851,11 +898,6 @@
                 }
                 // readOnlyBashCommands
                 // writeBashCommands
-                // {
-                  # deny PR merge — merging is a coordinator responsibility, never a worker's
-                  "gh pr merge" = "deny";
-                  "gh pr merge *" = "deny";
-                }
                 // tmuxDenyCommands;
               };
               plugin = [


### PR DESCRIPTION
## Summary

- Allow `external_directory` in both worker and coordinator containers (safe because the container filesystem boundary provides isolation)
- Align the **plan** agent bash permissions in the coordinator container with the host: deny-all base + `readOnlyBashCommands` + `tmuxDenyCommands`
- Add **build** agent to the coordinator container with host-comparable permissions: `edit`/`webfetch` allow, ask-default bash, `readOnlyBashCommands` + `writeBashCommands`, plus Atlassian MCP permissions mirroring the host global permission block