### PR TITLE
fix(prism): remove preCheck git identity block from prism.nix

### DIFF
--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -21,13 +21,6 @@ buildGoModule {
 
   nativeCheckInputs = [ git ];
 
-  preCheck = ''
-    export GIT_CONFIG_NOSYSTEM=1
-    export HOME=$(mktemp -d)
-    git config --global user.email "test@test.com"
-    git config --global user.name "Test"
-  '';
-
   meta = {
     description = "Prism — tmux-based AI development environment TUI";
     mainProgram = "prism";


### PR DESCRIPTION
## Summary

- Removes the `preCheck` block from `pkgs/prism.nix` that set a global git identity (`test@test.com` / `Test`) during the Nix build test phase
- This block was bleeding into `/prism-git/config` via the container mount, causing `Co-authored-by: Test <test@test.com>` to appear on every commit
- The Go tests set git identity themselves locally per-repo, making this block entirely redundant
- Keeps `nativeCheckInputs = [ git ]` since the tests still invoke git directly and need it on PATH

Closes #658