### PR TITLE
prism: allocate TTY on agent container (RFC #691 prep)

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -764,6 +764,12 @@ func (m *Manager) buildRunArgs() []string {
 	args := []string{
 		"run",
 		"--detach",
+		// --tty allocates a PTY on the container. The container currently runs
+		// "opencode serve" which does not use the PTY, but RFC #691 migrates to
+		// "opencode" (monolithic TUI mode) where podman attach bridges the PTY to
+		// the tmux pane. The flag must be set before that migration lands (see
+		// RFC #691, Phase 1a / Issue G).
+		"--tty",
 		"--name", m.name,
 	}
 


### PR DESCRIPTION
## Summary

Add `--tty` to the `podman run` args constructed by `buildRunArgs()` in `internal/container/container.go`.

The container continues to run `opencode serve` — the PTY is allocated but not yet used. This is a preparatory step for RFC #691 Phase 1a, which migrates to `opencode` (monolithic TUI mode) where `podman attach` bridges the PTY to the tmux pane. Setting the flag now keeps that future migration non-breaking.

A rationale comment in `buildRunArgs()` explains the intent and links to RFC #691.

## Changes

- `internal/container/container.go`: added `"--tty"` arg (with comment) to the `args` slice in `buildRunArgs()`, positioned between `--detach` and `--name`

## Testing

- `go build ./...` — passes
- `go test ./...` — all packages pass

Closes #714