### PR TITLE
enable enhanced parallel review system on m4mac

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -25,6 +25,7 @@ in
   nx = {
     programs = {
       prism.opencode.provider = "anthropic";
+      prism.opencode.enhancedReview = true;
       # Disable programs that default to enabled but aren't needed/available on Darwin
       podman.enable = false;
       dragon-drop.enable = false;


### PR DESCRIPTION
## Summary

- Enables `nx.programs.prism.opencode.enhancedReview = true` on the m4mac machine configuration
- Darwin nix build verified clean before opening this PR