### PR TITLE
pi: adopt pi-anthropic-oauth for Claude Pro/Max subscription auth

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -42,6 +42,27 @@
         cp ${awsSkillFile} $out/aws/SKILL.md
         cp -r ${./opencode/skills/acceptance-criteria}/* $out/acceptance-criteria/
       '';
+      # Pi agent settings.json content, defined once here so a future container
+      # role can reference the same value without duplication.
+      # Follow-up container support will add containerWorkerSettingsJson /
+      # containerCoordinatorSettingsJson options (analogous to the opencode.nix
+      # container config blobs at lines 29-73) and reference piSettings there.
+      piSettings = {
+        steeringMode = "one-at-a-time";
+        transport = "sse";
+        theme = "dark";
+        treeFilterMode = "default";
+        quietStartup = true;
+        enableInstallTelemetry = false;
+
+        # Fork fallback: if leohenon/pi-anthropic-oauth becomes unmaintained,
+        # fork to prismatic-koi/pi-anthropic-oauth, publish to npm (or vendor
+        # into the nix store), and update this packages entry. The three most
+        # likely break sites are CLIENT_ID, TOKEN_URL, and AUTHORIZE_URL in
+        # the extension's src/auth.ts.
+        packages = [ "npm:pi-anthropic-oauth@latest" ];
+      };
+
       piTheme =
         with config.theme;
         builtins.toJSON {
@@ -121,14 +142,7 @@
           pi = "PI_OFFLINE=1 ${envPrefix} pi";
         };
 
-        home.file.".pi/agent/settings.json".text = builtins.toJSON {
-          steeringMode = "one-at-a-time";
-          transport = "sse";
-          theme = "dark";
-          treeFilterMode = "default";
-          quietStartup = true;
-          enableInstallTelemetry = false;
-        };
+        home.file.".pi/agent/settings.json".text = builtins.toJSON piSettings;
         home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
         home.file.".pi/agent/coordinator-system-prompt.md".text = coordinatorSystemPrompt;
         # Custom theme derived from config.theme, deployed so pi picks it up

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -60,7 +60,7 @@
         # into the nix store), and update this packages entry. The three most
         # likely break sites are CLIENT_ID, TOKEN_URL, and AUTHORIZE_URL in
         # the extension's src/auth.ts.
-        packages = [ "npm:pi-anthropic-oauth@latest" ];
+        packages = [ "npm:pi-anthropic-oauth@0.1.9" ];
       };
 
       piTheme =


### PR DESCRIPTION
## Summary

- Adds `"npm:pi-anthropic-oauth@latest"` to the pi agent `settings.json` `packages` array, enabling OAuth authentication against Claude Pro/Max subscriptions via pi's native `registerProvider` API.
- Extracts the settings.json attrset into a `let`-bound `piSettings` value so a future container role can reference it without duplication; a comment at that binding names the upcoming `containerWorkerSettingsJson` / `containerCoordinatorSettingsJson` extension points.
- Adds a fork-fallback comment block documenting the procedure if `leohenon/pi-anthropic-oauth` becomes unmaintained.
- Change is confined to `modules/programs/prism/pi.nix` only; no other modules touched.

## Bootstrap

After this lands and you `switch`, run pi and execute `/login anthropic`,
then choose "Claude Pro/Max". This is a one-time per-host step — credentials
persist in `~/.pi/agent/auth.json`, which is already covered by `home.persistence`.

Closes #797