### PR TITLE
fix: extract Claude credentials from macOS Keychain for container mode

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -177,6 +178,12 @@ type Manager struct {
 	// allowed_signers temp file. buildRunArgs uses this to gate the bind-mount
 	// so that podman is never given a source path that doesn't exist on disk.
 	allowedSignersReady bool
+	// claudeCredentialsReady is true when writeClaudeCredentials successfully
+	// extracted Claude credentials from the macOS Keychain and wrote them to
+	// a temp file. buildRunArgs uses this to gate the bind-mount so that
+	// podman is never given a source path that doesn't exist on disk.
+	// This field is only ever true on Darwin.
+	claudeCredentialsReady bool
 }
 
 // New creates a Manager for the given config. It does not start the container.
@@ -218,6 +225,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.gitconfigFilePath())
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.opencodeConfigFilePath())
+	_ = os.Remove(m.claudeCredentialsFilePath())
 
 	// Check the container's instance label when we have our own InstanceID.
 	// This detects ownership mismatches where a container from a previous
@@ -294,6 +302,53 @@ func (m *Manager) allowedSignersFilePath() string {
 // file location.
 func (m *Manager) opencodeConfigFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-opencode-config-"+m.name)
+}
+
+// claudeCredentialsFilePath returns the host path for the temporary Claude
+// credentials file written before container start (Darwin only). On Darwin,
+// Claude Code stores OAuth credentials in the macOS Keychain rather than
+// ~/.claude/.credentials.json. We extract the token and write it to a temp
+// file so it can be bind-mounted at /root/.claude/.credentials.json inside
+// the container where opencode-claude-auth can read it.
+func (m *Manager) claudeCredentialsFilePath() string {
+	return filepath.Join(os.TempDir(), "prism-claude-creds-"+m.name)
+}
+
+// writeClaudeCredentials extracts Claude Code credentials from the macOS
+// Keychain and writes them to a temp file. On Linux, Claude Code stores
+// credentials in ~/.claude/.credentials.json which is already inside the
+// claudeMount bind-mounted directory and requires no special handling. On
+// Darwin, credentials are stored in the Keychain under the service name
+// "Claude Code-credentials" and never reach disk, so the container never
+// sees them via the directory mount alone.
+//
+// Sets m.claudeCredentialsReady to true on success so that buildRunArgs can
+// add the bind-mount. Logs and returns without error on failure — a missing
+// Keychain entry (e.g. not logged in) should surface as an auth error from
+// opencode rather than a hard container launch failure.
+func (m *Manager) writeClaudeCredentials() {
+	m.claudeCredentialsReady = false
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "security", "find-generic-password",
+		"-l", "Claude Code-credentials", "-w").Output()
+	if err != nil {
+		log.Printf("container: could not extract Claude credentials from macOS Keychain: %v — opencode-claude-auth may fail to authenticate", err)
+		return
+	}
+	creds := strings.TrimSpace(string(out))
+	if creds == "" {
+		log.Printf("container: macOS Keychain returned empty Claude credentials — run `claude login` to authenticate")
+		return
+	}
+	if err := os.WriteFile(m.claudeCredentialsFilePath(), []byte(creds), 0o600); err != nil {
+		log.Printf("container: failed to write Claude credentials temp file: %v", err)
+		return
+	}
+	m.claudeCredentialsReady = true
 }
 
 // writeGitconfig generates a minimal .gitconfig for the container and writes
@@ -475,6 +530,11 @@ func (m *Manager) Create(ctx context.Context) error {
 		}
 	}
 
+	// On Darwin, extract Claude Code credentials from the macOS Keychain and
+	// write them to a temp file so the container can find them. On Linux,
+	// ~/.claude/.credentials.json is already inside the claudeMount directory.
+	m.writeClaudeCredentials()
+
 	// Build the podman run arguments.
 	t0 = time.Now()
 	args := m.buildRunArgs()
@@ -617,6 +677,7 @@ func (m *Manager) Shutdown() {
 	_ = os.Remove(m.gitconfigFilePath())
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.opencodeConfigFilePath())
+	_ = os.Remove(m.claudeCredentialsFilePath())
 
 	log.Printf("container: %q removed", m.name)
 }
@@ -695,11 +756,26 @@ func (m *Manager) buildRunArgs() []string {
 		"--volume", opencodeCacheMount,
 		// bun transpiler cache — pre-compiled plugin modules from host.
 		"--volume", bunCacheMount,
-		// Claude credentials — read-write for auth plugin token refresh.
+		// Claude credentials directory — read-write for auth plugin token refresh.
+		// On Linux, ~/.claude/.credentials.json lives here.
+		// On Darwin, .credentials.json is absent (credentials are in the macOS
+		// Keychain); writeClaudeCredentials() extracts and writes it to a temp
+		// file that is bind-mounted below at /root/.claude/.credentials.json.
 		"--volume", claudeMount,
 		// Nix eval cache — flake input tarballs pre-unpacked from the host.
 		"--volume", nixCacheMount,
+	)
 
+	// Darwin: bind-mount the extracted Keychain credentials over
+	// /root/.claude/.credentials.json so opencode-claude-auth can find them.
+	// On Linux this file already exists inside the claudeMount directory.
+	if m.claudeCredentialsReady {
+		args = append(args,
+			"--volume", m.claudeCredentialsFilePath()+":/root/.claude/.credentials.json:ro",
+		)
+	}
+
+	args = append(args,
 		// Nix daemon socket — lets the container's nix CLI delegate store
 		// operations to the host's nix-daemon, reusing the host's /nix/store
 		// cache and persisting new build outputs for reuse across container

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -2038,6 +2039,81 @@ func TestBuildRunArgs_AllowedSignersNotMountedWhenSigningUnavailable(t *testing.
 			if strings.HasSuffix(args[i+1], ":/root/.ssh/allowed_signers:ro") {
 				t.Errorf("allowed_signers mount must not be present when signing keys are unavailable; found %q", args[i+1])
 			}
+		}
+	}
+}
+
+// ── writeClaudeCredentials / Darwin Keychain tests ───────────────────────────
+
+// TestWriteClaudeCredentials_NoopOnLinux verifies that writeClaudeCredentials
+// is a no-op on non-Darwin platforms: claudeCredentialsReady stays false and
+// no temp file is written. On Darwin this test still passes because it only
+// asserts the invariant that claudeCredentialsReady accurately tracks whether
+// the file was written — the Keychain call may succeed or fail, but the
+// ready flag must match.
+func TestWriteClaudeCredentials_NoopOnLinux(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping Linux-specific no-op check on Darwin")
+	}
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 9999})
+	m.writeClaudeCredentials()
+	if m.claudeCredentialsReady {
+		t.Error("claudeCredentialsReady should be false on non-Darwin")
+	}
+	if _, err := os.Stat(m.claudeCredentialsFilePath()); !os.IsNotExist(err) {
+		t.Errorf("credentials temp file should not exist on non-Darwin, got: %v", err)
+	}
+}
+
+// TestBuildRunArgs_ClaudeCredentialsMountedWhenReady verifies that when
+// claudeCredentialsReady is true (simulating a successful Keychain extraction),
+// buildRunArgs includes the bind-mount at /root/.claude/.credentials.json.
+func TestBuildRunArgs_ClaudeCredentialsMountedWhenReady(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14001})
+
+	// Simulate a successful writeClaudeCredentials by writing a fake file and
+	// setting the flag directly (avoids requiring actual Keychain access in CI).
+	fakeCredsContent := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-test"}}`
+	if err := os.WriteFile(m.claudeCredentialsFilePath(), []byte(fakeCredsContent), 0o600); err != nil {
+		t.Fatalf("write fake creds: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.claudeCredentialsFilePath()) })
+	m.claudeCredentialsReady = true
+
+	args := m.buildRunArgs()
+
+	wantDst := ":/root/.claude/.credentials.json:ro"
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) && strings.HasSuffix(args[i+1], wantDst) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("buildRunArgs missing Claude credentials mount ending in %q", wantDst)
+	}
+}
+
+// TestBuildRunArgs_ClaudeCredentialsNotMountedWhenNotReady verifies that when
+// claudeCredentialsReady is false (e.g. not logged in, or Linux), buildRunArgs
+// does NOT include the /root/.claude/.credentials.json bind-mount.
+func TestBuildRunArgs_ClaudeCredentialsNotMountedWhenNotReady(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14002})
+	// claudeCredentialsReady defaults to false — do not set it.
+
+	args := m.buildRunArgs()
+
+	wantDst := ":/root/.claude/.credentials.json:ro"
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) && strings.HasSuffix(args[i+1], wantDst) {
+			t.Errorf("Claude credentials mount must not be present when claudeCredentialsReady=false; found %q", args[i+1])
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- On macOS, Claude Code stores OAuth credentials in the macOS Keychain under `"Claude Code-credentials"`, not in `~/.claude/.credentials.json`
- The container only received the `~/.claude/` directory mount, which has no credentials file on macOS — causing `opencode-claude-auth` to fail silently and auth to break
- On Linux, `claude login` writes `~/.claude/.credentials.json` which IS inside the mounted directory, so it worked fine there

## Fix

Before container creation on Darwin, the sidecar now runs:
```
security find-generic-password -l "Claude Code-credentials" -w
```
to extract the Keychain JSON blob, writes it to a temp file, and bind-mounts it at `/root/.claude/.credentials.json:ro` inside the container. The temp file is cleaned up on container shutdown, following the same pattern as the `allowedSignersReady` flag for SSH signing keys.

Closes #681