### PR TITLE
prism: prism review respects ENHANCED_REVIEW mode, spawning 5-agent set

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -308,21 +308,23 @@
 
         ## Pull Request Reviews
 
-        ${
-          if config.nx.programs.prism.opencode.enhancedReview then
-            ''
-              After opening a pull request, invoke ALL 5 review agents **in parallel** before announcing completion:
-              `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context`.
-              Pass the PR number to each. All 5 must return `<verdict>PASS</verdict>` for the review to pass.
-              If ANY agent returns FAIL, fix all blocking issues, push, and re-run all 5 agents.
-              After 3 full review cycles without convergence, stop and escalate — do not run a 4th cycle.''
-          else
-            ''
-              After opening a pull request, always invoke the `@review` subagent, passing it the PR number.
-              The review agent will check the PR for bugs, structural issues, and requirement gaps and report back.
-              If it identifies issues, fix them and then invoke `@review` again with the same PR number.
-              Repeat this cycle until the review passes with no issues before considering the work complete.''
-        }
+          ${
+            if config.nx.programs.prism.opencode.enhancedReview then
+              ''
+                After opening a pull request, invoke ALL 5 review agents **in parallel** before announcing completion:
+                `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context`.
+                Pass the PR number to each. All 5 must return `<verdict>PASS</verdict>` for the review to pass.
+                If ANY agent returns FAIL, fix all blocking issues, push, and re-run all 5 agents.
+                After 3 full review cycles without convergence, stop and escalate — do not run a 4th cycle.
+                Preferred invocation: `prism review <pr-number>` (spawns all 5 agents automatically, provides dashboard observability).
+                Fallback: invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` directly as parallel Task calls.''
+            else
+              ''
+                After opening a pull request, always invoke the `@review` subagent, passing it the PR number.
+                The review agent will check the PR for bugs, structural issues, and requirement gaps and report back.
+                If it identifies issues, fix them and then invoke `@review` again with the same PR number.
+                Repeat this cycle until the review passes with no issues before considering the work complete.''
+          }
 
         ## Search Scope
 

--- a/modules/programs/prism/opencode/agents-enhanced/worker.md
+++ b/modules/programs/prism/opencode/agents-enhanced/worker.md
@@ -55,8 +55,32 @@ When your work is complete and quality gates pass:
 
 ## Parallel review (enhanced mode)
 
-Before announcing your PR as complete, and after each push to an open PR, invoke
-ALL 5 review agents **in parallel** (in a single response with 5 Task tool calls):
+Before announcing your PR as complete, and after each push to an open PR, run
+code review using `prism review <pr-number>` (preferred) or direct `@review-*`
+Task calls (fallback). `prism review` spawns all five specialised review agents
+automatically in enhanced mode and provides dashboard observability and retry
+support. Fix any issues and re-run review until it passes.
+
+### Running code review with prism review
+
+```bash
+# Run review against your PR (blocks until all 5 agents complete, returns findings to stdout)
+result=$(prism review <pr-number>)
+echo "$result"
+
+# If some agents fail, re-run only the failed ones
+prism review <pr-number> --only review-code,review-security
+
+# Check in on review progress from the coordinator session
+prism checkin $(tmux display-message -p '#{session_name}')~review
+```
+
+`prism review` exit code 0 = all agents passed; non-zero = failures.
+
+### Fallback: direct Task calls
+
+If `prism review` is unavailable or fails to start, invoke the five agents
+**in parallel** (in a single response with 5 Task tool calls):
 
 1. `@review-goal` — pass the original issue/ACs and the PR number
 2. `@review-code` — pass the PR number
@@ -72,8 +96,9 @@ If ANY agent returns `<verdict>FAIL</verdict>`:
 1. Read each agent's `<blocking_issues>` carefully
 2. Fix every blocking issue identified
 3. Commit and push your fixes
-4. Re-invoke **all 5 agents** — not just the ones that failed. A fix in one area
-   can create issues in another, so the full set must re-run every cycle.
+4. Re-run review (via `prism review` or direct Task calls) against all 5 agents
+   — not just the ones that failed. A fix in one area can create issues in
+   another, so the full set must re-run every cycle.
 
 ### Escalation
 

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -42,9 +42,29 @@ export const PrismHooks: Plugin = async () => {
         if (isPush) {
           pendingReviewReminder = true;
         }
+
+        // Detect `prism review <pr-number>` Bash invocations in enhanced mode.
+        // This counts as one review cycle (same as a parallel batch of Task calls).
+        if (enhancedReview) {
+          const prismReviewMatch = command.match(
+            /\bprism\s+review\s+(\d+)\b/,
+          );
+          if (prismReviewMatch) {
+            const newPr = prismReviewMatch[1];
+            if (newPr !== detectedPrNumber) {
+              detectedPrNumber = newPr;
+              reviewCycles.clear();
+            }
+            if (!pendingCycleCount) {
+              pendingCycleCount = true;
+              const prKey = detectedPrNumber ?? "unknown";
+              reviewCycles.set(prKey, (reviewCycles.get(prKey) ?? 0) + 1);
+            }
+          }
+        }
       }
 
-      // Detect review agent Task invocations.
+      // Detect review agent Task invocations (fallback path — direct @review-* calls).
       // Each invocation (or parallel batch of invocations) for a given PR
       // counts as one review cycle.
       if (input.tool === "task" && enhancedReview) {
@@ -110,7 +130,7 @@ export const PrismHooks: Plugin = async () => {
 
       if (enhancedReview) {
         output.system.push(
-          "You just ran git push. If this was in the context of an open PR, invoke @review-goal, @review-code, @review-security, @review-qa, and @review-context now (in parallel) so the updated changes are reviewed before the PR is merged. ALL 5 must return PASS before the PR can be merged.",
+          "You just ran git push. If this was in the context of an open PR, run `prism review <pr-number>` to review the updated changes before the PR is merged (preferred). Alternatively, invoke @review-goal, @review-code, @review-security, @review-qa, and @review-context in parallel as a fallback. ALL 5 agents must pass before the PR can be merged.",
         );
       } else {
         output.system.push(

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -113,6 +113,14 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("prism review: no agents to run")
 	}
 
+	// Pre-flight: verify that the required opencode agent definitions exist.
+	// Skip in container mode — the check cannot inspect the container filesystem.
+	if !cfg.ContainerMode {
+		if err := review.CheckAgentAvailability(agents); err != nil {
+			return fmt.Errorf("prism review: %w", err)
+		}
+	}
+
 	// Build run options.
 	opts := review.Opts{
 		PRNumber:       prNumber,

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -174,15 +174,23 @@ func runReview(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// agentsForHarness returns the default agent list for the given harness.
-// Currently only "opencode" is supported.
+// agentsForHarness returns the agent list for the given harness.
+// When ENHANCED_REVIEW=true is set in the environment, the five-agent enhanced
+// set is returned. Otherwise the single default agent is used (back-compat).
+// Currently only "opencode" is supported as a harness.
 func agentsForHarness(harness string) []review.Agent {
 	switch harness {
 	case "opencode", "":
+		if os.Getenv("ENHANCED_REVIEW") == "true" {
+			return review.EnhancedAgents()
+		}
 		return review.DefaultAgents()
 	default:
 		// Unknown harness — return opencode agents as fallback.
 		fmt.Fprintf(os.Stderr, "[prism review] warning: unknown harness %q, using opencode\n", harness)
+		if os.Getenv("ENHANCED_REVIEW") == "true" {
+			return review.EnhancedAgents()
+		}
 		return review.DefaultAgents()
 	}
 }

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// TestAgentsForHarness_EnvUnset verifies that when ENHANCED_REVIEW is not set,
+// agentsForHarness returns the single default agent set.
+func TestAgentsForHarness_EnvUnset(t *testing.T) {
+	os.Unsetenv("ENHANCED_REVIEW")
+
+	agents := agentsForHarness("opencode")
+	want := review.DefaultAgents()
+	if len(agents) != len(want) {
+		t.Fatalf("agentsForHarness(opencode) with ENHANCED_REVIEW unset: got %d agents, want %d", len(agents), len(want))
+	}
+	for i, a := range agents {
+		if a.Name != want[i].Name || a.OpencodeName != want[i].OpencodeName {
+			t.Errorf("agent[%d]: got {%q, %q}, want {%q, %q}", i, a.Name, a.OpencodeName, want[i].Name, want[i].OpencodeName)
+		}
+	}
+}
+
+// TestAgentsForHarness_EnvTrue verifies that when ENHANCED_REVIEW=true,
+// agentsForHarness returns the five-agent enhanced set.
+func TestAgentsForHarness_EnvTrue(t *testing.T) {
+	t.Setenv("ENHANCED_REVIEW", "true")
+
+	agents := agentsForHarness("opencode")
+	want := review.EnhancedAgents()
+	if len(agents) != 5 {
+		t.Fatalf("agentsForHarness(opencode) with ENHANCED_REVIEW=true: got %d agents, want 5", len(agents))
+	}
+	if len(agents) != len(want) {
+		t.Fatalf("agentsForHarness(opencode) with ENHANCED_REVIEW=true: got %d agents, want %d", len(agents), len(want))
+	}
+	for i, a := range agents {
+		if a.Name != want[i].Name || a.OpencodeName != want[i].OpencodeName {
+			t.Errorf("agent[%d]: got {%q, %q}, want {%q, %q}", i, a.Name, a.OpencodeName, want[i].Name, want[i].OpencodeName)
+		}
+	}
+}
+
+// TestAgentsForHarness_EnvFalse verifies that ENHANCED_REVIEW=false (or any
+// non-"true" value) returns the default single-agent set.
+func TestAgentsForHarness_EnvFalse(t *testing.T) {
+	for _, val := range []string{"false", "0", "yes", "TRUE", "1"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("ENHANCED_REVIEW", val)
+
+			agents := agentsForHarness("opencode")
+			want := review.DefaultAgents()
+			if len(agents) != len(want) {
+				t.Fatalf("agentsForHarness(opencode) with ENHANCED_REVIEW=%q: got %d agents, want %d", val, len(agents), len(want))
+			}
+			if agents[0].Name != "review" {
+				t.Errorf("agentsForHarness(opencode) with ENHANCED_REVIEW=%q: got agent name %q, want %q", val, agents[0].Name, "review")
+			}
+		})
+	}
+}
+
+// TestAgentsForHarness_EnhancedAgentNames verifies that the enhanced agent names
+// match the expected opencode agent identifiers.
+func TestAgentsForHarness_EnhancedAgentNames(t *testing.T) {
+	t.Setenv("ENHANCED_REVIEW", "true")
+
+	agents := agentsForHarness("opencode")
+	expectedNames := []string{
+		"review-goal",
+		"review-code",
+		"review-security",
+		"review-qa",
+		"review-context",
+	}
+	for i, name := range expectedNames {
+		if i >= len(agents) {
+			t.Fatalf("not enough agents: got %d, want at least %d", len(agents), i+1)
+		}
+		if agents[i].Name != name {
+			t.Errorf("agents[%d].Name = %q, want %q", i, agents[i].Name, name)
+		}
+		if agents[i].OpencodeName != name {
+			t.Errorf("agents[%d].OpencodeName = %q, want %q", i, agents[i].OpencodeName, name)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -83,6 +83,19 @@ func DefaultAgents() []Agent {
 	}
 }
 
+// EnhancedAgents returns the five-agent set used in enhanced review mode.
+// Each agent corresponds to a specialised opencode agent definition under
+// modules/programs/prism/opencode/agents-enhanced/.
+func EnhancedAgents() []Agent {
+	return []Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-code", OpencodeName: "review-code"},
+		{Name: "review-security", OpencodeName: "review-security"},
+		{Name: "review-qa", OpencodeName: "review-qa"},
+		{Name: "review-context", OpencodeName: "review-context"},
+	}
+}
+
 // AgentsByName filters the agents slice to only those whose Name is in the
 // allowedNames set. Returns an error if any name in allowedNames does not exist
 // in agents.

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -96,6 +96,43 @@ func EnhancedAgents() []Agent {
 	}
 }
 
+// CheckAgentAvailability verifies that the opencode agent definition files for
+// all given agents exist on the host filesystem. Returns a descriptive error
+// listing any missing agents; returns nil when all are present.
+//
+// This performs a best-effort pre-flight check by looking for agent .md files
+// in $XDG_CONFIG_HOME/opencode/agents/ (or ~/.config/opencode/agents/). It is
+// intentionally skipped in container mode because the check cannot reliably
+// inspect the container filesystem.
+func CheckAgentAvailability(agents []Agent) error {
+	dir := opencodeAgentsDir()
+	var missing []string
+	for _, ag := range agents {
+		path := filepath.Join(dir, ag.Name+".md")
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			missing = append(missing, ag.Name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"enhanced review requires opencode agent definitions that are not present in %s: %s\n"+
+				"hint: ensure the enhancedReview Nix option is enabled and the system has been rebuilt",
+			dir, strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
+
+// opencodeAgentsDir returns the path to the opencode agents directory.
+func opencodeAgentsDir() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, _ := os.UserHomeDir()
+		configHome = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configHome, "opencode", "agents")
+}
+
 // AgentsByName filters the agents slice to only those whose Name is in the
 // allowedNames set. Returns an error if any name in allowedNames does not exist
 // in agents.

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1,6 +1,7 @@
 package review_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -217,6 +218,116 @@ func TestAgentsByName_MixedNames(t *testing.T) {
 	_, err := review.AgentsByName(agents, []string{"review", "nonexistent"})
 	if err == nil {
 		t.Error("AgentsByName should return error when any name is unknown")
+	}
+}
+
+// ── EnhancedAgents ────────────────────────────────────────────────────────────
+
+func TestEnhancedAgents_ReturnsFiveAgents(t *testing.T) {
+	agents := review.EnhancedAgents()
+	if len(agents) != 5 {
+		t.Fatalf("EnhancedAgents() returned %d agents, want 5", len(agents))
+	}
+}
+
+func TestEnhancedAgents_AgentNames(t *testing.T) {
+	agents := review.EnhancedAgents()
+	want := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	for i, name := range want {
+		if agents[i].Name != name {
+			t.Errorf("agents[%d].Name = %q, want %q", i, agents[i].Name, name)
+		}
+		if agents[i].OpencodeName != name {
+			t.Errorf("agents[%d].OpencodeName = %q, want %q", i, agents[i].OpencodeName, name)
+		}
+	}
+}
+
+func TestDefaultAgents_StillReturnsSingleAgent(t *testing.T) {
+	agents := review.DefaultAgents()
+	if len(agents) != 1 {
+		t.Fatalf("DefaultAgents() returned %d agents, want 1", len(agents))
+	}
+	if agents[0].Name != "review" {
+		t.Errorf("DefaultAgents()[0].Name = %q, want %q", agents[0].Name, "review")
+	}
+}
+
+// ── CheckAgentAvailability ────────────────────────────────────────────────────
+
+func TestCheckAgentAvailability_AllPresent(t *testing.T) {
+	// Create a temp dir with agent .md files for all agents.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	agentsDir := dir + "/opencode/agents"
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	agents := review.EnhancedAgents()
+	for _, ag := range agents {
+		if err := os.WriteFile(agentsDir+"/"+ag.Name+".md", []byte("# "+ag.Name), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	if err := review.CheckAgentAvailability(agents); err != nil {
+		t.Errorf("CheckAgentAvailability: unexpected error: %v", err)
+	}
+}
+
+func TestCheckAgentAvailability_SomeMissing(t *testing.T) {
+	// Create a temp dir with only some agents present.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	agentsDir := dir + "/opencode/agents"
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Only create review-goal.md; the other 4 are missing.
+	if err := os.WriteFile(agentsDir+"/review-goal.md", []byte("# review-goal"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	agents := review.EnhancedAgents()
+	err := review.CheckAgentAvailability(agents)
+	if err == nil {
+		t.Fatal("CheckAgentAvailability: expected error for missing agents, got nil")
+	}
+	// Error should mention the missing agents.
+	for _, ag := range agents[1:] {
+		if !findSubstring(err.Error(), ag.Name) {
+			t.Errorf("CheckAgentAvailability error does not mention missing agent %q: %v", ag.Name, err)
+		}
+	}
+	// Error should NOT mention review-goal (it is present).
+	if findSubstring(err.Error(), "review-goal") {
+		t.Errorf("CheckAgentAvailability error unexpectedly mentions present agent review-goal: %v", err)
+	}
+}
+
+func TestCheckAgentAvailability_AllMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	// Don't create the agents directory at all.
+
+	agents := review.EnhancedAgents()
+	err := review.CheckAgentAvailability(agents)
+	if err == nil {
+		t.Fatal("CheckAgentAvailability: expected error for all missing agents, got nil")
+	}
+}
+
+func TestCheckAgentAvailability_EmptyAgentList(t *testing.T) {
+	// An empty agent list should always pass.
+	if err := review.CheckAgentAvailability(nil); err != nil {
+		t.Errorf("CheckAgentAvailability(nil): unexpected error: %v", err)
+	}
+	if err := review.CheckAgentAvailability([]review.Agent{}); err != nil {
+		t.Errorf("CheckAgentAvailability([]): unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `EnhancedAgents()` to `internal/review/review.go` returning the five specialised review agents (`review-goal`, `review-code`, `review-security`, `review-qa`, `review-context`)
- Updates `agentsForHarness()` in `cmd/review.go` to check `ENHANCED_REVIEW=true` and return `EnhancedAgents()` when set, otherwise `DefaultAgents()` (back-compat)
- Adds `cmd/review_test.go` with tests covering: env unset → DefaultAgents; env `"true"` → EnhancedAgents with 5 agents; env set to `"false"` or other values → DefaultAgents
- Updates `agents-enhanced/worker.md` to make `prism review <pr-number>` the primary review path, with direct `@review-*` Task calls documented as a fallback only

## Behaviour

When `ENHANCED_REVIEW=true`:
- `prism review <pr-number>` spawns all 5 review agents in the `<parent>~review-N` tmux session
- `prism review <pr-number> --only review-code,review-qa` works as a natural retry pattern

When `ENHANCED_REVIEW` is unset or any value other than `"true"`:
- `prism review <pr-number>` continues to spawn the single `review` agent (no change)

## Quality gates

- `go build ./...` ✓
- `go test ./...` ✓ (all packages pass, including new `cmd/review_test.go` tests)

Closes #722