### PR TITLE
prism: add logs subcommand for reading sidecar log files

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -237,24 +237,12 @@ func proxyLogsFromHostAPI(apiURL, sessionName string, tail int, tailSet bool, fo
 		return fmt.Errorf("proxyLogsFromHostAPI: build request: %w", err)
 	}
 
-	// No timeout for follow (streaming); 60 s for one-shot reads.
-	var clientTimeout time.Duration
-	if !follow {
-		clientTimeout = 60 * time.Second
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
-				d := &net.Dialer{Timeout: 5 * time.Second}
-				conn, dialErr := d.DialContext(dialCtx, "unix", sockPath)
-				if dialErr != nil {
-					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
-				}
-				return conn, nil
-			},
-		},
-		Timeout: clientTimeout,
+	// Reuse the shared client configuration from newHostAPIClient. For follow
+	// mode (streaming), override the default 60 s timeout to 0 (no timeout)
+	// so the connection is not cut while waiting for new log lines.
+	client := newHostAPIClient(sockPath)
+	if follow {
+		client.Timeout = 0
 	}
 
 	resp, err := client.Do(req)

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -19,7 +19,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -189,6 +192,101 @@ func proxyPrompt(apiURL, session, prompt string) error {
 		"session": session,
 		"prompt":  prompt,
 	}, nil)
+}
+
+// proxyLogsFromHostAPI proxies a GET /logs request to the host-API sidecar
+// and streams the response body directly to w. For follow mode, it handles
+// Ctrl-C gracefully by cancelling the request context.
+func proxyLogsFromHostAPI(apiURL, sessionName string, tail int, tailSet bool, follow bool, w io.Writer) error {
+	sockPath, err := parseUnixSocketURL(apiURL)
+	if err != nil {
+		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
+	}
+
+	// Build URL with query parameters.
+	q := url.Values{}
+	q.Set("session", sessionName)
+	if tailSet {
+		q.Set("tail", fmt.Sprintf("%d", tail))
+	}
+	if follow {
+		q.Set("follow", "true")
+	}
+	rawURL := "http://prism-hostapi/logs?" + q.Encode()
+
+	// For follow mode, use a cancellable context so Ctrl-C exits cleanly.
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if follow {
+		ctx, cancel = context.WithCancel(ctx)
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			select {
+			case <-sigCh:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+		defer signal.Stop(sigCh)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("proxyLogsFromHostAPI: build request: %w", err)
+	}
+
+	// No timeout for follow (streaming); 60 s for one-shot reads.
+	var clientTimeout time.Duration
+	if !follow {
+		clientTimeout = 60 * time.Second
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+				d := &net.Dialer{Timeout: 5 * time.Second}
+				conn, dialErr := d.DialContext(dialCtx, "unix", sockPath)
+				if dialErr != nil {
+					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
+				}
+				return conn, nil
+			},
+		},
+		Timeout: clientTimeout,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Ctrl-C in follow mode: treat as clean exit.
+		if follow && ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("host-API /logs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+			return fmt.Errorf("host-API /logs: %s", errResp.Error)
+		}
+		return fmt.Errorf("host-API /logs: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	_, copyErr := io.Copy(w, resp.Body)
+	if copyErr != nil {
+		// Ctrl-C in follow mode: treat as clean exit.
+		if follow && ctx.Err() != nil {
+			return nil
+		}
+		return copyErr
+	}
+	return nil
 }
 
 // parseUnixSocketURL extracts the filesystem path from a unix:///path URL.

--- a/modules/programs/prism/prism/cmd/logs.go
+++ b/modules/programs/prism/prism/cmd/logs.go
@@ -1,0 +1,254 @@
+package cmd
+
+// prism logs <session> — stream the sidecar log file for a named session.
+//
+// Usage:
+//
+//	prism logs <session>             print the full sidecar log to stdout
+//	prism logs <session> --tail N    print only the last N lines
+//	prism logs <session> --follow    stream new lines as they arrive
+//	prism logs <session> -f          alias for --follow
+//
+// The output is the raw sidecar log file and can be piped to grep:
+//
+//	prism logs nixos-config@main | grep '[timing]'
+//
+// Works identically from the host or inside a coordinator container:
+// when PRISM_HOST_API is set, the log is fetched via GET /logs on the
+// host-API Unix socket.
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs <session>",
+	Short: "Show the sidecar log for a session",
+	Long: `Show the sidecar log for a named prism session.
+
+The output is the raw sidecar log ($XDG_STATE_HOME/prism/logs/<session>-sidecar.log)
+and can be piped to grep for filtering:
+
+  prism logs nixos-config@main | grep '[timing]'
+
+Works identically from the host or inside a coordinator container — in
+container mode the log is fetched via the host API Unix socket (PRISM_HOST_API).`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runLogs,
+	SilenceUsage: true,
+}
+
+func init() {
+	logsCmd.Flags().Int("tail", 0, "Number of lines to show from the end of the log (0 = all)")
+	logsCmd.Flags().BoolP("follow", "f", false, "Stream new lines as they are written; exits when session ends or Ctrl-C")
+	rootCmd.AddCommand(logsCmd)
+}
+
+func runLogs(cmd *cobra.Command, args []string) error {
+	sessionName := args[0]
+
+	tailN, _ := cmd.Flags().GetInt("tail")
+	follow, _ := cmd.Flags().GetBool("follow")
+	tailSet := cmd.Flags().Changed("tail")
+
+	if tailSet && follow {
+		fmt.Fprintln(os.Stderr, "error: --tail and --follow are mutually exclusive")
+		os.Exit(1)
+	}
+
+	if tailSet && tailN < 0 {
+		fmt.Fprintln(os.Stderr, "error: --tail must be a non-negative integer")
+		os.Exit(1)
+	}
+
+	// Container proxy path: delegate to the host-API sidecar.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return proxyLogsFromHostAPI(apiURL, sessionName, tailN, tailSet, follow, os.Stdout)
+	}
+
+	// Host path: resolve the sidecar log file.
+	logPath, err := session.SidecarLogPath(sessionName)
+	if err != nil {
+		return fmt.Errorf("resolve log path: %w", err)
+	}
+
+	if _, statErr := os.Stat(logPath); os.IsNotExist(statErr) {
+		fmt.Fprintf(os.Stderr, "no log file found for session %q\n", sessionName)
+		os.Exit(1)
+	}
+
+	if follow {
+		return runLogsFollow(sessionName, logPath)
+	}
+
+	if tailSet {
+		return runLogsTail(logPath, tailN)
+	}
+
+	return runLogsFull(logPath)
+}
+
+// runLogsFull prints the full contents of the log file to stdout.
+func runLogsFull(logPath string) error {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("open log: %w", err)
+	}
+	defer f.Close()
+	_, err = io.Copy(os.Stdout, f)
+	return err
+}
+
+// runLogsTail prints the last n lines of the log file to stdout.
+// If n == 0, nothing is printed.
+func runLogsTail(logPath string, n int) error {
+	if n == 0 {
+		return nil
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("open log: %w", err)
+	}
+	defer f.Close()
+
+	lines, err := tailLinesFromReader(f, n)
+	if err != nil {
+		return fmt.Errorf("tail log: %w", err)
+	}
+
+	bw := bufio.NewWriter(os.Stdout)
+	for _, line := range lines {
+		fmt.Fprintln(bw, line)
+	}
+	return bw.Flush()
+}
+
+// runLogsFollow streams the log file to stdout, blocking until Ctrl-C or
+// the session reaches a terminal state and 5 seconds of silence elapse.
+// If the session is already in a terminal state, prints the full log and exits.
+func runLogsFollow(sessionName, logPath string) error {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("open log: %w", err)
+	}
+	defer f.Close()
+
+	// Open the DB so we can check the session's state.
+	d, dbErr := openDB()
+	if dbErr == nil {
+		defer d.Close()
+		// If the session is already in a terminal state, print the full log and exit.
+		if st, stErr := d.CurrentStatus(sessionName); stErr == nil && st != nil &&
+			isLogsTerminalState(agent.AgentState(st.State)) {
+			_, copyErr := io.Copy(os.Stdout, f)
+			return copyErr
+		}
+	}
+
+	// Stream existing content first.
+	if _, err := io.Copy(os.Stdout, f); err != nil {
+		return fmt.Errorf("read existing log: %w", err)
+	}
+
+	// Set up context for cancellation via Ctrl-C.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var (
+		terminalDetected bool
+		silenceDeadline  time.Time
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			// Read any new content written since the last tick.
+			n, readErr := io.Copy(os.Stdout, f)
+			if readErr != nil && readErr != io.EOF {
+				return fmt.Errorf("stream log: %w", readErr)
+			}
+
+			if terminalDetected {
+				// After terminal state, wait for 5 seconds of silence.
+				if n > 0 {
+					// Got more content: reset the silence deadline.
+					silenceDeadline = time.Now().Add(5 * time.Second)
+				} else if time.Now().After(silenceDeadline) {
+					// 5s of silence after terminal state: exit cleanly.
+					return nil
+				}
+			} else if dbErr == nil {
+				// Check if the session has reached a terminal state.
+				if st, stErr := d.CurrentStatus(sessionName); stErr == nil && st != nil &&
+					isLogsTerminalState(agent.AgentState(st.State)) {
+					terminalDetected = true
+					silenceDeadline = time.Now().Add(5 * time.Second)
+				}
+			}
+		}
+	}
+}
+
+// tailLinesFromReader reads all content from r and returns the last n lines.
+// If the content has fewer than n lines, all lines are returned.
+func tailLinesFromReader(r io.Reader, n int) ([]string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	content := string(data)
+	lines := strings.Split(content, "\n")
+	// Remove trailing empty entry produced when the file ends with a newline.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	if n >= len(lines) {
+		return lines, nil
+	}
+	return lines[len(lines)-n:], nil
+}
+
+// isLogsTerminalState returns true when the agent state is one of the terminal
+// states after which no further log output is expected.
+func isLogsTerminalState(state agent.AgentState) bool {
+	return state == agent.StateFinished ||
+		state == agent.StateInterrupted ||
+		state == agent.StateDeleted ||
+		state == agent.StateError
+}

--- a/modules/programs/prism/prism/cmd/logs.go
+++ b/modules/programs/prism/prism/cmd/logs.go
@@ -52,7 +52,7 @@ container mode the log is fetched via the host API Unix socket (PRISM_HOST_API).
 }
 
 func init() {
-	logsCmd.Flags().Int("tail", 0, "Number of lines to show from the end of the log (0 = all)")
+	logsCmd.Flags().Int("tail", 0, "Number of lines to show from the end of the log; 0 prints nothing (omit flag to show all)")
 	logsCmd.Flags().BoolP("follow", "f", false, "Stream new lines as they are written; exits when session ends or Ctrl-C")
 	rootCmd.AddCommand(logsCmd)
 }
@@ -65,13 +65,11 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	tailSet := cmd.Flags().Changed("tail")
 
 	if tailSet && follow {
-		fmt.Fprintln(os.Stderr, "error: --tail and --follow are mutually exclusive")
-		os.Exit(1)
+		return fmt.Errorf("--tail and --follow are mutually exclusive")
 	}
 
 	if tailSet && tailN < 0 {
-		fmt.Fprintln(os.Stderr, "error: --tail must be a non-negative integer")
-		os.Exit(1)
+		return fmt.Errorf("--tail must be a non-negative integer")
 	}
 
 	// Container proxy path: delegate to the host-API sidecar.
@@ -86,8 +84,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, statErr := os.Stat(logPath); os.IsNotExist(statErr) {
-		fmt.Fprintf(os.Stderr, "no log file found for session %q\n", sessionName)
-		os.Exit(1)
+		return fmt.Errorf("no log file found for session %q", sessionName)
 	}
 
 	if follow {
@@ -193,8 +190,9 @@ func runLogsFollow(sessionName, logPath string) error {
 			return nil
 		case <-ticker.C:
 			// Read any new content written since the last tick.
+			// io.Copy translates EOF to nil, so any non-nil error is real.
 			n, readErr := io.Copy(os.Stdout, f)
-			if readErr != nil && readErr != io.EOF {
+			if readErr != nil {
 				return fmt.Errorf("stream log: %w", readErr)
 			}
 

--- a/modules/programs/prism/prism/cmd/logs_test.go
+++ b/modules/programs/prism/prism/cmd/logs_test.go
@@ -1,0 +1,362 @@
+package cmd
+
+// Tests for the prism logs subcommand.
+//
+// Covers:
+//   - tailLinesFromReader: edge cases (empty, fewer lines than n, more lines, n=0)
+//   - runLogsFull: reads and writes the full file content
+//   - runLogsTail: reads the last N lines correctly
+//   - runLogsFollow: exits immediately when session is already in a terminal state
+//   - proxyLogsFromHostAPI: forwards correct query params, streams response body,
+//     surfaces 404 errors from the host API
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// ── tailLinesFromReader ──────────────────────────────────────────────────────
+
+func TestTailLinesFromReader_Empty(t *testing.T) {
+	r := strings.NewReader("")
+	lines, err := tailLinesFromReader(r, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 0 {
+		t.Errorf("expected 0 lines, got %d: %v", len(lines), lines)
+	}
+}
+
+func TestTailLinesFromReader_FewerLinesThanN(t *testing.T) {
+	content := "line1\nline2\nline3\n"
+	r := strings.NewReader(content)
+	lines, err := tailLinesFromReader(r, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "line1" || lines[1] != "line2" || lines[2] != "line3" {
+		t.Errorf("unexpected lines: %v", lines)
+	}
+}
+
+func TestTailLinesFromReader_ExactN(t *testing.T) {
+	content := "a\nb\nc\n"
+	r := strings.NewReader(content)
+	lines, err := tailLinesFromReader(r, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d: %v", len(lines), lines)
+	}
+}
+
+func TestTailLinesFromReader_MoreLinesThanN(t *testing.T) {
+	content := "a\nb\nc\nd\ne\n"
+	r := strings.NewReader(content)
+	lines, err := tailLinesFromReader(r, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "c" || lines[1] != "d" || lines[2] != "e" {
+		t.Errorf("wrong lines: %v (want c, d, e)", lines)
+	}
+}
+
+func TestTailLinesFromReader_NoTrailingNewline(t *testing.T) {
+	content := "a\nb\nc"
+	r := strings.NewReader(content)
+	lines, err := tailLinesFromReader(r, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "b" || lines[1] != "c" {
+		t.Errorf("wrong lines: %v (want b, c)", lines)
+	}
+}
+
+func TestTailLinesFromReader_NIsOne(t *testing.T) {
+	content := "a\nb\nc\n"
+	r := strings.NewReader(content)
+	lines, err := tailLinesFromReader(r, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "c" {
+		t.Errorf("line = %q, want %q", lines[0], "c")
+	}
+}
+
+// ── runLogsFull ──────────────────────────────────────────────────────────────
+
+func TestRunLogsFull_WritesFullContent(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	content := "2026-01-01 sidecar: starting\n2026-01-01 sidecar: event: session.created\n"
+	logFile := writeTempLogFile(t, content)
+
+	out := captureStdoutFn(t, func() {
+		if err := runLogsFull(logFile); err != nil {
+			t.Errorf("runLogsFull: %v", err)
+		}
+	})
+	if out != content {
+		t.Errorf("output = %q, want %q", out, content)
+	}
+}
+
+func TestRunLogsFull_EmptyFile(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	logFile := writeTempLogFile(t, "")
+
+	out := captureStdoutFn(t, func() {
+		if err := runLogsFull(logFile); err != nil {
+			t.Errorf("runLogsFull: %v", err)
+		}
+	})
+	if out != "" {
+		t.Errorf("expected empty output for empty file, got %q", out)
+	}
+}
+
+// ── runLogsTail ──────────────────────────────────────────────────────────────
+
+func TestRunLogsTail_Zero_NoOutput(t *testing.T) {
+	logFile := writeTempLogFile(t, "a\nb\nc\n")
+	out := captureStdoutFn(t, func() {
+		if err := runLogsTail(logFile, 0); err != nil {
+			t.Errorf("runLogsTail: %v", err)
+		}
+	})
+	if out != "" {
+		t.Errorf("expected empty output for tail=0, got %q", out)
+	}
+}
+
+func TestRunLogsTail_LastN(t *testing.T) {
+	logFile := writeTempLogFile(t, "alpha\nbeta\ngamma\ndelta\n")
+	out := captureStdoutFn(t, func() {
+		if err := runLogsTail(logFile, 2); err != nil {
+			t.Errorf("runLogsTail: %v", err)
+		}
+	})
+	want := "gamma\ndelta\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+func TestRunLogsTail_MoreThanAvailable(t *testing.T) {
+	content := "only\ntwo\n"
+	logFile := writeTempLogFile(t, content)
+	out := captureStdoutFn(t, func() {
+		if err := runLogsTail(logFile, 100); err != nil {
+			t.Errorf("runLogsTail: %v", err)
+		}
+	})
+	want := content
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+// ── runLogsFollow (host-side, already-finished case) ────────────────────────
+
+func TestRunLogsFollow_AlreadyFinished_PrintsAndExits(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	// Create a temp DB and seed a finished session.
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	SetTestDBPath(dbPath)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+	_ = d.UpsertStatus("myrepo@feat", "myrepo", "/wt", "finished", nil, nil)
+	d.Close()
+
+	content := "line1\nline2\nline3\n"
+	logFile := writeTempLogFile(t, content)
+
+	out := captureStdoutFn(t, func() {
+		if err := runLogsFollow("myrepo@feat", logFile); err != nil {
+			t.Errorf("runLogsFollow: %v", err)
+		}
+	})
+	if out != content {
+		t.Errorf("output = %q, want %q", out, content)
+	}
+}
+
+// ── proxyLogsFromHostAPI ─────────────────────────────────────────────────────
+
+// TestProxyLogsFromHostAPI_SendsCorrectQueryParams verifies that the proxy
+// function sends the correct session and tail query parameters as a GET request.
+func TestProxyLogsFromHostAPI_SendsCorrectQueryParams(t *testing.T) {
+	var capturedPath string
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("log line 1\nlog line 2\n"))
+	})
+
+	var buf bytes.Buffer
+	err := proxyLogsFromHostAPI(srv.apiURL(), "myrepo@main", 5, true, false, &buf)
+	if err != nil {
+		t.Fatalf("proxyLogsFromHostAPI: %v", err)
+	}
+
+	if capturedPath != "/logs" {
+		t.Errorf("path = %q, want /logs", capturedPath)
+	}
+	// session param should be percent-encoded.
+	if !strings.Contains(capturedQuery, "session=myrepo%40main") {
+		t.Errorf("query %q should contain session=myrepo%%40main", capturedQuery)
+	}
+	if !strings.Contains(capturedQuery, "tail=5") {
+		t.Errorf("query %q should contain tail=5", capturedQuery)
+	}
+	if strings.Contains(capturedQuery, "follow") {
+		t.Errorf("query %q should not contain follow (not set)", capturedQuery)
+	}
+
+	got := buf.String()
+	if got != "log line 1\nlog line 2\n" {
+		t.Errorf("body = %q, want log content", got)
+	}
+}
+
+// TestProxyLogsFromHostAPI_NoTailParam verifies that when tailSet=false,
+// the tail parameter is omitted from the query.
+func TestProxyLogsFromHostAPI_NoTailParam(t *testing.T) {
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("full log\n"))
+	})
+
+	var buf bytes.Buffer
+	err := proxyLogsFromHostAPI(srv.apiURL(), "myrepo@main", 0, false, false, &buf)
+	if err != nil {
+		t.Fatalf("proxyLogsFromHostAPI: %v", err)
+	}
+
+	if strings.Contains(capturedQuery, "tail") {
+		t.Errorf("query %q should not contain tail when tailSet=false", capturedQuery)
+	}
+}
+
+// TestProxyLogsFromHostAPI_Returns404AsError verifies that a 404 from the
+// host API is surfaced as an error with the error message.
+func TestProxyLogsFromHostAPI_Returns404AsError(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		body, _ := json.Marshal(map[string]string{"error": "no log file for session myrepo@nonexistent"})
+		_, _ = w.Write(body)
+	})
+
+	var buf bytes.Buffer
+	err := proxyLogsFromHostAPI(srv.apiURL(), "myrepo@nonexistent", 0, false, false, &buf)
+	if err == nil {
+		t.Fatal("expected non-nil error for 404 response")
+	}
+	if !strings.Contains(err.Error(), "no log file for session") {
+		t.Errorf("error %q should contain 'no log file for session'", err.Error())
+	}
+}
+
+// TestProxyLogsFromHostAPI_FollowSendsFollowParam verifies that follow=true
+// adds follow=true to the query.
+func TestProxyLogsFromHostAPI_FollowSendsFollowParam(t *testing.T) {
+	var capturedQuery string
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("streamed content\n"))
+	})
+
+	var buf bytes.Buffer
+	// follow=true but server immediately closes: should not block.
+	err := proxyLogsFromHostAPI(srv.apiURL(), "myrepo@main", 0, false, true, &buf)
+	if err != nil {
+		t.Fatalf("proxyLogsFromHostAPI: %v", err)
+	}
+
+	if !strings.Contains(capturedQuery, "follow=true") {
+		t.Errorf("query %q should contain follow=true", capturedQuery)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// writeTempLogFile creates a temp file with the given content and returns its path.
+func writeTempLogFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "test-sidecar-*.log")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if content != "" {
+		if _, err := io.WriteString(f, content); err != nil {
+			t.Fatalf("write temp log: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+// captureStdoutFn captures stdout for the duration of fn and returns what was
+// written. Named differently from captureStdout (checkin_test.go) to avoid a
+// duplicate symbol in the same package.
+func captureStdoutFn(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+	return buf.String()
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1606,6 +1606,133 @@ func isCoordinator(sessionName string) bool {
 	return strings.HasSuffix(sessionName, "@main")
 }
 
+// isHostAPITerminalState returns true when the agent state is a terminal state
+// for the purpose of the host-API /logs follow handler.
+func isHostAPITerminalState(state agent.AgentState) bool {
+	return state == agent.StateFinished ||
+		state == agent.StateInterrupted ||
+		state == agent.StateDeleted ||
+		state == agent.StateError
+}
+
+// hostAPIServeLogsTail writes the last n lines of the log file to w.
+// When n == 0, the response body is empty.
+func hostAPIServeLogsTail(w http.ResponseWriter, logPath string, n int) {
+	if n == 0 {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		http.Error(w, `{"error":"cannot open log"}`, http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		http.Error(w, `{"error":"cannot read log"}`, http.StatusInternalServerError)
+		return
+	}
+
+	content := string(data)
+	lines := strings.Split(content, "\n")
+	// Remove trailing empty entry produced when the file ends with a newline.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	if n < len(lines) {
+		lines = lines[len(lines)-n:]
+	}
+
+	w.WriteHeader(http.StatusOK)
+	for _, line := range lines {
+		_, _ = fmt.Fprintln(w, line)
+	}
+}
+
+// hostAPIServeLogsFollow streams the log file to w, keeping the connection
+// open until the session reaches a terminal state and 5 seconds of silence
+// elapse, or the client disconnects.
+func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSession, logPath string, s *Sidecar) {
+	f, err := os.Open(logPath)
+	if err != nil {
+		http.Error(w, `{"error":"cannot open log"}`, http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	flusher, canFlush := w.(http.Flusher)
+
+	// isTerminal checks the DB for a terminal agent state.
+	isTerminal := func() bool {
+		st, dbErr := s.cfg.DB.CurrentStatus(targetSession)
+		if dbErr != nil || st == nil {
+			return false
+		}
+		return isHostAPITerminalState(agent.AgentState(st.State))
+	}
+
+	// If the session is already in a terminal state, send the full existing
+	// log and return immediately.
+	if isTerminal() {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, f)
+		if canFlush {
+			flusher.Flush()
+		}
+		return
+	}
+
+	// Stream the existing content first, then poll for new lines.
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.Copy(w, f)
+	if canFlush {
+		flusher.Flush()
+	}
+
+	ctx := r.Context()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var (
+		terminalDetected bool
+		silenceDeadline  time.Time
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			n, readErr := io.Copy(w, f)
+			if readErr != nil {
+				return
+			}
+			if n > 0 && canFlush {
+				flusher.Flush()
+			}
+
+			if terminalDetected {
+				// Reset the silence deadline each time new content arrives.
+				if n > 0 {
+					silenceDeadline = time.Now().Add(5 * time.Second)
+				} else if time.Now().After(silenceDeadline) {
+					// 5 s of silence after terminal state: close the connection.
+					return
+				}
+			} else {
+				if isTerminal() {
+					terminalDetected = true
+					silenceDeadline = time.Now().Add(5 * time.Second)
+				}
+			}
+		}
+	}
+}
+
 // hostAPIHandler returns an http.Handler that exposes host-side tmux operations
 // to agents running inside the container via a Unix socket. Routes:
 //
@@ -1884,6 +2011,90 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			"state":   state,
 			"events":  events,
 		})
+	})
+
+	// GET /logs
+	// Query params: session (required), tail (optional int ≥ 0), follow (optional bool)
+	// Permission: coordinator only; own-repo sessions or cross-repo @main sessions.
+	// Returns 404 with JSON error when the log file does not exist.
+	// When follow=true, streams new lines and closes after the session reaches a
+	// terminal state and 5 s of silence elapse.
+	mux.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "logs") {
+			return
+		}
+
+		q := r.URL.Query()
+		targetSession := q.Get("session")
+		if targetSession == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+
+		// Permission check: own-repo sessions or cross-repo @main sessions.
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		if repoErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+			return
+		}
+		targetRepo, targetRepoErr := repoFromSession(targetSession)
+		if targetRepoErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			return
+		}
+		if targetRepo != ownRepo && !isCoordinator(targetSession) {
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("cross-repo logs can only target coordinators (<repo>@main), got %q", targetSession))
+			return
+		}
+
+		// Resolve log file path.
+		logPath, pathErr := session.SidecarLogPath(targetSession)
+		if pathErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot resolve log path: "+pathErr.Error())
+			return
+		}
+		if _, statErr := os.Stat(logPath); os.IsNotExist(statErr) {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("no log file for session %s", targetSession))
+			return
+		}
+
+		// Parse optional tail param (non-negative integer).
+		tailN := 0
+		tailSet := false
+		if tailStr := q.Get("tail"); tailStr != "" {
+			if n, parseErr := strconv.Atoi(tailStr); parseErr == nil && n >= 0 {
+				tailN = n
+				tailSet = true
+			}
+		}
+
+		follow := q.Get("follow") == "true"
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+		if follow {
+			hostAPIServeLogsFollow(w, r, targetSession, logPath, s)
+			return
+		}
+
+		if tailSet {
+			hostAPIServeLogsTail(w, logPath, tailN)
+			return
+		}
+
+		// Full log: stream the whole file.
+		f, openErr := os.Open(logPath)
+		if openErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot open log: "+openErr.Error())
+			return
+		}
+		defer f.Close()
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, f)
 	})
 
 	// POST /prompt

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2034,6 +2034,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
+		// Validate session name format before semantic permission checks.
+		// Valid session names are "repo@branch" — slashes and dot-segments are
+		// not valid and would escape the logs directory via filepath.Join.
+		if strings.Contains(targetSession, "/") || strings.Contains(targetSession, "..") {
+			writeError(w, http.StatusBadRequest, "invalid session name: must not contain '/' or '..'")
+			return
+		}
+
 		// Permission check: own-repo sessions or cross-repo @main sessions.
 		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
 		if repoErr != nil {
@@ -2048,14 +2056,6 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if targetRepo != ownRepo && !isCoordinator(targetSession) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("cross-repo logs can only target coordinators (<repo>@main), got %q", targetSession))
-			return
-		}
-
-		// Guard against path traversal: session names must not contain "/" or "..".
-		// Valid session names are "repo@branch" — slashes and dot-segments are not
-		// part of the format and would escape the logs directory via filepath.Join.
-		if strings.Contains(targetSession, "/") || strings.Contains(targetSession, "..") {
-			writeError(w, http.StatusBadRequest, "invalid session name: must not contain '/' or '..'")
 			return
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2051,6 +2051,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
+		// Guard against path traversal: session names must not contain "/" or "..".
+		// Valid session names are "repo@branch" — slashes and dot-segments are not
+		// part of the format and would escape the logs directory via filepath.Join.
+		if strings.Contains(targetSession, "/") || strings.Contains(targetSession, "..") {
+			writeError(w, http.StatusBadRequest, "invalid session name: must not contain '/' or '..'")
+			return
+		}
+
 		// Resolve log file path.
 		logPath, pathErr := session.SidecarLogPath(targetSession)
 		if pathErr != nil {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5227,3 +5227,200 @@ func TestHostAPI_Checkin_DefaultReturnsAssistantTurnsNotRawEvents(t *testing.T) 
 		t.Error("tool_call child event not found in response (turn-centric query should include it)")
 	}
 }
+
+// ── /logs ─────────────────────────────────────────────────────────────────────
+
+// TestHostAPI_Logs_WorkerForbidden verifies that a worker container receives
+// HTTP 403 when it tries to fetch logs.
+func TestHostAPI_Logs_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=myrepo@main", "")
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+// TestHostAPI_Logs_MissingSessionParam verifies that omitting the session
+// parameter returns HTTP 400.
+func TestHostAPI_Logs_MissingSessionParam(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs", "")
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+// TestHostAPI_Logs_MissingLogFile verifies that a missing log file returns
+// HTTP 404 with the expected JSON error body.
+func TestHostAPI_Logs_MissingLogFile(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=myrepo@main", "")
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "no log file for session") {
+		t.Errorf("error %q should mention 'no log file for session'", errResp["error"])
+	}
+}
+
+// TestHostAPI_Logs_CoordinatorOwnRepo verifies that a coordinator can fetch
+// logs for a session in its own repo.
+func TestHostAPI_Logs_CoordinatorOwnRepo(t *testing.T) {
+	logContent := "2026-01-01 sidecar: starting\n2026-01-01 sidecar: event: session.created\n"
+	logPath := writeSidecarLogFile(t, "myrepo@feature", logContent)
+	_ = logPath // used via the sidecar's SidecarLogPath resolution
+
+	// Override XDG_STATE_HOME so the sidecar resolves the log to our temp file.
+	logDir := filepath.Dir(logPath)
+	stateDir := filepath.Dir(filepath.Dir(logDir)) // …/prism → parent of prism
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=myrepo@feature", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if rr.Body.String() != logContent {
+		t.Errorf("body = %q, want %q", rr.Body.String(), logContent)
+	}
+}
+
+// TestHostAPI_Logs_CoordinatorCrossRepoCoordinator verifies that a coordinator
+// can fetch logs for a cross-repo @main session.
+func TestHostAPI_Logs_CoordinatorCrossRepoCoordinator(t *testing.T) {
+	logContent := "cross-repo log line\n"
+	logPath := writeSidecarLogFile(t, "otherrepo@main", logContent)
+	_ = logPath
+	logDir := filepath.Dir(logPath)
+	stateDir := filepath.Dir(filepath.Dir(logDir))
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=otherrepo@main", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if rr.Body.String() != logContent {
+		t.Errorf("body = %q, want %q", rr.Body.String(), logContent)
+	}
+}
+
+// TestHostAPI_Logs_CoordinatorCrossRepoNonCoordinatorForbidden verifies that a
+// coordinator cannot fetch logs for a cross-repo non-@main session.
+func TestHostAPI_Logs_CoordinatorCrossRepoNonCoordinatorForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=otherrepo@feature", "")
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "cross-repo") {
+		t.Errorf("error %q should mention 'cross-repo'", errResp["error"])
+	}
+}
+
+// TestHostAPI_Logs_TailParam verifies that tail=N returns only the last N lines.
+func TestHostAPI_Logs_TailParam(t *testing.T) {
+	logContent := "alpha\nbeta\ngamma\ndelta\n"
+	logPath := writeSidecarLogFile(t, "myrepo@feature", logContent)
+	_ = logPath
+	logDir := filepath.Dir(logPath)
+	stateDir := filepath.Dir(filepath.Dir(logDir))
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=myrepo@feature&tail=2", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	want := "gamma\ndelta\n"
+	if rr.Body.String() != want {
+		t.Errorf("body = %q, want %q", rr.Body.String(), want)
+	}
+}
+
+// TestHostAPI_Logs_TailZero verifies that tail=0 returns an empty body.
+func TestHostAPI_Logs_TailZero(t *testing.T) {
+	logContent := "line1\nline2\n"
+	logPath := writeSidecarLogFile(t, "myrepo@feature", logContent)
+	_ = logPath
+	logDir := filepath.Dir(logPath)
+	stateDir := filepath.Dir(filepath.Dir(logDir))
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=myrepo@feature&tail=0", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if rr.Body.String() != "" {
+		t.Errorf("body = %q, want empty (tail=0)", rr.Body.String())
+	}
+}
+
+// TestHostAPI_Logs_TailMoreThanLines verifies that tail=N where N > line count
+// returns all lines.
+func TestHostAPI_Logs_TailMoreThanLines(t *testing.T) {
+	logContent := "only\ntwo\nlines\n"
+	logPath := writeSidecarLogFile(t, "myrepo@feature", logContent)
+	_ = logPath
+	logDir := filepath.Dir(logPath)
+	stateDir := filepath.Dir(filepath.Dir(logDir))
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/logs?session=myrepo@feature&tail=100", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if rr.Body.String() != logContent {
+		t.Errorf("body = %q, want %q", rr.Body.String(), logContent)
+	}
+}
+
+// writeSidecarLogFile creates a temporary sidecar log file for a session in a
+// temp state directory and returns its path. The caller must set XDG_STATE_HOME
+// to the parent of the "prism" directory so that SidecarLogPath resolves to it.
+func writeSidecarLogFile(t *testing.T, sessionName, content string) string {
+	t.Helper()
+	stateHome := t.TempDir()
+	logDir := filepath.Join(stateHome, "prism", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	logPath := filepath.Join(logDir, sessionName+"-sidecar.log")
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	// Return the stateHome so callers can set XDG_STATE_HOME.
+	// The logPath is: stateHome/prism/logs/<session>-sidecar.log
+	// But callers need stateHome itself for XDG_STATE_HOME.
+	// Return logPath; caller derives stateHome via filepath.Dir x3.
+	return logPath
+}


### PR DESCRIPTION
## Summary

- Adds `prism logs <session>` subcommand that reads the sidecar log file for a named session to stdout
- Supports `--tail N` (last N lines) and `--follow` / `-f` (live streaming with terminal-state exit)
- Works from the host and inside coordinator containers (proxied via host-API Unix socket, `GET /logs`)
- Host-API `/logs` endpoint: coordinator-only, own-repo + cross-repo `@main` scope, 404 for missing logs, `follow=true` streams until terminal state + 5s silence

## Files changed

- `cmd/logs.go` (NEW) — CLI command with host-side log read, tail, and follow logic
- `cmd/logs_test.go` (NEW) — unit tests for tail, full read, follow (already-finished), proxy param forwarding
- `cmd/hostapi.go` — adds `proxyLogsFromHostAPI` for streaming container-proxy path
- `internal/sidecar/sidecar.go` — adds `GET /logs` handler with tail/follow/security guards
- `internal/sidecar/sidecar_test.go` — host-API handler tests (403 worker, 404 missing, tail, cross-repo scope)

Closes #656