### PR TITLE
ci: watch prism Go source in publish-prism-agent workflow

### DIFF
--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -7,6 +7,7 @@ name: publish-prism-agent
       - 'images/prism-agent.nix'
       - 'flake.nix'
       - 'flake.lock'
+      - 'modules/programs/prism/prism/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds `modules/programs/prism/prism/**` to the `paths` filter in `.github/workflows/publish-prism-agent.yml`
- Ensures changes to the prism Go source trigger a rebuild of the container image

Closes #684