### PR TITLE
fix(dashboard): add periodic session-list sync to persistent dashboard

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/model.go
+++ b/modules/programs/prism/prism/internal/dashboard/model.go
@@ -60,6 +60,12 @@ type GhTickMsg time.Time
 // GitStatTickMsg is sent on the 5-second git stat refresh timer.
 type GitStatTickMsg time.Time
 
+// SessionSyncTickMsg is sent on the 10-second session-list sync timer.
+// Receiving it triggers a full FetchSessionsFromDB to ensure the persistent
+// dashboard's session list converges with DB state (handles spawned or cleaned-up
+// sessions that are not covered by push events).
+type SessionSyncTickMsg time.Time
+
 // GitStatsOnlyMsg carries only the result of git.Stat calls, without a fresh
 // session list from the DB. It is used by the persistent dashboard's 5-second
 // git stat ticker to update diff counters in-place, leaving session states

--- a/modules/programs/prism/prism/internal/dashboard/persistent.go
+++ b/modules/programs/prism/prism/internal/dashboard/persistent.go
@@ -41,10 +41,13 @@ func NewPersistentModel(client, callerSession string) PersistentModel {
 
 func (m PersistentModel) Init() tea.Cmd {
 	// FetchSessionsFromDB populates the initial session list with git diff stats.
-	// GitStatTick schedules a 5-second periodic refresh to keep stats up to date
-	// independently of state-transition rendering (push events update only
+	// GitStatTick schedules a 5-second periodic refresh to keep git diff stats up
+	// to date independently of state-transition rendering (push events update only
 	// session state, not git stats).
-	return tea.Batch(FetchSessionsFromDB, FetchGitHubStats, GhTick(), GitStatTick())
+	// SessionSyncTick schedules a 10-second periodic full re-fetch from the DB so
+	// that sessions spawned or cleaned up after Init are reflected without manual
+	// refresh. This complements push events, which only update existing sessions.
+	return tea.Batch(FetchSessionsFromDB, FetchGitHubStats, GhTick(), GitStatTick(), SessionSyncTick())
 }
 
 func (m PersistentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -62,6 +65,16 @@ func (m PersistentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// then schedule the next tick. Using FetchGitStatsOnly ensures that
 		// push-event state updates are never overwritten by the ticker.
 		return m, tea.Batch(FetchGitStatsOnly, GitStatTick())
+
+	case SessionSyncTickMsg:
+		// 10-second full session-list re-sync from the DB. This catches sessions
+		// that were spawned or cleaned up since the last full refresh — changes
+		// that push events cannot communicate (they only update existing sessions).
+		// On success the resulting SessionsMsg replaces the session list exactly
+		// as a manual refresh (RefreshMsg) would. On DB error FetchSessionsFromDB
+		// returns an empty SessionsMsg; ApplySessionsMsg guards against clearing
+		// the list when Sessions is nil, so the last-known state is retained.
+		return m, tea.Batch(FetchSessionsFromDB, SessionSyncTick())
 
 	case GitStatsOnlyMsg:
 		// Apply updated git diff stats without touching session states.

--- a/modules/programs/prism/prism/internal/dashboard/persistent_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/persistent_test.go
@@ -1,0 +1,185 @@
+package dashboard_test
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/prismatic-koi/prism/internal/dashboard"
+)
+
+// TestPersistentInit_SchedulesSessionSyncTick verifies that PersistentModel.Init
+// returns a non-nil command batch that includes at least 5 commands:
+// FetchSessionsFromDB, FetchGitHubStats, GhTick, GitStatTick, SessionSyncTick.
+func TestPersistentInit_SchedulesSessionSyncTick(t *testing.T) {
+	m := dashboard.NewPersistentModel("", "")
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init() returned nil cmd; expected a batch of commands")
+	}
+
+	// Execute the cmd to get the batch message.
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Init() cmd produced %T, want tea.BatchMsg", msg)
+	}
+
+	// The batch must contain at least 5 commands:
+	//   FetchSessionsFromDB, FetchGitHubStats, GhTick, GitStatTick, SessionSyncTick
+	if len(batch) < 5 {
+		t.Errorf("Init() batch has %d cmds, want >= 5 (including SessionSyncTick)", len(batch))
+	}
+
+	for _, c := range batch {
+		if c == nil {
+			t.Error("Init() batch contains a nil cmd")
+		}
+	}
+}
+
+// TestPersistentUpdate_SessionSyncTickMsg_HandledGracefully verifies that
+// receiving a SessionSyncTickMsg causes Update to return a non-nil batch cmd
+// with at least two commands (FetchSessionsFromDB + the next SessionSyncTick),
+// and that one of those cmds produces a SessionsMsg when executed.
+//
+// The DB is pointed at a nonexistent path so FetchSessionsFromDB returns
+// SessionsMsg{} without needing a real database.
+func TestPersistentUpdate_SessionSyncTickMsg_HandledGracefully(t *testing.T) {
+	// Use a fake DB path so openDB fails cleanly — FetchSessionsFromDB will
+	// return an empty SessionsMsg rather than querying a real DB.
+	dashboard.SetTestDBPath("/nonexistent/path/prism.db")
+	t.Cleanup(func() { dashboard.SetTestDBPath("") })
+
+	m := dashboard.NewPersistentModel("", "")
+
+	// Send a SessionSyncTickMsg to Update.
+	updatedModel, cmd := m.Update(dashboard.SessionSyncTickMsg(time.Now()))
+
+	if updatedModel == nil {
+		t.Fatal("Update returned nil model")
+	}
+	if cmd == nil {
+		t.Fatal("Update(SessionSyncTickMsg) returned nil cmd; expected a batch to re-fetch and re-schedule")
+	}
+
+	// Execute the returned cmd — it should be a batch (FetchSessionsFromDB + SessionSyncTick).
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Update(SessionSyncTickMsg) cmd produced %T, want tea.BatchMsg", msg)
+	}
+	if len(batch) < 2 {
+		t.Errorf("SessionSyncTickMsg handler batch has %d cmds, want >= 2 (FetchSessionsFromDB + SessionSyncTick)", len(batch))
+	}
+
+	// Execute only the non-tick cmds looking for a SessionsMsg.
+	// We identify the DB-fetch cmd by running each cmd with a very short
+	// deadline: the tick cmd will block for 10s, so we skip any cmd that
+	// doesn't return quickly by only running cmds that we know are the DB fetch.
+	// The safe approach: run all cmds, but only the one that returns
+	// synchronously (FetchSessionsFromDB) produces a SessionsMsg immediately.
+	// We collect results using a channel with a short timeout.
+	var gotSessionsMsg bool
+	resultCh := make(chan tea.Msg, len(batch))
+	for _, c := range batch {
+		if c == nil {
+			t.Error("SessionSyncTickMsg handler batch contains a nil cmd")
+			continue
+		}
+		go func(fn tea.Cmd) {
+			resultCh <- fn()
+		}(c)
+	}
+
+	// Collect results with a 2-second timeout (FetchSessionsFromDB returns quickly;
+	// the tick cmd blocks for 10s and we don't wait for it).
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < len(batch); i++ {
+		select {
+		case msg := <-resultCh:
+			if _, isSessionsMsg := msg.(dashboard.SessionsMsg); isSessionsMsg {
+				gotSessionsMsg = true
+			}
+		case <-deadline:
+			// Timeout: remaining cmds are slow tickers; stop collecting.
+			i = len(batch) // break loop
+		}
+	}
+
+	if !gotSessionsMsg {
+		t.Error("SessionSyncTickMsg handler did not produce a SessionsMsg from FetchSessionsFromDB")
+	}
+}
+
+// TestPersistentUpdate_SessionSyncTickMsg_RetainsSessionsOnDBError verifies
+// that when the DB is unreachable during a session sync tick, the model retains
+// its last-known sessions rather than clearing them. FetchSessionsFromDB returns
+// SessionsMsg{} with nil Sessions on error; ApplySessionsMsg guards nil so the
+// existing session list is preserved.
+func TestPersistentUpdate_SessionSyncTickMsg_RetainsSessionsOnDBError(t *testing.T) {
+	// Point the DB at a nonexistent path so FetchSessionsFromDB always errors.
+	dashboard.SetTestDBPath("/nonexistent/path/prism.db")
+	t.Cleanup(func() { dashboard.SetTestDBPath("") })
+
+	m := dashboard.NewPersistentModel("", "")
+
+	// Simulate a prior successful DB fetch by applying a SessionsMsg with known sessions.
+	sessions := []dashboard.AgentSession{
+		{Name: "nixos-config@main"},
+		{Name: "nixos-config@feature"},
+	}
+	m2, _ := m.Update(dashboard.SessionsMsg{Sessions: sessions})
+	pm, ok := m2.(dashboard.PersistentModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want dashboard.PersistentModel", m2)
+	}
+	if len(pm.Sessions) != 2 {
+		t.Fatalf("pre-condition: expected 2 sessions, got %d", len(pm.Sessions))
+	}
+
+	// Fire a SessionSyncTickMsg — the DB query will fail (nonexistent path).
+	_, cmd := pm.Update(dashboard.SessionSyncTickMsg(time.Now()))
+	if cmd == nil {
+		t.Fatal("Update(SessionSyncTickMsg) returned nil cmd")
+	}
+
+	// Execute the batch and collect results with a timeout to avoid blocking on
+	// the next-tick timer cmd.
+	batchMsg := cmd()
+	batch, ok := batchMsg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected tea.BatchMsg, got %T", batchMsg)
+	}
+
+	resultCh := make(chan tea.Msg, len(batch))
+	for _, c := range batch {
+		if c == nil {
+			continue
+		}
+		go func(fn tea.Cmd) {
+			resultCh <- fn()
+		}(c)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < len(batch); i++ {
+		select {
+		case innerMsg := <-resultCh:
+			if sm, isSM := innerMsg.(dashboard.SessionsMsg); isSM {
+				// Apply the (empty) SessionsMsg to the model.
+				m3, _ := pm.Update(sm)
+				pm2, ok2 := m3.(dashboard.PersistentModel)
+				if !ok2 {
+					t.Fatalf("Update returned %T, want PersistentModel", m3)
+				}
+				// Sessions must not have been cleared — ApplySessionsMsg guards nil.
+				if len(pm2.Sessions) != 2 {
+					t.Errorf("DB error on sync tick cleared sessions: got %d, want 2", len(pm2.Sessions))
+				}
+			}
+		case <-deadline:
+			i = len(batch) // break loop
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -179,6 +179,19 @@ func GitStatTick() tea.Cmd {
 	})
 }
 
+// SessionSyncTick returns a tea.Cmd that fires a SessionSyncTickMsg after 10
+// seconds. The persistent dashboard uses this to periodically re-fetch the full
+// session list from the DB, ensuring that sessions spawned or cleaned up since
+// the last full refresh become visible (or disappear) within one tick interval.
+// The interval is intentionally coarser than GitStatTick (10s vs 5s) to avoid
+// unnecessary DB load; push events remain the primary mechanism for sub-second
+// state-change updates.
+func SessionSyncTick() tea.Cmd {
+	return tea.Tick(10*time.Second, func(t time.Time) tea.Msg {
+		return SessionSyncTickMsg(t)
+	})
+}
+
 // DashSentinelPath returns the path to the dashboard sentinel file.
 func DashSentinelPath() string {
 	stateHome := os.Getenv("XDG_STATE_HOME")


### PR DESCRIPTION
## Summary

The persistent dashboard (`prism-dashboard`) showed stale sessions after `prism spawn` or `prism cleanup` because its session list was only populated once at `Init()` and never re-queried automatically. This implements **Option A** from the issue: a periodic 10-second `FetchSessionsFromDB` tick as a low-frequency consistency safety net.

## Changes

- **`poll.go`**: Added `SessionSyncTick()` (analogous to `GitStatTick()`) — fires `SessionSyncTickMsg` on a 10-second interval
- **`model.go`**: Added `SessionSyncTickMsg` type with a doc comment explaining its purpose
- **`persistent.go`**: 
  - `Init()` now schedules `SessionSyncTick()` alongside the existing ticks
  - `Update()` handles `SessionSyncTickMsg` by calling `FetchSessionsFromDB` and scheduling the next tick
- **`persistent_test.go`** (new): Three tests covering Init scheduling, handler behaviour, and DB-error retention

## Behaviour

- After `prism spawn`: new session appears within ≤ 10s
- After `prism cleanup`: cleaned-up session disappears within ≤ 10s
- Push events continue to drive sub-second state-change updates for existing sessions (unchanged)
- On DB error during re-sync: model retains last-known sessions (nil-guard in `ApplySessionsMsg`)
- Popup dashboard: unchanged

Closes #723