### PR TITLE
feat(prism): real-time persistent dashboard updates via sidecar push events

### DIFF
--- a/modules/programs/prism/prism/cmd/dashboard.go
+++ b/modules/programs/prism/prism/cmd/dashboard.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -51,7 +52,11 @@ var dashboardCmd = &cobra.Command{
 				m := dashboard.NewPersistentModel(client, callerSession)
 				p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithReportFocus())
 				ctx, cancel := context.WithCancel(context.Background())
-				dashboard.WatchDashboardSentinel(ctx, p)
+				// Use socket listener for real-time push events (persistent dashboard only).
+				if _, err := dashboard.StartSocketListener(ctx, p); err != nil {
+					log.Printf("dashboard: socket listener: %v (falling back to sentinel polling)", err)
+					dashboard.WatchDashboardSentinel(ctx, p)
+				}
 				_, err := p.Run()
 				cancel()
 				return err

--- a/modules/programs/prism/prism/cmd/dashboard.go
+++ b/modules/programs/prism/prism/cmd/dashboard.go
@@ -53,9 +53,11 @@ var dashboardCmd = &cobra.Command{
 				p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithReportFocus())
 				ctx, cancel := context.WithCancel(context.Background())
 				// Use socket listener for real-time push events (persistent dashboard only).
+				// If socket creation fails, log and continue without it — the dashboard
+				// still renders correctly via the 5-second git stat ticker and on-demand
+				// DB refreshes; it just won't receive instant push events.
 				if _, err := dashboard.StartSocketListener(ctx, p); err != nil {
-					log.Printf("dashboard: socket listener: %v (falling back to sentinel polling)", err)
-					dashboard.WatchDashboardSentinel(ctx, p)
+					log.Printf("dashboard: socket listener: %v", err)
 				}
 				_, err := p.Run()
 				cancel()

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/dashboard"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -65,6 +66,10 @@ func Restore(dryRun bool) error {
 		fmt.Fprintf(os.Stderr, "prism restore: prune: %v\n", err)
 		// Non-fatal — continue with restore.
 	}
+
+	// Remove any stale dashboard socket left behind by a crashed dashboard.
+	// Non-fatal: a stale socket only affects real-time push delivery.
+	dashboard.RemoveStaleSocket()
 
 	statuses, err := d.AllActiveStatus()
 	if err != nil {

--- a/modules/programs/prism/prism/internal/dashboard/model.go
+++ b/modules/programs/prism/prism/internal/dashboard/model.go
@@ -57,8 +57,20 @@ type SessionsMsg struct {
 // GhTickMsg is sent on the 60-second GitHub stats refresh timer.
 type GhTickMsg time.Time
 
+// GitStatTickMsg is sent on the 5-second git stat refresh timer.
+type GitStatTickMsg time.Time
+
 // CursorTimeoutMsg is sent when the cursor auto-hide timeout fires.
 type CursorTimeoutMsg struct{}
+
+// PushEventMsg is sent by the socket listener goroutine when a sidecar pushes
+// a state-change event to the dashboard socket. It carries only the session
+// name, new state, and (optionally) title — no DB round-trip required.
+type PushEventMsg struct {
+	Session string
+	State   string
+	Title   string
+}
 
 // GithubStatsMsg carries the result of a GitHub PR fetch.
 type GithubStatsMsg struct {
@@ -226,6 +238,30 @@ func fuzzyMatch(s, pattern string) bool {
 		}
 	}
 	return true
+}
+
+// applyPushEvent updates d in response to a PushEventMsg: it finds the session
+// named msg.Session in d.Sessions and updates its AgentState (and AgentTitle if
+// non-empty) in-place. If the session is not found, d is returned unchanged
+// (no crash). After updating, RefilterShared is called to propagate the change
+// to Displayed.
+func applyPushEvent(d Shared, msg PushEventMsg) Shared {
+	found := false
+	for i, s := range d.Sessions {
+		if s.Name == msg.Session {
+			d.Sessions[i].AgentState = msg.State
+			if msg.Title != "" {
+				d.Sessions[i].AgentTitle = msg.Title
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		// Unknown session — ignore gracefully.
+		return d
+	}
+	return RefilterShared(d)
 }
 
 // ── db helper ─────────────────────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/dashboard/model.go
+++ b/modules/programs/prism/prism/internal/dashboard/model.go
@@ -60,6 +60,14 @@ type GhTickMsg time.Time
 // GitStatTickMsg is sent on the 5-second git stat refresh timer.
 type GitStatTickMsg time.Time
 
+// GitStatsOnlyMsg carries only the result of git.Stat calls, without a fresh
+// session list from the DB. It is used by the persistent dashboard's 5-second
+// git stat ticker to update diff counters in-place, leaving session states
+// (which may have been updated by push events) untouched.
+type GitStatsOnlyMsg struct {
+	GitStats map[string]GitStatResult // keyed by AgentPath
+}
+
 // CursorTimeoutMsg is sent when the cursor auto-hide timeout fires.
 type CursorTimeoutMsg struct{}
 

--- a/modules/programs/prism/prism/internal/dashboard/persistent.go
+++ b/modules/programs/prism/prism/internal/dashboard/persistent.go
@@ -58,9 +58,21 @@ func (m PersistentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, FetchSessionsFromDB
 
 	case GitStatTickMsg:
-		// 5-second git stat refresh: fetch sessions with git diff stats, then
-		// schedule the next tick.
-		return m, tea.Batch(FetchSessionsWithGitStats, GitStatTick())
+		// 5-second git stat refresh: fetch only git stats (not session states),
+		// then schedule the next tick. Using FetchGitStatsOnly ensures that
+		// push-event state updates are never overwritten by the ticker.
+		return m, tea.Batch(FetchGitStatsOnly, GitStatTick())
+
+	case GitStatsOnlyMsg:
+		// Apply updated git diff stats without touching session states.
+		if msg.GitStats != nil {
+			if m.GitStats == nil {
+				m.GitStats = make(map[string]GitStatResult)
+			}
+			for k, v := range msg.GitStats {
+				m.GitStats[k] = v
+			}
+		}
 
 	case PushEventMsg:
 		// A sidecar pushed a state-change event directly to the dashboard socket.

--- a/modules/programs/prism/prism/internal/dashboard/persistent.go
+++ b/modules/programs/prism/prism/internal/dashboard/persistent.go
@@ -40,7 +40,11 @@ func NewPersistentModel(client, callerSession string) PersistentModel {
 }
 
 func (m PersistentModel) Init() tea.Cmd {
-	return tea.Batch(FetchSessionsFromDB, FetchGitHubStats, GhTick())
+	// FetchSessionsFromDB populates the initial session list with git diff stats.
+	// GitStatTick schedules a 5-second periodic refresh to keep stats up to date
+	// independently of state-transition rendering (push events update only
+	// session state, not git stats).
+	return tea.Batch(FetchSessionsFromDB, FetchGitHubStats, GhTick(), GitStatTick())
 }
 
 func (m PersistentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -52,6 +56,18 @@ func (m PersistentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case RefreshMsg:
 		return m, FetchSessionsFromDB
+
+	case GitStatTickMsg:
+		// 5-second git stat refresh: fetch sessions with git diff stats, then
+		// schedule the next tick.
+		return m, tea.Batch(FetchSessionsWithGitStats, GitStatTick())
+
+	case PushEventMsg:
+		// A sidecar pushed a state-change event directly to the dashboard socket.
+		// Update the named session in-memory and re-render immediately — no DB
+		// round-trip, no git stat wait.
+		m.Shared = applyPushEvent(m.Shared, msg)
+		return m, nil
 
 	case DashStatusMsg:
 		m.StatusMsg = string(msg)

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -75,11 +75,14 @@ func FetchSessionsFromDB() tea.Msg {
 }
 
 // FetchGitStatsOnly queries the current set of active sessions from the DB
-// solely to discover their AgentPath values, then runs git.Stat on each unique
+// solely to discover their worktree paths, then runs git.Stat on each unique
 // path concurrently and returns a GitStatsOnlyMsg. It does NOT update the
 // session list or agent states — those are managed by FetchSessionsFromDB and
 // push events. This is what the persistent dashboard's 5-second git stat ticker
 // calls so that diff-counter updates never overwrite push-event state changes.
+//
+// Internal sessions (scratchpad, prism-dashboard) are filtered out before
+// collecting paths, consistent with FetchSessionsFromDB.
 func FetchGitStatsOnly() tea.Msg {
 	d, err := openDB()
 	if err != nil {
@@ -92,13 +95,22 @@ func FetchGitStatsOnly() tea.Msg {
 		return GitStatsOnlyMsg{}
 	}
 
-	// Collect unique agent paths.
+	// Convert to AgentSession so we can reuse FilterAgentSessions, then
+	// collect unique worktree paths (AgentPath field).
+	clientCounts := TmuxClientCounts()
+	sessions := make([]AgentSession, 0, len(statuses))
+	for _, s := range statuses {
+		sessions = append(sessions, StatusToAgentSession(s, clientCounts))
+	}
+	sessions = FilterAgentSessions(sessions)
+
+	// Collect unique AgentPath values (= worktree paths).
 	seen := map[string]bool{}
 	var paths []string
-	for _, s := range statuses {
-		if s.Worktree != "" && !seen[s.Worktree] {
-			seen[s.Worktree] = true
-			paths = append(paths, s.Worktree)
+	for _, s := range sessions {
+		if s.AgentPath != "" && !seen[s.AgentPath] {
+			seen[s.AgentPath] = true
+			paths = append(paths, s.AgentPath)
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -74,15 +74,52 @@ func FetchSessionsFromDB() tea.Msg {
 	return SessionsMsg{Sessions: sessions, GitStats: stats}
 }
 
-// FetchSessionsWithGitStats queries agent_status for all active sessions and
-// enriches them with git diff stats. Used by the persistent dashboard's 5s
-// git stat ticker to keep diff counts up to date independently of state
-// transition rendering.
-func FetchSessionsWithGitStats() tea.Msg {
-	// Delegates to FetchSessionsFromDB which includes git stats.
-	// Having a separate function pointer allows tests to stub just the ticker
-	// path without affecting the on-demand refresh path.
-	return FetchSessionsFromDB()
+// FetchGitStatsOnly queries the current set of active sessions from the DB
+// solely to discover their AgentPath values, then runs git.Stat on each unique
+// path concurrently and returns a GitStatsOnlyMsg. It does NOT update the
+// session list or agent states — those are managed by FetchSessionsFromDB and
+// push events. This is what the persistent dashboard's 5-second git stat ticker
+// calls so that diff-counter updates never overwrite push-event state changes.
+func FetchGitStatsOnly() tea.Msg {
+	d, err := openDB()
+	if err != nil {
+		return GitStatsOnlyMsg{}
+	}
+	defer d.Close()
+
+	statuses, err := d.AllActiveStatus()
+	if err != nil {
+		return GitStatsOnlyMsg{}
+	}
+
+	// Collect unique agent paths.
+	seen := map[string]bool{}
+	var paths []string
+	for _, s := range statuses {
+		if s.Worktree != "" && !seen[s.Worktree] {
+			seen[s.Worktree] = true
+			paths = append(paths, s.Worktree)
+		}
+	}
+
+	// Run git.Stat for each unique path concurrently.
+	stats := make(map[string]GitStatResult, len(paths))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, p := range paths {
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			diffStat, err := git.Stat(path)
+			result := GitStatResult{Stat: diffStat, Ok: err == nil}
+			mu.Lock()
+			stats[path] = result
+			mu.Unlock()
+		}(p)
+	}
+	wg.Wait()
+
+	return GitStatsOnlyMsg{GitStats: stats}
 }
 
 // FetchGitHubStats calls gh api via GraphQL to get the viewer's open PR count.
@@ -266,6 +303,13 @@ func handlePushConn(conn net.Conn, p *tea.Program) {
 // RemoveStaleSocket removes the dashboard socket at DashSocketPath() if it
 // exists but has no listening process. Used by prism restore to clean up
 // sockets left behind by a crashed dashboard.
+//
+// Liveness detection: a short dial is attempted. If the dial fails (connection
+// refused or timeout), the socket is stale and is removed. If the dial succeeds
+// the socket is live — the connection is immediately closed; the dashboard's
+// handlePushConn goroutine will receive an empty read and return silently after
+// its 2-second read deadline. This is a known and accepted side-effect
+// (restore runs once at login; the cost is one benign no-op goroutine).
 func RemoveStaleSocket() {
 	sockPath := DashSocketPath()
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
@@ -277,6 +321,6 @@ func RemoveStaleSocket() {
 		_ = os.Remove(sockPath)
 		return
 	}
-	// Socket is live — leave it alone.
+	// Socket is live — close immediately and leave the socket in place.
 	_ = conn.Close()
 }

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -1,7 +1,11 @@
 package dashboard
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"log"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +18,8 @@ import (
 )
 
 // FetchSessionsFromDB queries agent_status for all active sessions and
-// enriches them with git diff stats.
+// enriches them with git diff stats. Used by the popup dashboard (which fetches
+// fresh data on every open) and by the persistent dashboard's RefreshMsg path.
 func FetchSessionsFromDB() tea.Msg {
 	d, err := openDB()
 	if err != nil {
@@ -69,6 +74,17 @@ func FetchSessionsFromDB() tea.Msg {
 	return SessionsMsg{Sessions: sessions, GitStats: stats}
 }
 
+// FetchSessionsWithGitStats queries agent_status for all active sessions and
+// enriches them with git diff stats. Used by the persistent dashboard's 5s
+// git stat ticker to keep diff counts up to date independently of state
+// transition rendering.
+func FetchSessionsWithGitStats() tea.Msg {
+	// Delegates to FetchSessionsFromDB which includes git stats.
+	// Having a separate function pointer allows tests to stub just the ticker
+	// path without affecting the on-demand refresh path.
+	return FetchSessionsFromDB()
+}
+
 // FetchGitHubStats calls gh api via GraphQL to get the viewer's open PR count.
 // Runs as a tea.Cmd so it never blocks the render loop.
 func FetchGitHubStats() tea.Msg {
@@ -109,6 +125,13 @@ func GhTick() tea.Cmd {
 	})
 }
 
+// GitStatTick returns a tea.Cmd that fires a GitStatTickMsg after 5 seconds.
+func GitStatTick() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return GitStatTickMsg(t)
+	})
+}
+
 // DashSentinelPath returns the path to the dashboard sentinel file.
 func DashSentinelPath() string {
 	stateHome := os.Getenv("XDG_STATE_HOME")
@@ -119,6 +142,16 @@ func DashSentinelPath() string {
 	return filepath.Join(stateHome, "prism", "bus", ".dashboard.signal")
 }
 
+// DashSocketPath returns the path to the persistent dashboard Unix socket.
+func DashSocketPath() string {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism", "bus", "dashboard.sock")
+}
+
 // WatchDashboardSentinel starts a goroutine that polls the dashboard sentinel
 // file for changes and sends a RefreshMsg to the Bubble Tea program when a
 // change is detected. The goroutine exits when ctx is cancelled (call the
@@ -126,6 +159,9 @@ func DashSentinelPath() string {
 //
 // Uses a stat-poll rather than inotify/fsnotify to avoid adding a dependency.
 // The poll interval is 200ms — well under the 1-second target from the spec.
+//
+// This function is used by the popup dashboard only. The persistent dashboard
+// uses StartSocketListener instead.
 func WatchDashboardSentinel(ctx context.Context, p *tea.Program) {
 	sentinelPath := DashSentinelPath()
 	var lastMod time.Time
@@ -147,4 +183,100 @@ func WatchDashboardSentinel(ctx context.Context, p *tea.Program) {
 			time.Sleep(200 * time.Millisecond)
 		}
 	}()
+}
+
+// pushEvent is the JSON payload sent by the sidecar to the dashboard socket.
+type pushEvent struct {
+	Session string `json:"session"`
+	State   string `json:"state"`
+	Title   string `json:"title"`
+}
+
+// StartSocketListener creates the dashboard Unix socket, listens for push events
+// from sidecars, and sends PushEventMsg to the Bubble Tea program on each event.
+// The socket is created at DashSocketPath() with mode 0600. The goroutine is
+// stopped and the socket removed when ctx is cancelled.
+//
+// Returns the net.Listener (for explicit teardown by the caller) and any error
+// from socket creation. On error the caller should fall back to
+// WatchDashboardSentinel.
+func StartSocketListener(ctx context.Context, p *tea.Program) (net.Listener, error) {
+	sockPath := DashSocketPath()
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		return nil, err
+	}
+	// Remove any stale socket from a previous run.
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, err
+	}
+	// Restrict to owner only.
+	if err := os.Chmod(sockPath, 0o600); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				// Accept fails when the listener is closed (clean shutdown).
+				return
+			}
+			go handlePushConn(conn, p)
+		}
+	}()
+
+	// Close the listener and remove the socket when ctx is cancelled.
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
+	}()
+
+	return ln, nil
+}
+
+// handlePushConn reads a single push event from conn and sends a PushEventMsg
+// to p. Fire-and-forget: errors are silently discarded.
+func handlePushConn(conn net.Conn, p *tea.Program) {
+	defer conn.Close()
+	// Set a short read deadline so a stuck or misbehaving sidecar cannot
+	// block an Accept slot indefinitely.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	// Read one line (the JSON event).
+	scanner := bufio.NewScanner(conn)
+	if !scanner.Scan() {
+		return
+	}
+	line := scanner.Bytes()
+	var evt pushEvent
+	if err := json.Unmarshal(line, &evt); err != nil {
+		log.Printf("dashboard: socket: invalid push event: %v", err)
+		return
+	}
+	if evt.Session == "" || evt.State == "" {
+		return
+	}
+	p.Send(PushEventMsg{Session: evt.Session, State: evt.State, Title: evt.Title})
+}
+
+// RemoveStaleSocket removes the dashboard socket at DashSocketPath() if it
+// exists but has no listening process. Used by prism restore to clean up
+// sockets left behind by a crashed dashboard.
+func RemoveStaleSocket() {
+	sockPath := DashSocketPath()
+	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
+		return
+	}
+	// Attempt a dial; if connection is refused (or any error), remove the socket.
+	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
+	if err != nil {
+		_ = os.Remove(sockPath)
+		return
+	}
+	// Socket is live — leave it alone.
+	_ = conn.Close()
 }

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -95,22 +95,20 @@ func FetchGitStatsOnly() tea.Msg {
 		return GitStatsOnlyMsg{}
 	}
 
-	// Convert to AgentSession so we can reuse FilterAgentSessions, then
-	// collect unique worktree paths (AgentPath field).
-	clientCounts := TmuxClientCounts()
-	sessions := make([]AgentSession, 0, len(statuses))
-	for _, s := range statuses {
-		sessions = append(sessions, StatusToAgentSession(s, clientCounts))
-	}
-	sessions = FilterAgentSessions(sessions)
-
-	// Collect unique AgentPath values (= worktree paths).
+	// Collect unique worktree paths, skipping internal sessions
+	// (scratchpad, prism-dashboard) by name — the same filter applied by
+	// FilterAgentSessions. We operate directly on db.Status here to avoid
+	// the TmuxClientCounts() subprocess call that StatusToAgentSession
+	// requires but FetchGitStatsOnly does not use.
 	seen := map[string]bool{}
 	var paths []string
-	for _, s := range sessions {
-		if s.AgentPath != "" && !seen[s.AgentPath] {
-			seen[s.AgentPath] = true
-			paths = append(paths, s.AgentPath)
+	for _, s := range statuses {
+		if s.SessionName == "scratchpad" || s.SessionName == "prism-dashboard" {
+			continue
+		}
+		if s.Worktree != "" && !seen[s.Worktree] {
+			seen[s.Worktree] = true
+			paths = append(paths, s.Worktree)
 		}
 	}
 
@@ -247,8 +245,9 @@ type pushEvent struct {
 // stopped and the socket removed when ctx is cancelled.
 //
 // Returns the net.Listener (for explicit teardown by the caller) and any error
-// from socket creation. On error the caller should fall back to
-// WatchDashboardSentinel.
+// from socket creation. On error the caller should log and continue without
+// push events — the dashboard still renders correctly via the periodic git stat
+// ticker and on-demand DB refreshes; it just won't receive instant state updates.
 func StartSocketListener(ctx context.Context, p *tea.Program) (net.Listener, error) {
 	sockPath := DashSocketPath()
 	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -198,6 +198,11 @@ type Sidecar struct {
 	// already stops the timer; busyEpoch provides an additional guard for
 	// the timer closure so it can bail out even if Stop() loses the race.
 	busyEpoch uint64
+	// lastTitle is the most recently upserted session title. Used when
+	// pushing state-change events to the dashboard socket so the dashboard
+	// can update the title display immediately without a DB round-trip.
+	// Protected by s.mu.
+	lastTitle string
 }
 
 // New creates a Sidecar with the given configuration.
@@ -1249,6 +1254,10 @@ func (s *Sidecar) currentDBState() agent.AgentState {
 }
 
 func (s *Sidecar) upsertState(state agent.AgentState, title *string, opencodeSID *string) {
+	// Track the most recently seen title for dashboard push events.
+	if title != nil && *title != "" {
+		s.lastTitle = *title
+	}
 	// When AgentRole is set, use UpsertStatusWithRootAgent so that
 	// root_agent_name is seeded from the configured role on the initial INSERT
 	// and preserved via COALESCE on subsequent UPDATEs. AgentModel is also
@@ -1301,6 +1310,12 @@ func (s *Sidecar) writeStateChangeWithSID(state agent.AgentState, opencodeSID *s
 	log.Printf("sidecar: state: %s -> %s", s.lastState, state)
 	s.writeEvent("state_change", map[string]string{"state": string(state)}, opencodeSID)
 	s.lastState = state
+	// Push to the persistent dashboard socket (fire-and-forget, non-blocking).
+	// Also touch the sentinel for the popup dashboard which still polls it.
+	sessionName := s.cfg.SessionName
+	title := s.lastTitle
+	stateStr := string(state)
+	go pushDashboardEvent(sessionName, stateStr, title)
 	touchDashboardSentinel()
 }
 
@@ -1329,6 +1344,47 @@ func (s *Sidecar) writeEvent(eventType string, payload any, opencodeSID *string)
 	if err := s.cfg.DB.WriteEvent(e); err != nil {
 		log.Printf("sidecar: WriteEvent(%s) failed: %v", eventType, err)
 	}
+}
+
+// pushDashboardEvent connects to the persistent dashboard Unix socket and sends
+// a JSON push event with the session name, new state, and title. It is
+// fire-and-forget: any error (socket absent, connection refused, write failure)
+// is silently discarded. Must NOT be called with s.mu held (it is called via
+// goroutine from writeStateChangeWithSID).
+func pushDashboardEvent(sessionName, state, title string) {
+	sockPath := dashboardSocketPath()
+	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
+	if err != nil {
+		// Socket absent or stale — silently ignore.
+		return
+	}
+	defer conn.Close()
+
+	// Set a short write deadline so we never block the caller.
+	_ = conn.SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
+
+	data, err := json.Marshal(map[string]string{
+		"session": sessionName,
+		"state":   state,
+		"title":   title,
+	})
+	if err != nil {
+		return
+	}
+	// Append newline so the dashboard's bufio.Scanner can read the line.
+	data = append(data, '\n')
+	_, _ = conn.Write(data)
+}
+
+// dashboardSocketPath returns the path to the persistent dashboard Unix socket.
+// Mirrors dashboard.DashSocketPath() but avoids a package import cycle.
+func dashboardSocketPath() string {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism", "bus", "dashboard.sock")
 }
 
 // touchDashboardSentinel creates or updates the dashboard sentinel file's


### PR DESCRIPTION
## Summary

- Replaces the 200ms sentinel file polling loop in the persistent dashboard with a Unix socket push mechanism
- Sidecars push JSON state-change events directly to `$XDG_STATE_HOME/prism/bus/dashboard.sock`; the dashboard updates in-memory state and re-renders immediately without a DB round-trip or git stat wait
- Git diff stat computation is decoupled to a separate 5-second ticker (`FetchGitStatsOnly`/`GitStatsOnlyMsg`) that updates only the stats map, leaving session states from push events untouched
- `prism restore` now cleans up stale dashboard sockets with no listening process

## Changes

- `internal/dashboard/poll.go`: add `DashSocketPath()`, `StartSocketListener()`, `GitStatTick()`, `FetchGitStatsOnly()`, and `RemoveStaleSocket()`; `WatchDashboardSentinel()` is preserved unchanged for the popup dashboard
- `internal/dashboard/model.go`: add `PushEventMsg`, `GitStatTickMsg`, and `GitStatsOnlyMsg` types; add `applyPushEvent()` helper
- `internal/dashboard/persistent.go`: handle `PushEventMsg` (immediate in-memory state update), `GitStatTickMsg` (triggers 5s git-only refresh), and `GitStatsOnlyMsg` (merges git stats without touching session states); schedule `GitStatTick()` in `Init()`
- `cmd/dashboard.go`: persistent path uses `StartSocketListener()` instead of `WatchDashboardSentinel()`; on socket error logs and continues without push events (sentinel polling is not used as a fallback)
- `internal/sidecar/sidecar.go`: add `pushDashboardEvent()` and `dashboardSocketPath()`; call from `writeStateChangeWithSID()` (fire-and-forget goroutine); track `lastTitle` for the push payload; keep `touchDashboardSentinel()` for popup backward compat
- `cmd/restore.go`: call `dashboard.RemoveStaleSocket()` on restore to clean up sockets from crashed dashboards

Closes #687