### PR TITLE
fix(prism): probe /global/health instead of / to eliminate 3-4s startup delay

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -4,6 +4,12 @@
 // "opencode serve --port 4096", health-checks it until the HTTP endpoint
 // responds, and stops/removes the container on shutdown.
 //
+// Health check: we probe GET /global/health (not GET /) because the root URL
+// falls through to opencode's UIRoutes catch-all, which proxies to
+// https://app.opencode.ai/ when there is no embedded web UI — adding a 3–4 s
+// network round-trip on every container startup. /global/health is in
+// ControlPlaneRoutes and returns immediately with no external I/O.
+//
 // Design notes:
 //   - All podman operations use exec.Command("podman", ...) — no daemon or
 //     socket is required from Go's perspective, just a podman binary on PATH.
@@ -183,9 +189,14 @@ func New(cfg Config) *Manager {
 		httpClient = &http.Client{Timeout: 5 * time.Second}
 	}
 	return &Manager{
-		cfg:            cfg,
-		name:           containerName(cfg.SessionName),
-		healthCheckURL: fmt.Sprintf("http://127.0.0.1:%d/", cfg.AllocatedPort),
+		cfg:  cfg,
+		name: containerName(cfg.SessionName),
+		// Use /global/health rather than / — the root URL falls through to
+		// UIRoutes which proxies to https://app.opencode.ai/ when there is no
+		// embedded web UI, adding a 3–4 s network round-trip to every startup.
+		// /global/health is in ControlPlaneRoutes and returns immediately with
+		// no MCP initialisation, plugin loading, or external network calls.
+		healthCheckURL: fmt.Sprintf("http://127.0.0.1:%d/global/health", cfg.AllocatedPort),
 		httpClient:     httpClient,
 	}
 }


### PR DESCRIPTION
## Summary

- Root cause of the ~4-second startup cliff identified: `WaitHealthy` probed `GET /` which falls through to opencode's `UIRoutes` catch-all; without an embedded web UI, it proxies to `https://app.opencode.ai/` — a network round-trip that accounts for the entire silent gap
- Fix: change the health check URL from `/` to `/global/health`, which is served directly by `ControlPlaneRoutes` and returns `{healthy: true, version: ...}` with no external I/O

## Investigation findings

The profiling data in #659 showed a consistent ~4-second silent window between health probe failures and the first success. Tracing the opencode source:

1. `opencode serve` binds the HTTP port immediately via `Server.listen()` — not the bottleneck
2. `GET /` has no explicit handler in `ControlPlaneRoutes` or `InstanceRoutes`, so Hono falls through to `UIRoutes().all("/*", ...)`
3. `UIRoutes` tries to import `opencode-web-ui.gen.ts` — which doesn't exist in `opencode serve` mode — and falls back to proxying to `https://app.opencode.ai/path`
4. That external HTTPS round-trip takes ~3–4 s, explaining the cliff exactly

## Expected impact

- `WaitHealthy` drops from ~5–6 s to ~1–2 s (residual = bun/JS runtime startup + port binding)
- Total container spawn latency: ~6 s → ~2 s

## What was NOT the bottleneck

- MCP server initialisation (`mcp-atlassian-slim-proxy.mjs`) — this runs lazily on first MCP call, not at startup
- `InstanceBootstrap` — called on the first real request (e.g. `POST /session`), not during health check
- Bun/JS module loading — fast once the port is bound

Closes #659