### PR TITLE
review-prompts: document each agent's bash allowlist inline

### DIFF
--- a/modules/programs/prism/review-prompts/review-code.md
+++ b/modules/programs/prism/review-prompts/review-code.md
@@ -4,15 +4,30 @@ You do not check whether the right thing was built (that is `@review-goal`), whe
 
 ---
 
+## Tools available
+
+You do NOT have `gh` CLI access in this session. To inspect the PR:
+
+- The PR's head branch is already checked out as your worktree (your current working directory).
+- Use `git status` to confirm which branch you are on and `git log --oneline -20` to see recent history.
+- Use `git diff origin/<base>...HEAD -- <path>` to see the PR's diff. Replace `<base>` with the target branch (usually `main`).
+- Use `git show <ref>:<path>` to read a file at any revision.
+- `webfetch` is available if you need to retrieve external content (e.g. GitHub UI pages for the PR body or linked issues).
+
+The PR number for your review will be given in the prompt below.
+
+---
+
 ## Reading the PR
 
 Use these commands to gather context — never modify the working tree:
 
 ```bash
-gh pr view <number>              # PR title, description
-gh pr diff <number>              # the diff
-git show origin/<branch>:<path>  # read full files from the PR branch (not just the diff)
-git diff origin/main...origin/<branch>  # cross-branch diff
+git log --oneline -20                          # recent commits on this branch
+git diff origin/main...HEAD                    # the PR's full diff
+git diff origin/main...HEAD -- <path>          # diff for a specific file
+git show HEAD:<path>                           # read a file at the PR branch tip
+git show origin/main:<path>                   # read a file at main
 ```
 
 **Always read the full files being modified** — diffs alone are not enough. Code that looks wrong in isolation may be correct given surrounding logic, and vice versa.

--- a/modules/programs/prism/review-prompts/review-code.md
+++ b/modules/programs/prism/review-prompts/review-code.md
@@ -27,7 +27,7 @@ git log --oneline -20                          # recent commits on this branch
 git diff origin/main...HEAD                    # the PR's full diff
 git diff origin/main...HEAD -- <path>          # diff for a specific file
 git show HEAD:<path>                           # read a file at the PR branch tip
-git show origin/main:<path>                   # read a file at main
+git show origin/main:<path>                    # read a file at main
 ```
 
 **Always read the full files being modified** — diffs alone are not enough. Code that looks wrong in isolation may be correct given surrounding logic, and vice versa.

--- a/modules/programs/prism/review-prompts/review-context.md
+++ b/modules/programs/prism/review-prompts/review-context.md
@@ -4,6 +4,25 @@ You investigate whether the implementation missed relevant context from git hist
 
 ---
 
+## Tools available
+
+You have read-only `gh` CLI access for inspecting PRs, issues, runs, and repo metadata:
+- `gh pr view <n>`, `gh pr list`, `gh pr diff <n>`, `gh pr checks <n>`
+- `gh issue view <n>`, `gh issue list`
+- `gh repo view`
+- `gh run view <n>`, `gh run list`
+
+Use these freely — your role is to find and synthesise context that other review agents cannot see. You do NOT have `gh` commands that modify state (e.g. `gh pr merge`, `gh issue close`). Those are denied by the sandbox regardless.
+
+For reading the worktree, `git` is also available:
+- Use `git log --oneline -20` to see recent branch history.
+- Use `git diff origin/<base>...HEAD` to see the PR's diff.
+- Use `git show <ref>:<path>` to read a file at any revision.
+
+The PR number for your review will be given in the prompt below.
+
+---
+
 ## Reading the PR
 
 Use these commands to gather context — never modify the working tree:
@@ -11,8 +30,10 @@ Use these commands to gather context — never modify the working tree:
 ```bash
 gh pr view <number>              # PR title, description, branch name, linked issues
 gh pr diff <number>              # the diff
-git show origin/<branch>:<path>  # read full files from the PR branch
-git diff origin/main...origin/<branch>  # cross-branch comparison
+gh issue view <N>                # the original issue (from Closes #N in PR body)
+git log --oneline -20            # recent commits on this branch
+git diff origin/main...HEAD      # cross-branch comparison
+git show HEAD:<path>             # read a file at the PR branch tip
 ```
 
 **Never** use `git checkout`, `git stash`, `git apply`, or any command that modifies files or the index.

--- a/modules/programs/prism/review-prompts/review-goal.md
+++ b/modules/programs/prism/review-prompts/review-goal.md
@@ -27,7 +27,7 @@ git log --oneline -20                          # recent commits on this branch
 git diff origin/main...HEAD                    # the PR's full diff
 git diff origin/main...HEAD -- <path>          # diff for a specific file
 git show HEAD:<path>                           # read a file at the PR branch tip
-git show origin/main:<path>                   # read a file at main
+git show origin/main:<path>                    # read a file at main
 ```
 
 **Never** use `git checkout`, `git stash`, `git apply`, or any command that modifies files or the index.

--- a/modules/programs/prism/review-prompts/review-goal.md
+++ b/modules/programs/prism/review-prompts/review-goal.md
@@ -4,16 +4,30 @@ You do not comment on code quality, style, or security unless they directly caus
 
 ---
 
+## Tools available
+
+You do NOT have `gh` CLI access in this session. To inspect the PR:
+
+- The PR's head branch is already checked out as your worktree (your current working directory).
+- Use `git status` to confirm which branch you are on and `git log --oneline -20` to see recent history.
+- Use `git diff origin/<base>...HEAD -- <path>` to see the PR's diff. Replace `<base>` with the target branch (usually `main`).
+- Use `git show <ref>:<path>` to read a file at any revision.
+- `webfetch` is available if you need to retrieve external content (e.g. GitHub UI pages for the PR body or linked issues).
+
+The PR number for your review will be given in the prompt below.
+
+---
+
 ## Reading the PR
 
 Use these commands to gather context — never modify the working tree:
 
 ```bash
-gh pr view <number>              # PR title, description, linked issues
-gh pr diff <number>              # the diff
-gh issue view <N>                # the original issue (from Closes #N in PR body)
-git show origin/<branch>:<path>  # read full files from the PR branch
-git diff origin/main...origin/<branch>  # cross-branch diff
+git log --oneline -20                          # recent commits on this branch
+git diff origin/main...HEAD                    # the PR's full diff
+git diff origin/main...HEAD -- <path>          # diff for a specific file
+git show HEAD:<path>                           # read a file at the PR branch tip
+git show origin/main:<path>                   # read a file at main
 ```
 
 **Never** use `git checkout`, `git stash`, `git apply`, or any command that modifies files or the index.

--- a/modules/programs/prism/review-prompts/review-qa.md
+++ b/modules/programs/prism/review-prompts/review-qa.md
@@ -31,15 +31,15 @@ git log --oneline -20                          # recent commits on this branch
 git diff origin/main...HEAD                    # the PR's full diff
 git diff origin/main...HEAD -- <path>          # diff for a specific file
 git show HEAD:<path>                           # read a file at the PR branch tip
-git show origin/main:<path>                   # read a file at main
+git show origin/main:<path>                    # read a file at main
 ```
 
 **Working-tree safety — CRITICAL:** Never modify the working tree or index.
 
 - **Never** use `git checkout <branch> -- <path>` — this stages files into the working tree
 - **Never** use `git stash`, `git apply`, `git merge`, or any command that modifies files or the index
-- **Always** use `git show origin/<branch>:<path>` to read full file contents from the PR branch
-- **Always** use `git diff origin/main...origin/<branch>` for cross-branch diff comparison
+- **Always** use `git show HEAD:<path>` to read full file contents from the PR branch
+- **Always** use `git diff origin/main...HEAD` for cross-branch diff comparison
 
 For validation that requires executing code: run commands against files read via `git show` (e.g. pipe to a temp file), or run against the current checked-out state if appropriate. Do not check out the PR branch.
 

--- a/modules/programs/prism/review-prompts/review-qa.md
+++ b/modules/programs/prism/review-prompts/review-qa.md
@@ -4,15 +4,34 @@ You verify functionality by executing validation appropriate for the project typ
 
 ---
 
+## Tools available
+
+You do NOT have `gh` CLI access in this session. Use `git` for PR inspection:
+
+- The PR's head branch is already checked out as your worktree (your current working directory).
+- Use `git status` to confirm which branch you are on and `git log --oneline -20` to see recent history.
+- Use `git diff origin/<base>...HEAD -- <path>` to see the PR's diff. Replace `<base>` with the target branch (usually `main`).
+- Use `git show <ref>:<path>` to read a file at any revision.
+- `webfetch` is available if you need to retrieve external content (e.g. GitHub UI pages for the PR body or linked issues).
+
+You DO have build/test runners available for verification:
+- `go build ./...`, `go test ./...`, `go vet ./...`
+- `nix build <path>`, `nix flake check <path>`
+
+The PR number for your review will be given in the prompt below.
+
+---
+
 ## Reading the PR
 
 Use these commands to gather context — never modify the working tree:
 
 ```bash
-gh pr view <number>              # PR title, description, branch name
-gh pr diff <number>              # the diff
-git show origin/<branch>:<path>  # read full files from the PR branch
-git diff origin/main...origin/<branch>  # cross-branch diff
+git log --oneline -20                          # recent commits on this branch
+git diff origin/main...HEAD                    # the PR's full diff
+git diff origin/main...HEAD -- <path>          # diff for a specific file
+git show HEAD:<path>                           # read a file at the PR branch tip
+git show origin/main:<path>                   # read a file at main
 ```
 
 **Working-tree safety — CRITICAL:** Never modify the working tree or index.

--- a/modules/programs/prism/review-prompts/review-security.md
+++ b/modules/programs/prism/review-prompts/review-security.md
@@ -27,7 +27,7 @@ git log --oneline -20                          # recent commits on this branch
 git diff origin/main...HEAD                    # the PR's full diff
 git diff origin/main...HEAD -- <path>          # diff for a specific file
 git show HEAD:<path>                           # read a file at the PR branch tip
-git show origin/main:<path>                   # read a file at main
+git show origin/main:<path>                    # read a file at main
 ```
 
 **Always read the full files** for any security-sensitive code — authentication, input handling, file operations, network code, cryptography. Partial diffs are not sufficient for security review.

--- a/modules/programs/prism/review-prompts/review-security.md
+++ b/modules/programs/prism/review-prompts/review-security.md
@@ -4,15 +4,30 @@ You do not comment on code style, functionality, or requirements unless they cre
 
 ---
 
+## Tools available
+
+You do NOT have `gh` CLI access in this session. To inspect the PR:
+
+- The PR's head branch is already checked out as your worktree (your current working directory).
+- Use `git status` to confirm which branch you are on and `git log --oneline -20` to see recent history.
+- Use `git diff origin/<base>...HEAD -- <path>` to see the PR's diff. Replace `<base>` with the target branch (usually `main`).
+- Use `git show <ref>:<path>` to read a file at any revision.
+- `webfetch` is available if you need to retrieve external content (e.g. GitHub UI pages for the PR body or linked issues).
+
+The PR number for your review will be given in the prompt below.
+
+---
+
 ## Reading the PR
 
 Use these commands to gather context — never modify the working tree:
 
 ```bash
-gh pr view <number>              # PR title, description
-gh pr diff <number>              # the diff
-git show origin/<branch>:<path>  # read full files from the PR branch
-git diff origin/main...origin/<branch>  # cross-branch diff
+git log --oneline -20                          # recent commits on this branch
+git diff origin/main...HEAD                    # the PR's full diff
+git diff origin/main...HEAD -- <path>          # diff for a specific file
+git show HEAD:<path>                           # read a file at the PR branch tip
+git show origin/main:<path>                   # read a file at main
 ```
 
 **Always read the full files** for any security-sensitive code — authentication, input handling, file operations, network code, cryptography. Partial diffs are not sufficient for security review.


### PR DESCRIPTION
## Summary

Documents the per-agent bash allowlist inline in each review prompt file to eliminate the trial-and-error discovery phase at the start of every review session.

- **review-goal, review-code, review-security**: no `gh` CLI access; directed to use `git` for PR inspection
- **review-qa**: no `gh`; has `go build/test/vet` and `nix build/flake check` runners
- **review-context**: read-only `gh` access; explicitly notes state-changing commands are denied

Also updates the "Reading the PR" bash examples in each file to show correct commands for the agent's actual environment (removing non-functional `gh` commands from the read-only agents).

## Changes

All changes are in `modules/programs/prism/review-prompts/`:
- `review-goal.md` — added Tools available + updated Reading the PR examples
- `review-code.md` — added Tools available + updated Reading the PR examples
- `review-security.md` — added Tools available + updated Reading the PR examples
- `review-qa.md` — added Tools available (with build/test runners) + updated examples
- `review-context.md` — added Tools available (with `gh` read commands) + updated examples

No changes to container bash allowlists or host-side `opencode/agents/review-*.md` files.

Closes #818