### PR TITLE
prism: update tmux pane_current_command keybinds from opencode to podman

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -189,12 +189,12 @@ in
               bind a display-popup -E -d "#{pane_current_path}" -w 60% -h 20% -b single \
                 "${prism} spawn --attach"
 
-              # opencode scrolling keybinds (only active when opencode is running)
-              # Note: on NixOS/Linux, opencode runs directly as "opencode" in pane_current_command
-              bind -n C-u if-shell '[ "#{pane_current_command}" = "opencode" ]' 'send-keys C-M-u' 'send-keys C-u'
-              bind -n C-d if-shell '[ "#{pane_current_command}" = "opencode" ]' 'send-keys C-M-d' 'send-keys C-d'
-              bind -n C-g if-shell '[ "#{pane_current_command}" = "opencode" ]' 'send-keys Home'
-              bind -n C-M-g if-shell '[ "#{pane_current_command}" = "opencode" ]' 'send-keys End'
+              # opencode scrolling keybinds (only active when opencode is running inside podman)
+              # Note: after the podman-attach migration, the agent pane command is "podman"
+              bind -n C-u if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys C-M-u' 'send-keys C-u'
+              bind -n C-d if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys C-M-d' 'send-keys C-d'
+              bind -n C-g if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys Home'
+              bind -n C-M-g if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys End'
 
               # Clipboard paste bridge for container-mode opencode panes (issue #752).
               #


### PR DESCRIPTION
## Summary

After PR #732 introduced the podman-attach model, the agent pane command became `"podman"` rather than `"opencode"`. This meant the four conditional keybinds (`C-u`, `C-d`, `C-g`, `C-M-g`) were never firing because their `pane_current_command = "opencode"` checks always evaluated to false.

This PR updates all four checks to `pane_current_command = "podman"` and refreshes the surrounding comments to reflect the post-migration state.

## Changes

- `C-u`: checks `pane_current_command = "podman"` (was `"opencode"`)
- `C-d`: checks `pane_current_command = "podman"` (was `"opencode"`)
- `C-g`: checks `pane_current_command = "podman"` (was `"opencode"`)
- `C-M-g`: checks `pane_current_command = "podman"` (was `"opencode"`)
- Updated comments around line 152 to describe the post-migration state

Closes #742