### PR TITLE
fix: add variant=none to all non-thinking roles in profiles

### DIFF
--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -53,54 +53,67 @@
             };
             secondary = {
               model = "anthropic/claude-sonnet-4-6";
+              variant = "none";
             };
             lightweight = {
               model = "anthropic/claude-haiku-4-5";
+              variant = "none";
             };
           };
           anthropic-opus = {
             primary = {
               model = "anthropic/claude-opus-4-6";
+              variant = "none";
             };
             secondary = {
               model = "anthropic/claude-opus-4-6";
+              variant = "none";
             };
             lightweight = {
               model = "anthropic/claude-haiku-4-5";
+              variant = "none";
             };
           };
           gemini-hybrid = {
             primary = {
               model = "anthropic/claude-sonnet-4-6";
+              variant = "none";
             };
             secondary = {
               model = "google/gemini-3.1-pro-preview-customtools";
-              variant = "medium";
+              variant = "none";
             };
             lightweight = {
               model = "anthropic/claude-haiku-4-5";
+              variant = "none";
             };
           };
           github-copilot = {
             primary = {
               model = "github-copilot/claude-sonnet-4.6";
+              variant = "none";
             };
             secondary = {
               model = "github-copilot/claude-sonnet-4.6";
+              variant = "none";
             };
             lightweight = {
               model = "github-copilot/claude-haiku-4.5";
+              variant = "none";
             };
           };
           google = {
             primary = {
               model = "google/gemini-3-flash-preview";
+              variant = "none";
             };
             secondary = {
               model = "google/gemini-3.1-flash-lite-preview";
+              variant = "none";
             };
             lightweight = {
               model = "google/gemini-3.1-flash-lite-preview";
+              variant = "none";
             };
           };
         };


### PR DESCRIPTION
## Summary

- Workers and other non-thinking roles were inheriting `variant = "medium"` from persisted opencode state via the shared `~/.local/share/opencode` mount
- Add explicit `variant = "none"` to every role that should not use extended thinking, so the explicit value overrides any persisted state
- `anthropic.primary` retains `variant = "medium"` as the only role that should use thinking

## Changes

| Profile | Role | Before | After |
|---|---|---|---|
| `anthropic` | `secondary` | (none) | `"none"` |
| `anthropic` | `lightweight` | (none) | `"none"` |
| `anthropic-opus` | `primary` | (none) | `"none"` |
| `anthropic-opus` | `secondary` | (none) | `"none"` |
| `anthropic-opus` | `lightweight` | (none) | `"none"` |
| `gemini-hybrid` | `primary` | (none) | `"none"` |
| `gemini-hybrid` | `secondary` | `"medium"` | `"none"` |
| `gemini-hybrid` | `lightweight` | (none) | `"none"` |
| `github-copilot` | `primary` | (none) | `"none"` |
| `github-copilot` | `secondary` | (none) | `"none"` |
| `github-copilot` | `lightweight` | (none) | `"none"` |
| `google` | `primary` | (none) | `"none"` |
| `google` | `secondary` | (none) | `"none"` |
| `google` | `lightweight` | (none) | `"none"` |

Darwin nix build passes with these changes.