### PR TITLE
prism: set TERM=xterm-256color in container run args

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -898,6 +898,19 @@ func (m *Manager) buildRunArgs() []string {
 		"--volume", "/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket",
 		"--env", "NIX_CONFIG=store = daemon",
 
+		// Terminal type — set to xterm-256color so the opencode TUI inside the
+		// container has accurate terminal capability information. podman sets
+		// TERM=xterm (plain) by default when --tty is used without an explicit
+		// --env TERM=..., which breaks mouse events and SGR mouse protocol
+		// selection (issue #737). xterm-256color is correct because:
+		//   - Available in every Linux container (part of ncurses-base)
+		//   - Full SGR mouse support (1006 protocol), matching what tmux expects
+		//   - 256-colour support, matching the host terminal
+		// Do NOT pass through the host's $TERM (e.g. tmux-256color or
+		// screen-256color) — those terminfo entries may not exist in the
+		// container and would cause opencode to fall back to a minimal profile.
+		"--env", "TERM=xterm-256color",
+
 		// Prism context — tells prism CLI commands running inside the container
 		// where the worktree and bare repo are mounted. PRISM_SPAWN_PATH is the
 		// existing escape hatch used by prism spawn / list-sessions to infer the

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2503,6 +2503,26 @@ func TestBuildRunArgs_KubeNotMountedWhenAbsent(t *testing.T) {
 
 // ── MCP auth mount tests ─────────────────────────────────────────────────────
 
+// TestBuildRunArgs_TermEnvSet verifies that TERM=xterm-256color is passed as
+// an --env flag in the podman run arguments. Without this, podman defaults to
+// TERM=xterm (plain) when --tty is used, which breaks mouse events and SGR
+// mouse protocol selection inside the opencode TUI (issue #737).
+func TestBuildRunArgs_TermEnvSet(t *testing.T) {
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	found := false
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && args[i+1] == "TERM=xterm-256color" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("TERM=xterm-256color not found in buildRunArgs output; args: %v", args)
+	}
+}
+
 // TestBuildRunArgs_McpAuthMountedWhenPresent verifies that when ~/.mcp-auth
 // exists on the host, it is bind-mounted read-write at /root/.mcp-auth inside
 // the container so OAuth tokens written by mcp-remote persist back to the host.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2501,7 +2501,7 @@ func TestBuildRunArgs_KubeNotMountedWhenAbsent(t *testing.T) {
 	}
 }
 
-// ── MCP auth mount tests ─────────────────────────────────────────────────────
+// ── Terminal environment tests ───────────────────────────────────────────────
 
 // TestBuildRunArgs_TermEnvSet verifies that TERM=xterm-256color is passed as
 // an --env flag in the podman run arguments. Without this, podman defaults to
@@ -2522,6 +2522,8 @@ func TestBuildRunArgs_TermEnvSet(t *testing.T) {
 		t.Errorf("TERM=xterm-256color not found in buildRunArgs output; args: %v", args)
 	}
 }
+
+// ── MCP auth mount tests ─────────────────────────────────────────────────────
 
 // TestBuildRunArgs_McpAuthMountedWhenPresent verifies that when ~/.mcp-auth
 // exists on the host, it is bind-mounted read-write at /root/.mcp-auth inside


### PR DESCRIPTION
## Summary

Fixes the mouse events and in-TUI scrollback regression introduced in PR #732 (podman-attach migration).

- Adds `--env TERM=xterm-256color` to `buildRunArgs()` in `internal/container/container.go`
- Adds a test in `container_test.go` asserting `TERM=xterm-256color` appears in the args

## Root cause

`podman run --tty` sets `TERM=xterm` (plain) inside the container when no explicit `--env TERM=...` is provided. The opencode TUI then selects the wrong mouse reporting protocol (X10 vs SGR/1006), breaking click-to-expand and mouse-wheel scrollback.

## Why `xterm-256color`

- Always present in container terminfo (`ncurses-base`) — no terminfo gaps
- Full SGR 1006 mouse support, matching what tmux expects
- 256-colour support, matching the host terminal
- The host's `$TERM` (e.g. `tmux-256color`, `screen-256color`) is deliberately **not** passed through — those entries may not exist in the container's terminfo database

## Note on `images/prism-agent.nix`

The container image definition does **not** set `TERM` in its `config.Env` list (checked `images/prism-agent.nix`). The only env vars baked into the image are `PATH` and `NIX_SSL_CERT_FILE`. So there is no image-level `TERM` that this runtime flag overrides — the fix is purely additive.

Closes #737