### PR TITLE
prism review: route through host API when running inside a container

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -219,6 +219,96 @@ func proxyPrompt(apiURL, session, prompt string) error {
 	}, nil)
 }
 
+// reviewHostAPIResponse holds the response from the host-API /review endpoint.
+type reviewHostAPIResponse struct {
+	Output string `json:"output"`
+	Passed bool   `json:"passed"`
+}
+
+// proxyReview proxies a review request to the host-API sidecar when running
+// inside a container (PRISM_HOST_API is set). It sends POST /review to the
+// sidecar, which runs `prism review` on the host where tmux is available,
+// and streams back the aggregated review output.
+//
+// prNumber is the PR number to review (e.g. "123"). agents is an optional
+// list of agent names for --only filtering. timeout is an optional duration
+// string (e.g. "10m"). Returns the formatted output text, whether all agents
+// passed, and any error.
+func proxyReview(apiURL, prNumber string, agents []string, timeout string) (string, bool, error) {
+	// Build request body.
+	body := map[string]any{
+		"pr_number": prNumber,
+	}
+	if len(agents) > 0 {
+		body["agents"] = agents
+	}
+	if timeout != "" {
+		body["timeout"] = timeout
+	}
+
+	// Parse the timeout to set an appropriate HTTP client deadline.
+	// The sidecar will enforce its own deadline; we add 3 minutes of overhead
+	// so the HTTP transport does not time out before the sidecar responds.
+	clientTimeout := 13 * time.Minute // default: 10m review + 3m overhead
+	if timeout != "" {
+		if d, err := time.ParseDuration(timeout); err == nil {
+			clientTimeout = d + 3*time.Minute
+		}
+	}
+
+	// Build a custom client with the extended timeout so review requests
+	// (which can take 10+ minutes) are not cut off by the default 60s timeout.
+	var (
+		client *http.Client
+		reqURL string
+	)
+	if strings.HasPrefix(apiURL, "http://") {
+		client = &http.Client{Timeout: clientTimeout}
+		reqURL = apiURL + "/review"
+	} else {
+		sockPath, parseErr := parseUnixSocketURL(apiURL)
+		if parseErr != nil {
+			return "", false, fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+		}
+		client = &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					d := &net.Dialer{Timeout: 5 * time.Second}
+					conn, dialErr := d.DialContext(ctx, "unix", sockPath)
+					if dialErr != nil {
+						return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
+					}
+					return conn, nil
+				},
+			},
+			Timeout: clientTimeout,
+		}
+		reqURL = "http://prism-hostapi/review"
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return "", false, fmt.Errorf("proxyReview: marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", false, fmt.Errorf("proxyReview: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("host-API /review: %w", err)
+	}
+
+	var reviewResp reviewHostAPIResponse
+	if err := readHostAPIResponse("/review", resp, &reviewResp); err != nil {
+		return "", false, err
+	}
+	return reviewResp.Output, reviewResp.Passed, nil
+}
+
 // proxyLogsFromHostAPI proxies a GET /logs request to the host-API server and
 // streams the response body directly to w. For follow mode, it handles Ctrl-C
 // gracefully by cancelling the request context. apiURL is either a unix:// or

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -59,6 +59,32 @@ func runReview(cmd *cobra.Command, args []string) error {
 	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
 	onlyFlag, _ := cmd.Flags().GetString("only")
 
+	// Container-mode detection: when PRISM_HOST_API is set the process is
+	// running inside a container where tmux is not available. Route the review
+	// through the host sidecar instead of calling review.Run() directly.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		var agents []string
+		if onlyFlag != "" {
+			agents = splitCSV(onlyFlag)
+		}
+		timeoutStr := ""
+		if timeoutFlag > 0 {
+			timeoutStr = timeoutFlag.String()
+		}
+		output, passed, err := proxyReview(apiURL, prNumber, agents, timeoutStr)
+		if err != nil {
+			return fmt.Errorf("prism review: host API: %w", err)
+		}
+		fmt.Print(output)
+		if output != "" && !strings.HasSuffix(output, "\n") {
+			fmt.Println()
+		}
+		if !passed {
+			os.Exit(1)
+		}
+		return nil
+	}
+
 	// Resolve the parent session name.
 	parentSession := review.LookupParentSession()
 	if parentSession == "" {

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -63,15 +63,33 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// running inside a container where tmux is not available. Route the review
 	// through the host sidecar instead of calling review.Run() directly.
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		var agents []string
+		// Resolve the agent list client-side (inside the container), where
+		// ENHANCED_REVIEW and PRISM_HOST_API are set. This ensures that
+		// env-var-driven agent selection (e.g. ENHANCED_REVIEW=true) uses the
+		// container's environment, not the host sidecar's environment, and
+		// that the --only flag is applied correctly before forwarding.
+		allAgents := agentsForHarness(harnessFlag)
+		var selectedAgents []review.Agent
 		if onlyFlag != "" {
-			agents = splitCSV(onlyFlag)
+			var err error
+			names := splitCSV(onlyFlag)
+			selectedAgents, err = review.AgentsByName(allAgents, names)
+			if err != nil {
+				return fmt.Errorf("prism review: %w", err)
+			}
+		} else {
+			selectedAgents = allAgents
 		}
+		agentNames := make([]string, len(selectedAgents))
+		for i, ag := range selectedAgents {
+			agentNames[i] = ag.Name
+		}
+
 		timeoutStr := ""
 		if timeoutFlag > 0 {
 			timeoutStr = timeoutFlag.String()
 		}
-		output, passed, err := proxyReview(apiURL, prNumber, agents, timeoutStr)
+		output, passed, err := proxyReview(apiURL, prNumber, agentNames, timeoutStr)
 		if err != nil {
 			return fmt.Errorf("prism review: host API: %w", err)
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1956,6 +1956,7 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 // to agents running inside the container via a Unix socket. Routes:
 //
 //	POST /spawn        — spawn a new worktree session
+//	POST /review       — run review agents against a PR (coordinator only)
 //	POST /cleanup      — clean up an existing session
 //	POST /switch       — switch the tmux client to a session
 //	GET  /list-sessions — list active sessions (role-scoped)
@@ -2509,6 +2510,95 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			sessionName = ownRepo + "@" + req.Branch
 		}
 		writeJSON(w, http.StatusOK, map[string]string{"session_name": sessionName})
+	})
+
+	// POST /review
+	// Request:  {"pr_number":"123","agents":["review-code","review-goal"],"timeout":"10m"}
+	// agents is optional (all enhanced agents run by default).
+	// timeout is optional (default: 10m).
+	// Response: {"output":"...","passed":true} | {"error":"..."}
+	//
+	// This endpoint is called by workers running inside containers that cannot
+	// reach tmux directly. The sidecar runs on the host where tmux is
+	// available, so it delegates to `prism review` on the host side.
+	// Workers require coordinator role because review sessions are spawned
+	// under the coordinator's session namespace — same restriction as /spawn.
+	mux.HandleFunc("/review", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "review") {
+			return
+		}
+		var req struct {
+			PRNumber string   `json:"pr_number"`
+			Agents   []string `json:"agents"`
+			Timeout  string   `json:"timeout"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.PRNumber == "" {
+			writeError(w, http.StatusBadRequest, "pr_number is required")
+			return
+		}
+
+		args := []string{"review", req.PRNumber}
+		if len(req.Agents) > 0 {
+			args = append(args, "--only", strings.Join(req.Agents, ","))
+		}
+		if req.Timeout != "" {
+			args = append(args, "--timeout", req.Timeout)
+		}
+
+		log.Printf("sidecar: host-API /review: prism %s", strings.Join(args, " "))
+
+		// Parse the timeout to determine an appropriate exec deadline.
+		// Default to 10 minutes per agent; add 2 minutes of overhead.
+		// We must not cut off the prism review process before its own timeout fires.
+		execTimeout := 12 * time.Minute
+		if req.Timeout != "" {
+			if d, parseErr := time.ParseDuration(req.Timeout); parseErr == nil {
+				// Add 2 minutes overhead so the HTTP request outlives the review timeout.
+				execTimeout = d + 2*time.Minute
+			}
+		}
+
+		cmd := exec.Command(prismBinary(), args...)
+		// Use a context with deadline so hung review processes don't block forever.
+		ctx, cancel := context.WithTimeout(r.Context(), execTimeout)
+		defer cancel()
+		cmd = exec.CommandContext(ctx, prismBinary(), args...)
+
+		// Capture both stdout (formatted results) and stderr (progress messages).
+		out, err := cmd.Output()
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = string(exitErr.Stderr)
+		}
+
+		// prism review exits non-zero when one or more agents fail (exit 1).
+		// This is expected and not an infrastructure error — return the output
+		// with passed=false. Only treat it as a hard error if there is no output.
+		passed := err == nil
+		output := strings.TrimRight(string(out), "\n")
+
+		if output == "" && err != nil {
+			// No output produced — infrastructure failure.
+			errMsg := fmt.Sprintf("review failed: %v", err)
+			if stderr != "" {
+				errMsg += ": " + strings.TrimSpace(stderr)
+			}
+			log.Printf("sidecar: host-API /review: %v: %s", err, stderr)
+			writeError(w, http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"output": output,
+			"passed": passed,
+		})
 	})
 
 	// POST /cleanup

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2514,20 +2514,23 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 	// POST /review
 	// Request:  {"pr_number":"123","agents":["review-code","review-goal"],"timeout":"10m"}
-	// agents is optional (all enhanced agents run by default).
+	// agents is optional (empty = default set resolved by prism review on host).
 	// timeout is optional (default: 10m).
 	// Response: {"output":"...","passed":true} | {"error":"..."}
 	//
-	// This endpoint is called by workers running inside containers that cannot
-	// reach tmux directly. The sidecar runs on the host where tmux is
-	// available, so it delegates to `prism review` on the host side.
-	// Workers require coordinator role because review sessions are spawned
-	// under the coordinator's session namespace — same restriction as /spawn.
+	// This endpoint is called by workers and coordinators running inside
+	// containers that cannot reach tmux directly. The sidecar runs on the host
+	// where tmux is available, so it delegates to `prism review` on the host.
+	// Both worker and coordinator role sidecars are permitted: workers call
+	// `prism review` as part of their own PR workflow; the restriction to
+	// coordinator-only (like /spawn) does not apply here.
+	//
+	// PRISM_SESSION_NAME is injected into the subprocess environment so that
+	// `review.LookupParentSession()` can determine the parent session name
+	// (the sidecar daemon process does not run inside tmux, so the fallback
+	// tmux.CurrentSession() call would fail).
 	mux.HandleFunc("/review", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
-			return
-		}
-		if !requireCoordinator(w, "review") {
 			return
 		}
 		var req struct {
@@ -2565,11 +2568,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			}
 		}
 
-		cmd := exec.Command(prismBinary(), args...)
 		// Use a context with deadline so hung review processes don't block forever.
 		ctx, cancel := context.WithTimeout(r.Context(), execTimeout)
 		defer cancel()
-		cmd = exec.CommandContext(ctx, prismBinary(), args...)
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
+
+		// Inject PRISM_SESSION_NAME so review.LookupParentSession() resolves the
+		// parent session correctly. Without this, the subprocess would try to query
+		// the tmux current session (which fails since the sidecar is not inside tmux).
+		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+s.cfg.SessionName)
 
 		// Capture both stdout (formatted results) and stderr (progress messages).
 		out, err := cmd.Output()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1955,9 +1955,9 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 // hostAPIHandler returns an http.Handler that exposes host-side tmux operations
 // to agents running inside the container via a Unix socket. Routes:
 //
-//	POST /spawn        — spawn a new worktree session
-//	POST /review       — run review agents against a PR (coordinator only)
-//	POST /cleanup      — clean up an existing session
+//	POST /spawn        — spawn a new worktree session (coordinator only)
+//	POST /review       — run review agents against a PR (workers and coordinators)
+//	POST /cleanup      — clean up an existing session (coordinator only)
 //	POST /switch       — switch the tmux client to a session
 //	GET  /list-sessions — list active sessions (role-scoped)
 //	GET  /checkin      — return conversation history for a session (coordinator only)
@@ -2514,7 +2514,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 	// POST /review
 	// Request:  {"pr_number":"123","agents":["review-code","review-goal"],"timeout":"10m"}
+	// pr_number must be a numeric string (e.g. "123"). Non-numeric values are rejected.
 	// agents is optional (empty = default set resolved by prism review on host).
+	//   When agents contains enhanced-review names (review-goal, review-code, etc.),
+	//   ENHANCED_REVIEW=true is injected into the subprocess env automatically.
 	// timeout is optional (default: 10m).
 	// Response: {"output":"...","passed":true} | {"error":"..."}
 	//
@@ -2522,8 +2525,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// containers that cannot reach tmux directly. The sidecar runs on the host
 	// where tmux is available, so it delegates to `prism review` on the host.
 	// Both worker and coordinator role sidecars are permitted: workers call
-	// `prism review` as part of their own PR workflow; the restriction to
-	// coordinator-only (like /spawn) does not apply here.
+	// `prism review` as part of their own PR workflow.
 	//
 	// PRISM_SESSION_NAME is injected into the subprocess environment so that
 	// `review.LookupParentSession()` can determine the parent session name
@@ -2545,6 +2547,24 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.PRNumber == "" {
 			writeError(w, http.StatusBadRequest, "pr_number is required")
 			return
+		}
+		// Validate pr_number is numeric to prevent flag injection into the
+		// subprocess (e.g. "--keep" being interpreted as a cobra flag).
+		for _, c := range req.PRNumber {
+			if c < '0' || c > '9' {
+				writeError(w, http.StatusBadRequest, "pr_number must be a numeric string (e.g. \"123\")")
+				return
+			}
+		}
+
+		// Validate each agent name against the known set to prevent flag
+		// injection via the --only argument.
+		for _, name := range req.Agents {
+			if !isKnownReviewAgent(name) {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown agent name %q — must be one of: %s",
+					name, strings.Join(knownReviewAgentNames(), ", ")))
+				return
+			}
 		}
 
 		args := []string{"review", req.PRNumber}
@@ -2573,16 +2593,32 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		defer cancel()
 		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 
-		// Inject PRISM_SESSION_NAME so review.LookupParentSession() resolves the
-		// parent session correctly. Without this, the subprocess would try to query
-		// the tmux current session (which fails since the sidecar is not inside tmux).
-		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+s.cfg.SessionName)
+		// Build the subprocess environment with two injections:
+		// 1. PRISM_SESSION_NAME: so review.LookupParentSession() resolves the
+		//    parent session correctly. The sidecar daemon is not inside tmux,
+		//    so the fallback tmux.CurrentSession() would fail without this.
+		// 2. ENHANCED_REVIEW=true: when any enhanced agent names are requested,
+		//    propagate this flag so agentsForHarness() on the host recognises
+		//    them in the agent pool. The sidecar's own os.Environ() does not
+		//    carry ENHANCED_REVIEW (it's only set inside containers), so we
+		//    inject it when needed based on the agent names in the request.
+		env := append(os.Environ(), "PRISM_SESSION_NAME="+s.cfg.SessionName)
+		if containsEnhancedAgent(req.Agents) {
+			env = append(env, "ENHANCED_REVIEW=true")
+		}
+		cmd.Env = env
 
-		// Capture both stdout (formatted results) and stderr (progress messages).
+		// Capture stdout (formatted results); stderr is logged server-side only.
 		out, err := cmd.Output()
-		stderr := ""
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			stderr = string(exitErr.Stderr)
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				// Log stderr for diagnostics but do not include it in the HTTP
+				// response to avoid leaking internal paths or credentials to
+				// the container caller.
+				if len(exitErr.Stderr) > 0 {
+					log.Printf("sidecar: host-API /review: stderr: %s", strings.TrimSpace(string(exitErr.Stderr)))
+				}
+			}
 		}
 
 		// prism review exits non-zero when one or more agents fail (exit 1).
@@ -2592,13 +2628,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		output := strings.TrimRight(string(out), "\n")
 
 		if output == "" && err != nil {
-			// No output produced — infrastructure failure.
-			errMsg := fmt.Sprintf("review failed: %v", err)
-			if stderr != "" {
-				errMsg += ": " + strings.TrimSpace(stderr)
-			}
-			log.Printf("sidecar: host-API /review: %v: %s", err, stderr)
-			writeError(w, http.StatusInternalServerError, errMsg)
+			// No output produced — infrastructure failure. Log error server-side
+			// and return a generic message to avoid leaking details to the caller.
+			log.Printf("sidecar: host-API /review: review process failed: %v", err)
+			writeError(w, http.StatusInternalServerError, "review process failed — check host logs for details")
 			return
 		}
 
@@ -2722,6 +2755,65 @@ func (s *Sidecar) worktreePathForSession(sessionName string) (string, error) {
 		return "", fmt.Errorf("session %q has no worktree path in DB", sessionName)
 	}
 	return status.Worktree, nil
+}
+
+// reviewAgentAllowlist is the set of valid review agent names accepted by the
+// /review host-API endpoint. These match the names in review.DefaultAgents()
+// and review.EnhancedAgents(). New agents must be added here when introduced.
+// Keeping this inline avoids importing the review package from the sidecar.
+var reviewAgentAllowlist = map[string]bool{
+	// Default agent.
+	"review": true,
+	// Enhanced-mode agents (ENHANCED_REVIEW=true).
+	"review-goal":     true,
+	"review-code":     true,
+	"review-security": true,
+	"review-qa":       true,
+	"review-context":  true,
+}
+
+// enhancedReviewAgents is the set of enhanced agent names that require
+// ENHANCED_REVIEW=true in the subprocess environment.
+var enhancedReviewAgents = map[string]bool{
+	"review-goal":     true,
+	"review-code":     true,
+	"review-security": true,
+	"review-qa":       true,
+	"review-context":  true,
+}
+
+// isKnownReviewAgent returns true if name is a recognised review agent.
+func isKnownReviewAgent(name string) bool {
+	return reviewAgentAllowlist[name]
+}
+
+// knownReviewAgentNames returns the sorted list of known review agent names
+// for use in error messages.
+func knownReviewAgentNames() []string {
+	names := make([]string, 0, len(reviewAgentAllowlist))
+	for name := range reviewAgentAllowlist {
+		names = append(names, name)
+	}
+	// Sort for stable error messages.
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			if names[i] > names[j] {
+				names[i], names[j] = names[j], names[i]
+			}
+		}
+	}
+	return names
+}
+
+// containsEnhancedAgent returns true if any of the given agent names is an
+// enhanced-review agent (requires ENHANCED_REVIEW=true on the host side).
+func containsEnhancedAgent(agents []string) bool {
+	for _, a := range agents {
+		if enhancedReviewAgents[a] {
+			return true
+		}
+	}
+	return false
 }
 
 // parseSpawnSessionName parses the session name from the output of `prism spawn`

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6260,13 +6260,15 @@ exit 1
 }
 
 // TestHostAPI_Review_InfraFailureReturns500 verifies that when `prism review`
-// exits non-zero with no output, the response is HTTP 500 (infra failure).
+// exits non-zero with no output, the response is HTTP 500 (infra failure) with
+// a generic error message (stderr is not exposed to the caller).
 func TestHostAPI_Review_InfraFailureReturns500(t *testing.T) {
 	d := openTestDB(t)
 
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
-	// Exit non-zero with no stdout output: infra failure.
-	stubScript := "#!/bin/sh\nexit 2\n"
+	// Exit non-zero with no stdout; emit sensitive text on stderr to verify
+	// it is NOT reflected in the HTTP response.
+	stubScript := "#!/bin/sh\necho 'sensitive: /internal/path/secret' >&2\nexit 2\n"
 	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
 		t.Fatalf("write stub: %v", err)
 	}
@@ -6292,6 +6294,98 @@ func TestHostAPI_Review_InfraFailureReturns500(t *testing.T) {
 	decodeJSONBody(t, rr, &errResp)
 	if errResp["error"] == "" {
 		t.Error("expected error field in 500 response")
+	}
+	// Stderr must not be reflected in the HTTP response (security: avoid leaking
+	// internal paths or credentials to container callers).
+	if strings.Contains(errResp["error"], "sensitive") || strings.Contains(errResp["error"], "secret") {
+		t.Errorf("HTTP 500 response should not include subprocess stderr; got %q", errResp["error"])
+	}
+}
+
+// TestHostAPI_Review_NonNumericPRNumberReturns400 verifies that a pr_number
+// containing non-numeric characters is rejected with 400 (flag-injection guard).
+func TestHostAPI_Review_NonNumericPRNumberReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	for _, prNumber := range []string{"--keep", "12a", "1;2", "abc", "-1"} {
+		t.Run(prNumber, func(t *testing.T) {
+			body := fmt.Sprintf(`{"pr_number":%q}`, prNumber)
+			rr := doHostAPI(t, sc, http.MethodPost, "/review", body)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("pr_number=%q: status = %d, want 400", prNumber, rr.Code)
+			}
+			var errResp map[string]string
+			decodeJSONBody(t, rr, &errResp)
+			if !strings.Contains(errResp["error"], "pr_number must be a numeric string") {
+				t.Errorf("pr_number=%q: error %q should mention 'numeric'", prNumber, errResp["error"])
+			}
+		})
+	}
+}
+
+// TestHostAPI_Review_UnknownAgentNameReturns400 verifies that an unrecognised
+// agent name in the agents list is rejected with 400 (flag-injection guard).
+func TestHostAPI_Review_UnknownAgentNameReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review",
+		`{"pr_number":"123","agents":["--keep","review-code"]}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown agent name; body = %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "unknown agent name") {
+		t.Errorf("error %q should mention 'unknown agent name'", errResp["error"])
+	}
+}
+
+// TestHostAPI_Review_EnhancedReviewEnvInjected verifies that ENHANCED_REVIEW=true
+// is injected into the subprocess environment when enhanced agent names are
+// requested, so the host's agentsForHarness() returns the correct pool.
+func TestHostAPI_Review_EnhancedReviewEnvInjected(t *testing.T) {
+	d := openTestDB(t)
+
+	envFile := filepath.Join(t.TempDir(), "captured-env")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub writes ENHANCED_REVIEW value to envFile.
+	stubScript := `#!/bin/sh
+echo "$ENHANCED_REVIEW" > ` + envFile + `
+echo "✓ review-code          passed"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review",
+		`{"pr_number":"123","agents":["review-code","review-goal"]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedEnv, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read captured env: %v", err)
+	}
+	got := strings.TrimSpace(string(capturedEnv))
+	if got != "true" {
+		t.Errorf("ENHANCED_REVIEW = %q, want %q (must be injected when enhanced agents requested)", got, "true")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6062,19 +6062,34 @@ echo "session \"${last}@no-harness-branch\" created"
 
 // ── /review endpoint ──────────────────────────────────────────────────────────
 
-// TestHostAPI_Review_WorkerForbidden verifies that a worker-role sidecar
-// cannot call /review (coordinators only).
-func TestHostAPI_Review_WorkerForbidden(t *testing.T) {
+// TestHostAPI_Review_WorkerAllowed verifies that a worker-role sidecar can
+// call /review. Workers run `prism review` as part of their own PR workflow,
+// so the /review endpoint must not require coordinator role.
+func TestHostAPI_Review_WorkerAllowed(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
-	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"123"}`)
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", rr.Code)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := "#!/bin/sh\necho '✓ review               passed'\nexit 0\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
 	}
-	var errResp map[string]string
-	decodeJSONBody(t, rr, &errResp)
-	if errResp["error"] == "" {
-		t.Error("expected error field in 403 response")
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "myrepo@feature",
+		Repo:            "myrepo",
+		Worktree:        "/tmp/myrepo@feature",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "worker",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "worker", ""),
+	}
+	sc := New(cfg)
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"123"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (workers must be allowed to call /review); body = %s",
+			rr.Code, rr.Body.String())
 	}
 }
 
@@ -6277,5 +6292,52 @@ func TestHostAPI_Review_InfraFailureReturns500(t *testing.T) {
 	decodeJSONBody(t, rr, &errResp)
 	if errResp["error"] == "" {
 		t.Error("expected error field in 500 response")
+	}
+}
+
+// TestHostAPI_Review_SessionNameInjected verifies that the sidecar injects
+// PRISM_SESSION_NAME into the subprocess environment so that
+// review.LookupParentSession() resolves the session name correctly without
+// needing a live tmux session.
+func TestHostAPI_Review_SessionNameInjected(t *testing.T) {
+	d := openTestDB(t)
+
+	envFile := filepath.Join(t.TempDir(), "captured-env")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub writes PRISM_SESSION_NAME to envFile so the test can inspect it.
+	stubScript := `#!/bin/sh
+echo "$PRISM_SESSION_NAME" > ` + envFile + `
+echo "✓ review               passed"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@741-fix",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@741-fix",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"741"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedEnv, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read captured env: %v", err)
+	}
+	got := strings.TrimSpace(string(capturedEnv))
+	if got != "nixos-config@741-fix" {
+		t.Errorf("PRISM_SESSION_NAME = %q, want %q (must be injected by sidecar)", got, "nixos-config@741-fix")
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6059,3 +6059,223 @@ echo "session \"${last}@no-harness-branch\" created"
 		t.Errorf("captured args %q do not contain '--harness opencode' (harness was not defaulted or forwarded)", string(capturedArgs))
 	}
 }
+
+// ── /review endpoint ──────────────────────────────────────────────────────────
+
+// TestHostAPI_Review_WorkerForbidden verifies that a worker-role sidecar
+// cannot call /review (coordinators only).
+func TestHostAPI_Review_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"123"}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+// TestHostAPI_Review_WrongMethod verifies that GET /review returns 405.
+func TestHostAPI_Review_WrongMethod(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/review", "")
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+// TestHostAPI_Review_MissingPRNumber verifies that a request without pr_number
+// returns 400.
+func TestHostAPI_Review_MissingPRNumber(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for missing pr_number", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "pr_number is required") {
+		t.Errorf("error %q should mention 'pr_number is required'", errResp["error"])
+	}
+}
+
+// TestHostAPI_Review_PassesArgsToReview verifies that /review delegates to
+// `prism review` with the correct arguments and returns the output.
+func TestHostAPI_Review_PassesArgsToReview(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub echoes args to argsFile and prints review-like output to stdout.
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+echo "✓ review               passed"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"456"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var respBody map[string]any
+	decodeJSONBody(t, rr, &respBody)
+	if respBody["passed"] != true {
+		t.Errorf("passed = %v, want true", respBody["passed"])
+	}
+	if !strings.Contains(fmt.Sprintf("%v", respBody["output"]), "passed") {
+		t.Errorf("output %q should contain 'passed'", respBody["output"])
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "review 456") {
+		t.Errorf("captured args %q do not contain 'review 456'", string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Review_OnlyFlagForwarded verifies that when agents are specified
+// in the request, --only is passed to `prism review`.
+func TestHostAPI_Review_OnlyFlagForwarded(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+echo "✓ review-code          passed"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review",
+		`{"pr_number":"789","agents":["review-code","review-goal"]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "--only review-code,review-goal") {
+		t.Errorf("captured args %q do not contain '--only review-code,review-goal'", string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Review_FailedReviewReturnsOutputWithPassedFalse verifies that
+// when `prism review` exits non-zero with output, the response has passed=false
+// and the output is included (this is the normal "agents found issues" case).
+func TestHostAPI_Review_FailedReviewReturnsOutputWithPassedFalse(t *testing.T) {
+	d := openTestDB(t)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Exit 1 with output: indicates agents found issues (not an infra failure).
+	stubScript := `#!/bin/sh
+echo "✗ review-code"
+echo "  blocking issue found"
+exit 1
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"100"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for agent failure (not infra failure); body = %s", rr.Code, rr.Body.String())
+	}
+	var respBody map[string]any
+	decodeJSONBody(t, rr, &respBody)
+	if respBody["passed"] != false {
+		t.Errorf("passed = %v, want false", respBody["passed"])
+	}
+	if !strings.Contains(fmt.Sprintf("%v", respBody["output"]), "blocking issue found") {
+		t.Errorf("output %q should contain 'blocking issue found'", respBody["output"])
+	}
+}
+
+// TestHostAPI_Review_InfraFailureReturns500 verifies that when `prism review`
+// exits non-zero with no output, the response is HTTP 500 (infra failure).
+func TestHostAPI_Review_InfraFailureReturns500(t *testing.T) {
+	d := openTestDB(t)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Exit non-zero with no stdout output: infra failure.
+	stubScript := "#!/bin/sh\nexit 2\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"999"}`)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for infra failure (no output); body = %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 500 response")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `POST /review` endpoint to the sidecar host API so workers running inside containers can trigger review sessions on the host where tmux is available
- Adds container-mode detection to `cmd/review.go`: when `PRISM_HOST_API` is set, routes through the host API instead of calling `review.Run()` directly
- Adds `proxyReview()` in `cmd/hostapi.go` with an extended HTTP client timeout (per-agent timeout + 3 min overhead)
- Covers the change with 7 sidecar tests

## Root cause

After PR #732 (podman-attach model), workers run opencode inside containers. `prism review` calls tmux directly and fails silently inside containers — there is no tmux server. Workers fall back to `@review-*` Task subagents, losing all dashboard observability.

## Fix (Option A from the issue)

`prism review` now checks `PRISM_HOST_API` before doing anything. If set (container session), it sends `POST /review` to the sidecar host API instead. The sidecar runs on the host where tmux is available and executes `prism review` there via `exec.Command`. Results (formatted output + pass/fail) are returned as JSON.

The non-container path (direct `review.Run()` call) is completely unchanged.

## Acceptance criteria covered

- ✅ Worker inside container can call `prism review <pr>` — routed to host sidecar
- ✅ Host-mode sessions (non-container) continue to work unchanged
- ✅ `prism review --only <agent>` works from container sessions (forwarded via `agents` field)
- ✅ If host API unreachable: `proxyReview()` returns a clear error (transport error surfaced to user)
- ✅ `go build ./...` and `go test ./...` pass

Closes #741