### PR TITLE
prism: split review container config into 5 per-agent hardened configs

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -38,11 +38,39 @@
       internal = true;
       description = "Serialised opencode.json blob for coordinator containers (mounted as config file).";
     };
-    nx.programs.prism.opencode.containerReviewConfigJson = lib.mkOption {
+    # Per-agent review container config blobs — one per review agent.
+    # Each declares only its own agent; all other agents are disabled.
+    # Hardened: write/edit/patch denied, task tool disabled,
+    # prism review bash commands denied to prevent recursion.
+    nx.programs.prism.opencode.containerReviewGoalConfigJson = lib.mkOption {
       type = lib.types.str;
       default = "";
       internal = true;
-      description = "Serialised opencode.json blob for review containers (mounted as config file). Hardened: only review agent(s) declared, write/edit/patch denied, task tool disabled, prism review bash commands denied.";
+      description = "Serialised opencode.json blob for review-goal containers.";
+    };
+    nx.programs.prism.opencode.containerReviewCodeConfigJson = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Serialised opencode.json blob for review-code containers.";
+    };
+    nx.programs.prism.opencode.containerReviewSecurityConfigJson = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Serialised opencode.json blob for review-security containers.";
+    };
+    nx.programs.prism.opencode.containerReviewQaConfigJson = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Serialised opencode.json blob for review-qa containers.";
+    };
+    nx.programs.prism.opencode.containerReviewContextConfigJson = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Serialised opencode.json blob for review-context containers.";
     };
     nx.programs.prism.opencode.enhancedReview = lib.mkOption {
       type = lib.types.bool;
@@ -759,19 +787,98 @@
         provider = providerSettings;
       };
 
-      # Review container bash commands — deny-by-default with read-only allowlist.
-      # Critically: "prism review" and "prism review *" are denied to prevent
-      # review agents from recursively invoking prism review.
-      containerReviewBashCommands = {
+      # Shared deny-by-default bash base for all review agents.
+      # "prism review" recursion prevention is applied here; each per-agent set
+      # adds only the commands that specific agent needs.
+      containerReviewBaseBashCommands = {
         # Default: deny everything not explicitly allowed
         "*" = "deny";
         # prism review recursion prevention (belt-and-suspenders over deny-all)
         "prism review" = "deny";
         "prism review *" = "deny";
-      }
-      // readOnlyBashCommands
-      // {
-        # GitHub CLI read operations (review-context needs gh)
+        # Standard read-only file/text operations
+        "cat *" = "allow";
+        "head *" = "allow";
+        "less *" = "allow";
+        "more *" = "allow";
+        "strings *" = "allow";
+        "tail *" = "allow";
+        "file *" = "allow";
+        "find *" = "allow";
+        "ls *" = "allow";
+        "tree *" = "allow";
+        "awk *" = "allow";
+        "comm *" = "allow";
+        "cut *" = "allow";
+        "diff *" = "allow";
+        "grep *" = "allow";
+        "rg *" = "allow";
+        "sed *" = "allow";
+        "sort *" = "allow";
+        "uniq *" = "allow";
+        "wc *" = "allow";
+        "xargs *" = "allow";
+        "date *" = "allow";
+        "env *" = "allow";
+        "hostname *" = "allow";
+        "id *" = "allow";
+        "printenv *" = "allow";
+        "pwd *" = "allow";
+        "uname *" = "allow";
+        "whoami *" = "allow";
+        "jq *" = "allow";
+        "yq *" = "allow";
+        "yq eval *" = "allow";
+        "yq eval*" = "allow";
+        "basename *" = "allow";
+        "basename*" = "allow";
+        "command *" = "allow";
+        "command*" = "allow";
+        "dirname *" = "allow";
+        "dirname*" = "allow";
+        "echo *" = "allow";
+        "echo*" = "allow";
+        "printf *" = "allow";
+        "printf*" = "allow";
+        "sleep *" = "allow";
+        "sleep*" = "allow";
+        "type *" = "allow";
+        "type*" = "allow";
+        "which *" = "allow";
+        "which*" = "allow";
+        # git read-only operations (no push)
+        "git log *" = "allow";
+        "git diff *" = "allow";
+        "git show *" = "allow";
+        "git status" = "allow";
+        "git status *" = "allow";
+        "git branch" = "allow";
+        "git branch *" = "allow";
+        "git remote" = "allow";
+        "git remote *" = "allow";
+        "git fetch *" = "allow";
+        # prism read-only introspection
+        "prism checkin" = "allow";
+        "prism checkin *" = "allow";
+        "prism list-sessions" = "allow";
+      };
+
+      # review-code, review-goal, review-security: read-only bash.
+      # No test runners, no gh CLI (they don't need issue/PR context fetching).
+      containerReviewReadOnlyBashCommands = containerReviewBaseBashCommands;
+
+      # review-qa: adds test-runner commands on top of the read-only base.
+      containerReviewQaBashCommands = containerReviewBaseBashCommands // {
+        "go test *" = "allow";
+        "go build *" = "allow";
+        "go vet *" = "allow";
+        "nix build *" = "allow";
+        "nix flake check *" = "allow";
+      };
+
+      # review-context: adds gh issue/PR read commands and git log/show/diff
+      # on top of the read-only base.
+      containerReviewContextBashCommands = containerReviewBaseBashCommands // {
         "gh issue view *" = "allow";
         "gh issue list *" = "allow";
         "gh pr view *" = "allow";
@@ -781,136 +888,142 @@
         "gh repo view *" = "allow";
         "gh run view *" = "allow";
         "gh run list *" = "allow";
-        # prism read-only introspection
-        "prism checkin" = "allow";
-        "prism checkin *" = "allow";
-        "prism list-sessions" = "allow";
       };
 
-      # Review container opencode.json blob.
-      # Hardened config: only review agent(s) declared; no worker, coordinator,
-      # build, or plan. write/edit/patch denied. task tool disabled to prevent
-      # review agents delegating to peer @review-* agents. prism review bash
-      # commands denied to prevent recursion.
-      reviewContainerOpencodeJson = {
-        "$schema" = "https://opencode.ai/opencode.json";
-        autoupdate = false;
-        default_agent =
-          if config.nx.programs.prism.opencode.enhancedReview then "review-goal" else "review";
-        enabled_providers = containerEnabledProviders;
-        model = models.secondary;
-        agent =
-          let
-            profiledAgents =
-              config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider
-                (
-                  {
-                    # Explicitly disable non-review agents
-                    worker = {
-                      disable = true;
-                    };
-                    coordinator = {
-                      disable = true;
-                    };
-                    build = {
-                      disable = true;
-                    };
-                    plan = {
-                      disable = true;
-                    };
-                    ac = {
-                      disable = true;
-                    };
-                    explore = {
-                      disable = true;
-                    };
-                    title = {
-                      disable = true;
-                    };
-                    summary = {
-                      disable = true;
-                    };
-                    compaction = {
-                      disable = true;
-                    };
-                  }
-                  // (
-                    if config.nx.programs.prism.opencode.enhancedReview then
-                      {
-                        review-goal = {
-                          tools = {
-                            task = false;
-                          };
-                        };
-                        review-code = {
-                          tools = {
-                            task = false;
-                          };
-                        };
-                        review-security = {
-                          tools = {
-                            task = false;
-                          };
-                        };
-                        review-qa = {
-                          tools = {
-                            task = false;
-                          };
-                        };
-                        review-context = {
-                          tools = {
-                            task = false;
-                          };
-                        };
-                      }
-                    else
-                      {
-                        review = {
-                          tools = {
-                            task = false;
-                          };
-                        };
-                      }
-                  )
-                );
-            # Strip variant from disabled agents
-            sanitisedAgents = lib.mapAttrs (
-              _name: cfg: if cfg ? disable && cfg.disable then builtins.removeAttrs cfg [ "variant" ] else cfg
-            ) profiledAgents;
-          in
-          sanitisedAgents;
-        # Atlassian MCP may be present (read-only, for context lookup).
-        # lib.mkIf cannot be used here — serialised with builtins.toJSON.
-        mcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
-          atlasian = {
-            type = "local";
-            enabled = true;
-            command = [ "/root/.config/opencode/mcp-atlassian-slim-proxy.mjs" ];
-            environment = {
-              ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+      # Shared hardened permission block for all per-agent review containers.
+      # Write operations are denied (belt-and-braces: worktree is mounted read-only).
+      containerReviewPermission = bashCmds: {
+        edit = "deny";
+        patch = "deny";
+        write = "deny";
+        webfetch = "allow";
+        # Atlassian MCP permissions — review agents read only, no writes
+        "atlasian_*" = "deny";
+        "atlasian_atlassianUserInfo" = "allow";
+        "atlasian_get*" = "allow";
+        "atlasian_lookup*" = "allow";
+        "atlasian_search*" = "allow";
+        "atlasian_fetch" = "allow";
+        "atlasian_fetchAtlassian" = "allow";
+        bash = bashCmds;
+        external_directory = "allow"; # safe because inside container
+      };
+
+      # Helper to build a per-agent review opencode.json blob.
+      # agentName: the single review agent to declare (e.g. "review-goal").
+      # otherAgents: the other 4 review agents to disable.
+      # bashCmds: the bash permission map to use.
+      makeReviewAgentBlob =
+        agentName: otherAgents: bashCmds:
+        let
+          # Build the agent map: agentName gets task=false; all others are disabled.
+          baseAgentMap = {
+            worker = {
+              disable = true;
+            };
+            coordinator = {
+              disable = true;
+            };
+            build = {
+              disable = true;
+            };
+            plan = {
+              disable = true;
+            };
+            ac = {
+              disable = true;
+            };
+            explore = {
+              disable = true;
+            };
+            title = {
+              disable = true;
+            };
+            summary = {
+              disable = true;
+            };
+            compaction = {
+              disable = true;
+            };
+          }
+          // lib.genAttrs otherAgents (_: {
+            disable = true;
+          })
+          // {
+            ${agentName} = {
+              tools = {
+                task = false;
+              };
             };
           };
+          profiledAgents = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider baseAgentMap;
+          # Strip variant from disabled agents
+          sanitisedAgents = lib.mapAttrs (
+            _name: cfg: if cfg ? disable && cfg.disable then builtins.removeAttrs cfg [ "variant" ] else cfg
+          ) profiledAgents;
+        in
+        {
+          "$schema" = "https://opencode.ai/opencode.json";
+          autoupdate = false;
+          default_agent = agentName;
+          enabled_providers = containerEnabledProviders;
+          model = models.secondary;
+          agent = sanitisedAgents;
+          # Atlassian MCP may be present (read-only, for context lookup).
+          # lib.mkIf cannot be used here — serialised with builtins.toJSON.
+          mcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
+            atlasian = {
+              type = "local";
+              enabled = true;
+              command = [ "/root/.config/opencode/mcp-atlassian-slim-proxy.mjs" ];
+              environment = {
+                ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+              };
+            };
+          };
+          permission = containerReviewPermission bashCmds;
+          plugin = containerPlugins;
+          provider = providerSettings;
         };
-        permission = {
-          # Belt-and-suspenders: deny write operations (worktree is mounted read-only anyway)
-          edit = "deny";
-          patch = "deny";
-          write = "deny";
-          webfetch = "allow";
-          # Atlassian MCP permissions — review agents read only, no writes
-          "atlasian_*" = "deny";
-          "atlasian_atlassianUserInfo" = "allow";
-          "atlasian_get*" = "allow";
-          "atlasian_lookup*" = "allow";
-          "atlasian_search*" = "allow";
-          "atlasian_fetch" = "allow";
-          "atlasian_fetchAtlassian" = "allow";
-          bash = containerReviewBashCommands;
-          external_directory = "allow"; # safe because inside container
-        };
-        plugin = containerPlugins;
-        provider = providerSettings;
-      };
+
+      # Five per-agent review container opencode.json blobs.
+      # Each declares ONLY its own agent; all others (including the other 4
+      # review agents and worker/coordinator/build/plan/ac/explore/title/
+      # summary/compaction) are explicitly disabled.
+      reviewGoalContainerOpencodeJson = makeReviewAgentBlob "review-goal" [
+        "review-code"
+        "review-security"
+        "review-qa"
+        "review-context"
+      ] containerReviewReadOnlyBashCommands;
+
+      reviewCodeContainerOpencodeJson = makeReviewAgentBlob "review-code" [
+        "review-goal"
+        "review-security"
+        "review-qa"
+        "review-context"
+      ] containerReviewReadOnlyBashCommands;
+
+      reviewSecurityContainerOpencodeJson = makeReviewAgentBlob "review-security" [
+        "review-goal"
+        "review-code"
+        "review-qa"
+        "review-context"
+      ] containerReviewReadOnlyBashCommands;
+
+      reviewQaContainerOpencodeJson = makeReviewAgentBlob "review-qa" [
+        "review-goal"
+        "review-code"
+        "review-security"
+        "review-context"
+      ] containerReviewQaBashCommands;
+
+      reviewContextContainerOpencodeJson = makeReviewAgentBlob "review-context" [
+        "review-goal"
+        "review-code"
+        "review-security"
+        "review-qa"
+      ] containerReviewContextBashCommands;
     in
     lib.mkMerge [
       # Set container config JSON blobs as options so profiles.nix can embed
@@ -920,7 +1033,16 @@
         nx.programs.prism.opencode.containerWorkerConfigJson = builtins.toJSON workerContainerOpencodeJson;
         nx.programs.prism.opencode.containerCoordinatorConfigJson =
           builtins.toJSON coordinatorContainerOpencodeJson;
-        nx.programs.prism.opencode.containerReviewConfigJson = builtins.toJSON reviewContainerOpencodeJson;
+        nx.programs.prism.opencode.containerReviewGoalConfigJson =
+          builtins.toJSON reviewGoalContainerOpencodeJson;
+        nx.programs.prism.opencode.containerReviewCodeConfigJson =
+          builtins.toJSON reviewCodeContainerOpencodeJson;
+        nx.programs.prism.opencode.containerReviewSecurityConfigJson =
+          builtins.toJSON reviewSecurityContainerOpencodeJson;
+        nx.programs.prism.opencode.containerReviewQaConfigJson =
+          builtins.toJSON reviewQaContainerOpencodeJson;
+        nx.programs.prism.opencode.containerReviewContextConfigJson =
+          builtins.toJSON reviewContextContainerOpencodeJson;
       }
 
       # When enhanced review is on, inject ENHANCED_REVIEW=true into the agent

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -164,14 +164,12 @@ func runReview(cmd *cobra.Command, args []string) error {
 		ContainerMode:  cfg.ContainerMode,
 	}
 
-	// Load config content for container mode.
+	// Load profiles for container mode — passed through to review.Run so
+	// each agent's sidecar receives its own per-agent hardened config blob.
 	if cfg.ContainerMode {
 		pf, pfErr := config.LoadProfiles()
 		if pfErr == nil {
-			roleConfig, roleErr := config.ContainerConfigForRole(pf, "review")
-			if roleErr == nil && roleConfig != "" {
-				opts.ConfigContent = roleConfig
-			}
+			opts.ProfilesFile = pf
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -68,13 +68,16 @@ type ProfilesFile struct {
 	// JSON string) to inject as OPENCODE_CONFIG_CONTENT for coordinator
 	// containers. Written by Nix under container_coordinator_config.
 	ContainerCoordinatorConfig string `json:"container_coordinator_config"`
-	// ContainerReviewConfig is the full opencode.json blob (serialised JSON
-	// string) to inject as OPENCODE_CONFIG_CONTENT for review containers.
-	// Written by Nix under container_review_config. The blob is hardened:
-	// only review agent(s) are declared; write/edit/patch are denied; the
-	// task tool is disabled to prevent review agents delegating to peers;
-	// and "prism review" bash commands are denied to prevent recursion.
-	ContainerReviewConfig string `json:"container_review_config"`
+	// Per-agent review container configs — each blob declares only its own
+	// review agent and no others. Written by Nix under
+	// container_review_{goal,code,security,qa,context}_config.
+	// Each blob is hardened: write/edit/patch denied; task tool disabled;
+	// "prism review" bash commands denied to prevent recursion.
+	ContainerReviewGoalConfig     string `json:"container_review_goal_config"`
+	ContainerReviewCodeConfig     string `json:"container_review_code_config"`
+	ContainerReviewSecurityConfig string `json:"container_review_security_config"`
+	ContainerReviewQaConfig       string `json:"container_review_qa_config"`
+	ContainerReviewContextConfig  string `json:"container_review_context_config"`
 	// AgentEnvVars holds environment variables to inject into host-mode
 	// opencode processes. Values are fully expanded absolute paths (no $HOME).
 	// Written by Nix under agent_env_vars. These are prepended to the
@@ -84,12 +87,21 @@ type ProfilesFile struct {
 }
 
 // ContainerConfigForRole returns the OPENCODE_CONFIG_CONTENT blob for the
-// given agent role ("worker", "coordinator", or "review"). Returns ("", nil)
-// when pf is nil (no profiles file loaded) or when the role is not a
-// recognised container role (only "worker", "coordinator", and "review" have
-// dedicated container configs; subagent names like "plan", "explore", etc. are
-// valid opencode agents but do not have their own container configs — they
-// inherit from the session default).
+// given agent role. Returns ("", nil) when pf is nil (no profiles file loaded)
+// or when the role is not a recognised container role.
+//
+// Recognised roles:
+//   - "worker"           → ContainerWorkerConfig
+//   - "coordinator"      → ContainerCoordinatorConfig
+//   - "review-goal"      → ContainerReviewGoalConfig
+//   - "review-code"      → ContainerReviewCodeConfig
+//   - "review-security"  → ContainerReviewSecurityConfig
+//   - "review-qa"        → ContainerReviewQaConfig
+//   - "review-context"   → ContainerReviewContextConfig
+//
+// The old "review" role (from PR-A) is retired. Calling it returns ("", nil).
+// Subagent names like "plan", "explore", etc. also return ("", nil) — they
+// inherit from the session default.
 func ContainerConfigForRole(pf *ProfilesFile, role string) (string, error) {
 	if pf == nil {
 		return "", nil
@@ -99,10 +111,18 @@ func ContainerConfigForRole(pf *ProfilesFile, role string) (string, error) {
 		return pf.ContainerWorkerConfig, nil
 	case "coordinator":
 		return pf.ContainerCoordinatorConfig, nil
-	case "review":
-		return pf.ContainerReviewConfig, nil
+	case "review-goal":
+		return pf.ContainerReviewGoalConfig, nil
+	case "review-code":
+		return pf.ContainerReviewCodeConfig, nil
+	case "review-security":
+		return pf.ContainerReviewSecurityConfig, nil
+	case "review-qa":
+		return pf.ContainerReviewQaConfig, nil
+	case "review-context":
+		return pf.ContainerReviewContextConfig, nil
 	default:
-		// Not a container-level role (e.g. "plan", "explore").
+		// Not a container-level role (e.g. "plan", "explore", or the retired "review").
 		// Return empty string — no config injection — without error.
 		return "", nil
 	}

--- a/modules/programs/prism/prism/internal/config/profiles_test.go
+++ b/modules/programs/prism/prism/internal/config/profiles_test.go
@@ -258,36 +258,165 @@ func TestBuildConfigContent_UnknownProfile(t *testing.T) {
 	}
 }
 
-// sampleProfilesFileWithReview returns a ProfilesFile that also has a review
-// config blob, for testing ContainerConfigForRole. The fixture blobs use the
-// correct opencode.ai schema key "agent" (singular), matching what real
-// Nix-generated blobs produce.
+// sampleProfilesFileWithReview returns a ProfilesFile with per-agent review
+// config blobs set, for testing ContainerConfigForRole. The fixture blobs use
+// the correct opencode.ai schema key "agent" (singular), matching what real
+// Nix-generated blobs produce. Each blob declares only its own agent.
 func sampleProfilesFileWithReview() *config.ProfilesFile {
 	pf := sampleProfilesFile()
 	pf.ContainerWorkerConfig = `{"agent":{"worker":{}}}`
 	pf.ContainerCoordinatorConfig = `{"agent":{"coordinator":{}}}`
-	pf.ContainerReviewConfig = `{"agent":{"review":{}}}`
+	pf.ContainerReviewGoalConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-goal":{}}}`
+	pf.ContainerReviewCodeConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-code":{}}}`
+	pf.ContainerReviewSecurityConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-security":{}}}`
+	pf.ContainerReviewQaConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-qa":{}}}`
+	pf.ContainerReviewContextConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-context":{}}}`
 	return pf
 }
 
-// TestContainerConfigForRole_Review verifies that passing role "review" returns
-// the ContainerReviewConfig blob (non-empty, valid JSON, has "agent" key —
-// the correct opencode.ai schema key used in all container config blobs).
-func TestContainerConfigForRole_Review(t *testing.T) {
+// TestContainerConfigForRole_ReviewGoal verifies that passing role "review-goal"
+// returns the ContainerReviewGoalConfig blob (non-empty, valid JSON, has
+// "$schema" and "agent" keys).
+func TestContainerConfigForRole_ReviewGoal(t *testing.T) {
 	pf := sampleProfilesFileWithReview()
-	result, err := config.ContainerConfigForRole(pf, "review")
+	result, err := config.ContainerConfigForRole(pf, "review-goal")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result == "" {
-		t.Fatal("expected non-empty result for role=review")
+		t.Fatal("expected non-empty result for role=review-goal")
 	}
 	var cfg map[string]any
 	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
-	if _, ok := cfg["agent"]; !ok {
-		t.Error("expected top-level 'agent' key in review config blob")
+	if _, ok := cfg["$schema"]; !ok {
+		t.Error("expected top-level '$schema' key in review-goal config blob")
+	}
+	agents, ok := cfg["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected top-level 'agent' key in review-goal config blob")
+	}
+	if _, ok := agents["review-goal"]; !ok {
+		t.Error("expected 'review-goal' agent in review-goal config blob")
+	}
+	// Must NOT declare other review agents.
+	for _, other := range []string{"review-code", "review-security", "review-qa", "review-context"} {
+		if _, ok := agents[other]; ok {
+			t.Errorf("review-goal blob must not declare agent %q", other)
+		}
+	}
+}
+
+// TestContainerConfigForRole_ReviewCode verifies the review-code per-agent blob.
+func TestContainerConfigForRole_ReviewCode(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "review-code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for role=review-code")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	agents, ok := cfg["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'agent' key in review-code config blob")
+	}
+	if _, ok := agents["review-code"]; !ok {
+		t.Error("expected 'review-code' agent in review-code config blob")
+	}
+	for _, other := range []string{"review-goal", "review-security", "review-qa", "review-context"} {
+		if _, ok := agents[other]; ok {
+			t.Errorf("review-code blob must not declare agent %q", other)
+		}
+	}
+}
+
+// TestContainerConfigForRole_ReviewSecurity verifies the review-security per-agent blob.
+func TestContainerConfigForRole_ReviewSecurity(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "review-security")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for role=review-security")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	agents, ok := cfg["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'agent' key in review-security config blob")
+	}
+	if _, ok := agents["review-security"]; !ok {
+		t.Error("expected 'review-security' agent in review-security config blob")
+	}
+	for _, other := range []string{"review-goal", "review-code", "review-qa", "review-context"} {
+		if _, ok := agents[other]; ok {
+			t.Errorf("review-security blob must not declare agent %q", other)
+		}
+	}
+}
+
+// TestContainerConfigForRole_ReviewQa verifies the review-qa per-agent blob.
+func TestContainerConfigForRole_ReviewQa(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "review-qa")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for role=review-qa")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	agents, ok := cfg["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'agent' key in review-qa config blob")
+	}
+	if _, ok := agents["review-qa"]; !ok {
+		t.Error("expected 'review-qa' agent in review-qa config blob")
+	}
+	for _, other := range []string{"review-goal", "review-code", "review-security", "review-context"} {
+		if _, ok := agents[other]; ok {
+			t.Errorf("review-qa blob must not declare agent %q", other)
+		}
+	}
+}
+
+// TestContainerConfigForRole_ReviewContext verifies the review-context per-agent blob.
+func TestContainerConfigForRole_ReviewContext(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "review-context")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for role=review-context")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	agents, ok := cfg["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'agent' key in review-context config blob")
+	}
+	if _, ok := agents["review-context"]; !ok {
+		t.Error("expected 'review-context' agent in review-context config blob")
+	}
+	for _, other := range []string{"review-goal", "review-code", "review-security", "review-qa"} {
+		if _, ok := agents[other]; ok {
+			t.Errorf("review-context blob must not declare agent %q", other)
+		}
 	}
 }
 
@@ -318,10 +447,11 @@ func TestContainerConfigForRole_Coordinator(t *testing.T) {
 }
 
 // TestContainerConfigForRole_UnknownRole verifies that an unrecognised role
-// (e.g. "plan") returns ("", nil) without error.
+// (e.g. "plan") returns ("", nil) without error. The retired "review" role
+// (from PR-A) also returns ("", nil) after PR-B retires it.
 func TestContainerConfigForRole_UnknownRole(t *testing.T) {
 	pf := sampleProfilesFileWithReview()
-	for _, role := range []string{"plan", "explore", "ac", "unknown"} {
+	for _, role := range []string{"plan", "explore", "ac", "unknown", "review"} {
 		result, err := config.ContainerConfigForRole(pf, role)
 		if err != nil {
 			t.Errorf("role %q: unexpected error: %v", role, err)
@@ -335,7 +465,12 @@ func TestContainerConfigForRole_UnknownRole(t *testing.T) {
 // TestContainerConfigForRole_NilProfilesFile verifies that a nil *ProfilesFile
 // returns ("", nil) for all roles — no panic.
 func TestContainerConfigForRole_NilProfilesFile(t *testing.T) {
-	for _, role := range []string{"worker", "coordinator", "review", "plan", "unknown"} {
+	roles := []string{
+		"worker", "coordinator",
+		"review-goal", "review-code", "review-security", "review-qa", "review-context",
+		"review", "plan", "unknown",
+	}
+	for _, role := range roles {
 		result, err := config.ContainerConfigForRole(nil, role)
 		if err != nil {
 			t.Errorf("nil pf, role %q: unexpected error: %v", role, err)

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -196,8 +197,10 @@ type Opts struct {
 	DBPath string
 	// PluginHostPath is the path to the opencode plugin file.
 	PluginHostPath string
-	// ConfigContent is the JSON blob for the container's opencode.json config.
-	ConfigContent string
+	// ProfilesFile is the loaded profiles.json, used to resolve per-agent
+	// container config blobs via ContainerConfigForRole. When nil, no config
+	// injection is performed (equivalent to pre-PR-B behaviour).
+	ProfilesFile *config.ProfilesFile
 	// ContainerMode: when true, each agent runs in its own container.
 	ContainerMode bool
 }
@@ -293,6 +296,15 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 		// Build the prompt for the review agent.
 		prompt := buildReviewPrompt(opts.PRNumber)
 
+		// Resolve the per-agent config blob. Each agent gets its own hardened
+		// opencode.json that declares only that one review agent.
+		agentConfigContent := ""
+		if opts.ContainerMode && opts.ProfilesFile != nil {
+			if blob, cfgErr := config.ContainerConfigForRole(opts.ProfilesFile, ag.Name); cfgErr == nil {
+				agentConfigContent = blob
+			}
+		}
+
 		// Start the sidecar for this agent.
 		// WorktreeReadOnly=true ensures review containers cannot modify the
 		// branch under review (satisfies the [security] acceptance criterion).
@@ -303,7 +315,7 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 			Worktree:         worktree,
 			PluginHostPath:   opts.PluginHostPath,
 			InitialPrompt:    prompt,
-			ConfigContent:    opts.ConfigContent,
+			ConfigContent:    agentConfigContent,
 			WorktreeReadOnly: true,
 		}
 		if sidecarErr := session.StartSidecarWithOpts(agentSession, sidecarOpts); sidecarErr != nil {

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -143,7 +143,16 @@
           # opencode.jsonc can override agent identity or permissions.
           container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
           container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
-          container_review_config = config.nx.programs.prism.opencode.containerReviewConfigJson;
+          # Per-agent review configs — each blob declares only its own agent.
+          # The old container_review_config (PR-A) is retired; PR-B replaces it
+          # with five agent-specific blobs.
+          container_review_goal_config = config.nx.programs.prism.opencode.containerReviewGoalConfigJson;
+          container_review_code_config = config.nx.programs.prism.opencode.containerReviewCodeConfigJson;
+          container_review_security_config =
+            config.nx.programs.prism.opencode.containerReviewSecurityConfigJson;
+          container_review_qa_config = config.nx.programs.prism.opencode.containerReviewQaConfigJson;
+          container_review_context_config =
+            config.nx.programs.prism.opencode.containerReviewContextConfigJson;
           # Agent environment variables to inject into host-mode opencode processes.
           # Both $HOME and ${HOME} are expanded at Nix eval time so the JSON
           # always contains absolute paths regardless of which form is used.


### PR DESCRIPTION
## Summary

PR-B of 4 implementing RFC #759. Depends on PR-A (#764, already merged).

This PR splits the single `containerReviewConfigJson` (introduced in PR-A) into five per-agent hardened configs, one for each review agent. Each config blob declares **only** its own agent — a `review-goal` container has no knowledge of `review-code`, etc.

## Changes

### Go (`internal/config/profiles.go`)
- Replace `ContainerReviewConfig` field with five per-agent fields: `ContainerReviewGoalConfig`, `ContainerReviewCodeConfig`, `ContainerReviewSecurityConfig`, `ContainerReviewQaConfig`, `ContainerReviewContextConfig`
- Each serialised under `container_review_{goal,code,security,qa,context}_config` in JSON
- Update `ContainerConfigForRole` to handle the five per-agent role strings (`"review-goal"`, `"review-code"`, `"review-security"`, `"review-qa"`, `"review-context"`)
- Retire the old `"review"` role — calling `ContainerConfigForRole(pf, "review")` now returns `("", nil)` (default case)

### Go (`internal/review/review.go`)
- Replace `Opts.ConfigContent` (single shared blob) with `Opts.ProfilesFile` (`*config.ProfilesFile`)
- `Run()` now calls `config.ContainerConfigForRole(opts.ProfilesFile, ag.Name)` per agent inside the spawn loop, so each agent's sidecar receives its own config blob

### Go (`cmd/review.go`)
- Load profiles and pass `*ProfilesFile` to `Opts.ProfilesFile` instead of resolving a single blob

### Nix (`opencode.nix`)
- Replace single `containerReviewConfigJson` option with five per-agent options: `containerReview{Goal,Code,Security,Qa,Context}ConfigJson`
- Build five per-agent blobs via `makeReviewAgentBlob` helper:
  - Each declares only its own agent; all others (`worker`, `coordinator`, `build`, `plan`, `ac`, `explore`, `title`, `summary`, `compaction`, + other 4 review agents) are `disable = true`
  - `permission.edit/patch/write = "deny"` on all five
  - `tools.task = false` on the declared agent (prevents Task-based delegation)
  - `"prism review" = "deny"` and `"prism review *" = "deny"` in all bash maps
  - `review-qa`: adds `go test *`, `go build *`, `go vet *`, `nix build *`, `nix flake check *`
  - `review-context`: adds `gh issue view *`, `gh pr view *`, `gh pr diff *`, `git log *`, `git show *`, `git diff *`
  - `review-code`, `review-goal`, `review-security`: read-only bash only (no test runners, no gh write commands)

### Nix (`profiles.nix`)
- Replace `container_review_config` with five keys: `container_review_{goal,code,security,qa,context}_config`

### Tests (`internal/config/profiles_test.go`)
- Replace `TestContainerConfigForRole_Review` with five per-agent tests
- Each test asserts: non-empty, valid JSON, `$schema` present, own agent declared, peer agents NOT declared
- `TestContainerConfigForRole_UnknownRole` now includes `"review"` (retired) as an unknown role
- `TestContainerConfigForRole_NilProfilesFile` covers all five new per-agent roles plus the retired `"review"` role

## Retired: the `"review"` role

The `"review"` role from PR-A is retired. `ContainerConfigForRole(pf, "review")` returns `("", nil)` after this PR (falls through to the default case). PR-C will stop calling it entirely when it refactors the session shape.

## Quality Gates

- `go build ./...` ✅
- `go test ./...` ✅
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Refs #759
Closes #761