### PR TITLE
fix(container): Atlassian MCP — node shebang symlinks + mcp-auth passthrough

### DIFF
--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -225,6 +225,14 @@ pkgs.dockerTools.buildLayeredImage {
     exec /bin/.nix-real "$@"
     WRAPPER
     chmod +x bin/nix
+
+    # Expose Nix-provided Node.js at the standard Ubuntu paths so scripts with
+    # `#!/usr/bin/env node` shebangs resolve regardless of whether PATH is
+    # preserved when the script is spawned (e.g. opencode's MCP `environment:`
+    # dict does not propagate PATH to child processes).
+    mkdir -p usr/bin
+    ln -s /bin/node usr/bin/node
+    ln -s /bin/npx  usr/bin/npx
   '';
 
   config = {

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -729,6 +729,11 @@ func (m *Manager) buildRunArgs() []string {
 	// read-write so the opencode-claude-auth plugin can write back refreshed
 	// OAuth tokens to .credentials.json inside the container.
 	claudeMount := filepath.Join(home, ".claude") + ":/root/.claude"
+	// MCP auth — OAuth tokens written by mcp-remote (used by the Atlassian MCP
+	// shim and other MCP servers that use OAuth). Mounted read-write so that
+	// token refresh inside the container persists back to the host directory.
+	// Source path: ${home}/.mcp-auth — only mounted when it exists on the host.
+	mcpAuthDir := filepath.Join(home, ".mcp-auth")
 	// Nix eval cache — pre-populated git cache from the host so flake input
 	// tarballs (nixpkgs, home-manager, etc.) don't need to be re-fetched and
 	// unpacked on every container start. Read-write because nix writes to
@@ -803,6 +808,15 @@ func (m *Manager) buildRunArgs() []string {
 		// Nix eval cache — flake input tarballs pre-unpacked from the host.
 		"--volume", nixCacheMount,
 	)
+
+	// MCP auth: bind-mount ~/.mcp-auth into the container at /root/.mcp-auth
+	// so mcp-remote OAuth tokens obtained on the host are available inside the
+	// container. Mounted read-write so token refresh inside the container
+	// persists back to the host. Only mounted when the directory exists — hosts
+	// without Atlassian MCP configured are unaffected.
+	if _, err := os.Stat(mcpAuthDir); err == nil {
+		args = append(args, "--volume", mcpAuthDir+":/root/.mcp-auth")
+	}
 
 	// AWS: mount individual files/dirs into /root/.aws so the AWS CLI works at
 	// its default paths with no env var configuration. Each mount is conditional

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2386,3 +2386,62 @@ func TestBuildRunArgs_KubeNotMountedWhenAbsent(t *testing.T) {
 		}
 	}
 }
+
+// ── MCP auth mount tests ─────────────────────────────────────────────────────
+
+// TestBuildRunArgs_McpAuthMountedWhenPresent verifies that when ~/.mcp-auth
+// exists on the host, it is bind-mounted read-write at /root/.mcp-auth inside
+// the container so OAuth tokens written by mcp-remote persist back to the host.
+func TestBuildRunArgs_McpAuthMountedWhenPresent(t *testing.T) {
+	fakeHome := t.TempDir()
+	mcpAuthDir := filepath.Join(fakeHome, ".mcp-auth")
+	if err := os.MkdirAll(mcpAuthDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .mcp-auth: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.HasSuffix(v, ":/root/.mcp-auth") {
+				found = true
+				// Must be read-write (no :ro suffix).
+				if strings.Contains(v, ":ro") {
+					t.Errorf("mcp-auth mount %q must be read-write (no :ro)", v)
+				}
+				// Source must be the actual mcpAuthDir path.
+				if !strings.HasPrefix(v, mcpAuthDir+":") {
+					t.Errorf("mcp-auth mount source %q should be %q", v, mcpAuthDir)
+				}
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("mcp-auth volume mount at /root/.mcp-auth not found in args: %v", args)
+	}
+}
+
+// TestBuildRunArgs_McpAuthNotMountedWhenAbsent verifies that when ~/.mcp-auth
+// does not exist on the host, no mcp-auth mount is added and podman run
+// succeeds without error (skipped entirely).
+func TestBuildRunArgs_McpAuthNotMountedWhenAbsent(t *testing.T) {
+	fakeHome := t.TempDir()
+	// Intentionally do NOT create ~/.mcp-auth.
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			if strings.Contains(args[i+1], "/root/.mcp-auth") {
+				t.Errorf("mcp-auth mount must not be present when ~/.mcp-auth is absent; found %q", args[i+1])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `usr/bin/node` and `usr/bin/npx` symlinks in the `prism-agent` image so `#!/usr/bin/env node` shebangs resolve inside the container when PATH is not propagated (e.g. opencode MCP local transport does not forward PATH to child processes).
- Adds a conditional `~/.mcp-auth` → `/root/.mcp-auth` read-write bind-mount in `container.go` so mcp-remote OAuth tokens obtained on the host are available inside the container; the mount is skipped entirely when the directory does not exist.
- Adds two new tests in `container_test.go` covering the presence and absence cases for the `~/.mcp-auth` mount.

## Changes

### `images/prism-agent.nix`
- In `extraCommands`, add `mkdir -p usr/bin` and symlinks `ln -s /bin/node usr/bin/node` / `ln -s /bin/npx usr/bin/npx`.

### `modules/programs/prism/prism/internal/container/container.go`
- Compute `mcpAuthDir := filepath.Join(home, ".mcp-auth")` alongside `claudeMount`.
- After the fixed mount block, conditionally append `--volume mcpAuthDir:/root/.mcp-auth` when `os.Stat(mcpAuthDir)` succeeds.

### `modules/programs/prism/prism/internal/container/container_test.go`
- `TestBuildRunArgs_McpAuthMountedWhenPresent`: creates `~/.mcp-auth` in a temp home and asserts the read-write volume mount is present.
- `TestBuildRunArgs_McpAuthNotMountedWhenAbsent`: leaves `~/.mcp-auth` absent and asserts no mount is emitted.

## Testing
- `go build ./...` passes
- `go test ./...` passes (all 16 packages)
- `mcp-atlassian-slim-proxy.mjs` is not modified

Closes #706