### PR TITLE
fix(prism): inject PRISM_SESSION_NAME into containers and fix dashboard depth-1 tree gap

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -875,6 +875,7 @@ func (m *Manager) buildRunArgs() []string {
 		// of /workspace).
 		"--env", "PRISM_SPAWN_PATH=/workspace",
 		"--env", "PRISM_BARE_ROOT=/prism-git",
+		"--env", "PRISM_SESSION_NAME="+cfg.SessionName,
 
 		// Work inside the worktree by default.
 		"--workdir", "/workspace",

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -228,13 +228,13 @@ func RenderSessionRow(
 
 	// treePrefixW is 10 runes (matches view.go constant); pad treePrefix to that
 	// width using rune count (not byte count) since tree connector chars are
-	// multi-byte in UTF-8. Depth-1 prefixes (6 chars) are padded to 10;
-	// depth-2 prefixes (10 chars) fit exactly.
+	// multi-byte in UTF-8. All prefix strings (depth-1 and depth-2) are exactly
+	// 10 runes, so this padding path is a no-op in practice.
 	const treePrefixW = 10
 
 	// Build the session display area (treePrefixW+sessionW total width):
 	// - Top-level (treePrefix=""): full session name padded to treePrefixW+sessionW.
-	// - Child (treePrefix non-empty): tree prefix (6 runes) + branch name padded to sessionW.
+	// - Child (treePrefix non-empty): tree prefix (10 runes) + branch name padded to sessionW.
 	var sessionArea string
 	totalSessionW := treePrefixW + sessionW
 	if treePrefix == "" {

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -39,10 +39,10 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 
 	// ── column widths ────────────────────────────────────────────────────────
 	// Tree prefix slot for child rows.
-	//   Depth-1 prefixes: "  ├──     " or "  └──     " (padded to treePrefixW)
+	//   Depth-1 prefixes: "  ├────── " or "  └────── " (exactly treePrefixW)
 	//   Depth-2 prefixes: "  │   ├── " or "  │   └── " (exactly treePrefixW)
 	// treePrefixW=10 accommodates the widest depth-2 connector without overflow.
-	// Depth-1 connectors are 6 chars and are right-padded with spaces to 10.
+	// Both depth-1 and depth-2 prefixes are exactly 10 runes; no padding is added.
 	const treePrefixW = 10
 	const agentTypeW = 12 // "coordinator " or "worker      " or "            "
 	const stateW = 10
@@ -241,9 +241,9 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 					}
 				}
 				if isLastChild {
-					treePrefix = "  └── "
+					treePrefix = "  └────── "
 				} else {
-					treePrefix = "  ├── "
+					treePrefix = "  ├────── "
 				}
 			}
 			sb.WriteString(RenderSessionRow(d, s, i, treePrefix, currentSession, cursorActive, styleDim, styleIns, styleDel, styleFg, styleAgentType, sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelWFull, showType, showModel, showStat))


### PR DESCRIPTION
## Summary

- **Bug 1**: `PRISM_SESSION_NAME` was never injected into the container environment, causing `prism review` to fail with _"could not determine parent session name"_ when run from inside a container session. Fixed by adding `--env PRISM_SESSION_NAME=<cfg.SessionName>` alongside the existing `PRISM_SPAWN_PATH` and `PRISM_BARE_ROOT` entries in `container.go`.

- **Bug 2**: Depth-1 dashboard tree prefix strings (`"  ├── "`, `"  └── "`) were only 6 runes wide, causing `RenderSessionRow` to pad them to `treePrefixW=10` with 4 spaces — producing a 5-char gap between the connector glyphs and `@branchname`. Fixed by extending the strings to exactly 10 runes using dash connectors (`"  ├────── "`, `"  └────── "`), matching the depth-2 prefixes which were already correct.

Closes #699