### PR TITLE
coordinator: update prompts with lifecycle, planning scope, and parallel work guidance

### DIFF
--- a/modules/programs/prism/opencode/agents-enhanced/coordinator.md
+++ b/modules/programs/prism/opencode/agents-enhanced/coordinator.md
@@ -26,9 +26,21 @@ When the user asks you to create a ticket or issue: create it, then spawn an age
 
 ---
 
+## Planning scope
+
+If the work fits in one PR, file an issue. If it spans multiple PRs with dependencies or needs reviewer agreement on shape before coding, file a design doc with child issues. Each PR should be atomic — main stays coherent and shippable after every merge, not just after the final one. Sequence the train so each step leaves breaking changes minimised: add new capability before removing old, widen interfaces before narrowing them, land read paths before write paths. Every child issue states its dependencies (`Depends on: #X`) and closure policy (`Refs #parent` or `Closes #parent` — only the final PR closes the parent). State this in the issue body and repeat it in the spawn prompt.
+
+---
+
+## Parallel work
+
+Before spawning alongside an in-flight PR, check the file footprint — overlapping filenames and shared Go packages both count. When safe, spawn in parallel and let the workers know what else is in flight so they can route around it. When unsafe, sequence.
+
+---
+
 ## Acceptance criteria
 
-Before spawning a worker agent, invoke `@ac` with the ticket, issue, or prompt to produce a tagged AC checklist. Pass the resulting checklist as context in the spawn prompt so the worker agent knows exactly what "done" looks like.
+Before spawning a worker agent, invoke `@ac` with the ticket, issue, or prompt to produce a tagged AC checklist. Paste the `@ac` output inline in the spawn prompt under an `Acceptance Criteria` heading. Workers should see the exact checklist text, not a reference to it.
 
 If ACs already exist on the ticket or issue, pass them to `@ac` prefaced with "Review these ACs:" so it enters critique mode and improves them before proceeding.
 
@@ -120,11 +132,12 @@ When a spawned agent opens a PR:
 
 ## Merge and cleanup
 
-Once the sense-check passes:
+Once the sense-check passes, merge the PR and sync main before cleaning up:
 
-1. `gh pr merge <number>` — you will be prompted to confirm.
-2. `git pull` to sync with the merged result. (`@main` is the primary prism session — run this in the session where you are working, not in the spawned agent's session.)
-3. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
+1. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
+2. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+3. `git pull` to sync with the merged result.
+4. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
 
 ---
 

--- a/modules/programs/prism/opencode/agents-enhanced/coordinator.md
+++ b/modules/programs/prism/opencode/agents-enhanced/coordinator.md
@@ -134,8 +134,8 @@ When a spawned agent opens a PR:
 
 Once the sense-check passes, merge the PR and sync main before cleaning up:
 
-1. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
-2. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+1. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+2. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
 3. `git pull` to sync with the merged result.
 4. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
 

--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -26,9 +26,21 @@ When the user asks you to create a ticket or issue: create it, then spawn an age
 
 ---
 
+## Planning scope
+
+If the work fits in one PR, file an issue. If it spans multiple PRs with dependencies or needs reviewer agreement on shape before coding, file a design doc with child issues. Each PR should be atomic — main stays coherent and shippable after every merge, not just after the final one. Sequence the train so each step leaves breaking changes minimised: add new capability before removing old, widen interfaces before narrowing them, land read paths before write paths. Every child issue states its dependencies (`Depends on: #X`) and closure policy (`Refs #parent` or `Closes #parent` — only the final PR closes the parent). State this in the issue body and repeat it in the spawn prompt.
+
+---
+
+## Parallel work
+
+Before spawning alongside an in-flight PR, check the file footprint — overlapping filenames and shared Go packages both count. When safe, spawn in parallel and let the workers know what else is in flight so they can route around it. When unsafe, sequence.
+
+---
+
 ## Acceptance criteria
 
-Before spawning a worker agent, invoke `@ac` with the ticket, issue, or prompt to produce a tagged AC checklist. Pass the resulting checklist as context in the spawn prompt so the worker agent knows exactly what "done" looks like.
+Before spawning a worker agent, invoke `@ac` with the ticket, issue, or prompt to produce a tagged AC checklist. Paste the `@ac` output inline in the spawn prompt under an `Acceptance Criteria` heading. Workers should see the exact checklist text, not a reference to it.
 
 If ACs already exist on the ticket or issue, pass them to `@ac` prefaced with "Review these ACs:" so it enters critique mode and improves them before proceeding.
 
@@ -110,11 +122,12 @@ When a spawned agent opens a PR:
 
 ## Merge and cleanup
 
-Once both reviews pass:
+Once the sense-check passes, merge the PR and sync main before cleaning up:
 
-1. `gh pr merge <number>` — you will be prompted to confirm.
-2. `git pull` to sync with the merged result. (`@main` is the primary prism session — run this in the session where you are working, not in the spawned agent's session.)
-3. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
+1. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
+2. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+3. `git pull` to sync with the merged result.
+4. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
 
 ---
 

--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -62,7 +62,7 @@ Use `prism spawn`. Load the prism skill first if not already loaded. Record the 
 
 ### Primary signal: the finish notification
 
-The "has finished" notification (see [Worker notifications](#worker-notifications)) is the primary mechanism for knowing an agent has completed its work. **Wait for it.** Do not attempt to infer completion from a check-in. Do not begin your own PR review (`@review`, `gh pr diff`) until the finish notification has arrived.
+The "has finished" notification (see [Worker notifications](#worker-notifications)) is the primary mechanism for knowing an agent has completed its work. **Wait for it.** Do not attempt to infer completion from a check-in. Do not begin your own PR review until the finish notification has arrived.
 
 ### Polling anti-pattern — prohibited
 
@@ -124,8 +124,8 @@ When a spawned agent opens a PR:
 
 Once the sense-check passes, merge the PR and sync main before cleaning up:
 
-1. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
-2. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+1. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+2. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
 3. `git pull` to sync with the merged result.
 4. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
 
@@ -136,6 +136,6 @@ Once the sense-check passes, merge the PR and sync main before cleaning up:
 Bring the user back in when:
 
 - An agent is blocked or confused across two check-ins
-- The PR review cycle exceeds three iterations without convergence
+- A worker reports it has hit the 3-cycle review limit without convergence
 - The build fails after merge
 - The implementation diverges significantly from the original request and targeted prompts have not corrected it


### PR DESCRIPTION
## Summary

- Add **Planning scope** section covering issue-vs-design-doc decision, per-PR atomicity, breaking-change-minimising sequencing (add-before-remove, widen-before-narrow, reads-before-writes), and `Refs #parent` / `Closes #parent` convention for multi-PR plans.
- Add **Parallel work** section: check file footprint before spawning alongside in-flight PRs; sequence when unsafe, parallel when safe.
- Tighten **Merge and cleanup**: merge first then cleanup, `gh pr update-branch` for behind-main failures, `prism prompt` for rebase when that doesn't resolve it, wait for CI before merging (`IN_PROGRESS` = come back later).
- Update **Acceptance criteria**: paste `@ac` output inline in spawn prompt under `Acceptance Criteria` heading — not a reference to it.

Both files updated identically. The only section that differs between the two files remains the **Review gate** (preserved divergence: default uses `@review` + sense-check + 3 iterations; enhanced trusts worker review + metadata sense-check).

Closes #769