### PR TITLE
fix: switch Darwin container nix-daemon access to ssh-ng:// (virtiofs ENOTSUP)

### DIFF
--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -203,25 +203,24 @@ pkgs.dockerTools.buildLayeredImage {
     cp ${nixosRebuildGuard} bin/nixos-rebuild
     chmod +x bin/nixos-rebuild
 
-    # Nix wrapper: when the host's nix daemon socket is mounted (by
-    # container.go), transparently inject --eval-store auto so that
+    # Nix wrapper: transparently inject --eval-store auto so that
     # "nix build", "nix flake check", etc. evaluate locally (can see
-    # /workspace) but delegate store operations to the host daemon
-    # (reusing cached derivations). Without the socket the wrapper is
-    # a no-op passthrough to the real nix binary.
+    # /workspace) but delegate store operations to the remote store.
+    # On Linux, NIX_CONFIG=store=daemon routes to the host daemon socket.
+    # On Darwin, NIX_REMOTE=ssh-ng://user@host.containers.internal routes
+    # to the host daemon over SSH (virtiofs cannot service connect() on
+    # Unix sockets). In both cases --eval-store auto ensures local evaluation
+    # while builds and fetches go to the remote store.
     real_nix=$(readlink -f bin/nix)
     mv bin/nix bin/.nix-real
     cat > bin/nix << 'WRAPPER'
     #!/bin/bash
-    SOCKET=/nix/var/nix/daemon-socket/socket
-    if [ -S "$SOCKET" ]; then
-      # Subcommands that accept --eval-store
-      case "''${1:-}" in
-        build|eval|flake|develop|path-info|print-dev-env|log|derivation)
-          exec /bin/.nix-real "$1" --eval-store auto "''${@:2}"
-          ;;
-      esac
-    fi
+    # Subcommands that accept --eval-store: evaluate locally, build remotely.
+    case "''${1:-}" in
+      build|eval|flake|develop|path-info|print-dev-env|log|derivation)
+        exec /bin/.nix-real "$1" --eval-store auto "''${@:2}"
+        ;;
+    esac
     exec /bin/.nix-real "$@"
     WRAPPER
     chmod +x bin/nix

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -205,6 +205,12 @@ type Manager struct {
 	// podman is never given a source path that doesn't exist on disk.
 	// This field is only ever true on Darwin.
 	claudeCredentialsReady bool
+	// nixKnownHostsReady is true when writeNixKnownHosts successfully read the
+	// macOS SSH host key from /etc/ssh/ssh_host_*_key.pub and wrote a
+	// known_hosts file for host.containers.internal. buildRunArgs uses this to
+	// gate the bind-mount and to set StrictHostKeyChecking=yes in the SSH
+	// config for host.containers.internal. Only ever true on Darwin.
+	nixKnownHostsReady bool
 }
 
 // New creates a Manager for the given config. It does not start the container.
@@ -247,6 +253,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.opencodeConfigFilePath())
 	_ = os.Remove(m.claudeCredentialsFilePath())
+	_ = os.Remove(m.nixKnownHostsFilePath())
 
 	// Check the container's instance label when we have our own InstanceID.
 	// This detects ownership mismatches where a container from a previous
@@ -335,6 +342,15 @@ func (m *Manager) claudeCredentialsFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-claude-creds-"+m.name)
 }
 
+// nixKnownHostsFilePath returns the host path for the temporary known_hosts
+// file written before container start (Darwin only). The file contains the
+// macOS SSH host key listed under host.containers.internal so that the SSH
+// client inside the container can verify the host with StrictHostKeyChecking=yes
+// when nix uses ssh-ng://user@host.containers.internal as its remote store.
+func (m *Manager) nixKnownHostsFilePath() string {
+	return filepath.Join(os.TempDir(), "prism-nix-known-hosts-"+m.name)
+}
+
 // writeClaudeCredentials extracts Claude Code credentials from the macOS
 // Keychain and writes them to a temp file. On Linux, Claude Code stores
 // credentials in ~/.claude/.credentials.json which is already inside the
@@ -370,6 +386,55 @@ func (m *Manager) writeClaudeCredentials() {
 		return
 	}
 	m.claudeCredentialsReady = true
+}
+
+// writeNixKnownHosts generates a known_hosts file containing the macOS SSH
+// host key listed under host.containers.internal. The file is later mounted
+// at /root/.ssh/nix-known-hosts:ro inside the container so that the SSH client
+// used by nix's ssh-ng:// store can verify the host key with
+// StrictHostKeyChecking=yes.
+//
+// The key material is read from /etc/ssh/ssh_host_*_key.pub — the macOS sshd
+// host public keys. No network call is made: reading the local key file is
+// sufficient because the container connects to the same macOS host that
+// generated these keys.
+//
+// On non-Darwin platforms this is a no-op. Sets nixKnownHostsReady on success.
+func (m *Manager) writeNixKnownHosts() {
+	m.nixKnownHostsReady = false
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	// Prefer ed25519; fall back to ecdsa and rsa in case only those exist.
+	candidates := []string{
+		"/etc/ssh/ssh_host_ed25519_key.pub",
+		"/etc/ssh/ssh_host_ecdsa_key.pub",
+		"/etc/ssh/ssh_host_rsa_key.pub",
+	}
+	var entries strings.Builder
+	for _, pubKeyPath := range candidates {
+		data, err := os.ReadFile(pubKeyPath)
+		if err != nil {
+			continue
+		}
+		// The pub key file format is "<keytype> <base64> [comment]".
+		// The known_hosts format is "<hostname> <keytype> <base64> [comment]".
+		// Prepend the hostname to form a valid known_hosts entry.
+		line := strings.TrimSpace(string(data))
+		if line == "" {
+			continue
+		}
+		entries.WriteString("host.containers.internal " + line + "\n")
+	}
+	if entries.Len() == 0 {
+		log.Printf("container: no SSH host public keys found in /etc/ssh — nix ssh-ng host key verification will fail; check that macOS sshd host keys exist")
+		return
+	}
+	if err := os.WriteFile(m.nixKnownHostsFilePath(), []byte(entries.String()), 0o600); err != nil {
+		log.Printf("container: write nix known_hosts: %v", err)
+		return
+	}
+	m.nixKnownHostsReady = true
 }
 
 // writeGitconfig generates a minimal .gitconfig for the container and writes
@@ -522,12 +587,52 @@ func (m *Manager) Create(ctx context.Context) error {
 		}
 	}
 
+	// On Darwin, generate a known_hosts file for host.containers.internal from
+	// the macOS SSH host keys (/etc/ssh/ssh_host_*_key.pub). nixKnownHostsReady
+	// must be set BEFORE the SSH config is written below — it controls whether
+	// StrictHostKeyChecking=yes or accept-new is used for the nix ssh-ng host.
+	m.writeNixKnownHosts()
+
 	// Write a minimal SSH config for the container. The host's ~/.ssh/config
 	// is a nix store symlink with wrong ownership that SSH rejects. This
-	// config only needs to handle GitHub; other SSH hosts are not expected
-	// inside agent containers.
-	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile /root/.ssh/access-key\n  IdentitiesOnly yes\n"
-	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
+	// config handles GitHub for git push/fetch and, on Darwin, also configures
+	// host.containers.internal for nix ssh-ng:// store access.
+	var sshConfigSB strings.Builder
+	sshConfigSB.WriteString("Host github.com\n")
+	sshConfigSB.WriteString("  StrictHostKeyChecking accept-new\n")
+	sshConfigSB.WriteString("  IdentityFile /root/.ssh/access-key\n")
+	sshConfigSB.WriteString("  IdentitiesOnly yes\n")
+
+	if runtime.GOOS == "darwin" {
+		// host.containers.internal is the gvproxy bridge hostname that resolves
+		// to the macOS host from inside the container VM. Nix uses this as the
+		// remote store endpoint (ssh-ng://user@host.containers.internal).
+		//
+		// StrictHostKeyChecking=yes: reject unknown host keys — the known_hosts
+		// file is generated by writeNixKnownHosts() from /etc/ssh/ssh_host_*_key.pub.
+		// ForwardAgent no: do not forward the SSH agent into the build host.
+		// ControlMaster/ControlPersist: multiplex SSH connections so repeated nix
+		// invocations within a session reuse the same SSH connection instead of
+		// performing a full handshake on each nix build or store operation.
+		hostKeyCheck := "accept-new"
+		if m.nixKnownHostsReady {
+			hostKeyCheck = "yes"
+		}
+		sshConfigSB.WriteString("\nHost host.containers.internal\n")
+		sshConfigSB.WriteString("  IdentityFile /root/.ssh/access-key\n")
+		sshConfigSB.WriteString("  IdentitiesOnly yes\n")
+		sshConfigSB.WriteString("  StrictHostKeyChecking " + hostKeyCheck + "\n")
+		if m.nixKnownHostsReady {
+			sshConfigSB.WriteString("  UserKnownHostsFile /root/.ssh/nix-known-hosts\n")
+		}
+		sshConfigSB.WriteString("  ControlMaster auto\n")
+		sshConfigSB.WriteString("  ControlPath /tmp/ssh_mux_%h_%p_%r\n")
+		sshConfigSB.WriteString("  ControlPersist 5m\n")
+		sshConfigSB.WriteString("  ForwardAgent no\n")
+		sshConfigSB.WriteString("  Port 22\n")
+	}
+
+	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfigSB.String()), 0o600); err != nil {
 		return fmt.Errorf("container: write ssh config: %w", err)
 	}
 
@@ -710,6 +815,7 @@ func (m *Manager) Shutdown() {
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.opencodeConfigFilePath())
 	_ = os.Remove(m.claudeCredentialsFilePath())
+	_ = os.Remove(m.nixKnownHostsFilePath())
 
 	log.Printf("container: %q removed", m.name)
 }
@@ -964,30 +1070,39 @@ func (m *Manager) buildRunArgs() []string {
 		)
 	}
 
-	args = append(args,
-		// Nix daemon socket — lets the container's nix CLI delegate store
-		// operations to the host's nix-daemon, reusing the host's /nix/store
-		// cache and persisting new build outputs for reuse across container
-		// restarts. The host's nix-daemon trusts @wheel users (nix-options.nix);
-		// in rootless podman, container root maps to the host user who is in
-		// the wheel group, so the daemon accepts the connection.
-		//
-		// NIX_CONFIG sets store=daemon so nix uses the host daemon for all
-		// store operations. The container image includes a nix wrapper script
-		// that automatically injects --eval-store auto when the socket is
-		// present, so evaluation happens locally (can see /workspace) while
-		// builds/fetches go through the daemon.
-		//
-		// Mount the parent directory rather than the socket file itself.
-		// On Darwin, podman runs inside a VM with virtiofs host shares;
-		// statfs on a Unix socket through virtiofs returns ENOTSUP, causing
-		// podman to reject the mount. Mounting the directory avoids the
-		// socket-level statfs and lets the container reach the socket via
-		// the live directory mount — the same pattern used for the host-API
-		// socket (see #611 / #612).
-		"--volume", "/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket",
-		"--env", "NIX_CONFIG=store = daemon",
+	// Nix daemon access — platform-specific.
+	//
+	// On Darwin: virtiofs returns ENOTSUP on connect() for Unix sockets
+	// mounted into the container VM, so the daemon socket mount is omitted.
+	// Instead, NIX_REMOTE points to the host's nix-daemon via ssh-ng://.
+	// The SSH connection uses the access key already mounted at
+	// /root/.ssh/access-key. The host user is in @wheel (nix-options.nix),
+	// so the daemon accepts builds from that user.
+	//
+	// On Linux: the container can connect to the daemon socket directly.
+	// The parent directory is mounted (not the socket file itself) to avoid
+	// a statfs-on-socket issue in podman. NIX_CONFIG sets store=daemon.
+	if runtime.GOOS == "darwin" {
+		user := os.Getenv("USER")
+		if user == "" {
+			user = "root" // should not happen on macOS; sshd will reject root anyway
+		}
+		args = append(args, "--env", "NIX_REMOTE=ssh-ng://"+user+"@host.containers.internal")
+	} else {
+		args = append(args,
+			"--volume", "/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket",
+			"--env", "NIX_CONFIG=store = daemon",
+		)
+	}
 
+	// Darwin: mount the generated known_hosts for host.containers.internal
+	// so the SSH client inside the container can verify the host key with
+	// StrictHostKeyChecking=yes when nix uses ssh-ng:// as its remote store.
+	if m.nixKnownHostsReady {
+		args = append(args, "--volume", m.nixKnownHostsFilePath()+":/root/.ssh/nix-known-hosts:ro")
+	}
+
+	args = append(args,
 		// Terminal type — set to xterm-256color so the opencode TUI inside the
 		// container has accurate terminal capability information. podman sets
 		// TERM=xterm (plain) by default when --tty is used without an explicit

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2681,3 +2681,181 @@ func TestBuildRunArgs_AuthJsonOverlaySkippedWhenMissing(t *testing.T) {
 		}
 	}
 }
+
+// ── Nix daemon access (Darwin ssh-ng vs Linux socket) ────────────────────────
+
+// TestBuildRunArgs_NixDaemon_Darwin verifies that on Darwin:
+//   - NIX_REMOTE is set to ssh-ng://user@host.containers.internal
+//   - The daemon socket volume (/nix/var/nix/daemon-socket) is absent
+//   - NIX_CONFIG is not set
+func TestBuildRunArgs_NixDaemon_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Darwin-specific nix daemon test; skipping on non-Darwin")
+	}
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	user := os.Getenv("USER")
+	if user == "" {
+		t.Skip("USER env var not set; cannot determine expected ssh-ng URL")
+	}
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	wantEnv := "NIX_REMOTE=ssh-ng://" + user + "@host.containers.internal"
+	foundNIXRemote := false
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) {
+			if args[i+1] == wantEnv {
+				foundNIXRemote = true
+			}
+			// NIX_CONFIG must NOT be set on Darwin (uses ssh-ng instead)
+			if strings.HasPrefix(args[i+1], "NIX_CONFIG=") {
+				t.Errorf("NIX_CONFIG must not be set on Darwin (use NIX_REMOTE instead); got %q", args[i+1])
+			}
+		}
+		// Daemon socket must NOT be mounted on Darwin (virtiofs ENOTSUP)
+		if arg == "--volume" && i+1 < len(args) {
+			if strings.Contains(args[i+1], "/nix/var/nix/daemon-socket") {
+				t.Errorf("daemon socket volume must not be mounted on Darwin; got %q", args[i+1])
+			}
+		}
+	}
+	if !foundNIXRemote {
+		t.Errorf("expected --env %s in args, not found; args: %v", wantEnv, args)
+	}
+}
+
+// TestBuildRunArgs_NixDaemon_Linux verifies that on Linux:
+//   - The daemon socket volume (/nix/var/nix/daemon-socket) is present
+//   - NIX_CONFIG=store = daemon is set
+//   - NIX_REMOTE is not set
+func TestBuildRunArgs_NixDaemon_Linux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-specific nix daemon test; skipping on non-Linux")
+	}
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	foundSocketMount := false
+	foundNIXConfig := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			if strings.Contains(args[i+1], "/nix/var/nix/daemon-socket") {
+				foundSocketMount = true
+			}
+		}
+		if arg == "--env" && i+1 < len(args) {
+			if args[i+1] == "NIX_CONFIG=store = daemon" {
+				foundNIXConfig = true
+			}
+			// NIX_REMOTE must NOT be set on Linux
+			if strings.HasPrefix(args[i+1], "NIX_REMOTE=") {
+				t.Errorf("NIX_REMOTE must not be set on Linux (use socket instead); got %q", args[i+1])
+			}
+		}
+	}
+	if !foundSocketMount {
+		t.Errorf("daemon socket volume /nix/var/nix/daemon-socket must be present on Linux; args: %v", args)
+	}
+	if !foundNIXConfig {
+		t.Errorf("NIX_CONFIG=store = daemon must be set on Linux; args: %v", args)
+	}
+}
+
+// TestWriteNixKnownHosts_NoopOnLinux verifies that writeNixKnownHosts is a
+// no-op on non-Darwin platforms: nixKnownHostsReady stays false and no temp
+// file is written. On Darwin this test still passes because it only asserts
+// the invariant that nixKnownHostsReady accurately tracks whether the file
+// was written.
+func TestWriteNixKnownHosts_NoopOnLinux(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping Linux-specific no-op check on Darwin")
+	}
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 9999})
+	m.writeNixKnownHosts()
+	if m.nixKnownHostsReady {
+		t.Error("nixKnownHostsReady should be false on non-Darwin")
+	}
+	if _, err := os.Stat(m.nixKnownHostsFilePath()); !os.IsNotExist(err) {
+		t.Errorf("nix known_hosts temp file should not exist on non-Darwin, got: %v", err)
+	}
+}
+
+// TestWriteNixKnownHosts_Darwin verifies that on Darwin writeNixKnownHosts
+// reads the macOS SSH host key from /etc/ssh and writes a known_hosts file
+// with an entry for host.containers.internal.
+func TestWriteNixKnownHosts_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Darwin-specific known_hosts test; skipping on non-Darwin")
+	}
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 9999})
+	t.Cleanup(func() { _ = os.Remove(m.nixKnownHostsFilePath()) })
+	m.writeNixKnownHosts()
+	if !m.nixKnownHostsReady {
+		t.Fatal("nixKnownHostsReady should be true on Darwin when /etc/ssh host keys exist")
+	}
+	data, err := os.ReadFile(m.nixKnownHostsFilePath())
+	if err != nil {
+		t.Fatalf("failed to read nix known_hosts: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "host.containers.internal") {
+		t.Errorf("known_hosts should contain host.containers.internal; got:\n%s", content)
+	}
+}
+
+// TestBuildRunArgs_NixKnownHostsMountedWhenReady verifies that when
+// nixKnownHostsReady is true, buildRunArgs includes the nix-known-hosts bind-mount.
+func TestBuildRunArgs_NixKnownHostsMountedWhenReady(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14001})
+
+	// Simulate a successful writeNixKnownHosts by writing a fake file and
+	// setting the flag directly (avoids requiring actual Darwin/Keychain in CI).
+	fakeKnownHosts := "host.containers.internal ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA"
+	if err := os.WriteFile(m.nixKnownHostsFilePath(), []byte(fakeKnownHosts), 0o600); err != nil {
+		t.Fatalf("write fake known_hosts: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.nixKnownHostsFilePath()) })
+	m.nixKnownHostsReady = true
+
+	args := m.buildRunArgs()
+
+	wantDst := ":/root/.ssh/nix-known-hosts:ro"
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) && strings.HasSuffix(args[i+1], wantDst) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("buildRunArgs missing nix-known-hosts mount ending in %q; args: %v", wantDst, args)
+	}
+}
+
+// TestBuildRunArgs_NixKnownHostsNotMountedWhenNotReady verifies that when
+// nixKnownHostsReady is false, buildRunArgs does NOT include the nix-known-hosts bind-mount.
+func TestBuildRunArgs_NixKnownHostsNotMountedWhenNotReady(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14002})
+	// nixKnownHostsReady defaults to false — do not set it.
+
+	args := m.buildRunArgs()
+
+	wantDst := ":/root/.ssh/nix-known-hosts:ro"
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) && strings.HasSuffix(args[i+1], wantDst) {
+			t.Errorf("nix-known-hosts mount must not be present when nixKnownHostsReady=false; found %q", args[i+1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

On Darwin (macOS), `virtiofs` returns `ENOTSUP` on `connect()` calls for Unix sockets mounted into the container VM. The existing daemon-socket bind-mount in `container.go` was a workaround for the mount-time `statfs` issue, but `connect()` still fails at runtime — meaning `nix build` inside containers has never worked on Darwin.

This PR switches the Darwin path to `ssh-ng://\$USER@host.containers.internal`, which uses the already-running macOS `sshd` and the SSH key already mounted by prism's existing credential mechanism. Linux behaviour is unchanged.

## Changes

- **`container.go`**: Add `writeNixKnownHosts()` to read the macOS SSH host key from `/etc/ssh/ssh_host_*_key.pub` and write a `known_hosts` file for `host.containers.internal`. On Darwin, set `NIX_REMOTE=ssh-ng://user@host.containers.internal` (remove broken socket mount); on Linux keep existing socket+`NIX_CONFIG`. Add `host.containers.internal` SSH config stanza with `ControlMaster`/`ControlPersist` (connection reuse), `StrictHostKeyChecking yes`, `ForwardAgent no`.
- **`images/prism-agent.nix`**: Remove socket-existence check from the nix wrapper script. Always inject `--eval-store auto` so evaluation is local while builds go to the remote store (works with both `NIX_REMOTE` on Darwin and `NIX_CONFIG` on Linux).
- **`container_test.go`**: Add tests for Darwin `NIX_REMOTE` path, Linux socket path, `writeNixKnownHosts`, and `nix-known-hosts` mount gating.

## Security

- `StrictHostKeyChecking yes` with a pre-generated `known_hosts` (from `/etc/ssh/ssh_host_*_key.pub`)
- `ForwardAgent no` — no SSH agent forwarding
- No new private key material introduced; uses existing prism access key
- Host user is in `@wheel` in `nix-options.nix` — daemon accepts builds without `--trusted` workarounds

## Testing

- `go build ./...` ✅
- `go test ./internal/container/...` ✅ (all pass; Linux-specific and Darwin-specific tests appropriately skipped on wrong platform)  
- `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel` ✅

Closes #750