### PR TITLE
fix: resolve Darwin host-API bind conflict in container mode

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -29,11 +29,6 @@ const (
 	// ContainerPort is the port opencode serve listens on inside the container.
 	ContainerPort = 4096
 
-	// HostAPIContainerPort is the port the host-API TCP listener is mapped to
-	// inside the container on Darwin. Distinct from ContainerPort (4096) so the
-	// two services can coexist.
-	HostAPIContainerPort = 4097
-
 	// Image is the container image name used for all agent containers.
 	// The image is published to GHCR as a multi-arch image by CI and pulled
 	// on first use by the systemd/launchd service. podman resolves the correct
@@ -112,10 +107,10 @@ type Config struct {
 	HostAPISockPath string
 
 	// HostAPITCPPort is the host-side TCP port allocated by the sidecar for the
-	// host-API TCP listener (Darwin only). When non-zero, buildRunArgs emits a
-	// --publish 127.0.0.1:<HostAPITCPPort>:HostAPIContainerPort flag and sets
-	// PRISM_HOST_API=http://127.0.0.1:HostAPIContainerPort instead of using the
-	// Unix socket path. On Linux this field is zero and the Unix socket is used.
+	// host-API TCP listener (Darwin only). When non-zero, buildRunArgs sets
+	// PRISM_HOST_API=http://host.containers.internal:<HostAPITCPPort> so the
+	// container reaches the sidecar via the gvproxy bridge — no --publish flag
+	// is needed. On Linux this field is zero and the Unix socket is used.
 	HostAPITCPPort int
 
 	// InstanceID is the UUID instance identifier for the prism session that owns
@@ -732,20 +727,18 @@ func (m *Manager) buildRunArgs() []string {
 
 	// Host-API: tell the container how to reach the host-API server.
 	//
-	// On Darwin (cfg.HostAPITCPPort != 0): TCP port forwarding is used because
-	// virtiofs returns ENOTSUP on connect() for Unix sockets mounted into the
-	// container. The sidecar binds a TCP listener on 127.0.0.1:0 before container
-	// creation, records the allocated port, and passes it here. We emit a
-	// --publish flag to forward that host port to HostAPIContainerPort inside the
-	// container, and set PRISM_HOST_API to the container-side http:// address.
+	// On Darwin (cfg.HostAPITCPPort != 0): TCP is used because virtiofs returns
+	// ENOTSUP on connect() for Unix sockets mounted into the VM. The sidecar
+	// binds a TCP listener on 0.0.0.0:<port> before container creation and passes
+	// the port here. The container reaches the sidecar via host.containers.internal
+	// (192.168.127.254, the gvproxy bridge IP) — no --publish flag is needed
+	// because this is container→host outbound traffic, not inbound port forwarding.
 	//
 	// On Linux (cfg.HostAPITCPPort == 0): the Unix socket directory is mounted
 	// and PRISM_HOST_API is set to the unix:// path (existing behaviour).
 	if cfg.HostAPITCPPort != 0 {
-		hostAPIPortBinding := fmt.Sprintf("127.0.0.1:%d:%d", cfg.HostAPITCPPort, HostAPIContainerPort)
 		args = append(args,
-			"--publish", hostAPIPortBinding,
-			"--env", fmt.Sprintf("PRISM_HOST_API=http://127.0.0.1:%d", HostAPIContainerPort),
+			"--env", fmt.Sprintf("PRISM_HOST_API=http://host.containers.internal:%d", cfg.HostAPITCPPort),
 		)
 	} else if cfg.HostAPISockPath != "" {
 		args = append(args,

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -10,7 +10,9 @@
 //   - The container name is derived from the prism session name so it is
 //     predictable and idempotent.
 //   - Credentials are injected as environment variables, never as mounted files.
-//   - The container port is bound to 127.0.0.1 only — not 0.0.0.0.
+//   - The opencode serve container port (ContainerPort) is bound to 127.0.0.1
+//     only — not 0.0.0.0. The host-API TCP listener (Darwin only) intentionally
+//     binds 0.0.0.0 so the gvproxy bridge interface can reach it from the VM.
 package container
 
 import (

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -606,13 +606,15 @@ func TestBuildRunArgs_HostAPITCPPortPublishAndEnv(t *testing.T) {
 	})
 	args := m.buildRunArgs()
 
-	// Must NOT have --publish for the host-API port (no port forwarding needed;
-	// the container reaches the sidecar via host.containers.internal).
+	// Must NOT have --publish referencing the host-API port (no port forwarding
+	// needed; the container reaches the sidecar via host.containers.internal).
+	// AllocatedPort (14000) != hostPort (51234), so the opencode --publish is
+	// unambiguously distinct and needs no special carve-out.
 	for i, arg := range args {
 		if arg == "--publish" && i+1 < len(args) {
 			v := args[i+1]
-			if strings.Contains(v, fmt.Sprintf(":%d", hostPort)) && v != fmt.Sprintf("127.0.0.1:%d:%d", hostPort, ContainerPort) {
-				t.Errorf("unexpected --publish for host-API port when HostAPITCPPort is set: %q", v)
+			if strings.Contains(v, fmt.Sprintf(":%d", hostPort)) || strings.Contains(v, fmt.Sprintf("%d:", hostPort)) {
+				t.Errorf("unexpected --publish referencing host-API TCP port %d: %q", hostPort, v)
 			}
 		}
 	}

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -593,9 +593,9 @@ func TestBuildRunArgs_NoHostAPISockWhenEmpty(t *testing.T) {
 // ── HostAPITCPPort / Darwin TCP path tests ───────────────────────────────────
 
 // TestBuildRunArgs_HostAPITCPPortPublishAndEnv asserts that when HostAPITCPPort
-// is non-zero, buildRunArgs emits --publish 127.0.0.1:<port>:4097 and
-// PRISM_HOST_API=http://127.0.0.1:4097, and that NO unix:// env var or
-// socket-directory volume is present.
+// is non-zero, buildRunArgs sets PRISM_HOST_API=http://host.containers.internal:<port>
+// and does NOT emit a --publish flag for the host-API port or a unix:// env var
+// or socket-directory volume mount.
 func TestBuildRunArgs_HostAPITCPPortPublishAndEnv(t *testing.T) {
 	const hostPort = 51234
 	m := New(Config{
@@ -606,21 +606,19 @@ func TestBuildRunArgs_HostAPITCPPortPublishAndEnv(t *testing.T) {
 	})
 	args := m.buildRunArgs()
 
-	// Must have --publish 127.0.0.1:51234:4097.
-	wantPublish := fmt.Sprintf("127.0.0.1:%d:%d", hostPort, HostAPIContainerPort)
-	foundPublish := false
+	// Must NOT have --publish for the host-API port (no port forwarding needed;
+	// the container reaches the sidecar via host.containers.internal).
 	for i, arg := range args {
-		if arg == "--publish" && i+1 < len(args) && args[i+1] == wantPublish {
-			foundPublish = true
-			break
+		if arg == "--publish" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, fmt.Sprintf(":%d", hostPort)) && v != fmt.Sprintf("127.0.0.1:%d:%d", hostPort, ContainerPort) {
+				t.Errorf("unexpected --publish for host-API port when HostAPITCPPort is set: %q", v)
+			}
 		}
 	}
-	if !foundPublish {
-		t.Errorf("expected --publish %s in args, not found: %v", wantPublish, args)
-	}
 
-	// Must have PRISM_HOST_API=http://127.0.0.1:4097.
-	wantEnv := fmt.Sprintf("PRISM_HOST_API=http://127.0.0.1:%d", HostAPIContainerPort)
+	// Must have PRISM_HOST_API=http://host.containers.internal:<hostPort>.
+	wantEnv := fmt.Sprintf("PRISM_HOST_API=http://host.containers.internal:%d", hostPort)
 	foundEnv := false
 	for i, arg := range args {
 		if arg == "--env" && i+1 < len(args) && args[i+1] == wantEnv {
@@ -691,12 +689,14 @@ func TestBuildRunArgs_HostAPISockUnixPathLinux(t *testing.T) {
 		t.Errorf("expected --volume %s in args, not found: %v", wantMount, args)
 	}
 
-	// Must NOT have --publish for port 4097.
-	wantNoPublish := fmt.Sprintf(":%d", HostAPIContainerPort)
+	// Must NOT have --publish for a host-API port (the former HostAPIContainerPort
+	// 4097 is now gone; the Linux path never emits --publish for host-API).
 	for i, arg := range args {
 		if arg == "--publish" && i+1 < len(args) {
-			if strings.Contains(args[i+1], wantNoPublish) {
-				t.Errorf("unexpected --publish for port %d when HostAPITCPPort is zero: %q", HostAPIContainerPort, args[i+1])
+			v := args[i+1]
+			// The only --publish allowed is the opencode container port (4096).
+			if !strings.HasSuffix(v, ":4096") {
+				t.Errorf("unexpected --publish when HostAPITCPPort is zero: %q", v)
 			}
 		}
 	}
@@ -711,23 +711,25 @@ func TestBuildRunArgs_HostAPISockUnixPathLinux(t *testing.T) {
 	}
 }
 
-// TestBuildRunArgs_HostAPITCPPort_LoopbackOnly asserts that the --publish flag
-// for the host-API TCP port is constrained to 127.0.0.1 (never 0.0.0.0).
+// TestBuildRunArgs_HostAPITCPPort_LoopbackOnly asserts that when HostAPITCPPort
+// is set, no --publish flag is emitted for the host-API port (the container
+// reaches the sidecar via host.containers.internal, not port forwarding).
 func TestBuildRunArgs_HostAPITCPPort_LoopbackOnly(t *testing.T) {
+	const hostPort = 51234
 	m := New(Config{
 		SessionName:    "repo@feat",
 		AllocatedPort:  14000,
-		HostAPITCPPort: 51234,
+		HostAPITCPPort: hostPort,
 	})
 	args := m.buildRunArgs()
 
+	// No --publish should reference the host-API TCP port.
 	for i, arg := range args {
 		if arg == "--publish" && i+1 < len(args) {
 			v := args[i+1]
-			if strings.Contains(v, fmt.Sprintf(":%d", HostAPIContainerPort)) {
-				if !strings.HasPrefix(v, "127.0.0.1:") {
-					t.Errorf("host-API --publish is not loopback-only: %q", v)
-				}
+			// The only allowed --publish is the opencode container port (AllocatedPort:4096).
+			if strings.Contains(v, fmt.Sprintf("%d:", hostPort)) || strings.HasSuffix(v, fmt.Sprintf(":%d", hostPort)) {
+				t.Errorf("unexpected --publish referencing host-API TCP port %d: %q", hostPort, v)
 			}
 		}
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -244,22 +244,27 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	if s.cfg.Container != nil {
 		sessionStart := time.Now()
 
-		// On Darwin, start a TCP listener on 127.0.0.1:0 BEFORE container creation
-		// so the OS-allocated port is known when buildRunArgs() emits --publish.
+		// On Darwin, start a TCP listener on 0.0.0.0:0 BEFORE container creation
+		// so the OS-allocated port is known when the container env is configured.
 		// virtiofs returns ENOTSUP on connect() for Unix sockets mounted into the
-		// container VM, so TCP port forwarding is used instead (#661).
+		// container VM, so TCP is used instead (#661). The listener must bind on
+		// 0.0.0.0 (not 127.0.0.1) so that gvproxy's bridge interface
+		// (192.168.127.254) can reach it from inside the container VM — loopback
+		// is not reachable from the VM network. No --publish flag is needed:
+		// the container reaches the sidecar via host.containers.internal:<port>,
+		// which routes through the gvproxy bridge directly to this listener.
 		//
 		// Failure to bind is FATAL. A silent fallback to Unix-socket-only mode would
 		// reproduce the ENOTSUP bug (#661) — the container would start without a
 		// working host-API channel. Returning an error here aborts container startup
 		// with a clear message rather than creating a silently broken session.
 		if runtime.GOOS == "darwin" && s.cfg.HostAPISockPath != "" {
-			tcpLn, tcpErr := net.Listen("tcp", "127.0.0.1:0")
+			tcpLn, tcpErr := net.Listen("tcp", "0.0.0.0:0")
 			if tcpErr != nil {
 				return fmt.Errorf("sidecar: host-API TCP listener: %w", tcpErr)
 			}
 			port := tcpLn.Addr().(*net.TCPAddr).Port
-			log.Printf("sidecar: host-API TCP listener bound on 127.0.0.1:%d", port)
+			log.Printf("sidecar: host-API TCP listener bound on 0.0.0.0:%d", port)
 			s.cfg.HostAPITCPPort = port
 			s.cfg.Container.HostAPITCPPort = port
 			s.mu.Lock()
@@ -408,7 +413,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 						log.Printf("sidecar: host-API server (tcp): %v", err)
 					}
 				}()
-				log.Printf("sidecar: host-API TCP server serving on 127.0.0.1:%d", s.cfg.HostAPITCPPort)
+				log.Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
 			}
 		} else if s.cfg.HostAPISockPath == "" {
 			log.Printf("sidecar: host-API server: HostAPISockPath is empty — skipping (container mode active but no socket path configured)")


### PR DESCRIPTION
## Summary

Fixes two bugs in the Darwin TCP host-API path introduced by #673 that caused every container spawn to fail with a \"bind: address already in use\" error, leaving the container in \"created\" state.

**Bug 1 — double bind (immediate crash cause):** `sidecar.go` bound `127.0.0.1:P` before container creation, then `buildRunArgs()` emitted `--publish 127.0.0.1:P:4097`, causing gvproxy to also attempt to bind `127.0.0.1:P`. Two listeners can't share a port — gvproxy fails and the container is left in \"created\" state.

**Bug 2 — wrong network direction:** `PRISM_HOST_API=http://127.0.0.1:4097` inside the container pointed at the container's own loopback, not the macOS sidecar. `--publish` is for inbound connections to the container (macOS→container), not container→host communication.

## Changes

- **`sidecar.go`**: Bind TCP listener on `0.0.0.0:0` instead of `127.0.0.1:0` so the gvproxy bridge interface (`192.168.127.254`) can reach it from inside the VM. Updated comments and log lines.
- **`container.go`**: Remove the `--publish` flag for the host-API port entirely. Set `PRISM_HOST_API=http://host.containers.internal:<P>` so the container reaches the sidecar via the gvproxy bridge. Remove the now-dead `HostAPIContainerPort = 4097` constant.
- **`container_test.go`**: Update `TestBuildRunArgs_HostAPITCPPortPublishAndEnv` and `TestBuildRunArgs_HostAPITCPPort_LoopbackOnly` to assert the new model; update `TestBuildRunArgs_HostAPISockUnixPathLinux` to remove reference to the deleted constant.

Closes #674