### PR TITLE
feat(prism/db): add harness columns with v7→v8 migration and dual-write

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -55,21 +55,24 @@ type Event struct {
 
 // Status represents a row in the agent_status table.
 type Status struct {
-	SessionName   string
-	Repo          string
-	Worktree      string
-	State         string
-	Title         *string
-	OpencodeSID   *string
-	AgentName     *string
-	ModelID       *string
-	RootAgentName *string
-	RootModelID   *string
-	OpencodePort  *int
-	HostMode      bool
-	InstanceID    *string
-	LastSeen      time.Time
-	EndedAt       *time.Time
+	SessionName      string
+	Repo             string
+	Worktree         string
+	State            string
+	Title            *string
+	OpencodeSID      *string
+	AgentName        *string
+	ModelID          *string
+	RootAgentName    *string
+	RootModelID      *string
+	OpencodePort     *int
+	HostMode         bool
+	InstanceID       *string
+	LastSeen         time.Time
+	EndedAt          *time.Time
+	Harness          *string
+	HarnessSessionID *string
+	HarnessPort      *int
 }
 
 // BusMessage represents a row in the bus_messages table.
@@ -101,21 +104,24 @@ CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, crea
 CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS agent_status (
-  session_name    TEXT PRIMARY KEY,
-  repo            TEXT NOT NULL,
-  worktree        TEXT NOT NULL,
-  state           TEXT NOT NULL,
-  title           TEXT,
-  opencode_sid    TEXT,
-  agent_name      TEXT,
-  model_id        TEXT,
-  root_agent_name TEXT,
-  root_model_id   TEXT,
-  opencode_port   INTEGER,
-  host_mode       INTEGER NOT NULL DEFAULT 0,
-  instance_id     TEXT,
-  last_seen       INTEGER NOT NULL,
-  ended_at        INTEGER
+  session_name      TEXT PRIMARY KEY,
+  repo              TEXT NOT NULL,
+  worktree          TEXT NOT NULL,
+  state             TEXT NOT NULL,
+  title             TEXT,
+  opencode_sid      TEXT,
+  agent_name        TEXT,
+  model_id          TEXT,
+  root_agent_name   TEXT,
+  root_model_id     TEXT,
+  opencode_port     INTEGER,
+  host_mode         INTEGER NOT NULL DEFAULT 0,
+  instance_id       TEXT,
+  last_seen         INTEGER NOT NULL,
+  ended_at          INTEGER,
+  harness           TEXT NOT NULL DEFAULT 'opencode',
+  harness_session_id TEXT,
+  harness_port      INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS bus_messages (
@@ -140,12 +146,13 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 // Open opens (or creates) the prism database at path.
 // It creates parent directories as needed, enables WAL mode, runs the full
-// schema, and sets schema_version=7 if the table is empty. Pending migrations
+// schema, and sets schema_version=8 if the table is empty. Pending migrations
 // are applied in order: v1→v2 adds agent_name/model_id; v2→v3 adds
 // root_agent_name/root_model_id; v3→v4 adds opencode_port to agent_status;
 // v4→v5 adds host_mode to agent_status; v5→v6 adds instance_id to
 // agent_status and to_instance_id to bus_messages; v6→v7 adds failed_at to
-// bus_messages.
+// bus_messages; v7→v8 adds harness, harness_session_id, and harness_port to
+// agent_status.
 func Open(path string) (*DB, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("db: create parent dirs: %w", err)
@@ -175,15 +182,15 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("db: apply schema: %w", err)
 	}
 
-	// Set schema_version=7 if the table is empty (fresh database already has
-	// all columns including the v2, v3, v4, v5, v6, and v7 additions, so no migration is needed).
+	// Set schema_version=8 if the table is empty (fresh database already has
+	// all columns including the v2, v3, v4, v5, v6, v7, and v8 additions, so no migration is needed).
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("db: check schema_version: %w", err)
 	}
 	if count == 0 {
-		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (7)"); err != nil {
+		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (8)"); err != nil {
 			conn.Close()
 			return nil, fmt.Errorf("db: set schema_version: %w", err)
 		}
@@ -287,6 +294,28 @@ func Open(path string) (*DB, error) {
 		}
 		version = 7
 	}
+	if version == 7 {
+		// Migration v7 → v8: add harness columns to agent_status for multi-harness
+		// support (RFC #691). harness defaults to 'opencode' so existing rows
+		// retain their implicit harness assignment without data loss.
+		// harness_session_id and harness_port are nullable parallels of
+		// opencode_sid and opencode_port; both old and new columns are written
+		// simultaneously (dual-write) from this schema version onward.
+		// Additive — existing rows are unaffected.
+		migrations := []string{
+			"ALTER TABLE agent_status ADD COLUMN harness TEXT NOT NULL DEFAULT 'opencode'",
+			"ALTER TABLE agent_status ADD COLUMN harness_session_id TEXT",
+			"ALTER TABLE agent_status ADD COLUMN harness_port INTEGER",
+			"UPDATE schema_version SET version = 8",
+		}
+		for _, m := range migrations {
+			if _, err := conn.Exec(m); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v7→v8: %w", err)
+			}
+		}
+		version = 8
+	}
 
 	return &DB{conn: conn, path: path}, nil
 }
@@ -360,20 +389,25 @@ func (d *DB) UpsertStatus(sessionName, repo, worktree, state string, title *stri
 // modelID, which are written to agent_status.agent_name and agent_status.model_id
 // using COALESCE (only overwriting when non-nil). root_agent_name and root_model_id
 // are NOT touched by this method — use UpsertStatusWithRootAgent for session creation.
+//
+// Dual-write: harness is always written as 'opencode'; harness_session_id mirrors
+// opencode_sid via COALESCE so reads on the old column continue to work unchanged.
 func (d *DB) UpsertStatusWithAgent(sessionName, repo, worktree, state string, title *string, opencodeSID *string, agentName *string, modelID *string) error {
 	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusWithAgent")
 	now := time.Now().UnixMilli()
 	const q = `
-INSERT INTO agent_status (session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO agent_status (session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, last_seen, harness, harness_session_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'opencode', ?)
 ON CONFLICT(session_name) DO UPDATE SET
-  state        = excluded.state,
-  title        = COALESCE(excluded.title, title),
-  opencode_sid = COALESCE(excluded.opencode_sid, opencode_sid),
-  agent_name   = COALESCE(excluded.agent_name, agent_name),
-  model_id     = COALESCE(excluded.model_id, model_id),
-  last_seen    = excluded.last_seen`
-	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, opencodeSID, agentName, modelID, now)
+  state              = excluded.state,
+  title              = COALESCE(excluded.title, title),
+  opencode_sid       = COALESCE(excluded.opencode_sid, opencode_sid),
+  agent_name         = COALESCE(excluded.agent_name, agent_name),
+  model_id           = COALESCE(excluded.model_id, model_id),
+  last_seen          = excluded.last_seen,
+  harness            = 'opencode',
+  harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, opencodeSID, agentName, modelID, now, opencodeSID)
 	if err != nil {
 		return fmt.Errorf("db: upsert status: %w", err)
 	}
@@ -416,18 +450,20 @@ func (d *DB) UpsertStatusWithRootAgent(sessionName, repo, worktree, state string
 	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusWithRootAgent")
 	now := time.Now().UnixMilli()
 	const q = `
-INSERT INTO agent_status (session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO agent_status (session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, last_seen, harness, harness_session_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'opencode', ?)
 ON CONFLICT(session_name) DO UPDATE SET
-  state           = excluded.state,
-  title           = COALESCE(excluded.title, title),
-  opencode_sid    = COALESCE(excluded.opencode_sid, opencode_sid),
-  agent_name      = COALESCE(excluded.agent_name, agent_name),
-  model_id        = COALESCE(excluded.model_id, model_id),
-  root_agent_name = COALESCE(excluded.root_agent_name, root_agent_name),
-  root_model_id   = COALESCE(excluded.root_model_id, root_model_id),
-  last_seen       = excluded.last_seen`
-	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, opencodeSID, agentName, modelID, agentName, modelID, now)
+  state              = excluded.state,
+  title              = COALESCE(excluded.title, title),
+  opencode_sid       = COALESCE(excluded.opencode_sid, opencode_sid),
+  agent_name         = COALESCE(excluded.agent_name, agent_name),
+  model_id           = COALESCE(excluded.model_id, model_id),
+  root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
+  root_model_id      = COALESCE(excluded.root_model_id, root_model_id),
+  last_seen          = excluded.last_seen,
+  harness            = 'opencode',
+  harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, opencodeSID, agentName, modelID, agentName, modelID, now, opencodeSID)
 	if err != nil {
 		return fmt.Errorf("db: upsert status with root agent: %w", err)
 	}
@@ -619,10 +655,10 @@ func (d *DB) AllocatePort(sessionName string) (int, error) {
 		if !portAvailable(port) {
 			continue
 		}
-		// Write the allocated port to agent_status.
+		// Write the allocated port to agent_status (dual-write: opencode_port and harness_port).
 		res, err := d.conn.Exec(
-			"UPDATE agent_status SET opencode_port = ? WHERE session_name = ?",
-			port, sessionName,
+			"UPDATE agent_status SET opencode_port = ?, harness_port = ? WHERE session_name = ?",
+			port, port, sessionName,
 		)
 		if err != nil {
 			return 0, fmt.Errorf("db: allocate port: update: %w", err)
@@ -646,7 +682,7 @@ func (d *DB) AllocatePort(sessionName string) (int, error) {
 // idempotent and returns nil.
 func (d *DB) ReleasePort(sessionName string) error {
 	res, err := d.conn.Exec(
-		"UPDATE agent_status SET opencode_port = NULL WHERE session_name = ?",
+		"UPDATE agent_status SET opencode_port = NULL, harness_port = NULL WHERE session_name = ?",
 		sessionName,
 	)
 	if err != nil {
@@ -904,7 +940,7 @@ func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, ty
 // CurrentStatus returns the agent_status row for sessionName, or nil if not found.
 func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE session_name = ?`
 	row := d.conn.QueryRow(q, sessionName)
@@ -921,7 +957,7 @@ WHERE session_name = ?`
 // AllActiveStatus returns all agent_status rows where ended_at IS NULL.
 func (d *DB) AllActiveStatus() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
@@ -930,7 +966,7 @@ WHERE ended_at IS NULL`
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
@@ -948,7 +984,7 @@ func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
 	// percent signs in session names are matched exactly, not as wildcards.
 	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE session_name LIKE ? ESCAPE '\'`
 	return d.queryStatuses(q, escaped+"%")
@@ -1140,11 +1176,14 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
 // keep the stored SID current when the user creates a new opencode session
 // mid-conversation (e.g. via /continue or TUI restart).
 //
+// Dual-write: harness_session_id is also written with the same value so that
+// both old and new columns stay in sync.
+//
 // It is a no-op when no row exists for sessionName (returns nil).
 func (d *DB) UpdateOpencodeSID(sessionName, sid string) error {
 	_, err := d.conn.Exec(
-		"UPDATE agent_status SET opencode_sid = ? WHERE session_name = ?",
-		sid, sessionName,
+		"UPDATE agent_status SET opencode_sid = ?, harness_session_id = ? WHERE session_name = ?",
+		sid, sid, sessionName,
 	)
 	if err != nil {
 		return fmt.Errorf("db: update opencode_sid: %w", err)
@@ -1278,10 +1317,14 @@ func scanStatus(s scanner) (*Status, error) {
 	var port sql.NullInt64
 	var hostMode sql.NullInt64
 	var instanceID sql.NullString
+	var harness sql.NullString
+	var harnessSessionID sql.NullString
+	var harnessPort sql.NullInt64
 	err := s.Scan(
 		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
 		&st.Title, &st.OpencodeSID, &st.AgentName, &st.ModelID,
 		&st.RootAgentName, &st.RootModelID, &port, &hostMode, &instanceID, &lastSeen, &endedAt,
+		&harness, &harnessSessionID, &harnessPort,
 	)
 	if err != nil {
 		return nil, err
@@ -1302,6 +1345,18 @@ func scanStatus(s scanner) (*Status, error) {
 	if instanceID.Valid {
 		id := instanceID.String
 		st.InstanceID = &id
+	}
+	if harness.Valid {
+		h := harness.String
+		st.Harness = &h
+	}
+	if harnessSessionID.Valid {
+		hsid := harnessSessionID.String
+		st.HarnessSessionID = &hsid
+	}
+	if harnessPort.Valid {
+		hp := int(harnessPort.Int64)
+		st.HarnessPort = &hp
 	}
 	return &st, nil
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=7 (migrations are applied on Open).
+	// Verify schema_version=8 (migrations are applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version: got %d, want 8", version)
 	}
 
 	// Verify WAL mode.
@@ -766,20 +766,20 @@ func TestMigration_V1ToV2(t *testing.T) {
 		t.Fatalf("seed v1 db: %v", err)
 	}
 
-	// Open via db.Open — should apply the v1→v2, v2→v3, v3→v4, v4→v5, and v5→v6 migrations.
+	// Open via db.Open — should apply the v1→v2, v2→v3, v3→v4, v4→v5, v5→v6, v6→v7, and v7→v8 migrations.
 	d, err := db.Open(dbPath)
 	if err != nil {
 		t.Fatalf("db.Open on v1 db: %v", err)
 	}
 	defer d.Close()
 
-	// Verify schema_version=7.
+	// Verify schema_version=8.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version after migration: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -853,8 +853,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version after migration: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1354,8 +1354,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version after migration: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1420,8 +1420,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version after migration: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1490,8 +1490,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version after migration: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1585,8 +1585,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 7 {
-		t.Errorf("schema_version after migration: got %d, want 7", version)
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1620,6 +1620,161 @@ func TestMigration_V6ToV7(t *testing.T) {
 	}
 	if failedAt2 == nil {
 		t.Error("failed_at: got nil, want non-nil timestamp after WriteBusMessageFailed")
+	}
+}
+
+// TestMigration_V7ToV8 verifies that Open applies the v7→v8 migration to an
+// existing DB at schema_version=7 (no harness/harness_session_id/harness_port columns).
+// The migration is additive: all existing rows must be preserved unmodified, and the
+// new harness column must default to 'opencode' for pre-existing rows (AC-13 from #691).
+func TestMigration_V7ToV8(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v7.db")
+
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	const sid = "old-session-id"
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT, opencode_sid TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  opencode_port INTEGER, host_mode INTEGER NOT NULL DEFAULT 0,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (7);
+		INSERT INTO agent_status (session_name, repo, worktree, state, opencode_sid, opencode_port, host_mode, last_seen)
+		  VALUES ('repo@main', 'repo', '/code/repo/main', 'active', '` + sid + `', 14000, 0, 0);
+		INSERT INTO agent_status (session_name, repo, worktree, state, host_mode, last_seen)
+		  VALUES ('repo@feat', 'repo', '/code/repo/feat', 'finished', 0, 1000);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v7 db: %v", err)
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v7 db: %v", err)
+	}
+	defer d.Close()
+
+	// Schema version must be 8 after migration.
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 8 {
+		t.Errorf("schema_version after migration: got %d, want 8", version)
+	}
+
+	// All existing rows must be preserved unmodified (additive migration guarantee).
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus repo@main: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus repo@main: got nil, want existing row")
+	}
+	if s.State != "active" {
+		t.Errorf("State preserved: got %q, want \"active\"", s.State)
+	}
+	if s.OpencodeSID == nil || *s.OpencodeSID != sid {
+		t.Errorf("OpencodeSID preserved: got %v, want %q", s.OpencodeSID, sid)
+	}
+	if s.OpencodePort == nil || *s.OpencodePort != 14000 {
+		t.Errorf("OpencodePort preserved: got %v, want 14000", s.OpencodePort)
+	}
+
+	// harness column must default to 'opencode' for rows written before migration.
+	if s.Harness == nil || *s.Harness != "opencode" {
+		t.Errorf("Harness: got %v, want \"opencode\" (default for pre-migration rows)", s.Harness)
+	}
+	// harness_session_id and harness_port must be NULL for pre-migration rows.
+	if s.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID: got %v, want nil (not back-filled by migration)", s.HarnessSessionID)
+	}
+	if s.HarnessPort != nil {
+		t.Errorf("HarnessPort: got %v, want nil (not back-filled by migration)", s.HarnessPort)
+	}
+
+	// Second row (repo@feat) must also be preserved.
+	sf, err := d.CurrentStatus("repo@feat")
+	if err != nil {
+		t.Fatalf("CurrentStatus repo@feat: %v", err)
+	}
+	if sf == nil {
+		t.Fatal("CurrentStatus repo@feat: got nil, want existing row")
+	}
+	if sf.State != "finished" {
+		t.Errorf("State preserved for repo@feat: got %q, want \"finished\"", sf.State)
+	}
+	if sf.Harness == nil || *sf.Harness != "opencode" {
+		t.Errorf("Harness for repo@feat: got %v, want \"opencode\"", sf.Harness)
+	}
+
+	// Dual-write: UpdateOpencodeSID must now also write harness_session_id.
+	newSID := "new-session-id"
+	if err := d.UpdateOpencodeSID("repo@main", newSID); err != nil {
+		t.Fatalf("UpdateOpencodeSID after migration: %v", err)
+	}
+	s2, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus after UpdateOpencodeSID: %v", err)
+	}
+	if s2.OpencodeSID == nil || *s2.OpencodeSID != newSID {
+		t.Errorf("OpencodeSID after UpdateOpencodeSID: got %v, want %q", s2.OpencodeSID, newSID)
+	}
+	if s2.HarnessSessionID == nil || *s2.HarnessSessionID != newSID {
+		t.Errorf("HarnessSessionID after UpdateOpencodeSID: got %v, want %q (dual-write)", s2.HarnessSessionID, newSID)
+	}
+
+	// Dual-write: AllocatePort must now also write harness_port.
+	// First release the existing port so it's back in the pool, then re-allocate.
+	if err := d.ReleasePort("repo@main"); err != nil {
+		t.Fatalf("ReleasePort before re-allocate: %v", err)
+	}
+	port, err := d.AllocatePort("repo@main")
+	if err != nil {
+		t.Fatalf("AllocatePort after migration: %v", err)
+	}
+	s3, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus after AllocatePort: %v", err)
+	}
+	if s3.OpencodePort == nil || *s3.OpencodePort != port {
+		t.Errorf("OpencodePort after AllocatePort: got %v, want %d", s3.OpencodePort, port)
+	}
+	if s3.HarnessPort == nil || *s3.HarnessPort != port {
+		t.Errorf("HarnessPort after AllocatePort: got %v, want %d (dual-write)", s3.HarnessPort, port)
+	}
+
+	// ReleasePort must clear both columns.
+	if err := d.ReleasePort("repo@main"); err != nil {
+		t.Fatalf("ReleasePort: %v", err)
+	}
+	s4, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus after ReleasePort: %v", err)
+	}
+	if s4.OpencodePort != nil {
+		t.Errorf("OpencodePort after ReleasePort: got %v, want nil", s4.OpencodePort)
+	}
+	if s4.HarnessPort != nil {
+		t.Errorf("HarnessPort after ReleasePort: got %v, want nil (dual-write)", s4.HarnessPort)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements issue #711 (Phase 0b of RFC #691): adds three new columns to the `agent_status` table via an additive migration and updates all write paths to dual-write to both old and new columns.

### New columns

- `harness` — TEXT NOT NULL DEFAULT `'opencode'`; identifies the agent runtime (harness) for each session
- `harness_session_id` — TEXT nullable; parallel to `opencode_sid`
- `harness_port` — INTEGER nullable; parallel to `opencode_port`

### Schema version

7 → 8. Fresh databases are initialised at version 8 directly.

### Dual-write coverage

Every write path that touches `opencode_sid` or `opencode_port` now also writes the parallel new column:

| Method | Old column | New column |
|---|---|---|
| `UpsertStatusWithAgent` | `opencode_sid` (COALESCE) | `harness_session_id` (COALESCE), `harness='opencode'` |
| `UpsertStatusWithRootAgent` | `opencode_sid` (COALESCE) | `harness_session_id` (COALESCE), `harness='opencode'` |
| `UpdateOpencodeSID` | `opencode_sid` (unconditional) | `harness_session_id` (unconditional) |
| `AllocatePort` | `opencode_port` | `harness_port` |
| `ReleasePort` | `opencode_port = NULL` | `harness_port = NULL` |

Reads continue to use the old columns — the switch to new columns is a later phase of the RFC.

### Migration guarantee (AC-13 from #691)

The migration is additive: all three `ALTER TABLE` statements add nullable or defaulted columns. Existing opencode session rows are unmodified; `harness` defaults to `'opencode'` for pre-migration rows.

### Tests

- `TestMigration_V7ToV8`: seeds a v7 DB with existing rows, opens via `db.Open`, and verifies:
  - schema version bumped to 8
  - all existing rows preserved with correct field values
  - `harness` defaults to `'opencode'` for pre-migration rows
  - `harness_session_id` / `harness_port` are NULL for pre-migration rows (not back-filled)
  - dual-write works correctly for `UpdateOpencodeSID`, `AllocatePort`, and `ReleasePort`
- All existing migration tests updated to expect version 8 as the final target

`go build ./...` and `go test ./...` pass.

Closes #711