### PR TITLE
fix: remain-on-exit on for tmux

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -97,6 +97,8 @@ in
               set -g status-right-style 'bg=${bg1} fg=${primary}'
               # for kitty images in image.nvim
               set -gq allow-passthrough on
+              # sensible debugging behavior
+              set -g remain-on-exit on
               # Enable OSC 52 clipboard passthrough so opencode running inside a
               # container can write to the host clipboard via the podman attach PTY bridge.
               # Without this, tmux drops OSC 52 sequences and clipboard is silently broken.


### PR DESCRIPTION
## Summary

- Set `remain-on-exit on` globally in prism's tmux config.
- Fixes the bwrap-spawned agent window (`1:agent`) dying before opencode takes over — the exec chain `sh -c` → `prism agent-run` → `syscall.Exec(bwrap, ...)` → bwrap → opencode briefly looks like a child exit to tmux, which would close the pane (and with no other panes, destroy the window).
- Side benefit: dead panes now show a "Pane is dead" banner instead of silently vanishing, so when something actually goes wrong in a session the error is visible.

Diagnosis & justification for the global scope (vs. scoped-to-bwrap) discussed in the coordinator session.