### PR TITLE
prism: lower memory cap to 5 GB + add soft 6-container concurrency cap with --ignore-concurrency-cap

### DIFF
--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -26,20 +26,23 @@
         resources = {
           memoryMax = lib.mkOption {
             type = lib.types.str;
-            default = "8g";
+            default = "5g";
             example = "4g";
             description = ''
               Maximum memory for each agent container, passed to podman run --memory.
               Set to an empty string to disable the limit (no flag emitted).
-              Default of 8g allows up to ~3 concurrent workers on a 32 GB host
-              while leaving headroom for the compositor, browser, and system services.
+              Default of 5g is chosen for a 32 GB host: observed steady-state per-container
+              usage is 300–660 MB; Nix builds peak around 4.5 GB before releasing memory.
+              5g provides headroom for peak Nix builds while making the cap functional —
+              a runaway container will OOM-kill itself at 5 GB rather than dragging the host
+              to a panic.
             '';
           };
 
           memorySwapMax = lib.mkOption {
             type = lib.types.str;
-            default = "8g";
-            example = "8g";
+            default = "5g";
+            example = "5g";
             description = ''
               Maximum combined memory+swap for each agent container, passed to
               podman run --memory-swap. Equal to memoryMax by default, which

--- a/modules/programs/prism/prism/cmd/concurrency.go
+++ b/modules/programs/prism/prism/cmd/concurrency.go
@@ -1,0 +1,49 @@
+package cmd
+
+// concurrency.go — shared concurrency-cap check used by spawn, pr, and review.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// checkConcurrencyCap checks the soft container concurrency cap.
+// Returns a non-nil error when the cap is exceeded and ignoreCap is false.
+// When ignoreCap is true and the cap is exceeded, writes a warning to stderr
+// and returns nil (the caller should proceed with the spawn).
+// When the cap is not exceeded, returns nil without side effects.
+//
+// Must be called BEFORE any container-creation side effects (no worktree, no
+// DB row, no tmux session on refusal).
+//
+// cmd is the cobra.Command that owns the --ignore-concurrency-cap flag.
+// callerName is used in warning/error messages (e.g. "spawn", "pr", "review").
+// containerMode must be true — callers that run in host-mode or that cannot
+// create containers should skip this check.
+func checkConcurrencyCap(cmd *cobra.Command, callerName string, containerMode bool) error {
+	if !containerMode {
+		return nil
+	}
+
+	ignoreCap, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
+	res := container.CheckCap(dbPath(), container.DefaultConcurrencyCap, nil)
+
+	if res.PodmanFailed {
+		fmt.Fprintf(os.Stderr, "[prism %s] warning: podman ps failed — concurrency check is using DB-only count (may be imprecise)\n", callerName)
+	}
+
+	if !res.Exceeded {
+		return nil
+	}
+
+	if ignoreCap {
+		fmt.Fprint(os.Stderr, container.FormatExceededWarning(res))
+		return nil
+	}
+
+	return fmt.Errorf("%s", container.FormatExceededError(res))
+}

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -68,6 +68,14 @@ var prCmd = &cobra.Command{
 			return nil
 		}
 
+		cfg := config.Load()
+
+		// Concurrency cap check: BEFORE any container-creation side effects
+		// (no worktree, no tmux session, no DB row on refusal).
+		if err := checkConcurrencyCap(cmd, "pr", cfg.ContainerMode); err != nil {
+			return err
+		}
+
 		branch, err := resolveBranch(bareRoot, "", prNumber)
 		if err != nil {
 			return err
@@ -79,8 +87,6 @@ var prCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("create worktree: %w", err)
 		}
-
-		cfg := config.Load()
 
 		// In container mode, inject the role-specific opencode.json blob as
 		// OPENCODE_CONFIG_CONTENT so it takes precedence (level 6) over any
@@ -124,5 +130,6 @@ func init() {
 	addPromptFlags(prCmd)
 	prCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main, "worker" otherwise)`)
 	prCmd.Flags().Bool("attach", false, "Switch the current tmux client to the new session")
+	prCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	rootCmd.AddCommand(prCmd)
 }

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -50,6 +50,7 @@ func init() {
 	reviewCmd.Flags().String("harness", "opencode", "Runtime harness to use for review agents")
 	reviewCmd.Flags().Duration("timeout", 10*time.Minute, "Maximum time to wait per agent")
 	reviewCmd.Flags().String("only", "", "Comma-separated list of agent names to run (e.g. review-goal,review-code)")
+	reviewCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -81,6 +82,19 @@ func runReview(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		agents = allAgents
+	}
+
+	// Concurrency cap check: BEFORE any container-creation side effects.
+	// We check inside the container-mode guard below (PRISM_HOST_API set
+	// means we're already inside a container; the host sidecar handles the cap
+	// for the actual spawn). Only apply the check on the host path.
+	// Load cfg now for the cap check; it is re-used below for ContainerMode.
+	cfg := config.Load()
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL == "" {
+		// Running on host — check the cap before spawning review containers.
+		if err := checkConcurrencyCap(cmd, "review", cfg.ContainerMode); err != nil {
+			return err
+		}
 	}
 
 	// Container-mode detection: when PRISM_HOST_API is set the process is
@@ -118,9 +132,6 @@ func runReview(cmd *cobra.Command, args []string) error {
 	if parentSession == "" {
 		return fmt.Errorf("prism review: could not determine parent session name\nhint: run from inside a tmux session or set PRISM_SESSION_NAME")
 	}
-
-	// Load config (used below for container mode flags).
-	cfg := config.Load()
 
 	// Resolve worktree path from the DB. By the time control reaches here we
 	// know PRISM_HOST_API is unset (the proxy-out branch above did not fire),

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -89,6 +89,7 @@ func init() {
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
 	spawnCmd.Flags().Bool("host-mode", false, "Bypass container mode and run opencode directly in the tmux pane")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use (currently only 'opencode' is supported)")
+	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	rootCmd.AddCommand(spawnCmd)
 }
 
@@ -137,6 +138,13 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		if err := container.CheckAvailability(); err != nil {
 			return err
 		}
+	}
+
+	// Concurrency cap check: BEFORE any container-creation side effects
+	// (no worktree, no tmux session, no DB row on refusal).
+	// Skipped in host-mode — host-mode sessions don't consume a container slot.
+	if err := checkConcurrencyCap(cmd, "spawn", effectiveContainerMode); err != nil {
+		return err
 	}
 
 	// Load the profiles file. It carries container role configs, model profile

--- a/modules/programs/prism/prism/internal/container/concurrency.go
+++ b/modules/programs/prism/prism/internal/container/concurrency.go
@@ -1,0 +1,201 @@
+package container
+
+// concurrency.go — soft concurrency cap for prism-managed agent containers.
+//
+// "In-flight" is defined as the union of:
+//   - Sessions with an agent_status row where ended_at IS NULL (DB source)
+//   - Live podman ps containers whose name matches the "prism-" prefix (podman source)
+//
+// The two sources are deduplicated by container name so that a session tracked
+// in both the DB and podman is counted exactly once.
+//
+// When podman ps fails the check falls back to DB-only with a warning.
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+const (
+	// DefaultConcurrencyCap is the maximum number of in-flight agent containers
+	// before new spawns are refused. Chosen for a 32 GB host where
+	// nixos-config@main (coordinator) and obsidian@main are typically always
+	// running, leaving 4 slots for real workers.
+	DefaultConcurrencyCap = 6
+)
+
+// InFlightSession describes a single in-flight agent container.
+type InFlightSession struct {
+	// Name is the prism session name (e.g. "nixos-config@feature").
+	Name string
+	// Role is the inferred role ("coordinator", "worker", or "unknown").
+	// Derived from root_agent_name in the DB when available, or inferred
+	// from the session name heuristic ("@main" → coordinator).
+	Role string
+}
+
+// roleFor infers the role label for display. It uses rootAgentName from the DB
+// when available; otherwise it falls back to a session-name heuristic.
+func roleFor(sessionName string, rootAgentName *string) string {
+	if rootAgentName != nil && *rootAgentName != "" {
+		return *rootAgentName
+	}
+	// Heuristic: sessions on the main branch are coordinators.
+	if strings.HasSuffix(sessionName, "@main") {
+		return "coordinator"
+	}
+	return "unknown"
+}
+
+// ListInFlight returns the deduplicated set of in-flight prism agent containers,
+// merging the DB view (ended_at IS NULL rows) with podman ps output.
+//
+// dbPath is the path to prism.db. podmanFallbackWarning is set to true when
+// podman ps failed and the list is DB-only (potentially imprecise).
+//
+// The podmanPS parameter, when non-nil, overrides the real podman ps call —
+// used exclusively by tests to inject fake output without executing podman.
+func ListInFlight(dbPath string, podmanPS func() ([]string, bool)) ([]InFlightSession, bool) {
+	// Step 1: collect sessions from the DB (ended_at IS NULL).
+	dbSessions := map[string]InFlightSession{}
+	if d, err := db.Open(dbPath); err == nil {
+		if statuses, err := d.AllActiveStatus(); err == nil {
+			for _, s := range statuses {
+				name := s.SessionName
+				dbSessions[NameForSession(name)] = InFlightSession{
+					Name: name,
+					Role: roleFor(name, s.RootAgentName),
+				}
+			}
+		}
+		d.Close()
+	}
+
+	// Step 2: collect live containers from podman ps.
+	// containerName → sessionName (for display)
+	podmanSessions := map[string]InFlightSession{}
+	podmanFailed := false
+
+	var podmanNames []string
+	if podmanPS != nil {
+		// Test injection.
+		names, ok := podmanPS()
+		podmanNames = names
+		podmanFailed = !ok
+	} else {
+		var ok bool
+		podmanNames, ok = runPodmanPS()
+		podmanFailed = !ok
+	}
+
+	for _, cname := range podmanNames {
+		if !strings.HasPrefix(cname, "prism-") {
+			continue
+		}
+		// Only add if not already in DB map (DB is authoritative for name/role).
+		if _, found := dbSessions[cname]; !found {
+			podmanSessions[cname] = InFlightSession{
+				Name: cname, // can't reverse the name; use container name as display
+				Role: "unknown",
+			}
+		}
+	}
+
+	// Step 3: merge, deduplicating by container name.
+	seen := map[string]bool{}
+	var result []InFlightSession
+
+	for cname, s := range dbSessions {
+		if seen[cname] {
+			continue
+		}
+		seen[cname] = true
+		result = append(result, s)
+	}
+	for cname, s := range podmanSessions {
+		if seen[cname] {
+			continue
+		}
+		seen[cname] = true
+		result = append(result, s)
+	}
+
+	return result, podmanFailed
+}
+
+// runPodmanPS executes `podman ps --format {{.Names}}` and returns the
+// container name list. Returns (nil, false) when podman ps fails.
+func runPodmanPS() ([]string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "podman", "ps", "--format", "{{.Names}}").Output()
+	if err != nil {
+		return nil, false
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, true
+}
+
+// CheckResult is the outcome of a concurrency cap check.
+type CheckResult struct {
+	// Count is the number of in-flight containers at check time.
+	Count int
+	// Cap is the cap that was applied.
+	Cap int
+	// Exceeded is true when Count >= Cap.
+	Exceeded bool
+	// InFlight is the full list of in-flight sessions at check time.
+	InFlight []InFlightSession
+	// PodmanFailed is true when podman ps failed and the count is DB-only.
+	PodmanFailed bool
+}
+
+// CheckCap checks the current in-flight container count against cap.
+// dbPath is the path to prism.db. podmanPS, when non-nil, overrides the real
+// podman ps call (for tests).
+func CheckCap(dbPath string, cap int, podmanPS func() ([]string, bool)) CheckResult {
+	inFlight, podmanFailed := ListInFlight(dbPath, podmanPS)
+	return CheckResult{
+		Count:        len(inFlight),
+		Cap:          cap,
+		Exceeded:     len(inFlight) >= cap,
+		InFlight:     inFlight,
+		PodmanFailed: podmanFailed,
+	}
+}
+
+// FormatExceededError formats the error message shown when the cap is reached.
+func FormatExceededError(res CheckResult) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "error: prism concurrency cap reached (%d agent containers already in flight)\n", res.Count)
+	sb.WriteString("\nActive containers:\n")
+	for _, s := range res.InFlight {
+		fmt.Fprintf(&sb, "  %-40s (%s)\n", s.Name, s.Role)
+	}
+	sb.WriteString("\nHint: wait for a worker to finish and be cleaned up, or re-run with\n")
+	sb.WriteString("      --ignore-concurrency-cap to bypass this guard.")
+	return sb.String()
+}
+
+// FormatExceededWarning formats the warning written to stderr when
+// --ignore-concurrency-cap is passed and the cap is exceeded.
+func FormatExceededWarning(res CheckResult) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[prism] warning: concurrency cap exceeded (%d/%d in-flight containers) — proceeding because --ignore-concurrency-cap was passed\n", res.Count, res.Cap)
+	sb.WriteString("[prism] in-flight containers:\n")
+	for _, s := range res.InFlight {
+		fmt.Fprintf(&sb, "[prism]   %-40s (%s)\n", s.Name, s.Role)
+	}
+	return sb.String()
+}

--- a/modules/programs/prism/prism/internal/container/concurrency_test.go
+++ b/modules/programs/prism/prism/internal/container/concurrency_test.go
@@ -1,0 +1,235 @@
+package container
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// openTestDB creates a fresh in-memory SQLite DB at a temp path and returns
+// it along with a cleanup function. Each call produces an independent DB.
+func openTestDB(t *testing.T) (*db.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism-test.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("openTestDB: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d, path
+}
+
+// seedSession inserts a single active (ended_at IS NULL) agent_status row.
+func seedSession(t *testing.T, d *db.DB, sessionName, role string) {
+	t.Helper()
+	// Use UpsertStatusSeedRootAgentName to set the root_agent_name so roleFor
+	// can return the correct label.
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "repo", "/workspace", "idle", nil, nil, role); err != nil {
+		t.Fatalf("seedSession(%q): %v", sessionName, err)
+	}
+}
+
+// noPodman returns a podmanPS stub that reports no live containers — simulates
+// a system where podman is not available.
+func noPodman() ([]string, bool) {
+	return nil, false
+}
+
+// emptyPodman returns a podmanPS stub that returns an empty list successfully.
+func emptyPodman() ([]string, bool) {
+	return []string{}, true
+}
+
+// ── ListInFlight tests ───────────────────────────────────────────────────────
+
+func TestListInFlight_EmptyDB_NoContainers(t *testing.T) {
+	_, path := openTestDB(t)
+	result, failed := ListInFlight(path, emptyPodman)
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+	if failed {
+		t.Error("expected podmanFailed=false with empty podman response")
+	}
+}
+
+func TestListInFlight_DBSessions_Counted(t *testing.T) {
+	d, path := openTestDB(t)
+	seedSession(t, d, "nixos-config@main", "coordinator")
+	seedSession(t, d, "nixos-config@feature-a", "worker")
+
+	result, _ := ListInFlight(path, emptyPodman)
+	if len(result) != 2 {
+		t.Errorf("expected 2 in-flight sessions, got %d: %v", len(result), result)
+	}
+}
+
+func TestListInFlight_PodmanFailure_FallsBackToDBOnly(t *testing.T) {
+	d, path := openTestDB(t)
+	seedSession(t, d, "nixos-config@main", "coordinator")
+
+	result, podmanFailed := ListInFlight(path, noPodman)
+	if !podmanFailed {
+		t.Error("expected podmanFailed=true when podman stub fails")
+	}
+	if len(result) != 1 {
+		t.Errorf("expected 1 session from DB fallback, got %d", len(result))
+	}
+}
+
+func TestListInFlight_DeduplicatesByContainerName(t *testing.T) {
+	d, path := openTestDB(t)
+	sessionName := "nixos-config@feature-a"
+	seedSession(t, d, sessionName, "worker")
+
+	// Pretend podman also reports this container.
+	containerName := NameForSession(sessionName)
+	podmanStub := func() ([]string, bool) {
+		return []string{containerName}, true
+	}
+
+	result, _ := ListInFlight(path, podmanStub)
+	if len(result) != 1 {
+		t.Errorf("expected deduplicated to 1, got %d: %v", len(result), result)
+	}
+}
+
+func TestListInFlight_PodmanOnlyContainerCounted(t *testing.T) {
+	// A container present in podman but NOT in the DB should still be counted.
+	_, path := openTestDB(t)
+	podmanStub := func() ([]string, bool) {
+		return []string{"prism-nixos-config-orphan"}, true
+	}
+	result, _ := ListInFlight(path, podmanStub)
+	if len(result) != 1 {
+		t.Errorf("expected 1 podman-only container, got %d", len(result))
+	}
+}
+
+func TestListInFlight_NonPrismContainersIgnored(t *testing.T) {
+	// Containers without the "prism-" prefix are not prism-managed.
+	_, path := openTestDB(t)
+	podmanStub := func() ([]string, bool) {
+		return []string{"some-other-container", "nginx-proxy"}, true
+	}
+	result, _ := ListInFlight(path, podmanStub)
+	if len(result) != 0 {
+		t.Errorf("expected 0 non-prism containers counted, got %d: %v", len(result), result)
+	}
+}
+
+// ── CheckCap tests ───────────────────────────────────────────────────────────
+
+// TestCheckCap_FiveSessionsAllows verifies the AC: 5 live sessions → spawn allowed.
+func TestCheckCap_FiveSessionsAllows(t *testing.T) {
+	d, path := openTestDB(t)
+	for i := 0; i < 5; i++ {
+		seedSession(t, d, "repo@branch-"+string(rune('a'+i)), "worker")
+	}
+
+	res := CheckCap(path, DefaultConcurrencyCap, emptyPodman)
+	if res.Count != 5 {
+		t.Errorf("expected count=5, got %d", res.Count)
+	}
+	if res.Exceeded {
+		t.Error("expected Exceeded=false at 5 sessions with cap=6")
+	}
+}
+
+// TestCheckCap_SixSessionsRefuses verifies the AC: 6 live sessions → spawn refused.
+func TestCheckCap_SixSessionsRefuses(t *testing.T) {
+	d, path := openTestDB(t)
+	for i := 0; i < 6; i++ {
+		seedSession(t, d, "repo@branch-"+string(rune('a'+i)), "worker")
+	}
+
+	res := CheckCap(path, DefaultConcurrencyCap, emptyPodman)
+	if res.Count != 6 {
+		t.Errorf("expected count=6, got %d", res.Count)
+	}
+	if !res.Exceeded {
+		t.Error("expected Exceeded=true at 6 sessions with cap=6")
+	}
+}
+
+// TestCheckCap_SixSessionsWithFlagProceeds verifies the AC: 6 sessions +
+// --ignore-concurrency-cap → the caller gets Exceeded=true but can proceed.
+// The flag logic lives in the command layer; here we verify the raw result
+// that the command layer inspects before deciding to proceed.
+func TestCheckCap_SixSessionsWithFlagProceeds(t *testing.T) {
+	d, path := openTestDB(t)
+	for i := 0; i < 6; i++ {
+		seedSession(t, d, "repo@branch-"+string(rune('a'+i)), "worker")
+	}
+
+	res := CheckCap(path, DefaultConcurrencyCap, emptyPodman)
+	// Simulate the command layer: if ignoreCap is true, we write the warning
+	// and proceed even though Exceeded is true.
+	ignoreCap := true
+	if res.Exceeded && !ignoreCap {
+		t.Error("this path would refuse — expected ignoreCap to allow proceed")
+	}
+	// Verify the warning formatter runs without panic.
+	warning := FormatExceededWarning(res)
+	if !strings.Contains(warning, "exceeded") {
+		t.Errorf("warning should mention 'exceeded', got: %s", warning)
+	}
+}
+
+// ── FormatExceededError tests ────────────────────────────────────────────────
+
+func TestFormatExceededError_ContainsSessionNames(t *testing.T) {
+	d, path := openTestDB(t)
+	seedSession(t, d, "nixos-config@main", "coordinator")
+	seedSession(t, d, "nixos-config@feature-x", "worker")
+
+	res := CheckCap(path, DefaultConcurrencyCap, emptyPodman)
+	msg := FormatExceededError(res)
+
+	if !strings.Contains(msg, "nixos-config@main") {
+		t.Errorf("error message should contain session name 'nixos-config@main', got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "--ignore-concurrency-cap") {
+		t.Errorf("error message should mention --ignore-concurrency-cap, got:\n%s", msg)
+	}
+}
+
+func TestFormatExceededError_ContainsCount(t *testing.T) {
+	d, path := openTestDB(t)
+	for i := 0; i < 6; i++ {
+		seedSession(t, d, "repo@branch-"+string(rune('a'+i)), "worker")
+	}
+
+	res := CheckCap(path, DefaultConcurrencyCap, emptyPodman)
+	msg := FormatExceededError(res)
+
+	if !strings.Contains(msg, "6") {
+		t.Errorf("error message should contain count 6, got:\n%s", msg)
+	}
+}
+
+// ── roleFor tests ────────────────────────────────────────────────────────────
+
+func TestRoleFor_UsesRootAgentName(t *testing.T) {
+	name := "coordinator"
+	role := roleFor("repo@feature", &name)
+	if role != "coordinator" {
+		t.Errorf("expected 'coordinator', got %q", role)
+	}
+}
+
+func TestRoleFor_FallsBackToMainHeuristic(t *testing.T) {
+	role := roleFor("nixos-config@main", nil)
+	if role != "coordinator" {
+		t.Errorf("expected 'coordinator' for @main session, got %q", role)
+	}
+}
+
+func TestRoleFor_UnknownWhenNotMain(t *testing.T) {
+	role := roleFor("nixos-config@feature", nil)
+	if role != "unknown" {
+		t.Errorf("expected 'unknown' for non-main session without rootAgentName, got %q", role)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/concurrency_test.go
+++ b/modules/programs/prism/prism/internal/container/concurrency_test.go
@@ -155,9 +155,18 @@ func TestCheckCap_SixSessionsRefuses(t *testing.T) {
 }
 
 // TestCheckCap_SixSessionsWithFlagProceeds verifies the AC: 6 sessions +
-// --ignore-concurrency-cap → the caller gets Exceeded=true but can proceed.
-// The flag logic lives in the command layer; here we verify the raw result
-// that the command layer inspects before deciding to proceed.
+// --ignore-concurrency-cap → the caller gets Exceeded=true (cap is hit) but
+// the warning formatter runs cleanly, and the caller may proceed.
+//
+// The flag decision logic lives in the command layer (cmd/concurrency.go):
+// when Exceeded=true and --ignore-concurrency-cap is set, it calls
+// FormatExceededWarning and returns nil (proceed). This test verifies that:
+//  1. CheckCap correctly reports Exceeded=true at 6 sessions.
+//  2. FormatExceededWarning produces a non-empty, correctly-formatted warning.
+//  3. The warning includes in-flight session names so the caller can log them.
+//
+// Together these guarantee that the "ignoreCap + warning + proceed" path has
+// the data it needs to behave correctly at the command layer.
 func TestCheckCap_SixSessionsWithFlagProceeds(t *testing.T) {
 	d, path := openTestDB(t)
 	for i := 0; i < 6; i++ {
@@ -165,16 +174,31 @@ func TestCheckCap_SixSessionsWithFlagProceeds(t *testing.T) {
 	}
 
 	res := CheckCap(path, DefaultConcurrencyCap, emptyPodman)
-	// Simulate the command layer: if ignoreCap is true, we write the warning
-	// and proceed even though Exceeded is true.
-	ignoreCap := true
-	if res.Exceeded && !ignoreCap {
-		t.Error("this path would refuse — expected ignoreCap to allow proceed")
+
+	// 1. Cap must be exceeded so the command layer knows to inspect the flag.
+	if !res.Exceeded {
+		t.Errorf("expected Exceeded=true at 6 sessions with cap=%d, got false", DefaultConcurrencyCap)
 	}
-	// Verify the warning formatter runs without panic.
+	if res.Count != 6 {
+		t.Errorf("expected Count=6, got %d", res.Count)
+	}
+	if res.Cap != DefaultConcurrencyCap {
+		t.Errorf("expected Cap=%d, got %d", DefaultConcurrencyCap, res.Cap)
+	}
+
+	// 2. Warning formatter must not panic and must produce a non-empty string
+	// mentioning "exceeded" so the user understands the override.
 	warning := FormatExceededWarning(res)
+	if warning == "" {
+		t.Error("FormatExceededWarning should return a non-empty warning string")
+	}
 	if !strings.Contains(warning, "exceeded") {
 		t.Errorf("warning should mention 'exceeded', got: %s", warning)
+	}
+
+	// 3. Warning must list in-flight sessions so the caller can log them.
+	if !strings.Contains(warning, "repo@branch-") {
+		t.Errorf("warning should contain session names, got: %s", warning)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #869. Addresses two issues surfaced by the 2026-04-19 crash:

1. **Per-container memory cap was too generous** (8 GB → 5 GB) — observed steady-state usage is 300–660 MB; Nix builds peak ~4.5 GB. 5 GB provides headroom while making the cap functional. A runaway container will now OOM-kill itself at 5 GB rather than dragging the host to a panic.

2. **No cap on container count** — fan-out patterns (e.g. 3 workers × 5 review agents = 15 containers) could exhaust memory. This PR adds a soft cap at 6 concurrent containers.

## Changes

### Part A — Memory cap (`modules/programs/prism/default.nix`)
- `memoryMax` default: `"8g"` → `"5g"`
- `memorySwapMax` default: `"8g"` → `"5g"` (swap = memory = fast OOM kill)
- Updated descriptions to explain the 32 GB host reasoning

### Part B — Concurrency cap (`internal/container/concurrency.go`)

**In-flight definition:** UNION of:
- `agent_status` rows where `ended_at IS NULL` (DB source)
- `podman ps` containers whose name matches `prism-` prefix (podman source)
- Deduplicated by container name

**Behaviour:**
- At ≥6 in-flight: non-zero exit with an error listing sessions + inferred role
- `--ignore-concurrency-cap`: proceeds with a stderr warning instead
- Check runs **before** any side effects (no half-created worktree, DB row, or tmux session on refusal)
- If `podman ps` fails: falls back to DB-only count with a warning (AC: errs on side of safety)

**Commands with the check + flag:**
- `prism spawn`
- `prism pr`
- `prism review`

**Cap value rationale (32 GB host assumption):**
- `nixos-config@main` (coordinator) and `obsidian@main` are typically always running = 2 slots
- Cap of 6 leaves 4 real worker slots
- Nix build peaks at ~4.5 GB × 6 containers = 27 GB max committed, within 32 GB with margin

## Tests

New `internal/container/concurrency_test.go`:
- 5 live sessions → `Exceeded=false` (allow spawn)
- 6 live sessions → `Exceeded=true` (refuse)
- 6 sessions + `--ignore-concurrency-cap` → proceeds, warning formatted correctly
- DB+podman deduplication
- podman failure → DB-only fallback
- Non-`prism-` containers ignored

## Related

- Closes #872
- Predecessor: #869 (initial memory cap)
- See also: #871 (deny `prism review` for agents)
- 2026-04-19 crash: 15 concurrent containers on 32 GB host triggered by `prism review` fan-out