### PR TITLE
prism: add internal/harness package with Harness interface (Phase 0a)

### DIFF
--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -1,0 +1,93 @@
+// Package harness defines the Harness interface and its supporting types.
+//
+// A Harness is a pluggable adapter that teaches the prism sidecar how to
+// communicate with a specific agent runtime (e.g. opencode, PI, Claude Code).
+// Each harness implementation encapsulates the container command, health-check
+// logic, prompt-delivery mechanism, and event-stream mapping for one runtime.
+//
+// This package contains only the interface definition and its supporting types.
+// Concrete implementations live in sub-packages (e.g. internal/harness/opencode/).
+// No other package in the prism binary imports this package yet — it is pure
+// scaffolding for Phase 0a of the multi-harness migration (RFC #691).
+package harness
+
+import (
+	"context"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// Harness is the interface that each agent runtime adapter must implement.
+// The sidecar receives a Harness at construction time and delegates all
+// runtime-specific behaviour through it.
+type Harness interface {
+	// ContainerCommand returns the command string used to launch the agent
+	// runtime as the main process inside its container.
+	// Example: "opencode --port 4096 --hostname 0.0.0.0"
+	ContainerCommand() string
+
+	// HealthCheck verifies that the agent runtime is ready to accept requests
+	// on the given port. It should block until the runtime is healthy or ctx
+	// is cancelled.
+	HealthCheck(ctx context.Context, port int) error
+
+	// ConfigMountPath returns the XDG config path inside the container where
+	// the runtime expects its configuration to be mounted.
+	// Example: "/home/user/.config/opencode"
+	ConfigMountPath() string
+
+	// DeliverInitialPrompt delivers the initial prompt and role system prompt
+	// to the agent runtime after the container is healthy. The role parameter
+	// identifies the agent role (e.g. "worker" or "coordinator").
+	DeliverInitialPrompt(ctx context.Context, prompt, role string) error
+
+	// DeliverPrompt delivers a follow-up prompt to a running agent session.
+	DeliverPrompt(ctx context.Context, prompt string) error
+
+	// Subscribe returns a channel of HarnessEvents from the agent runtime's
+	// event stream. The channel is closed when the stream ends or ctx is
+	// cancelled.
+	Subscribe(ctx context.Context) (<-chan HarnessEvent, error)
+
+	// MapEvent maps a HarnessEvent to a StateTransition. The second return
+	// value is false if the event does not represent a state transition.
+	MapEvent(evt HarnessEvent) (StateTransition, bool)
+
+	// ExtractMessage extracts a Message from a HarnessEvent. The second
+	// return value is false if the event does not carry a message.
+	ExtractMessage(evt HarnessEvent) (Message, bool)
+}
+
+// HarnessEvent is a raw event received from the agent runtime's event stream.
+// It carries the event type and the raw payload bytes so that each harness
+// implementation can decode them in its own way.
+type HarnessEvent struct {
+	// Type is the event type identifier as emitted by the runtime.
+	Type string
+
+	// Data is the raw event payload (e.g. JSON bytes from an SSE stream or
+	// a JSON Lines record).
+	Data []byte
+}
+
+// StateTransition represents a change in agent lifecycle state as reported by
+// a HarnessEvent. The harness's MapEvent method produces one of these when an
+// event carries state information.
+type StateTransition struct {
+	// State is the new agent state indicated by the event.
+	State agent.AgentState
+}
+
+// Message represents an assistant or user message extracted from a HarnessEvent.
+// The harness's ExtractMessage method produces one of these when an event
+// carries message content.
+type Message struct {
+	// ID is the runtime-specific unique identifier for this message.
+	ID string
+
+	// Role is the message role: "user" or "assistant".
+	Role string
+
+	// Text is the plain-text content of the message.
+	Text string
+}


### PR DESCRIPTION
## Summary

Implements Phase 0a of the multi-harness migration (RFC #691): introduces the `internal/harness` package containing the `Harness` interface and its supporting types.

- Adds `internal/harness/harness.go` with the `Harness` interface (all 8 methods as specified in #691)
- Defines supporting types: `HarnessEvent`, `StateTransition` (referencing `agent.AgentState`), and `Message`
- The package compiles cleanly with no callers — pure scaffolding, zero behaviour change
- All existing tests continue to pass (`go test ./...` and `go vet ./...` pass from `modules/programs/prism/prism/`)

Closes #708