### PR TITLE
revert: stop recommending prism review; deny it in all agent profiles

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -247,6 +247,10 @@
         "prism checkin *" = "allow";
         "prism list-sessions" = "allow";
         "prism prompt *" = "allow";
+        # prism review is denied — it spawns heavy containers and can crash the
+        # host when multiple workers run it concurrently. Use @review-* Task calls.
+        "prism review" = "deny";
+        "prism review *" = "deny";
       };
 
       # Bash commands for the coordinator agent — inverted model: ask by default,
@@ -272,6 +276,10 @@
         "prism prompt *" = "allow";
         "prism cleanup *" = "allow";
         "prism pr *" = "allow";
+        # prism review is denied — spawns heavy containers, can crash host.
+        # Use @review-* Task calls instead.
+        "prism review" = "deny";
+        "prism review *" = "deny";
         # GitHub: PR/issue lifecycle
         "gh pr merge *" = "ask";
         "gh pr edit *" = "allow";
@@ -342,8 +350,7 @@
           Pass the PR number to each. All 5 must return `<verdict>PASS</verdict>` for the review to pass.
           If ANY agent returns FAIL, fix all blocking issues, push, and re-run all 5 agents.
           After 3 full review cycles without convergence, stop and escalate — do not run a 4th cycle.
-          Preferred invocation: `prism review <pr-number>` (spawns all 5 agents automatically, provides dashboard observability).
-          Fallback: invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` directly as parallel Task calls.
+          Invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` as parallel Task calls (all five in a single response).
 
         ## Search Scope
 
@@ -444,6 +451,10 @@
         "gh pr merge *" = "deny";
         "nixos-rebuild *" = "deny";
         "sudo nixos-rebuild *" = "deny";
+        # prism review spawns heavy containers — denied to prevent host overload.
+        # Use @review-* Task calls instead.
+        "prism review" = "deny";
+        "prism review *" = "deny";
       };
 
       # Coordinator container: strict deny-by-default allowlist.
@@ -511,6 +522,11 @@
         "rm *" = "deny";
         "mv *" = "deny";
         "mkdir *" = "deny";
+        # prism review spawns heavy containers — denied even under "prism *" = "allow".
+        # Use @review-* Task calls instead. Pattern specificity: these explicit denies
+        # win over the broader "prism *" = "allow" (last match wins).
+        "prism review" = "deny";
+        "prism review *" = "deny";
       };
 
       # Providers to expose in containers — restricts model list to these 3.
@@ -703,6 +719,10 @@
                 "prism spawn *" = "deny";
                 "prism pr" = "deny";
                 "prism pr *" = "deny";
+                # prism review spawns heavy containers — denied to prevent host overload.
+                # Use @review-* Task calls instead.
+                "prism review" = "deny";
+                "prism review *" = "deny";
               }
               // tmuxDenyCommands;
             };

--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -56,31 +56,8 @@ When your work is complete and quality gates pass:
 ## Parallel review
 
 Before announcing your PR as complete, and after each push to an open PR, run
-code review using `prism review <pr-number>` (preferred) or direct `@review-*`
-Task calls (fallback). `prism review` spawns all five specialised review agents
-automatically and provides dashboard observability and retry support. Fix any
-issues and re-run review until it passes.
-
-### Running code review with prism review
-
-```bash
-# Run review against your PR (blocks until all 5 agents complete, returns findings to stdout)
-result=$(prism review <pr-number>)
-echo "$result"
-
-# If some agents fail, re-run only the failed ones
-prism review <pr-number> --only review-code,review-security
-
-# Check in on review progress from the coordinator session
-prism checkin $(tmux display-message -p '#{session_name}')~review
-```
-
-`prism review` exit code 0 = all agents passed; non-zero = failures.
-
-### Fallback: direct Task calls
-
-If `prism review` is unavailable or fails to start, invoke the five agents
-**in parallel** (in a single response with 5 Task tool calls):
+code review by invoking the five review subagents **in parallel** (in a single
+response with 5 Task tool calls):
 
 1. `@review-goal` — pass the original issue/ACs and the PR number
 2. `@review-code` — pass the PR number
@@ -96,9 +73,9 @@ If ANY agent returns `<verdict>FAIL</verdict>`:
 1. Read each agent's `<blocking_issues>` carefully
 2. Fix every blocking issue identified
 3. Commit and push your fixes
-4. Re-run review (via `prism review` or direct Task calls) against all 5 agents
-   — not just the ones that failed. A fix in one area can create issues in
-   another, so the full set must re-run every cycle.
+4. Re-run all 5 review subagents in parallel — not just the ones that failed.
+   A fix in one area can create issues in another, so the full set must re-run
+   every cycle.
 
 ### Escalation
 

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -329,7 +329,7 @@ export const PrismHooks: Plugin = async (pluginInput) => {
       pendingReviewReminder = false;
 
       output.system.push(
-        "You just ran git push. If this was in the context of an open PR, run `prism review <pr-number>` to review the updated changes before the PR is merged (preferred). Alternatively, invoke @review-goal, @review-code, @review-security, @review-qa, and @review-context in parallel as a fallback. ALL 5 agents must pass before the PR can be merged.",
+        "You just ran git push. If this was in the context of an open PR, invoke @review-goal, @review-code, @review-security, @review-qa, and @review-context as parallel Task calls (all five in a single response) to review the updated changes before the PR is merged. ALL 5 agents must pass before the PR can be merged.",
       );
       return output;
     },

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -144,105 +144,24 @@ prism spawn \
   --prompt "find the plex container image in this repo and update it to the latest tag from dockerhub, then open a PR"
 ```
 
-## Running code review with prism review
+## Running code review
 
-`prism review <pr-number>` is the preferred way to run code review from a worker session. It spawns 5 independent review agent sessions and returns findings to stdout when all agents complete.
+Code review is done by invoking the five review subagents **in parallel** — all
+five as Task tool calls in a single response:
 
-```bash
-# Run review — blocks until all agents finish, returns findings to stdout
-result=$(prism review 268)
-echo "$result"
+1. `@review-goal` — pass the original issue/ACs and the PR number
+2. `@review-code` — pass the PR number
+3. `@review-security` — pass the PR number
+4. `@review-qa` — pass the PR number
+5. `@review-context` — pass the PR number
 
-# Re-run only specific agents (useful after a first pass with failures)
-prism review 268 --only review-code,review-security
+Wait for all 5 to complete. ALL must return `<verdict>PASS</verdict>` for the
+review to pass. If ANY returns `<verdict>FAIL</verdict>`, fix all blocking
+issues, push, and re-run all five. After 3 full cycles without convergence,
+stop and escalate — do not run a 4th cycle.
 
-# Custom timeout (default: 10m)
-prism review 268 --timeout 5m
-```
-
-**Output format:**
-```
-✓ review-goal         passed
-✓ review-code         passed
-✗ review-security     [findings...]
-✓ review-qa           passed
-✓ review-context      passed
-
-1 agent(s) failed. Retry: prism review 268 --only review-security
-```
-
-Exit code 0 = all passed, non-zero = failures.
-
-**Session shape:**
-
-Each review agent runs as its own independent top-level tmux session:
-```
-<parent>~review-<N>-review-goal
-<parent>~review-<N>-review-code
-<parent>~review-<N>-review-security
-<parent>~review-<N>-review-qa
-<parent>~review-<N>-review-context
-```
-- `N` is the round number, incremented on each `prism review` invocation.
-- Sessions **persist** after `prism review` completes — you can re-read findings later without re-running.
-- Sessions are only cleaned up when `prism cleanup` is invoked on the parent.
-
-**Review sessions appear in the dashboard** at depth 2, indented under their parent branch (sorted alphabetically by label):
-```
-nixos-config@main                   coordinator
-  ├── @feature-branch               worker
-  │   ├── ~review-1-review-code     finished
-  │   ├── ~review-1-review-context  finished
-  │   ├── ~review-1-review-goal     finished
-  │   ├── ~review-1-review-qa       finished
-  │   ├── ~review-1-review-security finished
-  │   ├── ~review-2-review-code     active
-  │   └── ~review-2-review-security active
-```
-
-Each review agent session is individually selectable in the **`C-f` picker** — after selecting the project repo, review sessions appear as additional entries (e.g. `~review-1-review-security  [finished]`). Jump directly to any reviewer with one keypress.
-
-**Checking in on review progress:**
-```bash
-# From the coordinator session, inspect all review sessions for a worker (grouped by round)
-prism checkin nixos-config@feature-branch~review
-
-# Inspect a specific agent session
-prism checkin nixos-config@feature-branch~review-1-review-security
-
-# Show full per-agent conversation
-prism checkin nixos-config@feature-branch~review --verbose
-```
-
-**Flags:**
-
-| Flag | Description |
-|---|---|
-| `--harness <name>` | Runtime harness (default: `opencode`) |
-| `--timeout <dur>` | Per-agent timeout (default: `10m`) |
-| `--only <csv>` | Run only named agents (e.g. `--only review-code,review-security`). See retry semantics below. |
-
-Note: `--keep` has been retired. Sessions now persist by default until `prism cleanup` on the parent.
-
-**`--only` retry semantics:**
-
-Each `prism review` invocation — including those using `--only` — increments the round counter `N`. Only the named agents are spawned in that round; sessions from previous rounds are left untouched. This means:
-
-- Full round: spawns 5 sessions as `~review-1-review-*`
-- `prism review 268 --only review-code,review-security`: spawns 2 sessions as `~review-2-review-code` and `~review-2-review-security`. The 5 round-1 sessions remain.
-- A subsequent full round: spawns 5 sessions as `~review-3-review-*`.
-
-The output with `--only` contains exactly one line per requested agent — not five lines with three marked "skipped".
-
-### When to use prism review vs direct Task calls
-
-| Situation | Use |
-|---|---|
-| Worker running in a tmux session (normal case) | `prism review` |
-| Want review visible in the dashboard | `prism review` |
-| Running in a context without tmux | Invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, `@review-context` as parallel Task calls |
-
-Both invocation styles run the same 5 agents — use whichever fits the context.
+> Note: the `prism review` command is explicitly disabled for agents at the
+> permissions layer. Direct subagent invocation is the canonical path.
 
 ## Example: reviewing a PR (manual spawn)
 


### PR DESCRIPTION
## Summary

- Removes all `prism review` guidance from agent-facing docs (worker.md, agentInstructions, prism-hooks.ts post-push reminder, SKILL.md) — direct `@review-*` Task calls are now the sole canonical path
- Adds `"prism review" = "deny"` and `"prism review *" = "deny"` to every opencode bash permission profile: `workerBashCommands`, `coordinatorBashCommands`, `containerWorkerBashCommands`, `containerCoordinatorBashCommands`, and the worker subagent (build agent) override block
- The Go `prism review` command itself is **not** changed — it remains available as a power-user escape hatch

## Context

`prism review` spawns 5 independent review containers per cycle. With 3 concurrent workers (as seen today), that's 15+ heavy containers — enough to crash the host even with the per-container memory caps from #869. The real fix is to stop agents reaching for it by default.

Closes #870
Context: #869