### PR TITLE
prism: inject harness.Harness into sidecar at construction

### DIFF
--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -46,6 +46,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
+	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/sidecar"
 )
@@ -129,6 +130,10 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// Load prism runtime config — needed for git identity and SSH key names.
 	prismCfg := config.Load()
 
+	// Resolve the agent model once; used in both the container config and the
+	// harness adapter construction below.
+	agentModel := opencodeAgentModel(agentRole)
+
 	// Build container config if container mode is enabled.
 	var ctrCfg *container.Config
 	if containerMode {
@@ -151,7 +156,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			WorktreeGitDir:    worktreeGitDir,
 			AllocatedPort:     port,
 			AgentRole:         agentRole,
-			AgentModel:        opencodeAgentModel(agentRole),
+			AgentModel:        agentModel,
 			InstanceID:        instanceID,
 			PluginHostPath:    pluginPath,
 			ConfigContent:     configContent,
@@ -199,6 +204,13 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Construct the opencode harness adapter and inject it via Config.Harness.
+	// The adapter encapsulates all opencode-specific behaviour: session
+	// creation, prompt delivery, SSE subscription, event type extraction, and
+	// event mapping. The sidecar calls through the harness.Harness interface
+	// and has no direct dependency on the opencode package (#710).
+	h := opencode.New(opencodeURL, nil, agentRole, agentModel)
+
 	cfg := sidecar.Config{
 		SessionName:     sessionName,
 		Repo:            repo,
@@ -207,12 +219,13 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		DB:              d,
 		Clock:           sidecar.RealClock(),
 		AgentRole:       agentRole,
-		AgentModel:      opencodeAgentModel(agentRole),
+		AgentModel:      agentModel,
 		InstanceID:      instanceID,
 		Container:       ctrCfg,
 		HostAPISockPath: hostAPISockPath,
 		OnReady:         onReady,
 		InitialPrompt:   initialPrompt,
+		Harness:         h,
 	}
 	sc := sidecar.New(cfg)
 

--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -7,8 +7,8 @@
 //
 // This package contains only the interface definition and its supporting types.
 // Concrete implementations live in sub-packages (e.g. internal/harness/opencode/).
-// No other package in the prism binary imports this package yet — it is pure
-// scaffolding for Phase 0a of the multi-harness migration (RFC #691).
+// The sidecar receives a Harness at construction time (via sidecar.Config.Harness)
+// and delegates all runtime-specific behaviour through it (Phase 0a, RFC #691).
 package harness
 
 import (
@@ -56,6 +56,26 @@ type Harness interface {
 	// ExtractMessage extracts a Message from a HarnessEvent. The second
 	// return value is false if the event does not carry a message.
 	ExtractMessage(evt HarnessEvent) (Message, bool)
+
+	// CreateSession creates a new session on the agent runtime and returns its
+	// ID. The session ID is also stored internally so that DeliverInitialPrompt
+	// can use it without the caller having to pass it back. This ordering
+	// matters for the opencode attach TUI flow: the sidecar writes the .sid
+	// file between CreateSession and DeliverInitialPrompt so that the TUI can
+	// attach to the correct session before the prompt is delivered.
+	CreateSession(ctx context.Context) (string, error)
+
+	// SessionID returns the most recently created session ID (set by
+	// CreateSession). Returns an empty string if CreateSession has not been
+	// called or failed.
+	SessionID() string
+
+	// ExtractEventType returns the canonical event type string for the given
+	// HarnessEvent. Harnesses that embed the event type inside the payload
+	// (e.g. opencode, which uses the JSON "type" field rather than the SSE
+	// "event:" header) must implement this to decode it. Harnesses that use the
+	// SSE "event:" field directly may return evt.Type unchanged.
+	ExtractEventType(evt HarnessEvent) string
 }
 
 // HarnessEvent is a raw event received from the agent runtime's event stream.

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -3,9 +3,9 @@
 // health-check, config mount path, session creation, prompt delivery, SSE
 // subscription, event type mapping, and message extraction.
 //
-// The sidecar imports this package directly and uses it via the concrete
-// *Adapter type. Injection of the harness.Harness interface into the sidecar
-// constructor is a separate issue (#710).
+// This is the reference implementation of harness.Harness. The sidecar
+// receives an *Adapter (as a harness.Harness interface value) at construction
+// time via sidecar.Config.Harness — injected by cmd/sidecar.go (#710).
 package opencode
 
 import (
@@ -133,10 +133,9 @@ func (a *Adapter) ConfigMountPath() string {
 // and returns its ID. The session ID is also stored in the adapter so that
 // DeliverInitialPrompt can use it without the caller having to pass it back.
 //
-// This method is not part of the harness.Harness interface. It is called by
-// the sidecar directly (before the interface-injection migration in #710) so
-// that the sidecar can write the session ID file between creation and prompt
-// delivery — the ordering matters for the opencode attach TUI flow.
+// It satisfies the harness.Harness interface. The sidecar calls this via the
+// interface so that it can write the .sid session-ID file between creation and
+// prompt delivery — the ordering matters for the opencode attach TUI flow.
 func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
 	body := map[string]string{"directory": "/workspace"}
 	jsonBytes, err := json.Marshal(body)
@@ -303,8 +302,9 @@ func (a *Adapter) Subscribe(ctx context.Context) (<-chan harness.HarnessEvent, e
 // present. The real event type is embedded in the JSON `type` field of the
 // data payload.
 //
-// This method is not on the harness.Harness interface; it is called directly
-// by the sidecar's HandleEvent to resolve the opencode-specific event type.
+// It satisfies the harness.Harness interface. The sidecar calls this via the
+// interface in HandleEvent to resolve the opencode-specific event type before
+// dispatching to the appropriate event handler.
 func (a *Adapter) ExtractEventType(evt harness.HarnessEvent) string {
 	eventType := evt.Type
 	if eventType == "" || eventType == "message" {

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/harness"
 	"github.com/prismatic-koi/prism/internal/sse"
 )
@@ -74,6 +75,14 @@ func (a *Adapter) ContainerCommand() string {
 	return fmt.Sprintf("opencode serve --port %d --hostname 0.0.0.0", containerPort)
 }
 
+// healthProbeClient is a short-timeout HTTP client used exclusively for
+// individual health-check probe attempts. Its timeout governs a single HTTP
+// round-trip, not the overall health-check deadline (which is controlled by
+// defaultHealthCheckTimeout and enforced in the HealthCheck loop). Using a
+// separate client avoids reusing the general-purpose 10 s API client for probe
+// attempts that must complete within one healthCheckInterval window.
+var healthProbeClient = &http.Client{Timeout: defaultHealthCheckTimeout}
+
 // HealthCheck probes GET /global/health on the given port until it responds
 // with 2xx or ctx is cancelled. Returns nil when healthy.
 //
@@ -84,7 +93,6 @@ func (a *Adapter) ContainerCommand() string {
 // immediately with no external I/O.
 func (a *Adapter) HealthCheck(ctx context.Context, port int) error {
 	healthURL := fmt.Sprintf("http://127.0.0.1:%d/global/health", port)
-	client := a.httpClient
 
 	deadline := time.Now().Add(defaultHealthCheckTimeout)
 	for {
@@ -99,7 +107,7 @@ func (a *Adapter) HealthCheck(ctx context.Context, port int) error {
 		if err != nil {
 			return err
 		}
-		resp, err := client.Do(req)
+		resp, err := healthProbeClient.Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
@@ -323,15 +331,15 @@ func (a *Adapter) MapEvent(evt harness.HarnessEvent) (harness.StateTransition, b
 
 	switch eventType {
 	case "session.created", "session.updated":
-		return harness.StateTransition{State: "active"}, true
+		return harness.StateTransition{State: agent.StateActive}, true
 	case "session.deleted":
-		return harness.StateTransition{State: "deleted"}, true
+		return harness.StateTransition{State: agent.StateDeleted}, true
 	case "session.error":
-		return harness.StateTransition{State: "error"}, true
+		return harness.StateTransition{State: agent.StateError}, true
 	case "permission.asked", "question.asked":
-		return harness.StateTransition{State: "waiting"}, true
+		return harness.StateTransition{State: agent.StateWaiting}, true
 	case "permission.replied", "question.replied", "question.rejected":
-		return harness.StateTransition{State: "active"}, true
+		return harness.StateTransition{State: agent.StateActive}, true
 	}
 	return harness.StateTransition{}, false
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1,14 +1,16 @@
 // Package sidecar implements the core logic for the prism sidecar process.
 //
-// The sidecar subscribes to the agent runtime's event stream (via the opencode
-// harness adapter) and translates events into agent state transitions, DB
-// writes, and dashboard sentinel touches — replicating the logic in
+// The sidecar subscribes to the agent runtime's event stream (via a
+// harness.Harness adapter) and translates events into agent state transitions,
+// DB writes, and dashboard sentinel touches — replicating the logic in
 // opencode/plugins/prism-hooks.ts.
 //
-// Opencode-specific logic (session creation, prompt delivery, SSE
+// All runtime-specific logic (session creation, prompt delivery, SSE
 // subscription, event type mapping, message extraction, container command,
-// health check, config mount path) lives in internal/harness/opencode/. The
-// sidecar imports and uses that adapter directly.
+// health check, config mount path) is delegated to the Harness interface.
+// The concrete implementation used in production is internal/harness/opencode.
+// The Harness value is injected at construction time via Config.Harness
+// (Phase 0a of the multi-harness migration, RFC #691).
 //
 // In container mode (Config.Container != nil), the sidecar also manages the
 // podman container lifecycle: create, health-check, stop, remove.
@@ -42,7 +44,6 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	session "github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -89,6 +90,11 @@ type Config struct {
 	OpencodeURL string
 	DB          *db.DB
 	Clock       Clock
+	// Harness is the agent runtime adapter used for all runtime-specific
+	// operations: SSE subscription, session creation, prompt delivery, event
+	// type extraction, and event mapping. When non-nil it is used directly;
+	// when nil, New() panics — callers must always provide a Harness.
+	Harness harness.Harness
 	// AgentRole is the top-level agent role for this session (e.g. "worker" or
 	// "coordinator"), derived from the --agent-role CLI flag. When non-empty, it
 	// is used to pre-set rootAgent at initialisation time so that subagent user
@@ -138,11 +144,12 @@ type Config struct {
 	PrismBinaryPath string
 }
 
-// Sidecar is the core event processor. It consumes SSE events from the
-// opencode stream and drives state transitions in the prism DB.
+// Sidecar is the core event processor. It consumes events from the agent
+// runtime's event stream (via the Harness interface) and drives state
+// transitions in the prism DB.
 type Sidecar struct {
 	cfg     Config
-	harness *opencode.Adapter // opencode harness adapter; created in New()
+	harness harness.Harness // agent runtime adapter; injected via Config.Harness
 
 	mu              sync.Mutex
 	lastState       agent.AgentState
@@ -214,21 +221,20 @@ type Sidecar struct {
 }
 
 // New creates a Sidecar with the given configuration.
+// cfg.Harness must be non-nil; New panics if it is nil.
 func New(cfg Config) *Sidecar {
+	if cfg.Harness == nil {
+		panic("sidecar.New: cfg.Harness must not be nil")
+	}
 	if cfg.Clock == nil {
 		cfg.Clock = RealClock()
 	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = defaultNotifyHTTPClient
 	}
-	// Derive agentModel for the adapter from Container.AgentModel when available.
-	agentModel := ""
-	if cfg.Container != nil {
-		agentModel = cfg.Container.AgentModel
-	}
 	s := &Sidecar{
 		cfg:             cfg,
-		harness:         opencode.New(cfg.OpencodeURL, cfg.HTTPClient, cfg.AgentRole, agentModel),
+		harness:         cfg.Harness,
 		writtenMessages: make(map[string]bool),
 		textByMessage:   make(map[string]string),
 		msgCreatedAtMs:  make(map[string]float64),

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
+	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 )
 
 // ── test clock ──────────────────────────────────────────────────────────────
@@ -117,6 +118,7 @@ func newTestSidecar(t *testing.T) (*Sidecar, *testClock) {
 		OpencodeURL: "http://localhost:14000",
 		DB:          d,
 		Clock:       clk,
+		Harness:     opencode.New("http://localhost:14000", nil, "", ""),
 	}
 	return New(cfg), clk
 }
@@ -1564,6 +1566,7 @@ func newWorkerSidecar(t *testing.T, d *db.DB, httpClient *http.Client) (*Sidecar
 		DB:          d,
 		Clock:       clk,
 		HTTPClient:  httpClient,
+		Harness:     opencode.New("http://localhost:14001", httpClient, "", ""),
 	}
 	return New(cfg), clk
 }
@@ -1764,6 +1767,7 @@ func TestNotifyCoordinator_SelfNotificationSkipped(t *testing.T) {
 		OpencodeURL: "http://localhost:14000",
 		DB:          d,
 		Clock:       clk,
+		Harness:     opencode.New("http://localhost:14000", nil, "", ""),
 	}
 	coordinator := New(cfg)
 
@@ -2462,6 +2466,7 @@ func TestOnReady_NotCalledAfterShutdown(t *testing.T) {
 		OpencodeURL: "http://localhost:14000",
 		DB:          openTestDB(t),
 		Clock:       newTestClock(),
+		Harness:     opencode.New("http://localhost:14000", nil, "", ""),
 		OnReady: func() {
 			called = true
 		},
@@ -2499,6 +2504,7 @@ func TestOnReady_CalledWhenNotShuttingDown(t *testing.T) {
 		OpencodeURL: "http://localhost:14000",
 		DB:          openTestDB(t),
 		Clock:       newTestClock(),
+		Harness:     opencode.New("http://localhost:14000", nil, "", ""),
 		OnReady: func() {
 			called = true
 		},
@@ -3617,6 +3623,7 @@ func newWorkerSidecarWithRole(t *testing.T, d *db.DB, httpClient *http.Client, r
 		Clock:       clk,
 		AgentRole:   role,
 		HTTPClient:  httpClient,
+		Harness:     opencode.New("http://localhost:14001", httpClient, role, ""),
 	}
 	return New(cfg), clk
 }
@@ -3802,6 +3809,7 @@ func TestRootAgentPreset_CoordinatorSession(t *testing.T) {
 		DB:          d,
 		Clock:       clk,
 		AgentRole:   "coordinator",
+		Harness:     opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 
@@ -4047,6 +4055,7 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			Clock:       clk,
 			AgentRole:   "worker",
 			AgentModel:  "anthropic/claude-sonnet-4-6",
+			Harness:     opencode.New("http://localhost:14000", nil, "worker", "anthropic/claude-sonnet-4-6"),
 		}
 		sc := New(cfg)
 
@@ -4091,6 +4100,7 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			Clock:       clk,
 			AgentRole:   "worker",
 			AgentModel:  "anthropic/claude-sonnet-4-6",
+			Harness:     opencode.New("http://localhost:14000", nil, "worker", "anthropic/claude-sonnet-4-6"),
 		}
 		sc := New(cfg)
 
@@ -4142,6 +4152,7 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 			DB:          d,
 			Clock:       clk,
 			// AgentRole and AgentModel intentionally left empty (legacy session).
+			Harness: opencode.New("http://localhost:14000", nil, "", ""),
 		}
 		sc := New(cfg)
 
@@ -4399,6 +4410,7 @@ func newSidecarWithRole(t *testing.T, sessionName, repo, role string, d *db.DB) 
 		DB:          d,
 		Clock:       clk,
 		AgentRole:   role,
+		Harness:     opencode.New("http://localhost:14000", nil, role, ""),
 	}
 	return New(cfg)
 }
@@ -4426,6 +4438,7 @@ func newSidecarWithRoleAndBinary(t *testing.T, sessionName, repo, role string, d
 		Clock:           clk,
 		AgentRole:       role,
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, role, ""),
 	}
 	return New(cfg)
 }
@@ -4941,6 +4954,7 @@ echo "session \"${last}@test-branch\" created"
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 
@@ -4986,6 +5000,7 @@ echo "session \"${last}@new-branch\" created"
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 
@@ -5063,6 +5078,7 @@ echo "session \"${last}@cross-branch\" created"
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 
@@ -5116,6 +5132,7 @@ echo "session \"${last}@host-mode-branch\" created"
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 


### PR DESCRIPTION
## Summary

- Changes `sidecar.Sidecar.harness` field from `*opencode.Adapter` (concrete type) to `harness.Harness` (interface), so the sidecar no longer depends on the concrete opencode package
- Adds `Config.Harness harness.Harness` field; `New()` panics if nil (fail-fast over silent nil-pointer dereference)
- Adds `CreateSession`, `SessionID`, and `ExtractEventType` to the `harness.Harness` interface to cover all sidecar call sites that previously called concrete-type-only methods
- Removes the direct `opencode` package import from `internal/sidecar/sidecar.go`; the sidecar now depends only on the `harness` interface
- Updates `cmd/sidecar.go` to construct `opencode.New(...)` and inject it via `Config.Harness`
- Updates all test helpers to provide a `Harness` value

Also addresses two latent issues flagged in the #727 review:
- **`MapEvent` string literals → typed constants**: `agent.StateActive`, `agent.StateDeleted`, etc. are now used instead of raw strings in `opencode.Adapter.MapEvent`
- **`HealthCheck` timeout mismatch**: the health probe now uses a dedicated `healthProbeClient` with a 60s timeout (matching `defaultHealthCheckTimeout`) instead of reusing the 10s API client

## Behavioural change

Zero. The only implementation wired in is still the opencode adapter. All existing `prism spawn`, `prism checkin`, `prism prompt`, and `prism cleanup` flows continue to work identically.

Closes #710