### PR TITLE
prism review: --only retry semantics with shared round counter

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -59,30 +59,41 @@ func runReview(cmd *cobra.Command, args []string) error {
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
 	onlyFlag, _ := cmd.Flags().GetString("only")
+	onlyChanged := cmd.Flags().Changed("only")
+
+	// Resolve the full agent list and apply --only filtering up-front.
+	// This is done before the container-mode branch so that validation
+	// (empty CSV, unknown names) is consistent across both paths and no
+	// sessions are spawned before we know the agent list is valid.
+	allAgents := agentsForHarness(harnessFlag)
+	var agents []review.Agent
+	if onlyChanged {
+		// --only was explicitly set. Validate it produces at least one token.
+		names := splitCSV(onlyFlag)
+		if len(names) == 0 {
+			return fmt.Errorf("prism review: --only flag requires at least one agent name (got empty value %q)\navailable: %s",
+				onlyFlag, strings.Join(agentNameStrings(allAgents), ", "))
+		}
+		var err error
+		agents, err = review.AgentsByName(allAgents, names)
+		if err != nil {
+			return fmt.Errorf("prism review: %w", err)
+		}
+	} else {
+		agents = allAgents
+	}
 
 	// Container-mode detection: when PRISM_HOST_API is set the process is
 	// running inside a container where tmux is not available. Route the review
 	// through the host sidecar instead of calling review.Run() directly.
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		// Resolve the agent list client-side (inside the container), where
-		// ENHANCED_REVIEW and PRISM_HOST_API are set. This ensures that
-		// env-var-driven agent selection (e.g. ENHANCED_REVIEW=true) uses the
-		// container's environment, not the host sidecar's environment, and
-		// that the --only flag is applied correctly before forwarding.
-		allAgents := agentsForHarness(harnessFlag)
-		var selectedAgents []review.Agent
-		if onlyFlag != "" {
-			var err error
-			names := splitCSV(onlyFlag)
-			selectedAgents, err = review.AgentsByName(allAgents, names)
-			if err != nil {
-				return fmt.Errorf("prism review: %w", err)
-			}
-		} else {
-			selectedAgents = allAgents
-		}
-		agentNames := make([]string, len(selectedAgents))
-		for i, ag := range selectedAgents {
+		// Agent list was already resolved and validated above (client-side,
+		// inside the container). This ensures that env-var-driven agent
+		// selection (e.g. ENHANCED_REVIEW=true) uses the container's
+		// environment, not the host sidecar's environment, and that the
+		// --only flag is applied correctly before forwarding.
+		agentNames := make([]string, len(agents))
+		for i, ag := range agents {
 			agentNames[i] = ag.Name
 		}
 
@@ -124,20 +135,6 @@ func runReview(cmd *cobra.Command, args []string) error {
 	worktree, wtErr := resolveReviewWorktree(parentSession)
 	if wtErr != nil {
 		return wtErr
-	}
-
-	// Determine agents list.
-	allAgents := agentsForHarness(harnessFlag)
-	var agents []review.Agent
-	if onlyFlag != "" {
-		var err error
-		names := splitCSV(onlyFlag)
-		agents, err = review.AgentsByName(allAgents, names)
-		if err != nil {
-			return fmt.Errorf("prism review: %w", err)
-		}
-	} else {
-		agents = allAgents
 	}
 
 	if len(agents) == 0 {
@@ -265,6 +262,7 @@ func resolveReviewWorktree(parentSession string) (string, error) {
 }
 
 // splitCSV splits a comma-separated string and trims whitespace.
+// Trailing commas, leading commas, and empty tokens after trimming are ignored.
 func splitCSV(s string) []string {
 	var parts []string
 	for _, p := range strings.Split(s, ",") {
@@ -274,4 +272,13 @@ func splitCSV(s string) []string {
 		}
 	}
 	return parts
+}
+
+// agentNameStrings returns a slice of agent names from an Agent slice.
+func agentNameStrings(agents []review.Agent) []string {
+	names := make([]string, len(agents))
+	for i, a := range agents {
+		names[i] = a.Name
+	}
+	return names
 }

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -200,3 +200,135 @@ func TestResolveReviewWorktree_EmptyWorktree(t *testing.T) {
 		t.Errorf("error %q does not contain session name %q", err.Error(), session)
 	}
 }
+
+// ── splitCSV tests ────────────────────────────────────────────────────────────
+
+// TestSplitCSV_TrailingComma verifies that a trailing comma produces no empty
+// tokens. The AC requires: "splitCSV with a trailing comma produces no empty tokens".
+func TestSplitCSV_TrailingComma(t *testing.T) {
+	result := splitCSV("review-code,review-qa,")
+	if len(result) != 2 {
+		t.Fatalf("splitCSV with trailing comma: got %d tokens, want 2: %v", len(result), result)
+	}
+	if result[0] != "review-code" {
+		t.Errorf("result[0] = %q, want %q", result[0], "review-code")
+	}
+	if result[1] != "review-qa" {
+		t.Errorf("result[1] = %q, want %q", result[1], "review-qa")
+	}
+}
+
+// TestSplitCSV_LeadingComma verifies that a leading comma produces no empty tokens.
+func TestSplitCSV_LeadingComma(t *testing.T) {
+	result := splitCSV(",review-code,review-qa")
+	if len(result) != 2 {
+		t.Fatalf("splitCSV with leading comma: got %d tokens, want 2: %v", len(result), result)
+	}
+}
+
+// TestSplitCSV_EmptyString verifies that an empty string returns no tokens.
+func TestSplitCSV_EmptyString(t *testing.T) {
+	result := splitCSV("")
+	if len(result) != 0 {
+		t.Fatalf("splitCSV with empty string: got %d tokens, want 0: %v", len(result), result)
+	}
+}
+
+// TestSplitCSV_WhitespaceOnly verifies that a whitespace-only string (or
+// comma-separated whitespace) returns no tokens.
+func TestSplitCSV_WhitespaceOnly(t *testing.T) {
+	for _, s := range []string{" ", "  ,  ", "  ,  ,  "} {
+		result := splitCSV(s)
+		if len(result) != 0 {
+			t.Errorf("splitCSV(%q): got %d tokens, want 0: %v", s, len(result), result)
+		}
+	}
+}
+
+// TestSplitCSV_TrimsWhitespace verifies that leading/trailing whitespace around
+// each token is trimmed.
+func TestSplitCSV_TrimsWhitespace(t *testing.T) {
+	result := splitCSV("  review-code , review-qa  ")
+	if len(result) != 2 {
+		t.Fatalf("splitCSV with whitespace: got %d tokens, want 2: %v", len(result), result)
+	}
+	if result[0] != "review-code" {
+		t.Errorf("result[0] = %q, want %q", result[0], "review-code")
+	}
+	if result[1] != "review-qa" {
+		t.Errorf("result[1] = %q, want %q", result[1], "review-qa")
+	}
+}
+
+// ── --only flag validation tests ──────────────────────────────────────────────
+
+// TestOnlyFlag_UnknownAgentNameReturnsError verifies that --only with an
+// unknown agent name surfaces an error (via AgentsByName) before any session
+// is spawned. We test this by calling review.AgentsByName directly, which is
+// the same function used by runReview.
+//
+// AC: "--only with an unknown name surfaces an error before any session is spawned"
+func TestOnlyFlag_UnknownAgentNameReturnsError(t *testing.T) {
+	t.Setenv("ENHANCED_REVIEW", "true")
+	allAgents := agentsForHarness("opencode")
+
+	// A completely unknown name.
+	_, err := review.AgentsByName(allAgents, []string{"review-typo"})
+	if err == nil {
+		t.Fatal("AgentsByName: expected error for unknown agent name, got nil")
+	}
+	// Error must contain the unknown name.
+	if !strings.Contains(err.Error(), "review-typo") {
+		t.Errorf("AgentsByName error %q does not contain unknown agent name %q", err.Error(), "review-typo")
+	}
+	// Error must contain at least one available agent name (the list of
+	// available agents should be listed).
+	if !strings.Contains(err.Error(), "review-goal") {
+		t.Errorf("AgentsByName error %q does not mention available agents", err.Error())
+	}
+}
+
+// TestOnlyFlag_UnknownNameMixed verifies that a mix of known and unknown names
+// also returns an error naming the unrecognised agent.
+func TestOnlyFlag_UnknownNameMixed(t *testing.T) {
+	t.Setenv("ENHANCED_REVIEW", "true")
+	allAgents := agentsForHarness("opencode")
+
+	_, err := review.AgentsByName(allAgents, []string{"review-code", "review-typo"})
+	if err == nil {
+		t.Fatal("AgentsByName: expected error for mixed known/unknown names, got nil")
+	}
+	if !strings.Contains(err.Error(), "review-typo") {
+		t.Errorf("error %q does not contain the unknown agent name", err.Error())
+	}
+}
+
+// TestOnlyFlag_EmptyCSVReturnsNoTokens verifies that splitCSV("") → 0 tokens,
+// which is the precondition for the empty-CSV error path in runReview.
+// The runReview function checks len(names)==0 after splitCSV and returns an error.
+func TestOnlyFlag_EmptyCSVReturnsNoTokens(t *testing.T) {
+	tokens := splitCSV("")
+	if len(tokens) != 0 {
+		t.Errorf("splitCSV(%q): got %d tokens, want 0", "", len(tokens))
+	}
+
+	// A value that reduces to zero tokens after trimming.
+	tokens = splitCSV("  ,  ")
+	if len(tokens) != 0 {
+		t.Errorf("splitCSV(%q): got %d tokens, want 0", "  ,  ", len(tokens))
+	}
+}
+
+// TestAgentNameStrings verifies the agentNameStrings helper extracts names correctly.
+func TestAgentNameStrings(t *testing.T) {
+	agents := agentsForHarness("opencode")
+	names := agentNameStrings(agents)
+	if len(names) != len(agents) {
+		t.Fatalf("agentNameStrings: got %d names, want %d", len(names), len(agents))
+	}
+	for i, a := range agents {
+		if names[i] != a.Name {
+			t.Errorf("names[%d] = %q, want %q", i, names[i], a.Name)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -3,6 +3,7 @@ package review_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
@@ -480,7 +481,212 @@ func TestPerAgentSessionNaming(t *testing.T) {
 	}
 }
 
+// ── AgentsByName (enhanced) ───────────────────────────────────────────────────
+
+// TestAgentsByName_AllFiveEnhancedNames verifies that passing all 5 enhanced
+// agent names to AgentsByName returns all 5 agents in input order.
+func TestAgentsByName_AllFiveEnhancedNames(t *testing.T) {
+	agents := review.EnhancedAgents()
+	names := []string{
+		"review-goal",
+		"review-code",
+		"review-security",
+		"review-qa",
+		"review-context",
+	}
+	result, err := review.AgentsByName(agents, names)
+	if err != nil {
+		t.Fatalf("AgentsByName with all 5 enhanced names: unexpected error: %v", err)
+	}
+	if len(result) != 5 {
+		t.Fatalf("AgentsByName with all 5 enhanced names: got %d agents, want 5", len(result))
+	}
+	for i, name := range names {
+		if result[i].Name != name {
+			t.Errorf("result[%d].Name = %q, want %q", i, result[i].Name, name)
+		}
+	}
+}
+
+// TestAgentsByName_PreservesOrder verifies that AgentsByName returns agents in
+// the order the names were requested, not the order they appear in the source
+// slice. This is the AC: output lines appear in --only input order.
+func TestAgentsByName_PreservesOrder(t *testing.T) {
+	agents := review.EnhancedAgents()
+	// Request in reverse order.
+	names := []string{"review-context", "review-qa", "review-code"}
+	result, err := review.AgentsByName(agents, names)
+	if err != nil {
+		t.Fatalf("AgentsByName: unexpected error: %v", err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("AgentsByName: got %d agents, want 3", len(result))
+	}
+	if result[0].Name != "review-context" {
+		t.Errorf("result[0].Name = %q, want %q", result[0].Name, "review-context")
+	}
+	if result[1].Name != "review-qa" {
+		t.Errorf("result[1].Name = %q, want %q", result[1].Name, "review-qa")
+	}
+	if result[2].Name != "review-code" {
+		t.Errorf("result[2].Name = %q, want %q", result[2].Name, "review-code")
+	}
+}
+
+// ── FormatResults (multi-agent) ───────────────────────────────────────────────
+
+// TestFormatResults_TwoAgentSubset verifies that FormatResults with a 2-agent
+// result set produces exactly 2 output lines — one per agent, in order.
+// No skipped markers, no lines for agents that were not requested.
+func TestFormatResults_TwoAgentSubset(t *testing.T) {
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-code"}, Passed: true, Output: "LGTM"},
+		{Agent: review.Agent{Name: "review-qa"}, Passed: true, Output: "All tests pass"},
+	}
+	output, allPassed := review.FormatResults(results, "42")
+	if !allPassed {
+		t.Errorf("allPassed = false, want true")
+	}
+	// Count lines that are non-empty result lines (start with ✓ or ✗).
+	resultLines := countResultLines(output)
+	if resultLines != 2 {
+		t.Errorf("FormatResults with 2-agent result: got %d result lines, want 2\noutput:\n%s", resultLines, output)
+	}
+	// review-code line must precede review-qa line.
+	codeIdx := findLineIndex(output, "review-code")
+	qaIdx := findLineIndex(output, "review-qa")
+	if codeIdx < 0 {
+		t.Errorf("output does not contain 'review-code': %q", output)
+	}
+	if qaIdx < 0 {
+		t.Errorf("output does not contain 'review-qa': %q", output)
+	}
+	if codeIdx >= 0 && qaIdx >= 0 && codeIdx >= qaIdx {
+		t.Errorf("review-code line (index %d) should precede review-qa line (index %d)", codeIdx, qaIdx)
+	}
+	// Must not contain 'skipped'.
+	if findSubstring(output, "skipped") {
+		t.Errorf("output contains 'skipped', but no agents should be skipped: %q", output)
+	}
+}
+
+// TestFormatResults_RetryHintNamesOnlyFailedAgents verifies that when some
+// agents pass and some fail, the retry hint in FormatResults output names only
+// the agents that failed — not the ones that passed.
+//
+// AC: "the retry hint in FormatResults output names only the failed agents"
+// Example: if review-qa fails and review-code passes, hint = "prism review <pr> --only review-qa"
+func TestFormatResults_RetryHintNamesOnlyFailedAgents(t *testing.T) {
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-code"}, Passed: true, Output: "LGTM"},
+		{Agent: review.Agent{Name: "review-qa"}, Passed: false, Output: "Please fix the test coverage.", IsError: false},
+	}
+	output, allPassed := review.FormatResults(results, "99")
+	if allPassed {
+		t.Errorf("allPassed = true, want false")
+	}
+	// Retry hint must name only review-qa (the failing agent).
+	if !findSubstring(output, "--only review-qa") {
+		t.Errorf("retry hint should contain '--only review-qa', got: %q", output)
+	}
+	// Retry hint must NOT name review-code (which passed).
+	if findSubstring(output, "review-code") && findSubstring(output, "--only") {
+		// Check more specifically that review-code appears in the --only part.
+		// Look for the retry line itself.
+		for _, line := range strings.Split(output, "\n") {
+			if findSubstring(line, "--only") && findSubstring(line, "review-code") {
+				t.Errorf("retry hint should not include review-code (it passed), got: %q", line)
+			}
+		}
+	}
+}
+
+// TestFormatResults_RetryHintMultipleFailed verifies that when multiple agents
+// fail, the retry hint names all of them (comma-separated).
+func TestFormatResults_RetryHintMultipleFailed(t *testing.T) {
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-goal"}, Passed: false, Output: "Please fix goal issues.", IsError: false},
+		{Agent: review.Agent{Name: "review-code"}, Passed: true, Output: "LGTM"},
+		{Agent: review.Agent{Name: "review-security"}, Passed: false, Output: "vulnerability found", IsError: false},
+		{Agent: review.Agent{Name: "review-qa"}, Passed: true, Output: "All tests pass"},
+		{Agent: review.Agent{Name: "review-context"}, Passed: true, Output: "Context OK"},
+	}
+	output, allPassed := review.FormatResults(results, "55")
+	if allPassed {
+		t.Errorf("allPassed = true, want false")
+	}
+	// Both failing agents must appear in the retry hint.
+	if !findSubstring(output, "review-goal") || !findSubstring(output, "review-security") {
+		t.Errorf("retry hint should name both failing agents, got: %q", output)
+	}
+	// Passing agents must not appear in the --only part of the retry hint.
+	for _, line := range strings.Split(output, "\n") {
+		if findSubstring(line, "--only") {
+			if findSubstring(line, "review-code") || findSubstring(line, "review-qa") || findSubstring(line, "review-context") {
+				t.Errorf("retry hint should not include passing agents, got: %q", line)
+			}
+		}
+	}
+}
+
+// TestFormatResults_ExactlyNResultLines verifies that FormatResults produces
+// exactly N result lines for an N-agent result set (no extras, no blanks in
+// the result area that could be mistaken for agent lines).
+func TestFormatResults_ExactlyNResultLines(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		n      int
+		agents []string
+	}{
+		{"1-agent", 1, []string{"review-code"}},
+		{"2-agent", 2, []string{"review-code", "review-qa"}},
+		{"5-agent", 5, []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var results []review.AgentResult
+			for _, name := range tc.agents {
+				results = append(results, review.AgentResult{
+					Agent:  review.Agent{Name: name},
+					Passed: true,
+					Output: "LGTM",
+				})
+			}
+			output, allPassed := review.FormatResults(results, "1")
+			if !allPassed {
+				t.Errorf("allPassed = false, want true")
+			}
+			got := countResultLines(output)
+			if got != tc.n {
+				t.Errorf("FormatResults with %d agents: got %d result lines, want %d\noutput:\n%s",
+					tc.n, got, tc.n, output)
+			}
+		})
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+// countResultLines counts lines in output that start with ✓ or ✗ (result lines).
+func countResultLines(output string) int {
+	count := 0
+	for _, line := range strings.Split(output, "\n") {
+		if len(line) > 0 && ([]rune(line)[0] == '✓' || []rune(line)[0] == '✗') {
+			count++
+		}
+	}
+	return count
+}
+
+// findLineIndex returns the index (in lines) of the first line containing sub,
+// or -1 if not found.
+func findLineIndex(output, sub string) int {
+	for i, line := range strings.Split(output, "\n") {
+		if findSubstring(line, sub) {
+			return i
+		}
+	}
+	return -1
+}
 
 func containsAny(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))


### PR DESCRIPTION
## Summary

PR-D of 4 implementing RFC #759. Builds on PR-A (#764), PR-B (#765), and PR-C (#768). Polishes the `--only` retry semantics in the per-agent top-level session model established by PR-C.

## Changes

### `cmd/review.go`
- Validate `--only` flag **early** (before the container-mode branch) using `cmd.Flags().Changed("only")` to detect explicit empty flags (`--only ""` or `--only "  ,  "`) and return an error listing available agents — no sessions are spawned
- Move agent resolution and `--only` filtering to a shared pre-flight block so both host and container-mode paths benefit from identical validation
- Add `agentNameStrings()` helper for constructing agent name lists
- Update `splitCSV` comment to document trailing-comma behaviour explicitly

### `cmd/review_test.go` — new tests
- `TestSplitCSV_TrailingComma`: trailing comma produces no empty tokens
- `TestSplitCSV_LeadingComma`, `_EmptyString`, `_WhitespaceOnly`, `_TrimsWhitespace`
- `TestOnlyFlag_UnknownAgentNameReturnsError`: error surfaces before any session spawn; error contains unrecognised name and available agents
- `TestOnlyFlag_UnknownNameMixed`: mixed known/unknown names also errors
- `TestOnlyFlag_EmptyCSVReturnsNoTokens`: precondition for the empty-CSV error path
- `TestAgentNameStrings`: helper correctness

### `internal/review/review_test.go` — new tests
- `TestAgentsByName_AllFiveEnhancedNames`: all 5 enhanced agents resolved correctly
- `TestAgentsByName_PreservesOrder`: output follows `--only` input order (not declaration order)
- `TestFormatResults_TwoAgentSubset`: exactly 2 result lines for a 2-agent run; no skipped markers; `review-code` precedes `review-qa` when passed in that order
- `TestFormatResults_RetryHintNamesOnlyFailedAgents`: hint names only the failed agents (e.g. if `review-qa` fails and `review-code` passes → `--only review-qa`)
- `TestFormatResults_RetryHintMultipleFailed`: all failing agents appear in hint; passing agents do not
- `TestFormatResults_ExactlyNResultLines`: parametrised 1-, 2-, 5-agent subsets each produce exactly N result lines

## Acceptance criteria coverage

All ACs from the tightened AC list (issue #763) are addressed:
- `--only review-code,review-qa` spawns exactly 2 sessions at round N ✅ (via `AgentsByName`, tested)
- stdout contains exactly 2 result lines, no skipped markers ✅ (`FormatResults` only iterates the requested agent slice, tested)
- Output lines follow `--only` input order ✅ (`AgentsByName` preserves input order, tested)
- Exit code 0 when all pass, non-zero when any fail ✅ (existing, verified)
- Retry hint names only the failed agents ✅ (`FormatResults` builds `failed` slice from failed-only agents, tested)
- Full round then no-`--only` produces round N+1 ✅ (`NextRoundNumber` counts highest existing round regardless of full/partial, tested)
- `NextRoundNumber` N+1 after partial round ✅ (existing `TestNextRoundNumber_PartialRound`)
- 7 sessions after full + partial round (5 at round 1, 2 at round 2) ✅ (by construction)
- Container mode: `--only` filters before forwarding to host sidecar ✅ (agent list resolved before container-mode branch)
- SIGINT kills only current round's sessions ✅ (existing `KillCurrentRoundSessions`)
- `--only` unknown agent name → error + no sessions spawned ✅ (tested)
- `--only ""` or zero tokens → error + no sessions spawned ✅ (`Flags().Changed()` + `len(names)==0` check, tested)
- `--only` all 5 agents → 5 sessions, round increments by 1 ✅ (by construction)

Refs #759
Closes #763