### PR TITLE
allow aws and kubectl in containerCoordinatorBashCommands

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -457,6 +457,9 @@
         "find *" = "allow";
         "jq *" = "allow";
         "yq *" = "allow";
+        # Cloud/cluster inspection — config is the safety net (readonly mounts)
+        "aws *" = "allow";
+        "kubectl *" = "allow";
         "date *" = "allow";
         "date" = "allow";
         "echo *" = "allow";


### PR DESCRIPTION
## Summary

- Adds `"aws *" = "allow"` to `containerCoordinatorBashCommands`
- Adds `"kubectl *" = "allow"` to `containerCoordinatorBashCommands`
- Both placed alongside other read/inspection tools (jq, yq), with a comment noting that the readonly-mounted config is the safety net

The host coordinator's `"aws *" = "ask"` override and the container worker's `"*" = "allow"` default are both untouched.