### PR TITLE
fix(prism-agent): add tini as PID 1 init to prevent zombie accumulation

### DIFF
--- a/images/prism-agent.nix
+++ b/images/prism-agent.nix
@@ -163,6 +163,13 @@ pkgs.dockerTools.buildLayeredImage {
         gopls
         typescript-language-server
         nil # Nix LSP
+
+        # Init process — sits at PID 1 to reap orphaned zombies and forward
+        # signals.  Without this, opencode runs as PID 1 and accumulates
+        # hundreds of defunct child processes (every git/go invocation that
+        # exits without being wait(2)-ed).  tini is ~24 KB, explicitly
+        # designed for this role, and runtime-agnostic (no --init flag needed).
+        tini
       ];
       pathsToLink = [
         "/bin"
@@ -241,6 +248,15 @@ pkgs.dockerTools.buildLayeredImage {
   '';
 
   config = {
+    # tini is the init process (PID 1).  It reaps orphaned zombie children and
+    # forwards signals to its child process (PID 2).  The "--" separator tells
+    # tini to exec everything that follows as its subprocess, so both the
+    # default Cmd and any runtime-supplied command override become PID 2+
+    # rather than PID 1.
+    Entrypoint = [
+      "/bin/tini"
+      "--"
+    ];
     Cmd = [ "/bin/bash" ];
     Env = [
       # /bin first so Nix-installed tools shadow Ubuntu's equivalents


### PR DESCRIPTION
## Summary

- Adds `pkgs.tini` to the `prism-agent-stable-infra` buildEnv `paths` so `/bin/tini` is present in the image
- Sets `Entrypoint = ["/bin/tini" "--"]` in the image `config` block so tini becomes PID 1 and opencode becomes PID 2
- The `--` separator ensures both the default `Cmd` (`/bin/bash`) and any runtime command override (e.g. `opencode --port ... --agent worker`) are exec-ed as tini's subprocess, preserving existing behaviour

## Root cause

opencode was running as PID 1 inside worker containers. Node.js does not install a SIGCHLD reaper, so every `git`/`go`/`bash` child process that exited was never reaped, accumulating as zombies. Observed live: 240+ zombies in a 28-minute session.

## Why this approach

The fix is baked into the image `Entrypoint`, not the container runtime invocation. This means every consumer of the image gets the fix regardless of how they launch it — no `podman run --init` flag needed, and no changes required to the sidecar's container-run code.

## Sidecar confirmation

No changes to `internal/session/sidecar.go` or `internal/container/container.go` are required. The image's `Entrypoint` handles it: the sidecar's command override (`opencode --port ... --agent worker ...`) becomes the argument to `tini --`, which then exec-s it as PID 2. The OCI spec guarantees that a runtime-supplied command replaces `Cmd` but not `Entrypoint`, so tini always remains PID 1.

## Side effects

This change is expected to also fix #833 (SIGTERM not forwarded to opencode) as a side effect — tini properly forwards signals to its child process. **Do not close #833 from this PR**; the coordinator will verify and close it separately after merge.

Closes #834