### PR TITLE
fix(prism): reliable coordinator notifications with SID validation and retry (#694)

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1029,11 +1029,13 @@ func (d *DB) ClearInstanceID(sessionName string) error {
 	return nil
 }
 
-// PurgeStaleInstanceMessages deletes all undelivered bus_messages addressed to
-// toSession whose to_instance_id does not match currentInstanceID. This purges
-// messages written to a previous incarnation of the session that never got
-// delivered. Messages with to_instance_id IS NULL (legacy / no instance
-// tagging) are left intact.
+// PurgeStaleInstanceMessages deletes undelivered and unfailed bus_messages
+// addressed to toSession whose to_instance_id does not match
+// currentInstanceID. This purges messages written to a previous incarnation
+// of the session that never got delivered. Messages with to_instance_id IS
+// NULL (legacy / no instance tagging), delivered messages
+// (delivered_at IS NOT NULL), and failed-delivery audit records
+// (failed_at IS NOT NULL) are all left intact.
 //
 // It is safe to call when no matching rows exist — the operation is a no-op
 // and returns nil.
@@ -1042,6 +1044,7 @@ func (d *DB) PurgeStaleInstanceMessages(toSession, currentInstanceID string) err
 DELETE FROM bus_messages
 WHERE to_session = ?
   AND delivered_at IS NULL
+  AND failed_at IS NULL
   AND to_instance_id IS NOT NULL
   AND to_instance_id != ?`
 	if _, err := d.conn.Exec(q, toSession, currentInstanceID); err != nil {
@@ -1050,14 +1053,17 @@ WHERE to_session = ?
 	return nil
 }
 
-// PurgeBusMessages deletes all undelivered bus_messages rows where
+// PurgeBusMessages deletes undelivered and unfailed bus_messages rows where
 // from_session or to_session matches sessionName. Delivered messages
-// (delivered_at IS NOT NULL) are left untouched. It is safe to call when no
-// matching rows exist — the operation is a no-op and returns nil.
+// (delivered_at IS NOT NULL) and failed messages (failed_at IS NOT NULL) are
+// left untouched so that delivery audit records survive session cleanup. It is
+// safe to call when no matching rows exist — the operation is a no-op and
+// returns nil.
 func (d *DB) PurgeBusMessages(sessionName string) error {
 	const q = `
 DELETE FROM bus_messages
 WHERE delivered_at IS NULL
+  AND failed_at IS NULL
   AND (from_session = ? OR to_session = ?)`
 	if _, err := d.conn.Exec(q, sessionName, sessionName); err != nil {
 		return fmt.Errorf("db: purge bus messages: %w", err)

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -83,6 +83,7 @@ type BusMessage struct {
 	Urgency      string
 	SentAt       time.Time
 	DeliveredAt  *time.Time
+	FailedAt     *time.Time
 }
 
 const schema = `
@@ -126,7 +127,8 @@ CREATE TABLE IF NOT EXISTS bus_messages (
   text             TEXT NOT NULL,
   urgency          TEXT NOT NULL DEFAULT 'normal',
   sent_at          INTEGER NOT NULL,
-  delivered_at     INTEGER
+  delivered_at     INTEGER,
+  failed_at        INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_bus_pending ON bus_messages(to_session, delivered_at)
   WHERE delivered_at IS NULL;
@@ -138,11 +140,12 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 // Open opens (or creates) the prism database at path.
 // It creates parent directories as needed, enables WAL mode, runs the full
-// schema, and sets schema_version=6 if the table is empty. Pending migrations
+// schema, and sets schema_version=7 if the table is empty. Pending migrations
 // are applied in order: v1→v2 adds agent_name/model_id; v2→v3 adds
 // root_agent_name/root_model_id; v3→v4 adds opencode_port to agent_status;
 // v4→v5 adds host_mode to agent_status; v5→v6 adds instance_id to
-// agent_status and to_instance_id to bus_messages.
+// agent_status and to_instance_id to bus_messages; v6→v7 adds failed_at to
+// bus_messages.
 func Open(path string) (*DB, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("db: create parent dirs: %w", err)
@@ -172,15 +175,15 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("db: apply schema: %w", err)
 	}
 
-	// Set schema_version=6 if the table is empty (fresh database already has
-	// all columns including the v2, v3, v4, v5, and v6 additions, so no migration is needed).
+	// Set schema_version=7 if the table is empty (fresh database already has
+	// all columns including the v2, v3, v4, v5, v6, and v7 additions, so no migration is needed).
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("db: check schema_version: %w", err)
 	}
 	if count == 0 {
-		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (6)"); err != nil {
+		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (7)"); err != nil {
 			conn.Close()
 			return nil, fmt.Errorf("db: set schema_version: %w", err)
 		}
@@ -266,6 +269,23 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 6
+	}
+	if version == 6 {
+		// Migration v6 → v7: add failed_at to bus_messages for honest delivery
+		// tracking. NULL means not yet attempted or delivered; a non-NULL value
+		// records the ms timestamp when delivery exhausted all retries.
+		// Additive — existing rows are unaffected.
+		migrations := []string{
+			"ALTER TABLE bus_messages ADD COLUMN failed_at INTEGER",
+			"UPDATE schema_version SET version = 7",
+		}
+		for _, m := range migrations {
+			if _, err := conn.Exec(m); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v6→v7: %w", err)
+			}
+		}
+		version = 7
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -1077,11 +1097,51 @@ func (d *DB) WriteBusMessageDelivered(msg BusMessage) error {
 		sentAt = msg.SentAt.UnixMilli()
 	}
 	const q = `
-INSERT INTO bus_messages (id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+INSERT INTO bus_messages (id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at, failed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`
 	_, err := d.conn.Exec(q, msg.ID, msg.FromSession, msg.ToSession, msg.ToInstanceID, msg.Repo, msg.Text, msg.Urgency, sentAt, now)
 	if err != nil {
 		return fmt.Errorf("db: write bus message delivered: %w", err)
+	}
+	return nil
+}
+
+// WriteBusMessageFailed inserts a new row into bus_messages with failed_at set
+// to now and delivered_at=NULL. This records a notification that was attempted
+// but could not be delivered after all retries were exhausted. It is the
+// authoritative signal that a notification was silently lost.
+func (d *DB) WriteBusMessageFailed(msg BusMessage) error {
+	now := time.Now().UnixMilli()
+	var sentAt int64
+	if msg.SentAt.IsZero() {
+		sentAt = now
+	} else {
+		sentAt = msg.SentAt.UnixMilli()
+	}
+	const q = `
+INSERT INTO bus_messages (id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at, failed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+	_, err := d.conn.Exec(q, msg.ID, msg.FromSession, msg.ToSession, msg.ToInstanceID, msg.Repo, msg.Text, msg.Urgency, sentAt, now)
+	if err != nil {
+		return fmt.Errorf("db: write bus message failed: %w", err)
+	}
+	return nil
+}
+
+// UpdateOpencodeSID unconditionally sets opencode_sid for sessionName to the
+// given sid value. Unlike UpsertStatus (which only updates opencode_sid via
+// COALESCE when non-nil), this always overwrites — allowing the sidecar to
+// keep the stored SID current when the user creates a new opencode session
+// mid-conversation (e.g. via /continue or TUI restart).
+//
+// It is a no-op when no row exists for sessionName (returns nil).
+func (d *DB) UpdateOpencodeSID(sessionName, sid string) error {
+	_, err := d.conn.Exec(
+		"UPDATE agent_status SET opencode_sid = ? WHERE session_name = ?",
+		sid, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("db: update opencode_sid: %w", err)
 	}
 	return nil
 }
@@ -1151,9 +1211,9 @@ func (d *DB) QueryAuditEvents(sessionName string, sinceMs int64, pattern string,
 	return events, nil
 }
 
-// Prune deletes agent_events older than olderThan, and delivered bus_messages
-// older than olderThan. It does NOT delete agent_status rows or undelivered
-// bus_messages.
+// Prune deletes agent_events older than olderThan, and delivered or failed
+// bus_messages older than olderThan. It does NOT delete agent_status rows or
+// undelivered/unfailed bus_messages.
 func (d *DB) Prune(olderThan time.Duration) error {
 	threshold := time.Now().Add(-olderThan).UnixMilli()
 
@@ -1166,7 +1226,13 @@ func (d *DB) Prune(olderThan time.Duration) error {
 	if _, err := d.conn.Exec(
 		"DELETE FROM bus_messages WHERE delivered_at IS NOT NULL AND delivered_at < ?", threshold,
 	); err != nil {
-		return fmt.Errorf("db: prune bus_messages: %w", err)
+		return fmt.Errorf("db: prune bus_messages (delivered): %w", err)
+	}
+
+	if _, err := d.conn.Exec(
+		"DELETE FROM bus_messages WHERE failed_at IS NOT NULL AND failed_at < ?", threshold,
+	); err != nil {
+		return fmt.Errorf("db: prune bus_messages (failed): %w", err)
 	}
 
 	return nil
@@ -1238,10 +1304,11 @@ func scanBusMessage(s scanner) (BusMessage, error) {
 	var m BusMessage
 	var sentAt int64
 	var deliveredAt sql.NullInt64
+	var failedAt sql.NullInt64
 	var toInstanceID sql.NullString
 	err := s.Scan(
 		&m.ID, &m.FromSession, &m.ToSession, &toInstanceID, &m.Repo, &m.Text, &m.Urgency,
-		&sentAt, &deliveredAt,
+		&sentAt, &deliveredAt, &failedAt,
 	)
 	if err != nil {
 		return BusMessage{}, err
@@ -1250,6 +1317,10 @@ func scanBusMessage(s scanner) (BusMessage, error) {
 	if deliveredAt.Valid {
 		t := time.UnixMilli(deliveredAt.Int64)
 		m.DeliveredAt = &t
+	}
+	if failedAt.Valid {
+		t := time.UnixMilli(failedAt.Int64)
+		m.FailedAt = &t
 	}
 	if toInstanceID.Valid {
 		id := toInstanceID.String

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=5 (migrations are applied on Open).
+	// Verify schema_version=7 (migrations are applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("schema_version: got %d, want 6", version)
+	if version != 7 {
+		t.Errorf("schema_version: got %d, want 7", version)
 	}
 
 	// Verify WAL mode.
@@ -739,13 +739,13 @@ func TestMigration_V1ToV2(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Verify schema_version=6.
+	// Verify schema_version=7.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("schema_version after migration: got %d, want 6", version)
+	if version != 7 {
+		t.Errorf("schema_version after migration: got %d, want 7", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -819,8 +819,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("schema_version after migration: got %d, want 6", version)
+	if version != 7 {
+		t.Errorf("schema_version after migration: got %d, want 7", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1320,8 +1320,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("schema_version after migration: got %d, want 6", version)
+	if version != 7 {
+		t.Errorf("schema_version after migration: got %d, want 7", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1386,8 +1386,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("schema_version after migration: got %d, want 6", version)
+	if version != 7 {
+		t.Errorf("schema_version after migration: got %d, want 7", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1456,8 +1456,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("schema_version after migration: got %d, want 6", version)
+	if version != 7 {
+		t.Errorf("schema_version after migration: got %d, want 7", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1498,6 +1498,205 @@ func TestMigration_V5ToV6(t *testing.T) {
 	// to_instance_id should be NULL (not set).
 	if toInstanceID != nil {
 		t.Errorf("ToInstanceID: got %v, want nil", toInstanceID)
+	}
+}
+
+// TestMigration_V6ToV7 verifies that Open applies the v6→v7 migration to an
+// existing DB at schema_version=6 (no failed_at column in bus_messages).
+func TestMigration_V6ToV7(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v6.db")
+
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT, opencode_sid TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  opencode_port INTEGER, host_mode INTEGER NOT NULL DEFAULT 0,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (6);
+		INSERT INTO agent_status (session_name, repo, worktree, state, host_mode, last_seen)
+		  VALUES ('repo@main', 'repo', '/code/repo/main', 'active', 0, 0);
+		INSERT INTO bus_messages (id, from_session, to_session, repo, text, urgency, sent_at, delivered_at)
+		  VALUES ('existing-msg', 'repo@feat', 'repo@main', 'repo', 'existing', 'normal', 1000, NULL);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v6 db: %v", err)
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v6 db: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 7 {
+		t.Errorf("schema_version after migration: got %d, want 7", version)
+	}
+
+	// Existing row must be preserved with failed_at = NULL.
+	var failedAt *int64
+	if err := d.QueryRow(
+		"SELECT failed_at FROM bus_messages WHERE id = ?", "existing-msg",
+	).Scan(&failedAt); err != nil {
+		t.Fatalf("query failed_at after v6→v7 migration: %v", err)
+	}
+	if failedAt != nil {
+		t.Errorf("failed_at: got %v, want nil (additive migration must not affect existing rows)", failedAt)
+	}
+
+	// WriteBusMessageFailed must work after migration.
+	msg := db.BusMessage{
+		ID:          "failed-after-migration",
+		FromSession: "repo@feat",
+		ToSession:   "repo@main",
+		Repo:        "repo",
+		Text:        "migration test",
+		Urgency:     "normal",
+	}
+	if err := d.WriteBusMessageFailed(msg); err != nil {
+		t.Fatalf("WriteBusMessageFailed after v6→v7 migration: %v", err)
+	}
+	var failedAt2 *int64
+	if err := d.QueryRow(
+		"SELECT failed_at FROM bus_messages WHERE id = ?", "failed-after-migration",
+	).Scan(&failedAt2); err != nil {
+		t.Fatalf("query failed_at after WriteBusMessageFailed: %v", err)
+	}
+	if failedAt2 == nil {
+		t.Error("failed_at: got nil, want non-nil timestamp after WriteBusMessageFailed")
+	}
+}
+
+// TestWriteBusMessageFailed verifies that WriteBusMessageFailed inserts a row
+// with failed_at set and delivered_at NULL.
+func TestWriteBusMessageFailed(t *testing.T) {
+	d := openTestDB(t)
+
+	msgID := "test-failed-" + uuid.New().String()
+	msg := db.BusMessage{
+		ID:          msgID,
+		FromSession: "repo@feature",
+		ToSession:   "repo@main",
+		Repo:        "repo",
+		Text:        "hello coordinator",
+		Urgency:     "normal",
+		SentAt:      time.Now(),
+	}
+
+	if err := d.WriteBusMessageFailed(msg); err != nil {
+		t.Fatalf("WriteBusMessageFailed: %v", err)
+	}
+
+	// Verify delivered_at IS NULL and failed_at IS NOT NULL.
+	var deliveredAt *int64
+	var failedAt *int64
+	if err := d.QueryRow(
+		"SELECT delivered_at, failed_at FROM bus_messages WHERE id = ?", msgID,
+	).Scan(&deliveredAt, &failedAt); err != nil {
+		t.Fatalf("scan bus_message row: %v", err)
+	}
+	if deliveredAt != nil {
+		t.Errorf("delivered_at: got %v, want nil (should not be set on failure)", deliveredAt)
+	}
+	if failedAt == nil {
+		t.Error("failed_at: got nil, want non-nil (should be set on failure)")
+	}
+}
+
+// TestWriteBusMessageDelivered_FailedAtNull verifies that WriteBusMessageDelivered
+// writes delivered_at and leaves failed_at NULL.
+func TestWriteBusMessageDelivered_FailedAtNull(t *testing.T) {
+	d := openTestDB(t)
+
+	msgID := "test-delivered-" + uuid.New().String()
+	msg := db.BusMessage{
+		ID:          msgID,
+		FromSession: "repo@feature",
+		ToSession:   "repo@main",
+		Repo:        "repo",
+		Text:        "hello coordinator",
+		Urgency:     "normal",
+		SentAt:      time.Now(),
+	}
+
+	if err := d.WriteBusMessageDelivered(msg); err != nil {
+		t.Fatalf("WriteBusMessageDelivered: %v", err)
+	}
+
+	var deliveredAt *int64
+	var failedAt *int64
+	if err := d.QueryRow(
+		"SELECT delivered_at, failed_at FROM bus_messages WHERE id = ?", msgID,
+	).Scan(&deliveredAt, &failedAt); err != nil {
+		t.Fatalf("scan bus_message row: %v", err)
+	}
+	if deliveredAt == nil {
+		t.Error("delivered_at: got nil, want non-nil after successful delivery")
+	}
+	if failedAt != nil {
+		t.Errorf("failed_at: got %v, want nil (should not be set on success)", failedAt)
+	}
+}
+
+// TestUpdateOpencodeSID verifies that UpdateOpencodeSID unconditionally
+// overwrites the stored opencode_sid (unlike COALESCE-based upserts).
+func TestUpdateOpencodeSID(t *testing.T) {
+	d := openTestDB(t)
+
+	oldSID := "old-session-id"
+	newSID := "new-session-id"
+
+	// Create a row with an initial SID.
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, &oldSID); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	s, _ := d.CurrentStatus("repo@main")
+	if s.OpencodeSID == nil || *s.OpencodeSID != oldSID {
+		t.Fatalf("pre-condition: opencode_sid = %v, want %q", s.OpencodeSID, oldSID)
+	}
+
+	// UpdateOpencodeSID must overwrite unconditionally.
+	if err := d.UpdateOpencodeSID("repo@main", newSID); err != nil {
+		t.Fatalf("UpdateOpencodeSID: %v", err)
+	}
+
+	s2, _ := d.CurrentStatus("repo@main")
+	if s2.OpencodeSID == nil || *s2.OpencodeSID != newSID {
+		t.Errorf("opencode_sid after UpdateOpencodeSID: got %v, want %q", s2.OpencodeSID, newSID)
+	}
+}
+
+// TestUpdateOpencodeSID_NoopWhenNoRow verifies that UpdateOpencodeSID is a
+// no-op when the session does not exist in agent_status.
+func TestUpdateOpencodeSID_NoopWhenNoRow(t *testing.T) {
+	d := openTestDB(t)
+
+	// Must not error when no row exists.
+	if err := d.UpdateOpencodeSID("nonexistent@branch", "some-sid"); err != nil {
+		t.Errorf("UpdateOpencodeSID on non-existent session: %v (want nil)", err)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -696,6 +696,40 @@ func TestPurgeBusMessages_PreservesDelivered(t *testing.T) {
 	}
 }
 
+// TestPurgeBusMessages_PreservesFailed verifies that messages with failed_at
+// set are not removed by PurgeBusMessages (failed-delivery audit records must
+// survive session cleanup, just like delivered messages).
+func TestPurgeBusMessages_PreservesFailed(t *testing.T) {
+	d := openTestDB(t)
+
+	msgID := uuid.New().String()
+	msg := db.BusMessage{
+		ID:          msgID,
+		FromSession: "repo@other",
+		ToSession:   "repo@target",
+		Repo:        "repo",
+		Text:        "failed delivery audit",
+		Urgency:     "normal",
+		SentAt:      time.Now(),
+	}
+	if err := d.WriteBusMessageFailed(msg); err != nil {
+		t.Fatalf("WriteBusMessageFailed: %v", err)
+	}
+
+	if err := d.PurgeBusMessages("repo@target"); err != nil {
+		t.Fatalf("PurgeBusMessages: %v", err)
+	}
+
+	// The failed row must still be present.
+	var count int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE id = ?", msgID).Scan(&count); err != nil {
+		t.Fatalf("count failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("failed row count after purge: got %d, want 1 (failed rows should survive purge)", count)
+	}
+}
+
 // TestMigration_V1ToV2 verifies that Open applies the v1→v2 migration to an
 // existing DB that was created at schema_version=1 (no agent_name/model_id).
 func TestMigration_V1ToV2(t *testing.T) {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1432,9 +1432,10 @@ func touchDashboardSentinel() {
 // If no coordinator exists, it has ended, or this session IS the coordinator,
 // the call is a silent no-op.
 //
-// Retry policy: up to 3 POST attempts with exponential backoff (500ms, 1s, 2s).
+// Retry policy: up to 3 POST attempts with exponential backoff (500ms, 1s).
 // SID validation (GET /session) is performed before each attempt. If GET /session
-// fails or returns an empty list, delivery is treated as failed immediately.
+// returns an empty list, delivery fails immediately (no retry). If GET /session
+// fails with a network or non-200 error, the retry policy applies.
 func (s *Sidecar) notifyCoordinator() {
 	// Self-notification guard: if this session is the coordinator, skip.
 	coordinatorName := s.cfg.Repo + "@main"
@@ -1494,7 +1495,9 @@ func (s *Sidecar) notifyCoordinator() {
 	}
 
 	const maxAttempts = 3
-	backoff := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
+	// backoff[i] is the sleep duration before attempt i+2 (i.e. before the
+	// 2nd and 3rd attempts). With 3 attempts, only 2 sleeps are needed.
+	backoff := []time.Duration{500 * time.Millisecond, 1 * time.Second}
 
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -1512,6 +1515,11 @@ func (s *Sidecar) notifyCoordinator() {
 		if validationErr != nil {
 			lastErr = fmt.Errorf("attempt %d: SID validation failed: %w", attempt, validationErr)
 			log.Printf("sidecar: notifyCoordinator: %v (coordinator=%s)", lastErr, coordinatorName)
+			// An empty session list is not a transient condition — retrying
+			// will not help. Break immediately to avoid unnecessary backoff.
+			if errors.Is(validationErr, errEmptySessionList) {
+				break
+			}
 			continue
 		}
 		// Keep storedSID current for next iteration if it was refreshed.
@@ -1543,6 +1551,11 @@ func (s *Sidecar) notifyCoordinator() {
 		maxAttempts, coordinatorName, storedSID, lastErr)
 }
 
+// errEmptySessionList is a sentinel error returned by validateOrRefreshCoordinatorSID
+// when GET /session returns an empty array. The caller treats this as a
+// non-retriable condition and breaks out of the retry loop immediately.
+var errEmptySessionList = errors.New("GET /session: empty session list — coordinator has no active opencode sessions")
+
 // opencodeSessionEntry is a single entry from the opencode GET /session response.
 type opencodeSessionEntry struct {
 	ID   string `json:"id"`
@@ -1558,7 +1571,9 @@ type opencodeSessionEntry struct {
 //   - If storedSID is present in the list, it is returned as-is.
 //   - If storedSID is absent, the most recently updated session ID is returned
 //     and agent_status is updated with the fresh SID.
-//   - If GET /session fails or returns an empty list, an error is returned.
+//   - If GET /session fails, an error is returned.
+//   - If GET /session returns an empty list, errEmptySessionList is returned
+//     (sentinel — caller should not retry).
 func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName string, database *db.DB, httpClient *http.Client) (string, error) {
 	url := fmt.Sprintf("http://localhost:%d/session", port)
 	req, err := http.NewRequest("GET", url, nil)
@@ -1582,7 +1597,9 @@ func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName
 	}
 
 	if len(sessions) == 0 {
-		return "", fmt.Errorf("GET /session: empty session list — coordinator has no active opencode sessions")
+		// Non-retriable: an empty session list is a definitive condition, not a
+		// transient failure. The caller will break immediately on this error.
+		return "", errEmptySessionList
 	}
 
 	// Check if stored SID is present.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -700,11 +700,23 @@ func (s *Sidecar) handleSessionCreated(evt sse.Event) {
 
 	info := payload.Properties.Info
 	s.opencodeSID = info.ID
+
+	// Always persist the new opencode_sid unconditionally so that if the user
+	// creates a new opencode session mid-conversation (e.g. via /continue or
+	// TUI restart), the DB stays current. upsertState uses COALESCE for
+	// opencode_sid (only overwriting when the incoming value is non-nil), which
+	// is insufficient here — we need an unconditional update so that a fresh
+	// session ID always replaces a stale one. (#694)
+	if info.ID != "" {
+		if err := s.cfg.DB.UpdateOpencodeSID(s.cfg.SessionName, info.ID); err != nil {
+			log.Printf("sidecar: handleSessionCreated: UpdateOpencodeSID failed: %v", err)
+		}
+	}
+
 	title := strPtr(info.Title)
 	sid := strPtr(info.ID)
 	s.upsertState(agent.StateActive, title, sid)
 	s.writeStateChange(agent.StateActive)
-
 }
 
 func (s *Sidecar) handleSessionUpdated(evt sse.Event) {
@@ -1411,13 +1423,18 @@ func touchDashboardSentinel() {
 // StateFinished, so s.mu must NOT be held when this method runs.
 //
 // The coordinator is discovered by looking up "<repo>@main" in the DB. If the
-// coordinator has an opencode_port and opencode_sid, the notification is
-// delivered via HTTP POST to /session/<sid>/prompt_async. On success, an audit
-// row is written via WriteBusMessageDelivered. If the coordinator has no port
-// or the HTTP call fails, the error is logged.
+// coordinator has an opencode_port, the notification is delivered via HTTP POST
+// to /session/<sid>/prompt_async after pre-validating that the stored SID is
+// present in the live session list. On confirmed delivery, an audit row is
+// written via WriteBusMessageDelivered. On exhausted retries, a row is written
+// via WriteBusMessageFailed and a structured error is logged.
 //
 // If no coordinator exists, it has ended, or this session IS the coordinator,
 // the call is a silent no-op.
+//
+// Retry policy: up to 3 POST attempts with exponential backoff (500ms, 1s, 2s).
+// SID validation (GET /session) is performed before each attempt. If GET /session
+// fails or returns an empty list, delivery is treated as failed immediately.
 func (s *Sidecar) notifyCoordinator() {
 	// Self-notification guard: if this session is the coordinator, skip.
 	coordinatorName := s.cfg.Repo + "@main"
@@ -1462,22 +1479,138 @@ func (s *Sidecar) notifyCoordinator() {
 		SentAt:       time.Now(),
 	}
 
-	// Require port and session ID for HTTP delivery.
-	if coordStatus.OpencodePort == nil || coordStatus.OpencodeSID == nil {
-		log.Printf("sidecar: notifyCoordinator: coordinator has no opencode port or session ID — cannot deliver notification")
+	// Require port for HTTP delivery.
+	if coordStatus.OpencodePort == nil {
+		log.Printf("sidecar: notifyCoordinator: coordinator has no opencode port — cannot deliver notification")
+		return
+	}
+	port := *coordStatus.OpencodePort
+
+	// storedSID is the SID currently recorded in the DB. May be stale if the
+	// coordinator created a new opencode session after the last DB write.
+	storedSID := ""
+	if coordStatus.OpencodeSID != nil {
+		storedSID = *coordStatus.OpencodeSID
+	}
+
+	const maxAttempts = 3
+	backoff := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			time.Sleep(backoff[attempt-2])
+		}
+
+		// Pre-delivery SID validation: call GET /session to confirm the stored
+		// SID is present in the coordinator's live session list. If not, pick
+		// the most recently active session and update the DB so future
+		// deliveries use the fresh SID.
+		targetSID, validationErr := validateOrRefreshCoordinatorSID(
+			port, storedSID, coordinatorName, s.cfg.DB, s.cfg.HTTPClient,
+		)
+		if validationErr != nil {
+			lastErr = fmt.Errorf("attempt %d: SID validation failed: %w", attempt, validationErr)
+			log.Printf("sidecar: notifyCoordinator: %v (coordinator=%s)", lastErr, coordinatorName)
+			continue
+		}
+		// Keep storedSID current for next iteration if it was refreshed.
+		storedSID = targetSID
+
+		log.Printf("sidecar: notifyCoordinator: attempt %d/%d POST to coordinator=%s sid=%s",
+			attempt, maxAttempts, coordinatorName, targetSID)
+
+		httpErr := deliverNotificationViaHTTP(port, targetSID, notifyText, coordStatus, s.cfg.HTTPClient)
+		if httpErr != nil {
+			lastErr = fmt.Errorf("attempt %d: HTTP delivery failed: %w", attempt, httpErr)
+			log.Printf("sidecar: notifyCoordinator: %v (coordinator=%s sid=%s)", lastErr, coordinatorName, targetSID)
+			continue
+		}
+
+		// Confirmed delivery: SID validated + POST returned 200.
+		if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
+			log.Printf("sidecar: notifyCoordinator: write delivered audit: %v", err)
+		}
+		log.Printf("sidecar: notifyCoordinator: delivered to coordinator=%s sid=%s", coordinatorName, targetSID)
 		return
 	}
 
-	httpErr := deliverNotificationViaHTTP(*coordStatus.OpencodePort, *coordStatus.OpencodeSID, notifyText, coordStatus, s.cfg.HTTPClient)
-	if httpErr != nil {
-		log.Printf("sidecar: notifyCoordinator: HTTP delivery failed: %v", httpErr)
-		return
+	// All retries exhausted — write failed_at and log structured error.
+	if err := s.cfg.DB.WriteBusMessageFailed(msg); err != nil {
+		log.Printf("sidecar: notifyCoordinator: write failed audit: %v", err)
+	}
+	log.Printf("sidecar: notifyCoordinator: FAILED after %d attempts — coordinator=%s sid=%s reason=%v",
+		maxAttempts, coordinatorName, storedSID, lastErr)
+}
+
+// opencodeSessionEntry is a single entry from the opencode GET /session response.
+type opencodeSessionEntry struct {
+	ID   string `json:"id"`
+	Time *struct {
+		Updated *float64 `json:"updated"`
+	} `json:"time"`
+}
+
+// validateOrRefreshCoordinatorSID calls GET /session on the coordinator's
+// opencode port to retrieve the live session list, checks whether storedSID is
+// present, and returns the SID to use for delivery.
+//
+//   - If storedSID is present in the list, it is returned as-is.
+//   - If storedSID is absent, the most recently updated session ID is returned
+//     and agent_status is updated with the fresh SID.
+//   - If GET /session fails or returns an empty list, an error is returned.
+func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName string, database *db.DB, httpClient *http.Client) (string, error) {
+	url := fmt.Sprintf("http://localhost:%d/session", port)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("create GET /session request: %w", err)
 	}
 
-	// HTTP succeeded — write audit trail with delivered_at set.
-	if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
-		log.Printf("sidecar: notifyCoordinator: write audit bus message: %v", err)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GET /session: %w", err)
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GET /session: http status %d", resp.StatusCode)
+	}
+
+	var sessions []opencodeSessionEntry
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		return "", fmt.Errorf("decode GET /session response: %w", err)
+	}
+
+	if len(sessions) == 0 {
+		return "", fmt.Errorf("GET /session: empty session list — coordinator has no active opencode sessions")
+	}
+
+	// Check if stored SID is present.
+	for _, s := range sessions {
+		if s.ID == storedSID {
+			// Stored SID confirmed present — use it.
+			return storedSID, nil
+		}
+	}
+
+	// Stored SID is absent (stale). Pick the most recently updated session.
+	bestSID := sessions[0].ID
+	var bestUpdated float64
+	for _, s := range sessions {
+		if s.Time != nil && s.Time.Updated != nil && *s.Time.Updated > bestUpdated {
+			bestUpdated = *s.Time.Updated
+			bestSID = s.ID
+		}
+	}
+
+	log.Printf("sidecar: notifyCoordinator: stored SID %q not found in coordinator session list — using most recent SID %q", storedSID, bestSID)
+
+	// Persist the refreshed SID so future deliveries use it.
+	if err := database.UpdateOpencodeSID(coordinatorName, bestSID); err != nil {
+		log.Printf("sidecar: notifyCoordinator: UpdateOpencodeSID failed: %v", err)
+	}
+
+	return bestSID, nil
 }
 
 // createOpencodeSession creates a new session on the opencode server via

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -1613,24 +1613,14 @@ ORDER BY sent_at DESC LIMIT 1`, toSession)
 func TestNotifyCoordinator_IdleDebouncePath(t *testing.T) {
 	d := openTestDB(t)
 
-	// Seed the coordinator with a known port and sid via a test HTTP server.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	coordSID := "coord-sid-123"
+	// Seed the coordinator with a known port and sid via a test HTTP server
+	// that properly serves GET /session (SID validation) and POST prompt_async.
+	srv, _ := makeSessionListServer(t, []string{coordSID}, http.StatusOK)
 	defer srv.Close()
 
-	// Extract the port from the test server URL.
-	var srvPort int
-	_, err := fmt.Sscanf(srv.URL, "http://127.0.0.1:%d", &srvPort)
-	if err != nil {
-		// Try localhost form.
-		_, err = fmt.Sscanf(srv.URL, "http://localhost:%d", &srvPort)
-	}
-	if err != nil {
-		t.Fatalf("parse test server port from %q: %v", srv.URL, err)
-	}
+	srvPort := parseSrvPort(t, srv.URL)
 
-	coordSID := "coord-sid-123"
 	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
 
 	// Create worker sidecar with the test server's HTTP client.
@@ -1806,12 +1796,24 @@ func TestNotifyCoordinator_SelfNotificationSkipped(t *testing.T) {
 func TestNotifyCoordinator_BusMessageAuditOnHTTPSuccess(t *testing.T) {
 	d := openTestDB(t)
 
-	// Record HTTP requests to verify the body.
+	coordSID := "coord-sid-audit"
+
+	// Record the POST body; also serve GET /session for SID validation.
 	var (
 		bodyMu       sync.Mutex
 		receivedBody []byte
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			// Return the coordinator's SID in the session list.
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		// POST /session/<sid>/prompt_async — capture body and respond 200.
 		body, _ := io.ReadAll(r.Body)
 		bodyMu.Lock()
 		receivedBody = body
@@ -1820,16 +1822,8 @@ func TestNotifyCoordinator_BusMessageAuditOnHTTPSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	var srvPort int
-	_, err := fmt.Sscanf(srv.URL, "http://127.0.0.1:%d", &srvPort)
-	if err != nil {
-		_, err = fmt.Sscanf(srv.URL, "http://localhost:%d", &srvPort)
-	}
-	if err != nil {
-		t.Fatalf("parse test server port: %v", err)
-	}
+	srvPort := parseSrvPort(t, srv.URL)
 
-	coordSID := "coord-sid-audit"
 	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
 
 	// Create worker sidecar with the test server's HTTP client.
@@ -1885,35 +1879,33 @@ func TestNotifyCoordinator_BusMessageAuditOnHTTPSuccess(t *testing.T) {
 	}
 }
 
-// TestNotifyCoordinator_HTTPFailure_NoFallback verifies that when HTTP delivery
-// fails, no bus message is written (no fallback — error is logged).
-func TestNotifyCoordinator_HTTPFailure_NoFallback(t *testing.T) {
+// TestNotifyCoordinator_HTTPFailure_WritesFailed verifies that when HTTP delivery
+// fails after all retries, a bus message with failed_at set (and delivered_at
+// NULL) is written — not silently dropped.
+func TestNotifyCoordinator_HTTPFailure_WritesFailed(t *testing.T) {
 	d := openTestDB(t)
 
-	// requestReceived is closed when the test server receives the HTTP request.
-	// This gives us a reliable synchronisation point: once the server has responded
-	// (with 500), the notifyCoordinator goroutine has finished its work and will
-	// not write anything further.
-	requestReceived := make(chan struct{})
+	coordSID := "coord-sid-http-fail"
+
+	// Server serves GET /session with the SID but always fails POST.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(requestReceived)
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		// POST always fails.
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
 
-	var srvPort int
-	_, err := fmt.Sscanf(srv.URL, "http://127.0.0.1:%d", &srvPort)
-	if err != nil {
-		_, err = fmt.Sscanf(srv.URL, "http://localhost:%d", &srvPort)
-	}
-	if err != nil {
-		t.Fatalf("parse test server port: %v", err)
-	}
-
-	coordSID := "coord-sid-http-fail"
+	srvPort := parseSrvPort(t, srv.URL)
 	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
 
-	// Create worker sidecar with the test server's HTTP client (returns 500).
+	// Create worker sidecar with the test server's HTTP client (POST returns 500).
 	worker, clk := newWorkerSidecar(t, d, srv.Client())
 
 	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
@@ -1925,21 +1917,18 @@ func TestNotifyCoordinator_HTTPFailure_NoFallback(t *testing.T) {
 	}
 	timer.Fire()
 
-	// Wait for the HTTP request to be received by the test server. Once the
-	// server has replied (with 500), the goroutine has completed its work.
-	select {
-	case <-requestReceived:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for HTTP request to coordinator")
+	// Wait for failed_at to be set (all 3 retries exhausted).
+	if !waitForBusMessageFailed(t, d, "test-repo@main") {
+		t.Fatal("timed out waiting for failed bus message — expected failed_at to be set after HTTP failure")
 	}
 
-	// No bus messages should be written — HTTP failure is logged, not fallen back.
-	var totalMsgs int
-	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
-		t.Fatalf("count bus_messages: %v", err)
+	// delivered_at must NOT be set.
+	var deliveredCount int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL", "test-repo@main").Scan(&deliveredCount); err != nil {
+		t.Fatalf("count delivered: %v", err)
 	}
-	if totalMsgs != 0 {
-		t.Errorf("expected no bus messages after HTTP failure (no fallback), got %d", totalMsgs)
+	if deliveredCount != 0 {
+		t.Errorf("expected no delivered messages after HTTP failure, got %d", deliveredCount)
 	}
 }
 
@@ -2089,12 +2078,19 @@ func TestNotifyCoordinator_SilentSkipWhenNoCoordinator(t *testing.T) {
 	}
 }
 
-// TestNotifyCoordinator_PortSetButNoSID_NoNotification verifies that when
-// the coordinator has a port but no opencode_sid, no notification is sent
-// and no bus message is written.
-func TestNotifyCoordinator_PortSetButNoSID_NoNotification(t *testing.T) {
+// TestNotifyCoordinator_PortSetButNoSID_TriesAndFails verifies that when
+// the coordinator has a port but no opencode_sid, notifyCoordinator still
+// attempts delivery (trying GET /session to discover the active session),
+// and if the port is unreachable, writes failed_at after retries.
+func TestNotifyCoordinator_PortSetButNoSID_TriesAndFails(t *testing.T) {
 	d := openTestDB(t)
-	worker, clk := newWorkerSidecar(t, d, nil)
+
+	// Use a server to make the port reachable but return an empty session list.
+	srv, _ := makeSessionListServer(t, []string{}, http.StatusOK)
+	defer srv.Close()
+	srvPort := parseSrvPort(t, srv.URL)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
 
 	// Seed coordinator with a port but no opencode_sid.
 	coordName := "test-repo@main"
@@ -2102,11 +2098,10 @@ func TestNotifyCoordinator_PortSetButNoSID_NoNotification(t *testing.T) {
 		t.Fatalf("seed coordinator: UpsertStatus: %v", err)
 	}
 	// Set port but leave opencode_sid = NULL.
-	var gotPort int
 	if err := d.QueryRow(
-		"UPDATE agent_status SET opencode_port = 19999 WHERE session_name = ? RETURNING opencode_port",
-		coordName,
-	).Scan(&gotPort); err != nil {
+		"UPDATE agent_status SET opencode_port = ? WHERE session_name = ? RETURNING opencode_port",
+		srvPort, coordName,
+	).Scan(new(int)); err != nil {
 		t.Fatalf("set port: %v", err)
 	}
 
@@ -2119,25 +2114,18 @@ func TestNotifyCoordinator_PortSetButNoSID_NoNotification(t *testing.T) {
 	}
 	timer.Fire()
 
-	// Verify state transitioned to finished — this DB write is synchronous and
-	// happens before go s.notifyCoordinator() is launched, so it serves as a
-	// reliable anchor that the goroutine has been started. The goroutine returns
-	// immediately (early-exit: no opencode_sid), so a brief sleep is sufficient
-	// to let it complete before the absence assertion. This matches the same
-	// pattern used by TestNotifyCoordinator_SilentSkipWhenNoCoordinator and
-	// other no-notification tests in this file.
 	if state := getState(t, d, worker.cfg.SessionName); state != "finished" {
 		t.Errorf("worker state = %q, want finished", state)
 	}
-	time.Sleep(50 * time.Millisecond)
 
-	// No bus messages should be written since port+sid combination is incomplete.
-	var totalMsgs int
-	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", coordName).Scan(&totalMsgs); err != nil {
-		t.Fatalf("count bus_messages: %v", err)
+	// Empty session list → failed_at is set, no delivered_at.
+	if !waitForBusMessageFailed(t, d, coordName) {
+		t.Fatal("timed out waiting for failed bus message — expected failed_at when empty session list")
 	}
-	if totalMsgs != 0 {
-		t.Errorf("expected no bus messages when coordinator has port but no sid, got %d", totalMsgs)
+	var deliveredCount int
+	_ = d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL", coordName).Scan(&deliveredCount)
+	if deliveredCount != 0 {
+		t.Errorf("delivered_at rows = %d, want 0 (empty session list)", deliveredCount)
 	}
 }
 
@@ -3317,26 +3305,29 @@ func TestSubagentFinish_NoSecondIdle_TransitionsToFinished(t *testing.T) {
 func TestSubagentFinish_IdleAlsoArrivesAfterRootMessage(t *testing.T) {
 	d := openTestDB(t)
 
+	coordSID := "coord-sid-race"
+
 	// Seed a real coordinator with a test HTTP server so we can count
 	// delivered notifications and verify exactly-once behaviour.
+	// The server must serve GET /session for SID validation.
 	var notifyCount int
 	var notifyMu sync.Mutex
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
 		notifyMu.Lock()
 		notifyCount++
 		notifyMu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	var srvPort int
-	_, err := fmt.Sscanf(srv.URL, "http://127.0.0.1:%d", &srvPort)
-	if err != nil {
-		_, err = fmt.Sscanf(srv.URL, "http://localhost:%d", &srvPort)
-	}
-	if err != nil {
-		t.Fatalf("parse test server port: %v", err)
-	}
-	coordSID := "coord-sid-race"
+	srvPort := parseSrvPort(t, srv.URL)
 	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
 
 	worker, clk := newWorkerSidecar(t, d, srv.Client())
@@ -3921,25 +3912,28 @@ func TestRootAgentPreset_EmptyAgentNameInUserMessage(t *testing.T) {
 func TestRootAgentPreset_NotifyCoordinatorAfterSubagentCycle(t *testing.T) {
 	d := openTestDB(t)
 
+	coordSID := "coord-sid-notify-test"
+
 	// Set up a test HTTP server to capture coordinator notifications.
+	// The server must serve GET /session for SID validation.
 	var notifyCount int
 	var notifyMu sync.Mutex
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
 		notifyMu.Lock()
 		notifyCount++
 		notifyMu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	var srvPort int
-	_, err := fmt.Sscanf(srv.URL, "http://127.0.0.1:%d", &srvPort)
-	if err != nil {
-		_, err = fmt.Sscanf(srv.URL, "http://localhost:%d", &srvPort)
-	}
-	if err != nil {
-		t.Fatalf("parse test server port: %v", err)
-	}
-	coordSID := "coord-sid-notify-test"
+	srvPort := parseSrvPort(t, srv.URL)
 	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
 
 	// Create worker sidecar with AgentRole="worker" pre-set (the fix).
@@ -5423,4 +5417,470 @@ func writeSidecarLogFile(t *testing.T, sessionName, content string) string {
 	// But callers need stateHome itself for XDG_STATE_HOME.
 	// Return logPath; caller derives stateHome via filepath.Dir x3.
 	return logPath
+}
+
+// ── notifyCoordinator SID validation tests ──────────────────────────────────
+
+// makeSessionListServer creates an httptest.Server that:
+//   - GET /session returns sessionIDs as a JSON array of {id, time: {updated: <ts>}}
+//   - POST /session/<sid>/prompt_async returns promptStatus
+func makeSessionListServer(t *testing.T, sessionIDs []string, promptStatus int) (*httptest.Server, *int) {
+	t.Helper()
+	promptCalls := new(int)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := make([]map[string]any, len(sessionIDs))
+			for i, id := range sessionIDs {
+				sessions[i] = map[string]any{
+					"id": id,
+					"time": map[string]any{
+						"updated": float64(1000 + i),
+					},
+				}
+			}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		// POST /session/<sid>/prompt_async
+		if r.Method == http.MethodPost {
+			*promptCalls++
+			w.WriteHeader(promptStatus)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	return srv, promptCalls
+}
+
+// parseSrvPort extracts the port from an httptest.Server URL.
+func parseSrvPort(t *testing.T, srvURL string) int {
+	t.Helper()
+	var port int
+	_, err := fmt.Sscanf(srvURL, "http://127.0.0.1:%d", &port)
+	if err != nil {
+		_, err = fmt.Sscanf(srvURL, "http://localhost:%d", &port)
+	}
+	if err != nil {
+		t.Fatalf("parse test server port from %q: %v", srvURL, err)
+	}
+	return port
+}
+
+// waitForBusMessageFailed polls the DB for a failed bus message (failed_at IS
+// NOT NULL and delivered_at IS NULL) to toSession.
+func waitForBusMessageFailed(t *testing.T, d *db.DB, toSession string) bool {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		var count int
+		if err := d.QueryRow(`
+SELECT COUNT(*) FROM bus_messages
+WHERE to_session = ? AND failed_at IS NOT NULL AND delivered_at IS NULL`,
+			toSession,
+		).Scan(&count); err == nil && count > 0 {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// TestNotifyCoordinator_SIDConfirmed_DeliveredAtSet verifies that when the
+// stored opencode_sid is present in GET /session, delivered_at is set and
+// failed_at remains NULL.
+func TestNotifyCoordinator_SIDConfirmed_DeliveredAtSet(t *testing.T) {
+	d := openTestDB(t)
+
+	coordSID := "coord-sid-valid"
+	srv, promptCalls := makeSessionListServer(t, []string{coordSID}, http.StatusOK)
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
+
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	msg := waitForBusMessageDelivered(t, d, "test-repo@main")
+	if msg == nil {
+		t.Fatal("expected delivered bus message — timed out")
+	}
+
+	// Exactly one POST must have been made.
+	if *promptCalls != 1 {
+		t.Errorf("prompt_async calls = %d, want 1", *promptCalls)
+	}
+
+	// Verify delivered_at IS NOT NULL and failed_at IS NULL directly via DB.
+	var deliveredAtRaw *int64
+	var failedAtRaw *int64
+	if err := d.QueryRow(
+		"SELECT delivered_at, failed_at FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL",
+		"test-repo@main",
+	).Scan(&deliveredAtRaw, &failedAtRaw); err != nil {
+		t.Fatalf("query delivered_at/failed_at: %v", err)
+	}
+	if deliveredAtRaw == nil {
+		t.Error("delivered_at: got nil, want non-nil")
+	}
+	if failedAtRaw != nil {
+		t.Errorf("failed_at: got %v, want nil (delivery succeeded)", failedAtRaw)
+	}
+}
+
+// TestNotifyCoordinator_StaleSID_FallsBackToMostRecent verifies that when the
+// stored opencode_sid is NOT present in GET /session, notifyCoordinator
+// uses the most recently updated session from the list instead.
+func TestNotifyCoordinator_StaleSID_FallsBackToMostRecent(t *testing.T) {
+	d := openTestDB(t)
+
+	staleSID := "stale-sid"
+	freshSID := "fresh-sid" // time.updated=1001 > 1000, so this is "most recent"
+	srv, promptCalls := makeSessionListServer(t, []string{"other-sid", freshSID}, http.StatusOK)
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	// Seed coordinator with the stale SID.
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, staleSID)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
+
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	msg := waitForBusMessageDelivered(t, d, "test-repo@main")
+	if msg == nil {
+		t.Fatal("expected delivered bus message — timed out")
+	}
+
+	// Exactly one successful POST was made (after SID refresh).
+	if *promptCalls != 1 {
+		t.Errorf("prompt_async calls = %d, want 1", *promptCalls)
+	}
+
+	// The coordinator's stored SID must have been updated to the fresh one.
+	coordStatus, _ := d.CurrentStatus("test-repo@main")
+	if coordStatus.OpencodeSID == nil || *coordStatus.OpencodeSID != freshSID {
+		t.Errorf("opencode_sid after fallback: got %v, want %q", coordStatus.OpencodeSID, freshSID)
+	}
+}
+
+// TestNotifyCoordinator_EmptySessionList_WritesFailed verifies that when
+// GET /session returns an empty list, failed_at is written and delivered_at
+// remains NULL (edge case: no active sessions).
+func TestNotifyCoordinator_EmptySessionList_WritesFailed(t *testing.T) {
+	d := openTestDB(t)
+
+	srv, _ := makeSessionListServer(t, []string{}, http.StatusOK)
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, "some-sid")
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
+
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	if !waitForBusMessageFailed(t, d, "test-repo@main") {
+		t.Fatal("timed out waiting for failed bus message — expected failed_at to be set")
+	}
+
+	// delivered_at must remain NULL.
+	var deliveredCount int
+	_ = d.QueryRow(
+		"SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL",
+		"test-repo@main",
+	).Scan(&deliveredCount)
+	if deliveredCount != 0 {
+		t.Errorf("delivered_at rows = %d, want 0 (delivery failed — empty session list)", deliveredCount)
+	}
+}
+
+// TestNotifyCoordinator_GetSessionFails_WritesFailed verifies that when
+// GET /session itself fails (non-200), failed_at is written after retries.
+func TestNotifyCoordinator_GetSessionFails_WritesFailed(t *testing.T) {
+	d := openTestDB(t)
+
+	// Server returns 500 for GET /session.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, "some-sid")
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
+
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	if !waitForBusMessageFailed(t, d, "test-repo@main") {
+		t.Fatal("timed out waiting for failed bus message — expected failed_at to be set")
+	}
+
+	// delivered_at must remain NULL.
+	var deliveredCount int
+	_ = d.QueryRow(
+		"SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL",
+		"test-repo@main",
+	).Scan(&deliveredCount)
+	if deliveredCount != 0 {
+		t.Errorf("delivered_at rows = %d, want 0 (GET /session failed)", deliveredCount)
+	}
+}
+
+// TestNotifyCoordinator_PostFails_Retries3Times_WritesFailed verifies that
+// when GET /session succeeds (SID confirmed) but the POST always fails, the
+// sidecar retries 3 times and ultimately writes failed_at.
+func TestNotifyCoordinator_PostFails_Retries3Times_WritesFailed(t *testing.T) {
+	d := openTestDB(t)
+
+	coordSID := "coord-sid-retries"
+	promptCalls := new(int)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		// Always fail the POST.
+		*promptCalls++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
+
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	if !waitForBusMessageFailed(t, d, "test-repo@main") {
+		t.Fatal("timed out waiting for failed bus message — expected failed_at to be set after retries")
+	}
+
+	// Exactly 3 POST attempts were made.
+	if *promptCalls != 3 {
+		t.Errorf("prompt_async calls = %d, want 3 (max retries)", *promptCalls)
+	}
+
+	// delivered_at must remain NULL.
+	var deliveredCount int
+	_ = d.QueryRow(
+		"SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL",
+		"test-repo@main",
+	).Scan(&deliveredCount)
+	if deliveredCount != 0 {
+		t.Errorf("delivered_at rows = %d, want 0 (POST always failed)", deliveredCount)
+	}
+}
+
+// TestNotifyCoordinator_StaleSIDNoDeliveredAt verifies that a stale SID (not
+// in the session list) does NOT result in delivered_at being set (AC: stale SID
+// never produces false-positive delivery).
+func TestNotifyCoordinator_StaleSIDNoDeliveredAt(t *testing.T) {
+	d := openTestDB(t)
+
+	// Server has no sessions containing the stale SID.
+	staleSID := "stale-sid-no-match"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			// Return list that does NOT contain staleSID — only a fresh one.
+			sessions := []map[string]any{{"id": "fresh-sid-abc", "time": map[string]any{"updated": 9999.0}}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		// POST /session/<sid>/prompt_async — succeeds for fresh SID.
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, staleSID)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "active", nil, nil)
+
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	// The delivery succeeds via fallback — no failed_at row.
+	msg := waitForBusMessageDelivered(t, d, "test-repo@main")
+	if msg == nil {
+		t.Fatal("expected delivered bus message via SID fallback — timed out")
+	}
+
+	// The coordinator's stored SID must have been refreshed.
+	coordStatus, _ := d.CurrentStatus("test-repo@main")
+	if coordStatus.OpencodeSID == nil || *coordStatus.OpencodeSID != "fresh-sid-abc" {
+		t.Errorf("opencode_sid after stale fallback: got %v, want \"fresh-sid-abc\"", coordStatus.OpencodeSID)
+	}
+}
+
+// TestHandleSessionCreated_AlwaysUpdatesOpencodeSID verifies that handling
+// multiple session.created events always updates the stored opencode_sid to the
+// latest value, keeping the DB current when the user creates a new opencode
+// session mid-conversation.
+func TestHandleSessionCreated_AlwaysUpdatesOpencodeSID(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	// Seed an initial row with an old SID.
+	oldSID := "old-session-id"
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, &oldSID)
+
+	// First session.created event with oldSID.
+	sc.HandleEvent(makeSSE("session.created", map[string]any{
+		"info": map[string]string{"id": oldSID, "title": "First"},
+	}))
+
+	s1, _ := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if s1.OpencodeSID == nil || *s1.OpencodeSID != oldSID {
+		t.Errorf("after first session.created: opencode_sid = %v, want %q", s1.OpencodeSID, oldSID)
+	}
+
+	// Second session.created event with a new SID (simulating /continue or TUI restart).
+	newSID := "new-session-id"
+	sc.HandleEvent(makeSSE("session.created", map[string]any{
+		"info": map[string]string{"id": newSID, "title": "Second"},
+	}))
+
+	s2, _ := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if s2.OpencodeSID == nil || *s2.OpencodeSID != newSID {
+		t.Errorf("after second session.created: opencode_sid = %v, want %q", s2.OpencodeSID, newSID)
+	}
+}
+
+// TestValidateOrRefreshCoordinatorSID_SIDPresent verifies that
+// validateOrRefreshCoordinatorSID returns the stored SID unchanged when it is
+// present in the session list.
+func TestValidateOrRefreshCoordinatorSID_SIDPresent(t *testing.T) {
+	d := openTestDB(t)
+
+	storedSID := "session-abc"
+	srv, _ := makeSessionListServer(t, []string{"session-xyz", storedSID}, http.StatusOK)
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+
+	got, err := validateOrRefreshCoordinatorSID(srvPort, storedSID, "test-repo@main", d, srv.Client())
+	if err != nil {
+		t.Fatalf("validateOrRefreshCoordinatorSID: unexpected error: %v", err)
+	}
+	if got != storedSID {
+		t.Errorf("returned SID = %q, want %q", got, storedSID)
+	}
+}
+
+// TestValidateOrRefreshCoordinatorSID_SIDAbsent verifies that when the stored
+// SID is absent, the most recently updated session is selected and the DB is
+// updated.
+func TestValidateOrRefreshCoordinatorSID_SIDAbsent(t *testing.T) {
+	d := openTestDB(t)
+
+	// Seed coordinator so UpdateOpencodeSID has a row to update.
+	coordName := "test-repo@main"
+	_ = d.UpsertStatus(coordName, "test-repo", "/wt", "active", nil, nil)
+
+	// Session list has two entries; "newer-sid" has higher updated timestamp.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessions := []map[string]any{
+			{"id": "older-sid", "time": map[string]any{"updated": 100.0}},
+			{"id": "newer-sid", "time": map[string]any{"updated": 200.0}},
+		}
+		data, _ := json.Marshal(sessions)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+	srvPort := parseSrvPort(t, srv.URL)
+
+	staleSID := "stale-sid"
+	got, err := validateOrRefreshCoordinatorSID(srvPort, staleSID, coordName, d, srv.Client())
+	if err != nil {
+		t.Fatalf("validateOrRefreshCoordinatorSID: unexpected error: %v", err)
+	}
+	if got != "newer-sid" {
+		t.Errorf("returned SID = %q, want %q", got, "newer-sid")
+	}
+
+	// DB must be updated.
+	status, _ := d.CurrentStatus(coordName)
+	if status.OpencodeSID == nil || *status.OpencodeSID != "newer-sid" {
+		t.Errorf("opencode_sid in DB = %v, want \"newer-sid\"", status.OpencodeSID)
+	}
+}
+
+// TestValidateOrRefreshCoordinatorSID_EmptyList returns an error.
+func TestValidateOrRefreshCoordinatorSID_EmptyList(t *testing.T) {
+	d := openTestDB(t)
+
+	srv, _ := makeSessionListServer(t, []string{}, http.StatusOK)
+	defer srv.Close()
+	srvPort := parseSrvPort(t, srv.URL)
+
+	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client())
+	if err == nil {
+		t.Error("expected error for empty session list, got nil")
+	}
+}
+
+// TestValidateOrRefreshCoordinatorSID_GetFails returns an error.
+func TestValidateOrRefreshCoordinatorSID_GetFails(t *testing.T) {
+	d := openTestDB(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	srvPort := parseSrvPort(t, srv.URL)
+
+	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client())
+	if err == nil {
+		t.Error("expected error when GET /session returns 500, got nil")
+	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -5855,7 +5856,7 @@ func TestValidateOrRefreshCoordinatorSID_SIDAbsent(t *testing.T) {
 	}
 }
 
-// TestValidateOrRefreshCoordinatorSID_EmptyList returns an error.
+// TestValidateOrRefreshCoordinatorSID_EmptyList returns errEmptySessionList.
 func TestValidateOrRefreshCoordinatorSID_EmptyList(t *testing.T) {
 	d := openTestDB(t)
 
@@ -5866,6 +5867,9 @@ func TestValidateOrRefreshCoordinatorSID_EmptyList(t *testing.T) {
 	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client())
 	if err == nil {
 		t.Error("expected error for empty session list, got nil")
+	}
+	if !errors.Is(err, errEmptySessionList) {
+		t.Errorf("expected errEmptySessionList, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #694 — `notifyCoordinator()` was setting `delivered_at` based solely on receiving HTTP 200 from `prompt_async`, even though opencode returns 200 for stale/non-existent session IDs. This caused notifications to be silently lost with a false-positive `delivered_at`.

## Changes

### 1. Keep `opencode_sid` fresh on every `session.created` event

`handleSessionCreated()` now calls `UpdateOpencodeSID()` unconditionally on every `session.created` event (not just using `upsertState`'s `COALESCE`-based update). This ensures the DB stays current when the user creates a new opencode session mid-conversation (e.g. via `/continue` or TUI restart).

### 2. Pre-delivery SID validation + fallback

Before POSTing to `prompt_async`, `notifyCoordinator()` now:
1. Calls `GET /session` on the coordinator's opencode port
2. Checks whether the stored `opencode_sid` is present in the response
3. If absent, picks the most recently active session ID and uses that instead (updating `agent_status` with the new SID)
4. If `GET /session` fails or returns an empty list, treats this as a delivery failure

### 3. Retry with backoff + honest `delivered_at` semantics

- Retries the POST up to 3 times with exponential backoff (500ms, 1s, 2s)
- Only sets `delivered_at` when: SID was confirmed present in session list AND POST returned HTTP 200
- On exhausted retries: sets `failed_at` instead, leaves `delivered_at` null
- Logs each retry attempt (attempt number, target SID, reason)
- On final failure: structured log with coordinator session name, SID, reason — visible via `prism logs`

### 4. DB migration (v6→v7)

Adds `failed_at INTEGER` (nullable, millisecond timestamp) to `bus_messages`. Additive migration — no existing rows affected. New `WriteBusMessageFailed` function and `UpdateOpencodeSID` helper added.

## Tests

All new acceptance criteria covered:
- `TestNotifyCoordinator_SIDConfirmed_DeliveredAtSet` — delivered_at set when SID confirmed
- `TestNotifyCoordinator_StaleSID_FallsBackToMostRecent` — fallback when SID stale
- `TestNotifyCoordinator_EmptySessionList_WritesFailed` — failed_at on empty session list
- `TestNotifyCoordinator_GetSessionFails_WritesFailed` — failed_at on GET /session failure
- `TestNotifyCoordinator_PostFails_Retries3Times_WritesFailed` — 3 retries then failed_at
- `TestNotifyCoordinator_StaleSIDNoDeliveredAt` — stale SID never produces false-positive
- `TestHandleSessionCreated_AlwaysUpdatesOpencodeSID` — opencode_sid updated on every event
- `TestValidateOrRefreshCoordinatorSID_*` — unit tests for SID validation helper
- `TestMigration_V6ToV7` — additive migration works, existing rows unaffected
- `TestWriteBusMessageFailed` / `TestWriteBusMessageDelivered_FailedAtNull`
- `TestUpdateOpencodeSID` / `TestUpdateOpencodeSID_NoopWhenNoRow`

Closes #694