### PR TITLE
prism: bring bwrap opencode-config allowlist to parity with podman

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -298,11 +298,26 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// plugins defined in the Nix module are available inside the sandbox.
 	// opencode.json is NOT mounted from the host — the sandbox uses the temp
 	// file above (ConfigContent). Matching the podman buildRunArgs allowlist.
+	//
+	// agents/ is excluded for review containers: the host agents/ directory
+	// contains review-*.md files with "mode: subagent" front-matter that
+	// overrides the "mode: primary" declaration in the container's
+	// opencode.json, causing opencode to fall back to the wrong agent. Review
+	// containers embed their role prompt inline via opencode.json instead.
+	// For non-review containers (worker, coordinator, etc.) agents/ is mounted
+	// so that @review-* subagent invocation works and all agents are accessible.
 	opencodeConfigDir := filepath.Join(home, ".config", "opencode")
 	opencodeAllowlist := []string{
 		"AGENTS.md",
 		"plugins",
 		"skills",
+		"command",
+		"tui.json",
+		".gitignore",
+		"mcp-atlassian-slim-proxy.mjs",
+	}
+	if !strings.HasPrefix(cfg.AgentRole, "review-") {
+		opencodeAllowlist = append(opencodeAllowlist, "agents")
 	}
 	for _, entry := range opencodeAllowlist {
 		p := filepath.Join(opencodeConfigDir, entry)

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -507,6 +507,140 @@ func TestBwrapBuildArgs_OpencodeJSONROBound(t *testing.T) {
 	}
 }
 
+// ── opencode config allowlist entries ────────────────────────────────────────
+
+// TestBwrapBuildArgs_OpencodeAllowlistNewEntries verifies that the entries
+// added to bring the bwrap allowlist to parity with the podman allowlist are
+// emitted when the corresponding paths exist on the host.
+func TestBwrapBuildArgs_OpencodeAllowlistNewEntries(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	opencodeConfigDir := filepath.Join(fakeHome, ".config", "opencode")
+
+	// Create each new allowlist entry so the conditional stat() succeeds.
+	newEntries := []string{
+		"command",
+		"tui.json",
+		".gitignore",
+		"mcp-atlassian-slim-proxy.mjs",
+	}
+	for _, entry := range newEntries {
+		p := filepath.Join(opencodeConfigDir, entry)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("MkdirAll for %q: %v", entry, err)
+		}
+		if err := os.WriteFile(p, []byte("fake"), 0o644); err != nil {
+			t.Fatalf("WriteFile %q: %v", entry, err)
+		}
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for _, entry := range newEntries {
+		p := filepath.Join(opencodeConfigDir, entry)
+		if !hasROBind(args, p) {
+			t.Errorf("opencode allowlist entry %q not found as --ro-bind SRC SRC in args: %v", entry, args)
+		}
+	}
+}
+
+// TestBwrapBuildArgs_OpencodeAllowlistNewEntriesOmittedWhenAbsent verifies
+// that new allowlist entries are omitted when they do not exist on the host.
+func TestBwrapBuildArgs_OpencodeAllowlistNewEntriesOmittedWhenAbsent(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	opencodeConfigDir := filepath.Join(fakeHome, ".config", "opencode")
+
+	// Do NOT create the new entries — they should be absent from args.
+	newEntries := []string{
+		"command",
+		"tui.json",
+		".gitignore",
+		"mcp-atlassian-slim-proxy.mjs",
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for _, entry := range newEntries {
+		p := filepath.Join(opencodeConfigDir, entry)
+		if hasROBind(args, p) {
+			t.Errorf("absent opencode allowlist entry %q should be omitted but found as --ro-bind in args: %v", entry, args)
+		}
+	}
+}
+
+// TestBwrapBuildArgs_AgentsDirMountedForNonReview verifies that agents/ is
+// included in the allowlist (and therefore bound) when AgentRole is empty,
+// "worker", or "coordinator" — i.e. any non-review-* value.
+func TestBwrapBuildArgs_AgentsDirMountedForNonReview(t *testing.T) {
+	for _, role := range []string{"", "worker", "coordinator"} {
+		t.Run("AgentRole="+role, func(t *testing.T) {
+			m, fakeHome, cleanup := bwrapFixture(t, Config{
+				SessionName:   "repo@main",
+				Worktree:      t.TempDir(),
+				AllocatedPort: 14010,
+				AgentRole:     role,
+			})
+			defer cleanup()
+
+			// Create agents/ so the stat() succeeds.
+			agentsDir := filepath.Join(fakeHome, ".config", "opencode", "agents")
+			if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll agents: %v", err)
+			}
+
+			b := &bwrapIsolator{name: m.name}
+			args := b.BuildArgs(m)
+
+			if !hasROBind(args, agentsDir) {
+				t.Errorf("AgentRole=%q: agents/ %q not found as --ro-bind SRC SRC in args: %v", role, agentsDir, args)
+			}
+		})
+	}
+}
+
+// TestBwrapBuildArgs_AgentsDirNotMountedForReview verifies that agents/ is
+// NOT bound when AgentRole starts with "review-" (e.g. "review-code",
+// "review-qa", "review-security", "review-goal", "review-context").
+func TestBwrapBuildArgs_AgentsDirNotMountedForReview(t *testing.T) {
+	for _, role := range []string{"review-code", "review-qa", "review-security", "review-goal", "review-context"} {
+		t.Run("AgentRole="+role, func(t *testing.T) {
+			m, fakeHome, cleanup := bwrapFixture(t, Config{
+				SessionName:   "repo@main",
+				Worktree:      t.TempDir(),
+				AllocatedPort: 14010,
+				AgentRole:     role,
+			})
+			defer cleanup()
+
+			// Create agents/ so the stat() would succeed if the code were wrong.
+			agentsDir := filepath.Join(fakeHome, ".config", "opencode", "agents")
+			if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll agents: %v", err)
+			}
+
+			b := &bwrapIsolator{name: m.name}
+			args := b.BuildArgs(m)
+
+			if hasROBind(args, agentsDir) {
+				t.Errorf("AgentRole=%q: agents/ should NOT be bound for review containers, but found as --ro-bind in args: %v", role, args)
+			}
+		})
+	}
+}
+
 // ── Env vars (--setenv K V) ──────────────────────────────────────────────────
 
 func TestBwrapBuildArgs_EnvVarsTranslated(t *testing.T) {


### PR DESCRIPTION
## Summary

- Extends the `opencodeAllowlist` in `bwrapIsolator.BuildArgs()` to include `command`, `tui.json`, `.gitignore`, and `mcp-atlassian-slim-proxy.mjs`, matching the podman `configAllowlist` in `container.go`.
- Adds the review-container conditional: `agents/` is mounted only when `cfg.AgentRole` does not start with `review-`. This prevents the subagent front-matter in `agents/` from overriding the inline role prompt in review containers.
- Adds `bwrap_test.go` coverage for all four new allowlist entries (present/absent) and both branches of the `AgentRole` conditional (worker/coordinator/empty get `agents/`; all `review-*` values do not).

## Root cause

`bwrapIsolator.BuildArgs()` only mounted `AGENTS.md`, `plugins`, and `skills` from `~/.config/opencode/`. The missing `agents/` entry meant opencode could not resolve custom agents (`worker`, `coordinator`, etc.) in bwrap sessions, producing the `Agent not found: worker` error.

## Post-merge manual verification

The integration AC ("no `Agent not found:` error in the opencode TUI") requires running on navi with `prism spawn --isolation bwrap`. After merging and switching, verify with:

```
prism spawn --isolation bwrap --branch smoke --prompt test
```

The TUI should show the configured default agent (worker) active and no `Agent not found:` error.

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #891