### PR TITLE
prism-hooks: auto-detect doom loops and steer the agent

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.test.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for prism-hooks.ts doom-loop detection logic.
+ *
+ * Run with: bun test prism-hooks.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+import { similarityKey } from "./prism-hooks";
+
+// ── similarityKey tests ──────────────────────────────────────────────────────
+
+describe("similarityKey — excluded tools", () => {
+  test("read returns null", () => {
+    expect(similarityKey("read", { filePath: "/foo.go" })).toBeNull();
+  });
+
+  test("grep returns null", () => {
+    expect(similarityKey("grep", { pattern: "foo" })).toBeNull();
+  });
+
+  test("glob returns null", () => {
+    expect(similarityKey("glob", { pattern: "**/*.ts" })).toBeNull();
+  });
+
+  test("todowrite returns null", () => {
+    expect(similarityKey("todowrite", { todos: [] })).toBeNull();
+  });
+});
+
+describe("similarityKey — bash similarity", () => {
+  test("same command and positional produces the same key", () => {
+    const a = similarityKey("bash", { command: "go test ./..." });
+    const b = similarityKey("bash", { command: "go test ./..." });
+    expect(a).toBe(b);
+    expect(a).not.toBeNull();
+  });
+
+  test("git log -1 and git log -3 produce the same key (same command+first-positional)", () => {
+    const a = similarityKey("bash", { command: "git log -1" });
+    const b = similarityKey("bash", { command: "git log -3" });
+    expect(a).toBe(b);
+  });
+
+  test("go test ./cmd/... and go build ./... produce different keys", () => {
+    const a = similarityKey("bash", { command: "go test ./cmd/..." });
+    const b = similarityKey("bash", { command: "go build ./..." });
+    expect(a).not.toBe(b);
+  });
+
+  test("git status with different flags produces the same key", () => {
+    const a = similarityKey("bash", { command: "git status" });
+    const b = similarityKey("bash", { command: "git status --short" });
+    // Both have same base "git" and first positional "status"
+    expect(a).toBe(b);
+  });
+
+  test("nix build and nix run produce different keys (different first positional)", () => {
+    const a = similarityKey("bash", { command: "nix build .#foo" });
+    const b = similarityKey("bash", { command: "nix run .#bar" });
+    expect(a).not.toBe(b);
+  });
+
+  test("key is prefixed with 'bash:'", () => {
+    const key = similarityKey("bash", { command: "go test ./..." });
+    expect(key).toMatch(/^bash:/);
+  });
+});
+
+describe("similarityKey — edit similarity", () => {
+  test("same file path produces the same key", () => {
+    const a = similarityKey("edit", { filePath: "/workspace/foo.go", newString: "a" });
+    const b = similarityKey("edit", { filePath: "/workspace/foo.go", newString: "b" });
+    expect(a).toBe(b);
+  });
+
+  test("different file paths produce different keys", () => {
+    const a = similarityKey("edit", { filePath: "/workspace/foo.go" });
+    const b = similarityKey("edit", { filePath: "/workspace/bar.go" });
+    expect(a).not.toBe(b);
+  });
+
+  test("key is prefixed with 'edit:'", () => {
+    const key = similarityKey("edit", { filePath: "/workspace/foo.go" });
+    expect(key).toMatch(/^edit:/);
+  });
+});
+
+describe("similarityKey — write similarity", () => {
+  test("same file path produces the same key regardless of content", () => {
+    const a = similarityKey("write", { filePath: "/workspace/foo.go", content: "package foo" });
+    const b = similarityKey("write", { filePath: "/workspace/foo.go", content: "package bar" });
+    expect(a).toBe(b);
+  });
+
+  test("different file paths produce different keys", () => {
+    const a = similarityKey("write", { filePath: "/workspace/foo.go" });
+    const b = similarityKey("write", { filePath: "/workspace/bar.go" });
+    expect(a).not.toBe(b);
+  });
+
+  test("key is prefixed with 'write:'", () => {
+    const key = similarityKey("write", { filePath: "/workspace/foo.go" });
+    expect(key).toMatch(/^write:/);
+  });
+});
+
+describe("similarityKey — webfetch similarity", () => {
+  test("same URL produces the same key", () => {
+    const a = similarityKey("webfetch", { url: "https://example.com" });
+    const b = similarityKey("webfetch", { url: "https://example.com" });
+    expect(a).toBe(b);
+  });
+
+  test("different URLs produce different keys", () => {
+    const a = similarityKey("webfetch", { url: "https://example.com/foo" });
+    const b = similarityKey("webfetch", { url: "https://example.com/bar" });
+    expect(a).not.toBe(b);
+  });
+
+  test("key is prefixed with 'webfetch:'", () => {
+    const key = similarityKey("webfetch", { url: "https://example.com" });
+    expect(key).toMatch(/^webfetch:/);
+  });
+});
+
+describe("similarityKey — default (byte-exact)", () => {
+  test("same args produce the same key for unknown tools", () => {
+    const a = similarityKey("task", { subagent_type: "explore", prompt: "search code" });
+    const b = similarityKey("task", { subagent_type: "explore", prompt: "search code" });
+    expect(a).toBe(b);
+  });
+
+  test("different args produce different keys for unknown tools", () => {
+    const a = similarityKey("task", { subagent_type: "explore", prompt: "search code" });
+    const b = similarityKey("task", { subagent_type: "review", prompt: "search code" });
+    expect(a).not.toBe(b);
+  });
+
+  test("key is prefixed with the tool name", () => {
+    const key = similarityKey("task", { prompt: "foo" });
+    expect(key).toMatch(/^task:/);
+  });
+});
+
+// ── Doom-loop state machine simulation ───────────────────────────────────────
+//
+// These tests simulate the detector state machine without running the full
+// plugin factory, verifying: suppression after firing, pattern-break reset,
+// threshold counting, and session isolation.
+
+// Inline minimal state machine (mirrors prism-hooks.ts detector logic).
+interface DoomLoopState {
+  currentKey: string | null;
+  consecutiveCount: number;
+  fired: boolean;
+}
+
+const DOOM_LOOP_THRESHOLD = 5;
+
+const EXCLUDED = new Set(["read", "grep", "glob", "todowrite"]);
+
+function processToolCall(
+  state: DoomLoopState,
+  tool: string,
+  args: any
+): { fired: boolean; suppressed: boolean } {
+  if (EXCLUDED.has(tool)) {
+    state.currentKey = null;
+    state.consecutiveCount = 0;
+    state.fired = false;
+    return { fired: false, suppressed: false };
+  }
+
+  const key = similarityKey(tool, args);
+  if (key === null) {
+    return { fired: false, suppressed: false };
+  }
+
+  if (key === state.currentKey) {
+    if (!state.fired) {
+      state.consecutiveCount++;
+      if (state.consecutiveCount >= DOOM_LOOP_THRESHOLD) {
+        state.fired = true;
+        return { fired: true, suppressed: false };
+      }
+    } else {
+      // Suppressed.
+      return { fired: false, suppressed: true };
+    }
+  } else {
+    state.currentKey = key;
+    state.consecutiveCount = 1;
+    state.fired = false;
+  }
+  return { fired: false, suppressed: false };
+}
+
+function newState(): DoomLoopState {
+  return { currentKey: null, consecutiveCount: 0, fired: false };
+}
+
+describe("doom-loop state machine", () => {
+  test("fires on the 5th consecutive bash call with same key", () => {
+    const state = newState();
+    const calls = Array(5).fill(null).map(() =>
+      processToolCall(state, "bash", { command: "go test ./..." })
+    );
+    expect(calls[4].fired).toBe(true);
+    expect(calls.slice(0, 4).every((c) => !c.fired)).toBe(true);
+  });
+
+  test("does NOT fire on 4 consecutive calls", () => {
+    const state = newState();
+    const calls = Array(4).fill(null).map(() =>
+      processToolCall(state, "bash", { command: "go test ./..." })
+    );
+    expect(calls.every((c) => !c.fired)).toBe(true);
+  });
+
+  test("after firing, 6th/7th+ calls are suppressed (no additional fire)", () => {
+    const state = newState();
+    // Fire on call 5.
+    for (let i = 0; i < 5; i++) {
+      processToolCall(state, "bash", { command: "go test ./..." });
+    }
+    const call6 = processToolCall(state, "bash", { command: "go test ./..." });
+    const call7 = processToolCall(state, "bash", { command: "go test ./..." });
+    expect(call6.fired).toBe(false);
+    expect(call6.suppressed).toBe(true);
+    expect(call7.fired).toBe(false);
+    expect(call7.suppressed).toBe(true);
+  });
+
+  test("pattern break (different bash command) resets suppression", () => {
+    const state = newState();
+    // Fire.
+    for (let i = 0; i < 5; i++) {
+      processToolCall(state, "bash", { command: "go test ./..." });
+    }
+    expect(state.fired).toBe(true);
+    // Different pattern breaks the run.
+    processToolCall(state, "bash", { command: "go build ./..." });
+    expect(state.fired).toBe(false);
+    expect(state.consecutiveCount).toBe(1);
+  });
+
+  test("new 5-call loop after pattern break fires a new event", () => {
+    const state = newState();
+    // First loop: fires on call 5.
+    for (let i = 0; i < 5; i++) {
+      processToolCall(state, "bash", { command: "go test ./..." });
+    }
+    // Break: resets state; "go build" is now count=1.
+    processToolCall(state, "bash", { command: "go build ./..." });
+    // 4 more calls needed to reach the threshold (total consecutive = 5).
+    const calls = Array(4).fill(null).map(() =>
+      processToolCall(state, "bash", { command: "go build ./..." })
+    );
+    // The 5th consecutive "go build" call (4 loop calls after the break call) fires.
+    expect(calls[3].fired).toBe(true);
+    expect(calls.slice(0, 3).every((c) => !c.fired)).toBe(true);
+  });
+
+  test("excluded tool (read) resets state without firing", () => {
+    const state = newState();
+    for (let i = 0; i < 4; i++) {
+      processToolCall(state, "bash", { command: "go test ./..." });
+    }
+    expect(state.consecutiveCount).toBe(4);
+    // Read breaks the run.
+    processToolCall(state, "read", { filePath: "/foo.go" });
+    expect(state.currentKey).toBeNull();
+    expect(state.consecutiveCount).toBe(0);
+    expect(state.fired).toBe(false);
+  });
+
+  test("excluded tool (todowrite) resets state without firing", () => {
+    const state = newState();
+    for (let i = 0; i < 4; i++) {
+      processToolCall(state, "bash", { command: "go test ./..." });
+    }
+    processToolCall(state, "todowrite", { todos: [] });
+    expect(state.currentKey).toBeNull();
+    expect(state.fired).toBe(false);
+  });
+
+  test("session isolation — two states do not cross-contaminate", () => {
+    const stateA = newState();
+    const stateB = newState();
+    // Session A: 4 calls.
+    for (let i = 0; i < 4; i++) {
+      processToolCall(stateA, "bash", { command: "go test ./..." });
+    }
+    // Session B: 4 calls.
+    for (let i = 0; i < 4; i++) {
+      processToolCall(stateB, "bash", { command: "go test ./..." });
+    }
+    // Neither has fired yet.
+    expect(stateA.fired).toBe(false);
+    expect(stateB.fired).toBe(false);
+    // 5th call on A — only A fires.
+    const resA = processToolCall(stateA, "bash", { command: "go test ./..." });
+    expect(resA.fired).toBe(true);
+    expect(stateB.fired).toBe(false);
+  });
+
+  test("edit/write same path fires on 5th call", () => {
+    const state = newState();
+    const calls = Array(5).fill(null).map(() =>
+      processToolCall(state, "edit", { filePath: "/workspace/foo.go", newString: "x" })
+    );
+    expect(calls[4].fired).toBe(true);
+  });
+
+  test("edit/write different paths do not fire", () => {
+    const state = newState();
+    const paths = ["/a.go", "/b.go", "/c.go", "/d.go", "/e.go"];
+    const calls = paths.map((p) =>
+      processToolCall(state, "edit", { filePath: p })
+    );
+    expect(calls.every((c) => !c.fired)).toBe(true);
+  });
+
+  test("webfetch same URL fires on 5th call", () => {
+    const state = newState();
+    const calls = Array(5).fill(null).map(() =>
+      processToolCall(state, "webfetch", { url: "https://example.com" })
+    );
+    expect(calls[4].fired).toBe(true);
+  });
+
+  test("webfetch different URLs do not fire", () => {
+    const state = newState();
+    const urls = ["https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com"];
+    const calls = urls.map((u) =>
+      processToolCall(state, "webfetch", { url: u })
+    );
+    expect(calls.every((c) => !c.fired)).toBe(true);
+  });
+});

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -7,7 +7,7 @@ import type { Plugin } from "@opencode-ai/plugin";
 // session start). It fires when all 5 are the same tool with "similar" arguments
 // (see similarityKey below), emits a doom_loop_detected event to the prism DB
 // via `prism event doom-loop-detected`, and injects a one-shot steering prompt
-// into the next LLM turn via experimental.chat.system.transform.
+// into the next LLM turn via experimental.chat.messages.transform.
 //
 // Similarity rules (per tool):
 //   bash      — compare command + first positional argument only (strips flags).
@@ -162,8 +162,7 @@ export const PrismHooks: Plugin = async (pluginInput) => {
         const text = pendingSteeringPrompt;
         pendingSteeringPrompt = null;
         // Inject a synthetic user-role message at the end of the history.
-        // The message ID is generated deterministically from the tool name to
-        // ensure uniqueness without a crypto dependency.
+        // The message ID is timestamp-based to ensure uniqueness.
         const syntheticMsg: any = {
           info: {
             id: `doom-loop-${Date.now()}`,
@@ -311,7 +310,8 @@ export const PrismHooks: Plugin = async (pluginInput) => {
     // Inject messages into the system prompt on the next LLM turn:
     // 1. Escalation warning if the review cycle limit has been reached.
     // 2. Review reminder after a git push (one-shot, cleared after injection).
-    // 3. Doom-loop steering prompt (one-shot, cleared after injection).
+    // Note: doom-loop steering is handled by experimental.chat.messages.transform,
+    // not here. This hook only manages the review-related system prompt injections.
     "experimental.chat.system.transform": async (_input, output) => {
       // Clear the per-turn cycle deduplication flag so the next batch of
       // review agent invocations counts as a fresh cycle.

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -256,9 +256,9 @@ export const PrismHooks: Plugin = async (pluginInput) => {
       }
 
       // ── Doom-loop detection ──────────────────────────────────────────────
-      // Excluded tools (read, grep, glob) do not contribute to loop counts but
-      // DO break an active run — a different tool being invoked resets the
-      // state so a subsequent same-tool loop can fire fresh.
+      // Excluded tools (read, grep, glob, todowrite) do not contribute to loop
+      // counts but DO break an active run — a different tool being invoked
+      // resets the state so a subsequent same-tool loop can fire fresh.
       if (EXCLUDED_TOOLS.has(input.tool)) {
         // Break the current run without tracking the excluded call.
         doomLoop.currentKey = null;

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -29,13 +29,16 @@ import type { Plugin } from "@opencode-ai/plugin";
 const DOOM_LOOP_THRESHOLD = 5;
 
 // excludedTools are never subject to doom-loop detection.
-const EXCLUDED_TOOLS = new Set(["read", "grep", "glob"]);
+// read/grep/glob: legitimate exploration revisits the same paths often.
+// todowrite: task-list management is a housekeeping pattern, not a loop.
+const EXCLUDED_TOOLS = new Set(["read", "grep", "glob", "todowrite"]);
 
 /**
  * Compute a normalised similarity key for a tool call.
  * Returns null for excluded tools (no detection).
+ * Exported for unit testing.
  */
-function similarityKey(tool: string, args: any): string | null {
+export function similarityKey(tool: string, args: any): string | null {
   if (EXCLUDED_TOOLS.has(tool)) {
     return null;
   }

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -1,6 +1,113 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
-export const PrismHooks: Plugin = async () => {
+// ── Doom-loop detection ──────────────────────────────────────────────────────
+//
+// The detector tracks the last N=5 tool calls in hook-local memory per plugin
+// instance (i.e. per opencode session — the plugin is re-initialised on each
+// session start). It fires when all 5 are the same tool with "similar" arguments
+// (see similarityKey below), emits a doom_loop_detected event to the prism DB
+// via `prism event doom-loop-detected`, and injects a one-shot steering prompt
+// into the next LLM turn via experimental.chat.system.transform.
+//
+// Similarity rules (per tool):
+//   bash      — compare command + first positional argument only (strips flags).
+//               "git log -1" and "git log -3" match; "go test ./cmd/..." and
+//               "go build ./..." do not.
+//   edit/write — same file path (first argument), ignoring content.
+//   webfetch  — same URL (first argument).
+//   read/grep/glob — EXCLUDED. Legitimate exploration revisits the same paths
+//               often; treating them as loops generates false positives.
+//   default   — byte-exact full argument string.
+//
+// After the hook fires, further consecutive matching calls are suppressed (one
+// nudge per loop). The suppression resets when the pattern breaks — a different
+// tool or meaningfully different arguments.
+//
+// Detection state is per-session (per plugin instance). Two concurrent sessions
+// each at 4 consecutive matching calls do NOT cross-contaminate.
+
+const DOOM_LOOP_THRESHOLD = 5;
+
+// excludedTools are never subject to doom-loop detection.
+const EXCLUDED_TOOLS = new Set(["read", "grep", "glob"]);
+
+/**
+ * Compute a normalised similarity key for a tool call.
+ * Returns null for excluded tools (no detection).
+ */
+function similarityKey(tool: string, args: any): string | null {
+  if (EXCLUDED_TOOLS.has(tool)) {
+    return null;
+  }
+
+  switch (tool) {
+    case "bash": {
+      // Extract the command string.
+      const cmd: string =
+        typeof args === "object" && args !== null
+          ? (args as any)?.command ?? ""
+          : String(args ?? "");
+      // Split into tokens, strip leading flags/options (anything starting with
+      // "-"), and keep the first two meaningful tokens (command + first positional).
+      const tokens = cmd.trim().split(/\s+/);
+      const meaningful = tokens.filter((t) => t.length > 0);
+      // Find the base command (first non-flag token).
+      let baseIdx = 0;
+      while (baseIdx < meaningful.length && meaningful[baseIdx].startsWith("-")) {
+        baseIdx++;
+      }
+      const base = meaningful[baseIdx] ?? "";
+      // Find the first positional argument after the base command (skip flags).
+      let firstPos = "";
+      for (let i = baseIdx + 1; i < meaningful.length; i++) {
+        if (!meaningful[i].startsWith("-")) {
+          firstPos = meaningful[i];
+          break;
+        }
+      }
+      return `bash:${base} ${firstPos}`.trimEnd();
+    }
+
+    case "edit":
+    case "write": {
+      // Same file path counts as similar, regardless of content.
+      const filePath: string =
+        typeof args === "object" && args !== null
+          ? (args as any)?.filePath ?? (args as any)?.path ?? ""
+          : String(args ?? "");
+      return `${tool}:${filePath}`;
+    }
+
+    case "webfetch": {
+      const url: string =
+        typeof args === "object" && args !== null
+          ? (args as any)?.url ?? ""
+          : String(args ?? "");
+      return `webfetch:${url}`;
+    }
+
+    default: {
+      // Conservative default: byte-exact full args string.
+      const raw =
+        typeof args === "object" && args !== null
+          ? JSON.stringify(args)
+          : String(args ?? "");
+      return `${tool}:${raw}`;
+    }
+  }
+}
+
+// DoomLoopState tracks consecutive matching calls for the current session.
+interface DoomLoopState {
+  // The similarity key of the current run.
+  currentKey: string | null;
+  // How many consecutive matching calls we have seen.
+  consecutiveCount: number;
+  // Whether we have already fired for this run (suppression flag).
+  fired: boolean;
+}
+
+export const PrismHooks: Plugin = async (pluginInput) => {
   // Set when a git push is detected; consumed on the next LLM turn to inject
   // a review reminder into the system prompt.
   let pendingReviewReminder = false;
@@ -28,7 +135,52 @@ export const PrismHooks: Plugin = async () => {
   // counts as exactly one cycle.
   let pendingCycleCount = false;
 
+  // ── Doom-loop state (per session / per plugin instance) ──────────────────
+  const doomLoop: DoomLoopState = {
+    currentKey: null,
+    consecutiveCount: 0,
+    fired: false,
+  };
+
+  // Steering prompt queued for injection on the next LLM turn.
+  // Contains the message text, or null when nothing is pending.
+  let pendingSteeringPrompt: string | null = null;
+
+  // Session name from the environment — needed for the prism event CLI call.
+  const sessionName = process.env.PRISM_SESSION_NAME ?? "";
+
   return {
+    // Inject doom-loop steering as a user-role message into the messages array.
+    // This fires on each LLM turn; the pending flag is one-shot (cleared after
+    // injection). The message is structurally distinguishable from real user
+    // input via the [PRISM-HOOKS DOOM-LOOP DETECTION] prefix.
+    "experimental.chat.messages.transform": async (_input, output) => {
+      if (pendingSteeringPrompt !== null) {
+        const text = pendingSteeringPrompt;
+        pendingSteeringPrompt = null;
+        // Inject a synthetic user-role message at the end of the history.
+        // The message ID is generated deterministically from the tool name to
+        // ensure uniqueness without a crypto dependency.
+        const syntheticMsg: any = {
+          info: {
+            id: `doom-loop-${Date.now()}`,
+            role: "user",
+            time: { created: Date.now() },
+          },
+          parts: [
+            {
+              id: `doom-loop-part-${Date.now()}`,
+              type: "text",
+              content: text,
+              time: { created: Date.now() },
+            },
+          ],
+        };
+        output.messages.push(syntheticMsg);
+      }
+      return output;
+    },
+
     // After a bash tool executes a git push, set a flag so the next LLM turn
     // gets a review reminder injected into the system prompt.
     "tool.execute.after": async (input) => {
@@ -100,11 +252,63 @@ export const PrismHooks: Plugin = async () => {
           }
         }
       }
+
+      // ── Doom-loop detection ──────────────────────────────────────────────
+      // Excluded tools (read, grep, glob) do not contribute to loop counts but
+      // DO break an active run — a different tool being invoked resets the
+      // state so a subsequent same-tool loop can fire fresh.
+      if (EXCLUDED_TOOLS.has(input.tool)) {
+        // Break the current run without tracking the excluded call.
+        doomLoop.currentKey = null;
+        doomLoop.consecutiveCount = 0;
+        doomLoop.fired = false;
+      } else {
+        const key = similarityKey(input.tool, input.args);
+
+        if (key === null) {
+          // Should not happen for non-excluded tools, but be defensive.
+        } else if (key === doomLoop.currentKey) {
+          // Same pattern — extend the run.
+          if (!doomLoop.fired) {
+            doomLoop.consecutiveCount++;
+
+            if (doomLoop.consecutiveCount >= DOOM_LOOP_THRESHOLD) {
+              // Fire!
+              doomLoop.fired = true;
+
+              const steeringText =
+                `[PRISM-HOOKS DOOM-LOOP DETECTION] You've called \`${input.tool}\` with the same arguments ${doomLoop.consecutiveCount} times in a row. ` +
+                `This usually means the current approach isn't working — stop and rethink. ` +
+                `Consider: is there a different tool that would help? Is there a misunderstanding about the task? Should you escalate to the user?`;
+              pendingSteeringPrompt = steeringText;
+
+              // Log the event to the prism DB asynchronously (fire-and-forget).
+              // We do not await this so the tool execution path is not blocked.
+              if (sessionName) {
+                const $ = (pluginInput as any).$;
+                if ($) {
+                  void $`prism event doom-loop-detected --session ${sessionName} --tool ${input.tool} --pattern ${key} --count ${String(doomLoop.consecutiveCount)}`.quiet().catch(() => {
+                    // Ignore errors — event logging is best-effort.
+                  });
+                }
+              }
+            }
+          }
+          // If already fired: suppress — do nothing for further matching calls.
+        } else {
+          // Pattern broke (different tool or different key) — reset state and
+          // start tracking the new pattern.
+          doomLoop.currentKey = key;
+          doomLoop.consecutiveCount = 1;
+          doomLoop.fired = false;
+        }
+      }
     },
 
     // Inject messages into the system prompt on the next LLM turn:
     // 1. Escalation warning if the review cycle limit has been reached.
     // 2. Review reminder after a git push (one-shot, cleared after injection).
+    // 3. Doom-loop steering prompt (one-shot, cleared after injection).
     "experimental.chat.system.transform": async (_input, output) => {
       // Clear the per-turn cycle deduplication flag so the next batch of
       // review agent invocations counts as a fresh cycle.

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -527,7 +527,8 @@ the plugin; this command only writes the event.`,
 			worktree = s.Worktree
 		}
 
-		payload := fmt.Sprintf(`{"tool":%q,"pattern":%q,"count":%d}`, tool, pattern, count)
+		now := time.Now()
+		payload := fmt.Sprintf(`{"tool":%q,"pattern":%q,"count":%d,"timestampMs":%d}`, tool, pattern, count, now.UnixMilli())
 		e := db.Event{
 			ID:          uuid.New().String(),
 			SessionName: session,
@@ -535,11 +536,12 @@ the plugin; this command only writes the event.`,
 			Worktree:    worktree,
 			Type:        "doom_loop_detected",
 			Payload:     payload,
-			CreatedAt:   time.Now(),
+			CreatedAt:   now,
 		}
 		if err := d.WriteEvent(e); err != nil {
 			return fmt.Errorf("event doom-loop-detected: write event: %w", err)
 		}
+		touchDashboardSentinel()
 		return nil
 	},
 }

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -4,12 +4,13 @@ package cmd
 //
 // Sub-subcommands:
 //
-//	state-change       --session <name> --state <state> --worktree <path>
-//	pane-died          --session <name> --window <name>
-//	tmux-session-start --session <name> --worktree <path>
-//	tmux-session-end   --session <name>
-//	compaction         --session <name>
-//	error              --session <name> --message <text>
+//	state-change          --session <name> --state <state> --worktree <path>
+//	pane-died             --session <name> --window <name>
+//	tmux-session-start    --session <name> --worktree <path>
+//	tmux-session-end      --session <name>
+//	compaction            --session <name>
+//	error                 --session <name> --message <text>
+//	doom-loop-detected    --session <name> --tool <tool> --pattern <pattern> --count <n>
 
 import (
 	"fmt"
@@ -491,6 +492,58 @@ var eventErrorCmd = &cobra.Command{
 	},
 }
 
+// --- doom-loop-detected ---
+
+var eventDoomLoopDetectedCmd = &cobra.Command{
+	Use:   "doom-loop-detected",
+	Short: "Write a doom_loop_detected event to prism.db",
+	Long: `Write a doom_loop_detected event to prism.db.
+
+Called by the prism-hooks plugin when it detects an agent repeating the same
+tool call with near-identical arguments N consecutive times in the same session.
+This is a hook-side log command — the detection and suppression logic lives in
+the plugin; this command only writes the event.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		session, _ := cmd.Flags().GetString("session")
+		tool, _ := cmd.Flags().GetString("tool")
+		pattern, _ := cmd.Flags().GetString("pattern")
+		count, _ := cmd.Flags().GetInt("count")
+
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("event doom-loop-detected: %w", err)
+		}
+		defer d.Close()
+
+		s, err := d.CurrentStatus(session)
+		if err != nil {
+			return fmt.Errorf("event doom-loop-detected: current status: %w", err)
+		}
+
+		repo := ""
+		worktree := ""
+		if s != nil {
+			repo = s.Repo
+			worktree = s.Worktree
+		}
+
+		payload := fmt.Sprintf(`{"tool":%q,"pattern":%q,"count":%d}`, tool, pattern, count)
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: session,
+			Repo:        repo,
+			Worktree:    worktree,
+			Type:        "doom_loop_detected",
+			Payload:     payload,
+			CreatedAt:   time.Now(),
+		}
+		if err := d.WriteEvent(e); err != nil {
+			return fmt.Errorf("event doom-loop-detected: write event: %w", err)
+		}
+		return nil
+	},
+}
+
 func init() {
 	// state-change flags
 	eventStateChangeCmd.Flags().String("session", "", "tmux session name")
@@ -527,12 +580,22 @@ func init() {
 	_ = eventErrorCmd.MarkFlagRequired("session")
 	_ = eventErrorCmd.MarkFlagRequired("message")
 
+	// doom-loop-detected flags
+	eventDoomLoopDetectedCmd.Flags().String("session", "", "tmux session name")
+	eventDoomLoopDetectedCmd.Flags().String("tool", "", "tool name that triggered detection")
+	eventDoomLoopDetectedCmd.Flags().String("pattern", "", "normalised argument pattern that matched")
+	eventDoomLoopDetectedCmd.Flags().Int("count", 5, "number of consecutive matching calls (default 5)")
+	_ = eventDoomLoopDetectedCmd.MarkFlagRequired("session")
+	_ = eventDoomLoopDetectedCmd.MarkFlagRequired("tool")
+	_ = eventDoomLoopDetectedCmd.MarkFlagRequired("pattern")
+
 	eventCmd.AddCommand(eventStateChangeCmd)
 	eventCmd.AddCommand(eventPaneDiedCmd)
 	eventCmd.AddCommand(eventTmuxSessionStartCmd)
 	eventCmd.AddCommand(eventTmuxSessionEndCmd)
 	eventCmd.AddCommand(eventCompactionCmd)
 	eventCmd.AddCommand(eventErrorCmd)
+	eventCmd.AddCommand(eventDoomLoopDetectedCmd)
 
 	rootCmd.AddCommand(eventCmd)
 }

--- a/modules/programs/prism/prism/cmd/event_doomloop_test.go
+++ b/modules/programs/prism/prism/cmd/event_doomloop_test.go
@@ -218,7 +218,7 @@ func TestEventDoomLoopDetected_PayloadContainsFields(t *testing.T) {
 	}
 
 	raw := events[0].Payload
-	for _, field := range []string{`"tool"`, `"pattern"`, `"count"`} {
+	for _, field := range []string{`"tool"`, `"pattern"`, `"count"`, `"timestampMs"`} {
 		if !strings.Contains(raw, field) {
 			t.Errorf("payload missing field %s\ngot: %s", field, raw)
 		}

--- a/modules/programs/prism/prism/cmd/event_doomloop_test.go
+++ b/modules/programs/prism/prism/cmd/event_doomloop_test.go
@@ -1,0 +1,226 @@
+package cmd
+
+// Tests for `prism event doom-loop-detected`.
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+// TestEventDoomLoopDetected_WritesEvent verifies that
+// `prism event doom-loop-detected` writes a doom_loop_detected event to the DB
+// with the correct payload fields.
+func TestEventDoomLoopDetected_WritesEvent(t *testing.T) {
+	const session = "testrepo@main"
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "doom-loop-detected",
+		"--session", session,
+		"--tool", "bash",
+		"--pattern", "bash:go test ./...",
+		"--count", "5",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	events, err := d2.QueryDoomLoopEvents(session, 0)
+	if err != nil {
+		t.Fatalf("QueryDoomLoopEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 doom_loop_detected event, got %d", len(events))
+	}
+
+	e := events[0]
+	if e.Type != "doom_loop_detected" {
+		t.Errorf("event type = %q, want \"doom_loop_detected\"", e.Type)
+	}
+	if e.SessionName != session {
+		t.Errorf("session_name = %q, want %q", e.SessionName, session)
+	}
+
+	var p payload.DoomLoopDetected
+	if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.Tool != "bash" {
+		t.Errorf("payload.tool = %q, want \"bash\"", p.Tool)
+	}
+	if p.Pattern != "bash:go test ./..." {
+		t.Errorf("payload.pattern = %q, want \"bash:go test ./...\"", p.Pattern)
+	}
+	if p.Count != 5 {
+		t.Errorf("payload.count = %d, want 5", p.Count)
+	}
+}
+
+// TestEventDoomLoopDetected_UnknownSession verifies that the command writes an
+// event even when the session does not have an agent_status row (repo/worktree
+// default to empty strings in that case).
+func TestEventDoomLoopDetected_UnknownSession(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "doom-loop-detected",
+		"--session", "unknown@session",
+		"--tool", "bash",
+		"--pattern", "bash:go test",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	events, err := d2.QueryDoomLoopEvents("unknown@session", 0)
+	if err != nil {
+		t.Fatalf("QueryDoomLoopEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	// repo and worktree should be empty strings when no status row exists.
+	if events[0].Repo != "" {
+		t.Errorf("repo = %q, want empty string for unknown session", events[0].Repo)
+	}
+}
+
+// TestEventDoomLoopDetected_DefaultCount verifies that the default count is 5
+// when not specified.
+func TestEventDoomLoopDetected_DefaultCount(t *testing.T) {
+	const session = "testrepo@main"
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "doom-loop-detected",
+		"--session", session,
+		"--tool", "edit",
+		"--pattern", "edit:/workspace/foo.go",
+		// no --count → default 5
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	events, err := d2.QueryDoomLoopEvents(session, 0)
+	if err != nil {
+		t.Fatalf("QueryDoomLoopEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	var p payload.DoomLoopDetected
+	if err := json.Unmarshal([]byte(events[0].Payload), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Count != 5 {
+		t.Errorf("default count = %d, want 5", p.Count)
+	}
+}
+
+// TestEventDoomLoopDetected_PayloadContainsFields verifies the raw JSON payload
+// contains the expected field names.
+func TestEventDoomLoopDetected_PayloadContainsFields(t *testing.T) {
+	const session = "testrepo@main"
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.UpsertStatus(session, "testrepo", "/code/testrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "doom-loop-detected",
+		"--session", session,
+		"--tool", "webfetch",
+		"--pattern", "webfetch:https://example.com",
+		"--count", "5",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	events, err := d2.QueryDoomLoopEvents(session, 0)
+	if err != nil {
+		t.Fatalf("QueryDoomLoopEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("no events found")
+	}
+
+	raw := events[0].Payload
+	for _, field := range []string{`"tool"`, `"pattern"`, `"count"`} {
+		if !strings.Contains(raw, field) {
+			t.Errorf("payload missing field %s\ngot: %s", field, raw)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -1030,11 +1030,7 @@ func runStatsDoomLoops(sessionFilter string, days int) error {
 	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
 
 	for _, e := range events {
-		var p struct {
-			Tool    string `json:"tool"`
-			Pattern string `json:"pattern"`
-			Count   int    `json:"count"`
-		}
+		var p payload.DoomLoopDetected
 		_ = json.Unmarshal([]byte(e.Payload), &p)
 
 		sessionStr := e.SessionName

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -9,6 +9,9 @@ package cmd
 //	prism stats --days N          historical aggregate over the last N days
 //	prism stats model             per-model performance breakdown over last 7 days
 //	prism stats model --days N    per-model performance breakdown over last N days
+//	prism stats --doomloops       doom_loop_detected events from the last 7 days
+//	prism stats --doomloops --days N  doom loop events over the last N days
+//	prism stats <session> --doomloops filter doom loop events to a specific session
 
 import (
 	"encoding/json"
@@ -68,6 +71,10 @@ Use --detail to force the detailed block format even for multi-session tmux sess
 
 Use --days N to show aggregate statistics over the last N days.
 
+Use --doomloops to show doom_loop_detected events. Defaults to the last 7 days
+cross-session; combine with --days N to change the window; combine with a
+session name argument to filter to a specific session.
+
 Use the 'model' subcommand for a per-provider/model performance breakdown.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStats,
@@ -76,12 +83,27 @@ Use the 'model' subcommand for a per-provider/model performance breakdown.`,
 func init() {
 	statsCmd.Flags().Int("days", 0, "Show aggregate statistics over the last N days")
 	statsCmd.Flags().Bool("detail", false, "Force detailed block format even for multi-session tmux sessions")
+	statsCmd.Flags().Bool("doomloops", false, "Show doom_loop_detected events (last 7 days by default)")
 	rootCmd.AddCommand(statsCmd)
 }
 
 func runStats(cmd *cobra.Command, args []string) error {
 	days, _ := cmd.Flags().GetInt("days")
 	detail, _ := cmd.Flags().GetBool("detail")
+	doomloops, _ := cmd.Flags().GetBool("doomloops")
+
+	if doomloops {
+		// --doomloops: default window is 7 days; --days N overrides it.
+		window := 7
+		if days > 0 {
+			window = days
+		}
+		sessionFilter := ""
+		if len(args) == 1 {
+			sessionFilter = args[0]
+		}
+		return runStatsDoomLoops(sessionFilter, window)
+	}
 
 	if days > 0 && len(args) > 0 {
 		return fmt.Errorf("--days is mutually exclusive with a session name")
@@ -951,6 +973,105 @@ func runStatsHistorical(days int) error {
 		}
 	}
 
+	return nil
+}
+
+// ---------- doom-loop events ----------
+
+// runStatsDoomLoops queries doom_loop_detected events and renders them as a
+// table sorted by timestamp descending. sessionFilter narrows to a specific
+// session when non-empty. days is the look-back window (must be > 0).
+func runStatsDoomLoops(sessionFilter string, days int) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats --doomloops: %w", err)
+	}
+	defer d.Close()
+
+	sinceMs := time.Now().Add(-time.Duration(days) * 24 * time.Hour).UnixMilli()
+
+	events, err := d.QueryDoomLoopEvents(sessionFilter, sinceMs)
+	if err != nil {
+		return fmt.Errorf("stats --doomloops: %w", err)
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleHeaderDim := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	title := fmt.Sprintf("Doom Loop Events — last %d days", days)
+	if sessionFilter != "" {
+		title = fmt.Sprintf("Doom Loop Events — session %s, last %d days", sessionFilter, days)
+	}
+	fmt.Println(styleHeader.Render(title))
+	fmt.Println()
+
+	if len(events) == 0 {
+		fmt.Println(styleDim.Render("  no doom_loop_detected events in the specified window"))
+		return nil
+	}
+
+	const (
+		wSession   = 32
+		wTool      = 12
+		wPattern   = 40
+		wCount     = 5
+		wTimestamp = 19
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %*s  %-*s",
+		wSession, "SESSION",
+		wTool, "TOOL",
+		wPattern, "ARG PATTERN",
+		wCount, "COUNT",
+		wTimestamp, "TIMESTAMP",
+	)
+	fmt.Println(styleHeaderDim.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, e := range events {
+		var p struct {
+			Tool    string `json:"tool"`
+			Pattern string `json:"pattern"`
+			Count   int    `json:"count"`
+		}
+		_ = json.Unmarshal([]byte(e.Payload), &p)
+
+		sessionStr := e.SessionName
+		if len(sessionStr) > wSession {
+			sessionStr = sessionStr[:wSession-3] + "..."
+		}
+
+		toolStr := p.Tool
+		if len(toolStr) > wTool {
+			toolStr = toolStr[:wTool-3] + "..."
+		}
+
+		patternStr := p.Pattern
+		if len(patternStr) > wPattern {
+			patternStr = patternStr[:wPattern-3] + "..."
+		}
+
+		countStr := fmt.Sprintf("%d", p.Count)
+		if p.Count == 0 {
+			countStr = "—"
+		}
+
+		tsStr := e.CreatedAt.Format("2006-01-02 15:04:05")
+
+		fmt.Printf("%-*s  %-*s  %-*s  %*s  %-*s\n",
+			wSession, sessionStr,
+			wTool, toolStr,
+			wPattern, patternStr,
+			wCount, countStr,
+			wTimestamp, tsStr,
+		)
+	}
+
+	fmt.Println()
+	if sessionFilter == "" {
+		fmt.Println(styleDim.Render("use `prism stats <session> --doomloops` to filter to a specific session"))
+	}
 	return nil
 }
 

--- a/modules/programs/prism/prism/cmd/stats_doomloops_test.go
+++ b/modules/programs/prism/prism/cmd/stats_doomloops_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+// Tests for `prism stats --doomloops` (runStatsDoomLoops).
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// writeDoomLoopEvent writes a doom_loop_detected event to the given DB.
+func writeDoomLoopEvent(t *testing.T, d *db.DB, session, tool, pattern string, count int, ts time.Time) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"tool":%q,"pattern":%q,"count":%d}`, tool, pattern, count)
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: session,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		Type:        "doom_loop_detected",
+		Payload:     payload,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+// TestRunStatsDoomLoops_EmptyWindow verifies graceful output when no doom loop
+// events exist in the window.
+func TestRunStatsDoomLoops_EmptyWindow(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsDoomLoops("", 7); err != nil {
+			t.Errorf("runStatsDoomLoops: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no doom_loop_detected events") {
+		t.Errorf("expected 'no doom_loop_detected events', got:\n%s", out)
+	}
+}
+
+// TestRunStatsDoomLoops_BasicOutput verifies that events within the window are
+// rendered with the expected columns.
+func TestRunStatsDoomLoops_BasicOutput(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeDoomLoopEvent(t, d, "testrepo@main", "bash", "go test ./...", 5, base.Add(-1*time.Hour))
+	writeDoomLoopEvent(t, d, "testrepo@feature", "edit", "/workspace/foo.go", 5, base.Add(-2*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsDoomLoops("", 7); err != nil {
+			t.Errorf("runStatsDoomLoops: %v", err)
+		}
+	})
+
+	// Headers must appear.
+	for _, want := range []string{"SESSION", "TOOL", "ARG PATTERN", "COUNT", "TIMESTAMP"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing column %q\ngot:\n%s", want, out)
+		}
+	}
+	// Both sessions should appear.
+	if !strings.Contains(out, "testrepo@main") {
+		t.Errorf("output missing 'testrepo@main'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "testrepo@feature") {
+		t.Errorf("output missing 'testrepo@feature'\ngot:\n%s", out)
+	}
+	// Tools should appear.
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output missing 'bash' tool\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "edit") {
+		t.Errorf("output missing 'edit' tool\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDoomLoops_WindowFilter verifies that events older than the window
+// are excluded.
+func TestRunStatsDoomLoops_WindowFilter(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Within 7-day window.
+	writeDoomLoopEvent(t, d, "testrepo@main", "bash", "go test ./...", 5, base.Add(-3*24*time.Hour))
+	// Outside 7-day window (8 days ago).
+	writeDoomLoopEvent(t, d, "testrepo@main", "bash", "go build ./...", 5, base.Add(-8*24*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsDoomLoops("", 7); err != nil {
+			t.Errorf("runStatsDoomLoops: %v", err)
+		}
+	})
+
+	// Only the within-window event should appear.
+	if !strings.Contains(out, "go test") {
+		t.Errorf("output should contain 'go test' (within window)\ngot:\n%s", out)
+	}
+	// The old event should NOT appear.
+	if strings.Contains(out, "go build") {
+		t.Errorf("output must NOT contain 'go build' (outside window)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDoomLoops_SessionFilter verifies that --doomloops with a session
+// filter returns only that session's events.
+func TestRunStatsDoomLoops_SessionFilter(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeDoomLoopEvent(t, d, "testrepo@main", "bash", "go test ./...", 5, base.Add(-1*time.Hour))
+	writeDoomLoopEvent(t, d, "testrepo@feature", "edit", "/workspace/foo.go", 5, base.Add(-2*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsDoomLoops("testrepo@main", 7); err != nil {
+			t.Errorf("runStatsDoomLoops: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "testrepo@main") {
+		t.Errorf("output should contain 'testrepo@main'\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "testrepo@feature") {
+		t.Errorf("output must NOT contain 'testrepo@feature' (different session)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDoomLoops_DaysFlag verifies that the window parameter limits
+// results correctly.
+func TestRunStatsDoomLoops_DaysFlag(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// 3 days ago — within 30-day window, outside 2-day window.
+	writeDoomLoopEvent(t, d, "testrepo@main", "bash", "git log", 5, base.Add(-3*24*time.Hour))
+
+	// Should appear with 30-day window.
+	out30 := captureStdout(t, func() {
+		if err := runStatsDoomLoops("", 30); err != nil {
+			t.Errorf("runStatsDoomLoops(30): %v", err)
+		}
+	})
+	if !strings.Contains(out30, "testrepo@main") {
+		t.Errorf("30-day window should include event from 3 days ago\ngot:\n%s", out30)
+	}
+
+	// Should NOT appear with 2-day window.
+	out2 := captureStdout(t, func() {
+		if err := runStatsDoomLoops("", 2); err != nil {
+			t.Errorf("runStatsDoomLoops(2): %v", err)
+		}
+	})
+	if strings.Contains(out2, "testrepo@main") {
+		t.Errorf("2-day window should exclude event from 3 days ago\ngot:\n%s", out2)
+	}
+}
+
+// TestRunStats_DoomloopsFlag verifies that runStats routes to runStatsDoomLoops
+// when --doomloops is set (default 7-day window, no session filter).
+func TestRunStats_DoomloopsFlag(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeDoomLoopEvent(t, d, "testrepo@main", "bash", "git status", 5, base.Add(-1*time.Hour))
+
+	statsCmd.Flags().Set("doomloops", "true")        //nolint:errcheck
+	defer statsCmd.Flags().Set("doomloops", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Doom Loop Events") {
+		t.Errorf("output missing 'Doom Loop Events' heading\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "git status") {
+		t.Errorf("output missing event 'git status'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStats_DoomloopsDaysMutuallyAccepted verifies that --doomloops with
+// --days does NOT return an error (unlike the --days + session name combination).
+func TestRunStats_DoomloopsDaysMutuallyAccepted(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	statsCmd.Flags().Set("doomloops", "true") //nolint:errcheck
+	statsCmd.Flags().Set("days", "30")        //nolint:errcheck
+	defer func() {
+		statsCmd.Flags().Set("doomloops", "false") //nolint:errcheck
+		statsCmd.Flags().Set("days", "0")          //nolint:errcheck
+	}()
+
+	if err := runStats(statsCmd, nil); err != nil {
+		t.Errorf("runStats --doomloops --days 30 returned error: %v", err)
+	}
+}

--- a/modules/programs/prism/prism/cmd/stats_doomloops_test.go
+++ b/modules/programs/prism/prism/cmd/stats_doomloops_test.go
@@ -15,7 +15,7 @@ import (
 // writeDoomLoopEvent writes a doom_loop_detected event to the given DB.
 func writeDoomLoopEvent(t *testing.T, d *db.DB, session, tool, pattern string, count int, ts time.Time) {
 	t.Helper()
-	payload := fmt.Sprintf(`{"tool":%q,"pattern":%q,"count":%d}`, tool, pattern, count)
+	payload := fmt.Sprintf(`{"tool":%q,"pattern":%q,"count":%d,"timestampMs":%d}`, tool, pattern, count, ts.UnixMilli())
 	e := db.Event{
 		ID:          uuid.New().String(),
 		SessionName: session,

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1191,6 +1191,51 @@ func (d *DB) UpdateOpencodeSID(sessionName, sid string) error {
 	return nil
 }
 
+// QueryDoomLoopEvents returns doom_loop_detected events from agent_events,
+// ordered by created_at DESC. Optional filters:
+//   - sessionName: when non-empty, restrict to this session only
+//   - sinceMs: when > 0, restrict to events created at or after this Unix ms timestamp
+func (d *DB) QueryDoomLoopEvents(sessionName string, sinceMs int64) ([]Event, error) {
+	args := []any{}
+	conditions := []string{"type = 'doom_loop_detected'"}
+
+	if sessionName != "" {
+		conditions = append(conditions, "session_name = ?")
+		args = append(args, sessionName)
+	}
+
+	if sinceMs > 0 {
+		conditions = append(conditions, "created_at >= ?")
+		args = append(args, sinceMs)
+	}
+
+	where := " WHERE " + strings.Join(conditions, " AND ")
+
+	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+		where + " ORDER BY created_at DESC"
+
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query doom loop events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		var createdAt int64
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+			return nil, fmt.Errorf("db: scan doom loop event: %w", err)
+		}
+		e.CreatedAt = time.UnixMilli(createdAt)
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate doom loop events: %w", err)
+	}
+	return events, nil
+}
+
 // QueryAuditEvents returns audit events from agent_events, ordered by
 // created_at DESC. Optional filters:
 //   - sessionName: when non-empty, restrict to this session only

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -165,11 +165,14 @@ type SubagentEnd struct {
 //
 // Tool is the tool name that triggered detection (e.g. "bash").
 // Pattern is the normalised argument pattern that matched (e.g. "go test ./...").
-// Count is the number of consecutive matching calls when detection fired (always 5).
+// Count is the number of consecutive matching calls when detection fired (threshold is 5).
+// TimestampMs is the Unix millisecond timestamp when detection fired, included
+// in the payload for consumers that need it without a DB join.
 type DoomLoopDetected struct {
-	Tool    string `json:"tool"`
-	Pattern string `json:"pattern"`
-	Count   int    `json:"count"`
+	Tool        string `json:"tool"`
+	Pattern     string `json:"pattern"`
+	Count       int    `json:"count"`
+	TimestampMs int64  `json:"timestampMs"`
 }
 
 // Audit is the payload for audit events, written when a high-impact bash

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -159,6 +159,19 @@ type SubagentEnd struct {
 	MessageID  string `json:"messageId"`
 }
 
+// DoomLoopDetected is the payload for doom_loop_detected events, written by
+// the prism-hooks plugin when it detects an agent repeating the same tool call
+// with near-identical arguments N consecutive times in the same session.
+//
+// Tool is the tool name that triggered detection (e.g. "bash").
+// Pattern is the normalised argument pattern that matched (e.g. "go test ./...").
+// Count is the number of consecutive matching calls when detection fired (always 5).
+type DoomLoopDetected struct {
+	Tool    string `json:"tool"`
+	Pattern string `json:"pattern"`
+	Count   int    `json:"count"`
+}
+
 // Audit is the payload for audit events, written when a high-impact bash
 // command is executed (e.g. gh pr merge, git push, prism spawn). These events
 // are promoted from the ephemeral opencode DB to the persistent prism DB so


### PR DESCRIPTION
## Summary

- Adds doom-loop detection to `prism-hooks.ts`: fires on the 5th consecutive tool call with a similar argument pattern, injects a `[PRISM-HOOKS DOOM-LOOP DETECTION]` user-role message via `experimental.chat.messages.transform`, and logs a `doom_loop_detected` event to the prism DB.
- Tool-specific similarity rules: bash (command + first positional), edit/write (file path), webfetch (URL), default (byte-exact). `read`/`grep`/`glob` are excluded from detection and break the current run.
- Suppression: one nudge per loop; resets when pattern breaks (different tool, different key, or excluded tool).
- New `prism event doom-loop-detected` CLI subcommand writes the event to prism DB.
- New `prism stats --doomloops` flag surfaces doom loop events (default 7-day window, `--days N` override, session filter).
- Unit tests: `stats_doomloops_test.go` and `event_doomloop_test.go`.

Closes #770