### PR TITLE
prism: enable tmux set-clipboard for OSC 52 clipboard passthrough

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -57,6 +57,10 @@ in
               set -g status-right-style 'bg=${bg1} fg=${primary}'
               # for kitty images in image.nvim
               set -gq allow-passthrough on
+              # Enable OSC 52 clipboard passthrough so opencode running inside a
+              # container can write to the host clipboard via the podman attach PTY bridge.
+              # Without this, tmux drops OSC 52 sequences and clipboard is silently broken.
+              set -g set-clipboard on
               # pane switching
               bind -r h select-pane -L
               bind -r j select-pane -D


### PR DESCRIPTION
## Summary

Adds `set -g set-clipboard on` to the tmux `extraConfig` in `modules/programs/prism/tmux.nix`.

This fixes clipboard copy operations for opencode sessions running inside the prism-agent container (introduced in PR #732). After the podman-attach migration, opencode falls back to OSC 52 terminal escape sequences for clipboard access. Without `set-clipboard on`, tmux silently drops those sequences — this setting instructs tmux to intercept them and write to the host system clipboard via `wl-copy` (NixOS/Wayland) or the platform equivalent.

A comment is included explaining the OSC 52 PTY chain and why this is needed.

## Changes

- `modules/programs/prism/tmux.nix`: add `set -g set-clipboard on` with explanatory comment, grouped with other `set -gq`/`set -g` appearance options

## Testing

- Nix build (`nix build .#nixosConfigurations.navi.config.system.build.toplevel`) passes ✓
- No Go source changes; no Go tests needed

Closes #738