### PR TITLE
bump opencode adapter default HTTP timeout from 10s to 20s

### DIFF
--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -64,7 +64,7 @@ type Adapter struct {
 // (e.g. "anthropic/claude-sonnet-4-6").
 func New(opencodeURL string, httpClient *http.Client, agentRole, agentModel string) *Adapter {
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
+		httpClient = &http.Client{Timeout: 20 * time.Second}
 	}
 	return &Adapter{
 		opencodeURL: opencodeURL,

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -103,7 +103,7 @@ func (a *Adapter) ContainerCommand() string {
 // individual health-check probe attempts. Its timeout governs a single HTTP
 // round-trip, not the overall health-check deadline (which is controlled by
 // defaultHealthCheckTimeout and enforced in the HealthCheck loop). Using a
-// separate client avoids reusing the general-purpose 10 s API client for probe
+// separate client avoids reusing the general-purpose 20 s API client for probe
 // attempts that must complete within one healthCheckInterval window.
 var healthProbeClient = &http.Client{Timeout: defaultHealthCheckTimeout}
 


### PR DESCRIPTION
## Summary

Bumps the default `http.Client` timeout in `opencode.New` from 10 seconds to 20 seconds to absorb cold-start latency on the `GET /session` call.

## Context

The opencode HTTP server cold-start latency routinely exceeds 10 seconds under realistic load, even after the TCP health probe passes. Two observed failures both missed the 10s timeout by small margins (~10.3s and ~10.9s), causing the sidecar to wedge with no session ID. A 20s timeout comfortably absorbs all observed latencies with margin to spare.

The `healthProbeClient` at line 108 is unchanged — its timeout is still `defaultHealthCheckTimeout`.

## Change

Single-line change in `internal/harness/opencode/adapter.go`:
- `10 * time.Second` → `20 * time.Second` (default HTTP client timeout)

No logic changes, no new retry loops, no behaviour changes beyond a longer per-call HTTP timeout.

Closes #841