### PR TITLE
fix: invert COALESCE direction in UpsertStatusWithRootAgent so sidecar wins

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -361,9 +361,9 @@ ON CONFLICT(session_name) DO UPDATE SET
 }
 
 // UpdateRootModelID unconditionally sets root_model_id for sessionName to the
-// given model value. Unlike UpsertStatusWithRootAgent (which uses COALESCE to
-// preserve the existing value), this method always overwrites, allowing the
-// current session's model to replace a stale value from a prior session.
+// given model value. Like UpsertStatusWithRootAgent, this always reflects the
+// latest sidecar-provided model, ensuring coordinator notifications always
+// reflect the live model configuration.
 //
 // It is a no-op when no row exists for sessionName (returns nil).
 // Called by the sidecar when a completed assistant message from the root agent
@@ -381,14 +381,16 @@ func (d *DB) UpdateRootModelID(sessionName, modelID string) error {
 }
 
 // UpsertStatusWithRootAgent is like UpsertStatusWithAgent but also writes
-// root_agent_name and root_model_id on the initial INSERT. On conflict (update),
-// root_agent_name and root_model_id are preserved via COALESCE — once set, they
-// are never overwritten.
+// root_agent_name and root_model_id. On conflict (update), root_agent_name and
+// root_model_id prefer the incoming (excluded) value via COALESCE — the sidecar
+// is authoritative and can correct a stale or wrong value on every state update.
 //
 // The Go sidecar is the authoritative source of root_agent_name: it calls this
-// method on every state transition when Config.AgentRole is set, seeding the
-// value from the agent role on the initial INSERT and preserving it on subsequent
-// UPDATEs. The TypeScript plugin (prism-hooks.ts) does not write root_agent_name.
+// method on every state transition when Config.AgentRole is set. Because the
+// sidecar value takes precedence, a row written with the wrong root_agent_name
+// (e.g. from a legacy or race-condition write) is corrected on the very next
+// sidecar call. The TypeScript plugin (prism-hooks.ts) does not write
+// root_agent_name.
 func (d *DB) UpsertStatusWithRootAgent(sessionName, repo, worktree, state string, title *string, opencodeSID *string, agentName *string, modelID *string) error {
 	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusWithRootAgent")
 	now := time.Now().UnixMilli()
@@ -401,8 +403,8 @@ ON CONFLICT(session_name) DO UPDATE SET
   opencode_sid    = COALESCE(excluded.opencode_sid, opencode_sid),
   agent_name      = COALESCE(excluded.agent_name, agent_name),
   model_id        = COALESCE(excluded.model_id, model_id),
-  root_agent_name = COALESCE(root_agent_name, excluded.root_agent_name),
-  root_model_id   = COALESCE(root_model_id, excluded.root_model_id),
+  root_agent_name = COALESCE(excluded.root_agent_name, root_agent_name),
+  root_model_id   = COALESCE(excluded.root_model_id, root_model_id),
   last_seen       = excluded.last_seen`
 	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, opencodeSID, agentName, modelID, agentName, modelID, now)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -361,9 +361,10 @@ ON CONFLICT(session_name) DO UPDATE SET
 }
 
 // UpdateRootModelID unconditionally sets root_model_id for sessionName to the
-// given model value. Like UpsertStatusWithRootAgent, this always reflects the
-// latest sidecar-provided model, ensuring coordinator notifications always
-// reflect the live model configuration.
+// given model value. Unlike UpsertStatusWithRootAgent (which falls back to the
+// existing value when the incoming value is nil), this method always overwrites,
+// allowing the current session's model to replace a stale value from a prior
+// session.
 //
 // It is a no-op when no row exists for sessionName (returns nil).
 // Called by the sidecar when a completed assistant message from the root agent

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -881,7 +881,8 @@ func TestUpsertStatusWithAgent(t *testing.T) {
 }
 
 // TestUpsertStatusWithRootAgent verifies that root_agent_name and root_model_id
-// are set on initial insert and never overwritten on subsequent upserts.
+// are set on insert and that a subsequent UpsertStatusWithRootAgent call with a
+// non-nil value overwrites them (sidecar is authoritative).
 func TestUpsertStatusWithRootAgent(t *testing.T) {
 	d := openTestDB(t)
 
@@ -930,7 +931,8 @@ func TestUpsertStatusWithRootAgent(t *testing.T) {
 		t.Errorf("RootModelID after subagent: got %v, want preserved original model", s2.RootModelID)
 	}
 
-	// UpsertStatusWithRootAgent on existing row must also not overwrite root fields.
+	// UpsertStatusWithRootAgent on existing row must overwrite root fields with
+	// the new sidecar-provided values (sidecar is authoritative, corrects stale values).
 	newAgent := strPtr("coordinator")
 	newModel := strPtr("github-copilot/gpt-4o")
 	if err := d.UpsertStatusWithRootAgent("repo@main", "repo", "/code/repo/main", "active", nil, nil, newAgent, newModel); err != nil {
@@ -940,11 +942,51 @@ func TestUpsertStatusWithRootAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CurrentStatus (second root upsert): %v", err)
 	}
-	if s3.RootAgentName == nil || *s3.RootAgentName != "worker" {
-		t.Errorf("RootAgentName after second root upsert: got %v, want still \"worker\"", s3.RootAgentName)
+	if s3.RootAgentName == nil || *s3.RootAgentName != "coordinator" {
+		t.Errorf("RootAgentName after second root upsert: got %v, want \"coordinator\" (sidecar value wins)", s3.RootAgentName)
+	}
+	if s3.RootModelID == nil || *s3.RootModelID != "github-copilot/gpt-4o" {
+		t.Errorf("RootModelID after second root upsert: got %v, want \"github-copilot/gpt-4o\" (sidecar value wins)", s3.RootModelID)
 	}
 	if s3.AgentName == nil || *s3.AgentName != "coordinator" {
 		t.Errorf("AgentName after second root upsert: got %v, want \"coordinator\" (current agent updated)", s3.AgentName)
+	}
+}
+
+// TestUpsertStatusWithRootAgent_SidecarWins verifies that calling
+// UpsertStatusWithRootAgent twice — first with agentName="worker", then with
+// agentName="coordinator" — results in root_agent_name="coordinator".
+// The sidecar is authoritative and must be able to correct a stale or wrong value.
+func TestUpsertStatusWithRootAgent_SidecarWins(t *testing.T) {
+	d := openTestDB(t)
+
+	// First call: write with "worker" (simulating a stale/wrong initial value).
+	if err := d.UpsertStatusWithRootAgent("repo@main", "repo", "/code/repo/main", "idle", nil, nil, strPtr("worker"), strPtr("model-old")); err != nil {
+		t.Fatalf("UpsertStatusWithRootAgent (first call): %v", err)
+	}
+
+	s1, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus (first call): %v", err)
+	}
+	if s1.RootAgentName == nil || *s1.RootAgentName != "worker" {
+		t.Errorf("RootAgentName after first call: got %v, want \"worker\"", s1.RootAgentName)
+	}
+
+	// Second call: sidecar corrects with "coordinator". The new value must win.
+	if err := d.UpsertStatusWithRootAgent("repo@main", "repo", "/code/repo/main", "active", nil, nil, strPtr("coordinator"), strPtr("model-new")); err != nil {
+		t.Fatalf("UpsertStatusWithRootAgent (second call): %v", err)
+	}
+
+	s2, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus (second call): %v", err)
+	}
+	if s2.RootAgentName == nil || *s2.RootAgentName != "coordinator" {
+		t.Errorf("RootAgentName after second call: got %v, want \"coordinator\" (sidecar value must win)", s2.RootAgentName)
+	}
+	if s2.RootModelID == nil || *s2.RootModelID != "model-new" {
+		t.Errorf("RootModelID after second call: got %v, want \"model-new\" (sidecar value must win)", s2.RootModelID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes the inverted COALESCE direction in `UpsertStatusWithRootAgent` so the incoming sidecar value takes precedence over any existing DB value for `root_agent_name` and `root_model_id`
- Updates the function comment to reflect that the sidecar is authoritative and corrects stale values on every state update
- Adds a unit test `TestUpsertStatusWithRootAgent_SidecarWins` that calls `UpsertStatusWithRootAgent` twice (worker → coordinator) and asserts the second value wins
- Updates the existing `TestUpsertStatusWithRootAgent` test to expect the correct new behaviour

## Root cause

The previous SQL preserved the first-written value forever:
```sql
root_agent_name = COALESCE(root_agent_name, excluded.root_agent_name)
```

If the first write was wrong (e.g. a legacy session or race condition), the wrong value was frozen even though every subsequent sidecar call passed the correct `AgentRole`.

## Fix

```sql
root_agent_name = COALESCE(excluded.root_agent_name, root_agent_name)
root_model_id   = COALESCE(excluded.root_model_id, root_model_id)
```

The sidecar value now takes precedence. A `NULL` incoming value still falls back to the existing DB value (preserving the no-op-when-nil behaviour for calls that don't provide a value).

Closes #668