### PR TITLE
feat(prism): show harness column in list-sessions and dashboard

### DIFF
--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -74,15 +74,25 @@ func init() {
 	rootCmd.AddCommand(listSessionsCmd)
 }
 
-// renderSessionTable renders a []db.Status as a sorted SESSION/STATE/PORT/TITLE
+// displayHarness returns the harness display string for a session, falling
+// back to "opencode" when the field is nil or empty (pre-migration rows).
+func displayHarness(h *string) string {
+	if h == nil || *h == "" {
+		return "opencode"
+	}
+	return *h
+}
+
+// renderSessionTable renders a []db.Status as a sorted SESSION/STATE/PORT/HARNESS/TITLE
 // table to stdout. Both the direct DB path and the host-API proxy path use
 // this shared renderer.
 func renderSessionTable(ss []db.Status) error {
 	type row struct {
-		name  string
-		state string
-		port  string
-		title string
+		name    string
+		state   string
+		port    string
+		harness string
+		title   string
 	}
 
 	var rows []row
@@ -95,7 +105,7 @@ func renderSessionTable(ss []db.Status) error {
 		if s.OpencodePort != nil {
 			port = fmt.Sprintf("%d", *s.OpencodePort)
 		}
-		rows = append(rows, row{name: s.SessionName, state: s.State, port: port, title: title})
+		rows = append(rows, row{name: s.SessionName, state: s.State, port: port, harness: displayHarness(s.Harness), title: title})
 	}
 
 	// Sort rows alphabetically by session name for stable, predictable output.
@@ -118,7 +128,7 @@ func renderSessionTable(ss []db.Status) error {
 	styleName := lipgloss.NewStyle().Bold(true)
 	styleTitle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 
-	fmt.Println(styleHeader.Render(fmt.Sprintf("%-40s  %-8s  %-6s  %s", "SESSION", "STATE", "PORT", "TITLE")))
+	fmt.Println(styleHeader.Render(fmt.Sprintf("%-40s  %-8s  %-6s  %-10s  %s", "SESSION", "STATE", "PORT", "HARNESS", "TITLE")))
 	for _, r := range rows {
 		state := r.state
 		if state == "" {
@@ -137,10 +147,11 @@ func renderSessionTable(ss []db.Status) error {
 			nameStyle = styleName
 		}
 
-		fmt.Printf("%s  %s  %s  %s\n",
+		fmt.Printf("%s  %s  %s  %s  %s\n",
 			nameStyle.Render(fmt.Sprintf("%-40s", r.name)),
 			stateStyled,
 			styleTitle.Render(fmt.Sprintf("%-6s", r.port)),
+			styleTitle.Render(fmt.Sprintf("%-10s", r.harness)),
 			styleTitle.Render(title),
 		)
 	}

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -21,6 +21,7 @@ type AgentSession struct {
 	AgentTitle   string // current session title from agent_status.title
 	AgentName    string // coordinator | worker | "" — from agent_status.agent_name
 	ModelID      string // model identifier from agent_status.model_id
+	Harness      string // harness name from agent_status.harness, defaults to "opencode"
 	OpencodePort *int   // allocated port from agent_status.opencode_port, nil when unset
 	ClientCount  int    // tmux clients currently attached (best-effort, 0 on error)
 }
@@ -40,6 +41,10 @@ func StatusToAgentSession(s db.Status, clientCounts map[string]int) AgentSession
 	if s.ModelID != nil {
 		modelID = *s.ModelID
 	}
+	harness := "opencode"
+	if s.Harness != nil && *s.Harness != "" {
+		harness = *s.Harness
+	}
 	return AgentSession{
 		Name:         s.SessionName,
 		AgentState:   s.State,
@@ -47,6 +52,7 @@ func StatusToAgentSession(s db.Status, clientCounts map[string]int) AgentSession
 		AgentTitle:   title,
 		AgentName:    agentName,
 		ModelID:      modelID,
+		Harness:      harness,
 		OpencodePort: s.OpencodePort,
 		ClientCount:  clientCounts[s.SessionName],
 	}
@@ -209,8 +215,8 @@ func RenderSessionRow(
 	currentSession string,
 	cursorActive bool,
 	styleDim, styleIns, styleDel, styleFg, styleAgentType lipgloss.Style,
-	sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelW int,
-	showType, showModel, showStat bool,
+	sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelW, harnessW int,
+	showType, showHarness, showModel, showStat bool,
 ) string {
 	isHere := s.Name == currentSession
 	isSelected := cursorIdx == d.Cursor
@@ -267,6 +273,9 @@ func RenderSessionRow(
 
 	agentLabel := agentTypeLabel(s.AgentName)
 	paddedAgentLabel := fmt.Sprintf("%-*s", agentTypeW, agentLabel)
+
+	harnessLabel := s.Harness
+	paddedHarnessLabel := fmt.Sprintf("%-*s", harnessW, harnessLabel)
 
 	modelLabel := s.ModelID
 	if utf8.RuneCountInString(modelLabel) > modelW {
@@ -331,6 +340,9 @@ func RenderSessionRow(
 		if showType {
 			plain += fmt.Sprintf("  %-*s", agentTypeW, agentLabel)
 		}
+		if showHarness {
+			plain += fmt.Sprintf("  %-*s", harnessW, harnessLabel)
+		}
 		if showModel {
 			plain += fmt.Sprintf("  %-*s", modelW, modelLabel)
 		}
@@ -364,6 +376,7 @@ func RenderSessionRow(
 		Render(fmt.Sprintf("%-*s", stateW, stateLabel(s.AgentState)))
 
 	agentTypeStr := styleAgentType.Render(paddedAgentLabel)
+	harnessStr := styleDim.Render(paddedHarnessLabel)
 	modelStr := styleDim.Render(paddedModelLabel)
 
 	var statStr string
@@ -402,6 +415,9 @@ func RenderSessionRow(
 	row := prefix
 	if showType {
 		row += styleFg.Render("  ") + agentTypeStr
+	}
+	if showHarness {
+		row += styleFg.Render("  ") + harnessStr
 	}
 	if showModel {
 		row += styleFg.Render("  ") + modelStr

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -52,6 +52,7 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	const statWFull = 22     // "2 files +122 -14"
 	const statWCompact = 10  // "+122 -14"
 	const modelWFull = 22    // e.g. "claude-sonnet-4-6    "
+	const harnessW = 10      // "opencode  " or future harness names
 
 	// fixedCore is the non-negotiable fixed overhead: leading space + dot +
 	// treePrefixW + gap-before-state + stateW.
@@ -59,6 +60,7 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 
 	showType := true
 	showModel := true
+	showHarness := true
 	showStat := true
 	statW := statWFull
 	sessionW := sessionWStart
@@ -68,6 +70,9 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 		w := fixedCore + sessionW
 		if showType {
 			w += agentTypeW + 2
+		}
+		if showHarness {
+			w += harnessW + 2
 		}
 		if showModel {
 			w += modelWFull + 2
@@ -106,6 +111,11 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	if titleW < 0 {
 		// Drop model.
 		showModel = false
+		titleW = growSession(calcTitleW())
+	}
+	if titleW < 0 {
+		// Drop harness.
+		showHarness = false
 		titleW = growSession(calcTitleW())
 	}
 	if titleW < 0 {
@@ -148,6 +158,9 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	if showType {
 		header += fmt.Sprintf("  %-*s", agentTypeW, "type")
 	}
+	if showHarness {
+		header += fmt.Sprintf("  %-*s", harnessW, "harness")
+	}
 	if showModel {
 		header += fmt.Sprintf("  %-*s", modelWFull, "model")
 	}
@@ -172,7 +185,7 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	} else if d.FilterActive {
 		// Flat list while filter is active (no grouping — easier to scan).
 		for i, s := range sessions {
-			sb.WriteString(RenderSessionRow(d, s, i, "" /*treePrefix*/, currentSession, cursorActive, styleDim, styleIns, styleDel, styleFg, styleAgentType, sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelWFull, showType, showModel, showStat))
+			sb.WriteString(RenderSessionRow(d, s, i, "" /*treePrefix*/, currentSession, cursorActive, styleDim, styleIns, styleDel, styleFg, styleAgentType, sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelWFull, harnessW, showType, showHarness, showModel, showStat))
 		}
 	} else {
 		// Flat view with inline child detection via look-ahead.
@@ -246,7 +259,7 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 					treePrefix = "  ├── "
 				}
 			}
-			sb.WriteString(RenderSessionRow(d, s, i, treePrefix, currentSession, cursorActive, styleDim, styleIns, styleDel, styleFg, styleAgentType, sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelWFull, showType, showModel, showStat))
+			sb.WriteString(RenderSessionRow(d, s, i, treePrefix, currentSession, cursorActive, styleDim, styleIns, styleDel, styleFg, styleAgentType, sessionW, agentTypeW, stateW, statW, statWCompact, titleW, modelWFull, harnessW, showType, showHarness, showModel, showStat))
 		}
 	}
 


### PR DESCRIPTION
## Summary

Surface the `harness` column (added by #711) in two CLI surfaces:

- **`prism list-sessions`**: adds a `HARNESS` column between `PORT` and `TITLE`
- **`prism dashboard`** TUI: adds a `harness` column between `type` and `model`

Both surfaces fall back to `"opencode"` when `agent_status.harness` is NULL (pre-migration rows) or empty. The fallback is a simple nil-check in Go (`displayHarness()` helper in list_sessions.go; inline in `StatusToAgentSession()` in sessions.go).

The dashboard column participates in the existing responsive column-shedding logic — it is dropped after `model` is dropped and before `stat` is dropped, keeping narrow-terminal behaviour correct.

No write-path changes, no query changes (the SELECT already includes `harness` via #711). Pure display plumbing.

Closes #713