### PR TITLE
prism: extract opencode harness adapter into internal/harness/opencode/

### DIFF
--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -1,0 +1,382 @@
+// Package opencode implements the harness.Harness interface for the opencode
+// agent runtime. It encapsulates all opencode-specific logic: container command,
+// health-check, config mount path, session creation, prompt delivery, SSE
+// subscription, event type mapping, and message extraction.
+//
+// The sidecar imports this package directly and uses it via the concrete
+// *Adapter type. Injection of the harness.Harness interface into the sidecar
+// constructor is a separate issue (#710).
+package opencode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/sse"
+)
+
+// containerPort is the port opencode serve listens on inside the container.
+// Mirrors container.ContainerPort but avoids an import cycle.
+const containerPort = 4096
+
+// healthCheckInterval is the pause between consecutive health-check probes.
+const healthCheckInterval = 500 * time.Millisecond
+
+// defaultHealthCheckTimeout is the maximum time to wait for the container
+// to become healthy. Matches container.DefaultHealthCheckTimeout.
+const defaultHealthCheckTimeout = 60 * time.Second
+
+// Compile-time assertion that *Adapter implements harness.Harness.
+var _ harness.Harness = (*Adapter)(nil)
+
+// Adapter implements harness.Harness for the opencode runtime. It holds the
+// opencode HTTP base URL and the HTTP client used for all API calls.
+type Adapter struct {
+	opencodeURL string
+	httpClient  *http.Client
+	agentRole   string
+	agentModel  string
+
+	mu        sync.Mutex
+	sessionID string // set by CreateSession; used by DeliverInitialPrompt
+}
+
+// New creates a new Adapter for the given opencode base URL.
+//
+// opencodeURL is the base URL of the opencode HTTP server (e.g.
+// "http://localhost:4096"). httpClient is used for all HTTP requests; pass nil
+// to use a default short-timeout client. agentRole is the agent role for this
+// session (e.g. "worker" or "coordinator"); agentModel is the model identifier
+// (e.g. "anthropic/claude-sonnet-4-6").
+func New(opencodeURL string, httpClient *http.Client, agentRole, agentModel string) *Adapter {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Adapter{
+		opencodeURL: opencodeURL,
+		httpClient:  httpClient,
+		agentRole:   agentRole,
+		agentModel:  agentModel,
+	}
+}
+
+// ContainerCommand returns the command string used to launch opencode as the
+// main process inside its container.
+func (a *Adapter) ContainerCommand() string {
+	return fmt.Sprintf("opencode serve --port %d --hostname 0.0.0.0", containerPort)
+}
+
+// HealthCheck probes GET /global/health on the given port until it responds
+// with 2xx or ctx is cancelled. Returns nil when healthy.
+//
+// /global/health is used rather than / because the root URL falls through to
+// opencode's UIRoutes catch-all, which proxies to https://app.opencode.ai/
+// when there is no embedded web UI — adding a 3–4 s network round-trip on
+// every container startup. /global/health is in ControlPlaneRoutes and returns
+// immediately with no external I/O.
+func (a *Adapter) HealthCheck(ctx context.Context, port int) error {
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/global/health", port)
+	client := a.httpClient
+
+	deadline := time.Now().Add(defaultHealthCheckTimeout)
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("opencode: health check timed out after %s on port %d", defaultHealthCheckTimeout, port)
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(healthCheckInterval):
+		}
+	}
+}
+
+// ConfigMountPath returns the XDG config path inside the container where
+// opencode expects its configuration to be mounted.
+func (a *Adapter) ConfigMountPath() string {
+	return "/root/.config/opencode"
+}
+
+// CreateSession creates a new session on the opencode server via POST /session
+// and returns its ID. The session ID is also stored in the adapter so that
+// DeliverInitialPrompt can use it without the caller having to pass it back.
+//
+// This method is not part of the harness.Harness interface. It is called by
+// the sidecar directly (before the interface-injection migration in #710) so
+// that the sidecar can write the session ID file between creation and prompt
+// delivery — the ordering matters for the opencode attach TUI flow.
+func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
+	body := map[string]string{"directory": "/workspace"}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("opencode: marshal session body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.opencodeURL+"/session", bytes.NewReader(jsonBytes))
+	if err != nil {
+		return "", fmt.Errorf("opencode: create session request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("opencode: create session http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("opencode: create session: http status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("opencode: decode session response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("opencode: empty session ID in response")
+	}
+
+	a.mu.Lock()
+	a.sessionID = result.ID
+	a.mu.Unlock()
+
+	return result.ID, nil
+}
+
+// SessionID returns the most recently created session ID (set by CreateSession).
+// Returns an empty string if CreateSession has not been called or failed.
+func (a *Adapter) SessionID() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sessionID
+}
+
+// DeliverInitialPrompt delivers the initial prompt to the session previously
+// created by CreateSession. The role parameter overrides the adapter's
+// configured agentRole when non-empty.
+//
+// It satisfies the harness.Harness interface. When called via the interface
+// (post-#710), the adapter will need to have already had CreateSession called
+// (or will create a session internally). For the current direct-call path,
+// CreateSession is always called first by the sidecar.
+func (a *Adapter) DeliverInitialPrompt(ctx context.Context, prompt, role string) error {
+	a.mu.Lock()
+	sid := a.sessionID
+	a.mu.Unlock()
+
+	if sid == "" {
+		return fmt.Errorf("opencode: DeliverInitialPrompt called without a session ID — call CreateSession first")
+	}
+
+	agentRole := role
+	if agentRole == "" {
+		agentRole = a.agentRole
+	}
+	if agentRole == "" {
+		agentRole = "worker"
+	}
+
+	body := map[string]any{
+		"parts": []map[string]string{
+			{"type": "text", "text": prompt},
+		},
+		"agent": agentRole,
+	}
+
+	if a.agentModel != "" {
+		slashIdx := strings.Index(a.agentModel, "/")
+		if slashIdx >= 0 {
+			body["model"] = map[string]string{
+				"providerID": a.agentModel[:slashIdx],
+				"modelID":    a.agentModel[slashIdx+1:],
+			}
+		}
+	}
+
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("opencode: marshal prompt body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/session/%s/prompt_async", a.opencodeURL, sid)
+	log.Printf("opencode: DeliverInitialPrompt: POST %s (agent=%s)", url, agentRole)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("opencode: create prompt request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("opencode: deliver prompt http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("opencode: deliver prompt: http status %d", resp.StatusCode)
+	}
+
+	log.Printf("opencode: DeliverInitialPrompt: completed for session %s", sid)
+	return nil
+}
+
+// DeliverPrompt delivers a follow-up prompt to the current opencode session.
+// It satisfies the harness.Harness interface. The session ID must have been
+// established via CreateSession or a prior DeliverInitialPrompt call.
+func (a *Adapter) DeliverPrompt(ctx context.Context, prompt string) error {
+	return a.DeliverInitialPrompt(ctx, prompt, "")
+}
+
+// Subscribe connects to the opencode SSE event stream and returns a channel of
+// harness.HarnessEvents. The channel is closed when the stream ends or ctx is
+// cancelled. It uses the same retry/reconnect policy as the previous inline
+// sse.Client setup in the sidecar.
+func (a *Adapter) Subscribe(ctx context.Context) (<-chan harness.HarnessEvent, error) {
+	url := a.opencodeURL + "/event"
+	client := &sse.Client{
+		InitialRetryDelay: 1 * time.Second,
+		MaxRetryDelay:     30 * time.Second,
+	}
+
+	sseCh, err := client.Connect(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("opencode: connect to SSE stream: %w", err)
+	}
+
+	out := make(chan harness.HarnessEvent, 64)
+	go func() {
+		defer close(out)
+		for evt := range sseCh {
+			select {
+			case out <- harness.HarnessEvent{
+				Type: evt.Type,
+				Data: []byte(evt.Data),
+			}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+// ExtractEventType extracts the real opencode event type from a HarnessEvent.
+//
+// opencode sends all events as plain `data:` lines with no `event:` field. The
+// SSE spec defaults the event type to "message" when no `event:` line is
+// present. The real event type is embedded in the JSON `type` field of the
+// data payload.
+//
+// This method is not on the harness.Harness interface; it is called directly
+// by the sidecar's HandleEvent to resolve the opencode-specific event type.
+func (a *Adapter) ExtractEventType(evt harness.HarnessEvent) string {
+	eventType := evt.Type
+	if eventType == "" || eventType == "message" {
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(evt.Data, &envelope); err == nil && envelope.Type != "" {
+			eventType = envelope.Type
+		}
+	}
+	return eventType
+}
+
+// MapEvent maps an opencode HarnessEvent to a StateTransition. It returns
+// (StateTransition, true) when the event represents a state change, and
+// (StateTransition{}, false) when it does not.
+//
+// This implements the harness.Harness interface. The full opencode event
+// handling logic (including timer management, DB writes, and compaction state)
+// remains in the sidecar; MapEvent covers the subset of events that directly
+// and unconditionally indicate a state transition.
+func (a *Adapter) MapEvent(evt harness.HarnessEvent) (harness.StateTransition, bool) {
+	eventType := a.ExtractEventType(evt)
+
+	switch eventType {
+	case "session.created", "session.updated":
+		return harness.StateTransition{State: "active"}, true
+	case "session.deleted":
+		return harness.StateTransition{State: "deleted"}, true
+	case "session.error":
+		return harness.StateTransition{State: "error"}, true
+	case "permission.asked", "question.asked":
+		return harness.StateTransition{State: "waiting"}, true
+	case "permission.replied", "question.replied", "question.rejected":
+		return harness.StateTransition{State: "active"}, true
+	}
+	return harness.StateTransition{}, false
+}
+
+// ExtractMessage extracts a harness.Message from an opencode HarnessEvent.
+// It returns (Message, true) for completed assistant messages and user
+// messages that have accumulated text. For all other events it returns
+// (Message{}, false).
+//
+// This is a simplified extraction for interface compliance. The sidecar's
+// full message handling (including TTFT, token counts, and per-message dedup)
+// is performed via HandleEvent and remains in the sidecar.
+func (a *Adapter) ExtractMessage(evt harness.HarnessEvent) (harness.Message, bool) {
+	eventType := a.ExtractEventType(evt)
+	if eventType != "message.updated" {
+		return harness.Message{}, false
+	}
+
+	var payload struct {
+		Properties struct {
+			Info struct {
+				ID   string `json:"id"`
+				Role string `json:"role"`
+				Time *struct {
+					Completed *float64 `json:"completed"`
+				} `json:"time"`
+			} `json:"info"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
+		return harness.Message{}, false
+	}
+
+	info := payload.Properties.Info
+	if info.ID == "" || info.Role == "" {
+		return harness.Message{}, false
+	}
+
+	// For assistant messages: only emit when the message is complete.
+	if info.Role == "assistant" && (info.Time == nil || info.Time.Completed == nil) {
+		return harness.Message{}, false
+	}
+
+	return harness.Message{
+		ID:   info.ID,
+		Role: info.Role,
+	}, true
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1,8 +1,14 @@
 // Package sidecar implements the core logic for the prism sidecar process.
 //
-// The sidecar connects to the opencode SSE event stream and translates events
-// into agent state transitions, DB writes, and dashboard sentinel touches —
-// replicating the logic in opencode/plugins/prism-hooks.ts.
+// The sidecar subscribes to the agent runtime's event stream (via the opencode
+// harness adapter) and translates events into agent state transitions, DB
+// writes, and dashboard sentinel touches — replicating the logic in
+// opencode/plugins/prism-hooks.ts.
+//
+// Opencode-specific logic (session creation, prompt delivery, SSE
+// subscription, event type mapping, message extraction, container command,
+// health check, config mount path) lives in internal/harness/opencode/. The
+// sidecar imports and uses that adapter directly.
 //
 // In container mode (Config.Container != nil), the sidecar also manages the
 // podman container lifecycle: create, health-check, stop, remove.
@@ -35,8 +41,9 @@ import (
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	session "github.com/prismatic-koi/prism/internal/session"
-	"github.com/prismatic-koi/prism/internal/sse"
 )
 
 // defaultNotifyHTTPClient is the HTTP client used for coordinator notification
@@ -134,7 +141,8 @@ type Config struct {
 // Sidecar is the core event processor. It consumes SSE events from the
 // opencode stream and drives state transitions in the prism DB.
 type Sidecar struct {
-	cfg Config
+	cfg     Config
+	harness *opencode.Adapter // opencode harness adapter; created in New()
 
 	mu              sync.Mutex
 	lastState       agent.AgentState
@@ -213,8 +221,14 @@ func New(cfg Config) *Sidecar {
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = defaultNotifyHTTPClient
 	}
+	// Derive agentModel for the adapter from Container.AgentModel when available.
+	agentModel := ""
+	if cfg.Container != nil {
+		agentModel = cfg.Container.AgentModel
+	}
 	s := &Sidecar{
 		cfg:             cfg,
+		harness:         opencode.New(cfg.OpencodeURL, cfg.HTTPClient, cfg.AgentRole, agentModel),
 		writtenMessages: make(map[string]bool),
 		textByMessage:   make(map[string]string),
 		msgCreatedAtMs:  make(map[string]float64),
@@ -347,7 +361,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		// 4. POST /session/<sid>/prompt_async — deliver the prompt. The TUI is
 		//    now attaching/subscribed so execution begins immediately.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
-			sid, createErr := s.createOpencodeSession(s.cfg.OpencodeURL, s.cfg.HTTPClient)
+			sid, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
 			} else {
@@ -360,8 +374,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 				s.cfg.OnReady()
 			}
 			if createErr == nil {
+				initialPrompt := s.cfg.InitialPrompt
 				go func() {
-					s.deliverInitialPrompt(s.cfg.OpencodeURL, sid, s.cfg.InitialPrompt, s.cfg.HTTPClient)
+					if err := s.harness.DeliverInitialPrompt(ctx, initialPrompt, s.cfg.AgentRole); err != nil {
+						log.Printf("sidecar: deliverInitialPrompt: %v", err)
+					}
 					log.Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 				}()
 			}
@@ -425,13 +442,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		}
 	}
 
-	url := s.cfg.OpencodeURL + "/event"
-	client := &sse.Client{
-		InitialRetryDelay: 1 * time.Second,
-		MaxRetryDelay:     30 * time.Second,
-	}
-
-	ch, err := client.Connect(ctx, url)
+	ch, err := s.harness.Subscribe(ctx)
 	if err != nil {
 		return fmt.Errorf("sidecar: connect to SSE stream: %w", err)
 	}
@@ -460,25 +471,16 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// HandleEvent processes a single SSE event. It is safe for concurrent use
+// HandleEvent processes a single harness event. It is safe for concurrent use
 // (protected by s.mu). Exported for testing.
-func (s *Sidecar) HandleEvent(evt sse.Event) {
+func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// opencode sends all events as plain `data:` lines with no `event:` field.
-	// The SSE spec defaults the event type to "message" when no `event:` line
-	// is present. Extract the real event type from the JSON `type` field in the
-	// data payload when the SSE-level type is "message" or empty.
-	eventType := evt.Type
-	if eventType == "" || eventType == "message" {
-		var envelope struct {
-			Type string `json:"type"`
-		}
-		if err := json.Unmarshal([]byte(evt.Data), &envelope); err == nil && envelope.Type != "" {
-			eventType = envelope.Type
-		}
-	}
+	// Delegate opencode-specific event type extraction to the harness adapter.
+	// opencode sends all events as plain `data:` lines with no `event:` field;
+	// the real event type is embedded in the JSON `type` field of the payload.
+	eventType := s.harness.ExtractEventType(evt)
 
 	log.Printf("sidecar: event: %s", eventType)
 
@@ -612,7 +614,7 @@ func (s *Sidecar) handleServerConnected() {
 	})
 }
 
-func (s *Sidecar) handleSessionStatus(evt sse.Event) {
+func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Status struct {
@@ -620,7 +622,7 @@ func (s *Sidecar) handleSessionStatus(evt sse.Event) {
 			} `json:"status"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: session.status parse error: %v", err)
 		return
 	}
@@ -684,7 +686,7 @@ func (s *Sidecar) handleSessionIdle() {
 	})
 }
 
-func (s *Sidecar) handleSessionCreated(evt sse.Event) {
+func (s *Sidecar) handleSessionCreated(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Info struct {
@@ -693,7 +695,7 @@ func (s *Sidecar) handleSessionCreated(evt sse.Event) {
 			} `json:"info"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: session.created parse error: %v", err)
 		return
 	}
@@ -719,7 +721,7 @@ func (s *Sidecar) handleSessionCreated(evt sse.Event) {
 	s.writeStateChange(agent.StateActive)
 }
 
-func (s *Sidecar) handleSessionUpdated(evt sse.Event) {
+func (s *Sidecar) handleSessionUpdated(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Info struct {
@@ -731,7 +733,7 @@ func (s *Sidecar) handleSessionUpdated(evt sse.Event) {
 			} `json:"info"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: session.updated parse error: %v", err)
 		return
 	}
@@ -781,7 +783,7 @@ func (s *Sidecar) handleSessionUpdated(evt sse.Event) {
 	}
 }
 
-func (s *Sidecar) handleSessionError(evt sse.Event) {
+func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Error *struct {
@@ -789,7 +791,7 @@ func (s *Sidecar) handleSessionError(evt sse.Event) {
 			} `json:"error"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: session.error parse error: %v", err)
 		return
 	}
@@ -831,7 +833,7 @@ func (s *Sidecar) handleSessionCompacted() {
 	s.writeEvent("compaction", map[string]string{"note": "compaction complete"}, nil)
 }
 
-func (s *Sidecar) handleSessionDeleted(evt sse.Event) {
+func (s *Sidecar) handleSessionDeleted(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Info struct {
@@ -839,7 +841,7 @@ func (s *Sidecar) handleSessionDeleted(evt sse.Event) {
 			} `json:"info"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: session.deleted parse error: %v", err)
 		return
 	}
@@ -853,7 +855,7 @@ func (s *Sidecar) handleSessionDeleted(evt sse.Event) {
 	s.writeStateChangeWithSID(agent.StateDeleted, sid)
 }
 
-func (s *Sidecar) handlePermissionAsked(evt sse.Event) {
+func (s *Sidecar) handlePermissionAsked(evt harness.HarnessEvent) {
 	s.upsertState(agent.StateWaiting, nil, nil)
 	s.writeStateChange(agent.StateWaiting)
 
@@ -867,7 +869,7 @@ func (s *Sidecar) handlePermissionAsked(evt sse.Event) {
 			} `json:"tool"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err == nil {
+	if err := json.Unmarshal(evt.Data, &payload); err == nil {
 		tool := payload.Properties.Permission
 		if tool == "" {
 			tool = "unknown"
@@ -884,13 +886,13 @@ func (s *Sidecar) handlePermissionAsked(evt sse.Event) {
 	}
 }
 
-func (s *Sidecar) handlePermissionReplied(evt sse.Event) {
+func (s *Sidecar) handlePermissionReplied(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Reply string `json:"reply"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: permission.replied parse error: %v", err)
 		return
 	}
@@ -906,7 +908,7 @@ func (s *Sidecar) handlePermissionReplied(evt sse.Event) {
 	s.writeStateChange(agent.StateActive)
 }
 
-func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
+func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Info struct {
@@ -934,7 +936,7 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 			} `json:"info"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: message.updated parse error: %v", err)
 		return
 	}
@@ -1143,7 +1145,7 @@ func (s *Sidecar) handleMessageUpdated(evt sse.Event) {
 	}
 }
 
-func (s *Sidecar) handleMessagePartUpdated(evt sse.Event) {
+func (s *Sidecar) handleMessagePartUpdated(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Part struct {
@@ -1167,7 +1169,7 @@ func (s *Sidecar) handleMessagePartUpdated(evt sse.Event) {
 			} `json:"part"`
 		} `json:"properties"`
 	}
-	if err := json.Unmarshal([]byte(evt.Data), &payload); err != nil {
+	if err := json.Unmarshal(evt.Data, &payload); err != nil {
 		log.Printf("sidecar: message.part.updated parse error: %v", err)
 		return
 	}
@@ -1628,102 +1630,6 @@ func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName
 	}
 
 	return bestSID, nil
-}
-
-// createOpencodeSession creates a new session on the opencode server via
-// POST /session and returns its ID. The directory defaults to /workspace
-// (the container's working directory).
-func (s *Sidecar) createOpencodeSession(opencodeURL string, httpClient *http.Client) (string, error) {
-	body := map[string]string{"directory": "/workspace"}
-	jsonBytes, err := json.Marshal(body)
-	if err != nil {
-		return "", fmt.Errorf("marshal session body: %w", err)
-	}
-
-	req, err := http.NewRequest("POST", opencodeURL+"/session", bytes.NewReader(jsonBytes))
-	if err != nil {
-		return "", fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("http status %d", resp.StatusCode)
-	}
-
-	var result struct {
-		ID string `json:"id"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("decode response: %w", err)
-	}
-	if result.ID == "" {
-		return "", fmt.Errorf("empty session ID in response")
-	}
-	return result.ID, nil
-}
-
-// deliverInitialPrompt sends the initial spawn prompt to an existing opencode
-// session via POST /session/<sid>/prompt_async (#487).
-//
-// The session must already exist (created by createOpencodeSession). The TUI
-// will have received the sid and opened that session via opencode attach -s
-// before this is called, so prompt_async fires into a subscribed session.
-func (s *Sidecar) deliverInitialPrompt(opencodeURL, sid, prompt string, httpClient *http.Client) {
-	agentRole := s.cfg.AgentRole
-	if agentRole == "" {
-		agentRole = "worker"
-	}
-
-	body := map[string]any{
-		"parts": []map[string]string{
-			{"type": "text", "text": prompt},
-		},
-		"agent": agentRole,
-	}
-	if s.cfg.Container != nil && s.cfg.Container.AgentModel != "" {
-		slashIdx := strings.Index(s.cfg.Container.AgentModel, "/")
-		if slashIdx >= 0 {
-			body["model"] = map[string]string{
-				"providerID": s.cfg.Container.AgentModel[:slashIdx],
-				"modelID":    s.cfg.Container.AgentModel[slashIdx+1:],
-			}
-		}
-	}
-
-	jsonBytes, err := json.Marshal(body)
-	if err != nil {
-		log.Printf("sidecar: deliverInitialPrompt: marshal body: %v", err)
-		return
-	}
-
-	url := fmt.Sprintf("%s/session/%s/prompt_async", opencodeURL, sid)
-	log.Printf("sidecar: deliverInitialPrompt: POST %s (agent=%s)", url, agentRole)
-
-	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBytes))
-	if err != nil {
-		log.Printf("sidecar: deliverInitialPrompt: create request: %v", err)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		log.Printf("sidecar: deliverInitialPrompt: http request: %v", err)
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Printf("sidecar: deliverInitialPrompt: http status %d", resp.StatusCode)
-		return
-	}
-	log.Printf("sidecar: deliverInitialPrompt: completed for session %s", sid)
 }
 
 // deliverNotificationViaHTTP sends a notification prompt to the opencode HTTP API.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
-	"github.com/prismatic-koi/prism/internal/sse"
+	"github.com/prismatic-koi/prism/internal/harness"
 )
 
 // ── test clock ──────────────────────────────────────────────────────────────
@@ -121,22 +121,23 @@ func newTestSidecar(t *testing.T) (*Sidecar, *testClock) {
 	return New(cfg), clk
 }
 
-// makeSSE creates an sse.Event using the real wire format that opencode emits.
-// opencode does NOT use the SSE `event:` field — it sends all events as plain
-// `data:` lines. The SSE client therefore sets Type to "message" (the SSE
-// spec default). The real event type and properties are embedded inside the
-// JSON data payload, mirroring what opencode actually sends:
+// makeSSE creates a harness.HarnessEvent using the real wire format that
+// opencode emits. opencode does NOT use the SSE `event:` field — it sends all
+// events as plain `data:` lines. The SSE client therefore sets Type to
+// "message" (the SSE spec default). The real event type and properties are
+// embedded inside the JSON data payload, mirroring what opencode actually
+// sends:
 //
 //	data: {"type":"session.status","properties":{...}}
 //
 // Using this wire format ensures the tests exercise the same code path as
 // production (type extraction from JSON data), not a shortcut that bypasses it.
-func makeSSE(eventType string, properties any) sse.Event {
+func makeSSE(eventType string, properties any) harness.HarnessEvent {
 	data, _ := json.Marshal(map[string]any{
 		"type":       eventType,
 		"properties": properties,
 	})
-	return sse.Event{Type: "message", Data: string(data)}
+	return harness.HarnessEvent{Type: "message", Data: data}
 }
 
 // getState reads the current agent state from the DB.
@@ -1527,9 +1528,9 @@ func TestServerConnected_SilentlyIgnored(t *testing.T) {
 	// server.connected arrives via the real wire format (Type: "message", type
 	// embedded in the JSON data). It should be silently ignored — no state
 	// change, no error, no state_change event written.
-	sc.HandleEvent(sse.Event{
+	sc.HandleEvent(harness.HarnessEvent{
 		Type: "message",
-		Data: `{"type":"server.connected"}`,
+		Data: []byte(`{"type":"server.connected"}`),
 	})
 
 	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
@@ -2134,10 +2135,10 @@ func TestNotifyCoordinator_PortSetButNoSID_TriesAndFails(t *testing.T) {
 
 // makeAssistantMessage creates a message.part.updated + message.updated pair
 // that simulates an assistant message completing, as opencode sends them.
-func makeAssistantMessage(messageID, agentName, text string) []sse.Event {
+func makeAssistantMessage(messageID, agentName, text string) []harness.HarnessEvent {
 	created := 1000.0
 	completed := 2000.0
-	return []sse.Event{
+	return []harness.HarnessEvent{
 		makeSSE("message.part.updated", map[string]any{
 			"part": map[string]any{
 				"type":      "text",
@@ -2163,8 +2164,8 @@ func makeAssistantMessage(messageID, agentName, text string) []sse.Event {
 
 // makeUserMessage creates a message.part.updated + message.updated pair that
 // simulates a user message, as opencode sends them.
-func makeUserMessage(messageID, agentName, text string) []sse.Event {
-	return []sse.Event{
+func makeUserMessage(messageID, agentName, text string) []harness.HarnessEvent {
+	return []harness.HarnessEvent{
 		makeSSE("message.part.updated", map[string]any{
 			"part": map[string]any{
 				"type":      "text",
@@ -2182,7 +2183,7 @@ func makeUserMessage(messageID, agentName, text string) []sse.Event {
 	}
 }
 
-func sendEvents(sc *Sidecar, evts []sse.Event) {
+func sendEvents(sc *Sidecar, evts []harness.HarnessEvent) {
 	for _, e := range evts {
 		sc.HandleEvent(e)
 	}


### PR DESCRIPTION
## Summary

Implements Phase 0a of the multi-harness migration (RFC #691). Moves all
opencode-specific logic out of `internal/sidecar/sidecar.go` into a new
`internal/harness/opencode/` package that implements the `Harness` interface
from #708.

## What moved

| Before (sidecar.go) | After (harness/opencode/adapter.go) |
|---|---|
| `createOpencodeSession()` | `Adapter.CreateSession()` |
| `deliverInitialPrompt()` | `Adapter.DeliverInitialPrompt()` |
| `sse.Client` setup in `Run()` | `Adapter.Subscribe()` |
| JSON envelope event type extraction in `HandleEvent()` | `Adapter.ExtractEventType()` |
| Container command string (literal) | `Adapter.ContainerCommand()` |
| Health check URL (`/global/health`) | `Adapter.HealthCheck()` |
| Config mount path | `Adapter.ConfigMountPath()` |

Also implements `MapEvent()` and `ExtractMessage()` to satisfy the full
`harness.Harness` interface. A compile-time assertion
`var _ harness.Harness = (*Adapter)(nil)` is included.

## What didn't change

- The sidecar still calls the opencode adapter **directly** (not via the interface). Interface injection into the sidecar constructor is a separate issue (#710).
- Zero behaviour change: all existing sidecar tests pass unchanged.
- The sidecar's `HandleEvent` now takes `harness.HarnessEvent` instead of `sse.Event`; the test helper `makeSSE()` is updated accordingly.

## Testing

`go build ./...` and `go test ./...` pass with zero regressions from
`modules/programs/prism/prism/`.

Closes #709