### PR TITLE
darwin: add boot.initrd.systemd stub for impermanence compatibility

### DIFF
--- a/modules/darwin/impermanence-stub.nix
+++ b/modules/darwin/impermanence-stub.nix
@@ -56,6 +56,18 @@
       description = "Stub for boot.initrd.postDeviceCommands (darwin compatibility)";
     };
 
+    boot.initrd.systemd.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Stub for boot.initrd.systemd.enable (darwin compatibility)";
+    };
+
+    boot.initrd.systemd.services = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = { };
+      description = "Stub for boot.initrd.systemd.services (darwin compatibility)";
+    };
+
     boot.loader.grub = lib.mkOption {
       type = lib.types.submodule {
         options = {


### PR DESCRIPTION
## Summary

- Adds `boot.initrd.systemd.enable` and `boot.initrd.systemd.services` stubs to `modules/darwin/impermanence-stub.nix`
- Fixes the Darwin CI build failure introduced by PR #698 which added `boot.initrd.systemd` options to `modules/system/impermanence.nix`
- nix-darwin evaluates option paths even under a `false` `lib.mkIf`, so stubs are required even for Linux-only code paths

## Fix

Added two stubs alongside the existing `boot.initrd.postDeviceCommands` stub:
- `boot.initrd.systemd.enable` — `lib.types.bool`, default `false`
- `boot.initrd.systemd.services` — `lib.types.attrsOf lib.types.anything`, default `{}`

## Testing

- Darwin config evaluates cleanly (returns derivation path, no option errors)
- NixOS `tui` build succeeds
- Darwin build fails only due to `aarch64-darwin` cross-build limitation on CI (expected — not an evaluation error)

Closes #700