### PR TITLE
prism: add --harness flag to prism spawn (opencode-only, reject unknown)

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -15,6 +15,7 @@ package cmd
 //	--model <name>        model identifier override (overrides profile's primary model)
 //	--variant <name>      model variant override (overrides all agents' variant)
 //	--host-mode           bypass container mode and run opencode directly in the tmux pane
+//	--harness <name>      agent harness to use (default: "opencode"; only "opencode" is supported)
 
 import (
 	"fmt"
@@ -46,6 +47,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	modelFlag, _ := cmd.Flags().GetString("model")
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
+	harnessFlag, _ := cmd.Flags().GetString("harness")
 	promptFlag, err := resolvePrompt(cmd)
 	if err != nil {
 		return err
@@ -61,6 +63,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"model":     modelFlag,
 		"variant":   variantFlag,
 		"host_mode": hostModeFlag,
+		"harness":   harnessFlag,
 	}, &resp); err != nil {
 		return err
 	}
@@ -85,6 +88,7 @@ func init() {
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
 	spawnCmd.Flags().Bool("host-mode", false, "Bypass container mode and run opencode directly in the tmux pane")
+	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use (currently only 'opencode' is supported)")
 	rootCmd.AddCommand(spawnCmd)
 }
 
@@ -101,6 +105,13 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	modelFlag, _ := cmd.Flags().GetString("model")
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
+	harnessFlag, _ := cmd.Flags().GetString("harness")
+
+	// Validate harness BEFORE any session state is created (no worktree, no
+	// tmux session, no DB row). Only "opencode" is supported in this version.
+	if harnessFlag != "opencode" {
+		return fmt.Errorf("unknown harness %q: only 'opencode' is supported in this version of prism", harnessFlag)
+	}
 
 	promptFlag, err := resolvePrompt(cmd)
 	if err != nil {

--- a/modules/programs/prism/prism/cmd/spawn_harness_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_harness_test.go
@@ -1,0 +1,231 @@
+package cmd
+
+// Tests for the --harness flag on prism spawn.
+//
+// Coverage:
+//   - runSpawn rejects unknown harness values before any state is created
+//   - runSpawn accepts "opencode" (explicitly or as default)
+//   - proxySpawn forwards the harness field to the host-API /spawn endpoint
+//   - Container-mode (PRISM_HOST_API set): harness forwarded correctly
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// ── runSpawn harness validation ───────────────────────────────────────────────
+
+// TestRunSpawn_UnknownHarness_ReturnsErrorBeforeStateCreated verifies that
+// an unknown --harness value causes runSpawn to return a non-nil error
+// immediately, before any worktree, tmux session, or DB row is created.
+//
+// Because runSpawn validates harness BEFORE git.CreateWorktree(), the error
+// fires even when no git repo is available — the test does not need a real repo.
+func TestRunSpawn_UnknownHarness_ReturnsErrorBeforeStateCreated(t *testing.T) {
+	// Build a minimal cobra command wired with the same flags as spawnCmd.
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+
+	// Set an unknown harness.
+	_ = cmd.Flags().Set("harness", "pi")
+
+	// runSpawn must return an error. We must ensure PRISM_HOST_API is unset
+	// so the proxy guard is not triggered (which would try to contact a server).
+	t.Setenv("PRISM_HOST_API", "")
+
+	err := runSpawn(cmd, nil)
+	if err == nil {
+		t.Fatal("runSpawn with --harness pi: expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown harness "pi"`) {
+		t.Errorf("error %q does not contain expected text 'unknown harness \"pi\"'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "only 'opencode' is supported") {
+		t.Errorf("error %q does not mention 'only 'opencode' is supported'", err.Error())
+	}
+}
+
+// TestRunSpawn_HarnessOpencode_Explicit_PassesValidation verifies that when
+// --harness opencode is set explicitly, the validation passes (no harness error).
+//
+// We intentionally exercise the validation only — not the full spawn flow —
+// by ensuring PRISM_HOST_API is unset and the command does not have a valid
+// repo context, so runSpawn will fail later with a different error (e.g.
+// "not inside a git repo"). The test just asserts the error is NOT a harness
+// validation error, proving that validation passed.
+func TestRunSpawn_HarnessOpencode_Explicit_PassesValidation(t *testing.T) {
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+
+	_ = cmd.Flags().Set("harness", "opencode")
+
+	t.Setenv("PRISM_HOST_API", "")
+	// Clear PRISM_SPAWN_PATH so tmux is not called.
+	t.Setenv("PRISM_SPAWN_PATH", "")
+	// PRISM_BARE_ROOT points to nowhere — runSpawn will fail, but not on harness.
+	t.Setenv("PRISM_BARE_ROOT", "")
+
+	err := runSpawn(cmd, nil)
+	// We expect a non-nil error (no git repo, no tmux pane), but it must not be
+	// a harness validation error.
+	if err != nil && strings.Contains(err.Error(), "unknown harness") {
+		t.Errorf("runSpawn with --harness opencode returned harness validation error: %v", err)
+	}
+}
+
+// TestRunSpawn_HarnessDefault_PassesValidation verifies that when --harness is
+// omitted (defaults to "opencode"), the validation passes.
+//
+// Same approach as TestRunSpawn_HarnessOpencode_Explicit_PassesValidation: the
+// command will fail after the harness check, but not on the harness itself.
+func TestRunSpawn_HarnessDefault_PassesValidation(t *testing.T) {
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+	// No --harness flag set — stays at default "opencode".
+
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("PRISM_SPAWN_PATH", "")
+	t.Setenv("PRISM_BARE_ROOT", "")
+
+	err := runSpawn(cmd, nil)
+	if err != nil && strings.Contains(err.Error(), "unknown harness") {
+		t.Errorf("runSpawn with default harness returned harness validation error: %v", err)
+	}
+}
+
+// ── proxySpawn harness forwarding (container mode) ───────────────────────────
+
+// TestProxySpawn_HarnessForwarded verifies that proxySpawn includes the harness
+// field in the JSON body sent to the host-API /spawn endpoint.
+func TestProxySpawn_HarnessForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch  string `json:"branch"`
+		Harness string `json:"harness"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spawn" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@test-harness"}`))
+	})
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+
+	_ = cmd.Flags().Set("branch", "test-harness")
+	_ = cmd.Flags().Set("harness", "opencode")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Branch != "test-harness" {
+			t.Errorf("branch = %q, want %q", req.Branch, "test-harness")
+		}
+		if req.Harness != "opencode" {
+			t.Errorf("harness = %q, want %q", req.Harness, "opencode")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// TestProxySpawn_HarnessDefaultForwarded verifies that when --harness is not
+// explicitly set (defaults to "opencode"), the default value is still forwarded
+// to the host-API in the JSON body.
+func TestProxySpawn_HarnessDefaultForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch  string `json:"branch"`
+		Harness string `json:"harness"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@default-harness"}`))
+	})
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+
+	_ = cmd.Flags().Set("branch", "default-harness")
+	// harness stays at default ("opencode")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Harness != "opencode" {
+			t.Errorf("harness = %q, want %q (default)", req.Harness, "opencode")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2479,7 +2479,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	})
 
 	// POST /spawn
-	// Request:  {"branch":"my-feature","prompt":"...","agent":"worker","profile":"gemini-hybrid","host_mode":false}
+	// Request:  {"branch":"my-feature","prompt":"...","agent":"worker","profile":"gemini-hybrid","host_mode":false,"harness":"opencode"}
 	// The "repo" field is accepted but ignored — the sidecar always substitutes
 	// its own repo (derived from its session name) so that a client sending a
 	// mount-path name (e.g. "prism-git") still spawns into the correct repo
@@ -2501,6 +2501,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Model    string `json:"model"`
 			Variant  string `json:"variant"`
 			HostMode bool   `json:"host_mode"`
+			Harness  string `json:"harness"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -2508,6 +2509,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Branch == "" {
 			writeError(w, http.StatusBadRequest, "branch is required")
+			return
+		}
+		// Validate harness before spawning. Default empty string to "opencode"
+		// for backwards compatibility with clients that don't send the field.
+		if req.Harness == "" {
+			req.Harness = "opencode"
+		}
+		if req.Harness != "opencode" {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown harness %q: only 'opencode' is supported in this version of prism", req.Harness))
 			return
 		}
 
@@ -2541,6 +2551,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			args = append(args, "--host-mode")
 		}
+		args = append(args, "--harness", req.Harness)
 		args = append(args, "--repo", ownRepo)
 
 		// Log without the prompt value — it may contain sensitive context.
@@ -2563,6 +2574,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			logArgs = append(logArgs, "--host-mode")
 		}
+		logArgs = append(logArgs, "--harness", req.Harness)
 		logArgs = append(logArgs, "--repo", ownRepo)
 		log.Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
 		cmd := exec.Command(prismBinary(), args...)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5888,3 +5888,153 @@ func TestValidateOrRefreshCoordinatorSID_GetFails(t *testing.T) {
 		t.Error("expected error when GET /session returns 500, got nil")
 	}
 }
+
+// ── /spawn harness validation ─────────────────────────────────────────────────
+
+// TestHostAPI_Spawn_UnknownHarnessReturns400 verifies that an unknown harness
+// value in a /spawn request is rejected with 400 and a clear error message,
+// without attempting to run the prism binary or create any session state.
+func TestHostAPI_Spawn_UnknownHarnessReturns400(t *testing.T) {
+	d := openTestDB(t)
+	// Use a stub that would record a call if invoked — we assert it is NOT called.
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"feature","harness":"pi"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown harness; body = %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], `unknown harness "pi"`) {
+		t.Errorf("error %q should mention 'unknown harness \"pi\"'", errResp["error"])
+	}
+	if !strings.Contains(errResp["error"], "only 'opencode' is supported") {
+		t.Errorf("error %q should mention 'only 'opencode' is supported'", errResp["error"])
+	}
+	// The stub must NOT have been called (no state was created).
+	if _, err := os.Stat(argsFile); err == nil {
+		captured, _ := os.ReadFile(argsFile)
+		t.Errorf("prism binary was invoked with unknown harness — args file exists: %s", string(captured))
+	}
+
+	// Verify no agent_status row was created for the rejected branch.
+	st, dbErr := d.CurrentStatus("nixos-config@feature")
+	if dbErr != nil && !strings.Contains(dbErr.Error(), "not found") {
+		t.Errorf("unexpected DB error: %v", dbErr)
+	}
+	if st != nil {
+		t.Errorf("agent_status row was created for rejected session — state = %q", st.State)
+	}
+}
+
+// TestHostAPI_Spawn_KnownHarnessForwarded verifies that when harness="opencode"
+// is sent, it is passed as --harness opencode to the spawned prism binary.
+func TestHostAPI_Spawn_KnownHarnessForwarded(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@harness-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"harness-branch","harness":"opencode"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "--harness opencode") {
+		t.Errorf("captured args %q do not contain '--harness opencode'", string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Spawn_MissingHarnessDefaultsToOpencode verifies that when the
+// harness field is absent from the request, the server defaults to "opencode"
+// and the spawn proceeds without error.
+func TestHostAPI_Spawn_MissingHarnessDefaultsToOpencode(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@no-harness-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+	}
+	sc := New(cfg)
+
+	// No "harness" field in request body — must default to "opencode".
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"no-harness-branch"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for missing harness (default opencode); body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	// The spawned prism binary must have received --harness opencode.
+	if !strings.Contains(string(capturedArgs), "--harness opencode") {
+		t.Errorf("captured args %q do not contain '--harness opencode' (harness was not defaulted or forwarded)", string(capturedArgs))
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `--harness <name>` flag to `prism spawn` (default: `opencode`). Any value other than `opencode` is rejected with a clear, actionable error message before any session state is created.

## Changes

- **`cmd/spawn.go`**: Register `--harness` flag in `init()` with default `"opencode"`. Validate in `runSpawn()` *before* `git.CreateWorktree()` — an invalid harness never creates a worktree, tmux session, or DB row. Forward flag in `proxySpawn()` to host-API request body.
- **`internal/sidecar/sidecar.go`**: Accept `harness` field in `/spawn` host-API handler. Default empty value to `"opencode"` for backwards compatibility. Reject unknown values with HTTP 400. Forward `--harness <value>` to the spawned `prism` binary.
- **`cmd/spawn_harness_test.go`** (new): Tests for flag validation in `runSpawn` and forwarding in `proxySpawn`.
- **`internal/sidecar/sidecar_test.go`**: Tests for unknown harness rejection, known harness forwarding, and missing harness defaulting in the host-API `/spawn` handler.

## Test coverage

- `TestRunSpawn_UnknownHarness_ReturnsErrorBeforeStateCreated` — unknown value errors before any state
- `TestRunSpawn_HarnessOpencode_Explicit_PassesValidation` — explicit `opencode` passes
- `TestRunSpawn_HarnessDefault_PassesValidation` — omitted flag defaults to `opencode`
- `TestProxySpawn_HarnessForwarded` — harness forwarded in container-mode proxy
- `TestProxySpawn_HarnessDefaultForwarded` — default harness forwarded in container-mode proxy
- `TestHostAPI_Spawn_UnknownHarnessReturns400` — host-API rejects unknown harness, binary not invoked, no DB row
- `TestHostAPI_Spawn_KnownHarnessForwarded` — `--harness opencode` passed to spawned binary
- `TestHostAPI_Spawn_MissingHarnessDefaultsToOpencode` — absent field defaults + forwarded

Closes #717