### PR TITLE
pi: remove User-Agent from token-exchange headers (Cloudflare WAF blocks claude-code/*)

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
@@ -48,12 +48,17 @@ it is more actively maintained and is the source of the PR #193 fix.
 
 1. **`auth.ts` token-exchange wire format tracks griffinmartin `credentials.ts::refreshViaOAuth`**.
    The OAuth token endpoint URL (`TOKEN_URL`), request body construction
-   (`URLSearchParams` / `application/x-www-form-urlencoded`), and `User-Agent`
-   header in `auth.ts` now mirror griffinmartin's `credentials.ts::refreshViaOAuth`
-   rather than leohenon's original JSON-body approach. The local-callback-server
-   PKCE flow, `loginAnthropic` / `refreshAnthropicToken` function signatures, and
-   `pi.registerProvider` wrapper continue to mirror leohenon.
-   Ported in: issue #885, griffinmartin SHA `df1b0cbc9e94ff9a8081ac98aa837893fd2be35e`.
+   (`URLSearchParams` / `application/x-www-form-urlencoded`), and absence of a
+   `User-Agent` header in `makeTokenHeaders()` all mirror griffinmartin's
+   `credentials.ts::refreshViaOAuth` exactly. No `User-Agent` is sent on
+   token-exchange or token-refresh requests — Anthropic's Cloudflare WAF on
+   `claude.ai/v1/oauth/token` blocks requests carrying `User-Agent: claude-code/*`
+   with a 429. The `USER_AGENT` constant remains declared and exported for use on
+   the API-call path (`index.ts`), but is not included in token-exchange headers.
+   The local-callback-server PKCE flow, `loginAnthropic` / `refreshAnthropicToken`
+   function signatures, and `pi.registerProvider` wrapper continue to mirror leohenon.
+   Wire-format ported in: issue #885, griffinmartin SHA `df1b0cbc9e94ff9a8081ac98aa837893fd2be35e`.
+   User-Agent removed in: issue #888.
 
 2. **`index.ts` is pi-specific and will never match griffinmartin's `index.ts`**.
    griffinmartin's entry point uses opencode's `Plugin` type with `auth.loader`,

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/auth.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/auth.test.ts
@@ -79,9 +79,8 @@ describe("refreshAnthropicToken", () => {
       "application/x-www-form-urlencoded",
     )
 
-    // AC: User-Agent header equals USER_AGENT constant
-    assert.equal(headers.get("user-agent"), USER_AGENT)
-    assert.equal(USER_AGENT, "claude-code/2.1.97")
+    // AC: User-Agent must NOT be sent on token-exchange requests (Cloudflare WAF blocks it)
+    assert.equal(headers.has("user-agent"), false)
 
     // AC: form-encoded body with correct fields
     const body = parseBody(init.body)
@@ -169,9 +168,8 @@ describe("loginAnthropic", () => {
       "application/x-www-form-urlencoded",
     )
 
-    // AC: User-Agent
-    assert.equal(headers.get("user-agent"), USER_AGENT)
-    assert.equal(USER_AGENT, "claude-code/2.1.97")
+    // AC: User-Agent must NOT be sent on token-exchange requests (Cloudflare WAF blocks it)
+    assert.equal(headers.has("user-agent"), false)
 
     // AC: form-encoded body with correct fields
     const body = parseBody(init.body)

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts
@@ -266,7 +266,6 @@ async function fetchWithRetry(
 function makeTokenHeaders(): HeadersInit {
   return {
     "Content-Type": "application/x-www-form-urlencoded",
-    "User-Agent": USER_AGENT,
   }
 }
 


### PR DESCRIPTION
## Summary

Anthropic's Cloudflare WAF on `claude.ai/v1/oauth/token` now returns `429 rate_limit_error` for any request carrying `User-Agent: claude-code/2.1.97`. This was added in #886; it needs to come back out.

The fix matches griffinmartin's `credentials.ts::refreshViaOAuth` exactly — send **no `User-Agent`** on token-exchange or token-refresh requests. The `USER_AGENT` constant remains declared and exported in `auth.ts` for use on the API-call path in `index.ts`.

## Changes

- `auth.ts`: remove `"User-Agent": USER_AGENT` from `makeTokenHeaders()` — only `Content-Type: application/x-www-form-urlencoded` is sent
- `auth.test.ts`: flip the two `user-agent` assertions from `assert.equal(headers.get("user-agent"), USER_AGENT)` to `assert.equal(headers.has("user-agent"), false)`
- `UPSTREAM.md`: correct divergence #1 to accurately describe the wire format (no UA sent on token-exchange)

## Verification

- `node --test modules/programs/prism/pi/extensions/anthropic-oauth/auth.test.ts` — 2 pass, 0 fail ✓
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — succeeded ✓

## Manual verification (post-merge on navi)

1. `rm -f ~/.pi/agent/auth.json ~/.pi/agent/pi-anthropic-oauth-debug.log`
2. Run `pi`, then `/login anthropic`, select "Claude Pro/Max".
3. Complete the browser OAuth flow.
4. **Expected:** token exchange succeeds; a new `~/.pi/agent/auth.json` is written; pi session is ready.
5. `cat ~/.pi/agent/pi-anthropic-oauth-debug.log` should show a `login_complete` event, not another `login_token_exchange_start` hanging with no completion.
6. Issue a prompt that invokes tools. Verify no "You're out of extra usage" warning.

Closes #888