### PR TITLE
fix(prism): resolve review worktree from DB instead of PRISM_SPAWN_PATH/workspace

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -109,34 +109,20 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("prism review: could not determine parent session name\nhint: run from inside a tmux session or set PRISM_SESSION_NAME")
 	}
 
-	// Load config for container mode (must be before DB block to gate it).
+	// Load config (used below for container mode flags).
 	cfg := config.Load()
 
-	// Resolve worktree path.
-	var worktree string
-	if cfg.ContainerMode {
-		worktree = os.Getenv("PRISM_SPAWN_PATH")
-		if worktree == "" {
-			worktree = "/workspace"
-		}
-	} else {
-		// Validate parent session exists in DB.
-		d, dbErr := openDB()
-		if dbErr != nil {
-			return fmt.Errorf("prism review: open db: %w", dbErr)
-		}
-		status, stErr := d.CurrentStatus(parentSession)
-		d.Close()
-		if stErr != nil {
-			return fmt.Errorf("prism review: lookup session %q: %w", parentSession, stErr)
-		}
-		if status == nil {
-			return fmt.Errorf("prism review: parent session %q not found in DB\nhint: the session must be registered in the prism DB", parentSession)
-		}
-		worktree = status.Worktree
-		if worktree == "" {
-			return fmt.Errorf("prism review: no worktree path for session %q", parentSession)
-		}
+	// Resolve worktree path from the DB. By the time control reaches here we
+	// know PRISM_HOST_API is unset (the proxy-out branch above did not fire),
+	// so this process is running on the host regardless of cfg.ContainerMode.
+	// cfg.ContainerMode is a Nix-time flag meaning "this host spawns workers
+	// inside containers"; it does NOT mean "this process is running inside a
+	// container". Reading PRISM_SPAWN_PATH or falling back to /workspace here
+	// would use the container-internal path, which does not exist on the host
+	// and causes `statfs /workspace: no such file or directory` in podman.
+	worktree, wtErr := resolveReviewWorktree(parentSession)
+	if wtErr != nil {
+		return wtErr
 	}
 
 	// Determine agents list.
@@ -245,6 +231,31 @@ func agentsForHarness(harness string) []review.Agent {
 		}
 		return review.DefaultAgents()
 	}
+}
+
+// resolveReviewWorktree returns the host-side worktree path for parentSession
+// by looking it up in the prism DB. It is called from runReview after the
+// PRISM_HOST_API proxy-out branch, so we are always on the host regardless of
+// cfg.ContainerMode. Using PRISM_SPAWN_PATH or a /workspace fallback here
+// would pass the container-internal mount path to podman, causing a
+// "statfs /workspace: no such file or directory" error on the host.
+func resolveReviewWorktree(parentSession string) (string, error) {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return "", fmt.Errorf("prism review: open db: %w", dbErr)
+	}
+	status, stErr := d.CurrentStatus(parentSession)
+	d.Close()
+	if stErr != nil {
+		return "", fmt.Errorf("prism review: lookup session %q: %w", parentSession, stErr)
+	}
+	if status == nil {
+		return "", fmt.Errorf("prism review: parent session %q not found in DB\nhint: the session must be registered in the prism DB", parentSession)
+	}
+	if status.Worktree == "" {
+		return "", fmt.Errorf("prism review: no worktree path for session %q", parentSession)
+	}
+	return status.Worktree, nil
 }
 
 // splitCSV splits a comma-separated string and trims whitespace.

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
 )
 
@@ -86,5 +89,114 @@ func TestAgentsForHarness_EnhancedAgentNames(t *testing.T) {
 		if agents[i].OpencodeName != name {
 			t.Errorf("agents[%d].OpencodeName = %q, want %q", i, agents[i].OpencodeName, name)
 		}
+	}
+}
+
+// ── resolveReviewWorktree tests ────────────────────────────────────────────────
+//
+// These tests cover the three scenarios mandated by #751:
+//
+//  1. Happy path: session present in DB with a real host-side worktree path →
+//     resolveReviewWorktree returns that path (not "/workspace").
+//
+//  2. Missing DB row: session not found → error containing the session name.
+//
+//  3. Empty worktree: session found but Worktree == "" → error containing the
+//     session name.
+//
+// All tests set testDBPath so that openDB() (via SetTestDBPath) uses an
+// isolated temp DB, never the real prism.db.
+
+// openReviewTestDB opens a temp SQLite DB for review tests, registers cleanup,
+// and points SetTestDBPath at it so resolveReviewWorktree uses it.
+func openReviewTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+	return d
+}
+
+// TestResolveReviewWorktree_ContainerMode_UsesDBPath verifies that when
+// cfg.ContainerMode is true on the host and PRISM_HOST_API is unset,
+// resolveReviewWorktree returns the host-side worktree stored in the DB, not
+// "/workspace" (the container-internal fallback that was the root of bug #751).
+//
+// The test seeds a session with a host-side path, then calls
+// resolveReviewWorktree and asserts the returned path matches the DB value.
+func TestResolveReviewWorktree_ContainerMode_UsesDBPath(t *testing.T) {
+	// Ensure we are exercising the host-side code path (PRISM_HOST_API unset).
+	t.Setenv("PRISM_HOST_API", "")
+	// Ensure PRISM_SPAWN_PATH is unset — the old code read this on the
+	// container-mode branch, which must NOT be used.
+	t.Setenv("PRISM_SPAWN_PATH", "")
+
+	d := openReviewTestDB(t)
+
+	const session = "nixos-config@fix-worktree-leak"
+	hostWorktree := "/Users/bensherman/code/nixos-config/fix-worktree-leak"
+
+	if err := d.UpsertStatus(session, "nixos-config", hostWorktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	got, err := resolveReviewWorktree(session)
+	if err != nil {
+		t.Fatalf("resolveReviewWorktree: unexpected error: %v", err)
+	}
+	if got != hostWorktree {
+		t.Errorf("resolveReviewWorktree = %q, want %q", got, hostWorktree)
+	}
+	// Explicit guard: the old broken fallback must not be returned.
+	if got == "/workspace" {
+		t.Errorf("resolveReviewWorktree returned /workspace — this is the container-internal path, not the host path")
+	}
+}
+
+// TestResolveReviewWorktree_SessionNotInDB verifies that when the parent
+// session has no row in the DB, resolveReviewWorktree returns a descriptive
+// error containing the session name.
+func TestResolveReviewWorktree_SessionNotInDB(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	// Open an empty DB — no rows seeded.
+	openReviewTestDB(t)
+
+	const session = "nixos-config@missing-session"
+	_, err := resolveReviewWorktree(session)
+	if err == nil {
+		t.Fatal("resolveReviewWorktree: expected error for missing session, got nil")
+	}
+	if !strings.Contains(err.Error(), session) {
+		t.Errorf("error %q does not contain session name %q", err.Error(), session)
+	}
+}
+
+// TestResolveReviewWorktree_EmptyWorktree verifies that when the DB row for
+// the parent session exists but has an empty Worktree field,
+// resolveReviewWorktree returns a descriptive error containing the session
+// name and does not proceed with an empty path.
+func TestResolveReviewWorktree_EmptyWorktree(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	d := openReviewTestDB(t)
+
+	const session = "nixos-config@empty-worktree"
+	// Seed a row with an empty worktree. UpsertStatus accepts "" for worktree.
+	if err := d.UpsertStatus(session, "nixos-config", "", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	_, err := resolveReviewWorktree(session)
+	if err == nil {
+		t.Fatal("resolveReviewWorktree: expected error for empty worktree, got nil")
+	}
+	if !strings.Contains(err.Error(), session) {
+		t.Errorf("error %q does not contain session name %q", err.Error(), session)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `prism review <pr>` invoked from a worker container would fail with `statfs /workspace: no such file or directory` because the worktree path passed to `podman run --volume` was the container-internal path `/workspace` instead of the host-side path.

## Root cause

In `cmd/review.go`, `runReview` had a branch:

```go
if cfg.ContainerMode {
    worktree = os.Getenv("PRISM_SPAWN_PATH")
    if worktree == "" {
        worktree = "/workspace"  // ← container-internal path, doesn't exist on host
    }
} else {
    // DB lookup
}
```

`cfg.ContainerMode` is a **Nix-time** flag meaning *"this host spawns workers in containers"*. It does **not** mean *"this process is running inside a container"*. By the time control reaches this block, `PRISM_HOST_API` is already confirmed unset (the proxy-out branch above did not fire), so the process is always on the host. Reading `PRISM_SPAWN_PATH` (unset on the host) and falling back to `/workspace` passed the container-internal path into podman, which rejected it.

## Fix

- Remove the `if cfg.ContainerMode { ... } else { ... }` block entirely
- Extract worktree resolution into a new `resolveReviewWorktree(parentSession)` helper that always does the DB lookup
- Add 3 unit tests: happy path with host-side worktree, missing DB row, empty Worktree field

The remaining `cfg.ContainerMode` usages in `runReview` (lines 148, 164, 168) are left unchanged per the issue scope instructions.

## Tests

```
=== RUN   TestResolveReviewWorktree_ContainerMode_UsesDBPath
--- PASS: TestResolveReviewWorktree_ContainerMode_UsesDBPath (0.06s)
=== RUN   TestResolveReviewWorktree_SessionNotInDB
--- PASS: TestResolveReviewWorktree_SessionNotInDB (0.05s)
=== RUN   TestResolveReviewWorktree_EmptyWorktree
--- PASS: TestResolveReviewWorktree_EmptyWorktree (0.06s)
```

All existing tests pass (`go test ./...`). NixOS build passes.

Closes #751