### PR TITLE
prism: extract IsMetaSession helper — eliminate scattered scratchpad/prism-dashboard comparisons

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/payload"
+	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -1346,7 +1347,7 @@ func runCheckinNoArg(showAll bool) error {
 	// Convert tmux sessions to a minimal Status slice for the shared renderer.
 	var ss []db.Status
 	for _, s := range sessions {
-		if s.Name == "scratchpad" || s.Name == "prism-dashboard" {
+		if prismSession.IsMetaSession(s.Name) {
 			continue
 		}
 		state := s.AgentState

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -103,7 +104,7 @@ var eventStateChangeCmd = &cobra.Command{
 		// non-worktree sessions like "obsidian" — are tracked. Mirror the
 		// guard used by tmux-session-start so state transitions flow through
 		// for every session that start already wrote a row for.
-		if session == "scratchpad" || session == "prism-dashboard" {
+		if prismSession.IsMetaSession(session) {
 			return nil
 		}
 
@@ -236,7 +237,7 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 			// non-worktree sessions (e.g. "obsidian") are legitimate user
 			// sessions and get a row with repo="" — consistent with the port
 			// allocation path in switch.go:allocatePortForSession.
-			if session == "scratchpad" || session == "prism-dashboard" {
+			if prismSession.IsMetaSession(session) {
 				return nil
 			}
 			// Fall through: UpsertStatus will be called with repo="" below.

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -195,24 +195,20 @@ func restoreSession(d *db.DB, s db.Status, threshold int, pendingStagger *bool, 
 		return restoreOutcomeSkipped, nil
 	}
 
-	switch s.SessionName {
-	case "prism-dashboard":
-		// Defensive guard — prism-dashboard is an internal meta-session
-		// explicitly skipped by name in cmd/event.go:tmux-session-start and
-		// will never appear in agent_status under normal operation. This case
-		// is retained as a safety net.
+	// Defensive guard — meta-sessions (scratchpad, prism-dashboard) are
+	// explicitly skipped by IsMetaSession in cmd/event.go:tmux-session-start
+	// and will never appear in agent_status under normal operation. This
+	// block is retained as a safety net. The scratchpad has special restore
+	// behaviour (re-create via ensureAndSwitch); all other meta-sessions are
+	// simply skipped.
+	if session.IsMetaSession(s.SessionName) {
+		if s.SessionName == session.ScratchpadSession {
+			return restoreOutcomeCreated, ensureAndSwitch("[scratchpad]", "", session.Opts{Headless: true})
+		}
 		return restoreOutcomeSkipped, nil
-
-	case "scratchpad":
-		// Defensive guard — scratchpad is an internal meta-session explicitly
-		// skipped by name in cmd/event.go:tmux-session-start and will never
-		// appear in agent_status under normal operation. This case is retained
-		// as a safety net.
-		return restoreOutcomeCreated, ensureAndSwitch("[scratchpad]", "", session.Opts{Headless: true})
-
-	default:
-		return restoreProjectSession(d, s, threshold, pendingStagger, staggerDelay)
 	}
+
+	return restoreProjectSession(d, s, threshold, pendingStagger, staggerDelay)
 }
 
 // restoreProjectSession recreates a project session using the shared

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -15,6 +15,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // FetchSessionsFromDB queries agent_status for all active sessions and
@@ -103,7 +104,7 @@ func FetchGitStatsOnly() tea.Msg {
 	seen := map[string]bool{}
 	var paths []string
 	for _, s := range statuses {
-		if s.SessionName == "scratchpad" || s.SessionName == "prism-dashboard" {
+		if session.IsMetaSession(s.SessionName) {
 			continue
 		}
 		if s.Worktree != "" && !seen[s.Worktree] {

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -475,7 +476,7 @@ func SessionColumnWidth(sessions []AgentSession) int {
 func FilterAgentSessions(all []AgentSession) []AgentSession {
 	var out []AgentSession
 	for _, s := range all {
-		if s.Name == "scratchpad" || s.Name == "prism-dashboard" {
+		if session.IsMetaSession(s.Name) {
 			continue
 		}
 		out = append(out, s)

--- a/modules/programs/prism/prism/internal/session/meta.go
+++ b/modules/programs/prism/prism/internal/session/meta.go
@@ -1,12 +1,15 @@
 package session
 
+// ScratchpadSession is the canonical name of the prism scratchpad tmux session.
+const ScratchpadSession = "scratchpad"
+
 // IsMetaSession reports whether a session name identifies a prism-internal
 // meta-session (scratchpad, dashboard, etc.) rather than a user-spawned agent
 // session. Meta-sessions must not appear in agent_status and are excluded from
 // all session listings.
 func IsMetaSession(name string) bool {
 	switch name {
-	case "scratchpad", "prism-dashboard":
+	case ScratchpadSession, "prism-dashboard":
 		return true
 	}
 	return false

--- a/modules/programs/prism/prism/internal/session/meta.go
+++ b/modules/programs/prism/prism/internal/session/meta.go
@@ -1,0 +1,13 @@
+package session
+
+// IsMetaSession reports whether a session name identifies a prism-internal
+// meta-session (scratchpad, dashboard, etc.) rather than a user-spawned agent
+// session. Meta-sessions must not appear in agent_status and are excluded from
+// all session listings.
+func IsMetaSession(name string) bool {
+	switch name {
+	case "scratchpad", "prism-dashboard":
+		return true
+	}
+	return false
+}

--- a/modules/programs/prism/prism/internal/session/meta_test.go
+++ b/modules/programs/prism/prism/internal/session/meta_test.go
@@ -1,0 +1,35 @@
+package session
+
+import "testing"
+
+func TestIsMetaSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Known meta-sessions — must return true.
+		{"scratchpad", true},
+		{"prism-dashboard", true},
+
+		// Non-meta sessions — must return false.
+		{"nixos-config@main", false},
+		{"nixos-config@feature-branch", false},
+		{"worker", false},
+		{"coordinator", false},
+		{"obsidian", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsMetaSession(tt.name)
+			if got != tt.want {
+				t.Errorf("IsMetaSession(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/session.IsMetaSession(name string) bool` as the single authoritative function for identifying prism meta-sessions (scratchpad, prism-dashboard).
- Replaces all five inline `== "scratchpad" || == "prism-dashboard"` comparisons across `cmd/event.go`, `cmd/checkin.go`, `internal/dashboard/sessions.go`, and `internal/dashboard/poll.go` with calls to `session.IsMetaSession`.
- Adds a unit test in `internal/session/meta_test.go` covering known meta-session names and several non-meta names.

## Acceptance criteria

- [x] `IsMetaSession` exists in `internal/session` package.
- [x] All prior hard-coded filter comparisons now call `IsMetaSession`.
- [x] Behaviour is unchanged — same sessions are classified as meta.
- [x] No new session types added to the denylist.
- [x] `go build ./...` passes.
- [x] `go test ./...` passes with new unit test.

Closes #856