### PR TITLE
prism: remove dead sid-file code (SidecarSessionPath, .sid write, reset cleanup)

### DIFF
--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -9,7 +9,7 @@ package cmd
 //  3. Mark all non-ended rows in agent_status as ended (sets ended_at = now;
 //     state is intentionally left at its last known value — ended_at IS NULL
 //     is the canonical "active session" filter throughout the codebase).
-//  4. Kill all sidecar processes and remove stale run files (PID, ready, SID)
+//  4. Kill all sidecar processes and remove stale run files (PID, ready)
 //     from ~/.local/state/prism/run/.
 //  5. (Unless --no-launch) invoke `prism launch` to restart the server.
 //
@@ -208,11 +208,10 @@ func resetMarkDBEnded() error {
 
 // resetKillSidecars scans ~/.local/state/prism/run/ for *-sidecar.pid files,
 // sends SIGTERM to each recorded process via session.KillSidecar, and then
-// removes stale *-sidecar.ready and *-sidecar.sid files for the same sessions.
+// removes stale *-sidecar.ready files for the same sessions.
 //
-// Removing the .ready and .sid files prevents a re-launched session from
-// finding stale readiness state or a deleted opencode session ID from a prior
-// run and misbehaving on startup.
+// Removing the .ready files prevents a re-launched session from finding stale
+// readiness state from a prior run and misbehaving on startup.
 //
 // The directory may be absent (fresh install or already cleaned up) — that
 // is treated as a no-op, not an error.
@@ -253,10 +252,6 @@ func resetKillSidecars() error {
 		readyPath, _ := prismSession.SidecarReadyPath(sessionName)
 		if readyPath != "" {
 			_ = os.Remove(readyPath)
-		}
-		sidPath, _ := prismSession.SidecarSessionPath(sessionName)
-		if sidPath != "" {
-			_ = os.Remove(sidPath)
 		}
 
 		killed++

--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -247,8 +247,8 @@ func resetKillSidecars() error {
 		// Send SIGTERM and remove the PID file.
 		prismSession.KillSidecar(sessionName)
 
-		// Remove stale readiness and session-ID files so a re-launched session
-		// for the same name starts fresh rather than picking up stale state.
+		// Remove stale readiness file so a re-launched session for the same
+		// name starts fresh rather than picking up stale state.
 		readyPath, _ := prismSession.SidecarReadyPath(sessionName)
 		if readyPath != "" {
 			_ = os.Remove(readyPath)

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 
 	// Sidecar container settings.
 	// ContainerMode, when true, causes spawn and switch to run opencode inside
-	// a podman container managed by the sidecar, using "opencode attach" in the
+	// a podman container managed by the sidecar, using "podman attach" in the
 	// agent window rather than launching opencode directly.
 	ContainerMode bool `json:"container_mode"`
 	// SidecarPluginPath is the host-side path to the opencode plugin file that

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -382,8 +382,6 @@ func createAgentWindow(reviewSession string, idx int, windowName, worktree, agen
 		readyPath, pathErr := session.SidecarReadyPath(agentSession)
 		if pathErr == nil {
 			// Remove any stale ready file from a previous lifecycle.
-			// The .sid file is left alone — writing it is handled by the sidecar
-			// (cleanup deferred to #716); podman attach does not need it.
 			_ = os.Remove(readyPath)
 			cmd = buildReadinessWaitCmd(readyPath, agentCmd)
 		}
@@ -394,8 +392,6 @@ func createAgentWindow(reviewSession string, idx int, windowName, worktree, agen
 
 // buildReadinessWaitCmd mirrors session.buildReadinessWaitCmd (unexported).
 // Polls for the readiness file and runs the attach command directly once ready.
-// The .sid handoff is omitted — "podman attach" connects to the container's PTY
-// directly and does not need an opencode session ID (RFC #691, Phase 1a).
 func buildReadinessWaitCmd(readyPath, attachCmd string) string {
 	return fmt.Sprintf(
 		`i=0; while [ ! -f %s ] && [ $i -lt 240 ]; do sleep 0.5; i=$((i+1)); done; `+

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -325,8 +325,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 			fmt.Fprintf(os.Stderr, "warning: could not determine ready path for %q, skipping readiness wait: %v\n", name, pathErr)
 		} else {
 			// Remove any stale ready file from a previous session lifecycle
-			// before the pane script starts polling. The .sid file is left
-			// alone — writing it is handled by the sidecar (cleanup is #716).
+			// before the pane script starts polling.
 			_ = os.Remove(readyPath)
 			agentCmd = buildReadinessWaitCmd(readyPath, agentCmd)
 		}
@@ -364,11 +363,6 @@ func setupFullLayout(name, directory string, opts Opts) error {
 // buildReadinessWaitCmd builds a shell command that polls for the sidecar
 // readiness file and, once found, runs the given attach command.
 // If the wait times out (120s), it prints an error and exits (AC-20).
-//
-// The .sid file handoff is intentionally omitted here: "podman attach" connects
-// to the container's PTY directly — no opencode session ID is needed. The sidecar
-// still writes the .sid file (cleanup deferred to #716); this function simply
-// does not read it.
 func buildReadinessWaitCmd(readyPath, attachCmd string) string {
 	// Poll every 0.5s for up to 120s (240 iterations).
 	// On success, exec the attach command directly.

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -57,21 +57,6 @@ func SidecarReadyPath(sessionName string) (string, error) {
 	return filepath.Join(base, "run", sessionName+"-sidecar.ready"), nil
 }
 
-// SidecarSessionPath returns the path to the file where the sidecar writes the
-// opencode session ID after creating it via prompt delivery (#487). This file
-// is written by the sidecar for diagnostics and forensics; the tmux pane no
-// longer reads it — "podman attach" connects to the container PTY directly
-// (RFC #691, Phase 1a). The write path and this helper are cleaned up in #716.
-//
-// Session file: $XDG_STATE_HOME/prism/run/<session>-sidecar.sid
-func SidecarSessionPath(sessionName string) (string, error) {
-	base, err := sidecarStateDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(base, "run", sessionName+"-sidecar.sid"), nil
-}
-
 // SidecarPIDPath returns the PID file path for the named session's sidecar.
 func SidecarPIDPath(sessionName string) (string, error) {
 	base, err := sidecarStateDir()

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -240,7 +240,6 @@ func TestBuildReadinessWaitCmd_ExitsOneOnTimeout(t *testing.T) {
 
 // TestBuildReadinessWaitCmd_NoSidHandoff verifies that the readiness wait
 // script does not contain any .sid file read or -s flag injection.
-// The .sid file is written by the sidecar but is no longer consumed here —
 // "podman attach" connects to the container PTY directly (RFC #691, Phase 1a).
 func TestBuildReadinessWaitCmd_NoSidHandoff(t *testing.T) {
 	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -370,21 +370,14 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		// 1. GET /session  — retrieve the session opencode already created
 		//    (via --prompt on CLI). In non-container mode, POST /session creates
 		//    a new session. The harness adapter handles both cases.
-		// 2. Write the .sid file (for forensics/diagnostics; no longer consumed by
-		//    the agent window — "podman attach" connects to the PTY directly).
-		//    Cleanup of the .sid write path is deferred to #716.
-		// 3. Call OnReady  — unblocks the TUI pane, which runs "podman attach".
-		// 4. DeliverInitialPrompt — no-op in container mode (prompt already sent
+		// 2. Call OnReady  — unblocks the TUI pane, which runs "podman attach".
+		// 3. DeliverInitialPrompt — no-op in container mode (prompt already sent
 		//    via CLI). This entire block is inside `if s.cfg.Container != nil`
 		//    so it only runs in container mode; host-mode sessions never reach here.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
-			sid, createErr := s.harness.CreateSession(ctx)
+			_, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
-			} else {
-				if sidPath, err := session.SidecarSessionPath(s.cfg.SessionName); err == nil {
-					_ = os.WriteFile(sidPath, []byte(sid), 0o644)
-				}
 			}
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {


### PR DESCRIPTION
## Summary

Removes code that was made dead by the podman-attach migration in #715 (issue #715). This is a pure deletion PR — no behaviour changes.

### What was deleted

- **`internal/session/sidecar.go`** — `SidecarSessionPath()` function entirely removed. This helper returned the `.sid` file path and was only used by the sidecar write path (now gone) and `cmd/reset.go` (also cleaned up).
- **`internal/sidecar/sidecar.go`** — Removed the `os.WriteFile` call that wrote the opencode session ID to `SidecarSessionPath()`. The session ID is now obtained by the adapter via `GET /session` at health-check time; writing it to disk is no longer needed.
- **`cmd/reset.go`** — Removed the `SidecarSessionPath` call that cleaned up `.sid` files on reset, and updated the function/file-level comments to no longer reference `.sid` files.
- **Stale comments** — Updated `internal/session/session.go`, `internal/review/review.go`, `internal/config/config.go`, and `internal/session/sidecar_test.go` to remove forward references to #716 cleanup and other now-incorrect mentions of the `.sid` write path.

### Verification

- `rg "SidecarSessionPath"` → no matches
- `rg "opencode attach"` in non-test Go source → no matches
- `go build ./...` → passes
- `go test ./...` → passes (all 17 packages)

Closes #716