### PR TITLE
prism: add review role to ContainerConfigForRole with hardened config

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -38,6 +38,12 @@
       internal = true;
       description = "Serialised opencode.json blob for coordinator containers (mounted as config file).";
     };
+    nx.programs.prism.opencode.containerReviewConfigJson = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Serialised opencode.json blob for review containers (mounted as config file). Hardened: only review agent(s) declared, write/edit/patch denied, task tool disabled, prism review bash commands denied.";
+    };
     nx.programs.prism.opencode.enhancedReview = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -752,15 +758,169 @@
         plugin = containerPlugins;
         provider = providerSettings;
       };
+
+      # Review container bash commands — deny-by-default with read-only allowlist.
+      # Critically: "prism review" and "prism review *" are denied to prevent
+      # review agents from recursively invoking prism review.
+      containerReviewBashCommands = {
+        # Default: deny everything not explicitly allowed
+        "*" = "deny";
+        # prism review recursion prevention (belt-and-suspenders over deny-all)
+        "prism review" = "deny";
+        "prism review *" = "deny";
+      }
+      // readOnlyBashCommands
+      // {
+        # GitHub CLI read operations (review-context needs gh)
+        "gh issue view *" = "allow";
+        "gh issue list *" = "allow";
+        "gh pr view *" = "allow";
+        "gh pr list *" = "allow";
+        "gh pr diff *" = "allow";
+        "gh pr checks *" = "allow";
+        "gh repo view *" = "allow";
+        "gh run view *" = "allow";
+        "gh run list *" = "allow";
+        # prism read-only introspection
+        "prism checkin" = "allow";
+        "prism checkin *" = "allow";
+        "prism list-sessions" = "allow";
+      };
+
+      # Review container opencode.json blob.
+      # Hardened config: only review agent(s) declared; no worker, coordinator,
+      # build, or plan. write/edit/patch denied. task tool disabled to prevent
+      # review agents delegating to peer @review-* agents. prism review bash
+      # commands denied to prevent recursion.
+      reviewContainerOpencodeJson = {
+        "$schema" = "https://opencode.ai/opencode.json";
+        autoupdate = false;
+        default_agent =
+          if config.nx.programs.prism.opencode.enhancedReview then "review-goal" else "review";
+        enabled_providers = containerEnabledProviders;
+        model = models.secondary;
+        agent =
+          let
+            profiledAgents =
+              config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider
+                (
+                  {
+                    # Explicitly disable non-review agents
+                    worker = {
+                      disable = true;
+                    };
+                    coordinator = {
+                      disable = true;
+                    };
+                    build = {
+                      disable = true;
+                    };
+                    plan = {
+                      disable = true;
+                    };
+                    ac = {
+                      disable = true;
+                    };
+                    explore = {
+                      disable = true;
+                    };
+                    title = {
+                      disable = true;
+                    };
+                    summary = {
+                      disable = true;
+                    };
+                    compaction = {
+                      disable = true;
+                    };
+                  }
+                  // (
+                    if config.nx.programs.prism.opencode.enhancedReview then
+                      {
+                        review-goal = {
+                          tools = {
+                            task = false;
+                          };
+                        };
+                        review-code = {
+                          tools = {
+                            task = false;
+                          };
+                        };
+                        review-security = {
+                          tools = {
+                            task = false;
+                          };
+                        };
+                        review-qa = {
+                          tools = {
+                            task = false;
+                          };
+                        };
+                        review-context = {
+                          tools = {
+                            task = false;
+                          };
+                        };
+                      }
+                    else
+                      {
+                        review = {
+                          tools = {
+                            task = false;
+                          };
+                        };
+                      }
+                  )
+                );
+            # Strip variant from disabled agents
+            sanitisedAgents = lib.mapAttrs (
+              _name: cfg: if cfg ? disable && cfg.disable then builtins.removeAttrs cfg [ "variant" ] else cfg
+            ) profiledAgents;
+          in
+          sanitisedAgents;
+        # Atlassian MCP may be present (read-only, for context lookup).
+        # lib.mkIf cannot be used here — serialised with builtins.toJSON.
+        mcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
+          atlasian = {
+            type = "local";
+            enabled = true;
+            command = [ "/root/.config/opencode/mcp-atlassian-slim-proxy.mjs" ];
+            environment = {
+              ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+            };
+          };
+        };
+        permission = {
+          # Belt-and-suspenders: deny write operations (worktree is mounted read-only anyway)
+          edit = "deny";
+          patch = "deny";
+          write = "deny";
+          webfetch = "allow";
+          # Atlassian MCP permissions — review agents read only, no writes
+          "atlasian_*" = "deny";
+          "atlasian_atlassianUserInfo" = "allow";
+          "atlasian_get*" = "allow";
+          "atlasian_lookup*" = "allow";
+          "atlasian_search*" = "allow";
+          "atlasian_fetch" = "allow";
+          "atlasian_fetchAtlassian" = "allow";
+          bash = containerReviewBashCommands;
+          external_directory = "allow"; # safe because inside container
+        };
+        plugin = containerPlugins;
+        provider = providerSettings;
+      };
     in
     lib.mkMerge [
       # Set container config JSON blobs as options so profiles.nix can embed
       # them into profiles.json under container_worker_config /
-      # container_coordinator_config.
+      # container_coordinator_config / container_review_config.
       {
         nx.programs.prism.opencode.containerWorkerConfigJson = builtins.toJSON workerContainerOpencodeJson;
         nx.programs.prism.opencode.containerCoordinatorConfigJson =
           builtins.toJSON coordinatorContainerOpencodeJson;
+        nx.programs.prism.opencode.containerReviewConfigJson = builtins.toJSON reviewContainerOpencodeJson;
       }
 
       # When enhanced review is on, inject ENHANCED_REVIEW=true into the agent

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -68,6 +68,13 @@ type ProfilesFile struct {
 	// JSON string) to inject as OPENCODE_CONFIG_CONTENT for coordinator
 	// containers. Written by Nix under container_coordinator_config.
 	ContainerCoordinatorConfig string `json:"container_coordinator_config"`
+	// ContainerReviewConfig is the full opencode.json blob (serialised JSON
+	// string) to inject as OPENCODE_CONFIG_CONTENT for review containers.
+	// Written by Nix under container_review_config. The blob is hardened:
+	// only review agent(s) are declared; write/edit/patch are denied; the
+	// task tool is disabled to prevent review agents delegating to peers;
+	// and "prism review" bash commands are denied to prevent recursion.
+	ContainerReviewConfig string `json:"container_review_config"`
 	// AgentEnvVars holds environment variables to inject into host-mode
 	// opencode processes. Values are fully expanded absolute paths (no $HOME).
 	// Written by Nix under agent_env_vars. These are prepended to the
@@ -77,11 +84,12 @@ type ProfilesFile struct {
 }
 
 // ContainerConfigForRole returns the OPENCODE_CONFIG_CONTENT blob for the
-// given agent role ("worker" or "coordinator"). Returns ("", nil) when pf is
-// nil (no profiles file loaded) or when the role is not a recognised container
-// role (only "worker" and "coordinator" have dedicated container configs;
-// subagent names like "plan", "review", etc. are valid opencode agents but do
-// not have their own container configs — they inherit from the session default).
+// given agent role ("worker", "coordinator", or "review"). Returns ("", nil)
+// when pf is nil (no profiles file loaded) or when the role is not a
+// recognised container role (only "worker", "coordinator", and "review" have
+// dedicated container configs; subagent names like "plan", "explore", etc. are
+// valid opencode agents but do not have their own container configs — they
+// inherit from the session default).
 func ContainerConfigForRole(pf *ProfilesFile, role string) (string, error) {
 	if pf == nil {
 		return "", nil
@@ -91,8 +99,10 @@ func ContainerConfigForRole(pf *ProfilesFile, role string) (string, error) {
 		return pf.ContainerWorkerConfig, nil
 	case "coordinator":
 		return pf.ContainerCoordinatorConfig, nil
+	case "review":
+		return pf.ContainerReviewConfig, nil
 	default:
-		// Not a container-level role (e.g. "plan", "review", "explore").
+		// Not a container-level role (e.g. "plan", "explore").
 		// Return empty string — no config injection — without error.
 		return "", nil
 	}

--- a/modules/programs/prism/prism/internal/config/profiles_test.go
+++ b/modules/programs/prism/prism/internal/config/profiles_test.go
@@ -259,17 +259,20 @@ func TestBuildConfigContent_UnknownProfile(t *testing.T) {
 }
 
 // sampleProfilesFileWithReview returns a ProfilesFile that also has a review
-// config blob, for testing ContainerConfigForRole.
+// config blob, for testing ContainerConfigForRole. The fixture blobs use the
+// correct opencode.ai schema key "agent" (singular), matching what real
+// Nix-generated blobs produce.
 func sampleProfilesFileWithReview() *config.ProfilesFile {
 	pf := sampleProfilesFile()
-	pf.ContainerWorkerConfig = `{"agents":{"worker":{}}}`
-	pf.ContainerCoordinatorConfig = `{"agents":{"coordinator":{}}}`
-	pf.ContainerReviewConfig = `{"agents":{"review":{}}}`
+	pf.ContainerWorkerConfig = `{"agent":{"worker":{}}}`
+	pf.ContainerCoordinatorConfig = `{"agent":{"coordinator":{}}}`
+	pf.ContainerReviewConfig = `{"agent":{"review":{}}}`
 	return pf
 }
 
 // TestContainerConfigForRole_Review verifies that passing role "review" returns
-// the ContainerReviewConfig blob (non-empty, valid JSON, has "agents" key).
+// the ContainerReviewConfig blob (non-empty, valid JSON, has "agent" key —
+// the correct opencode.ai schema key used in all container config blobs).
 func TestContainerConfigForRole_Review(t *testing.T) {
 	pf := sampleProfilesFileWithReview()
 	result, err := config.ContainerConfigForRole(pf, "review")
@@ -283,8 +286,8 @@ func TestContainerConfigForRole_Review(t *testing.T) {
 	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
-	if _, ok := cfg["agents"]; !ok {
-		t.Error("expected top-level 'agents' key in review config blob")
+	if _, ok := cfg["agent"]; !ok {
+		t.Error("expected top-level 'agent' key in review config blob")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/config/profiles_test.go
+++ b/modules/programs/prism/prism/internal/config/profiles_test.go
@@ -258,6 +258,91 @@ func TestBuildConfigContent_UnknownProfile(t *testing.T) {
 	}
 }
 
+// sampleProfilesFileWithReview returns a ProfilesFile that also has a review
+// config blob, for testing ContainerConfigForRole.
+func sampleProfilesFileWithReview() *config.ProfilesFile {
+	pf := sampleProfilesFile()
+	pf.ContainerWorkerConfig = `{"agents":{"worker":{}}}`
+	pf.ContainerCoordinatorConfig = `{"agents":{"coordinator":{}}}`
+	pf.ContainerReviewConfig = `{"agents":{"review":{}}}`
+	return pf
+}
+
+// TestContainerConfigForRole_Review verifies that passing role "review" returns
+// the ContainerReviewConfig blob (non-empty, valid JSON, has "agents" key).
+func TestContainerConfigForRole_Review(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "review")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for role=review")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if _, ok := cfg["agents"]; !ok {
+		t.Error("expected top-level 'agents' key in review config blob")
+	}
+}
+
+// TestContainerConfigForRole_Worker verifies that "worker" still returns the
+// worker blob (regression guard).
+func TestContainerConfigForRole_Worker(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "worker")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != pf.ContainerWorkerConfig {
+		t.Errorf("worker blob: got %q, want %q", result, pf.ContainerWorkerConfig)
+	}
+}
+
+// TestContainerConfigForRole_Coordinator verifies that "coordinator" still
+// returns the coordinator blob (regression guard).
+func TestContainerConfigForRole_Coordinator(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "coordinator")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != pf.ContainerCoordinatorConfig {
+		t.Errorf("coordinator blob: got %q, want %q", result, pf.ContainerCoordinatorConfig)
+	}
+}
+
+// TestContainerConfigForRole_UnknownRole verifies that an unrecognised role
+// (e.g. "plan") returns ("", nil) without error.
+func TestContainerConfigForRole_UnknownRole(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	for _, role := range []string{"plan", "explore", "ac", "unknown"} {
+		result, err := config.ContainerConfigForRole(pf, role)
+		if err != nil {
+			t.Errorf("role %q: unexpected error: %v", role, err)
+		}
+		if result != "" {
+			t.Errorf("role %q: expected empty string, got %q", role, result)
+		}
+	}
+}
+
+// TestContainerConfigForRole_NilProfilesFile verifies that a nil *ProfilesFile
+// returns ("", nil) for all roles — no panic.
+func TestContainerConfigForRole_NilProfilesFile(t *testing.T) {
+	for _, role := range []string{"worker", "coordinator", "review", "plan", "unknown"} {
+		result, err := config.ContainerConfigForRole(nil, role)
+		if err != nil {
+			t.Errorf("nil pf, role %q: unexpected error: %v", role, err)
+		}
+		if result != "" {
+			t.Errorf("nil pf, role %q: expected empty string, got %q", role, result)
+		}
+	}
+}
+
 func TestLoadProfiles_MissingFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/nonexistent/path")
 	_, err := config.LoadProfiles()

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -143,6 +143,7 @@
           # opencode.jsonc can override agent identity or permissions.
           container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
           container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
+          container_review_config = config.nx.programs.prism.opencode.containerReviewConfigJson;
           # Agent environment variables to inject into host-mode opencode processes.
           # Both $HOME and ${HOME} are expanded at Nix eval time so the JSON
           # always contains absolute paths regardless of which form is used.


### PR DESCRIPTION
## Summary

PR-A of 4 implementing RFC #759.

`prism review` in container mode passes `role = "review"` to `ContainerConfigForRole`, but that function previously only recognised `"worker"` and `"coordinator"` — everything else fell through the default case and returned `("", nil)`. Review agent containers therefore started with no opencode.json, no valid `agent` block, and `opencode --agent review-goal` found no such agent and silently fell back to the default `build` agent (symptom described in #735).

This PR wires up the `review` role so `ContainerConfigForRole(pf, "review")` returns a real, hardened opencode.json blob.

## Changes

### Go (`internal/config/profiles.go`)
- Add `ContainerReviewConfig string \`json:"container_review_config"\`` field to `ProfilesFile`
- Add `case "review":` to `ContainerConfigForRole` returning `pf.ContainerReviewConfig`

### Nix (`opencode.nix`)
- Add `nx.programs.prism.opencode.containerReviewConfigJson` option (parallel to worker/coordinator)
- Build `reviewContainerOpencodeJson` blob with full hardening:
  - **Agents**: only review agent(s) declared — `review` in default mode, `review-{goal,code,security,qa,context}` in `enhancedReview` mode. `worker`, `coordinator`, `build`, `plan`, `ac`, `explore`, etc. all explicitly `disable = true`
  - **Permissions**: `edit = "deny"`, `patch = "deny"`, `write = "deny"` (belt-and-braces; worktree is already mounted read-only)
  - **Task tool**: `tools.task = false` on each review agent — prevents review agents delegating to peer `@review-*` agents
  - **Bash commands**: `"prism review" = "deny"` and `"prism review *" = "deny"` — prevents recursive `prism review` invocations
  - **MCP**: Atlassian MCP present (read-only, for context lookup); no write-capable or agent-delegation MCP servers

### Nix (`profiles.nix`)
- Add `container_review_config` to the `profiles.json` output (parallel to `container_worker_config` and `container_coordinator_config`)

### Tests (`internal/config/profiles_test.go`)
- `TestContainerConfigForRole_Review` — review role returns non-empty, valid JSON with `agents` key
- `TestContainerConfigForRole_Worker` — regression: worker still returns worker blob
- `TestContainerConfigForRole_Coordinator` — regression: coordinator still returns coordinator blob
- `TestContainerConfigForRole_UnknownRole` — plan/explore/etc. still return `("", nil)`
- `TestContainerConfigForRole_NilProfilesFile` — nil pf returns `("", nil)` for all roles, no panic

## Scope

**No session-shape changes** — the multi-window `<parent>~review-N` tmux session is unchanged. **No per-agent configs** — that is PR-B. This PR just makes the single review-role config exist, be valid, and be hardened.

## Quality Gates

- `go build ./...` ✅
- `go test ./...` ✅
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Refs #759
Closes #760