### PR TITLE
fix: add mode=primary to review agent in makeReviewAgentBlob

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -918,6 +918,7 @@
           })
           // {
             ${agentName} = {
+              mode = "primary";
               tools = {
                 task = false;
               };


### PR DESCRIPTION
## Summary

- Fixes a crash in all review-agent containers where opencode's TUI would crash at boot with `TypeError: undefined is not an object (evaluating 'agents()[0].name')`.
- Root cause: `makeReviewAgentBlob` in `opencode.nix` was constructing the target review agent entry without a `mode` field. Opencode silently drops agents without a `mode` from the displayable list; with all other agents explicitly `disable: true`, the filtered array was empty, causing the immediate crash.
- Fix: one line — `mode = "primary"` added alongside `tools.task = false` in the `agentName` entry. Because `makeReviewAgentBlob` is shared by all five review container blobs, this fixes `review-goal`, `review-code`, `review-security`, `review-qa`, and `review-context` in one shot.

## Verification

- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅ passes.
- Live container reproduction was already performed by the coordinator (see issue #802 for full steps): patching the mounted config JSON with `mode = "primary"` produced a clean TUI boot to `Review-Goal · Claude Sonnet 4.6 · Anthropic` as expected.

## Review note

This PR is the fix for the review-agent crash. Running `prism review` on this PR would exercise the pre-fix code (the images haven't been rebuilt yet), so review cycles are skipped per the coordinator's instruction. The coordinator will perform a sense-check merge directly.

## Changed files

- `modules/programs/prism/opencode.nix` — one-line addition in `makeReviewAgentBlob`

Closes #802