### PR TITLE
ci: add pr-gate always-run status check workflow

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Gate passed
-        run: echo "pr-gate: ok"
+        run: echo "pr-gate ok"

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,12 @@
+name: pr-gate
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  gate:
+    name: pr-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate passed
+        run: echo "pr-gate: ok"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-gate.yml` — a lightweight no-op workflow that runs on **every** PR targeting `main` with no path filter. This unblocks workflow-only and doc-only PRs that are permanently stuck in `BLOCKED` merge state because `build-linux` (from `validate-flakes`) never fires when no `.nix` files are changed.

Closes #805

## What this adds

- A single job (`gate`, `name: pr-gate`) that runs `echo "pr-gate: ok"` and exits 0
- No path filter — runs unconditionally on every PR to `main`
- Completes in well under 30 seconds (no checkout, no setup, no dependencies)
- The stable check name that appears in `gh pr view <n> --json statusCheckRollup` is: **`pr-gate`**

## What this does NOT change

- `validate-flakes` and its path filter are untouched
- `build-linux` continues to run on `.nix` / `flake.lock` changes as before
- No other workflows are modified

---

## ⚠️ Post-merge ruleset change required (coordinator action)

After this PR is merged, the coordinator must update the `main` branch ruleset in GitHub to require the new check. Without this step, the deadlock is not resolved.

### Steps (GitHub UI)

1. Go to **Settings → Rules → Rulesets** on the repo
2. Open the ruleset that protects `main`
3. Under **Required status checks**, add:
   - **Check name:** `pr-gate`
   - *(This is the `name:` field on the job in `pr-gate.yml`, which is what GitHub uses as the check identifier)*
4. Optionally, decide what to do with `build-linux`:
   - **Recommended:** Leave `build-linux` as a required check **and** add `pr-gate`. GitHub's "require status checks to pass" only blocks on checks that actually ran. If `build-linux` didn't run (no `.nix` files changed), it won't block merge. Adding `pr-gate` as an additional required check ensures there is always at least one green check present.
   - If the ruleset uses "require all configured checks to succeed" semantics, `build-linux` will only block when it fires — so keeping both is safe.
5. Save the ruleset.

### Quick verification after ruleset update

Open a trivial workflow-only or doc-only PR and confirm:
```bash
gh pr view <n> --json statusCheckRollup
# → should show pr-gate: SUCCESS
gh pr merge <n> --squash
# → should succeed without --admin
```