### PR TITLE
prism: host-side clipboard paste bridge for container-mode opencode

### DIFF
--- a/modules/programs/prism/prism/cmd/clipboard.go
+++ b/modules/programs/prism/prism/cmd/clipboard.go
@@ -1,0 +1,283 @@
+package cmd
+
+// prism clipboard — host-side clipboard utilities for container-mode opencode.
+//
+// Subcommands:
+//
+//	paste-image   Read a PNG image from the host clipboard, stage it to
+//	              ~/.cache/prism/clipboard/<uuid>.png, and print the path.
+//	              Exits non-zero when the clipboard contains no image or an
+//	              image format other than PNG; emits no output in that case.
+//
+//	clean         Remove stale files from ~/.cache/prism/clipboard/ (older
+//	              than the configured TTL, default 1 hour). Idempotent — safe
+//	              to run even when the directory does not exist.
+//
+// Design notes:
+//   - All clipboard I/O is done on the host. No clipboard tool, socket, or
+//     env var is exposed inside the running container.
+//   - The staging directory (~/.cache/prism/clipboard/) is bind-mounted into
+//     the container read-only so opencode's stat() call resolves without
+//     modification. The container cannot write to it.
+//   - Platform detection is done at runtime via WAYLAND_DISPLAY / DISPLAY
+//     env vars on Linux, and runtime.GOOS on Darwin.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+// clipboardCacheDir returns the path to the clipboard staging directory.
+func clipboardCacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("clipboard: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".cache", "prism", "clipboard"), nil
+}
+
+// clipboardStagingTTL is the age after which files in the clipboard staging
+// directory are considered stale and eligible for cleanup.
+const clipboardStagingTTL = time.Hour
+
+// readClipboardPNG reads PNG image bytes from the host clipboard.
+// Returns an error when the clipboard contains no image or a non-PNG format.
+//
+// Platform dispatch:
+//   - Darwin: osascript reads NSPasteboard as PNG → temp file → bytes.
+//   - Linux/Wayland (WAYLAND_DISPLAY set): wl-paste -t image/png.
+//   - Linux/X11 (DISPLAY set, no WAYLAND_DISPLAY): xclip -selection clipboard -t image/png -o.
+//   - Otherwise: returns an error.
+func readClipboardPNG() ([]byte, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return readClipboardPNGDarwin()
+	case "linux":
+		return readClipboardPNGLinux()
+	default:
+		return nil, fmt.Errorf("clipboard: unsupported platform %q", runtime.GOOS)
+	}
+}
+
+// readClipboardPNGLinux reads PNG image bytes from the host clipboard on Linux.
+// Tries Wayland first (WAYLAND_DISPLAY), then X11 (DISPLAY).
+func readClipboardPNGLinux() ([]byte, error) {
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		// Wayland: wl-paste -t image/png exits non-zero when the clipboard
+		// contains no image or a different MIME type.
+		out, err := exec.Command("wl-paste", "-t", "image/png").Output()
+		if err != nil {
+			return nil, fmt.Errorf("clipboard: no PNG image in Wayland clipboard (wl-paste: %w)", err)
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("clipboard: wl-paste returned empty output")
+		}
+		if !isPNG(out) {
+			return nil, fmt.Errorf("clipboard: clipboard data is not a PNG image")
+		}
+		return out, nil
+	}
+
+	if os.Getenv("DISPLAY") != "" {
+		// X11: xclip exits non-zero when the clipboard target type is unavailable.
+		out, err := exec.Command("xclip", "-selection", "clipboard", "-t", "image/png", "-o").Output()
+		if err != nil {
+			return nil, fmt.Errorf("clipboard: no PNG image in X11 clipboard (xclip: %w)", err)
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("clipboard: xclip returned empty output")
+		}
+		if !isPNG(out) {
+			return nil, fmt.Errorf("clipboard: clipboard data is not a PNG image")
+		}
+		return out, nil
+	}
+
+	return nil, fmt.Errorf("clipboard: neither WAYLAND_DISPLAY nor DISPLAY is set — cannot access host clipboard")
+}
+
+// readClipboardPNGDarwin reads PNG image bytes from the macOS NSPasteboard.
+// Uses osascript to write the pasteboard contents to a temp file as PNG, then
+// reads and returns the bytes. Returns an error when the pasteboard contains
+// no image or the image cannot be written as PNG.
+func readClipboardPNGDarwin() ([]byte, error) {
+	// Write a temp file path for osascript to use as the output destination.
+	tmpFile, err := os.CreateTemp("", "prism-clipboard-*.png")
+	if err != nil {
+		return nil, fmt.Errorf("clipboard: create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	// osascript: read NSPasteboard as PNG and write to the temp file.
+	// If the pasteboard has no image, `theImage` will be missing data and
+	// the write will fail with an error, causing osascript to exit non-zero.
+	script := fmt.Sprintf(`
+set tmpPath to %q
+try
+    set theImage to (the clipboard as «class PNGf»)
+on error errMsg
+    error "No PNG image in clipboard: " & errMsg
+end try
+set fileRef to open for access (POSIX file tmpPath) with write permission
+set eof of fileRef to 0
+write theImage to fileRef
+close access fileRef
+`, tmpPath)
+
+	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
+	if err != nil {
+		// Remove the temp file (it may be empty or partial) so cleanup is clean.
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("clipboard: osascript failed (no PNG in pasteboard?): %w — %s", err, string(out))
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("clipboard: read osascript output: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("clipboard: osascript wrote empty file — clipboard may contain no image")
+	}
+	if !isPNG(data) {
+		return nil, fmt.Errorf("clipboard: clipboard data is not a PNG image")
+	}
+	return data, nil
+}
+
+// isPNG returns true when data begins with the PNG file magic bytes.
+// The PNG signature is: 0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
+func isPNG(data []byte) bool {
+	if len(data) < 8 {
+		return false
+	}
+	return data[0] == 0x89 &&
+		data[1] == 'P' &&
+		data[2] == 'N' &&
+		data[3] == 'G' &&
+		data[4] == 0x0D &&
+		data[5] == 0x0A &&
+		data[6] == 0x1A &&
+		data[7] == 0x0A
+}
+
+// runClipboardPasteImage is the implementation of `prism clipboard paste-image`.
+// It reads a PNG from the host clipboard, stages it to the clipboard cache dir,
+// and prints the absolute path on stdout. Exits non-zero silently when there is
+// no image (or a non-PNG image) in the clipboard.
+func runClipboardPasteImage(cmd *cobra.Command, args []string) error {
+	data, err := readClipboardPNG()
+	if err != nil {
+		// Exit non-zero but emit no output so the tmux keybind can detect
+		// failure and fall through without injecting a spurious bracketed-paste.
+		return fmt.Errorf("%w", err)
+	}
+
+	cacheDir, err := clipboardCacheDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return fmt.Errorf("clipboard: create staging dir %q: %w", cacheDir, err)
+	}
+
+	id := uuid.New().String()
+	stagingPath := filepath.Join(cacheDir, id+".png")
+	if err := os.WriteFile(stagingPath, data, 0o644); err != nil {
+		return fmt.Errorf("clipboard: write staged image %q: %w", stagingPath, err)
+	}
+
+	fmt.Println(stagingPath)
+	return nil
+}
+
+// runClipboardClean removes stale files from the clipboard staging directory.
+// Files older than clipboardStagingTTL are removed. Directories (unexpected)
+// are left in place. Errors on individual files are logged to stderr but do not
+// cause the command to exit non-zero.
+func runClipboardClean(cmd *cobra.Command, args []string) error {
+	cacheDir, err := clipboardCacheDir()
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(cacheDir)
+	if os.IsNotExist(err) {
+		// Directory doesn't exist yet — nothing to clean.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("clipboard clean: read dir %q: %w", cacheDir, err)
+	}
+
+	cutoff := time.Now().Add(-clipboardStagingTTL)
+	cleaned := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "clipboard clean: stat %q: %v\n", entry.Name(), err)
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			path := filepath.Join(cacheDir, entry.Name())
+			if err := os.Remove(path); err != nil {
+				fmt.Fprintf(os.Stderr, "clipboard clean: remove %q: %v\n", path, err)
+			} else {
+				cleaned++
+			}
+		}
+	}
+
+	fmt.Printf("clipboard clean: removed %d stale file(s) from %s\n", cleaned, cacheDir)
+	return nil
+}
+
+var clipboardCmd = &cobra.Command{
+	Use:   "clipboard",
+	Short: "Host-side clipboard utilities for container-mode opencode",
+}
+
+var clipboardPasteImageCmd = &cobra.Command{
+	Use:   "paste-image",
+	Short: "Read a PNG from the host clipboard, stage it, and print the path",
+	Long: `Read a PNG image from the host clipboard, write it to
+~/.cache/prism/clipboard/<uuid>.png, and print the absolute path on stdout.
+
+Exits non-zero (with no output) when the clipboard contains no image or an
+image format other than PNG, so the tmux keybind can detect failure and fall
+through to default behaviour without injecting a spurious bracketed-paste.
+
+Platform support:
+  - Linux/Wayland: wl-paste -t image/png
+  - Linux/X11: xclip -selection clipboard -t image/png -o
+  - macOS: osascript reading NSPasteboard as PNG`,
+	RunE:         runClipboardPasteImage,
+	SilenceUsage: true,
+}
+
+var clipboardCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Remove stale files from the clipboard staging directory",
+	Long: `Remove files older than 1 hour from ~/.cache/prism/clipboard/.
+
+Idempotent — safe to run even when the directory does not exist.
+Run by prism daemon startup and session-end hooks to prevent unbounded growth.`,
+	RunE: runClipboardClean,
+}
+
+func init() {
+	clipboardCmd.AddCommand(clipboardPasteImageCmd)
+	clipboardCmd.AddCommand(clipboardCleanCmd)
+	rootCmd.AddCommand(clipboardCmd)
+}

--- a/modules/programs/prism/prism/cmd/clipboard_test.go
+++ b/modules/programs/prism/prism/cmd/clipboard_test.go
@@ -1,0 +1,299 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── isPNG tests ───────────────────────────────────────────────────────────────
+
+func TestIsPNG_ValidSignature(t *testing.T) {
+	// Valid PNG header: 0x89 P N G \r \n 0x1A \n
+	pngHeader := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00}
+	if !isPNG(pngHeader) {
+		t.Error("expected isPNG to return true for valid PNG header")
+	}
+}
+
+func TestIsPNG_InvalidSignature(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"JPEG", []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46}},
+		{"GIF", []byte{'G', 'I', 'F', '8', '9', 'a', 0x00, 0x00}},
+		{"BMP", []byte{'B', 'M', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{"empty", []byte{}},
+		{"too short", []byte{0x89, 'P', 'N'}},
+		{"text", []byte("hello world")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if isPNG(tc.data) {
+				t.Errorf("isPNG(%q) = true, want false", tc.data)
+			}
+		})
+	}
+}
+
+func TestIsPNG_ExactlyEightBytes(t *testing.T) {
+	// Exactly 8 bytes — minimum valid input.
+	pngHeader := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	if !isPNG(pngHeader) {
+		t.Error("expected isPNG to return true for 8-byte PNG header")
+	}
+}
+
+func TestIsPNG_SevenBytes(t *testing.T) {
+	// Seven bytes — one short of the PNG magic; must return false.
+	pngHeader := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A}
+	if isPNG(pngHeader) {
+		t.Error("expected isPNG to return false for 7-byte buffer (too short)")
+	}
+}
+
+// ── clipboardCacheDir tests ───────────────────────────────────────────────────
+
+func TestClipboardCacheDir_ReturnsExpectedPath(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	dir, err := clipboardCacheDir()
+	if err != nil {
+		t.Fatalf("clipboardCacheDir returned error: %v", err)
+	}
+	want := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if dir != want {
+		t.Errorf("clipboardCacheDir() = %q, want %q", dir, want)
+	}
+}
+
+// ── runClipboardClean tests ───────────────────────────────────────────────────
+
+func TestRunClipboardClean_NoOpWhenDirAbsent(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Directory does not exist — should return nil without error.
+	if err := runClipboardClean(nil, nil); err != nil {
+		t.Errorf("runClipboardClean with absent dir returned error: %v", err)
+	}
+}
+
+func TestRunClipboardClean_RemovesStaleFiles(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	cacheDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Write a stale file (mtime in the past, older than TTL).
+	stalePath := filepath.Join(cacheDir, "stale.png")
+	if err := os.WriteFile(stalePath, []byte("fake"), 0o644); err != nil {
+		t.Fatalf("WriteFile stale: %v", err)
+	}
+	// Set mtime to 2 hours ago (beyond the 1-hour TTL).
+	staleTime := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(stalePath, staleTime, staleTime); err != nil {
+		t.Fatalf("Chtimes stale: %v", err)
+	}
+
+	// Write a fresh file (mtime now — should NOT be removed).
+	freshPath := filepath.Join(cacheDir, "fresh.png")
+	if err := os.WriteFile(freshPath, []byte("fake"), 0o644); err != nil {
+		t.Fatalf("WriteFile fresh: %v", err)
+	}
+
+	if err := runClipboardClean(nil, nil); err != nil {
+		t.Fatalf("runClipboardClean returned error: %v", err)
+	}
+
+	// Stale file should be gone.
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("stale file %q should have been removed, but still exists", stalePath)
+	}
+
+	// Fresh file should still be present.
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Errorf("fresh file %q should still exist: %v", freshPath, err)
+	}
+}
+
+func TestRunClipboardClean_SkipsDirectories(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	cacheDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Create a subdirectory — clean should ignore it (not error or remove).
+	subDir := filepath.Join(cacheDir, "subdir")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll subdir: %v", err)
+	}
+	// Make the subdir appear "stale" by setting old mtime.
+	staleTime := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(subDir, staleTime, staleTime); err != nil {
+		t.Fatalf("Chtimes subdir: %v", err)
+	}
+
+	if err := runClipboardClean(nil, nil); err != nil {
+		t.Fatalf("runClipboardClean returned error: %v", err)
+	}
+
+	// Subdirectory should still be present (clean only removes files).
+	if _, err := os.Stat(subDir); err != nil {
+		t.Errorf("runClipboardClean should not remove directories, but subdir is gone: %v", err)
+	}
+}
+
+// ── runClipboardPasteImage tests ──────────────────────────────────────────────
+
+func TestRunClipboardPasteImage_WritesStagedFile(t *testing.T) {
+	// Build a minimal valid PNG (just the 8-byte header + IHDR chunk).
+	// We only need isPNG to return true — a full valid PNG is not required.
+	pngData := buildMinimalPNG()
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Override readClipboardPNG to return our test data.
+	// We do this by setting up a fake clipboard via WAYLAND_DISPLAY pointing at
+	// a fake wl-paste that outputs the PNG bytes. However, since we cannot
+	// easily mock exec.Command in Go tests without process injection, we instead
+	// test runClipboardPasteImage indirectly by exercising the staging path.
+	//
+	// The staging logic is in runClipboardPasteImage itself (after readClipboardPNG
+	// succeeds), so we test it via a minimal integration: write a fake PNG to a
+	// temp file and call the write/stat portion directly.
+	cacheDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Simulate what runClipboardPasteImage does after readClipboardPNG succeeds.
+	id := "test-uuid-1234"
+	stagingPath := filepath.Join(cacheDir, id+".png")
+	if err := os.WriteFile(stagingPath, pngData, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Verify the staged file exists and has the right content.
+	data, err := os.ReadFile(stagingPath)
+	if err != nil {
+		t.Fatalf("ReadFile staged: %v", err)
+	}
+	if !isPNG(data) {
+		t.Errorf("staged file does not have PNG header")
+	}
+	if string(data) != string(pngData) {
+		t.Errorf("staged file content mismatch")
+	}
+}
+
+func TestRunClipboardPasteImage_StagingPathUnderCacheDir(t *testing.T) {
+	// Verify that runClipboardPasteImage uses clipboardCacheDir() as the
+	// staging directory and that the path contains the expected components.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	dir, err := clipboardCacheDir()
+	if err != nil {
+		t.Fatalf("clipboardCacheDir: %v", err)
+	}
+
+	// Staging dir must be under ~/.cache/prism/clipboard.
+	wantPrefix := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if dir != wantPrefix {
+		t.Errorf("staging dir %q should be under %q", dir, wantPrefix)
+	}
+}
+
+// ── container clipboard mount tests ──────────────────────────────────────────
+// These tests live in the cmd package but test the container package via
+// the exported buildRunArgs helper path through New().
+
+func TestClipboardStagingDirNotMountedWhenAbsent(t *testing.T) {
+	// When ~/.cache/prism/clipboard/ does not exist on the host, buildRunArgs
+	// must NOT add a bind-mount for it. The container should start normally.
+	// This test verifies the conditional-mount AC:
+	//   "When ~/.cache/prism/clipboard/ does not exist at container spawn time,
+	//    buildRunArgs() skips the bind-mount."
+	//
+	// We use a temp HOME that has no clipboard dir.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Import is in internal/container but we exercise it via the cmd package
+	// test helper (same approach as container_test.go).
+	// Use the container.Manager directly through the internal package.
+	// Since this is package cmd, we call the internal package via a test stub.
+	//
+	// Actually, this test validates the behaviour in container.go which is in
+	// a different package. The test for buildRunArgs with clipboard staging dir
+	// lives in container_test.go. This test validates that clipboardCacheDir()
+	// points to the right path and that when it doesn't exist, our conditional
+	// os.Stat check would return an error (IsNotExist).
+
+	cacheDir, err := clipboardCacheDir()
+	if err != nil {
+		t.Fatalf("clipboardCacheDir: %v", err)
+	}
+
+	// Verify it doesn't exist.
+	_, statErr := os.Stat(cacheDir)
+	if !os.IsNotExist(statErr) {
+		t.Errorf("expected clipboard cache dir %q to not exist in fresh home, got: %v", cacheDir, statErr)
+	}
+}
+
+func TestClipboardStagingDirMountedWhenPresent(t *testing.T) {
+	// Verify that when the clipboard staging dir exists, it would be detected
+	// by the os.Stat check and its path is correct (the dir-present case is
+	// tested in container_test.go with full buildRunArgs verification).
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	cacheDir, err := clipboardCacheDir()
+	if err != nil {
+		t.Fatalf("clipboardCacheDir: %v", err)
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Verify it exists and os.Stat returns nil (triggers the conditional mount).
+	if _, statErr := os.Stat(cacheDir); statErr != nil {
+		t.Errorf("clipboard cache dir %q should exist after MkdirAll, got: %v", cacheDir, statErr)
+	}
+
+	// The mount path should contain "prism/clipboard" to confirm it's the right dir.
+	if !strings.Contains(cacheDir, filepath.Join("prism", "clipboard")) {
+		t.Errorf("clipboard cache dir %q should contain 'prism/clipboard'", cacheDir)
+	}
+}
+
+// buildMinimalPNG returns a byte slice with a valid PNG file header.
+// This is the minimum needed for isPNG to return true.
+func buildMinimalPNG() []byte {
+	return []byte{
+		0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+		// Minimal IHDR chunk (13 bytes of data)
+		0x00, 0x00, 0x00, 0x0D, // chunk length: 13
+		'I', 'H', 'D', 'R', // chunk type: IHDR
+		0x00, 0x00, 0x00, 0x01, // width: 1
+		0x00, 0x00, 0x00, 0x01, // height: 1
+		0x08,             // bit depth: 8
+		0x02,             // colour type: RGB
+		0x00, 0x00, 0x00, // compression, filter, interlace
+		0x90, 0x77, 0x53, 0xDE, // CRC (pre-computed)
+	}
+}

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -262,6 +262,16 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
+	// Run clipboard staging dir cleanup in the background at sidecar startup.
+	// This implements the TTL sweep that prevents ~/.cache/prism/clipboard/ from
+	// growing unboundedly across multiple paste operations. The sweep is
+	// fire-and-forget; errors are non-fatal (logged by runClipboardClean itself).
+	if containerMode {
+		go func() {
+			_ = runClipboardClean(nil, nil)
+		}()
+	}
+
 	fmt.Fprintf(os.Stderr, "[prism sidecar] starting: session=%s url=%s container=%v\n",
 		sessionName, opencodeURL, containerMode)
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -853,6 +853,12 @@ func (m *Manager) buildRunArgs() []string {
 	// any env var configuration. Only the agents/readonly kubeconfig is mounted —
 	// the admin kubeconfig is never exposed to agents.
 	kubeAgentsConfig := filepath.Join(home, ".config", "kube", "agents-config")
+	// Clipboard staging directory — images staged by `prism clipboard paste-image`
+	// on the host are placed here and bind-mounted read-only into the container at
+	// the identical absolute path so that opencode's stat() call resolves without
+	// modification. No clipboard tool, socket, or env var is exposed inside the
+	// container — clipboard read occurs entirely host-side.
+	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
 
 	args := []string{
 		"run",
@@ -953,6 +959,18 @@ func (m *Manager) buildRunArgs() []string {
 	// kubeconfig is never mounted into agent containers.
 	if resolved, err := filepath.EvalSymlinks(kubeAgentsConfig); err == nil {
 		args = append(args, "--volume", resolved+":/root/.kube/config:ro")
+	}
+
+	// Clipboard staging directory: bind-mount ~/.cache/prism/clipboard/ at
+	// the identical host path inside the container, read-only. Images staged
+	// by `prism clipboard paste-image` (running host-side via the tmux keybind)
+	// are written here; opencode's drag-drop handler stat()s the path and reads
+	// the bytes. The read-only mount ensures the container cannot write to the
+	// host's staging directory. Only mounted when the directory exists — skipped
+	// silently at container spawn time when no paste has occurred yet (consistent
+	// with the conditional-mount pattern used for AWS/MCP-auth/kube config).
+	if _, err := os.Stat(clipboardCacheDir); err == nil {
+		args = append(args, "--volume", clipboardCacheDir+":"+clipboardCacheDir+":ro")
 	}
 
 	// Darwin: bind-mount the extracted Keychain credentials over

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -752,6 +752,18 @@ func (m *Manager) prepareVolumeDirs() error {
 		errs = append(errs, err.Error())
 	}
 
+	// Clipboard staging directory: pre-create so that the bind-mount in
+	// buildRunArgs() is always active, even on the first paste. Without this,
+	// a first-ever paste on a fresh system would write the file host-side but
+	// the container would not see it (the bind-mount only fires when the dir
+	// exists at container spawn time). Creating it eagerly here ensures the
+	// directory always exists before buildRunArgs() runs its os.Stat check.
+	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(clipboardCacheDir, 0o755); err != nil {
+		log.Printf("container: failed to create clipboard staging dir %q: %v", clipboardCacheDir, err)
+		errs = append(errs, err.Error())
+	}
+
 	if len(errs) > 1 {
 		return fmt.Errorf("%d directories could not be created", len(errs))
 	}

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2681,3 +2681,168 @@ func TestBuildRunArgs_AuthJsonOverlaySkippedWhenMissing(t *testing.T) {
 		}
 	}
 }
+
+// ── Clipboard staging directory mount tests ──────────────────────────────────
+
+// TestBuildRunArgs_ClipboardStagingDirMountedWhenPresent verifies that when
+// ~/.cache/prism/clipboard/ exists on the host, buildRunArgs adds a read-only
+// bind-mount at the identical absolute path inside the container.
+// This allows opencode's drag-drop handler to stat() the path verbatim and
+// read the staged image bytes without any path translation.
+func TestBuildRunArgs_ClipboardStagingDirMountedWhenPresent(t *testing.T) {
+	fakeHome := t.TempDir()
+	clipboardDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(clipboardDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll clipboard dir: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	// The mount must be: <clipboardDir>:<clipboardDir>:ro
+	// (identical host and container path, read-only).
+	wantMount := clipboardDir + ":" + clipboardDir + ":ro"
+	found := false
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			if args[i+1] == wantMount {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("clipboard staging dir mount %q not found in args: %v", wantMount, args)
+	}
+}
+
+// TestBuildRunArgs_ClipboardStagingDirNotMountedWhenAbsent verifies that when
+// ~/.cache/prism/clipboard/ does not exist at container spawn time, buildRunArgs
+// skips the bind-mount (consistent with the conditional-mount pattern used for
+// AWS/MCP-auth/kube config). The container starts normally without error.
+func TestBuildRunArgs_ClipboardStagingDirNotMountedWhenAbsent(t *testing.T) {
+	fakeHome := t.TempDir()
+	// Intentionally do NOT create ~/.cache/prism/clipboard/.
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	// No mount should reference the clipboard staging directory.
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, filepath.Join("prism", "clipboard")) {
+				t.Errorf("clipboard staging dir must not be mounted when absent; found %q", v)
+			}
+		}
+	}
+}
+
+// TestBuildRunArgs_ClipboardMountIsReadOnly verifies that the clipboard staging
+// directory bind-mount uses read-only access (:ro) from the container's
+// perspective. The container reads staged image files but must not write to the
+// host's staging directory.
+func TestBuildRunArgs_ClipboardMountIsReadOnly(t *testing.T) {
+	fakeHome := t.TempDir()
+	clipboardDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(clipboardDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll clipboard dir: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, filepath.Join("prism", "clipboard")) {
+				if !strings.HasSuffix(v, ":ro") {
+					t.Errorf("clipboard staging dir mount must be read-only, got: %q", v)
+				}
+				break
+			}
+		}
+	}
+}
+
+// TestBuildRunArgs_ClipboardMountSamePathBothSides verifies that the clipboard
+// staging directory is bind-mounted at the identical absolute path on both the
+// host side and the container side. opencode's stat() call uses the host path
+// (printed by `prism clipboard paste-image`) without any translation.
+func TestBuildRunArgs_ClipboardMountSamePathBothSides(t *testing.T) {
+	fakeHome := t.TempDir()
+	clipboardDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(clipboardDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll clipboard dir: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--volume" && i+1 < len(args) {
+			v := args[i+1]
+			if strings.Contains(v, filepath.Join("prism", "clipboard")) {
+				// Volume spec: host-path:container-path[:opts]
+				// Both sides must be the same absolute path.
+				parts := strings.SplitN(v, ":", 3)
+				if len(parts) < 2 {
+					t.Errorf("malformed volume spec: %q", v)
+					break
+				}
+				hostPath := parts[0]
+				containerPath := parts[1]
+				if hostPath != containerPath {
+					t.Errorf("clipboard mount host path %q != container path %q (must be identical)", hostPath, containerPath)
+				}
+				break
+			}
+		}
+	}
+}
+
+// TestBuildRunArgs_ClipboardMountNoWaylandOrX11Sockets verifies that no
+// Wayland socket, X11 socket, dbus socket, pipewire, or pulseaudio socket is
+// added alongside the clipboard staging directory mount. Clipboard read occurs
+// entirely host-side; no clipboard access mechanism is exposed inside the container.
+func TestBuildRunArgs_ClipboardMountNoWaylandOrX11Sockets(t *testing.T) {
+	fakeHome := t.TempDir()
+	clipboardDir := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(clipboardDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll clipboard dir: %v", err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "repo@feat", AllocatedPort: 14000})
+	args := m.buildRunArgs()
+
+	// Specific paths that must NOT appear in volume mounts or env vars.
+	// These are security-sensitive clipboard access mechanisms that must remain
+	// entirely host-side. We check specific known paths/patterns rather than
+	// substring matching to avoid false positives from temp dir names.
+	forbiddenContainerPaths := []string{
+		"/run/user",        // XDG_RUNTIME_DIR (contains Wayland sockets)
+		".X11-unix",        // X11 socket directory
+		"wayland-",         // Wayland socket files (wayland-0, wayland-1, etc.)
+		"/run/dbus",        // dbus socket
+		"/run/pipewire",    // pipewire socket
+		"/run/pulseaudio",  // pulseaudio socket
+		"xdg_runtime_dir",  // env var exposing the runtime dir
+		"wayland_display=", // env var exposing Wayland socket name
+		"display=:",        // env var exposing X11 display
+	}
+	for i, arg := range args {
+		if (arg == "--volume" || arg == "--mount" || arg == "--env") && i+1 < len(args) {
+			v := strings.ToLower(args[i+1])
+			for _, f := range forbiddenContainerPaths {
+				if strings.Contains(v, strings.ToLower(f)) {
+					t.Errorf("forbidden mount/env pattern %q found in args (security: clipboard must be read host-side only): %q", f, args[i+1])
+				}
+			}
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2591,8 +2591,9 @@ func TestBuildRunArgs_McpAuthNotMountedWhenAbsent(t *testing.T) {
 // ── prepareVolumeDirs tests (AC-1, AC-4) ─────────────────────────────────────
 
 // TestPrepareVolumeDirs_CreatesSessionDir verifies that prepareVolumeDirs creates
-// the per-session opencode state directory and the two cache directories under
-// the given HOME, so that buildRunArgs() remains a pure argument builder.
+// the per-session opencode state directory, cache directories, and the clipboard
+// staging directory under the given HOME, so that buildRunArgs() remains a pure
+// argument builder.
 func TestPrepareVolumeDirs_CreatesSessionDir(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
@@ -2605,8 +2606,11 @@ func TestPrepareVolumeDirs_CreatesSessionDir(t *testing.T) {
 	wantSession := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", m.Name())
 	wantOpencode := filepath.Join(fakeHome, ".cache", "opencode")
 	wantBun := filepath.Join(fakeHome, ".cache", "bun")
+	// Clipboard staging dir is pre-created so that the bind-mount in buildRunArgs()
+	// is always active, even on the first ever paste operation.
+	wantClipboard := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
 
-	for _, dir := range []string{wantSession, wantOpencode, wantBun} {
+	for _, dir := range []string{wantSession, wantOpencode, wantBun, wantClipboard} {
 		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
 			t.Errorf("expected directory to exist: %s (err: %v)", dir, err)
 		}

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -156,6 +156,34 @@ in
               bind -n C-g if-shell '[ "#{pane_current_command}" = "opencode" ]' 'send-keys Home'
               bind -n C-M-g if-shell '[ "#{pane_current_command}" = "opencode" ]' 'send-keys End'
 
+              # Clipboard paste bridge for container-mode opencode panes (issue #752).
+              #
+              # When Ctrl-V is pressed in a pane whose current command is "podman"
+              # (i.e. `podman attach` is running the container's opencode TUI):
+              #   1. Run `prism clipboard paste-image` host-side to read the PNG from
+              #      the host clipboard and stage it to ~/.cache/prism/clipboard/.
+              #   2. If it succeeds (exit 0), inject the file path into the pane as a
+              #      bracketed-paste sequence so opencode's existing drag-drop handler
+              #      picks it up as an image attachment.
+              #   3. If it fails (no image, tool absent, compositor error), fall through
+              #      silently — Ctrl-V with text content still reaches the pane via the
+              #      default bracketed-paste path handled by the terminal.
+              #
+              # Guard: if-shell checks pane_current_command and only intercepts when
+              # it equals "podman". All other panes (plain shell, editor, non-container
+              # windows) are unaffected — Ctrl-V reaches them via the else branch
+              # which sends a literal Ctrl-V (standard bracketed-paste passthrough).
+              #
+              # Implementation: run-shell in the then-branch executes synchronously
+              # (no -b) so the bracketed-paste send-keys fires only after paste-image
+              # completes. On failure (no image, subprocess error) paste-image exits
+              # non-zero; the script exits silently without injecting anything.
+              # #{pane_id} is expanded by tmux before the shell receives the string.
+              bind -n C-v \
+                if-shell '[ "#{pane_current_command}" = "podman" ]' \
+                  'run-shell "img=\$(${prism} clipboard paste-image 2>/dev/null); [ -n \"\$img\" ] && ${pkgs.tmux}/bin/tmux send-keys -t #{pane_id} -l -- \"\033[200~\$img\033[201~\"; true"' \
+                  'send-keys C-v'
+
               # toggle a split pane with edit and agent
               bind-key Space if-shell "[ $(tmux display-message -t 'edit' -p '#{window_panes}') -gt 1 ]" \
                   "break-pane -s 'edit.1' -n 'agent'" \

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -10,6 +10,46 @@ let
   isDarwin = pkgs.stdenv.isDarwin;
   prismPkg = pkgs.callPackage ../../../pkgs/prism.nix { };
   prism = "${prismPkg}/bin/prism";
+
+  # Host-side clipboard paste bridge script for container-mode opencode panes.
+  # Invoked by the tmux Ctrl-V keybind when pane_current_command is "podman".
+  # Argument $1 is the tmux pane ID (e.g. "%3") to inject the paste into.
+  #
+  # Two cases:
+  #   1. Clipboard has a PNG: stage it and inject the path as bracketed-paste.
+  #   2. Clipboard has text (or paste-image fails): read text from clipboard
+  #      and inject it as bracketed-paste (preserving pre-PR text-paste behaviour).
+  #
+  # Using writeShellScript avoids complex quoting in the tmux bind-key string.
+  # ESC bytes are written as literal escape chars inside the Nix string with $'\033'.
+  clipboardPasteScript = pkgs.writeShellScript "prism-clipboard-paste" ''
+    pane_id="$1"
+    tmux="${pkgs.tmux}/bin/tmux"
+
+    # Try image paste first.
+    img="$(${prism} clipboard paste-image 2>/dev/null)"
+    if [ -n "$img" ]; then
+      # Image in clipboard: inject file path as bracketed-paste.
+      # opencode's drag-drop handler will stat() the path and attach the image.
+      seq="$(printf '\033[200~%s\033[201~' "$img")"
+      "$tmux" send-keys -t "$pane_id" -l -- "$seq"
+      exit 0
+    fi
+
+    # No image: fall back to text clipboard paste.
+    # This preserves pre-PR behaviour: before this keybind existed, the terminal
+    # emulator's own bracketed-paste handled text Ctrl-V transparently through
+    # the podman attach PTY. Since we now intercept C-v we must replicate this.
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+      txt="$(wl-paste --no-newline 2>/dev/null)"
+    elif [ -n "$DISPLAY" ]; then
+      txt="$(xclip -selection clipboard -o 2>/dev/null)"
+    fi
+    if [ -n "$txt" ]; then
+      seq="$(printf '\033[200~%s\033[201~' "$txt")"
+      "$tmux" send-keys -t "$pane_id" -l -- "$seq"
+    fi
+  '';
 in
 {
   options = {
@@ -160,28 +200,30 @@ in
               #
               # When Ctrl-V is pressed in a pane whose current command is "podman"
               # (i.e. `podman attach` is running the container's opencode TUI):
-              #   1. Run `prism clipboard paste-image` host-side to read the PNG from
-              #      the host clipboard and stage it to ~/.cache/prism/clipboard/.
-              #   2. If it succeeds (exit 0), inject the file path into the pane as a
-              #      bracketed-paste sequence so opencode's existing drag-drop handler
-              #      picks it up as an image attachment.
-              #   3. If it fails (no image, tool absent, compositor error), fall through
-              #      silently — Ctrl-V with text content still reaches the pane via the
-              #      default bracketed-paste path handled by the terminal.
+              #
+              #   Image path: `prism clipboard paste-image` reads the host clipboard,
+              #   stages the PNG to ~/.cache/prism/clipboard/<uuid>.png, and prints
+              #   the path. The path is injected into the pane as a bracketed-paste
+              #   sequence so opencode's existing drag-drop handler attaches it.
+              #
+              #   Text fallback path: if paste-image exits non-zero (no image in
+              #   clipboard), read text from the host clipboard and inject it as a
+              #   bracketed-paste sequence. This ensures text Ctrl-V continues to
+              #   work in container panes even though tmux has intercepted C-v.
+              #   Without this fallback, text paste would be silently dropped.
               #
               # Guard: if-shell checks pane_current_command and only intercepts when
               # it equals "podman". All other panes (plain shell, editor, non-container
               # windows) are unaffected — Ctrl-V reaches them via the else branch
               # which sends a literal Ctrl-V (standard bracketed-paste passthrough).
               #
-              # Implementation: run-shell in the then-branch executes synchronously
-              # (no -b) so the bracketed-paste send-keys fires only after paste-image
-              # completes. On failure (no image, subprocess error) paste-image exits
-              # non-zero; the script exits silently without injecting anything.
-              # #{pane_id} is expanded by tmux before the shell receives the string.
+              # The script is written to the Nix store via writeShellScript to avoid
+              # complex quoting of ESC bytes and printf format strings inside the
+              # tmux bind-key string. #{pane_id} is expanded by tmux before the
+              # shell receives it as $1.
               bind -n C-v \
                 if-shell '[ "#{pane_current_command}" = "podman" ]' \
-                  'run-shell "img=\$(${prism} clipboard paste-image 2>/dev/null); [ -n \"\$img\" ] && ${pkgs.tmux}/bin/tmux send-keys -t #{pane_id} -l -- \"\033[200~\$img\033[201~\"; true"' \
+                  'run-shell "${clipboardPasteScript} #{pane_id}"' \
                   'send-keys C-v'
 
               # toggle a split pane with edit and agent


### PR DESCRIPTION
## Summary

- Adds \`prism clipboard paste-image\` host-side subcommand that reads a PNG from the host clipboard (Wayland/X11/Darwin) and stages it to \`~/.cache/prism/clipboard/<uuid>.png\`, printing the path on stdout. Exits non-zero silently when no PNG is available.
- Bind-mounts the staging directory read-only into the container at the identical absolute path, so opencode's existing drag-drop handler can \`stat()\` and read staged images without path translation.
- Adds a tmux \`Ctrl-V\` keybind (guarded by \`pane_current_command = podman\`) that runs the host helper and injects the path as a bracketed-paste sequence into the container pane. When paste-image fails (no image), falls through to text clipboard paste via \`wl-paste\` (Wayland) or \`xclip\` (X11) so that text Ctrl-V is not broken.
- Adds \`prism clipboard clean\` for TTL-based cleanup (1h), invoked in the background when the container sidecar starts.

## Testing

- Go: \`go build ./...\` and \`go test ./...\` pass (all existing + new tests green).
- Nix (NixOS): \`nix build .#nixosConfigurations.navi.config.system.build.toplevel\` passes.
- **Nix (Darwin): \`nix build .#darwinConfigurations.m4mac.config.system.build.toplevel\` was NOT run** — this build requires macOS. The implementation follows issue #752 spec for the Darwin (osascript) path. Manual verification on macOS is required. The Darwin code path compiles (no Linux-specific imports in Darwin-conditional code).
- **Text paste in container panes**: The tmux keybind includes a text fallthrough path (wl-paste on Wayland, xclip on X11). Text paste in container panes should work as before. Darwin text paste fallthrough would require \`pbpaste\` — this is noted for the Darwin verification pass.

## Security

- No Wayland socket, X11 socket, dbus, pipewire, or pulseaudio socket added to the container.
- Staging directory is bind-mounted read-only (\`:ro\`) — container cannot write to the host staging dir.
- All clipboard I/O is host-side; no clipboard access mechanism (socket, env var, binary) is exposed inside the container.

## Darwin verification checklist (for manual follow-up)

- [ ] \`nix build .#darwinConfigurations.m4mac.config.system.build.toplevel\` passes
- [ ] Ctrl-V with a screenshot in clipboard attaches an \`[Image N]\` in the opencode TUI
- [ ] Text paste via Ctrl-V still works in container panes (may need \`pbpaste\` in the text fallback path)

Closes #752