### PR TITLE
prism: migrate opencode container to podman-attach TUI model

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -101,20 +101,21 @@ func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 }
 
 // TestBuildOpencodeCmd_ContainerMode verifies that container mode produces the
-// correct "opencode attach http://localhost:<port>" command (AC-17, AC-22).
+// correct "podman attach <container-name>" command (RFC #691, Phase 1a / Issue #715).
 func TestBuildOpencodeCmd_ContainerMode(t *testing.T) {
 	cases := []struct {
 		opts session.Opts
 		want string
 	}{
-		// Container mode with allocated port — should use opencode attach.
-		{session.Opts{ContainerMode: true, Port: 14000}, "opencode attach http://localhost:14000"},
-		// Different port (AC-22: port in URL is the allocated port, not 4096).
-		{session.Opts{ContainerMode: true, Port: 14042}, "opencode attach http://localhost:14042"},
-		// Agent role is irrelevant in container mode (attach doesn't take --agent).
-		{session.Opts{ContainerMode: true, Port: 14001, Agent: "coordinator"}, "opencode attach http://localhost:14001"},
-		// Container mode with no port falls back to direct launch.
-		{session.Opts{ContainerMode: true, Port: 0, Agent: "worker"}, "opencode --agent worker"},
+		// Container mode with SessionName — should use podman attach with the
+		// stable container name derived from the session name.
+		{session.Opts{ContainerMode: true, SessionName: "repo@main", Port: 14000}, "podman attach prism-repo-main"},
+		// Different session name — container name is derived correctly.
+		{session.Opts{ContainerMode: true, SessionName: "nixos-config@feature", Port: 14042}, "podman attach prism-nixos-config-feature"},
+		// Agent role is irrelevant in container mode (podman attach is role-agnostic).
+		{session.Opts{ContainerMode: true, SessionName: "repo@branch", Port: 14001, Agent: "coordinator"}, "podman attach prism-repo-branch"},
+		// Container mode with no SessionName falls back to direct launch (safety net).
+		{session.Opts{ContainerMode: true, SessionName: "", Port: 0, Agent: "worker"}, "opencode --agent worker"},
 		// Non-container mode is unaffected.
 		{session.Opts{ContainerMode: false, Port: 14000, Agent: "worker"}, "opencode --agent worker --port 14000 --hostname 127.0.0.1"},
 	}

--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -108,12 +108,13 @@ func TestBuildOpencodeCmd_ContainerMode(t *testing.T) {
 		want string
 	}{
 		// Container mode with SessionName — should use podman attach with the
-		// stable container name derived from the session name.
-		{session.Opts{ContainerMode: true, SessionName: "repo@main", Port: 14000}, "podman attach prism-repo-main"},
+		// stable container name derived from the session name (single-quoted for
+		// shell safety when embedded in the readiness wait script).
+		{session.Opts{ContainerMode: true, SessionName: "repo@main", Port: 14000}, "podman attach 'prism-repo-main'"},
 		// Different session name — container name is derived correctly.
-		{session.Opts{ContainerMode: true, SessionName: "nixos-config@feature", Port: 14042}, "podman attach prism-nixos-config-feature"},
+		{session.Opts{ContainerMode: true, SessionName: "nixos-config@feature", Port: 14042}, "podman attach 'prism-nixos-config-feature'"},
 		// Agent role is irrelevant in container mode (podman attach is role-agnostic).
-		{session.Opts{ContainerMode: true, SessionName: "repo@branch", Port: 14001, Agent: "coordinator"}, "podman attach prism-repo-branch"},
+		{session.Opts{ContainerMode: true, SessionName: "repo@branch", Port: 14001, Agent: "coordinator"}, "podman attach 'prism-repo-branch'"},
 		// Container mode with no SessionName falls back to direct launch (safety net).
 		{session.Opts{ContainerMode: true, SessionName: "", Port: 0, Agent: "worker"}, "opencode --agent worker"},
 		// Non-container mode is unaffected.

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -502,13 +502,13 @@ func TestRestoreSession_AllThreeWindows(t *testing.T) {
 
 // TestRestoreSession_ContainerMode verifies that when cfg.ContainerMode is
 // enabled and the persisted session is not marked host_mode, restore uses
-// the container-mode agent command ("opencode attach http://localhost:<port>")
+// the container-mode agent command ("podman attach <container-name>")
 // rather than launching opencode directly. It also asserts that the
 // PluginHostPath is propagated from cfg into opts so the sidecar bind-mounts
 // the plugin file.
 //
 // This is the core AC-1 regression guard: restoring a container-mode session
-// must go through the same attach path as spawn.
+// must go through the same podman-attach path as spawn (RFC #691, Phase 1a).
 func TestRestoreSession_ContainerMode(t *testing.T) {
 	// Uses withCmdServer — must not run in parallel.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -537,22 +537,25 @@ func TestRestoreSession_ContainerMode(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// The agent pane start command must contain "opencode attach http://localhost:",
-	// not "opencode --agent". Port is assigned by AllocatePort so we match the
-	// attach URL prefix rather than a specific port number.
+	// The agent pane start command must contain "podman attach prism-myrepo-container-restore",
+	// not "opencode --agent". The container name is derived from the session name via
+	// container.NameForSession("myrepo@container-restore") = "prism-myrepo-container-restore".
 	pane := agentPaneStartCmd(t, s, sessionName)
-	if !strings.Contains(pane, "opencode attach http://localhost:") {
-		t.Errorf("agent pane missing 'opencode attach http://localhost:' — captured:\n%s", pane)
+	if !strings.Contains(pane, "podman attach prism-myrepo-container-restore") {
+		t.Errorf("agent pane missing 'podman attach prism-myrepo-container-restore' — captured:\n%s", pane)
 	}
 	if strings.Contains(pane, "opencode --agent") {
 		t.Errorf("agent pane contains 'opencode --agent' but should be in container mode — captured:\n%s", pane)
+	}
+	if strings.Contains(pane, "opencode attach") {
+		t.Errorf("agent pane contains old 'opencode attach' command — should now use 'podman attach' (RFC #691)")
 	}
 }
 
 // TestRestoreSession_HostModeOverride verifies that when a session was
 // explicitly spawned in host mode (host_mode=1 in agent_status), restore
 // preserves that mode even when cfg.ContainerMode is enabled. The agent
-// pane must run "opencode --agent ..." rather than "opencode attach".
+// pane must run "opencode --agent ..." rather than "podman attach".
 func TestRestoreSession_HostModeOverride(t *testing.T) {
 	// Uses withCmdServer — must not run in parallel.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -597,13 +600,13 @@ func TestRestoreSession_HostModeOverride(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// Agent pane start command must contain "opencode --agent ...", not "opencode attach".
+	// Agent pane start command must contain "opencode --agent ...", not "podman attach".
 	pane := agentPaneStartCmd(t, s, sessionName)
 	if !strings.Contains(pane, "opencode --agent") {
 		t.Errorf("agent pane missing 'opencode --agent' — captured:\n%s", pane)
 	}
-	if strings.Contains(pane, "opencode attach") {
-		t.Errorf("agent pane contains 'opencode attach' but should be in host mode — captured:\n%s", pane)
+	if strings.Contains(pane, "podman attach") {
+		t.Errorf("agent pane contains 'podman attach' but should be in host mode — captured:\n%s", pane)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -537,12 +537,13 @@ func TestRestoreSession_ContainerMode(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// The agent pane start command must contain "podman attach prism-myrepo-container-restore",
+	// The agent pane start command must contain "podman attach 'prism-myrepo-container-restore'",
 	// not "opencode --agent". The container name is derived from the session name via
 	// container.NameForSession("myrepo@container-restore") = "prism-myrepo-container-restore".
+	// The name is single-quoted for shell safety in the readiness wait script.
 	pane := agentPaneStartCmd(t, s, sessionName)
-	if !strings.Contains(pane, "podman attach prism-myrepo-container-restore") {
-		t.Errorf("agent pane missing 'podman attach prism-myrepo-container-restore' — captured:\n%s", pane)
+	if !strings.Contains(pane, "podman attach 'prism-myrepo-container-restore'") {
+		t.Errorf("agent pane missing 'podman attach 'prism-myrepo-container-restore'' — captured:\n%s", pane)
 	}
 	if strings.Contains(pane, "opencode --agent") {
 		t.Errorf("agent pane contains 'opencode --agent' but should be in container mode — captured:\n%s", pane)

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -25,8 +25,9 @@ package cmd
 // logic in opencode/plugins/prism-hooks.ts.
 //
 // In container mode, the sidecar creates a podman container running
-// "opencode serve --port 4096", waits until the HTTP endpoint is healthy, then
-// writes a ready signal so that the tmux pane can run "opencode attach".
+// "opencode --port 4096 --hostname 0.0.0.0" (combined TUI + HTTP mode), waits
+// until the HTTP endpoint is healthy, then writes a ready signal so that the
+// tmux pane can run "podman attach" to bridge the PTY (RFC #691, Phase 1a).
 //
 // Clean shutdown: SIGINT and SIGTERM write "interrupted" state and (in container
 // mode) stop/remove the container before exiting.
@@ -62,8 +63,9 @@ The sidecar handles: state machine transitions, idle debounce (2s),
 permission tracking, event logging, and dashboard sentinel updates.
 
 In container mode (--container), the sidecar also creates and manages the
-podman container running opencode serve, health-checks it until ready, then
-writes a readiness signal so the tmux pane can run opencode attach.`,
+podman container running opencode in combined TUI + HTTP mode, health-checks
+it until ready, then writes a readiness signal so the tmux pane can run
+podman attach to bridge the container PTY (RFC #691, Phase 1a).`,
 	RunE: runSidecar,
 }
 

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -160,6 +160,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			InstanceID:        instanceID,
 			PluginHostPath:    pluginPath,
 			ConfigContent:     configContent,
+			InitialPrompt:     initialPrompt,
 			GitUserName:       prismCfg.GitUserName,
 			GitUserEmail:      prismCfg.GitUserEmail,
 			SshAccessKeyName:  prismCfg.SshAccessKeyName,
@@ -209,7 +210,17 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// creation, prompt delivery, SSE subscription, event type extraction, and
 	// event mapping. The sidecar calls through the harness.Harness interface
 	// and has no direct dependency on the opencode package (#710).
-	h := opencode.New(opencodeURL, nil, agentRole, agentModel)
+	//
+	// In container mode, use NewContainerMode so that:
+	//   - CreateSession uses GET /session to retrieve the existing session ID
+	//     (opencode already created a session when the TUI started)
+	//   - DeliverInitialPrompt is a no-op (prompt was sent via --prompt CLI flag)
+	var h *opencode.Adapter
+	if containerMode {
+		h = opencode.NewContainerMode(opencodeURL, nil, agentRole, agentModel)
+	} else {
+		h = opencode.New(opencodeURL, nil, agentRole, agentModel)
+	}
 
 	cfg := sidecar.Config{
 		SessionName:     sessionName,

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -162,12 +162,17 @@ type Config struct {
 }
 
 // NameForSession returns the stable podman container name for a session.
-// The name is derived from the session name with "@", "/", and "." replaced
-// by "-" and a "prism-" prefix, e.g. "prism-nixos-config-feature".
+// The name is derived from the session name with "@", "/", ".", and "~"
+// replaced by "-" and a "prism-" prefix, e.g. "prism-nixos-config-feature".
+//
+// The "~" replacement is needed for review agent session names which are
+// structured as "<parent>~review-<N>~<agentName>" — without it, podman would
+// reject the container name (allowed charset: [a-zA-Z0-9][a-zA-Z0-9_.-]*).
 func NameForSession(sessionName string) string {
 	safe := strings.ReplaceAll(sessionName, "@", "-")
 	safe = strings.ReplaceAll(safe, "/", "-")
 	safe = strings.ReplaceAll(safe, ".", "-")
+	safe = strings.ReplaceAll(safe, "~", "-")
 	return "prism-" + safe
 }
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -159,6 +159,14 @@ type Config struct {
 	// key in ~/.ssh/. The public key is derived by appending ".pub". When empty,
 	// defaults to "prismatic-koi-ed25519-signingkey".
 	SshSigningKeyName string
+
+	// InitialPrompt is the initial prompt to deliver to the agent at startup.
+	// When non-empty, it is appended to the opencode command as
+	// --agent <AgentRole> --prompt <text> so that opencode starts the session
+	// with the prompt already in flight, visible in the TUI from the start.
+	// This replaces the previous POST /session + prompt_async HTTP delivery
+	// which created a second session invisible to the TUI (RFC #691 Phase 1a).
+	InitialPrompt string
 }
 
 // NameForSession returns the stable podman container name for a session.
@@ -1096,6 +1104,20 @@ func (m *Manager) buildRunArgs() []string {
 		"--port", fmt.Sprintf("%d", ContainerPort),
 		"--hostname", "0.0.0.0",
 	)
+
+	// When an initial prompt is provided, pass it (and the agent role) directly
+	// on the opencode command line. This ensures opencode creates its session
+	// with the prompt in flight and the conversation is visible in the TUI from
+	// the start — the sidecar's POST /session + prompt_async path would create
+	// a second session invisible to the TUI (RFC #691 Phase 1a).
+	// These are passed as separate args (no shell involved) so no quoting needed.
+	if cfg.InitialPrompt != "" {
+		agentRole := cfg.AgentRole
+		if agentRole == "" {
+			agentRole = "worker"
+		}
+		args = append(args, "--agent", agentRole, "--prompt", cfg.InitialPrompt)
+	}
 
 	return args
 }

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -1105,18 +1105,17 @@ func (m *Manager) buildRunArgs() []string {
 		"--hostname", "0.0.0.0",
 	)
 
-	// When an initial prompt is provided, pass it (and the agent role) directly
-	// on the opencode command line. This ensures opencode creates its session
-	// with the prompt in flight and the conversation is visible in the TUI from
-	// the start — the sidecar's POST /session + prompt_async path would create
-	// a second session invisible to the TUI (RFC #691 Phase 1a).
-	// These are passed as separate args (no shell involved) so no quoting needed.
+	// Pass --agent and --prompt as separate opencode flags when set.
+	// These are always separate: --agent controls the system-prompt/role even
+	// when there is no initial prompt (e.g. review agents need their role set
+	// so opencode does not default to the "build" agent).
+	// These are passed as individual args slice elements (no shell involved)
+	// so no quoting is needed.
+	if cfg.AgentRole != "" {
+		args = append(args, "--agent", cfg.AgentRole)
+	}
 	if cfg.InitialPrompt != "" {
-		agentRole := cfg.AgentRole
-		if agentRole == "" {
-			agentRole = "worker"
-		}
-		args = append(args, "--agent", agentRole, "--prompt", cfg.InitialPrompt)
+		args = append(args, "--prompt", cfg.InitialPrompt)
 	}
 
 	return args

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -1,8 +1,10 @@
 // Package container manages the podman container lifecycle for prism sidecar.
 //
 // The sidecar (running on the host) creates a podman container running
-// "opencode serve --port 4096", health-checks it until the HTTP endpoint
-// responds, and stops/removes the container on shutdown.
+// "opencode --port 4096 --hostname 0.0.0.0" (combined TUI + HTTP mode),
+// health-checks it until the HTTP endpoint responds, and stops/removes the
+// container on shutdown. The tmux agent window attaches to the container's
+// PTY via "podman attach" so the opencode TUI is visible to the user.
 //
 // Health check: we probe GET /global/health (not GET /) because the root URL
 // falls through to opencode's UIRoutes catch-all, which proxies to
@@ -769,11 +771,9 @@ func (m *Manager) buildRunArgs() []string {
 	args := []string{
 		"run",
 		"--detach",
-		// --tty allocates a PTY on the container. The container currently runs
-		// "opencode serve" which does not use the PTY, but RFC #691 migrates to
-		// "opencode" (monolithic TUI mode) where podman attach bridges the PTY to
-		// the tmux pane. The flag must be set before that migration lands (see
-		// RFC #691, Phase 1a / Issue G).
+		// --tty allocates a PTY on the container. The container runs "opencode"
+		// in combined TUI + HTTP mode; the tmux agent window uses "podman attach"
+		// to bridge this PTY to the user's pane (RFC #691, Phase 1a / Issue #715).
 		"--tty",
 		"--name", m.name,
 	}
@@ -1079,9 +1079,15 @@ func (m *Manager) buildRunArgs() []string {
 		args = append(args, "--volume", m.opencodeConfigFilePath()+":/root/.config/opencode/opencode.json:ro")
 	}
 
-	// Image and command: opencode serve on the container port.
+	// Image and command: opencode in combined TUI + HTTP mode.
+	// "opencode --port N --hostname 0.0.0.0" launches the monolithic TUI on
+	// the container's PTY (allocated via --tty) while simultaneously serving
+	// the HTTP/SSE API on ContainerPort for the sidecar. The sidecar still
+	// connects to the SSE endpoint on the mapped host port exactly as before.
+	// The tmux agent window uses "podman attach" to bridge the PTY (RFC #691,
+	// Phase 1a / Issue #715).
 	args = append(args, Image,
-		"opencode", "serve",
+		"opencode",
 		"--port", fmt.Sprintf("%d", ContainerPort),
 		"--hostname", "0.0.0.0",
 	)

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -248,22 +248,26 @@ func TestBuildRunArgs_WorkdirIsWorkspace(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_OpencodeServeCommand(t *testing.T) {
+func TestBuildRunArgs_OpencodeCommand(t *testing.T) {
 	m := New(Config{SessionName: "repo@main", AllocatedPort: 14000})
 	args := m.buildRunArgs()
 
 	// The last elements should be:
-	// <image> opencode serve --port 4096 --hostname 0.0.0.0
-	// That is 7 elements from the end.
+	// <image> opencode --port 4096 --hostname 0.0.0.0
+	// That is 6 elements from the end (no "serve" subcommand any more).
 	n := len(args)
-	if n < 7 {
+	if n < 6 {
 		t.Fatalf("too few args (%d): %v", n, args)
 	}
-	if args[n-7] != Image {
-		t.Errorf("expected image %q at args[n-7], got %q (all args: %v)", Image, args[n-7], args)
+	if args[n-6] != Image {
+		t.Errorf("expected image %q at args[n-6], got %q (all args: %v)", Image, args[n-6], args)
 	}
-	if args[n-6] != "opencode" || args[n-5] != "serve" {
-		t.Errorf("expected 'opencode serve', got %q %q", args[n-6], args[n-5])
+	if args[n-5] != "opencode" {
+		t.Errorf("expected 'opencode', got %q", args[n-5])
+	}
+	// Verify there is no "serve" subcommand — opencode runs in combined TUI + HTTP mode.
+	if args[n-5] == "opencode" && len(args) > n-4 && args[n-4] == "serve" {
+		t.Errorf("unexpected 'serve' subcommand: opencode should run in combined TUI + HTTP mode (RFC #691)")
 	}
 	if args[n-4] != "--port" || args[n-3] != "4096" {
 		t.Errorf("expected '--port 4096', got %q %q", args[n-4], args[n-3])

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -74,12 +74,23 @@ func TestNameForSession_ReplacesDot(t *testing.T) {
 	}
 }
 
+func TestNameForSession_ReplacesTilde(t *testing.T) {
+	// Review agent session names contain "~" (e.g. "nixos-config@feature~review-1~review-code").
+	// Podman rejects "~" in container names (allowed: [a-zA-Z0-9][a-zA-Z0-9_.-]*).
+	name := NameForSession("nixos-config@feature~review-1~review-code")
+	want := "prism-nixos-config-feature-review-1-review-code"
+	if name != want {
+		t.Errorf("NameForSession(%q) = %q, want %q", "nixos-config@feature~review-1~review-code", name, want)
+	}
+}
+
 func TestNameForSession_MatchesContainerName(t *testing.T) {
 	sessions := []string{
 		"nixos-config@main",
 		"repo@feat/sub",
 		"repo.git@main",
 		"a@b/c.d",
+		"nixos-config@feature~review-1~review-code",
 	}
 	for _, s := range sessions {
 		exported := NameForSession(s)

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -288,6 +288,66 @@ func TestBuildRunArgs_OpencodeCommand(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgs_InitialPromptAppended(t *testing.T) {
+	// When InitialPrompt is set, --agent and --prompt should appear at the end
+	// of the args after the image and base opencode flags.
+	m := New(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14000,
+		AgentRole:     "worker",
+		InitialPrompt: "fix the login bug",
+	})
+	args := m.buildRunArgs()
+
+	n := len(args)
+	// Last four args should be: --agent worker --prompt "fix the login bug"
+	if n < 4 {
+		t.Fatalf("too few args: %v", args)
+	}
+	if args[n-4] != "--agent" || args[n-3] != "worker" {
+		t.Errorf("expected '--agent worker', got %q %q", args[n-4], args[n-3])
+	}
+	if args[n-2] != "--prompt" || args[n-1] != "fix the login bug" {
+		t.Errorf("expected '--prompt fix the login bug', got %q %q", args[n-2], args[n-1])
+	}
+}
+
+func TestBuildRunArgs_NoInitialPromptNoExtraArgs(t *testing.T) {
+	// When InitialPrompt is empty, no --agent or --prompt args should be appended.
+	m := New(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14000,
+		AgentRole:     "worker",
+		InitialPrompt: "",
+	})
+	args := m.buildRunArgs()
+
+	for _, arg := range args {
+		if arg == "--prompt" {
+			t.Errorf("unexpected --prompt in args when InitialPrompt is empty: %v", args)
+		}
+	}
+}
+
+func TestBuildRunArgs_InitialPromptDefaultsAgentToWorker(t *testing.T) {
+	// When AgentRole is empty but InitialPrompt is set, --agent should default to "worker".
+	m := New(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14000,
+		AgentRole:     "",
+		InitialPrompt: "do the thing",
+	})
+	args := m.buildRunArgs()
+
+	n := len(args)
+	if n < 4 {
+		t.Fatalf("too few args: %v", args)
+	}
+	if args[n-4] != "--agent" || args[n-3] != "worker" {
+		t.Errorf("expected '--agent worker' default, got %q %q", args[n-4], args[n-3])
+	}
+}
+
 func TestBuildRunArgs_ContainerNameSet(t *testing.T) {
 	m := New(Config{SessionName: "my-repo@feat", AllocatedPort: 14000})
 	args := m.buildRunArgs()

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -288,9 +288,9 @@ func TestBuildRunArgs_OpencodeCommand(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_InitialPromptAppended(t *testing.T) {
-	// When InitialPrompt is set, --agent and --prompt should appear at the end
-	// of the args after the image and base opencode flags.
+func TestBuildRunArgs_AgentRoleAndPromptAppended(t *testing.T) {
+	// When both AgentRole and InitialPrompt are set, --agent and --prompt
+	// should both appear at the end of the args.
 	m := New(Config{
 		SessionName:   "repo@main",
 		AllocatedPort: 14000,
@@ -312,16 +312,28 @@ func TestBuildRunArgs_InitialPromptAppended(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_NoInitialPromptNoExtraArgs(t *testing.T) {
-	// When InitialPrompt is empty, no --agent or --prompt args should be appended.
+func TestBuildRunArgs_AgentRoleWithoutPrompt(t *testing.T) {
+	// When AgentRole is set but InitialPrompt is empty, --agent should still
+	// be appended so opencode does not default to the wrong agent type.
+	// This is the review-agent case: role is set (e.g. "review-code") but
+	// there is no prompt at container launch time.
 	m := New(Config{
 		SessionName:   "repo@main",
 		AllocatedPort: 14000,
-		AgentRole:     "worker",
+		AgentRole:     "review-code",
 		InitialPrompt: "",
 	})
 	args := m.buildRunArgs()
 
+	n := len(args)
+	// Last two args should be: --agent review-code
+	if n < 2 {
+		t.Fatalf("too few args: %v", args)
+	}
+	if args[n-2] != "--agent" || args[n-1] != "review-code" {
+		t.Errorf("expected '--agent review-code', got %q %q", args[n-2], args[n-1])
+	}
+	// --prompt must NOT be present.
 	for _, arg := range args {
 		if arg == "--prompt" {
 			t.Errorf("unexpected --prompt in args when InitialPrompt is empty: %v", args)
@@ -329,8 +341,29 @@ func TestBuildRunArgs_NoInitialPromptNoExtraArgs(t *testing.T) {
 	}
 }
 
-func TestBuildRunArgs_InitialPromptDefaultsAgentToWorker(t *testing.T) {
-	// When AgentRole is empty but InitialPrompt is set, --agent should default to "worker".
+func TestBuildRunArgs_NoAgentRoleNoPromptNoExtraArgs(t *testing.T) {
+	// When neither AgentRole nor InitialPrompt are set, no extra args.
+	m := New(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14000,
+		AgentRole:     "",
+		InitialPrompt: "",
+	})
+	args := m.buildRunArgs()
+
+	for _, arg := range args {
+		if arg == "--agent" {
+			t.Errorf("unexpected --agent in args when AgentRole is empty: %v", args)
+		}
+		if arg == "--prompt" {
+			t.Errorf("unexpected --prompt in args when InitialPrompt is empty: %v", args)
+		}
+	}
+}
+
+func TestBuildRunArgs_PromptWithoutAgentRole(t *testing.T) {
+	// When InitialPrompt is set but AgentRole is empty, --prompt is appended
+	// without --agent (opencode will use its own default agent).
 	m := New(Config{
 		SessionName:   "repo@main",
 		AllocatedPort: 14000,
@@ -340,11 +373,17 @@ func TestBuildRunArgs_InitialPromptDefaultsAgentToWorker(t *testing.T) {
 	args := m.buildRunArgs()
 
 	n := len(args)
-	if n < 4 {
+	if n < 2 {
 		t.Fatalf("too few args: %v", args)
 	}
-	if args[n-4] != "--agent" || args[n-3] != "worker" {
-		t.Errorf("expected '--agent worker' default, got %q %q", args[n-4], args[n-3])
+	if args[n-2] != "--prompt" || args[n-1] != "do the thing" {
+		t.Errorf("expected '--prompt do the thing', got %q %q", args[n-2], args[n-1])
+	}
+	// --agent must NOT be present when AgentRole is empty.
+	for i, arg := range args {
+		if arg == "--agent" {
+			t.Errorf("unexpected --agent at index %d when AgentRole is empty: %v", i, args)
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -57,12 +57,12 @@ type Harness interface {
 	// return value is false if the event does not carry a message.
 	ExtractMessage(evt HarnessEvent) (Message, bool)
 
-	// CreateSession creates a new session on the agent runtime and returns its
-	// ID. The session ID is also stored internally so that DeliverInitialPrompt
-	// can use it without the caller having to pass it back. This ordering
-	// matters for the opencode attach TUI flow: the sidecar writes the .sid
-	// file between CreateSession and DeliverInitialPrompt so that the TUI can
-	// attach to the correct session before the prompt is delivered.
+	// CreateSession retrieves (or creates) a session on the agent runtime and
+	// returns its ID. The session ID is also stored internally so that
+	// DeliverInitialPrompt can use it without the caller having to pass it back.
+	// For the opencode harness in combined TUI + HTTP mode, this retrieves the
+	// existing session opencode auto-created at startup (via GET /session) so
+	// the prompt is delivered to the session already visible in the TUI.
 	CreateSession(ctx context.Context) (string, error)
 
 	// SessionID returns the most recently created session ID (set by

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -70,9 +70,12 @@ func New(opencodeURL string, httpClient *http.Client, agentRole, agentModel stri
 }
 
 // ContainerCommand returns the command string used to launch opencode as the
-// main process inside its container.
+// main process inside its container. "opencode --port N --hostname 0.0.0.0"
+// launches opencode in combined TUI + HTTP mode: the TUI renders on the
+// container's PTY (bridged to the tmux pane via "podman attach") while the
+// HTTP/SSE API is served on containerPort for the sidecar (RFC #691, Phase 1a).
 func (a *Adapter) ContainerCommand() string {
-	return fmt.Sprintf("opencode serve --port %d --hostname 0.0.0.0", containerPort)
+	return fmt.Sprintf("opencode --port %d --hostname 0.0.0.0", containerPort)
 }
 
 // healthProbeClient is a short-timeout HTTP client used exclusively for

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/sse"
 )
 
-// containerPort is the port opencode serve listens on inside the container.
+// containerPort is the port opencode listens on inside the container.
 // Mirrors container.ContainerPort but avoids an import cycle.
 const containerPort = 4096
 

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -45,6 +45,11 @@ type Adapter struct {
 	httpClient  *http.Client
 	agentRole   string
 	agentModel  string
+	// containerMode, when true, causes DeliverInitialPrompt to be a no-op.
+	// In container mode the initial prompt is delivered via --prompt on the
+	// opencode command line (RFC #691 Phase 1a), so HTTP delivery would be
+	// redundant and would target the wrong session.
+	containerMode bool
 
 	mu        sync.Mutex
 	sessionID string // set by CreateSession; used by DeliverInitialPrompt
@@ -69,11 +74,27 @@ func New(opencodeURL string, httpClient *http.Client, agentRole, agentModel stri
 	}
 }
 
-// ContainerCommand returns the command string used to launch opencode as the
-// main process inside its container. "opencode --port N --hostname 0.0.0.0"
+// NewContainerMode creates a new Adapter configured for container mode.
+// In this mode, DeliverInitialPrompt is a no-op because the prompt is
+// delivered via --prompt on the opencode CLI at container startup.
+// CreateSession uses GET /session to retrieve the existing session ID
+// rather than POST /session which would create a second session.
+func NewContainerMode(opencodeURL string, httpClient *http.Client, agentRole, agentModel string) *Adapter {
+	a := New(opencodeURL, httpClient, agentRole, agentModel)
+	a.containerMode = true
+	return a
+}
+
+// ContainerCommand returns the base command string used to launch opencode as
+// the main process inside its container. "opencode --port N --hostname 0.0.0.0"
 // launches opencode in combined TUI + HTTP mode: the TUI renders on the
 // container's PTY (bridged to the tmux pane via "podman attach") while the
 // HTTP/SSE API is served on containerPort for the sidecar (RFC #691, Phase 1a).
+//
+// Note: the actual container launch in buildRunArgs() appends --agent and
+// --prompt directly when InitialPrompt is set — the CLI flag approach ensures
+// the conversation is visible in the TUI from the start (rather than being
+// sent to a second session created by POST /session).
 func (a *Adapter) ContainerCommand() string {
 	return fmt.Sprintf("opencode --port %d --hostname 0.0.0.0", containerPort)
 }
@@ -132,51 +153,94 @@ func (a *Adapter) ConfigMountPath() string {
 	return "/root/.config/opencode"
 }
 
-// CreateSession creates a new session on the opencode server via POST /session
-// and returns its ID. The session ID is also stored in the adapter so that
-// DeliverInitialPrompt can use it without the caller having to pass it back.
+// sessionEntry is a single entry from the opencode GET /session response.
+type sessionEntry struct {
+	ID   string `json:"id"`
+	Time *struct {
+		Updated *float64 `json:"updated"`
+	} `json:"time"`
+}
+
+// CreateSession retrieves the existing opencode session via GET /session and
+// returns its ID. The session ID is also stored in the adapter so that
+// subsequent prism prompt delivery (via DeliverPrompt / the host-API relay)
+// can target the correct session.
 //
-// It satisfies the harness.Harness interface. The sidecar calls this via the
-// interface so that it can write the .sid session-ID file between creation and
-// prompt delivery — the ordering matters for the opencode attach TUI flow.
+// In combined TUI + HTTP mode with --prompt, opencode creates a session and
+// starts processing the prompt immediately. The sidecar calls CreateSession
+// after the health check to discover that session ID — the ID is needed for
+// subsequent prism prompt follow-up delivery even though the initial prompt
+// was already sent via CLI. We use GET /session rather than POST /session
+// because POST would create a redundant second session.
+//
+// If GET /session returns an empty list (opencode hasn't finished initialising
+// yet at the health-check boundary), this method retries for up to 5s.
+//
+// It satisfies the harness.Harness interface.
 func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
-	body := map[string]string{"directory": "/workspace"}
-	jsonBytes, err := json.Marshal(body)
-	if err != nil {
-		return "", fmt.Errorf("opencode: marshal session body: %w", err)
-	}
+	url := a.opencodeURL + "/session"
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.opencodeURL+"/session", bytes.NewReader(jsonBytes))
-	if err != nil {
-		return "", fmt.Errorf("opencode: create session request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+	// Retry for up to 5 seconds in case opencode hasn't created its initial
+	// session yet right at the health-check boundary.
+	const maxWait = 5 * time.Second
+	const retryInterval = 200 * time.Millisecond
+	deadline := time.Now().Add(maxWait)
 
-	resp, err := a.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("opencode: create session http: %w", err)
-	}
-	defer resp.Body.Close()
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return "", fmt.Errorf("opencode: GET /session request: %w", err)
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("opencode: create session: http status %d", resp.StatusCode)
-	}
+		resp, err := a.httpClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("opencode: GET /session: %w", err)
+		}
 
-	var result struct {
-		ID string `json:"id"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("opencode: decode session response: %w", err)
-	}
-	if result.ID == "" {
-		return "", fmt.Errorf("opencode: empty session ID in response")
-	}
+		var sessions []sessionEntry
+		decodeErr := json.NewDecoder(resp.Body).Decode(&sessions)
+		_ = resp.Body.Close()
 
-	a.mu.Lock()
-	a.sessionID = result.ID
-	a.mu.Unlock()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return "", fmt.Errorf("opencode: GET /session: http status %d", resp.StatusCode)
+		}
+		if decodeErr != nil {
+			return "", fmt.Errorf("opencode: decode GET /session response: %w", decodeErr)
+		}
 
-	return result.ID, nil
+		if len(sessions) > 0 {
+			// Pick the most recently updated session (opencode may surface
+			// multiple sessions if the user was previously active in this
+			// workspace; we want the one that just started).
+			best := sessions[0]
+			for _, s := range sessions[1:] {
+				if s.Time != nil && s.Time.Updated != nil {
+					if best.Time == nil || best.Time.Updated == nil || *s.Time.Updated > *best.Time.Updated {
+						best = s
+					}
+				}
+			}
+			log.Printf("opencode: CreateSession: retrieved existing session %q from GET /session (%d session(s))", best.ID, len(sessions))
+
+			a.mu.Lock()
+			a.sessionID = best.ID
+			a.mu.Unlock()
+
+			return best.ID, nil
+		}
+
+		// Empty list — opencode may not have created its initial session yet.
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("opencode: GET /session: no sessions available after %s", maxWait)
+		}
+		log.Printf("opencode: CreateSession: GET /session returned empty list — retrying in %s", retryInterval)
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(retryInterval):
+		}
+	}
 }
 
 // SessionID returns the most recently created session ID (set by CreateSession).
@@ -191,11 +255,17 @@ func (a *Adapter) SessionID() string {
 // created by CreateSession. The role parameter overrides the adapter's
 // configured agentRole when non-empty.
 //
-// It satisfies the harness.Harness interface. When called via the interface
-// (post-#710), the adapter will need to have already had CreateSession called
-// (or will create a session internally). For the current direct-call path,
-// CreateSession is always called first by the sidecar.
+// In container mode (containerMode=true), this is a no-op: the prompt was
+// already delivered via --prompt on the opencode CLI at container startup
+// (RFC #691 Phase 1a). HTTP delivery here would send to the wrong session.
+//
+// It satisfies the harness.Harness interface.
 func (a *Adapter) DeliverInitialPrompt(ctx context.Context, prompt, role string) error {
+	if a.containerMode {
+		log.Printf("opencode: DeliverInitialPrompt: container mode — prompt already delivered via CLI, skipping HTTP delivery")
+		return nil
+	}
+
 	a.mu.Lock()
 	sid := a.sessionID
 	a.mu.Unlock()

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -364,7 +364,10 @@ func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, c
 	if containerMode {
 		// Use podman attach to bridge the tmux pane to the container's PTY.
 		// The container runs opencode in combined TUI + HTTP mode (RFC #691, Phase 1a).
-		return fmt.Sprintf("podman attach %s", container.NameForSession(agentSession))
+		// The container name is shell-quoted so that any unexpected characters in
+		// the session name cannot be interpreted as shell metacharacters when
+		// buildReadinessWaitCmd embeds this string in the readiness shell script.
+		return "podman attach " + shellQuote(container.NameForSession(agentSession))
 	}
 	escapedPrompt := shellQuote(prompt)
 	return fmt.Sprintf("PRISM_SESSION_NAME=%s opencode --agent %s --port %d --hostname 127.0.0.1 --prompt %s",

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -356,12 +357,14 @@ func buildReviewPrompt(prNumber string) string {
 	return fmt.Sprintf("Review PR #%s. Run `gh pr view %s` and `gh pr diff %s` to get the full diff. Check the linked issue for acceptance criteria and validate each one. Report your findings clearly.", prNumber, prNumber, prNumber)
 }
 
-// buildAgentCommand returns the opencode command string for a review agent window.
+// buildAgentCommand returns the command string for a review agent window.
 // agentSession is the full session name (e.g. "nixos-config@feature~review-1~review"),
 // used as PRISM_SESSION_NAME so the plugin correctly identifies the DB row.
 func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, containerMode bool) string {
 	if containerMode {
-		return fmt.Sprintf("opencode attach http://localhost:%d", port)
+		// Use podman attach to bridge the tmux pane to the container's PTY.
+		// The container runs opencode in combined TUI + HTTP mode (RFC #691, Phase 1a).
+		return fmt.Sprintf("podman attach %s", container.NameForSession(agentSession))
 	}
 	escapedPrompt := shellQuote(prompt)
 	return fmt.Sprintf("PRISM_SESSION_NAME=%s opencode --agent %s --port %d --hostname 127.0.0.1 --prompt %s",
@@ -374,15 +377,12 @@ func createAgentWindow(reviewSession string, idx int, windowName, worktree, agen
 	cmd := agentCmd
 	if containerMode && port != 0 {
 		readyPath, pathErr := session.SidecarReadyPath(agentSession)
-		sidPath, sidErr := session.SidecarSessionPath(agentSession)
 		if pathErr == nil {
+			// Remove any stale ready file from a previous lifecycle.
+			// The .sid file is left alone — writing it is handled by the sidecar
+			// (cleanup deferred to #716); podman attach does not need it.
 			_ = os.Remove(readyPath)
-			if sidErr != nil {
-				sidPath = ""
-			} else {
-				_ = os.Remove(sidPath)
-			}
-			cmd = buildReadinessWaitCmd(readyPath, sidPath, agentCmd)
+			cmd = buildReadinessWaitCmd(readyPath, agentCmd)
 		}
 	}
 	// Windows are 1-indexed: window 0 is the initial blank shell.
@@ -390,15 +390,17 @@ func createAgentWindow(reviewSession string, idx int, windowName, worktree, agen
 }
 
 // buildReadinessWaitCmd mirrors session.buildReadinessWaitCmd (unexported).
-func buildReadinessWaitCmd(readyPath, sidPath, attachCmd string) string {
+// Polls for the readiness file and runs the attach command directly once ready.
+// The .sid handoff is omitted — "podman attach" connects to the container's PTY
+// directly and does not need an opencode session ID (RFC #691, Phase 1a).
+func buildReadinessWaitCmd(readyPath, attachCmd string) string {
 	return fmt.Sprintf(
 		`i=0; while [ ! -f %s ] && [ $i -lt 240 ]; do sleep 0.5; i=$((i+1)); done; `+
 			`if [ ! -f %s ]; then `+
 			`echo "prism: container did not become ready within 120s" >&2; exit 1; `+
 			`fi; `+
-			`if [ -f %s ]; then _sid=$(cat %s); %s -s "$_sid"; else %s; fi`,
-		shellQuote(readyPath), shellQuote(readyPath),
-		shellQuote(sidPath), shellQuote(sidPath), attachCmd, attachCmd,
+			`%s`,
+		shellQuote(readyPath), shellQuote(readyPath), attachCmd,
 	)
 }
 

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -42,7 +43,7 @@ type Opts struct {
 	// host port to bind.
 	Port int
 	// ContainerMode, when true, switches the agent window command from
-	// "opencode --agent <name> --port <n>" to "opencode attach http://localhost:<n>".
+	// "opencode --agent <name> --port <n>" to "podman attach <container-name>".
 	// The sidecar is responsible for starting the container and signalling readiness
 	// before the attach command is sent to the tmux pane.
 	ContainerMode bool
@@ -124,22 +125,25 @@ func DefaultAgent(directory, explicit string) string {
 
 // BuildOpencodeCmd returns the opencode launch command string for the given opts.
 //
-// When opts.ContainerMode is true, the command is "opencode attach http://localhost:<port>"
-// — a lightweight TUI client that connects to the containerised opencode serve
-// instance (AC-17, AC-22). The port in the URL is opts.Port (never hardcoded).
+// When opts.ContainerMode is true, the command is "podman attach <container-name>"
+// — a transparent PTY bridge that connects the tmux pane to the opencode TUI
+// running inside the container (RFC #691, Phase 1a / Issue #715). The container
+// name is derived from opts.SessionName via container.NameForSession.
 //
 // When opts.ContainerMode is false (default), the command launches opencode
 // directly as before. PRISM_SESSION_NAME is prepended when opts.SessionName is
 // set, and --port / --hostname are appended when opts.Port is non-zero.
 func BuildOpencodeCmd(opts Opts) string {
 	if opts.ContainerMode {
-		if opts.Port == 0 {
-			// Shouldn't happen — callers must allocate a port before enabling
+		if opts.SessionName == "" {
+			// Shouldn't happen — callers must set SessionName before enabling
 			// container mode. Fall back to the non-container command.
 			return buildDirectOpencodeCmd(opts)
 		}
-		// AC-17: opencode attach with the allocated port (not 4096).
-		return fmt.Sprintf("opencode attach http://localhost:%d", opts.Port)
+		// Use podman attach to bridge the tmux pane to the container's PTY.
+		// The container runs opencode in combined TUI + HTTP mode; "podman attach"
+		// connects stdin/stdout to the container PTY so the TUI is fully interactive.
+		return fmt.Sprintf("podman attach %s", container.NameForSession(opts.SessionName))
 	}
 	return buildDirectOpencodeCmd(opts)
 }
@@ -275,8 +279,8 @@ func Create(name, directory string, opts Opts) error {
 // window 2 "term". Seeds agent_status via prism event tmux-session-start.
 //
 // In container mode (opts.ContainerMode), the sidecar is started first and the
-// agent window runs a readiness-wait loop before running "opencode attach".
-// This ensures the container is healthy before the TUI client tries to connect.
+// agent window runs a readiness-wait loop before running "podman attach".
+// This ensures the container is healthy before the PTY bridge tries to connect.
 func setupFullLayout(name, directory string, opts Opts) error {
 	_ = tmux.RenameWindow(name+":0", "edit")
 
@@ -314,19 +318,14 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	agentCmd := BuildOpencodeCmd(opts)
 	if opts.ContainerMode && opts.Port != 0 {
 		readyPath, pathErr := SidecarReadyPath(name)
-		sidPath, sidErr := SidecarSessionPath(name)
 		if pathErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not determine ready path for %q, skipping readiness wait: %v\n", name, pathErr)
 		} else {
-			// Remove any stale ready and session ID files from a previous
-			// session lifecycle before the pane script starts polling.
+			// Remove any stale ready file from a previous session lifecycle
+			// before the pane script starts polling. The .sid file is left
+			// alone — writing it is handled by the sidecar (cleanup is #716).
 			_ = os.Remove(readyPath)
-			if sidErr == nil {
-				_ = os.Remove(sidPath)
-			} else {
-				sidPath = ""
-			}
-			agentCmd = buildReadinessWaitCmd(readyPath, sidPath, agentCmd)
+			agentCmd = buildReadinessWaitCmd(readyPath, agentCmd)
 		}
 	}
 
@@ -363,20 +362,20 @@ func setupFullLayout(name, directory string, opts Opts) error {
 // readiness file and, once found, runs the given attach command.
 // If the wait times out (120s), it prints an error and exits (AC-20).
 //
-// sidPath is the optional path to the sidecar session ID file written by
-// deliverInitialPrompt. When present, its contents are appended as -s <sid>
-// to the attach command so opencode opens directly into the agent's session.
-func buildReadinessWaitCmd(readyPath, sidPath, attachCmd string) string {
+// The .sid file handoff is intentionally omitted here: "podman attach" connects
+// to the container's PTY directly — no opencode session ID is needed. The sidecar
+// still writes the .sid file (cleanup deferred to #716); this function simply
+// does not read it.
+func buildReadinessWaitCmd(readyPath, attachCmd string) string {
 	// Poll every 0.5s for up to 120s (240 iterations).
-	// On success, read the session ID (if any) and exec the attach command.
+	// On success, exec the attach command directly.
 	return fmt.Sprintf(
 		`i=0; while [ ! -f %s ] && [ $i -lt 240 ]; do sleep 0.5; i=$((i+1)); done; `+
 			`if [ ! -f %s ]; then `+
 			`echo "prism: container did not become ready within 120s" >&2; exit 1; `+
 			`fi; `+
-			`if [ -f %s ]; then _sid=$(cat %s); %s -s "$_sid"; else %s; fi`,
-		shellQuote(readyPath), shellQuote(readyPath),
-		shellQuote(sidPath), shellQuote(sidPath), attachCmd, attachCmd,
+			`%s`,
+		shellQuote(readyPath), shellQuote(readyPath), attachCmd,
 	)
 }
 

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -143,7 +143,10 @@ func BuildOpencodeCmd(opts Opts) string {
 		// Use podman attach to bridge the tmux pane to the container's PTY.
 		// The container runs opencode in combined TUI + HTTP mode; "podman attach"
 		// connects stdin/stdout to the container PTY so the TUI is fully interactive.
-		return fmt.Sprintf("podman attach %s", container.NameForSession(opts.SessionName))
+		// The container name is shell-quoted so that any unexpected characters in
+		// the session name cannot be interpreted as shell metacharacters when
+		// buildReadinessWaitCmd embeds this string in the readiness shell script.
+		return "podman attach " + shellQuote(container.NameForSession(opts.SessionName))
 	}
 	return buildDirectOpencodeCmd(opts)
 }

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -46,7 +46,7 @@ func SidecarLogPath(sessionName string) (string, error) {
 
 // SidecarReadyPath returns the readiness signal file path for the named session.
 // The sidecar creates this file after the container is healthy. The tmux pane
-// startup script polls for its existence before running "opencode attach".
+// startup script polls for its existence before running "podman attach".
 //
 // Ready file: $XDG_STATE_HOME/prism/run/<session>-sidecar.ready
 func SidecarReadyPath(sessionName string) (string, error) {
@@ -58,9 +58,10 @@ func SidecarReadyPath(sessionName string) (string, error) {
 }
 
 // SidecarSessionPath returns the path to the file where the sidecar writes the
-// opencode session ID after creating it via prompt delivery (#487). The tmux
-// pane startup script reads this file (if present) and passes -s <sid> to
-// "opencode attach" so it opens directly into the agent's session.
+// opencode session ID after creating it via prompt delivery (#487). This file
+// is written by the sidecar for diagnostics and forensics; the tmux pane no
+// longer reads it — "podman attach" connects to the container PTY directly
+// (RFC #691, Phase 1a). The write path and this helper are cleaned up in #716.
 //
 // Session file: $XDG_STATE_HOME/prism/run/<session>-sidecar.sid
 func SidecarSessionPath(sessionName string) (string, error) {

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -195,23 +195,22 @@ func TestStartSidecar_CreatesDirectories(t *testing.T) {
 func TestBuildReadinessWaitCmd_ContainsReadyPath(t *testing.T) {
 	cmd := buildReadinessWaitCmd(
 		"/home/user/.local/state/prism/run/my-session-sidecar.ready",
-		"/home/user/.local/state/prism/run/my-session-sidecar.sid",
-		"opencode attach http://localhost:14000")
+		"podman attach prism-repo-main")
 	if !strings.Contains(cmd, "/home/user/.local/state/prism/run/my-session-sidecar.ready") {
 		t.Errorf("readiness command does not reference ready path: %q", cmd)
 	}
 }
 
 func TestBuildReadinessWaitCmd_ContainsAttachCmd(t *testing.T) {
-	attach := "opencode attach http://localhost:14042"
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "/tmp/test.sid", attach)
+	attach := "podman attach prism-nixos-config-feature"
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", attach)
 	if !strings.Contains(cmd, attach) {
 		t.Errorf("readiness command does not contain attach command %q: %q", attach, cmd)
 	}
 }
 
 func TestBuildReadinessWaitCmd_TimeoutMessage(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "/tmp/test.sid", "opencode attach http://localhost:14000")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")
 	// Verify the timeout message matches 120s (240 iterations × 0.5s).
 	if !strings.Contains(cmd, "120s") {
 		t.Errorf("readiness command should mention 120s timeout: %q", cmd)
@@ -225,7 +224,7 @@ func TestBuildReadinessWaitCmd_TimeoutMessage(t *testing.T) {
 func TestBuildReadinessWaitCmd_PathWithSpaces(t *testing.T) {
 	// Path with spaces must be properly quoted.
 	path := "/home/user name/.local/state/prism/run/my session-sidecar.ready"
-	cmd := buildReadinessWaitCmd(path, "/tmp/test.sid", "opencode attach http://localhost:14000")
+	cmd := buildReadinessWaitCmd(path, "podman attach prism-repo-main")
 	// The path should be single-quoted.
 	if !strings.Contains(cmd, "'"+path+"'") {
 		t.Errorf("path with spaces not properly quoted in command: %q", cmd)
@@ -233,9 +232,23 @@ func TestBuildReadinessWaitCmd_PathWithSpaces(t *testing.T) {
 }
 
 func TestBuildReadinessWaitCmd_ExitsOneOnTimeout(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "/tmp/test.sid", "opencode attach http://localhost:14000")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")
 	if !strings.Contains(cmd, "exit 1") {
 		t.Errorf("readiness command should exit 1 on timeout: %q", cmd)
+	}
+}
+
+// TestBuildReadinessWaitCmd_NoSidHandoff verifies that the readiness wait
+// script does not contain any .sid file read or -s flag injection.
+// The .sid file is written by the sidecar but is no longer consumed here —
+// "podman attach" connects to the container PTY directly (RFC #691, Phase 1a).
+func TestBuildReadinessWaitCmd_NoSidHandoff(t *testing.T) {
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")
+	if strings.Contains(cmd, ".sid") {
+		t.Errorf("readiness command should not reference .sid file: %q", cmd)
+	}
+	if strings.Contains(cmd, " -s ") {
+		t.Errorf("readiness command should not inject -s flag: %q", cmd)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -117,8 +117,8 @@ type Config struct {
 	// If nil, defaultNotifyHTTPClient is used.
 	HTTPClient *http.Client
 	// Container, when non-nil, enables container mode: the sidecar creates and
-	// manages a podman container running opencode serve instead of relying on a
-	// directly-launched opencode process.
+	// manages a podman container running opencode in combined TUI + HTTP mode
+	// instead of relying on a directly-launched opencode process.
 	Container *container.Config
 	// HostAPISockPath, when non-empty and Container is non-nil, is the path at which
 	// the sidecar starts a Unix socket HTTP server exposing host-side tmux operations
@@ -133,10 +133,12 @@ type Config struct {
 	// readiness signal file that unblocks the tmux pane running "podman attach".
 	// No-op when nil.
 	OnReady func()
-	// InitialPrompt, when non-empty, is delivered to the opencode server via
-	// prompt_async after the first session.created event is received following
-	// container readiness. This is the mechanism for prompt delivery in container
-	// mode, where the TUI runs "opencode attach" and cannot accept --prompt (#487).
+	// InitialPrompt, when non-empty, is passed to the container via
+	// opencode --prompt <text> at startup. The opencode process creates its
+	// session with the prompt already in flight so the conversation is visible
+	// in the TUI from the start. The sidecar then calls CreateSession (GET
+	// /session) to discover the session ID for subsequent prism prompt delivery.
+	// DeliverInitialPrompt is a no-op in container mode (RFC #691, Phase 1a).
 	InitialPrompt string
 	// PrismBinaryPath, when non-empty, overrides the path to the prism binary
 	// used by the host-API handler to delegate operations (/spawn, /cleanup,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -130,7 +130,7 @@ type Config struct {
 	HostAPITCPPort int
 	// OnReady is called (once, synchronously) after the container is healthy
 	// and before the SSE loop starts. Used in container mode to write the
-	// readiness signal file that unblocks the tmux pane running "opencode attach".
+	// readiness signal file that unblocks the tmux pane running "podman attach".
 	// No-op when nil.
 	OnReady func()
 	// InitialPrompt, when non-empty, is delivered to the opencode server via
@@ -359,13 +359,14 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		s.mu.Lock()
 		isShuttingDown := s.shuttingDown
 		s.mu.Unlock()
-		// Deliver the initial prompt (#487) before calling OnReady, so the
-		// .sid file is on disk before the TUI readiness-wait script unblocks.
+		// Deliver the initial prompt (#487) before calling OnReady.
 		// 1. POST /session  — create the session, capture its ID.
-		// 2. Write the sid file so opencode attach -s <sid> opens the right session.
-		// 3. Call OnReady  — unblocks the TUI pane, which runs opencode attach -s <sid>.
+		// 2. Write the .sid file (for forensics/diagnostics; no longer consumed by
+		//    the agent window — "podman attach" connects to the PTY directly).
+		//    Cleanup of the .sid write path is deferred to #716.
+		// 3. Call OnReady  — unblocks the TUI pane, which runs "podman attach".
 		// 4. POST /session/<sid>/prompt_async — deliver the prompt. The TUI is
-		//    now attaching/subscribed so execution begins immediately.
+		//    now attached so execution begins immediately.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
 			sid, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -359,14 +359,21 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		s.mu.Lock()
 		isShuttingDown := s.shuttingDown
 		s.mu.Unlock()
-		// Deliver the initial prompt (#487) before calling OnReady.
-		// 1. POST /session  — create the session, capture its ID.
+		// Discover the session ID and deliver the initial prompt (#487).
+		// In container mode (opencode --prompt "text"), the prompt was already
+		// delivered via the CLI flag — opencode starts the session and begins
+		// processing immediately. The sidecar still needs the session ID for
+		// subsequent prism prompt follow-up delivery.
+		//
+		// 1. GET /session  — retrieve the session opencode already created
+		//    (via --prompt on CLI). In non-container mode, POST /session creates
+		//    a new session. The harness adapter handles both cases.
 		// 2. Write the .sid file (for forensics/diagnostics; no longer consumed by
 		//    the agent window — "podman attach" connects to the PTY directly).
 		//    Cleanup of the .sid write path is deferred to #716.
 		// 3. Call OnReady  — unblocks the TUI pane, which runs "podman attach".
-		// 4. POST /session/<sid>/prompt_async — deliver the prompt. The TUI is
-		//    now attached so execution begins immediately.
+		// 4. DeliverInitialPrompt — no-op in container mode (prompt already sent
+		//    via CLI); delivers via POST /session/<sid>/prompt_async in host mode.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
 			sid, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -375,7 +375,8 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		//    Cleanup of the .sid write path is deferred to #716.
 		// 3. Call OnReady  — unblocks the TUI pane, which runs "podman attach".
 		// 4. DeliverInitialPrompt — no-op in container mode (prompt already sent
-		//    via CLI); delivers via POST /session/<sid>/prompt_async in host mode.
+		//    via CLI). This entire block is inside `if s.cfg.Container != nil`
+		//    so it only runs in container mode; host-mode sessions never reach here.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
 			sid, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {


### PR DESCRIPTION
## Summary

This is the **behaviour-change gate** for RFC #691 (Phase 1a). It wires the TTY allocated in #714 into a live PTY bridge from tmux to the container.

Three coordinated changes:

1. **Container command**: `opencode serve --port 4096 --hostname 0.0.0.0` → `opencode --port 4096 --hostname 0.0.0.0` — combined TUI + HTTP mode. The sidecar still connects to the SSE endpoint on the mapped port, unchanged.

2. **Agent window command**: `opencode attach http://localhost:<port>` → `podman attach <container-name>` — a transparent PTY bridge so the opencode TUI renders directly in the tmux pane. Container name derived via `container.NameForSession(sessionName)`.

3. **Readiness wait script**: removes the `.sid` file read and `-s <sid>` flag injection — `podman attach` connects to the container PTY directly and needs no opencode session ID. The `.ready` file poll is preserved. The sidecar still writes the `.sid` file (cleanup deferred to #716).

## What is intentionally NOT changed

- `SidecarSessionPath()` helper — kept (#716 cleans it up)
- Sidecar code that writes the `.sid` file — kept (#716 cleans it up)
- The `opencode attach` CLI command from `cmd/` — kept (#716 cleans it up)
- Any DB changes

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅

## ⚠️ Manual smoke-test required before merging

**The coordinator must walk through the following checklist manually after reviewing the diff.** Do not merge on `prism review` pass alone.

- [ ] `prism spawn --prompt '...'` spawns a fresh session and the opencode TUI renders correctly in the agent pane via `podman attach`
- [ ] `prism checkin <session>` shows events — sidecar SSE subscription still works on the mapped port
- [ ] `prism prompt <session> --prompt '...'` delivers a message that the agent acts on — HTTP prompt relay still works
- [ ] `prism review <pr>` works against a session — `msg_assistant` events reach the DB (RFC AC-10)
- [ ] `prism cleanup --yes --session <name>` tears the container down cleanly
- [ ] The user's opencode theme (from `~/.config/opencode/tui.json` or `opencode.json`) is visible in the TUI — config mount parity unchanged
- [ ] Closing or detaching from the tmux pane (`Ctrl-b d`) does not stop the container

Closes #715