### PR TITLE
prism: remove bus_messages fallback, simplify prompt delivery to HTTP-only

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -253,9 +253,6 @@ prism prompt nixos-config@update-plex --prompt-file /tmp/p.txt
 prism prompt nixos-config@update-plex --prompt - <<'EOF'
 run `make test` and fix any failures
 EOF
-
-# Urgent delivery — interrupt the agent within ~2 seconds
-prism prompt nixos-config@update-plex --urgent --prompt 'stop what you are doing and open the PR now'
 ```
 
 The same shell-escaping conventions that apply to `prism spawn` apply here —
@@ -267,9 +264,8 @@ see [Passing prompts safely](#passing-prompts-safely--shell-escaping) above.
 |---|---|
 | `--prompt <text>` | Prompt text to send. Supports `-` to read from stdin. |
 | `--prompt-file <path>` | Read prompt from a file. Mutually exclusive with `--prompt`. |
-| `--urgent` | Deliver within ~2 seconds via interrupt polling instead of waiting for the next idle event. |
 
-The prompt is written to the message bus and delivered by the opencode plugin. The session must exist and have an agent window — use `prism list-sessions` to check first.
+The prompt is delivered directly via HTTP to the opencode session. The session must exist and have an active opencode port — use `prism list-sessions` to check first.
 
 ### Waiting state guard
 

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -357,12 +357,12 @@ var eventTmuxSessionEndCmd = &cobra.Command{
 			return fmt.Errorf("event tmux-session-end: purge bus messages: %w", err)
 		}
 
-		// Clean up the per-session bus sentinel written by `prism prompt`
-		// (Stage 7). This file is named <session>.signal and is separate from
-		// the shared .dashboard.signal used by Stage 8. Removing it here
-		// prevents stale sentinel files accumulating after a session ends.
-		// The removal is best-effort — the file may not exist if Stage 7 was
-		// never exercised.
+		// Clean up any per-session bus sentinel files that may have been written
+		// by older versions of `prism prompt`. The sentinel (<session>.signal in
+		// prism/bus/) is no longer created as of the HTTP-only delivery refactor,
+		// but the removal is retained to clean up files left from prior runs.
+		// It is separate from the shared .dashboard.signal used by the dashboard
+		// watcher. The removal is best-effort — the file may not exist.
 		stateHome := os.Getenv("XDG_STATE_HOME")
 		if stateHome == "" {
 			home, _ := os.UserHomeDir()

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -184,11 +184,10 @@ func proxyCheckin(apiURL, session string, limit int, before, after *string, type
 
 // proxyPrompt proxies a prompt delivery request to the host-API sidecar.
 // apiURL is the value of PRISM_HOST_API.
-func proxyPrompt(apiURL, session, prompt string, urgent bool) error {
+func proxyPrompt(apiURL, session, prompt string) error {
 	return proxyToHostAPI(apiURL, "/prompt", map[string]any{
 		"session": session,
 		"prompt":  prompt,
-		"urgent":  urgent,
 	}, nil)
 }
 

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -594,7 +594,6 @@ func TestProxyPrompt_SendsCorrectPayload(t *testing.T) {
 	type promptReq struct {
 		Session string `json:"session"`
 		Prompt  string `json:"prompt"`
-		Urgent  bool   `json:"urgent"`
 	}
 
 	reqCh := make(chan promptReq, 1)
@@ -612,7 +611,7 @@ func TestProxyPrompt_SendsCorrectPayload(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	if err := proxyPrompt(srv.apiURL(), "myrepo@main", "do the thing", false); err != nil {
+	if err := proxyPrompt(srv.apiURL(), "myrepo@main", "do the thing"); err != nil {
 		t.Fatalf("proxyPrompt: %v", err)
 	}
 
@@ -638,7 +637,7 @@ func TestProxyPrompt_Returns403AsError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"workers can only prompt their own coordinator"}`))
 	})
 
-	err := proxyPrompt(srv.apiURL(), "otherrepo@main", "hello", false)
+	err := proxyPrompt(srv.apiURL(), "otherrepo@main", "hello")
 	if err == nil {
 		t.Fatal("expected non-nil error for 403 response")
 	}

--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -7,7 +7,6 @@ package cmd
 //	prism prompt <session> --prompt <text>
 //	prism prompt <session> --prompt - < /tmp/prompt.txt
 //	prism prompt <session> --prompt-file /tmp/prompt.txt
-//	prism prompt <session> --urgent --prompt <text>
 
 import (
 	"bytes"
@@ -15,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,20 +34,15 @@ var promptCmd = &cobra.Command{
 	Long: `Send a follow-up message to the opencode agent running in the named tmux
 session. The session must already exist and have an agent window.
 
-When the target session has an opencode HTTP port, the prompt is delivered
-directly via POST /session/:id/prompt_async for instant delivery. A record
-is also written to bus_messages (with delivered_at set) for audit.
-
-If the target session has no port (pre-port-allocation sessions) or the
-HTTP request fails, the prompt falls back to writing to bus_messages for
-the plugin to deliver on its next poll cycle.`,
+The prompt is delivered directly via POST /session/:id/prompt_async for
+instant delivery. A record is also written to bus_messages (with delivered_at
+set) for audit. If HTTP delivery fails, an error is returned.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runPrompt,
 }
 
 func init() {
 	addPromptFlags(promptCmd)
-	promptCmd.Flags().Bool("urgent", false, "Accepted for backward compatibility (no-op — HTTP delivery is instant)")
 	rootCmd.AddCommand(promptCmd)
 }
 
@@ -61,12 +54,8 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// --urgent is accepted but ignored (HTTP delivery is instant).
-	urgentFlag, _ := cmd.Flags().GetBool("urgent")
-	_ = urgentFlag
-
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyPrompt(apiURL, sessionName, promptText, urgentFlag)
+		return proxyPrompt(apiURL, sessionName, promptText, false)
 	}
 
 	// Open DB.
@@ -137,34 +126,22 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 		SentAt:       time.Now(),
 	}
 
-	// Try HTTP delivery if port and session ID are available.
-	if status.OpencodePort != nil && status.OpencodeSID != nil {
-		httpErr := deliverViaHTTP(*status.OpencodePort, *status.OpencodeSID, promptText, status)
-		if httpErr == nil {
-			// HTTP delivery succeeded — write audit trail with delivered_at set.
-			if err := database.WriteBusMessageDelivered(msg); err != nil {
-				// Non-fatal: HTTP delivery succeeded; audit write is best-effort.
-				fmt.Fprintf(os.Stderr, "warning: could not write audit bus message: %v\n", err)
-			}
-			fmt.Printf("prompt delivered to %s via HTTP\n", sessionName)
-			return nil
-		}
-		// HTTP failed — log and fall through to bus_messages.
-		fmt.Fprintf(os.Stderr, "warning: HTTP delivery failed, falling back to bus: %v\n", httpErr)
+	// Require port and session ID for HTTP delivery.
+	if status.OpencodePort == nil || status.OpencodeSID == nil {
+		return fmt.Errorf("session %q has no opencode port or session ID — cannot deliver prompt", sessionName)
 	}
 
-	// Fallback: write to bus_messages for plugin-based delivery.
-	if err := database.WriteBusMessage(msg); err != nil {
-		return fmt.Errorf("write bus message: %w", err)
+	httpErr := deliverViaHTTP(*status.OpencodePort, *status.OpencodeSID, promptText, status)
+	if httpErr != nil {
+		return fmt.Errorf("HTTP delivery failed: %w", httpErr)
 	}
 
-	// Touch sentinel file so the Stage 8 dashboard watcher can react.
-	if err := touchBusSentinel(sessionName); err != nil {
-		// Non-fatal: DB write succeeded; sentinel is best-effort.
-		fmt.Fprintf(os.Stderr, "warning: could not touch bus sentinel: %v\n", err)
+	// HTTP delivery succeeded — write audit trail with delivered_at set.
+	if err := database.WriteBusMessageDelivered(msg); err != nil {
+		// Non-fatal: HTTP delivery succeeded; audit write is best-effort.
+		fmt.Fprintf(os.Stderr, "warning: could not write audit bus message: %v\n", err)
 	}
-
-	fmt.Printf("prompt queued for %s\n", sessionName)
+	fmt.Printf("prompt delivered to %s via HTTP\n", sessionName)
 	return nil
 }
 
@@ -245,32 +222,4 @@ func deriveSessionNameFromCWD(cwd string) string {
 		return ""
 	}
 	return session.NameFor(cwd, bareRoot)
-}
-
-// touchBusSentinel creates/updates the sentinel file at
-// $XDG_STATE_HOME/prism/bus/<session>.signal. The directory is created if
-// it does not exist.
-func touchBusSentinel(sessionName string) error {
-	stateHome := os.Getenv("XDG_STATE_HOME")
-	if stateHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("home dir: %w", err)
-		}
-		stateHome = filepath.Join(home, ".local", "state")
-	}
-	busDir := filepath.Join(stateHome, "prism", "bus")
-	if err := os.MkdirAll(busDir, 0o755); err != nil {
-		return fmt.Errorf("mkdir bus: %w", err)
-	}
-	sentinelPath := filepath.Join(busDir, sessionName+".signal")
-	f, err := os.OpenFile(sentinelPath, os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-	now := time.Now()
-	return os.Chtimes(sentinelPath, now, now)
 }

--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -55,7 +55,7 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	}
 
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyPrompt(apiURL, sessionName, promptText, false)
+		return proxyPrompt(apiURL, sessionName, promptText)
 	}
 
 	// Open DB.

--- a/modules/programs/prism/prism/cmd/prompt_test.go
+++ b/modules/programs/prism/prism/cmd/prompt_test.go
@@ -276,16 +276,7 @@ func TestRunPrompt_HTTPDelivery(t *testing.T) {
 		t.Errorf("output should mention HTTP: got %q", output)
 	}
 
-	// Verify an audit bus_messages row was written with delivered_at set.
-	pending, err := d.PendingMessages("repo@main", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
-	}
-	if len(pending) != 0 {
-		t.Errorf("pending messages should be 0 (delivered_at set): got %d", len(pending))
-	}
-
-	// Verify the audit row exists (delivered).
+	// Verify the audit row exists (delivered_at set).
 	var count int
 	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "repo@main").Scan(&count); err != nil {
 		t.Fatalf("count audit row: %v", err)
@@ -295,35 +286,25 @@ func TestRunPrompt_HTTPDelivery(t *testing.T) {
 	}
 }
 
-// TestRunPrompt_BusFallback_NoPort verifies that prompts fall back to
-// bus_messages when opencode_port is NULL.
-func TestRunPrompt_BusFallback_NoPort(t *testing.T) {
+// TestRunPrompt_NoPort_ReturnsError verifies that prompts return an error
+// when opencode_port is NULL (no HTTP delivery possible).
+func TestRunPrompt_NoPort_ReturnsError(t *testing.T) {
 	d := openPromptTestDB(t)
 	seedSession(t, d, "repo@legacy", "active", nil, nil, nil, nil)
 
-	rootCmd.SetArgs([]string{"prompt", "repo@legacy", "--prompt", "fallback test"})
-	output := captureStdout(t, func() {
-		if err := rootCmd.Execute(); err != nil {
-			t.Fatalf("Execute: %v", err)
-		}
-	})
-
-	if !strings.Contains(output, "queued") {
-		t.Errorf("output should mention queued: got %q", output)
+	rootCmd.SetArgs([]string{"prompt", "repo@legacy", "--prompt", "test"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when session has no port, got nil")
 	}
-
-	pending, err := d.PendingMessages("repo@legacy", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
-	}
-	if len(pending) != 1 {
-		t.Errorf("pending count: got %d, want 1", len(pending))
+	if !strings.Contains(err.Error(), "no opencode port") {
+		t.Errorf("error should mention missing port: got %q", err.Error())
 	}
 }
 
-// TestRunPrompt_BusFallback_HTTPError verifies that when HTTP delivery fails,
-// the prompt falls back to bus_messages.
-func TestRunPrompt_BusFallback_HTTPError(t *testing.T) {
+// TestRunPrompt_HTTPError_ReturnsError verifies that when HTTP delivery fails,
+// an error is returned (no fallback to bus).
+func TestRunPrompt_HTTPError_ReturnsError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
@@ -339,22 +320,21 @@ func TestRunPrompt_BusFallback_HTTPError(t *testing.T) {
 	seedSession(t, d, "repo@fail", "active", intPtr(port), strPtr("oc-sid-2"), strPtr("worker"), strPtr("anthropic/claude-sonnet-4.6"))
 
 	rootCmd.SetArgs([]string{"prompt", "repo@fail", "--prompt", "retry me"})
-	output := captureStdout(t, func() {
-		if err := rootCmd.Execute(); err != nil {
-			t.Fatalf("Execute: %v", err)
-		}
-	})
-
-	if !strings.Contains(output, "queued") {
-		t.Errorf("output should mention queued: got %q", output)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when HTTP delivery fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTP delivery failed") {
+		t.Errorf("error should mention HTTP delivery failure: got %q", err.Error())
 	}
 
-	pending, err := d.PendingMessages("repo@fail", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
+	// Verify no undelivered bus_messages row was written.
+	var count int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NULL", "repo@fail").Scan(&count); err != nil {
+		t.Fatalf("count undelivered: %v", err)
 	}
-	if len(pending) != 1 {
-		t.Errorf("pending count: got %d, want 1", len(pending))
+	if count != 0 {
+		t.Errorf("no undelivered bus messages expected after HTTP failure, got %d", count)
 	}
 }
 
@@ -408,26 +388,8 @@ func TestRunPrompt_SessionNotFound(t *testing.T) {
 	}
 }
 
-// TestRunPrompt_UrgentFlagAccepted verifies that --urgent is accepted without
-// error (backward compatibility) even though it's now a no-op.
-func TestRunPrompt_UrgentFlagAccepted(t *testing.T) {
-	d := openPromptTestDB(t)
-	seedSession(t, d, "repo@urgent", "active", nil, nil, nil, nil)
-
-	rootCmd.SetArgs([]string{"prompt", "repo@urgent", "--urgent", "--prompt", "urgent test"})
-	output := captureStdout(t, func() {
-		if err := rootCmd.Execute(); err != nil {
-			t.Fatalf("Execute: %v", err)
-		}
-	})
-
-	if !strings.Contains(output, "queued") {
-		t.Errorf("output should mention queued: got %q", output)
-	}
-}
-
 // TestWriteBusMessageDelivered verifies that WriteBusMessageDelivered inserts
-// a row with delivered_at set (not pending).
+// a row with delivered_at set (audit trail for HTTP-delivered prompts).
 func TestWriteBusMessageDelivered(t *testing.T) {
 	d := openPromptTestDB(t)
 
@@ -445,18 +407,9 @@ func TestWriteBusMessageDelivered(t *testing.T) {
 		t.Fatalf("WriteBusMessageDelivered: %v", err)
 	}
 
-	// Must NOT appear in pending messages (delivered_at is set).
-	pending, err := d.PendingMessages("repo@receiver", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
-	}
-	if len(pending) != 0 {
-		t.Errorf("pending count: got %d, want 0 (message is already delivered)", len(pending))
-	}
-
 	// Verify the row exists with delivered_at set.
 	var deliveredAt *int64
-	err = d.QueryRow("SELECT delivered_at FROM bus_messages WHERE id = ?", "test-delivered-1").Scan(&deliveredAt)
+	err := d.QueryRow("SELECT delivered_at FROM bus_messages WHERE id = ?", "test-delivered-1").Scan(&deliveredAt)
 	if err != nil {
 		t.Fatalf("query delivered_at: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -961,49 +961,6 @@ func (d *DB) WaitingCount() (int, error) {
 	return n, nil
 }
 
-// PendingMessages returns undelivered bus_messages for toSession with the given
-// urgency. When instanceID is non-empty, only messages whose to_instance_id
-// matches are returned (messages addressed to a prior instance are excluded).
-// When instanceID is empty (legacy / no instance isolation), all undelivered
-// messages for toSession are returned regardless of to_instance_id.
-func (d *DB) PendingMessages(toSession string, urgency string, instanceID string) ([]BusMessage, error) {
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	if instanceID != "" {
-		const q = `
-SELECT id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at
-FROM bus_messages
-WHERE to_session = ? AND urgency = ? AND delivered_at IS NULL
-  AND (to_instance_id IS NULL OR to_instance_id = ?)`
-		rows, err = d.conn.Query(q, toSession, urgency, instanceID)
-	} else {
-		const q = `
-SELECT id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at
-FROM bus_messages
-WHERE to_session = ? AND urgency = ? AND delivered_at IS NULL`
-		rows, err = d.conn.Query(q, toSession, urgency)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("db: pending messages: %w", err)
-	}
-	defer rows.Close()
-
-	var msgs []BusMessage
-	for rows.Next() {
-		m, err := scanBusMessage(rows)
-		if err != nil {
-			return nil, fmt.Errorf("db: scan bus message: %w", err)
-		}
-		msgs = append(msgs, m)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("db: iterate bus messages: %w", err)
-	}
-	return msgs, nil
-}
-
 // SetInstanceID writes a UUID instance_id to the agent_status row for
 // sessionName. Called on tmux-session-start to uniquely identify this session
 // incarnation.
@@ -1048,19 +1005,6 @@ WHERE to_session = ?
   AND to_instance_id != ?`
 	if _, err := d.conn.Exec(q, toSession, currentInstanceID); err != nil {
 		return fmt.Errorf("db: purge stale instance messages: %w", err)
-	}
-	return nil
-}
-
-// MarkDelivered sets delivered_at on the given bus message.
-func (d *DB) MarkDelivered(messageID string) error {
-	now := time.Now().UnixMilli()
-	_, err := d.conn.Exec(
-		"UPDATE bus_messages SET delivered_at = ? WHERE id = ?",
-		now, messageID,
-	)
-	if err != nil {
-		return fmt.Errorf("db: mark delivered: %w", err)
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -588,12 +588,13 @@ func TestPurgeBusMessages(t *testing.T) {
 			Urgency:     "normal",
 			SentAt:      time.Now(),
 		}
-		if err := d.WriteBusMessage(msg); err != nil {
-			t.Fatalf("WriteBusMessage %s: %v", id, err)
-		}
 		if delivered {
-			if err := d.MarkDelivered(id); err != nil {
-				t.Fatalf("MarkDelivered %s: %v", id, err)
+			if err := d.WriteBusMessageDelivered(msg); err != nil {
+				t.Fatalf("WriteBusMessageDelivered %s: %v", id, err)
+			}
+		} else {
+			if err := d.WriteBusMessage(msg); err != nil {
+				t.Fatalf("WriteBusMessage %s: %v", id, err)
 			}
 		}
 	}
@@ -617,17 +618,18 @@ func TestPurgeBusMessages(t *testing.T) {
 		t.Fatalf("PurgeBusMessages: %v", err)
 	}
 
-	// After purge, pending messages for target must be empty (to_session path).
-	pending, err := d.PendingMessages(target, "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages(target): %v", err)
+	// After purge, undelivered messages for target must be gone (to_session path).
+	var toTargetCount int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NULL", target,
+	).Scan(&toTargetCount); err != nil {
+		t.Fatalf("count to-target undelivered: %v", err)
 	}
-	if len(pending) != 0 {
-		t.Errorf("pending messages for target after purge: got %d, want 0", len(pending))
+	if toTargetCount != 0 {
+		t.Errorf("undelivered messages for target after purge: got %d, want 0", toTargetCount)
 	}
 
-	// Explicitly verify the from_session row was also deleted (PendingMessages
-	// only queries to_session, so we must check via a direct row count).
+	// Explicitly verify the from_session row was also deleted.
 	var fromCount int
 	if err := d.QueryRow(
 		"SELECT COUNT(*) FROM bus_messages WHERE id = ?", "from-target-undelivered",
@@ -638,13 +640,15 @@ func TestPurgeBusMessages(t *testing.T) {
 		t.Errorf("from-target-undelivered row still present after purge: got %d, want 0", fromCount)
 	}
 
-	// Pending messages for other sessions must be unaffected.
-	pendingOther, err := d.PendingMessages("repo@third", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages(other): %v", err)
+	// Undelivered messages for other sessions must be unaffected.
+	var otherCount int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NULL", "repo@third",
+	).Scan(&otherCount); err != nil {
+		t.Fatalf("count other undelivered: %v", err)
 	}
-	if len(pendingOther) != 1 {
-		t.Errorf("pending messages for other after purge: got %d, want 1", len(pendingOther))
+	if otherCount != 1 {
+		t.Errorf("undelivered messages for other after purge: got %d, want 1", otherCount)
 	}
 }
 
@@ -674,11 +678,8 @@ func TestPurgeBusMessages_PreservesDelivered(t *testing.T) {
 		Urgency:     "normal",
 		SentAt:      time.Now(),
 	}
-	if err := d.WriteBusMessage(msg); err != nil {
-		t.Fatalf("WriteBusMessage: %v", err)
-	}
-	if err := d.MarkDelivered(msgID); err != nil {
-		t.Fatalf("MarkDelivered: %v", err)
+	if err := d.WriteBusMessageDelivered(msg); err != nil {
+		t.Fatalf("WriteBusMessageDelivered: %v", err)
 	}
 
 	if err := d.PurgeBusMessages("repo@target"); err != nil {
@@ -692,55 +693,6 @@ func TestPurgeBusMessages_PreservesDelivered(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("delivered row count after purge: got %d, want 1", count)
-	}
-}
-
-// TestWriteBusMessage_PendingMessages_MarkDelivered tests the full bus message lifecycle.
-func TestWriteBusMessage_PendingMessages_MarkDelivered(t *testing.T) {
-	d := openTestDB(t)
-
-	msgID := uuid.New().String()
-	msg := db.BusMessage{
-		ID:          msgID,
-		FromSession: "repo@feat",
-		ToSession:   "repo@main",
-		Repo:        "repo",
-		Text:        "hello coordinator",
-		Urgency:     "normal",
-		SentAt:      time.Now(),
-	}
-
-	if err := d.WriteBusMessage(msg); err != nil {
-		t.Fatalf("WriteBusMessage: %v", err)
-	}
-
-	// Must appear in pending messages.
-	pending, err := d.PendingMessages("repo@main", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
-	}
-	if len(pending) != 1 {
-		t.Fatalf("pending count: got %d, want 1", len(pending))
-	}
-	if pending[0].ID != msgID {
-		t.Errorf("message ID: got %q, want %q", pending[0].ID, msgID)
-	}
-	if pending[0].DeliveredAt != nil {
-		t.Error("DeliveredAt: got non-nil, want nil")
-	}
-
-	// Mark delivered.
-	if err := d.MarkDelivered(msgID); err != nil {
-		t.Fatalf("MarkDelivered: %v", err)
-	}
-
-	// Must no longer appear in pending messages.
-	pending2, err := d.PendingMessages("repo@main", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages after deliver: %v", err)
-	}
-	if len(pending2) != 0 {
-		t.Errorf("pending count after deliver: got %d, want 0", len(pending2))
 	}
 }
 
@@ -1481,7 +1433,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 		t.Errorf("State preserved: got %q, want \"active\"", s.State)
 	}
 
-	// Verify that to_instance_id was added to bus_messages by writing and reading a message.
+	// Verify that to_instance_id was added to bus_messages by writing a message
+	// and checking that the column exists with a NULL value.
 	msg := db.BusMessage{
 		ID:          "test-instance-migration",
 		FromSession: "repo@feat",
@@ -1493,16 +1446,16 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.WriteBusMessage(msg); err != nil {
 		t.Fatalf("WriteBusMessage after v5→v6 migration: %v", err)
 	}
-	pending, err := d.PendingMessages("repo@main", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages after v5→v6 migration: %v", err)
-	}
-	if len(pending) != 1 {
-		t.Fatalf("pending count: got %d, want 1", len(pending))
+	// Query to_instance_id directly to confirm the column exists and is NULL.
+	var toInstanceID *string
+	if err := d.QueryRow(
+		"SELECT to_instance_id FROM bus_messages WHERE id = ?", "test-instance-migration",
+	).Scan(&toInstanceID); err != nil {
+		t.Fatalf("query to_instance_id after v5→v6 migration: %v", err)
 	}
 	// to_instance_id should be NULL (not set).
-	if pending[0].ToInstanceID != nil {
-		t.Errorf("ToInstanceID: got %v, want nil", pending[0].ToInstanceID)
+	if toInstanceID != nil {
+		t.Errorf("ToInstanceID: got %v, want nil", toInstanceID)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/integration_test.go
+++ b/modules/programs/prism/prism/internal/integration/integration_test.go
@@ -234,8 +234,9 @@ func TestDBLifecycle_IdleActiveFinished(t *testing.T) {
 	}
 }
 
-// TestDBLifecycle_BusMessage verifies WriteBusMessage and PendingMessages.
-func TestDBLifecycle_BusMessage(t *testing.T) {
+// TestDBLifecycle_BusMessageDelivered verifies WriteBusMessageDelivered writes
+// an audit row with delivered_at set (HTTP-delivered prompt audit trail).
+func TestDBLifecycle_BusMessageDelivered(t *testing.T) {
 	t.Parallel()
 	d := openTestDB(t)
 
@@ -249,38 +250,18 @@ func TestDBLifecycle_BusMessage(t *testing.T) {
 		Urgency:     "normal",
 		SentAt:      time.Now(),
 	}
-	if err := d.WriteBusMessage(msg); err != nil {
-		t.Fatalf("WriteBusMessage: %v", err)
+	if err := d.WriteBusMessageDelivered(msg); err != nil {
+		t.Fatalf("WriteBusMessageDelivered: %v", err)
 	}
 
-	// Must appear as a pending message for the target session.
-	pending, err := d.PendingMessages("myrepo@main", "normal", "")
+	// Row must exist with delivered_at set.
+	var deliveredAt *int64
+	err := d.QueryRow("SELECT delivered_at FROM bus_messages WHERE id = ?", msgID).Scan(&deliveredAt)
 	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
+		t.Fatalf("query delivered_at: %v", err)
 	}
-	if len(pending) != 1 {
-		t.Fatalf("pending count: got %d, want 1", len(pending))
-	}
-	if pending[0].ID != msgID {
-		t.Errorf("message ID: got %q, want %q", pending[0].ID, msgID)
-	}
-	if pending[0].ToSession != "myrepo@main" {
-		t.Errorf("to_session: got %q, want %q", pending[0].ToSession, "myrepo@main")
-	}
-	if pending[0].Urgency != "normal" {
-		t.Errorf("urgency: got %q, want %q", pending[0].Urgency, "normal")
-	}
-	if pending[0].DeliveredAt != nil {
-		t.Error("DeliveredAt: got non-nil, want nil (undelivered)")
-	}
-
-	// Messages to a different session must not appear.
-	otherPending, err := d.PendingMessages("myrepo@feat", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages (wrong session): %v", err)
-	}
-	if len(otherPending) != 0 {
-		t.Errorf("wrong session pending count: got %d, want 0", len(otherPending))
+	if deliveredAt == nil {
+		t.Error("delivered_at: got nil, want non-nil (message delivered via HTTP)")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1261,8 +1261,7 @@ func touchDashboardSentinel() {
 // coordinator has an opencode_port and opencode_sid, the notification is
 // delivered via HTTP POST to /session/<sid>/prompt_async. On success, an audit
 // row is written via WriteBusMessageDelivered. If the coordinator has no port
-// or the HTTP call fails, the notification falls back to WriteBusMessage
-// (undelivered, for plugin polling).
+// or the HTTP call fails, the error is logged.
 //
 // If no coordinator exists, it has ended, or this session IS the coordinator,
 // the call is a silent no-op.
@@ -1310,23 +1309,21 @@ func (s *Sidecar) notifyCoordinator() {
 		SentAt:       time.Now(),
 	}
 
-	// Try HTTP delivery if coordinator has port and session ID.
-	if coordStatus.OpencodePort != nil && coordStatus.OpencodeSID != nil {
-		httpErr := deliverNotificationViaHTTP(*coordStatus.OpencodePort, *coordStatus.OpencodeSID, notifyText, coordStatus, s.cfg.HTTPClient)
-		if httpErr == nil {
-			// HTTP succeeded — write audit trail with delivered_at set.
-			if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
-				log.Printf("sidecar: notifyCoordinator: write audit bus message: %v", err)
-			}
-			return
-		}
-		// HTTP failed — log and fall through to bus_messages fallback.
-		log.Printf("sidecar: notifyCoordinator: HTTP delivery failed, falling back to bus: %v", httpErr)
+	// Require port and session ID for HTTP delivery.
+	if coordStatus.OpencodePort == nil || coordStatus.OpencodeSID == nil {
+		log.Printf("sidecar: notifyCoordinator: coordinator has no opencode port or session ID — cannot deliver notification")
+		return
 	}
 
-	// Fallback: write to bus_messages for plugin-based delivery.
-	if err := s.cfg.DB.WriteBusMessage(msg); err != nil {
-		log.Printf("sidecar: notifyCoordinator: write bus message: %v", err)
+	httpErr := deliverNotificationViaHTTP(*coordStatus.OpencodePort, *coordStatus.OpencodeSID, notifyText, coordStatus, s.cfg.HTTPClient)
+	if httpErr != nil {
+		log.Printf("sidecar: notifyCoordinator: HTTP delivery failed: %v", httpErr)
+		return
+	}
+
+	// HTTP succeeded — write audit trail with delivered_at set.
+	if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
+		log.Printf("sidecar: notifyCoordinator: write audit bus message: %v", err)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1887,7 +1887,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	})
 
 	// POST /prompt
-	// Request:  {"session":"<target>", "prompt":"<text>", "urgent": false}
+	// Request:  {"session":"<target>", "prompt":"<text>"}
 	// Permission: worker → own coordinator (@main) only;
 	//             coordinator → own repo any session, cross-repo coordinator only.
 	mux.HandleFunc("/prompt", func(w http.ResponseWriter, r *http.Request) {
@@ -1898,7 +1898,6 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			Session string `json:"session"`
 			Prompt  string `json:"prompt"`
-			Urgent  bool   `json:"urgent"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -1589,24 +1589,6 @@ func seedCoordinatorWithPort(t *testing.T, d *db.DB, repo string, port int, sid 
 	}
 }
 
-// waitForBusMessage polls the DB for a bus message to toSession, with a short
-// timeout. Returns the first message found or nil.
-func waitForBusMessage(t *testing.T, d *db.DB, toSession string) *db.BusMessage {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		msgs, err := d.PendingMessages(toSession, "normal", "")
-		if err != nil {
-			t.Fatalf("PendingMessages: %v", err)
-		}
-		if len(msgs) > 0 {
-			return &msgs[0]
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return nil
-}
-
 // waitForBusMessageDelivered polls the DB for a delivered bus message
 // (delivered_at IS NOT NULL) to toSession.
 func waitForBusMessageDelivered(t *testing.T, d *db.DB, toSession string) *db.BusMessage {
@@ -1868,13 +1850,13 @@ func TestNotifyCoordinator_BusMessageAuditOnHTTPSuccess(t *testing.T) {
 		t.Fatal("expected delivered audit bus message")
 	}
 
-	// Verify no undelivered message was written.
-	undelivered, err := d.PendingMessages("test-repo@main", "normal", "")
-	if err != nil {
-		t.Fatalf("PendingMessages: %v", err)
+	// Verify no undelivered message was written (only the audit delivered row).
+	var undeliveredCount int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NULL", "test-repo@main").Scan(&undeliveredCount); err != nil {
+		t.Fatalf("count undelivered: %v", err)
 	}
-	if len(undelivered) != 0 {
-		t.Errorf("expected no undelivered messages after HTTP success, got %d", len(undelivered))
+	if undeliveredCount != 0 {
+		t.Errorf("expected no undelivered messages after HTTP success, got %d", undeliveredCount)
 	}
 
 	// Verify the HTTP body contained the notification text.
@@ -1903,7 +1885,9 @@ func TestNotifyCoordinator_BusMessageAuditOnHTTPSuccess(t *testing.T) {
 	}
 }
 
-func TestNotifyCoordinator_WriteBusMessageFallbackOnHTTPFailure(t *testing.T) {
+// TestNotifyCoordinator_HTTPFailure_NoFallback verifies that when HTTP delivery
+// fails, no bus message is written (no fallback — error is logged).
+func TestNotifyCoordinator_HTTPFailure_NoFallback(t *testing.T) {
 	d := openTestDB(t)
 
 	// Use a server that returns an error status.
@@ -1921,7 +1905,7 @@ func TestNotifyCoordinator_WriteBusMessageFallbackOnHTTPFailure(t *testing.T) {
 		t.Fatalf("parse test server port: %v", err)
 	}
 
-	coordSID := "coord-sid-fallback"
+	coordSID := "coord-sid-http-fail"
 	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
 
 	// Create worker sidecar with the test server's HTTP client (returns 500).
@@ -1936,14 +1920,16 @@ func TestNotifyCoordinator_WriteBusMessageFallbackOnHTTPFailure(t *testing.T) {
 	}
 	timer.Fire()
 
-	// Wait for fallback bus message (undelivered).
-	msg := waitForBusMessage(t, d, "test-repo@main")
-	if msg == nil {
-		t.Fatal("expected fallback bus message after HTTP failure")
+	// Give a brief window for the async notification goroutine to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	// No bus messages should be written — HTTP failure is logged, not fallen back.
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
 	}
-	wantText := "Agent test-repo@feature has finished its current task"
-	if msg.Text != wantText {
-		t.Errorf("bus message text = %q, want %q", msg.Text, wantText)
+	if totalMsgs != 0 {
+		t.Errorf("expected no bus messages after HTTP failure (no fallback), got %d", totalMsgs)
 	}
 }
 
@@ -2093,7 +2079,10 @@ func TestNotifyCoordinator_SilentSkipWhenNoCoordinator(t *testing.T) {
 	}
 }
 
-func TestNotifyCoordinator_PortSetButNoSID_FallsBackToBus(t *testing.T) {
+// TestNotifyCoordinator_PortSetButNoSID_NoNotification verifies that when
+// the coordinator has a port but no opencode_sid, no notification is sent
+// and no bus message is written.
+func TestNotifyCoordinator_PortSetButNoSID_NoNotification(t *testing.T) {
 	d := openTestDB(t)
 	worker, clk := newWorkerSidecar(t, d, nil)
 
@@ -2120,14 +2109,16 @@ func TestNotifyCoordinator_PortSetButNoSID_FallsBackToBus(t *testing.T) {
 	}
 	timer.Fire()
 
-	// Should fall back to undelivered bus message since opencode_sid is nil.
-	msg := waitForBusMessage(t, d, coordName)
-	if msg == nil {
-		t.Fatal("expected fallback bus message when coordinator has port but no sid")
+	// Give a brief window for the async notification goroutine to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	// No bus messages should be written since port+sid combination is incomplete.
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", coordName).Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
 	}
-	wantText := "Agent test-repo@feature has finished its current task"
-	if msg.Text != wantText {
-		t.Errorf("bus message text = %q, want %q", msg.Text, wantText)
+	if totalMsgs != 0 {
+		t.Errorf("expected no bus messages when coordinator has port but no sid, got %d", totalMsgs)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -1890,8 +1890,13 @@ func TestNotifyCoordinator_BusMessageAuditOnHTTPSuccess(t *testing.T) {
 func TestNotifyCoordinator_HTTPFailure_NoFallback(t *testing.T) {
 	d := openTestDB(t)
 
-	// Use a server that returns an error status.
+	// requestReceived is closed when the test server receives the HTTP request.
+	// This gives us a reliable synchronisation point: once the server has responded
+	// (with 500), the notifyCoordinator goroutine has finished its work and will
+	// not write anything further.
+	requestReceived := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestReceived)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
@@ -1920,8 +1925,13 @@ func TestNotifyCoordinator_HTTPFailure_NoFallback(t *testing.T) {
 	}
 	timer.Fire()
 
-	// Give a brief window for the async notification goroutine to complete.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the HTTP request to be received by the test server. Once the
+	// server has replied (with 500), the goroutine has completed its work.
+	select {
+	case <-requestReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for HTTP request to coordinator")
+	}
 
 	// No bus messages should be written — HTTP failure is logged, not fallen back.
 	var totalMsgs int
@@ -2109,8 +2119,17 @@ func TestNotifyCoordinator_PortSetButNoSID_NoNotification(t *testing.T) {
 	}
 	timer.Fire()
 
-	// Give a brief window for the async notification goroutine to complete.
-	time.Sleep(100 * time.Millisecond)
+	// Verify state transitioned to finished — this DB write is synchronous and
+	// happens before go s.notifyCoordinator() is launched, so it serves as a
+	// reliable anchor that the goroutine has been started. The goroutine returns
+	// immediately (early-exit: no opencode_sid), so a brief sleep is sufficient
+	// to let it complete before the absence assertion. This matches the same
+	// pattern used by TestNotifyCoordinator_SilentSkipWhenNoCoordinator and
+	// other no-notification tests in this file.
+	if state := getState(t, d, worker.cfg.SessionName); state != "finished" {
+		t.Errorf("worker state = %q, want finished", state)
+	}
+	time.Sleep(50 * time.Millisecond)
 
 	// No bus messages should be written since port+sid combination is incomplete.
 	var totalMsgs int


### PR DESCRIPTION
## Summary

- Removes the dead `bus_messages` fallback delivery path from `cmd/prompt.go` and `internal/sidecar/sidecar.go` — HTTP failure now returns an error rather than silently falling back to unread bus rows
- Removes `PendingMessages()` and `MarkDelivered()` from `internal/db/db.go` — both were dead code (never called in production)
- Removes `--urgent` flag from `prism prompt` (was already a no-op since HTTP delivery replaced it)
- Removes `touchBusSentinel()` (bus sentinel file logic) while keeping the dashboard sentinel unchanged
- Updates all affected tests, skill file, and removes the integration test that tested the removed path
- `WriteBusMessageDelivered()`, `PurgeBusMessages()`, `WriteBusMessage()`, and `Prune()` are all retained

Closes #646