### PR TITLE
container: build and publish prism-agent as multi-arch image to GHCR

### DIFF
--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -103,7 +103,7 @@ jobs:
             ghcr.io/prismatic-koi/prism-agent:latest-arm64
           docker manifest push ghcr.io/prismatic-koi/prism-agent:latest
 
-          docker manifest create \
+          docker manifest create --amend \
             ghcr.io/prismatic-koi/prism-agent:${{ github.sha }} \
             ghcr.io/prismatic-koi/prism-agent:latest-amd64 \
             ghcr.io/prismatic-koi/prism-agent:latest-arm64

--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -5,6 +5,7 @@ name: publish-prism-agent
       - main
     paths:
       - 'images/prism-agent.nix'
+      - 'flake.nix'
       - 'flake.lock'
   workflow_dispatch:
 

--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -1,0 +1,108 @@
+name: publish-prism-agent
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - 'images/prism-agent.nix'
+      - 'flake.lock'
+  workflow_dispatch:
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          swap-storage: false
+          tool-cache: true
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |-
+            accept-flake-config = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v17
+        with:
+          authToken: ${{ secrets.CACHIX_TOKEN }}
+          extraPullNames: nix-community
+          name: lucidph3nx-nixos-config
+      - name: Build prism-agent image (amd64)
+        run: nix build --print-build-logs '.#packages.x86_64-linux.prismAgentImage'
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push amd64 image to GHCR
+        run: |
+          nix run nixpkgs#skopeo -- copy \
+            oci-archive:$(readlink result) \
+            docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          swap-storage: false
+          tool-cache: true
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |-
+            accept-flake-config = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v17
+        with:
+          authToken: ${{ secrets.CACHIX_TOKEN }}
+          extraPullNames: nix-community
+          name: lucidph3nx-nixos-config
+      - name: Build prism-agent image (arm64)
+        run: nix build --print-build-logs '.#packages.aarch64-linux.prismAgentImage'
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push arm64 image to GHCR
+        run: |
+          nix run nixpkgs#skopeo -- copy \
+            oci-archive:$(readlink result) \
+            docker://ghcr.io/prismatic-koi/prism-agent:latest-arm64
+
+  publish-manifest:
+    runs-on: ubuntu-24.04
+    needs:
+      - build-amd64
+      - build-arm64
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create \
+            ghcr.io/prismatic-koi/prism-agent:latest \
+            ghcr.io/prismatic-koi/prism-agent:latest-amd64 \
+            ghcr.io/prismatic-koi/prism-agent:latest-arm64
+          docker manifest push ghcr.io/prismatic-koi/prism-agent:latest
+
+          docker manifest create \
+            ghcr.io/prismatic-koi/prism-agent:${{ github.sha }} \
+            ghcr.io/prismatic-koi/prism-agent:latest-amd64 \
+            ghcr.io/prismatic-koi/prism-agent:latest-arm64
+          docker manifest push ghcr.io/prismatic-koi/prism-agent:${{ github.sha }}

--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -95,7 +95,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push multi-arch manifest
         run: |
-          docker manifest create \
+          # --amend allows overwriting an existing local manifest (needed on
+          # subsequent runs when :latest already exists in the local store).
+          docker manifest create --amend \
             ghcr.io/prismatic-koi/prism-agent:latest \
             ghcr.io/prismatic-koi/prism-agent:latest-amd64 \
             ghcr.io/prismatic-koi/prism-agent:latest-arm64

--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,8 @@
         let
           # Substituter config baked into the image's nix.conf so that agents
           # running inside the container can pull from Cachix without extra setup.
+          # Keep these in sync with nixConfig.extra-substituters and
+          # nixConfig.extra-trusted-public-keys at the top of this file.
           cachixSubstituters = [
             "https://nix-community.cachix.org"
             "https://lucidph3nx-nixos-config.cachix.org"

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,37 @@
         };
       };
 
+      packages =
+        let
+          # Substituter config baked into the image's nix.conf so that agents
+          # running inside the container can pull from Cachix without extra setup.
+          cachixSubstituters = [
+            "https://nix-community.cachix.org"
+            "https://lucidph3nx-nixos-config.cachix.org"
+          ];
+          trustedPublicKeys = [
+            "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+            "lucidph3nx-nixos-config.cachix.org-1:gXiGMMDnozkXCjvOs9fOwKPZNIqf94ZA/YksjrKekHE="
+          ];
+          mkPrismAgentImage =
+            system:
+            let
+              pkgs = import nixpkgs {
+                inherit system;
+                config.allowUnfree = true;
+                overlays = [ self.overlays.modifications ];
+              };
+            in
+            import ./images/prism-agent.nix {
+              inherit pkgs cachixSubstituters trustedPublicKeys;
+              lib = nixpkgs.lib;
+            };
+        in
+        {
+          x86_64-linux.prismAgentImage = mkPrismAgentImage "x86_64-linux";
+          aarch64-linux.prismAgentImage = mkPrismAgentImage "aarch64-linux";
+        };
+
       devShells = forEachSystem (pkgs: {
         default = pkgs.mkShell {
           buildInputs = [

--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -13,8 +13,6 @@
 #   trustedPublicKeys  — list of trusted public keys for the above substituters
 #
 # This function is called by:
-#   - modules/programs/prism/container-image.nix (NixOS module, passes values from
-#     config.nix.settings)
 #   - flake.nix (exposes packages.x86_64-linux.prismAgentImage and
 #     packages.aarch64-linux.prismAgentImage for CI to build and push to GHCR)
 {

--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -26,15 +26,33 @@
 
 let
   # Ubuntu 24.04 LTS base image pulled at evaluation time.
-  # Re-run nix-prefetch-docker to refresh when the upstream image changes:
-  #   nix run nixpkgs#nix-prefetch-docker -- ubuntu 24.04 --os linux --arch amd64
-  ubuntuBase = pkgs.dockerTools.pullImage {
-    imageName = "ubuntu";
-    imageDigest = "sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c";
-    hash = "sha256-8DXLXnojKTuXpneMIHCEvcqJRHyA4dAKmMYE36QGMMU=";
-    finalImageName = "ubuntu";
-    finalImageTag = "24.04";
-  };
+  # Architecture-aware: selects the correct digest for the target platform so
+  # that both the base layer and the Nix-built contents are for the same arch.
+  #
+  # To refresh these digests when the upstream image changes:
+  #   amd64: nix run nixpkgs#nix-prefetch-docker -- ubuntu 24.04 --os linux --arch amd64
+  #   arm64: nix run nixpkgs#nix-prefetch-docker -- ubuntu 24.04 --os linux --arch arm64
+  ubuntuBase =
+    if pkgs.stdenv.hostPlatform.system == "aarch64-linux" then
+      pkgs.dockerTools.pullImage {
+        imageName = "ubuntu";
+        imageDigest = "sha256:11c7dd0cbd7effee6cd4f11811caffb5fdf682f1667c7f152c5cee7d32cc337c";
+        hash = "sha256-F36by0wuN+sFI/9f7U+73TLh8tn1LVThRm7FQVXo6AU=";
+        finalImageName = "ubuntu";
+        finalImageTag = "24.04";
+        os = "linux";
+        arch = "arm64";
+      }
+    else
+      pkgs.dockerTools.pullImage {
+        imageName = "ubuntu";
+        imageDigest = "sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c";
+        hash = "sha256-8DXLXnojKTuXpneMIHCEvcqJRHyA4dAKmMYE36QGMMU=";
+        finalImageName = "ubuntu";
+        finalImageTag = "24.04";
+        os = "linux";
+        arch = "amd64";
+      };
 
   # Build nix.conf content from the provided substituter config so it stays in
   # sync with the caller's nix settings.

--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -1,0 +1,224 @@
+# Standalone prism-agent container image derivation.
+#
+# This file is a pure function that builds the prism-agent OCI image for a
+# given pkgs (which determines the target architecture and package versions).
+#
+# Arguments:
+#   pkgs               — nixpkgs package set for the target architecture
+#                        (e.g. pkgs for x86_64-linux or aarch64-linux)
+#   lib                — nixpkgs lib (passed separately so callers can use
+#                        their own lib without pulling in pkgs.lib)
+#   cachixSubstituters — list of extra substituter URLs to bake into the image's
+#                        nix.conf (e.g. ["https://lucidph3nx-nixos-config.cachix.org"])
+#   trustedPublicKeys  — list of trusted public keys for the above substituters
+#
+# This function is called by:
+#   - modules/programs/prism/container-image.nix (NixOS module, passes values from
+#     config.nix.settings)
+#   - flake.nix (exposes packages.x86_64-linux.prismAgentImage and
+#     packages.aarch64-linux.prismAgentImage for CI to build and push to GHCR)
+{
+  pkgs,
+  lib,
+  cachixSubstituters ? [ ],
+  trustedPublicKeys ? [ ],
+}:
+
+let
+  # Ubuntu 24.04 LTS base image pulled at evaluation time.
+  # Re-run nix-prefetch-docker to refresh when the upstream image changes:
+  #   nix run nixpkgs#nix-prefetch-docker -- ubuntu 24.04 --os linux --arch amd64
+  ubuntuBase = pkgs.dockerTools.pullImage {
+    imageName = "ubuntu";
+    imageDigest = "sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c";
+    hash = "sha256-8DXLXnojKTuXpneMIHCEvcqJRHyA4dAKmMYE36QGMMU=";
+    finalImageName = "ubuntu";
+    finalImageTag = "24.04";
+  };
+
+  # Build nix.conf content from the provided substituter config so it stays in
+  # sync with the caller's nix settings.
+  nixConfLines = [
+    "experimental-features = nix-command flakes"
+  ]
+  ++ lib.optionals (cachixSubstituters != [ ]) [
+    "extra-substituters = ${lib.concatStringsSep " " cachixSubstituters}"
+    "extra-trusted-public-keys = ${lib.concatStringsSep " " trustedPublicKeys}"
+  ];
+  nixConfFile = pkgs.writeText "container-nix.conf" (lib.concatStringsSep "\n" nixConfLines + "\n");
+
+  # nixos-rebuild guard — prevents agents from accidentally trying to apply
+  # NixOS configuration inside a container (which would fail without systemd).
+  nixosRebuildGuard = pkgs.writeShellScript "nixos-rebuild" ''
+    echo "error: nixos-rebuild is not available inside agent containers" >&2
+    echo "Use 'nix build' to validate the flake instead." >&2
+    exit 1
+  '';
+in
+# The prism agent container image.
+# Built with buildLayeredImage so each Nix package gets its own layer —
+# podman can cache unchanged layers and only reload what changed.
+#
+# `contents` accepts a list of derivations to copy to the image root.
+# Wrapping packages in buildEnv merges them into a single /bin, /lib,
+# etc. symlink farm so binaries land on PATH. Passing raw package
+# derivations directly would place them at their Nix store paths only,
+# leaving them unreachable via PATH.
+#
+# The packages are split into two buildEnv groups.  buildLayeredImage merges
+# all contents entries via symlinkJoin into one customisation layer, but the
+# per-package layers come from the Nix store closure graph — each store path
+# gets its own layer.  By isolating opencode/claude-code/prism into their own
+# buildEnv, the ai-tooling store path (and its closure) changes independently
+# from the stable-infra store path.  When only the AI tools bump, only those
+# layers in the closure are invalidated; the stable-infra closure layers
+# remain cache-hits in podman.
+pkgs.dockerTools.buildLayeredImage {
+  name = "prism-agent";
+  tag = "latest";
+
+  # Ubuntu 24.04 base provides apt, standard system libs, and a familiar
+  # runtime environment.  Agents may apt-get install additional tools at
+  # runtime; those changes are discarded with the container.
+  fromImage = ubuntuBase;
+
+  contents = [
+    # CA certificates — places bundles at /etc/ssl/certs/ca-bundle.crt and
+    # /etc/ssl/certs/ca-certificates.crt so curl, git, gh, and opencode all
+    # find them without needing env var overrides.
+    pkgs.dockerTools.caCertificates
+
+    # Stable infrastructure tools — rarely change, so this layer is almost
+    # always cache-hit when only AI tooling is updated.
+    (pkgs.buildEnv {
+      name = "prism-agent-stable-infra";
+      paths = with pkgs; [
+        # Shell and core utilities — pin the Nix versions so PATH is consistent
+        # regardless of what Ubuntu provides
+        bash
+        coreutils
+
+        # Development tools
+        git
+        openssh # git push/fetch over SSH remotes
+        gh
+        go
+        gcc # C compiler — required for cgo
+        nodejs # LTS Node.js for JavaScript/TypeScript tooling
+        bun # Fast JavaScript runtime / bundler
+        jq
+        yq-go
+        ripgrep
+        fd
+        curl
+        wget
+        unzip
+        sqlite # prism uses SQLite; agents may query it directly
+        python3 # scripting, data processing, quick automation
+
+        # Browser automation — playwright-cli wraps chromium
+        playwright-cli
+
+        # Cloud and infrastructure
+        kubectl
+        kubernetes-helm
+        awscli2
+        opentofu
+        fluxcd
+
+        # Secrets tooling — agents may read or edit sops-encrypted files
+        sops
+        age
+        openssl
+
+        # Per-project environment management
+        direnv
+
+        # Nix toolchain — agents run nix build/eval/flake check and nixfmt
+        nix
+        nixfmt
+
+        # cacert — Nix itself needs NIX_SSL_CERT_FILE to point at the bundle.
+        # dockerTools.caCertificates (added as a top-level content entry below)
+        # handles the /etc/ssl/certs layout that other tools expect.
+        cacert
+
+        # LSP servers
+        gopls
+        typescript-language-server
+        nil # Nix LSP
+      ];
+      pathsToLink = [
+        "/bin"
+        "/lib"
+        "/share"
+        "/etc"
+      ];
+    })
+
+    # AI tooling — updated frequently; isolated so the stable-infra layer
+    # above is unaffected when opencode, claude-code, or prism bump versions.
+    # Note: /etc is intentionally omitted from pathsToLink — these packages
+    # don't install to /etc, and including it would risk a symlinkJoin
+    # collision with cacert's /etc/ssl/certs/ from the stable-infra group.
+    (pkgs.buildEnv {
+      name = "prism-agent-ai-tooling";
+      paths = with pkgs; [
+        opencode
+        claude-code
+        # Prism CLI — agents need prism spawn, prompt, checkin, etc.
+        prism
+      ];
+      pathsToLink = [
+        "/bin"
+        "/lib"
+        "/share"
+      ];
+    })
+  ];
+
+  extraCommands = ''
+    # Nix configuration — experimental features plus substituters/keys
+    # sourced from the caller's nix settings so they stay in sync with the host.
+    mkdir -p etc/nix
+    cp ${nixConfFile} etc/nix/nix.conf
+
+    # nixos-rebuild guard
+    cp ${nixosRebuildGuard} bin/nixos-rebuild
+    chmod +x bin/nixos-rebuild
+
+    # Nix wrapper: when the host's nix daemon socket is mounted (by
+    # container.go), transparently inject --eval-store auto so that
+    # "nix build", "nix flake check", etc. evaluate locally (can see
+    # /workspace) but delegate store operations to the host daemon
+    # (reusing cached derivations). Without the socket the wrapper is
+    # a no-op passthrough to the real nix binary.
+    real_nix=$(readlink -f bin/nix)
+    mv bin/nix bin/.nix-real
+    cat > bin/nix << 'WRAPPER'
+    #!/bin/bash
+    SOCKET=/nix/var/nix/daemon-socket/socket
+    if [ -S "$SOCKET" ]; then
+      # Subcommands that accept --eval-store
+      case "''${1:-}" in
+        build|eval|flake|develop|path-info|print-dev-env|log|derivation)
+          exec /bin/.nix-real "$1" --eval-store auto "''${@:2}"
+          ;;
+      esac
+    fi
+    exec /bin/.nix-real "$@"
+    WRAPPER
+    chmod +x bin/nix
+  '';
+
+  config = {
+    Cmd = [ "/bin/bash" ];
+    Env = [
+      # /bin first so Nix-installed tools shadow Ubuntu's equivalents
+      "PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      # CA bundle — used by Nix itself (other tools find certs via the
+      # standard /etc/ssl/certs/ paths placed by dockerTools.caCertificates).
+      "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+    ];
+  };
+}

--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -7,247 +7,35 @@
 # This module is imported unconditionally but its config block is wrapped
 # in the same mkIf guard as the rest of the prism module (see default.nix).
 #
-# On Linux, the prism-agent image is loaded into the user's rootless podman
-# store via a systemd user service that runs at every login.
+# On Linux, the prism-agent image is pulled from GHCR into the user's rootless
+# podman store via a systemd user service that runs at every login. The pull is
+# guarded so it is a no-op when the image is already present.
 #
 # On Darwin, podman runs inside a Linux VM managed by `podman machine`.
 # A Home Manager LaunchAgent fires at login to:
 #   1. Start the podman machine (guarded: checks state first and skips start
 #      if already running, since `podman machine start` exits non-zero when the
 #      VM is already up).
-#   2. Load the prism-agent image into the VM.
+#   2. Pull the prism-agent image into the VM from GHCR (guarded: skipped when
+#      the image is already present).
 # Failures are captured in /tmp/podman-machine-start.log so they are visible
 # for debugging; the prism fallback-to-host-mode mechanism (#472) handles the
 # case where the VM is unavailable at spawn time.
 let
   username = config.nx.username;
 
-  # Ubuntu 24.04 LTS base image pulled at evaluation time.
-  # Re-run nix-prefetch-docker to refresh when the upstream image changes:
-  #   nix run nixpkgs#nix-prefetch-docker -- ubuntu 24.04 --os linux --arch amd64
-  ubuntuBase = pkgs.dockerTools.pullImage {
-    imageName = "ubuntu";
-    imageDigest = "sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c";
-    hash = "sha256-8DXLXnojKTuXpneMIHCEvcqJRHyA4dAKmMYE36QGMMU=";
-    finalImageName = "ubuntu";
-    finalImageTag = "24.04";
-  };
-
-  # The prism agent container image.
-  # Built with buildLayeredImage so each Nix package gets its own layer —
-  # podman can cache unchanged layers and only reload what changed.
-  #
-  # `contents` accepts a list of derivations to copy to the image root.
-  # Wrapping packages in buildEnv merges them into a single /bin, /lib,
-  # etc. symlink farm so binaries land on PATH. Passing raw package
-  # derivations directly would place them at their Nix store paths only,
-  # leaving them unreachable via PATH.
-  #
-  # The packages are split into two buildEnv groups.  buildLayeredImage merges
-  # all contents entries via symlinkJoin into one customisation layer, but the
-  # per-package layers come from the Nix store closure graph — each store path
-  # gets its own layer.  By isolating opencode/claude-code/prism into their own
-  # buildEnv, the ai-tooling store path (and its closure) changes independently
-  # from the stable-infra store path.  When only the AI tools bump, only those
-  # layers in the closure are invalidated; the stable-infra closure layers
-  # remain cache-hits in podman.
-  prismAgentImage = pkgs.dockerTools.buildLayeredImage {
-    name = "prism-agent";
-    tag = "latest";
-
-    # Ubuntu 24.04 base provides apt, standard system libs, and a familiar
-    # runtime environment.  Agents may apt-get install additional tools at
-    # runtime; those changes are discarded with the container.
-    fromImage = ubuntuBase;
-
-    contents = [
-      # CA certificates — places bundles at /etc/ssl/certs/ca-bundle.crt and
-      # /etc/ssl/certs/ca-certificates.crt so curl, git, gh, and opencode all
-      # find them without needing env var overrides.
-      pkgs.dockerTools.caCertificates
-
-      # Stable infrastructure tools — rarely change, so this layer is almost
-      # always cache-hit when only AI tooling is updated.
-      (pkgs.buildEnv {
-        name = "prism-agent-stable-infra";
-        paths = with pkgs; [
-          # Shell and core utilities — pin the Nix versions so PATH is consistent
-          # regardless of what Ubuntu provides
-          bash
-          coreutils
-
-          # Development tools
-          git
-          openssh # git push/fetch over SSH remotes
-          gh
-          go
-          gcc # C compiler — required for cgo
-          nodejs # LTS Node.js for JavaScript/TypeScript tooling
-          bun # Fast JavaScript runtime / bundler
-          jq
-          yq-go
-          ripgrep
-          fd
-          curl
-          wget
-          unzip
-          sqlite # prism uses SQLite; agents may query it directly
-          python3 # scripting, data processing, quick automation
-
-          # Browser automation — playwright-cli wraps chromium
-          playwright-cli
-
-          # Cloud and infrastructure
-          kubectl
-          kubernetes-helm
-          awscli2
-          opentofu
-          fluxcd
-
-          # Secrets tooling — agents may read or edit sops-encrypted files
-          sops
-          age
-          openssl
-
-          # Per-project environment management
-          direnv
-
-          # Nix toolchain — agents run nix build/eval/flake check and nixfmt
-          nix
-          nixfmt
-
-          # cacert — Nix itself needs NIX_SSL_CERT_FILE to point at the bundle.
-          # dockerTools.caCertificates (added as a top-level content entry below)
-          # handles the /etc/ssl/certs layout that other tools expect.
-          cacert
-
-          # LSP servers
-          gopls
-          typescript-language-server
-          nil # Nix LSP
-        ];
-        pathsToLink = [
-          "/bin"
-          "/lib"
-          "/share"
-          "/etc"
-        ];
-      })
-
-      # AI tooling — updated frequently; isolated so the stable-infra layer
-      # above is unaffected when opencode, claude-code, or prism bump versions.
-      # Note: /etc is intentionally omitted from pathsToLink — these packages
-      # don't install to /etc, and including it would risk a symlinkJoin
-      # collision with cacert's /etc/ssl/certs/ from the stable-infra group.
-      (pkgs.buildEnv {
-        name = "prism-agent-ai-tooling";
-        paths = with pkgs; [
-          opencode
-          claude-code
-          # Prism CLI — agents need prism spawn, prompt, checkin, etc.
-          prism
-        ];
-        pathsToLink = [
-          "/bin"
-          "/lib"
-          "/share"
-        ];
-      })
-    ];
-
-    extraCommands =
-      let
-        # Build nix.conf content from the NixOS module system config so it
-        # stays in sync with the host's nix settings automatically.
-        #
-        # Combine both trusted-substituters (user-addable caches) and
-        # substituters (active caches) so the container nix.conf stays in sync
-        # regardless of which attribute future cachix entries are added to.
-        # cache.nixos.org is excluded since it is always present in the daemon.
-        allSubstituters = lib.unique (
-          config.nix.settings.trusted-substituters ++ config.nix.settings.substituters
-        );
-        cachixSubstituters = builtins.filter (
-          s: s != "https://cache.nixos.org/" && s != "https://cache.nixos.org"
-        ) allSubstituters;
-        nixConfLines = [
-          "experimental-features = nix-command flakes"
-        ]
-        ++ lib.optionals (cachixSubstituters != [ ]) [
-          "extra-substituters = ${lib.concatStringsSep " " cachixSubstituters}"
-          "extra-trusted-public-keys = ${lib.concatStringsSep " " config.nix.settings.trusted-public-keys}"
-        ];
-        nixConfFile = pkgs.writeText "container-nix.conf" (lib.concatStringsSep "\n" nixConfLines + "\n");
-        # nixos-rebuild guard — prevents agents from accidentally trying to apply
-        # NixOS configuration inside a container (which would fail without systemd).
-        nixosRebuildGuard = pkgs.writeShellScript "nixos-rebuild" ''
-          echo "error: nixos-rebuild is not available inside agent containers" >&2
-          echo "Use 'nix build' to validate the flake instead." >&2
-          exit 1
-        '';
-      in
-      ''
-        # Nix configuration — experimental features plus substituters/keys
-        # sourced from the NixOS module system so they stay in sync with the host.
-        mkdir -p etc/nix
-        cp ${nixConfFile} etc/nix/nix.conf
-
-        # nixos-rebuild guard
-        cp ${nixosRebuildGuard} bin/nixos-rebuild
-        chmod +x bin/nixos-rebuild
-
-        # Nix wrapper: when the host's nix daemon socket is mounted (by
-        # container.go), transparently inject --eval-store auto so that
-        # "nix build", "nix flake check", etc. evaluate locally (can see
-        # /workspace) but delegate store operations to the host daemon
-        # (reusing cached derivations). Without the socket the wrapper is
-        # a no-op passthrough to the real nix binary.
-        real_nix=$(readlink -f bin/nix)
-        mv bin/nix bin/.nix-real
-        cat > bin/nix << 'WRAPPER'
-        #!/bin/bash
-        SOCKET=/nix/var/nix/daemon-socket/socket
-        if [ -S "$SOCKET" ]; then
-          # Subcommands that accept --eval-store
-          case "''${1:-}" in
-            build|eval|flake|develop|path-info|print-dev-env|log|derivation)
-              exec /bin/.nix-real "$1" --eval-store auto "''${@:2}"
-              ;;
-          esac
-        fi
-        exec /bin/.nix-real "$@"
-        WRAPPER
-        chmod +x bin/nix
-      '';
-
-    config = {
-      Cmd = [ "/bin/bash" ];
-      Env = [
-        # /bin first so Nix-installed tools shadow Ubuntu's equivalents
-        "PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        # CA bundle — used by Nix itself (other tools find certs via the
-        # standard /etc/ssl/certs/ paths placed by dockerTools.caCertificates).
-        "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-      ];
-    };
-  };
-
+  image = "ghcr.io/prismatic-koi/prism-agent:latest";
 in
 {
   config = lib.mkIf config.nx.programs.prism.enable (
     lib.mkMerge [
       # ── Linux ────────────────────────────────────────────────────────────────
-      # Load the image via a systemd user service at every login.
+      # Pull the image from GHCR via a systemd user service at every login.
       # podman.enable is included in the guard so the service is skipped
       # entirely when the user has explicitly disabled podman.
       (lib.mkIf (pkgs.stdenv.isLinux && config.nx.programs.podman.enable) {
-        # Load the prism-agent container image into the user's podman store on
-        # login via a systemd user service.
-        #
-        # This replaces the former nixos-rebuild activation script, which only ran
-        # at switch time.  ~/.local/share/containers/ is now persisted by
-        # impermanence, so the image survives reboots and only needs reloading
-        # when the image definition changes (incremental, layer-cached).
+        # Pull the prism-agent container image from GHCR into the user's podman
+        # store on login via a systemd user service.
         #
         # The service is declared as oneshot with RemainAfterExit=yes: systemd
         # considers it "active" once ExecStart returns successfully and will NOT
@@ -255,12 +43,8 @@ in
         # requirement.  On the next login (e.g. after a reboot) the unit is in
         # the "inactive" state again and will re-run.
         #
-        # Idempotency:
-        #   1. Remove the existing tag first — prevents the old manifest becoming a
-        #      dangling <none>:<none> image when the tag is moved to the new image.
-        #   2. Prune dangling images after load — cleans up any layers that were
-        #      previously unreferenced (e.g. from an interrupted switch).
-        #   Both commands use `|| true` so a missing image or empty prune is not fatal.
+        # Idempotency: the script checks `podman image exists` first and skips
+        # the pull when the image is already present.
         home-manager.users.${username} = {
           home.persistence."/persist" = {
             directories = [
@@ -269,44 +53,25 @@ in
           };
           systemd.user.services.prism-agent-image = {
             Unit = {
-              Description = "Load prism-agent container image into rootless podman storage";
+              Description = "Pull prism-agent container image from GHCR into rootless podman storage";
               # Run before prism session restore so the image is available when
               # the first container spawn happens.
               Before = [ "prism-restore.service" ];
-              # Only restart the service when the image derivation itself changes,
-              # not on every home-manager switch.  Passing prismAgentImage as a
-              # derivation (not a string interpolation) ensures home-manager hashes
-              # the store path and triggers a restart only when it changes.
-              X-Restart-Triggers = [ prismAgentImage ];
             };
             Service = {
               Type = "oneshot";
               RemainAfterExit = true;
               ExecStart =
                 let
-                  # The expected image ID is derived from the Nix store path at
-                  # build time. podman load prints "Loaded image: <id>" on the
-                  # last line — we extract the sha256 digest from the archive
-                  # manifest so we can skip the load when the image is unchanged.
-                  script = pkgs.writeShellScript "load-prism-agent-image" ''
+                  script = pkgs.writeShellScript "pull-prism-agent-image" ''
                     PODMAN="${pkgs.podman}/bin/podman"
 
-                    # Extract the expected image ID from the archive manifest.
-                    EXPECTED_ID=$(${pkgs.gnutar}/bin/tar -xf ${prismAgentImage} --to-stdout manifest.json 2>/dev/null \
-                      | ${pkgs.jq}/bin/jq -r '.[0].Config // empty' 2>/dev/null \
-                      | ${pkgs.gnused}/bin/sed 's/\.json$//')
-                    CURRENT_ID=$($PODMAN image inspect localhost/prism-agent:latest --format '{{.Id}}' 2>/dev/null || true)
-
-                    if [ -n "$EXPECTED_ID" ] && [ "$CURRENT_ID" = "$EXPECTED_ID" ]; then
-                      echo "prism: localhost/prism-agent:latest is up to date ($EXPECTED_ID), skipping load." >&2
-                      exit 0
+                    if $PODMAN image exists ${image}; then
+                      echo "prism: ${image} already present, skipping pull." >&2
+                    else
+                      echo "prism: pulling ${image}..." >&2
+                      $PODMAN pull ${image}
                     fi
-
-                    echo "prism: loading localhost/prism-agent:latest into podman..." >&2
-                    $PODMAN image rm localhost/prism-agent:latest 2>/dev/null || true
-                    $PODMAN load < ${prismAgentImage}
-                    $PODMAN image prune --force 2>/dev/null || true
-                    echo "prism: localhost/prism-agent:latest loaded successfully." >&2
                   '';
                 in
                 script;
@@ -319,7 +84,7 @@ in
       })
 
       # ── Darwin ───────────────────────────────────────────────────────────────
-      # Start the podman machine VM and load the image at login via a
+      # Start the podman machine VM and pull the image at login via a
       # Home Manager LaunchAgent.  Home Manager writes the plist to
       # ~/Library/LaunchAgents/ and loads/unloads it automatically;
       # after `darwin-rebuild switch` the plist is updated in place.
@@ -332,7 +97,7 @@ in
       # enabled.
       (lib.mkIf pkgs.stdenv.isDarwin (
         let
-          # Shell script that starts the podman machine then loads the prism-agent
+          # Shell script that starts the podman machine then pulls the prism-agent
           # image into it.  Written as a separate derivation so the LaunchAgent
           # ProgramArguments array can reference it directly.
           #
@@ -340,11 +105,10 @@ in
           #   - `podman machine start` exits non-zero (exit 125) if the VM is already
           #     running.  We check state explicitly via `podman machine inspect` before
           #     calling start so that a running VM is treated as a success, not a failure.
-          #   - We pipe the image tarball through `podman machine ssh` rather than
-          #     calling `podman load` directly, because on Darwin `podman load` routes
-          #     through the socket and cannot stream from stdin reliably at login time.
-          #     `podman machine ssh -- podman load` runs inside the VM where stdin is
-          #     a proper pipe.
+          #   - We pull the image inside the VM via `podman machine ssh -- podman pull`
+          #     rather than calling `podman pull` directly on the host, because on Darwin
+          #     `podman pull` routes through the machine socket and the image must reside
+          #     inside the Linux VM.
           #   - All output goes to stdout/stderr which the LaunchAgent captures in
           #     StandardOutPath / StandardErrorPath below.
           podmanMachineStartScript = pkgs.writeShellScript "podman-machine-start" ''
@@ -364,20 +128,19 @@ in
               echo "podman-machine-start: machine is already running, skipping start." >&2
             else
               "$PODMAN" machine start || {
-                echo "podman-machine-start: 'podman machine start' failed, aborting image load." >&2
+                echo "podman-machine-start: 'podman machine start' failed, aborting image pull." >&2
                 exit 1
               }
             fi
 
-            echo "podman-machine-start: loading prism-agent image into VM..." >&2
-            # Remove the old tag first so it does not become a dangling <none>:<none>
-            # after the new image is loaded.
-            "$PODMAN" machine ssh -- podman image rm localhost/prism-agent:latest 2>/dev/null || true
-            # Stream the image tarball into the VM via podman machine ssh.
-            "$PODMAN" machine ssh -- podman load < ${prismAgentImage}
-            "$PODMAN" machine ssh -- podman image prune --force 2>/dev/null || true
-
-            echo "podman-machine-start: localhost/prism-agent:latest loaded successfully." >&2
+            echo "podman-machine-start: checking prism-agent image in VM..." >&2
+            if "$PODMAN" machine ssh -- podman image exists ${image}; then
+              echo "podman-machine-start: ${image} already present in VM, skipping pull." >&2
+            else
+              echo "podman-machine-start: pulling ${image} into VM..." >&2
+              "$PODMAN" machine ssh -- podman pull ${image}
+              echo "podman-machine-start: ${image} pulled successfully." >&2
+            fi
           '';
         in
         {

--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -8,16 +8,18 @@
 # in the same mkIf guard as the rest of the prism module (see default.nix).
 #
 # On Linux, the prism-agent image is pulled from GHCR into the user's rootless
-# podman store via a systemd user service that runs at every login. The pull is
-# guarded so it is a no-op when the image is already present.
+# podman store via a systemd user service that runs at every login. `podman pull`
+# is unconditional — it checks the manifest digest and skips downloading layers
+# that are already cached, so it is fast when nothing has changed and always
+# picks up new image versions when they are published.
 #
 # On Darwin, podman runs inside a Linux VM managed by `podman machine`.
 # A Home Manager LaunchAgent fires at login to:
 #   1. Start the podman machine (guarded: checks state first and skips start
 #      if already running, since `podman machine start` exits non-zero when the
 #      VM is already up).
-#   2. Pull the prism-agent image into the VM from GHCR (guarded: skipped when
-#      the image is already present).
+#   2. Pull the prism-agent image into the VM from GHCR unconditionally (same
+#      rationale as Linux: fast when unchanged, always picks up new versions).
 # Failures are captured in /tmp/podman-machine-start.log so they are visible
 # for debugging; the prism fallback-to-host-mode mechanism (#472) handles the
 # case where the VM is unavailable at spawn time.
@@ -39,12 +41,13 @@ in
         #
         # The service is declared as oneshot with RemainAfterExit=yes: systemd
         # considers it "active" once ExecStart returns successfully and will NOT
-        # re-run it within the same login session, satisfying the idempotency
-        # requirement.  On the next login (e.g. after a reboot) the unit is in
-        # the "inactive" state again and will re-run.
+        # re-run it within the same login session.  On the next login (e.g. after
+        # a reboot) the unit is in the "inactive" state again and will re-run.
         #
-        # Idempotency: the script checks `podman image exists` first and skips
-        # the pull when the image is already present.
+        # `podman pull` is unconditional: it compares the remote manifest digest
+        # against what is stored locally and skips layer downloads when nothing
+        # has changed.  This keeps the image up to date automatically on every
+        # login without requiring manual intervention.
         home-manager.users.${username} = {
           home.persistence."/persist" = {
             directories = [
@@ -54,9 +57,6 @@ in
           systemd.user.services.prism-agent-image = {
             Unit = {
               Description = "Pull prism-agent container image from GHCR into rootless podman storage";
-              # Wait for the network to be ready before attempting the pull.
-              After = [ "network-online.target" ];
-              Wants = [ "network-online.target" ];
               # Run before prism session restore so the image is available when
               # the first container spawn happens.
               Before = [ "prism-restore.service" ];
@@ -68,13 +68,8 @@ in
                 let
                   script = pkgs.writeShellScript "pull-prism-agent-image" ''
                     PODMAN="${pkgs.podman}/bin/podman"
-
-                    if $PODMAN image exists ${image}; then
-                      echo "prism: ${image} already present, skipping pull." >&2
-                    else
-                      echo "prism: pulling ${image}..." >&2
-                      $PODMAN pull ${image}
-                    fi
+                    echo "prism: pulling ${image}..." >&2
+                    $PODMAN pull ${image}
                   '';
                 in
                 script;
@@ -111,7 +106,9 @@ in
           #   - We pull the image inside the VM via `podman machine ssh -- podman pull`
           #     rather than calling `podman pull` directly on the host, because on Darwin
           #     `podman pull` routes through the machine socket and the image must reside
-          #     inside the Linux VM.
+          #     inside the Linux VM.  `podman pull` is idempotent: it compares the remote
+          #     manifest digest against the local cache and skips layer downloads when
+          #     nothing has changed.
           #   - All output goes to stdout/stderr which the LaunchAgent captures in
           #     StandardOutPath / StandardErrorPath below.
           podmanMachineStartScript = pkgs.writeShellScript "podman-machine-start" ''
@@ -136,14 +133,9 @@ in
               }
             fi
 
-            echo "podman-machine-start: checking prism-agent image in VM..." >&2
-            if "$PODMAN" machine ssh -- podman image exists ${image}; then
-              echo "podman-machine-start: ${image} already present in VM, skipping pull." >&2
-            else
-              echo "podman-machine-start: pulling ${image} into VM..." >&2
-              "$PODMAN" machine ssh -- podman pull ${image}
-              echo "podman-machine-start: ${image} pulled successfully." >&2
-            fi
+            echo "podman-machine-start: pulling ${image} into VM..." >&2
+            "$PODMAN" machine ssh -- podman pull ${image}
+            echo "podman-machine-start: ${image} pulled successfully." >&2
           '';
         in
         {

--- a/modules/programs/prism/container-image.nix
+++ b/modules/programs/prism/container-image.nix
@@ -54,6 +54,9 @@ in
           systemd.user.services.prism-agent-image = {
             Unit = {
               Description = "Pull prism-agent container image from GHCR into rootless podman storage";
+              # Wait for the network to be ready before attempting the pull.
+              After = [ "network-online.target" ];
+              Wants = [ "network-online.target" ];
               # Run before prism session restore so the image is available when
               # the first container spawn happens.
               Before = [ "prism-restore.service" ];

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -30,11 +30,10 @@ const (
 	ContainerPort = 4096
 
 	// Image is the container image name used for all agent containers.
-	// The localhost/ prefix is required for podman to resolve locally-loaded
-	// images correctly on both Linux and Darwin. Without it, podman falls
-	// through to unqualified-search registries and tries docker.io/library/,
-	// which fails for images that were loaded via `podman load`.
-	Image = "localhost/prism-agent:latest"
+	// The image is published to GHCR as a multi-arch image by CI and pulled
+	// on first use by the systemd/launchd service. podman resolves the correct
+	// arch (amd64/arm64) automatically from the multi-arch manifest.
+	Image = "ghcr.io/prismatic-koi/prism-agent:latest"
 
 	// DefaultHealthCheckTimeout is the maximum time to wait for the container
 	// to become healthy before giving up.
@@ -1014,7 +1013,7 @@ func IsNoSuchContainerError(output string) bool {
 // CheckAvailability verifies that:
 //  1. podman is on PATH,
 //  2. the podman socket is reachable (podman info succeeds), and
-//  3. the localhost/prism-agent:latest image is loaded.
+//  3. the ghcr.io/prismatic-koi/prism-agent:latest image is present locally.
 //
 // Returns a descriptive error for the first failing check, including a hint to
 // use --host-mode as an escape hatch. Returns nil when all checks pass.

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -1039,7 +1039,7 @@ func CheckAvailability() error {
 		)
 	}
 
-	// 3. localhost/prism-agent:latest image loaded.
+	// 3. ghcr.io/prismatic-koi/prism-agent:latest image present locally.
 	imagesCtx, imagesCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer imagesCancel()
 	imagesCmd := exec.CommandContext(imagesCtx, "podman", "images", "--quiet", Image)


### PR DESCRIPTION
## Summary

- Extracts `prismAgentImage` from the NixOS module into `images/prism-agent.nix` — a standalone function taking `pkgs`, `lib`, `cachixSubstituters`, and `trustedPublicKeys`
- Exposes `packages.x86_64-linux.prismAgentImage` and `packages.aarch64-linux.prismAgentImage` as flake outputs in `flake.nix`
- Adds `.github/workflows/publish-prism-agent.yml`: two parallel native-runner jobs build each arch and push to GHCR, then a third job creates a multi-arch manifest tagged `latest` and the commit SHA
- Updates `container.go` `Image` constant from `localhost/prism-agent:latest` to `ghcr.io/prismatic-koi/prism-agent:latest`
- Replaces load-from-store systemd service (Linux) and launchd agent (Darwin) with pull-if-absent services that check `podman image exists` before pulling from GHCR

## Motivation

On Apple Silicon Macs, the image was built with the host (aarch64-darwin) `pkgs`, producing macOS binaries inside a Linux container — causing `Exec format error` on every spawn. Building on CI with Linux x86_64 and aarch64 native runners and publishing a multi-arch manifest to GHCR fixes this permanently. Any system (NixOS or Darwin) can now pull the correct arch automatically.

## Build verification

- `go build ./...` ✅
- `go test ./internal/container/...` ✅
- `nix build .#packages.x86_64-linux.prismAgentImage` ✅
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅
- Darwin build requires aarch64-darwin hardware (pre-existing limitation in this environment)

Closes #634
Closes #637