### PR TITLE
fix: wire --repo flag into prism spawn (issue #692)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup_container_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_container_test.go
@@ -187,6 +187,7 @@ func TestRemoveContainerIfExists_NoSuchContainer(t *testing.T) {
 // operations are skipped and only the sidecar/container/DB teardown runs.
 // Covers the host_mode short-circuit added in #471.
 func TestHeadlessCleanup_HostMode_SkipsPodman(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	logFile := installFakePodman(t, "ok")
 
 	// Seed a temp DB with a host-mode row.
@@ -244,6 +245,7 @@ func TestHeadlessCleanup_HostMode_SkipsPodman(t *testing.T) {
 //
 // Covers AC-2 (headlessCleanup path) directly.
 func TestHeadlessCleanup_ContainerMode_StopsAndRemoves(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	logFile := installFakePodman(t, "ok")
 
 	dbFile := filepath.Join(t.TempDir(), "prism.db")

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -91,6 +91,7 @@ func TestWorktreePathFromSession_DBFallback(t *testing.T) {
 //
 // Runs without tmux, so it exercises only the DB-update path.
 func TestHeadlessCleanup_EmptyWorktreePath(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	// Seed a temp DB.
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
@@ -136,6 +137,7 @@ func TestHeadlessCleanup_EmptyWorktreePath(t *testing.T) {
 // when the worktree path exists on disk but is not a registered git worktree,
 // headlessCleanup warns and continues rather than returning an error.
 func TestHeadlessCleanup_InvalidWorktreePath(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found in PATH — skipping integration test")
 	}
@@ -480,6 +482,7 @@ func TestCleanupYes_DefaultBranch(t *testing.T) {
 //
 // Runs without tmux, so it exercises only the DB-update path.
 func TestHeadlessCloseSession_NonWorktree_MarksEnded(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {
@@ -518,6 +521,7 @@ func TestHeadlessCloseSession_NonWorktree_MarksEnded(t *testing.T) {
 // TestHeadlessCloseSession_NonWorktree_NoDB verifies that headlessCloseSession
 // exits 0 even when no DB row exists for the session (never recorded).
 func TestHeadlessCloseSession_NonWorktree_NoDB(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	// Point openDB at an empty temp DB (no row for the session).
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
@@ -630,6 +634,7 @@ func TestCleanupYes_NonWorktreeSession(t *testing.T) {
 // no longer exists (already killed or never started). This calls
 // headlessCloseSession directly — it does not exercise cleanupCmd routing.
 func TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -76,6 +76,7 @@ var spawnCmd = &cobra.Command{
 func init() {
 	spawnCmd.Flags().String("branch", "", "Branch name (default: timestamped)")
 	spawnCmd.Flags().String("pr", "", "PR number — check out its branch")
+	spawnCmd.Flags().String("repo", "", "Repo shorthand name or absolute path (default: inferred from current pane)")
 	addPromptFlags(spawnCmd)
 	spawnCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main, "worker" otherwise)`)
 	spawnCmd.Flags().Bool("attach", false, "Switch the current tmux client to the new session")
@@ -93,6 +94,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 
 	branchFlag, _ := cmd.Flags().GetString("branch")
 	prFlag, _ := cmd.Flags().GetString("pr")
+	repoFlag, _ := cmd.Flags().GetString("repo")
 	agentFlag, _ := cmd.Flags().GetString("agent")
 	profileFlag, _ := cmd.Flags().GetString("profile")
 	modelFlag, _ := cmd.Flags().GetString("model")
@@ -148,8 +150,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve the bare repo root from the current pane path.
-	bareRoot, err := resolveBareRoot("")
+	// Resolve the bare repo root from the current pane path (or --repo flag).
+	bareRoot, err := resolveBareRoot(repoFlag)
 	if err != nil {
 		return err
 	}
@@ -229,7 +231,6 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 // resolveBareRoot returns the bare repo root to operate on.
 // If repoFlag is set, it is resolved as a shorthand name under ~/code or as a
 // full path. If not set, the current pane path is used (existing behaviour).
-// repoFlag is currently only used by prism pr.
 func resolveBareRoot(repoFlag string) (string, error) {
 	if repoFlag != "" {
 		return resolveRepo(repoFlag)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -7,6 +7,7 @@ package cmd
 //
 //	--branch <name>       use a specific branch name instead of a timestamp
 //	--pr <number>         check out the branch for a given PR number
+//	--repo <name>         repo shorthand name or absolute path (default: inferred from current pane)
 //	--prompt <text>       pass an initial prompt to opencode on launch
 //	--prompt-file <path>  read the initial prompt from a file
 //	--agent <name>        opencode agent to use (default: "coordinator" on main, "worker" otherwise)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2335,7 +2335,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			args = append(args, "--host-mode")
 		}
-		args = append(args, ownRepo)
+		args = append(args, "--repo", ownRepo)
 
 		// Log without the prompt value — it may contain sensitive context.
 		logArgs := []string{"spawn", "--branch", req.Branch}
@@ -2357,7 +2357,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			logArgs = append(logArgs, "--host-mode")
 		}
-		logArgs = append(logArgs, ownRepo)
+		logArgs = append(logArgs, "--repo", ownRepo)
 		log.Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
 		cmd := exec.Command(prismBinary(), args...)
 		out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

- Adds a `--repo` flag to `prism spawn` so callers can explicitly specify which repo to operate on
- Updates the host-API `/spawn` handler in `sidecar.go` to pass `--repo ownRepo` as a named flag instead of a bare positional argument
- Existing fallback behaviour (no `--repo` → pane path detection) is preserved for direct `prism spawn` calls

## Root cause

The sidecar correctly derived `ownRepo` from its session name and appended it to the subprocess args — but as a **positional argument**. The `spawn` command never declared a `--repo` flag, so `resolveBareRoot` was always called with an empty string, falling through to `tmux.CurrentPanePath()` and using whatever pane was active at spawn time.

## Files changed

- `cmd/spawn.go` — add `--repo` flag, read `repoFlag` in `runSpawn`, pass to `resolveBareRoot`
- `internal/sidecar/sidecar.go` — change `args = append(args, ownRepo)` to `args = append(args, "--repo", ownRepo)` (and same for `logArgs`)

Closes #692