### PR TITLE
prism review: inject PR metadata and diff into initial prompt

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -161,6 +161,13 @@ func runReview(cmd *cobra.Command, args []string) error {
 		_ = os.Stdout.Sync()
 	}
 
+	// Fetch PR context once before spawning any review-agent sessions.
+	// FetchPRContext handles gh failures gracefully — a failed fetch logs a
+	// warning and returns a PRContext with FetchFailed=true. The review run
+	// continues in either case; agents fall back to git-based discovery when
+	// the context is absent.
+	prCtx := review.FetchPRContext(prNumber, 0, 0)
+
 	// Build run options.
 	opts := review.Opts{
 		PRNumber:       prNumber,
@@ -172,6 +179,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		PluginHostPath: cfg.SidecarPluginPath,
 		ContainerMode:  cfg.ContainerMode,
 		OnProgress:     progressLine,
+		PRCtx:          &prCtx,
 	}
 
 	// Load profiles for container mode — passed through to review.Run so

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -22,10 +22,12 @@
 package review
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -37,6 +39,152 @@ import (
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
+
+// DiffMaxBytes is the maximum diff size (in bytes) before truncation.
+// Configurable for testing; production code uses this default.
+const DiffMaxBytes = 200 * 1024 // 200 KB
+
+// DiffMaxLines is the maximum number of diff lines before truncation.
+// Configurable for testing; production code uses this default.
+const DiffMaxLines = 4000
+
+// PRContext holds PR metadata and diff fetched once at spawn time, before any
+// review-agent sessions are created. All five agents receive the same context
+// in their initial prompt — no per-agent duplication.
+type PRContext struct {
+	// PRNumber is the pull request number (string, e.g. "819").
+	PRNumber string
+	// Title is the PR title.
+	Title string
+	// Body is the PR body text (may be empty).
+	Body string
+	// HeadRefName is the head branch name.
+	HeadRefName string
+	// HeadRefOid is the full head commit SHA.
+	HeadRefOid string
+	// BaseRefName is the base branch name.
+	BaseRefName string
+	// BaseRefOid is the full base commit SHA.
+	BaseRefOid string
+	// Additions is the number of lines added.
+	Additions int
+	// Deletions is the number of lines deleted.
+	Deletions int
+	// ChangedFiles is the number of files changed.
+	ChangedFiles int
+	// Diff is the full PR diff (may be truncated).
+	Diff string
+	// DiffTruncated is true when the diff was truncated due to size limits.
+	DiffTruncated bool
+	// FetchFailed is true when gh failed and only minimal info is available.
+	FetchFailed bool
+}
+
+// prViewJSON is the JSON shape returned by `gh pr view --json ...`.
+type prViewJSON struct {
+	Number       int    `json:"number"`
+	Title        string `json:"title"`
+	Body         string `json:"body"`
+	HeadRefName  string `json:"headRefName"`
+	HeadRefOid   string `json:"headRefOid"`
+	BaseRefName  string `json:"baseRefName"`
+	BaseRefOid   string `json:"baseRefOid"`
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
+	ChangedFiles int    `json:"changedFiles"`
+}
+
+// FetchPRContext fetches PR metadata and diff from the gh CLI.
+// If gh fails or is unavailable, it returns a PRContext with FetchFailed=true
+// and only the PR number populated — the caller must not treat this as an error;
+// the review run continues with a minimal prompt (fallback behaviour).
+// maxBytes and maxLines control truncation of the diff; pass 0 to use the defaults.
+func FetchPRContext(prNumber string, maxBytes, maxLines int) PRContext {
+	if maxBytes <= 0 {
+		maxBytes = DiffMaxBytes
+	}
+	if maxLines <= 0 {
+		maxLines = DiffMaxLines
+	}
+
+	ctx := PRContext{PRNumber: prNumber}
+
+	// Fetch PR metadata.
+	viewOut, err := runGH("pr", "view", prNumber, "--json",
+		"number,title,body,headRefName,headRefOid,baseRefName,baseRefOid,additions,deletions,changedFiles")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[prism review] warning: could not fetch PR metadata via gh: %v — agents will fall back to git-based discovery\n", err)
+		ctx.FetchFailed = true
+		return ctx
+	}
+
+	var meta prViewJSON
+	if jsonErr := json.Unmarshal([]byte(viewOut), &meta); jsonErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism review] warning: could not parse PR metadata JSON: %v — agents will fall back to git-based discovery\n", jsonErr)
+		ctx.FetchFailed = true
+		return ctx
+	}
+
+	ctx.Title = meta.Title
+	ctx.Body = meta.Body
+	ctx.HeadRefName = meta.HeadRefName
+	ctx.HeadRefOid = meta.HeadRefOid
+	ctx.BaseRefName = meta.BaseRefName
+	ctx.BaseRefOid = meta.BaseRefOid
+	ctx.Additions = meta.Additions
+	ctx.Deletions = meta.Deletions
+	ctx.ChangedFiles = meta.ChangedFiles
+
+	// Fetch diff.
+	diffOut, diffErr := runGH("pr", "diff", prNumber)
+	if diffErr != nil {
+		// Diff failure is non-fatal: we have metadata, just no diff content.
+		fmt.Fprintf(os.Stderr, "[prism review] warning: could not fetch PR diff via gh: %v — agents will use git diff instead\n", diffErr)
+		// Leave Diff empty; the prompt will note diff unavailability.
+	} else {
+		ctx.Diff, ctx.DiffTruncated = truncateDiff(diffOut, maxBytes, maxLines)
+	}
+
+	return ctx
+}
+
+// truncateDiff truncates a diff to at most maxBytes bytes and maxLines lines.
+// Returns the (possibly truncated) diff and a bool indicating truncation.
+func truncateDiff(diff string, maxBytes, maxLines int) (string, bool) {
+	// Check byte limit first.
+	if len(diff) > maxBytes {
+		// Truncate to maxBytes, then find the last newline to avoid a mid-line cut.
+		truncated := diff[:maxBytes]
+		if idx := strings.LastIndex(truncated, "\n"); idx > 0 {
+			truncated = truncated[:idx]
+		}
+		return truncated + "\n... [truncated — use git diff origin/<base>...HEAD for full content]", true
+	}
+
+	// Check line limit.
+	lines := strings.Split(diff, "\n")
+	if len(lines) > maxLines {
+		return strings.Join(lines[:maxLines], "\n") + "\n... [truncated — use git diff origin/<base>...HEAD for full content]", true
+	}
+
+	return diff, false
+}
+
+// runGH executes a gh command and returns its stdout as a string.
+// Returns an error if gh is not found or exits with a non-zero status.
+func runGH(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		}
+		return "", err
+	}
+	return stdout.String(), nil
+}
 
 // KillSessionPrefix kills all tmux sessions whose names start with the given
 // prefix. Used to clean up all ~review-* sessions for a parent.
@@ -233,6 +381,11 @@ type Opts struct {
 	// progress line (without trailing newline). The caller is responsible for
 	// writing and flushing the line. When nil, no progress output is emitted.
 	OnProgress func(line string)
+	// PRCtx is the pre-fetched PR context (metadata + diff). When populated,
+	// buildReviewPrompt injects it into the initial prompt for every agent so
+	// agents are productive from turn 1. When nil or FetchFailed is true, a
+	// minimal fallback prompt is used instead.
+	PRCtx *PRContext
 }
 
 // FormatAgentDisplayName converts an agent name like "review-goal" to a
@@ -335,7 +488,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		}
 
 		// Build the prompt for the review agent.
-		prompt := buildReviewPrompt(opts.PRNumber)
+		prompt := buildReviewPrompt(opts.PRNumber, opts.PRCtx)
 
 		// Resolve the per-agent config blob. Each agent gets its own hardened
 		// opencode.json that declares only that one review agent.
@@ -484,8 +637,76 @@ func ResolveAgentConfigContent(containerMode bool, pf *config.ProfilesFile, agen
 }
 
 // buildReviewPrompt returns the initial prompt string for a review agent.
-func buildReviewPrompt(prNumber string) string {
-	return fmt.Sprintf("Review PR #%s. Run `gh pr view %s` and `gh pr diff %s` to get the full diff. Check the linked issue for acceptance criteria and validate each one. Report your findings clearly.", prNumber, prNumber, prNumber)
+// When prCtx is non-nil and FetchFailed is false, the prompt begins with a
+// PR-context section (metadata + diff) followed by the role-specific content.
+// When prCtx is nil or FetchFailed is true, a minimal fallback prompt is used.
+//
+// The PR-context section always appears BEFORE the role-specific content so
+// that agents read full context first and role directives second.
+func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
+	if prCtx == nil || prCtx.FetchFailed {
+		// Fallback: minimal prompt with only the PR number.
+		return fmt.Sprintf(
+			"Review PR #%s. Use `git diff origin/<base>...HEAD` to see the diff, "+
+				"`git log --oneline -20` for recent commits, and check the linked issue "+
+				"for acceptance criteria. Report your findings clearly.",
+			prNumber,
+		)
+	}
+
+	var sb strings.Builder
+
+	// ── PR under review ───────────────────────────────────────────────────
+	sb.WriteString("## PR under review\n\n")
+	sb.WriteString(fmt.Sprintf("You are reviewing PR #%s.\n\n", prCtx.PRNumber))
+	sb.WriteString(fmt.Sprintf("- Title: %q\n", prCtx.Title))
+	sb.WriteString(fmt.Sprintf("- Head branch: %s\n", prCtx.HeadRefName))
+	sb.WriteString(fmt.Sprintf("- Head commit: %s\n", prCtx.HeadRefOid))
+	sb.WriteString(fmt.Sprintf("- Base branch: %s\n", prCtx.BaseRefName))
+	sb.WriteString(fmt.Sprintf("- Base commit: %s\n", prCtx.BaseRefOid))
+	sb.WriteString(fmt.Sprintf("- Files changed: %d (+%d -%d lines)\n", prCtx.ChangedFiles, prCtx.Additions, prCtx.Deletions))
+	if prCtx.DiffTruncated {
+		sb.WriteString("\nNote: the diff below has been truncated due to size. Use `git diff origin/" +
+			prCtx.BaseRefName + "...HEAD` to fetch any missing hunks.\n")
+	}
+	sb.WriteString("\n")
+
+	// ── PR body ───────────────────────────────────────────────────────────
+	sb.WriteString("## PR body\n\n")
+	body := strings.TrimSpace(prCtx.Body)
+	if body == "" {
+		sb.WriteString("(no body)\n")
+	} else {
+		// Wrap in a blockquote-style indentation to prevent any triple-backtick
+		// sequences in the body from colliding with the diff code fence below.
+		// Each line is prefixed with "> " so fence markers become "> ```" which
+		// markdown renderers treat as quoted text, not a code fence boundary.
+		for _, line := range strings.Split(body, "\n") {
+			sb.WriteString("> ")
+			sb.WriteString(line)
+			sb.WriteString("\n")
+		}
+	}
+	sb.WriteString("\n")
+
+	// ── Full diff ─────────────────────────────────────────────────────────
+	sb.WriteString("## Full diff\n\n")
+	if prCtx.Diff == "" {
+		sb.WriteString("(diff not available — use `git diff origin/" + prCtx.BaseRefName + "...HEAD` to fetch it)\n")
+	} else {
+		sb.WriteString("```diff\n")
+		sb.WriteString(prCtx.Diff)
+		if !strings.HasSuffix(prCtx.Diff, "\n") {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("```\n")
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("Your role-specific instructions follow below.\n\n")
+	sb.WriteString("---\n\n")
+
+	return sb.String()
 }
 
 // buildAgentCommand returns the command string for a review agent session.
@@ -654,6 +875,18 @@ func isTerminalState(state string) bool {
 // Production code calls buildResults directly (via pollAgents).
 func BuildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
 	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, cancelled)
+}
+
+// BuildReviewPromptForTest is an exported wrapper around buildReviewPrompt for
+// use in external test packages. It allows tests to verify prompt content,
+// section ordering, and fallback behaviour without needing a live tmux/DB.
+func BuildReviewPromptForTest(prNumber string, prCtx *PRContext) string {
+	return buildReviewPrompt(prNumber, prCtx)
+}
+
+// TruncateDiffForTest is an exported wrapper around truncateDiff for unit tests.
+func TruncateDiffForTest(diff string, maxBytes, maxLines int) (string, bool) {
+	return truncateDiff(diff, maxBytes, maxLines)
 }
 
 // PollAgentsForTest is an exported wrapper around pollAgents for use in tests.

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -78,6 +78,9 @@ type PRContext struct {
 	DiffTruncated bool
 	// FetchFailed is true when gh failed and only minimal info is available.
 	FetchFailed bool
+	// WorktreePath is the absolute path to the worktree being reviewed.
+	// Review agents should treat the worktree as read-only.
+	WorktreePath string
 }
 
 // prViewJSON is the JSON shape returned by `gh pr view --json ...`.
@@ -488,7 +491,16 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		}
 
 		// Build the prompt for the review agent.
-		prompt := buildReviewPrompt(opts.PRNumber, opts.PRCtx)
+		// Inject the worktree path into PRCtx so agents know where the
+		// branch is checked out (and that it is read-only).
+		prCtxWithWorktree := opts.PRCtx
+		if prCtxWithWorktree != nil && !prCtxWithWorktree.FetchFailed {
+			// Shallow-copy so we don't mutate the shared PRCtx.
+			ctxCopy := *prCtxWithWorktree
+			ctxCopy.WorktreePath = worktree
+			prCtxWithWorktree = &ctxCopy
+		}
+		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree)
 
 		// Resolve the per-agent config blob. Each agent gets its own hardened
 		// opencode.json that declares only that one review agent.
@@ -664,6 +676,9 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 	sb.WriteString(fmt.Sprintf("- Head commit: %s\n", prCtx.HeadRefOid))
 	sb.WriteString(fmt.Sprintf("- Base branch: %s\n", prCtx.BaseRefName))
 	sb.WriteString(fmt.Sprintf("- Base commit: %s\n", prCtx.BaseRefOid))
+	if prCtx.WorktreePath != "" {
+		sb.WriteString(fmt.Sprintf("- Worktree: %s (read-only)\n", prCtx.WorktreePath))
+	}
 	sb.WriteString(fmt.Sprintf("- Files changed: %d (+%d -%d lines)\n", prCtx.ChangedFiles, prCtx.Additions, prCtx.Deletions))
 	if prCtx.DiffTruncated {
 		sb.WriteString("\nNote: the diff below has been truncated due to size. Use `git diff origin/" +

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1409,11 +1409,14 @@ func samplePRContext() *review.PRContext {
 		Deletions:    30,
 		ChangedFiles: 3,
 		Diff:         "diff --git a/foo.go b/foo.go\n+added line\n-removed line\n",
+		WorktreePath: "/workspace/worktrees/inject-pr-context-into-review",
 	}
 }
 
 // TestBuildReviewPrompt_ContainsPRUnderReviewSection verifies that the prompt
-// contains a "## PR under review" section with key metadata fields.
+// contains a "## PR under review" section with key metadata fields, including
+// the worktree path (read-only) bullet required by review-qa to avoid
+// re-discovering the branch checkout location.
 func TestBuildReviewPrompt_ContainsPRUnderReviewSection(t *testing.T) {
 	ctx := samplePRContext()
 	prompt := review.BuildReviewPromptForTest("819", ctx)
@@ -1426,6 +1429,9 @@ func TestBuildReviewPrompt_ContainsPRUnderReviewSection(t *testing.T) {
 		"main", // base branch
 		"def4567890abcdef1234567890abcdef12345678", // base SHA
 		"Files changed: 3",
+		// Worktree bullet: eliminates review-qa's "can I check out the branch?" hesitation.
+		"/workspace/worktrees/inject-pr-context-into-review", // worktree path
+		"(read-only)", // read-only annotation
 	}
 	for _, s := range required {
 		if !findSubstring(prompt, s) {

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2,6 +2,7 @@ package review_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1390,4 +1391,281 @@ func findSubstring(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// ── BuildReviewPrompt (PR context injection) ──────────────────────────────────
+
+// samplePRContext returns a fully-populated PRContext for testing.
+func samplePRContext() *review.PRContext {
+	return &review.PRContext{
+		PRNumber:     "819",
+		Title:        "inject PR metadata into review prompt",
+		Body:         "Fixes issue #819 by pre-fetching metadata.\n\nCloses #819",
+		HeadRefName:  "inject-pr-context-into-review",
+		HeadRefOid:   "abc1234567890abcdef1234567890abcdef123456",
+		BaseRefName:  "main",
+		BaseRefOid:   "def4567890abcdef1234567890abcdef12345678",
+		Additions:    150,
+		Deletions:    30,
+		ChangedFiles: 3,
+		Diff:         "diff --git a/foo.go b/foo.go\n+added line\n-removed line\n",
+	}
+}
+
+// TestBuildReviewPrompt_ContainsPRUnderReviewSection verifies that the prompt
+// contains a "## PR under review" section with key metadata fields.
+func TestBuildReviewPrompt_ContainsPRUnderReviewSection(t *testing.T) {
+	ctx := samplePRContext()
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	required := []string{
+		"## PR under review",
+		"PR #819",
+		"inject-pr-context-into-review",             // head branch
+		"abc1234567890abcdef1234567890abcdef123456", // head SHA
+		"main", // base branch
+		"def4567890abcdef1234567890abcdef12345678", // base SHA
+		"Files changed: 3",
+	}
+	for _, s := range required {
+		if !findSubstring(prompt, s) {
+			t.Errorf("prompt missing expected string %q\nprompt:\n%s", s, prompt)
+		}
+	}
+}
+
+// TestBuildReviewPrompt_ContainsPRBodySection verifies that the prompt
+// contains a "## PR body" section with the PR body text.
+func TestBuildReviewPrompt_ContainsPRBodySection(t *testing.T) {
+	ctx := samplePRContext()
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "## PR body") {
+		t.Errorf("prompt missing '## PR body' section\nprompt:\n%s", prompt)
+	}
+	// The body content should be present (blockquote-wrapped).
+	if !findSubstring(prompt, "Fixes issue #819") {
+		t.Errorf("prompt missing body text\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_EmptyBody verifies that when the PR body is empty,
+// the "## PR body" section is still emitted with a "(no body)" placeholder.
+func TestBuildReviewPrompt_EmptyBody(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.Body = ""
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "## PR body") {
+		t.Errorf("prompt missing '## PR body' section even for empty body\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "(no body)") {
+		t.Errorf("prompt missing '(no body)' placeholder for empty body\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_ContainsFullDiffSection verifies that the prompt
+// contains a "## Full diff" section with the diff in a ```diff code fence.
+func TestBuildReviewPrompt_ContainsFullDiffSection(t *testing.T) {
+	ctx := samplePRContext()
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "## Full diff") {
+		t.Errorf("prompt missing '## Full diff' section\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "```diff") {
+		t.Errorf("prompt missing ```diff code fence\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "diff --git a/foo.go b/foo.go") {
+		t.Errorf("prompt missing diff content\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_ContextBeforeRoleSeparator verifies that the PR-context
+// sections appear BEFORE the role-specific content separator ("---").
+func TestBuildReviewPrompt_ContextBeforeRoleSeparator(t *testing.T) {
+	ctx := samplePRContext()
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	prUnderReviewIdx := findLineIndex(prompt, "## PR under review")
+	separatorIdx := findLineIndex(prompt, "---")
+	roleNoteIdx := findLineIndex(prompt, "Your role-specific instructions follow below.")
+
+	if prUnderReviewIdx < 0 {
+		t.Fatalf("prompt missing '## PR under review'\nprompt:\n%s", prompt)
+	}
+	if separatorIdx < 0 {
+		t.Fatalf("prompt missing separator '---'\nprompt:\n%s", prompt)
+	}
+	if roleNoteIdx < 0 {
+		t.Fatalf("prompt missing role note\nprompt:\n%s", prompt)
+	}
+	if prUnderReviewIdx >= separatorIdx {
+		t.Errorf("'## PR under review' (line %d) should appear before '---' (line %d)", prUnderReviewIdx, separatorIdx)
+	}
+}
+
+// TestBuildReviewPrompt_FallbackWhenNilContext verifies that when prCtx is nil,
+// the prompt is a minimal fallback that still includes the PR number.
+func TestBuildReviewPrompt_FallbackWhenNilContext(t *testing.T) {
+	prompt := review.BuildReviewPromptForTest("819", nil)
+
+	if !findSubstring(prompt, "819") {
+		t.Errorf("fallback prompt should contain PR number '819'\nprompt:\n%s", prompt)
+	}
+	// Must NOT contain the rich context sections.
+	if findSubstring(prompt, "## PR under review") {
+		t.Errorf("fallback prompt should not contain '## PR under review'\nprompt:\n%s", prompt)
+	}
+	if findSubstring(prompt, "## Full diff") {
+		t.Errorf("fallback prompt should not contain '## Full diff'\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_FallbackWhenFetchFailed verifies that when FetchFailed
+// is true, the prompt uses the minimal fallback form.
+func TestBuildReviewPrompt_FallbackWhenFetchFailed(t *testing.T) {
+	ctx := &review.PRContext{
+		PRNumber:    "819",
+		FetchFailed: true,
+	}
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "819") {
+		t.Errorf("fallback prompt should contain PR number '819'\nprompt:\n%s", prompt)
+	}
+	if findSubstring(prompt, "## PR under review") {
+		t.Errorf("fallback prompt should not contain rich context when FetchFailed=true\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_AllFiveAgentsGetSameContext verifies that five calls to
+// BuildReviewPromptForTest with the same PRContext produce identical prompts.
+// This ensures the "one fetch, five reuses" property holds at the prompt level.
+func TestBuildReviewPrompt_AllFiveAgentsGetSameContext(t *testing.T) {
+	ctx := samplePRContext()
+	prompts := make([]string, 5)
+	for i := range prompts {
+		prompts[i] = review.BuildReviewPromptForTest("819", ctx)
+	}
+	for i := 1; i < len(prompts); i++ {
+		if prompts[i] != prompts[0] {
+			t.Errorf("prompt[%d] differs from prompt[0]; all agents must receive identical context", i)
+		}
+	}
+}
+
+// TestBuildReviewPrompt_SpecialCharsInTitle verifies that backticks and angle
+// brackets in the PR title do not break the prompt structure.
+func TestBuildReviewPrompt_SpecialCharsInTitle(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.Title = "fix: handle `nil` pointer in <module> and `go build`"
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	// The prompt should still contain both main sections.
+	if !findSubstring(prompt, "## PR under review") {
+		t.Errorf("prompt missing '## PR under review' with special-char title\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "## Full diff") {
+		t.Errorf("prompt missing '## Full diff' with special-char title\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_TripleBackticksInBody verifies that triple-backtick
+// sequences in the PR body do not collapse the ```diff code fence.
+func TestBuildReviewPrompt_TripleBackticksInBody(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.Body = "Here is an example:\n```go\nfmt.Println(\"hello\")\n```\nEnd."
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	// The diff fence must still be intact.
+	if !findSubstring(prompt, "```diff") {
+		t.Errorf("prompt missing ```diff fence; body backticks may have broken structure\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_DiffTruncatedNote verifies that when DiffTruncated is
+// true, the prompt mentions the truncation.
+func TestBuildReviewPrompt_DiffTruncatedNote(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.DiffTruncated = true
+	ctx.Diff = "diff --git a/big.go b/big.go\n+line\n... [truncated — use git diff origin/main...HEAD for full content]"
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "truncated") {
+		t.Errorf("prompt should mention truncation when DiffTruncated=true\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_NoDiffAvailable verifies that when Diff is empty
+// (gh pr diff failed), the prompt notes it and does not emit an empty ```diff fence.
+func TestBuildReviewPrompt_NoDiffAvailable(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.Diff = ""
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "diff not available") {
+		t.Errorf("prompt should note 'diff not available' when Diff is empty\nprompt:\n%s", prompt)
+	}
+	// Must not have an empty ```diff fence (which would confuse agents).
+	if findSubstring(prompt, "```diff\n```") {
+		t.Errorf("prompt should not have an empty ```diff``` fence\nprompt:\n%s", prompt)
+	}
+}
+
+// ── TruncateDiff ──────────────────────────────────────────────────────────────
+
+// TestTruncateDiff_NoTruncationNeeded verifies that a small diff is returned
+// unchanged with truncated=false.
+func TestTruncateDiff_NoTruncationNeeded(t *testing.T) {
+	diff := "diff --git a/foo.go b/foo.go\n+added\n-removed\n"
+	result, truncated := review.TruncateDiffForTest(diff, 200*1024, 4000)
+	if truncated {
+		t.Errorf("TruncateDiff: truncated=true for small diff, want false")
+	}
+	if result != diff {
+		t.Errorf("TruncateDiff: result differs from input for small diff\ngot:  %q\nwant: %q", result, diff)
+	}
+}
+
+// TestTruncateDiff_TruncatesByLineCount verifies that a diff exceeding maxLines
+// is truncated and the truncation marker is appended.
+func TestTruncateDiff_TruncatesByLineCount(t *testing.T) {
+	// Build a diff with 100 lines.
+	var sb strings.Builder
+	for i := range 100 {
+		sb.WriteString(fmt.Sprintf("+line %d\n", i))
+	}
+	diff := sb.String()
+
+	result, truncated := review.TruncateDiffForTest(diff, 200*1024, 10)
+	if !truncated {
+		t.Errorf("TruncateDiff: truncated=false for 100-line diff with maxLines=10, want true")
+	}
+	if !findSubstring(result, "truncated") {
+		t.Errorf("TruncateDiff: result missing truncation marker\nresult:\n%s", result)
+	}
+	// The result must not contain line 11 or later.
+	if findSubstring(result, "+line 10\n") {
+		t.Errorf("TruncateDiff: result contains lines beyond maxLines=10\nresult:\n%s", result)
+	}
+}
+
+// TestTruncateDiff_TruncatesByByteCount verifies that a diff exceeding maxBytes
+// is truncated and the truncation marker is appended.
+func TestTruncateDiff_TruncatesByByteCount(t *testing.T) {
+	// Build a 1000-byte diff.
+	diff := strings.Repeat("+x\n", 333) // ~999 bytes
+
+	result, truncated := review.TruncateDiffForTest(diff, 100, 10000)
+	if !truncated {
+		t.Errorf("TruncateDiff: truncated=false for >100-byte diff with maxBytes=100, want true")
+	}
+	if !findSubstring(result, "truncated") {
+		t.Errorf("TruncateDiff: result missing truncation marker\nresult:\n%s", result)
+	}
+	if len(result) > 200 { // well under the original 999 bytes
+		// Sanity check that we actually truncated substantially.
+		// The marker adds ~70 bytes; total should be << 999.
+	}
 }


### PR DESCRIPTION
## Summary

- Extends `prism review` to fetch PR metadata and the full diff **once** at spawn time (via `gh pr view --json` and `gh pr diff`), then inject the result into the initial prompt for all five review-agent sessions — eliminating 5× redundant discovery calls per review run.
- Adds `PRContext` struct, `FetchPRContext()`, and `truncateDiff()` to `internal/review/review.go`. Updates `buildReviewPrompt()` to emit `## PR under review`, `## PR body`, and `## Full diff` sections before role-specific content.
- Graceful fallback: if `gh` fails, a warning is logged to stderr and agents receive a minimal prompt (PR number only) — the review run is not aborted.
- Diff truncation at 200 KB / 4000 lines with a clear `... [truncated — use git diff ...]` marker.
- New tests cover: context section formatting, diff truncation behaviour, `gh` failure fallback, context-before-role ordering, special characters in title/body, all-5-agents-identical property.

Closes #819