### PR TITLE
prism: two-level checkin verbosity — rich default with truncated tool results

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -200,7 +200,7 @@ Use `prism list-sessions` to see all active agent sessions with their state and 
 prism list-sessions
 ```
 
-Use `prism checkin <session>` to read the recent conversation history for a session, sourced from the prism DB. Output is structured as message turns (user and assistant pairs) with tool calls, tool results, and permission events rendered inline under their parent assistant message:
+Use `prism checkin <session>` to read the recent conversation history for a session, sourced from the prism DB. The default view shows assistant messages, state changes, and tool call one-liners interleaved chronologically — giving a full narrative without the noise of raw event dumps:
 
 ```bash
 prism checkin nixos-config@update-plex
@@ -211,16 +211,27 @@ checkin: nixos-config@update-plex
 
 state: active
 
-[2026-04-03 14:22:01] user
+[2026-04-03 14:22:01] ▶ user
 implement the feature and open a PR
 
 [2026-04-03 14:22:05] assistant
 I'll implement this now.
-  → Bash: ls src/
-  → result: main.go utils.go
+  → read: main.go ✓ (42 lines)
+  → edit: main.go ✓
+  → bash: go build ./... ✓
+  → bash: go test ./... — ok (3.2s)
+
+[2026-04-03 14:23:10] assistant
+Tests pass. Opening PR.
+  → bash: git commit -m "implement feature" ✓
+  → bash: gh pr create ... ✓
+
+[2026-04-03 14:23:15] ● finished
 
 ── end of event log ──
 ```
+
+Tool call one-liners show: tool name, key argument (file path or command), and a one-line result summary. Use `--verbose` for full forensic output with complete args and results.
 
 With no argument, `prism checkin` lists available sessions and exits with a hint.
 
@@ -231,8 +242,8 @@ With no argument, `prism checkin` lists available sessions and exits with a hint
 | `--last <N>` | Number of message turns to show (default 10) |
 | `--from <id>` | Show N events forward from this event ID |
 | `--before <id>` | Show N events backward from this event ID |
-| `--types <list>` | Comma-separated event types to filter (default: `msg_user,msg_assistant,tool_call,tool_result,permission_ask,permission_denied`) |
-| `--verbose` | Show full tool args/results without truncation |
+| `--types <list>` | Orthogonal escape hatch for targeted queries (e.g. `--types audit`). Bypasses the default rich view. |
+| `--verbose` | Full tool args/results without truncation — use for forensic investigation |
 | `--all` | (no-arg mode only) List all sessions across all repos |
 
 These commands are useful when you need to know where a spawned agent is at without switching to its session.

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -1093,7 +1093,7 @@ func toolOneLiner(toolName, args, result string) string {
 		return fmt.Sprintf("grep: %s %d matches", pat, n)
 
 	case "task":
-		desc := truncateRunes(args, 60)
+		desc := extractFirstArgument(args)
 		if looksLikeToolError(result) {
 			return fmt.Sprintf("task: %s ✗", desc)
 		}
@@ -1181,7 +1181,7 @@ func extractFirstArgument(args string) string {
 	if len(args) > 0 && args[0] == '{' {
 		var obj map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(args), &obj); err == nil {
-			for _, key := range []string{"pattern", "query", "glob", "regex", "include"} {
+			for _, key := range []string{"pattern", "query", "glob", "regex", "include", "description"} {
 				if raw, ok := obj[key]; ok {
 					var s string
 					if err := json.Unmarshal(raw, &s); err == nil && s != "" {

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -244,10 +244,15 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 
 	// Fetch state_change events within [earliest, latest] and include them in
 	// the timeline so state transitions are visible in the default view.
+	// Fetch state_change events from [earliest, +∞) with an open upper bound.
+	// The terminal state transition (e.g. active → finished) almost always
+	// occurs after the last assistant turn and would be excluded by a closed
+	// upper bound. Since there are typically only 2–3 state_change events per
+	// session, fetching all and filtering by lower bound is inexpensive.
 	stateChangeEventsAll, _ := d.QueryEvents(session, 0, nil, nil, []string{"state_change"})
 	var stateChangeEventsInWindow []db.Event
 	for _, sc := range stateChangeEventsAll {
-		if !sc.CreatedAt.Before(earliest) && !sc.CreatedAt.After(latest) {
+		if !sc.CreatedAt.Before(earliest) {
 			stateChangeEventsInWindow = append(stateChangeEventsInWindow, sc)
 		}
 	}
@@ -597,9 +602,9 @@ func renderCheckinEventsRaw(session string, d *db.DB, events []db.Event, verbose
 			}
 			label := turnLabel(up.Agent, up.Model)
 			if label != "" {
-				fmt.Printf("[%s] user  [%s]\n%s\n\n", ts, label, text)
+				fmt.Printf("[%s] ▶ user  [%s]\n%s\n\n", ts, label, text)
 			} else {
-				fmt.Printf("[%s] user\n%s\n\n", ts, text)
+				fmt.Printf("[%s] ▶ user\n%s\n\n", ts, text)
 			}
 
 		case "msg_assistant":
@@ -744,9 +749,9 @@ func renderProxiedCheckin(raw []byte, verbose bool) error {
 			}
 			label := turnLabel(up.Agent, up.Model)
 			if label != "" {
-				fmt.Printf("[%s] user  [%s]\n%s\n\n", ts, label, text)
+				fmt.Printf("[%s] ▶ user  [%s]\n%s\n\n", ts, label, text)
 			} else {
-				fmt.Printf("[%s] user\n%s\n\n", ts, text)
+				fmt.Printf("[%s] ▶ user\n%s\n\n", ts, text)
 			}
 
 		case "msg_assistant":
@@ -1030,7 +1035,22 @@ func renderChildEventsForTurn(children []childEvent, verbose bool, prefix string
 func toolOneLiner(toolName, args, result string) string {
 	switch toolName {
 	case "bash":
-		cmd := truncateRunes(args, 80)
+		// The sidecar stores bash args as a JSON object {"command":"..."}.
+		// Extract the command string; fall back to raw args if not JSON.
+		cmd := args
+		trimmedArgs := strings.TrimSpace(args)
+		if len(trimmedArgs) > 0 && trimmedArgs[0] == '{' {
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(trimmedArgs), &obj); err == nil {
+				if raw, ok := obj["command"]; ok {
+					var s string
+					if json.Unmarshal(raw, &s) == nil && s != "" {
+						cmd = s
+					}
+				}
+			}
+		}
+		cmd = truncateRunes(cmd, 80)
 		summary := bashResultSummary(result)
 		return fmt.Sprintf("bash: %s %s", cmd, summary)
 
@@ -1190,9 +1210,23 @@ func countResultLines(result string) int {
 }
 
 // looksLikeToolError returns true when a tool result appears to indicate failure.
+// It checks for error/failed/exception as a line prefix, not anywhere in the text,
+// to avoid false positives from output that merely mentions these words
+// (e.g. "Ran 42 tests, 0 failed." or "No errors found.").
 func looksLikeToolError(result string) bool {
-	lower := strings.ToLower(result)
-	return strings.Contains(lower, "error") ||
-		strings.Contains(lower, "failed") ||
-		strings.Contains(lower, "exception")
+	if result == "" {
+		return false
+	}
+	for _, line := range strings.Split(result, "\n") {
+		l := strings.TrimSpace(strings.ToLower(line))
+		if l == "" {
+			continue
+		}
+		if l == "error" || strings.HasPrefix(l, "error:") || strings.HasPrefix(l, "error ") ||
+			l == "failed" || strings.HasPrefix(l, "failed:") || strings.HasPrefix(l, "failed ") ||
+			l == "exception" || strings.HasPrefix(l, "exception:") || strings.HasPrefix(l, "exception ") {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,6 +29,13 @@ import (
 	"github.com/prismatic-koi/prism/internal/payload"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
+
+// childEvent holds a single child event (tool_call, tool_result, permission_ask,
+// permission_denied, or thinking) associated with a parent assistant turn.
+type childEvent struct {
+	eventType string
+	payload   string
+}
 
 var checkinCmd = &cobra.Command{
 	Use:   "checkin [session]",
@@ -45,7 +53,7 @@ func init() {
 	checkinCmd.Flags().Int("last", 10, "Number of conversation turns to show")
 	checkinCmd.Flags().String("from", "", "Show events forward from this event ID")
 	checkinCmd.Flags().String("before", "", "Show events backward from this event ID")
-	checkinCmd.Flags().String("types", "", "Comma-separated event types to filter (default includes msg_user, msg_assistant, tool_call, tool_result, permission_ask, permission_denied)")
+	checkinCmd.Flags().String("types", "", "Comma-separated event types to filter. Orthogonal escape hatch for targeted queries (e.g. --types audit). The default rich view already includes state_change, msg_user, msg_assistant, tool_call, tool_result, permission_ask, and permission_denied.")
 	checkinCmd.Flags().Bool("verbose", false, "Show full tool args/results without truncation")
 	checkinCmd.Flags().Bool("all", false, "List all sessions across all repos (no-arg mode only)")
 	rootCmd.AddCommand(checkinCmd)
@@ -199,10 +207,6 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	secondary, serr := d.QueryEventsByMessageIDs(session, messageIDs, childTypes)
 
 	// Organise children by messageId.
-	type childEvent struct {
-		eventType string
-		payload   string
-	}
 	childrenByMsgID := make(map[string][]childEvent)
 	if serr == nil {
 		for _, e := range secondary {
@@ -215,7 +219,7 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	}
 
 	// Determine the time window spanned by the fetched assistant turns so that
-	// we can include msg_user events that fall within it.
+	// we can include msg_user and state_change events that fall within it.
 	earliest := assistantEvents[0].CreatedAt
 	latest := assistantEvents[len(assistantEvents)-1].CreatedAt
 	for _, ae := range assistantEvents {
@@ -238,18 +242,32 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 		}
 	}
 
-	// Merge assistant events and user events into a single timeline sorted ASC.
+	// Fetch state_change events within [earliest, latest] and include them in
+	// the timeline so state transitions are visible in the default view.
+	stateChangeEventsAll, _ := d.QueryEvents(session, 0, nil, nil, []string{"state_change"})
+	var stateChangeEventsInWindow []db.Event
+	for _, sc := range stateChangeEventsAll {
+		if !sc.CreatedAt.Before(earliest) && !sc.CreatedAt.After(latest) {
+			stateChangeEventsInWindow = append(stateChangeEventsInWindow, sc)
+		}
+	}
+
+	// Merge assistant, user, and state_change events into a single timeline sorted ASC.
 	// assistantEvents is already ASC from QueryEvents; userEventsInWindow is also ASC.
 	type timelineEntry struct {
-		isUser bool
-		event  db.Event
+		isUser        bool
+		isStateChange bool
+		event         db.Event
 	}
-	timeline := make([]timelineEntry, 0, len(assistantEvents)+len(userEventsInWindow))
+	timeline := make([]timelineEntry, 0, len(assistantEvents)+len(userEventsInWindow)+len(stateChangeEventsInWindow))
 	for _, ae := range assistantEvents {
 		timeline = append(timeline, timelineEntry{isUser: false, event: ae})
 	}
 	for _, ue := range userEventsInWindow {
 		timeline = append(timeline, timelineEntry{isUser: true, event: ue})
+	}
+	for _, sc := range stateChangeEventsInWindow {
+		timeline = append(timeline, timelineEntry{isStateChange: true, event: sc})
 	}
 	// Sort by created_at ASC (stable, preserving insertion order for ties).
 	for i := 1; i < len(timeline); i++ {
@@ -261,8 +279,12 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	// isSubagentEntry returns true when an entry's agent differs from the root
 	// agent, indicating it belongs to a subagent invocation. When rootAgentName
 	// is empty (pre-migration sessions), all entries are treated as root-agent
-	// entries to preserve current behaviour.
+	// entries to preserve current behaviour. state_change entries are never
+	// considered subagent entries.
 	isSubagentEntry := func(entry timelineEntry) bool {
+		if entry.isStateChange {
+			return false
+		}
 		if rootAgentName == "" {
 			return false
 		}
@@ -346,6 +368,16 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			prefix = "  │ "
 		}
 
+		// State-change entries render inline with a ● marker (session-level, no agent prefix).
+		if entry.isStateChange {
+			var sc payload.StateChange
+			if jerr := json.Unmarshal([]byte(e.Payload), &sc); jerr == nil && sc.State != "" {
+				fmt.Printf("[%s] ● %s\n\n", ts, sc.State)
+			}
+			i++
+			continue
+		}
+
 		if entry.isUser {
 			var up payload.MsgUser
 			if jerr := json.Unmarshal([]byte(e.Payload), &up); jerr != nil {
@@ -357,9 +389,9 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 			}
 			label := turnLabel(up.Agent, up.Model)
 			if label != "" {
-				fmt.Printf("%s[%s] user  [%s]\n", prefix, ts, label)
+				fmt.Printf("%s[%s] ▶ user  [%s]\n", prefix, ts, label)
 			} else {
-				fmt.Printf("%s[%s] user\n", prefix, ts)
+				fmt.Printf("%s[%s] ▶ user\n", prefix, ts)
 			}
 			fmt.Printf("%s%s\n\n", prefix, text)
 			i++
@@ -384,9 +416,7 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 		fmt.Printf("%s%s\n", prefix, atext)
 
 		msgID := extractMessageID(e.Payload)
-		for _, child := range childrenByMsgID[msgID] {
-			renderChildEvent(child.eventType, child.payload, verbose, prefix)
-		}
+		renderChildEventsForTurn(childrenByMsgID[msgID], verbose, prefix)
 		fmt.Println()
 		i++
 	}
@@ -626,7 +656,14 @@ func renderCheckinEventsRaw(session string, d *db.DB, events []db.Event, verbose
 			renderChildEvent("permission_denied", e.Payload, verbose, "")
 
 		default:
-			// state_change, compaction, error, etc.
+			if e.Type == "state_change" {
+				var sc payload.StateChange
+				if err := json.Unmarshal([]byte(e.Payload), &sc); err == nil && sc.State != "" {
+					fmt.Printf("[%s] ● %s\n\n", ts, sc.State)
+					continue
+				}
+			}
+			// compaction, error, etc.
 			fmt.Printf("[%s] %s: %s\n", ts, e.Type, e.Payload)
 		}
 	}
@@ -770,6 +807,12 @@ func renderProxiedCheckin(raw []byte, verbose bool) error {
 				continue
 			}
 			renderChildEvent("thinking", e.Payload, verbose, "")
+
+		case "state_change":
+			var sc payload.StateChange
+			if err := json.Unmarshal([]byte(e.Payload), &sc); err == nil && sc.State != "" {
+				fmt.Printf("[%s] ● %s\n\n", ts, sc.State)
+			}
 
 		default:
 			fmt.Printf("[%s] %s: %s\n", ts, e.Type, e.Payload)
@@ -920,4 +963,236 @@ func printSessionTable(ss []db.Status) error {
 	fmt.Println(lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Render(hint))
 
 	return nil
+}
+
+// renderChildEventsForTurn renders all child events for an assistant turn.
+//
+// Default mode: tool_call+result pairs are combined into one-liners using
+// toolOneLiner. Each tool_call is matched with the first unused tool_result
+// for the same tool name that appears after it in the list.
+//
+// Verbose mode: full args and full result for each event, rendered separately
+// using renderChildEvent (existing behaviour).
+func renderChildEventsForTurn(children []childEvent, verbose bool, prefix string) {
+	if verbose {
+		for _, c := range children {
+			renderChildEvent(c.eventType, c.payload, verbose, prefix)
+		}
+		return
+	}
+
+	// Default mode: pair tool_calls with results into one-liners.
+	used := make([]bool, len(children))
+	for i, c := range children {
+		if used[i] {
+			continue
+		}
+		switch c.eventType {
+		case "tool_call":
+			var tc payload.ToolCall
+			if err := json.Unmarshal([]byte(c.payload), &tc); err != nil {
+				fmt.Printf("%s  → (tool_call parse error)\n", prefix)
+				used[i] = true
+				continue
+			}
+			// Find the first matching unused tool_result after this call.
+			result := ""
+			for j := i + 1; j < len(children); j++ {
+				if used[j] || children[j].eventType != "tool_result" {
+					continue
+				}
+				var tr payload.ToolResult
+				if err := json.Unmarshal([]byte(children[j].payload), &tr); err != nil {
+					continue
+				}
+				if tr.Tool == tc.Tool {
+					result = tr.Result
+					used[j] = true
+					break
+				}
+			}
+			line := toolOneLiner(tc.Tool, tc.Args, result)
+			fmt.Printf("%s  → %s\n", prefix, line)
+			used[i] = true
+		case "tool_result":
+			// Orphaned result (no matching call) — skip in default mode.
+			used[i] = true
+		default:
+			// permission_ask, permission_denied, thinking
+			renderChildEvent(c.eventType, c.payload, verbose, prefix)
+			used[i] = true
+		}
+	}
+}
+
+// toolOneLiner returns a single-line summary for a tool call + result pair.
+// Format: "<tool>: <key_arg> <result_summary>"
+func toolOneLiner(toolName, args, result string) string {
+	switch toolName {
+	case "bash":
+		cmd := truncateRunes(args, 80)
+		summary := bashResultSummary(result)
+		return fmt.Sprintf("bash: %s %s", cmd, summary)
+
+	case "read", "read_file":
+		fp := extractToolFilePath(args)
+		if result == "" {
+			return fmt.Sprintf("%s: %s ✓", toolName, fp)
+		}
+		n := countResultLines(result)
+		return fmt.Sprintf("%s: %s ✓ (%d lines)", toolName, fp, n)
+
+	case "edit", "edit_file":
+		fp := extractToolFilePath(args)
+		if looksLikeToolError(result) {
+			return fmt.Sprintf("%s: %s ✗", toolName, fp)
+		}
+		return fmt.Sprintf("%s: %s ✓", toolName, fp)
+
+	case "write", "write_file":
+		fp := extractToolFilePath(args)
+		if looksLikeToolError(result) {
+			return fmt.Sprintf("%s: %s ✗", toolName, fp)
+		}
+		return fmt.Sprintf("%s: %s ✓", toolName, fp)
+
+	case "glob":
+		pat := extractFirstArgument(args)
+		n := countResultLines(result)
+		if n == 0 {
+			return fmt.Sprintf("glob: %s no matches", pat)
+		}
+		return fmt.Sprintf("glob: %s %d matches", pat, n)
+
+	case "grep", "ripgrep":
+		pat := extractFirstArgument(args)
+		n := countResultLines(result)
+		if n == 0 {
+			return fmt.Sprintf("grep: %s no matches", pat)
+		}
+		return fmt.Sprintf("grep: %s %d matches", pat, n)
+
+	case "task":
+		desc := truncateRunes(args, 60)
+		if looksLikeToolError(result) {
+			return fmt.Sprintf("task: %s ✗", desc)
+		}
+		return fmt.Sprintf("task: %s ✓", desc)
+
+	case "todowrite", "todo_write":
+		return "todowrite ✓"
+
+	default:
+		keyArg := truncateRunes(args, 60)
+		if result == "" {
+			return fmt.Sprintf("%s: %s ✓", toolName, keyArg)
+		}
+		first := firstMeaningfulLine(result, 80)
+		if first == "" {
+			return fmt.Sprintf("%s: %s ✓", toolName, keyArg)
+		}
+		return fmt.Sprintf("%s: %s — %s", toolName, keyArg, first)
+	}
+}
+
+// truncateRunes truncates s to at most n runes, appending "..." if truncated.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "..."
+}
+
+// bashResultSummary returns the result summary portion for a bash one-liner.
+// Returns "✓" for empty output; "— <first line>" for non-empty output.
+func bashResultSummary(result string) string {
+	result = strings.TrimSpace(result)
+	if result == "" {
+		return "✓"
+	}
+	line := firstMeaningfulLine(result, 80)
+	if line == "" {
+		return "✓"
+	}
+	return "— " + line
+}
+
+// firstMeaningfulLine returns the first non-empty, non-whitespace line of s,
+// truncated to maxLen runes. Returns "" if no such line exists.
+func firstMeaningfulLine(s string, maxLen int) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return truncateRunes(line, maxLen)
+		}
+	}
+	return ""
+}
+
+// extractToolFilePath extracts a file path from tool args.
+// Tries JSON parsing first (for {filePath:...} shapes), falls back to raw string.
+// Returns the base filename component for brevity.
+func extractToolFilePath(args string) string {
+	args = strings.TrimSpace(args)
+	if len(args) > 0 && args[0] == '{' {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(args), &obj); err == nil {
+			for _, key := range []string{"filePath", "file_path", "path", "filename"} {
+				if raw, ok := obj[key]; ok {
+					var s string
+					if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+						return filepath.Base(s)
+					}
+				}
+			}
+		}
+	}
+	if args == "" {
+		return args
+	}
+	return filepath.Base(args)
+}
+
+// extractFirstArgument extracts the primary argument (pattern, query, etc.)
+// from tool args. Tries JSON parsing first, falls back to the raw string.
+func extractFirstArgument(args string) string {
+	args = strings.TrimSpace(args)
+	if len(args) > 0 && args[0] == '{' {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(args), &obj); err == nil {
+			for _, key := range []string{"pattern", "query", "glob", "regex", "include"} {
+				if raw, ok := obj[key]; ok {
+					var s string
+					if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+						return truncateRunes(s, 60)
+					}
+				}
+			}
+		}
+	}
+	return truncateRunes(args, 60)
+}
+
+// countResultLines counts non-empty lines in the result string.
+func countResultLines(result string) int {
+	result = strings.TrimSpace(result)
+	if result == "" {
+		return 0
+	}
+	n := 0
+	for _, line := range strings.Split(result, "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// looksLikeToolError returns true when a tool result appears to indicate failure.
+func looksLikeToolError(result string) bool {
+	lower := strings.ToLower(result)
+	return strings.Contains(lower, "error") ||
+		strings.Contains(lower, "failed") ||
+		strings.Contains(lower, "exception")
 }

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -1059,8 +1059,9 @@ func TestRenderCheckinTurns_StateChangeInWindow(t *testing.T) {
 	}
 }
 
-// TestRenderCheckinTurns_StateChangeAfterTurn verifies that a state_change
-// just after the last assistant turn IS included when it falls at the window boundary.
+// TestRenderCheckinTurns_StateChangeMultipleTurns verifies that state_change events
+// within [earliest, +∞) are shown inline, including terminal transitions that
+// follow the last assistant turn.
 func TestRenderCheckinTurns_StateChangeMultipleTurns(t *testing.T) {
 	d := openCheckinTestDB(t)
 	const session = "repo@main"
@@ -1074,13 +1075,19 @@ func TestRenderCheckinTurns_StateChangeMultipleTurns(t *testing.T) {
 	ae2 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
 		assistantPayload(msg2, "second turn"), base.Add(15*time.Second))
 
-	// State change at t=10s — inside [5s, 15s] window, should appear.
+	// State change at t=10s — inside [5s, ∞), should appear.
 	writeEvent(t, d, uuid.New().String(), session, "state_change",
 		stateChangePayload("paused"), base.Add(10*time.Second))
 
-	// State change at t=20s — after window, should NOT appear.
+	// State change at t=20s — after last assistant turn, but still inside [5s, ∞).
+	// This is the primary fix: terminal transitions SHOULD appear even when they
+	// follow the last assistant turn in the window.
 	writeEvent(t, d, uuid.New().String(), session, "state_change",
 		stateChangePayload("finished"), base.Add(20*time.Second))
+
+	// State change at t=1s — before earliest (5s), should NOT appear.
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("idle"), base.Add(time.Second))
 
 	out := captureStdout(t, func() {
 		if err := renderCheckinTurns(session, d, []db.Event{ae1, ae2}, false); err != nil {
@@ -1091,8 +1098,13 @@ func TestRenderCheckinTurns_StateChangeMultipleTurns(t *testing.T) {
 	if !strings.Contains(out, "● paused") {
 		t.Errorf("output missing in-window '● paused'\ngot:\n%s", out)
 	}
-	if strings.Contains(out, "● finished") {
-		t.Errorf("output unexpectedly contains out-of-window '● finished'\ngot:\n%s", out)
+	// ● finished should appear: it's after the last turn but within [earliest, ∞).
+	if !strings.Contains(out, "● finished") {
+		t.Errorf("output missing post-turn '● finished' (terminal state should always appear)\ngot:\n%s", out)
+	}
+	// ● idle should NOT appear: it's before earliest.
+	if strings.Contains(out, "● idle") {
+		t.Errorf("output unexpectedly contains pre-earliest '● idle'\ngot:\n%s", out)
 	}
 	// ● marker should appear BETWEEN the two assistant turns.
 	firstTurnPos := strings.Index(out, "first turn")
@@ -1113,10 +1125,15 @@ func TestToolOneLiner_Bash(t *testing.T) {
 		result string
 		want   string
 	}{
+		// Plain string args (legacy / test shape)
 		{"echo hello", "hello\n", "bash: echo hello — hello"},
 		{"go build ./...", "", "bash: go build ./... ✓"},
 		{strings.Repeat("x", 100), "", "bash: " + strings.Repeat("x", 80) + "... ✓"},
 		{"ls", "file1\nfile2\nfile3", "bash: ls — file1"},
+		// JSON-object args (real sidecar shape: {"command":"..."})
+		{`{"command":"echo hello"}`, "hello\n", "bash: echo hello — hello"},
+		{`{"command":"go build ./..."}`, "", "bash: go build ./... ✓"},
+		{`{"command":"` + strings.Repeat("x", 100) + `"}`, "", "bash: " + strings.Repeat("x", 80) + "... ✓"},
 	}
 	for _, tc := range cases {
 		got := toolOneLiner("bash", tc.args, tc.result)
@@ -1134,9 +1151,13 @@ func TestToolOneLiner_Read(t *testing.T) {
 		result string
 		want   string
 	}{
+		// Plain string args
 		{"read_file", "main.go", "line1\nline2\nline3", "read_file: main.go ✓ (3 lines)"},
 		{"read_file", "main.go", "", "read_file: main.go ✓"},
 		{"read", "/path/to/db.go", "a\nb", "read: db.go ✓ (2 lines)"},
+		// JSON-object args (real sidecar shape: {"filePath":"..."})
+		{"read_file", `{"filePath":"internal/db/db.go"}`, "a\nb\nc", "read_file: db.go ✓ (3 lines)"},
+		{"read", `{"path":"/home/user/main.go"}`, "", "read: main.go ✓"},
 	}
 	for _, tc := range cases {
 		got := toolOneLiner(tc.tool, tc.args, tc.result)
@@ -1154,10 +1175,17 @@ func TestToolOneLiner_EditWrite(t *testing.T) {
 		result string
 		want   string
 	}{
+		// Plain string args
 		{"edit", "container.go", "ok", "edit: container.go ✓"},
 		{"edit", "container.go", "error: file not found", "edit: container.go ✗"},
 		{"write", "output.json", "", "write: output.json ✓"},
 		{"write_file", "/path/to/file.go", "failed: permission denied", "write_file: file.go ✗"},
+		// JSON-object args (real sidecar shape: {"filePath":"..."})
+		{"edit", `{"filePath":"internal/container.go"}`, "ok", "edit: container.go ✓"},
+		{"write", `{"filePath":"output/result.json"}`, "error: disk full", "write: result.json ✗"},
+		// looksLikeToolError false-positive regression cases
+		{"edit", "file.go", "Replaced 3 occurrences. No errors.", "edit: file.go ✓"},
+		{"task", "run tests", "Ran 42 tests, 0 failed.", "task: run tests ✓"},
 	}
 	for _, tc := range cases {
 		got := toolOneLiner(tc.tool, tc.args, tc.result)
@@ -1175,10 +1203,14 @@ func TestToolOneLiner_GlobGrep(t *testing.T) {
 		result string
 		want   string
 	}{
+		// Plain string args
 		{"glob", "**/*.go", "a.go\nb.go\nc.go", "glob: **/*.go 3 matches"},
 		{"glob", "**/*.go", "", "glob: **/*.go no matches"},
 		{"grep", "TODO", "file1:1:TODO fix\nfile2:3:TODO check", "grep: TODO 2 matches"},
 		{"grep", "TODO", "", "grep: TODO no matches"},
+		// JSON-object args (real sidecar shape)
+		{"glob", `{"pattern":"**/*.go"}`, "a.go\nb.go", "glob: **/*.go 2 matches"},
+		{"grep", `{"pattern":"TODO","path":"."}`, "a:1:TODO\nb:2:TODO", "grep: TODO 2 matches"},
 	}
 	for _, tc := range cases {
 		got := toolOneLiner(tc.tool, tc.args, tc.result)
@@ -1277,5 +1309,40 @@ func TestRenderCheckinTurns_VerboseToolCallAndResult(t *testing.T) {
 	}
 	if strings.Contains(outDefault, "→ result: hi") {
 		t.Errorf("default: should not show separate result line\ngot:\n%s", outDefault)
+	}
+}
+
+// TestLooksLikeToolError verifies that looksLikeToolError distinguishes actual
+// errors from output that merely mentions error-related words in passing.
+func TestLooksLikeToolError(t *testing.T) {
+	truePositives := []string{
+		"error: file not found",
+		"Error: permission denied",
+		"failed: could not write",
+		"Failed to open file",
+		"exception: nil pointer",
+		"error",
+		"failed",
+	}
+	for _, s := range truePositives {
+		if !looksLikeToolError(s) {
+			t.Errorf("looksLikeToolError(%q) = false, want true", s)
+		}
+	}
+
+	falsePositives := []string{
+		"Replaced 3 occurrences. No errors.",
+		"Ran 42 tests, 0 failed.",
+		"No errors found.",
+		"error_handler.go was modified.",
+		"The operation succeeded without exception.",
+		"",
+		"ok",
+		"File written successfully.",
+	}
+	for _, s := range falsePositives {
+		if looksLikeToolError(s) {
+			t.Errorf("looksLikeToolError(%q) = true, want false (false positive)", s)
+		}
 	}
 }

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -187,15 +187,17 @@ func TestRenderCheckinTurns_ToolChildrenIndented(t *testing.T) {
 		t.Errorf("missing 'second assistant'\ngot:\n%s", out)
 	}
 
-	// Tool children rendered with indentation.
-	if !strings.Contains(out, "  → bash: echo hello") {
-		t.Errorf("missing indented bash tool_call\ngot:\n%s", out)
+	// bash one-liner: call and result merged — "bash: echo hello — hello"
+	if !strings.Contains(out, "  → bash: echo hello — hello") {
+		t.Errorf("missing bash one-liner with result\ngot:\n%s", out)
 	}
-	if !strings.Contains(out, "  → result: hello") {
-		t.Errorf("missing indented tool_result\ngot:\n%s", out)
+	// result should NOT appear as a separate line in default mode
+	if strings.Contains(out, "  → result: hello") {
+		t.Errorf("tool_result should be merged into one-liner in default mode, not shown separately\ngot:\n%s", out)
 	}
+	// read_file one-liner: no result event, so just ✓
 	if !strings.Contains(out, "  → read_file: main.go") {
-		t.Errorf("missing indented read_file tool_call\ngot:\n%s", out)
+		t.Errorf("missing read_file one-liner\ngot:\n%s", out)
 	}
 
 	// The bash tool should appear before read_file in output (ae1 before ae2).
@@ -1011,5 +1013,269 @@ func TestRenderChildEvent_PermissionAsk_AbsentTool(t *testing.T) {
 	}
 	if !strings.Contains(out, "unknown") {
 		t.Errorf("output should use 'unknown' fallback\ngot: %s", out)
+	}
+}
+
+// stateChangePayload returns a minimal state_change JSON payload.
+func stateChangePayload(state string) string {
+	return fmt.Sprintf(`{"state":%q}`, state)
+}
+
+// TestRenderCheckinTurns_StateChangeInWindow verifies that state_change events
+// within the assistant-turn time window are shown inline with a ● marker.
+func TestRenderCheckinTurns_StateChangeInWindow(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Assistant turn at t=10s.
+	msgID := "msg-sc"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "doing work"), base.Add(10*time.Second))
+
+	// State change at t=15s — inside [t=10s, t=10s] window... wait, window is just the turn.
+	// Since window is [earliest, latest] and there's only one assistant turn, window=[10s,10s].
+	// State change AT t=10s should be included (at boundary).
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("finished"), base.Add(10*time.Second))
+
+	// State change at t=5s — BEFORE window, should not appear.
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("active"), base.Add(5*time.Second))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// "● finished" must appear (at boundary).
+	if !strings.Contains(out, "● finished") {
+		t.Errorf("output missing '● finished'\ngot:\n%s", out)
+	}
+	// "● active" must NOT appear (before window).
+	if strings.Contains(out, "● active") {
+		t.Errorf("output unexpectedly contains out-of-window '● active'\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_StateChangeAfterTurn verifies that a state_change
+// just after the last assistant turn IS included when it falls at the window boundary.
+func TestRenderCheckinTurns_StateChangeMultipleTurns(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Two assistant turns at t=5s and t=15s.
+	msg1 := "msg-1"
+	msg2 := "msg-2"
+	ae1 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msg1, "first turn"), base.Add(5*time.Second))
+	ae2 := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msg2, "second turn"), base.Add(15*time.Second))
+
+	// State change at t=10s — inside [5s, 15s] window, should appear.
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("paused"), base.Add(10*time.Second))
+
+	// State change at t=20s — after window, should NOT appear.
+	writeEvent(t, d, uuid.New().String(), session, "state_change",
+		stateChangePayload("finished"), base.Add(20*time.Second))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae1, ae2}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "● paused") {
+		t.Errorf("output missing in-window '● paused'\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "● finished") {
+		t.Errorf("output unexpectedly contains out-of-window '● finished'\ngot:\n%s", out)
+	}
+	// ● marker should appear BETWEEN the two assistant turns.
+	firstTurnPos := strings.Index(out, "first turn")
+	statePos := strings.Index(out, "● paused")
+	secondTurnPos := strings.Index(out, "second turn")
+	if firstTurnPos < 0 || statePos < 0 || secondTurnPos < 0 {
+		t.Fatalf("missing expected content\ngot:\n%s", out)
+	}
+	if !(firstTurnPos < statePos && statePos < secondTurnPos) {
+		t.Errorf("state change should appear between turns\ngot:\n%s", out)
+	}
+}
+
+// TestToolOneLiner_Bash verifies bash one-liner formatting.
+func TestToolOneLiner_Bash(t *testing.T) {
+	cases := []struct {
+		args   string
+		result string
+		want   string
+	}{
+		{"echo hello", "hello\n", "bash: echo hello — hello"},
+		{"go build ./...", "", "bash: go build ./... ✓"},
+		{strings.Repeat("x", 100), "", "bash: " + strings.Repeat("x", 80) + "... ✓"},
+		{"ls", "file1\nfile2\nfile3", "bash: ls — file1"},
+	}
+	for _, tc := range cases {
+		got := toolOneLiner("bash", tc.args, tc.result)
+		if got != tc.want {
+			t.Errorf("toolOneLiner(bash, %q, %q) = %q, want %q", tc.args, tc.result, got, tc.want)
+		}
+	}
+}
+
+// TestToolOneLiner_Read verifies read/read_file one-liner formatting.
+func TestToolOneLiner_Read(t *testing.T) {
+	cases := []struct {
+		tool   string
+		args   string
+		result string
+		want   string
+	}{
+		{"read_file", "main.go", "line1\nline2\nline3", "read_file: main.go ✓ (3 lines)"},
+		{"read_file", "main.go", "", "read_file: main.go ✓"},
+		{"read", "/path/to/db.go", "a\nb", "read: db.go ✓ (2 lines)"},
+	}
+	for _, tc := range cases {
+		got := toolOneLiner(tc.tool, tc.args, tc.result)
+		if got != tc.want {
+			t.Errorf("toolOneLiner(%s, %q, ...) = %q, want %q", tc.tool, tc.args, got, tc.want)
+		}
+	}
+}
+
+// TestToolOneLiner_EditWrite verifies edit/write one-liner formatting.
+func TestToolOneLiner_EditWrite(t *testing.T) {
+	cases := []struct {
+		tool   string
+		args   string
+		result string
+		want   string
+	}{
+		{"edit", "container.go", "ok", "edit: container.go ✓"},
+		{"edit", "container.go", "error: file not found", "edit: container.go ✗"},
+		{"write", "output.json", "", "write: output.json ✓"},
+		{"write_file", "/path/to/file.go", "failed: permission denied", "write_file: file.go ✗"},
+	}
+	for _, tc := range cases {
+		got := toolOneLiner(tc.tool, tc.args, tc.result)
+		if got != tc.want {
+			t.Errorf("toolOneLiner(%s, %q, %q) = %q, want %q", tc.tool, tc.args, tc.result, got, tc.want)
+		}
+	}
+}
+
+// TestToolOneLiner_GlobGrep verifies glob/grep one-liner formatting.
+func TestToolOneLiner_GlobGrep(t *testing.T) {
+	cases := []struct {
+		tool   string
+		args   string
+		result string
+		want   string
+	}{
+		{"glob", "**/*.go", "a.go\nb.go\nc.go", "glob: **/*.go 3 matches"},
+		{"glob", "**/*.go", "", "glob: **/*.go no matches"},
+		{"grep", "TODO", "file1:1:TODO fix\nfile2:3:TODO check", "grep: TODO 2 matches"},
+		{"grep", "TODO", "", "grep: TODO no matches"},
+	}
+	for _, tc := range cases {
+		got := toolOneLiner(tc.tool, tc.args, tc.result)
+		if got != tc.want {
+			t.Errorf("toolOneLiner(%s, %q, ...) = %q, want %q", tc.tool, tc.args, got, tc.want)
+		}
+	}
+}
+
+// TestToolOneLiner_Todowrite verifies todowrite one-liner.
+func TestToolOneLiner_Todowrite(t *testing.T) {
+	got := toolOneLiner("todowrite", "some todos json", "ok")
+	want := "todowrite ✓"
+	if got != want {
+		t.Errorf("toolOneLiner(todowrite) = %q, want %q", got, want)
+	}
+}
+
+// TestRenderCheckinTurns_UserDistinct verifies that msg_user messages use
+// the ▶ prefix to distinguish them from assistant messages.
+func TestRenderCheckinTurns_UserDistinct(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	// Write user message at t=0 and assistant at t=1s (within window).
+	umsgID := uuid.New().String()
+	amsgID := uuid.New().String()
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload(umsgID, "please do something"), base)
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(amsgID, "on it"), base.Add(time.Second))
+
+	// User at t=0 is at the boundary (earliest assistant = t=1s), so it is
+	// NOT in window. Write one at t=1s that IS in window.
+	umsgID2 := uuid.New().String()
+	writeEvent(t, d, uuid.New().String(), session, "msg_user",
+		userPayload(umsgID2, "confirm please"), base.Add(time.Second))
+
+	out := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns: %v", err)
+		}
+	})
+
+	// User messages must use ▶ prefix.
+	if !strings.Contains(out, "▶ user") {
+		t.Errorf("output missing '▶ user' prefix for msg_user\ngot:\n%s", out)
+	}
+	// Assistant messages must NOT use ▶ prefix.
+	if strings.Contains(out, "▶ assistant") {
+		t.Errorf("output should not prefix assistant with ▶\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "] assistant") {
+		t.Errorf("output missing '] assistant' header\ngot:\n%s", out)
+	}
+}
+
+// TestRenderCheckinTurns_VerboseToolCallAndResult verifies that in verbose mode
+// tool_call and tool_result render as separate lines (not merged).
+func TestRenderCheckinTurns_VerboseToolCallAndResult(t *testing.T) {
+	d := openCheckinTestDB(t)
+	const session = "repo@main"
+	base := time.Now().Truncate(time.Second)
+
+	msgID := "msg-verbose-pair"
+	ae := writeEvent(t, d, uuid.New().String(), session, "msg_assistant",
+		assistantPayload(msgID, "verbose test"), base)
+	writeEvent(t, d, uuid.New().String(), session, "tool_call",
+		toolCallPayload(msgID, "bash", "echo hi"), base.Add(100*time.Millisecond))
+	writeEvent(t, d, uuid.New().String(), session, "tool_result",
+		toolResultPayload(msgID, "bash", "hi"), base.Add(200*time.Millisecond))
+
+	outVerbose := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, true); err != nil {
+			t.Errorf("renderCheckinTurns (verbose): %v", err)
+		}
+	})
+
+	// In verbose mode, tool_call and tool_result appear as separate lines.
+	if !strings.Contains(outVerbose, "→ bash: echo hi") {
+		t.Errorf("verbose: missing tool_call line\ngot:\n%s", outVerbose)
+	}
+	if !strings.Contains(outVerbose, "→ result: hi") {
+		t.Errorf("verbose: missing separate tool_result line\ngot:\n%s", outVerbose)
+	}
+
+	// Default mode merges them into one line.
+	outDefault := captureStdout(t, func() {
+		if err := renderCheckinTurns(session, d, []db.Event{ae}, false); err != nil {
+			t.Errorf("renderCheckinTurns (default): %v", err)
+		}
+	})
+	if !strings.Contains(outDefault, "→ bash: echo hi — hi") {
+		t.Errorf("default: missing merged one-liner\ngot:\n%s", outDefault)
+	}
+	if strings.Contains(outDefault, "→ result: hi") {
+		t.Errorf("default: should not show separate result line\ngot:\n%s", outDefault)
 	}
 }

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -1229,6 +1229,28 @@ func TestToolOneLiner_Todowrite(t *testing.T) {
 	}
 }
 
+// TestToolOneLiner_Task verifies task one-liner formatting, including JSON-object args.
+func TestToolOneLiner_Task(t *testing.T) {
+	cases := []struct {
+		args   string
+		result string
+		want   string
+	}{
+		// Plain string args (fallback)
+		{"run tests", "ok", "task: run tests ✓"},
+		{"run tests", "error: tests failed", "task: run tests ✗"},
+		// JSON-object args (real sidecar shape: {"description":"..."})
+		{`{"description":"implement the feature"}`, "ok", "task: implement the feature ✓"},
+		{`{"description":"run the test suite"}`, "failed: 3 tests failed", "task: run the test suite ✗"},
+	}
+	for _, tc := range cases {
+		got := toolOneLiner("task", tc.args, tc.result)
+		if got != tc.want {
+			t.Errorf("toolOneLiner(task, %q, %q) = %q, want %q", tc.args, tc.result, got, tc.want)
+		}
+	}
+}
+
 // TestRenderCheckinTurns_UserDistinct verifies that msg_user messages use
 // the ▶ prefix to distinguish them from assistant messages.
 func TestRenderCheckinTurns_UserDistinct(t *testing.T) {


### PR DESCRIPTION
Implements the design from issue #649.

## What changed

### Default output (no flags)

`prism checkin <session>` now shows a rich narrative view:

- **▶ user** messages with a distinct prefix (visually separate from assistant output)
- **Assistant messages** with full text (unchanged)
- **State changes** shown inline as `● <state>` (e.g. `● finished`)
- **Tool call one-liners**: `→ <tool>: <key_arg> <result_summary>`
  - `bash`: truncated command + first meaningful output line (or `✓` if empty)
  - `read`/`read_file`: file path + `✓ (N lines)`
  - `edit`/`write`: file path + `✓` or `✗`
  - `glob`/`grep`: pattern + `N matches` or `no matches`
  - `task`: description + `✓` or `✗`
  - `todowrite`: `✓`

Tool calls and their results are **paired into a single line** in default mode.

### `--verbose`

Full tool args and full results rendered as separate lines — same as existing behaviour.

### `--types`

Kept as an orthogonal escape hatch. `state_change` events now render with `●` in raw mode too.

## Example output

```
[2026-04-03 14:22:01] ▶ user
implement the feature and open a PR

[2026-04-03 14:22:05] assistant
I'll implement this now.
  → read: main.go ✓ (42 lines)
  → edit: main.go ✓
  → bash: go build ./... ✓
  → bash: go test ./... — ok (3.2s)

[2026-04-03 14:23:10] assistant
Tests pass. Opening PR.
  → bash: git commit -m "implement feature" ✓
  → bash: gh pr create ... ✓

[2026-04-03 14:23:15] ● finished

── end of event log ──
```

## Files changed

- `cmd/checkin.go` — new `renderChildEventsForTurn`, `toolOneLiner`, and helpers; state_change timeline integration; `▶` user prefix
- `cmd/checkin_test.go` — updated existing test, added 9 new tests
- `opencode/skills/prism/SKILL.md` — updated checkin section with new format and guidance

Closes #649