### PR TITLE
fix(m4mac): replace mysql80 with mysql84

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -61,7 +61,7 @@ in
     [
       arping
       gnutar
-      mysql80
+      mysql84
       podman # darwin doesn't use virtualisation.podman
       postgresql
       rustup


### PR DESCRIPTION
## Summary

- `mysql80` reached end of life on 2026-04-30 and was removed from nixpkgs, causing the Darwin eval to throw on every PR since the flake input was bumped past 2026-04-08
- Replaces `mysql80` with `mysql84` (version 8.4.8, current MySQL LTS)
- Verified: `nix eval .#darwinConfigurations.m4mac.config.system.build.toplevel.outPath` now succeeds cleanly

Closes #828