### PR TITLE
fix(test): use random session name in TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -485,7 +485,7 @@ func TestHeadlessCloseSession_NonWorktree_MarksEnded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	sessionName := "obsidian"
+	sessionName := fmt.Sprintf("prism-test-headless-%d", time.Now().UnixNano())
 	if err := d.UpsertStatus(sessionName, "", "", "running", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
@@ -518,7 +518,7 @@ func TestHeadlessCloseSession_NonWorktree_MarksEnded(t *testing.T) {
 // TestHeadlessCloseSession_NonWorktree_NoDB verifies that headlessCloseSession
 // exits 0 even when no DB row exists for the session (never recorded).
 func TestHeadlessCloseSession_NonWorktree_NoDB(t *testing.T) {
-	// Point openDB at an empty temp DB (no row for "obsidian").
+	// Point openDB at an empty temp DB (no row for the session).
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {
@@ -529,7 +529,8 @@ func TestHeadlessCloseSession_NonWorktree_NoDB(t *testing.T) {
 	SetTestDBPath(dbFile)
 	t.Cleanup(func() { SetTestDBPath("") })
 
-	if err := headlessCloseSession("obsidian"); err != nil {
+	sessionName := fmt.Sprintf("prism-test-headless-%d", time.Now().UnixNano())
+	if err := headlessCloseSession(sessionName); err != nil {
 		t.Errorf("headlessCloseSession returned error %v, want nil (no DB row)", err)
 	}
 }

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -634,7 +634,7 @@ func TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	sessionName := "obsidian"
+	sessionName := fmt.Sprintf("prism-test-headless-%d", time.Now().UnixNano())
 	if err := d.UpsertStatus(sessionName, "", "", "running", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"obsidian"` session name in `TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded` with a unique randomly-generated name using `fmt.Sprintf("prism-test-headless-%d", time.Now().UnixNano())`
- This prevents the test from colliding with (and killing) a live tmux session named `obsidian` when the test suite runs
- The test still exercises the same code path: `headlessCloseSession` is called with no matching tmux session present, and the DB row is correctly marked as ended

Closes #666