### PR TITLE
feat(pi): vendor pi-anthropic-oauth extension with MD5 hash tool obfuscation

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -42,6 +42,16 @@
         cp ${awsSkillFile} $out/aws/SKILL.md
         cp -r ${./opencode/skills/acceptance-criteria}/* $out/acceptance-criteria/
       '';
+
+      # Vendored pi extensions directory — built as a single derivation so it
+      # lands at a stable nix-store path and is correctly GC-rooted via
+      # home.file. Mirrors the skillsDir pattern above.
+      # See pi/extensions/anthropic-oauth/UPSTREAM.md for the port procedure.
+      piExtensionsDir = pkgs.runCommand "pi-extensions" { } ''
+        mkdir -p $out/anthropic-oauth
+        cp -r ${./pi/extensions/anthropic-oauth}/* $out/anthropic-oauth/
+      '';
+
       # Pi agent settings.json content, defined once here so a future container
       # role can reference the same value without duplication.
       # Follow-up container support will add containerWorkerSettingsJson /
@@ -55,12 +65,12 @@
         quietStartup = true;
         enableInstallTelemetry = false;
 
-        # Fork fallback: if leohenon/pi-anthropic-oauth becomes unmaintained,
-        # fork to prismatic-koi/pi-anthropic-oauth, publish to npm (or vendor
-        # into the nix store), and update this packages entry. The three most
-        # likely break sites are CLIENT_ID, TOKEN_URL, and AUTHORIZE_URL in
-        # the extension's src/auth.ts.
-        packages = [ "npm:pi-anthropic-oauth@0.1.9" ];
+        # Vendored extension: replaces the previous npm:pi-anthropic-oauth@0.1.9
+        # package. The extension is stored in the nix store as plain TypeScript
+        # files and loaded by pi's jiti-based extension loader at runtime.
+        # To port a future upstream fix, see:
+        #   modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
+        extensions = [ "${piExtensionsDir}/anthropic-oauth/index.ts" ];
       };
 
       piTheme =
@@ -150,6 +160,10 @@
         # config.theme.name and all colour values come from the system palette.
         home.file.".pi/agent/themes/${config.theme.name}.json".text = piTheme;
         home.file.".pi/agent/skills".source = skillsDir;
+        # Vendored extensions directory — GC-rooted via this home.file entry.
+        # The extension path referenced in settings.json points into this
+        # nix-store path, so nix-store --gc will not remove it.
+        home.file.".pi/agent/extensions".source = piExtensionsDir;
 
         home.persistence."/persist" = {
           directories = [ ".pi" ];

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/LICENSE-griffinmartin
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/LICENSE-griffinmartin
@@ -1,0 +1,34 @@
+MIT License
+
+Copyright (c) 2026 gmartin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Origin: https://github.com/griffinmartin/opencode-claude-auth
+
+Files in this vendored extension that primarily originate from this upstream:
+  - transforms.ts  (MD5 hash obfuscation from PR #193, system prompt logic)
+  - betas.ts       (beta flag management)
+  - signing.ts     (billing header computation)
+  - model-config.ts (model list, cc version)
+  - logger.ts      (structured logging pattern)
+  - credentials.ts (OAuth refresh via subprocess, parseOAuthResponse)
+  - anthropic-prompt.txt (verbatim copy)

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/LICENSE-leohenon
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/LICENSE-leohenon
@@ -1,0 +1,33 @@
+MIT License
+
+Copyright (c) 2026 Leo Henon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Origin: https://github.com/leohenon/pi-anthropic-oauth
+
+Files in this vendored extension that primarily originate from this upstream:
+  - index.ts   (pi.registerProvider wrapper structure, ensureClaudeCodeSymlink,
+                getAnthropicModels, model list fallback)
+  - auth.ts    (OAuth PKCE flow, local callback server, loginAnthropic,
+                refreshAnthropicToken, CLIENT_ID, TOKEN_URL, AUTHORIZE_URL)
+  - stream.ts  (pi message conversion patterns from convert.ts + prompt.ts;
+                SSE parsing replaces @anthropic-ai/sdk with native fetch)

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
@@ -1,0 +1,110 @@
+# Upstream Sync State
+
+This vendored extension is derived from two upstream repositories. This file
+documents the current sync state and the procedure for porting future fixes.
+
+## Source upstreams
+
+| Upstream | URL | Role |
+|---|---|---|
+| `griffinmartin/opencode-claude-auth` | https://github.com/griffinmartin/opencode-claude-auth | Primary source for business logic: transforms, betas, signing, model-config, logger, credentials (OAuth helpers), anthropic-prompt.txt |
+| `leohenon/pi-anthropic-oauth` | https://github.com/leohenon/pi-anthropic-oauth | Source for pi-specific wrapper: index.ts pattern, auth.ts (OAuth PKCE + callback server), stream.ts (message conversion) |
+
+When the two disagree on an implementation detail, **griffinmartin takes priority** —
+it is more actively maintained and is the source of the PR #193 fix.
+
+## Current sync commit SHAs
+
+| Upstream | SHA | Date |
+|---|---|---|
+| `griffinmartin/opencode-claude-auth` main | `df1b0cbc9e94ff9a8081ac98aa837893fd2be35e` | 2026-04 (chore(main): release 1.5.0 #204) |
+| `griffinmartin/opencode-claude-auth` PR #193 | `9420fbef60567968bcd21a260db21be9f7dd475b` | 2026-04-14 (the MD5 hash obfuscation approach) |
+| `leohenon/pi-anthropic-oauth` | `86d9d97829776a66aec58e3433900173ff7e184a` | 2026-04 (update readme) |
+
+> **Note on PR #193**: At the time of vendoring, griffinmartin PR #193 was open
+> but not yet merged into main. The MD5 hash-based tool name obfuscation from
+> that PR was incorporated anyway (per the issue spec) because:
+> 1. It is strictly superior to the PascalCase approach on griffinmartin's main.
+> 2. The blacklisted names (`todowrite`, `background_output`, `background_cancel`)
+>    are handled by the general hashing rather than a special-case list.
+> When PR #193 eventually merges, bump the griffinmartin SHA to its merge commit.
+
+## File-level mapping
+
+| Our file | Primary upstream | griffinmartin file | leohenon file |
+|---|---|---|---|
+| `index.ts` | leohenon (pi-specific) | `src/index.ts` (different API, skip when porting) | `src/index.ts` |
+| `auth.ts` | leohenon | `src/credentials.ts` (OAuth helpers only, no callback server) | `src/auth.ts` |
+| `stream.ts` | leohenon | *(no equivalent — opencode uses different streaming)* | `src/stream.ts`, `src/convert.ts`, `src/prompt.ts` |
+| `credentials.ts` | griffinmartin | `src/credentials.ts` | `src/auth.ts` (partial) |
+| `transforms.ts` | griffinmartin PR #193 | `src/transforms.ts` | *(no equivalent)* |
+| `betas.ts` | griffinmartin | `src/betas.ts` | *(no equivalent)* |
+| `signing.ts` | griffinmartin | `src/signing.ts` | *(no equivalent)* |
+| `model-config.ts` | griffinmartin | `src/model-config.ts` | *(no equivalent)* |
+| `logger.ts` | griffinmartin | `src/logger.ts` | *(no equivalent)* |
+| `anthropic-prompt.txt` | griffinmartin | `src/anthropic-prompt.txt` | *(no equivalent)* |
+
+## Known divergences
+
+1. **`index.ts` is pi-specific and will never match griffinmartin's `index.ts`**.
+   griffinmartin's entry point uses opencode's `Plugin` type with `auth.loader`,
+   `experimental.chat.system.transform`, and `config` hooks. Pi's extension API
+   uses `pi.registerProvider(name, { oauth: {...}, streamSimple: ... })`. These
+   are structurally different and cannot be reconciled.
+
+2. **`stream.ts` has no griffinmartin equivalent**. griffinmartin delegates HTTP
+   and SSE parsing to the opencode runtime; pi requires explicit streaming.
+   Our `stream.ts` replaces leohenon's `@anthropic-ai/sdk`-based streaming with
+   native `fetch()` + manual SSE parsing, matching the zero-npm-deps commitment.
+
+3. **`betas.ts` reads `PI_ANTHROPIC_ENABLE_1M_CONTEXT`** instead of griffinmartin's
+   `ANTHROPIC_ENABLE_1M_CONTEXT` (which goes through `plugin-config.ts`). Pi has
+   no plugin config mechanism, so we read the env var directly.
+
+4. **`logger.ts` default log path** is `~/.pi/agent/pi-anthropic-oauth-debug.log`
+   instead of griffinmartin's `~/.local/share/opencode/claude-auth-debug.log`.
+   The env var is `PI_ANTHROPIC_OAUTH_DEBUG` instead of `CLAUDE_AUTH_DEBUG`.
+
+5. **`credentials.ts` is single-account only** (no keychain, no multi-account).
+   griffinmartin's version supports macOS Keychain + multi-account. Pi stores
+   credentials in `~/.pi/agent/auth.json` and is single-account.
+
+6. **MD5 hash obfuscation vs PascalCase**: Our `transforms.ts` uses PR #193's
+   MD5 approach (`t_<8hex>`) instead of griffinmartin main's `mcp_` PascalCase
+   approach. This is intentional — see PR #193 for the rationale.
+
+## Port procedure for future upstream fixes
+
+When griffinmartin ships a fix you want to port:
+
+1. **Identify what changed**:
+   ```bash
+   cd /tmp/upstream-griffinmartin
+   git fetch origin
+   git diff <recorded-sha> origin/main -- src/<filename>.ts
+   ```
+
+2. **Apply the equivalent change** to our file of the same name.
+   - Skip any changes to `src/index.ts` — our `index.ts` is pi-specific.
+   - Skip any changes to `src/keychain.ts` or `src/plugin-config.ts` —
+     these have no equivalents here (see divergences above).
+   - For `src/credentials.ts` changes: apply the OAuth-helper portions
+     (refreshViaOAuth, parseOAuthResponse), skip the keychain/multi-account code.
+
+3. **Update the SHA** in this file to the new griffinmartin HEAD (or the
+   specific merge commit if the fix came via PR).
+
+4. **Run the nix build** to verify:
+   ```bash
+   nix build .#nixosConfigurations.navi.config.system.build.toplevel
+   ```
+
+5. **Commit and PR** with `Closes #<issue>` in the body.
+
+When leohenon ships a fix to the pi wrapper or auth flow:
+
+1. `git diff <leohenon-sha> origin/master -- src/<filename>` in leohenon's repo.
+2. Apply the equivalent change to `auth.ts` or `stream.ts` as appropriate.
+3. Update the leohenon SHA in this file.
+4. Note: leohenon fixes to `src/stream.ts` may need adaptation since our
+   `stream.ts` does not use `@anthropic-ai/sdk`.

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/anthropic-prompt.txt
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/anthropic-prompt.txt
@@ -1,0 +1,166 @@
+You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: Assist with defensive security tasks only. Refuse to create, modify, or improve code that may be used maliciously. Do not assist with credential discovery or harvesting, including bulk crawling for SSH keys, browser cookies, or cryptocurrency wallets. Allow security analysis, detection rules, vulnerability explanations, defensive tools, and security documentation.
+IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+
+If the user asks for help or wants to give feedback inform them of the following: 
+- /help: Get help with using Claude Code
+- To give feedback, users should report the issue at https://github.com/anthropics/claude-code/issues
+
+When the user directly asks about Claude Code (eg. "can Claude Code do...", "does Claude Code have..."), or asks in second person (eg. "are you able...", "can you do..."), or asks how to use a specific Claude Code feature (eg. implement a hook, or write a slash command), use the WebFetch tool to gather information to answer the question from Claude Code docs. The list of available docs is available at https://docs.claude.com/en/docs/claude-code/claude_code_docs_map.md.
+
+# Tone and style
+You should be concise, direct, and to the point, while providing complete information and matching the level of detail you provide in your response with the level of complexity of the user's query or the work you have completed. 
+A concise response is generally less than 4 lines, not including tool calls or code generated. You should provide more detail when the task is complex or when the user asks you to.
+IMPORTANT: You should minimize output tokens as much as possible while maintaining helpfulness, quality, and accuracy. Only address the specific task at hand, avoiding tangential information unless absolutely critical for completing the request. If you can answer in 1-3 sentences or a short paragraph, please do.
+IMPORTANT: You should NOT answer with unnecessary preamble or postamble (such as explaining your code or summarizing your action), unless the user asks you to.
+Do not add additional code explanation summary unless requested by the user. After working on a file, briefly confirm that you have completed the task, rather than providing an explanation of what you did.
+Answer the user's question directly, avoiding any elaboration, explanation, introduction, conclusion, or excessive details. Brief answers are best, but be sure to provide complete information. You MUST avoid extra preamble before/after your response, such as "The answer is <answer>.", "Here is the content of the file..." or "Based on the information provided, the answer is..." or "Here is what I will do next...".
+
+Here are some examples to demonstrate appropriate verbosity:
+<example>
+user: 2 + 2
+assistant: 4
+</example>
+
+<example>
+user: what is 2+2?
+assistant: 4
+</example>
+
+<example>
+user: is 11 a prime number?
+assistant: Yes
+</example>
+
+<example>
+user: what command should I run to list files in the current directory?
+assistant: ls
+</example>
+
+<example>
+user: what command should I run to watch files in the current directory?
+assistant: [runs ls to list the files in the current directory, then read docs/commands in the relevant file to find out how to watch files]
+npm run dev
+</example>
+
+<example>
+user: How many golf balls fit inside a jetta?
+assistant: 150000
+</example>
+
+<example>
+user: what files are in the directory src/?
+assistant: [runs ls and sees foo.c, bar.c, baz.c]
+user: which file contains the implementation of foo?
+assistant: src/foo.c
+</example>
+When you run a non-trivial bash command, you should explain what the command does and why you are running it, to make sure the user understands what you are doing (this is especially important when you are running a command that will make changes to the user's system).
+Remember that your output will be displayed on a command line interface. Your responses can use GitHub-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
+Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
+If you cannot or will not help the user with something, please do not say why or what it could lead to, since this comes across as preachy and annoying. Please offer helpful alternatives if possible, and otherwise keep your response to 1-2 sentences.
+Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
+IMPORTANT: Keep your responses short, since they will be displayed on a command line interface.
+
+# Proactiveness
+You are allowed to be proactive, but only when the user asks you to do something. You should strive to strike a balance between:
+- Doing the right thing when asked, including taking actions and follow-up actions
+- Not surprising the user with actions you take without asking
+For example, if the user asks you how to approach something, you should do your best to answer their question first, and not immediately jump into taking actions.
+
+# Professional objectivity
+Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if Claude honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.
+
+# Task Management
+You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
+
+It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
+
+Examples:
+
+<example>
+user: Run the build and fix any type errors
+assistant: I'm going to use the TodoWrite tool to write the following items to the todo list: 
+- Run the build
+- Fix any type errors
+
+I'm now going to run the build using Bash.
+
+Looks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.
+
+marking the first todo as in_progress
+
+Let me start working on the first item...
+
+The first item has been fixed, let me mark the first todo as completed, and move on to the second item...
+..
+..
+</example>
+In the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.
+
+<example>
+user: Help me write a new feature that allows users to track their usage metrics and export them to various formats
+
+assistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.
+Adding the following todos to the todo list:
+1. Research existing metrics tracking in the codebase
+2. Design the metrics collection system
+3. Implement core metrics tracking functionality
+4. Create export functionality for different formats
+
+Let me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.
+
+I'm going to search for any existing metrics or telemetry code in the project.
+
+I've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...
+
+[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]
+</example>
+
+
+Users may configure 'hooks', shell commands that execute in response to events like tool calls, in settings. Treat feedback from hooks, including <user-prompt-submit-hook>, as coming from the user. If you get blocked by a hook, determine if you can adjust your actions in response to the blocked message. If not, ask the user to check their hooks configuration.
+
+# Doing tasks
+The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
+- Use the TodoWrite tool to plan the task if required
+
+- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.
+
+
+# Tool usage policy
+- When doing file search, prefer to use the Task tool in order to reduce context usage.
+- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.
+
+- When WebFetch returns a message about a redirect to a different host, you should immediately make a new WebFetch request with the redirect URL provided in the response.
+- You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. When making multiple bash tool calls, you MUST send a single message with multiple tools calls to run the calls in parallel. For example, if you need to run "git status" and "git diff", send a single message with two tool calls to run the calls in parallel.
+- If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.
+- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
+
+
+Here is useful information about the environment you are running in:
+<env>
+Working directory: /home/thdxr/dev/projects/anomalyco/opencode/packages/opencode
+Is directory a git repo: Yes
+Platform: linux
+OS Version: Linux 6.12.4-arch1-1
+Today's date: 2025-09-30
+</env>
+You are powered by the model named Sonnet 4.5. The exact model ID is claude-sonnet-4-5-20250929.
+
+Assistant knowledge cutoff is January 2025.
+
+
+IMPORTANT: Assist with defensive security tasks only. Refuse to create, modify, or improve code that may be used maliciously. Do not assist with credential discovery or harvesting, including bulk crawling for SSH keys, browser cookies, or cryptocurrency wallets. Allow security analysis, detection rules, vulnerability explanations, defensive tools, and security documentation.
+
+
+IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.
+
+# Code References
+
+When referencing specific functions or pieces of code include the pattern `file_path:line_number` to allow the user to easily navigate to the source code location.
+
+<example>
+user: Where are errors from the client handled?
+assistant: Clients are marked as failed in the `connectToServer` function in src/services/process.ts:712.
+</example>

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts
@@ -1,0 +1,400 @@
+// Pi-specific OAuth 2.0 + PKCE flow with local callback server.
+// Primary source: leohenon/pi-anthropic-oauth src/auth.ts
+// Mirror target: griffinmartin/opencode-claude-auth src/credentials.ts (OAuth helpers)
+//
+// pi-specific: This file implements pi's OAuthLoginCallbacks interface
+// (loginAnthropic / refreshAnthropicToken). griffinmartin has no equivalent
+// because opencode uses a different auth bootstrapping mechanism.
+
+import { createServer } from "node:http"
+import { log } from "./logger.ts"
+
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+const TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+const REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+const SCOPES = [
+  "org:create_api_key",
+  "user:profile",
+  "user:inference",
+  "user:sessions:claude_code",
+  "user:mcp_servers",
+  "user:file_upload",
+].join(" ")
+const USER_AGENT = "claude-code/2.1.97"
+const CALLBACK_PORT = 53692
+const CALLBACK_HOST = "127.0.0.1"
+const LOCAL_CALLBACK_TIMEOUT = 5 * 60 * 1000
+const MAX_TOKEN_RETRIES = 2
+const INITIAL_RETRY_DELAY_MS = 5000
+
+export { USER_AGENT, CLIENT_ID }
+
+export interface OAuthCredentials {
+  access: string
+  refresh: string
+  expires: number
+}
+
+// pi-specific: OAuthLoginCallbacks mirrors @mariozechner/pi-ai's interface
+export interface OAuthLoginCallbacks {
+  onAuth: (opts: { url: string; instructions: string }) => void
+  onManualCodeInput?: () => Promise<string>
+  onPrompt: (opts: { message: string }) => Promise<string>
+  signal?: AbortSignal
+}
+
+type ParsedAuthInput = { code: string; state: string }
+type LocalAuthorization = {
+  redirectUri: string
+  waitForCallback: () => Promise<string | null>
+  cancel: () => void
+}
+
+export function isClaudeOAuthAccessToken(apiKey: string): boolean {
+  return apiKey.includes("sk-ant-oat")
+}
+
+// pi-specific: loginAnthropic is called by pi.registerProvider oauth.login
+export async function loginAnthropic(
+  callbacks: OAuthLoginCallbacks,
+): Promise<OAuthCredentials> {
+  const { verifier, challenge } = await generatePKCE()
+  const state = crypto.randomUUID().replace(/-/g, "")
+
+  let authInput: string | null = null
+  let redirectUri = REDIRECT_URI
+
+  try {
+    const localAuthorization = await createLocalAuthorization(state)
+    redirectUri = localAuthorization.redirectUri
+
+    callbacks.onAuth({
+      url: makeAuthorizeUrl(challenge, state, redirectUri),
+      instructions:
+        "Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
+    })
+
+    if (callbacks.onManualCodeInput) {
+      let manualInput: string | undefined
+      let manualError: Error | undefined
+      const manualPromise = callbacks
+        .onManualCodeInput()
+        .then((input) => {
+          manualInput = input
+          localAuthorization.cancel()
+        })
+        .catch((err) => {
+          manualError = err instanceof Error ? err : new Error(String(err))
+          localAuthorization.cancel()
+        })
+
+      const callbackResult = await localAuthorization.waitForCallback()
+
+      if (manualError) throw manualError
+
+      if (callbackResult) {
+        authInput = callbackResult
+      } else if (manualInput) {
+        authInput = manualInput
+      }
+
+      if (!authInput) {
+        await manualPromise
+        if (manualError) throw manualError
+        if (manualInput) authInput = manualInput
+      }
+    } else {
+      authInput = await localAuthorization.waitForCallback()
+    }
+  } catch (err) {
+    log("login_local_auth_error", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  if (!authInput) {
+    redirectUri = REDIRECT_URI
+    callbacks.onAuth({
+      url: makeAuthorizeUrl(challenge, state, redirectUri),
+      instructions:
+        "Sign in with Claude, then paste the full callback URL or the code#state value.",
+    })
+    authInput = await callbacks.onPrompt({
+      message: "Paste the callback URL or code#state:",
+    })
+  }
+
+  const parsed = parseAuthInput(authInput)
+  if (!parsed) throw new Error("Could not parse authorization callback input.")
+  if (parsed.state !== state) throw new Error("OAuth state mismatch.")
+
+  log("login_token_exchange_start", {})
+  const tokenResponse = await fetchWithRetry(
+    TOKEN_URL,
+    {
+      method: "POST",
+      headers: makeTokenHeaders(),
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: CLIENT_ID,
+        code: parsed.code,
+        state: parsed.state,
+        redirect_uri: redirectUri,
+        code_verifier: verifier,
+      }),
+      signal: callbacks.signal,
+    },
+    "Token exchange",
+  )
+
+  const data = (await tokenResponse.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  log("login_complete", {})
+  return {
+    access: data.access_token,
+    refresh: data.refresh_token,
+    expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+  }
+}
+
+// pi-specific: refreshAnthropicToken is called by pi.registerProvider oauth.refreshToken
+export async function refreshAnthropicToken(
+  credentials: OAuthCredentials,
+): Promise<OAuthCredentials> {
+  let response: Response
+  try {
+    response = await fetchWithRetry(
+      TOKEN_URL,
+      {
+        method: "POST",
+        headers: makeTokenHeaders(),
+        body: JSON.stringify({
+          grant_type: "refresh_token",
+          client_id: CLIENT_ID,
+          refresh_token: credentials.refresh,
+        }),
+      },
+      "Token refresh",
+    )
+  } catch (err) {
+    log("refresh_network_error", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    if (credentials.expires > Date.now()) {
+      return { ...credentials, expires: Date.now() + 30_000 }
+    }
+    throw new Error("Token refresh failed and token has expired.")
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  log("refresh_complete", {})
+  return {
+    access: data.access_token,
+    refresh: data.refresh_token || credentials.refresh,
+    expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+  }
+}
+
+function makeAuthorizeUrl(
+  challenge: string,
+  state: string,
+  redirectUri: string,
+): string {
+  const authParams = new URLSearchParams({
+    code: "true",
+    client_id: CLIENT_ID,
+    response_type: "code",
+    redirect_uri: redirectUri,
+    scope: SCOPES,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state,
+  })
+
+  return `${AUTHORIZE_URL}?${authParams.toString()}`
+}
+
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  label: string,
+): Promise<Response> {
+  let lastError: Error | undefined
+
+  for (let attempt = 0; attempt <= MAX_TOKEN_RETRIES; attempt++) {
+    const response = await fetch(url, init)
+
+    if (response.ok) return response
+
+    const bodyText = await response.text()
+
+    const shouldRetry = response.headers.get("x-should-retry")
+    if (shouldRetry === "false") {
+      throw new Error(`${label} failed: ${response.status} ${bodyText}`)
+    }
+
+    if (
+      attempt < MAX_TOKEN_RETRIES &&
+      (response.status === 429 || response.status >= 500)
+    ) {
+      const retryAfter = response.headers.get("retry-after")
+      const delayMs = retryAfter
+        ? Math.min(Number(retryAfter) * 1000, 30_000)
+        : INITIAL_RETRY_DELAY_MS * 2 ** attempt
+
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      lastError = new Error(`${label} failed: ${response.status} ${bodyText}`)
+      continue
+    }
+
+    throw new Error(`${label} failed: ${response.status} ${bodyText}`)
+  }
+
+  throw lastError ?? new Error(`${label} failed after retries`)
+}
+
+function makeTokenHeaders(): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+    "User-Agent": USER_AGENT,
+  }
+}
+
+async function createLocalAuthorization(
+  state: string,
+): Promise<LocalAuthorization> {
+  const server = createServer()
+
+  return new Promise((resolve, reject) => {
+    let done = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let complete!: (value: string | null) => void
+    const wait = new Promise<string | null>((innerResolve) => {
+      complete = innerResolve
+    })
+
+    const finish = (value: string | null) => {
+      if (done) return
+      done = true
+      if (timer) clearTimeout(timer)
+      complete(value)
+      if (server.listening) {
+        server.closeAllConnections?.()
+        server.close()
+      }
+    }
+
+    server.on("request", (req, res) => {
+      const url = new URL(
+        req.url ?? "/",
+        `http://${req.headers.host ?? "localhost"}`,
+      )
+
+      if (url.pathname !== "/callback") {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("Not found")
+        return
+      }
+
+      const code = url.searchParams.get("code")
+      const gotState = url.searchParams.get("state")
+      if (!code || !gotState) {
+        res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("Missing code or state")
+        return
+      }
+
+      if (gotState !== state) {
+        res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("Invalid state")
+        finish(null)
+        return
+      }
+
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        Connection: "close",
+      })
+      res.end(makeCallbackPage())
+      finish(url.toString())
+    })
+
+    server.once("error", reject)
+
+    server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+      timer = setTimeout(() => finish(null), LOCAL_CALLBACK_TIMEOUT)
+      resolve({
+        redirectUri: `http://localhost:${CALLBACK_PORT}/callback`,
+        waitForCallback: () => wait,
+        cancel: () => finish(null),
+      })
+    })
+  })
+}
+
+function makeCallbackPage(): string {
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Authorization complete</title></head>
+  <body>
+    <h1>Authorization complete</h1>
+    <p>You can close this window and return to pi.</p>
+  </body>
+</html>`
+}
+
+async function generatePKCE(): Promise<{
+  verifier: string
+  challenge: string
+}> {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  const verifier = toBase64Url(bytes)
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier),
+  )
+  return {
+    verifier,
+    challenge: toBase64Url(new Uint8Array(digest)),
+  }
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "")
+}
+
+function parseAuthInput(input: string): ParsedAuthInput | null {
+  const text = input.trim()
+
+  try {
+    const url = new URL(text)
+    const code = url.searchParams.get("code")
+    const state = url.searchParams.get("state")
+    if (code && state) return { code, state }
+  } catch {}
+
+  const split = text.split("#")
+  if (split.length === 2 && split[0] && split[1]) {
+    return { code: split[0], state: split[1] }
+  }
+
+  const params = new URLSearchParams(text)
+  const code = params.get("code")
+  const state = params.get("state")
+  return code && state ? { code, state } : null
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/betas.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/betas.ts
@@ -1,0 +1,133 @@
+// Mirror of griffinmartin/opencode-claude-auth src/betas.ts
+// Source: https://github.com/griffinmartin/opencode-claude-auth
+//
+// pi-specific: isEnable1mContext() reads PI_ANTHROPIC_ENABLE_1M_CONTEXT
+// instead of ANTHROPIC_ENABLE_1M_CONTEXT.
+
+import { config, getModelOverride } from "./model-config.ts"
+
+// Beta flags to try removing in order when "long context" errors occur
+export const LONG_CONTEXT_BETAS = config.longContextBetas
+
+function getRequiredBetas(): string[] {
+  return (process.env.ANTHROPIC_BETA_FLAGS ?? config.baseBetas.join(","))
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+// Session-level cache of excluded beta flags per model (resets on process restart)
+const excludedBetas: Map<string, Set<string>> = new Map()
+
+// Track the last-seen beta flags env var and model to detect changes
+let lastBetaFlagsEnv: string | undefined = process.env.ANTHROPIC_BETA_FLAGS
+let lastModelId: string | undefined
+
+export function getExcludedBetas(modelId: string): Set<string> {
+  // Reset exclusions if user changed ANTHROPIC_BETA_FLAGS
+  const currentBetaFlags = process.env.ANTHROPIC_BETA_FLAGS
+  if (currentBetaFlags !== lastBetaFlagsEnv) {
+    excludedBetas.clear()
+    lastBetaFlagsEnv = currentBetaFlags
+  }
+
+  // Reset exclusions if user switched models (new model may support different betas)
+  if (lastModelId !== undefined && lastModelId !== modelId) {
+    excludedBetas.clear()
+  }
+  lastModelId = modelId
+
+  return excludedBetas.get(modelId) ?? new Set()
+}
+
+export function addExcludedBeta(modelId: string, beta: string): void {
+  const existing = excludedBetas.get(modelId) ?? new Set()
+  existing.add(beta)
+  excludedBetas.set(modelId, existing)
+}
+
+export function resetExcludedBetas(): void {
+  excludedBetas.clear()
+  lastModelId = undefined
+}
+
+export function isLongContextError(responseBody: string): boolean {
+  return (
+    responseBody.includes(
+      "Extra usage is required for long context requests",
+    ) || responseBody.includes("long context beta is not yet available")
+  )
+}
+
+export function getNextBetaToExclude(modelId: string): string | null {
+  const excluded = getExcludedBetas(modelId)
+  for (const beta of LONG_CONTEXT_BETAS) {
+    if (!excluded.has(beta)) {
+      return beta
+    }
+  }
+  return null // All long-context betas already excluded
+}
+
+export function supports1mContext(modelId: string): boolean {
+  const lower = modelId.toLowerCase()
+  if (!lower.includes("opus") && !lower.includes("sonnet")) return false
+  const versionMatch = lower.match(/(opus|sonnet)-(\d+)-(\d+)/)
+  if (!versionMatch) return false
+  const major = parseInt(versionMatch[2], 10)
+  const minor = parseInt(versionMatch[3], 10)
+  // Date suffixes like 20250514 are not minor versions — treat as x.0
+  const effectiveMinor = minor > 99 ? 0 : minor
+  return major > 4 || (major === 4 && effectiveMinor >= 6)
+}
+
+// pi-specific: read PI_ANTHROPIC_ENABLE_1M_CONTEXT env var (mirrors
+// griffinmartin's isEnable1mContext() via plugin-config.ts, but pi has no
+// plugin-config concept so we read the env var directly).
+export function isEnable1mContext(): boolean {
+  const envVal = process.env.PI_ANTHROPIC_ENABLE_1M_CONTEXT
+  if (envVal !== undefined) return envVal === "true"
+  return false
+}
+
+export function getModelBetas(
+  modelId: string,
+  excluded?: Set<string>,
+): string[] {
+  const betas = [...getRequiredBetas()]
+
+  // context-1m is OPT-IN only, matching the official Claude CLI behavior.
+  // The CLI only sends this beta when the model ID has a [1m] suffix.
+  // Without it, the API enforces a 200k context limit. Sending the beta
+  // without a subscription that covers long context billing causes
+  // "Extra usage is required for long context requests" errors.
+  //
+  // Users who want 1M context should set PI_ANTHROPIC_ENABLE_1M_CONTEXT=true
+  // (requires a Claude Max subscription or a plan that covers extra usage).
+  if (isEnable1mContext() && supports1mContext(modelId)) {
+    betas.push(config.longContextBetas[0])
+  }
+
+  // Apply per-model overrides (e.g. haiku excludes claude-code-20250219)
+  const override = getModelOverride(modelId)
+  if (override) {
+    if (override.exclude) {
+      for (const ex of override.exclude) {
+        const idx = betas.indexOf(ex)
+        if (idx !== -1) betas.splice(idx, 1)
+      }
+    }
+    if (override.add) {
+      for (const add of override.add) {
+        if (!betas.includes(add)) betas.push(add)
+      }
+    }
+  }
+
+  // Filter out excluded betas (from previous failed requests due to long context errors)
+  if (excluded && excluded.size > 0) {
+    return betas.filter((beta) => !excluded.has(beta))
+  }
+
+  return betas
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
@@ -1,0 +1,257 @@
+// Mirror of griffinmartin/opencode-claude-auth src/credentials.ts
+// adapted for pi's credential storage at ~/.pi/agent/auth.json.
+// Source: https://github.com/griffinmartin/opencode-claude-auth
+//
+// pi-specific divergences:
+//   - No keychain.ts (macOS only) — pi stores OAuth creds in auth.json
+//   - Credential path is ~/.pi/agent/auth.json (not opencode's auth.json)
+//   - refreshViaOAuth is the primary refresh path (no CLI fallback)
+//   - No multi-account/account-switching support (pi is single-account)
+
+import { execFileSync } from "node:child_process"
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { log } from "./logger.ts"
+
+export interface ClaudeCredentials {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+}
+
+const CREDENTIAL_CACHE_TTL_MS = 30_000
+
+let cachedCreds: { creds: ClaudeCredentials; cachedAt: number } | null = null
+
+export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+function getAuthJsonPath(): string {
+  return join(homedir(), ".pi", "agent", "auth.json")
+}
+
+/**
+ * Read OAuth credentials from ~/.pi/agent/auth.json.
+ * Returns null if the file is absent, malformed, or missing required fields.
+ */
+export function readCredentials(): ClaudeCredentials | null {
+  const authPath = getAuthJsonPath()
+  try {
+    if (!existsSync(authPath)) return null
+    const raw = readFileSync(authPath, "utf-8").trim()
+    if (!raw) return null
+    const data = JSON.parse(raw) as {
+      access?: string
+      refresh?: string
+      expires?: number
+    }
+    if (
+      typeof data.access !== "string" ||
+      typeof data.refresh !== "string" ||
+      typeof data.expires !== "number"
+    ) {
+      log("credentials_read_malformed", { path: authPath })
+      return null
+    }
+    log("credentials_read_ok", { path: authPath })
+    return {
+      accessToken: data.access,
+      refreshToken: data.refresh,
+      expiresAt: data.expires,
+    }
+  } catch (err) {
+    log("credentials_read_error", {
+      path: authPath,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
+}
+
+/**
+ * Write updated credentials back to ~/.pi/agent/auth.json.
+ * Preserves any extra fields already in the file (e.g. pi's own keys).
+ */
+export function writeCredentials(creds: ClaudeCredentials): void {
+  const authPath = getAuthJsonPath()
+  let existing: Record<string, unknown> = {}
+  try {
+    if (existsSync(authPath)) {
+      const raw = readFileSync(authPath, "utf-8").trim()
+      if (raw) existing = JSON.parse(raw) as Record<string, unknown>
+    }
+  } catch {
+    // Start fresh if malformed
+  }
+
+  existing.access = creds.accessToken
+  existing.refresh = creds.refreshToken
+  existing.expires = creds.expiresAt
+
+  const dir = dirname(authPath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+  writeFileSync(authPath, JSON.stringify(existing, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  })
+  if (process.platform !== "win32") {
+    chmodSync(authPath, 0o600)
+  }
+  log("credentials_write_ok", { path: authPath })
+}
+
+/**
+ * Parse a raw OAuth token response into ClaudeCredentials.
+ * Returns null if the response is missing a valid access_token.
+ * Defaults expires_in to 36000s (10h) to match observed Claude token lifetime.
+ */
+export function parseOAuthResponse(
+  raw: string,
+  currentRefreshToken: string,
+  now: number = Date.now(),
+): ClaudeCredentials | null {
+  let data: {
+    access_token?: string
+    refresh_token?: string
+    expires_in?: number
+    error?: string
+  }
+  try {
+    data = JSON.parse(raw)
+  } catch {
+    return null
+  }
+
+  if (!data.access_token) return null
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? currentRefreshToken,
+    expiresAt: now + (data.expires_in ?? 36_000) * 1000,
+  }
+}
+
+export function refreshViaOAuth(
+  refreshToken: string,
+): ClaudeCredentials | null {
+  // Use a Node subprocess to perform the HTTP request synchronously.
+  // The refresh token is passed via stdin to avoid exposure in process args.
+  const script = `
+    process.stdin.resume();
+    let input = '';
+    process.stdin.on('data', c => input += c);
+    process.stdin.on('end', () => {
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: '${OAUTH_CLIENT_ID}',
+        refresh_token: input.trim()
+      });
+      fetch('${OAUTH_TOKEN_URL}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+      })
+      .then(r => { if (!r.ok) throw new Error(String(r.status)); return r.json(); })
+      .then(d => { process.stdout.write(JSON.stringify(d)); })
+      .catch(e => { process.stdout.write(JSON.stringify({ error: String(e) })); process.exit(1); });
+    });
+  `
+
+  try {
+    log("refresh_started", { source: "oauth" })
+    const result = execFileSync(process.execPath, ["-e", script], {
+      input: refreshToken,
+      timeout: 15_000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+
+    const creds = parseOAuthResponse(result, refreshToken)
+    if (!creds) {
+      log("refresh_failed", {
+        source: "oauth",
+        error: "no access_token in response",
+      })
+      return null
+    }
+
+    log("refresh_success", { source: "oauth" })
+    return creds
+  } catch (err) {
+    log("refresh_failed", {
+      source: "oauth",
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
+}
+
+export function refreshIfNeeded(
+  creds: ClaudeCredentials,
+): ClaudeCredentials | null {
+  if (creds.expiresAt > Date.now() + 60_000) return creds
+
+  log("refresh_needed", {
+    expiresAt: creds.expiresAt,
+    expiresIn: creds.expiresAt - Date.now(),
+  })
+
+  if (creds.refreshToken) {
+    const fresh = refreshViaOAuth(creds.refreshToken)
+    if (fresh && fresh.expiresAt > Date.now() + 60_000) {
+      writeCredentials(fresh)
+      cachedCreds = null // invalidate cache so next call sees fresh creds
+      return fresh
+    }
+  }
+
+  log("refresh_exhausted", { expiresAt: creds.expiresAt })
+  return null
+}
+
+export function getCachedCredentials(): ClaudeCredentials | null {
+  const now = Date.now()
+
+  if (
+    cachedCreds &&
+    now - cachedCreds.cachedAt < CREDENTIAL_CACHE_TTL_MS &&
+    cachedCreds.creds.expiresAt > now + 60_000
+  ) {
+    log("cache_hit", {
+      ttlRemaining: CREDENTIAL_CACHE_TTL_MS - (now - cachedCreds.cachedAt),
+    })
+    return cachedCreds.creds
+  }
+
+  log("cache_miss", { reason: cachedCreds ? "stale or expiring" : "empty" })
+
+  const stored = readCredentials()
+  if (!stored) {
+    log("credentials_unavailable", { reason: "not found in auth.json" })
+    cachedCreds = null
+    return null
+  }
+
+  const fresh = refreshIfNeeded(stored)
+  if (!fresh) {
+    log("credentials_unavailable", { reason: "refresh failed" })
+    cachedCreds = null
+    return null
+  }
+
+  cachedCreds = { creds: fresh, cachedAt: now }
+  return fresh
+}
+
+export function invalidateCache(): void {
+  cachedCreds = null
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -1,0 +1,308 @@
+// pi-specific: pi.registerProvider wrapper for the Anthropic OAuth extension.
+// This is the ONE pi-specific file — it will NEVER match griffinmartin's index.ts
+// exactly because opencode and pi use different plugin/extension APIs.
+//
+// griffinmartin/opencode-claude-auth uses plugin.auth.loader + hook APIs.
+// pi uses pi.registerProvider(name, { oauth: { login, refreshToken, getApiKey } }).
+//
+// When porting a future upstream fix that touches griffinmartin's index.ts,
+// skip it — that file corresponds to nothing here. All business logic changes
+// in other griffinmartin files DO have 1:1 mirrors here and should be ported.
+//
+// See UPSTREAM.md for the port procedure.
+
+import { existsSync, symlinkSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import {
+  AuthStorage,
+  ModelRegistry,
+  type ExtensionAPI,
+  type ProviderConfig,
+} from "@mariozechner/pi-coding-agent"
+import type { OAuthCredentials } from "@mariozechner/pi-ai"
+import { initLogger, log } from "./logger.ts"
+import {
+  loginAnthropic,
+  refreshAnthropicToken,
+  isClaudeOAuthAccessToken,
+} from "./auth.ts"
+import { getCachedCredentials } from "./credentials.ts"
+import { transformBody, transformResponseStream } from "./transforms.ts"
+import { getModelBetas, getExcludedBetas } from "./betas.ts"
+import { config } from "./model-config.ts"
+import {
+  buildAnthropicSystemPrompt,
+  convertPiMessagesToAnthropic,
+  convertPiToolsToAnthropic,
+  fromClaudeCodeToolName,
+  parseSSEStream,
+} from "./stream.ts"
+
+const DEFAULT_OPUS_4_7: NonNullable<ProviderConfig["models"]>[number] = {
+  id: "claude-opus-4-7",
+  name: "Claude Opus 4.7",
+  api: "anthropic-messages",
+  reasoning: true,
+  input: ["text", "image"],
+  cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  contextWindow: 1000000,
+  maxTokens: 128000,
+  compat: undefined,
+}
+
+// pi-specific: create a ~/.Claude Code → ~/.pi symlink so that pi's jiti
+// resolver can find modules in the expected Claude Code credential path.
+function ensureClaudeCodeSymlink() {
+  const target = join(homedir(), ".pi")
+  const link = join(homedir(), ".Claude Code")
+  if (existsSync(target) && !existsSync(link)) {
+    try {
+      symlinkSync(target, link)
+    } catch {}
+  }
+}
+
+function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
+  const modelRegistry = ModelRegistry.create(AuthStorage.inMemory())
+  const models: NonNullable<ProviderConfig["models"]> = modelRegistry
+    .getAll()
+    .filter((model) => model.provider === "anthropic")
+    .map((model) => ({
+      id: model.id,
+      name: model.name,
+      api: model.api ?? "anthropic-messages",
+      reasoning: model.reasoning,
+      input: model.input,
+      cost: model.cost,
+      contextWindow: model.contextWindow,
+      maxTokens: model.maxTokens,
+      compat: model.compat,
+    }))
+
+  if (!models.some((model) => model.id === DEFAULT_OPUS_4_7.id)) {
+    models.push(DEFAULT_OPUS_4_7)
+  }
+
+  return models
+}
+
+function getUserAgent(): string {
+  return (
+    process.env.ANTHROPIC_USER_AGENT ??
+    `claude-cli/${config.ccVersion} (external, cli)`
+  )
+}
+
+// pi-specific: extension entry point — pi calls this with its ExtensionAPI
+export default function (pi: ExtensionAPI) {
+  initLogger()
+  log("extension_init", { version: config.ccVersion })
+
+  ensureClaudeCodeSymlink()
+  const models = getAnthropicModels()
+
+  pi.registerProvider("anthropic", {
+    baseUrl: "https://api.anthropic.com",
+    api: "anthropic-messages",
+    models,
+    oauth: {
+      name: "Claude Pro/Max",
+      usesCallbackServer: true,
+      // pi-specific: login triggers the full OAuth PKCE flow (auth.ts)
+      login: loginAnthropic,
+      // pi-specific: refreshToken is called by pi when tokens are near expiry
+      refreshToken: refreshAnthropicToken,
+      // pi-specific: getApiKey extracts the bearer token from stored credentials
+      getApiKey: (credentials: OAuthCredentials) => credentials.access,
+    } as unknown as ProviderConfig["oauth"],
+
+    // pi-specific: streamSimple wraps the Anthropic messages endpoint with:
+    //   - Bearer token injection from ~/.pi/agent/auth.json
+    //   - Beta header construction (mirrors griffinmartin's buildRequestHeaders)
+    //   - Request body transformation (billing header + MD5 tool obfuscation)
+    //   - Response stream deobfuscation (stripToolPrefix via transformResponseStream)
+    //   - Automatic token refresh on 401
+    //   - Manual SSE parsing (zero npm deps — no @anthropic-ai/sdk)
+    streamSimple: (model, context, options) => {
+      const { createAssistantMessageEventStream, calculateCost } =
+        require("@mariozechner/pi-ai") as typeof import("@mariozechner/pi-ai")
+
+      const stream = createAssistantMessageEventStream()
+
+      void (async () => {
+        try {
+          const apiKey = options?.apiKey
+          if (!apiKey) {
+            throw new Error(
+              "No Anthropic auth available. Run /login anthropic.",
+            )
+          }
+
+          const isOAuth = isClaudeOAuthAccessToken(apiKey)
+
+          const buildHeaders = (): Headers => {
+            const headers = new Headers()
+
+            if (isOAuth) {
+              const creds = getCachedCredentials()
+              const token = creds?.accessToken ?? apiKey
+              const excluded = getExcludedBetas(model.id)
+              const betas = getModelBetas(model.id, excluded)
+              headers.set("authorization", `Bearer ${token}`)
+              headers.set("anthropic-version", "2023-06-01")
+              headers.set("anthropic-beta", betas.join(","))
+              headers.set("x-app", "cli")
+              headers.set("user-agent", getUserAgent())
+              headers.set("x-client-request-id", crypto.randomUUID())
+            }
+
+            if (options?.headers) {
+              for (const [key, value] of Object.entries(options.headers)) {
+                const norm = key.toLowerCase()
+                if (isOAuth && norm === "x-api-key") continue
+                headers.set(key, value)
+              }
+            }
+
+            return headers
+          }
+
+          const maxTokens =
+            options?.maxTokens || Math.floor(model.maxTokens / 3)
+
+          const body: Record<string, unknown> = {
+            model: model.id,
+            max_tokens: maxTokens,
+            stream: true,
+          }
+
+          body.messages = convertPiMessagesToAnthropic(
+            context.messages,
+            isOAuth,
+          )
+
+          const system = buildAnthropicSystemPrompt(
+            context.systemPrompt,
+            isOAuth,
+          )
+          if (system) body.system = system
+
+          if (context.tools?.length) {
+            body.tools = convertPiToolsToAnthropic(context.tools, isOAuth)
+          }
+
+          if (options?.reasoning && model.reasoning && maxTokens > 1) {
+            const defaultBudgets: Record<string, number> = {
+              minimal: 1024,
+              low: 4096,
+              medium: 10240,
+              high: 20480,
+              xhigh: 32000,
+            }
+            const customBudget =
+              options.thinkingBudgets?.[
+                options.reasoning as keyof typeof options.thinkingBudgets
+              ]
+            const requestedBudget =
+              customBudget ?? defaultBudgets[options.reasoning] ?? 10240
+            body.thinking = {
+              type: "enabled",
+              budget_tokens: Math.min(requestedBudget, maxTokens - 1),
+            }
+          }
+
+          const bodyStr = JSON.stringify(body)
+          const transformedBody = isOAuth ? transformBody(bodyStr) : bodyStr
+          const headers = buildHeaders()
+
+          let response = await fetch(`${model.baseUrl}/v1/messages`, {
+            method: "POST",
+            headers,
+            body: transformedBody as string,
+            signal: options?.signal,
+          })
+
+          log("fetch_response", { status: response.status, modelId: model.id })
+
+          // On 401, rebuild headers (may refresh credential) and retry once
+          if (response.status === 401 && isOAuth) {
+            log("fetch_401_retry", { modelId: model.id })
+            const retryHeaders = buildHeaders()
+            response = await fetch(`${model.baseUrl}/v1/messages`, {
+              method: "POST",
+              headers: retryHeaders,
+              body: transformedBody as string,
+              signal: options?.signal,
+            })
+          }
+
+          const finalResponse = isOAuth
+            ? transformResponseStream(response)
+            : response
+
+          if (!finalResponse.ok || !finalResponse.body) {
+            const errorText = await finalResponse.text()
+            throw new Error(
+              `Anthropic API error ${finalResponse.status}: ${errorText}`,
+            )
+          }
+
+          const output = await parseSSEStream(
+            finalResponse,
+            model,
+            context,
+            isOAuth,
+            stream,
+            options,
+          )
+
+          calculateCost(model, output.usage)
+
+          stream.push({
+            type: "done",
+            reason: output.stopReason as "stop" | "length" | "toolUse",
+            message: output,
+          })
+          stream.end()
+        } catch (error) {
+          const stopReason = options?.signal?.aborted ? "aborted" : "error"
+          const errorMessage =
+            error instanceof Error ? error.message : String(error)
+          log("stream_error", { error: errorMessage })
+          stream.push({
+            type: "error",
+            reason: stopReason,
+            error: {
+              role: "assistant",
+              content: [],
+              api: model.api,
+              provider: model.provider,
+              model: model.id,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  total: 0,
+                },
+              },
+              stopReason,
+              errorMessage,
+              timestamp: Date.now(),
+            },
+          })
+          stream.end()
+        }
+      })()
+
+      return stream
+    },
+  })
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/logger.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/logger.ts
@@ -1,0 +1,94 @@
+// Mirror of griffinmartin/opencode-claude-auth src/logger.ts
+// Source: https://github.com/griffinmartin/opencode-claude-auth
+
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { homedir } from "node:os"
+import type { Writable } from "node:stream"
+
+const JWT_PATTERN = /^eyJ[A-Za-z0-9_-]{10,}/
+
+type LogMode = "disabled" | "file" | "stream"
+
+let mode: LogMode = "disabled"
+let logFilePath: string | null = null
+let logStream: Writable | null = null
+
+function getDefaultLogPath(): string {
+  return join(homedir(), ".pi", "agent", "pi-anthropic-oauth-debug.log")
+}
+
+export function initLogger(options?: { stream?: Writable }): void {
+  closeLogger()
+
+  if (options?.stream) {
+    mode = "stream"
+    logStream = options.stream
+    return
+  }
+
+  const envVal = process.env.PI_ANTHROPIC_OAUTH_DEBUG
+  if (!envVal) {
+    mode = "disabled"
+    return
+  }
+
+  mode = "file"
+  logFilePath = envVal === "1" ? getDefaultLogPath() : envVal
+
+  const dir = dirname(logFilePath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  writeFileSync(logFilePath, "", "utf-8")
+}
+
+export function log(event: string, data?: Record<string, unknown>): void {
+  if (mode === "disabled") return
+
+  const entry = {
+    ts: new Date().toISOString(),
+    event,
+    ...redact(data ?? {}),
+  }
+  const line = JSON.stringify(entry) + "\n"
+
+  if (mode === "file" && logFilePath) {
+    appendFileSync(logFilePath, line, "utf-8")
+  } else if (mode === "stream" && logStream) {
+    logStream.write(line)
+  }
+}
+
+export function closeLogger(): void {
+  mode = "disabled"
+  logFilePath = null
+  logStream = null
+}
+
+function redactValue(key: string, value: unknown): unknown {
+  if (typeof value !== "string") return value
+
+  if (key === "refreshToken" || key === "x-api-key" || key === "refresh") {
+    return "REDACTED"
+  }
+
+  if (key === "accessToken" || key === "access") {
+    const prefix = value.slice(0, 8)
+    return `${prefix}...REDACTED`
+  }
+
+  if (JWT_PATTERN.test(value)) {
+    return `${value.slice(0, 8)}...REDACTED`
+  }
+
+  return value
+}
+
+export function redact(data: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    result[key] = redactValue(key, value)
+  }
+  return result
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/model-config.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/model-config.ts
@@ -1,0 +1,58 @@
+// Mirror of griffinmartin/opencode-claude-auth src/model-config.ts
+// Source: https://github.com/griffinmartin/opencode-claude-auth
+
+export interface ModelOverride {
+  exclude?: string[]
+  add?: string[]
+  disableEffort?: boolean
+}
+
+export interface ModelConfig {
+  ccVersion: string
+  baseBetas: string[]
+  longContextBetas: string[]
+  modelOverrides: Record<string, ModelOverride>
+}
+
+export const config: ModelConfig = {
+  ccVersion: "2.1.90",
+  baseBetas: [
+    "claude-code-20250219",
+    "oauth-2025-04-20",
+    "interleaved-thinking-2025-05-14",
+    "prompt-caching-scope-2026-01-05",
+    "context-management-2025-06-27",
+  ],
+  longContextBetas: [
+    "context-1m-2025-08-07",
+    "interleaved-thinking-2025-05-14",
+  ],
+  modelOverrides: {
+    haiku: {
+      exclude: ["interleaved-thinking-2025-05-14"],
+      disableEffort: true,
+    },
+    "4-6": {
+      add: ["effort-2025-11-24"],
+    },
+    "4-7": {
+      add: ["effort-2025-11-24"],
+    },
+  },
+}
+
+/**
+ * Find the override entry matching a model ID.
+ * Keys are matched via includes() against the lowercased model ID.
+ *
+ * First-match-wins: if multiple keys match, only the first (by insertion
+ * order) is returned. List more specific keys before broader ones
+ * (e.g. "opus-4-6" before "opus") so they take priority.
+ */
+export function getModelOverride(modelId: string): ModelOverride | null {
+  const lower = modelId.toLowerCase()
+  for (const [pattern, override] of Object.entries(config.modelOverrides)) {
+    if (lower.includes(pattern)) return override
+  }
+  return null
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/signing.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/signing.ts
@@ -1,0 +1,74 @@
+// Mirror of griffinmartin/opencode-claude-auth src/signing.ts
+// Source: https://github.com/griffinmartin/opencode-claude-auth
+
+import { createHash } from "node:crypto"
+
+const BILLING_SALT = "59cf53e54c78"
+
+interface Message {
+  role?: string
+  content?: string | Array<{ type?: string; text?: string }>
+}
+
+/**
+ * Extract text from the first user message's first text block.
+ * Matches Claude Code's K19() function exactly: find the first message
+ * with role "user", then return the text of its first text content block.
+ */
+export function extractFirstUserMessageText(messages: Message[]): string {
+  const userMsg = messages.find((m) => m.role === "user")
+  if (!userMsg) return ""
+  const content = userMsg.content
+  if (typeof content === "string") return content
+  if (Array.isArray(content)) {
+    const textBlock = content.find((b) => b.type === "text")
+    if (textBlock && textBlock.type === "text" && textBlock.text) {
+      return textBlock.text
+    }
+  }
+  return ""
+}
+
+/**
+ * Compute cch: first 5 hex characters of SHA-256(messageText).
+ */
+export function computeCch(messageText: string): string {
+  return createHash("sha256").update(messageText).digest("hex").slice(0, 5)
+}
+
+/**
+ * Compute the 3-char version suffix.
+ * Samples characters at indices 4, 7, 20 from the message text (padding
+ * with "0" when the message is shorter), then hashes with the billing salt
+ * and version string.
+ */
+export function computeVersionSuffix(
+  messageText: string,
+  version: string,
+): string {
+  const sampled = [4, 7, 20]
+    .map((i) => (i < messageText.length ? messageText[i] : "0"))
+    .join("")
+  const input = `${BILLING_SALT}${sampled}${version}`
+  return createHash("sha256").update(input).digest("hex").slice(0, 3)
+}
+
+/**
+ * Build the complete billing header string for insertion into system[0].
+ * Format: x-anthropic-billing-header: cc_version=V.S; cc_entrypoint=E; cch=H;
+ */
+export function buildBillingHeaderValue(
+  messages: Message[],
+  version: string,
+  entrypoint: string,
+): string {
+  const text = extractFirstUserMessageText(messages)
+  const suffix = computeVersionSuffix(text, version)
+  const cch = computeCch(text)
+  return (
+    `x-anthropic-billing-header: ` +
+    `cc_version=${version}.${suffix}; ` +
+    `cc_entrypoint=${entrypoint}; ` +
+    `cch=${cch};`
+  )
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts
@@ -1,0 +1,628 @@
+// Pi-specific SSE stream parsing and message conversion.
+// Replaces leohenon's stream.ts which used @anthropic-ai/sdk.
+// This file uses only host fetch() and manual SSE parsing (zero npm deps).
+//
+// Source patterns from:
+//   leohenon/pi-anthropic-oauth src/stream.ts (structure, pi API types)
+//   leohenon/pi-anthropic-oauth src/convert.ts (message conversion)
+//   leohenon/pi-anthropic-oauth src/prompt.ts (system prompt building)
+
+import type {
+  AssistantMessage,
+  AssistantMessageEventStream,
+  Context,
+  Model,
+  Api,
+  SimpleStreamOptions,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  ImageContent,
+  ToolResultMessage,
+  Message,
+  Tool,
+} from "@mariozechner/pi-ai"
+
+// ──────────────────────────────────────────────
+// Type helpers
+// ──────────────────────────────────────────────
+
+type ContentBlockParam =
+  | { type: "text"; text: string; cache_control?: { type: string } }
+  | {
+      type: "image"
+      source: {
+        type: "base64"
+        media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp"
+        data: string
+      }
+    }
+  | {
+      type: "tool_use"
+      id: string
+      name: string
+      input: Record<string, unknown>
+    }
+  | {
+      type: "tool_result"
+      tool_use_id: string
+      content: string | ToolResultContentBlock[]
+      is_error?: boolean
+    }
+
+type ToolResultContentBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "image"
+      source: {
+        type: "base64"
+        media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp"
+        data: string
+      }
+    }
+
+export type IndexedBlock =
+  | (TextContent & { index: number })
+  | (ThinkingContent & { index: number; thinkingSignature?: string })
+  | (ToolCall & { index: number; partialJson: string })
+
+// ──────────────────────────────────────────────
+// System prompt utilities (from leohenon/prompt.ts)
+// ──────────────────────────────────────────────
+
+const CLAUDE_CODE_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude."
+const PI_REMOVAL_ANCHORS = [
+  "pi-coding-agent",
+  "@mariozechner/pi-coding-agent",
+  "badlogic/pi-mono",
+] as const
+
+export function sanitizeSurrogates(text: string): string {
+  return text.replace(/[\uD800-\uDFFF]/g, "\uFFFD")
+}
+
+export function buildAnthropicSystemPrompt(
+  systemPrompt: string | undefined,
+  isOAuth: boolean,
+): Array<{ type: string; text: string; cache_control?: { type: string } }> | undefined {
+  const blocks: Array<{
+    type: string
+    text: string
+    cache_control?: { type: string }
+  }> = []
+
+  if (isOAuth) {
+    blocks.push({
+      type: "text",
+      text: CLAUDE_CODE_IDENTITY,
+      cache_control: { type: "ephemeral" },
+    })
+  }
+
+  const sanitized = systemPrompt ? sanitizeSystemText(systemPrompt) : ""
+  if (sanitized) {
+    blocks.push({
+      type: "text",
+      text: sanitized,
+      cache_control: { type: "ephemeral" },
+    })
+  }
+
+  return blocks.length > 0 ? blocks : undefined
+}
+
+function sanitizeSystemText(text: string): string {
+  const paragraphs = text.split(/\n\n+/)
+  const filtered = paragraphs.filter((paragraph) => {
+    const lower = paragraph.toLowerCase()
+    if (lower.includes("you are pi")) return false
+    return !PI_REMOVAL_ANCHORS.some((anchor) => paragraph.includes(anchor))
+  })
+
+  return filtered
+    .join("\n\n")
+    .replace(/\bpi\b/g, "Claude Code")
+    .replace(/\bPi\b/g, "Claude Code")
+    .trim()
+}
+
+// ──────────────────────────────────────────────
+// Message conversion (from leohenon/convert.ts)
+// ──────────────────────────────────────────────
+
+const claudeCodeTools = [
+  "Read",
+  "Write",
+  "Edit",
+  "Bash",
+  "Grep",
+  "Glob",
+  "AskUserQuestion",
+  "TodoWrite",
+  "WebFetch",
+  "WebSearch",
+] as const
+
+const claudeCodeToolLookup = new Map(
+  claudeCodeTools.map((name) => [name.toLowerCase(), name]),
+)
+
+export function toClaudeCodeToolName(name: string): string {
+  return claudeCodeToolLookup.get(name.toLowerCase()) ?? name
+}
+
+export function fromClaudeCodeToolName(
+  name: string,
+  tools?: Tool[],
+): string {
+  const lower = name.toLowerCase()
+  return tools?.find((tool) => tool.name.toLowerCase() === lower)?.name ?? name
+}
+
+export function convertPiMessagesToAnthropic(
+  messages: Message[],
+  isOAuth: boolean,
+): Array<{ role: string; content: string | ContentBlockParam[] }> {
+  const params: Array<{ role: string; content: string | ContentBlockParam[] }> =
+    []
+  const toolIdMap = new Map<string, string>()
+  const usedToolIds = new Set<string>()
+
+  const getAnthropicToolId = (id: string): string => {
+    const existing = toolIdMap.get(id)
+    if (existing) return existing
+
+    let base = sanitizeSurrogates(id).replace(/[^a-zA-Z0-9_-]/g, "_")
+    if (!base) base = "tool"
+    let candidate = base
+    let suffix = 1
+    while (usedToolIds.has(candidate)) {
+      candidate = `${base}_${suffix++}`
+    }
+    usedToolIds.add(candidate)
+    toolIdMap.set(id, candidate)
+    return candidate
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+
+    if (message.role === "user") {
+      if (typeof message.content === "string") {
+        if (message.content.trim())
+          params.push({
+            role: "user",
+            content: sanitizeSurrogates(message.content),
+          })
+      } else {
+        const blocks: ContentBlockParam[] = (
+          message.content as (TextContent | ImageContent)[]
+        ).map((item) =>
+          item.type === "text"
+            ? { type: "text", text: sanitizeSurrogates(item.text) }
+            : {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: (item as ImageContent).mimeType as
+                    | "image/jpeg"
+                    | "image/png"
+                    | "image/gif"
+                    | "image/webp",
+                  data: (item as ImageContent).data,
+                },
+              },
+        )
+        if (blocks.length > 0) params.push({ role: "user", content: blocks })
+      }
+      continue
+    }
+
+    if (message.role === "assistant") {
+      const blocks: ContentBlockParam[] = []
+      for (const block of message.content as (
+        | TextContent
+        | ThinkingContent
+        | ToolCall
+      )[]) {
+        if (block.type === "text" && (block as TextContent).text.trim()) {
+          blocks.push({
+            type: "text",
+            text: sanitizeSurrogates((block as TextContent).text),
+          })
+        } else if (block.type === "toolCall") {
+          const tb = block as ToolCall
+          blocks.push({
+            type: "tool_use",
+            id: getAnthropicToolId(tb.id),
+            name: isOAuth ? toClaudeCodeToolName(tb.name) : tb.name,
+            input: tb.arguments,
+          })
+        }
+      }
+      if (blocks.length > 0)
+        params.push({ role: "assistant", content: blocks })
+      continue
+    }
+
+    if (message.role === "toolResult") {
+      const msg = message as ToolResultMessage
+      const toolResults: ContentBlockParam[] = [
+        {
+          type: "tool_result",
+          tool_use_id: getAnthropicToolId(msg.toolCallId),
+          content: convertToolResultContentToAnthropic(msg.content),
+          is_error: msg.isError,
+        },
+      ]
+
+      let j = i + 1
+      while (j < messages.length && messages[j]?.role === "toolResult") {
+        const nextMessage = messages[j] as ToolResultMessage
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: getAnthropicToolId(nextMessage.toolCallId),
+          content: convertToolResultContentToAnthropic(nextMessage.content),
+          is_error: nextMessage.isError,
+        })
+        j++
+      }
+      i = j - 1
+      params.push({ role: "user", content: toolResults })
+    }
+  }
+
+  // Add cache_control to last user message block (matches leohenon pattern)
+  const last = params.at(-1)
+  if (
+    last?.role === "user" &&
+    Array.isArray(last.content) &&
+    last.content.length > 0
+  ) {
+    const lastBlock = last.content[last.content.length - 1] as {
+      cache_control?: { type: string }
+    }
+    lastBlock.cache_control = { type: "ephemeral" }
+  }
+
+  return params
+}
+
+export function convertPiToolsToAnthropic(
+  tools: Tool[],
+  isOAuth: boolean,
+): Array<{
+  name: string
+  description: string
+  input_schema: { type: "object"; properties: Record<string, unknown>; required: string[] }
+}> {
+  return tools.map((tool) => ({
+    name: isOAuth ? toClaudeCodeToolName(tool.name) : tool.name,
+    description: tool.description,
+    input_schema: {
+      type: "object" as const,
+      properties:
+        (tool.parameters as { properties?: Record<string, unknown> })
+          .properties ?? {},
+      required:
+        (tool.parameters as { required?: string[] }).required ?? [],
+    },
+  }))
+}
+
+function convertToolResultContentToAnthropic(
+  content: (TextContent | ImageContent)[],
+): string | ToolResultContentBlock[] {
+  const hasImages = content.some((block) => block.type === "image")
+  if (!hasImages) {
+    return sanitizeSurrogates(
+      content
+        .filter((block): block is TextContent => block.type === "text")
+        .map((block) => block.text)
+        .join("\n"),
+    )
+  }
+
+  const blocks: ToolResultContentBlock[] = content.map((block) => {
+    if (block.type === "text")
+      return { type: "text" as const, text: sanitizeSurrogates(block.text) }
+    const img = block as ImageContent
+    return {
+      type: "image" as const,
+      source: {
+        type: "base64" as const,
+        media_type: img.mimeType as
+          | "image/jpeg"
+          | "image/png"
+          | "image/gif"
+          | "image/webp",
+        data: img.data,
+      },
+    }
+  })
+
+  if (!blocks.some((block) => block.type === "text")) {
+    blocks.unshift({ type: "text", text: "(see attached image)" })
+  }
+
+  return blocks
+}
+
+// ──────────────────────────────────────────────
+// SSE stream parsing (replaces @anthropic-ai/sdk streaming)
+// ──────────────────────────────────────────────
+
+function mapStopReason(reason: string | null | undefined): string {
+  switch (reason) {
+    case "end_turn":
+    case "pause_turn":
+    case "stop_sequence":
+      return "stop"
+    case "max_tokens":
+      return "length"
+    case "tool_use":
+      return "toolUse"
+    default:
+      return "error"
+  }
+}
+
+/**
+ * Parse an SSE stream from the Anthropic API into pi's AssistantMessageEventStream.
+ * Uses only ReadableStream / TextDecoder — zero npm deps.
+ */
+export async function parseSSEStream(
+  response: Response,
+  model: Model<Api>,
+  context: Context,
+  isOAuth: boolean,
+  stream: AssistantMessageEventStream,
+  options?: SimpleStreamOptions,
+): Promise<AssistantMessage> {
+  const output: AssistantMessage = {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  }
+
+  stream.push({ type: "start", partial: output })
+
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  const blocks = output.content as IndexedBlock[]
+
+  const processEvent = (eventText: string) => {
+    const lines = eventText.split("\n")
+    let eventType = ""
+    let dataStr = ""
+
+    for (const line of lines) {
+      if (line.startsWith("event: ")) {
+        eventType = line.slice(7).trim()
+      } else if (line.startsWith("data: ")) {
+        dataStr = line.slice(6).trim()
+      }
+    }
+
+    if (!dataStr || dataStr === "[DONE]") return
+
+    let event: Record<string, unknown>
+    try {
+      event = JSON.parse(dataStr) as Record<string, unknown>
+    } catch {
+      return
+    }
+
+    const type = (event.type as string) ?? eventType
+
+    if (type === "message_start") {
+      const msg = event.message as {
+        usage?: {
+          input_tokens?: number
+          output_tokens?: number
+          cache_read_input_tokens?: number
+          cache_creation_input_tokens?: number
+        }
+      }
+      const usage = msg?.usage ?? {}
+      output.usage.input = usage.input_tokens ?? 0
+      output.usage.output = usage.output_tokens ?? 0
+      output.usage.cacheRead = usage.cache_read_input_tokens ?? 0
+      output.usage.cacheWrite = usage.cache_creation_input_tokens ?? 0
+      output.usage.totalTokens =
+        output.usage.input +
+        output.usage.output +
+        output.usage.cacheRead +
+        output.usage.cacheWrite
+      return
+    }
+
+    if (type === "content_block_start") {
+      const idx = event.index as number
+      const cb = event.content_block as { type: string; id?: string; name?: string }
+      if (cb.type === "text") {
+        output.content.push({ type: "text", text: "", index: idx } as IndexedBlock)
+        stream.push({
+          type: "text_start",
+          contentIndex: output.content.length - 1,
+          partial: output,
+        })
+      } else if (cb.type === "thinking") {
+        output.content.push({
+          type: "thinking",
+          thinking: "",
+          thinkingSignature: "",
+          index: idx,
+        } as IndexedBlock)
+        stream.push({
+          type: "thinking_start",
+          contentIndex: output.content.length - 1,
+          partial: output,
+        })
+      } else if (cb.type === "tool_use") {
+        const toolName = isOAuth
+          ? fromClaudeCodeToolName(cb.name ?? "", context.tools)
+          : (cb.name ?? "")
+        output.content.push({
+          type: "toolCall",
+          id: cb.id ?? "",
+          name: toolName,
+          arguments: {},
+          partialJson: "",
+          index: idx,
+        } as IndexedBlock)
+        stream.push({
+          type: "toolcall_start",
+          contentIndex: output.content.length - 1,
+          partial: output,
+        })
+      }
+      return
+    }
+
+    if (type === "content_block_delta") {
+      const idx = event.index as number
+      const contentIndex = blocks.findIndex((b) => b.index === idx)
+      const block = blocks[contentIndex]
+      if (!block) return
+
+      const delta = event.delta as { type: string; text?: string; thinking?: string; signature?: string; partial_json?: string }
+
+      if (delta.type === "text_delta" && block.type === "text") {
+        (block as TextContent & { index: number }).text += delta.text ?? ""
+        stream.push({
+          type: "text_delta",
+          contentIndex,
+          delta: delta.text ?? "",
+          partial: output,
+        })
+      } else if (delta.type === "thinking_delta" && block.type === "thinking") {
+        (block as ThinkingContent & { index: number }).thinking +=
+          delta.thinking ?? ""
+        stream.push({
+          type: "thinking_delta",
+          contentIndex,
+          delta: delta.thinking ?? "",
+          partial: output,
+        })
+      } else if (delta.type === "signature_delta" && block.type === "thinking") {
+        const tb = block as ThinkingContent & {
+          index: number
+          thinkingSignature?: string
+        }
+        tb.thinkingSignature = (tb.thinkingSignature ?? "") + (delta.signature ?? "")
+      } else if (delta.type === "input_json_delta" && block.type === "toolCall") {
+        const tb = block as ToolCall & { index: number; partialJson: string }
+        tb.partialJson += delta.partial_json ?? ""
+        try {
+          tb.arguments = JSON.parse(tb.partialJson) as Record<string, unknown>
+        } catch {}
+        stream.push({
+          type: "toolcall_delta",
+          contentIndex,
+          delta: delta.partial_json ?? "",
+          partial: output,
+        })
+      }
+      return
+    }
+
+    if (type === "content_block_stop") {
+      const idx = event.index as number
+      const contentIndex = blocks.findIndex((b) => b.index === idx)
+      const block = blocks[contentIndex]
+      if (!block) return
+
+      delete (block as { index?: number }).index
+      if (block.type === "text") {
+        stream.push({
+          type: "text_end",
+          contentIndex,
+          content: (block as TextContent).text,
+          partial: output,
+        })
+      } else if (block.type === "thinking") {
+        stream.push({
+          type: "thinking_end",
+          contentIndex,
+          content: (block as ThinkingContent).thinking,
+          partial: output,
+        })
+      } else if (block.type === "toolCall") {
+        const tb = block as ToolCall & { index?: number; partialJson?: string }
+        try {
+          tb.arguments = JSON.parse(tb.partialJson ?? "") as Record<
+            string,
+            unknown
+          >
+        } catch {}
+        delete tb.partialJson
+        stream.push({
+          type: "toolcall_end",
+          contentIndex,
+          toolCall: block as ToolCall,
+          partial: output,
+        })
+      }
+      return
+    }
+
+    if (type === "message_delta") {
+      const delta = event.delta as { stop_reason?: string }
+      const usage = event.usage as {
+        input_tokens?: number
+        output_tokens?: number
+        cache_read_input_tokens?: number
+        cache_creation_input_tokens?: number
+      }
+      output.stopReason = mapStopReason(delta.stop_reason)
+      if (usage) {
+        output.usage.input = usage.input_tokens ?? output.usage.input
+        output.usage.output = usage.output_tokens ?? output.usage.output
+        output.usage.cacheRead = usage.cache_read_input_tokens ?? 0
+        output.usage.cacheWrite = usage.cache_creation_input_tokens ?? 0
+        output.usage.totalTokens =
+          output.usage.input +
+          output.usage.output +
+          output.usage.cacheRead +
+          output.usage.cacheWrite
+      }
+    }
+  }
+
+  // Read the SSE stream chunk by chunk
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    // Process complete SSE events (separated by \n\n)
+    for (;;) {
+      const boundary = buffer.indexOf("\n\n")
+      if (boundary === -1) break
+      const event = buffer.slice(0, boundary)
+      buffer = buffer.slice(boundary + 2)
+      if (event.trim()) processEvent(event)
+    }
+  }
+
+  // Process any remaining buffer
+  if (buffer.trim()) processEvent(buffer)
+
+  return output
+}

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/transforms.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/transforms.ts
@@ -1,0 +1,354 @@
+// Mirror of griffinmartin/opencode-claude-auth src/transforms.ts
+// with MD5 hash-based tool name obfuscation from PR #193
+// Source: https://github.com/griffinmartin/opencode-claude-auth
+//
+// Key divergence from griffinmartin main branch: uses MD5 hash obfuscation
+// (PR #193 approach) instead of the PascalCase mcp_ prefix approach (#191).
+// PR #193 is more robust: hashing ALL tool names to t_<8hex> is blacklist-proof,
+// whereas the mcp_ prefix approach can be added to the blacklist trivially.
+
+import { buildBillingHeaderValue } from "./signing.ts"
+import { config, getModelOverride } from "./model-config.ts"
+
+// Obfuscate tool names: the API blacklists certain tool names (todowrite,
+// background_output, background_cancel). To avoid detection we hash ALL tool
+// names on the way out and reverse-map them on the way back.
+import { createHash } from "node:crypto"
+
+const toolNameMap = new Map<string, string>() // obfuscated → original
+const toolNameReverseMap = new Map<string, string>() // original → obfuscated
+
+function obfuscateToolName(name: string): string {
+  const existing = toolNameReverseMap.get(name)
+  if (existing) return existing
+  const hash = createHash("md5").update(name).digest("hex").slice(0, 8)
+  const obf = `t_${hash}`
+  toolNameMap.set(obf, name)
+  toolNameReverseMap.set(name, obf)
+  return obf
+}
+
+function deobfuscateToolName(obf: string): string {
+  return toolNameMap.get(obf) ?? obf
+}
+
+const SYSTEM_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude."
+
+type SystemEntry = { type?: string; text?: string } & Record<string, unknown>
+type ContentBlock = { type?: string; text?: string } & Record<string, unknown>
+type Message = {
+  role?: string
+  content?: string | ContentBlock[]
+}
+
+export function repairToolPairs(messages: Message[]): Message[] {
+  // Collect all tool_use ids and tool_result tool_use_ids
+  const toolUseIds = new Set<string>()
+  const toolResultIds = new Set<string>()
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue
+    for (const block of message.content) {
+      const id = block["id"]
+      if (block.type === "tool_use" && typeof id === "string") {
+        toolUseIds.add(id)
+      }
+      const toolUseId = block["tool_use_id"]
+      if (block.type === "tool_result" && typeof toolUseId === "string") {
+        toolResultIds.add(toolUseId)
+      }
+    }
+  }
+
+  // Find orphaned IDs
+  const orphanedUses = new Set<string>()
+  for (const id of toolUseIds) {
+    if (!toolResultIds.has(id)) orphanedUses.add(id)
+  }
+  const orphanedResults = new Set<string>()
+  for (const id of toolResultIds) {
+    if (!toolUseIds.has(id)) orphanedResults.add(id)
+  }
+
+  // Early return if nothing to fix
+  if (orphanedUses.size === 0 && orphanedResults.size === 0) {
+    return messages
+  }
+
+  // Filter orphaned blocks and remove messages with empty content arrays
+  return messages
+    .map((message) => {
+      if (!Array.isArray(message.content)) return message
+      const filtered = message.content.filter((block) => {
+        const id = block["id"]
+        if (block.type === "tool_use" && typeof id === "string") {
+          return !orphanedUses.has(id)
+        }
+        const toolUseId = block["tool_use_id"]
+        if (block.type === "tool_result" && typeof toolUseId === "string") {
+          return !orphanedResults.has(toolUseId)
+        }
+        return true
+      })
+      return { ...message, content: filtered }
+    })
+    .filter(
+      (message) =>
+        !(Array.isArray(message.content) && message.content.length === 0),
+    )
+}
+
+export function transformBody(
+  body: BodyInit | null | undefined,
+): BodyInit | null | undefined {
+  if (typeof body !== "string") {
+    return body
+  }
+
+  try {
+    const parsed = JSON.parse(body) as {
+      model?: string
+      system?: SystemEntry[]
+      thinking?: Record<string, unknown>
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      output_config?: Record<string, unknown>
+      tools?: Array<{ name?: string } & Record<string, unknown>>
+      messages?: Array<{
+        role?: string
+        content?:
+          | string
+          | Array<{ type?: string; text?: string } & Record<string, unknown>>
+      }>
+    }
+
+    // --- Billing header: inject as system[0] (no cache_control) ---
+    const version = process.env.ANTHROPIC_CLI_VERSION ?? config.ccVersion
+    const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? "cli"
+    const billingHeader = buildBillingHeaderValue(
+      (parsed.messages ?? []) as Array<{
+        role?: string
+        content?: string | Array<{ type?: string; text?: string }>
+      }>,
+      version,
+      entrypoint,
+    )
+
+    if (!Array.isArray(parsed.system)) {
+      parsed.system = []
+    }
+
+    // Remove any existing billing header entries
+    parsed.system = parsed.system.filter(
+      (e) =>
+        !(
+          e.type === "text" &&
+          typeof e.text === "string" &&
+          e.text.startsWith("x-anthropic-billing-header")
+        ),
+    )
+
+    // Insert billing header as system[0], without cache_control
+    parsed.system.unshift({ type: "text", text: billingHeader })
+
+    // --- Split identity prefix into its own system entry ---
+    // pi's system prompt may concatenate all system entries into a single
+    // text block. Anthropic's API requires the identity string as a separate
+    // entry for OAuth validation.
+    const splitSystem: SystemEntry[] = []
+    for (const entry of parsed.system) {
+      if (
+        entry.type === "text" &&
+        typeof entry.text === "string" &&
+        entry.text.startsWith(SYSTEM_IDENTITY) &&
+        entry.text.length > SYSTEM_IDENTITY.length
+      ) {
+        const rest = entry.text
+          .slice(SYSTEM_IDENTITY.length)
+          .replace(/^\n+/, "")
+        // Preserve all properties except text (e.g. cache_control)
+        const { text: _text, ...entryProps } = entry
+        // Only keep cache_control on the remainder block to avoid exceeding
+        // the API limit of 4 cache_control blocks per request.
+        const { cache_control: _cc, ...identityProps } = entryProps
+        splitSystem.push({ ...identityProps, text: SYSTEM_IDENTITY })
+        if (rest.length > 0) {
+          splitSystem.push({ ...entryProps, text: rest })
+        }
+      } else {
+        splitSystem.push(entry)
+      }
+    }
+    parsed.system = splitSystem
+
+    // --- Relocate non-core system entries to user messages ---
+    // Anthropic's API now validates the system prompt for OAuth-authenticated
+    // requests that use Claude Code billing. Third-party system prompts
+    // trigger a 400 "out of extra usage" rejection when they appear inside
+    // the system[] array alongside the identity prefix.
+    //
+    // Work-around: keep only the billing header and identity prefix in
+    // system[], and prepend all other system content to the first user
+    // message where it is functionally equivalent but avoids the check.
+    const BILLING_PREFIX = "x-anthropic-billing-header"
+    const keptSystem: SystemEntry[] = []
+    const movedTexts: string[] = []
+    for (const entry of parsed.system) {
+      const txt = typeof entry === "string" ? entry : (entry.text ?? "")
+      if (txt.startsWith(BILLING_PREFIX) || txt.startsWith(SYSTEM_IDENTITY)) {
+        keptSystem.push(entry)
+      } else if (txt.length > 0) {
+        movedTexts.push(txt)
+      }
+    }
+    if (movedTexts.length > 0 && Array.isArray(parsed.messages)) {
+      const firstUser = parsed.messages.find((m) => m.role === "user")
+      if (firstUser) {
+        parsed.system = keptSystem
+        const prefix = movedTexts.join("\n\n")
+        if (typeof firstUser.content === "string") {
+          firstUser.content = prefix + "\n\n" + firstUser.content
+        } else if (Array.isArray(firstUser.content)) {
+          firstUser.content.unshift({ type: "text", text: prefix })
+        }
+      }
+    }
+
+    // Strip effort for models that don't support it (e.g. haiku).
+    const modelId = parsed.model ?? ""
+    const override = getModelOverride(modelId)
+    if (override?.disableEffort) {
+      if (parsed.output_config) {
+        delete parsed.output_config.effort
+        if (Object.keys(parsed.output_config).length === 0) {
+          delete parsed.output_config
+        }
+      }
+      if (parsed.thinking && "effort" in parsed.thinking) {
+        delete parsed.thinking.effort
+        if (Object.keys(parsed.thinking).length === 0) {
+          delete parsed.thinking
+        }
+      }
+    }
+
+    // Obfuscate tool names to avoid API blacklist detection.
+    // MD5-hashes ALL tool names to t_<8hex> (PR #193 approach).
+    // This covers todowrite, background_output, background_cancel, and any
+    // future blacklist additions without requiring plugin updates.
+    if (Array.isArray(parsed.tools)) {
+      parsed.tools = parsed.tools.map((tool) => ({
+        ...tool,
+        name: tool.name ? obfuscateToolName(tool.name) : tool.name,
+      }))
+    }
+
+    if (Array.isArray(parsed.messages)) {
+      parsed.messages = parsed.messages.map((message) => {
+        if (!Array.isArray(message.content)) return message
+        return {
+          ...message,
+          content: message.content.map((block) => {
+            if (block.type === "tool_use" && typeof block.name === "string") {
+              return { ...block, name: obfuscateToolName(block.name) }
+            }
+            if (
+              block.type === "tool_result" &&
+              typeof block["tool_use_id"] === "string"
+            ) {
+              // tool_result references tool_use by id, not name — no change needed
+            }
+            return block
+          }),
+        }
+      })
+    }
+
+    if (Array.isArray(parsed.messages)) {
+      parsed.messages = repairToolPairs(parsed.messages)
+    }
+
+    return JSON.stringify(parsed)
+  } catch {
+    return body
+  }
+}
+
+export function stripToolPrefix(text: string): string {
+  // Reverse-map obfuscated tool names back to originals in response stream
+  return text.replace(/"name"\s*:\s*"(t_[0-9a-f]{8})"/g, (_match, obf) => {
+    const original = deobfuscateToolName(obf)
+    return `"name": "${original}"`
+  })
+}
+
+export function transformResponseStream(response: Response): Response {
+  if (!response.body) {
+    return response
+  }
+
+  // Don't wrap error responses through the SSE parser — pass them through
+  // with only tool-prefix stripping on the raw body. This preserves error
+  // messages for pi / AI SDK to handle properly.
+  if (!response.ok) {
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    const encoder = new TextEncoder()
+
+    const passthrough = new ReadableStream({
+      async pull(controller) {
+        const { done, value } = await reader.read()
+        if (done) {
+          controller.close()
+          return
+        }
+        const text = decoder.decode(value, { stream: true })
+        controller.enqueue(encoder.encode(stripToolPrefix(text)))
+      },
+    })
+
+    return new Response(passthrough, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ""
+
+  const stream = new ReadableStream({
+    async pull(controller) {
+      for (;;) {
+        const boundary = buffer.indexOf("\n\n")
+        if (boundary !== -1) {
+          const completeEvent = buffer.slice(0, boundary + 2)
+          buffer = buffer.slice(boundary + 2)
+          controller.enqueue(encoder.encode(stripToolPrefix(completeEvent)))
+          return
+        }
+
+        const { done, value } = await reader.read()
+
+        if (done) {
+          if (buffer) {
+            controller.enqueue(encoder.encode(stripToolPrefix(buffer)))
+            buffer = ""
+          }
+          controller.close()
+          return
+        }
+
+        buffer += decoder.decode(value, { stream: true })
+      }
+    },
+  })
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}


### PR DESCRIPTION
## Summary

Replaces `npm:pi-anthropic-oauth@0.1.9` with a vendored TypeScript extension stored directly in the nix store at `modules/programs/prism/pi/extensions/anthropic-oauth/`.

### What was ported and from where

**Primary source — `griffinmartin/opencode-claude-auth`** (`df1b0cbc`):
- `transforms.ts`: system prompt manipulation, billing header injection, tool name obfuscation, SSE response deobfuscation, orphaned tool-pair repair
- `betas.ts`: beta flag management, long-context error handling
- `signing.ts`: billing header computation (CCH, version suffix)
- `model-config.ts`: model list, cc version, beta flags
- `logger.ts`: structured logging pattern
- `credentials.ts`: OAuth refresh via Node subprocess, credential parsing
- `anthropic-prompt.txt`: verbatim copy

**Key fix from griffinmartin PR #193** (`9420fbef`) — not yet merged to main:
- `transforms.ts` uses MD5 hash-based tool name obfuscation (`t_<8hex>`) instead of the weaker PascalCase `mcp_` prefix approach on griffinmartin's current main
- All tool names are hashed via MD5 before being sent to Anthropic, with a stateful reverse map for deobfuscation in responses
- Covers `todowrite`, `background_output`, `background_cancel`, and any future blacklisted names without requiring plugin updates

**Secondary source — `leohenon/pi-anthropic-oauth`** (`86d9d978`):
- `index.ts`: pi.registerProvider wrapper structure, ensureClaudeCodeSymlink, model registry
- `auth.ts`: OAuth PKCE flow, local callback server, loginAnthropic, refreshAnthropicToken
- `stream.ts`: pi message conversion (from leohenon's convert.ts + prompt.ts) — **@anthropic-ai/sdk replaced with native fetch + manual SSE parsing**

### Zero npm dependencies

The vendored extension has no runtime npm deps. HTTP uses host `fetch()`; SSE streams are parsed manually in `stream.ts`. Pi's virtual-bundled modules (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-ai`) are available via jiti's virtualModules without any `node_modules` tree.

### Nix integration

- `piExtensionsDir`: `pkgs.runCommand "pi-extensions"` derivation (mirrors `skillsDir` pattern in pi.nix lines 36-44)
- `piSettings.extensions`: replaces `packages = [ "npm:pi-anthropic-oauth@0.1.9" ]` with the nix-store path to `index.ts`
- `home.file.".pi/agent/extensions"`: GC-roots the derivation so `nix-store --gc` cannot remove it

### Upstream SHAs in UPSTREAM.md

| Upstream | SHA |
|---|---|
| griffinmartin/opencode-claude-auth main | `df1b0cbc9e94ff9a8081ac98aa837893fd2be35e` |
| griffinmartin PR #193 (MD5 approach) | `9420fbef60567968bcd21a260db21be9f7dd475b` |
| leohenon/pi-anthropic-oauth | `86d9d97829776a66aec58e3433900173ff7e184a` |

## Post-merge manual verification steps (on navi after `nixos-rebuild switch`)

Three ACs cannot be verified from inside this agent session and require running pi on navi with live Anthropic credentials:

1. **Fresh login flow**: `rm -f ~/.pi/agent/auth.json && pi`, then run `/login anthropic` → select "Claude Pro/Max". Verify the browser opens, callback server works on port 53692, and credentials are written to `~/.pi/agent/auth.json`.

2. **No "extra usage" warning**: Submit a prompt that invokes tools (e.g. Read, TodoWrite, Bash). The MD5 hash obfuscation should prevent the "You're out of extra usage" 400 error that the previous `npm:pi-anthropic-oauth@0.1.9` triggered.

3. **Extension loaded**: Confirm pi starts without errors and the extension is loaded (visible in pi's session log or UI). With `PI_ANTHROPIC_OAUTH_DEBUG=1` set, check `~/.pi/agent/pi-anthropic-oauth-debug.log` for `extension_init` event.

4. **Existing token flow**: If `~/.pi/agent/auth.json` already exists, pi should authenticate without prompting for login. Verify session works end-to-end.

Closes #808