### PR TITLE
fix(container): replace broken x86_64 /usr/bin/env with Nix aarch64 symlink

### DIFF
--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -233,6 +233,11 @@ pkgs.dockerTools.buildLayeredImage {
     mkdir -p usr/bin
     ln -s /bin/node usr/bin/node
     ln -s /bin/npx  usr/bin/npx
+    # Replace the Ubuntu base layer's x86_64 /usr/bin/env binary with the
+    # Nix-provided aarch64 one. The Ubuntu binary cannot execute on aarch64
+    # hosts, causing posix_spawn ENOENT when the kernel tries to run shebang
+    # scripts with `#!/usr/bin/env`. Use -f to force-replace the existing file.
+    ln -sf /bin/env usr/bin/env
   '';
 
   config = {


### PR DESCRIPTION
## Summary

The Ubuntu base layer in the `prism-agent` image ships `/usr/bin/env` as an x86_64 ELF binary. On aarch64 hosts (Apple Silicon), this binary cannot execute, causing `posix_spawn ENOENT` when the kernel tries to run scripts with `#!/usr/bin/env` shebangs — including MCP proxy scripts.

## Fix

Add a single `ln -sf /bin/env usr/bin/env` to the `extraCommands` block in `images/prism-agent.nix`, alongside the existing `node`/`npx` symlinks from PR #720. The `-f` flag force-replaces the broken Ubuntu binary with a symlink to `/bin/env` (the working Nix coreutils aarch64 binary).

## Verification

- `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel` passes
- After rebuilding the image, `/usr/bin/env` inside the container will be a symlink to `/bin/env`
- `/usr/bin/env node --version` will execute successfully
- MCP proxy scripts with `#!/usr/bin/env node` shebangs will resolve correctly

Closes #729