### PR TITLE
fix(ci): use docker-archive skopeo transport for image push

### DIFF
--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Push amd64 image to GHCR
         run: |
           set -euo pipefail
-          skopeo copy \
+          nix run nixpkgs#skopeo -- copy \
             docker-archive:$(readlink result) \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
 
@@ -78,7 +78,7 @@ jobs:
       - name: Push arm64 image to GHCR
         run: |
           set -euo pipefail
-          skopeo copy \
+          nix run nixpkgs#skopeo -- copy \
             docker-archive:$(readlink result) \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-arm64
 

--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -42,8 +42,10 @@ jobs:
       - name: Push amd64 image to GHCR
         run: |
           set -euo pipefail
+          archive=$(readlink result)
           nix run nixpkgs#skopeo -- copy \
-            docker-archive:$(readlink result) \
+            --insecure-policy \
+            "docker-archive:${archive}" \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
 
   build-arm64:
@@ -78,8 +80,10 @@ jobs:
       - name: Push arm64 image to GHCR
         run: |
           set -euo pipefail
+          archive=$(readlink result)
           nix run nixpkgs#skopeo -- copy \
-            docker-archive:$(readlink result) \
+            --insecure-policy \
+            "docker-archive:${archive}" \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-arm64
 
   publish-manifest:

--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -42,20 +42,8 @@ jobs:
       - name: Push amd64 image to GHCR
         run: |
           set -euo pipefail
-          # skopeo copy from oci-archive: untars the archive to /var/tmp and
-          # tries to chown entries to restore tar-header ownership, which fails
-          # on unprivileged GitHub Actions runners.  Pre-extract with GNU tar's
-          # --no-same-owner to strip the ownership metadata, then copy from the
-          # resulting directory using the oci: scheme (no untar needed).
-          # -xf (without -z) lets GNU tar auto-detect compression so this works
-          # whether the Nix output is a plain .tar or a .tar.gz.
-          archive=$(readlink result)
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          tar --no-same-owner -xf "$archive" -C "$tmpdir"
-          nix run nixpkgs#skopeo -- copy \
-            --insecure-policy \
-            oci:"$tmpdir" \
+          skopeo copy \
+            docker-archive:$(readlink result) \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-amd64
 
   build-arm64:
@@ -90,17 +78,8 @@ jobs:
       - name: Push arm64 image to GHCR
         run: |
           set -euo pipefail
-          # Same workaround as amd64: pre-extract with --no-same-owner to avoid
-          # the chown failure skopeo hits when unpacking oci-archive: sources on
-          # unprivileged runners.  Use -xf (no -z) for auto-detection of
-          # compression format, and trap EXIT to ensure cleanup on failure.
-          archive=$(readlink result)
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "$tmpdir"' EXIT
-          tar --no-same-owner -xf "$archive" -C "$tmpdir"
-          nix run nixpkgs#skopeo -- copy \
-            --insecure-policy \
-            oci:"$tmpdir" \
+          skopeo copy \
+            docker-archive:$(readlink result) \
             docker://ghcr.io/prismatic-koi/prism-agent:latest-arm64
 
   publish-manifest:


### PR DESCRIPTION
## Summary

Fixes the `publish-prism-agent` CI workflow which was failing with:
```
level=fatal msg="initializing source oci:/home/runner/work/_temp/tmp.fedh6rUt6c:: open .../index.json: no such file or directory"
```

**Root cause:** Nix's `dockerTools.buildLayeredImage` produces a Docker v2 manifest archive (`manifest.json`), not an OCI image layout (`index.json` + `oci-layout`). The previous workaround extracted the tarball to a temp directory and used the `oci:` transport — which fails because no `index.json` is present in the extracted layout.

**Fix:** Switch to `docker-archive:` transport, which reads the Docker v2 tarball directly. This eliminates the need for:
- The `mktemp` temp directory
- The `tar --no-same-owner` extraction step
- The `trap` cleanup

The `nix run nixpkgs#skopeo --` invocation and `--insecure-policy` flag are retained — the former because skopeo is not on PATH on GHA ubuntu runners (only Nix itself is installed), the latter because the runner has no `/etc/containers/policy.json` and skopeo will fatal without it.