### PR TITLE
prism: two-level checkin verbosity — rich default with tool one-liners and state changes

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -200,7 +200,7 @@ Use `prism list-sessions` to see all active agent sessions with their state and 
 prism list-sessions
 ```
 
-Use `prism checkin <session>` to read the recent conversation history for a session, sourced from the prism DB. Output is structured as message turns (user and assistant pairs) with tool calls, tool results, and permission events rendered inline under their parent assistant message:
+Use `prism checkin <session>` to read the recent conversation history for a session, sourced from the prism DB. The default output is a rich narrative view: assistant messages, state changes, and tool call one-liners interleaved chronologically.
 
 ```bash
 prism checkin nixos-config@update-plex
@@ -209,18 +209,37 @@ prism checkin nixos-config@update-plex
 ```
 checkin: nixos-config@update-plex
 
-state: active
+state: finished
 
-[2026-04-03 14:22:01] user
-implement the feature and open a PR
+[18:48:35] assistant
+I'll fix both issues from the review.
+  → edit: container.go ✓
+  → edit: sidecar.go ✓
+  → bash: go build ./... ✓
+  → bash: go test ./internal/... ok (9.2s)
 
-[2026-04-03 14:22:05] assistant
-I'll implement this now.
-  → Bash: ls src/
-  → result: main.go utils.go
+[18:49:16] assistant
+Tests pass. Committing and pushing.
+  → bash: git commit -m "fix: capture elapsed..." ✓
+  → bash: git push ✓
+
+[18:50:25] ● finished
 
 ── end of event log ──
 ```
+
+**Tool one-liner format**: `→ <tool>: <key_arg> <result_summary>`
+
+- **bash** — key arg is the command (first ~80 chars); result is first meaningful output line, `✓` for empty stdout, `✗ <message>` on error
+- **read** — key arg is the file path; result is `✓ (N lines)`
+- **edit / write** — key arg is the file path; result is `✓` or `✗`
+- **task** — key arg is the description; result is `✓` or `✗`
+- **glob / grep** — key arg is the pattern; result is `N matches` or `no matches`
+- **todowrite** — result is `✓` (key arg omitted)
+
+**State changes** appear inline as `● <state>` (e.g. `● finished`) with a timestamp.
+
+**User messages** (`▶ user`) are visually distinct from assistant turns so coordinator prompts and bus notifications are easy to spot.
 
 With no argument, `prism checkin` lists available sessions and exits with a hint.
 
@@ -231,8 +250,8 @@ With no argument, `prism checkin` lists available sessions and exits with a hint
 | `--last <N>` | Number of message turns to show (default 10) |
 | `--from <id>` | Show N events forward from this event ID |
 | `--before <id>` | Show N events backward from this event ID |
-| `--types <list>` | Comma-separated event types to filter (default: `msg_user,msg_assistant,tool_call,tool_result,permission_ask,permission_denied`) |
-| `--verbose` | Show full tool args/results without truncation |
+| `--verbose` / `-v` | Full forensic output: full tool args and full results with no truncation |
+| `--types <list>` | Orthogonal event-type filter — routes to the raw-event path (e.g. `--types audit`, `--types state_change`). Not needed for the narrative view; tool calls are included by default. |
 | `--all` | (no-arg mode only) List all sessions across all repos |
 
 These commands are useful when you need to know where a spawned agent is at without switching to its session.

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -330,6 +330,8 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			// Collapse consecutive subagent turns into a single summary line.
 			// Count tool calls across all subagent entries in this run and
 			// measure the duration from first to last event.
+			// state_change events that fall between subagent turns are rendered
+			// inline before being consumed so they are not silently dropped.
 			runStart := entry.event.CreatedAt
 			runEnd := entry.event.CreatedAt
 			toolCalls := 0
@@ -338,6 +340,21 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			j := i
 			for j < len(timeline) && (timeline[j].entryKind == entryStateChange || isSubagentEntry(timeline[j])) {
 				e := timeline[j]
+				if e.entryKind == entryStateChange {
+					// Render state_change inline rather than silently dropping it.
+					var sc payload.StateChange
+					if jerr := json.Unmarshal([]byte(e.event.Payload), &sc); jerr != nil {
+						sc.State = e.event.Payload
+					}
+					scTS := e.event.CreatedAt.Local().Format("15:04:05")
+					scState := sc.State
+					if scState == "" {
+						scState = "(unknown)"
+					}
+					fmt.Printf("[%s] ● %s\n\n", scTS, scState)
+					j++
+					continue
+				}
 				if e.event.CreatedAt.After(runEnd) {
 					runEnd = e.event.CreatedAt
 				}
@@ -690,10 +707,15 @@ func renderChildEventsDefault(children []childEventItem, prefix string) {
 		}
 
 		keyArg := toolKeyArg(tc.tool, tc.args)
-		if resultSummary != "" {
+		switch {
+		case keyArg != "" && resultSummary != "":
 			fmt.Printf("%s  → %s: %s %s\n", prefix, tc.tool, keyArg, resultSummary)
-		} else {
+		case keyArg != "":
 			fmt.Printf("%s  → %s: %s\n", prefix, tc.tool, keyArg)
+		case resultSummary != "":
+			fmt.Printf("%s  → %s: %s\n", prefix, tc.tool, resultSummary)
+		default:
+			fmt.Printf("%s  → %s\n", prefix, tc.tool)
 		}
 	}
 
@@ -848,11 +870,24 @@ func bashResultSummary(result string) string {
 }
 
 // isErrorResult returns true if the result string looks like an error.
+// Uses conservative heuristics to avoid false positives — e.g. a file named
+// "error_handler.go" or a commit message containing "error" should not trigger
+// this. We require the error marker to appear at the start of the result, at
+// the start of a line, or as part of a well-known error pattern.
 func isErrorResult(result string) bool {
+	if strings.Contains(result, "✗") {
+		return true
+	}
 	lower := strings.ToLower(result)
-	return strings.Contains(lower, "error") ||
-		strings.Contains(lower, "failed") ||
-		strings.Contains(lower, "✗")
+	// "Error:" at the beginning of the result or after a newline.
+	if strings.HasPrefix(lower, "error") ||
+		strings.Contains(lower, "\nerror") {
+		return true
+	}
+	// Explicit failure patterns.
+	return strings.Contains(lower, "failed:") ||
+		strings.Contains(lower, "failed\n") ||
+		strings.HasSuffix(lower, "failed")
 }
 
 // matchCountSummary returns "N matches" or "no matches" from a glob/grep result.
@@ -1079,8 +1114,13 @@ func renderCheckinEventsRaw(session string, d *db.DB, events []db.Event, verbose
 //
 //	{"session":"<name>", "state":"<state>", "events":[...db.Event...]}
 //
-// It follows the same rendering logic as runCheckinSession but works from
-// pre-fetched events rather than the local DB.
+// NOTE: This function uses the legacy raw-event rendering (separate tool_call
+// and tool_result lines) rather than the rich default one-liner format. The
+// sidecar /checkin endpoint returns flat raw events, and the assistant-turn-centric
+// pairing logic used by renderCheckinTurns requires either a live DB connection
+// or a secondary query to resolve children by messageId — both of which are
+// unavailable in the proxy context. Upgrading this path to match the rich default
+// is tracked as future work.
 func renderProxiedCheckin(raw []byte, verbose bool) error {
 	var resp struct {
 		Session string     `json:"session"`

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -9,9 +9,13 @@ package cmd
 //	prism checkin <session> --last N          show last N turns (default 10)
 //	prism checkin <session> --from <id>       show N events forward from event ID
 //	prism checkin <session> --before <id>     show N events backward from event ID
-//	prism checkin <session> --types <list>    comma-separated event types
-//	prism checkin <session> --verbose         full tool args/results (no truncation)
+//	prism checkin <session> --types <list>    comma-separated event types (orthogonal filter)
+//	prism checkin <session> --verbose / -v    full tool args/results (no truncation)
 //	prism checkin --all                       (no-arg) list all sessions across all repos
+//
+// Default output (no flags): interleaved assistant messages + state changes +
+// tool call one-liners with truncated results. --verbose shows full forensic
+// output. --types is an orthogonal filter for targeted queries (e.g. --types audit).
 
 import (
 	"encoding/json"
@@ -45,8 +49,8 @@ func init() {
 	checkinCmd.Flags().Int("last", 10, "Number of conversation turns to show")
 	checkinCmd.Flags().String("from", "", "Show events forward from this event ID")
 	checkinCmd.Flags().String("before", "", "Show events backward from this event ID")
-	checkinCmd.Flags().String("types", "", "Comma-separated event types to filter (default includes msg_user, msg_assistant, tool_call, tool_result, permission_ask, permission_denied)")
-	checkinCmd.Flags().Bool("verbose", false, "Show full tool args/results without truncation")
+	checkinCmd.Flags().String("types", "", "Orthogonal event-type filter (e.g. --types audit, --types state_change). When set, routes to the raw-event path instead of the rich default view.")
+	checkinCmd.Flags().BoolP("verbose", "v", false, "Show full tool args/results without truncation (forensic mode)")
 	checkinCmd.Flags().Bool("all", false, "List all sessions across all repos (no-arg mode only)")
 	rootCmd.AddCommand(checkinCmd)
 }
@@ -150,10 +154,17 @@ func runCheckinSessionRaw(session string, limit int, before, after *string, type
 // approach: one turn = one assistant message + its tool/permission/thinking children.
 // msg_user events whose created_at falls within the time window of the fetched
 // assistant turns are also rendered, immediately before the assistant turn that
-// follows them in the timeline.
+// follows them in the timeline. state_change events within the window are also
+// interleaved with a ● marker.
 //
 // assistantEvents may be nil (session has events but no assistant turns yet);
 // in that case only the header and footer are rendered.
+//
+// Default mode (verbose=false): rich one-liner per tool call, state changes
+// shown inline, msg_user shown with ▶ prefix.
+//
+// Verbose mode (verbose=true): full tool args + full results, no truncation;
+// same as prior behaviour. Subagent turns shown inline with │ prefix.
 //
 // Subagent turns (where the agent field differs from the session's root agent)
 // are collapsed into a single summary line in default mode. In verbose mode they
@@ -199,23 +210,19 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	secondary, serr := d.QueryEventsByMessageIDs(session, messageIDs, childTypes)
 
 	// Organise children by messageId.
-	type childEvent struct {
-		eventType string
-		payload   string
-	}
-	childrenByMsgID := make(map[string][]childEvent)
+	childrenByMsgID := make(map[string][]childEventItem)
 	if serr == nil {
 		for _, e := range secondary {
 			msgID := extractMessageID(e.Payload)
 			if msgID == "" {
 				continue
 			}
-			childrenByMsgID[msgID] = append(childrenByMsgID[msgID], childEvent{e.Type, e.Payload})
+			childrenByMsgID[msgID] = append(childrenByMsgID[msgID], childEventItem{e.Type, e.Payload})
 		}
 	}
 
 	// Determine the time window spanned by the fetched assistant turns so that
-	// we can include msg_user events that fall within it.
+	// we can include msg_user and state_change events that fall within it.
 	earliest := assistantEvents[0].CreatedAt
 	latest := assistantEvents[len(assistantEvents)-1].CreatedAt
 	for _, ae := range assistantEvents {
@@ -228,8 +235,6 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	}
 
 	// Fetch msg_user events within [earliest, latest] (inclusive).
-	// We use QueryEventsByMessageIDs with no messageID filter — instead we do a
-	// plain QueryEvents for msg_user and filter by timestamp in Go.
 	userEventsAll, _ := d.QueryEvents(session, 0, nil, nil, []string{"msg_user"})
 	var userEventsInWindow []db.Event
 	for _, ue := range userEventsAll {
@@ -238,20 +243,38 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 		}
 	}
 
-	// Merge assistant events and user events into a single timeline sorted ASC.
-	// assistantEvents is already ASC from QueryEvents; userEventsInWindow is also ASC.
-	type timelineEntry struct {
-		isUser bool
-		event  db.Event
+	// Fetch state_change events within [earliest, latest] (inclusive).
+	// These are interleaved chronologically with ● markers in the default view.
+	stateChangeEventsAll, _ := d.QueryEvents(session, 0, nil, nil, []string{"state_change"})
+	var stateChangeEventsInWindow []db.Event
+	for _, se := range stateChangeEventsAll {
+		if !se.CreatedAt.Before(earliest) && !se.CreatedAt.After(latest) {
+			stateChangeEventsInWindow = append(stateChangeEventsInWindow, se)
+		}
 	}
-	timeline := make([]timelineEntry, 0, len(assistantEvents)+len(userEventsInWindow))
+
+	// Merge assistant events, user events, and state_change events into a
+	// single timeline sorted ASC.
+	const (
+		entryAssistant   = 0
+		entryUser        = 1
+		entryStateChange = 2
+	)
+	type timelineEntry struct {
+		entryKind int // entryAssistant, entryUser, or entryStateChange
+		event     db.Event
+	}
+	timeline := make([]timelineEntry, 0, len(assistantEvents)+len(userEventsInWindow)+len(stateChangeEventsInWindow))
 	for _, ae := range assistantEvents {
-		timeline = append(timeline, timelineEntry{isUser: false, event: ae})
+		timeline = append(timeline, timelineEntry{entryKind: entryAssistant, event: ae})
 	}
 	for _, ue := range userEventsInWindow {
-		timeline = append(timeline, timelineEntry{isUser: true, event: ue})
+		timeline = append(timeline, timelineEntry{entryKind: entryUser, event: ue})
 	}
-	// Sort by created_at ASC (stable, preserving insertion order for ties).
+	for _, se := range stateChangeEventsInWindow {
+		timeline = append(timeline, timelineEntry{entryKind: entryStateChange, event: se})
+	}
+	// Sort by created_at ASC (stable insertion sort, preserving insertion order for ties).
 	for i := 1; i < len(timeline); i++ {
 		for j := i; j > 0 && timeline[j].event.CreatedAt.Before(timeline[j-1].event.CreatedAt); j-- {
 			timeline[j], timeline[j-1] = timeline[j-1], timeline[j]
@@ -267,12 +290,13 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			return false
 		}
 		var entryAgent string
-		if entry.isUser {
+		switch entry.entryKind {
+		case entryUser:
 			var up payload.MsgUser
 			if err := json.Unmarshal([]byte(entry.event.Payload), &up); err == nil {
 				entryAgent = up.Agent
 			}
-		} else {
+		case entryAssistant:
 			var ap payload.MsgAssistant
 			if err := json.Unmarshal([]byte(entry.event.Payload), &ap); err == nil {
 				entryAgent = ap.Agent
@@ -286,6 +310,22 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	for i < len(timeline) {
 		entry := timeline[i]
 
+		// state_change events are never considered subagent entries — render them always.
+		if entry.entryKind == entryStateChange {
+			var sc payload.StateChange
+			if jerr := json.Unmarshal([]byte(entry.event.Payload), &sc); jerr != nil {
+				sc.State = entry.event.Payload
+			}
+			ts := entry.event.CreatedAt.Local().Format("15:04:05")
+			newState := sc.State
+			if newState == "" {
+				newState = "(unknown)"
+			}
+			fmt.Printf("[%s] ● %s\n\n", ts, newState)
+			i++
+			continue
+		}
+
 		if isSubagentEntry(entry) && !verbose {
 			// Collapse consecutive subagent turns into a single summary line.
 			// Count tool calls across all subagent entries in this run and
@@ -296,12 +336,12 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			subagentName := ""
 
 			j := i
-			for j < len(timeline) && isSubagentEntry(timeline[j]) {
+			for j < len(timeline) && (timeline[j].entryKind == entryStateChange || isSubagentEntry(timeline[j])) {
 				e := timeline[j]
 				if e.event.CreatedAt.After(runEnd) {
 					runEnd = e.event.CreatedAt
 				}
-				if !e.isUser {
+				if e.entryKind == entryAssistant {
 					var ap payload.MsgAssistant
 					if err := json.Unmarshal([]byte(e.event.Payload), &ap); err == nil {
 						if subagentName == "" {
@@ -338,7 +378,7 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 		}
 
 		e := entry.event
-		ts := e.CreatedAt.Local().Format("2006-01-02 15:04:05")
+		ts := e.CreatedAt.Local().Format("15:04:05")
 
 		// In verbose mode, prefix subagent lines with an indent marker.
 		prefix := ""
@@ -346,7 +386,7 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			prefix = "  │ "
 		}
 
-		if entry.isUser {
+		if entry.entryKind == entryUser {
 			var up payload.MsgUser
 			if jerr := json.Unmarshal([]byte(e.Payload), &up); jerr != nil {
 				up.Text = e.Payload
@@ -357,9 +397,9 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			}
 			label := turnLabel(up.Agent, up.Model)
 			if label != "" {
-				fmt.Printf("%s[%s] user  [%s]\n", prefix, ts, label)
+				fmt.Printf("%s[%s] ▶ user  [%s]\n", prefix, ts, label)
 			} else {
-				fmt.Printf("%s[%s] user\n", prefix, ts)
+				fmt.Printf("%s[%s] ▶ user\n", prefix, ts)
 			}
 			fmt.Printf("%s%s\n\n", prefix, text)
 			i++
@@ -384,8 +424,15 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 		fmt.Printf("%s%s\n", prefix, atext)
 
 		msgID := extractMessageID(e.Payload)
-		for _, child := range childrenByMsgID[msgID] {
-			renderChildEvent(child.eventType, child.payload, verbose, prefix)
+		children := childrenByMsgID[msgID]
+		if verbose {
+			// Verbose mode: render each child event individually (full args/results).
+			for _, child := range children {
+				renderChildEventVerbose(child.eventType, child.payload, prefix)
+			}
+		} else {
+			// Default mode: render paired tool one-liners + permission/thinking events.
+			renderChildEventsDefault(children, prefix)
 		}
 		fmt.Println()
 		i++
@@ -424,9 +471,9 @@ func turnLabel(agent, model string) string {
 	return agent + " · " + model
 }
 
-// renderChildEvent prints a single child event (tool call, result, permission,
-// or thinking) indented under its parent assistant turn. prefix is prepended
-// before the leading spaces (used for verbose subagent indentation).
+// renderChildEvent prints a single child event using the legacy raw-event style.
+// Used by renderCheckinEventsRaw (--types path) and renderProxiedCheckin.
+// prefix is prepended before the leading spaces (used for subagent indentation).
 func renderChildEvent(eventType, rawPayload string, verbose bool, prefix string) {
 	switch eventType {
 	case "tool_call":
@@ -494,6 +541,398 @@ func renderChildEvent(eventType, rawPayload string, verbose bool, prefix string)
 			fmt.Printf("%s  [thinking: %s]\n", prefix, t)
 		}
 	}
+}
+
+// renderChildEventVerbose prints a single child event with full args/results
+// (no truncation). Used in verbose mode under renderCheckinTurns.
+func renderChildEventVerbose(eventType, rawPayload string, prefix string) {
+	switch eventType {
+	case "tool_call":
+		var p payload.ToolCall
+		if err := json.Unmarshal([]byte(rawPayload), &p); err != nil {
+			fmt.Printf("%s  → (tool_call parse error)\n", prefix)
+			return
+		}
+		fmt.Printf("%s  → %s: %s\n", prefix, p.Tool, p.Args)
+
+	case "tool_result":
+		var p payload.ToolResult
+		if err := json.Unmarshal([]byte(rawPayload), &p); err != nil {
+			fmt.Printf("%s  → (tool_result parse error)\n", prefix)
+			return
+		}
+		fmt.Printf("%s  → result: %s\n", prefix, p.Result)
+
+	case "permission_ask":
+		var p payload.PermissionAsk
+		if err := json.Unmarshal([]byte(rawPayload), &p); err != nil {
+			fmt.Printf("%s  [⏳ waiting for approval: (parse error)]\n", prefix)
+			return
+		}
+		tool := string(p.Tool)
+		if tool == "" {
+			tool = "unknown"
+		}
+		if len(p.Patterns) > 0 {
+			fmt.Printf("%s  [⏳ waiting for approval: %s — %s]\n", prefix, tool, strings.Join(p.Patterns, ", "))
+		} else {
+			fmt.Printf("%s  [⏳ waiting for approval: %s]\n", prefix, tool)
+		}
+
+	case "permission_denied":
+		var p payload.PermissionDenied
+		if err := json.Unmarshal([]byte(rawPayload), &p); err != nil {
+			fmt.Printf("%s  [❌ denied: (parse error)]\n", prefix)
+			return
+		}
+		tool := p.Tool
+		if tool == "" {
+			tool = "unknown"
+		}
+		fmt.Printf("%s  [❌ denied: %s]\n", prefix, tool)
+
+	case "thinking":
+		var p payload.Thinking
+		if err := json.Unmarshal([]byte(rawPayload), &p); err != nil {
+			return
+		}
+		if p.Text != "" {
+			fmt.Printf("%s  [thinking: %s]\n", prefix, p.Text)
+		}
+	}
+}
+
+// childEventItem holds an event type and its raw payload JSON.
+// Used for grouping child events (tool_call, tool_result, permission_ask,
+// permission_denied, thinking) under their parent assistant turn.
+type childEventItem struct {
+	eventType string
+	payload   string
+}
+
+// renderChildEventsDefault renders child events under an assistant turn in the
+// rich default mode (no --verbose). Tool calls and their results are paired
+// into a single one-liner: `→ <tool>: <key_arg> <result_summary>`.
+//
+// The key arg and result summary format per tool:
+//   - bash:      first ~80 chars of command | first meaningful output line or ✓ (empty) or ✗ + stderr
+//   - read:      file path | ✓ (N lines)
+//   - edit/write: file path | ✓ or ✗
+//   - task:      description | ✓ or ✗
+//   - glob/grep: pattern | N matches or no matches
+//   - todowrite: (dim or omit key arg) | ✓
+//
+// Tool results are matched positionally to tool calls of the same tool name
+// within the message. Permission and thinking events are rendered as before.
+func renderChildEventsDefault(children []childEventItem, prefix string) {
+	// Split children into tool_calls, tool_results (by tool name for pairing),
+	// and other events (permission_ask, permission_denied, thinking).
+	//
+	// Pairing strategy: maintain a per-tool FIFO queue of results. When we
+	// encounter a tool_call for tool T, dequeue the next result for T (if any).
+	// This handles the common case where results appear in the same order as calls.
+	type toolCallEntry struct {
+		tool    string
+		args    string
+		payload string
+	}
+	type toolResultEntry struct {
+		tool    string
+		result  string
+		payload string
+	}
+
+	// Collect tool calls and results in order.
+	var toolCalls []toolCallEntry
+	resultsByTool := make(map[string][]toolResultEntry)
+
+	// Also collect other events in order (permission_ask, permission_denied, thinking)
+	// to be rendered after the tool one-liners.
+	type otherEvent struct {
+		eventType string
+		payload   string
+	}
+	var others []otherEvent
+
+	for _, c := range children {
+		switch c.eventType {
+		case "tool_call":
+			var p payload.ToolCall
+			if err := json.Unmarshal([]byte(c.payload), &p); err == nil {
+				toolCalls = append(toolCalls, toolCallEntry{tool: p.Tool, args: p.Args, payload: c.payload})
+				// Pre-index result slot (will be filled when result arrives).
+			} else {
+				toolCalls = append(toolCalls, toolCallEntry{tool: "?", args: "", payload: c.payload})
+			}
+		case "tool_result":
+			var p payload.ToolResult
+			if err := json.Unmarshal([]byte(c.payload), &p); err == nil {
+				resultsByTool[p.Tool] = append(resultsByTool[p.Tool], toolResultEntry{tool: p.Tool, result: p.Result, payload: c.payload})
+			}
+		default:
+			others = append(others, otherEvent{c.eventType, c.payload})
+		}
+	}
+
+	// Render tool one-liners, consuming results from the per-tool FIFO queue.
+	usedResults := make(map[string]int) // tool → count consumed
+	for _, tc := range toolCalls {
+		// Dequeue the next result for this tool.
+		resultList := resultsByTool[tc.tool]
+		usedIdx := usedResults[tc.tool]
+		var resultSummary string
+		if usedIdx < len(resultList) {
+			resultSummary = toolResultSummary(tc.tool, resultList[usedIdx].result)
+			usedResults[tc.tool] = usedIdx + 1
+		} else {
+			// No result available (still running or not recorded).
+			resultSummary = ""
+		}
+
+		keyArg := toolKeyArg(tc.tool, tc.args)
+		if resultSummary != "" {
+			fmt.Printf("%s  → %s: %s %s\n", prefix, tc.tool, keyArg, resultSummary)
+		} else {
+			fmt.Printf("%s  → %s: %s\n", prefix, tc.tool, keyArg)
+		}
+	}
+
+	// Render other events (permission_ask, permission_denied, thinking).
+	for _, o := range others {
+		renderChildEvent(o.eventType, o.payload, false, prefix)
+	}
+}
+
+// toolKeyArg extracts the key argument for the one-liner display per tool type.
+// For bash: first ~80 chars of the command string.
+// For read/edit/write: the file path.
+// For task: the description.
+// For glob/grep: the pattern.
+// For todowrite: empty string (tool name alone is sufficient).
+// For unknown tools: first ~80 chars of args.
+func toolKeyArg(tool, args string) string {
+	switch tool {
+	case "bash", "Bash":
+		// Args for bash is typically the command string directly.
+		cmd := extractBashCommand(args)
+		if len([]rune(cmd)) > 80 {
+			runes := []rune(cmd)
+			return string(runes[:80]) + "..."
+		}
+		return cmd
+
+	case "read", "Read":
+		return extractStringField(args, "filePath", "path", "file_path")
+
+	case "edit", "Edit":
+		return extractStringField(args, "filePath", "path", "file_path")
+
+	case "write", "Write":
+		return extractStringField(args, "filePath", "path", "file_path")
+
+	case "task", "Task":
+		desc := extractStringField(args, "description", "desc", "prompt")
+		if len([]rune(desc)) > 80 {
+			runes := []rune(desc)
+			return string(runes[:80]) + "..."
+		}
+		return desc
+
+	case "glob", "Glob":
+		return extractStringField(args, "pattern", "glob")
+
+	case "grep", "Grep":
+		return extractStringField(args, "pattern", "regex", "query")
+
+	case "todowrite", "TodoWrite", "Todowrite":
+		return ""
+
+	default:
+		// Generic: first ~80 chars of raw args.
+		if len([]rune(args)) > 80 {
+			runes := []rune(args)
+			return string(runes[:80]) + "..."
+		}
+		return args
+	}
+}
+
+// toolResultSummary produces a one-line result summary for the given tool and
+// raw result string.
+func toolResultSummary(tool, result string) string {
+	switch tool {
+	case "bash", "Bash":
+		return bashResultSummary(result)
+
+	case "read", "Read":
+		// Count lines in result.
+		if result == "" {
+			return "✓ (0 lines)"
+		}
+		n := strings.Count(result, "\n") + 1
+		// If result ends with a trailing newline, don't count the empty last line.
+		if strings.HasSuffix(result, "\n") && n > 1 {
+			n--
+		}
+		return fmt.Sprintf("✓ (%d lines)", n)
+
+	case "edit", "Edit":
+		if isErrorResult(result) {
+			return "✗"
+		}
+		return "✓"
+
+	case "write", "Write":
+		if isErrorResult(result) {
+			return "✗"
+		}
+		return "✓"
+
+	case "task", "Task":
+		if isErrorResult(result) {
+			return "✗"
+		}
+		return "✓"
+
+	case "glob", "Glob":
+		return matchCountSummary(result)
+
+	case "grep", "Grep":
+		return matchCountSummary(result)
+
+	case "todowrite", "TodoWrite", "Todowrite":
+		return "✓"
+
+	default:
+		// Generic: first meaningful line or ✓ if empty.
+		if result == "" {
+			return "✓"
+		}
+		line := firstMeaningfulLine(result)
+		if len([]rune(line)) > 60 {
+			runes := []rune(line)
+			return string(runes[:60]) + "..."
+		}
+		return line
+	}
+}
+
+// bashResultSummary extracts a one-line summary from a bash tool result.
+// Returns ✓ for empty output, ✗ + first stderr line for errors, or the
+// first meaningful output line otherwise.
+func bashResultSummary(result string) string {
+	if result == "" {
+		return "✓"
+	}
+	// Check for common error indicators in the result.
+	lower := strings.ToLower(result)
+	isErr := strings.Contains(lower, "error:") ||
+		strings.Contains(lower, "command not found") ||
+		strings.Contains(lower, "exit status") ||
+		strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "no such file")
+
+	line := firstMeaningfulLine(result)
+	if isErr {
+		if len([]rune(line)) > 60 {
+			runes := []rune(line)
+			return "✗ " + string(runes[:60]) + "..."
+		}
+		return "✗ " + line
+	}
+	if len([]rune(line)) > 60 {
+		runes := []rune(line)
+		return string(runes[:60]) + "..."
+	}
+	return line
+}
+
+// isErrorResult returns true if the result string looks like an error.
+func isErrorResult(result string) bool {
+	lower := strings.ToLower(result)
+	return strings.Contains(lower, "error") ||
+		strings.Contains(lower, "failed") ||
+		strings.Contains(lower, "✗")
+}
+
+// matchCountSummary returns "N matches" or "no matches" from a glob/grep result.
+func matchCountSummary(result string) string {
+	if result == "" {
+		return "no matches"
+	}
+	// Count non-empty lines as matches.
+	count := 0
+	for _, line := range strings.Split(result, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	if count == 0 {
+		return "no matches"
+	}
+	if count == 1 {
+		return "1 match"
+	}
+	return fmt.Sprintf("%d matches", count)
+}
+
+// firstMeaningfulLine returns the first non-empty, non-whitespace line from s.
+func firstMeaningfulLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return s
+}
+
+// extractBashCommand extracts the command string from bash tool args.
+// The args may be a plain string (the command itself) or a JSON object
+// with a "command" or "cmd" field.
+func extractBashCommand(args string) string {
+	// Try JSON object first.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(args), &obj); err == nil {
+		for _, key := range []string{"command", "cmd"} {
+			if raw, ok := obj[key]; ok {
+				var s string
+				if err := json.Unmarshal(raw, &s); err == nil {
+					return s
+				}
+			}
+		}
+	}
+	// Try plain JSON string.
+	var s string
+	if err := json.Unmarshal([]byte(args), &s); err == nil {
+		return s
+	}
+	// Fall back to raw args.
+	return args
+}
+
+// extractStringField extracts a string value from a JSON object by trying
+// each key in order. Returns the raw string if none match or if args is not JSON.
+func extractStringField(args string, keys ...string) string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(args), &obj); err != nil {
+		// Not a JSON object — try plain JSON string.
+		var s string
+		if err2 := json.Unmarshal([]byte(args), &s); err2 == nil {
+			return s
+		}
+		return args
+	}
+	for _, key := range keys {
+		if raw, ok := obj[key]; ok {
+			var s string
+			if err := json.Unmarshal(raw, &s); err == nil {
+				return s
+			}
+		}
+	}
+	return args
 }
 
 // extractMessageID returns the messageId field from a payload JSON string.

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -1199,6 +1199,49 @@ func TestToolKeyArg(t *testing.T) {
 	}
 }
 
+// TestRenderCheckinTurns_StateChangeInsideSubagentCollapse verifies that
+// state_change events between subagent turns are rendered inline rather than
+// silently dropped when the subagent collapse logic fires (bug regression test).
+func TestRenderCheckinTurns_StateChangeInsideSubagentCollapse(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	const rootAgent = "opencode"
+	const subAgent = "review"
+	base := time.Now().Truncate(time.Second)
+
+	setRootAgent(t, d, session, rootAgent)
+
+	// Two subagent turns that bracket a state_change event.
+	sub1MsgID := "msg-sub1"
+	sub2MsgID := "msg-sub2"
+	sub1 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayloadWithAgent(sub1MsgID, "sub turn 1", subAgent), base.Add(time.Second))
+	sub2 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayloadWithAgent(sub2MsgID, "sub turn 2", subAgent), base.Add(3*time.Second))
+
+	// state_change at t=2s — between sub1 (t=1s) and sub2 (t=3s), so it falls
+	// within the [t=1s, t=3s] window and enters the timeline.
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("finished"), base.Add(2*time.Second))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{sub1, sub2}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// The state_change must appear even though the surrounding entries are
+	// subagent turns (which would otherwise be collapsed).
+	if !strings.Contains(out, "● finished") {
+		t.Errorf("state_change inside subagent collapse was silently dropped\ngot:\n%s", out)
+	}
+
+	// The subagent summary line must still appear.
+	if !strings.Contains(out, "└─ review") {
+		t.Errorf("subagent summary line missing\ngot:\n%s", out)
+	}
+}
+
 // TestToolResultSummary verifies result summary generation for various tool types.
 func TestToolResultSummary(t *testing.T) {
 	cases := []struct {

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -148,7 +148,8 @@ func TestRenderCheckinTurns_AllAssistantTurnsShown(t *testing.T) {
 }
 
 // TestRenderCheckinTurns_ToolChildrenIndented verifies AC-2:
-// each assistant turn is followed by its own indented tool_call/tool_result children.
+// each assistant turn is followed by its own indented tool one-liner children.
+// In default mode, tool_call and tool_result are paired into a single line.
 func TestRenderCheckinTurns_ToolChildrenIndented(t *testing.T) {
 	d := openCheckinTestDB(t)
 	const session = "repo@main"
@@ -187,15 +188,18 @@ func TestRenderCheckinTurns_ToolChildrenIndented(t *testing.T) {
 		t.Errorf("missing 'second assistant'\ngot:\n%s", out)
 	}
 
-	// Tool children rendered with indentation.
+	// Default mode: tool_call + tool_result paired into a single one-liner.
+	// bash: "echo hello" (key arg) + "hello" (result summary from output).
 	if !strings.Contains(out, "  → bash: echo hello") {
-		t.Errorf("missing indented bash tool_call\ngot:\n%s", out)
+		t.Errorf("missing indented bash tool one-liner\ngot:\n%s", out)
 	}
-	if !strings.Contains(out, "  → result: hello") {
-		t.Errorf("missing indented tool_result\ngot:\n%s", out)
+	// Separate "result:" lines must NOT appear in default mode — they are now
+	// folded into the tool one-liner.
+	if strings.Contains(out, "  → result:") {
+		t.Errorf("default mode must not show separate '→ result:' lines\ngot:\n%s", out)
 	}
 	if !strings.Contains(out, "  → read_file: main.go") {
-		t.Errorf("missing indented read_file tool_call\ngot:\n%s", out)
+		t.Errorf("missing indented read_file tool one-liner\ngot:\n%s", out)
 	}
 
 	// The bash tool should appear before read_file in output (ae1 before ae2).
@@ -1011,5 +1015,212 @@ func TestRenderChildEvent_PermissionAsk_AbsentTool(t *testing.T) {
 	}
 	if !strings.Contains(out, "unknown") {
 		t.Errorf("output should use 'unknown' fallback\ngot: %s", out)
+	}
+}
+
+// stateChangePayload returns a minimal state_change JSON payload.
+func stateChangePayload(state string) string {
+	return fmt.Sprintf(`{"state":%q}`, state)
+}
+
+// TestRenderCheckinTurns_StateChangesInWindow verifies that state_change events
+// within the assistant-turn time window are interleaved chronologically with a
+// ● marker in the default output.
+func TestRenderCheckinTurns_StateChangesInWindow(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Assistant turn at t=5s.
+	msgID := "msg-sc"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "working on it"), base.Add(5*time.Second))
+
+	// state_change at t=3s — BEFORE window (should NOT appear).
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("active"), base.Add(3*time.Second))
+
+	// state_change at t=5s — AT start of window (should appear).
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("active"), base.Add(5*time.Second))
+
+	// state_change at t=8s — AFTER window (should NOT appear).
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("finished"), base.Add(8*time.Second))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// The in-window state_change (t=5s) should appear with ● marker.
+	if !strings.Contains(out, "● active") {
+		t.Errorf("output missing in-window state_change '● active'\ngot:\n%s", out)
+	}
+
+	// Out-of-window state_change (t=3s, t=8s) must NOT appear.
+	// The "active" at t=3s would overlap with the in-window one, so we just
+	// check that "finished" doesn't appear.
+	if strings.Contains(out, "● finished") {
+		t.Errorf("output unexpectedly contains out-of-window '● finished'\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_UserMsgVisuallyDistinct verifies that msg_user events
+// appear with the ▶ prefix to distinguish them from assistant messages.
+func TestRenderCheckinTurns_UserMsgVisuallyDistinct(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// User message at t=10s (within window), assistant at t=11s.
+	umsgID := "umsg-distinct"
+	amsgID := "amsg-distinct"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(amsgID, "here is the answer"), base.Add(11*time.Second))
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload(umsgID, "what is 2+2?"), base.Add(11*time.Second))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// msg_user must carry the ▶ prefix for visual distinction.
+	if !strings.Contains(out, "▶ user") {
+		t.Errorf("output missing '▶ user' prefix for msg_user event\ngot:\n%s", out)
+	}
+	// Assistant header must NOT carry the ▶ prefix.
+	if strings.Contains(out, "▶ assistant") {
+		t.Errorf("output unexpectedly has '▶ assistant' prefix\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_ToolOneLinerReadFile verifies that a read-file tool
+// call produces a one-liner with line count result summary.
+func TestRenderCheckinTurns_ToolOneLinerReadFile(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	msgID := "msg-read"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "reading file"), base)
+
+	// Tool call/result for a read tool. Args is stored as a JSON-encoded string
+	// containing a JSON object (as the opencode plugin produces).
+	readResult := "line1\nline2\nline3\n"
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID, "read", `{"filePath":"/workspace/main.go"}`),
+		base.Add(100*time.Millisecond))
+	writeEvent(t, d, uuid.New().String(), session, "tool_result",
+		toolResultPayload(msgID, "read", readResult),
+		base.Add(200*time.Millisecond))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// One-liner: → read: /workspace/main.go ✓ (3 lines)
+	if !strings.Contains(out, "→ read: /workspace/main.go") {
+		t.Errorf("output missing read file path\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "✓ (3 lines)") {
+		t.Errorf("output missing line count '✓ (3 lines)'\ngot:\n%s", out)
+	}
+	// Separate result line must not appear in default mode.
+	if strings.Contains(out, "→ result:") {
+		t.Errorf("default mode must not show separate '→ result:' lines\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_ToolOneLinerVerboseShowsSeparateLines verifies that
+// in verbose mode, tool_call and tool_result are still rendered as separate lines.
+func TestRenderCheckinTurns_ToolOneLinerVerboseShowsSeparateLines(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	msgID := "msg-verbose-pair"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "verbose pair test"), base)
+
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID, "bash", "go test ./..."), base.Add(100*time.Millisecond))
+	writeEvent(t, d, uuid.New().String(), session, "tool_result",
+		toolResultPayload(msgID, "bash", "ok  github.com/foo/bar"), base.Add(200*time.Millisecond))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, true); err != nil {
+			t.Errorf("renderCheckinTurns (verbose): %v", err)
+		}
+	})
+
+	// In verbose mode, tool_call line present.
+	if !strings.Contains(out, "→ bash: go test ./...") {
+		t.Errorf("verbose: missing tool_call line\ngot:\n%s", out)
+	}
+	// In verbose mode, tool_result shown on separate line.
+	if !strings.Contains(out, "→ result: ok  github.com/foo/bar") {
+		t.Errorf("verbose: missing separate tool_result line\ngot:\n%s", out)
+	}
+}
+
+// TestToolKeyArg verifies key argument extraction for various tool types.
+func TestToolKeyArg(t *testing.T) {
+	cases := []struct {
+		tool    string
+		args    string
+		wantSub string // substring that should appear in the result
+	}{
+		{"bash", "go build ./...", "go build ./..."},
+		{"bash", `{"command":"npm install"}`, "npm install"},
+		{"Read", `{"filePath":"/workspace/foo.go"}`, "/workspace/foo.go"},
+		{"edit", `{"filePath":"bar.go"}`, "bar.go"},
+		{"write", `{"filePath":"out.txt"}`, "out.txt"},
+		{"task", `{"description":"check the PR"}`, "check the PR"},
+		{"glob", `{"pattern":"**/*.go"}`, "**/*.go"},
+		{"grep", `{"pattern":"func main"}`, "func main"},
+		{"todowrite", `{"todos":[]}`, ""},
+	}
+	for _, tc := range cases {
+		got := toolKeyArg(tc.tool, tc.args)
+		if tc.wantSub == "" {
+			if got != "" {
+				t.Errorf("toolKeyArg(%q, %q) = %q, want empty", tc.tool, tc.args, got)
+			}
+		} else if !strings.Contains(got, tc.wantSub) {
+			t.Errorf("toolKeyArg(%q, %q) = %q, want to contain %q", tc.tool, tc.args, got, tc.wantSub)
+		}
+	}
+}
+
+// TestToolResultSummary verifies result summary generation for various tool types.
+func TestToolResultSummary(t *testing.T) {
+	cases := []struct {
+		tool   string
+		result string
+		want   string
+	}{
+		{"bash", "", "✓"},
+		{"bash", "hello\nworld", "hello"},
+		{"read", "line1\nline2\nline3\n", "✓ (3 lines)"},
+		{"read", "", "✓ (0 lines)"},
+		{"edit", "", "✓"},
+		{"write", "", "✓"},
+		{"glob", "a.go\nb.go\n", "2 matches"},
+		{"glob", "", "no matches"},
+		{"grep", "match1", "1 match"},
+		{"todowrite", "anything", "✓"},
+	}
+	for _, tc := range cases {
+		got := toolResultSummary(tc.tool, tc.result)
+		if got != tc.want {
+			t.Errorf("toolResultSummary(%q, %q) = %q, want %q", tc.tool, tc.result, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Default `prism checkin <session>` now shows a rich narrative view: assistant messages + state changes + tool call one-liners interleaved chronologically
- Tool calls are paired with their results as `→ <tool>: <key_arg> <result_summary>` one-liners (e.g. `→ bash: go build ./... ✓`, `→ read: main.go ✓ (42 lines)`)
- State changes shown inline as `[HH:MM:SS] ● <state>` with a distinct `●` marker
- `msg_user` events shown with `▶` prefix for visual distinction from assistant turns
- `--verbose` / `-v` gives full forensic output (separate tool_call + tool_result lines, no truncation) — same as prior `--verbose` behaviour
- `--types` documented as an orthogonal escape hatch (e.g. `--types audit`), not the way to see tool calls in the default view
- Prism skill file updated with new default output format and examples

Closes #649