### PR TITLE
fix: switch host-API to TCP on Darwin to avoid virtiofs ENOTSUP

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -27,8 +27,7 @@ import (
 )
 
 // newHostAPIClient returns an *http.Client that dials sockPath over a Unix
-// socket. Both proxyToHostAPI and proxyGetFromHostAPI share this client to
-// avoid duplicating the transport configuration.
+// socket. Used when PRISM_HOST_API begins with "unix://".
 func newHostAPIClient(sockPath string) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
@@ -41,6 +40,15 @@ func newHostAPIClient(sockPath string) *http.Client {
 				return conn, nil
 			},
 		},
+		Timeout: 60 * time.Second,
+	}
+}
+
+// newTCPHostAPIClient returns a standard *http.Client that dials over TCP.
+// Used when PRISM_HOST_API begins with "http://". No custom DialContext is
+// needed — the default transport resolves and dials the host:port from the URL.
+func newTCPHostAPIClient() *http.Client {
+	return &http.Client{
 		Timeout: 60 * time.Second,
 	}
 }
@@ -74,27 +82,37 @@ func readHostAPIResponse(endpoint string, resp *http.Response, respDst any) erro
 	return nil
 }
 
-// proxyToHostAPI sends a request to the host-API Unix socket server and returns
-// the parsed response. apiURL is the value of PRISM_HOST_API
-// (e.g. "unix:///var/run/prism-host/nixos-config@main-hostapi.sock"). endpoint is the path
-// (e.g. "/spawn"). body is marshalled to JSON and sent as the request body.
-// On success, response JSON is unmarshalled into respDst (may be nil).
+// proxyToHostAPI sends a request to the host-API server and returns the parsed
+// response. apiURL is the value of PRISM_HOST_API — either a unix:// URL (Linux)
+// or an http:// URL (Darwin TCP path). endpoint is the path (e.g. "/spawn").
+// body is marshalled to JSON and sent as the request body. On success, response
+// JSON is unmarshalled into respDst (may be nil).
 func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
-	sockPath, err := parseUnixSocketURL(apiURL)
-	if err != nil {
-		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
-	}
-
-	client := newHostAPIClient(sockPath)
-
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("proxyToHostAPI: marshal request body: %w", err)
 	}
 
-	// Use "prism-hostapi" as the Host header — it is irrelevant for Unix socket
-	// connections but required by http.Client for a valid HTTP/1.1 request.
-	req, err := http.NewRequest(http.MethodPost, "http://prism-hostapi"+endpoint, bytes.NewReader(bodyBytes))
+	var client *http.Client
+	var reqURL string
+
+	if strings.HasPrefix(apiURL, "http://") {
+		// TCP path (Darwin): use the http:// URL directly — standard TCP dial.
+		client = newTCPHostAPIClient()
+		reqURL = apiURL + endpoint
+	} else {
+		// Unix socket path (Linux): extract socket path and use a fake host.
+		sockPath, parseErr := parseUnixSocketURL(apiURL)
+		if parseErr != nil {
+			return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+		}
+		client = newHostAPIClient(sockPath)
+		// "prism-hostapi" is a placeholder Host header — irrelevant for Unix
+		// socket connections but required for a valid HTTP/1.1 request.
+		reqURL = "http://prism-hostapi" + endpoint
+	}
+
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("proxyToHostAPI: build request: %w", err)
 	}
@@ -107,21 +125,28 @@ func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
 	return readHostAPIResponse(endpoint, resp, respDst)
 }
 
-// proxyGetFromHostAPI sends a GET request to the host-API Unix socket server
-// with optional query parameters and returns the parsed response. apiURL is the
-// value of PRISM_HOST_API. endpoint is the path (e.g. "/list-sessions").
-// params are appended as properly-encoded URL query parameters. On success,
-// response JSON is unmarshalled into respDst (may be nil).
+// proxyGetFromHostAPI sends a GET request to the host-API server with optional
+// query parameters and returns the parsed response. apiURL is the value of
+// PRISM_HOST_API — either unix:// or http://. endpoint is the path (e.g.
+// "/list-sessions"). params are appended as properly-encoded URL query
+// parameters. On success, response JSON is unmarshalled into respDst (may be nil).
 func proxyGetFromHostAPI(apiURL, endpoint string, params map[string]string, respDst any) error {
-	sockPath, err := parseUnixSocketURL(apiURL)
-	if err != nil {
-		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
+	var client *http.Client
+	var rawURL string
+
+	if strings.HasPrefix(apiURL, "http://") {
+		client = newTCPHostAPIClient()
+		rawURL = apiURL + endpoint
+	} else {
+		sockPath, parseErr := parseUnixSocketURL(apiURL)
+		if parseErr != nil {
+			return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+		}
+		client = newHostAPIClient(sockPath)
+		rawURL = "http://prism-hostapi" + endpoint
 	}
 
-	client := newHostAPIClient(sockPath)
-
-	// Build URL with properly percent-encoded query parameters.
-	rawURL := "http://prism-hostapi" + endpoint
+	// Append properly percent-encoded query parameters.
 	if len(params) > 0 {
 		q := url.Values{}
 		for k, v := range params {
@@ -194,13 +219,24 @@ func proxyPrompt(apiURL, session, prompt string) error {
 	}, nil)
 }
 
-// proxyLogsFromHostAPI proxies a GET /logs request to the host-API sidecar
-// and streams the response body directly to w. For follow mode, it handles
-// Ctrl-C gracefully by cancelling the request context.
+// proxyLogsFromHostAPI proxies a GET /logs request to the host-API server and
+// streams the response body directly to w. For follow mode, it handles Ctrl-C
+// gracefully by cancelling the request context. apiURL is either a unix:// or
+// http:// URL depending on the platform.
 func proxyLogsFromHostAPI(apiURL, sessionName string, tail int, tailSet bool, follow bool, w io.Writer) error {
-	sockPath, err := parseUnixSocketURL(apiURL)
-	if err != nil {
-		return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, err)
+	var client *http.Client
+	var baseURL string
+
+	if strings.HasPrefix(apiURL, "http://") {
+		client = newTCPHostAPIClient()
+		baseURL = apiURL
+	} else {
+		sockPath, parseErr := parseUnixSocketURL(apiURL)
+		if parseErr != nil {
+			return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+		}
+		client = newHostAPIClient(sockPath)
+		baseURL = "http://prism-hostapi"
 	}
 
 	// Build URL with query parameters.
@@ -212,7 +248,7 @@ func proxyLogsFromHostAPI(apiURL, sessionName string, tail int, tailSet bool, fo
 	if follow {
 		q.Set("follow", "true")
 	}
-	rawURL := "http://prism-hostapi/logs?" + q.Encode()
+	rawURL := baseURL + "/logs?" + q.Encode()
 
 	// For follow mode, use a cancellable context so Ctrl-C exits cleanly.
 	ctx := context.Background()
@@ -237,10 +273,8 @@ func proxyLogsFromHostAPI(apiURL, sessionName string, tail int, tailSet bool, fo
 		return fmt.Errorf("proxyLogsFromHostAPI: build request: %w", err)
 	}
 
-	// Reuse the shared client configuration from newHostAPIClient. For follow
-	// mode (streaming), override the default 60 s timeout to 0 (no timeout)
-	// so the connection is not cut while waiting for new log lines.
-	client := newHostAPIClient(sockPath)
+	// For follow mode (streaming), override the default 60 s timeout to 0
+	// (no timeout) so the connection is not cut while waiting for new log lines.
 	if follow {
 		client.Timeout = 0
 	}

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -58,6 +58,34 @@ func (m *mockUnixServer) apiURL() string {
 	return "unix://" + m.sockPath
 }
 
+// newMockTCPServer starts a minimal HTTP server on a real TCP listener bound to
+// 127.0.0.1:0 and returns the server. The allocated address (including port) is
+// available via srv.Addr().
+type mockTCPServer struct {
+	listener net.Listener
+	server   *http.Server
+}
+
+func newMockTCPServer(t *testing.T, handlerFn http.HandlerFunc) *mockTCPServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	srv := &http.Server{Handler: handlerFn}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = ln.Close()
+	})
+	return &mockTCPServer{listener: ln, server: srv}
+}
+
+// apiURL returns the http:// URL for this TCP server.
+func (m *mockTCPServer) apiURL() string {
+	return "http://" + m.listener.Addr().String()
+}
+
 // ── proxyToHostAPI unit tests ─────────────────────────────────────────────────
 
 // TestProxyToHostAPI_SendsCorrectRequestAndParsesResponse verifies AC-4 and
@@ -131,10 +159,11 @@ func TestProxyToHostAPI_ReturnsErrorOnHTTP500(t *testing.T) {
 	}
 }
 
-// TestProxyToHostAPI_MalformedURL verifies AC-8: a URL that does not start
-// with "unix://" returns a clear error rather than panicking.
+// TestProxyToHostAPI_MalformedURL verifies that a URL with an unsupported scheme
+// (neither "unix://" nor "http://") returns a clear "unsupported scheme" error.
 func TestProxyToHostAPI_MalformedURL(t *testing.T) {
-	err := proxyToHostAPI("http://localhost:1234", "/spawn", map[string]any{}, nil)
+	// "ftp://" is neither unix:// nor http:// — should return unsupported scheme.
+	err := proxyToHostAPI("ftp://localhost:1234", "/spawn", map[string]any{}, nil)
 	if err == nil {
 		t.Fatal("expected non-nil error for unsupported scheme")
 	}
@@ -642,6 +671,146 @@ func TestProxyPrompt_Returns403AsError(t *testing.T) {
 		t.Fatal("expected non-nil error for 403 response")
 	}
 	if !strings.Contains(err.Error(), "workers can only prompt") {
+		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}
+
+// ── TCP (http://) scheme tests ────────────────────────────────────────────────
+
+// TestProxyToHostAPI_TCPScheme starts a real TCP server, sets PRISM_HOST_API
+// to http://127.0.0.1:<port>, calls proxyToHostAPI, and asserts the request is
+// received and the response is parsed correctly.
+func TestProxyToHostAPI_TCPScheme(t *testing.T) {
+	type reqBody struct {
+		Session string `json:"session"`
+		Prompt  string `json:"prompt"`
+	}
+	type respBody struct {
+		OK bool `json:"ok"`
+	}
+
+	var capturedMethod string
+	var capturedPath string
+	var capturedBody reqBody
+
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	var got respBody
+	err := proxyToHostAPI(srv.apiURL(), "/prompt",
+		reqBody{Session: "myrepo@main", Prompt: "do the thing"}, &got)
+	if err != nil {
+		t.Fatalf("proxyToHostAPI (TCP): %v", err)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", capturedMethod)
+	}
+	if capturedPath != "/prompt" {
+		t.Errorf("path = %q, want /prompt", capturedPath)
+	}
+	if capturedBody.Session != "myrepo@main" {
+		t.Errorf("body.session = %q, want myrepo@main", capturedBody.Session)
+	}
+	if capturedBody.Prompt != "do the thing" {
+		t.Errorf("body.prompt = %q, want 'do the thing'", capturedBody.Prompt)
+	}
+	if !got.OK {
+		t.Error("response ok = false, want true")
+	}
+}
+
+// TestProxyGetFromHostAPI_TCPScheme verifies that proxyGetFromHostAPI routes
+// through the TCP client when PRISM_HOST_API is an http:// address.
+func TestProxyGetFromHostAPI_TCPScheme(t *testing.T) {
+	var capturedMethod string
+	var capturedPath string
+	var capturedQuery string
+
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	var got []any
+	err := proxyGetFromHostAPI(srv.apiURL(), "/list-sessions",
+		map[string]string{"all": "true"}, &got)
+	if err != nil {
+		t.Fatalf("proxyGetFromHostAPI (TCP): %v", err)
+	}
+
+	if capturedMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", capturedMethod)
+	}
+	if capturedPath != "/list-sessions" {
+		t.Errorf("path = %q, want /list-sessions", capturedPath)
+	}
+	if capturedQuery != "all=true" {
+		t.Errorf("query = %q, want all=true", capturedQuery)
+	}
+}
+
+// TestProxyLogsFromHostAPI_TCPScheme starts a real TCP server, sets
+// PRISM_HOST_API to an http:// address, calls proxyLogsFromHostAPI, and asserts
+// the request reaches the TCP server and the response body is streamed correctly.
+func TestProxyLogsFromHostAPI_TCPScheme(t *testing.T) {
+	const logBody = "line1\nline2\nline3\n"
+
+	var capturedPath string
+	var capturedQuery string
+
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(logBody))
+	})
+
+	var buf strings.Builder
+	err := proxyLogsFromHostAPI(srv.apiURL(), "myrepo@main", 20, true, false, &buf)
+	if err != nil {
+		t.Fatalf("proxyLogsFromHostAPI (TCP): %v", err)
+	}
+
+	if capturedPath != "/logs" {
+		t.Errorf("path = %q, want /logs", capturedPath)
+	}
+	if !strings.Contains(capturedQuery, "session=myrepo%40main") {
+		t.Errorf("query %q does not contain encoded session param", capturedQuery)
+	}
+	if !strings.Contains(capturedQuery, "tail=20") {
+		t.Errorf("query %q does not contain tail=20", capturedQuery)
+	}
+	if buf.String() != logBody {
+		t.Errorf("streamed body = %q, want %q", buf.String(), logBody)
+	}
+}
+
+// TestProxyToHostAPI_TCPScheme_ErrorResponse verifies that a non-2xx response
+// from a TCP server is surfaced as an error with the server's error message.
+func TestProxyToHostAPI_TCPScheme_ErrorResponse(t *testing.T) {
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"tcp server error"}`))
+	})
+
+	err := proxyToHostAPI(srv.apiURL(), "/spawn", map[string]any{}, nil)
+	if err == nil {
+		t.Fatal("expected non-nil error from TCP server 500 response")
+	}
+	if !strings.Contains(err.Error(), "tcp server error") {
 		t.Errorf("error %q does not contain expected message", err.Error())
 	}
 }

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -29,6 +29,11 @@ const (
 	// ContainerPort is the port opencode serve listens on inside the container.
 	ContainerPort = 4096
 
+	// HostAPIContainerPort is the port the host-API TCP listener is mapped to
+	// inside the container on Darwin. Distinct from ContainerPort (4096) so the
+	// two services can coexist.
+	HostAPIContainerPort = 4097
+
 	// Image is the container image name used for all agent containers.
 	// The image is published to GHCR as a multi-arch image by CI and pulled
 	// on first use by the systemd/launchd service. podman resolves the correct
@@ -99,11 +104,19 @@ type Config struct {
 	WorktreeGitDir string
 
 	// HostAPISockPath is the absolute host path to the sidecar's host-API Unix socket.
-	// When non-empty, the socket's parent directory is bind-mounted into the container
-	// at /var/run/prism-host and PRISM_HOST_API is set to
-	// unix:///var/run/prism-host/<sockfilename> so that prism CLI commands inside
-	// the container can proxy tmux operations to the host sidecar.
+	// When non-empty and HostAPITCPPort is zero, the socket's parent directory is
+	// bind-mounted into the container at /var/run/prism-host and PRISM_HOST_API is set
+	// to unix:///var/run/prism-host/<sockfilename> so that prism CLI commands inside
+	// the container can proxy tmux operations to the host sidecar. On Darwin this field
+	// is still set but HostAPITCPPort takes precedence over the Unix socket.
 	HostAPISockPath string
+
+	// HostAPITCPPort is the host-side TCP port allocated by the sidecar for the
+	// host-API TCP listener (Darwin only). When non-zero, buildRunArgs emits a
+	// --publish 127.0.0.1:<HostAPITCPPort>:HostAPIContainerPort flag and sets
+	// PRISM_HOST_API=http://127.0.0.1:HostAPIContainerPort instead of using the
+	// Unix socket path. On Linux this field is zero and the Unix socket is used.
+	HostAPITCPPort int
 
 	// InstanceID is the UUID instance identifier for the prism session that owns
 	// this container. When non-empty it is written as a
@@ -717,11 +730,24 @@ func (m *Manager) buildRunArgs() []string {
 		"--workdir", "/workspace",
 	)
 
-	// Host-API socket: mount the sidecar's Unix socket into the container and
-	// tell prism CLI where to find it. Container root can access the socket because
-	// rootless podman maps container root to the host user UID (same mechanism as
-	// the nix-daemon socket mount already in use above).
-	if cfg.HostAPISockPath != "" {
+	// Host-API: tell the container how to reach the host-API server.
+	//
+	// On Darwin (cfg.HostAPITCPPort != 0): TCP port forwarding is used because
+	// virtiofs returns ENOTSUP on connect() for Unix sockets mounted into the
+	// container. The sidecar binds a TCP listener on 127.0.0.1:0 before container
+	// creation, records the allocated port, and passes it here. We emit a
+	// --publish flag to forward that host port to HostAPIContainerPort inside the
+	// container, and set PRISM_HOST_API to the container-side http:// address.
+	//
+	// On Linux (cfg.HostAPITCPPort == 0): the Unix socket directory is mounted
+	// and PRISM_HOST_API is set to the unix:// path (existing behaviour).
+	if cfg.HostAPITCPPort != 0 {
+		hostAPIPortBinding := fmt.Sprintf("127.0.0.1:%d:%d", cfg.HostAPITCPPort, HostAPIContainerPort)
+		args = append(args,
+			"--publish", hostAPIPortBinding,
+			"--env", fmt.Sprintf("PRISM_HOST_API=http://127.0.0.1:%d", HostAPIContainerPort),
+		)
+	} else if cfg.HostAPISockPath != "" {
 		args = append(args,
 			"--volume", filepath.Dir(cfg.HostAPISockPath)+":/var/run/prism-host:Z",
 			"--env", "PRISM_HOST_API=unix:///var/run/prism-host/"+filepath.Base(cfg.HostAPISockPath),

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -590,6 +590,149 @@ func TestBuildRunArgs_NoHostAPISockWhenEmpty(t *testing.T) {
 	}
 }
 
+// ── HostAPITCPPort / Darwin TCP path tests ───────────────────────────────────
+
+// TestBuildRunArgs_HostAPITCPPortPublishAndEnv asserts that when HostAPITCPPort
+// is non-zero, buildRunArgs emits --publish 127.0.0.1:<port>:4097 and
+// PRISM_HOST_API=http://127.0.0.1:4097, and that NO unix:// env var or
+// socket-directory volume is present.
+func TestBuildRunArgs_HostAPITCPPortPublishAndEnv(t *testing.T) {
+	const hostPort = 51234
+	m := New(Config{
+		SessionName:     "repo@feat",
+		AllocatedPort:   14000,
+		HostAPISockPath: "/home/user/.local/state/prism/run/repo@feat-hostapi.sock",
+		HostAPITCPPort:  hostPort,
+	})
+	args := m.buildRunArgs()
+
+	// Must have --publish 127.0.0.1:51234:4097.
+	wantPublish := fmt.Sprintf("127.0.0.1:%d:%d", hostPort, HostAPIContainerPort)
+	foundPublish := false
+	for i, arg := range args {
+		if arg == "--publish" && i+1 < len(args) && args[i+1] == wantPublish {
+			foundPublish = true
+			break
+		}
+	}
+	if !foundPublish {
+		t.Errorf("expected --publish %s in args, not found: %v", wantPublish, args)
+	}
+
+	// Must have PRISM_HOST_API=http://127.0.0.1:4097.
+	wantEnv := fmt.Sprintf("PRISM_HOST_API=http://127.0.0.1:%d", HostAPIContainerPort)
+	foundEnv := false
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && args[i+1] == wantEnv {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Errorf("expected --env %s in args, not found: %v", wantEnv, args)
+	}
+
+	// Must NOT have unix:// env var.
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) {
+			if strings.Contains(args[i+1], "unix://") {
+				t.Errorf("unexpected unix:// in PRISM_HOST_API when HostAPITCPPort is set: %q", args[i+1])
+			}
+		}
+	}
+
+	// Must NOT have socket-directory volume mount (/var/run/prism-host).
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			if strings.Contains(args[i+1], "prism-host") {
+				t.Errorf("unexpected socket-directory volume mount when HostAPITCPPort is set: %q", args[i+1])
+			}
+		}
+	}
+}
+
+// TestBuildRunArgs_HostAPISockUnixPathLinux asserts that when HostAPITCPPort is
+// zero and HostAPISockPath is non-empty (Linux path), the args still include the
+// unix:// env var and socket-directory volume, and no --publish flag for port
+// 4097 is present.
+func TestBuildRunArgs_HostAPISockUnixPathLinux(t *testing.T) {
+	const sockPath = "/home/user/.local/state/prism/run/repo@feat-hostapi.sock"
+	m := New(Config{
+		SessionName:     "repo@feat",
+		AllocatedPort:   14000,
+		HostAPISockPath: sockPath,
+		HostAPITCPPort:  0, // Linux path
+	})
+	args := m.buildRunArgs()
+
+	// Must have unix:// env var.
+	wantEnv := "PRISM_HOST_API=unix:///var/run/prism-host/repo@feat-hostapi.sock"
+	foundEnv := false
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && args[i+1] == wantEnv {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Errorf("expected --env %s in args, not found: %v", wantEnv, args)
+	}
+
+	// Must have socket-directory volume mount.
+	wantMount := "/home/user/.local/state/prism/run:/var/run/prism-host:Z"
+	foundMount := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) && args[i+1] == wantMount {
+			foundMount = true
+			break
+		}
+	}
+	if !foundMount {
+		t.Errorf("expected --volume %s in args, not found: %v", wantMount, args)
+	}
+
+	// Must NOT have --publish for port 4097.
+	wantNoPublish := fmt.Sprintf(":%d", HostAPIContainerPort)
+	for i, arg := range args {
+		if arg == "--publish" && i+1 < len(args) {
+			if strings.Contains(args[i+1], wantNoPublish) {
+				t.Errorf("unexpected --publish for port %d when HostAPITCPPort is zero: %q", HostAPIContainerPort, args[i+1])
+			}
+		}
+	}
+
+	// Must NOT have http:// in PRISM_HOST_API.
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) {
+			if strings.HasPrefix(args[i+1], "PRISM_HOST_API=http://") {
+				t.Errorf("unexpected http:// PRISM_HOST_API when HostAPITCPPort is zero: %q", args[i+1])
+			}
+		}
+	}
+}
+
+// TestBuildRunArgs_HostAPITCPPort_LoopbackOnly asserts that the --publish flag
+// for the host-API TCP port is constrained to 127.0.0.1 (never 0.0.0.0).
+func TestBuildRunArgs_HostAPITCPPort_LoopbackOnly(t *testing.T) {
+	m := New(Config{
+		SessionName:    "repo@feat",
+		AllocatedPort:  14000,
+		HostAPITCPPort: 51234,
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--publish" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, fmt.Sprintf(":%d", HostAPIContainerPort)) {
+				if !strings.HasPrefix(v, "127.0.0.1:") {
+					t.Errorf("host-API --publish is not loopback-only: %q", v)
+				}
+			}
+		}
+	}
+}
+
 // ── credentialEnvVars tests ──────────────────────────────────────────────────
 
 func TestCredentialEnvVars_LLMKeysForwarded(t *testing.T) {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -248,8 +248,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		// so the OS-allocated port is known when buildRunArgs() emits --publish.
 		// virtiofs returns ENOTSUP on connect() for Unix sockets mounted into the
 		// container VM, so TCP port forwarding is used instead (#661).
-		// Failure to bind is fatal — we must not silently fall back to Unix-socket-only
-		// mode, which would reproduce the ENOTSUP bug.
+		//
+		// Failure to bind is FATAL. A silent fallback to Unix-socket-only mode would
+		// reproduce the ENOTSUP bug (#661) — the container would start without a
+		// working host-API channel. Returning an error here aborts container startup
+		// with a clear message rather than creating a silently broken session.
 		if runtime.GOOS == "darwin" && s.cfg.HostAPISockPath != "" {
 			tcpLn, tcpErr := net.Listen("tcp", "127.0.0.1:0")
 			if tcpErr != nil {
@@ -264,6 +267,25 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			s.mu.Unlock()
 		}
 
+		// closeTCPListenerOnEarlyReturn closes the TCP listener (Darwin only) when
+		// Run() returns an error before the SSE loop — i.e. before Shutdown() has been
+		// (or will be) called by the signal handler. We use a flag rather than a
+		// defer-always so that the normal success path leaves the listener open for the
+		// running HTTP server (which is closed by Shutdown() later).
+		tcpListenerClosed := false
+		closeTCPListenerOnError := func() {
+			if tcpListenerClosed {
+				return
+			}
+			s.mu.Lock()
+			ln := s.hostAPITCPListener
+			s.mu.Unlock()
+			if ln != nil {
+				_ = ln.Close()
+				tcpListenerClosed = true
+			}
+		}
+
 		mgr := container.New(*s.cfg.Container)
 		s.mu.Lock()
 		s.container = &containerMgr{mgr: mgr}
@@ -273,6 +295,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		log.Printf("sidecar: creating container %q", mgr.Name())
 		t0 := time.Now()
 		if err := mgr.Create(ctx); err != nil {
+			closeTCPListenerOnError()
 			return fmt.Errorf("sidecar: container create: %w", err)
 		}
 		log.Printf("[timing] Create: %s", time.Since(t0).Round(time.Millisecond))
@@ -291,6 +314,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// (no Shutdown yet), avoiding a double-Shutdown with spurious log lines.
 			if ctx.Err() == nil {
 				mgr.Shutdown()
+				closeTCPListenerOnError()
 			}
 			return fmt.Errorf("sidecar: container health check: %w", err)
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -110,6 +111,10 @@ type Config struct {
 	// the sidecar starts a Unix socket HTTP server exposing host-side tmux operations
 	// to agents running inside the container.
 	HostAPISockPath string
+	// HostAPITCPPort is the OS-allocated TCP port used on Darwin for the host-API
+	// listener. It is set by Run() after binding the listener and recorded here for
+	// reference. Zero means no TCP listener was started (Linux path).
+	HostAPITCPPort int
 	// OnReady is called (once, synchronously) after the container is healthy
 	// and before the SSE loop starts. Used in container mode to write the
 	// readiness signal file that unblocks the tmux pane running "opencode attach".
@@ -163,6 +168,13 @@ type Sidecar struct {
 	// Stored so Shutdown() can drain in-flight requests gracefully.
 	// Protected by mu.
 	hostAPISrv *http.Server
+	// hostAPITCPListener is the TCP listener for the host-API HTTP server on Darwin.
+	// Started in Run() before container creation so the allocated port is known before
+	// the container is launched. Protected by mu.
+	hostAPITCPListener net.Listener
+	// hostAPITCPSrv is the HTTP server for the host-API TCP listener (Darwin only).
+	// Stored so Shutdown() can drain in-flight requests gracefully. Protected by mu.
+	hostAPITCPSrv *http.Server
 	// shuttingDown is set to true at the start of Shutdown(). Used by Run()
 	// to prevent OnReady from firing after SIGTERM even when the HTTP health
 	// probe succeeds during podman stop's grace period. Protected by mu.
@@ -231,6 +243,26 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	// Container mode: create and health-check the container before connecting.
 	if s.cfg.Container != nil {
 		sessionStart := time.Now()
+
+		// On Darwin, start a TCP listener on 127.0.0.1:0 BEFORE container creation
+		// so the OS-allocated port is known when buildRunArgs() emits --publish.
+		// virtiofs returns ENOTSUP on connect() for Unix sockets mounted into the
+		// container VM, so TCP port forwarding is used instead (#661).
+		// Failure to bind is fatal — we must not silently fall back to Unix-socket-only
+		// mode, which would reproduce the ENOTSUP bug.
+		if runtime.GOOS == "darwin" && s.cfg.HostAPISockPath != "" {
+			tcpLn, tcpErr := net.Listen("tcp", "127.0.0.1:0")
+			if tcpErr != nil {
+				return fmt.Errorf("sidecar: host-API TCP listener: %w", tcpErr)
+			}
+			port := tcpLn.Addr().(*net.TCPAddr).Port
+			log.Printf("sidecar: host-API TCP listener bound on 127.0.0.1:%d", port)
+			s.cfg.HostAPITCPPort = port
+			s.cfg.Container.HostAPITCPPort = port
+			s.mu.Lock()
+			s.hostAPITCPListener = tcpLn
+			s.mu.Unlock()
+		}
 
 		mgr := container.New(*s.cfg.Container)
 		s.mu.Lock()
@@ -306,16 +338,19 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			}
 		}
 
-		// Start the host-API Unix socket server (AC-1, AC-9).
+		// Start the host-API servers (AC-1, AC-9).
 		// Guard with !isShuttingDown: if SIGTERM arrived between WaitHealthy
-		// and here, Shutdown() will have already run and we must not create a
-		// new listener that would never be closed.
+		// and here, Shutdown() will have already run and we must not create
+		// listeners that would never be closed.
 		if !isShuttingDown && s.cfg.HostAPISockPath != "" {
-			// Remove stale socket file from a previous crashed session.
+			// Unix socket server — always started when HostAPISockPath is set,
+			// regardless of platform. On Darwin the container uses TCP
+			// (HostAPITCPPort), but the Unix socket is still available for
+			// host-side tooling.
 			_ = os.Remove(s.cfg.HostAPISockPath)
 			ln, listenErr := net.Listen("unix", s.cfg.HostAPISockPath)
 			if listenErr != nil {
-				log.Printf("sidecar: host-API server: listen: %v", listenErr)
+				log.Printf("sidecar: host-API server: listen unix: %v", listenErr)
 			} else {
 				srv := &http.Server{Handler: s.hostAPIHandler()}
 				s.mu.Lock()
@@ -326,9 +361,30 @@ func (s *Sidecar) Run(ctx context.Context) error {
 					if err := srv.Serve(ln); err != nil &&
 						!errors.Is(err, http.ErrServerClosed) &&
 						!errors.Is(err, net.ErrClosed) {
-						log.Printf("sidecar: host-API server: %v", err)
+						log.Printf("sidecar: host-API server (unix): %v", err)
 					}
 				}()
+			}
+
+			// TCP server — Darwin only, when the TCP listener was bound before
+			// container creation. Uses a separate http.Server with the same handler
+			// so both transports serve identical API endpoints.
+			s.mu.Lock()
+			tcpLn := s.hostAPITCPListener
+			s.mu.Unlock()
+			if tcpLn != nil {
+				tcpSrv := &http.Server{Handler: s.hostAPIHandler()}
+				s.mu.Lock()
+				s.hostAPITCPSrv = tcpSrv
+				s.mu.Unlock()
+				go func() {
+					if err := tcpSrv.Serve(tcpLn); err != nil &&
+						!errors.Is(err, http.ErrServerClosed) &&
+						!errors.Is(err, net.ErrClosed) {
+						log.Printf("sidecar: host-API server (tcp): %v", err)
+					}
+				}()
+				log.Printf("sidecar: host-API TCP server serving on 127.0.0.1:%d", s.cfg.HostAPITCPPort)
 			}
 		} else if s.cfg.HostAPISockPath == "" {
 			log.Printf("sidecar: host-API server: HostAPISockPath is empty — skipping (container mode active but no socket path configured)")
@@ -449,6 +505,8 @@ func (s *Sidecar) Shutdown() {
 	s.mu.Lock()
 	ln := s.hostAPIListener
 	srv := s.hostAPISrv
+	tcpLn := s.hostAPITCPListener
+	tcpSrv := s.hostAPITCPSrv
 	s.mu.Unlock()
 	if srv != nil {
 		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -459,6 +517,16 @@ func (s *Sidecar) Shutdown() {
 	}
 	if ln != nil {
 		_ = os.Remove(s.cfg.HostAPISockPath)
+	}
+	// Close the TCP host-API listener/server (Darwin only). Idempotent when
+	// the listener was never started (both are nil on Linux or when container
+	// mode is inactive).
+	if tcpSrv != nil {
+		shutCtx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel2()
+		_ = tcpSrv.Shutdown(shutCtx2)
+	} else if tcpLn != nil {
+		_ = tcpLn.Close()
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

- On Darwin, `connect()` on a Unix socket mounted via virtiofs returns `ENOTSUP`, making the host-API unreachable from inside the container. This switches the container→host API channel to TCP on Darwin.
- The sidecar starts a TCP listener on `127.0.0.1:0` (OS-allocated port) **before** container creation, so the port is known before `--publish` is emitted.
- `buildRunArgs()` emits `--publish 127.0.0.1:<hostPort>:4097` and `PRISM_HOST_API=http://127.0.0.1:4097` on Darwin (`HostAPITCPPort != 0`); Linux continues using unix:// unchanged.
- `proxyToHostAPI`, `proxyGetFromHostAPI`, and `proxyLogsFromHostAPI` route through a standard TCP `http.Client` when `PRISM_HOST_API` begins with `http://`.
- Failure to bind the TCP listener on Darwin is fatal — no silent fallback to Unix-socket-only mode.

Closes #661