### PR TITLE
prism review: per-agent top-level sessions, dashboard visibility

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -146,45 +146,69 @@ prism spawn \
 
 ## Running code review with prism review
 
-`prism review <pr-number>` is the preferred way to run code review from a worker session. It spawns review agents in a dedicated, observable tmux session (`<parent>~review-N`) and returns findings to stdout when all agents complete.
+`prism review <pr-number>` is the preferred way to run code review from a worker session. In enhanced mode it spawns 5 independent review agent sessions and returns findings to stdout when all agents complete.
 
 ```bash
 # Run review — blocks until all agents finish, returns findings to stdout
 result=$(prism review 268)
 echo "$result"
 
-# Re-run only failed agents
-prism review 268 --only review
-
-# Keep the review session open for debugging (default: session is killed on exit)
-prism review 268 --keep
+# Re-run only specific agents (useful after a first pass with failures)
+prism review 268 --only review-code,review-security
 
 # Custom timeout (default: 10m)
 prism review 268 --timeout 5m
 ```
 
-**Output format:**
+**Output format (enhanced mode with ENHANCED_REVIEW=true):**
 ```
-✓ review              passed
-✗ review              [findings...]
+✓ review-goal         passed
+✓ review-code         passed
+✗ review-security     [findings...]
+✓ review-qa           passed
+✓ review-context      passed
 
-1 agent(s) failed. Retry: prism review 268 --only review
+1 agent(s) failed. Retry: prism review 268 --only review-security
 ```
 
 Exit code 0 = all passed, non-zero = failures.
+
+**Session shape (PR-C, enhanced mode):**
+
+Each review agent runs as its own independent top-level tmux session:
+```
+<parent>~review-<N>-review-goal
+<parent>~review-<N>-review-code
+<parent>~review-<N>-review-security
+<parent>~review-<N>-review-qa
+<parent>~review-<N>-review-context
+```
+- `N` is the round number, incremented on each `prism review` invocation.
+- Sessions **persist** after `prism review` completes — you can re-read findings later without re-running.
+- Sessions are only cleaned up when `prism cleanup` is invoked on the parent.
 
 **Review sessions appear in the dashboard** at depth 2, indented under their parent branch:
 ```
 nixos-config@main                   coordinator
   ├── @feature-branch               worker
-  │   ├── ~review-1                 round 1 (finished)
-  │   └── ~review-2                 round 2 (active)
+  │   ├── ~review-1-review-goal     finished
+  │   ├── ~review-1-review-code     finished
+  │   ├── ~review-1-review-security finished
+  │   ├── ~review-1-review-qa       finished
+  │   ├── ~review-1-review-context  finished
+  │   ├── ~review-2-review-code     active
+  │   └── ~review-2-review-security active
 ```
+
+Each review agent session is individually selectable in the `C-f` picker — jump directly to any reviewer with one keypress.
 
 **Checking in on review progress:**
 ```bash
-# From the coordinator session, inspect all review rounds for a worker
+# From the coordinator session, inspect all review sessions for a worker (grouped by round)
 prism checkin nixos-config@feature-branch~review
+
+# Inspect a specific agent session
+prism checkin nixos-config@feature-branch~review-1-review-security
 
 # Show full per-agent conversation
 prism checkin nixos-config@feature-branch~review --verbose
@@ -195,9 +219,10 @@ prism checkin nixos-config@feature-branch~review --verbose
 | Flag | Description |
 |---|---|
 | `--harness <name>` | Runtime harness (default: `opencode`) |
-| `--keep` | Keep the review session open after completion |
 | `--timeout <dur>` | Per-agent timeout (default: `10m`) |
-| `--only <csv>` | Run only named agents (e.g. `--only review`) |
+| `--only <csv>` | Run only named agents (e.g. `--only review-code,review-security`) |
+
+Note: `--keep` has been retired. Sessions now persist by default until `prism cleanup` on the parent.
 
 ### When to use prism review vs @review
 

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -187,20 +187,20 @@ Each review agent runs as its own independent top-level tmux session:
 - Sessions **persist** after `prism review` completes — you can re-read findings later without re-running.
 - Sessions are only cleaned up when `prism cleanup` is invoked on the parent.
 
-**Review sessions appear in the dashboard** at depth 2, indented under their parent branch:
+**Review sessions appear in the dashboard** at depth 2, indented under their parent branch (sorted alphabetically by label):
 ```
 nixos-config@main                   coordinator
   ├── @feature-branch               worker
-  │   ├── ~review-1-review-goal     finished
   │   ├── ~review-1-review-code     finished
-  │   ├── ~review-1-review-security finished
-  │   ├── ~review-1-review-qa       finished
   │   ├── ~review-1-review-context  finished
+  │   ├── ~review-1-review-goal     finished
+  │   ├── ~review-1-review-qa       finished
+  │   ├── ~review-1-review-security finished
   │   ├── ~review-2-review-code     active
   │   └── ~review-2-review-security active
 ```
 
-Each review agent session is individually selectable in the `C-f` picker — jump directly to any reviewer with one keypress.
+Each review agent session is individually selectable in the **`C-f` picker** — after selecting the project repo, review sessions appear as additional entries (e.g. `~review-1-review-security  [finished]`). Jump directly to any reviewer with one keypress.
 
 **Checking in on review progress:**
 ```bash

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -1412,14 +1412,22 @@ func printSessionTable(ss []db.Status) error {
 }
 
 // runCheckinReviewRounds handles `prism checkin <parent>~review` — a prefix
-// match that lists all ~review-N rounds for the parent session.
+// match that lists all review agent sessions for the parent, grouped by round.
 //
-// Default mode: one summary entry per round (the final aggregated output from
-// the last msg_assistant event per round session).
-// Verbose mode (--verbose): shows the full per-agent conversation for each round.
+// Supports both the new per-agent session shape (PR-C):
+//
+//	<parent>~review-<N>-<agent>
+//
+// and old-shape round sessions (pre-PR-C):
+//
+//	<parent>~review-<N>          (pure integer suffix — old round session)
+//	<parent>~review-<N>~<agent>  (old agent sub-session)
+//
+// Default mode: one summary entry per agent session (last msg_assistant output).
+// Verbose mode (--verbose): shows the full per-agent conversation.
 func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
-	// reviewPrefix is e.g. "nixos-config@feature~review" — the actual round
-	// sessions are "nixos-config@feature~review-1", "~review-2", etc.
+	// reviewPrefix is e.g. "nixos-config@feature~review" — agent sessions
+	// are "nixos-config@feature~review-1-review-goal", etc.
 	roundPrefix := reviewPrefix + "-"
 
 	d, err := openDB()
@@ -1429,89 +1437,145 @@ func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
 	defer d.Close()
 
 	// Find all sessions (active and ended) whose name starts with roundPrefix.
-	// This includes both round sessions and agent sub-sessions; we filter below.
 	all, err := d.AllStatusesWithPrefix(roundPrefix)
 	if err != nil {
 		return fmt.Errorf("checkin review: query db: %w", err)
 	}
 
-	// Filter to only round-level sessions. A round session has a suffix that is
-	// a pure integer (e.g. "nixos-config@feature~review-1"). Agent sub-sessions
-	// have an additional ~ separator (e.g. "nixos-config@feature~review-1~review").
-	var rounds []db.Status
-	for _, s := range all {
-		suffix := strings.TrimPrefix(s.SessionName, roundPrefix)
-		// Only include if suffix is a pure integer (no further separators).
-		if _, convErr := strconv.Atoi(suffix); convErr == nil {
-			rounds = append(rounds, s)
-		}
-	}
-
-	if len(rounds) == 0 {
-		fmt.Printf("no review rounds found matching %q\n", reviewPrefix)
+	if len(all) == 0 {
+		fmt.Printf("no review sessions found matching %q\n", reviewPrefix)
 		return nil
 	}
 
-	// Sort rounds numerically by round number.
-	// Since the session names share the same prefix, lexicographic sorting is
-	// correct for single-digit rounds; for safety we sort by the numeric suffix.
-	for i := 1; i < len(rounds); i++ {
-		key := rounds[i]
-		keySuffix := strings.TrimPrefix(key.SessionName, roundPrefix)
-		keyN, _ := strconv.Atoi(keySuffix)
-		j := i - 1
-		for j >= 0 {
-			jSuffix := strings.TrimPrefix(rounds[j].SessionName, roundPrefix)
-			jN, _ := strconv.Atoi(jSuffix)
-			if jN <= keyN {
-				break
+	// Classify sessions and group by round number.
+	// New shape: <prefix>N-<agent>  → roundN = N, label = ~review-N-<agent>
+	// Old round: <prefix>N          → roundN = N, label = ~review-N
+	// Old agent: <prefix>N~<agent>  → roundN = N, label = ~review-N~<agent>
+	type agentEntry struct {
+		sessionName string
+		label       string
+		state       string
+	}
+	roundAgents := make(map[int][]agentEntry) // round number → agent sessions
+	var roundNums []int
+	seenRounds := make(map[int]bool)
+
+	for _, s := range all {
+		suffix := strings.TrimPrefix(s.SessionName, roundPrefix)
+		// suffix examples:
+		//   new shape:  "1-review-goal"
+		//   old round:  "1"
+		//   old agent:  "1~review-goal"
+
+		var roundN int
+		var agentLabel string
+
+		if dashIdx := strings.Index(suffix, "-"); dashIdx > 0 {
+			// New shape: N-<agent-name> (no ~ in agent part).
+			nStr := suffix[:dashIdx]
+			n, convErr := strconv.Atoi(nStr)
+			if convErr != nil {
+				continue // not a recognised shape
 			}
-			rounds[j+1] = rounds[j]
+			agentPart := suffix[dashIdx+1:]
+			if strings.Contains(agentPart, "~") {
+				continue // old agent sub-session (N-something with ~)
+			}
+			roundN = n
+			agentLabel = "~review-" + suffix // e.g. ~review-1-review-goal
+		} else if tildeIdx := strings.Index(suffix, "~"); tildeIdx > 0 {
+			// Old agent sub-session shape: N~<agent>.
+			nStr := suffix[:tildeIdx]
+			n, convErr := strconv.Atoi(nStr)
+			if convErr != nil {
+				continue
+			}
+			roundN = n
+			agentLabel = "~review-" + suffix // e.g. ~review-1~review-goal
+		} else {
+			// Old round session shape: pure integer N.
+			n, convErr := strconv.Atoi(suffix)
+			if convErr != nil {
+				continue
+			}
+			roundN = n
+			agentLabel = "~review-" + suffix // e.g. ~review-1
+		}
+
+		if !seenRounds[roundN] {
+			seenRounds[roundN] = true
+			roundNums = append(roundNums, roundN)
+		}
+		roundAgents[roundN] = append(roundAgents[roundN], agentEntry{
+			sessionName: s.SessionName,
+			label:       agentLabel,
+			state:       s.State,
+		})
+	}
+
+	// Sort round numbers ascending.
+	for i := 1; i < len(roundNums); i++ {
+		key := roundNums[i]
+		j := i - 1
+		for j >= 0 && roundNums[j] > key {
+			roundNums[j+1] = roundNums[j]
 			j--
 		}
-		rounds[j+1] = key
+		roundNums[j+1] = key
 	}
 
 	styleBold := lipgloss.NewStyle().Bold(true)
 	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 
-	for _, round := range rounds {
-		roundName := round.SessionName
-		// Extract round label: everything after the last "~".
-		label := roundName
-		if idx := strings.LastIndex(roundName, "~"); idx >= 0 {
-			label = roundName[idx:] // e.g. "~review-1"
+	for _, roundN := range roundNums {
+		agents := roundAgents[roundN]
+
+		// Sort agents within the round alphabetically by label.
+		for i := 1; i < len(agents); i++ {
+			key := agents[i]
+			j := i - 1
+			for j >= 0 && agents[j].label > key.label {
+				agents[j+1] = agents[j]
+				j--
+			}
+			agents[j+1] = key
 		}
 
-		fmt.Printf("%s\n\n", styleBold.Render(label+" ("+roundName+")"))
+		fmt.Printf("%s\n\n", styleBold.Render(fmt.Sprintf("round %d (%d session(s))", roundN, len(agents))))
 
-		if verbose {
-			// Show full conversation for this round.
-			if err := runCheckinSession(roundName, 20, nil, nil, nil, true); err != nil {
-				fmt.Fprintf(os.Stderr, "  [error reading round %s: %v]\n", label, err)
+		for _, ag := range agents {
+			fmt.Printf("  %s\n", styleBold.Render(ag.label))
+			if ag.state != "" {
+				stateStyled := stateStyle(ag.state).Render(ag.state)
+				fmt.Printf("  state: %s\n", stateStyled)
 			}
-		} else {
-			// Show summary: last msg_assistant event per round session.
-			// The round session itself receives the aggregated output from the
-			// review agents (via the prism review CLI output). If no msg_assistant
-			// events exist for the round session, fall back to showing the agent
-			// sub-session output.
-			events, qerr := d.QueryEvents(roundName, 1, nil, nil, []string{"msg_assistant"})
-			if qerr != nil || len(events) == 0 {
-				fmt.Println(styleDim.Render("  (no output recorded for this round)"))
+
+			if verbose {
+				// Show full conversation for this agent session.
+				if err := runCheckinSession(ag.sessionName, 20, nil, nil, nil, true); err != nil {
+					fmt.Fprintf(os.Stderr, "  [error reading session %s: %v]\n", ag.label, err)
+				}
 			} else {
-				e := events[len(events)-1]
-				ts := e.CreatedAt.Local().Format("15:04:05")
-				var ap struct {
-					Text string `json:"text"`
+				// Show summary: last msg_assistant event.
+				events, qerr := d.QueryEvents(ag.sessionName, 1, nil, nil, []string{"msg_assistant"})
+				if qerr != nil || len(events) == 0 {
+					fmt.Println(styleDim.Render("  (no output recorded)"))
+				} else {
+					e := events[len(events)-1]
+					ts := e.CreatedAt.Local().Format("15:04:05")
+					var ap struct {
+						Text string `json:"text"`
+					}
+					text := e.Payload
+					if jerr := json.Unmarshal([]byte(e.Payload), &ap); jerr == nil && ap.Text != "" {
+						text = ap.Text
+					}
+					fmt.Printf("  [%s]\n  %s\n", ts, strings.ReplaceAll(text, "\n", "\n  "))
 				}
-				text := e.Payload
-				if jerr := json.Unmarshal([]byte(e.Payload), &ap); jerr == nil && ap.Text != "" {
-					text = ap.Text
-				}
-				fmt.Printf("  [%s]\n  %s\n", ts, strings.ReplaceAll(text, "\n", "\n  "))
 			}
+			fmt.Println()
 		}
+
 		fmt.Println(styleDim.Render("── end of round ──"))
 		fmt.Println()
 	}

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -200,9 +200,6 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			}
 		}
 
-		// Kill any review sessions spawned by this parent session.
-		review.KillReviewSessionsForParent(m.session)
-
 		// Ensure scratchpad exists.
 		if !tmux.HasSession("scratchpad") {
 			home, _ := os.UserHomeDir()
@@ -223,6 +220,9 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 		_ = tmux.KillSession(m.session)
 		prismSession.KillSidecar(m.session)
 		if d, err := openDB(); err == nil {
+			// Kill and clean up all review sessions spawned by this parent session,
+			// including their port allocations and DB rows.
+			review.CleanupReviewSessionsForParent(d, m.session)
 			if !hostModeFromDB(d, m.session) {
 				removeContainerIfExists(m.session)
 			}
@@ -234,6 +234,7 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			d.Close()
 		} else {
 			// DB unavailable — still attempt container removal conservatively.
+			review.KillReviewSessionsForParent(m.session)
 			removeContainerIfExists(m.session)
 		}
 
@@ -468,13 +469,13 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		}
 	}
 
-	// Kill any review sessions spawned by this parent session.
-	review.KillReviewSessionsForParent(session)
-
 	fmt.Printf("killing session %s\n", session)
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
 	if d, err := openDB(); err == nil {
+		// Kill and clean up all review sessions spawned by this parent session,
+		// including their port allocations and DB rows.
+		review.CleanupReviewSessionsForParent(d, session)
 		if !hostModeFromDB(d, session) {
 			removeContainerIfExists(session)
 		}
@@ -486,6 +487,8 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		d.Close()
 	} else {
 		// DB unavailable — still attempt container removal conservatively.
+		// Also try to kill review sessions via tmux even without DB cleanup.
+		review.KillReviewSessionsForParent(session)
 		removeContainerIfExists(session)
 	}
 	fmt.Println("done")
@@ -547,9 +550,6 @@ func headlessCloseSession(session string) error {
 
 	fmt.Printf("closing session %s...\n", session)
 
-	// Kill any review sessions spawned by this parent session.
-	review.KillReviewSessionsForParent(session)
-
 	// Ensure scratchpad exists.
 	if !tmux.HasSession("scratchpad") {
 		home, _ := os.UserHomeDir()
@@ -570,6 +570,9 @@ func headlessCloseSession(session string) error {
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
 	if d, err := openDB(); err == nil {
+		// Kill and clean up all review sessions spawned by this parent session,
+		// including their port allocations and DB rows.
+		review.CleanupReviewSessionsForParent(d, session)
 		if !hostModeFromDB(d, session) {
 			removeContainerIfExists(session)
 		}
@@ -581,6 +584,8 @@ func headlessCloseSession(session string) error {
 		d.Close()
 	} else {
 		// DB unavailable — still attempt container removal conservatively.
+		// Also try to kill review sessions via tmux even without DB cleanup.
+		review.KillReviewSessionsForParent(session)
 		removeContainerIfExists(session)
 	}
 	fmt.Println("done")

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -2,17 +2,19 @@ package cmd
 
 // prism review <pr-number> — platform-native review primitive.
 //
-// Spawns review agent sessions in a dedicated tmux session named
-// <parent-session>~review-N (N = 1-indexed round number), polls the prism DB
-// until all agents reach the "finished" state, reads their last msg_assistant
-// event, and returns aggregated findings to stdout.
+// Spawns review agent sessions as independent top-level tmux sessions named
+// <parent-session>~review-N-<agent> (N = 1-indexed round number), polls the
+// prism DB until all agents reach the "finished" state, reads their last
+// msg_assistant event, and returns aggregated findings to stdout.
+//
+// Sessions persist until prism cleanup is invoked on the parent — this allows
+// re-reading review-security's findings tomorrow without re-running.
 //
 // Flags:
 //
 //	--harness <name>    Runtime harness (default: "opencode")
-//	--keep              Keep the review session open after completion
 //	--timeout <dur>     Per-agent timeout (default: 10m)
-//	--only <csv>        Run only the named agents (e.g. review)
+//	--only <csv>        Run only the named agents (e.g. review-goal,review-code)
 
 import (
 	"context"
@@ -32,11 +34,12 @@ import (
 var reviewCmd = &cobra.Command{
 	Use:   "review <pr-number>",
 	Short: "Run review agents against a PR and return aggregated findings",
-	Long: `Spawn review agent sessions in a dedicated tmux session and poll the
-prism DB until all agents complete. Returns aggregated findings to stdout.
+	Long: `Spawn review agent sessions as independent top-level tmux sessions and poll
+the prism DB until all agents complete. Returns aggregated findings to stdout.
 
-The review session is named <parent-session>~review-N where N is incremented
-on each invocation. Previous ~review-* sessions are killed before starting.
+Each agent gets its own session named <parent-session>~review-N-<agent> where N
+is incremented on each invocation. Previous rounds' sessions persist until
+prism cleanup is invoked on the parent.
 
 Exit code 0 = all agents passed. Non-zero = one or more agents failed or errored.`,
 	Args: cobra.ExactArgs(1),
@@ -45,9 +48,8 @@ Exit code 0 = all agents passed. Non-zero = one or more agents failed or errored
 
 func init() {
 	reviewCmd.Flags().String("harness", "opencode", "Runtime harness to use for review agents")
-	reviewCmd.Flags().Bool("keep", false, "Keep the review session open after completion (for debugging)")
 	reviewCmd.Flags().Duration("timeout", 10*time.Minute, "Maximum time to wait per agent")
-	reviewCmd.Flags().String("only", "", "Comma-separated list of agent names to run (e.g. review)")
+	reviewCmd.Flags().String("only", "", "Comma-separated list of agent names to run (e.g. review-goal,review-code)")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -55,7 +57,6 @@ func runReview(cmd *cobra.Command, args []string) error {
 	prNumber := args[0]
 
 	harnessFlag, _ := cmd.Flags().GetString("harness")
-	keepFlag, _ := cmd.Flags().GetBool("keep")
 	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
 	onlyFlag, _ := cmd.Flags().GetString("only")
 
@@ -159,7 +160,6 @@ func runReview(cmd *cobra.Command, args []string) error {
 		Agents:         agents,
 		Harness:        harnessFlag,
 		Timeout:        timeoutFlag,
-		Keep:           keepFlag,
 		PluginHostPath: cfg.SidecarPluginPath,
 		ContainerMode:  cfg.ContainerMode,
 	}
@@ -177,21 +177,29 @@ func runReview(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Install SIGTERM/SIGINT handler. Kill all ~review-* sessions for the parent
-	// and cancel the context. KillReviewSessionsForParent is idempotent and
-	// covers all rounds without needing the specific session name, avoiding
-	// any data race on a shared variable.
+	// currentRoundSessions holds the session names spawned in this invocation.
+	// It is written once by Run's onSessionsCreated callback (before polling
+	// begins) and read by the SIGINT handler. Protected by the assumption that
+	// the callback fires before the goroutine needs to read it (the goroutine
+	// only acts on a signal, which arrives after spawning is complete).
+	var currentRoundSessions []string
+
+	// Install SIGTERM/SIGINT handler. On signal, kill only the current round's
+	// in-progress sessions — previous rounds' persisted sessions remain untouched.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		<-sigCh
-		review.KillReviewSessionsForParent(parentSession)
+		review.KillCurrentRoundSessions(currentRoundSessions)
 		cancel()
 	}()
 
 	// Run the review.
-	results, runErr := review.Run(ctx, opts, func(sessionName string) {
-		fmt.Fprintf(os.Stderr, "[prism review] review session: %s\n", sessionName)
+	results, runErr := review.Run(ctx, opts, func(sessionNames []string) {
+		currentRoundSessions = sessionNames
+		for _, name := range sessionNames {
+			fmt.Fprintf(os.Stderr, "[prism review] agent session: %s\n", name)
+		}
 	})
 
 	signal.Stop(sigCh)

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -44,9 +44,10 @@ func switchProjectSpecific() []string {
 
 // entry is a selectable item in the picker.
 type entry struct {
-	display string // shown in the list
-	path    string // resolved filesystem path (empty for specials)
-	special string // "[dashboard]", "[scratchpad]", "[+ create new worktree]"
+	display    string // shown in the list
+	path       string // resolved filesystem path (empty for specials)
+	special    string // "[dashboard]", "[scratchpad]", "[+ create new worktree]"
+	sessionRef string // when non-empty, selecting this entry attaches to the named tmux session
 }
 
 func expandHome(path string) string {
@@ -578,11 +579,31 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 	for _, w := range worktrees {
 		items = append(items, entry{display: filepath.Base(w), path: w})
 	}
+
+	// Include any active review sessions for worktrees in this bare repo.
+	// These are per-agent top-level sessions named <repo>@<branch>~review-N-<agent>.
+	// They appear as selectable entries in the picker; selecting one attaches
+	// directly to that tmux session without creating a new one.
+	items = append(items, activeReviewSessionEntries(projectPath, worktrees)...)
+
 	items = append(items, createNew)
 
 	chosen := pick("worktree> ", items)
 	if chosen == nil {
 		return nil
+	}
+
+	// Review session entry: attach directly to the named tmux session.
+	if chosen.sessionRef != "" {
+		client, _ := tmux.CurrentClient()
+		if client == "" {
+			client = tmux.CallerClient()
+		}
+		if client != "" {
+			return tmux.SwitchClient(client, chosen.sessionRef)
+		}
+		_, err := tmux.SwitchClientCurrent(chosen.sessionRef)
+		return err
 	}
 
 	if chosen.special == "[+ create new worktree]" {
@@ -612,6 +633,68 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 		}
 	}
 	return ensureAndSwitch(chosen.path, projectPath, opts)
+}
+
+// activeReviewSessionEntries returns picker entries for active review agent
+// sessions associated with worktrees in projectPath. Each entry has sessionRef
+// set to the tmux session name; selecting it attaches to that session directly.
+// Returns an empty slice if the DB is unavailable or no review sessions exist.
+func activeReviewSessionEntries(projectPath string, worktrees []string) []entry {
+	// Derive the repo name from the project path (last component).
+	repoName := filepath.Base(projectPath)
+
+	d, err := openDB()
+	if err != nil {
+		return nil
+	}
+	defer d.Close()
+
+	// Query all active sessions for this repo.
+	all, err := d.AllActiveStatusForRepo(repoName)
+	if err != nil {
+		return nil
+	}
+
+	var entries []entry
+	for _, s := range all {
+		// Only include review agent sessions: name must contain "~review-"
+		// followed by a round number and agent name.
+		if !strings.Contains(s.SessionName, "~review-") {
+			continue
+		}
+		// Verify it matches the new per-agent shape: <repo>@<branch>~review-N-<agent>
+		// The session must also exist in tmux (not just the DB).
+		if !tmux.HasSession(s.SessionName) {
+			continue
+		}
+		// Extract the label: everything from the first "~review-" onwards.
+		label := s.SessionName
+		if idx := strings.Index(s.SessionName, "~review-"); idx >= 0 {
+			label = s.SessionName[idx:] // e.g. "~review-1-review-goal"
+		}
+		state := s.State
+		if state == "" {
+			state = "idle"
+		}
+		display := fmt.Sprintf("%s  [%s]", label, state)
+		entries = append(entries, entry{
+			display:    display,
+			sessionRef: s.SessionName,
+		})
+	}
+
+	// Sort entries alphabetically by display label for stable output.
+	for i := 1; i < len(entries); i++ {
+		key := entries[i]
+		j := i - 1
+		for j >= 0 && entries[j].display > key.display {
+			entries[j+1] = entries[j]
+			j--
+		}
+		entries[j+1] = key
+	}
+
+	return entries
 }
 
 func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts) error {

--- a/modules/programs/prism/prism/internal/dashboard/depth2_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/depth2_test.go
@@ -14,9 +14,15 @@ func TestIsDepth2Session(t *testing.T) {
 		{"nixos-config@main", false},
 		{"nixos-config@feature", false},
 		{"scratchpad", false},
+		// Old-shape round sessions (pre-PR-C) — still detected as depth-2.
 		{"nixos-config@feature~review-1", true},
 		{"nixos-config@feature~review-2", true},
-		{"nixos-config@feature~review-1~review", true}, // agent sub-session
+		// Old-shape agent sub-sessions (pre-PR-C).
+		{"nixos-config@feature~review-1~review", true},
+		// New per-agent session shape (PR-C).
+		{"nixos-config@feature~review-1-review-goal", true},
+		{"nixos-config@feature~review-1-review-code", true},
+		{"nixos-config@feature~review-2-review-qa", true},
 		{"repo@branch~something", true},
 	}
 	for _, tt := range tests {
@@ -32,9 +38,14 @@ func TestDepth2ParentBranch(t *testing.T) {
 		name string
 		want string
 	}{
+		// Old-shape (pre-PR-C).
 		{"nixos-config@feature~review-1", "@feature"},
 		{"nixos-config@feature~review-2", "@feature"},
 		{"nixos-config@feature~review-1~review", "@feature"},
+		// New per-agent shape (PR-C).
+		{"nixos-config@feature~review-1-review-goal", "@feature"},
+		{"nixos-config@feature~review-2-review-security", "@feature"},
+		// Non-review depth-2.
 		{"nixos-config@main", ""},    // top-level
 		{"nixos-config@feature", ""}, // depth-1, no ~
 		{"scratchpad", ""},
@@ -52,8 +63,14 @@ func TestDepth2Label(t *testing.T) {
 		name string
 		want string
 	}{
+		// Old-shape (pre-PR-C).
 		{"nixos-config@feature~review-1", "~review-1"},
 		{"nixos-config@feature~review-2", "~review-2"},
+		// New per-agent shape (PR-C): label includes agent name.
+		{"nixos-config@feature~review-1-review-goal", "~review-1-review-goal"},
+		{"nixos-config@feature~review-1-review-code", "~review-1-review-code"},
+		{"nixos-config@feature~review-2-review-qa", "~review-2-review-qa"},
+		// Non-review.
 		{"nixos-config@main", ""},
 		{"nixos-config@feature", ""},
 		{"scratchpad", ""},
@@ -83,6 +100,72 @@ func TestSortDisplayed_Depth2AfterParent(t *testing.T) {
 		"nixos-config@feature~review-2",
 	}
 	for i, w := range want {
+		if sessions[i].Name != w {
+			t.Errorf("position %d: got %q, want %q", i, sessions[i].Name, w)
+		}
+	}
+}
+
+// TestSortDisplayed_PerAgentSessionsAfterParent verifies that the new per-agent
+// session shape (PR-C) sorts correctly: all 5 agents grouped under the parent
+// branch, sorted alphabetically by ~review-N-<agent> label.
+func TestSortDisplayed_PerAgentSessionsAfterParent(t *testing.T) {
+	sessions := []dashboard.AgentSession{
+		{Name: "nixos-config@feature~review-1-review-security"},
+		{Name: "nixos-config@main"},
+		{Name: "nixos-config@feature~review-1-review-goal"},
+		{Name: "nixos-config@feature~review-1-review-qa"},
+		{Name: "nixos-config@feature"},
+		{Name: "nixos-config@feature~review-1-review-code"},
+		{Name: "nixos-config@feature~review-1-review-context"},
+	}
+	dashboard.SortDisplayed(sessions)
+
+	// Expected: @main first, then @feature, then all 5 review agents sorted
+	// alphabetically by label under @feature.
+	want := []string{
+		"nixos-config@main",
+		"nixos-config@feature",
+		"nixos-config@feature~review-1-review-code",
+		"nixos-config@feature~review-1-review-context",
+		"nixos-config@feature~review-1-review-goal",
+		"nixos-config@feature~review-1-review-qa",
+		"nixos-config@feature~review-1-review-security",
+	}
+	for i, w := range want {
+		if i >= len(sessions) {
+			t.Fatalf("position %d: want %q but only %d sessions", i, w, len(sessions))
+		}
+		if sessions[i].Name != w {
+			t.Errorf("position %d: got %q, want %q", i, sessions[i].Name, w)
+		}
+	}
+}
+
+// TestSortDisplayed_MultipleRoundsPerAgentSessions verifies that sessions from
+// round 1 all appear before sessions from round 2 (sorted by label).
+func TestSortDisplayed_MultipleRoundsPerAgentSessions(t *testing.T) {
+	sessions := []dashboard.AgentSession{
+		{Name: "nixos-config@feature~review-2-review-goal"},
+		{Name: "nixos-config@feature~review-1-review-goal"},
+		{Name: "nixos-config@feature~review-2-review-code"},
+		{Name: "nixos-config@feature~review-1-review-code"},
+		{Name: "nixos-config@feature"},
+	}
+	dashboard.SortDisplayed(sessions)
+
+	// Labels: ~review-1-review-code < ~review-1-review-goal < ~review-2-review-code < ~review-2-review-goal
+	want := []string{
+		"nixos-config@feature",
+		"nixos-config@feature~review-1-review-code",
+		"nixos-config@feature~review-1-review-goal",
+		"nixos-config@feature~review-2-review-code",
+		"nixos-config@feature~review-2-review-goal",
+	}
+	for i, w := range want {
+		if i >= len(sessions) {
+			t.Fatalf("position %d: want %q but only %d sessions", i, w, len(sessions))
+		}
 		if sessions[i].Name != w {
 			t.Errorf("position %d: got %q, want %q", i, sessions[i].Name, w)
 		}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -1,15 +1,21 @@
 // Package review implements the prism review execution engine.
 //
-// prism review <pr-number> spawns N review agent sessions in a dedicated tmux
-// session named <parent>~review-N (where N is the 1-indexed round number),
-// polls the prism DB until all agents reach the "finished" state, reads their
-// last msg_assistant event, and returns aggregated findings to stdout.
+// prism review <pr-number> spawns N review agent sessions as independent
+// top-level tmux sessions named <parent>~review-<N>-<agent-name> (where N is
+// the 1-indexed round number), polls the prism DB until all agents reach the
+// "finished" state, reads their last msg_assistant event, and returns
+// aggregated findings to stdout.
 //
-// Session architecture:
-//   - One tmux session per review round: <parent-session>~review-N
-//   - One tmux window per review agent within the session
-//   - Each agent gets its own sidecar + container mounting the parent worktree read-only
-//   - No new worktree is created
+// Session architecture (new per-agent model, PR-C):
+//   - Five independent top-level tmux sessions per review round:
+//     <parent>~review-<N>-review-goal
+//     <parent>~review-<N>-review-code
+//     <parent>~review-<N>-review-security
+//     <parent>~review-<N>-review-qa
+//     <parent>~review-<N>-review-context
+//   - Each session has its own port allocation, sidecar, and container.
+//   - Sessions persist until prism cleanup is invoked on the parent.
+//   - No round-level multi-window session is created.
 //
 // The ~ separator in the session name is used by the dashboard for depth-2
 // child detection (review sessions appear indented under their parent branch).
@@ -47,10 +53,21 @@ func KillSessionPrefix(prefix string) {
 	}
 }
 
+// KillSessionsByNames kills the specified tmux sessions by exact name.
+func KillSessionsByNames(names []string) {
+	for _, name := range names {
+		_ = tmux.KillSession(name)
+	}
+}
+
 // NextRoundNumber returns the next round number for the given parent session.
-// It queries the DB for all round sessions (not live tmux sessions) so that
-// the count is accurate even after previous rounds have been cleaned up.
+// It queries the DB for all per-agent sessions (new shape: ~review-<N>-<agent>)
+// so that the count is accurate even after previous rounds have been cleaned up.
 // Returns 1 when no prior rounds exist.
+//
+// Old-shape round sessions (~review-<N> with pure integer suffix) are NOT
+// counted — they belong to the pre-PR-C model and should not affect the counter.
+// Old-shape agent sub-sessions (~review-<N>~<agent>) are also excluded.
 func NextRoundNumber(d *db.DB, parentSession string) int {
 	prefix := parentSession + "~review-"
 	rows, err := d.AllStatusesWithPrefix(prefix)
@@ -59,11 +76,28 @@ func NextRoundNumber(d *db.DB, parentSession string) int {
 	}
 	max := 0
 	for _, row := range rows {
-		// Only count round-level sessions (no further ~ after the round number).
 		suffix := strings.TrimPrefix(row.SessionName, prefix)
-		// suffix should be a pure integer (e.g. "1", "2") for round sessions.
-		// Agent sub-sessions have a suffix like "1~review", which won't parse.
-		if n, err := strconv.Atoi(suffix); err == nil && n > max {
+		// New shape: "N-<agent-name>" (e.g. "1-review-goal", "2-review-code").
+		// Extract the leading integer before the first '-'.
+		dashIdx := strings.Index(suffix, "-")
+		if dashIdx <= 0 {
+			// Pure integer (old round session, e.g. "1") or no dash at all —
+			// skip; these are old-shape rows that we do not count.
+			continue
+		}
+		nStr := suffix[:dashIdx]
+		// Ensure nStr is a pure integer (not something like "1~review" from
+		// old-shape agent sub-sessions that somehow snuck in).
+		n, err := strconv.Atoi(nStr)
+		if err != nil || n <= 0 {
+			continue
+		}
+		// Validate: the agent portion must not contain '~' (old-shape markers).
+		agentPart := suffix[dashIdx+1:]
+		if strings.Contains(agentPart, "~") {
+			continue
+		}
+		if n > max {
 			max = n
 		}
 	}
@@ -72,9 +106,9 @@ func NextRoundNumber(d *db.DB, parentSession string) int {
 
 // Agent describes a single review agent to run.
 type Agent struct {
-	// Name is the agent identifier, e.g. "review".
+	// Name is the agent identifier, e.g. "review-goal".
 	Name string
-	// OpencodeName is the opencode --agent flag value, e.g. "review".
+	// OpencodeName is the opencode --agent flag value, e.g. "review-goal".
 	OpencodeName string
 }
 
@@ -191,8 +225,6 @@ type Opts struct {
 	Harness string
 	// Timeout is the per-agent maximum wait time.
 	Timeout time.Duration
-	// Keep: if true, the review session is not killed after completion.
-	Keep bool
 	// DBPath is the path to the prism database. If empty, the default is used.
 	DBPath string
 	// PluginHostPath is the path to the opencode plugin file.
@@ -205,12 +237,17 @@ type Opts struct {
 	ContainerMode bool
 }
 
-// Run executes the review. It returns the aggregated results and a boolean
-// indicating whether all agents passed.
+// Run executes the review. It returns the aggregated results and an error.
 //
-// On signal (SIGTERM/SIGINT), the caller is expected to kill the review session
-// using the session name returned via the onSessionCreated callback.
-func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName string)) ([]AgentResult, error) {
+// Each agent is spawned as its own independent top-level tmux session named
+// <parent>~review-<N>-<agent.Name>. Previous rounds' sessions are NOT killed
+// — they persist until prism cleanup is invoked on the parent. This is a
+// deliberate behaviour change from the old multi-window round model.
+//
+// On SIGINT, only the current round's in-progress sessions are killed by the
+// caller via KillSessionsByNames (using the session names from onSessionsCreated).
+// Previous rounds remain untouched.
+func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []string)) ([]AgentResult, error) {
 	if opts.ParentSession == "" {
 		return nil, fmt.Errorf("parent session name is required")
 	}
@@ -232,43 +269,23 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 	}
 	defer d.Close()
 
-	// Determine round number from DB BEFORE killing previous sessions.
-	// Using DB-based counting ensures correctness even after prior sessions
-	// are killed (tmux sessions disappear, but DB rows persist).
+	// Determine round number from DB. We do NOT kill previous review sessions —
+	// they persist until prism cleanup on the parent (deliberate).
 	round := NextRoundNumber(d, opts.ParentSession)
-	reviewSession := fmt.Sprintf("%s~review-%d", opts.ParentSession, round)
+	roundPrefix := fmt.Sprintf("%s~review-%d-", opts.ParentSession, round)
 
-	// Kill any previous review sessions for this parent.
-	reviewPrefix := opts.ParentSession + "~review-"
-	KillSessionPrefix(reviewPrefix)
-
-	// Create the review tmux session.
-	if err := tmux.NewSessionDetached(reviewSession, worktree); err != nil {
-		return nil, fmt.Errorf("create review session %q: %w", reviewSession, err)
-	}
-
-	if onSessionCreated != nil {
-		onSessionCreated(reviewSession)
-	}
-
-	// Insert the round session into the DB so it shows up in checkin.
-	// The repo field is derived from the parent session name.
 	repo := deriveRepo(opts.ParentSession)
-	if err := d.UpsertStatus(reviewSession, repo, worktree, "idle", nil, nil); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism review] warning: upsert round session status: %v\n", err)
-	}
 
 	agents := opts.Agents
 	if len(agents) == 0 {
 		agents = DefaultAgents()
 	}
 
-	// Spawn each agent in its own tmux window within the review session.
+	// Spawn each agent as its own independent top-level tmux session.
 	agentSessions := make([]string, len(agents))
 	for i, ag := range agents {
-		// Agent sub-sessions are named <reviewSession>~<agentName>.
-		// They have a second ~ in the branch component, making them depth-2+.
-		agentSession := fmt.Sprintf("%s~%s", reviewSession, ag.Name)
+		// Per-agent session: <parent>~review-<N>-<agent.Name>
+		agentSession := roundPrefix + ag.Name
 		agentSessions[i] = agentSession
 
 		// Seed agent_status for the agent session.
@@ -277,8 +294,8 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 			for j := 0; j < i; j++ {
 				session.KillSidecar(agentSessions[j])
 				cleanupAgentSession(d, agentSessions[j])
+				_ = tmux.KillSession(agentSessions[j])
 			}
-			_ = tmux.KillSession(reviewSession)
 			return nil, fmt.Errorf("seed status for %s: %w", ag.Name, err)
 		}
 
@@ -288,8 +305,10 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 			for j := 0; j < i; j++ {
 				session.KillSidecar(agentSessions[j])
 				cleanupAgentSession(d, agentSessions[j])
+				_ = tmux.KillSession(agentSessions[j])
 			}
-			_ = tmux.KillSession(reviewSession)
+			// Also clean up the DB row we just seeded for i.
+			_ = d.SetEnded(agentSession)
 			return nil, fmt.Errorf("allocate port for %s: %w", ag.Name, portErr)
 		}
 
@@ -322,43 +341,38 @@ func Run(ctx context.Context, opts Opts, onSessionCreated func(sessionName strin
 			fmt.Fprintf(os.Stderr, "[prism review] warning: could not start sidecar for %s: %v\n", ag.Name, sidecarErr)
 		}
 
-		// Create the agent window within the review session.
+		// Create the independent top-level tmux session for this agent.
 		agentCmd := buildAgentCommand(ag, agentSession, port, prompt, opts.ContainerMode)
-		if err := createAgentWindow(reviewSession, i, ag.Name, worktree, agentCmd, port, agentSession, opts.ContainerMode); err != nil {
-			// Clean up agents 0..i (including the current one whose window failed).
-			for j := 0; j <= i; j++ {
+		if err := createAgentSession(agentSession, worktree, agentCmd, port, opts.ContainerMode); err != nil {
+			// Clean up agents 0..i (including the current one whose session failed).
+			// Kill the sidecar for agent i (already started above).
+			session.KillSidecar(agentSession)
+			cleanupAgentSession(d, agentSession)
+			// Kill tmux session for agent i if it was created (best effort).
+			_ = tmux.KillSession(agentSession)
+
+			// Clean up agents 0..i-1 that fully started.
+			for j := 0; j < i; j++ {
 				session.KillSidecar(agentSessions[j])
 				cleanupAgentSession(d, agentSessions[j])
+				_ = tmux.KillSession(agentSessions[j])
 			}
-			_ = tmux.KillSession(reviewSession)
-			return nil, fmt.Errorf("create window for %s: %w", ag.Name, err)
+			return nil, fmt.Errorf("create session for %s: %w", ag.Name, err)
 		}
 	}
 
-	// Remove the initial blank window (window 0) that was created with the session.
-	// All agents are in windows 1..N.
-	_, _ = tmux.Run("kill-window", "-t", reviewSession+":0")
+	// Notify the caller with all session names for SIGINT handling.
+	if onSessionsCreated != nil {
+		onSessionsCreated(agentSessions)
+	}
 
 	// Poll DB until all agents finish or timeout.
 	results, pollErr := pollAgents(ctx, d, agents, agentSessions, opts.Timeout)
 
-	// Mark round session as finished in the DB.
-	_ = d.UpsertStatus(reviewSession, repo, worktree, "finished", nil, nil)
-
-	// Clean up sidecar processes.
+	// Sessions persist — do NOT kill them here. The user can re-read them later.
+	// Sidecar processes are cleaned up since the agent has finished.
 	for _, agentSession := range agentSessions {
 		session.KillSidecar(agentSession)
-	}
-
-	// Kill the review session unless --keep.
-	if !opts.Keep {
-		_ = tmux.KillSession(reviewSession)
-		// Clean up DB entries for agent sub-sessions.
-		for _, agentSession := range agentSessions {
-			cleanupAgentSession(d, agentSession)
-		}
-		// Mark the round session as ended.
-		_ = d.SetEnded(reviewSession)
 	}
 
 	return results, pollErr
@@ -369,8 +383,8 @@ func buildReviewPrompt(prNumber string) string {
 	return fmt.Sprintf("Review PR #%s. Run `gh pr view %s` and `gh pr diff %s` to get the full diff. Check the linked issue for acceptance criteria and validate each one. Report your findings clearly.", prNumber, prNumber, prNumber)
 }
 
-// buildAgentCommand returns the command string for a review agent window.
-// agentSession is the full session name (e.g. "nixos-config@feature~review-1~review"),
+// buildAgentCommand returns the command string for a review agent session.
+// agentSession is the full session name (e.g. "nixos-config@feature~review-1-review-goal"),
 // used as PRISM_SESSION_NAME so the plugin correctly identifies the DB row.
 func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, containerMode bool) string {
 	if containerMode {
@@ -386,9 +400,11 @@ func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, c
 		shellQuote(agentSession), ag.OpencodeName, port, escapedPrompt)
 }
 
-// createAgentWindow creates a tmux window for a review agent.
-// In container mode it prepends a readiness wait like the standard session setup.
-func createAgentWindow(reviewSession string, idx int, windowName, worktree, agentCmd string, port int, agentSession string, containerMode bool) error {
+// createAgentSession creates a new independent top-level tmux session for a
+// review agent. In container mode it prepends a readiness wait like the
+// standard session setup. The session is created with a single "agent" window
+// that runs the given command.
+func createAgentSession(agentSession, worktree, agentCmd string, port int, containerMode bool) error {
 	cmd := agentCmd
 	if containerMode && port != 0 {
 		readyPath, pathErr := session.SidecarReadyPath(agentSession)
@@ -398,8 +414,19 @@ func createAgentWindow(reviewSession string, idx int, windowName, worktree, agen
 			cmd = buildReadinessWaitCmd(readyPath, agentCmd)
 		}
 	}
-	// Windows are 1-indexed: window 0 is the initial blank shell.
-	return tmux.NewWindow(reviewSession, idx+1, windowName, worktree, cmd)
+	// Create the session (starts with a bare shell in window 0).
+	if err := tmux.NewSessionDetached(agentSession, worktree); err != nil {
+		return fmt.Errorf("new-session %q: %w", agentSession, err)
+	}
+	// Create window 1 with the agent command. Window 0 remains as a shell.
+	// Using NewWindow ensures the command runs via "sh -c" and semicolons in
+	// the readiness wait script are not consumed by tmux's command parser.
+	if err := tmux.NewWindow(agentSession, 1, "agent", worktree, cmd); err != nil {
+		return fmt.Errorf("new-window for %q: %w", agentSession, err)
+	}
+	// Select the agent window (1) as the default.
+	_ = tmux.SelectWindow(agentSession, 1)
+	return nil
 }
 
 // buildReadinessWaitCmd mirrors session.buildReadinessWaitCmd (unexported).
@@ -594,7 +621,7 @@ func AssessPassed(text string) bool {
 	return true
 }
 
-// cleanupAgentSession cleans up the DB state for a completed agent sub-session.
+// cleanupAgentSession cleans up the DB state for a completed agent session.
 func cleanupAgentSession(d *db.DB, agentSession string) {
 	_ = d.ReleasePort(agentSession)
 	_ = d.SetEnded(agentSession)
@@ -651,18 +678,62 @@ func LookupParentSession() string {
 	return sess
 }
 
-// IsRoundSession returns true if the given session name is a review round
-// session (not an agent sub-session). Round sessions have exactly one ~ in
-// the branch component and the suffix after ~review- is a pure integer.
-// Agent sub-sessions have a second ~ (e.g. "~review-1~review").
-func IsRoundSession(sessionName, parentSession string) bool {
+// IsPerAgentSession returns true if the given session name matches the new
+// per-agent session shape: <parent>~review-<N>-<agent-name>.
+// This is used to distinguish new-model sessions from old-shape round sessions.
+func IsPerAgentSession(sessionName, parentSession string) bool {
 	prefix := parentSession + "~review-"
 	if !strings.HasPrefix(sessionName, prefix) {
 		return false
 	}
 	suffix := strings.TrimPrefix(sessionName, prefix)
-	_, err := strconv.Atoi(suffix)
-	return err == nil
+	// Must have a dash separating the round number from the agent name.
+	dashIdx := strings.Index(suffix, "-")
+	if dashIdx <= 0 {
+		return false
+	}
+	nStr := suffix[:dashIdx]
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n <= 0 {
+		return false
+	}
+	// Agent portion must not contain '~' (old-shape marker).
+	agentPart := suffix[dashIdx+1:]
+	return agentPart != "" && !strings.Contains(agentPart, "~")
+}
+
+// KillReviewSessionsForParent kills all ~review-* tmux sessions for the given parent.
+// This is the public API used by cleanup.go for cascading parent cleanup.
+// It kills ALL review sessions across all rounds (for prism cleanup --yes --session <parent>).
+func KillReviewSessionsForParent(parentSession string) {
+	prefix := parentSession + "~review-"
+	KillSessionPrefix(prefix)
+}
+
+// CleanupReviewSessionsForParent kills all ~review-* tmux sessions for the
+// given parent AND cleans up their DB rows (port allocations, ended state,
+// bus messages). Called by prism cleanup --yes --session <parent> to cascade
+// the cleanup to all review sessions.
+func CleanupReviewSessionsForParent(d *db.DB, parentSession string) {
+	prefix := parentSession + "~review-"
+
+	// Find all review session rows in the DB.
+	rows, err := d.AllStatusesWithPrefix(prefix)
+	if err == nil {
+		for _, row := range rows {
+			cleanupAgentSession(d, row.SessionName)
+		}
+	}
+
+	// Kill the tmux sessions (best effort, idempotent).
+	KillSessionPrefix(prefix)
+}
+
+// KillCurrentRoundSessions kills only the sessions in the given list.
+// Used by SIGINT handlers to kill only the current round's in-progress sessions
+// without touching previous rounds' persisted sessions.
+func KillCurrentRoundSessions(agentSessions []string) {
+	KillSessionsByNames(agentSessions)
 }
 
 // defaultDBPath returns the default prism DB path.
@@ -694,11 +765,4 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dm", int(d.Minutes()))
 	}
 	return fmt.Sprintf("%ds", int(d.Seconds()))
-}
-
-// KillReviewSessionsForParent kills all ~review-* sessions for the given parent.
-// This is the public API used by cleanup.go.
-func KillReviewSessionsForParent(parentSession string) {
-	prefix := parentSession + "~review-"
-	KillSessionPrefix(prefix)
 }

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -30,21 +30,107 @@ func TestNextRoundNumber_NoExistingRounds_Returns1(t *testing.T) {
 	}
 }
 
-func TestNextRoundNumber_WithExistingRounds(t *testing.T) {
+// TestNextRoundNumber_WithPerAgentSessions verifies that the new per-agent
+// session shape (~review-N-<agent>) is counted correctly.
+func TestNextRoundNumber_WithPerAgentSessions(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@feature"
 
-	_ = d.UpsertStatus(parent+"~review-1", "nixos-config", "/wt", "finished", nil, nil)
-	_ = d.UpsertStatus(parent+"~review-2", "nixos-config", "/wt", "idle", nil, nil)
-	// Agent sub-session — should NOT count as a round.
-	_ = d.UpsertStatus(parent+"~review-1~review", "nixos-config", "/wt", "idle", nil, nil)
+	// Seed round 1 per-agent sessions.
+	_ = d.UpsertStatus(parent+"~review-1-review-goal", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1-review-code", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1-review-security", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1-review-qa", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1-review-context", "nixos-config", "/wt", "finished", nil, nil)
 
 	n := review.NextRoundNumber(d, parent)
-	if n != 3 {
-		t.Errorf("NextRoundNumber = %d, want 3", n)
+	if n != 2 {
+		t.Errorf("NextRoundNumber = %d, want 2 (after one full round)", n)
 	}
 }
 
+// TestNextRoundNumber_TwoRoundsOfPerAgentSessions verifies round counting after
+// two full rounds of per-agent sessions.
+func TestNextRoundNumber_TwoRoundsOfPerAgentSessions(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@feature"
+
+	// Round 1 (5 agents).
+	for _, agent := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
+		_ = d.UpsertStatus(parent+"~review-1-"+agent, "nixos-config", "/wt", "finished", nil, nil)
+	}
+	// Round 2 (5 agents).
+	for _, agent := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
+		_ = d.UpsertStatus(parent+"~review-2-"+agent, "nixos-config", "/wt", "finished", nil, nil)
+	}
+
+	n := review.NextRoundNumber(d, parent)
+	if n != 3 {
+		t.Errorf("NextRoundNumber = %d, want 3 (after two full rounds)", n)
+	}
+}
+
+// TestNextRoundNumber_PartialRound verifies that a partial round (e.g. --only
+// with 2 agents) is still counted as a round (the round number includes
+// whichever N was used, regardless of how many agents were spawned).
+func TestNextRoundNumber_PartialRound(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@feature"
+
+	// Only 2 agents from round 1.
+	_ = d.UpsertStatus(parent+"~review-1-review-code", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1-review-qa", "nixos-config", "/wt", "finished", nil, nil)
+
+	n := review.NextRoundNumber(d, parent)
+	if n != 2 {
+		t.Errorf("NextRoundNumber = %d, want 2 (partial round still counts)", n)
+	}
+}
+
+// TestNextRoundNumber_OldShapeSessionsNotCounted verifies that old-shape round
+// sessions (~review-N pure integer suffix) and old-shape agent sub-sessions
+// (~review-N~agent) do NOT count toward the round number. This ensures
+// migration is safe: zombie old-shape rows don't inflate the counter.
+func TestNextRoundNumber_OldShapeSessionsNotCounted(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@feature"
+
+	// Old-shape round sessions (pre-PR-C): pure integer suffix.
+	_ = d.UpsertStatus(parent+"~review-1", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-2", "nixos-config", "/wt", "finished", nil, nil)
+	// Old-shape agent sub-sessions (pre-PR-C): ~review-N~agent.
+	_ = d.UpsertStatus(parent+"~review-1~review", "nixos-config", "/wt", "idle", nil, nil)
+
+	// Despite those rows, NextRoundNumber should return 1 (no new-shape rounds exist).
+	n := review.NextRoundNumber(d, parent)
+	if n != 1 {
+		t.Errorf("NextRoundNumber = %d, want 1 (old-shape rows should not count)", n)
+	}
+}
+
+// TestNextRoundNumber_MixedOldAndNewShape verifies that when both old-shape
+// zombie rows and new-shape per-agent rows exist, only the new-shape rows
+// determine the round counter.
+func TestNextRoundNumber_MixedOldAndNewShape(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@feature"
+
+	// Old-shape zombies.
+	_ = d.UpsertStatus(parent+"~review-1", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1~review", "nixos-config", "/wt", "finished", nil, nil)
+
+	// New-shape round 1 agents.
+	_ = d.UpsertStatus(parent+"~review-1-review-goal", "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.UpsertStatus(parent+"~review-1-review-code", "nixos-config", "/wt", "finished", nil, nil)
+
+	n := review.NextRoundNumber(d, parent)
+	if n != 2 {
+		t.Errorf("NextRoundNumber = %d, want 2 (only new-shape rows count)", n)
+	}
+}
+
+// TestNextRoundNumber_SkipsNonRoundSessions verifies that sessions with
+// suffixes that are not round-numbered are ignored.
 func TestNextRoundNumber_SkipsNonRoundSessions(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@feature"
@@ -55,6 +141,41 @@ func TestNextRoundNumber_SkipsNonRoundSessions(t *testing.T) {
 	n := review.NextRoundNumber(d, parent)
 	if n != 1 {
 		t.Errorf("NextRoundNumber = %d, want 1 (sub-sessions should not count)", n)
+	}
+}
+
+// ── IsPerAgentSession ─────────────────────────────────────────────────────────
+
+func TestIsPerAgentSession_NewShape(t *testing.T) {
+	parent := "nixos-config@feature"
+	newShapeNames := []string{
+		parent + "~review-1-review-goal",
+		parent + "~review-1-review-code",
+		parent + "~review-1-review-security",
+		parent + "~review-1-review-qa",
+		parent + "~review-1-review-context",
+		parent + "~review-2-review-goal",
+	}
+	for _, name := range newShapeNames {
+		if !review.IsPerAgentSession(name, parent) {
+			t.Errorf("IsPerAgentSession(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestIsPerAgentSession_OldShape(t *testing.T) {
+	parent := "nixos-config@feature"
+	oldShapeNames := []string{
+		parent + "~review-1",           // old round session
+		parent + "~review-1~review",    // old agent sub-session
+		parent + "~review-1~review-qa", // old agent sub-session variant
+		"other-session",                // unrelated
+		parent,                         // parent itself
+	}
+	for _, name := range oldShapeNames {
+		if review.IsPerAgentSession(name, parent) {
+			t.Errorf("IsPerAgentSession(%q) = true, want false (old-shape or unrelated)", name)
+		}
 	}
 }
 
@@ -328,6 +449,34 @@ func TestCheckAgentAvailability_EmptyAgentList(t *testing.T) {
 	}
 	if err := review.CheckAgentAvailability([]review.Agent{}); err != nil {
 		t.Errorf("CheckAgentAvailability([]): unexpected error: %v", err)
+	}
+}
+
+// ── Session name construction ─────────────────────────────────────────────────
+
+// TestPerAgentSessionNaming verifies that the session names produced by the
+// round prefix construction match the expected shape.
+func TestPerAgentSessionNaming(t *testing.T) {
+	parent := "nixos-config@feature"
+	roundN := 1
+
+	agents := review.EnhancedAgents()
+	roundPrefix := parent + "~review-1-"
+
+	expectedSessions := []string{
+		parent + "~review-1-review-goal",
+		parent + "~review-1-review-code",
+		parent + "~review-1-review-security",
+		parent + "~review-1-review-qa",
+		parent + "~review-1-review-context",
+	}
+	_ = roundN // used to construct roundPrefix above
+
+	for i, ag := range agents {
+		got := roundPrefix + ag.Name
+		if got != expectedSessions[i] {
+			t.Errorf("agent session[%d]: got %q, want %q", i, got, expectedSessions[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

PR-C of 4 implementing RFC #759. **This PR closes the RFC.**

Depends on PR-A (#764) and PR-B (#765) — both already merged.

### What this PR does

Replaces the old multi-window round session model (`<parent>~review-N` with 5 windows) with **5 independent top-level tmux sessions**, one per review agent:

```
<parent>~review-<N>-review-goal
<parent>~review-<N>-review-code
<parent>~review-<N>-review-security
<parent>~review-<N>-review-qa
<parent>~review-<N>-review-context
```

Each session has its own port allocation, sidecar process, and container. All 5 are visible as individual rows in `prism list-sessions` and the `C-f` picker.

### Key architectural changes

**Session persistence (critical semantic change):**
- Sessions now **persist** after `prism review` completes — you can re-read `review-security`'s findings tomorrow without re-running.
- A new `prism review` invocation does **NOT** kill previous rounds' sessions.
- Sessions are only cleaned up by `prism cleanup --yes --session <parent>`, which cascades to all `<parent>~review-*` sessions including DB rows and port allocations.
- SIGINT during a review kills only the **current round's** in-progress sessions; previous rounds remain untouched.

**`--keep` flag retired:**
Sessions persist by default until parent cleanup, so `--keep` is redundant. The flag has been removed.

**`NextRoundNumber` updated:**
Now counts new-shape sessions (`~review-N-<agent>`) only. Old-shape rows (`~review-N` pure int, `~review-N~agent`) are excluded from the counter, so zombie rows don't inflate the round number.

**`prism checkin <parent>~review`:**
Updated to group all per-agent sessions by round number and display a summary per agent. Compatible with both new-shape and old-shape zombie rows.

**Dashboard:**
`Depth2Label` already correctly extracts `~review-N-<agent>` labels (no code change needed — the existing `~`-split logic handles the new shape). New tests added.

### Files changed

- `internal/review/review.go` — core rewrite: per-agent sessions, new `NextRoundNumber`, `CleanupReviewSessionsForParent`, `KillCurrentRoundSessions`, `IsPerAgentSession`
- `internal/review/review_test.go` — new tests for round counting, shape discrimination, session naming
- `internal/dashboard/depth2_test.go` — new tests for new-shape labels and sort order
- `cmd/review.go` — retire `--keep`, update SIGINT handler, update `Run` callback signature
- `cmd/checkin.go` — rewrite `runCheckinReviewRounds` for new per-agent shape
- `cmd/cleanup.go` — use `CleanupReviewSessionsForParent` for DB cascade cleanup
- `opencode/skills/prism/SKILL.md` — updated session shape docs, dashboard example, flag table

### Migration strategy for old-shape DB rows

**Option (b): document as manually cleanable.**

Old-shape zombie rows (`~review-N` and `~review-N~agent`) from previous sessions remain in the DB as stale entries. They appear in `list-sessions` but do not affect `NextRoundNumber` (new-shape counter ignores them).

To clean them up manually:
```bash
# Headless cleanup of specific old-shape sessions
prism cleanup --yes --session nixos-config@feature~review-1
prism cleanup --yes --session nixos-config@feature~review-1~review

# Or bulk SQL cleanup (caution: modifies prism.db directly)
sqlite3 ~/.local/state/prism/prism.db \
  "DELETE FROM agent_status WHERE session_name LIKE '%~review-%~%';"
sqlite3 ~/.local/state/prism/prism.db \
  "DELETE FROM port_allocations WHERE session_name LIKE '%~review-%~%';"
```

### Quality gates

- `go build ./...` ✅
- `go test ./...` ✅  
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #759
Closes #762