### PR TITLE
prism: pass --sig-proxy=false to podman attach so Ctrl-C interrupts the opencode turn instead of killing the container

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -101,7 +101,7 @@ func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 }
 
 // TestBuildOpencodeCmd_ContainerMode verifies that container mode produces the
-// correct "podman attach <container-name>" command (RFC #691, Phase 1a / Issue #715).
+// correct "podman attach --sig-proxy=false <container-name>" command (RFC #691, Phase 1a / Issue #715).
 func TestBuildOpencodeCmd_ContainerMode(t *testing.T) {
 	cases := []struct {
 		opts session.Opts
@@ -110,11 +110,11 @@ func TestBuildOpencodeCmd_ContainerMode(t *testing.T) {
 		// Container mode with SessionName — should use podman attach with the
 		// stable container name derived from the session name (single-quoted for
 		// shell safety when embedded in the readiness wait script).
-		{session.Opts{ContainerMode: true, SessionName: "repo@main", Port: 14000}, "podman attach 'prism-repo-main'"},
+		{session.Opts{ContainerMode: true, SessionName: "repo@main", Port: 14000}, "podman attach --sig-proxy=false 'prism-repo-main'"},
 		// Different session name — container name is derived correctly.
-		{session.Opts{ContainerMode: true, SessionName: "nixos-config@feature", Port: 14042}, "podman attach 'prism-nixos-config-feature'"},
+		{session.Opts{ContainerMode: true, SessionName: "nixos-config@feature", Port: 14042}, "podman attach --sig-proxy=false 'prism-nixos-config-feature'"},
 		// Agent role is irrelevant in container mode (podman attach is role-agnostic).
-		{session.Opts{ContainerMode: true, SessionName: "repo@branch", Port: 14001, Agent: "coordinator"}, "podman attach 'prism-repo-branch'"},
+		{session.Opts{ContainerMode: true, SessionName: "repo@branch", Port: 14001, Agent: "coordinator"}, "podman attach --sig-proxy=false 'prism-repo-branch'"},
 		// Container mode with no SessionName falls back to direct launch (safety net).
 		{session.Opts{ContainerMode: true, SessionName: "", Port: 0, Agent: "worker"}, "opencode --agent worker"},
 		// Non-container mode is unaffected.

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -502,7 +502,7 @@ func TestRestoreSession_AllThreeWindows(t *testing.T) {
 
 // TestRestoreSession_ContainerMode verifies that when cfg.ContainerMode is
 // enabled and the persisted session is not marked host_mode, restore uses
-// the container-mode agent command ("podman attach <container-name>")
+// the container-mode agent command ("podman attach --sig-proxy=false <container-name>")
 // rather than launching opencode directly. It also asserts that the
 // PluginHostPath is propagated from cfg into opts so the sidecar bind-mounts
 // the plugin file.
@@ -537,13 +537,13 @@ func TestRestoreSession_ContainerMode(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// The agent pane start command must contain "podman attach 'prism-myrepo-container-restore'",
+	// The agent pane start command must contain "podman attach --sig-proxy=false 'prism-myrepo-container-restore'",
 	// not "opencode --agent". The container name is derived from the session name via
 	// container.NameForSession("myrepo@container-restore") = "prism-myrepo-container-restore".
 	// The name is single-quoted for shell safety in the readiness wait script.
 	pane := agentPaneStartCmd(t, s, sessionName)
-	if !strings.Contains(pane, "podman attach 'prism-myrepo-container-restore'") {
-		t.Errorf("agent pane missing 'podman attach 'prism-myrepo-container-restore'' — captured:\n%s", pane)
+	if !strings.Contains(pane, "podman attach --sig-proxy=false 'prism-myrepo-container-restore'") {
+		t.Errorf("agent pane missing 'podman attach --sig-proxy=false 'prism-myrepo-container-restore'' — captured:\n%s", pane)
 	}
 	if strings.Contains(pane, "opencode --agent") {
 		t.Errorf("agent pane contains 'opencode --agent' but should be in container mode — captured:\n%s", pane)

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -424,10 +424,14 @@ func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, c
 	if containerMode {
 		// Use podman attach to bridge the tmux pane to the container's PTY.
 		// The container runs opencode in combined TUI + HTTP mode (RFC #691, Phase 1a).
+		// --sig-proxy=false prevents podman from forwarding signals (e.g. SIGINT from
+		// Ctrl-C) to the container process; instead the ^C byte reaches opencode's TUI
+		// as literal stdin input, which it handles as an interrupt keystroke — matching
+		// host-mode behaviour where Ctrl-C interrupts the current turn, not the process.
 		// The container name is shell-quoted so that any unexpected characters in
 		// the session name cannot be interpreted as shell metacharacters when
 		// buildReadinessWaitCmd embeds this string in the readiness shell script.
-		return "podman attach " + shellQuote(container.NameForSession(agentSession))
+		return "podman attach --sig-proxy=false " + shellQuote(container.NameForSession(agentSession))
 	}
 	escapedPrompt := shellQuote(prompt)
 	return fmt.Sprintf("PRISM_SESSION_NAME=%s opencode --agent %s --port %d --hostname 127.0.0.1 --prompt %s",

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -159,10 +159,14 @@ func BuildOpencodeCmd(opts Opts) string {
 		// Use podman attach to bridge the tmux pane to the container's PTY.
 		// The container runs opencode in combined TUI + HTTP mode; "podman attach"
 		// connects stdin/stdout to the container PTY so the TUI is fully interactive.
+		// --sig-proxy=false prevents podman from forwarding signals (e.g. SIGINT from
+		// Ctrl-C) to the container process; instead the ^C byte reaches opencode's TUI
+		// as literal stdin input, which it handles as an interrupt keystroke — matching
+		// host-mode behaviour where Ctrl-C interrupts the current turn, not the process.
 		// The container name is shell-quoted so that any unexpected characters in
 		// the session name cannot be interpreted as shell metacharacters when
 		// buildReadinessWaitCmd embeds this string in the readiness shell script.
-		return "podman attach " + shellQuote(container.NameForSession(opts.SessionName))
+		return "podman attach --sig-proxy=false " + shellQuote(container.NameForSession(opts.SessionName))
 	}
 	return buildDirectOpencodeCmd(opts)
 }

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -195,14 +195,14 @@ func TestStartSidecar_CreatesDirectories(t *testing.T) {
 func TestBuildReadinessWaitCmd_ContainsReadyPath(t *testing.T) {
 	cmd := buildReadinessWaitCmd(
 		"/home/user/.local/state/prism/run/my-session-sidecar.ready",
-		"podman attach prism-repo-main")
+		"podman attach --sig-proxy=false prism-repo-main")
 	if !strings.Contains(cmd, "/home/user/.local/state/prism/run/my-session-sidecar.ready") {
 		t.Errorf("readiness command does not reference ready path: %q", cmd)
 	}
 }
 
 func TestBuildReadinessWaitCmd_ContainsAttachCmd(t *testing.T) {
-	attach := "podman attach prism-nixos-config-feature"
+	attach := "podman attach --sig-proxy=false prism-nixos-config-feature"
 	cmd := buildReadinessWaitCmd("/tmp/test.ready", attach)
 	if !strings.Contains(cmd, attach) {
 		t.Errorf("readiness command does not contain attach command %q: %q", attach, cmd)
@@ -210,7 +210,7 @@ func TestBuildReadinessWaitCmd_ContainsAttachCmd(t *testing.T) {
 }
 
 func TestBuildReadinessWaitCmd_TimeoutMessage(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach --sig-proxy=false prism-repo-main")
 	// Verify the timeout message matches 120s (240 iterations × 0.5s).
 	if !strings.Contains(cmd, "120s") {
 		t.Errorf("readiness command should mention 120s timeout: %q", cmd)
@@ -224,7 +224,7 @@ func TestBuildReadinessWaitCmd_TimeoutMessage(t *testing.T) {
 func TestBuildReadinessWaitCmd_PathWithSpaces(t *testing.T) {
 	// Path with spaces must be properly quoted.
 	path := "/home/user name/.local/state/prism/run/my session-sidecar.ready"
-	cmd := buildReadinessWaitCmd(path, "podman attach prism-repo-main")
+	cmd := buildReadinessWaitCmd(path, "podman attach --sig-proxy=false prism-repo-main")
 	// The path should be single-quoted.
 	if !strings.Contains(cmd, "'"+path+"'") {
 		t.Errorf("path with spaces not properly quoted in command: %q", cmd)
@@ -232,7 +232,7 @@ func TestBuildReadinessWaitCmd_PathWithSpaces(t *testing.T) {
 }
 
 func TestBuildReadinessWaitCmd_ExitsOneOnTimeout(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach --sig-proxy=false prism-repo-main")
 	if !strings.Contains(cmd, "exit 1") {
 		t.Errorf("readiness command should exit 1 on timeout: %q", cmd)
 	}
@@ -240,9 +240,9 @@ func TestBuildReadinessWaitCmd_ExitsOneOnTimeout(t *testing.T) {
 
 // TestBuildReadinessWaitCmd_NoSidHandoff verifies that the readiness wait
 // script does not contain any .sid file read or -s flag injection.
-// "podman attach" connects to the container PTY directly (RFC #691, Phase 1a).
+// "podman attach --sig-proxy=false" connects to the container PTY directly (RFC #691, Phase 1a).
 func TestBuildReadinessWaitCmd_NoSidHandoff(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach prism-repo-main")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach --sig-proxy=false prism-repo-main")
 	if strings.Contains(cmd, ".sid") {
 		t.Errorf("readiness command should not reference .sid file: %q", cmd)
 	}


### PR DESCRIPTION
## Summary

In container mode, `podman attach` by default proxies signals from the attaching terminal to the container's PID 1. This means Ctrl-C sends SIGINT directly to opencode (running as PID 1), killing it — rather than being read as a keystroke by opencode's TUI interrupt handler, which is the desired behaviour.

`--sig-proxy=false` tells podman not to forward signals. The `^C` byte then reaches opencode via stdin as literal input, which the TUI handles as an interrupt-current-turn keystroke — matching host-mode behaviour exactly.

## Changes

- `internal/session/session.go`: Updated `BuildOpencodeCmd` to use `podman attach --sig-proxy=false` for container-mode sessions
- `internal/review/review.go`: Updated `buildAgentCommand` to use `podman attach --sig-proxy=false` for review-agent sessions
- Updated all test assertions that encode the exact command string (`sidecar_test.go`, `agent_default_test.go`, `restore_test.go`)
- Updated nearby comments to clarify the purpose of `--sig-proxy=false`

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all 17 packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #800