### PR TITLE
fix(prism): provide Harness in sidecar test Config literals from #728

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5934,6 +5934,7 @@ exit 0
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 
@@ -5992,6 +5993,7 @@ echo "session \"${last}@harness-branch\" created"
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 
@@ -6037,6 +6039,7 @@ echo "session \"${last}@no-harness-branch\" created"
 		Clock:           clk,
 		AgentRole:       "coordinator",
 		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
 	}
 	sc := New(cfg)
 


### PR DESCRIPTION
## Summary

Three tests added by #728 constructed `sidecar.Config{}` literals without a `Harness` field — because when #728 was written, the field didn't exist yet. #730 subsequently made `Harness harness.Harness` a required field with a nil-guard panic in `sidecar.New()`, but it landed before re-checking whether #728's new tests needed the same update.

This is a merge-order conflict: #728 merged first, #730 merged second, and the three tests in #728 were left without the `Harness` field that #730 required.

## Fix

Added `Harness: opencode.New("http://localhost:14000", nil, "coordinator", "")` to the `Config{}` literals in the three affected tests:

- `TestHostAPI_Spawn_UnknownHarnessReturns400`
- `TestHostAPI_Spawn_KnownHarnessForwarded`
- `TestHostAPI_Spawn_MissingHarnessDefaultsToOpencode`

This matches exactly the pattern used in the 16 other test `Config{}` literals that #730 updated.

## Verification

`go build ./...` and `go test ./...` both pass cleanly.

Related: #728, #730