### PR TITLE
fix: strip variant from disabled agents in worker container config

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -512,46 +512,57 @@
         default_agent = "worker";
         enabled_providers = containerEnabledProviders;
         model = models.secondary;
-        agent = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider (
-          {
-            worker = {
-              description = "Default worker agent with full tool access";
-              mode = "primary";
-              color = config.theme.red;
-              permission = {
-                bash = containerWorkerBashCommands;
-              };
-            };
-            ac = { };
-            explore = { };
-            title = { };
-            summary = { };
-            compaction = { };
-            coordinator = {
-              disable = true;
-            };
-            build = {
-              disable = true;
-            };
-            plan = {
-              disable = true;
-            };
-          }
-          // (
-            if config.nx.programs.prism.opencode.enhancedReview then
-              {
-                review-goal = { };
-                review-code = { };
-                review-security = { };
-                review-qa = { };
-                review-context = { };
-              }
-            else
-              {
-                review = { };
-              }
-          )
-        );
+        agent =
+          let
+            profiledAgents =
+              config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider
+                (
+                  {
+                    worker = {
+                      description = "Default worker agent with full tool access";
+                      mode = "primary";
+                      color = config.theme.red;
+                      permission = {
+                        bash = containerWorkerBashCommands;
+                      };
+                    };
+                    ac = { };
+                    explore = { };
+                    title = { };
+                    summary = { };
+                    compaction = { };
+                    coordinator = {
+                      disable = true;
+                    };
+                    build = {
+                      disable = true;
+                    };
+                    plan = {
+                      disable = true;
+                    };
+                  }
+                  // (
+                    if config.nx.programs.prism.opencode.enhancedReview then
+                      {
+                        review-goal = { };
+                        review-code = { };
+                        review-security = { };
+                        review-qa = { };
+                        review-context = { };
+                      }
+                    else
+                      {
+                        review = { };
+                      }
+                  )
+                );
+            # Strip variant from disabled agents so their primary-role "medium"
+            # doesn't poison the model's thinking level for the worker.
+            sanitisedAgents = lib.mapAttrs (
+              _name: cfg: if cfg ? disable && cfg.disable then builtins.removeAttrs cfg [ "variant" ] else cfg
+            ) profiledAgents;
+          in
+          sanitisedAgents;
         # lib.mkIf cannot be used here — this is serialised with builtins.toJSON,
         # not processed by the module system. Use optionalAttrs so the key is
         # absent entirely on Linux rather than emitting a malformed _type object.


### PR DESCRIPTION
## Summary

- `applyProfile` was applying primary-role config (`variant=medium` for the `anthropic` profile) to `coordinator` and `plan` agents even when they were set to `disable=true` in the worker container config
- Since `coordinator`, `plan`, and `worker` all share the same model (`anthropic/claude-sonnet-4-6`), opencode resolved the model's thinking level to `medium`, overriding the worker's `none`
- Fix post-processes the result of `applyProfile` in `workerContainerOpencodeJson` to remove the `variant` key from any agent with `disable=true`

## Verification

After the fix, no agent in the worker container config has `variant: "medium"`. The coordinator container config is unaffected — `coordinator` and `plan` retain `variant: "medium"` there.

Closes #682