### PR TITLE
prism: cap agent container memory/pids and enable oomd on user slices

### DIFF
--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -22,6 +22,42 @@
           };
           description = "Environment variables to set for the AI agent (opencode)";
         };
+
+        resources = {
+          memoryMax = lib.mkOption {
+            type = lib.types.str;
+            default = "8g";
+            example = "4g";
+            description = ''
+              Maximum memory for each agent container, passed to podman run --memory.
+              Set to an empty string to disable the limit (no flag emitted).
+              Default of 8g allows up to ~3 concurrent workers on a 32 GB host
+              while leaving headroom for the compositor, browser, and system services.
+            '';
+          };
+
+          memorySwapMax = lib.mkOption {
+            type = lib.types.str;
+            default = "8g";
+            example = "8g";
+            description = ''
+              Maximum combined memory+swap for each agent container, passed to
+              podman run --memory-swap. Equal to memoryMax by default, which
+              effectively disables swap for the container so a runaway process
+              dies fast rather than thrashing. Set to an empty string to disable.
+            '';
+          };
+
+          pidsLimit = lib.mkOption {
+            type = lib.types.int;
+            default = 4096;
+            example = 2048;
+            description = ''
+              Maximum number of processes (PIDs) for each agent container, passed
+              to podman run --pids-limit. Set to 0 to disable the limit.
+            '';
+          };
+        };
       };
 
       worktreeExclude = lib.mkOption {
@@ -107,6 +143,17 @@
       agentEnvPrefix = lib.concatStringsSep " " (
         lib.mapAttrsToList (name: value: "${name}=${value}") config.nx.programs.prism.agent.envVars
       );
+      agentResources = {
+        memoryMax = config.nx.programs.prism.agent.resources.memoryMax;
+        memorySwapMax = config.nx.programs.prism.agent.resources.memorySwapMax;
+        pidsLimit = config.nx.programs.prism.agent.resources.pidsLimit;
+      };
     };
+
+    # systemd-oomd: enable monitoring on user slices so that oomd can
+    # intervene when memory pressure on the user slice crosses 80%, acting
+    # as a safety net if pressure escapes the per-container cgroup caps.
+    # Guarded by isLinux — Darwin does not have systemd.
+    systemd.oomd.enableUserSlices = lib.mkIf pkgs.stdenv.isLinux true;
   };
 }

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -137,6 +137,16 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// harness adapter construction below.
 	agentModel := opencodeAgentModel(agentRole)
 
+	// Load profiles to extract container resource caps. Non-fatal if missing
+	// (e.g. running without the nix module) — resource fields remain at their
+	// zero values and no resource flags are emitted.
+	var containerResources config.ContainerResources
+	if containerMode {
+		if pf, pfErr := config.LoadProfiles(); pfErr == nil {
+			containerResources = pf.ContainerResources
+		}
+	}
+
 	// Build container config if container mode is enabled.
 	var ctrCfg *container.Config
 	if containerMode {
@@ -168,6 +178,9 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			GitUserEmail:      prismCfg.GitUserEmail,
 			SshAccessKeyName:  prismCfg.SshAccessKeyName,
 			SshSigningKeyName: prismCfg.SshSigningKeyName,
+			MemoryMax:         containerResources.MemoryMax,
+			MemorySwapMax:     containerResources.MemorySwapMax,
+			PidsLimit:         containerResources.PidsLimit,
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -84,6 +84,26 @@ type ProfilesFile struct {
 	// opencode command string in buildDirectOpencodeCmd so that sh -c
 	// sessions (which do not load .zshrc or zsh aliases) receive them.
 	AgentEnvVars map[string]string `json:"agent_env_vars,omitempty"`
+	// ContainerResources holds per-container resource cap values to be passed
+	// to podman run as --memory, --memory-swap, and --pids-limit.
+	// Written by Nix under container_resources.
+	ContainerResources ContainerResources `json:"container_resources,omitempty"`
+}
+
+// ContainerResources holds the per-container resource cap values that are
+// passed to podman run via buildRunArgs. Zero values / empty strings mean
+// "no flag emitted" so that callers not running via the nix module are
+// not affected.
+type ContainerResources struct {
+	// MemoryMax is the value for podman run --memory (e.g. "8g").
+	// Empty string means no --memory flag.
+	MemoryMax string `json:"memoryMax,omitempty"`
+	// MemorySwapMax is the value for podman run --memory-swap (e.g. "8g").
+	// Empty string means no --memory-swap flag.
+	MemorySwapMax string `json:"memorySwapMax,omitempty"`
+	// PidsLimit is the value for podman run --pids-limit.
+	// Zero means no --pids-limit flag.
+	PidsLimit int `json:"pidsLimit,omitempty"`
 }
 
 // ContainerConfigForRole returns the OPENCODE_CONFIG_CONTENT blob for the

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -167,6 +167,19 @@ type Config struct {
 	// This replaces the previous POST /session + prompt_async HTTP delivery
 	// which created a second session invisible to the TUI (RFC #691 Phase 1a).
 	InitialPrompt string
+
+	// MemoryMax is the value for podman run --memory (e.g. "8g").
+	// When empty, no --memory flag is emitted. This preserves existing
+	// behaviour for callers not using the nix module.
+	MemoryMax string
+
+	// MemorySwapMax is the value for podman run --memory-swap (e.g. "8g").
+	// When empty, no --memory-swap flag is emitted.
+	MemorySwapMax string
+
+	// PidsLimit is the value for podman run --pids-limit.
+	// When zero, no --pids-limit flag is emitted.
+	PidsLimit int
 }
 
 // NameForSession returns the stable podman container name for a session.
@@ -1237,6 +1250,20 @@ func (m *Manager) buildRunArgs() []string {
 	// "./plugins/my-plugin") resolve correctly from the config file's directory.
 	if cfg.ConfigContent != "" {
 		args = append(args, "--volume", m.opencodeConfigFilePath()+":/root/.config/opencode/opencode.json:ro")
+	}
+
+	// Resource caps: emit --memory, --memory-swap, and --pids-limit only when
+	// the corresponding Config field is non-zero / non-empty. This preserves
+	// existing behaviour for callers not using the nix module (empty fields →
+	// no flag emitted).
+	if cfg.MemoryMax != "" {
+		args = append(args, "--memory="+cfg.MemoryMax)
+	}
+	if cfg.MemorySwapMax != "" {
+		args = append(args, "--memory-swap="+cfg.MemorySwapMax)
+	}
+	if cfg.PidsLimit != 0 {
+		args = append(args, fmt.Sprintf("--pids-limit=%d", cfg.PidsLimit))
 	}
 
 	// Image and command: opencode in combined TUI + HTTP mode.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -2947,3 +2947,98 @@ func TestBuildRunArgs_WorkerContainerHasAgentsMount(t *testing.T) {
 		t.Errorf("worker container must have agents/ mount at /root/.config/opencode/agents, but it does not; args: %v", args)
 	}
 }
+
+// ── Resource cap tests (issue #868) ──────────────────────────────────────────
+
+// TestBuildRunArgs_ResourceCapsPresentWhenSet asserts that when MemoryMax,
+// MemorySwapMax, and PidsLimit are set on Config, the corresponding podman flags
+// (--memory, --memory-swap, --pids-limit) appear in the buildRunArgs output.
+func TestBuildRunArgs_ResourceCapsPresentWhenSet(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		MemoryMax:     "8g",
+		MemorySwapMax: "8g",
+		PidsLimit:     4096,
+	})
+	args := m.buildRunArgs()
+
+	wantMemory := "--memory=8g"
+	wantSwap := "--memory-swap=8g"
+	wantPids := "--pids-limit=4096"
+
+	foundMemory, foundSwap, foundPids := false, false, false
+	for _, arg := range args {
+		switch arg {
+		case wantMemory:
+			foundMemory = true
+		case wantSwap:
+			foundSwap = true
+		case wantPids:
+			foundPids = true
+		}
+	}
+	if !foundMemory {
+		t.Errorf("%q not found in args: %v", wantMemory, args)
+	}
+	if !foundSwap {
+		t.Errorf("%q not found in args: %v", wantSwap, args)
+	}
+	if !foundPids {
+		t.Errorf("%q not found in args: %v", wantPids, args)
+	}
+}
+
+// TestBuildRunArgs_ResourceCapsAbsentWhenUnset asserts that when MemoryMax,
+// MemorySwapMax, and PidsLimit are zero/empty (not set), no --memory,
+// --memory-swap, or --pids-limit flags appear in buildRunArgs. This preserves
+// existing behaviour for callers not using the nix module.
+func TestBuildRunArgs_ResourceCapsAbsentWhenUnset(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		// MemoryMax, MemorySwapMax: empty string (zero value)
+		// PidsLimit: 0 (zero value)
+	})
+	args := m.buildRunArgs()
+
+	for _, arg := range args {
+		if arg == "--memory" || strings.HasPrefix(arg, "--memory=") {
+			t.Errorf("unexpected --memory flag when MemoryMax is empty: %q", arg)
+		}
+		if arg == "--memory-swap" || strings.HasPrefix(arg, "--memory-swap=") {
+			t.Errorf("unexpected --memory-swap flag when MemorySwapMax is empty: %q", arg)
+		}
+		if arg == "--pids-limit" || strings.HasPrefix(arg, "--pids-limit=") {
+			t.Errorf("unexpected --pids-limit flag when PidsLimit is zero: %q", arg)
+		}
+	}
+}
+
+// TestBuildRunArgs_ResourceCapMemoryOnlySet asserts that when only MemoryMax
+// is set, only --memory is emitted; --memory-swap and --pids-limit are absent.
+func TestBuildRunArgs_ResourceCapMemoryOnlySet(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		MemoryMax:     "4g",
+		// MemorySwapMax and PidsLimit intentionally left at zero values.
+	})
+	args := m.buildRunArgs()
+
+	foundMemory := false
+	for _, arg := range args {
+		if arg == "--memory=4g" {
+			foundMemory = true
+		}
+		if arg == "--memory-swap" || strings.HasPrefix(arg, "--memory-swap=") {
+			t.Errorf("unexpected --memory-swap when MemorySwapMax is empty: %q", arg)
+		}
+		if arg == "--pids-limit" || strings.HasPrefix(arg, "--pids-limit=") {
+			t.Errorf("unexpected --pids-limit when PidsLimit is zero: %q", arg)
+		}
+	}
+	if !foundMemory {
+		t.Errorf("--memory=4g not found in args: %v", args)
+	}
+}

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -169,6 +169,12 @@
               ]
               value
           ) config.nx.programs.prism.agent.envVars;
+          # Per-container resource caps. These are read by the prism sidecar
+          # and passed to container.Config so that podman run receives
+          # --memory, --memory-swap, and --pids-limit for every agent container.
+          # Values flow: nix option → _internal.agentResources → here → profiles.json
+          # → prism sidecar → container.Config → buildRunArgs → podman run.
+          container_resources = config.nx.programs.prism._internal.agentResources;
         };
 
       applyProfile =


### PR DESCRIPTION
## Summary

- Adds \`nx.programs.prism.agent.resources\` nix options (\`memoryMax\`, \`memorySwapMax\`, \`pidsLimit\`) with defaults \`"8g"\`, \`"8g"\`, \`4096\` — wired through \`_internal\` → \`profiles.json\` → sidecar → \`container.Config\` → \`buildRunArgs\` as \`--memory\`, \`--memory-swap\`, \`--pids-limit\` podman flags on every agent container
- Enables \`systemd.oomd.enableUserSlices = true\` (guarded by \`pkgs.stdenv.isLinux\`) as a backstop for memory pressure escaping per-container cgroup caps
- Adds unit tests asserting resource flags are present when set and absent when unset (zero/empty values)

## Data flow

```
nix option → nx.programs.prism.agent.resources
           → nx.programs.prism._internal.agentResources
           → profiles.nix container_resources key in profiles.json
           → sidecar cmd/sidecar.go loads profiles.LoadProfiles() → populates container.Config
           → container.buildRunArgs() → podman run --memory=8g --memory-swap=8g --pids-limit=4096
```

## Quality gates

- `go build ./...` and `go test ./...` pass from `modules/programs/prism/prism/`
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds
- `nix eval .#darwinConfigurations.m4mac.config.system.build.toplevel.drvPath` evaluates successfully (build not possible on x86_64-linux/aarch64-darwin mismatch — eval correctness confirmed)
- `nix eval .#nixosConfigurations.navi.config.systemd.oomd.enableUserSlices` returns `true`
- `nix eval .#darwinConfigurations.m4mac.pkgs.stdenv.isLinux` returns `false` confirming isLinux guard

## AC #10: Machine-level override verification (nix eval)

The issue requires that a machine-level override (`nx.programs.prism.agent.resources.memoryMax = "4g"`) is verified by nix eval rather than code inspection alone.

Using `extendModules` to apply the override inline:

```
nix eval --impure --expr '
let
  flake = builtins.getFlake "git+file:///workspace";
  naviBase = flake.nixosConfigurations.navi;
  withOverride = naviBase.extendModules {
    modules = [ { nx.programs.prism.agent.resources.memoryMax = "4g"; } ];
  };
in {
  before = naviBase.config.nx.programs.prism._internal.agentResources.memoryMax;
  after = withOverride.config.nx.programs.prism._internal.agentResources.memoryMax;
}'
```

Output: `{ after = "4g"; before = "8g"; }`

This confirms the override propagates correctly through `_internal.agentResources` → `profiles.json` `container_resources` field → sidecar → `container.Config.MemoryMax` → `buildRunArgs` → `--memory=4g`.

Closes #868