### PR TITLE
ci: add Darwin (m4mac) build job to build-and-cache workflow

### DIFF
--- a/.github/workflows/build-and-cache.yml
+++ b/.github/workflows/build-and-cache.yml
@@ -31,3 +31,20 @@ jobs:
           name: lucidph3nx-nixos-config
       - name: Build NixOS config for ${{ matrix.config }}
         run: nix build --print-build-logs '.#nixosConfigurations.${{ matrix.config }}.config.system.build.toplevel'
+  build-darwin:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |-
+            accept-flake-config = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v17
+        with:
+          authToken: ${{ secrets.CACHIX_TOKEN }}
+          extraPullNames: nix-community
+          name: lucidph3nx-nixos-config
+      - name: Build Darwin config for m4mac
+        run: nix build --print-build-logs '.#darwinConfigurations.m4mac.config.system.build.toplevel'


### PR DESCRIPTION
## Summary

- Adds a `build-darwin` job that runs on the free `macos-15` arm64 Apple Silicon runner
- Uses the same Nix + Cachix setup as the existing `build-linux` job
- Builds `.#darwinConfigurations.m4mac.config.system.build.toplevel` to validate the Darwin config in CI
- Does not include `jlumbroso/free-disk-space` (Linux-only)
- Existing `build-linux` job and workflow triggers are unchanged

Closes #639