### PR TITLE
pi: add PI_OFFLINE=1 to alias and manage settings.json declaratively

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -118,9 +118,17 @@
         ];
 
         programs.zsh.shellAliases = {
-          pi = "${envPrefix} pi";
+          pi = "PI_OFFLINE=1 ${envPrefix} pi";
         };
 
+        home.file.".pi/agent/settings.json".text = builtins.toJSON {
+          steeringMode = "one-at-a-time";
+          transport = "sse";
+          theme = "dark";
+          treeFilterMode = "default";
+          quietStartup = true;
+          enableInstallTelemetry = false;
+        };
         home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
         home.file.".pi/agent/coordinator-system-prompt.md".text = coordinatorSystemPrompt;
         # Custom theme derived from config.theme, deployed so pi picks it up


### PR DESCRIPTION
## Summary

- Prefixes the `pi` zsh alias with `PI_OFFLINE=1` to disable startup network operations; `PI_OFFLINE` is set only in the alias and not added to the shared `nx.programs.prism.agent.envVars`.
- Adds a declarative `home.file.".pi/agent/settings.json"` entry managed via `builtins.toJSON`, containing exactly the six specified keys: `steeringMode`, `transport`, `theme`, `treeFilterMode`, `quietStartup`, and `enableInstallTelemetry`.

## Migration

On any host where pi has previously been used (e.g. `navi`), a real file exists at `~/.pi/agent/settings.json`. Home Manager will refuse to replace it with a store symlink. Before running `nixos-rebuild switch`, manually remove the file:

```
rm ~/.pi/agent/settings.json
```

No activation scripts or backup logic have been added — one-time manual cleanup is the accepted migration path.

Closes #795