### PR TITLE
feat: prism review — platform-native review primitive with tmux window observability

### DIFF
--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -49,6 +49,24 @@ When your work is complete and quality gates pass:
 2. Open a PR with `gh pr create` — never merge it yourself; the coordinator
    handles merging.
 3. Never push to `main` — direct push is blocked by repository rules.
-4. Invoke the `@review` subagent with your PR number. Fix any issues it raises
-   and re-invoke `@review` until the review passes.
+4. Run code review using `prism review <pr-number>` (preferred) or the
+   `@review` subagent. Both are valid; `prism review` provides better
+   observability (visible in the dashboard) and isolation. Fix any issues and
+   re-run review until it passes.
 5. Provide a clear handoff summary so the coordinator has full context.
+
+### Running code review with prism review
+
+```bash
+# Run review against your PR (blocks until complete, returns findings to stdout)
+result=$(prism review <pr-number>)
+echo "$result"
+
+# If some agents fail, re-run only the failed ones
+prism review <pr-number> --only review
+
+# Check in on review progress from the coordinator session
+prism checkin $(tmux display-message -p '#{session_name}')~review
+```
+
+`prism review` exit code 0 = all agents passed; non-zero = failures.

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -144,7 +144,72 @@ prism spawn \
   --prompt "find the plex container image in this repo and update it to the latest tag from dockerhub, then open a PR"
 ```
 
-## Example: reviewing a PR
+## Running code review with prism review
+
+`prism review <pr-number>` is the preferred way to run code review from a worker session. It spawns review agents in a dedicated, observable tmux session (`<parent>~review-N`) and returns findings to stdout when all agents complete.
+
+```bash
+# Run review — blocks until all agents finish, returns findings to stdout
+result=$(prism review 268)
+echo "$result"
+
+# Re-run only failed agents
+prism review 268 --only review
+
+# Keep the review session open for debugging (default: session is killed on exit)
+prism review 268 --keep
+
+# Custom timeout (default: 10m)
+prism review 268 --timeout 5m
+```
+
+**Output format:**
+```
+✓ review              passed
+✗ review              [findings...]
+
+1 agent(s) failed. Retry: prism review 268 --only review
+```
+
+Exit code 0 = all passed, non-zero = failures.
+
+**Review sessions appear in the dashboard** at depth 2, indented under their parent branch:
+```
+nixos-config@main                   coordinator
+  ├── @feature-branch               worker
+  │   ├── ~review-1                 round 1 (finished)
+  │   └── ~review-2                 round 2 (active)
+```
+
+**Checking in on review progress:**
+```bash
+# From the coordinator session, inspect all review rounds for a worker
+prism checkin nixos-config@feature-branch~review
+
+# Show full per-agent conversation
+prism checkin nixos-config@feature-branch~review --verbose
+```
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--harness <name>` | Runtime harness (default: `opencode`) |
+| `--keep` | Keep the review session open after completion |
+| `--timeout <dur>` | Per-agent timeout (default: `10m`) |
+| `--only <csv>` | Run only named agents (e.g. `--only review`) |
+
+### When to use prism review vs @review
+
+| Situation | Use |
+|---|---|
+| Worker running in a tmux session (normal case) | `prism review` |
+| Want review visible in the dashboard | `prism review` |
+| Running in a context without tmux | `@review` subagent |
+
+Both paths coexist — use whichever is appropriate.
+
+## Example: reviewing a PR (manual spawn)
 
 ```bash
 # PR in the current repo

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1428,9 +1429,22 @@ func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
 	defer d.Close()
 
 	// Find all sessions (active and ended) whose name starts with roundPrefix.
-	rounds, err := d.AllStatusesWithPrefix(roundPrefix)
+	// This includes both round sessions and agent sub-sessions; we filter below.
+	all, err := d.AllStatusesWithPrefix(roundPrefix)
 	if err != nil {
 		return fmt.Errorf("checkin review: query db: %w", err)
+	}
+
+	// Filter to only round-level sessions. A round session has a suffix that is
+	// a pure integer (e.g. "nixos-config@feature~review-1"). Agent sub-sessions
+	// have an additional ~ separator (e.g. "nixos-config@feature~review-1~review").
+	var rounds []db.Status
+	for _, s := range all {
+		suffix := strings.TrimPrefix(s.SessionName, roundPrefix)
+		// Only include if suffix is a pure integer (no further separators).
+		if _, convErr := strconv.Atoi(suffix); convErr == nil {
+			rounds = append(rounds, s)
+		}
 	}
 
 	if len(rounds) == 0 {
@@ -1438,12 +1452,20 @@ func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
 		return nil
 	}
 
-	// Sort rounds by session name (lexicographic order works since round
-	// numbers are 1-indexed integers and the prefix is the same length).
+	// Sort rounds numerically by round number.
+	// Since the session names share the same prefix, lexicographic sorting is
+	// correct for single-digit rounds; for safety we sort by the numeric suffix.
 	for i := 1; i < len(rounds); i++ {
 		key := rounds[i]
+		keySuffix := strings.TrimPrefix(key.SessionName, roundPrefix)
+		keyN, _ := strconv.Atoi(keySuffix)
 		j := i - 1
-		for j >= 0 && rounds[j].SessionName > key.SessionName {
+		for j >= 0 {
+			jSuffix := strings.TrimPrefix(rounds[j].SessionName, roundPrefix)
+			jN, _ := strconv.Atoi(jSuffix)
+			if jN <= keyN {
+				break
+			}
 			rounds[j+1] = rounds[j]
 			j--
 		}
@@ -1469,10 +1491,14 @@ func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
 				fmt.Fprintf(os.Stderr, "  [error reading round %s: %v]\n", label, err)
 			}
 		} else {
-			// Show summary: last msg_assistant event per round.
+			// Show summary: last msg_assistant event per round session.
+			// The round session itself receives the aggregated output from the
+			// review agents (via the prism review CLI output). If no msg_assistant
+			// events exist for the round session, fall back to showing the agent
+			// sub-session output.
 			events, qerr := d.QueryEvents(roundName, 1, nil, nil, []string{"msg_assistant"})
 			if qerr != nil || len(events) == 0 {
-				fmt.Println(styleDim.Render("  (no output)"))
+				fmt.Println(styleDim.Render("  (no output recorded for this round)"))
 			} else {
 				e := events[len(events)-1]
 				ts := e.CreatedAt.Local().Format("15:04:05")

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -87,7 +87,16 @@ func runCheckin(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return runCheckinSession(args[0], last, beforePtr, afterPtr, types, verbose)
+	sessionArg := args[0]
+
+	// Special case: if the session argument ends with "~review" (no round number),
+	// prefix-match all ~review-* rounds for the parent session and display a
+	// summary of each round.
+	if strings.HasSuffix(sessionArg, "~review") {
+		return runCheckinReviewRounds(sessionArg, verbose)
+	}
+
+	return runCheckinSession(sessionArg, last, beforePtr, afterPtr, types, verbose)
 }
 
 // runCheckinSession is the DB-backed path. Falls back to legacy screen-scrape
@@ -1397,6 +1406,89 @@ func printSessionTable(ss []db.Status) error {
 	fmt.Println()
 	hint := "run `prism checkin <session>` to inspect a session"
 	fmt.Println(lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Render(hint))
+
+	return nil
+}
+
+// runCheckinReviewRounds handles `prism checkin <parent>~review` — a prefix
+// match that lists all ~review-N rounds for the parent session.
+//
+// Default mode: one summary entry per round (the final aggregated output from
+// the last msg_assistant event per round session).
+// Verbose mode (--verbose): shows the full per-agent conversation for each round.
+func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
+	// reviewPrefix is e.g. "nixos-config@feature~review" — the actual round
+	// sessions are "nixos-config@feature~review-1", "~review-2", etc.
+	roundPrefix := reviewPrefix + "-"
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("checkin review: open db: %w", err)
+	}
+	defer d.Close()
+
+	// Find all sessions (active and ended) whose name starts with roundPrefix.
+	rounds, err := d.AllStatusesWithPrefix(roundPrefix)
+	if err != nil {
+		return fmt.Errorf("checkin review: query db: %w", err)
+	}
+
+	if len(rounds) == 0 {
+		fmt.Printf("no review rounds found matching %q\n", reviewPrefix)
+		return nil
+	}
+
+	// Sort rounds by session name (lexicographic order works since round
+	// numbers are 1-indexed integers and the prefix is the same length).
+	for i := 1; i < len(rounds); i++ {
+		key := rounds[i]
+		j := i - 1
+		for j >= 0 && rounds[j].SessionName > key.SessionName {
+			rounds[j+1] = rounds[j]
+			j--
+		}
+		rounds[j+1] = key
+	}
+
+	styleBold := lipgloss.NewStyle().Bold(true)
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	for _, round := range rounds {
+		roundName := round.SessionName
+		// Extract round label: everything after the last "~".
+		label := roundName
+		if idx := strings.LastIndex(roundName, "~"); idx >= 0 {
+			label = roundName[idx:] // e.g. "~review-1"
+		}
+
+		fmt.Printf("%s\n\n", styleBold.Render(label+" ("+roundName+")"))
+
+		if verbose {
+			// Show full conversation for this round.
+			if err := runCheckinSession(roundName, 20, nil, nil, nil, true); err != nil {
+				fmt.Fprintf(os.Stderr, "  [error reading round %s: %v]\n", label, err)
+			}
+		} else {
+			// Show summary: last msg_assistant event per round.
+			events, qerr := d.QueryEvents(roundName, 1, nil, nil, []string{"msg_assistant"})
+			if qerr != nil || len(events) == 0 {
+				fmt.Println(styleDim.Render("  (no output)"))
+			} else {
+				e := events[len(events)-1]
+				ts := e.CreatedAt.Local().Format("15:04:05")
+				var ap struct {
+					Text string `json:"text"`
+				}
+				text := e.Payload
+				if jerr := json.Unmarshal([]byte(e.Payload), &ap); jerr == nil && ap.Text != "" {
+					text = ap.Text
+				}
+				fmt.Printf("  [%s]\n  %s\n", ts, strings.ReplaceAll(text, "\n", "\n  "))
+			}
+		}
+		fmt.Println(styleDim.Render("── end of round ──"))
+		fmt.Println()
+	}
 
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/review"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -198,6 +199,9 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 				_ = branchErr
 			}
 		}
+
+		// Kill any review sessions spawned by this parent session.
+		review.KillReviewSessionsForParent(m.session)
 
 		// Ensure scratchpad exists.
 		if !tmux.HasSession("scratchpad") {
@@ -464,6 +468,9 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		}
 	}
 
+	// Kill any review sessions spawned by this parent session.
+	review.KillReviewSessionsForParent(session)
+
 	fmt.Printf("killing session %s\n", session)
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
@@ -539,6 +546,9 @@ func headlessCloseSession(session string) error {
 	}
 
 	fmt.Printf("closing session %s...\n", session)
+
+	// Kill any review sessions spawned by this parent session.
+	review.KillReviewSessionsForParent(session)
 
 	// Ensure scratchpad exists.
 	if !tmux.HasSession("scratchpad") {

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/review"
-	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
 var reviewCmd = &cobra.Command{
@@ -135,25 +134,20 @@ func runReview(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Track the review session name for cleanup on signal.
-	var reviewSessionName string
-
-	// Install SIGTERM/SIGINT handler.
+	// Install SIGTERM/SIGINT handler. Kill all ~review-* sessions for the parent
+	// and cancel the context. KillReviewSessionsForParent is idempotent and
+	// covers all rounds without needing the specific session name, avoiding
+	// any data race on a shared variable.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		<-sigCh
-		// Kill all review sessions for this parent.
-		if reviewSessionName != "" {
-			_ = tmux.KillSession(reviewSessionName)
-		}
 		review.KillReviewSessionsForParent(parentSession)
 		cancel()
 	}()
 
 	// Run the review.
 	results, runErr := review.Run(ctx, opts, func(sessionName string) {
-		reviewSessionName = sessionName
 		fmt.Fprintf(os.Stderr, "[prism review] review session: %s\n", sessionName)
 	})
 

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -1,0 +1,199 @@
+package cmd
+
+// prism review <pr-number> — platform-native review primitive.
+//
+// Spawns review agent sessions in a dedicated tmux session named
+// <parent-session>~review-N (N = 1-indexed round number), polls the prism DB
+// until all agents reach the "finished" state, reads their last msg_assistant
+// event, and returns aggregated findings to stdout.
+//
+// Flags:
+//
+//	--harness <name>    Runtime harness (default: "opencode")
+//	--keep              Keep the review session open after completion
+//	--timeout <dur>     Per-agent timeout (default: 10m)
+//	--only <csv>        Run only the named agents (e.g. review)
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+var reviewCmd = &cobra.Command{
+	Use:   "review <pr-number>",
+	Short: "Run review agents against a PR and return aggregated findings",
+	Long: `Spawn review agent sessions in a dedicated tmux session and poll the
+prism DB until all agents complete. Returns aggregated findings to stdout.
+
+The review session is named <parent-session>~review-N where N is incremented
+on each invocation. Previous ~review-* sessions are killed before starting.
+
+Exit code 0 = all agents passed. Non-zero = one or more agents failed or errored.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReview,
+}
+
+func init() {
+	reviewCmd.Flags().String("harness", "opencode", "Runtime harness to use for review agents")
+	reviewCmd.Flags().Bool("keep", false, "Keep the review session open after completion (for debugging)")
+	reviewCmd.Flags().Duration("timeout", 10*time.Minute, "Maximum time to wait per agent")
+	reviewCmd.Flags().String("only", "", "Comma-separated list of agent names to run (e.g. review)")
+	rootCmd.AddCommand(reviewCmd)
+}
+
+func runReview(cmd *cobra.Command, args []string) error {
+	prNumber := args[0]
+
+	harnessFlag, _ := cmd.Flags().GetString("harness")
+	keepFlag, _ := cmd.Flags().GetBool("keep")
+	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
+	onlyFlag, _ := cmd.Flags().GetString("only")
+
+	// Resolve the parent session name.
+	parentSession := review.LookupParentSession()
+	if parentSession == "" {
+		return fmt.Errorf("prism review: could not determine parent session name\nhint: run from inside a tmux session or set PRISM_SESSION_NAME")
+	}
+
+	// Validate parent session exists in DB.
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("prism review: open db: %w", dbErr)
+	}
+	status, stErr := d.CurrentStatus(parentSession)
+	d.Close()
+	if stErr != nil {
+		return fmt.Errorf("prism review: lookup session %q: %w", parentSession, stErr)
+	}
+	if status == nil {
+		return fmt.Errorf("prism review: parent session %q not found in DB\nhint: the session must be registered in the prism DB", parentSession)
+	}
+
+	// Resolve worktree path.
+	worktree := status.Worktree
+	if worktree == "" {
+		return fmt.Errorf("prism review: no worktree path for session %q", parentSession)
+	}
+
+	// Determine agents list.
+	allAgents := agentsForHarness(harnessFlag)
+	var agents []review.Agent
+	if onlyFlag != "" {
+		var err error
+		names := splitCSV(onlyFlag)
+		agents, err = review.AgentsByName(allAgents, names)
+		if err != nil {
+			return fmt.Errorf("prism review: %w", err)
+		}
+	} else {
+		agents = allAgents
+	}
+
+	if len(agents) == 0 {
+		return fmt.Errorf("prism review: no agents to run")
+	}
+
+	// Load config for container mode.
+	cfg := config.Load()
+
+	// Build run options.
+	opts := review.Opts{
+		PRNumber:       prNumber,
+		ParentSession:  parentSession,
+		Worktree:       worktree,
+		Agents:         agents,
+		Harness:        harnessFlag,
+		Timeout:        timeoutFlag,
+		Keep:           keepFlag,
+		PluginHostPath: cfg.SidecarPluginPath,
+		ContainerMode:  cfg.ContainerMode,
+	}
+
+	// Load config content for container mode.
+	if cfg.ContainerMode {
+		pf, pfErr := config.LoadProfiles()
+		if pfErr == nil {
+			roleConfig, roleErr := config.ContainerConfigForRole(pf, "review")
+			if roleErr == nil && roleConfig != "" {
+				opts.ConfigContent = roleConfig
+			}
+		}
+	}
+
+	// Set up context with signal handling.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Track the review session name for cleanup on signal.
+	var reviewSessionName string
+
+	// Install SIGTERM/SIGINT handler.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		// Kill all review sessions for this parent.
+		if reviewSessionName != "" {
+			_ = tmux.KillSession(reviewSessionName)
+		}
+		review.KillReviewSessionsForParent(parentSession)
+		cancel()
+	}()
+
+	// Run the review.
+	results, runErr := review.Run(ctx, opts, func(sessionName string) {
+		reviewSessionName = sessionName
+		fmt.Fprintf(os.Stderr, "[prism review] review session: %s\n", sessionName)
+	})
+
+	signal.Stop(sigCh)
+
+	if runErr != nil && runErr != context.Canceled {
+		return fmt.Errorf("prism review: %w", runErr)
+	}
+
+	// Format and print results.
+	output, allPassed := review.FormatResults(results, prNumber)
+	fmt.Print(output)
+
+	if !allPassed {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// agentsForHarness returns the default agent list for the given harness.
+// Currently only "opencode" is supported.
+func agentsForHarness(harness string) []review.Agent {
+	switch harness {
+	case "opencode", "":
+		return review.DefaultAgents()
+	default:
+		// Unknown harness — return opencode agents as fallback.
+		fmt.Fprintf(os.Stderr, "[prism review] warning: unknown harness %q, using opencode\n", harness)
+		return review.DefaultAgents()
+	}
+}
+
+// splitCSV splits a comma-separated string and trims whitespace.
+func splitCSV(s string) []string {
+	var parts []string
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -76,6 +76,7 @@ func init() {
 	sidecarCmd.Flags().String("initial-prompt", "", "Initial prompt to deliver to the agent after container readiness (container mode only)")
 	sidecarCmd.Flags().String("config-content", "", "JSON blob for container opencode.json; written to temp file and mounted (container mode only)")
 	sidecarCmd.Flags().String("instance-id", "", "UUID instance identifier for this session incarnation (for container labels and bus message scoping)")
+	sidecarCmd.Flags().Bool("worktree-readonly", false, "Mount the worktree read-only inside the container (used for review agents)")
 	_ = sidecarCmd.MarkFlagRequired("session")
 	_ = sidecarCmd.MarkFlagRequired("opencode-url")
 	rootCmd.AddCommand(sidecarCmd)
@@ -91,6 +92,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	initialPrompt, _ := cmd.Flags().GetString("initial-prompt")
 	configContent, _ := cmd.Flags().GetString("config-content")
 	instanceID, _ := cmd.Flags().GetString("instance-id")
+	worktreeReadOnly, _ := cmd.Flags().GetBool("worktree-readonly")
 
 	// Derive repo and worktree from session name and environment.
 	// The session name format is "repo@branch". The worktree is expected
@@ -144,6 +146,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		ctrCfg = &container.Config{
 			SessionName:       sessionName,
 			Worktree:          worktree,
+			WorktreeReadOnly:  worktreeReadOnly,
 			BareRoot:          bareRoot,
 			WorktreeGitDir:    worktreeGitDir,
 			AllocatedPort:     port,

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -59,8 +59,14 @@ type Config struct {
 	SessionName string
 
 	// Worktree is the absolute path to the git worktree on the host.
-	// Mounted read-write at /workspace inside the container.
+	// Mounted at /workspace inside the container. When WorktreeReadOnly is
+	// true, the mount is read-only; otherwise it is read-write.
 	Worktree string
+
+	// WorktreeReadOnly, when true, mounts the worktree read-only inside
+	// the container. Used by review agent containers so agents cannot
+	// modify the branch under review.
+	WorktreeReadOnly bool
 
 	// AllocatedPort is the host port to bind to ContainerPort inside the container.
 	AllocatedPort int
@@ -695,7 +701,14 @@ func (m *Manager) buildRunArgs() []string {
 	portBinding := fmt.Sprintf("127.0.0.1:%d:%d", cfg.AllocatedPort, ContainerPort)
 
 	// Volume mounts (AC-2, AC-3, AC-4, AC-5).
-	worktreeMount := cfg.Worktree + ":/workspace:Z"
+	// Worktree is mounted read-only for review agents (WorktreeReadOnly=true)
+	// and read-write for worker/coordinator agents.
+	var worktreeMount string
+	if cfg.WorktreeReadOnly {
+		worktreeMount = cfg.Worktree + ":/workspace:ro,Z"
+	} else {
+		worktreeMount = cfg.Worktree + ":/workspace:Z"
+	}
 	opencodeStateMount := filepath.Join(home, ".local", "share", "opencode") +
 		":/root/.local/share/opencode:Z"
 	// opencodeConfigDir is the host's opencode config directory, mounted

--- a/modules/programs/prism/prism/internal/dashboard/depth2_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/depth2_test.go
@@ -1,0 +1,90 @@
+package dashboard_test
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+)
+
+func TestIsDepth2Session(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"nixos-config@main", false},
+		{"nixos-config@feature", false},
+		{"scratchpad", false},
+		{"nixos-config@feature~review-1", true},
+		{"nixos-config@feature~review-2", true},
+		{"nixos-config@feature~review-1~review", true}, // agent sub-session
+		{"repo@branch~something", true},
+	}
+	for _, tt := range tests {
+		got := dashboard.IsDepth2Session(tt.name)
+		if got != tt.want {
+			t.Errorf("IsDepth2Session(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestDepth2ParentBranch(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"nixos-config@feature~review-1", "@feature"},
+		{"nixos-config@feature~review-2", "@feature"},
+		{"nixos-config@feature~review-1~review", "@feature"},
+		{"nixos-config@main", ""},    // top-level
+		{"nixos-config@feature", ""}, // depth-1, no ~
+		{"scratchpad", ""},
+	}
+	for _, tt := range tests {
+		got := dashboard.Depth2ParentBranch(tt.name)
+		if got != tt.want {
+			t.Errorf("Depth2ParentBranch(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestDepth2Label(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"nixos-config@feature~review-1", "~review-1"},
+		{"nixos-config@feature~review-2", "~review-2"},
+		{"nixos-config@main", ""},
+		{"nixos-config@feature", ""},
+		{"scratchpad", ""},
+	}
+	for _, tt := range tests {
+		got := dashboard.Depth2Label(tt.name)
+		if got != tt.want {
+			t.Errorf("Depth2Label(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestSortDisplayed_Depth2AfterParent(t *testing.T) {
+	sessions := []dashboard.AgentSession{
+		{Name: "nixos-config@feature~review-2"},
+		{Name: "nixos-config@main"},
+		{Name: "nixos-config@feature~review-1"},
+		{Name: "nixos-config@feature"},
+	}
+	dashboard.SortDisplayed(sessions)
+
+	// Expected order: @main, @feature, @feature~review-1, @feature~review-2
+	want := []string{
+		"nixos-config@main",
+		"nixos-config@feature",
+		"nixos-config@feature~review-1",
+		"nixos-config@feature~review-2",
+	}
+	for i, w := range want {
+		if sessions[i].Name != w {
+			t.Errorf("position %d: got %q, want %q", i, sessions[i].Name, w)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -71,14 +71,61 @@ func SessionBranch(name string) string {
 	return name
 }
 
+// IsDepth2Session returns true when the session name contains a "~" in the
+// branch component (after "@"), indicating it is a depth-2 review child.
+// Example: "nixos-config@feature~review-1" → true.
+func IsDepth2Session(name string) bool {
+	branch := SessionBranch(name)
+	// branch is "@feature~review-1" or the full name when no "@".
+	// Strip the leading "@" for the tilde check.
+	if len(branch) > 0 && branch[0] == '@' {
+		branch = branch[1:]
+	}
+	return strings.Contains(branch, "~")
+}
+
+// Depth2ParentBranch returns the branch component of the parent session for a
+// depth-2 review session. Given "nixos-config@feature~review-1" it returns
+// "@feature". Returns "" when the session is not a depth-2 session.
+func Depth2ParentBranch(name string) string {
+	branch := SessionBranch(name)
+	if len(branch) == 0 || branch[0] != '@' {
+		return ""
+	}
+	inner := branch[1:] // strip leading "@"
+	if idx := strings.Index(inner, "~"); idx >= 0 {
+		return "@" + inner[:idx]
+	}
+	return ""
+}
+
+// Depth2Label returns the display label for a depth-2 review session.
+// Given "nixos-config@feature~review-1" it returns "~review-1".
+// Returns "" when not a depth-2 session.
+func Depth2Label(name string) string {
+	branch := SessionBranch(name)
+	if len(branch) == 0 || branch[0] != '@' {
+		return ""
+	}
+	inner := branch[1:] // strip leading "@"
+	if idx := strings.Index(inner, "~"); idx >= 0 {
+		return inner[idx:] // e.g. "~review-1"
+	}
+	return ""
+}
+
 // SortDisplayed sorts a session slice in-place to match the flat visual render
 // order: alphabetical by repo name, @main first within each repo, then other
-// branches alphabetically. Uses insertion sort (no stdlib import needed for
-// small N).
+// branches alphabetically, with depth-2 review sessions (containing ~)
+// sorted immediately after their parent branch. Uses insertion sort
+// (no stdlib import needed for small N).
 func SortDisplayed(ss []AgentSession) {
-	// sessionKey returns a sort key for a session: "repo\x00" for @main and
-	// sessions without @, so they sort before any branch, or "repo\x01branch"
-	// for other worktree branches.
+	// sessionKey returns a sort key for a session:
+	//   - Plain sessions (no @): "repo\x00<name>"  — sorts first within repo
+	//   - @main sessions:        "repo\x00<name>"  — sorts first within repo
+	//   - Branch sessions:       "repo\x01<branch>\x00"  — sorts after @main
+	//   - Depth-2 review:        "repo\x01<parent-branch>\x00~<label>"
+	//     — sorts immediately after the parent branch
 	sessionKey := func(s AgentSession) string {
 		repo := SessionRepo(s.Name)
 		branch := SessionBranch(s.Name)
@@ -86,7 +133,14 @@ func SortDisplayed(ss []AgentSession) {
 			// No "@" (plain session) or @main — sorts first within repo.
 			return repo + "\x00" + s.Name
 		}
-		return repo + "\x01" + branch
+		// Depth-2 session: sort directly after its parent branch.
+		if IsDepth2Session(s.Name) {
+			parentBranch := Depth2ParentBranch(s.Name)
+			label := Depth2Label(s.Name)
+			return repo + "\x01" + parentBranch + "\x00" + label
+		}
+		// Regular branch session.
+		return repo + "\x01" + branch + "\x00"
 	}
 	for i := 1; i < len(ss); i++ {
 		key := ss[i]
@@ -195,7 +249,14 @@ func RenderSessionRow(
 		if runeCount < treePrefixW {
 			paddedPrefix += strings.Repeat(" ", treePrefixW-runeCount)
 		}
-		branch := SessionBranch(s.Name)
+		// For depth-2 sessions, display only the ~review-N label rather than
+		// the full @feature~review-N branch string.
+		var branch string
+		if label := Depth2Label(s.Name); label != "" {
+			branch = label
+		} else {
+			branch = SessionBranch(s.Name)
+		}
 		if sessionW == 0 {
 			branch = ""
 		} else if utf8.RuneCountInString(branch) > sessionW {

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -226,9 +226,11 @@ func RenderSessionRow(
 		dot = "  "
 	}
 
-	// treePrefixW is always 6 runes; pad treePrefix to that width using rune
-	// count (not byte count) since tree connector chars are multi-byte in UTF-8.
-	const treePrefixW = 6
+	// treePrefixW is 10 runes (matches view.go constant); pad treePrefix to that
+	// width using rune count (not byte count) since tree connector chars are
+	// multi-byte in UTF-8. Depth-1 prefixes (6 chars) are padded to 10;
+	// depth-2 prefixes (10 chars) fit exactly.
+	const treePrefixW = 10
 
 	// Build the session display area (treePrefixW+sessionW total width):
 	// - Top-level (treePrefix=""): full session name padded to treePrefixW+sessionW.

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -177,6 +177,9 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 			branch := SessionBranch(name)
 			return branch == name || branch == "@main"
 		}
+		isDepth1Child := func(name string) bool {
+			return !isTopLevel(name) && !IsDepth2Session(name)
+		}
 		// groupHasTopLevel returns true if the contiguous run of same-repo
 		// sessions that includes sessions[i] contains at least one top-level row.
 		groupHasTopLevel := func(i int) bool {
@@ -194,17 +197,42 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 			return false
 		}
 		for i, s := range sessions {
-			isChild := !isTopLevel(s.Name) && groupHasTopLevel(i)
+			isD1Child := isDepth1Child(s.Name) && groupHasTopLevel(i)
+			isD2Child := IsDepth2Session(s.Name)
 			var treePrefix string
-			if isChild {
-				// Look ahead to determine if this is the last child in the group.
+			if isD2Child {
+				// Depth-2 review session: "  │   ├── " or "  │   └── "
+				// Look ahead within the same parent branch to determine if last sibling.
+				parentBranch := Depth2ParentBranch(s.Name)
+				isLastD2 := true
+				for j := i + 1; j < len(sessions); j++ {
+					next := sessions[j]
+					if SessionRepo(next.Name) != SessionRepo(s.Name) {
+						break
+					}
+					if IsDepth2Session(next.Name) && Depth2ParentBranch(next.Name) == parentBranch {
+						isLastD2 = false
+						break
+					}
+					// If we hit a non-depth-2 session in the same repo, stop.
+					if !IsDepth2Session(next.Name) {
+						break
+					}
+				}
+				if isLastD2 {
+					treePrefix = "  │   └── "
+				} else {
+					treePrefix = "  │   ├── "
+				}
+			} else if isD1Child {
+				// Look ahead to determine if this is the last depth-1 child in the group.
 				isLastChild := true
 				thisRepo := SessionRepo(s.Name)
 				for j := i + 1; j < len(sessions); j++ {
 					if SessionRepo(sessions[j].Name) != thisRepo {
 						break
 					}
-					if !isTopLevel(sessions[j].Name) {
+					if isDepth1Child(sessions[j].Name) || IsDepth2Session(sessions[j].Name) {
 						isLastChild = false
 						break
 					}

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -24,7 +24,7 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	// fixedCore (defined below) is the irreducible column overhead. At widths
 	// below fixedCore+1, the session header word "session" (7 chars) overflows
 	// its 6-char slot when sessionW=0, so render a skeleton instead.
-	const minUsableWidth = 22 // fixedCore+1
+	const minUsableWidth = 26 // fixedCore+1
 	if d.Width < minUsableWidth {
 		return SkeletonView(d.Width)
 	}
@@ -38,9 +38,12 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	styleAgentType := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 
 	// ── column widths ────────────────────────────────────────────────────────
-	// Tree prefix for worktree child rows: "  ├── " or "  └── " (6 chars).
-	// Top-level rows use no prefix; their name is padded to treePrefixW+sessionW.
-	const treePrefixW = 6
+	// Tree prefix slot for child rows.
+	//   Depth-1 prefixes: "  ├──     " or "  └──     " (padded to treePrefixW)
+	//   Depth-2 prefixes: "  │   ├── " or "  │   └── " (exactly treePrefixW)
+	// treePrefixW=10 accommodates the widest depth-2 connector without overflow.
+	// Depth-1 connectors are 6 chars and are right-padded with spaces to 10.
+	const treePrefixW = 10
 	const agentTypeW = 12 // "coordinator " or "worker      " or "            "
 	const stateW = 10
 	const dotW = 2

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -916,6 +916,17 @@ WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
 }
 
+// AllStatusesWithPrefix returns all agent_status rows (active and ended)
+// whose session_name starts with the given prefix. Used by `prism checkin
+// <parent>~review` to enumerate all review rounds including completed ones.
+func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at
+FROM agent_status
+WHERE session_name LIKE ?`
+	return d.queryStatuses(q, prefix+"%")
+}
+
 // AllSessionEvents returns all events for a session, ordered by created_at ASC.
 // Unlike QueryEvents, this has no limit — it returns the full event history.
 func (d *DB) AllSessionEvents(sessionName string) ([]Event, error) {

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -919,12 +919,19 @@ WHERE ended_at IS NULL AND repo = ?`
 // AllStatusesWithPrefix returns all agent_status rows (active and ended)
 // whose session_name starts with the given prefix. Used by `prism checkin
 // <parent>~review` to enumerate all review rounds including completed ones.
+//
+// The prefix is matched using LIKE with proper escaping of SQL LIKE wildcard
+// characters (`%`, `_`, `\`) so that session names containing these characters
+// are handled correctly.
 func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
+	// Escape LIKE special characters in the prefix so literal underscores and
+	// percent signs in session names are matched exactly, not as wildcards.
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
 SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at
 FROM agent_status
-WHERE session_name LIKE ?`
-	return d.queryStatuses(q, prefix+"%")
+WHERE session_name LIKE ? ESCAPE '\'`
+	return d.queryStatuses(q, escaped+"%")
 }
 
 // AllSessionEvents returns all events for a session, ordered by created_at ASC.

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -1967,3 +1967,83 @@ func TestQueryAuditEvents_OrderedDescending(t *testing.T) {
 		t.Errorf("events not in DESC order: [0]=%v [1]=%v", events[0].CreatedAt, events[1].CreatedAt)
 	}
 }
+
+// ── AllStatusesWithPrefix ──────────────────────────────────────────────────────
+
+func TestAllStatusesWithPrefix_ReturnsMatchingRows(t *testing.T) {
+	d := openTestDB(t)
+
+	// Insert rows with and without the target prefix.
+	parent := "nixos-config@feature"
+	if err := d.UpsertStatus(parent+"~review-1", "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus(parent+"~review-2", "nixos-config", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	// Agent sub-session: also starts with the prefix.
+	if err := d.UpsertStatus(parent+"~review-1~review", "nixos-config", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	// Unrelated row.
+	if err := d.UpsertStatus("nixos-config@other~review-1", "nixos-config", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	rows, err := d.AllStatusesWithPrefix(parent + "~review-")
+	if err != nil {
+		t.Fatalf("AllStatusesWithPrefix: %v", err)
+	}
+
+	// Should return 3 rows (2 rounds + 1 sub-session), not the unrelated row.
+	if len(rows) != 3 {
+		t.Errorf("got %d rows, want 3; rows: %v", len(rows), sessionNames(rows))
+	}
+	for _, r := range rows {
+		if r.SessionName == "nixos-config@other~review-1" {
+			t.Errorf("unexpected row %q returned", r.SessionName)
+		}
+	}
+}
+
+func TestAllStatusesWithPrefix_UnderscoreInPrefix_ExactMatch(t *testing.T) {
+	d := openTestDB(t)
+
+	// Session name with underscore — the prefix should match exactly (not use _ as wildcard).
+	_ = d.UpsertStatus("repo@feat_ure~review-1", "repo", "/wt", "idle", nil, nil)
+	_ = d.UpsertStatus("repo@featXure~review-1", "repo", "/wt", "idle", nil, nil) // should NOT match
+
+	rows, err := d.AllStatusesWithPrefix("repo@feat_ure~review-")
+	if err != nil {
+		t.Fatalf("AllStatusesWithPrefix: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("got %d rows, want 1 (exact underscore match); names: %v", len(rows), sessionNames(rows))
+	}
+	if len(rows) > 0 && rows[0].SessionName != "repo@feat_ure~review-1" {
+		t.Errorf("got %q, want %q", rows[0].SessionName, "repo@feat_ure~review-1")
+	}
+}
+
+func TestAllStatusesWithPrefix_IncludesEndedRows(t *testing.T) {
+	d := openTestDB(t)
+
+	_ = d.UpsertStatus("nixos@feat~review-1", "nixos", "/wt", "finished", nil, nil)
+	_ = d.SetEnded("nixos@feat~review-1")
+
+	rows, err := d.AllStatusesWithPrefix("nixos@feat~review-")
+	if err != nil {
+		t.Fatalf("AllStatusesWithPrefix: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("got %d rows, want 1 (ended row should be included)", len(rows))
+	}
+}
+
+func sessionNames(rows []db.Status) []string {
+	names := make([]string, len(rows))
+	for i, r := range rows {
+		names[i] = r.SessionName
+	}
+	return names
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -219,12 +219,23 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 
 		// Seed agent_status for the agent session.
 		if err := d.UpsertStatus(agentSession, repo, worktree, "idle", nil, nil); err != nil {
+			// Clean up already-started agents before returning.
+			for j := 0; j < i; j++ {
+				session.KillSidecar(agentSessions[j])
+				cleanupAgentSession(d, agentSessions[j])
+			}
+			_ = tmux.KillSession(reviewSession)
 			return nil, fmt.Errorf("seed status for %s: %w", ag.Name, err)
 		}
 
 		// Allocate a port for this agent session.
 		port, portErr := d.AllocatePort(agentSession)
 		if portErr != nil {
+			for j := 0; j < i; j++ {
+				session.KillSidecar(agentSessions[j])
+				cleanupAgentSession(d, agentSessions[j])
+			}
+			_ = tmux.KillSession(reviewSession)
 			return nil, fmt.Errorf("allocate port for %s: %w", ag.Name, portErr)
 		}
 
@@ -232,14 +243,17 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 		prompt := buildReviewPrompt(opts.PRNumber)
 
 		// Start the sidecar for this agent.
+		// WorktreeReadOnly=true ensures review containers cannot modify the
+		// branch under review (satisfies the [security] acceptance criterion).
 		sidecarOpts := session.StartSidecarOpts{
-			Port:           port,
-			ContainerMode:  opts.ContainerMode,
-			AgentRole:      ag.Name,
-			Worktree:       worktree,
-			PluginHostPath: opts.PluginHostPath,
-			InitialPrompt:  prompt,
-			ConfigContent:  opts.ConfigContent,
+			Port:             port,
+			ContainerMode:    opts.ContainerMode,
+			AgentRole:        ag.Name,
+			Worktree:         worktree,
+			PluginHostPath:   opts.PluginHostPath,
+			InitialPrompt:    prompt,
+			ConfigContent:    opts.ConfigContent,
+			WorktreeReadOnly: true,
 		}
 		if sidecarErr := session.StartSidecarWithOpts(agentSession, sidecarOpts); sidecarErr != nil {
 			fmt.Fprintf(os.Stderr, "[prism review] warning: could not start sidecar for %s: %v\n", ag.Name, sidecarErr)
@@ -248,6 +262,12 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 		// Create the agent window within the review session.
 		agentCmd := buildAgentCommand(ag, agentSession, port, prompt, opts.ContainerMode)
 		if err := createAgentWindow(reviewSession, i, ag.Name, worktree, agentCmd, port, agentSession, opts.ContainerMode); err != nil {
+			// Clean up agents 0..i (including the current one whose window failed).
+			for j := 0; j <= i; j++ {
+				session.KillSidecar(agentSessions[j])
+				cleanupAgentSession(d, agentSessions[j])
+			}
+			_ = tmux.KillSession(reviewSession)
 			return nil, fmt.Errorf("create window for %s: %w", ag.Name, err)
 		}
 	}
@@ -369,7 +389,7 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 		select {
 		case <-ctx.Done():
 			// Build partial results with all non-finished agents as timed out.
-			return buildResults(agents, agentSessions, d, timedOut, timeout, true), ctx.Err()
+			return buildResults(agents, agentSessions, d, finished, timedOut, timeout, true), ctx.Err()
 		default:
 		}
 
@@ -390,7 +410,7 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 		time.Sleep(pollInterval)
 	}
 
-	return buildResults(agents, agentSessions, d, timedOut, timeout, false), nil
+	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, false), nil
 }
 
 // isTerminalState returns true if the state is considered terminal (finished or error).
@@ -403,11 +423,18 @@ func isTerminalState(state string) bool {
 }
 
 // buildResults constructs AgentResult entries from polling outcomes.
-func buildResults(agents []Agent, agentSessions []string, d *db.DB, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
+// finished[i] is true when agent i reached a terminal DB state; timedOut[i] is
+// true when it did not finish before the deadline; cancelled is true on context
+// cancellation (e.g. SIGINT). Agents in finished[i]=true always show their
+// actual output, even when the process is being cancelled.
+func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
 	results := make([]AgentResult, len(agents))
 	for i, ag := range agents {
 		agentSession := agentSessions[i]
-		if timedOut[i] || cancelled {
+		// Only report as timed-out / cancelled when the agent genuinely did not
+		// finish. An agent that completed before a signal arrived should still
+		// show its actual output.
+		if (timedOut[i] || cancelled) && !finished[i] {
 			results[i] = AgentResult{
 				Agent:   ag,
 				Passed:  false,

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -1,0 +1,603 @@
+// Package review implements the prism review execution engine.
+//
+// prism review <pr-number> spawns N review agent sessions in a dedicated tmux
+// session named <parent>~review-N (where N is the 1-indexed round number),
+// polls the prism DB until all agents reach the "finished" state, reads their
+// last msg_assistant event, and returns aggregated findings to stdout.
+//
+// Session architecture:
+//   - One tmux session per review round: <parent-session>~review-N
+//   - One tmux window per review agent within the session
+//   - Each agent gets its own sidecar + container mounting the parent worktree read-only
+//   - No new worktree is created
+//
+// The ~ separator in the session name is used by the dashboard for depth-2
+// child detection (review sessions appear indented under their parent branch).
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// KillSessionPrefix kills all tmux sessions whose names start with the given
+// prefix. Used to clean up all ~review-* sessions for a parent.
+func KillSessionPrefix(prefix string) {
+	out, err := tmux.Run("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		return
+	}
+	for _, name := range strings.Split(out, "\n") {
+		name = strings.TrimSpace(name)
+		if name != "" && strings.HasPrefix(name, prefix) {
+			_ = tmux.KillSession(name)
+		}
+	}
+}
+
+// NextRoundNumber returns the next round number for the given parent session.
+// It scans existing tmux sessions for ~review-N patterns and returns max(N)+1.
+// Returns 1 when no prior rounds exist.
+func NextRoundNumber(parentSession string) int {
+	prefix := parentSession + "~review-"
+	out, err := tmux.Run("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		return 1
+	}
+	max := 0
+	for _, name := range strings.Split(out, "\n") {
+		name = strings.TrimSpace(name)
+		if strings.HasPrefix(name, prefix) {
+			suffix := strings.TrimPrefix(name, prefix)
+			if n, err := strconv.Atoi(suffix); err == nil && n > max {
+				max = n
+			}
+		}
+	}
+	return max + 1
+}
+
+// Agent describes a single review agent to run.
+type Agent struct {
+	// Name is the agent identifier, e.g. "review".
+	Name string
+	// OpencodeName is the opencode --agent flag value, e.g. "review".
+	OpencodeName string
+}
+
+// DefaultAgents returns the default set of review agents for the opencode harness.
+func DefaultAgents() []Agent {
+	return []Agent{
+		{Name: "review", OpencodeName: "review"},
+	}
+}
+
+// AgentsByName filters the agents slice to only those whose Name is in the
+// allowedNames set. Returns an error if any name in allowedNames does not exist
+// in agents.
+func AgentsByName(agents []Agent, allowedNames []string) ([]Agent, error) {
+	available := make(map[string]Agent, len(agents))
+	for _, a := range agents {
+		available[a.Name] = a
+	}
+	var result []Agent
+	var unknown []string
+	for _, name := range allowedNames {
+		if a, ok := available[name]; ok {
+			result = append(result, a)
+		} else {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown agent name(s): %s\navailable: %s",
+			strings.Join(unknown, ", "),
+			strings.Join(agentNames(agents), ", "),
+		)
+	}
+	return result, nil
+}
+
+func agentNames(agents []Agent) []string {
+	names := make([]string, len(agents))
+	for i, a := range agents {
+		names[i] = a.Name
+	}
+	return names
+}
+
+// AgentResult holds the outcome for a single review agent.
+type AgentResult struct {
+	Agent   Agent
+	Passed  bool   // true = passed, false = failed / errored
+	Output  string // last assistant message text, or error description
+	IsError bool   // true = infrastructure/timeout failure
+}
+
+// Opts configures a review run.
+type Opts struct {
+	// PRNumber is the pull request number to review.
+	PRNumber string
+	// ParentSession is the prism session name of the calling worker/coordinator.
+	ParentSession string
+	// Worktree is the absolute path to the parent session's worktree.
+	Worktree string
+	// Agents is the list of review agents to spawn.
+	Agents []Agent
+	// Harness is the runtime harness to use ("opencode").
+	Harness string
+	// Timeout is the per-agent maximum wait time.
+	Timeout time.Duration
+	// Keep: if true, the review session is not killed after completion.
+	Keep bool
+	// DBPath is the path to the prism database. If empty, the default is used.
+	DBPath string
+	// PrismBin is the path to the prism binary. Derived from os.Executable if empty.
+	PrismBin string
+	// PluginHostPath is the path to the opencode plugin file.
+	PluginHostPath string
+	// ConfigContent is the JSON blob for the container's opencode.json config.
+	ConfigContent string
+	// ContainerMode: when true, each agent runs in its own container.
+	ContainerMode bool
+}
+
+// Run executes the review. It returns the aggregated results and a boolean
+// indicating whether all agents passed.
+//
+// On signal (SIGTERM/SIGINT), the caller is expected to kill the review session
+// using the session name returned via the onSessionCreated callback.
+func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName string)) ([]AgentResult, error) {
+	prismBin := opts.PrismBin
+	if prismBin == "" {
+		var err error
+		prismBin, err = os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("resolve prism binary: %w", err)
+		}
+	}
+
+	if opts.ParentSession == "" {
+		return nil, fmt.Errorf("parent session name is required")
+	}
+
+	// Kill any previous review sessions for this parent.
+	reviewPrefix := opts.ParentSession + "~review-"
+	KillSessionPrefix(reviewPrefix)
+
+	// Determine round number.
+	round := NextRoundNumber(opts.ParentSession)
+	reviewSession := fmt.Sprintf("%s~review-%d", opts.ParentSession, round)
+
+	// Resolve worktree path.
+	worktree := opts.Worktree
+	if worktree == "" {
+		return nil, fmt.Errorf("worktree path is required")
+	}
+
+	// Open DB.
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath = defaultDBPath()
+	}
+	d, err := db.Open(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	defer d.Close()
+
+	// Create the review tmux session.
+	if err := tmux.NewSessionDetached(reviewSession, worktree); err != nil {
+		return nil, fmt.Errorf("create review session %q: %w", reviewSession, err)
+	}
+
+	if onSessionCreated != nil {
+		onSessionCreated(reviewSession)
+	}
+
+	agents := opts.Agents
+	if len(agents) == 0 {
+		agents = DefaultAgents()
+	}
+
+	// Spawn each agent in its own tmux window within the review session.
+	agentSessions := make([]string, len(agents))
+	for i, ag := range agents {
+		agentSession := fmt.Sprintf("%s~%s", reviewSession, ag.Name)
+		agentSessions[i] = agentSession
+
+		// Seed agent_status for the agent session.
+		if err := seedAgentStatus(d, agentSession, opts.ParentSession, worktree); err != nil {
+			return nil, fmt.Errorf("seed status for %s: %w", ag.Name, err)
+		}
+
+		// Allocate a port for this agent session.
+		port, portErr := d.AllocatePort(agentSession)
+		if portErr != nil {
+			return nil, fmt.Errorf("allocate port for %s: %w", ag.Name, portErr)
+		}
+
+		// Build the prompt for the review agent.
+		prompt := buildReviewPrompt(opts.PRNumber)
+
+		// Start the sidecar for this agent.
+		sidecarOpts := session.StartSidecarOpts{
+			Port:           port,
+			ContainerMode:  opts.ContainerMode,
+			AgentRole:      ag.Name,
+			Worktree:       worktree,
+			PluginHostPath: opts.PluginHostPath,
+			InitialPrompt:  prompt,
+			ConfigContent:  opts.ConfigContent,
+		}
+		if sidecarErr := session.StartSidecarWithOpts(agentSession, sidecarOpts); sidecarErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism review] warning: could not start sidecar for %s: %v\n", ag.Name, sidecarErr)
+		}
+
+		// Create the agent window within the review session.
+		agentCmd := buildAgentCommand(ag, port, prompt, opts.ContainerMode)
+		if err := createAgentWindow(reviewSession, i, ag.Name, worktree, agentCmd, port, agentSession, opts.ContainerMode); err != nil {
+			return nil, fmt.Errorf("create window for %s: %w", ag.Name, err)
+		}
+
+		// Seed agent_status with the port so it shows up in list-sessions.
+		if updateErr := d.UpsertStatus(agentSession, opts.ParentSession, worktree, "idle", nil, nil); updateErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism review] warning: upsert status for %s: %v\n", ag.Name, updateErr)
+		}
+	}
+
+	// Remove the initial blank window (window 0) that was created with the session.
+	// All agents are in windows 1..N.
+	_, _ = tmux.Run("kill-window", "-t", reviewSession+":0")
+
+	// Poll DB until all agents finish or timeout.
+	results, pollErr := pollAgents(ctx, d, agents, agentSessions, opts.Timeout)
+
+	// Clean up sidecar processes.
+	for _, agentSession := range agentSessions {
+		session.KillSidecar(agentSession)
+	}
+
+	// Kill the review session unless --keep.
+	if !opts.Keep {
+		_ = tmux.KillSession(reviewSession)
+		// Clean up DB entries for agent sub-sessions.
+		for _, agentSession := range agentSessions {
+			cleanupAgentSession(d, agentSession)
+		}
+	}
+
+	return results, pollErr
+}
+
+// seedAgentStatus inserts an initial agent_status row for the review agent session.
+func seedAgentStatus(d *db.DB, agentSession, repo, worktree string) error {
+	return d.UpsertStatus(agentSession, repo, worktree, "idle", nil, nil)
+}
+
+// buildReviewPrompt returns the initial prompt string for a review agent.
+func buildReviewPrompt(prNumber string) string {
+	return fmt.Sprintf("Review PR #%s. Run `gh pr view %s` and `gh pr diff %s` to get the full diff. Check the linked issue for acceptance criteria and validate each one. Report your findings clearly.", prNumber, prNumber, prNumber)
+}
+
+// buildAgentCommand returns the opencode command string for a review agent window.
+func buildAgentCommand(ag Agent, port int, prompt string, containerMode bool) string {
+	if containerMode {
+		return fmt.Sprintf("opencode attach http://localhost:%d", port)
+	}
+	escapedPrompt := shellQuote(prompt)
+	return fmt.Sprintf("PRISM_SESSION_NAME=%s opencode --agent %s --port %d --hostname 127.0.0.1 --prompt %s",
+		shellQuote(ag.Name), ag.OpencodeName, port, escapedPrompt)
+}
+
+// createAgentWindow creates a tmux window for a review agent.
+// In container mode it prepends a readiness wait like the standard session setup.
+func createAgentWindow(reviewSession string, idx int, windowName, worktree, agentCmd string, port int, agentSession string, containerMode bool) error {
+	cmd := agentCmd
+	if containerMode && port != 0 {
+		readyPath, pathErr := session.SidecarReadyPath(agentSession)
+		sidPath, sidErr := session.SidecarSessionPath(agentSession)
+		if pathErr == nil {
+			_ = os.Remove(readyPath)
+			if sidErr != nil {
+				sidPath = ""
+			} else {
+				_ = os.Remove(sidPath)
+			}
+			cmd = buildReadinessWaitCmd(readyPath, sidPath, agentCmd)
+		}
+	}
+	// Windows are 1-indexed: window 0 is the initial blank shell.
+	return tmux.NewWindow(reviewSession, idx+1, windowName, worktree, cmd)
+}
+
+// buildReadinessWaitCmd mirrors session.buildReadinessWaitCmd (unexported).
+func buildReadinessWaitCmd(readyPath, sidPath, attachCmd string) string {
+	return fmt.Sprintf(
+		`i=0; while [ ! -f %s ] && [ $i -lt 240 ]; do sleep 0.5; i=$((i+1)); done; `+
+			`if [ ! -f %s ]; then `+
+			`echo "prism: container did not become ready within 120s" >&2; exit 1; `+
+			`fi; `+
+			`if [ -f %s ]; then _sid=$(cat %s); %s -s "$_sid"; else %s; fi`,
+		shellQuote(readyPath), shellQuote(readyPath),
+		shellQuote(sidPath), shellQuote(sidPath), attachCmd, attachCmd,
+	)
+}
+
+// pollAgents polls the DB until all agents reach "finished" or the timeout expires.
+func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration) ([]AgentResult, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+
+	deadline := time.Now().Add(timeout)
+	finished := make([]bool, len(agents))
+	timedOut := make([]bool, len(agents))
+
+	const pollInterval = 2 * time.Second
+
+	for {
+		allDone := true
+		for i, agentSession := range agentSessions {
+			if finished[i] || timedOut[i] {
+				continue
+			}
+			status, err := d.CurrentStatus(agentSession)
+			if err != nil {
+				// DB error — treat as still running.
+				allDone = false
+				continue
+			}
+			if status != nil && isTerminalState(status.State) {
+				finished[i] = true
+			} else if time.Now().After(deadline) {
+				timedOut[i] = true
+			} else {
+				allDone = false
+			}
+		}
+
+		// Check context cancellation.
+		select {
+		case <-ctx.Done():
+			// Build partial results with all non-finished agents as timed out.
+			return buildResults(agents, agentSessions, d, timedOut, timeout, true), ctx.Err()
+		default:
+		}
+
+		if allDone {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			// Mark all remaining as timed out.
+			for i := range agents {
+				if !finished[i] {
+					timedOut[i] = true
+				}
+			}
+			break
+		}
+
+		time.Sleep(pollInterval)
+	}
+
+	return buildResults(agents, agentSessions, d, timedOut, timeout, false), nil
+}
+
+// isTerminalState returns true if the state is considered terminal (finished or error).
+func isTerminalState(state string) bool {
+	switch state {
+	case "finished", "interrupted", "error":
+		return true
+	}
+	return false
+}
+
+// buildResults constructs AgentResult entries from polling outcomes.
+func buildResults(agents []Agent, agentSessions []string, d *db.DB, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
+	results := make([]AgentResult, len(agents))
+	for i, ag := range agents {
+		agentSession := agentSessions[i]
+		if timedOut[i] || cancelled {
+			results[i] = AgentResult{
+				Agent:   ag,
+				Passed:  false,
+				Output:  fmt.Sprintf("ERROR: timed out after %s", formatDuration(timeout)),
+				IsError: true,
+			}
+			continue
+		}
+
+		// Read last msg_assistant event.
+		events, err := d.QueryEvents(agentSession, 1, nil, nil, []string{"msg_assistant"})
+		if err != nil || len(events) == 0 {
+			// Check if there was a crash (state is interrupted/error without output).
+			status, _ := d.CurrentStatus(agentSession)
+			if status != nil && (status.State == "interrupted" || status.State == "error") {
+				results[i] = AgentResult{
+					Agent:   ag,
+					Passed:  false,
+					Output:  fmt.Sprintf("ERROR: agent crashed (state: %s)", status.State),
+					IsError: true,
+				}
+			} else {
+				results[i] = AgentResult{
+					Agent:   ag,
+					Passed:  false,
+					Output:  "ERROR: no output produced",
+					IsError: true,
+				}
+			}
+			continue
+		}
+
+		// Extract text from the last msg_assistant event.
+		text := extractAssistantText(events[len(events)-1].Payload)
+		passed := assessPassed(text)
+
+		results[i] = AgentResult{
+			Agent:  ag,
+			Passed: passed,
+			Output: text,
+		}
+	}
+	return results
+}
+
+// extractAssistantText parses the text field from a msg_assistant payload.
+func extractAssistantText(payload string) string {
+	var p struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err == nil && p.Text != "" {
+		return p.Text
+	}
+	return payload
+}
+
+// assessPassed heuristically determines whether a review agent passed.
+// A review "passes" when the agent found no blocking issues. We look for
+// common patterns that indicate a clean review.
+func assessPassed(text string) bool {
+	lower := strings.ToLower(text)
+	// Explicit failure indicators.
+	failPhrases := []string{
+		"please fix",
+		"needs to be fixed",
+		"must be fixed",
+		"blocking issue",
+		"this is a bug",
+		"error found",
+		"security issue",
+		"vulnerability",
+	}
+	for _, phrase := range failPhrases {
+		if strings.Contains(lower, phrase) {
+			return false
+		}
+	}
+	// If the text contains ✗ it likely has failures.
+	if strings.Contains(text, "✗") {
+		return false
+	}
+	return true
+}
+
+// cleanupAgentSession cleans up the DB state for a completed agent sub-session.
+func cleanupAgentSession(d *db.DB, agentSession string) {
+	if releaseErr := d.ReleasePort(agentSession); releaseErr != nil {
+		// Port may not have been allocated — ignore.
+		_ = releaseErr
+	}
+	_ = d.SetEnded(agentSession)
+	_ = d.PurgeBusMessages(agentSession)
+}
+
+// FormatResults formats the aggregated results as a human-readable report.
+// Returns the formatted string and a boolean indicating whether all passed.
+func FormatResults(results []AgentResult, prNumber string) (string, bool) {
+	var sb strings.Builder
+	allPassed := true
+	var failed []string
+
+	for _, r := range results {
+		if r.Passed {
+			sb.WriteString(fmt.Sprintf("✓ %-20s passed\n", r.Agent.Name))
+		} else {
+			allPassed = false
+			failed = append(failed, r.Agent.Name)
+			if r.IsError {
+				sb.WriteString(fmt.Sprintf("✗ %-20s %s\n", r.Agent.Name, r.Output))
+			} else {
+				// Content failure: include the output.
+				sb.WriteString(fmt.Sprintf("✗ %-20s\n", r.Agent.Name))
+				// Indent the output.
+				for _, line := range strings.Split(r.Output, "\n") {
+					sb.WriteString("  " + line + "\n")
+				}
+			}
+		}
+	}
+
+	if !allPassed {
+		sb.WriteString(fmt.Sprintf("\n%d agent(s) failed. Retry: prism review %s --only %s\n",
+			len(failed), prNumber, strings.Join(failed, ",")))
+	}
+
+	return sb.String(), allPassed
+}
+
+// LookupParentSession looks up the parent session from the environment or DB.
+// When called from inside a container, PRISM_SESSION_NAME is set to the
+// agent's session name. We then derive the parent by stripping the ~review-N
+// suffix if present, or using the session directly.
+func LookupParentSession() string {
+	// Try PRISM_SESSION_NAME first (set when running inside a container/agent).
+	if s := os.Getenv("PRISM_SESSION_NAME"); s != "" {
+		return s
+	}
+	// Fall back to TMUX current session.
+	sess, err := tmux.CurrentSession()
+	if err != nil {
+		return ""
+	}
+	return sess
+}
+
+// LookupWorktreePath returns the worktree path for the given session from the DB.
+func LookupWorktreePath(dbPath, sessionName string) string {
+	if dbPath == "" {
+		dbPath = defaultDBPath()
+	}
+	d, err := db.Open(dbPath)
+	if err != nil {
+		return ""
+	}
+	defer d.Close()
+	status, err := d.CurrentStatus(sessionName)
+	if err != nil || status == nil {
+		return ""
+	}
+	return status.Worktree
+}
+
+// defaultDBPath returns the default prism DB path.
+func defaultDBPath() string {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism", "prism.db")
+}
+
+// shellQuote wraps s in single quotes, escaping any single quotes within.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// formatDuration formats a duration as "Xm" or "Xs" for display.
+func formatDuration(d time.Duration) string {
+	if d >= time.Minute {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%ds", int(d.Seconds()))
+}
+
+// KillReviewSessionsForParent kills all ~review-* sessions for the given parent.
+// This is the public API used by cleanup.go.
+func KillReviewSessionsForParent(parentSession string) {
+	prefix := parentSession + "~review-"
+	KillSessionPrefix(prefix)
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -46,22 +46,23 @@ func KillSessionPrefix(prefix string) {
 }
 
 // NextRoundNumber returns the next round number for the given parent session.
-// It scans existing tmux sessions for ~review-N patterns and returns max(N)+1.
+// It queries the DB for all round sessions (not live tmux sessions) so that
+// the count is accurate even after previous rounds have been cleaned up.
 // Returns 1 when no prior rounds exist.
-func NextRoundNumber(parentSession string) int {
+func NextRoundNumber(d *db.DB, parentSession string) int {
 	prefix := parentSession + "~review-"
-	out, err := tmux.Run("list-sessions", "-F", "#{session_name}")
+	rows, err := d.AllStatusesWithPrefix(prefix)
 	if err != nil {
 		return 1
 	}
 	max := 0
-	for _, name := range strings.Split(out, "\n") {
-		name = strings.TrimSpace(name)
-		if strings.HasPrefix(name, prefix) {
-			suffix := strings.TrimPrefix(name, prefix)
-			if n, err := strconv.Atoi(suffix); err == nil && n > max {
-				max = n
-			}
+	for _, row := range rows {
+		// Only count round-level sessions (no further ~ after the round number).
+		suffix := strings.TrimPrefix(row.SessionName, prefix)
+		// suffix should be a pure integer (e.g. "1", "2") for round sessions.
+		// Agent sub-sessions have a suffix like "1~review", which won't parse.
+		if n, err := strconv.Atoi(suffix); err == nil && n > max {
+			max = n
 		}
 	}
 	return max + 1
@@ -142,8 +143,6 @@ type Opts struct {
 	Keep bool
 	// DBPath is the path to the prism database. If empty, the default is used.
 	DBPath string
-	// PrismBin is the path to the prism binary. Derived from os.Executable if empty.
-	PrismBin string
 	// PluginHostPath is the path to the opencode plugin file.
 	PluginHostPath string
 	// ConfigContent is the JSON blob for the container's opencode.json config.
@@ -158,26 +157,9 @@ type Opts struct {
 // On signal (SIGTERM/SIGINT), the caller is expected to kill the review session
 // using the session name returned via the onSessionCreated callback.
 func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName string)) ([]AgentResult, error) {
-	prismBin := opts.PrismBin
-	if prismBin == "" {
-		var err error
-		prismBin, err = os.Executable()
-		if err != nil {
-			return nil, fmt.Errorf("resolve prism binary: %w", err)
-		}
-	}
-
 	if opts.ParentSession == "" {
 		return nil, fmt.Errorf("parent session name is required")
 	}
-
-	// Kill any previous review sessions for this parent.
-	reviewPrefix := opts.ParentSession + "~review-"
-	KillSessionPrefix(reviewPrefix)
-
-	// Determine round number.
-	round := NextRoundNumber(opts.ParentSession)
-	reviewSession := fmt.Sprintf("%s~review-%d", opts.ParentSession, round)
 
 	// Resolve worktree path.
 	worktree := opts.Worktree
@@ -196,6 +178,16 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 	}
 	defer d.Close()
 
+	// Determine round number from DB BEFORE killing previous sessions.
+	// Using DB-based counting ensures correctness even after prior sessions
+	// are killed (tmux sessions disappear, but DB rows persist).
+	round := NextRoundNumber(d, opts.ParentSession)
+	reviewSession := fmt.Sprintf("%s~review-%d", opts.ParentSession, round)
+
+	// Kill any previous review sessions for this parent.
+	reviewPrefix := opts.ParentSession + "~review-"
+	KillSessionPrefix(reviewPrefix)
+
 	// Create the review tmux session.
 	if err := tmux.NewSessionDetached(reviewSession, worktree); err != nil {
 		return nil, fmt.Errorf("create review session %q: %w", reviewSession, err)
@@ -203,6 +195,13 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 
 	if onSessionCreated != nil {
 		onSessionCreated(reviewSession)
+	}
+
+	// Insert the round session into the DB so it shows up in checkin.
+	// The repo field is derived from the parent session name.
+	repo := deriveRepo(opts.ParentSession)
+	if err := d.UpsertStatus(reviewSession, repo, worktree, "idle", nil, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "[prism review] warning: upsert round session status: %v\n", err)
 	}
 
 	agents := opts.Agents
@@ -213,11 +212,13 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 	// Spawn each agent in its own tmux window within the review session.
 	agentSessions := make([]string, len(agents))
 	for i, ag := range agents {
+		// Agent sub-sessions are named <reviewSession>~<agentName>.
+		// They have a second ~ in the branch component, making them depth-2+.
 		agentSession := fmt.Sprintf("%s~%s", reviewSession, ag.Name)
 		agentSessions[i] = agentSession
 
 		// Seed agent_status for the agent session.
-		if err := seedAgentStatus(d, agentSession, opts.ParentSession, worktree); err != nil {
+		if err := d.UpsertStatus(agentSession, repo, worktree, "idle", nil, nil); err != nil {
 			return nil, fmt.Errorf("seed status for %s: %w", ag.Name, err)
 		}
 
@@ -245,14 +246,9 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 		}
 
 		// Create the agent window within the review session.
-		agentCmd := buildAgentCommand(ag, port, prompt, opts.ContainerMode)
+		agentCmd := buildAgentCommand(ag, agentSession, port, prompt, opts.ContainerMode)
 		if err := createAgentWindow(reviewSession, i, ag.Name, worktree, agentCmd, port, agentSession, opts.ContainerMode); err != nil {
 			return nil, fmt.Errorf("create window for %s: %w", ag.Name, err)
-		}
-
-		// Seed agent_status with the port so it shows up in list-sessions.
-		if updateErr := d.UpsertStatus(agentSession, opts.ParentSession, worktree, "idle", nil, nil); updateErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism review] warning: upsert status for %s: %v\n", ag.Name, updateErr)
 		}
 	}
 
@@ -262,6 +258,9 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 
 	// Poll DB until all agents finish or timeout.
 	results, pollErr := pollAgents(ctx, d, agents, agentSessions, opts.Timeout)
+
+	// Mark round session as finished in the DB.
+	_ = d.UpsertStatus(reviewSession, repo, worktree, "finished", nil, nil)
 
 	// Clean up sidecar processes.
 	for _, agentSession := range agentSessions {
@@ -275,14 +274,11 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 		for _, agentSession := range agentSessions {
 			cleanupAgentSession(d, agentSession)
 		}
+		// Mark the round session as ended.
+		_ = d.SetEnded(reviewSession)
 	}
 
 	return results, pollErr
-}
-
-// seedAgentStatus inserts an initial agent_status row for the review agent session.
-func seedAgentStatus(d *db.DB, agentSession, repo, worktree string) error {
-	return d.UpsertStatus(agentSession, repo, worktree, "idle", nil, nil)
 }
 
 // buildReviewPrompt returns the initial prompt string for a review agent.
@@ -291,13 +287,15 @@ func buildReviewPrompt(prNumber string) string {
 }
 
 // buildAgentCommand returns the opencode command string for a review agent window.
-func buildAgentCommand(ag Agent, port int, prompt string, containerMode bool) string {
+// agentSession is the full session name (e.g. "nixos-config@feature~review-1~review"),
+// used as PRISM_SESSION_NAME so the plugin correctly identifies the DB row.
+func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, containerMode bool) string {
 	if containerMode {
 		return fmt.Sprintf("opencode attach http://localhost:%d", port)
 	}
 	escapedPrompt := shellQuote(prompt)
 	return fmt.Sprintf("PRISM_SESSION_NAME=%s opencode --agent %s --port %d --hostname 127.0.0.1 --prompt %s",
-		shellQuote(ag.Name), ag.OpencodeName, port, escapedPrompt)
+		shellQuote(agentSession), ag.OpencodeName, port, escapedPrompt)
 }
 
 // createAgentWindow creates a tmux window for a review agent.
@@ -496,10 +494,7 @@ func assessPassed(text string) bool {
 
 // cleanupAgentSession cleans up the DB state for a completed agent sub-session.
 func cleanupAgentSession(d *db.DB, agentSession string) {
-	if releaseErr := d.ReleasePort(agentSession); releaseErr != nil {
-		// Port may not have been allocated — ignore.
-		_ = releaseErr
-	}
+	_ = d.ReleasePort(agentSession)
 	_ = d.SetEnded(agentSession)
 	_ = d.PurgeBusMessages(agentSession)
 }
@@ -540,8 +535,7 @@ func FormatResults(results []AgentResult, prNumber string) (string, bool) {
 
 // LookupParentSession looks up the parent session from the environment or DB.
 // When called from inside a container, PRISM_SESSION_NAME is set to the
-// agent's session name. We then derive the parent by stripping the ~review-N
-// suffix if present, or using the session directly.
+// agent's session name. We use that directly (the worker's session name).
 func LookupParentSession() string {
 	// Try PRISM_SESSION_NAME first (set when running inside a container/agent).
 	if s := os.Getenv("PRISM_SESSION_NAME"); s != "" {
@@ -555,21 +549,18 @@ func LookupParentSession() string {
 	return sess
 }
 
-// LookupWorktreePath returns the worktree path for the given session from the DB.
-func LookupWorktreePath(dbPath, sessionName string) string {
-	if dbPath == "" {
-		dbPath = defaultDBPath()
+// IsRoundSession returns true if the given session name is a review round
+// session (not an agent sub-session). Round sessions have exactly one ~ in
+// the branch component and the suffix after ~review- is a pure integer.
+// Agent sub-sessions have a second ~ (e.g. "~review-1~review").
+func IsRoundSession(sessionName, parentSession string) bool {
+	prefix := parentSession + "~review-"
+	if !strings.HasPrefix(sessionName, prefix) {
+		return false
 	}
-	d, err := db.Open(dbPath)
-	if err != nil {
-		return ""
-	}
-	defer d.Close()
-	status, err := d.CurrentStatus(sessionName)
-	if err != nil || status == nil {
-		return ""
-	}
-	return status.Worktree
+	suffix := strings.TrimPrefix(sessionName, prefix)
+	_, err := strconv.Atoi(suffix)
+	return err == nil
 }
 
 // defaultDBPath returns the default prism DB path.
@@ -580,6 +571,14 @@ func defaultDBPath() string {
 		stateHome = filepath.Join(home, ".local", "state")
 	}
 	return filepath.Join(stateHome, "prism", "prism.db")
+}
+
+// deriveRepo returns the repo portion of a session name (before "@").
+func deriveRepo(sessionName string) string {
+	if idx := strings.Index(sessionName, "@"); idx >= 0 {
+		return sessionName[:idx]
+	}
+	return sessionName
 }
 
 // shellQuote wraps s in single quotes, escaping any single quotes within.

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -407,7 +407,17 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 			break
 		}
 
-		time.Sleep(pollInterval)
+		// Sleep while remaining responsive to context cancellation.
+		select {
+		case <-ctx.Done():
+			for i := range agents {
+				if !finished[i] {
+					timedOut[i] = true
+				}
+			}
+			return buildResults(agents, agentSessions, d, finished, timedOut, timeout, true), ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, false), nil
@@ -469,7 +479,7 @@ func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 
 		// Extract text from the last msg_assistant event.
 		text := extractAssistantText(events[len(events)-1].Payload)
-		passed := assessPassed(text)
+		passed := AssessPassed(text)
 
 		results[i] = AgentResult{
 			Agent:  ag,
@@ -491,10 +501,12 @@ func extractAssistantText(payload string) string {
 	return payload
 }
 
-// assessPassed heuristically determines whether a review agent passed.
+// AssessPassed heuristically determines whether a review agent passed.
 // A review "passes" when the agent found no blocking issues. We look for
 // common patterns that indicate a clean review.
-func assessPassed(text string) bool {
+//
+// Exported so it can be tested directly without needing a live DB.
+func AssessPassed(text string) bool {
 	lower := strings.ToLower(text)
 	// Explicit failure indicators.
 	failPhrases := []string{

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -142,6 +142,55 @@ func TestFormatResults_PassFailPhrases(t *testing.T) {
 	}
 }
 
+// ── AssessPassed ──────────────────────────────────────────────────────────────
+
+func TestAssessPassed_FailingPhrases(t *testing.T) {
+	failingTexts := []struct {
+		text   string
+		phrase string
+	}{
+		{"Please fix the above before this PR is merged.", "please fix"},
+		{"This needs to be fixed before merging.", "needs to be fixed"},
+		{"The function must be fixed to handle nil inputs.", "must be fixed"},
+		{"There is a blocking issue in the auth flow.", "blocking issue"},
+		{"This is a bug in the state machine.", "this is a bug"},
+		{"Error found in the input validation.", "error found"},
+		{"There is a security issue with the token handling.", "security issue"},
+		{"A vulnerability was found in the deserialization path.", "vulnerability"},
+		{"Output contains ✗ indicating failure.", "✗"},
+	}
+	for _, tt := range failingTexts {
+		if review.AssessPassed(tt.text) {
+			t.Errorf("AssessPassed(%q) = true, want false (phrase %q should trigger fail)", tt.text, tt.phrase)
+		}
+	}
+}
+
+func TestAssessPassed_PassingTexts(t *testing.T) {
+	passingTexts := []string{
+		"The implementation looks correct. All acceptance criteria are met.",
+		"LGTM. No issues found. The code follows existing conventions.",
+		"Reviewed thoroughly. The PR is ready to merge.",
+		"All acceptance criteria pass. The error handling is correct.",
+		"The PR looks good. I checked the diff and the linked issue's ACs.",
+	}
+	for _, text := range passingTexts {
+		if !review.AssessPassed(text) {
+			t.Errorf("AssessPassed(%q) = false, want true", text)
+		}
+	}
+}
+
+func TestAssessPassed_CaseInsensitive(t *testing.T) {
+	// Failure phrases should be detected regardless of case.
+	if review.AssessPassed("PLEASE FIX THE ABOVE BEFORE THIS PR IS MERGED.") {
+		t.Error("AssessPassed should detect 'PLEASE FIX' case-insensitively")
+	}
+	if review.AssessPassed("Please Fix the above.") {
+		t.Error("AssessPassed should detect 'Please Fix' case-insensitively")
+	}
+}
+
 // ── AgentsByName ──────────────────────────────────────────────────────────────
 
 func TestAgentsByName_ValidNames(t *testing.T) {

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1,0 +1,190 @@
+package review_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// ── NextRoundNumber ───────────────────────────────────────────────────────────
+
+func TestNextRoundNumber_NoExistingRounds_Returns1(t *testing.T) {
+	d := openTestDB(t)
+	n := review.NextRoundNumber(d, "nixos-config@feature")
+	if n != 1 {
+		t.Errorf("NextRoundNumber = %d, want 1", n)
+	}
+}
+
+func TestNextRoundNumber_WithExistingRounds(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@feature"
+
+	_ = d.UpsertStatus(parent+"~review-1", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-2", "nixos-config", "/wt", "idle", nil, nil)
+	// Agent sub-session — should NOT count as a round.
+	_ = d.UpsertStatus(parent+"~review-1~review", "nixos-config", "/wt", "idle", nil, nil)
+
+	n := review.NextRoundNumber(d, parent)
+	if n != 3 {
+		t.Errorf("NextRoundNumber = %d, want 3", n)
+	}
+}
+
+func TestNextRoundNumber_SkipsNonRoundSessions(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@feature"
+
+	// Only sub-sessions exist — no round sessions.
+	_ = d.UpsertStatus(parent+"~review-1~review", "nixos-config", "/wt", "idle", nil, nil)
+
+	n := review.NextRoundNumber(d, parent)
+	if n != 1 {
+		t.Errorf("NextRoundNumber = %d, want 1 (sub-sessions should not count)", n)
+	}
+}
+
+// ── assessPassed ──────────────────────────────────────────────────────────────
+// assessPassed is unexported; test it indirectly via FormatResults.
+
+func TestFormatResults_AllPassed(t *testing.T) {
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review"}, Passed: true, Output: "LGTM, no issues found."},
+	}
+	output, allPassed := review.FormatResults(results, "42")
+	if !allPassed {
+		t.Errorf("allPassed = false, want true")
+	}
+	if len(output) == 0 {
+		t.Error("output is empty")
+	}
+	// Should contain the tick mark.
+	if !containsAny(output, "✓") {
+		t.Errorf("output does not contain ✓: %q", output)
+	}
+	// Should NOT contain retry command.
+	if containsAny(output, "Retry:") {
+		t.Errorf("output unexpectedly contains 'Retry': %q", output)
+	}
+}
+
+func TestFormatResults_SomeFailed(t *testing.T) {
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review"}, Passed: false, Output: "Please fix the above before this PR is merged.", IsError: false},
+	}
+	output, allPassed := review.FormatResults(results, "42")
+	if allPassed {
+		t.Errorf("allPassed = true, want false")
+	}
+	if !containsAny(output, "✗") {
+		t.Errorf("output does not contain ✗: %q", output)
+	}
+	if !containsAny(output, "Retry: prism review 42") {
+		t.Errorf("output does not contain retry command: %q", output)
+	}
+}
+
+func TestFormatResults_InfraError(t *testing.T) {
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review"}, Passed: false, Output: "ERROR: timed out after 10m", IsError: true},
+	}
+	output, allPassed := review.FormatResults(results, "42")
+	if allPassed {
+		t.Errorf("allPassed = true, want false")
+	}
+	if !containsAny(output, "ERROR: timed out") {
+		t.Errorf("output does not contain timeout error: %q", output)
+	}
+	if !containsAny(output, "Retry:") {
+		t.Errorf("output does not contain retry command: %q", output)
+	}
+}
+
+func TestFormatResults_PassFailPhrases(t *testing.T) {
+	// Test that failure-indicating phrases cause the agent to be marked failed.
+	failingOutputs := []string{
+		"Please fix the above before this PR is merged.",
+		"This is a bug that needs to be fixed.",
+		"There is a security issue in the code.",
+		"Found a vulnerability in authentication.",
+	}
+	for _, text := range failingOutputs {
+		results := []review.AgentResult{
+			{Agent: review.Agent{Name: "review"}, Passed: false, Output: text},
+		}
+		_, allPassed := review.FormatResults(results, "1")
+		if allPassed {
+			t.Errorf("FormatResults with output %q: allPassed=true, want false", text)
+		}
+	}
+
+	// A clean review should pass.
+	cleanOutput := "The implementation looks correct. All acceptance criteria verified. No issues found."
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review"}, Passed: true, Output: cleanOutput},
+	}
+	_, allPassed := review.FormatResults(results, "1")
+	if !allPassed {
+		t.Errorf("FormatResults with clean output: allPassed=false, want true")
+	}
+}
+
+// ── AgentsByName ──────────────────────────────────────────────────────────────
+
+func TestAgentsByName_ValidNames(t *testing.T) {
+	agents := review.DefaultAgents()
+	result, err := review.AgentsByName(agents, []string{"review"})
+	if err != nil {
+		t.Fatalf("AgentsByName: %v", err)
+	}
+	if len(result) != 1 || result[0].Name != "review" {
+		t.Errorf("AgentsByName = %v, want [{review}]", result)
+	}
+}
+
+func TestAgentsByName_UnknownName(t *testing.T) {
+	agents := review.DefaultAgents()
+	_, err := review.AgentsByName(agents, []string{"nonexistent"})
+	if err == nil {
+		t.Error("AgentsByName should return error for unknown agent name")
+	}
+}
+
+func TestAgentsByName_MixedNames(t *testing.T) {
+	agents := review.DefaultAgents()
+	_, err := review.AgentsByName(agents, []string{"review", "nonexistent"})
+	if err == nil {
+		t.Error("AgentsByName should return error when any name is unknown")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func containsAny(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
+}
+
+func findSubstring(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -182,6 +182,10 @@ type StartSidecarOpts struct {
 	// without needing to read it back from the DB (which would race with the
 	// tmux-session-start event that writes instance_id to agent_status).
 	InstanceID string
+	// WorktreeReadOnly, when true, mounts the worktree read-only inside the
+	// container. Set for review agent containers so they cannot modify the
+	// branch under review. Passed via --worktree-readonly to the sidecar.
+	WorktreeReadOnly bool
 }
 
 // StartSidecar launches a detached `prism sidecar` process for the given
@@ -255,6 +259,9 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 	}
 	if opts.InstanceID != "" {
 		cmdArgs = append(cmdArgs, "--instance-id", opts.InstanceID)
+	}
+	if opts.WorktreeReadOnly {
+		cmdArgs = append(cmdArgs, "--worktree-readonly")
 	}
 
 	cmd := exec.Command(self, cmdArgs...)


### PR DESCRIPTION
## Summary

Implements `prism review <pr-number>` as a first-class CLI command for the prism tool, as described in #654.

- **`prism review <pr-number>`** spawns review agents in a dedicated tmux session named `<parent>~review-N`, polls the prism DB until all agents complete, and returns aggregated findings to stdout with pass/fail labelling per agent
- **Dashboard depth-2 rendering**: review sessions appear indented under their parent branch with `  │   ├──` / `  │   └──` tree connectors
- **`prism checkin <parent>~review`** prefix-matches all review rounds and shows the final output per round (with `--verbose` for full conversation)
- **Cleanup propagation**: parent session cleanup (both TUI and headless paths) kills all `<parent>~review-*` sessions
- **SIGTERM/SIGINT handling**: `prism review` kills review sessions and exits cleanly on signal
- **Worker and skill docs** updated to document `prism review` alongside `@review`

## Files changed

- `internal/review/review.go` (NEW) — execution logic, session naming, polling, output formatting
- `cmd/review.go` (NEW) — CLI command with `--harness`, `--keep`, `--timeout`, `--only` flags
- `cmd/cleanup.go` — kill `<session>~review-*` in all cleanup paths
- `internal/dashboard/sessions.go` — depth-2 detection via `~` separator, sort order, display helpers
- `internal/dashboard/view.go` — depth-2 tree rendering
- `internal/db/db.go` — `AllStatusesWithPrefix` for checkin round enumeration
- `cmd/checkin.go` — `~review` prefix-match support
- `opencode/agents/worker.md` — document `prism review` usage
- `opencode/skills/prism/SKILL.md` — full `prism review` documentation

Closes #654