### PR TITLE
container: add bwrapIsolator implementation (unreachable from CLI)

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -94,18 +94,21 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--bind", cfg.Worktree, cfg.Worktree)
 	}
 
-	// ── /prism-git (bare repo) ──────────────────────────────────────────────
-	// When BareRoot is set, mount the .bare directory at /prism-git so that
-	// git commondir resolution works inside the sandbox.
+	// ── Bare repo and worktree private git state (read-write) ──────────────
+	// Dst == Src: both directories mount at their host paths inside the
+	// sandbox, not at the /prism-git canonical container path used by the
+	// podman path. This is correct bwrap behaviour — the git commondir pointer
+	// inside WorktreeGitDir/commondir already points at the absolute host path
+	// for the bare dir, so no remapping is needed. PRISM_BARE_ROOT is updated
+	// below to point at the actual host path rather than /prism-git.
 	if cfg.BareRoot != "" && cfg.WorktreeGitDir != "" {
 		bareDir := filepath.Join(cfg.BareRoot, ".bare")
 		if _, err := os.Stat(bareDir); err == nil {
-			args = append(args, "--bind", bareDir, "/prism-git")
+			args = append(args, "--bind", bareDir, bareDir)
 		}
 		// Worktree private git state (HEAD, index, logs, etc.) — read-write.
-		branch := filepath.Base(cfg.WorktreeGitDir)
 		if _, err := os.Stat(cfg.WorktreeGitDir); err == nil {
-			args = append(args, "--bind", cfg.WorktreeGitDir, "/prism-git/worktrees/"+branch)
+			args = append(args, "--bind", cfg.WorktreeGitDir, cfg.WorktreeGitDir)
 		}
 	}
 
@@ -206,11 +209,26 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// TERM: xterm-256color for full SGR mouse support in the TUI.
 	args = append(args, "--setenv", "TERM", "xterm-256color")
 
-	// Prism context variables (mirror the podman path).
-	// PRISM_SPAWN_PATH and PRISM_BARE_ROOT keep their podman values for now
-	// because the wiring PR (#877) will decide whether to remap them for bwrap.
-	args = append(args, "--setenv", "PRISM_SPAWN_PATH", "/workspace")
-	args = append(args, "--setenv", "PRISM_BARE_ROOT", "/prism-git")
+	// Prism context variables.
+	// PRISM_SPAWN_PATH: use the actual host worktree path (not /workspace).
+	// In the bwrap sandbox the worktree is mounted at its host path, so
+	// prism CLI commands inside the sandbox see the same absolute path the
+	// host does — no remap required.
+	if cfg.Worktree != "" {
+		args = append(args, "--setenv", "PRISM_SPAWN_PATH", cfg.Worktree)
+	} else {
+		args = append(args, "--setenv", "PRISM_SPAWN_PATH", "/workspace")
+	}
+	// PRISM_BARE_ROOT: use the actual host bare repo root (not /prism-git).
+	// Dst==Src mounts mean the bare dir is visible at its host path inside
+	// the sandbox. Set PRISM_BARE_ROOT to cfg.BareRoot so that
+	// resolveBareRoot finds it at the correct path.
+	// TODO(#877): confirm the correct value when wiring bwrap end-to-end.
+	if cfg.BareRoot != "" {
+		args = append(args, "--setenv", "PRISM_BARE_ROOT", cfg.BareRoot)
+	} else {
+		args = append(args, "--setenv", "PRISM_BARE_ROOT", "/prism-git")
+	}
 	args = append(args, "--setenv", "PRISM_SESSION_NAME", cfg.SessionName)
 
 	// OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: 15-minute bash timeout.
@@ -224,10 +242,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		)
 	} else if cfg.HostAPISockPath != "" {
 		sockDir := filepath.Dir(cfg.HostAPISockPath)
-		sockFile := filepath.Base(cfg.HostAPISockPath)
 		args = append(args, "--bind", sockDir, sockDir)
 		args = append(args, "--setenv", "PRISM_HOST_API", "unix://"+cfg.HostAPISockPath)
-		_ = sockFile // sockFile is part of the path already
 	}
 
 	// ── Working directory ────────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -1,0 +1,322 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file defines bwrapIsolator, a bubblewrap-based implementation of the
+// Isolator interface. It is a pure addition — nothing constructs bwrapIsolator
+// at runtime yet. The wiring (CLI flag / config field) is intentionally deferred
+// to a follow-up PR (#877).
+package container
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// bwrapIsolator implements Isolator using bubblewrap (bwrap). It satisfies the
+// interface through Run, Shutdown, HasExited, and DumpLogs. BuildRunArgs()
+// returns nil (a no-op stub) because the real argument construction is
+// performed by BuildArgs(m *Manager), which has access to the Manager's config
+// and state.
+//
+// Design decision (option 2 from issue #876): the interface is not widened yet.
+// BuildRunArgs() is a stub; BuildArgs is a concrete method. The widening is
+// deferred to the wiring PR so this PR stays a pure addition.
+type bwrapIsolator struct {
+	// name is the stable session identifier (same as the container name, used
+	// for log messages and process identification).
+	name string
+
+	// mu guards cmd and logBuf.
+	mu     sync.Mutex
+	cmd    *exec.Cmd
+	logBuf strings.Builder
+}
+
+// newBwrapIsolator returns an Isolator backed by bubblewrap for the given
+// session name. The returned value satisfies the Isolator interface.
+func newBwrapIsolator(name string) Isolator {
+	return &bwrapIsolator{name: name}
+}
+
+// BuildRunArgs satisfies the Isolator interface. It returns nil because the
+// real argument construction requires Manager state and is implemented by the
+// concrete BuildArgs(m *Manager) method below.
+func (b *bwrapIsolator) BuildRunArgs() []string {
+	return nil
+}
+
+// BuildArgs constructs the bwrap argument list that is equivalent to the
+// podman run arguments built by Manager.buildRunArgs(), translating podman
+// syntax into bubblewrap equivalents:
+//
+//   - --volume SRC:DST:ro → --ro-bind SRC DST
+//   - --volume SRC:DST[:Z] → --bind SRC DST
+//   - --env K=V → --setenv K V
+//   - --workdir X → --chdir X
+//
+// Key design decision: Dst == Src for all mounts (no /workspace remap).
+// Worktrees mount at their host path directly inside the bwrap sandbox.
+//
+// The returned slice begins with the baseline namespace flags and ends with
+// -- followed by the opencode invocation.
+func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
+	cfg := m.cfg
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+
+	// ── Baseline namespace flags ────────────────────────────────────────────
+	// These establish the minimal sandbox: private PID, IPC, and UTS
+	// namespaces; a fresh /proc and /dev; a tmpfs on /tmp; and a guarantee
+	// that the sandbox dies when the parent process exits.
+	args := []string{
+		"--unshare-pid",
+		"--unshare-ipc",
+		"--unshare-uts",
+		"--proc", "/proc",
+		"--dev", "/dev",
+		"--tmpfs", "/tmp",
+		"--die-with-parent",
+	}
+
+	// ── Worktree (read-write) ───────────────────────────────────────────────
+	// Dst == Src: the worktree mounts at its host path inside the sandbox.
+	// No /workspace remap — this is the key bwrap design difference.
+	if cfg.Worktree != "" {
+		args = append(args, "--bind", cfg.Worktree, cfg.Worktree)
+	}
+
+	// ── /prism-git (bare repo) ──────────────────────────────────────────────
+	// When BareRoot is set, mount the .bare directory at /prism-git so that
+	// git commondir resolution works inside the sandbox.
+	if cfg.BareRoot != "" && cfg.WorktreeGitDir != "" {
+		bareDir := filepath.Join(cfg.BareRoot, ".bare")
+		if _, err := os.Stat(bareDir); err == nil {
+			args = append(args, "--bind", bareDir, "/prism-git")
+		}
+		// Worktree private git state (HEAD, index, logs, etc.) — read-write.
+		branch := filepath.Base(cfg.WorktreeGitDir)
+		if _, err := os.Stat(cfg.WorktreeGitDir); err == nil {
+			args = append(args, "--bind", cfg.WorktreeGitDir, "/prism-git/worktrees/"+branch)
+		}
+	}
+
+	// ── ~/.claude (read-write) ──────────────────────────────────────────────
+	claudeDir := filepath.Join(home, ".claude")
+	args = append(args, "--bind", claudeDir, claudeDir)
+
+	// ── ~/.mcp-auth (read-write, conditional) ──────────────────────────────
+	mcpAuthDir := filepath.Join(home, ".mcp-auth")
+	if _, err := os.Stat(mcpAuthDir); err == nil {
+		args = append(args, "--bind", mcpAuthDir, mcpAuthDir)
+	}
+
+	// ── opencode session state dir (read-write) ─────────────────────────────
+	opencodeSessionDir := filepath.Join(home, ".local", "share", "opencode", "prism-sessions", m.name)
+	args = append(args, "--bind", opencodeSessionDir, opencodeSessionDir)
+
+	// ── Nix daemon socket dir (read-write) ──────────────────────────────────
+	// Mount the parent directory, not the socket file directly (same pattern
+	// as the podman path — avoids statfs ENOTSUP on certain filesystems).
+	nixDaemonSocketDir := "/nix/var/nix/daemon-socket"
+	args = append(args, "--bind", nixDaemonSocketDir, nixDaemonSocketDir)
+
+	// ── ~/.cache/nix (read-write) ────────────────────────────────────────────
+	nixCacheDir := filepath.Join(home, ".cache", "nix")
+	args = append(args, "--bind", nixCacheDir, nixCacheDir)
+
+	// ── AWS readonly-config (read-only, conditional) ─────────────────────────
+	awsReadonlyConfig := filepath.Join(home, ".config", "aws", "readonly-config")
+	if resolved, err := filepath.EvalSymlinks(awsReadonlyConfig); err == nil {
+		args = append(args, "--ro-bind", resolved, resolved)
+	}
+
+	// ── Kube agents-config (read-only, conditional) ─────────────────────────
+	kubeAgentsConfig := filepath.Join(home, ".config", "kube", "agents-config")
+	if resolved, err := filepath.EvalSymlinks(kubeAgentsConfig); err == nil {
+		args = append(args, "--ro-bind", resolved, resolved)
+	}
+
+	// ── SSH keys (read-only, conditional) ───────────────────────────────────
+	sshDir := filepath.Join(home, ".ssh")
+
+	accessKeyName := cfg.SshAccessKeyName
+	if accessKeyName == "" {
+		accessKeyName = "prismatic-koi-ed25519"
+	}
+	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, accessKeyName)); err == nil {
+		args = append(args, "--ro-bind", resolved, resolved)
+	}
+
+	signingKeyName := cfg.SshSigningKeyName
+	if signingKeyName == "" {
+		signingKeyName = "prismatic-koi-ed25519-signingkey"
+	}
+	signingKeyResolved, errPriv := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName))
+	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName+".pub"))
+	if errPriv == nil && errPub == nil {
+		args = append(args,
+			"--ro-bind", signingKeyResolved, signingKeyResolved,
+			"--ro-bind", signingKeyPubResolved, signingKeyPubResolved,
+		)
+		if m.allowedSignersReady {
+			allowedSignersPath := m.allowedSignersFilePath()
+			args = append(args, "--ro-bind", allowedSignersPath, allowedSignersPath)
+		}
+	}
+
+	// ── known_hosts (read-only, conditional) ────────────────────────────────
+	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "known_hosts")); err == nil {
+		args = append(args, "--ro-bind", resolved, resolved)
+	}
+
+	// ── Generated SSH config (read-only) ────────────────────────────────────
+	sshConfigPath := m.sshConfigFilePath()
+	args = append(args, "--ro-bind", sshConfigPath, sshConfigPath)
+
+	// ── Generated .gitconfig (read-only) ────────────────────────────────────
+	gitconfigPath := m.gitconfigFilePath()
+	args = append(args, "--ro-bind", gitconfigPath, gitconfigPath)
+
+	// ── opencode.json (read-only, conditional) ──────────────────────────────
+	if cfg.ConfigContent != "" {
+		opencodeConfigPath := m.opencodeConfigFilePath()
+		args = append(args, "--ro-bind", opencodeConfigPath, opencodeConfigPath)
+	}
+
+	// ── Environment variables ────────────────────────────────────────────────
+	// Translate --env K=V (podman) → --setenv K V (bwrap).
+	// Inject the same set of env vars as the podman path.
+	for _, kv := range m.credentialEnvVars() {
+		k, v, _ := strings.Cut(kv, "=")
+		args = append(args, "--setenv", k, v)
+	}
+
+	// NIX_CONFIG: tell nix to use the host daemon for store operations.
+	args = append(args, "--setenv", "NIX_CONFIG", "store = daemon")
+
+	// TERM: xterm-256color for full SGR mouse support in the TUI.
+	args = append(args, "--setenv", "TERM", "xterm-256color")
+
+	// Prism context variables (mirror the podman path).
+	// PRISM_SPAWN_PATH and PRISM_BARE_ROOT keep their podman values for now
+	// because the wiring PR (#877) will decide whether to remap them for bwrap.
+	args = append(args, "--setenv", "PRISM_SPAWN_PATH", "/workspace")
+	args = append(args, "--setenv", "PRISM_BARE_ROOT", "/prism-git")
+	args = append(args, "--setenv", "PRISM_SESSION_NAME", cfg.SessionName)
+
+	// OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: 15-minute bash timeout.
+	args = append(args, "--setenv", "OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS", "900000")
+
+	// Host-API env var.
+	if cfg.HostAPITCPPort != 0 {
+		args = append(args,
+			"--setenv", "PRISM_HOST_API",
+			fmt.Sprintf("http://host.containers.internal:%d", cfg.HostAPITCPPort),
+		)
+	} else if cfg.HostAPISockPath != "" {
+		sockDir := filepath.Dir(cfg.HostAPISockPath)
+		sockFile := filepath.Base(cfg.HostAPISockPath)
+		args = append(args, "--bind", sockDir, sockDir)
+		args = append(args, "--setenv", "PRISM_HOST_API", "unix://"+cfg.HostAPISockPath)
+		_ = sockFile // sockFile is part of the path already
+	}
+
+	// ── Working directory ────────────────────────────────────────────────────
+	// --chdir points at the worktree source path (not /workspace).
+	args = append(args, "--chdir", cfg.Worktree)
+
+	// ── Terminator: -- opencode --port <port> --hostname 127.0.0.1 ──────────
+	// bwrap uses 127.0.0.1 (not 0.0.0.0): the host network namespace is shared
+	// (no --unshare-net), so binding to 0.0.0.0 would be overly broad.
+	args = append(args, "--",
+		"opencode",
+		"--port", fmt.Sprintf("%d", ContainerPort),
+		"--hostname", "127.0.0.1",
+	)
+
+	if cfg.AgentRole != "" {
+		args = append(args, "--agent", cfg.AgentRole)
+	}
+	if cfg.InitialPrompt != "" {
+		args = append(args, "--prompt", cfg.InitialPrompt)
+	}
+
+	return args
+}
+
+// Run launches "bwrap <args...>" and waits for it to complete. Stdout and
+// stderr are forwarded to the sidecar's stderr log. Returns a wrapped error
+// on failure.
+func (b *bwrapIsolator) Run(ctx context.Context, args []string) error {
+	cmd := exec.CommandContext(ctx, "bwrap", args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	b.mu.Lock()
+	b.cmd = cmd
+	b.mu.Unlock()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("container: bwrap run %q: %w", b.name, err)
+	}
+	return nil
+}
+
+// Shutdown sends SIGTERM to the bwrap process if it is still running. It uses
+// a background context with a 30-second timeout so cleanup proceeds even after
+// the parent context has been cancelled.
+func (b *bwrapIsolator) Shutdown() {
+	b.mu.Lock()
+	cmd := b.cmd
+	b.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = cmd.Wait()
+	}()
+
+	// Send SIGTERM and wait up to 30 seconds for the process to exit.
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+}
+
+// HasExited returns (true, exitCode) when the bwrap process has terminated,
+// or (false, 0) when it is still running or has not been started.
+func (b *bwrapIsolator) HasExited() (bool, int) {
+	b.mu.Lock()
+	cmd := b.cmd
+	b.mu.Unlock()
+
+	if cmd == nil || cmd.ProcessState == nil {
+		return false, 0
+	}
+	if cmd.ProcessState.Exited() {
+		return true, cmd.ProcessState.ExitCode()
+	}
+	return false, 0
+}
+
+// DumpLogs logs a message indicating that log capture is not yet implemented
+// for bwrap (stdout/stderr are forwarded live to the sidecar log during Run).
+func (b *bwrapIsolator) DumpLogs() {
+	log.Printf("container: bwrap %q: live output was forwarded to sidecar stderr during Run", b.name)
+}

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -65,6 +65,22 @@ func (b *bwrapIsolator) BuildRunArgs() []string {
 //
 // The returned slice begins with the baseline namespace flags and ends with
 // -- followed by the opencode invocation.
+//
+// # Mounts deferred to the wiring PR (#877)
+//
+// The following mounts exist in Manager.buildRunArgs() (podman) but are
+// intentionally omitted here until the end-to-end wiring is in place:
+//
+//   - opencode config allowlist (~/.config/opencode/{AGENTS.md,plugins,skills,...})
+//   - auth.json overlay (~/.local/share/opencode/auth.json, r/w over session dir)
+//   - opencode plugin cache (~/.cache/opencode/, read-only)
+//   - bun transpiler cache (~/.cache/bun/, read-only)
+//   - Additional AWS mounts (credentials, sso/, cli/ — AC lists only readonly-config)
+//   - Clipboard staging dir (~/.cache/prism/clipboard/)
+//   - WorktreeReadOnly handling (review agents — separate concern from base wiring)
+//   - Darwin Keychain credentials (darwin-only, not applicable on Linux)
+//
+// These are tracked in #877 and will be added when bwrap is wired end-to-end.
 func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	cfg := m.cfg
 

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -1,0 +1,933 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// findPairs returns all (flag, value) pairs in args where args[i] == flag.
+// For single-value flags like --bind SRC DST, use findTriples.
+func findPairs(args []string, flag string) [][2]string {
+	var out [][2]string
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			out = append(out, [2]string{args[i+1], ""})
+		}
+	}
+	return out
+}
+
+// findTriples returns all (flag, v1, v2) triples where args[i] == flag.
+func findTriples(args []string, flag string) [][3]string {
+	var out [][3]string
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == flag {
+			out = append(out, [3]string{args[i+1], args[i+2], ""})
+		}
+	}
+	return out
+}
+
+// hasArg returns true when args contains the given element.
+func hasArg(args []string, s string) bool {
+	for _, a := range args {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+// hasBind returns true when args contains --bind src src (same src and dst).
+func hasBind(args []string, src string) bool {
+	for _, t := range findTriples(args, "--bind") {
+		if t[0] == src && t[1] == src {
+			return true
+		}
+	}
+	return false
+}
+
+// hasROBind returns true when args contains --ro-bind src src.
+func hasROBind(args []string, src string) bool {
+	for _, t := range findTriples(args, "--ro-bind") {
+		if t[0] == src && t[1] == src {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSetenv returns true when args contains --setenv key value.
+func hasSetenv(args []string, key, value string) bool {
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == "--setenv" && args[i+1] == key && args[i+2] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// newBwrapManager creates a Manager and injects a bwrapIsolator, setting up
+// the fake HOME so that conditional path checks can be controlled.
+func newBwrapManager(cfg Config) *Manager {
+	m := New(cfg)
+	m.isolator = newBwrapIsolator(m.name)
+	return m
+}
+
+// bwrapFixture creates a Manager with a temporary HOME directory and enough
+// fake paths to exercise all branches of BuildArgs. The returned cleanup
+// function removes all temporary state.
+func bwrapFixture(t *testing.T, cfg Config) (m *Manager, fakeHome string, cleanup func()) {
+	t.Helper()
+
+	fakeHome = t.TempDir()
+
+	// Pre-create directories that BuildArgs expects unconditionally.
+	dirs := []string{
+		filepath.Join(fakeHome, ".claude"),
+		filepath.Join(fakeHome, ".mcp-auth"),
+		filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions"),
+		filepath.Join(fakeHome, ".cache", "nix"),
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("fixture: MkdirAll %q: %v", d, err)
+		}
+	}
+
+	// Ensure the opencode session dir exists (named after the container).
+	containerN := containerName(cfg.SessionName)
+	sessionDir := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", containerN)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("fixture: MkdirAll session dir: %v", err)
+	}
+
+	// Create fake SSH keys (regular files, so EvalSymlinks resolves them).
+	sshDir := filepath.Join(fakeHome, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("fixture: MkdirAll ssh dir: %v", err)
+	}
+	sshFiles := []string{
+		"prismatic-koi-ed25519",
+		"prismatic-koi-ed25519-signingkey",
+		"prismatic-koi-ed25519-signingkey.pub",
+		"known_hosts",
+	}
+	for _, f := range sshFiles {
+		p := filepath.Join(sshDir, f)
+		if err := os.WriteFile(p, []byte("fake"), 0o600); err != nil {
+			t.Fatalf("fixture: WriteFile %q: %v", p, err)
+		}
+	}
+
+	// AWS readonly-config.
+	awsDir := filepath.Join(fakeHome, ".config", "aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatalf("fixture: MkdirAll aws dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(awsDir, "readonly-config"), []byte("fake"), 0o600); err != nil {
+		t.Fatalf("fixture: WriteFile aws readonly-config: %v", err)
+	}
+
+	// Kube agents-config.
+	kubeDir := filepath.Join(fakeHome, ".config", "kube")
+	if err := os.MkdirAll(kubeDir, 0o755); err != nil {
+		t.Fatalf("fixture: MkdirAll kube dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kubeDir, "agents-config"), []byte("fake"), 0o600); err != nil {
+		t.Fatalf("fixture: WriteFile kube agents-config: %v", err)
+	}
+
+	// Override HOME for the duration of this test.
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", fakeHome); err != nil {
+		t.Fatalf("fixture: Setenv HOME: %v", err)
+	}
+
+	m = newBwrapManager(cfg)
+
+	// Write the SSH config and gitconfig temp files BuildArgs expects.
+	if err := os.WriteFile(m.sshConfigFilePath(), []byte("fake ssh config"), 0o600); err != nil {
+		t.Fatalf("fixture: WriteFile ssh config: %v", err)
+	}
+	if err := os.WriteFile(m.gitconfigFilePath(), []byte("fake gitconfig"), 0o600); err != nil {
+		t.Fatalf("fixture: WriteFile gitconfig: %v", err)
+	}
+
+	cleanup = func() {
+		_ = os.Setenv("HOME", origHome)
+	}
+	return m, fakeHome, cleanup
+}
+
+// ── Baseline namespace flags ─────────────────────────────────────────────────
+
+func TestBwrapBuildArgs_BaselineFlags(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	// The first 8 elements must be the baseline namespace flags in order.
+	want := []string{
+		"--unshare-pid",
+		"--unshare-ipc",
+		"--unshare-uts",
+		"--proc", "/proc",
+		"--dev", "/dev",
+		"--tmpfs", "/tmp",
+		"--die-with-parent",
+	}
+	for i, w := range want {
+		if i >= len(args) {
+			t.Fatalf("args too short (%d): missing baseline flag %q", len(args), w)
+		}
+		if args[i] != w {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], w)
+		}
+	}
+}
+
+// ── Read-write binds ─────────────────────────────────────────────────────────
+
+func TestBwrapBuildArgs_WorktreeBound(t *testing.T) {
+	worktree := t.TempDir()
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      worktree,
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasBind(args, worktree) {
+		t.Errorf("worktree %q not found as --bind SRC SRC in args: %v", worktree, args)
+	}
+}
+
+func TestBwrapBuildArgs_ClaudeDirBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	claudeDir := filepath.Join(fakeHome, ".claude")
+	if !hasBind(args, claudeDir) {
+		t.Errorf("~/.claude %q not found as --bind SRC SRC in args: %v", claudeDir, args)
+	}
+}
+
+func TestBwrapBuildArgs_McpAuthBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	mcpAuthDir := filepath.Join(fakeHome, ".mcp-auth")
+	if !hasBind(args, mcpAuthDir) {
+		t.Errorf("~/.mcp-auth %q not found as --bind SRC SRC in args: %v", mcpAuthDir, args)
+	}
+}
+
+func TestBwrapBuildArgs_OpencodeSessionDirBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	sessionDir := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", m.name)
+	if !hasBind(args, sessionDir) {
+		t.Errorf("opencode session dir %q not found as --bind SRC SRC in args: %v", sessionDir, args)
+	}
+}
+
+func TestBwrapBuildArgs_NixDaemonSocketDirBound(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasBind(args, "/nix/var/nix/daemon-socket") {
+		t.Errorf("/nix/var/nix/daemon-socket not found as --bind SRC SRC in args: %v", args)
+	}
+}
+
+func TestBwrapBuildArgs_NixCacheDirBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	nixCacheDir := filepath.Join(fakeHome, ".cache", "nix")
+	if !hasBind(args, nixCacheDir) {
+		t.Errorf("~/.cache/nix %q not found as --bind SRC SRC in args: %v", nixCacheDir, args)
+	}
+}
+
+// ── Read-only binds ──────────────────────────────────────────────────────────
+
+func TestBwrapBuildArgs_AWSReadonlyConfigROBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	awsConfig := filepath.Join(fakeHome, ".config", "aws", "readonly-config")
+	if !hasROBind(args, awsConfig) {
+		t.Errorf("AWS readonly-config %q not found as --ro-bind SRC SRC in args: %v", awsConfig, args)
+	}
+}
+
+func TestBwrapBuildArgs_KubeAgentsConfigROBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	kubeConfig := filepath.Join(fakeHome, ".config", "kube", "agents-config")
+	if !hasROBind(args, kubeConfig) {
+		t.Errorf("kube agents-config %q not found as --ro-bind SRC SRC in args: %v", kubeConfig, args)
+	}
+}
+
+func TestBwrapBuildArgs_SSHAccessKeyROBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	accessKey := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519")
+	if !hasROBind(args, accessKey) {
+		t.Errorf("SSH access key %q not found as --ro-bind SRC SRC in args: %v", accessKey, args)
+	}
+}
+
+func TestBwrapBuildArgs_SSHSigningKeyROBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	signingKey := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey")
+	signingKeyPub := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey.pub")
+	if !hasROBind(args, signingKey) {
+		t.Errorf("SSH signing key (private) %q not found as --ro-bind SRC SRC in args: %v", signingKey, args)
+	}
+	if !hasROBind(args, signingKeyPub) {
+		t.Errorf("SSH signing key (public) %q not found as --ro-bind SRC SRC in args: %v", signingKeyPub, args)
+	}
+}
+
+func TestBwrapBuildArgs_KnownHostsROBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	knownHosts := filepath.Join(fakeHome, ".ssh", "known_hosts")
+	if !hasROBind(args, knownHosts) {
+		t.Errorf("known_hosts %q not found as --ro-bind SRC SRC in args: %v", knownHosts, args)
+	}
+}
+
+func TestBwrapBuildArgs_GeneratedSSHConfigROBound(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	sshConfigPath := m.sshConfigFilePath()
+	if !hasROBind(args, sshConfigPath) {
+		t.Errorf("generated SSH config %q not found as --ro-bind SRC SRC in args: %v", sshConfigPath, args)
+	}
+}
+
+func TestBwrapBuildArgs_GeneratedGitconfigROBound(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	gitconfigPath := m.gitconfigFilePath()
+	if !hasROBind(args, gitconfigPath) {
+		t.Errorf("generated gitconfig %q not found as --ro-bind SRC SRC in args: %v", gitconfigPath, args)
+	}
+}
+
+func TestBwrapBuildArgs_OpencodeJSONROBound(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		ConfigContent: `{"model":"claude-3-5-sonnet"}`,
+	})
+	defer cleanup()
+
+	// Write the opencode config temp file as Create() would.
+	if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o600); err != nil {
+		t.Fatalf("WriteFile opencode config: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	configPath := m.opencodeConfigFilePath()
+	if !hasROBind(args, configPath) {
+		t.Errorf("opencode.json %q not found as --ro-bind SRC SRC in args: %v", configPath, args)
+	}
+}
+
+// ── Env vars (--setenv K V) ──────────────────────────────────────────────────
+
+func TestBwrapBuildArgs_EnvVarsTranslated(t *testing.T) {
+	// Set a known env var that credentialEnvVars() will pick up.
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "ANTHROPIC_API_KEY", "test-anthropic-key") {
+		t.Errorf("--setenv ANTHROPIC_API_KEY test-anthropic-key not found in args: %v", args)
+	}
+}
+
+func TestBwrapBuildArgs_NixConfigSetenv(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "NIX_CONFIG", "store = daemon") {
+		t.Errorf("--setenv NIX_CONFIG 'store = daemon' not found in args: %v", args)
+	}
+}
+
+func TestBwrapBuildArgs_TermSetenv(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "TERM", "xterm-256color") {
+		t.Errorf("--setenv TERM xterm-256color not found in args: %v", args)
+	}
+}
+
+func TestBwrapBuildArgs_PrismSessionNameSetenv(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "myrepo@feat",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "PRISM_SESSION_NAME", "myrepo@feat") {
+		t.Errorf("--setenv PRISM_SESSION_NAME myrepo@feat not found in args: %v", args)
+	}
+}
+
+// ── --chdir points at the worktree source path ───────────────────────────────
+
+func TestBwrapBuildArgs_ChdirIsWorktree(t *testing.T) {
+	worktree := t.TempDir()
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      worktree,
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	found := false
+	for i, a := range args {
+		if a == "--chdir" && i+1 < len(args) {
+			if args[i+1] == worktree {
+				found = true
+			} else {
+				t.Errorf("--chdir value = %q, want %q", args[i+1], worktree)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("--chdir %q not found in args: %v", worktree, args)
+	}
+}
+
+func TestBwrapBuildArgs_ChdirIsNotSlashWorkspace(t *testing.T) {
+	// The bwrap path must NOT remap to /workspace.
+	worktree := t.TempDir()
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      worktree,
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for i, a := range args {
+		if a == "--chdir" && i+1 < len(args) {
+			if args[i+1] == "/workspace" {
+				t.Errorf("--chdir must not be /workspace in bwrap mode; got %q", args[i+1])
+			}
+		}
+	}
+}
+
+// ── Terminator: -- opencode --port <port> --hostname 127.0.0.1 ───────────────
+
+func TestBwrapBuildArgs_Terminator(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	// Find the -- separator.
+	sepIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	if sepIdx < 0 {
+		t.Fatalf("-- separator not found in args: %v", args)
+	}
+
+	tail := args[sepIdx+1:]
+	if len(tail) < 5 {
+		t.Fatalf("tail after -- too short (%d): %v", len(tail), tail)
+	}
+	if tail[0] != "opencode" {
+		t.Errorf("tail[0] = %q, want opencode", tail[0])
+	}
+	if tail[1] != "--port" {
+		t.Errorf("tail[1] = %q, want --port", tail[1])
+	}
+	wantPort := fmt.Sprintf("%d", ContainerPort)
+	if tail[2] != wantPort {
+		t.Errorf("tail[2] = %q, want %q", tail[2], wantPort)
+	}
+	if tail[3] != "--hostname" {
+		t.Errorf("tail[3] = %q, want --hostname", tail[3])
+	}
+	if tail[4] != "127.0.0.1" {
+		t.Errorf("tail[4] = %q, want 127.0.0.1", tail[4])
+	}
+}
+
+func TestBwrapBuildArgs_AgentRoleAndPromptInTail(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentRole:     "worker",
+		InitialPrompt: "fix the bug",
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	n := len(args)
+	if n < 4 {
+		t.Fatalf("too few args (%d): %v", n, args)
+	}
+	if args[n-4] != "--agent" || args[n-3] != "worker" {
+		t.Errorf("expected --agent worker near end, got %q %q", args[n-4], args[n-3])
+	}
+	if args[n-2] != "--prompt" || args[n-1] != "fix the bug" {
+		t.Errorf("expected --prompt 'fix the bug' near end, got %q %q", args[n-2], args[n-1])
+	}
+}
+
+func TestBwrapBuildArgs_NoAgentNorPromptWhenEmpty(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasArg(args, "--agent") {
+		t.Errorf("--agent unexpectedly present when AgentRole is empty: %v", args)
+	}
+	if hasArg(args, "--prompt") {
+		t.Errorf("--prompt unexpectedly present when InitialPrompt is empty: %v", args)
+	}
+}
+
+// ── Hostname is 127.0.0.1 (not 0.0.0.0) ─────────────────────────────────────
+
+func TestBwrapBuildArgs_HostnameIs127(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for i, a := range args {
+		if a == "--hostname" && i+1 < len(args) {
+			if args[i+1] != "127.0.0.1" {
+				t.Errorf("--hostname = %q, want 127.0.0.1", args[i+1])
+			}
+		}
+	}
+}
+
+// ── Edge case: missing host path omitted ─────────────────────────────────────
+
+func TestBwrapBuildArgs_MissingMountOmitted(t *testing.T) {
+	// Create a fixture with all the standard paths present, then remove the
+	// AWS readonly-config to verify it is omitted from the arg list.
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	// Remove AWS readonly-config — should be absent from bwrap args.
+	awsConfig := filepath.Join(fakeHome, ".config", "aws", "readonly-config")
+	if err := os.Remove(awsConfig); err != nil {
+		t.Fatalf("Remove aws config: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasROBind(args, awsConfig) {
+		t.Errorf("missing AWS readonly-config should be omitted but found as --ro-bind in args: %v", args)
+	}
+}
+
+func TestBwrapBuildArgs_MissingMcpAuthOmitted(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	mcpAuthDir := filepath.Join(fakeHome, ".mcp-auth")
+	if err := os.RemoveAll(mcpAuthDir); err != nil {
+		t.Fatalf("RemoveAll mcp-auth: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasBind(args, mcpAuthDir) {
+		t.Errorf("missing ~/.mcp-auth should be omitted but found as --bind in args: %v", args)
+	}
+}
+
+func TestBwrapBuildArgs_MissingKubeConfigOmitted(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	kubeConfig := filepath.Join(fakeHome, ".config", "kube", "agents-config")
+	if err := os.Remove(kubeConfig); err != nil {
+		t.Fatalf("Remove kube agents-config: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasROBind(args, kubeConfig) {
+		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind in args: %v", args)
+	}
+}
+
+// ── Isolator interface compliance ────────────────────────────────────────────
+
+func TestBwrapIsolator_ImplementsIsolator(t *testing.T) {
+	// Compile-time check: bwrapIsolator must implement Isolator.
+	var _ Isolator = &bwrapIsolator{}
+}
+
+func TestBwrapIsolator_BuildRunArgsReturnsNil(t *testing.T) {
+	// BuildRunArgs() is a stub on bwrapIsolator — it returns nil.
+	b := &bwrapIsolator{name: "test"}
+	if got := b.BuildRunArgs(); got != nil {
+		t.Errorf("BuildRunArgs() = %v, want nil", got)
+	}
+}
+
+func TestBwrapIsolator_HasExitedBeforeRun(t *testing.T) {
+	// Before Run is called, HasExited must return (false, 0).
+	b := &bwrapIsolator{name: "test"}
+	exited, code := b.HasExited()
+	if exited {
+		t.Errorf("HasExited() = (true, %d) before Run, want (false, 0)", code)
+	}
+	if code != 0 {
+		t.Errorf("HasExited() code = %d before Run, want 0", code)
+	}
+}
+
+// ── newBwrapIsolator returns an Isolator ─────────────────────────────────────
+
+func TestNewBwrapIsolator_ReturnsIsolator(t *testing.T) {
+	var _ Isolator = newBwrapIsolator("test")
+}
+
+// ── No references to bwrapIsolator outside this package ──────────────────────
+// (This is a structural guarantee enforced by the file-scope test below.)
+
+func TestBwrapIsolator_NotUsedInContainerGo(t *testing.T) {
+	// Read container.go from the package directory and assert it does not
+	// reference bwrapIsolator. This guards against accidental wiring before
+	// the follow-up PR (#877).
+	containerSrc, err := os.ReadFile(filepath.Join("container.go"))
+	if err != nil {
+		t.Fatalf("could not read container.go: %v", err)
+	}
+	if strings.Contains(string(containerSrc), "bwrapIsolator") {
+		t.Errorf("container.go must not reference bwrapIsolator (wiring is deferred to #877)")
+	}
+}
+
+// ── Representative full-fixture test ─────────────────────────────────────────
+
+// TestBwrapBuildArgs_FullFixture exercises a representative Manager with
+// multiple config fields set and asserts the key structural properties of the
+// generated arg list.
+func TestBwrapBuildArgs_FullFixture(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("GITHUB_TOKEN", "ghp_test")
+
+	worktree := t.TempDir()
+
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "nixos-config@feature",
+		Worktree:      worktree,
+		AllocatedPort: 14020,
+		AgentRole:     "worker",
+		InitialPrompt: "implement the feature",
+		ConfigContent: `{"model":"claude-3-5-sonnet"}`,
+		GitUserName:   "Test User",
+		GitUserEmail:  "test@example.com",
+	})
+	defer cleanup()
+
+	// Write the opencode config temp file.
+	if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o600); err != nil {
+		t.Fatalf("WriteFile opencode config: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	t.Logf("full bwrap args (%d): %v", len(args), args)
+
+	// Baseline flags present.
+	for _, flag := range []string{"--unshare-pid", "--unshare-ipc", "--unshare-uts", "--die-with-parent"} {
+		if !hasArg(args, flag) {
+			t.Errorf("baseline flag %q missing from args", flag)
+		}
+	}
+	for _, pair := range [][2]string{
+		{"--proc", "/proc"},
+		{"--dev", "/dev"},
+		{"--tmpfs", "/tmp"},
+	} {
+		found := false
+		for i, a := range args {
+			if a == pair[0] && i+1 < len(args) && args[i+1] == pair[1] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s %s missing from args", pair[0], pair[1])
+		}
+	}
+
+	// Worktree bound read-write.
+	if !hasBind(args, worktree) {
+		t.Errorf("worktree %q not found as --bind in args", worktree)
+	}
+
+	// --chdir points at worktree.
+	found := false
+	for i, a := range args {
+		if a == "--chdir" && i+1 < len(args) && args[i+1] == worktree {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("--chdir %q not found in args", worktree)
+	}
+
+	// env vars translated.
+	if !hasSetenv(args, "ANTHROPIC_API_KEY", "sk-ant-test") {
+		t.Errorf("--setenv ANTHROPIC_API_KEY not found in args")
+	}
+	if !hasSetenv(args, "GITHUB_TOKEN", "ghp_test") {
+		t.Errorf("--setenv GITHUB_TOKEN not found in args")
+	}
+	if !hasSetenv(args, "PRISM_SESSION_NAME", "nixos-config@feature") {
+		t.Errorf("--setenv PRISM_SESSION_NAME not found in args")
+	}
+
+	// -- separator present.
+	if !hasArg(args, "--") {
+		t.Errorf("-- separator missing from args")
+	}
+
+	// Tail: opencode --port 4096 --hostname 127.0.0.1 --agent worker --prompt ...
+	n := len(args)
+	if args[n-4] != "--agent" || args[n-3] != "worker" {
+		t.Errorf("expected --agent worker near end, got %q %q", args[n-4], args[n-3])
+	}
+	if args[n-2] != "--prompt" || args[n-1] != "implement the feature" {
+		t.Errorf("expected --prompt 'implement the feature' near end, got %q %q", args[n-2], args[n-1])
+	}
+
+	// Kube and AWS ro-binds present.
+	if !hasROBind(args, filepath.Join(fakeHome, ".config", "aws", "readonly-config")) {
+		t.Errorf("AWS readonly-config --ro-bind missing")
+	}
+	if !hasROBind(args, filepath.Join(fakeHome, ".config", "kube", "agents-config")) {
+		t.Errorf("kube agents-config --ro-bind missing")
+	}
+	if !hasROBind(args, m.opencodeConfigFilePath()) {
+		t.Errorf("opencode.json --ro-bind missing")
+	}
+}
+
+// ── findPairs/findTriples smoke tests ────────────────────────────────────────
+
+func TestHelpers_FindTriples(t *testing.T) {
+	args := []string{"--bind", "/a", "/a", "--ro-bind", "/b", "/b", "--bind", "/c", "/c"}
+	triples := findTriples(args, "--bind")
+	if len(triples) != 2 {
+		t.Errorf("expected 2 --bind triples, got %d: %v", len(triples), triples)
+	}
+}
+
+func TestHelpers_HasSetenv(t *testing.T) {
+	args := []string{"--setenv", "FOO", "bar", "--setenv", "BAZ", "qux"}
+	if !hasSetenv(args, "FOO", "bar") {
+		t.Error("hasSetenv(FOO, bar) should return true")
+	}
+	if hasSetenv(args, "FOO", "wrong") {
+		t.Error("hasSetenv(FOO, wrong) should return false")
+	}
+}

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -10,18 +10,6 @@ import (
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-// findPairs returns all (flag, value) pairs in args where args[i] == flag.
-// For single-value flags like --bind SRC DST, use findTriples.
-func findPairs(args []string, flag string) [][2]string {
-	var out [][2]string
-	for i := 0; i+1 < len(args); i++ {
-		if args[i] == flag {
-			out = append(out, [2]string{args[i+1], ""})
-		}
-	}
-	return out
-}
-
 // findTriples returns all (flag, v1, v2) triples where args[i] == flag.
 func findTriples(args []string, flag string) [][3]string {
 	var out [][3]string
@@ -300,6 +288,74 @@ func TestBwrapBuildArgs_NixCacheDirBound(t *testing.T) {
 	nixCacheDir := filepath.Join(fakeHome, ".cache", "nix")
 	if !hasBind(args, nixCacheDir) {
 		t.Errorf("~/.cache/nix %q not found as --bind SRC SRC in args: %v", nixCacheDir, args)
+	}
+}
+
+func TestBwrapBuildArgs_BareRepoBoundAtHostPath(t *testing.T) {
+	// When BareRoot and WorktreeGitDir are set, the bare repo (.bare dir) and
+	// worktree private git state are both bound at their host paths (Dst == Src),
+	// not remapped to /prism-git as in the podman path.
+	bareRoot := t.TempDir()
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll bareDir: %v", err)
+	}
+
+	worktreeGitDir := t.TempDir()
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:    "repo@feat",
+		Worktree:       t.TempDir(),
+		AllocatedPort:  14010,
+		BareRoot:       bareRoot,
+		WorktreeGitDir: worktreeGitDir,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	// Bare dir is bound at its actual host path (Dst == Src).
+	if !hasBind(args, bareDir) {
+		t.Errorf("bare dir %q not found as --bind SRC SRC in args: %v", bareDir, args)
+	}
+
+	// Worktree private git state is also bound at its host path (Dst == Src).
+	if !hasBind(args, worktreeGitDir) {
+		t.Errorf("worktree git dir %q not found as --bind SRC SRC in args: %v", worktreeGitDir, args)
+	}
+
+	// Confirm /prism-git is NOT a destination (no remapping).
+	for _, tri := range findTriples(args, "--bind") {
+		if tri[1] == "/prism-git" {
+			t.Errorf("unexpected --bind _ /prism-git found (bwrap must use Dst==Src): %v", args)
+		}
+	}
+}
+
+func TestBwrapBuildArgs_MissingBareRootOmitted(t *testing.T) {
+	// When BareRoot is set but the .bare directory does not exist,
+	// the bind should be omitted.
+	bareRoot := t.TempDir()
+	// Do NOT create bareRoot/.bare — it should be absent.
+
+	worktreeGitDir := t.TempDir()
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:    "repo@feat",
+		Worktree:       t.TempDir(),
+		AllocatedPort:  14010,
+		BareRoot:       bareRoot,
+		WorktreeGitDir: worktreeGitDir,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if hasBind(args, bareDir) {
+		t.Errorf("missing bareDir %q should be omitted but found as --bind in args: %v", bareDir, args)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements \`bwrapIsolator\` in \`internal/container/bwrap.go\` as a second implementation of the \`Isolator\` interface. The type is **not wired into any code path** — nothing constructs it at runtime. The wiring (CLI flag / config field) is deferred to the follow-up PR (#877).

## Design decisions

**Option 2 from #876**: \`BuildRunArgs()\` returns \`nil\` (a stub satisfying the interface); the real argument construction is in the concrete \`BuildArgs(m *Manager)\` method, which has access to all Manager state. The interface is not widened yet — that is deferred to the wiring PR.

**Dst == Src for all mounts**: worktrees, the bare repo dir, and the worktree git state dir all mount at their host paths directly inside the bwrap sandbox. No \`/workspace\` or \`/prism-git\` remapping — this obsoletes the old remap logic. PRISM_SPAWN_PATH and PRISM_BARE_ROOT are set to the actual host paths accordingly.

**Hostname is \`127.0.0.1\`** (not \`0.0.0.0\`): the bwrap sandbox shares the host network namespace, so binding to \`0.0.0.0\` would be overly broad.

## What's included

- Baseline sandbox flags: \`--unshare-pid\`, \`--unshare-ipc\`, \`--unshare-uts\`, \`--proc /proc\`, \`--dev /dev\`, \`--tmpfs /tmp\`, \`--die-with-parent\`
- All read-write binds from the AC: worktree, bare repo (.bare dir), worktree git state dir, \`~/.claude\`, \`~/.mcp-auth\`, opencode session state dir, nix daemon socket dir, \`~/.cache/nix\`
- All read-only binds from the AC: AWS readonly-config, kube agents-config, SSH access/signing keys, known_hosts, generated gitconfig, generated SSH config, opencode.json
- All \`--env K=V\` → \`--setenv K V\` translations (credentials, NIX_CONFIG, TERM, PRISM_* vars)
- Conditional mount pattern: host paths that don't exist are silently omitted
- \`--chdir\` pointing at the worktree source path (not \`/workspace\`)
- Terminator: \`-- opencode --port 4096 --hostname 127.0.0.1\` with optional \`--agent\`/\`--prompt\` tail

## Deferred mounts (tracked in #877)

The following mounts exist in \`buildRunArgs\` (podman) but are intentionally out of scope for this PR per issue #876's explicit AC enumeration. They are documented in the \`BuildArgs\` godoc and will be added when bwrap is wired end-to-end:

- opencode config allowlist (\`~/.config/opencode/{AGENTS.md,plugins,skills,...}\`)
- auth.json overlay (\`~/.local/share/opencode/auth.json\`)
- opencode plugin cache (\`~/.cache/opencode/\`) and bun transpiler cache (\`~/.cache/bun/\`)
- Additional AWS mounts (credentials, sso/, cli/)
- Clipboard staging dir (\`~/.cache/prism/clipboard/\`)
- \`WorktreeReadOnly\` handling (review agents)
- Darwin Keychain credentials (darwin-only)

## Tests

\`bwrap_test.go\` contains 38 tests covering every AC from the issue: baseline flags, all read-write binds (including bare repo at host path), all read-only binds, env var translation, \`--chdir\` target, terminator structure, edge cases (missing host path omitted, bare dir absent), and interface compliance.

All tests pass. No existing tests changed.

Closes #876