### PR TITLE
container: propagate PATH and standard env vars into bwrap sandbox

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -51,6 +51,43 @@ func (b *bwrapIsolator) BuildRunArgs() []string {
 	return nil
 }
 
+// fallbackPATH is the PATH value used when os.Getenv("PATH") is empty.
+// It covers the NixOS system profile and standard POSIX paths.
+const fallbackPATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+
+// standardSandboxEnvArgs returns the --setenv pairs for the standard set of
+// environment variables that must be propagated from the host into the bwrap
+// sandbox. This ensures binaries resolve on PATH and tools behave correctly.
+//
+// Rules:
+//   - PATH: always emitted; falls back to fallbackPATH when the host value is
+//     empty (e.g. in a stripped environment).
+//   - HOME, USER, LOGNAME, LANG, LC_ALL, SHELL: forwarded when the host has
+//     them set; omitted entirely when unset, so the sandbox does not receive a
+//     spurious empty string.
+//
+// TERM is NOT included here — it is handled separately by BuildArgs so that
+// its fixed value ("xterm-256color") is always used regardless of the host.
+func standardSandboxEnvArgs() []string {
+	var args []string
+
+	// PATH — always emitted, with fallback when host value is empty.
+	pathVal := os.Getenv("PATH")
+	if pathVal == "" {
+		pathVal = fallbackPATH
+	}
+	args = append(args, "--setenv", "PATH", pathVal)
+
+	// Optional vars — only emitted when the host has them set.
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "SHELL"} {
+		if val := os.Getenv(key); val != "" {
+			args = append(args, "--setenv", key, val)
+		}
+	}
+
+	return args
+}
+
 // BuildArgs constructs the bwrap argument list that is equivalent to the
 // podman run arguments built by Manager.buildRunArgs(), translating podman
 // syntax into bubblewrap equivalents:
@@ -278,6 +315,11 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 
 	// TERM: xterm-256color for full SGR mouse support in the TUI.
 	args = append(args, "--setenv", "TERM", "xterm-256color")
+
+	// Standard env vars: PATH (with fallback), HOME, USER, LOGNAME, LANG,
+	// LC_ALL, SHELL. These ensure that binaries resolve correctly inside the
+	// sandbox and that tools behave as they do on the host.
+	args = append(args, standardSandboxEnvArgs()...)
 
 	// Prism context variables.
 	// PRISM_SPAWN_PATH: use the actual host worktree path (not /workspace).

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -559,6 +559,157 @@ func TestBwrapBuildArgs_TermSetenv(t *testing.T) {
 	}
 }
 
+// ── Standard sandbox env vars (PATH, HOME, USER, etc.) ──────────────────────
+
+// TestStandardSandboxEnvArgs_PathFallbackWhenUnset verifies that when PATH is
+// not set, the fallback chain is emitted.
+func TestStandardSandboxEnvArgs_PathFallbackWhenUnset(t *testing.T) {
+	t.Setenv("PATH", "")
+	args := standardSandboxEnvArgs()
+	if !hasSetenv(args, "PATH", fallbackPATH) {
+		t.Errorf("expected --setenv PATH %q when PATH is empty, got args: %v", fallbackPATH, args)
+	}
+}
+
+// TestStandardSandboxEnvArgs_PathFromHostWhenSet verifies that when PATH is
+// set on the host, that exact value is forwarded.
+func TestStandardSandboxEnvArgs_PathFromHostWhenSet(t *testing.T) {
+	hostPath := "/custom/bin:/usr/local/bin:/usr/bin"
+	t.Setenv("PATH", hostPath)
+	args := standardSandboxEnvArgs()
+	if !hasSetenv(args, "PATH", hostPath) {
+		t.Errorf("expected --setenv PATH %q, got args: %v", hostPath, args)
+	}
+}
+
+// TestStandardSandboxEnvArgs_OptionalVarsPresentWhenSet verifies that HOME,
+// USER, LOGNAME, LANG, LC_ALL, and SHELL are forwarded when set on the host.
+func TestStandardSandboxEnvArgs_OptionalVarsPresentWhenSet(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("USER", "testuser")
+	t.Setenv("LOGNAME", "testuser")
+	t.Setenv("LANG", "en_US.UTF-8")
+	t.Setenv("LC_ALL", "en_US.UTF-8")
+	t.Setenv("SHELL", "/bin/bash")
+
+	args := standardSandboxEnvArgs()
+
+	cases := [][2]string{
+		{"HOME", "/home/testuser"},
+		{"USER", "testuser"},
+		{"LOGNAME", "testuser"},
+		{"LANG", "en_US.UTF-8"},
+		{"LC_ALL", "en_US.UTF-8"},
+		{"SHELL", "/bin/bash"},
+	}
+	for _, c := range cases {
+		if !hasSetenv(args, c[0], c[1]) {
+			t.Errorf("expected --setenv %s %q in args: %v", c[0], c[1], args)
+		}
+	}
+}
+
+// TestStandardSandboxEnvArgs_OptionalVarsOmittedWhenUnset verifies that
+// optional vars (HOME, USER, LOGNAME, LANG, LC_ALL, SHELL) are NOT emitted
+// when they are not set on the host.
+func TestStandardSandboxEnvArgs_OptionalVarsOmittedWhenUnset(t *testing.T) {
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "SHELL"} {
+		t.Setenv(key, "")
+	}
+	args := standardSandboxEnvArgs()
+
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "SHELL"} {
+		for i := 0; i+2 < len(args); i++ {
+			if args[i] == "--setenv" && args[i+1] == key {
+				t.Errorf("optional var %s should be omitted when unset but found in args: %v", key, args)
+			}
+		}
+	}
+}
+
+// TestStandardSandboxEnvArgs_PathFallbackExact verifies the fallback PATH is
+// exactly the specified string — not reordered or otherwise altered.
+func TestStandardSandboxEnvArgs_PathFallbackExact(t *testing.T) {
+	t.Setenv("PATH", "")
+	args := standardSandboxEnvArgs()
+	want := "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+	if !hasSetenv(args, "PATH", want) {
+		t.Errorf("fallback PATH = unexpected value; want exactly %q, got args: %v", want, args)
+	}
+}
+
+// TestBwrapBuildArgs_PathSetenvPresentInBuildArgs verifies that BuildArgs
+// emits --setenv PATH (via standardSandboxEnvArgs) before the -- terminator.
+func TestBwrapBuildArgs_PathSetenvPresentInBuildArgs(t *testing.T) {
+	hostPath := "/nix/store/test/bin:/run/current-system/sw/bin"
+	t.Setenv("PATH", hostPath)
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	// Confirm --setenv PATH appears before the -- separator.
+	sepIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	if sepIdx < 0 {
+		t.Fatalf("-- separator not found in args: %v", args)
+	}
+
+	pre := args[:sepIdx]
+	if !hasSetenv(pre, "PATH", hostPath) {
+		t.Errorf("--setenv PATH %q not found before -- in args: %v", hostPath, args)
+	}
+}
+
+// TestBwrapBuildArgs_PathFallbackInBuildArgs verifies that when PATH is empty
+// on the host, BuildArgs emits the fallback PATH via standardSandboxEnvArgs.
+func TestBwrapBuildArgs_PathFallbackInBuildArgs(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "PATH", fallbackPATH) {
+		t.Errorf("expected fallback --setenv PATH %q when PATH empty, got args: %v", fallbackPATH, args)
+	}
+}
+
+// TestBwrapBuildArgs_TermRegression guards the existing TERM=xterm-256color
+// behaviour from #876 — it must still be present after adding standard env vars.
+func TestBwrapBuildArgs_TermRegression(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "TERM", "xterm-256color") {
+		t.Errorf("regression: --setenv TERM xterm-256color missing from args: %v", args)
+	}
+}
+
 func TestBwrapBuildArgs_PrismSessionNameSetenv(t *testing.T) {
 	m, _, cleanup := bwrapFixture(t, Config{
 		SessionName:   "myrepo@feat",


### PR DESCRIPTION
## Summary

- `bwrapIsolator.BuildArgs()` did not forward `PATH` (or standard env vars) into the bubblewrap sandbox, causing `execvp("opencode")` to fail immediately with `bwrap: execvp opencode: No such file or directory`.
- Adds `standardSandboxEnvArgs()` — an unexported, unit-testable helper — that emits `--setenv` pairs for `PATH` (with fallback), `HOME`, `USER`, `LOGNAME`, `LANG`, `LC_ALL`, and `SHELL`.
- Extends `bwrap_test.go` with tests covering all AC cases: PATH forwarding, PATH fallback when empty, exact fallback string, optional vars forwarded/omitted, positional requirement (before `--`), and TERM regression guard.

## Implementation

**`standardSandboxEnvArgs()`** (new unexported helper):
- `PATH`: always emitted; falls back to `/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin` when host `PATH` is empty.
- `HOME`, `USER`, `LOGNAME`, `LANG`, `LC_ALL`, `SHELL`: forwarded from host when set, omitted entirely when unset.
- `TERM` is NOT included — `BuildArgs` continues to emit `TERM=xterm-256color` directly (unchanged, regression guard for #876).

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

## Manual verification required (post-merge on navi)

The two runtime ACs cannot be exercised from this worker session and require running on navi after merge:

1. `prism spawn --isolation bwrap --branch smoke --prompt test` → tmux session opens with opencode TUI in window 1 (no `bwrap: execvp opencode` error)
2. Inside the bwrap session: `git --version`, `nix --version`, `rg --version` all succeed via the agent's `Bash` tool

The coordinator should run these on navi after merging.

Closes #883