### PR TITLE
prism: wire --isolation flag and agent.isolation.default nix option, bwrap end-to-end

### DIFF
--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -23,6 +23,29 @@
           description = "Environment variables to set for the AI agent (opencode)";
         };
 
+        isolation = {
+          default = lib.mkOption {
+            type = lib.types.enum [
+              "podman"
+              "bwrap"
+              "host"
+            ];
+            default = if pkgs.stdenv.hostPlatform.isLinux then "podman" else "host";
+            example = "bwrap";
+            description = ''
+              Default isolation mode for new agent sessions. Valid values:
+              - "podman": run opencode inside a rootless podman container (default on Linux).
+              - "bwrap":  run opencode inside a bubblewrap sandbox (Linux-only).
+              - "host":   run opencode directly in the tmux pane with no isolation (default on Darwin).
+
+              This value is written to ~/.config/prism/config.json as default_isolation_mode.
+              It can be overridden per-spawn via `prism spawn --isolation <mode>`.
+
+              Setting "bwrap" on a Darwin host fails at eval time.
+            '';
+          };
+        };
+
         resources = {
           memoryMax = lib.mkOption {
             type = lib.types.str;
@@ -125,38 +148,58 @@
     ./prism-tui.nix
   ];
 
-  config = lib.mkIf config.nx.programs.prism.enable {
-    # Enable all submodules by default (can be individually disabled)
-    nx.programs.prism.neovim.enable = lib.mkDefault true;
-    nx.programs.prism.opencode.enable = lib.mkDefault true;
-    nx.programs.prism.tmux.enable = lib.mkDefault true;
-    nx.programs.prism.sessioniser.enable = lib.mkDefault true;
-    nx.programs.prism.contextSwitcher.enable = lib.mkDefault true;
-    nx.programs.prism.claude-code.enable = lib.mkDefault true;
-    nx.programs.prism.pi.enable = lib.mkDefault true;
-    nx.programs.prism.tui.enable = lib.mkDefault true;
+  config = lib.mkIf config.nx.programs.prism.enable (
+    lib.mkMerge [
+      {
+        # Assert that bwrap isolation is not requested on Darwin.
+        # bubblewrap is Linux-only; setting default = "bwrap" on Darwin is
+        # a configuration error that should fail at eval time.
+        assertions = [
+          {
+            assertion =
+              !(config.nx.programs.prism.agent.isolation.default == "bwrap" && !pkgs.stdenv.hostPlatform.isLinux);
+            message = ''
+              nx.programs.prism.agent.isolation.default = "bwrap" requires Linux.
+              bubblewrap is not available on ${pkgs.stdenv.hostPlatform.system}.
+              Use "podman" or "host" instead, or only set "bwrap" on Linux hosts.
+            '';
+          }
+        ];
+      }
+      {
+        # Enable all submodules by default (can be individually disabled)
+        nx.programs.prism.neovim.enable = lib.mkDefault true;
+        nx.programs.prism.opencode.enable = lib.mkDefault true;
+        nx.programs.prism.tmux.enable = lib.mkDefault true;
+        nx.programs.prism.sessioniser.enable = lib.mkDefault true;
+        nx.programs.prism.contextSwitcher.enable = lib.mkDefault true;
+        nx.programs.prism.claude-code.enable = lib.mkDefault true;
+        nx.programs.prism.pi.enable = lib.mkDefault true;
+        nx.programs.prism.tui.enable = lib.mkDefault true;
 
-    # Auto-enable choose on Darwin when contextSwitcher is enabled
-    nx.programs.choose.enable = lib.mkDefault (
-      pkgs.stdenv.isDarwin && config.nx.programs.prism.contextSwitcher.enable
-    );
+        # Auto-enable choose on Darwin when contextSwitcher is enabled
+        nx.programs.choose.enable = lib.mkDefault (
+          pkgs.stdenv.isDarwin && config.nx.programs.prism.contextSwitcher.enable
+        );
 
-    # Computed values that submodules can reference
-    nx.programs.prism._internal = {
-      agentEnvPrefix = lib.concatStringsSep " " (
-        lib.mapAttrsToList (name: value: "${name}=${value}") config.nx.programs.prism.agent.envVars
-      );
-      agentResources = {
-        memoryMax = config.nx.programs.prism.agent.resources.memoryMax;
-        memorySwapMax = config.nx.programs.prism.agent.resources.memorySwapMax;
-        pidsLimit = config.nx.programs.prism.agent.resources.pidsLimit;
-      };
-    };
+        # Computed values that submodules can reference
+        nx.programs.prism._internal = {
+          agentEnvPrefix = lib.concatStringsSep " " (
+            lib.mapAttrsToList (name: value: "${name}=${value}") config.nx.programs.prism.agent.envVars
+          );
+          agentResources = {
+            memoryMax = config.nx.programs.prism.agent.resources.memoryMax;
+            memorySwapMax = config.nx.programs.prism.agent.resources.memorySwapMax;
+            pidsLimit = config.nx.programs.prism.agent.resources.pidsLimit;
+          };
+        };
 
-    # systemd-oomd: enable monitoring on user slices so that oomd can
-    # intervene when memory pressure on the user slice crosses 80%, acting
-    # as a safety net if pressure escapes the per-container cgroup caps.
-    # Guarded by isLinux — Darwin does not have systemd.
-    systemd.oomd.enableUserSlices = lib.mkIf pkgs.stdenv.isLinux true;
-  };
+        # systemd-oomd: enable monitoring on user slices so that oomd can
+        # intervene when memory pressure on the user slice crosses 80%, acting
+        # as a safety net if pressure escapes the per-container cgroup caps.
+        # Guarded by isLinux — Darwin does not have systemd.
+        systemd.oomd.enableUserSlices = lib.mkIf pkgs.stdenv.isLinux true;
+      }
+    ]
+  );
 }

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -29,6 +29,7 @@ let
       ) gitCfg.includes;
     in
     if emails != [ ] then builtins.head emails else "";
+  isolationDefault = config.nx.programs.prism.agent.isolation.default;
   prismConfig = {
     color_primary = primary;
     color_secondary = secondary;
@@ -40,7 +41,10 @@ let
     color_foreground = foreground;
     color_bg0 = bg0;
     kitty_bin = "${pkgs.kitty}/bin/kitty";
-    container_mode = pkgs.stdenv.hostPlatform.isLinux;
+    # default_isolation_mode is the authoritative field; container_mode is
+    # derived from it for back-compat with Go code that reads the old field.
+    default_isolation_mode = isolationDefault;
+    container_mode = isolationDefault == "podman";
     sidecar_plugin_path = "${
       config.home-manager.users.${config.nx.username}.xdg.configHome
     }/opencode/plugins/prism-hooks.ts";
@@ -107,7 +111,11 @@ in
     home-manager.users.${config.nx.username} = {
       home.packages = [
         (pkgs.callPackage ../../../pkgs/prism.nix { })
-      ];
+      ]
+      # bubblewrap is required for bwrap isolation mode on Linux.
+      # Included whenever the prism TUI is enabled on Linux so that the
+      # binary is available even before a user opts in to bwrap mode.
+      ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.bubblewrap ];
 
       xdg.configFile."prism/config.json".text = builtins.toJSON prismConfig;
 

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -1,0 +1,175 @@
+package cmd
+
+// prism agent-run — exec the bwrap sandbox for a bwrap-mode agent session.
+//
+// This command is invoked by the tmux agent window when the resolved isolation
+// mode is "bwrap". It reconstructs the container.Manager from the session's DB
+// row and config, writes the same temp files that Manager.Create() writes for
+// podman sessions (SSH config, gitconfig, opencode.json), and then execs:
+//
+//	bwrap <args...>
+//
+// The bwrap subprocess runs opencode directly inside the sandbox. It is owned
+// by this process (and thus by the tmux pane) — not by the sidecar. The sidecar
+// is already running for bwrap sessions, handling SSE, state transitions, and
+// the host-API socket.
+//
+// On non-Linux platforms the command fails immediately with a clear error
+// because bubblewrap is Linux-only.
+//
+// Flags:
+//
+//	--session <name>   prism session name (e.g. "nixos-config@feature")
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+var agentRunCmd = &cobra.Command{
+	Use:   "agent-run",
+	Short: "Exec the bwrap sandbox for a bwrap-mode agent session (internal)",
+	Long: `Exec the bwrap sandbox for a bwrap-mode agent session.
+
+This command is an internal implementation detail invoked by the tmux agent
+window when the isolation mode is "bwrap". It is not intended for direct user
+invocation.
+
+It reconstructs the container config from the session's DB row, writes temp
+files (SSH config, gitconfig), builds the bwrap argument list, and execs bwrap
+directly — replacing the current process with the bwrap sandbox running opencode.`,
+	RunE: runAgentRun,
+}
+
+func init() {
+	agentRunCmd.Flags().String("session", "", "Prism session name (e.g. nixos-config@main)")
+	_ = agentRunCmd.MarkFlagRequired("session")
+	rootCmd.AddCommand(agentRunCmd)
+}
+
+func runAgentRun(cmd *cobra.Command, args []string) error {
+	// Fail fast on non-Linux: bubblewrap is Linux-only.
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("prism agent-run: bwrap isolation requires Linux; current platform is %s", runtime.GOOS)
+	}
+
+	sessionName, _ := cmd.Flags().GetString("session")
+
+	// Open the prism database to look up session state.
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("agent-run: open database: %w", err)
+	}
+	status, err := d.CurrentStatus(sessionName)
+	d.Close()
+	if err != nil {
+		return fmt.Errorf("agent-run: query session %q: %w", sessionName, err)
+	}
+	if status == nil {
+		return fmt.Errorf("agent-run: session %q not found in DB", sessionName)
+	}
+
+	// Verify this is actually a bwrap session.
+	isoMode := status.EffectiveIsolationMode()
+	if isoMode != "bwrap" {
+		return fmt.Errorf("agent-run: session %q has isolation mode %q, not bwrap; this command is only for bwrap sessions", sessionName, isoMode)
+	}
+
+	// Load prism config for git identity and SSH key names.
+	cfg := config.Load()
+
+	// Reconstruct the container.Config from the session state.
+	worktree := status.Worktree
+	if worktree == "" {
+		return fmt.Errorf("agent-run: session %q has no recorded worktree", sessionName)
+	}
+	bareRoot := git.BareRoot(worktree)
+	var worktreeGitDir string
+	if bareRoot != "" {
+		worktreeGitDir = filepath.Join(bareRoot, ".bare", "worktrees", filepath.Base(worktree))
+	}
+
+	// Resolve port from the DB status. AllocatedPort is used for the opencode
+	// --port flag in the bwrap args.
+	port := 0
+	if status.OpencodePort != nil {
+		port = *status.OpencodePort
+	}
+
+	// Resolve agent role from status.
+	agentRole := ""
+	if status.RootAgentName != nil {
+		agentRole = *status.RootAgentName
+	}
+	if agentRole == "" {
+		agentRole = session.DefaultAgent(worktree, "")
+	}
+
+	// Look up the host-API socket path so bwrap can mount it.
+	hostAPISockPath := ""
+	if sockPath, sockErr := session.SidecarHostAPIPath(sessionName); sockErr == nil {
+		hostAPISockPath = sockPath
+	}
+
+	ctrCfg := container.Config{
+		SessionName:       sessionName,
+		Worktree:          worktree,
+		BareRoot:          bareRoot,
+		WorktreeGitDir:    worktreeGitDir,
+		AllocatedPort:     port,
+		AgentRole:         agentRole,
+		GitUserName:       cfg.GitUserName,
+		GitUserEmail:      cfg.GitUserEmail,
+		SshAccessKeyName:  cfg.SshAccessKeyName,
+		SshSigningKeyName: cfg.SshSigningKeyName,
+		HostAPISockPath:   hostAPISockPath,
+	}
+
+	// Construct the Manager. PrepareBwrap will write temp files and build args.
+	m := container.New(ctrCfg)
+
+	bwrapArgs, err := m.PrepareBwrap()
+	if err != nil {
+		return fmt.Errorf("agent-run: prepare bwrap args: %w", err)
+	}
+
+	// Locate the bwrap binary.
+	bwrapBin, err := findBwrap()
+	if err != nil {
+		return fmt.Errorf("agent-run: %w", err)
+	}
+
+	// exec replaces the current process with bwrap. argv[0] must be the binary path.
+	argv := append([]string{bwrapBin}, bwrapArgs...)
+	return syscall.Exec(bwrapBin, argv, os.Environ())
+}
+
+// findBwrap locates the bwrap binary on PATH or in well-known Nix store paths.
+func findBwrap() (string, error) {
+	// Try PATH first.
+	if path, err := exec.LookPath("bwrap"); err == nil {
+		return path, nil
+	}
+	// Fall back to common NixOS store locations.
+	candidates := []string{
+		"/run/current-system/sw/bin/bwrap",
+		"/usr/bin/bwrap",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("bwrap binary not found on PATH or in well-known locations; ensure bubblewrap is installed (pkgs.bubblewrap)")
+}

--- a/modules/programs/prism/prism/cmd/concurrency.go
+++ b/modules/programs/prism/prism/cmd/concurrency.go
@@ -22,10 +22,10 @@ import (
 //
 // cmd is the cobra.Command that owns the --ignore-concurrency-cap flag.
 // callerName is used in warning/error messages (e.g. "spawn", "pr", "review").
-// containerMode must be true — callers that run in host-mode or that cannot
-// create containers should skip this check.
-func checkConcurrencyCap(cmd *cobra.Command, callerName string, containerMode bool) error {
-	if !containerMode {
+// conCapped must be true for modes that consume a container/sandbox slot —
+// currently "podman" and "bwrap". Pass false for "host" mode (no cap needed).
+func checkConcurrencyCap(cmd *cobra.Command, callerName string, conCapped bool) error {
+	if !conCapped {
 		return nil
 	}
 

--- a/modules/programs/prism/prism/cmd/isolation_test.go
+++ b/modules/programs/prism/prism/cmd/isolation_test.go
@@ -1,0 +1,205 @@
+package cmd
+
+// isolation_test.go — unit tests for the --isolation flag, isolation mode
+// resolution, and sidecar command construction per mode.
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// newSpawnCmdForTest returns a fresh cobra.Command with the same flags as
+// spawnCmd but isolated from the global state, preventing test pollution.
+func newSpawnCmdForTest() *cobra.Command {
+	cmd := &cobra.Command{Use: "spawn-test"}
+	cmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, or host")
+	cmd.Flags().Bool("host-mode", false, "Deprecated alias for --isolation host")
+	return cmd
+}
+
+// TestResolveIsolationMode_ValidValues verifies that each valid isolation mode
+// string is accepted and returned correctly by resolveIsolationMode.
+func TestResolveIsolationMode_ValidValues(t *testing.T) {
+	cases := []struct {
+		flag string
+		want config.IsolationMode
+	}{
+		{"podman", config.IsolationPodman},
+		{"bwrap", config.IsolationBwrap},
+		{"host", config.IsolationHost},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.flag, func(t *testing.T) {
+			if tc.flag == "bwrap" && runtime.GOOS != "linux" {
+				t.Skip("bwrap only available on Linux")
+			}
+			cmd := newSpawnCmdForTest()
+			if err := cmd.Flags().Set("isolation", tc.flag); err != nil {
+				t.Fatalf("set --isolation: %v", err)
+			}
+			cfg := config.Config{}
+			got, err := resolveIsolationMode(cmd, cfg)
+			if err != nil {
+				t.Fatalf("resolveIsolationMode: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveIsolationMode_UnknownValue verifies that an unknown isolation mode
+// returns an error with a message listing the valid values.
+func TestResolveIsolationMode_UnknownValue(t *testing.T) {
+	cmd := newSpawnCmdForTest()
+	if err := cmd.Flags().Set("isolation", "docker"); err != nil {
+		t.Fatalf("set --isolation: %v", err)
+	}
+	cfg := config.Config{}
+	_, err := resolveIsolationMode(cmd, cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown isolation mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown isolation mode") {
+		t.Errorf("error %q does not contain 'unknown isolation mode'", err.Error())
+	}
+	// Error message must list valid values.
+	for _, m := range []string{"podman", "bwrap", "host"} {
+		if !strings.Contains(err.Error(), m) {
+			t.Errorf("error %q does not mention valid mode %q", err.Error(), m)
+		}
+	}
+}
+
+// TestResolveIsolationMode_HostModeAlias verifies that --host-mode maps to "host".
+func TestResolveIsolationMode_HostModeAlias(t *testing.T) {
+	cmd := newSpawnCmdForTest()
+	if err := cmd.Flags().Set("host-mode", "true"); err != nil {
+		t.Fatalf("set --host-mode: %v", err)
+	}
+	cfg := config.Config{}
+	got, err := resolveIsolationMode(cmd, cfg)
+	if err != nil {
+		t.Fatalf("resolveIsolationMode: %v", err)
+	}
+	if got != config.IsolationHost {
+		t.Errorf("got %q, want %q", got, config.IsolationHost)
+	}
+}
+
+// TestResolveIsolationMode_BothIsolationAndHostMode verifies that using both
+// --isolation and --host-mode together returns an error.
+func TestResolveIsolationMode_BothIsolationAndHostMode(t *testing.T) {
+	cmd := newSpawnCmdForTest()
+	if err := cmd.Flags().Set("isolation", "host"); err != nil {
+		t.Fatalf("set --isolation: %v", err)
+	}
+	if err := cmd.Flags().Set("host-mode", "true"); err != nil {
+		t.Fatalf("set --host-mode: %v", err)
+	}
+	cfg := config.Config{}
+	_, err := resolveIsolationMode(cmd, cfg)
+	if err == nil {
+		t.Fatal("expected error when both --isolation and --host-mode are set")
+	}
+	if !strings.Contains(err.Error(), "--isolation and --host-mode") {
+		t.Errorf("error %q does not mention both flags", err.Error())
+	}
+}
+
+// TestResolveIsolationMode_FallbackFromConfig verifies that when no flags are
+// set the effective isolation mode from config.Config is used.
+func TestResolveIsolationMode_FallbackFromConfig(t *testing.T) {
+	cases := []struct {
+		cfgMode config.IsolationMode
+		want    config.IsolationMode
+	}{
+		{config.IsolationPodman, config.IsolationPodman},
+		{config.IsolationHost, config.IsolationHost},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.cfgMode), func(t *testing.T) {
+			cmd := newSpawnCmdForTest() // fresh command, no flags set
+			cfg := config.Config{DefaultIsolationMode: tc.cfgMode}
+			got, err := resolveIsolationMode(cmd, cfg)
+			if err != nil {
+				t.Fatalf("resolveIsolationMode: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveIsolationMode_BwrapOnDarwin verifies that --isolation bwrap on
+// non-Linux returns a clear error.
+func TestResolveIsolationMode_BwrapOnDarwin(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("this test validates non-Linux platform rejection; skipping on Linux")
+	}
+	cmd := newSpawnCmdForTest()
+	if err := cmd.Flags().Set("isolation", "bwrap"); err != nil {
+		t.Fatalf("set --isolation: %v", err)
+	}
+	cfg := config.Config{}
+	_, err := resolveIsolationMode(cmd, cfg)
+	if err == nil {
+		t.Fatal("expected error for bwrap on non-Linux, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires Linux") {
+		t.Errorf("error %q does not mention 'requires Linux'", err.Error())
+	}
+}
+
+// TestIsolationFlagExists verifies that the --isolation flag is registered
+// on spawnCmd with the correct default value.
+func TestIsolationFlagExists(t *testing.T) {
+	flag := spawnCmd.Flags().Lookup("isolation")
+	if flag == nil {
+		t.Fatal("--isolation flag not found on spawnCmd")
+	}
+	// Default should be empty (falls back to config.json at runtime).
+	if flag.DefValue != "" {
+		t.Errorf("--isolation default = %q, want %q (empty, falls back to config)", flag.DefValue, "")
+	}
+}
+
+// TestHostModeFlagDeprecationExists verifies that --host-mode still exists
+// as a deprecated alias.
+func TestHostModeFlagDeprecationExists(t *testing.T) {
+	flag := spawnCmd.Flags().Lookup("host-mode")
+	if flag == nil {
+		t.Fatal("--host-mode flag not found on spawnCmd (should still exist as deprecated alias)")
+	}
+}
+
+// TestSidecarCmd_IsolationModeFlag verifies that the --isolation-mode flag
+// is registered on sidecarCmd.
+func TestSidecarCmd_IsolationModeFlag(t *testing.T) {
+	flag := sidecarCmd.Flags().Lookup("isolation-mode")
+	if flag == nil {
+		t.Fatal("--isolation-mode flag not found on sidecarCmd")
+	}
+	// Default should be empty (sidecar falls back to --container for back-compat).
+	if flag.DefValue != "" {
+		t.Errorf("--isolation-mode default = %q, want %q (empty, falls back to --container flag)", flag.DefValue, "")
+	}
+}
+
+// TestAgentRunCmd_SessionFlagExists verifies that the prism agent-run
+// subcommand exists and has the required --session flag.
+func TestAgentRunCmd_SessionFlagExists(t *testing.T) {
+	flag := agentRunCmd.Flags().Lookup("session")
+	if flag == nil {
+		t.Fatal("--session flag not found on agentRunCmd")
+	}
+}

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -69,10 +69,13 @@ var prCmd = &cobra.Command{
 		}
 
 		cfg := config.Load()
+		isoMode := cfg.EffectiveIsolationMode()
+		effectiveContainerMode := isoMode == config.IsolationPodman
+		conCapped := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
 
 		// Concurrency cap check: BEFORE any container-creation side effects
 		// (no worktree, no tmux session, no DB row on refusal).
-		if err := checkConcurrencyCap(cmd, "pr", cfg.ContainerMode); err != nil {
+		if err := checkConcurrencyCap(cmd, "pr", conCapped); err != nil {
 			return err
 		}
 
@@ -88,11 +91,11 @@ var prCmd = &cobra.Command{
 			return fmt.Errorf("create worktree: %w", err)
 		}
 
-		// In container mode, inject the role-specific opencode.json blob as
-		// OPENCODE_CONFIG_CONTENT so it takes precedence (level 6) over any
+		// In container/bwrap mode, inject the role-specific opencode.json blob
+		// as OPENCODE_CONFIG_CONTENT so it takes precedence (level 6) over any
 		// project-level opencode.jsonc. This mirrors the pattern in spawn.go.
 		var configContent string
-		if cfg.ContainerMode {
+		if effectiveContainerMode {
 			pf, pfErr := config.LoadProfiles()
 			if pfErr != nil {
 				return pfErr
@@ -113,7 +116,8 @@ var prCmd = &cobra.Command{
 			Prompt:         promptFlag,
 			Agent:          agentFlag,
 			Headless:       !attachFlag,
-			ContainerMode:  cfg.ContainerMode,
+			ContainerMode:  effectiveContainerMode,
+			IsolationMode:  string(isoMode),
 			PluginHostPath: cfg.SidecarPluginPath,
 			ConfigContent:  configContent,
 			// ForceFresh=true: prism pr creates a new worktree; if a session

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -280,12 +280,11 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	} else if s.HostMode {
 		isoMode = config.IsolationHost
 	} else {
-		// Pre-v10 row without isolation_mode: fall back to global config,
-		// treating the absence of host_mode as container/podman mode.
+		// Pre-v10 row without isolation_mode and without host_mode:
+		// fall back to the global config's effective isolation mode.
+		// This restores pre-v10 sessions with the same mode the machine
+		// is currently configured for.
 		isoMode = cfg.EffectiveIsolationMode()
-		if s.HostMode {
-			isoMode = config.IsolationHost
-		}
 	}
 
 	containerMode := isoMode == config.IsolationPodman

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -267,13 +267,28 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	// setupFullLayout from forking "prism event tmux-session-start" — we
 	// manage agent_status directly below via the open DB handle.
 	//
-	// ContainerMode is derived from both the global cfg and the per-session
-	// s.HostMode flag: a session that was explicitly spawned with --host-mode
-	// must be restored in host mode regardless of the current cfg setting.
-	// When ContainerMode is enabled, PluginHostPath is also copied from cfg so
-	// the sidecar can bind-mount the plugin into the container.
+	// IsolationMode is read from the DB row (s.IsolationMode) when recorded.
+	// When absent (pre-v10 rows), fall back to the back-compat derivation:
+	// HostMode=true → "host", else use the global cfg's effective mode.
+	// This ensures sessions spawned before the isolation_mode column was added
+	// are restored with the same behaviour they were created with.
 	cfg := loadRestoreConfig()
-	containerMode := cfg.ContainerMode && !s.HostMode
+
+	var isoMode config.IsolationMode
+	if s.IsolationMode != "" {
+		isoMode = config.IsolationMode(s.IsolationMode)
+	} else if s.HostMode {
+		isoMode = config.IsolationHost
+	} else {
+		// Pre-v10 row without isolation_mode: fall back to global config,
+		// treating the absence of host_mode as container/podman mode.
+		isoMode = cfg.EffectiveIsolationMode()
+		if s.HostMode {
+			isoMode = config.IsolationHost
+		}
+	}
+
+	containerMode := isoMode == config.IsolationPodman
 	opencodeSession := ""
 	if s.OpencodeSID != nil {
 		opencodeSession = *s.OpencodeSID
@@ -286,6 +301,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		Layout:          session.LayoutFull,
 		SkipStatusSeed:  true,
 		ContainerMode:   containerMode,
+		IsolationMode:   string(isoMode),
 	}
 	if containerMode {
 		opts.PluginHostPath = cfg.SidecarPluginPath

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -90,9 +90,11 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// for the actual spawn). Only apply the check on the host path.
 	// Load cfg now for the cap check; it is re-used below for ContainerMode.
 	cfg := config.Load()
+	isoMode := cfg.EffectiveIsolationMode()
+	conCapped := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL == "" {
 		// Running on host — check the cap before spawning review containers.
-		if err := checkConcurrencyCap(cmd, "review", cfg.ContainerMode); err != nil {
+		if err := checkConcurrencyCap(cmd, "review", conCapped); err != nil {
 			return err
 		}
 	}
@@ -180,6 +182,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	prCtx := review.FetchPRContext(prNumber, 0, 0)
 
 	// Build run options.
+	effectiveContainerMode := isoMode == config.IsolationPodman
 	opts := review.Opts{
 		PRNumber:       prNumber,
 		ParentSession:  parentSession,
@@ -188,7 +191,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		Harness:        harnessFlag,
 		Timeout:        timeoutFlag,
 		PluginHostPath: cfg.SidecarPluginPath,
-		ContainerMode:  cfg.ContainerMode,
+		ContainerMode:  effectiveContainerMode,
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,
 	}
@@ -199,7 +202,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// per-agent opencode.json cannot be mounted, which causes the container
 	// to fall back to the image default (build agent). Surface this as an
 	// explicit error rather than silently spawning broken review containers.
-	if cfg.ContainerMode {
+	if effectiveContainerMode {
 		pf, pfErr := config.LoadProfiles()
 		if pfErr != nil {
 			return fmt.Errorf("prism review: container mode requires profiles.json but it could not be loaded: %w\nhint: ensure the system has been rebuilt with the prism NixOS module enabled", pfErr)

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -5,30 +5,43 @@ package cmd
 //
 // Flags:
 //
-//	--session <name>          prism session name (e.g. "nixos-config@main")
-//	--opencode-url <url>      base URL of the opencode HTTP server
-//	                          (e.g. "http://localhost:14000")
-//	--container               enable container mode: create and manage a podman
-//	                          container running opencode serve before connecting
-//	--agent-role <role>       "worker" or "coordinator" (used in container mode
-//	                          to select the correct GitHub token; when empty,
-//	                          the role is inferred from SSE events at runtime)
-//	--port <n>                allocated host port (required in container mode)
-//	--plugin-path <path>      host path to the prism-hooks.ts plugin; mounted
-//	                          read-only into the container (container mode only)
-//	--config-content <json>   JSON blob for the container's opencode.json;
-//	                          written to a temp file and mounted into the
-//	                          container (container mode only)
+//	--session <name>           prism session name (e.g. "nixos-config@main")
+//	--opencode-url <url>       base URL of the opencode HTTP server
+//	                           (e.g. "http://localhost:14000")
+//	--isolation-mode <mode>    isolation mode: "podman", "bwrap", or "host"
+//	                           (default: "host" for back-compat when absent)
+//	--container                enable container mode: create and manage a podman
+//	                           container running opencode serve before connecting.
+//	                           Deprecated: use --isolation-mode=podman instead.
+//	--agent-role <role>        "worker" or "coordinator" (used in container mode
+//	                           to select the correct GitHub token; when empty,
+//	                           the role is inferred from SSE events at runtime)
+//	--port <n>                 allocated host port (required in container/bwrap mode)
+//	--plugin-path <path>       host path to the prism-hooks.ts plugin; mounted
+//	                           read-only into the container (container mode only)
+//	--config-content <json>    JSON blob for the container's opencode.json;
+//	                           written to a temp file and mounted into the
+//	                           container (container mode only)
 //
 // The sidecar connects to <opencode-url>/event and maps opencode SSE events to
 // agent state transitions, writing them to prism.db. It handles idle debounce,
 // permission tracking, and dashboard sentinel updates — replacing the equivalent
 // logic in opencode/plugins/prism-hooks.ts.
 //
-// In container mode, the sidecar creates a podman container running
-// "opencode --port 4096 --hostname 0.0.0.0" (combined TUI + HTTP mode), waits
-// until the HTTP endpoint is healthy, then writes a ready signal so that the
-// tmux pane can run "podman attach" to bridge the PTY (RFC #691, Phase 1a).
+// In podman mode (--isolation-mode=podman or legacy --container), the sidecar
+// creates a podman container running "opencode --port 4096 --hostname 0.0.0.0"
+// (combined TUI + HTTP mode), waits until the HTTP endpoint is healthy, then
+// writes a ready signal so that the tmux pane can run "podman attach" to bridge
+// the PTY (RFC #691, Phase 1a).
+//
+// In bwrap mode (--isolation-mode=bwrap), the sidecar does NOT create a
+// container. The bwrap sandbox is launched and owned by the tmux pane via
+// "prism agent-run". The sidecar still sets up the host-API Unix socket,
+// selects the NewContainerMode harness adapter, and runs the full SSE loop.
+//
+// In host mode (--isolation-mode=host or no --container flag), the sidecar
+// connects to an already-running opencode process. No container or sandbox
+// management is performed.
 //
 // Clean shutdown: SIGINT and SIGTERM write "interrupted" state and (in container
 // mode) stop/remove the container before exiting.
@@ -63,19 +76,24 @@ by prism spawn.
 The sidecar handles: state machine transitions, idle debounce (2s),
 permission tracking, event logging, and dashboard sentinel updates.
 
-In container mode (--container), the sidecar also creates and manages the
-podman container running opencode in combined TUI + HTTP mode, health-checks
-it until ready, then writes a readiness signal so the tmux pane can run
-podman attach to bridge the container PTY (RFC #691, Phase 1a).`,
+In podman mode (--isolation-mode=podman or legacy --container), the sidecar
+also creates and manages the podman container running opencode in combined
+TUI + HTTP mode, health-checks it until ready, then writes a readiness signal
+so the tmux pane can run podman attach to bridge the container PTY (RFC #691).
+
+In bwrap mode (--isolation-mode=bwrap), the sidecar sets up the host-API Unix
+socket and runs the full SSE loop, but does NOT create a container or write a
+readiness signal. The bwrap sandbox is owned by the tmux pane.`,
 	RunE: runSidecar,
 }
 
 func init() {
 	sidecarCmd.Flags().String("session", "", "Prism session name (e.g. nixos-config@main)")
 	sidecarCmd.Flags().String("opencode-url", "", "Base URL of the opencode HTTP server")
-	sidecarCmd.Flags().Bool("container", false, "Enable container mode (create/manage podman container)")
+	sidecarCmd.Flags().String("isolation-mode", "", "Isolation mode: podman, bwrap, or host (default: derived from --container flag)")
+	sidecarCmd.Flags().Bool("container", false, "Enable container mode (create/manage podman container) — deprecated, use --isolation-mode=podman")
 	sidecarCmd.Flags().String("agent-role", "", "Agent role: worker or coordinator (used in container mode; inferred from SSE events when empty)")
-	sidecarCmd.Flags().Int("port", 0, "Allocated host port (required in container mode)")
+	sidecarCmd.Flags().Int("port", 0, "Allocated host port (required in container/bwrap mode)")
 	sidecarCmd.Flags().String("plugin-path", "", "Host path to prism-hooks.ts plugin (container mode only)")
 	sidecarCmd.Flags().String("initial-prompt", "", "Initial prompt to deliver to the agent after container readiness (container mode only)")
 	sidecarCmd.Flags().String("config-content", "", "JSON blob for container opencode.json; written to temp file and mounted (container mode only)")
@@ -89,7 +107,8 @@ func init() {
 func runSidecar(cmd *cobra.Command, args []string) error {
 	sessionName, _ := cmd.Flags().GetString("session")
 	opencodeURL, _ := cmd.Flags().GetString("opencode-url")
-	containerMode, _ := cmd.Flags().GetBool("container")
+	isolationModeFlag, _ := cmd.Flags().GetString("isolation-mode")
+	containerFlag, _ := cmd.Flags().GetBool("container")
 	agentRole, _ := cmd.Flags().GetString("agent-role")
 	port, _ := cmd.Flags().GetInt("port")
 	pluginPath, _ := cmd.Flags().GetString("plugin-path")
@@ -97,6 +116,27 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	configContent, _ := cmd.Flags().GetString("config-content")
 	instanceID, _ := cmd.Flags().GetString("instance-id")
 	worktreeReadOnly, _ := cmd.Flags().GetBool("worktree-readonly")
+
+	// Resolve the effective isolation mode. When --isolation-mode is set it
+	// takes precedence. Otherwise fall back to --container for back-compat.
+	var isolationMode config.IsolationMode
+	if isolationModeFlag != "" && config.IsValidIsolationMode(isolationModeFlag) {
+		isolationMode = config.IsolationMode(isolationModeFlag)
+	} else if containerFlag {
+		isolationMode = config.IsolationPodman
+	} else {
+		isolationMode = config.IsolationHost
+	}
+
+	// Derive the legacy bool for paths that still use it.
+	podmanMode := isolationMode == config.IsolationPodman
+	bwrapMode := isolationMode == config.IsolationBwrap
+	// needsHostAPI is true for podman and bwrap (the agent runs in a sandbox
+	// without direct access to host tmux, so the host-API socket is required).
+	needsHostAPI := podmanMode || bwrapMode
+	// useContainerHarness is true for podman and bwrap (opencode is pre-created
+	// with --prompt at launch in both cases).
+	useContainerHarness := podmanMode || bwrapMode
 
 	// Derive repo and worktree from session name and environment.
 	// The session name format is "repo@branch". The worktree is expected
@@ -141,17 +181,18 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// (e.g. running without the nix module) — resource fields remain at their
 	// zero values and no resource flags are emitted.
 	var containerResources config.ContainerResources
-	if containerMode {
+	if podmanMode {
 		if pf, pfErr := config.LoadProfiles(); pfErr == nil {
 			containerResources = pf.ContainerResources
 		}
 	}
 
-	// Build container config if container mode is enabled.
+	// Build container config — only for podman mode. bwrap mode does not
+	// use a container.Config; the bwrap sandbox is owned by the tmux pane.
 	var ctrCfg *container.Config
-	if containerMode {
+	if podmanMode {
 		if port == 0 {
-			return fmt.Errorf("sidecar: --port is required in container mode")
+			return fmt.Errorf("sidecar: --port is required in podman container mode")
 		}
 		// Derive git bare-root and worktree private git dir so that git works
 		// inside the container without following the absolute host path stored
@@ -184,9 +225,14 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Build the host-API socket path for container mode (A-1).
+	// Build the host-API socket path for podman and bwrap modes. The agent
+	// runs in a sandbox without direct access to host tmux in both cases, so
+	// the host-API Unix socket is required for proxying prism CLI calls.
 	var hostAPISockPath string
-	if containerMode {
+	if needsHostAPI {
+		if port == 0 && bwrapMode {
+			return fmt.Errorf("sidecar: --port is required in bwrap mode")
+		}
 		sockPath, err := prismSession.SidecarHostAPIPath(sessionName)
 		if err != nil {
 			return fmt.Errorf("sidecar: resolve host-API socket path: %w", err)
@@ -194,13 +240,19 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		hostAPISockPath = sockPath
 		// Wire the socket path into the container config so the container
 		// gets the socket mounted and PRISM_HOST_API injected (A-2).
-		ctrCfg.HostAPISockPath = sockPath
+		// In bwrap mode ctrCfg is nil — the bwrap args are built by
+		// bwrapIsolator.BuildArgs at prism agent-run time, not here.
+		if ctrCfg != nil {
+			ctrCfg.HostAPISockPath = sockPath
+		}
 	}
 
-	// Build the OnReady callback for container mode (AC-18, AC-19).
-	// Written to the config before creating the sidecar.
+	// Build the OnReady callback — only for podman mode (AC-18, AC-19).
+	// In bwrap mode the sidecar does NOT write the readiness signal:
+	// "prism agent-run" in the tmux pane starts immediately without waiting.
+	// In host mode there is no readiness file at all.
 	var onReady func()
-	if containerMode {
+	if podmanMode {
 		onReady = func() {
 			readyPath, pathErr := prismSession.SidecarReadyPath(sessionName)
 			if pathErr != nil {
@@ -227,12 +279,12 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// event mapping. The sidecar calls through the harness.Harness interface
 	// and has no direct dependency on the opencode package (#710).
 	//
-	// In container mode, use NewContainerMode so that:
+	// In podman and bwrap mode, use NewContainerMode so that:
 	//   - CreateSession uses GET /session to retrieve the existing session ID
 	//     (opencode already created a session when the TUI started)
 	//   - DeliverInitialPrompt is a no-op (prompt was sent via --prompt CLI flag)
 	var h *opencode.Adapter
-	if containerMode {
+	if useContainerHarness {
 		h = opencode.NewContainerMode(opencodeURL, nil, agentRole, agentModel)
 	} else {
 		h = opencode.New(opencodeURL, nil, agentRole, agentModel)
@@ -280,14 +332,16 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// This implements the TTL sweep that prevents ~/.cache/prism/clipboard/ from
 	// growing unboundedly across multiple paste operations. The sweep is
 	// fire-and-forget; errors are non-fatal (logged by runClipboardClean itself).
-	if containerMode {
+	// Runs for podman and bwrap modes (both run the agent in a sandbox where
+	// the clipboard staging dir is mounted).
+	if needsHostAPI {
 		go func() {
 			_ = runClipboardClean(nil, nil)
 		}()
 	}
 
-	fmt.Fprintf(os.Stderr, "[prism sidecar] starting: session=%s url=%s container=%v\n",
-		sessionName, opencodeURL, containerMode)
+	fmt.Fprintf(os.Stderr, "[prism sidecar] starting: session=%s url=%s isolation=%s\n",
+		sessionName, opencodeURL, isolationMode)
 
 	if err := sc.Run(ctx); err != nil && ctx.Err() == nil {
 		return fmt.Errorf("sidecar: %w", err)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -11,16 +11,19 @@ package cmd
 //	--prompt <text>       pass an initial prompt to opencode on launch
 //	--prompt-file <path>  read the initial prompt from a file
 //	--agent <name>        opencode agent to use (default: "coordinator" on main, "worker" otherwise)
-//	--profile <name>      model profile to use (from ~/.config/prism/profiles.json)
+//	--profile <name>      model profile to use from ~/.config/prism/profiles.json
 //	--model <name>        model identifier override (overrides profile's primary model)
 //	--variant <name>      model variant override (overrides all agents' variant)
-//	--host-mode           bypass container mode and run opencode directly in the tmux pane
+//	--isolation <mode>    isolation mode: podman, bwrap, or host (default: from config.json)
+//	--host-mode           deprecated alias for --isolation host
 //	--harness <name>      agent harness to use (default: "opencode"; only "opencode" is supported)
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -87,10 +90,72 @@ func init() {
 	spawnCmd.Flags().String("profile", "", "Model profile name from ~/.config/prism/profiles.json (e.g. anthropic, gemini-hybrid)")
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
-	spawnCmd.Flags().Bool("host-mode", false, "Bypass container mode and run opencode directly in the tmux pane")
+	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, or host (default: from ~/.config/prism/config.json)")
+	spawnCmd.Flags().Bool("host-mode", false, "Deprecated alias for --isolation host; bypass container mode and run opencode directly in the tmux pane")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use (currently only 'opencode' is supported)")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	rootCmd.AddCommand(spawnCmd)
+}
+
+// resolveIsolationMode returns the effective isolation mode for a spawn
+// invocation, applying flag precedence and validation:
+//
+//  1. --isolation flag (explicit override), validated against known values
+//  2. --host-mode flag (deprecated alias for "host")
+//  3. cfg.EffectiveIsolationMode() (from config.json)
+//
+// Returns an error if both --isolation and --host-mode are set, or if
+// --isolation has an unknown value, or if the resolved mode is "bwrap" on
+// a non-Linux platform.
+func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.IsolationMode, error) {
+	isolationFlag, _ := cmd.Flags().GetString("isolation")
+	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
+
+	// Detect if flags were explicitly set by the user.
+	isolationChanged := cmd.Flags().Changed("isolation")
+	hostModeChanged := cmd.Flags().Changed("host-mode")
+
+	// Reject simultaneous use of --isolation and --host-mode.
+	if isolationChanged && hostModeChanged {
+		return "", fmt.Errorf("--isolation and --host-mode cannot be used together; --host-mode is a deprecated alias for --isolation host")
+	}
+
+	// --isolation flag takes precedence.
+	if isolationChanged {
+		if !config.IsValidIsolationMode(isolationFlag) {
+			valid := make([]string, len(config.ValidIsolationModes))
+			for i, m := range config.ValidIsolationModes {
+				valid[i] = string(m)
+			}
+			return "", fmt.Errorf("unknown isolation mode %q; valid values: %s", isolationFlag, strings.Join(valid, ", "))
+		}
+		mode := config.IsolationMode(isolationFlag)
+		if err := checkBwrapPlatform(mode); err != nil {
+			return "", err
+		}
+		return mode, nil
+	}
+
+	// --host-mode (deprecated alias).
+	if hostModeChanged && hostModeFlag {
+		return config.IsolationHost, nil
+	}
+
+	// Fall back to config.json default.
+	mode := cfg.EffectiveIsolationMode()
+	if err := checkBwrapPlatform(mode); err != nil {
+		return "", err
+	}
+	return mode, nil
+}
+
+// checkBwrapPlatform returns an error if the isolation mode is "bwrap" on a
+// non-Linux platform (bubblewrap is Linux-only).
+func checkBwrapPlatform(mode config.IsolationMode) error {
+	if mode == config.IsolationBwrap && runtime.GOOS != "linux" {
+		return fmt.Errorf("isolation mode %q requires Linux; current platform is %s", mode, runtime.GOOS)
+	}
+	return nil
 }
 
 func runSpawn(cmd *cobra.Command, args []string) error {
@@ -105,7 +170,6 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	profileFlag, _ := cmd.Flags().GetString("profile")
 	modelFlag, _ := cmd.Flags().GetString("model")
 	variantFlag, _ := cmd.Flags().GetString("variant")
-	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 
 	// Validate harness BEFORE any session state is created (no worktree, no
@@ -125,16 +189,20 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""
 	cfg := config.Load()
 
-	// Determine the effective container mode: cfg.ContainerMode can be
-	// overridden to false when --host-mode is passed.
-	effectiveContainerMode := cfg.ContainerMode
-	if hostModeFlag {
-		effectiveContainerMode = false
+	// Resolve the effective isolation mode. This validates --isolation,
+	// maps --host-mode to "host", and falls back to config.json.
+	// Done BEFORE any side effects (no worktree, no tmux session, no DB row).
+	isolationMode, err := resolveIsolationMode(cmd, cfg)
+	if err != nil {
+		return err
 	}
 
-	// Container availability check: when container mode is active (and
-	// --host-mode is not) verify podman is available before touching anything.
-	if cfg.ContainerMode && !hostModeFlag {
+	// Derive the legacy ContainerMode boolean for callers that still use it.
+	effectiveContainerMode := isolationMode == config.IsolationPodman
+
+	// Container availability check: when container mode is active verify
+	// podman is available before touching anything.
+	if isolationMode == config.IsolationPodman {
 		if err := container.CheckAvailability(); err != nil {
 			return err
 		}
@@ -143,7 +211,9 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// Concurrency cap check: BEFORE any container-creation side effects
 	// (no worktree, no tmux session, no DB row on refusal).
 	// Skipped in host-mode — host-mode sessions don't consume a container slot.
-	if err := checkConcurrencyCap(cmd, "spawn", effectiveContainerMode); err != nil {
+	// bwrap sessions are treated as concurrency-capped (same as podman).
+	conCapped := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap
+	if err := checkConcurrencyCap(cmd, "spawn", conCapped); err != nil {
 		return err
 	}
 
@@ -188,7 +258,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create worktree: %w", err)
 	}
 
-	// In container mode, inject the role-specific opencode.json blob as
+	// In container/bwrap mode, inject the role-specific opencode.json blob as
 	// OPENCODE_CONFIG_CONTENT so it takes precedence (level 6) over any
 	// project-level opencode.jsonc. This ensures agent identity is always
 	// determined by Nix config, not by the project file.
@@ -222,6 +292,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		ConfigContent:  configContent,
 		Headless:       !fromKeybind && !attachFlag,
 		ContainerMode:  effectiveContainerMode,
+		IsolationMode:  string(isolationMode),
 		PluginHostPath: cfg.SidecarPluginPath,
 		// ForceFresh=true: spawn always wants a new instance. If a session with
 		// the same name already exists it is a stale zombie and should be killed.
@@ -237,15 +308,19 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Persist host_mode in the DB so cleanup can skip container teardown.
-	if hostModeFlag {
-		sessionName := session.NameFor(worktreePath, bareRoot)
-		if d, dbErr := openDB(); dbErr == nil {
+	// Persist isolation_mode in the DB so restore can re-spawn correctly.
+	// Also persist host_mode for back-compat with cleanup code.
+	sessionName := session.NameFor(worktreePath, bareRoot)
+	if d, dbErr := openDB(); dbErr == nil {
+		if setErr := d.SetIsolationMode(sessionName, string(isolationMode)); setErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism] spawn: set isolation_mode: %v\n", setErr)
+		}
+		if isolationMode == config.IsolationHost {
 			if setErr := d.SetHostMode(sessionName, true); setErr != nil {
 				fmt.Fprintf(os.Stderr, "[prism] spawn: set host_mode: %v\n", setErr)
 			}
-			d.Close()
 		}
+		d.Close()
 	}
 
 	return nil

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -15,6 +15,38 @@ import (
 	"time"
 )
 
+// IsolationMode represents the isolation mechanism for agent sessions.
+// Valid values are "podman", "bwrap", and "host".
+type IsolationMode string
+
+const (
+	// IsolationPodman runs opencode inside a rootless podman container,
+	// managed by the sidecar. The agent window attaches via "podman attach".
+	IsolationPodman IsolationMode = "podman"
+
+	// IsolationBwrap runs opencode inside a bubblewrap sandbox, launched and
+	// owned by the tmux pane via "prism agent-run". The sidecar does not
+	// manage the process lifecycle. Linux only.
+	IsolationBwrap IsolationMode = "bwrap"
+
+	// IsolationHost runs opencode directly in the tmux pane with no isolation.
+	// Equivalent to the legacy --host-mode flag.
+	IsolationHost IsolationMode = "host"
+)
+
+// ValidIsolationModes lists all valid isolation mode strings.
+var ValidIsolationModes = []IsolationMode{IsolationPodman, IsolationBwrap, IsolationHost}
+
+// IsValidIsolationMode reports whether s is a valid isolation mode.
+func IsValidIsolationMode(s string) bool {
+	for _, m := range ValidIsolationModes {
+		if string(m) == s {
+			return true
+		}
+	}
+	return false
+}
+
 // Config holds all host-specific runtime configuration for prism.
 type Config struct {
 	// Theme colours (hex strings, e.g. "#d4be98").
@@ -35,7 +67,15 @@ type Config struct {
 	// ContainerMode, when true, causes spawn and switch to run opencode inside
 	// a podman container managed by the sidecar, using "podman attach" in the
 	// agent window rather than launching opencode directly.
+	// Deprecated: use DefaultIsolationMode instead. When DefaultIsolationMode
+	// is present it takes precedence; ContainerMode is derived from it for
+	// back-compat (ContainerMode == (DefaultIsolationMode == "podman")).
 	ContainerMode bool `json:"container_mode"`
+
+	// DefaultIsolationMode is the machine-level default isolation mode for new
+	// agent sessions. Valid values: "podman", "bwrap", "host". When absent,
+	// falls back to ContainerMode for back-compat (true → "podman", false → "host").
+	DefaultIsolationMode IsolationMode `json:"default_isolation_mode,omitempty"`
 	// SidecarPluginPath is the host-side path to the opencode plugin file that
 	// is bind-mounted into the container. Empty string = no plugin.
 	SidecarPluginPath string `json:"sidecar_plugin_path"`
@@ -83,6 +123,7 @@ type parsedConfig struct {
 	ColorBg0                       string    `json:"color_bg0"`
 	KittyBin                       string    `json:"kitty_bin"`
 	ContainerMode                  *bool     `json:"container_mode"`
+	DefaultIsolationMode           string    `json:"default_isolation_mode"`
 	SidecarPluginPath              string    `json:"sidecar_plugin_path"`
 	GitUserName                    string    `json:"git_user_name"`
 	GitUserEmail                   string    `json:"git_user_email"`
@@ -188,8 +229,20 @@ func load() Config {
 	if parsed.KittyBin != "" {
 		cfg.KittyBin = parsed.KittyBin
 	}
-	if parsed.ContainerMode != nil {
+	// DefaultIsolationMode takes precedence when present and valid.
+	// When absent, fall back to ContainerMode for back-compat.
+	if parsed.DefaultIsolationMode != "" && IsValidIsolationMode(parsed.DefaultIsolationMode) {
+		cfg.DefaultIsolationMode = IsolationMode(parsed.DefaultIsolationMode)
+		// Derive ContainerMode from the new field for back-compat callers.
+		cfg.ContainerMode = cfg.DefaultIsolationMode == IsolationPodman
+	} else if parsed.ContainerMode != nil {
 		cfg.ContainerMode = *parsed.ContainerMode
+		// Derive DefaultIsolationMode from ContainerMode for back-compat.
+		if cfg.ContainerMode {
+			cfg.DefaultIsolationMode = IsolationPodman
+		} else {
+			cfg.DefaultIsolationMode = IsolationHost
+		}
 	}
 	if parsed.SidecarPluginPath != "" {
 		cfg.SidecarPluginPath = parsed.SidecarPluginPath
@@ -266,6 +319,20 @@ func (c Config) CircuitBreakerThreshold() int {
 		return 0
 	}
 	return n
+}
+
+// EffectiveIsolationMode returns the effective isolation mode, applying
+// defaults and back-compat logic. When DefaultIsolationMode is set and valid
+// it is returned directly. Otherwise ContainerMode is used for back-compat:
+// true → "podman", false → "host".
+func (c Config) EffectiveIsolationMode() IsolationMode {
+	if c.DefaultIsolationMode != "" {
+		return c.DefaultIsolationMode
+	}
+	if c.ContainerMode {
+		return IsolationPodman
+	}
+	return IsolationHost
 }
 
 // configFilePath returns the path to look for the config file.

--- a/modules/programs/prism/prism/internal/config/config_test.go
+++ b/modules/programs/prism/prism/internal/config/config_test.go
@@ -147,6 +147,103 @@ func TestSshKeyNameAbsentKeepsDefault(t *testing.T) {
 	}
 }
 
+func TestIsolationModeFromNewField(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"default_isolation_mode": "bwrap", "container_mode": true}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+	cfg := config.LoadFresh()
+
+	// default_isolation_mode takes precedence over container_mode.
+	if cfg.DefaultIsolationMode != config.IsolationBwrap {
+		t.Errorf("DefaultIsolationMode: got %q, want %q", cfg.DefaultIsolationMode, config.IsolationBwrap)
+	}
+	// ContainerMode derived from new field: bwrap is not podman → false.
+	if cfg.ContainerMode {
+		t.Errorf("ContainerMode: got true, want false (bwrap is not podman)")
+	}
+	if cfg.EffectiveIsolationMode() != config.IsolationBwrap {
+		t.Errorf("EffectiveIsolationMode: got %q, want %q", cfg.EffectiveIsolationMode(), config.IsolationBwrap)
+	}
+}
+
+func TestIsolationModeFallbackToContainerMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// container_mode=true, no default_isolation_mode.
+	raw := `{"container_mode": true}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+	cfg := config.LoadFresh()
+
+	if cfg.ContainerMode != true {
+		t.Errorf("ContainerMode: got false, want true")
+	}
+	if cfg.DefaultIsolationMode != config.IsolationPodman {
+		t.Errorf("DefaultIsolationMode: got %q, want %q (derived from container_mode=true)", cfg.DefaultIsolationMode, config.IsolationPodman)
+	}
+	if cfg.EffectiveIsolationMode() != config.IsolationPodman {
+		t.Errorf("EffectiveIsolationMode: got %q, want %q", cfg.EffectiveIsolationMode(), config.IsolationPodman)
+	}
+}
+
+func TestIsolationModeFallbackHostMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// container_mode=false, no default_isolation_mode.
+	raw := `{"container_mode": false}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+	cfg := config.LoadFresh()
+
+	if cfg.DefaultIsolationMode != config.IsolationHost {
+		t.Errorf("DefaultIsolationMode: got %q, want %q (derived from container_mode=false)", cfg.DefaultIsolationMode, config.IsolationHost)
+	}
+	if cfg.EffectiveIsolationMode() != config.IsolationHost {
+		t.Errorf("EffectiveIsolationMode: got %q, want %q", cfg.EffectiveIsolationMode(), config.IsolationHost)
+	}
+}
+
+func TestIsolationModeDefaultWhenNeitherFieldPresent(t *testing.T) {
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+	cfg := config.LoadFresh()
+
+	// Neither field in config — EffectiveIsolationMode falls back to host
+	// (ContainerMode defaults to false).
+	mode := cfg.EffectiveIsolationMode()
+	if mode != config.IsolationHost {
+		t.Errorf("EffectiveIsolationMode: got %q, want %q (default when no config)", mode, config.IsolationHost)
+	}
+}
+
+func TestIsolationModeInvalidIgnored(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// An invalid mode string should be ignored; fall back to container_mode.
+	raw := `{"default_isolation_mode": "unknown-mode", "container_mode": true}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+	cfg := config.LoadFresh()
+
+	// Invalid mode is ignored; container_mode=true → DefaultIsolationMode=podman.
+	if cfg.DefaultIsolationMode != config.IsolationPodman {
+		t.Errorf("DefaultIsolationMode: got %q, want %q (invalid mode falls back to container_mode)", cfg.DefaultIsolationMode, config.IsolationPodman)
+	}
+}
+
 func TestMalformedJSON(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.json")

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -66,21 +66,11 @@ func (b *bwrapIsolator) BuildRunArgs() []string {
 // The returned slice begins with the baseline namespace flags and ends with
 // -- followed by the opencode invocation.
 //
-// # Mounts deferred to the wiring PR (#877)
+// # Mounts not included (deferred or out of scope)
 //
-// The following mounts exist in Manager.buildRunArgs() (podman) but are
-// intentionally omitted here until the end-to-end wiring is in place:
-//
-//   - opencode config allowlist (~/.config/opencode/{AGENTS.md,plugins,skills,...})
-//   - auth.json overlay (~/.local/share/opencode/auth.json, r/w over session dir)
-//   - opencode plugin cache (~/.cache/opencode/, read-only)
-//   - bun transpiler cache (~/.cache/bun/, read-only)
-//   - Additional AWS mounts (credentials, sso/, cli/ — AC lists only readonly-config)
-//   - Clipboard staging dir (~/.cache/prism/clipboard/)
-//   - WorktreeReadOnly handling (review agents — separate concern from base wiring)
-//   - Darwin Keychain credentials (darwin-only, not applicable on Linux)
-//
-// These are tracked in #877 and will be added when bwrap is wired end-to-end.
+//   - WorktreeReadOnly handling (review agents under bwrap — deferred to a
+//     future PR; bwrap review support is tracked separately).
+//   - Darwin Keychain credentials (darwin-only, not applicable on Linux).
 func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	cfg := m.cfg
 
@@ -209,6 +199,70 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	if cfg.ConfigContent != "" {
 		opencodeConfigPath := m.opencodeConfigFilePath()
 		args = append(args, "--ro-bind", opencodeConfigPath, opencodeConfigPath)
+	}
+
+	// ── opencode config allowlist (read-only, conditional) ──────────────────
+	// Mount specific files from ~/.config/opencode/ so agents, skills, and
+	// plugins defined in the Nix module are available inside the sandbox.
+	// opencode.json is NOT mounted from the host — the sandbox uses the temp
+	// file above (ConfigContent). Matching the podman buildRunArgs allowlist.
+	opencodeConfigDir := filepath.Join(home, ".config", "opencode")
+	opencodeAllowlist := []string{
+		"AGENTS.md",
+		"plugins",
+		"skills",
+	}
+	for _, entry := range opencodeAllowlist {
+		p := filepath.Join(opencodeConfigDir, entry)
+		if _, err := os.Stat(p); err == nil {
+			args = append(args, "--ro-bind", p, p)
+		}
+	}
+
+	// ── auth.json overlay (read-write, conditional) ──────────────────────────
+	// Share the host's OAuth token file across sessions. The opencode-claude-auth
+	// plugin writes back refreshed credentials, so it must be read-write.
+	// Mounted at the exact host path (Dst==Src).
+	opencodeAuthJSON := filepath.Join(home, ".local", "share", "opencode", "auth.json")
+	if _, err := os.Stat(opencodeAuthJSON); err == nil {
+		args = append(args, "--bind", opencodeAuthJSON, opencodeAuthJSON)
+	}
+
+	// ── opencode plugin cache (read-only, conditional) ───────────────────────
+	opencodeCacheDir := filepath.Join(home, ".cache", "opencode")
+	if _, err := os.Stat(opencodeCacheDir); err == nil {
+		args = append(args, "--ro-bind", opencodeCacheDir, opencodeCacheDir)
+	}
+
+	// ── bun transpiler cache (read-only, conditional) ───────────────────────
+	bunCacheDir := filepath.Join(home, ".cache", "bun")
+	if _, err := os.Stat(bunCacheDir); err == nil {
+		args = append(args, "--ro-bind", bunCacheDir, bunCacheDir)
+	}
+
+	// ── Additional AWS mounts (read-only, conditional) ───────────────────────
+	// Match the podman buildRunArgs pattern: credentials file and SSO/CLI
+	// cache dirs are conditionally mounted when present on the host.
+	awsCredentials := filepath.Join(home, ".config", "aws", "credentials")
+	if resolved, err := filepath.EvalSymlinks(awsCredentials); err == nil {
+		args = append(args, "--ro-bind", resolved, resolved)
+	}
+	awsSSOCacheDir := filepath.Join(home, ".aws", "sso")
+	if _, err := os.Stat(awsSSOCacheDir); err == nil {
+		args = append(args, "--bind", awsSSOCacheDir, awsSSOCacheDir)
+	}
+	awsCLICacheDir := filepath.Join(home, ".aws", "cli")
+	if _, err := os.Stat(awsCLICacheDir); err == nil {
+		args = append(args, "--bind", awsCLICacheDir, awsCLICacheDir)
+	}
+
+	// ── Clipboard staging dir (read-only, conditional) ───────────────────────
+	// Images staged by `prism clipboard paste-image` on the host are placed here
+	// and bind-mounted read-only so opencode's stat() call resolves without
+	// modification. Dst == Src (no remap needed).
+	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
+	if _, err := os.Stat(clipboardCacheDir); err == nil {
+		args = append(args, "--ro-bind", clipboardCacheDir, clipboardCacheDir)
 	}
 
 	// ── Environment variables ────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -842,19 +841,50 @@ func TestNewBwrapIsolator_ReturnsIsolator(t *testing.T) {
 	var _ Isolator = newBwrapIsolator("test")
 }
 
-// ── No references to bwrapIsolator outside this package ──────────────────────
-// (This is a structural guarantee enforced by the file-scope test below.)
+// ── PrepareBwrap uses bwrapIsolator via container.go (wired in #877) ─────────
+// The old guard test (TestBwrapIsolator_NotUsedInContainerGo) is removed: the
+// wiring PR (#877) intentionally references bwrapIsolator from container.go
+// via Manager.PrepareBwrap(). The structural guarantee from #876 is now met
+// by the AC that bwrap is NOT wired into Manager.Create() (the sidecar path).
 
-func TestBwrapIsolator_NotUsedInContainerGo(t *testing.T) {
-	// Read container.go from the package directory and assert it does not
-	// reference bwrapIsolator. This guards against accidental wiring before
-	// the follow-up PR (#877).
-	containerSrc, err := os.ReadFile(filepath.Join("container.go"))
+func TestPrepareBwrap_WritesSSHConfigAndGitconfig(t *testing.T) {
+	// PrepareBwrap must write the SSH config and gitconfig temp files and
+	// return a non-empty arg list. It must NOT write gitdir fixup files.
+	worktree := t.TempDir()
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@feat",
+		Worktree:      worktree,
+		AllocatedPort: 14020,
+		AgentRole:     "worker",
+		GitUserName:   "Test User",
+		GitUserEmail:  "test@example.com",
+	})
+	defer cleanup()
+
+	args, err := m.PrepareBwrap()
 	if err != nil {
-		t.Fatalf("could not read container.go: %v", err)
+		t.Fatalf("PrepareBwrap: %v", err)
 	}
-	if strings.Contains(string(containerSrc), "bwrapIsolator") {
-		t.Errorf("container.go must not reference bwrapIsolator (wiring is deferred to #877)")
+	if len(args) == 0 {
+		t.Fatalf("PrepareBwrap returned empty arg list")
+	}
+
+	// SSH config must exist.
+	if _, err := os.Stat(m.SshConfigFilePath()); err != nil {
+		t.Errorf("SSH config temp file not written: %v", err)
+	}
+
+	// Gitconfig must exist.
+	if _, err := os.Stat(m.GitconfigFilePath()); err != nil {
+		t.Errorf("Gitconfig temp file not written: %v", err)
+	}
+
+	// Gitdir fixup files must NOT exist (they are podman-only).
+	if _, err := os.Stat(m.GitdirFilePath()); err == nil {
+		t.Errorf("gitdir fixup file should not be written by PrepareBwrap")
+	}
+	if _, err := os.Stat(m.WorktreeGitdirFilePath()); err == nil {
+		t.Errorf("worktree gitdir fixup file should not be written by PrepareBwrap")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -311,6 +311,9 @@ func (m *Manager) gitdirFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-gitdir-"+m.name)
 }
 
+// GitdirFilePath is the exported version of gitdirFilePath for tests.
+func (m *Manager) GitdirFilePath() string { return m.gitdirFilePath() }
+
 // sshConfigFilePath returns the host path for the temporary SSH config
 // written before container start. The container needs a minimal SSH config
 // for git push/fetch over SSH remotes, but the host's ~/.ssh/config is a
@@ -320,12 +323,18 @@ func (m *Manager) sshConfigFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-ssh-config-"+m.name)
 }
 
+// SshConfigFilePath is the exported version of sshConfigFilePath for tests.
+func (m *Manager) SshConfigFilePath() string { return m.sshConfigFilePath() }
+
 // gitconfigFilePath returns the host path for the temporary .gitconfig
 // written before container start. The container needs a minimal gitconfig
 // for commit identity and SSH signing. Mounted read-only at /root/.gitconfig.
 func (m *Manager) gitconfigFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-gitconfig-"+m.name)
 }
+
+// GitconfigFilePath is the exported version of gitconfigFilePath for tests.
+func (m *Manager) GitconfigFilePath() string { return m.gitconfigFilePath() }
 
 // allowedSignersFilePath returns the host path for the temporary
 // allowed_signers file written before container start. The file is mounted
@@ -506,6 +515,9 @@ func (m *Manager) writeGitconfig() error {
 func (m *Manager) worktreeGitdirFilePath() string {
 	return filepath.Join(os.TempDir(), "prism-wt-gitdir-"+m.name)
 }
+
+// WorktreeGitdirFilePath is the exported version of worktreeGitdirFilePath for tests.
+func (m *Manager) WorktreeGitdirFilePath() string { return m.worktreeGitdirFilePath() }
 
 // Create creates and starts the podman container for this session.
 // It first calls EnsureRemoved to handle any stale container with the same name.
@@ -698,6 +710,51 @@ func (m *Manager) Shutdown() {
 	_ = os.Remove(m.claudeCredentialsFilePath())
 
 	log.Printf("container: %q removed", m.name)
+}
+
+// PrepareBwrap writes the same temp files that Create() writes for podman
+// sessions (SSH config, gitconfig, opencode.json config) and returns the
+// complete bwrap argument list via bwrapIsolator.BuildArgs. It does NOT write
+// the gitdir fixup files (prism-gitdir-*, prism-wt-gitdir-*) because bwrap
+// uses Dst==Src mounts, so the host git paths are visible at their exact
+// locations inside the sandbox without remapping.
+//
+// Call this from "prism agent-run" in the tmux pane for bwrap mode. The
+// returned args slice is suitable for passing directly to exec.Exec("bwrap").
+//
+// Note: this method also calls prepareVolumeDirs() to ensure bind-mount
+// sources exist. bwrap (unlike podman) does not emit an exit-125 error for
+// missing sources — it simply fails to bind. Eagerly creating the directories
+// avoids confusing "No such file or directory" errors at bwrap startup.
+func (m *Manager) PrepareBwrap() ([]string, error) {
+	// Write a minimal SSH config. Mirrors the Create() path.
+	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile " + m.cfg.SshAccessKeyName + "\n  IdentitiesOnly yes\n"
+	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
+		return nil, fmt.Errorf("container: bwrap: write ssh config: %w", err)
+	}
+
+	// Write the gitconfig. Mirrors the Create() path.
+	if err := m.writeGitconfig(); err != nil {
+		return nil, fmt.Errorf("container: bwrap: write gitconfig: %w", err)
+	}
+
+	// Write the opencode config file, if provided.
+	if m.cfg.ConfigContent != "" {
+		if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o644); err != nil {
+			return nil, fmt.Errorf("container: bwrap: write opencode config: %w", err)
+		}
+	}
+
+	// Pre-create directories that BuildArgs will reference as bind-mount
+	// sources. bwrap silently fails rather than printing a clear error, so
+	// we create eagerly here.
+	if err := m.prepareVolumeDirs(); err != nil {
+		log.Printf("container: bwrap: prepareVolumeDirs partial failure: %v", err)
+	}
+
+	// Build the bwrap args.
+	b := &bwrapIsolator{name: m.name}
+	return b.BuildArgs(m), nil
 }
 
 // prepareVolumeDirs eagerly creates host directories that buildRunArgs() will

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -727,8 +727,26 @@ func (m *Manager) Shutdown() {
 // missing sources — it simply fails to bind. Eagerly creating the directories
 // avoids confusing "No such file or directory" errors at bwrap startup.
 func (m *Manager) PrepareBwrap() ([]string, error) {
-	// Write a minimal SSH config. Mirrors the Create() path.
-	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile " + m.cfg.SshAccessKeyName + "\n  IdentitiesOnly yes\n"
+	// Write a minimal SSH config for bwrap. Unlike the podman path, which uses
+	// the in-container path "/root/.ssh/access-key" (where the key is mounted),
+	// bwrap uses Dst==Src mounts — the key is visible at its resolved host path
+	// inside the sandbox. Resolve the symlink to get the absolute path that
+	// BuildArgs mounts with --ro-bind.
+	accessKeyName := m.cfg.SshAccessKeyName
+	if accessKeyName == "" {
+		accessKeyName = "prismatic-koi-ed25519"
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		home = os.Getenv("HOME")
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	accessKeyPath := filepath.Join(sshDir, accessKeyName)
+	if resolved, err := filepath.EvalSymlinks(accessKeyPath); err == nil {
+		// Use the resolved path — that's what BuildArgs mounts with --ro-bind.
+		accessKeyPath = resolved
+	}
+	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile " + accessKeyPath + "\n  IdentitiesOnly yes\n"
 	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
 		return nil, fmt.Errorf("container: bwrap: write ssh config: %w", err)
 	}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -68,12 +68,27 @@ type Status struct {
 	RootModelID      *string
 	OpencodePort     *int
 	HostMode         bool
+	IsolationMode    string // "podman", "bwrap", or "host"; "" means not recorded (back-compat)
 	InstanceID       *string
 	LastSeen         time.Time
 	EndedAt          *time.Time
 	Harness          *string
 	HarnessSessionID *string
 	HarnessPort      *int
+}
+
+// EffectiveIsolationMode returns the effective isolation mode for this session.
+// When IsolationMode is non-empty it is returned directly. Otherwise the mode
+// is derived from HostMode for back-compat with pre-v10 DB rows:
+// HostMode=true → "host", HostMode=false → "podman".
+func (s Status) EffectiveIsolationMode() string {
+	if s.IsolationMode != "" {
+		return s.IsolationMode
+	}
+	if s.HostMode {
+		return "host"
+	}
+	return "podman"
 }
 
 // BusMessage represents a row in the bus_messages table.
@@ -123,6 +138,7 @@ CREATE TABLE IF NOT EXISTS agent_status (
   root_model_id     TEXT,
   opencode_port     INTEGER,
   host_mode         INTEGER NOT NULL DEFAULT 0,
+  isolation_mode    TEXT,
   instance_id       TEXT,
   last_seen         INTEGER NOT NULL,
   ended_at          INTEGER,
@@ -154,7 +170,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 // Open opens (or creates) the prism database at path.
 // It creates parent directories as needed, enables WAL mode, enforces foreign
-// keys, runs the full schema, and sets schema_version=9 if the table is empty.
+// keys, runs the full schema, and sets schema_version=10 if the table is empty.
 // Pending migrations are applied in order: v1→v2 adds agent_name/model_id;
 // v2→v3 adds root_agent_name/root_model_id; v3→v4 adds opencode_port to
 // agent_status; v4→v5 adds host_mode to agent_status; v5→v6 adds instance_id
@@ -163,7 +179,8 @@ CREATE TABLE IF NOT EXISTS schema_version (
 // agent_status; v8→v9 adds the session_groups table and group_id FK column
 // (with ON DELETE SET NULL) to agent_status via rename-and-recreate so that
 // the REFERENCES clause is present in the schema metadata and fully enforced
-// by PRAGMA foreign_keys = ON on both fresh and migrated databases.
+// by PRAGMA foreign_keys = ON on both fresh and migrated databases;
+// v9→v10 adds isolation_mode TEXT to agent_status (nullable, back-compat).
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -205,15 +222,15 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("db: apply schema: %w", err)
 	}
 
-	// Set schema_version=9 if the table is empty (fresh database already has
-	// all columns including the v2–v9 additions, so no migration is needed).
+	// Set schema_version=10 if the table is empty (fresh database already has
+	// all columns including the v2–v10 additions, so no migration is needed).
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("db: check schema_version: %w", err)
 	}
 	if count == 0 {
-		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (9)"); err != nil {
+		if _, err := conn.Exec("INSERT INTO schema_version (version) VALUES (10)"); err != nil {
 			conn.Close()
 			return nil, fmt.Errorf("db: set schema_version: %w", err)
 		}
@@ -425,6 +442,22 @@ func Open(path string) (*DB, error) {
 			return nil, fmt.Errorf("db: migration v8→v9: %w", err)
 		}
 		version = 9
+	}
+	if version == 9 {
+		// Migration v9 → v10: add isolation_mode TEXT to agent_status.
+		// Nullable so existing rows receive NULL (back-compat with pre-10 data).
+		// When NULL, callers derive the mode from host_mode for back-compat.
+		migrations := []string{
+			"ALTER TABLE agent_status ADD COLUMN isolation_mode TEXT",
+			"UPDATE schema_version SET version = 10",
+		}
+		for _, m := range migrations {
+			if _, err := conn.Exec(m); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v9→v10: %w", err)
+			}
+		}
+		version = 10
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -866,6 +899,21 @@ func (d *DB) SetHostMode(sessionName string, hostMode bool) error {
 	return nil
 }
 
+// SetIsolationMode records the resolved isolation mode for the given session.
+// mode is one of "podman", "bwrap", or "host". This is persisted so that
+// prism restore can re-spawn the session in the same isolation mode.
+// It is a no-op when no row exists for sessionName (returns nil).
+func (d *DB) SetIsolationMode(sessionName, mode string) error {
+	_, err := d.conn.Exec(
+		"UPDATE agent_status SET isolation_mode = ? WHERE session_name = ?",
+		mode, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("db: set isolation_mode: %w", err)
+	}
+	return nil
+}
+
 // portAvailable checks whether a TCP port is available on localhost by
 // attempting a brief listen. Returns true if the port is free.
 func portAvailable(port int) bool {
@@ -1089,7 +1137,7 @@ func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, ty
 // CurrentStatus returns the agent_status row for sessionName, or nil if not found.
 func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE session_name = ?`
 	row := d.conn.QueryRow(q, sessionName)
@@ -1106,7 +1154,7 @@ WHERE session_name = ?`
 // AllActiveStatus returns all agent_status rows where ended_at IS NULL.
 func (d *DB) AllActiveStatus() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
@@ -1115,7 +1163,7 @@ WHERE ended_at IS NULL`
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
@@ -1133,7 +1181,7 @@ func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
 	// percent signs in session names are matched exactly, not as wildcards.
 	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
 FROM agent_status
 WHERE session_name LIKE ? ESCAPE '\'`
 	return d.queryStatuses(q, escaped+"%")
@@ -1560,10 +1608,11 @@ func scanStatus(s scanner) (*Status, error) {
 	var harness sql.NullString
 	var harnessSessionID sql.NullString
 	var harnessPort sql.NullInt64
+	var isolationMode sql.NullString
 	err := s.Scan(
 		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
 		&st.Title, &st.OpencodeSID, &st.AgentName, &st.ModelID,
-		&st.RootAgentName, &st.RootModelID, &port, &hostMode, &instanceID, &lastSeen, &endedAt,
+		&st.RootAgentName, &st.RootModelID, &port, &hostMode, &isolationMode, &instanceID, &lastSeen, &endedAt,
 		&harness, &harnessSessionID, &harnessPort,
 	)
 	if err != nil {
@@ -1581,6 +1630,11 @@ func scanStatus(s scanner) (*Status, error) {
 	// host_mode: treat NULL (rows written before migration) as 0/false.
 	if hostMode.Valid {
 		st.HostMode = hostMode.Int64 != 0
+	}
+	// isolation_mode: NULL means not recorded (pre-v10 row); callers derive
+	// the mode from host_mode for back-compat in that case.
+	if isolationMode.Valid {
+		st.IsolationMode = isolationMode.String
 	}
 	if instanceID.Valid {
 		id := instanceID.String

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=9 (migrations are applied on Open).
+	// Verify schema_version=10 (migrations are applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version: got %d, want 10", version)
 	}
 
 	// Verify WAL mode.
@@ -773,13 +773,13 @@ func TestMigration_V1ToV2(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Verify schema_version=9.
+	// Verify schema_version=10.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -853,8 +853,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1354,8 +1354,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1420,8 +1420,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1490,8 +1490,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1585,8 +1585,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1672,13 +1672,13 @@ func TestMigration_V7ToV8(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must be 9 after migration.
+	// Schema version must be 10 after migration.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2271,13 +2271,13 @@ func TestMigration_V8ToV9(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must be 9 after migration.
+	// Schema version must be 10 after migration.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 9 {
-		t.Errorf("schema_version after migration: got %d, want 9", version)
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2305,6 +2305,97 @@ func TestMigration_V8ToV9(t *testing.T) {
 	}
 	if groupID != nil {
 		t.Errorf("group_id for migrated row: got %v, want nil", groupID)
+	}
+}
+
+// TestMigration_V9ToV10 verifies that Open applies the v9→v10 migration to an
+// existing DB that was created at schema_version=9 (no isolation_mode column).
+func TestMigration_V9ToV10(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v9.db")
+
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT, opencode_sid TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  opencode_port INTEGER, host_mode INTEGER NOT NULL DEFAULT 0,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT, harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (9);
+		INSERT INTO agent_status (session_name, repo, worktree, state, harness, last_seen)
+		  VALUES ('repo@main', 'repo', '/code/repo/main', 'active', 'opencode', 0);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v9 db: %v", err)
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v9 db: %v", err)
+	}
+	defer d.Close()
+
+	// Schema version must be 10 after migration.
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 10 {
+		t.Errorf("schema_version after migration: got %d, want 10", version)
+	}
+
+	// isolation_mode column must exist (NULL for pre-migration rows).
+	var isoMode *string
+	if err := d.QueryRow("SELECT isolation_mode FROM agent_status WHERE session_name = 'repo@main'").Scan(&isoMode); err != nil {
+		t.Fatalf("query isolation_mode column after migration: %v", err)
+	}
+	if isoMode != nil {
+		t.Errorf("isolation_mode for migrated row: got %q, want nil", *isoMode)
+	}
+
+	// Existing row must still be present and unmodified.
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus after migration: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil, want existing row")
+	}
+	if s.State != "active" {
+		t.Errorf("State preserved: got %q, want \"active\"", s.State)
+	}
+	// IsolationMode for pre-migration rows must be "".
+	if s.IsolationMode != "" {
+		t.Errorf("IsolationMode: got %q, want \"\" (NULL → empty)", s.IsolationMode)
+	}
+	// EffectiveIsolationMode with HostMode=false falls back to "podman".
+	if s.EffectiveIsolationMode() != "podman" {
+		t.Errorf("EffectiveIsolationMode: got %q, want %q", s.EffectiveIsolationMode(), "podman")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -46,7 +46,14 @@ type Opts struct {
 	// "opencode --agent <name> --port <n>" to "podman attach <container-name>".
 	// The sidecar is responsible for starting the container and signalling readiness
 	// before the attach command is sent to the tmux pane.
+	// Deprecated: use IsolationMode instead. When IsolationMode is set it
+	// takes precedence; ContainerMode is kept for callers that have not migrated.
 	ContainerMode bool
+
+	// IsolationMode is the resolved isolation mode for this session.
+	// Valid values: "podman", "bwrap", "host". When non-empty it overrides
+	// ContainerMode.
+	IsolationMode string
 	// PluginHostPath is the host-side path to the opencode plugin file that
 	// is bind-mounted into the container. Empty string = no plugin. Only used
 	// when ContainerMode is true.
@@ -139,18 +146,30 @@ func DefaultAgent(directory, explicit string) string {
 	return "worker"
 }
 
+// effectiveIsolationMode returns the resolved isolation mode for opts,
+// falling back to ContainerMode for back-compat.
+func effectiveIsolationMode(opts Opts) string {
+	if opts.IsolationMode != "" {
+		return opts.IsolationMode
+	}
+	if opts.ContainerMode {
+		return "podman"
+	}
+	return "host"
+}
+
 // BuildOpencodeCmd returns the opencode launch command string for the given opts.
 //
-// When opts.ContainerMode is true, the command is "podman attach <container-name>"
-// — a transparent PTY bridge that connects the tmux pane to the opencode TUI
-// running inside the container (RFC #691, Phase 1a / Issue #715). The container
-// name is derived from opts.SessionName via container.NameForSession.
+// Isolation mode determines the command:
+//   - "podman": "podman attach --sig-proxy=false <container-name>"
+//   - "bwrap":  "prism agent-run --session <session-name>"
+//   - "host":   direct opencode invocation (legacy behaviour)
 //
-// When opts.ContainerMode is false (default), the command launches opencode
-// directly as before. PRISM_SESSION_NAME is prepended when opts.SessionName is
-// set, and --port / --hostname are appended when opts.Port is non-zero.
+// For back-compat, ContainerMode=true maps to "podman" when IsolationMode is empty.
 func BuildOpencodeCmd(opts Opts) string {
-	if opts.ContainerMode {
+	mode := effectiveIsolationMode(opts)
+	switch mode {
+	case "podman":
 		if opts.SessionName == "" {
 			// Shouldn't happen — callers must set SessionName before enabling
 			// container mode. Fall back to the non-container command.
@@ -167,8 +186,20 @@ func BuildOpencodeCmd(opts Opts) string {
 		// the session name cannot be interpreted as shell metacharacters when
 		// buildReadinessWaitCmd embeds this string in the readiness shell script.
 		return "podman attach --sig-proxy=false " + shellQuote(container.NameForSession(opts.SessionName))
+
+	case "bwrap":
+		if opts.SessionName == "" {
+			// Shouldn't happen — fall back to direct opencode command.
+			return buildDirectOpencodeCmd(opts)
+		}
+		// The bwrap sandbox is owned by the tmux pane, not the sidecar.
+		// "prism agent-run" reads the resolved bwrap args from the session
+		// state and execs "bwrap <args...> -- opencode ..." directly.
+		return "prism agent-run --session " + shellQuote(opts.SessionName)
+
+	default: // "host" or any unknown value
+		return buildDirectOpencodeCmd(opts)
 	}
-	return buildDirectOpencodeCmd(opts)
 }
 
 // opencodeExperimentalBashTimeout is the default bash-tool timeout (in ms) injected
@@ -356,24 +387,34 @@ func Create(name, directory string, opts Opts) error {
 // window 0 "edit" (nvim auto-launched), window 1 "agent" (opencode),
 // window 2 "term". Seeds agent_status via prism event tmux-session-start.
 //
-// In container mode (opts.ContainerMode), the sidecar is started first and the
-// agent window runs a readiness-wait loop before running "podman attach".
+// In podman mode (isolation mode "podman"), the sidecar is started first and
+// the agent window runs a readiness-wait loop before running "podman attach".
 // This ensures the container is healthy before the PTY bridge tries to connect.
+//
+// In bwrap mode (isolation mode "bwrap"), the sidecar is still started (for
+// SSE, state machine, and host-API) but the agent window runs
+// "prism agent-run --session <name>" directly — no readiness wait, because
+// bwrap is owned by the tmux pane and doesn't use a sidecar-written ready file.
 func setupFullLayout(name, directory string, opts Opts) error {
+	mode := effectiveIsolationMode(opts)
+
 	_ = tmux.RenameWindow(name+":0", "edit")
 
 	nvimCmd := NvimCmd(directory)
 	_ = tmux.SendKeys(name+":0", nvimCmd)
 
 	// Start the sidecar before creating the agent window.
-	// In container mode the sidecar creates the container; we must start it
-	// before the attach command is queued so readiness signalling works.
+	// In podman and bwrap mode the sidecar handles SSE, state transitions,
+	// and host-API — we must start it before the pane command so readiness
+	// signalling and prompt delivery are in place.
+	// In host mode the sidecar runs without --container (no container creation).
 	if opts.Port == 0 {
 		fmt.Fprintf(os.Stderr, "warning: sidecar skipped for %q — no port allocated\n", name)
 	} else {
 		sidecarOpts := StartSidecarOpts{
 			Port:           opts.Port,
-			ContainerMode:  opts.ContainerMode,
+			ContainerMode:  mode == "podman",
+			IsolationMode:  mode,
 			AgentRole:      opts.Agent,
 			Worktree:       directory,
 			PluginHostPath: opts.PluginHostPath,
@@ -388,13 +429,15 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	}
 
 	// Build the agent window command.
-	// In container mode, prepend a readiness wait so the pane blocks until
+	// In podman mode, prepend a readiness wait so the pane blocks until
 	// the sidecar has health-checked the container (AC-18, AC-19, AC-20).
+	// In bwrap mode, no readiness wait — "prism agent-run" runs immediately
+	// and the sidecar does not write a ready file for bwrap sessions.
 	// opts.SessionName must be set by the caller before setupFullLayout is
 	// invoked — both ensureAndSwitch and restoreProjectSession do this.
 	// BuildOpencodeCmd uses it to prefix PRISM_SESSION_NAME for the plugin.
 	agentCmd := BuildOpencodeCmd(opts)
-	if opts.ContainerMode && opts.Port != 0 {
+	if mode == "podman" && opts.Port != 0 {
 		readyPath, pathErr := SidecarReadyPath(name)
 		if pathErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not determine ready path for %q, skipping readiness wait: %v\n", name, pathErr)

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -131,6 +131,71 @@ func TestBuildDirectOpencodeCmd_AgentEnvVarsNil(t *testing.T) {
 	}
 }
 
+// ── Isolation mode command construction ─────────────────────────────────────
+
+// TestBuildOpencodeCmd_PodmanMode verifies that IsolationMode="podman" produces
+// "podman attach --sig-proxy=false <container-name>".
+func TestBuildOpencodeCmd_PodmanMode(t *testing.T) {
+	opts := Opts{
+		IsolationMode: "podman",
+		SessionName:   "nixos-config@feature",
+	}
+	cmd := BuildOpencodeCmd(opts)
+	if !strings.HasPrefix(cmd, "podman attach --sig-proxy=false") {
+		t.Errorf("podman mode: got %q, want prefix 'podman attach --sig-proxy=false'", cmd)
+	}
+}
+
+// TestBuildOpencodeCmd_BwrapMode verifies that IsolationMode="bwrap" produces
+// "prism agent-run --session <session-name>".
+func TestBuildOpencodeCmd_BwrapMode(t *testing.T) {
+	opts := Opts{
+		IsolationMode: "bwrap",
+		SessionName:   "nixos-config@feature",
+	}
+	cmd := BuildOpencodeCmd(opts)
+	if !strings.HasPrefix(cmd, "prism agent-run --session") {
+		t.Errorf("bwrap mode: got %q, want prefix 'prism agent-run --session'", cmd)
+	}
+	if !strings.Contains(cmd, "nixos-config@feature") {
+		t.Errorf("bwrap mode: session name not in cmd: %q", cmd)
+	}
+}
+
+// TestBuildOpencodeCmd_HostMode verifies that IsolationMode="host" produces
+// a direct opencode command (not podman attach).
+func TestBuildOpencodeCmd_HostMode(t *testing.T) {
+	opts := Opts{
+		IsolationMode: "host",
+		Agent:         "worker",
+		Port:          14000,
+		SessionName:   "nixos-config@feature",
+	}
+	cmd := BuildOpencodeCmd(opts)
+	if strings.HasPrefix(cmd, "podman") {
+		t.Errorf("host mode: got podman command %q, want direct opencode invocation", cmd)
+	}
+	if strings.HasPrefix(cmd, "prism agent-run") {
+		t.Errorf("host mode: got prism agent-run command %q, want direct opencode invocation", cmd)
+	}
+	if !strings.Contains(cmd, "opencode") {
+		t.Errorf("host mode: cmd does not contain 'opencode': %q", cmd)
+	}
+}
+
+// TestBuildOpencodeCmd_ContainerModeFallback verifies that ContainerMode=true
+// with no IsolationMode falls back to "podman" (back-compat).
+func TestBuildOpencodeCmd_ContainerModeFallback(t *testing.T) {
+	opts := Opts{
+		ContainerMode: true,
+		SessionName:   "nixos-config@feature",
+	}
+	cmd := BuildOpencodeCmd(opts)
+	if !strings.HasPrefix(cmd, "podman attach --sig-proxy=false") {
+		t.Errorf("ContainerMode fallback: got %q, want 'podman attach --sig-proxy=false ...'", cmd)
+	}
+}
+
 // TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted verifies that env var
 // values containing spaces or special characters are properly shell-quoted.
 func TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted(t *testing.T) {

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -138,8 +138,13 @@ type StartSidecarOpts struct {
 	// Port is the allocated opencode serve port.
 	Port int
 	// ContainerMode, when true, passes --container to the sidecar so it creates
-	// and manages a podman container.
+	// and manages a podman container. Deprecated: use IsolationMode instead.
 	ContainerMode bool
+	// IsolationMode is the resolved isolation mode for this session. When set,
+	// it is passed to the sidecar via --isolation-mode so the sidecar can
+	// branch on it (e.g. skip container creation for "bwrap" and "host").
+	// Valid values: "podman", "bwrap", "host".
+	IsolationMode string
 	// AgentRole is "worker" or "coordinator". Passed via --agent-role when in
 	// container mode to select the appropriate credential set.
 	AgentRole string
@@ -227,8 +232,34 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 		"--opencode-url", opencodeURL,
 	}
 
+	// Pass --isolation-mode when set; the sidecar uses this to branch on
+	// container creation, harness selection, and host-API socket setup.
+	if opts.IsolationMode != "" {
+		cmdArgs = append(cmdArgs, "--isolation-mode", opts.IsolationMode)
+	}
+
+	// --container enables the full container lifecycle (podman create/stop/rm).
+	// For bwrap mode the sidecar is started but --container is NOT passed —
+	// bwrap's process lifecycle is owned by the tmux pane (prism agent-run).
 	if opts.ContainerMode {
 		cmdArgs = append(cmdArgs, "--container")
+		cmdArgs = append(cmdArgs, "--port", strconv.Itoa(opts.Port))
+		if opts.AgentRole != "" {
+			cmdArgs = append(cmdArgs, "--agent-role", opts.AgentRole)
+		}
+		if opts.PluginHostPath != "" {
+			cmdArgs = append(cmdArgs, "--plugin-path", opts.PluginHostPath)
+		}
+		if opts.InitialPrompt != "" {
+			cmdArgs = append(cmdArgs, "--initial-prompt", opts.InitialPrompt)
+		}
+		if opts.ConfigContent != "" {
+			cmdArgs = append(cmdArgs, "--config-content", opts.ConfigContent)
+		}
+	} else if opts.IsolationMode == "bwrap" {
+		// bwrap mode: pass --port and common options but not --container.
+		// The sidecar sets up the host-API socket and harness but does not
+		// create a container.
 		cmdArgs = append(cmdArgs, "--port", strconv.Itoa(opts.Port))
 		if opts.AgentRole != "" {
 			cmdArgs = append(cmdArgs, "--agent-role", opts.AgentRole)


### PR DESCRIPTION
## Summary

This PR wires the `bwrapIsolator` (landed in #880) into the prism CLI and Nix module, delivering end-to-end bwrap isolation support.

### What's included

**Nix module changes:**
- New `nx.programs.prism.agent.isolation.default` enum option (`podman`/`bwrap`/`host`), defaulting to `"podman"` on Linux and `"host"` on Darwin
- Eval-time assertion that `"bwrap"` on Darwin fails with a clear message
- `pkgs.bubblewrap` added to the Linux package set when the prism TUI is enabled
- `~/.config/prism/config.json` now includes `default_isolation_mode`; `container_mode` is derived from it for back-compat

**Go CLI changes:**
- `config.IsolationMode` type with `podman`/`bwrap`/`host` constants and back-compat from `container_mode` boolean
- DB schema v9→v10: `isolation_mode TEXT` column added to `agent_status`; `SetIsolationMode()` method added
- `prism spawn --isolation <mode>` flag; `--host-mode` retained as deprecated alias; simultaneous use rejected with a clear error
- New `prism agent-run --session <name>` subcommand: execs `bwrap <args...>` in the tmux pane for bwrap sessions
- `prism sidecar --isolation-mode <mode>` flag; sidecar branches on mode for container creation, harness selection, and host-API socket setup
- `BuildOpencodeCmd`: `podman` → `podman attach`, `bwrap` → `prism agent-run`, `host` → direct opencode
- `Manager.PrepareBwrap()`: writes SSH config, gitconfig, opencode config temp files and returns bwrap args (without gitdir fixup files)
- `concurrency.go`, `pr.go`, `review.go`: bwrap treated as concurrency-capped (same as podman)
- `restore.go`: reads `isolation_mode` from DB; falls back to `HostMode` for pre-v10 rows
- `bwrap.go`: added deferred mounts from #880 (opencode config allowlist, auth.json, caches, clipboard, additional AWS mounts)

### ACs requiring post-merge manual verification

These ACs involve runtime behaviour inside a bwrap sandbox that cannot be exercised from within this spawned session:

- `prism spawn --isolation bwrap` produces a working session with opencode TUI visible
- `cat ~/.aws/config` (admin) fails inside bwrap session
- `cat ~/.aws/readonly-config` succeeds inside bwrap session
- Write to read-only mount fails inside bwrap session
- `git commit`/`git push` succeed inside bwrap session
- `nix build` succeeds inside bwrap session
- `prism restore` re-spawns bwrap sessions correctly
- `prism.db` rows have correct `isolation_mode` after sessions in each mode

### In-flight work overlap

PR #753 (`darwin-nix-daemon-ssh-ng`) is still open and modifies `container.go`. This PR also modifies `container.go` (added `PrepareBwrap()` and exported accessor methods). If #753 merges first, a rebase onto main is needed before merging this PR.

Closes #877