### PR TITLE
ci: broaden publish-prism-agent path filter to modules/programs/prism/**

### DIFF
--- a/.github/workflows/publish-prism-agent.yml
+++ b/.github/workflows/publish-prism-agent.yml
@@ -7,7 +7,7 @@ name: publish-prism-agent
       - 'images/prism-agent.nix'
       - 'flake.nix'
       - 'flake.lock'
-      - 'modules/programs/prism/prism/**'
+      - 'modules/programs/prism/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Broadens the `on.push.paths` filter in `.github/workflows/publish-prism-agent.yml` from the narrow `modules/programs/prism/prism/**` (Go source only) to the full `modules/programs/prism/**`, so any image-affecting change under the prism module tree triggers a rebuild.

This fixes the silent-staleness failure mode described in #807: changes to `opencode.nix`, `profiles.nix`, `opencode/agents/**`, `opencode/skills/**`, and `opencode/plugins/**` previously did not trigger `publish-prism-agent`, meaning the container image could lag behind main indefinitely until an unrelated Go change happened to trigger a rebuild.

## Changes

- `.github/workflows/publish-prism-agent.yml`: replace `modules/programs/prism/prism/**` with `modules/programs/prism/**` in the `paths:` filter. No other changes.

## Path filter after change

```yaml
paths:
  - 'images/prism-agent.nix'
  - 'flake.nix'
  - 'flake.lock'
  - 'modules/programs/prism/**'
```

The `modules/programs/prism/prism/**` entry is removed as it is a strict subset of the new broader glob.

Closes #807