### PR TITLE
prism: add group_id schema (v9) — session_groups table, FK enforcement, group helpers

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -160,8 +160,10 @@ CREATE TABLE IF NOT EXISTS schema_version (
 // agent_status; v4→v5 adds host_mode to agent_status; v5→v6 adds instance_id
 // to agent_status and to_instance_id to bus_messages; v6→v7 adds failed_at to
 // bus_messages; v7→v8 adds harness, harness_session_id, and harness_port to
-// agent_status; v8→v9 adds the session_groups table and group_id FK column to
-// agent_status.
+// agent_status; v8→v9 adds the session_groups table and group_id FK column
+// (with ON DELETE SET NULL) to agent_status via rename-and-recreate so that
+// the REFERENCES clause is present in the schema metadata and fully enforced
+// by PRAGMA foreign_keys = ON on both fresh and migrated databases.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -345,25 +347,82 @@ func Open(path string) (*DB, error) {
 		// sessions without removing their history.
 		//
 		// SQLite does not support adding a column with a REFERENCES clause via
-		// ALTER TABLE, so we add the column first (untyped, nullable) and the FK
-		// constraint is enforced at the application level via PRAGMA foreign_keys
-		// = ON set in Open(). The REFERENCES clause is present in the CREATE TABLE
-		// schema (for new databases); existing databases gain the FK semantics
-		// through PRAGMA enforcement operating on the column we add here.
-		migrations := []string{
-			`CREATE TABLE IF NOT EXISTS session_groups (
-			  group_id       TEXT PRIMARY KEY,
-			  parent_session TEXT NOT NULL,
-			  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-			)`,
-			"ALTER TABLE agent_status ADD COLUMN group_id TEXT",
-			"UPDATE schema_version SET version = 9",
-		}
-		for _, m := range migrations {
-			if _, err := conn.Exec(m); err != nil {
-				conn.Close()
-				return nil, fmt.Errorf("db: migration v8→v9: %w", err)
+		// ALTER TABLE ADD COLUMN. We therefore use the recommended rename-and-
+		// recreate pattern: create a new table with the REFERENCES clause, copy
+		// all rows across, drop the old table, and rename the new one. This is
+		// wrapped in a transaction with PRAGMA foreign_keys = OFF (required by
+		// the SQLite docs for schema changes) so the intermediate state — where
+		// the old table has no FK and the new table exists alongside it — is
+		// never visible to concurrent readers and does not trigger spurious FK
+		// violations. foreign_keys is re-enabled immediately after.
+		//
+		// See https://www.sqlite.org/lang_altertable.html#otheralter
+		if err := func() error {
+			if _, err := conn.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+				return fmt.Errorf("disable FK: %w", err)
 			}
+			tx, err := conn.Begin()
+			if err != nil {
+				return fmt.Errorf("begin tx: %w", err)
+			}
+			defer tx.Rollback() //nolint:errcheck
+			steps := []string{
+				// Create the session_groups table first (the FK target must
+				// exist before we can reference it).
+				`CREATE TABLE IF NOT EXISTS session_groups (
+				  group_id       TEXT PRIMARY KEY,
+				  parent_session TEXT NOT NULL,
+				  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)`,
+				// Recreate agent_status with the REFERENCES clause.
+				`CREATE TABLE agent_status_new (
+				  session_name      TEXT PRIMARY KEY,
+				  repo              TEXT NOT NULL,
+				  worktree          TEXT NOT NULL,
+				  state             TEXT NOT NULL,
+				  title             TEXT,
+				  opencode_sid      TEXT,
+				  agent_name        TEXT,
+				  model_id          TEXT,
+				  root_agent_name   TEXT,
+				  root_model_id     TEXT,
+				  opencode_port     INTEGER,
+				  host_mode         INTEGER NOT NULL DEFAULT 0,
+				  instance_id       TEXT,
+				  last_seen         INTEGER NOT NULL,
+				  ended_at          INTEGER,
+				  harness           TEXT NOT NULL DEFAULT 'opencode',
+				  harness_session_id TEXT,
+				  harness_port      INTEGER,
+				  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+				)`,
+				// Copy all existing rows; new group_id column gets NULL.
+				`INSERT INTO agent_status_new
+				  SELECT session_name, repo, worktree, state, title,
+				         opencode_sid, agent_name, model_id,
+				         root_agent_name, root_model_id, opencode_port,
+				         host_mode, instance_id, last_seen, ended_at,
+				         harness, harness_session_id, harness_port, NULL
+				  FROM agent_status`,
+				"DROP TABLE agent_status",
+				"ALTER TABLE agent_status_new RENAME TO agent_status",
+				"UPDATE schema_version SET version = 9",
+			}
+			for _, s := range steps {
+				if _, err := tx.Exec(s); err != nil {
+					return fmt.Errorf("step %q: %w", s[:min(40, len(s))], err)
+				}
+			}
+			if err := tx.Commit(); err != nil {
+				return fmt.Errorf("commit: %w", err)
+			}
+			if _, err := conn.Exec("PRAGMA foreign_keys = ON"); err != nil {
+				return fmt.Errorf("re-enable FK: %w", err)
+			}
+			return nil
+		}(); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v8→v9: %w", err)
 		}
 		version = 9
 	}
@@ -1571,7 +1630,11 @@ type GroupMemberResult struct {
 }
 
 // terminalStates is the set of agent states that indicate a session has stopped
-// working and will not make further progress.
+// working and will not make further progress. Note: this includes "deleted"
+// (cleaned up mid-run) intentionally — a deleted session will never complete,
+// so it counts as terminal for GroupCompleted purposes. This differs from
+// review.go's isTerminalState, which omits "deleted" because prism review
+// uses separate cleanup detection logic.
 var terminalStates = []string{"finished", "interrupted", "error", "deleted"}
 
 // isTerminalState reports whether state is a terminal agent state.
@@ -1625,7 +1688,7 @@ func (d *DB) GroupCompleted(groupID string) (bool, error) {
 // GroupCompleted returns true. Members that are still active are included but
 // their State may be non-terminal.
 //
-// LastMessage is populated from the most recent assistant_message event payload
+// LastMessage is populated from the most recent msg_assistant event payload
 // for each session. It is empty when no such event has been recorded.
 func (d *DB) GroupResults(groupID string) (map[string]GroupMemberResult, error) {
 	// Fetch each member's session_name, state, and root_agent_name.
@@ -1651,11 +1714,11 @@ WHERE group_id = ?`
 		return nil, fmt.Errorf("db: group results: iterate statuses: %w", err)
 	}
 
-	// For each member, fetch the last assistant_message event payload.
+	// For each member, fetch the last msg_assistant event payload.
 	for name, r := range results {
 		const msgQ = `
 SELECT payload FROM agent_events
-WHERE session_name = ? AND type = 'assistant_message'
+WHERE session_name = ? AND type = 'msg_assistant'
 ORDER BY created_at DESC, rowid DESC
 LIMIT 1`
 		var payload string

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1,8 +1,8 @@
 // Package db provides the prism SQLite database layer.
 //
 // The database is located at $XDG_STATE_HOME/prism/prism.db, falling back to
-// $HOME/.local/state/prism/prism.db. All four tables (agent_events,
-// agent_status, bus_messages, schema_version) are created on Open if they do
+// $HOME/.local/state/prism/prism.db. All tables (agent_events, agent_status,
+// bus_messages, session_groups, schema_version) are created on Open if they do
 // not already exist.
 package db
 
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/agent"
 	_ "modernc.org/sqlite" // register sqlite3 driver
 )
@@ -103,6 +104,12 @@ CREATE TABLE IF NOT EXISTS agent_events (
 CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
 
+CREATE TABLE IF NOT EXISTS session_groups (
+  group_id       TEXT PRIMARY KEY,
+  parent_session TEXT NOT NULL,
+  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS agent_status (
   session_name      TEXT PRIMARY KEY,
   repo              TEXT NOT NULL,
@@ -121,7 +128,8 @@ CREATE TABLE IF NOT EXISTS agent_status (
   ended_at          INTEGER,
   harness           TEXT NOT NULL DEFAULT 'opencode',
   harness_session_id TEXT,
-  harness_port      INTEGER
+  harness_port      INTEGER,
+  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS bus_messages (
@@ -145,14 +153,19 @@ CREATE TABLE IF NOT EXISTS schema_version (
 `
 
 // Open opens (or creates) the prism database at path.
-// It creates parent directories as needed, enables WAL mode, runs the full
-// schema, and sets schema_version=8 if the table is empty. Pending migrations
-// are applied in order: v1→v2 adds agent_name/model_id; v2→v3 adds
-// root_agent_name/root_model_id; v3→v4 adds opencode_port to agent_status;
-// v4→v5 adds host_mode to agent_status; v5→v6 adds instance_id to
-// agent_status and to_instance_id to bus_messages; v6→v7 adds failed_at to
+// It creates parent directories as needed, enables WAL mode, enforces foreign
+// keys, runs the full schema, and sets schema_version=9 if the table is empty.
+// Pending migrations are applied in order: v1→v2 adds agent_name/model_id;
+// v2→v3 adds root_agent_name/root_model_id; v3→v4 adds opencode_port to
+// agent_status; v4→v5 adds host_mode to agent_status; v5→v6 adds instance_id
+// to agent_status and to_instance_id to bus_messages; v6→v7 adds failed_at to
 // bus_messages; v7→v8 adds harness, harness_session_id, and harness_port to
+// agent_status; v8→v9 adds the session_groups table and group_id FK column to
 // agent_status.
+//
+// PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
+// It is set explicitly here — the single constructor through which all prism
+// DB connections are opened — so every connection benefits automatically.
 func Open(path string) (*DB, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("db: create parent dirs: %w", err)
@@ -176,21 +189,29 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("db: set busy timeout: %w", err)
 	}
 
+	// Enforce foreign-key constraints. SQLite disables FK enforcement by
+	// default; this must be set per connection, which is why it lives here
+	// (the single constructor used for every prism DB connection).
+	if _, err := conn.Exec("PRAGMA foreign_keys = ON;"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("db: enable foreign keys: %w", err)
+	}
+
 	// Create all tables.
 	if _, err := conn.Exec(schema); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("db: apply schema: %w", err)
 	}
 
-	// Set schema_version=8 if the table is empty (fresh database already has
-	// all columns including the v2, v3, v4, v5, v6, v7, and v8 additions, so no migration is needed).
+	// Set schema_version=9 if the table is empty (fresh database already has
+	// all columns including the v2–v9 additions, so no migration is needed).
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("db: check schema_version: %w", err)
 	}
 	if count == 0 {
-		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (8)"); err != nil {
+		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (9)"); err != nil {
 			conn.Close()
 			return nil, fmt.Errorf("db: set schema_version: %w", err)
 		}
@@ -315,6 +336,36 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 8
+	}
+	if version == 8 {
+		// Migration v8 → v9: introduce session_groups table and add group_id FK
+		// column to agent_status. group_id is nullable so existing rows are
+		// unaffected (they receive NULL). The FK is enforced with ON DELETE SET
+		// NULL so that deleting a session_groups row clears group_id on member
+		// sessions without removing their history.
+		//
+		// SQLite does not support adding a column with a REFERENCES clause via
+		// ALTER TABLE, so we add the column first (untyped, nullable) and the FK
+		// constraint is enforced at the application level via PRAGMA foreign_keys
+		// = ON set in Open(). The REFERENCES clause is present in the CREATE TABLE
+		// schema (for new databases); existing databases gain the FK semantics
+		// through PRAGMA enforcement operating on the column we add here.
+		migrations := []string{
+			`CREATE TABLE IF NOT EXISTS session_groups (
+			  group_id       TEXT PRIMARY KEY,
+			  parent_session TEXT NOT NULL,
+			  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`,
+			"ALTER TABLE agent_status ADD COLUMN group_id TEXT",
+			"UPDATE schema_version SET version = 9",
+		}
+		for _, m := range migrations {
+			if _, err := conn.Exec(m); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v8→v9: %w", err)
+			}
+		}
+		version = 9
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -1508,6 +1559,115 @@ LIMIT ?`
 		return 0, fmt.Errorf("db: consecutive sidecar failures: iterate: %w", err)
 	}
 	return count, nil
+}
+
+// GroupMemberResult holds the terminal state and last assistant message for a
+// single member of a session group. Used by GroupResults to aggregate outcomes.
+type GroupMemberResult struct {
+	SessionName string
+	RootAgent   string // from root_agent_name; empty when not set
+	State       string // terminal state: finished / interrupted / error / deleted
+	LastMessage string // last assistant turn from agent_events; empty when none
+}
+
+// terminalStates is the set of agent states that indicate a session has stopped
+// working and will not make further progress.
+var terminalStates = []string{"finished", "interrupted", "error", "deleted"}
+
+// isTerminalState reports whether state is a terminal agent state.
+func isTerminalState(state string) bool {
+	for _, s := range terminalStates {
+		if state == s {
+			return true
+		}
+	}
+	return false
+}
+
+// RegisterGroup inserts a new row into session_groups and returns the generated
+// group_id. parent_session identifies the session that owns this group (e.g.
+// the worker running `prism review`).
+func (d *DB) RegisterGroup(parentSession string) (string, error) {
+	groupID := uuid.New().String()
+	const q = `INSERT INTO session_groups (group_id, parent_session) VALUES (?, ?)`
+	if _, err := d.conn.Exec(q, groupID, parentSession); err != nil {
+		return "", fmt.Errorf("db: register group: %w", err)
+	}
+	return groupID, nil
+}
+
+// GroupCompleted reports whether every agent_status row with this group_id has
+// reached a terminal state (finished, interrupted, error, or deleted).
+// Returns (true, nil) when all members are terminal (including the case where
+// there are no members yet — caller should guard against that if needed).
+// Returns (false, nil) when at least one member is still running.
+// Returns (false, err) on a database error.
+func (d *DB) GroupCompleted(groupID string) (bool, error) {
+	// Build the NOT IN list for terminal states.
+	placeholders := make([]string, len(terminalStates))
+	args := make([]any, 0, 1+len(terminalStates))
+	args = append(args, groupID)
+	for i, s := range terminalStates {
+		placeholders[i] = "?"
+		args = append(args, s)
+	}
+	q := `SELECT COUNT(*) FROM agent_status WHERE group_id = ? AND state NOT IN (` +
+		strings.Join(placeholders, ",") + `)`
+	var nonTerminalCount int
+	if err := d.conn.QueryRow(q, args...).Scan(&nonTerminalCount); err != nil {
+		return false, fmt.Errorf("db: group completed: %w", err)
+	}
+	return nonTerminalCount == 0, nil
+}
+
+// GroupResults returns the terminal state and last assistant message for every
+// member of the group, keyed by session_name. It is intended for use after
+// GroupCompleted returns true. Members that are still active are included but
+// their State may be non-terminal.
+//
+// LastMessage is populated from the most recent assistant_message event payload
+// for each session. It is empty when no such event has been recorded.
+func (d *DB) GroupResults(groupID string) (map[string]GroupMemberResult, error) {
+	// Fetch each member's session_name, state, and root_agent_name.
+	const statusQ = `
+SELECT session_name, state, COALESCE(root_agent_name, '')
+FROM agent_status
+WHERE group_id = ?`
+	rows, err := d.conn.Query(statusQ, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("db: group results: query statuses: %w", err)
+	}
+	defer rows.Close()
+
+	results := make(map[string]GroupMemberResult)
+	for rows.Next() {
+		var r GroupMemberResult
+		if err := rows.Scan(&r.SessionName, &r.State, &r.RootAgent); err != nil {
+			return nil, fmt.Errorf("db: group results: scan status: %w", err)
+		}
+		results[r.SessionName] = r
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: group results: iterate statuses: %w", err)
+	}
+
+	// For each member, fetch the last assistant_message event payload.
+	for name, r := range results {
+		const msgQ = `
+SELECT payload FROM agent_events
+WHERE session_name = ? AND type = 'assistant_message'
+ORDER BY created_at DESC, rowid DESC
+LIMIT 1`
+		var payload string
+		err := d.conn.QueryRow(msgQ, name).Scan(&payload)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("db: group results: last message for %q: %w", name, err)
+		}
+		r.LastMessage = payload
+		results[name] = r
+	}
+
+	return results, nil
 }
 
 func scanBusMessage(s scanner) (BusMessage, error) {

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=8 (migrations are applied on Open).
+	// Verify schema_version=9 (migrations are applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version: got %d, want 9", version)
 	}
 
 	// Verify WAL mode.
@@ -766,20 +766,20 @@ func TestMigration_V1ToV2(t *testing.T) {
 		t.Fatalf("seed v1 db: %v", err)
 	}
 
-	// Open via db.Open — should apply the v1→v2, v2→v3, v3→v4, v4→v5, v5→v6, v6→v7, and v7→v8 migrations.
+	// Open via db.Open — should apply v1→v2 through v8→v9 migrations.
 	d, err := db.Open(dbPath)
 	if err != nil {
 		t.Fatalf("db.Open on v1 db: %v", err)
 	}
 	defer d.Close()
 
-	// Verify schema_version=8.
+	// Verify schema_version=9.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -853,8 +853,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1354,8 +1354,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1420,8 +1420,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1490,8 +1490,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1585,8 +1585,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1672,13 +1672,13 @@ func TestMigration_V7ToV8(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must be 8 after migration.
+	// Schema version must be 9 after migration.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 8 {
-		t.Errorf("schema_version after migration: got %d, want 8", version)
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2190,6 +2190,419 @@ func TestCheckTransition_EmptyStates(t *testing.T) {
 		t.Logf("UpsertStatus with empty toState returned error (acceptable): %v", err)
 	}
 	// If we reach here, no panic occurred.
+}
+
+// ── TestOpen_CreatesSchema addendum: session_groups and group_id column ────────
+
+// TestOpen_CreatesSessionGroupsTable verifies that the session_groups table and
+// the group_id column on agent_status exist after Open (fresh DB).
+func TestOpen_CreatesSessionGroupsTable(t *testing.T) {
+	d := openTestDB(t)
+
+	// session_groups table must exist.
+	var name string
+	if err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='session_groups'").Scan(&name); err != nil {
+		t.Fatalf("session_groups table not found: %v", err)
+	}
+	if name != "session_groups" {
+		t.Errorf("session_groups: got %q, want \"session_groups\"", name)
+	}
+
+	// group_id column must exist on agent_status.
+	// We probe it by inserting a NULL group_id row.
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	var groupID *string
+	if err := d.QueryRow("SELECT group_id FROM agent_status WHERE session_name = 'repo@main'").Scan(&groupID); err != nil {
+		t.Fatalf("query group_id column: %v", err)
+	}
+	if groupID != nil {
+		t.Errorf("group_id for new row: got %v, want nil", groupID)
+	}
+}
+
+// ── Migration v8→v9 ────────────────────────────────────────────────────────────
+
+// TestMigration_V8ToV9 verifies that Open applies the v8→v9 migration to an
+// existing DB that was created at schema_version=8 (no session_groups table,
+// no group_id column).
+func TestMigration_V8ToV9(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v8.db")
+
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT, opencode_sid TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  opencode_port INTEGER, host_mode INTEGER NOT NULL DEFAULT 0,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT, harness_port INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (8);
+		INSERT INTO agent_status (session_name, repo, worktree, state, harness, last_seen)
+		  VALUES ('repo@main', 'repo', '/code/repo/main', 'active', 'opencode', 0);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v8 db: %v", err)
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v8 db: %v", err)
+	}
+	defer d.Close()
+
+	// Schema version must be 9 after migration.
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 9 {
+		t.Errorf("schema_version after migration: got %d, want 9", version)
+	}
+
+	// session_groups table must exist after migration.
+	var tname string
+	if err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='session_groups'").Scan(&tname); err != nil {
+		t.Fatalf("session_groups table not found after v8→v9 migration: %v", err)
+	}
+
+	// Existing row must still be present and unmodified.
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus after migration: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil, want existing row")
+	}
+	if s.State != "active" {
+		t.Errorf("State preserved: got %q, want \"active\"", s.State)
+	}
+
+	// group_id column must exist and be NULL for pre-migration rows.
+	var groupID *string
+	if err := d.QueryRow("SELECT group_id FROM agent_status WHERE session_name = 'repo@main'").Scan(&groupID); err != nil {
+		t.Fatalf("query group_id column after migration: %v", err)
+	}
+	if groupID != nil {
+		t.Errorf("group_id for migrated row: got %v, want nil", groupID)
+	}
+}
+
+// ── RegisterGroup, GroupCompleted, GroupResults ───────────────────────────────
+
+// TestRegisterGroup verifies that RegisterGroup inserts a row into
+// session_groups and returns a non-empty group_id.
+func TestRegisterGroup(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if groupID == "" {
+		t.Fatal("RegisterGroup returned empty group_id")
+	}
+
+	// The row must be present in session_groups.
+	var parent string
+	if err := d.QueryRow(
+		"SELECT parent_session FROM session_groups WHERE group_id = ?", groupID,
+	).Scan(&parent); err != nil {
+		t.Fatalf("query session_groups: %v", err)
+	}
+	if parent != "nixos-config@feature" {
+		t.Errorf("parent_session: got %q, want \"nixos-config@feature\"", parent)
+	}
+
+	// Each call must return a distinct group_id.
+	groupID2, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("second RegisterGroup: %v", err)
+	}
+	if groupID2 == groupID {
+		t.Error("RegisterGroup: second call returned same group_id as first")
+	}
+}
+
+// TestGroupCompleted_AllTerminal verifies that GroupCompleted returns true when
+// all members have reached a terminal state.
+func TestGroupCompleted_AllTerminal(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Create three member sessions and assign them to the group.
+	members := []struct {
+		name  string
+		state string
+	}{
+		{"nixos-config@feature~review-1-goal", "finished"},
+		{"nixos-config@feature~review-1-code", "finished"},
+		{"nixos-config@feature~review-1-security", "interrupted"},
+	}
+	for _, m := range members {
+		if err := d.UpsertStatus(m.name, "nixos-config", "/wt", m.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", m.name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, m.name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", m.name, err)
+		}
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted: got false, want true (all members terminal)")
+	}
+}
+
+// TestGroupCompleted_ActiveMember verifies that GroupCompleted returns false
+// when at least one member is still active.
+func TestGroupCompleted_ActiveMember(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	members := []struct {
+		name  string
+		state string
+	}{
+		{"nixos-config@feature~review-1-goal", "finished"},
+		{"nixos-config@feature~review-1-code", "active"}, // still running
+	}
+	for _, m := range members {
+		if err := d.UpsertStatus(m.name, "nixos-config", "/wt", m.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", m.name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, m.name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", m.name, err)
+		}
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if done {
+		t.Error("GroupCompleted: got true, want false (active member present)")
+	}
+}
+
+// TestGroupCompleted_NoMembers verifies that GroupCompleted returns true for a
+// group that exists but has no members assigned yet.
+func TestGroupCompleted_NoMembers(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	// No members = all zero members are terminal = true.
+	if !done {
+		t.Error("GroupCompleted with no members: got false, want true")
+	}
+}
+
+// TestGroupResults verifies that GroupResults returns state and last message for
+// all group members, keyed by session_name.
+func TestGroupResults(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Create two members.
+	for _, name := range []string{"nixos-config@feature~review-1-goal", "nixos-config@feature~review-1-code"} {
+		if err := d.UpsertStatus(name, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", name, err)
+		}
+	}
+
+	// Write an assistant_message event for the first member only.
+	goalSession := "nixos-config@feature~review-1-goal"
+	if err := d.WriteEvent(db.Event{
+		ID:          "evt-assistant-1",
+		SessionName: goalSession,
+		Repo:        "nixos-config",
+		Worktree:    "/wt",
+		Type:        "assistant_message",
+		Payload:     `{"content":"<verdict>PASS</verdict>"}`,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	results, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("GroupResults: got %d results, want 2", len(results))
+	}
+
+	goalResult, ok := results[goalSession]
+	if !ok {
+		t.Fatalf("GroupResults: missing entry for %q", goalSession)
+	}
+	if goalResult.State != "finished" {
+		t.Errorf("goal State: got %q, want \"finished\"", goalResult.State)
+	}
+	if goalResult.LastMessage != `{"content":"<verdict>PASS</verdict>"}` {
+		t.Errorf("goal LastMessage: got %q, want assistant_message payload", goalResult.LastMessage)
+	}
+
+	codeSession := "nixos-config@feature~review-1-code"
+	codeResult, ok := results[codeSession]
+	if !ok {
+		t.Fatalf("GroupResults: missing entry for %q", codeSession)
+	}
+	if codeResult.State != "finished" {
+		t.Errorf("code State: got %q, want \"finished\"", codeResult.State)
+	}
+	if codeResult.LastMessage != "" {
+		t.Errorf("code LastMessage: got %q, want \"\" (no assistant_message)", codeResult.LastMessage)
+	}
+}
+
+// ── Foreign key enforcement tests ─────────────────────────────────────────────
+
+// TestGroupFK_Violation verifies that attempting to set agent_status.group_id to
+// a value not present in session_groups raises a FK constraint error. This proves
+// PRAGMA foreign_keys = ON is active for every connection opened by db.Open.
+func TestGroupFK_Violation(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Attempt to set group_id to a non-existent group — must fail with FK error.
+	err := d.QueryRow(
+		"UPDATE agent_status SET group_id = 'does-not-exist' WHERE session_name = 'repo@main' RETURNING 1",
+	).Scan(new(int))
+	if err == nil {
+		t.Fatal("expected FK constraint error when setting group_id to non-existent group, got nil")
+	}
+	// The error message from SQLite for FK violations contains "FOREIGN KEY".
+	if !strings.Contains(strings.ToUpper(err.Error()), "FOREIGN KEY") {
+		t.Errorf("error should mention FOREIGN KEY constraint: got %q", err.Error())
+	}
+}
+
+// TestGroupFK_OnDeleteSetNull verifies that deleting a session_groups row clears
+// agent_status.group_id (SET NULL cascade) for all members, while leaving all
+// other columns untouched.
+func TestGroupFK_OnDeleteSetNull(t *testing.T) {
+	d := openTestDB(t)
+
+	// Register a group.
+	groupID, err := d.RegisterGroup("coordinator@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Create two member sessions and assign them to the group.
+	for _, name := range []string{"coordinator@main~review-1-goal", "coordinator@main~review-1-code"} {
+		if err := d.UpsertStatus(name, "repo", "/wt", "active", strPtr("My Title"), nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", name, err)
+		}
+	}
+
+	// Confirm group_id is set for both members.
+	var gid *string
+	if err := d.QueryRow(
+		"SELECT group_id FROM agent_status WHERE session_name = 'coordinator@main~review-1-goal'",
+	).Scan(&gid); err != nil || gid == nil || *gid != groupID {
+		t.Fatalf("pre-condition: group_id not set correctly: gid=%v, err=%v", gid, err)
+	}
+
+	// Delete the session_groups row — should cascade SET NULL to members.
+	if err := d.QueryRow(
+		"DELETE FROM session_groups WHERE group_id = ? RETURNING group_id", groupID,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("delete session_groups row: %v", err)
+	}
+
+	// Both members should now have group_id = NULL.
+	for _, name := range []string{"coordinator@main~review-1-goal", "coordinator@main~review-1-code"} {
+		var groupIDAfter *string
+		if err := d.QueryRow(
+			"SELECT group_id FROM agent_status WHERE session_name = ?", name,
+		).Scan(&groupIDAfter); err != nil {
+			t.Fatalf("query group_id for %s: %v", name, err)
+		}
+		if groupIDAfter != nil {
+			t.Errorf("group_id for %s after group deletion: got %v, want nil (SET NULL cascade)", name, *groupIDAfter)
+		}
+
+		// State and title must be preserved (other columns untouched).
+		s, err := d.CurrentStatus(name)
+		if err != nil {
+			t.Fatalf("CurrentStatus %s: %v", name, err)
+		}
+		if s == nil {
+			t.Fatalf("CurrentStatus %s: got nil", name)
+		}
+		if s.State != "active" {
+			t.Errorf("State for %s after group deletion: got %q, want \"active\"", name, s.State)
+		}
+		if s.Title == nil || *s.Title != "My Title" {
+			t.Errorf("Title for %s after group deletion: got %v, want \"My Title\"", name, s.Title)
+		}
+	}
 }
 
 // setPort is a test helper that writes opencode_port directly via QueryRow.

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -2465,14 +2465,14 @@ func TestGroupResults(t *testing.T) {
 		}
 	}
 
-	// Write an assistant_message event for the first member only.
+	// Write a msg_assistant event for the first member only.
 	goalSession := "nixos-config@feature~review-1-goal"
 	if err := d.WriteEvent(db.Event{
 		ID:          "evt-assistant-1",
 		SessionName: goalSession,
 		Repo:        "nixos-config",
 		Worktree:    "/wt",
-		Type:        "assistant_message",
+		Type:        "msg_assistant",
 		Payload:     `{"content":"<verdict>PASS</verdict>"}`,
 		CreatedAt:   time.Now(),
 	}); err != nil {
@@ -2495,7 +2495,7 @@ func TestGroupResults(t *testing.T) {
 		t.Errorf("goal State: got %q, want \"finished\"", goalResult.State)
 	}
 	if goalResult.LastMessage != `{"content":"<verdict>PASS</verdict>"}` {
-		t.Errorf("goal LastMessage: got %q, want assistant_message payload", goalResult.LastMessage)
+		t.Errorf("goal LastMessage: got %q, want msg_assistant payload", goalResult.LastMessage)
 	}
 
 	codeSession := "nixos-config@feature~review-1-code"
@@ -2507,7 +2507,7 @@ func TestGroupResults(t *testing.T) {
 		t.Errorf("code State: got %q, want \"finished\"", codeResult.State)
 	}
 	if codeResult.LastMessage != "" {
-		t.Errorf("code LastMessage: got %q, want \"\" (no assistant_message)", codeResult.LastMessage)
+		t.Errorf("code LastMessage: got %q, want \"\" (no msg_assistant)", codeResult.LastMessage)
 	}
 }
 
@@ -2602,6 +2602,140 @@ func TestGroupFK_OnDeleteSetNull(t *testing.T) {
 		if s.Title == nil || *s.Title != "My Title" {
 			t.Errorf("Title for %s after group deletion: got %v, want \"My Title\"", name, s.Title)
 		}
+	}
+}
+
+// seedV8DB creates a raw SQLite database at dbPath seeded with the v8 schema
+// and an existing agent_status row, simulating a real pre-migration database.
+func seedV8DB(t *testing.T, dbPath string) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open v8 db: %v", err)
+	}
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT, opencode_sid TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  opencode_port INTEGER, host_mode INTEGER NOT NULL DEFAULT 0,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT, harness_port INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (8);
+		INSERT INTO agent_status (session_name, repo, worktree, state, harness, last_seen)
+		  VALUES ('repo@main', 'repo', '/code/repo/main', 'active', 'opencode', 0);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v8 db: %v", err)
+	}
+}
+
+// TestGroupFK_Violation_MigratedDB verifies that FK enforcement works on a
+// database that was migrated from v8 to v9 (not freshly created). This is
+// the critical production path: most deployed prism instances will arrive
+// at v9 via migration, not via a fresh Open. The rename-and-recreate pattern
+// used in the migration ensures the REFERENCES clause is present in the
+// schema metadata, so PRAGMA foreign_keys = ON can enforce it.
+func TestGroupFK_Violation_MigratedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v8_fk_violation.db")
+	seedV8DB(t, dbPath)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v8 db: %v", err)
+	}
+	defer d.Close()
+
+	// Attempt to set group_id to a non-existent group — must fail with FK error.
+	err = d.QueryRow(
+		"UPDATE agent_status SET group_id = 'does-not-exist' WHERE session_name = 'repo@main' RETURNING 1",
+	).Scan(new(int))
+	if err == nil {
+		t.Fatal("expected FK constraint error on migrated DB when setting group_id to non-existent group, got nil")
+	}
+	if !strings.Contains(strings.ToUpper(err.Error()), "FOREIGN KEY") {
+		t.Errorf("error should mention FOREIGN KEY constraint on migrated DB: got %q", err.Error())
+	}
+}
+
+// TestGroupFK_OnDeleteSetNull_MigratedDB verifies that the ON DELETE SET NULL
+// cascade works on a database that was migrated from v8 to v9. The
+// rename-and-recreate migration pattern is required for this to work: a plain
+// ALTER TABLE ADD COLUMN cannot carry a REFERENCES clause, so without the
+// recreate the cascade would silently do nothing.
+func TestGroupFK_OnDeleteSetNull_MigratedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v8_fk_cascade.db")
+	seedV8DB(t, dbPath)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v8 db: %v", err)
+	}
+	defer d.Close()
+
+	// Register a group, assign the existing row to it.
+	groupID, err := d.RegisterGroup("coordinator@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.QueryRow(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = 'repo@main' RETURNING 1",
+		groupID,
+	).Scan(new(int)); err != nil {
+		t.Fatalf("set group_id: %v", err)
+	}
+
+	// Confirm group_id is set.
+	var gid *string
+	if err := d.QueryRow(
+		"SELECT group_id FROM agent_status WHERE session_name = 'repo@main'",
+	).Scan(&gid); err != nil || gid == nil || *gid != groupID {
+		t.Fatalf("pre-condition: group_id not set correctly: gid=%v, err=%v", gid, err)
+	}
+
+	// Delete the session_groups row — ON DELETE SET NULL must clear group_id.
+	if err := d.QueryRow(
+		"DELETE FROM session_groups WHERE group_id = ? RETURNING group_id", groupID,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("delete session_groups: %v", err)
+	}
+
+	// group_id must now be NULL.
+	var groupIDAfter *string
+	if err := d.QueryRow(
+		"SELECT group_id FROM agent_status WHERE session_name = 'repo@main'",
+	).Scan(&groupIDAfter); err != nil {
+		t.Fatalf("query group_id after cascade: %v", err)
+	}
+	if groupIDAfter != nil {
+		t.Errorf("group_id after ON DELETE SET NULL on migrated DB: got %v, want nil", *groupIDAfter)
+	}
+
+	// State must be preserved (other columns untouched).
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil")
+	}
+	if s.State != "active" {
+		t.Errorf("State after cascade on migrated DB: got %q, want \"active\"", s.State)
 	}
 }
 


### PR DESCRIPTION
## Summary

Foundational schema work from #858. Introduces the `group_id` concept for prism sessions as a first-class DB concept, unblocking Issues E, F, and J from #849.

- Adds a new `session_groups` table and a nullable `group_id` FK column on `agent_status`
- Enforces `PRAGMA foreign_keys = ON` on every DB connection
- Implements `RegisterGroup`, `GroupCompleted`, and `GroupResults` helpers with unit tests

**No caller changes** — `prism review`, `prism spawn`, `prism cleanup`, `prism list-sessions`, and dashboard all behave identically. Wiring up is for future issues.

## Schema migration (v8 → v9)

```sql
-- New table
CREATE TABLE session_groups (
  group_id       TEXT PRIMARY KEY,
  parent_session TEXT NOT NULL,
  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
);

-- New nullable FK column on agent_status
ALTER TABLE agent_status ADD COLUMN group_id TEXT;
-- (REFERENCES session_groups(group_id) ON DELETE SET NULL enforced via PRAGMA)
```

Existing rows receive `NULL` for `group_id` (additive, no data loss). Deleting a `session_groups` row clears `agent_status.group_id` for its members via `SET NULL` cascade.

## PRAGMA foreign_keys = ON audit

The **single** DB constructor for the prism database is `db.Open()` in `internal/db/db.go`. `PRAGMA foreign_keys = ON` is set there, immediately after `busy_timeout`. All callers go through this constructor:

- `cmd/db.go` → `openDB()` → `db.Open(dbPath())`
- `internal/dashboard/db.go` → `db.Open(dbPath())`
- `internal/review/review.go` → `db.Open(dbPath)`

`internal/opencode/session.go` opens the **opencode** database (not the prism DB) in read-only mode for session-ID lookup only. It does not interact with prism schema tables and is not part of this audit scope.

## Tests added

- `TestOpen_CreatesSessionGroupsTable` — verifies `session_groups` table and `group_id` column exist on fresh DB
- `TestMigration_V8ToV9` — existing v8 DB migrates cleanly; existing rows have `NULL` group_id
- `TestRegisterGroup` — inserts a row, returns non-empty UUID, second call returns different ID
- `TestGroupCompleted_AllTerminal` — returns true when all members are terminal
- `TestGroupCompleted_ActiveMember` — returns false when at least one member is active
- `TestGroupCompleted_NoMembers` — returns true when group has no members
- `TestGroupResults` — returns state and last assistant_message payload per member
- `TestGroupFK_Violation` — setting `group_id` to a non-existent group raises FK error (proves `PRAGMA foreign_keys = ON` is active)
- `TestGroupFK_OnDeleteSetNull` — deleting a `session_groups` row clears `group_id` on members; other columns untouched

Closes #858