### PR TITLE
fix: pre-extract OCI archive to avoid skopeo chown failure on CI

### DIFF
--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -41,19 +41,22 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push amd64 image to GHCR
         run: |
+          set -euo pipefail
           # skopeo copy from oci-archive: untars the archive to /var/tmp and
           # tries to chown entries to restore tar-header ownership, which fails
           # on unprivileged GitHub Actions runners.  Pre-extract with GNU tar's
           # --no-same-owner to strip the ownership metadata, then copy from the
           # resulting directory using the oci: scheme (no untar needed).
+          # -xf (without -z) lets GNU tar auto-detect compression so this works
+          # whether the Nix output is a plain .tar or a .tar.gz.
           archive=$(readlink result)
           tmpdir=$(mktemp -d)
-          tar --no-same-owner -xzf "$archive" -C "$tmpdir"
+          trap 'rm -rf "$tmpdir"' EXIT
+          tar --no-same-owner -xf "$archive" -C "$tmpdir"
           nix run nixpkgs#skopeo -- copy \
             --insecure-policy \
             oci:"$tmpdir" \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
-          rm -rf "$tmpdir"
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
@@ -86,17 +89,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push arm64 image to GHCR
         run: |
+          set -euo pipefail
           # Same workaround as amd64: pre-extract with --no-same-owner to avoid
           # the chown failure skopeo hits when unpacking oci-archive: sources on
-          # unprivileged runners.
+          # unprivileged runners.  Use -xf (no -z) for auto-detection of
+          # compression format, and trap EXIT to ensure cleanup on failure.
           archive=$(readlink result)
           tmpdir=$(mktemp -d)
-          tar --no-same-owner -xzf "$archive" -C "$tmpdir"
+          trap 'rm -rf "$tmpdir"' EXIT
+          tar --no-same-owner -xf "$archive" -C "$tmpdir"
           nix run nixpkgs#skopeo -- copy \
             --insecure-policy \
             oci:"$tmpdir" \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-arm64
-          rm -rf "$tmpdir"
 
   publish-manifest:
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -41,10 +41,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push amd64 image to GHCR
         run: |
+          # skopeo copy from oci-archive: untars the archive to /var/tmp and
+          # tries to chown entries to restore tar-header ownership, which fails
+          # on unprivileged GitHub Actions runners.  Pre-extract with GNU tar's
+          # --no-same-owner to strip the ownership metadata, then copy from the
+          # resulting directory using the oci: scheme (no untar needed).
+          archive=$(readlink result)
+          tmpdir=$(mktemp -d)
+          tar --no-same-owner -xzf "$archive" -C "$tmpdir"
           nix run nixpkgs#skopeo -- copy \
             --insecure-policy \
-            oci-archive:$(readlink result) \
+            oci:"$tmpdir" \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
+          rm -rf "$tmpdir"
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
@@ -77,10 +86,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push arm64 image to GHCR
         run: |
+          # Same workaround as amd64: pre-extract with --no-same-owner to avoid
+          # the chown failure skopeo hits when unpacking oci-archive: sources on
+          # unprivileged runners.
+          archive=$(readlink result)
+          tmpdir=$(mktemp -d)
+          tar --no-same-owner -xzf "$archive" -C "$tmpdir"
           nix run nixpkgs#skopeo -- copy \
             --insecure-policy \
-            oci-archive:$(readlink result) \
+            oci:"$tmpdir" \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-arm64
+          rm -rf "$tmpdir"
 
   publish-manifest:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Diagnoses the root cause of the ongoing \`publish-prism-agent\` CI failures: skopeo's \`oci-archive:\` source handler always untars the archive to \`/var/tmp/\` and calls \`chown\` to restore tar entry ownership (which is set to root from the Nix build). Unprivileged GitHub Actions runners cannot \`chown\` to root, so the copy fails.
- Corrects the misdiagnosis in #640 — \`--insecure-policy\` bypasses GPG policy checks only; it has no effect on the temp-dir untar path that causes the failure.
- Fixes both \`build-amd64\` and \`build-arm64\` jobs by pre-extracting the OCI archive with \`tar --no-same-owner\` (strips ownership metadata), then pointing skopeo at the extracted directory via the \`oci:\` scheme (directory-based, no untar needed).

## Root cause

\`\`\`
level=fatal msg="...oci-archive:/nix/store/.../prism-agent.tar.gz::
  creating temp directory: untarring file \"/var/tmp/container_images_ociXXXX\":
  chown /var/tmp/.../74bdc670...: operation not permitted"
\`\`\`

The \`oci-archive:\` skopeo source type internally untars the \`.tar.gz\` to a temp directory before processing. The tar entries have root ownership (from the Nix build environment). The \`runner\` user on GitHub Actions cannot \`chown\` to root → EPERM → fatal.

## Fix

\`\`\`bash
set -euo pipefail
archive=$(readlink result)
tmpdir=$(mktemp -d)
trap 'rm -rf "$tmpdir"' EXIT         # clean up on success or failure
tar --no-same-owner -xf "$archive" -C "$tmpdir"   # -xf auto-detects compression
nix run nixpkgs#skopeo -- copy \
  --insecure-policy \
  oci:"$tmpdir" \                    # directory source, no untar needed
  docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
\`\`\`