### PR TITLE
prism review: print per-agent progress lines during blocking review run

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -152,6 +152,15 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("prism review: %w", err)
 	}
 
+	// progressLine writes and flushes a single progress line to stdout.
+	// Flushing after each write is critical: the enclosing bash tool invocation
+	// makes stdout a pipe (not a TTY), so Go's default buffering would hold
+	// lines until the buffer fills. os.Stdout.Sync() forces an immediate flush.
+	progressLine := func(line string) {
+		fmt.Fprintln(os.Stdout, line)
+		_ = os.Stdout.Sync()
+	}
+
 	// Build run options.
 	opts := review.Opts{
 		PRNumber:       prNumber,
@@ -162,6 +171,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		Timeout:        timeoutFlag,
 		PluginHostPath: cfg.SidecarPluginPath,
 		ContainerMode:  cfg.ContainerMode,
+		OnProgress:     progressLine,
 	}
 
 	// Load profiles for container mode — passed through to review.Run so
@@ -212,6 +222,10 @@ func runReview(cmd *cobra.Command, args []string) error {
 	if runErr != nil && runErr != context.Canceled {
 		return fmt.Errorf("prism review: %w", runErr)
 	}
+
+	// Print a blank line to separate progress output from the aggregated summary.
+	fmt.Fprintln(os.Stdout)
+	_ = os.Stdout.Sync()
 
 	// Format and print results.
 	output, allPassed := review.FormatResults(results, prNumber)

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -228,6 +228,34 @@ type Opts struct {
 	ProfilesFile *config.ProfilesFile
 	// ContainerMode: when true, each agent runs in its own container.
 	ContainerMode bool
+	// OnProgress is an optional callback invoked for each progress event:
+	// spawn, finish, timeout, and spawn failure. It receives a formatted
+	// progress line (without trailing newline). The caller is responsible for
+	// writing and flushing the line. When nil, no progress output is emitted.
+	OnProgress func(line string)
+}
+
+// FormatAgentDisplayName converts an agent name like "review-goal" to a
+// display name like "Review-Goal" for progress output lines.
+func FormatAgentDisplayName(name string) string {
+	parts := strings.Split(name, "-")
+	for i, p := range parts {
+		if len(p) > 0 {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "-")
+}
+
+// FormatProgressDuration formats a duration for progress output lines.
+// Below 60s: "28.4s". At or above 60s: "1m12s".
+func FormatProgressDuration(d time.Duration) string {
+	if d < 60*time.Second {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) - m*60
+	return fmt.Sprintf("%dm%ds", m, s)
 }
 
 // Run executes the review. It returns the aggregated results and an error.
@@ -275,7 +303,12 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 	}
 
 	// Spawn each agent as its own independent top-level tmux session.
+	// spawnErr[i] is non-nil if agent i failed to spawn. Agents that fail to
+	// spawn are excluded from polling; they receive an error AgentResult.
 	agentSessions := make([]string, len(agents))
+	spawnErr := make([]error, len(agents))
+	spawnTimes := make([]time.Time, len(agents))
+
 	for i, ag := range agents {
 		// Per-agent session: <parent>~review-<N>-<agent.Name>
 		agentSession := roundPrefix + ag.Name
@@ -283,26 +316,22 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 
 		// Seed agent_status for the agent session.
 		if err := d.UpsertStatus(agentSession, repo, worktree, "idle", nil, nil); err != nil {
-			// Clean up already-started agents before returning.
-			for j := 0; j < i; j++ {
-				session.KillSidecar(agentSessions[j])
-				cleanupAgentSession(d, agentSessions[j])
-				_ = tmux.KillSession(agentSessions[j])
+			spawnErr[i] = fmt.Errorf("seed status for %s: %w", ag.Name, err)
+			if opts.OnProgress != nil {
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), err))
 			}
-			return nil, fmt.Errorf("seed status for %s: %w", ag.Name, err)
+			continue
 		}
 
 		// Allocate a port for this agent session.
 		port, portErr := d.AllocatePort(agentSession)
 		if portErr != nil {
-			for j := 0; j < i; j++ {
-				session.KillSidecar(agentSessions[j])
-				cleanupAgentSession(d, agentSessions[j])
-				_ = tmux.KillSession(agentSessions[j])
-			}
-			// Also clean up the DB row we just seeded for i.
 			_ = d.SetEnded(agentSession)
-			return nil, fmt.Errorf("allocate port for %s: %w", ag.Name, portErr)
+			spawnErr[i] = fmt.Errorf("allocate port for %s: %w", ag.Name, portErr)
+			if opts.OnProgress != nil {
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), portErr))
+			}
+			continue
 		}
 
 		// Build the prompt for the review agent.
@@ -316,14 +345,12 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// surfaces this as an explicit error to prevent silent build-agent spawns.
 		agentConfigContent, configErr := ResolveAgentConfigContent(opts.ContainerMode, opts.ProfilesFile, ag.Name)
 		if configErr != nil {
-			// Clean up any already-started agents before returning.
-			for j := 0; j < i; j++ {
-				session.KillSidecar(agentSessions[j])
-				cleanupAgentSession(d, agentSessions[j])
-				_ = tmux.KillSession(agentSessions[j])
-			}
 			_ = d.SetEnded(agentSession)
-			return nil, configErr
+			spawnErr[i] = configErr
+			if opts.OnProgress != nil {
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
+			}
+			continue
 		}
 
 		// Start the sidecar for this agent.
@@ -346,35 +373,79 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// Create the independent top-level tmux session for this agent.
 		agentCmd := buildAgentCommand(ag, agentSession, port, prompt, opts.ContainerMode)
 		if err := createAgentSession(agentSession, worktree, agentCmd, port, opts.ContainerMode); err != nil {
-			// Clean up agents 0..i (including the current one whose session failed).
-			// Kill the sidecar for agent i (already started above).
+			// Emit spawn-failure progress line immediately.
+			if opts.OnProgress != nil {
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), err))
+			}
+			// Clean up this agent's resources (sidecar, DB row, tmux session).
 			session.KillSidecar(agentSession)
 			cleanupAgentSession(d, agentSession)
-			// Kill tmux session for agent i if it was created (best effort).
 			_ = tmux.KillSession(agentSession)
+			spawnErr[i] = fmt.Errorf("create session for %s: %w", ag.Name, err)
+			continue
+		}
 
-			// Clean up agents 0..i-1 that fully started.
-			for j := 0; j < i; j++ {
-				session.KillSidecar(agentSessions[j])
-				cleanupAgentSession(d, agentSessions[j])
-				_ = tmux.KillSession(agentSessions[j])
-			}
-			return nil, fmt.Errorf("create session for %s: %w", ag.Name, err)
+		// Emit "started" progress line immediately after successful spawn.
+		if opts.OnProgress != nil {
+			opts.OnProgress(fmt.Sprintf("%s started", FormatAgentDisplayName(ag.Name)))
+		}
+		spawnTimes[i] = time.Now()
+	}
+
+	// Check if all agents failed to spawn — surface a combined error.
+	allFailed := true
+	for _, se := range spawnErr {
+		if se == nil {
+			allFailed = false
+			break
+		}
+	}
+	if allFailed {
+		return nil, fmt.Errorf("all review agents failed to spawn")
+	}
+
+	// Build the subset of agents that successfully spawned for polling and
+	// SIGINT notification.
+	var liveAgents []Agent
+	var liveSessions []string
+	var liveSpawnTimes []time.Time
+	for i, se := range spawnErr {
+		if se == nil {
+			liveAgents = append(liveAgents, agents[i])
+			liveSessions = append(liveSessions, agentSessions[i])
+			liveSpawnTimes = append(liveSpawnTimes, spawnTimes[i])
 		}
 	}
 
-	// Notify the caller with all session names for SIGINT handling.
+	// Notify the caller with all successfully-spawned session names for SIGINT handling.
 	if onSessionsCreated != nil {
-		onSessionsCreated(agentSessions)
+		onSessionsCreated(liveSessions)
 	}
 
-	// Poll DB until all agents finish or timeout.
-	results, pollErr := pollAgents(ctx, d, agents, agentSessions, opts.Timeout)
+	// Poll DB until all live agents finish or timeout.
+	liveResults, pollErr := pollAgents(ctx, d, liveAgents, liveSessions, opts.Timeout, liveSpawnTimes, opts.OnProgress)
 
 	// Sessions persist — do NOT kill them here. The user can re-read them later.
-	// Sidecar processes are cleaned up since the agent has finished.
-	for _, agentSession := range agentSessions {
+	// Sidecar processes are cleaned up since the agents have finished.
+	for _, agentSession := range liveSessions {
 		session.KillSidecar(agentSession)
+	}
+
+	// Merge live results with spawn-failure results, preserving original agent order.
+	results := make([]AgentResult, len(agents))
+	liveIdx := 0
+	for i, ag := range agents {
+		if spawnErr[i] != nil {
+			results[i] = AgentResult{
+				Agent:   ag,
+				Passed:  false,
+				Output:  fmt.Sprintf("ERROR: failed to spawn agent: %v", spawnErr[i]),
+				IsError: true,
+			}
+		} else {
+			results[i] = liveResults[liveIdx]
+			liveIdx++
+		}
 	}
 
 	return results, pollErr
@@ -477,7 +548,10 @@ func buildReadinessWaitCmd(readyPath, attachCmd string) string {
 }
 
 // pollAgents polls the DB until all agents reach "finished" or the timeout expires.
-func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration) ([]AgentResult, error) {
+// spawnTimes[i] is the time agent i was spawned; used to compute durations for
+// progress output. onProgress is called for each "finished" or "timed out" event;
+// it may be nil.
+func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string)) ([]AgentResult, error) {
 	if timeout <= 0 {
 		timeout = 10 * time.Minute
 	}
@@ -502,8 +576,18 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 			}
 			if status != nil && isTerminalState(status.State) {
 				finished[i] = true
+				// Emit "finished" progress line.
+				if onProgress != nil {
+					elapsed := time.Since(spawnTimes[i])
+					onProgress(fmt.Sprintf("%s finished in %s", FormatAgentDisplayName(agents[i].Name), FormatProgressDuration(elapsed)))
+				}
 			} else if time.Now().After(deadline) {
 				timedOut[i] = true
+				// Emit "timed out" progress line.
+				if onProgress != nil {
+					elapsed := time.Since(spawnTimes[i])
+					onProgress(fmt.Sprintf("%s timed out after %s", FormatAgentDisplayName(agents[i].Name), FormatProgressDuration(elapsed)))
+				}
 			} else {
 				allDone = false
 			}
@@ -522,10 +606,14 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 		}
 
 		if time.Now().After(deadline) {
-			// Mark all remaining as timed out.
+			// Mark all remaining as timed out and emit progress lines.
 			for i := range agents {
-				if !finished[i] {
+				if !finished[i] && !timedOut[i] {
 					timedOut[i] = true
+					if onProgress != nil {
+						elapsed := time.Since(spawnTimes[i])
+						onProgress(fmt.Sprintf("%s timed out after %s", FormatAgentDisplayName(agents[i].Name), FormatProgressDuration(elapsed)))
+					}
 				}
 			}
 			break
@@ -560,6 +648,13 @@ func isTerminalState(state string) bool {
 // Production code calls buildResults directly (via pollAgents).
 func BuildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
 	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, cancelled)
+}
+
+// PollAgentsForTest is an exported wrapper around pollAgents for use in tests.
+// It accepts pre-seeded DB rows and returns both results and the progress lines
+// emitted via onProgress.
+func PollAgentsForTest(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string)) ([]AgentResult, error) {
+	return pollAgents(ctx, d, agents, agentSessions, timeout, spawnTimes, onProgress)
 }
 
 // buildResults constructs AgentResult entries from polling outcomes.

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1281,6 +1281,67 @@ func TestPollAgents_ProgressCallback_Timeout(t *testing.T) {
 	}
 }
 
+// TestRun_ProgressCallback_SpawnFailure verifies that when an agent fails to
+// spawn due to a configuration error (container mode with nil ProfilesFile),
+// a "failed to start" progress line is emitted immediately and the overall run
+// returns an error. This covers the spawn-failure path AC from issue #782:
+// "unit tests verify the progress-line output format for spawn-failure path."
+//
+// The ResolveAgentConfigContent failure path fires after successful DB
+// operations (UpsertStatus, AllocatePort) but before any tmux session is
+// created — so no tmux is needed for this test.
+func TestRun_ProgressCallback_SpawnFailure(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+
+	// Single agent to keep the test focused.
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+	}
+
+	// container mode with nil ProfilesFile triggers ResolveAgentConfigContent
+	// to return a "nil ProfilesFile" error before any tmux session is created.
+	opts := review.Opts{
+		PRNumber:      "999",
+		ParentSession: "test@spawn-failure",
+		Worktree:      t.TempDir(),
+		Agents:        agents,
+		Timeout:       30 * time.Second,
+		DBPath:        dbPath,
+		ContainerMode: true,
+		ProfilesFile:  nil,
+	}
+
+	var progressLines []string
+	opts.OnProgress = func(line string) {
+		progressLines = append(progressLines, line)
+	}
+
+	ctx := context.Background()
+	_, err := review.Run(ctx, opts, nil)
+
+	// Run must return an error when all agents fail to spawn.
+	if err == nil {
+		t.Fatal("Run: expected error when all agents fail to spawn, got nil")
+	}
+
+	// At least one progress line must have been emitted.
+	if len(progressLines) == 0 {
+		t.Fatal("Run: expected at least one progress line for spawn failure, got none")
+	}
+
+	// The progress line must contain the display name and "failed to start".
+	if !linesContain(progressLines, "Review-Goal failed to start") {
+		t.Errorf("expected 'Review-Goal failed to start' in progress lines, got: %v", progressLines)
+	}
+
+	// Must NOT emit a "started" line — spawn failed before session creation.
+	for _, line := range progressLines {
+		if len(line) > 0 && findSubstring(line, "Review-Goal started") {
+			t.Errorf("unexpected 'started' line emitted on spawn failure: %q", line)
+		}
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // linesContain returns true if any of the given lines contains sub.

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1,6 +1,7 @@
 package review_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1054,7 +1055,243 @@ func TestResolveAgentConfigContent_ContainerMode_WorkerRole(t *testing.T) {
 	}
 }
 
+// ── FormatAgentDisplayName ────────────────────────────────────────────────────
+
+// TestFormatAgentDisplayName_AllAgents verifies that the five review agent
+// names produce the expected title-cased display names for progress output.
+func TestFormatAgentDisplayName_AllAgents(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"review-goal", "Review-Goal"},
+		{"review-code", "Review-Code"},
+		{"review-security", "Review-Security"},
+		{"review-qa", "Review-Qa"},
+		{"review-context", "Review-Context"},
+	}
+	for _, tc := range cases {
+		got := review.FormatAgentDisplayName(tc.input)
+		if got != tc.want {
+			t.Errorf("FormatAgentDisplayName(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestFormatAgentDisplayName_SingleWord verifies that a single-word name is
+// capitalised correctly.
+func TestFormatAgentDisplayName_SingleWord(t *testing.T) {
+	got := review.FormatAgentDisplayName("worker")
+	if got != "Worker" {
+		t.Errorf("FormatAgentDisplayName(%q) = %q, want %q", "worker", got, "Worker")
+	}
+}
+
+// ── FormatProgressDuration ────────────────────────────────────────────────────
+
+// TestFormatProgressDuration_BelowMinute verifies the "Xs.Xf" format for
+// durations below 60 seconds.
+func TestFormatProgressDuration_BelowMinute(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{28*time.Second + 400*time.Millisecond, "28.4s"},
+		{0, "0.0s"},
+		{1*time.Second + 100*time.Millisecond, "1.1s"},
+		{59*time.Second + 900*time.Millisecond, "59.9s"},
+	}
+	for _, tc := range cases {
+		got := review.FormatProgressDuration(tc.d)
+		if got != tc.want {
+			t.Errorf("FormatProgressDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// TestFormatProgressDuration_AtOrAboveMinute verifies the "Xm Ys" format for
+// durations at or above 60 seconds.
+func TestFormatProgressDuration_AtOrAboveMinute(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{60 * time.Second, "1m0s"},
+		{72 * time.Second, "1m12s"},
+		{90 * time.Second, "1m30s"},
+		{125 * time.Second, "2m5s"},
+	}
+	for _, tc := range cases {
+		got := review.FormatProgressDuration(tc.d)
+		if got != tc.want {
+			t.Errorf("FormatProgressDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// ── Progress callback (OnProgress) ───────────────────────────────────────────
+
+// TestPollAgents_ProgressCallback_HappyPath verifies that PollAgentsForTest
+// emits one "finished" progress line per agent when all agents complete
+// successfully. This covers the happy-path AC: progress lines are emitted in
+// completion order, not start order.
+func TestPollAgents_ProgressCallback_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-code", OpencodeName: "review-code"},
+	}
+	sessions := []string{
+		"test@parent~review-1-review-goal",
+		"test@parent~review-1-review-code",
+	}
+
+	// Pre-seed both agents as finished.
+	for _, sess := range sessions {
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+	}
+
+	var lines []string
+	spawnTimes := []time.Time{time.Now(), time.Now()}
+
+	results, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Minute, spawnTimes, func(line string) {
+		lines = append(lines, line)
+	})
+	if err != nil {
+		t.Fatalf("PollAgentsForTest: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("PollAgentsForTest: got %d results, want 2", len(results))
+	}
+
+	// Exactly 2 "finished" progress lines must have been emitted.
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 progress lines, got %d: %v", len(lines), lines)
+	}
+	// Each line must match the "Review-X finished in Ys.Yf" pattern.
+	for _, line := range lines {
+		if !findSubstring(line, "finished in") {
+			t.Errorf("progress line %q does not contain 'finished in'", line)
+		}
+	}
+	// review-goal must appear in one of the lines.
+	if !linesContain(lines, "Review-Goal finished") {
+		t.Errorf("expected a 'Review-Goal finished' line, got: %v", lines)
+	}
+	// review-code must appear in one of the lines.
+	if !linesContain(lines, "Review-Code finished") {
+		t.Errorf("expected a 'Review-Code finished' line, got: %v", lines)
+	}
+}
+
+// TestPollAgents_ProgressCallback_OnlySubset verifies that when a subset of
+// agents is requested (simulating --only), progress lines are emitted only for
+// the requested agents — not for the full 5-agent set.
+func TestPollAgents_ProgressCallback_OnlySubset(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	// Only 2 agents (simulating --only review-code,review-qa).
+	agents := []review.Agent{
+		{Name: "review-code", OpencodeName: "review-code"},
+		{Name: "review-qa", OpencodeName: "review-qa"},
+	}
+	sessions := []string{
+		"test@parent~review-1-review-code",
+		"test@parent~review-1-review-qa",
+	}
+	for _, sess := range sessions {
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+	}
+
+	var lines []string
+	spawnTimes := []time.Time{time.Now(), time.Now()}
+
+	_, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Minute, spawnTimes, func(line string) {
+		lines = append(lines, line)
+	})
+	if err != nil {
+		t.Fatalf("PollAgentsForTest: %v", err)
+	}
+
+	// Exactly 2 finished lines — not 5 (no stray lines for the other agents).
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 progress lines for --only subset, got %d: %v", len(lines), lines)
+	}
+	if !linesContain(lines, "Review-Code finished") {
+		t.Errorf("expected 'Review-Code finished' line, got: %v", lines)
+	}
+	if !linesContain(lines, "Review-Qa finished") {
+		t.Errorf("expected 'Review-Qa finished' line, got: %v", lines)
+	}
+	// Must not contain lines for agents outside the subset.
+	for _, line := range lines {
+		for _, unexpected := range []string{"Review-Goal", "Review-Security", "Review-Context"} {
+			if findSubstring(line, unexpected) {
+				t.Errorf("unexpected progress line for out-of-subset agent: %q", line)
+			}
+		}
+	}
+}
+
+// TestPollAgents_ProgressCallback_Timeout verifies that when an agent times
+// out, a "timed out after <duration>" progress line is emitted and the
+// remaining agents continue.
+func TestPollAgents_ProgressCallback_Timeout(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-code", OpencodeName: "review-code"},
+	}
+	sessions := []string{
+		"test@parent~review-5-review-goal",
+		"test@parent~review-5-review-code",
+	}
+
+	// review-goal is finished; review-code stays idle (will time out).
+	if err := d.UpsertStatus(sessions[0], "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus(sessions[1], "nixos-config", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	var lines []string
+	spawnTimes := []time.Time{time.Now(), time.Now()}
+
+	// Very short timeout so review-code times out quickly.
+	_, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Millisecond, spawnTimes, func(line string) {
+		lines = append(lines, line)
+	})
+	if err != nil {
+		t.Fatalf("PollAgentsForTest: %v", err)
+	}
+
+	// Must have at least one "timed out after" line for review-code.
+	if !linesContain(lines, "Review-Code timed out after") {
+		t.Errorf("expected 'Review-Code timed out after' line, got: %v", lines)
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+// linesContain returns true if any of the given lines contains sub.
+func linesContain(lines []string, sub string) bool {
+	for _, line := range lines {
+		if findSubstring(line, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 // countResultLines counts lines in output that start with ✓ or ✗ (result lines).
 func countResultLines(output string) int {


### PR DESCRIPTION
## Summary

- Adds real-time progress output to `prism review`: one `<Agent-Name> started` line per agent immediately after spawn, and one `<Agent-Name> finished in <duration>` line when each agent completes.
- Stdout is explicitly flushed via `os.Stdout.Sync()` after each progress line so the enclosing `bash` tool invocation surfaces them as they arrive through a pipe.
- Improves spawn-failure handling: a failing agent emits `<Agent-Name> failed to start: <error>` and remaining agents continue (previously the whole run aborted on first failure).
- Duration format: `28.4s` below 60s, `1m12s` at or above 60s.
- A blank line separates the progress output from the existing aggregated pass/fail summary (unchanged).

## Output shape

```
Review-Goal started
Review-Code started
Review-Security started
Review-Qa started
Review-Context started
Review-Goal finished in 28.4s
Review-Qa finished in 31.1s
Review-Code finished in 45.7s
Review-Security finished in 47.2s
Review-Context finished in 52.9s

✓ review-goal              passed
✓ review-code              passed
...
```

## Changes

- `internal/review/review.go`:
  - `Opts.OnProgress` callback field for progress events
  - `FormatAgentDisplayName()` — title-cases agent names for display (`review-goal` → `Review-Goal`)
  - `FormatProgressDuration()` — human-readable duration format
  - `PollAgentsForTest()` — exported test wrapper around `pollAgents`
  - `pollAgents()` receives spawn times and `onProgress` callback, emits `finished`/`timed out` lines in completion order
  - Spawn loop: fault-tolerant (failed agents emit `failed to start`, rest continue)

- `cmd/review.go`:
  - Wires `progressLine` closure as `opts.OnProgress` with `os.Stdout.Sync()` flush after each write
  - Prints blank line separator before the aggregated summary

- `internal/review/review_test.go`:
  - `TestFormatAgentDisplayName_AllAgents` / `_SingleWord`
  - `TestFormatProgressDuration_BelowMinute` / `_AtOrAboveMinute`
  - `TestPollAgents_ProgressCallback_HappyPath`
  - `TestPollAgents_ProgressCallback_OnlySubset`
  - `TestPollAgents_ProgressCallback_Timeout`

Closes #782