### PR TITLE
perf: add structured timing instrumentation to container spawn startup path

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -468,8 +468,9 @@ func (m *Manager) WaitHealthy(ctx context.Context) error {
 		}
 
 		probeCount++
+		healthy := m.isHealthy(ctx)
 		elapsed := time.Since(waitStart).Round(time.Millisecond)
-		if m.isHealthy(ctx) {
+		if healthy {
 			log.Printf("[timing] WaitHealthy probe %d: %s elapsed — ok", probeCount, elapsed)
 			log.Printf("[timing] WaitHealthy: %s (%d probes)", time.Since(waitStart).Round(time.Millisecond), probeCount)
 			return nil

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -364,8 +364,11 @@ func (m *Manager) worktreeGitdirFilePath() string {
 // It first calls EnsureRemoved to handle any stale container with the same name.
 // Returns an error if podman create or start fails.
 func (m *Manager) Create(ctx context.Context) error {
+	createStart := time.Now()
+
 	// Remove any stale container first (AC-15).
 	m.EnsureRemoved(ctx)
+	log.Printf("[timing] EnsureRemoved: %s", time.Since(createStart).Round(time.Millisecond))
 
 	// Write corrected git pointer files for the container.
 	if m.cfg.BareRoot != "" && m.cfg.WorktreeGitDir != "" {
@@ -404,9 +407,11 @@ func (m *Manager) Create(ctx context.Context) error {
 	// in ~/.config/git/config (managed by home-manager) and is not mounted into
 	// containers. We generate a minimal config with identity, signing, and
 	// convenience settings.
+	t0 := time.Now()
 	if err := m.writeGitconfig(); err != nil {
 		return fmt.Errorf("container: write gitconfig: %w", err)
 	}
+	log.Printf("[timing] writeGitconfig: %s", time.Since(t0).Round(time.Millisecond))
 
 	// Write the opencode config file for the container. This replaces the
 	// previous OPENCODE_CONFIG_CONTENT env var approach so that relative plugin
@@ -419,16 +424,23 @@ func (m *Manager) Create(ctx context.Context) error {
 	}
 
 	// Build the podman run arguments.
+	t0 = time.Now()
 	args := m.buildRunArgs()
+	log.Printf("[timing] buildRunArgs: %s", time.Since(t0).Round(time.Millisecond))
 
 	log.Printf("container: creating %q: podman %s", m.name, strings.Join(redactArgs(args), " "))
 
 	cmd := exec.CommandContext(ctx, "podman", args...)
 	cmd.Stdout = os.Stderr // forward container stdout to sidecar's stderr log
 	cmd.Stderr = os.Stderr
+	podmanStart := time.Now()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("container: podman run %q: %w", m.name, err)
 	}
+	log.Printf("[timing] podman run: %s (total to here: %s)",
+		time.Since(podmanStart).Round(time.Millisecond),
+		time.Since(createStart).Round(time.Millisecond))
+	log.Printf("[timing] Create total: %s", time.Since(createStart).Round(time.Millisecond))
 
 	return nil
 }
@@ -442,7 +454,9 @@ func (m *Manager) WaitHealthy(ctx context.Context) error {
 		timeout = DefaultHealthCheckTimeout
 	}
 
-	deadline := time.Now().Add(timeout)
+	waitStart := time.Now()
+	probeCount := 0
+	deadline := waitStart.Add(timeout)
 	for {
 		if time.Now().After(deadline) {
 			m.dumpLogs()
@@ -453,9 +467,14 @@ func (m *Manager) WaitHealthy(ctx context.Context) error {
 			return ctx.Err()
 		}
 
+		probeCount++
+		elapsed := time.Since(waitStart).Round(time.Millisecond)
 		if m.isHealthy(ctx) {
+			log.Printf("[timing] WaitHealthy probe %d: %s elapsed — ok", probeCount, elapsed)
+			log.Printf("[timing] WaitHealthy: %s (%d probes)", time.Since(waitStart).Round(time.Millisecond), probeCount)
 			return nil
 		}
+		log.Printf("[timing] WaitHealthy probe %d: %s elapsed — fail", probeCount, elapsed)
 
 		// Check if the container exited early — no point polling a dead
 		// container until the timeout expires.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -284,8 +284,8 @@ func (s *Sidecar) Run(ctx context.Context) error {
 					_ = os.WriteFile(sidPath, []byte(sid), 0o644)
 				}
 			}
+			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {
-				log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 				s.cfg.OnReady()
 			}
 			if createErr == nil {
@@ -294,9 +294,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 					log.Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 				}()
 			}
-		} else if !isShuttingDown && s.cfg.OnReady != nil {
+		} else if !isShuttingDown {
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
-			s.cfg.OnReady()
+			if s.cfg.OnReady != nil {
+				s.cfg.OnReady()
+			}
 		}
 
 		// Start the host-API Unix socket server (AC-1, AC-9).

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -225,17 +225,23 @@ type containerMgr struct {
 func (s *Sidecar) Run(ctx context.Context) error {
 	// Container mode: create and health-check the container before connecting.
 	if s.cfg.Container != nil {
+		sessionStart := time.Now()
+
 		mgr := container.New(*s.cfg.Container)
 		s.mu.Lock()
 		s.container = &containerMgr{mgr: mgr}
 		s.mu.Unlock()
 
+		log.Printf("[timing] pre-Create: %s", time.Since(sessionStart).Round(time.Millisecond))
 		log.Printf("sidecar: creating container %q", mgr.Name())
+		t0 := time.Now()
 		if err := mgr.Create(ctx); err != nil {
 			return fmt.Errorf("sidecar: container create: %w", err)
 		}
+		log.Printf("[timing] Create: %s", time.Since(t0).Round(time.Millisecond))
 
 		log.Printf("sidecar: waiting for container %q to become healthy", mgr.Name())
+		t0 = time.Now()
 		if err := mgr.WaitHealthy(ctx); err != nil {
 			log.Printf("sidecar: health check failed: %v", err)
 			// AC-14: genuine timeout — Shutdown() has not been called yet, so we
@@ -251,6 +257,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			}
 			return fmt.Errorf("sidecar: container health check: %w", err)
 		}
+		log.Printf("[timing] WaitHealthy: %s", time.Since(t0).Round(time.Millisecond))
 		log.Printf("sidecar: container %q is healthy", mgr.Name())
 
 		// Signal readiness after the container is healthy (AC-7, AC-19).
@@ -278,12 +285,17 @@ func (s *Sidecar) Run(ctx context.Context) error {
 				}
 			}
 			if !isShuttingDown && s.cfg.OnReady != nil {
+				log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 				s.cfg.OnReady()
 			}
 			if createErr == nil {
-				go s.deliverInitialPrompt(s.cfg.OpencodeURL, sid, s.cfg.InitialPrompt, s.cfg.HTTPClient)
+				go func() {
+					s.deliverInitialPrompt(s.cfg.OpencodeURL, sid, s.cfg.InitialPrompt, s.cfg.HTTPClient)
+					log.Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
+				}()
 			}
 		} else if !isShuttingDown && s.cfg.OnReady != nil {
+			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			s.cfg.OnReady()
 		}
 


### PR DESCRIPTION
## Summary

Adds `[timing]` log lines to the hot path of container session startup so bottlenecks can be identified by grepping the sidecar log with `grep '\[timing\]' <sidecar-log>`.

### In `container.Create()`
- Captures `createStart` at entry; logs `[timing] EnsureRemoved` after cleanup
- Logs `[timing] writeGitconfig` and `[timing] buildRunArgs` for each step
- Logs `[timing] podman run` (individual) and `[timing] Create total` after `cmd.Run()`

### In `container.WaitHealthy()`
- Captures `waitStart` and `probeCount`; logs each probe attempt with number, elapsed time, and pass/fail outcome
- On success, logs `[timing] WaitHealthy: <duration> (<n> probes)`

### In `sidecar.Run()`
- Captures `sessionStart` at the top of the container-mode block
- Logs `[timing] pre-Create` before `Create()`, `[timing] Create` after
- Logs `[timing] WaitHealthy` after `WaitHealthy()` returns
- Logs `[timing] ready` before calling `OnReady()`
- Logs `[timing] prompt delivered` after `deliverInitialPrompt` completes

### Example output
```
[timing] EnsureRemoved: 42ms
[timing] writeGitconfig: 3ms
[timing] buildRunArgs: 1ms
[timing] podman run: 1.23s (total to here: 1.28s)
[timing] Create total: 1.28s
[timing] WaitHealthy probe 1: 500ms elapsed — fail
[timing] WaitHealthy probe 6: 3.00s elapsed — ok
[timing] WaitHealthy: 2.72s (6 probes)
[timing] pre-Create: 2ms
[timing] Create: 1.28s
[timing] WaitHealthy: 2.72s
[timing] ready: 4.01s from start
[timing] prompt delivered: 4.85s from start
```

No new dependencies added — plain `log.Printf` with `time.Since`.

Closes #627