### PR TITLE
prism stats: add --denials and --asks for permission friction visibility

### DIFF
--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -12,6 +12,12 @@ package cmd
 //	prism stats --doomloops       doom_loop_detected events from the last 7 days
 //	prism stats --doomloops --days N  doom loop events over the last N days
 //	prism stats <session> --doomloops filter doom loop events to a specific session
+//	prism stats --denials         permission_denied events from the last 7 days
+//	prism stats --denials --days N  permission denied events over the last N days
+//	prism stats <session> --denials filter permission denied events to a specific session
+//	prism stats --asks            permission_ask events from the last 7 days
+//	prism stats --asks --days N   permission ask events over the last N days
+//	prism stats <session> --asks  filter permission ask events to a specific session
 
 import (
 	"encoding/json"
@@ -75,6 +81,14 @@ Use --doomloops to show doom_loop_detected events. Defaults to the last 7 days
 cross-session; combine with --days N to change the window; combine with a
 session name argument to filter to a specific session.
 
+Use --denials to show permission_denied events aggregated by (session, tool).
+Defaults to the last 7 days cross-session; combine with --days N to change the
+window; combine with a session name argument to filter to a specific session.
+
+Use --asks to show permission_ask events aggregated by (session, tool, pattern).
+Defaults to the last 7 days cross-session; combine with --days N to change the
+window; combine with a session name argument to filter to a specific session.
+
 Use the 'model' subcommand for a per-provider/model performance breakdown.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStats,
@@ -84,6 +98,8 @@ func init() {
 	statsCmd.Flags().Int("days", 0, "Show aggregate statistics over the last N days")
 	statsCmd.Flags().Bool("detail", false, "Force detailed block format even for multi-session tmux sessions")
 	statsCmd.Flags().Bool("doomloops", false, "Show doom_loop_detected events (last 7 days by default)")
+	statsCmd.Flags().Bool("denials", false, "Show permission_denied events aggregated by (session, tool) (last 7 days by default)")
+	statsCmd.Flags().Bool("asks", false, "Show permission_ask events aggregated by (session, tool, pattern) (last 7 days by default)")
 	rootCmd.AddCommand(statsCmd)
 }
 
@@ -91,9 +107,13 @@ func runStats(cmd *cobra.Command, args []string) error {
 	days, _ := cmd.Flags().GetInt("days")
 	detail, _ := cmd.Flags().GetBool("detail")
 	doomloops, _ := cmd.Flags().GetBool("doomloops")
+	denials, _ := cmd.Flags().GetBool("denials")
+	asks, _ := cmd.Flags().GetBool("asks")
 
-	if doomloops {
-		// --doomloops: default window is 7 days; --days N overrides it.
+	// --doomloops, --denials, and --asks bypass the --days+session guard.
+	// They each have their own session-filter path and --days is additive.
+	if doomloops || denials || asks {
+		// Default window is 7 days; --days N overrides it.
 		window := 7
 		if days > 0 {
 			window = days
@@ -102,7 +122,23 @@ func runStats(cmd *cobra.Command, args []string) error {
 		if len(args) == 1 {
 			sessionFilter = args[0]
 		}
-		return runStatsDoomLoops(sessionFilter, window)
+
+		if doomloops {
+			if err := runStatsDoomLoops(sessionFilter, window); err != nil {
+				return err
+			}
+		}
+		if denials {
+			if err := runStatsDenials(sessionFilter, window); err != nil {
+				return err
+			}
+		}
+		if asks {
+			if err := runStatsAsks(sessionFilter, window); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	if days > 0 && len(args) > 0 {
@@ -1067,6 +1103,282 @@ func runStatsDoomLoops(sessionFilter string, days int) error {
 	fmt.Println()
 	if sessionFilter == "" {
 		fmt.Println(styleDim.Render("use `prism stats <session> --doomloops` to filter to a specific session"))
+	}
+	return nil
+}
+
+// ---------- permission denied events ----------
+
+// denialKey is the aggregation key for permission_denied events.
+type denialKey struct {
+	Session string
+	Tool    string
+}
+
+// runStatsDenials queries permission_denied events and renders them as a table
+// aggregated by (session_name, tool), sorted by count descending.
+// sessionFilter narrows to a specific session when non-empty.
+// days is the look-back window (must be > 0).
+func runStatsDenials(sessionFilter string, days int) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats --denials: %w", err)
+	}
+	defer d.Close()
+
+	// Validate session exists when a filter is provided.
+	if sessionFilter != "" {
+		status, err := d.CurrentStatus(sessionFilter)
+		if err != nil {
+			return fmt.Errorf("stats --denials: %w", err)
+		}
+		events, _ := d.AllSessionEvents(sessionFilter)
+		if status == nil && len(events) == 0 {
+			return fmt.Errorf("session %q not found", sessionFilter)
+		}
+	}
+
+	sinceMs := time.Now().Add(-time.Duration(days) * 24 * time.Hour).UnixMilli()
+
+	events, err := d.QueryPermissionEvents("permission_denied", sessionFilter, sinceMs)
+	if err != nil {
+		return fmt.Errorf("stats --denials: %w", err)
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleHeaderDim := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	title := fmt.Sprintf("Permission Denials — last %d days", days)
+	if sessionFilter != "" {
+		title = fmt.Sprintf("Permission Denials — session %s, last %d days", sessionFilter, days)
+	}
+	fmt.Println(styleHeader.Render(title))
+	fmt.Println()
+
+	if len(events) == 0 {
+		msg := fmt.Sprintf("No permission denials in the last %d days", days)
+		if sessionFilter != "" {
+			msg = fmt.Sprintf("No permission denials for session %s in the last %d days", sessionFilter, days)
+		}
+		fmt.Println(styleDim.Render("  " + msg))
+		return nil
+	}
+
+	// Aggregate by (session, tool).
+	counts := make(map[denialKey]int)
+	for _, e := range events {
+		var p payload.PermissionDenied
+		_ = json.Unmarshal([]byte(e.Payload), &p)
+		tool := p.Tool
+		if tool == "" {
+			tool = "<unknown>"
+		}
+		counts[denialKey{Session: e.SessionName, Tool: tool}]++
+	}
+
+	// Sort by count descending, then session, then tool.
+	type denialRow struct {
+		Session string
+		Tool    string
+		Count   int
+	}
+	var rows []denialRow
+	for k, c := range counts {
+		rows = append(rows, denialRow{Session: k.Session, Tool: k.Tool, Count: c})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		if rows[i].Session != rows[j].Session {
+			return rows[i].Session < rows[j].Session
+		}
+		return rows[i].Tool < rows[j].Tool
+	})
+
+	const (
+		wDSession = 36
+		wDTool    = 20
+		wDCount   = 5
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %*s",
+		wDSession, "SESSION",
+		wDTool, "TOOL",
+		wDCount, "COUNT",
+	)
+	fmt.Println(styleHeaderDim.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, r := range rows {
+		sessionStr := r.Session
+		if len(sessionStr) > wDSession {
+			sessionStr = sessionStr[:wDSession-3] + "..."
+		}
+		toolStr := r.Tool
+		if len(toolStr) > wDTool {
+			toolStr = toolStr[:wDTool-3] + "..."
+		}
+		fmt.Printf("%-*s  %-*s  %*d\n",
+			wDSession, sessionStr,
+			wDTool, toolStr,
+			wDCount, r.Count,
+		)
+	}
+
+	fmt.Println()
+	if sessionFilter == "" {
+		fmt.Println(styleDim.Render("use `prism stats <session> --denials` to filter to a specific session"))
+	}
+	return nil
+}
+
+// ---------- permission ask events ----------
+
+// askKey is the aggregation key for permission_ask events.
+type askKey struct {
+	Session string
+	Tool    string
+	Pattern string
+}
+
+// runStatsAsks queries permission_ask events and renders them as a table
+// aggregated by (session_name, tool, pattern), sorted by count descending.
+// sessionFilter narrows to a specific session when non-empty.
+// days is the look-back window (must be > 0).
+func runStatsAsks(sessionFilter string, days int) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats --asks: %w", err)
+	}
+	defer d.Close()
+
+	// Validate session exists when a filter is provided.
+	if sessionFilter != "" {
+		status, err := d.CurrentStatus(sessionFilter)
+		if err != nil {
+			return fmt.Errorf("stats --asks: %w", err)
+		}
+		events, _ := d.AllSessionEvents(sessionFilter)
+		if status == nil && len(events) == 0 {
+			return fmt.Errorf("session %q not found", sessionFilter)
+		}
+	}
+
+	sinceMs := time.Now().Add(-time.Duration(days) * 24 * time.Hour).UnixMilli()
+
+	events, err := d.QueryPermissionEvents("permission_ask", sessionFilter, sinceMs)
+	if err != nil {
+		return fmt.Errorf("stats --asks: %w", err)
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleHeaderDim := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	title := fmt.Sprintf("Permission Asks — last %d days", days)
+	if sessionFilter != "" {
+		title = fmt.Sprintf("Permission Asks — session %s, last %d days", sessionFilter, days)
+	}
+	fmt.Println(styleHeader.Render(title))
+	fmt.Println()
+
+	if len(events) == 0 {
+		msg := fmt.Sprintf("No permission asks in the last %d days", days)
+		if sessionFilter != "" {
+			msg = fmt.Sprintf("No permission asks for session %s in the last %d days", sessionFilter, days)
+		}
+		fmt.Println(styleDim.Render("  " + msg))
+		return nil
+	}
+
+	// Aggregate by (session, tool, pattern). Each pattern in the patterns slice
+	// produces a separate aggregation row per the spec.
+	counts := make(map[askKey]int)
+	for _, e := range events {
+		var p payload.PermissionAsk
+		_ = json.Unmarshal([]byte(e.Payload), &p)
+		tool := string(p.Tool)
+		if tool == "" {
+			tool = "<unknown>"
+		}
+		if len(p.Patterns) == 0 {
+			counts[askKey{Session: e.SessionName, Tool: tool, Pattern: "<no pattern>"}]++
+		} else {
+			for _, pat := range p.Patterns {
+				if pat == "" {
+					pat = "<no pattern>"
+				}
+				counts[askKey{Session: e.SessionName, Tool: tool, Pattern: pat}]++
+			}
+		}
+	}
+
+	// Sort by count descending, then session, tool, pattern.
+	type askRow struct {
+		Session string
+		Tool    string
+		Pattern string
+		Count   int
+	}
+	var rows []askRow
+	for k, c := range counts {
+		rows = append(rows, askRow{Session: k.Session, Tool: k.Tool, Pattern: k.Pattern, Count: c})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		if rows[i].Session != rows[j].Session {
+			return rows[i].Session < rows[j].Session
+		}
+		if rows[i].Tool != rows[j].Tool {
+			return rows[i].Tool < rows[j].Tool
+		}
+		return rows[i].Pattern < rows[j].Pattern
+	})
+
+	const (
+		wASession = 36
+		wATool    = 20
+		wAPattern = 30
+		wACount   = 5
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %*s",
+		wASession, "SESSION",
+		wATool, "TOOL",
+		wAPattern, "PATTERN",
+		wACount, "COUNT",
+	)
+	fmt.Println(styleHeaderDim.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, r := range rows {
+		sessionStr := r.Session
+		if len(sessionStr) > wASession {
+			sessionStr = sessionStr[:wASession-3] + "..."
+		}
+		toolStr := r.Tool
+		if len(toolStr) > wATool {
+			toolStr = toolStr[:wATool-3] + "..."
+		}
+		patternStr := r.Pattern
+		if len(patternStr) > wAPattern {
+			patternStr = patternStr[:wAPattern-3] + "..."
+		}
+		fmt.Printf("%-*s  %-*s  %-*s  %*d\n",
+			wASession, sessionStr,
+			wATool, toolStr,
+			wAPattern, patternStr,
+			wACount, r.Count,
+		)
+	}
+
+	fmt.Println()
+	if sessionFilter == "" {
+		fmt.Println(styleDim.Render("use `prism stats <session> --asks` to filter to a specific session"))
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/stats_permissions_test.go
+++ b/modules/programs/prism/prism/cmd/stats_permissions_test.go
@@ -1,0 +1,620 @@
+package cmd
+
+// Tests for `prism stats --denials` (runStatsDenials) and
+// `prism stats --asks` (runStatsAsks).
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// writeDenialEvent writes a permission_denied event to the given DB.
+func writeDenialEvent(t *testing.T, d *db.DB, session, tool string, ts time.Time) {
+	t.Helper()
+	p := fmt.Sprintf(`{"tool":%q,"messageId":"msg-%s"}`, tool, uuid.New().String())
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: session,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		Type:        "permission_denied",
+		Payload:     p,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+// writeAskEvent writes a permission_ask event to the given DB.
+// patterns is the list of patterns to include in the payload.
+func writeAskEvent(t *testing.T, d *db.DB, session, tool string, patterns []string, ts time.Time) {
+	t.Helper()
+	// Build patterns JSON array.
+	patJSON := "[]"
+	if len(patterns) > 0 {
+		parts := make([]string, len(patterns))
+		for i, pat := range patterns {
+			parts[i] = fmt.Sprintf("%q", pat)
+		}
+		patJSON = "[" + strings.Join(parts, ",") + "]"
+	}
+	p := fmt.Sprintf(`{"tool":%q,"patterns":%s,"messageId":"msg-%s"}`, tool, patJSON, uuid.New().String())
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: session,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		Type:        "permission_ask",
+		Payload:     p,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+// writeAskEventLegacyTool writes a permission_ask event where the tool field
+// is a JSON object (legacy format), not a plain string.
+func writeAskEventLegacyTool(t *testing.T, d *db.DB, session string, patterns []string, ts time.Time) {
+	t.Helper()
+	patJSON := "[]"
+	if len(patterns) > 0 {
+		parts := make([]string, len(patterns))
+		for i, pat := range patterns {
+			parts[i] = fmt.Sprintf("%q", pat)
+		}
+		patJSON = "[" + strings.Join(parts, ",") + "]"
+	}
+	// Legacy tool: JSON object instead of plain string.
+	p := fmt.Sprintf(`{"tool":{"messageID":"msg-legacy","callID":"call-123"},"patterns":%s,"messageId":"msg-legacy"}`, patJSON)
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: session,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		Type:        "permission_ask",
+		Payload:     p,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+// --- runStatsDenials tests ---
+
+// TestRunStatsDenials_EmptyWindow verifies graceful output when no
+// permission_denied events exist in the window.
+func TestRunStatsDenials_EmptyWindow(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsDenials("", 7); err != nil {
+			t.Errorf("runStatsDenials: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No permission denials") {
+		t.Errorf("expected empty-state message, got:\n%s", out)
+	}
+}
+
+// TestRunStatsDenials_AggregationCorrectness verifies that counts are summed
+// correctly by (session, tool) and the table is sorted by count desc.
+func TestRunStatsDenials_AggregationCorrectness(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// session A: bash denied 3 times, go-test denied 1 time
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-5*time.Hour))
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-4*time.Hour))
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-3*time.Hour))
+	writeDenialEvent(t, d, "repo@main", "go-test", base.Add(-2*time.Hour))
+
+	// session B: kubectl denied 2 times
+	writeDenialEvent(t, d, "repo@feature", "kubectl", base.Add(-1*time.Hour))
+	writeDenialEvent(t, d, "repo@feature", "kubectl", base.Add(-30*time.Minute))
+
+	out := captureStdout(t, func() {
+		if err := runStatsDenials("", 7); err != nil {
+			t.Errorf("runStatsDenials: %v", err)
+		}
+	})
+
+	// Headers must appear.
+	for _, want := range []string{"SESSION", "TOOL", "COUNT"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing column %q\ngot:\n%s", want, out)
+		}
+	}
+
+	// Both sessions should appear.
+	if !strings.Contains(out, "repo@main") {
+		t.Errorf("output missing 'repo@main'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "repo@feature") {
+		t.Errorf("output missing 'repo@feature'\ngot:\n%s", out)
+	}
+
+	// Tools should appear.
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output missing 'bash'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "kubectl") {
+		t.Errorf("output missing 'kubectl'\ngot:\n%s", out)
+	}
+
+	// bash count=3 should appear before kubectl count=2.
+	bashPos := strings.Index(out, "bash")
+	kubectlPos := strings.Index(out, "kubectl")
+	if bashPos == -1 || kubectlPos == -1 {
+		t.Fatalf("could not find 'bash' or 'kubectl' in output:\n%s", out)
+	}
+	if bashPos > kubectlPos {
+		t.Errorf("expected 'bash' (count=3) before 'kubectl' (count=2) in sorted output\ngot:\n%s", out)
+	}
+
+	// Count 3 for bash should appear.
+	if !strings.Contains(out, "3") {
+		t.Errorf("output missing count '3' for bash\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDenials_SessionFilter verifies that a session filter restricts
+// results to the named session only.
+func TestRunStatsDenials_SessionFilter(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-1*time.Hour))
+	writeDenialEvent(t, d, "repo@feature", "kubectl", base.Add(-2*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsDenials("repo@main", 7); err != nil {
+			t.Errorf("runStatsDenials: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "repo@main") {
+		t.Errorf("output should contain 'repo@main'\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "repo@feature") {
+		t.Errorf("output must NOT contain 'repo@feature' (different session)\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output should contain 'bash'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDenials_WindowFilter verifies that events older than the window
+// are excluded.
+func TestRunStatsDenials_WindowFilter(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Within window (3 days ago, window=7).
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-3*24*time.Hour))
+	// Outside window (8 days ago, window=7).
+	writeDenialEvent(t, d, "repo@main", "kubectl", base.Add(-8*24*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsDenials("", 7); err != nil {
+			t.Errorf("runStatsDenials: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output should contain 'bash' (within window)\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "kubectl") {
+		t.Errorf("output must NOT contain 'kubectl' (outside window)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDenials_MissingSession verifies that an unknown session returns
+// a non-zero error referencing the session name.
+func TestRunStatsDenials_MissingSession(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	err := runStatsDenials("nonexistent@main", 7)
+	if err == nil {
+		t.Fatal("expected error for nonexistent session, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nonexistent@main") {
+		t.Errorf("error should mention the session name, got: %v", err)
+	}
+}
+
+// TestRunStats_DenialsFlag verifies that runStats routes to runStatsDenials
+// when --denials is set.
+func TestRunStats_DenialsFlag(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-1*time.Hour))
+
+	statsCmd.Flags().Set("denials", "true")        //nolint:errcheck
+	defer statsCmd.Flags().Set("denials", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Permission Denials") {
+		t.Errorf("output missing 'Permission Denials' heading\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output missing 'bash'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStats_DenialsDaysMutuallyAccepted verifies that --denials with --days
+// does NOT return an error.
+func TestRunStats_DenialsDaysMutuallyAccepted(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	statsCmd.Flags().Set("denials", "true") //nolint:errcheck
+	statsCmd.Flags().Set("days", "30")      //nolint:errcheck
+	defer func() {
+		statsCmd.Flags().Set("denials", "false") //nolint:errcheck
+		statsCmd.Flags().Set("days", "0")        //nolint:errcheck
+	}()
+
+	if err := runStats(statsCmd, nil); err != nil {
+		t.Errorf("runStats --denials --days 30 returned error: %v", err)
+	}
+}
+
+// --- runStatsAsks tests ---
+
+// TestRunStatsAsks_EmptyWindow verifies graceful output when no
+// permission_ask events exist in the window.
+func TestRunStatsAsks_EmptyWindow(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No permission asks") {
+		t.Errorf("expected empty-state message, got:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_AggregationCorrectness verifies that counts are aggregated
+// correctly by (session, tool, pattern) and sorted by count desc.
+func TestRunStatsAsks_AggregationCorrectness(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// bash asked 3 times with pattern "atlasian_create*"
+	writeAskEvent(t, d, "repo@main", "bash", []string{"atlasian_create*"}, base.Add(-5*time.Hour))
+	writeAskEvent(t, d, "repo@main", "bash", []string{"atlasian_create*"}, base.Add(-4*time.Hour))
+	writeAskEvent(t, d, "repo@main", "bash", []string{"atlasian_create*"}, base.Add(-3*time.Hour))
+
+	// webfetch asked 2 times with no pattern
+	writeAskEvent(t, d, "repo@feature", "webfetch", []string{}, base.Add(-2*time.Hour))
+	writeAskEvent(t, d, "repo@feature", "webfetch", []string{}, base.Add(-1*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	// Headers must appear.
+	for _, want := range []string{"SESSION", "TOOL", "PATTERN", "COUNT"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing column %q\ngot:\n%s", want, out)
+		}
+	}
+
+	// Both sessions should appear.
+	if !strings.Contains(out, "repo@main") {
+		t.Errorf("output missing 'repo@main'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "repo@feature") {
+		t.Errorf("output missing 'repo@feature'\ngot:\n%s", out)
+	}
+
+	// Tools should appear.
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output missing 'bash'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "webfetch") {
+		t.Errorf("output missing 'webfetch'\ngot:\n%s", out)
+	}
+
+	// Pattern should appear.
+	if !strings.Contains(out, "atlasian_create*") {
+		t.Errorf("output missing 'atlasian_create*'\ngot:\n%s", out)
+	}
+
+	// Empty-patterns should show <no pattern>.
+	if !strings.Contains(out, "<no pattern>") {
+		t.Errorf("output missing '<no pattern>' for empty patterns\ngot:\n%s", out)
+	}
+
+	// bash (count=3) should appear before webfetch (count=2).
+	bashPos := strings.Index(out, "bash")
+	webfetchPos := strings.Index(out, "webfetch")
+	if bashPos == -1 || webfetchPos == -1 {
+		t.Fatalf("could not find 'bash' or 'webfetch' in output:\n%s", out)
+	}
+	if bashPos > webfetchPos {
+		t.Errorf("expected 'bash' (count=3) before 'webfetch' (count=2)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_MultiplePatternsSplitRows verifies that a single event with
+// multiple patterns produces one row per pattern (not one combined row).
+func TestRunStatsAsks_MultiplePatternsSplitRows(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// One event with two patterns → two separate aggregation rows.
+	writeAskEvent(t, d, "repo@main", "bash", []string{"git push*", "gh pr*"}, base)
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "git push*") {
+		t.Errorf("output missing 'git push*'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "gh pr*") {
+		t.Errorf("output missing 'gh pr*'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_NullPatterns verifies that events with an empty patterns
+// slice render as <no pattern>, not as a blank or panic.
+func TestRunStatsAsks_NullPatterns(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Null/empty patterns.
+	writeAskEvent(t, d, "repo@main", "webfetch", []string{}, base)
+
+	// Also test explicit null JSON (no patterns key).
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "repo@main",
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		Type:        "permission_ask",
+		Payload:     `{"tool":"bash","messageId":"msg-null"}`, // no patterns key → nil slice
+		CreatedAt:   base.Add(time.Second),
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "<no pattern>") {
+		t.Errorf("output missing '<no pattern>' for empty/null patterns\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_LegacyToolObject verifies that events with a JSON object in
+// the tool field (legacy format) render as <unknown> without error.
+func TestRunStatsAsks_LegacyToolObject(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeAskEventLegacyTool(t, d, "repo@main", []string{"some-pattern"}, base)
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	// Should not crash and should show <unknown> for the tool.
+	if !strings.Contains(out, "<unknown>") {
+		t.Errorf("output missing '<unknown>' for legacy tool object\ngot:\n%s", out)
+	}
+	// The pattern should still appear.
+	if !strings.Contains(out, "some-pattern") {
+		t.Errorf("output missing 'some-pattern'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_SessionFilter verifies that a session filter restricts
+// results to the named session only.
+func TestRunStatsAsks_SessionFilter(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	writeAskEvent(t, d, "repo@main", "bash", []string{"git*"}, base.Add(-1*time.Hour))
+	writeAskEvent(t, d, "repo@feature", "kubectl", []string{"apply*"}, base.Add(-2*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("repo@main", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "repo@main") {
+		t.Errorf("output should contain 'repo@main'\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "repo@feature") {
+		t.Errorf("output must NOT contain 'repo@feature' (different session)\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "git*") {
+		t.Errorf("output should contain 'git*'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_WindowFilter verifies that events older than the window
+// are excluded.
+func TestRunStatsAsks_WindowFilter(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Within window (3 days ago, window=7).
+	writeAskEvent(t, d, "repo@main", "bash", []string{"inside-window"}, base.Add(-3*24*time.Hour))
+	// Outside window (8 days ago, window=7).
+	writeAskEvent(t, d, "repo@main", "bash", []string{"outside-window"}, base.Add(-8*24*time.Hour))
+
+	out := captureStdout(t, func() {
+		if err := runStatsAsks("", 7); err != nil {
+			t.Errorf("runStatsAsks: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "inside-window") {
+		t.Errorf("output should contain 'inside-window' (within window)\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "outside-window") {
+		t.Errorf("output must NOT contain 'outside-window' (outside window)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsAsks_MissingSession verifies that an unknown session returns a
+// non-zero error referencing the session name.
+func TestRunStatsAsks_MissingSession(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	err := runStatsAsks("nonexistent@main", 7)
+	if err == nil {
+		t.Fatal("expected error for nonexistent session, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nonexistent@main") {
+		t.Errorf("error should mention the session name, got: %v", err)
+	}
+}
+
+// TestRunStats_AsksFlag verifies that runStats routes to runStatsAsks when
+// --asks is set.
+func TestRunStats_AsksFlag(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeAskEvent(t, d, "repo@main", "bash", []string{"git*"}, base.Add(-1*time.Hour))
+
+	statsCmd.Flags().Set("asks", "true")        //nolint:errcheck
+	defer statsCmd.Flags().Set("asks", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Permission Asks") {
+		t.Errorf("output missing 'Permission Asks' heading\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output missing 'bash'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStats_AsksDaysMutuallyAccepted verifies that --asks with --days does
+// NOT return an error.
+func TestRunStats_AsksDaysMutuallyAccepted(t *testing.T) {
+	_ = openStatsTestDB(t)
+
+	statsCmd.Flags().Set("asks", "true") //nolint:errcheck
+	statsCmd.Flags().Set("days", "30")   //nolint:errcheck
+	defer func() {
+		statsCmd.Flags().Set("asks", "false") //nolint:errcheck
+		statsCmd.Flags().Set("days", "0")     //nolint:errcheck
+	}()
+
+	if err := runStats(statsCmd, nil); err != nil {
+		t.Errorf("runStats --asks --days 30 returned error: %v", err)
+	}
+}
+
+// TestRunStats_DenialsAndAsks verifies that --denials and --asks together
+// produce both datasets without error.
+func TestRunStats_DenialsAndAsks(t *testing.T) {
+	d := openStatsTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	writeDenialEvent(t, d, "repo@main", "bash", base.Add(-1*time.Hour))
+	writeAskEvent(t, d, "repo@main", "webfetch", []string{"https://*"}, base.Add(-2*time.Hour))
+
+	statsCmd.Flags().Set("denials", "true") //nolint:errcheck
+	statsCmd.Flags().Set("asks", "true")    //nolint:errcheck
+	defer func() {
+		statsCmd.Flags().Set("denials", "false") //nolint:errcheck
+		statsCmd.Flags().Set("asks", "false")    //nolint:errcheck
+	}()
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats --denials --asks: %v", err)
+		}
+	})
+
+	// Both sections should appear.
+	if !strings.Contains(out, "Permission Denials") {
+		t.Errorf("output missing 'Permission Denials' heading\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "Permission Asks") {
+		t.Errorf("output missing 'Permission Asks' heading\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "bash") {
+		t.Errorf("output missing 'bash' (from denials)\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "webfetch") {
+		t.Errorf("output missing 'webfetch' (from asks)\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDenials_FlagRegistered verifies that --denials is a registered
+// Bool flag on statsCmd and appears in --help output.
+func TestRunStatsDenials_FlagRegistered(t *testing.T) {
+	f := statsCmd.Flags().Lookup("denials")
+	if f == nil {
+		t.Fatal("statsCmd should have a --denials flag but it is not registered")
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("--denials flag should be Bool, got %q", f.Value.Type())
+	}
+}
+
+// TestRunStatsAsks_FlagRegistered verifies that --asks is a registered Bool
+// flag on statsCmd.
+func TestRunStatsAsks_FlagRegistered(t *testing.T) {
+	f := statsCmd.Flags().Lookup("asks")
+	if f == nil {
+		t.Fatal("statsCmd should have an --asks flag but it is not registered")
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("--asks flag should be Bool, got %q", f.Value.Type())
+	}
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1236,6 +1236,52 @@ func (d *DB) QueryDoomLoopEvents(sessionName string, sinceMs int64) ([]Event, er
 	return events, nil
 }
 
+// QueryPermissionEvents returns permission_denied or permission_ask events from
+// agent_events, ordered by created_at ASC. Optional filters:
+//   - eventType: must be "permission_denied" or "permission_ask"
+//   - sessionName: when non-empty, restrict to this session only
+//   - sinceMs: when > 0, restrict to events created at or after this Unix ms timestamp
+func (d *DB) QueryPermissionEvents(eventType, sessionName string, sinceMs int64) ([]Event, error) {
+	args := []any{eventType}
+	conditions := []string{"type = ?"}
+
+	if sessionName != "" {
+		conditions = append(conditions, "session_name = ?")
+		args = append(args, sessionName)
+	}
+
+	if sinceMs > 0 {
+		conditions = append(conditions, "created_at >= ?")
+		args = append(args, sinceMs)
+	}
+
+	where := " WHERE " + strings.Join(conditions, " AND ")
+
+	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+		where + " ORDER BY created_at ASC"
+
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query permission events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		var createdAt int64
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+			return nil, fmt.Errorf("db: scan permission event: %w", err)
+		}
+		e.CreatedAt = time.UnixMilli(createdAt)
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate permission events: %w", err)
+	}
+	return events, nil
+}
+
 // QueryAuditEvents returns audit events from agent_events, ordered by
 // created_at DESC. Optional filters:
 //   - sessionName: when non-empty, restrict to this session only


### PR DESCRIPTION
## Summary

- Adds `--denials` flag to `prism stats`: queries `permission_denied` events from `agent_events`, aggregates by `(session_name, tool)`, and prints a `SESSION / TOOL / COUNT` table sorted by count desc.
- Adds `--asks` flag to `prism stats`: queries `permission_ask` events, aggregates by `(session_name, tool, pattern)` — each entry in the `patterns` slice produces a separate row — and prints a `SESSION / TOOL / PATTERN / COUNT` table sorted by count desc.
- Both flags support `--days N` for window control and `<session>` argument for session-scoped queries, bypassing the existing `--days`+session mutual-exclusion guard (same pattern as `--doomloops`). When both flags are set together, both tables are printed in a single invocation.
- Adds `QueryPermissionEvents` to the db package for parameterised `permission_denied` / `permission_ask` queries.
- 20 new unit tests covering: aggregation correctness, session filtering, window filtering, empty-result handling, missing-session error, multi-pattern splitting, null/empty patterns (`<no pattern>`), legacy tool-object format (`<unknown>`), and flag registration.

Closes #771