### PR TITLE
prism: audit logging for high-impact tool calls in prism DB

### DIFF
--- a/modules/programs/prism/prism/cmd/audit.go
+++ b/modules/programs/prism/prism/cmd/audit.go
@@ -1,0 +1,153 @@
+package cmd
+
+// prism audit — query the persistent audit trail of high-impact tool calls.
+//
+// Usage:
+//
+//	prism audit                          last 20 audit events across all sessions
+//	prism audit <session>                audit events for a specific session
+//	prism audit --days N                 events from the last N days
+//	prism audit --pattern "gh pr merge"  filter by command substring
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+var auditCmd = &cobra.Command{
+	Use:   "audit [session]",
+	Short: "Query the audit trail of high-impact tool calls",
+	Long: `Query the persistent audit trail of high-impact bash tool calls.
+
+High-impact commands (gh pr merge, git push, gh pr create, gh issue close,
+prism spawn, prism cleanup, prism prompt) are promoted from the ephemeral
+opencode DB to the persistent prism DB as 'audit' events, so they survive
+worktree cleanup and remain attributable to a specific prism session.
+
+With no arguments, shows the last 20 audit events across all sessions.
+
+With a session name, shows audit events for that session only.
+
+Use --days N to restrict to events from the last N days.
+Use --pattern TEXT to filter by a command substring (case-insensitive).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runAudit,
+}
+
+func init() {
+	auditCmd.Flags().Int("days", 0, "Restrict to events from the last N days")
+	auditCmd.Flags().String("pattern", "", "Filter by command substring (case-insensitive)")
+	auditCmd.Flags().Int("limit", 0, "Maximum number of events to return (default 20 when no session filter)")
+	rootCmd.AddCommand(auditCmd)
+}
+
+func runAudit(cmd *cobra.Command, args []string) error {
+	days, _ := cmd.Flags().GetInt("days")
+	pattern, _ := cmd.Flags().GetString("pattern")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	sessionName := ""
+	if len(args) == 1 {
+		sessionName = args[0]
+	}
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	defer d.Close()
+
+	var sinceMs int64
+	if days > 0 {
+		sinceMs = time.Now().Add(-time.Duration(days) * 24 * time.Hour).UnixMilli()
+	}
+
+	events, err := d.QueryAuditEvents(sessionName, sinceMs, pattern, limit)
+	if err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+
+	if len(events) == 0 {
+		if sessionName != "" {
+			fmt.Printf("no audit events found for session %q\n", sessionName)
+		} else {
+			fmt.Println("no audit events found")
+		}
+		if pattern != "" {
+			fmt.Printf("  (filter: %q)\n", pattern)
+		}
+		return nil
+	}
+
+	renderAuditEvents(events)
+	return nil
+}
+
+func renderAuditEvents(events []db.Event) {
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	styleCmd := lipgloss.NewStyle().Bold(true)
+
+	fmt.Println(styleHeader.Render(fmt.Sprintf("Audit Trail (%d events)", len(events))))
+	fmt.Println()
+
+	// Column header.
+	const (
+		wTime    = 19
+		wSession = 32
+		wCommand = 60
+	)
+	header := fmt.Sprintf("%-*s  %-*s  %-*s",
+		wTime, "TIME",
+		wSession, "SESSION",
+		wCommand, "COMMAND",
+	)
+	fmt.Println(styleDim.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, e := range events {
+		var p payload.Audit
+		if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+			// Fallback: print raw payload on unmarshal failure.
+			fmt.Printf("%-*s  %-*s  %s\n",
+				wTime, e.CreatedAt.Format("2006-01-02 15:04:05"),
+				wSession, truncateStr(e.SessionName, wSession),
+				e.Payload,
+			)
+			continue
+		}
+
+		sessionStr := p.SessionName
+		if sessionStr == "" {
+			sessionStr = e.SessionName
+		}
+
+		cmdStr := p.Command
+		if cmdStr == "" {
+			cmdStr = "(no command)"
+		}
+
+		timeStr := e.CreatedAt.Format("2006-01-02 15:04:05")
+
+		sessionTrunc := truncateStr(sessionStr, wSession)
+		cmdTrunc := truncateStr(cmdStr, wCommand)
+
+		fmt.Printf("%s  %s  %s\n",
+			styleDim.Render(fmt.Sprintf("%-*s", wTime, timeStr)),
+			styleLabel.Render(fmt.Sprintf("%-*s", wSession, sessionTrunc)),
+			styleCmd.Render(cmdTrunc),
+		)
+	}
+
+	fmt.Println()
+	fmt.Println(styleDim.Render("Audit events are written for: gh pr merge/create, gh issue close, git push, prism spawn/cleanup/prompt"))
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1040,6 +1040,10 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 //     contains this substring (case-insensitive)
 //   - limit: when > 0, return at most this many events (default 20 when both
 //     limit==0 and sessionName=="")
+//
+// Note: audit events are subject to the same 90-day Prune() threshold as all
+// other agent_events rows. For the forensic use-case described in issue #642,
+// 90 days is sufficient, but audit events are not retained indefinitely.
 func (d *DB) QueryAuditEvents(sessionName string, sinceMs int64, pattern string, limit int) ([]Event, error) {
 	args := []any{}
 	conditions := []string{"type = 'audit'"}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1032,6 +1032,67 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	return nil
 }
 
+// QueryAuditEvents returns audit events from agent_events, ordered by
+// created_at DESC. Optional filters:
+//   - sessionName: when non-empty, restrict to this session only
+//   - sinceMs: when > 0, restrict to events created at or after this Unix ms timestamp
+//   - pattern: when non-empty, restrict to events whose payload command field
+//     contains this substring (case-insensitive)
+//   - limit: when > 0, return at most this many events (default 20 when both
+//     limit==0 and sessionName=="")
+func (d *DB) QueryAuditEvents(sessionName string, sinceMs int64, pattern string, limit int) ([]Event, error) {
+	args := []any{}
+	conditions := []string{"type = 'audit'"}
+
+	if sessionName != "" {
+		conditions = append(conditions, "session_name = ?")
+		args = append(args, sessionName)
+	}
+
+	if sinceMs > 0 {
+		conditions = append(conditions, "created_at >= ?")
+		args = append(args, sinceMs)
+	}
+
+	if pattern != "" {
+		conditions = append(conditions, "LOWER(JSON_EXTRACT(payload, '$.command')) LIKE ?")
+		args = append(args, "%"+strings.ToLower(pattern)+"%")
+	}
+
+	where := " WHERE " + strings.Join(conditions, " AND ")
+
+	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+		where + " ORDER BY created_at DESC"
+
+	if limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", limit)
+	} else if sessionName == "" {
+		// Default: return the last 20 audit events when no session filter.
+		q += " LIMIT 20"
+	}
+
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query audit events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		var createdAt int64
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+			return nil, fmt.Errorf("db: scan audit event: %w", err)
+		}
+		e.CreatedAt = time.UnixMilli(createdAt)
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate audit events: %w", err)
+	}
+	return events, nil
+}
+
 // Prune deletes agent_events older than olderThan, and delivered bus_messages
 // older than olderThan. It does NOT delete agent_status rows or undelivered
 // bus_messages.

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -1728,3 +1728,156 @@ func setPort(d *db.DB, sessionName string, port int) error {
 	).Scan(&dummy)
 	return err
 }
+
+// ── QueryAuditEvents tests ────────────────────────────────────────────────────
+
+// writeAuditEvent is a test helper that writes an audit event to the DB.
+func writeAuditEvent(t *testing.T, d *db.DB, sessionName, repo, command string, createdAt time.Time) {
+	t.Helper()
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/code/" + repo + "/main",
+		Type:        "audit",
+		Payload:     fmt.Sprintf(`{"tool":"bash","command":%q,"sessionName":%q}`, command, sessionName),
+		CreatedAt:   createdAt,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent audit: %v", err)
+	}
+}
+
+func TestQueryAuditEvents_NoFilter(t *testing.T) {
+	d := openTestDB(t)
+
+	now := time.Now()
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr merge 1", now.Add(-3*time.Hour))
+	writeAuditEvent(t, d, "repo@feat", "repo", "git push origin feat", now.Add(-2*time.Hour))
+	writeAuditEvent(t, d, "repo@feat", "repo", "gh pr create --title foo", now.Add(-1*time.Hour))
+
+	// Also write a non-audit event — should not appear.
+	if err := d.WriteEvent(db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "tool_call",
+		Payload:     `{"tool":"bash","args":"ls"}`,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatalf("WriteEvent tool_call: %v", err)
+	}
+
+	events, err := d.QueryAuditEvents("", 0, "", 0)
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	// Default limit is 20; all 3 audit events should be present.
+	if len(events) != 3 {
+		t.Errorf("got %d events, want 3", len(events))
+	}
+	// Verify all returned events have type=audit.
+	for _, e := range events {
+		if e.Type != "audit" {
+			t.Errorf("unexpected event type %q", e.Type)
+		}
+	}
+}
+
+func TestQueryAuditEvents_SessionFilter(t *testing.T) {
+	d := openTestDB(t)
+
+	now := time.Now()
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr merge 1", now.Add(-2*time.Hour))
+	writeAuditEvent(t, d, "repo@feat", "repo", "git push origin feat", now.Add(-1*time.Hour))
+
+	events, err := d.QueryAuditEvents("repo@main", 0, "", 0)
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].SessionName != "repo@main" {
+		t.Errorf("sessionName = %q, want repo@main", events[0].SessionName)
+	}
+}
+
+func TestQueryAuditEvents_SinceFilter(t *testing.T) {
+	d := openTestDB(t)
+
+	now := time.Now()
+	old := now.Add(-48 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr merge 1", old)
+	writeAuditEvent(t, d, "repo@main", "repo", "git push origin main", recent)
+
+	// Filter to last 24h.
+	sinceMs := now.Add(-24 * time.Hour).UnixMilli()
+	events, err := d.QueryAuditEvents("", sinceMs, "", 0)
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 (only recent)", len(events))
+	}
+}
+
+func TestQueryAuditEvents_PatternFilter(t *testing.T) {
+	d := openTestDB(t)
+
+	now := time.Now()
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr merge 1 --squash", now.Add(-3*time.Hour))
+	writeAuditEvent(t, d, "repo@main", "repo", "git push origin main", now.Add(-2*time.Hour))
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr create --title foo", now.Add(-1*time.Hour))
+
+	// Pattern matching "merge" should match only the first.
+	events, err := d.QueryAuditEvents("", 0, "merge", 0)
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if !strings.Contains(events[0].Payload, "merge") {
+		t.Errorf("event payload does not contain 'merge': %s", events[0].Payload)
+	}
+}
+
+func TestQueryAuditEvents_LimitFilter(t *testing.T) {
+	d := openTestDB(t)
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		writeAuditEvent(t, d, "repo@main", "repo", fmt.Sprintf("gh pr merge %d", i), now.Add(time.Duration(i)*time.Minute))
+	}
+
+	events, err := d.QueryAuditEvents("", 0, "", 3)
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	if len(events) != 3 {
+		t.Errorf("got %d events, want 3", len(events))
+	}
+}
+
+func TestQueryAuditEvents_OrderedDescending(t *testing.T) {
+	d := openTestDB(t)
+
+	now := time.Now()
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr merge 1", now.Add(-2*time.Hour))
+	writeAuditEvent(t, d, "repo@main", "repo", "gh pr merge 2", now.Add(-1*time.Hour))
+
+	events, err := d.QueryAuditEvents("", 0, "", 0)
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	// Results should be DESC (newest first).
+	if !events[0].CreatedAt.After(events[1].CreatedAt) {
+		t.Errorf("events not in DESC order: [0]=%v [1]=%v", events[0].CreatedAt, events[1].CreatedAt)
+	}
+}

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -166,6 +166,11 @@ type SubagentEnd struct {
 //
 // The Command field contains the full command string as passed to the bash tool.
 // SessionName, OpencodeSID, and MessageID provide forensic attribution.
+//
+// Note: an instanceId field (per issue #641) is intentionally absent until
+// the instance-ID feature lands. Once #641 is implemented, add an InstanceID
+// field here and populate it from the sidecar's instance ID so that audit
+// events can be attributed to a specific sidecar process invocation.
 type Audit struct {
 	Tool        string `json:"tool"`
 	Command     string `json:"command"`

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -158,3 +158,18 @@ type SubagentEnd struct {
 	DurationMs int64  `json:"durationMs,omitempty"`
 	MessageID  string `json:"messageId"`
 }
+
+// Audit is the payload for audit events, written when a high-impact bash
+// command is executed (e.g. gh pr merge, git push, prism spawn). These events
+// are promoted from the ephemeral opencode DB to the persistent prism DB so
+// they survive worktree cleanup.
+//
+// The Command field contains the full command string as passed to the bash tool.
+// SessionName, OpencodeSID, and MessageID provide forensic attribution.
+type Audit struct {
+	Tool        string `json:"tool"`
+	Command     string `json:"command"`
+	SessionName string `json:"sessionName"`
+	OpencodeSID string `json:"opencodeSID,omitempty"`
+	MessageID   string `json:"messageId,omitempty"`
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1077,6 +1077,24 @@ func (s *Sidecar) handleMessagePartUpdated(evt sse.Event) {
 				"result":    result,
 				"messageId": part.MessageID,
 			}, nil)
+
+			// Promote high-impact bash commands to the persistent audit log.
+			if part.Tool == "bash" {
+				if cmd := extractBashCommand(part.State.Input); isHighImpactCommand(cmd) {
+					opencodeSID := ""
+					if s.opencodeSID != "" {
+						opencodeSID = s.opencodeSID
+					}
+					s.writeEvent("audit", map[string]any{
+						"tool":        "bash",
+						"command":     cmd,
+						"sessionName": s.cfg.SessionName,
+						"opencodeSID": opencodeSID,
+						"messageId":   part.MessageID,
+					}, nil)
+					log.Printf("sidecar: audit: high-impact command recorded: %s", truncate(cmd, 120))
+				}
+			}
 		}
 
 	case "reasoning":
@@ -1476,6 +1494,51 @@ func marshalTruncated(v any, maxLen int) string {
 		return "{}"
 	}
 	return truncate(string(data), maxLen)
+}
+
+// ── audit helpers ────────────────────────────────────────────────────────────
+
+// highImpactPrefixes lists the command prefixes that trigger an audit event.
+// Each entry is lowercased and compared against the trimmed, lowercased command.
+var highImpactPrefixes = []string{
+	"gh pr merge",
+	"gh pr create",
+	"gh issue close",
+	"git push",
+	"prism spawn",
+	"prism cleanup",
+	"prism prompt",
+}
+
+// isHighImpactCommand reports whether cmd matches any high-impact prefix.
+// Matching is case-insensitive and ignores leading whitespace.
+func isHighImpactCommand(cmd string) bool {
+	lower := strings.ToLower(strings.TrimSpace(cmd))
+	for _, prefix := range highImpactPrefixes {
+		if lower == prefix || strings.HasPrefix(lower, prefix+" ") || strings.HasPrefix(lower, prefix+"\t") {
+			return true
+		}
+	}
+	return false
+}
+
+// extractBashCommand extracts the "command" field from the bash tool's input.
+// The input is the raw value of part.State.Input, which is a map[string]any
+// after JSON unmarshalling by the SSE parser. Returns an empty string when the
+// input is not a map or does not contain a "command" key with a string value.
+func extractBashCommand(input any) string {
+	if input == nil {
+		return ""
+	}
+	m, ok := input.(map[string]any)
+	if !ok {
+		return ""
+	}
+	cmd, ok := m["command"].(string)
+	if !ok {
+		return ""
+	}
+	return cmd
 }
 
 // ── host-API handler ─────────────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1081,15 +1081,11 @@ func (s *Sidecar) handleMessagePartUpdated(evt sse.Event) {
 			// Promote high-impact bash commands to the persistent audit log.
 			if part.Tool == "bash" {
 				if cmd := extractBashCommand(part.State.Input); isHighImpactCommand(cmd) {
-					opencodeSID := ""
-					if s.opencodeSID != "" {
-						opencodeSID = s.opencodeSID
-					}
 					s.writeEvent("audit", map[string]any{
 						"tool":        "bash",
 						"command":     cmd,
 						"sessionName": s.cfg.SessionName,
-						"opencodeSID": opencodeSID,
+						"opencodeSID": s.opencodeSID,
 						"messageId":   part.MessageID,
 					}, nil)
 					log.Printf("sidecar: audit: high-impact command recorded: %s", truncate(cmd, 120))
@@ -1512,6 +1508,13 @@ var highImpactPrefixes = []string{
 
 // isHighImpactCommand reports whether cmd matches any high-impact prefix.
 // Matching is case-insensitive and ignores leading whitespace.
+//
+// Limitation: only the first (trimmed) line of the command is considered.
+// Multi-line shell scripts where a high-impact command appears after an earlier
+// line (e.g. "set -e\ngh pr merge 42") will not be matched. This is an
+// accepted trade-off: simple prefix matching is sufficient for the forensic
+// use-case and avoids false positives from subcommand arguments that happen to
+// start with a matched prefix.
 func isHighImpactCommand(cmd string) bool {
 	lower := strings.ToLower(strings.TrimSpace(cmd))
 	for _, prefix := range highImpactPrefixes {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -868,6 +868,208 @@ func TestMessagePartUpdated_ToolCall(t *testing.T) {
 	}
 }
 
+// TestIsHighImpactCommand verifies the command pattern matching logic.
+func TestIsHighImpactCommand(t *testing.T) {
+	cases := []struct {
+		cmd      string
+		wantHigh bool
+	}{
+		// High-impact commands.
+		{"gh pr merge 42 --squash", true},
+		{"gh pr create --title 'foo'", true},
+		{"gh issue close 99", true},
+		{"git push", true},
+		{"git push origin main", true},
+		{"git push --force", true},
+		{"prism spawn nixos-config@feature", true},
+		{"prism cleanup nixos-config@feature", true},
+		{"prism prompt nixos-config@feature --prompt done", true},
+		// Case-insensitive.
+		{"GH PR MERGE 42", true},
+		{"GIT PUSH", true},
+		// Leading whitespace ignored.
+		{"  git push origin", true},
+		// Non-high-impact commands.
+		{"ls -la", false},
+		{"git status", false},
+		{"gh pr view 42", false},
+		{"git commit -m 'test'", false},
+		{"prism stats", false},
+		{"echo hello", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		got := isHighImpactCommand(tc.cmd)
+		if got != tc.wantHigh {
+			t.Errorf("isHighImpactCommand(%q) = %v, want %v", tc.cmd, got, tc.wantHigh)
+		}
+	}
+}
+
+// TestExtractBashCommand verifies bash input extraction.
+func TestExtractBashCommand(t *testing.T) {
+	t.Run("map input", func(t *testing.T) {
+		input := map[string]any{"command": "git push origin main"}
+		got := extractBashCommand(input)
+		if got != "git push origin main" {
+			t.Errorf("got %q, want %q", got, "git push origin main")
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		got := extractBashCommand(nil)
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("non-map input", func(t *testing.T) {
+		got := extractBashCommand("not a map")
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("map without command key", func(t *testing.T) {
+		input := map[string]any{"other": "value"}
+		got := extractBashCommand(input)
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// TestMessagePartUpdated_HighImpactBashCommand verifies that completing a
+// high-impact bash tool call also writes an audit event alongside the regular
+// tool_call and tool_result events.
+func TestMessagePartUpdated_HighImpactBashCommand(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	start := 1000.0
+	end := 2500.0
+	evt := makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "tool",
+			"messageID": "msg-audit-1",
+			"tool":      "bash",
+			"state": map[string]any{
+				"status": "completed",
+				"input":  map[string]string{"command": "gh pr merge 42 --squash"},
+				"output": "Merged pull request #42",
+				"time":   map[string]*float64{"start": &start, "end": &end},
+			},
+		},
+	})
+	sc.HandleEvent(evt)
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var toolCalls, toolResults, auditEvents int
+	for _, e := range events {
+		switch e.Type {
+		case "tool_call":
+			toolCalls++
+		case "tool_result":
+			toolResults++
+		case "audit":
+			auditEvents++
+			// Verify audit payload fields.
+			var p map[string]any
+			if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+				t.Errorf("unmarshal audit payload: %v", err)
+				continue
+			}
+			if p["tool"] != "bash" {
+				t.Errorf("audit tool = %v, want bash", p["tool"])
+			}
+			if p["command"] != "gh pr merge 42 --squash" {
+				t.Errorf("audit command = %v, want 'gh pr merge 42 --squash'", p["command"])
+			}
+			if p["sessionName"] != sc.cfg.SessionName {
+				t.Errorf("audit sessionName = %v, want %q", p["sessionName"], sc.cfg.SessionName)
+			}
+			if p["messageId"] != "msg-audit-1" {
+				t.Errorf("audit messageId = %v, want msg-audit-1", p["messageId"])
+			}
+		}
+	}
+	if toolCalls != 1 {
+		t.Errorf("tool_call count = %d, want 1", toolCalls)
+	}
+	if toolResults != 1 {
+		t.Errorf("tool_result count = %d, want 1", toolResults)
+	}
+	if auditEvents != 1 {
+		t.Errorf("audit event count = %d, want 1", auditEvents)
+	}
+}
+
+// TestMessagePartUpdated_NonHighImpactBashCommand verifies that low-impact
+// bash commands do NOT produce an audit event.
+func TestMessagePartUpdated_NonHighImpactBashCommand(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	start := 1000.0
+	end := 2000.0
+	evt := makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "tool",
+			"messageID": "msg-noaudit-1",
+			"tool":      "bash",
+			"state": map[string]any{
+				"status": "completed",
+				"input":  map[string]string{"command": "ls -la"},
+				"output": "total 0",
+				"time":   map[string]*float64{"start": &start, "end": &end},
+			},
+		},
+	})
+	sc.HandleEvent(evt)
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	for _, e := range events {
+		if e.Type == "audit" {
+			t.Errorf("unexpected audit event for low-impact command 'ls -la': payload=%s", e.Payload)
+		}
+	}
+}
+
+// TestMessagePartUpdated_NonBashToolNoAudit verifies that high-impact-looking
+// args on non-bash tools do NOT trigger an audit event.
+func TestMessagePartUpdated_NonBashToolNoAudit(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	start := 1000.0
+	end := 2000.0
+	evt := makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "tool",
+			"messageID": "msg-nontool-1",
+			"tool":      "read", // non-bash tool
+			"state": map[string]any{
+				"status": "completed",
+				"input":  map[string]string{"command": "gh pr merge 42"},
+				"output": "file contents",
+				"time":   map[string]*float64{"start": &start, "end": &end},
+			},
+		},
+	})
+	sc.HandleEvent(evt)
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	for _, e := range events {
+		if e.Type == "audit" {
+			t.Errorf("unexpected audit event for non-bash tool: payload=%s", e.Payload)
+		}
+	}
+}
+
 func TestMessagePartUpdated_Thinking(t *testing.T) {
 	sc, _ := newTestSidecar(t)
 


### PR DESCRIPTION
## Summary

- Promotes high-impact bash tool calls (`gh pr merge`, `git push`, `gh pr create`, `gh issue close`, `prism spawn`, `prism cleanup`, `prism prompt`) from the ephemeral opencode DB to the persistent prism DB as `audit` events
- Adds `prism audit` CLI command to query the audit trail by session, time range, and command pattern
- Adds `QueryAuditEvents` DB query helper and `Audit` payload struct

## Changes

- `internal/sidecar/sidecar.go`: In `handleMessagePartUpdated`, after writing `tool_call`/`tool_result` events for bash tools, check if the command matches high-impact prefixes and write an `audit` event. Adds `isHighImpactCommand()` and `extractBashCommand()` helpers.
- `internal/payload/payload.go`: New `Audit` struct for typed audit event payloads (tool, command, sessionName, opencodeSID, messageId)
- `internal/db/db.go`: New `QueryAuditEvents()` with optional session, sinceMs, pattern, and limit filters; returns events ordered by `created_at DESC`
- `cmd/audit.go`: New `prism audit [session] [--days N] [--pattern TEXT] [--limit N]` subcommand with tabular output

## Verification

- `go build ./...` passes
- `go test ./...` passes (all 13 packages OK; `cmd` failures under `PRISM_HOST_API` are pre-existing environment issues unrelated to this change)
- Nix build passes

Closes #642