### PR TITLE
fix: rename programs.opencode.rules to programs.opencode.context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ For example:
 - opencode configuration → `modules/programs/prism/opencode.nix`
 - Custom opencode agents → `modules/programs/prism/opencode/agents/`
 - opencode skills → `modules/programs/prism/opencode/skills/`
-- Global opencode agent instructions (`~/.config/opencode/AGENTS.md`) → `modules/programs/prism/opencode.nix` (the `agentInstructions` string, rendered via `programs.opencode.rules`) — **never edit the file at `~/.config` directly, it is overwritten on every switch**
+- Global opencode agent instructions (`~/.config/opencode/AGENTS.md`) → `modules/programs/prism/opencode.nix` (the `agentInstructions` string, rendered via `programs.opencode.context`) — **never edit the file at `~/.config` directly, it is overwritten on every switch**
 
 If you need to understand how something is configured, `grep` or `glob` within the working directory before reaching outside it.
 

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -921,7 +921,7 @@
               ++ authPlugins;
               provider = providerSettings;
             };
-            rules = agentInstructions;
+            context = agentInstructions;
           };
           # Copy the MCP proxy script
           xdg.configFile."opencode/mcp-atlassian-slim-proxy.mjs" = {


### PR DESCRIPTION
## Summary

- Renames `programs.opencode.rules` to `programs.opencode.context` in `modules/programs/prism/opencode.nix` to fix a deprecation warning on every `darwin-rebuild switch`
- Updates the documentation reference in `AGENTS.md` to use the new option name

## Acceptance Criteria
- [x] `programs.opencode.rules` replaced with `programs.opencode.context` in opencode.nix
- [x] `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel` succeeds with no warning about `programs.opencode.rules`
- [x] No other files reference `programs.opencode.rules`