### PR TITLE
fix: change auth.json container mount from :ro,Z to :Z

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -905,12 +905,16 @@ func (m *Manager) buildRunArgs() []string {
 	// the SQLite DB. Only mounted when the file exists — skipped silently when
 	// absent (e.g. after the parent dir was deleted for DB recovery). Uses the
 	// same bind-mount-inside-mounted-dir pattern as the gitdir overlay.
-	// Mounted read-only: opencode reads auth.json for OAuth tokens but token
-	// refresh writes go to the per-session state directory, not back to this
-	// file. :Z applies the SELinux label so podman can bind-mount it on
+	// Mounted read-write (:Z, not :ro,Z): the opencode-claude-auth plugin calls
+	// writeFileSync on auth.json on every load to sync the active OAuth
+	// credentials. A read-only mount causes EROFS and breaks Anthropic auth
+	// inside the container. Keeping it writable also means token refreshes
+	// written inside one session propagate back to the shared host file and are
+	// visible to subsequent sessions — the intended shared-credentials behaviour.
+	// :Z applies the SELinux label so podman can bind-mount it on
 	// SELinux-enforcing hosts (Fedora/RHEL).
 	if _, err := os.Stat(opencodeAuthJSON); err == nil {
-		args = append(args, "--volume", opencodeAuthJSON+":/root/.local/share/opencode/auth.json:ro,Z")
+		args = append(args, "--volume", opencodeAuthJSON+":/root/.local/share/opencode/auth.json:Z")
 	}
 
 	// MCP auth: bind-mount ~/.mcp-auth into the container at /root/.mcp-auth

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -793,8 +793,9 @@ func (m *Manager) buildRunArgs() []string {
 	// by bind-mounting it over the per-session dir's auth.json. Only added when
 	// the file exists on the host — skipped silently when absent (e.g. after the
 	// parent dir was deleted for DB recovery).
-	// Mounted read-only: opencode reads auth.json for OAuth tokens but does not
-	// write back to it — token refresh writes go to the per-session state dir.
+	// Mounted read-write (:Z): the opencode-claude-auth plugin calls
+	// writeFileSync on auth.json on every load to sync active OAuth credentials.
+	// A :ro mount causes EROFS and breaks Anthropic auth inside the container.
 	opencodeAuthJSON := filepath.Join(home, ".local", "share", "opencode", "auth.json")
 
 	// opencodeConfigDir is the host's opencode config directory, mounted

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2634,7 +2634,10 @@ func TestBuildRunArgs_AuthJsonOverlayMountedWhenExists(t *testing.T) {
 	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
 	args := m.buildRunArgs()
 
-	wantDst := ":/root/.local/share/opencode/auth.json:ro,Z"
+	// The mount must be read-write (:Z, not :ro,Z): the opencode-claude-auth
+	// plugin calls writeFileSync on auth.json on every load, so a :ro mount
+	// causes EROFS and breaks Anthropic auth inside the container.
+	wantDst := ":/root/.local/share/opencode/auth.json:Z"
 	found := false
 	for i, arg := range args {
 		if arg == "--volume" && i+1 < len(args) {
@@ -2644,6 +2647,10 @@ func TestBuildRunArgs_AuthJsonOverlayMountedWhenExists(t *testing.T) {
 				// Source must be the host auth.json path.
 				if !strings.HasPrefix(v, authJSON+":") {
 					t.Errorf("auth.json overlay source %q should be %q", v, authJSON)
+				}
+				// Must NOT contain :ro — the plugin writes to this file.
+				if strings.Contains(v, ":ro") {
+					t.Errorf("auth.json overlay mount %q must not be read-only (:ro causes EROFS)", v)
 				}
 				break
 			}


### PR DESCRIPTION
## Summary

- The `opencode-claude-auth` plugin calls `writeFileSync` on `auth.json` on every load to sync active OAuth credentials. The previous `:ro,Z` mount mode caused `EROFS` and broke Anthropic auth entirely inside the container.
- Changed the mount mode to `:Z` (read-write) so the plugin can write, and token refreshes written by one session are reflected in the shared host `auth.json` for subsequent sessions — the intended shared-credentials behaviour.
- Updated the corresponding test (`TestBuildRunArgs_AuthJsonOverlayMountedWhenExists`) to expect `:Z` instead of `:ro,Z`, and added an assertion that `:ro` is absent.

Closes #748