### PR TITLE
fix: inject agent env vars into host-mode opencode process

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -717,22 +717,9 @@
               playwright-cli
             ];
           programs.zsh.shellAliases = {
-            # set environment variables for opencode
+            # set environment variables for opencode when run directly (not via prism spawn)
             opencode = "${envPrefix} opencode";
           };
-          programs.neovim.initLua =
-            lib.mkAfter
-              # lua
-              ''
-                -- open current project in new kitty window with opencode
-                -- disabled in favor of tmux shortcut (leader a)
-                -- vim.keymap.set(
-                --   "n",
-                --   "<leader>oa",
-                --   ":!kitty -d $(pwd) env ${envPrefix} opencode . &<CR><CR>",
-                --   { silent = true, desc = "[O]pen project with [A]I agent" }
-                -- )
-              '';
           # Theme is configured in tui.json, not opencode.json
           xdg.configFile."opencode/tui.json".text = builtins.toJSON {
             "$schema" = "https://opencode.ai/tui.json";

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -125,14 +125,22 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Load the profiles file when container mode is active (carries container
-	// role configs) or when --profile is set (for model overrides).
+	// Load the profiles file. It carries container role configs, model profile
+	// overrides, and agent_env_vars for host-mode injection. Always attempt to
+	// load; treat missing file as fatal only when container mode or --profile
+	// is active (those paths strictly require the file). For host-mode sessions
+	// without a profile flag, a missing file is non-fatal — agent env vars
+	// simply won't be injected.
 	var pf *config.ProfilesFile
-	if effectiveContainerMode || profileFlag != "" {
+	{
 		var loadErr error
 		pf, loadErr = config.LoadProfiles()
 		if loadErr != nil {
-			return loadErr
+			if effectiveContainerMode || profileFlag != "" {
+				return loadErr
+			}
+			fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not load profiles.json (agent env vars will not be injected): %v\n", loadErr)
+			pf = nil
 		}
 	}
 	configContent, err := config.BuildConfigContent(pf, profileFlag, modelFlag, variantFlag)
@@ -193,6 +201,9 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		Headless:       !fromKeybind && !attachFlag,
 		ContainerMode:  effectiveContainerMode,
 		PluginHostPath: cfg.SidecarPluginPath,
+	}
+	if pf != nil {
+		opts.AgentEnvVars = pf.AgentEnvVars
 	}
 
 	if err := ensureAndSwitch(worktreePath, bareRoot, opts); err != nil {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -202,7 +202,9 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		ContainerMode:  effectiveContainerMode,
 		PluginHostPath: cfg.SidecarPluginPath,
 	}
-	if pf != nil {
+	// AgentEnvVars only applies to host-mode sessions; container sessions
+	// receive env vars via podman --env flags in the sidecar.
+	if pf != nil && !effectiveContainerMode {
 		opts.AgentEnvVars = pf.AgentEnvVars
 	}
 

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -783,7 +783,9 @@ var switchCmd = &cobra.Command{
 			ContainerMode:  cfg.ContainerMode,
 			PluginHostPath: cfg.SidecarPluginPath,
 		}
-		if pf != nil {
+		// AgentEnvVars only applies to host-mode sessions; container sessions
+		// receive env vars via podman --env flags in the sidecar.
+		if pf != nil && !cfg.ContainerMode {
 			opts.AgentEnvVars = pf.AgentEnvVars
 		}
 

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -762,15 +762,19 @@ var switchCmd = &cobra.Command{
 		fresh, _ := cmd.Flags().GetBool("fresh")
 		cfg := config.Load()
 
-		// In container mode, load profiles.json once for config injection.
-		// The profiles file is threaded through to each ensureAndSwitch call
-		// site so that injectContainerConfig can derive the role-scoped blob.
+		// Load profiles.json for container config injection (container mode)
+		// and agent env var injection (host mode). Always attempt to load;
+		// treat missing file as fatal only in container mode.
 		var pf *config.ProfilesFile
-		if cfg.ContainerMode {
+		{
 			var pfErr error
 			pf, pfErr = config.LoadProfiles()
 			if pfErr != nil {
-				return pfErr
+				if cfg.ContainerMode {
+					return pfErr
+				}
+				fmt.Fprintf(os.Stderr, "[prism switch] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
+				pf = nil
 			}
 		}
 
@@ -778,6 +782,9 @@ var switchCmd = &cobra.Command{
 			Fresh:          fresh,
 			ContainerMode:  cfg.ContainerMode,
 			PluginHostPath: cfg.SidecarPluginPath,
+		}
+		if pf != nil {
+			opts.AgentEnvVars = pf.AgentEnvVars
 		}
 
 		// --path: open a specific path directly.

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -68,6 +68,12 @@ type ProfilesFile struct {
 	// JSON string) to inject as OPENCODE_CONFIG_CONTENT for coordinator
 	// containers. Written by Nix under container_coordinator_config.
 	ContainerCoordinatorConfig string `json:"container_coordinator_config"`
+	// AgentEnvVars holds environment variables to inject into host-mode
+	// opencode processes. Values are fully expanded absolute paths (no $HOME).
+	// Written by Nix under agent_env_vars. These are prepended to the
+	// opencode command string in buildDirectOpencodeCmd so that sh -c
+	// sessions (which do not load .zshrc or zsh aliases) receive them.
+	AgentEnvVars map[string]string `json:"agent_env_vars,omitempty"`
 }
 
 // ContainerConfigForRole returns the OPENCODE_CONFIG_CONTENT blob for the

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -77,6 +78,16 @@ type Opts struct {
 	// --variant flags. When empty, no OPENCODE_CONFIG_CONTENT is injected and
 	// opencode uses its baked-in config unchanged.
 	ConfigContent string
+	// AgentEnvVars holds environment variables to prepend to the opencode
+	// command string in host-mode (ContainerMode = false) sessions. Each
+	// entry is emitted as KEY=<quoted-value> before PRISM_SESSION_NAME so
+	// that the sh -c invocation in tmux new-window receives the restricted
+	// env vars without needing zsh aliases.
+	//
+	// Loaded from the agent_env_vars key of profiles.json (written by Nix).
+	// Ignored when ContainerMode is true — container sessions are handled via
+	// podman --env flags in the sidecar.
+	AgentEnvVars map[string]string
 }
 
 // Layout selects the window layout used when creating a new session.
@@ -156,6 +167,24 @@ func buildDirectOpencodeCmd(opts Opts) string {
 	}
 	if opts.SessionName != "" {
 		cmd = "PRISM_SESSION_NAME=" + shellQuote(opts.SessionName) + " " + cmd
+	}
+	// Prepend agent env vars before PRISM_SESSION_NAME, in sorted key order
+	// for determinism. Only applies to host-mode sessions — container sessions
+	// receive env vars via podman --env flags in the sidecar.
+	if !opts.ContainerMode && len(opts.AgentEnvVars) > 0 {
+		keys := make([]string, 0, len(opts.AgentEnvVars))
+		for k := range opts.AgentEnvVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var prefix strings.Builder
+		for _, k := range keys {
+			prefix.WriteString(k)
+			prefix.WriteString("=")
+			prefix.WriteString(shellQuote(opts.AgentEnvVars[k]))
+			prefix.WriteString(" ")
+		}
+		cmd = prefix.String() + cmd
 	}
 	return cmd
 }

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildDirectOpencodeCmd_AgentEnvVars verifies that AgentEnvVars are
+// prepended to the command string before PRISM_SESSION_NAME in host-mode
+// (ContainerMode = false) sessions.
+func TestBuildDirectOpencodeCmd_AgentEnvVars(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		Port:        14000,
+		SessionName: "myrepo@branch",
+		AgentEnvVars: map[string]string{
+			"AWS_CONFIG_FILE": "/Users/bensherman/.config/aws/readonly-config",
+			"GIT_EDITOR":      "true",
+			"KUBECONFIG":      "/Users/bensherman/.config/kube/agents-config",
+		},
+	}
+	cmd := buildDirectOpencodeCmd(opts)
+
+	// All three env vars should appear in the command.
+	for _, envVar := range []string{"AWS_CONFIG_FILE", "GIT_EDITOR", "KUBECONFIG"} {
+		if !strings.Contains(cmd, envVar) {
+			t.Errorf("expected env var %q in cmd, got: %q", envVar, cmd)
+		}
+	}
+
+	// PRISM_SESSION_NAME should appear in the command.
+	sessionIdx := strings.Index(cmd, "PRISM_SESSION_NAME")
+	if sessionIdx == -1 {
+		t.Fatalf("PRISM_SESSION_NAME not found in cmd: %q", cmd)
+	}
+
+	// Each env var should appear before PRISM_SESSION_NAME.
+	for _, envVar := range []string{"AWS_CONFIG_FILE", "GIT_EDITOR", "KUBECONFIG"} {
+		envIdx := strings.Index(cmd, envVar)
+		if envIdx == -1 {
+			t.Errorf("env var %q not found in cmd: %q", envVar, cmd)
+			continue
+		}
+		if envIdx > sessionIdx {
+			t.Errorf("env var %q (at %d) should appear before PRISM_SESSION_NAME (at %d) in cmd: %q",
+				envVar, envIdx, sessionIdx, cmd)
+		}
+	}
+
+	// PRISM_SESSION_NAME should appear before the opencode binary.
+	opencodeIdx := strings.Index(cmd, "opencode ")
+	if opencodeIdx == -1 {
+		t.Fatalf("opencode command not found in cmd: %q", cmd)
+	}
+	if sessionIdx > opencodeIdx {
+		t.Errorf("PRISM_SESSION_NAME (at %d) should appear before opencode (at %d) in cmd: %q",
+			sessionIdx, opencodeIdx, cmd)
+	}
+
+	// Keys should be in sorted order (AWS < GIT < KUBECONFIG).
+	awsIdx := strings.Index(cmd, "AWS_CONFIG_FILE")
+	gitIdx := strings.Index(cmd, "GIT_EDITOR")
+	kubeIdx := strings.Index(cmd, "KUBECONFIG")
+	if awsIdx > gitIdx || gitIdx > kubeIdx {
+		t.Errorf("env vars not in sorted order (AWS=%d, GIT=%d, KUBE=%d) in cmd: %q",
+			awsIdx, gitIdx, kubeIdx, cmd)
+	}
+}
+
+// TestBuildDirectOpencodeCmd_AgentEnvVars_ContainerMode verifies that
+// AgentEnvVars are NOT injected when ContainerMode is true, even via the
+// buildDirectOpencodeCmd fallback path (ContainerMode=true, Port=0).
+func TestBuildDirectOpencodeCmd_AgentEnvVars_ContainerMode(t *testing.T) {
+	opts := Opts{
+		Agent:         "worker",
+		Port:          0, // Port=0 triggers buildDirectOpencodeCmd fallback in BuildOpencodeCmd
+		SessionName:   "myrepo@branch",
+		ContainerMode: true,
+		AgentEnvVars: map[string]string{
+			"AWS_CONFIG_FILE": "/Users/bensherman/.config/aws/readonly-config",
+		},
+	}
+	cmd := buildDirectOpencodeCmd(opts)
+
+	if strings.Contains(cmd, "AWS_CONFIG_FILE") {
+		t.Errorf("AgentEnvVars should not be injected when ContainerMode=true, got: %q", cmd)
+	}
+}
+
+// TestBuildDirectOpencodeCmd_AgentEnvVarsEmpty verifies that an empty
+// AgentEnvVars map produces no change to the command.
+func TestBuildDirectOpencodeCmd_AgentEnvVarsEmpty(t *testing.T) {
+	opts := Opts{
+		Agent:        "worker",
+		Port:         14000,
+		SessionName:  "myrepo@branch",
+		AgentEnvVars: map[string]string{},
+	}
+	cmd := buildDirectOpencodeCmd(opts)
+
+	// Should still begin with PRISM_SESSION_NAME (no env vars prepended).
+	if !strings.HasPrefix(cmd, "PRISM_SESSION_NAME=") {
+		t.Errorf("expected cmd to begin with PRISM_SESSION_NAME when AgentEnvVars is empty, got: %q", cmd)
+	}
+}
+
+// TestBuildDirectOpencodeCmd_AgentEnvVarsNil verifies that a nil AgentEnvVars
+// map produces no change to the command.
+func TestBuildDirectOpencodeCmd_AgentEnvVarsNil(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		Port:        14000,
+		SessionName: "myrepo@branch",
+		// AgentEnvVars intentionally nil
+	}
+	cmd := buildDirectOpencodeCmd(opts)
+
+	if !strings.HasPrefix(cmd, "PRISM_SESSION_NAME=") {
+		t.Errorf("expected cmd to begin with PRISM_SESSION_NAME when AgentEnvVars is nil, got: %q", cmd)
+	}
+}
+
+// TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted verifies that env var
+// values containing spaces or special characters are properly shell-quoted.
+func TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		Port:        14000,
+		SessionName: "myrepo@branch",
+		AgentEnvVars: map[string]string{
+			"GIT_EDITOR": "true",
+		},
+	}
+	cmd := buildDirectOpencodeCmd(opts)
+
+	// Value should be single-quoted.
+	if !strings.Contains(cmd, "GIT_EDITOR='true'") {
+		t.Errorf("expected GIT_EDITOR='true' in cmd, got: %q", cmd)
+	}
+}

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -106,22 +106,31 @@
         };
       };
 
-      json = builtins.toJSON {
-        default = config.nx.programs.prism.opencode.provider;
-        role_mapping = config.nx.programs.prism.profiles.data.roleMapping;
-        profiles = lib.mapAttrs (
-          _name: profileEntry:
-          lib.mapAttrs (
-            _role: roleCfg:
-            { model = roleCfg.model; } // (lib.optionalAttrs (roleCfg ? variant) { variant = roleCfg.variant; })
-          ) profileEntry
-        ) config.nx.programs.prism.profiles.data.profiles;
-        # Container role configs — full opencode.json blobs injected as
-        # OPENCODE_CONFIG_CONTENT (precedence level 6) so no project-level
-        # opencode.jsonc can override agent identity or permissions.
-        container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
-        container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
-      };
+      json =
+        let
+          homeDir = config.home-manager.users.${config.nx.username}.home.homeDirectory;
+        in
+        builtins.toJSON {
+          default = config.nx.programs.prism.opencode.provider;
+          role_mapping = config.nx.programs.prism.profiles.data.roleMapping;
+          profiles = lib.mapAttrs (
+            _name: profileEntry:
+            lib.mapAttrs (
+              _role: roleCfg:
+              { model = roleCfg.model; } // (lib.optionalAttrs (roleCfg ? variant) { variant = roleCfg.variant; })
+            ) profileEntry
+          ) config.nx.programs.prism.profiles.data.profiles;
+          # Container role configs — full opencode.json blobs injected as
+          # OPENCODE_CONFIG_CONTENT (precedence level 6) so no project-level
+          # opencode.jsonc can override agent identity or permissions.
+          container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
+          container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
+          # Agent environment variables to inject into host-mode opencode processes.
+          # $HOME is expanded at Nix eval time so the JSON contains absolute paths.
+          agent_env_vars = lib.mapAttrs (
+            _name: value: lib.strings.replaceStrings [ "$HOME" ] [ homeDir ] value
+          ) config.nx.programs.prism.agent.envVars;
+        };
 
       applyProfile =
         profileName: baseAgents:

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -126,9 +126,20 @@
           container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
           container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
           # Agent environment variables to inject into host-mode opencode processes.
-          # $HOME is expanded at Nix eval time so the JSON contains absolute paths.
+          # Both $HOME and ${HOME} are expanded at Nix eval time so the JSON
+          # always contains absolute paths regardless of which form is used.
           agent_env_vars = lib.mapAttrs (
-            _name: value: lib.strings.replaceStrings [ "$HOME" ] [ homeDir ] value
+            _name: value:
+            lib.strings.replaceStrings
+              [
+                "$HOME"
+                "\${HOME}"
+              ]
+              [
+                homeDir
+                homeDir
+              ]
+              value
           ) config.nx.programs.prism.agent.envVars;
         };
 


### PR DESCRIPTION
## Summary

- Bakes `agent_env_vars` into `profiles.json` with `$HOME` (and `${HOME}`) expanded at Nix eval time, so the JSON always contains absolute paths
- Reads `agent_env_vars` from `profiles.json` in `spawn.go` and `switch.go` and passes them through `session.Opts.AgentEnvVars` (host-mode only — not set for container-mode sessions)
- `buildDirectOpencodeCmd` prepends all entries (sorted for determinism) before `PRISM_SESSION_NAME` so `sh -c` tmux sessions receive the restricted env vars correctly
- Container-mode sessions are unaffected — env injection there is handled by podman `--env` flags in the sidecar
- The zsh alias `opencode = "... opencode"` is **intentionally retained** for manual host invocations (deliberate divergence from the original AC, per maintainer decision after initial implementation)
- Adds unit tests for the new `buildDirectOpencodeCmd` behaviour

Closes #671