### PR TITLE
prism: deliver --prompt to bwrap sessions via PRISM_INITIAL_PROMPT pane env var

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -136,6 +136,13 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		HostAPISockPath:   hostAPISockPath,
 	}
 
+	// Read the initial prompt from the pane env var set by session.go at
+	// window-creation time. When non-empty, populate InitialPrompt so that
+	// bwrap.go's BuildArgs appends --prompt to the opencode invocation.
+	// The env var is set via tmux's -e flag in tmux.NewWindow, which means
+	// it lives only in this pane's environment and dies with the pane.
+	applyInitialPromptEnvVar(&ctrCfg)
+
 	// Construct the Manager. PrepareBwrap will write temp files and build args.
 	m := container.New(ctrCfg)
 
@@ -153,6 +160,17 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	// exec replaces the current process with bwrap. argv[0] must be the binary path.
 	argv := append([]string{bwrapBin}, bwrapArgs...)
 	return syscall.Exec(bwrapBin, argv, os.Environ())
+}
+
+// applyInitialPromptEnvVar reads PRISM_INITIAL_PROMPT from the process
+// environment and, when non-empty, sets cfg.InitialPrompt. This feeds the
+// existing bwrap.go BuildArgs --prompt append at lines 466-468 without
+// requiring any new persistent state: the env var is set by tmux.NewWindow
+// via the -e flag and exists only for the lifetime of this pane.
+func applyInitialPromptEnvVar(cfg *container.Config) {
+	if initialPrompt := os.Getenv("PRISM_INITIAL_PROMPT"); initialPrompt != "" {
+		cfg.InitialPrompt = initialPrompt
+	}
 }
 
 // findBwrap locates the bwrap binary on PATH or in well-known Nix store paths.

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+// Unit tests for the PRISM_INITIAL_PROMPT env-var read in agent_run.go.
+//
+// These tests verify that applyInitialPromptEnvVar reads the env var and sets
+// InitialPrompt on a container.Config correctly, without needing a real DB
+// connection, bwrap binary, or syscall.Exec path.
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// TestApplyInitialPromptEnvVar_Set verifies that when PRISM_INITIAL_PROMPT is
+// set in the environment, applyInitialPromptEnvVar assigns it to InitialPrompt.
+func TestApplyInitialPromptEnvVar_Set(t *testing.T) {
+	t.Setenv("PRISM_INITIAL_PROMPT", "foo")
+
+	cfg := container.Config{}
+	applyInitialPromptEnvVar(&cfg)
+
+	if cfg.InitialPrompt != "foo" {
+		t.Errorf("InitialPrompt = %q, want %q", cfg.InitialPrompt, "foo")
+	}
+}
+
+// TestApplyInitialPromptEnvVar_Unset verifies that when PRISM_INITIAL_PROMPT
+// is not set (empty string), InitialPrompt remains empty.
+func TestApplyInitialPromptEnvVar_Unset(t *testing.T) {
+	// Ensure the env var is absent/empty.
+	t.Setenv("PRISM_INITIAL_PROMPT", "")
+
+	cfg := container.Config{}
+	applyInitialPromptEnvVar(&cfg)
+
+	if cfg.InitialPrompt != "" {
+		t.Errorf("InitialPrompt = %q, want empty string when env var is unset", cfg.InitialPrompt)
+	}
+}
+
+// TestApplyInitialPromptEnvVar_SpecialChars verifies that prompts containing
+// special characters (newlines, quotes, backticks, equals signs) are read
+// verbatim — no shell interpretation occurs in the env-var pipeline.
+func TestApplyInitialPromptEnvVar_SpecialChars(t *testing.T) {
+	prompt := "line1\nline2 'single' \"double\" `backtick` KEY=value is part of the message"
+	t.Setenv("PRISM_INITIAL_PROMPT", prompt)
+
+	cfg := container.Config{}
+	applyInitialPromptEnvVar(&cfg)
+
+	if cfg.InitialPrompt != prompt {
+		t.Errorf("InitialPrompt = %q, want %q", cfg.InitialPrompt, prompt)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -770,7 +770,7 @@ func createAgentSession(agentSession, worktree, agentCmd string, port int, conta
 	// Create window 1 with the agent command. Window 0 remains as a shell.
 	// Using NewWindow ensures the command runs via "sh -c" and semicolons in
 	// the readiness wait script are not consumed by tmux's command parser.
-	if err := tmux.NewWindow(agentSession, 1, "agent", worktree, cmd); err != nil {
+	if err := tmux.NewWindow(agentSession, 1, "agent", worktree, cmd, nil); err != nil {
 		return fmt.Errorf("new-window for %q: %w", agentSession, err)
 	}
 	// Select the agent window (1) as the default.

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -410,6 +410,20 @@ func Create(name, directory string, opts Opts) error {
 	return nil
 }
 
+// agentPaneEnvVars builds the env-var map for the agent tmux pane.
+// When opts.Prompt is non-empty, PRISM_INITIAL_PROMPT is included so that
+// "prism agent-run" can read it and populate container.Config.InitialPrompt,
+// activating bwrap's --prompt CLI-append path.
+// Returns nil when no env vars are needed, producing no -e flags in tmux.
+func agentPaneEnvVars(opts Opts) map[string]string {
+	if opts.Prompt == "" {
+		return nil
+	}
+	return map[string]string{
+		"PRISM_INITIAL_PROMPT": opts.Prompt,
+	}
+}
+
 // setupFullLayout configures the three-window layout for a project session:
 // window 0 "edit" (nvim auto-launched), window 1 "agent" (opencode),
 // window 2 "term". Seeds agent_status via prism event tmux-session-start.
@@ -505,7 +519,9 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	// creation time. This runs the command via "sh -c <cmd>", bypassing
 	// tmux's command parser — semicolons in the readiness-wait script are
 	// delivered verbatim to the shell instead of being consumed by tmux.
-	_ = tmux.NewWindow(name, 1, "agent", directory, agentCmd)
+	// agentPaneEnvVars returns PRISM_INITIAL_PROMPT when a prompt is set,
+	// enabling bwrap's --prompt delivery path via prism agent-run.
+	_ = tmux.NewWindow(name, 1, "agent", directory, agentCmd, agentPaneEnvVars(opts))
 
 	if !opts.SkipStatusSeed {
 		self, selfErr := os.Executable()
@@ -528,7 +544,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 		}
 	}
 
-	_ = tmux.NewWindow(name, 2, "term", directory, "")
+	_ = tmux.NewWindow(name, 2, "term", directory, "", nil)
 
 	focusIdx := 1
 	if strings.Contains(directory, "obsidian") {

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -1,11 +1,13 @@
 package session
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
 // TestBuildDirectOpencodeCmd_AgentEnvVars verifies that AgentEnvVars are
@@ -353,5 +355,132 @@ func TestIsolationMode_PodmanWrittenBeforeWindow(t *testing.T) {
 	}
 	if st.IsolationMode != "podman" {
 		t.Errorf("isolation_mode = %q, want %q", st.IsolationMode, "podman")
+	}
+}
+
+// ── agentPaneEnvVars (initial-prompt env var) ─────────────────────────────────
+
+// TestAgentPaneEnvVars_WithPrompt verifies that agentPaneEnvVars returns a map
+// containing PRISM_INITIAL_PROMPT when opts.Prompt is non-empty.
+func TestAgentPaneEnvVars_WithPrompt(t *testing.T) {
+	opts := Opts{Prompt: "hello"}
+	got := agentPaneEnvVars(opts)
+	if got == nil {
+		t.Fatal("agentPaneEnvVars(Prompt=hello): got nil, want non-nil map")
+	}
+	if v, ok := got["PRISM_INITIAL_PROMPT"]; !ok || v != "hello" {
+		t.Errorf("agentPaneEnvVars(Prompt=hello): PRISM_INITIAL_PROMPT = %q, want %q", v, "hello")
+	}
+}
+
+// TestAgentPaneEnvVars_NoPrompt verifies that agentPaneEnvVars returns nil
+// when opts.Prompt is empty, ensuring no -e flag is emitted.
+func TestAgentPaneEnvVars_NoPrompt(t *testing.T) {
+	opts := Opts{Prompt: ""}
+	got := agentPaneEnvVars(opts)
+	if got != nil {
+		t.Errorf("agentPaneEnvVars(Prompt=''): got %v, want nil", got)
+	}
+}
+
+// TestAgentPaneEnvVars_SpecialChars verifies that a prompt containing newlines,
+// quotes, backticks, and equals signs is stored verbatim.
+func TestAgentPaneEnvVars_SpecialChars(t *testing.T) {
+	prompt := "line1\nline2 'single' \"double\" `backtick` KEY=value"
+	opts := Opts{Prompt: prompt}
+	got := agentPaneEnvVars(opts)
+	if got == nil {
+		t.Fatal("agentPaneEnvVars: got nil, want non-nil map")
+	}
+	if v := got["PRISM_INITIAL_PROMPT"]; v != prompt {
+		t.Errorf("PRISM_INITIAL_PROMPT = %q, want %q", v, prompt)
+	}
+}
+
+// spyTmuxBin creates a fake tmux binary that records its arguments (one per line)
+// to argsFile, redirects tmux.TmuxBin for the duration of the test, and returns
+// the path to argsFile. Only call this from non-parallel tests.
+func spyTmuxBin(t *testing.T) string {
+	t.Helper()
+	argsFile := t.TempDir() + "/tmux-args"
+	wrapperPath := t.TempDir() + "/tmux"
+	script := "#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> " + argsFile + "; done\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write spy tmux: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+	return argsFile
+}
+
+// readSpyArgs reads the arguments recorded by the spy tmux binary.
+func readSpyArgs(argsFile string) []string {
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		return nil
+	}
+	var args []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+	return args
+}
+
+// containsSeq returns true when needle appears as a contiguous sub-slice of haystack.
+func containsSeq(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		match := true
+		for j, n := range needle {
+			if haystack[i+j] != n {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSpawnSession_PromptEnvVar_WithPrompt verifies that when opts.Prompt is
+// set, the tmux new-window call for the agent pane contains
+// -e PRISM_INITIAL_PROMPT=<prompt>.
+// It calls tmux.NewWindow directly (the same call path used by setupFullLayout)
+// via the spy so no real tmux session is required.
+func TestSpawnSession_PromptEnvVar_WithPrompt(t *testing.T) {
+	argsFile := spyTmuxBin(t)
+
+	// Call tmux.NewWindow with the env var map that agentPaneEnvVars would
+	// return for a non-empty prompt. This mirrors setupFullLayout's call site.
+	opts := Opts{Prompt: "hello"}
+	_ = tmux.NewWindow("test-session", 1, "agent", "/tmp", "echo hi", agentPaneEnvVars(opts))
+
+	args := readSpyArgs(argsFile)
+	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT=hello"}) {
+		t.Errorf("tmux new-window args %v do not contain [-e PRISM_INITIAL_PROMPT=hello]", args)
+	}
+}
+
+// TestSpawnSession_PromptEnvVar_NoPrompt verifies that when opts.Prompt is
+// empty, the tmux new-window call does NOT include any -e flag.
+func TestSpawnSession_PromptEnvVar_NoPrompt(t *testing.T) {
+	argsFile := spyTmuxBin(t)
+
+	opts := Opts{Prompt: ""}
+	_ = tmux.NewWindow("test-session", 1, "agent", "/tmp", "echo hi", agentPaneEnvVars(opts))
+
+	args := readSpyArgs(argsFile)
+	for _, a := range args {
+		if a == "-e" {
+			t.Errorf("tmux new-window args %v contain -e flag, expected none when no prompt", args)
+			break
+		}
 	}
 }

--- a/modules/programs/prism/prism/internal/tmux/tmux.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
@@ -214,10 +215,26 @@ func RenameWindow(target, name string) error {
 // semicolons in the command being treated as tmux command separators (which
 // would happen with SendKeys). Note: when a command is given, the pane exits
 // when the command exits — the user's default shell is NOT started.
-func NewWindow(session string, idx int, name, dir string, cmd string) error {
+//
+// envVars is an optional map of environment variables to set in the new pane
+// via tmux's -e KEY=VALUE flag. Each entry produces one -e flag. Pass nil or
+// an empty map for no additional env vars. The map is iterated in sorted key
+// order so the resulting argument list is deterministic.
+func NewWindow(session string, idx int, name, dir string, cmd string, envVars map[string]string) error {
 	args := []string{"new-window", "-t", fmt.Sprintf("%s:%d", session, idx), "-n", name}
 	if dir != "" {
 		args = append(args, "-c", dir)
+	}
+	// Emit -e KEY=VALUE flags in sorted key order for determinism.
+	if len(envVars) > 0 {
+		keys := make([]string, 0, len(envVars))
+		for k := range envVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "-e", k+"="+envVars[k])
+		}
 	}
 	if cmd != "" {
 		args = append(args, "sh", "-c", cmd)

--- a/modules/programs/prism/prism/internal/tmux/tmux_test.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux_test.go
@@ -12,6 +12,8 @@
 package tmux_test
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -704,6 +706,177 @@ func TestCleanupRedirectMultiClient_Direct(t *testing.T) {
 	}
 	if gotC != "nixos-config@main" {
 		t.Errorf("clientC = %q after cleanup redirect, want %q (bystander must not be redirected)", gotC, "nixos-config@main")
+	}
+}
+
+// ─── NewWindow env-var tests ──────────────────────────────────────────────────
+
+// spyTmux creates a fake tmux binary that records its arguments (one per line)
+// to argsFile and exits 0. It redirects TmuxBin for the duration of the test.
+//
+// Only call this from non-parallel tests — TmuxBin is a package-level global.
+func spyTmux(t *testing.T) string {
+	t.Helper()
+	argsFile := t.TempDir() + "/tmux-args"
+	wrapperPath := t.TempDir() + "/tmux"
+	// The script appends each argument on a separate line to argsFile.
+	script := "#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> " + argsFile + "; done\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write spy tmux: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+	return argsFile
+}
+
+// readArgs reads the recorded args from a spy tmux invocation.
+func readArgs(argsFile string) []string {
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		return nil
+	}
+	var args []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+	return args
+}
+
+// containsSequence returns true when needle appears as a contiguous sub-slice of haystack.
+func containsSequence(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		match := true
+		for j, n := range needle {
+			if haystack[i+j] != n {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNewWindow_EnvVar_WithPrompt verifies that NewWindow emits "-e KEY=VALUE"
+// in its args when envVars contains an entry.
+func TestNewWindow_EnvVar_WithPrompt(t *testing.T) {
+	argsFile := spyTmux(t)
+
+	err := tmux.NewWindow("mysession", 1, "agent", "/tmp", "echo hi", map[string]string{
+		"PRISM_INITIAL_PROMPT": "hello world",
+	})
+	if err != nil {
+		// The spy script exits 0, so an error here is unexpected.
+		t.Fatalf("NewWindow: %v", err)
+	}
+
+	args := readArgs(argsFile)
+	if !containsSequence(args, []string{"-e", "PRISM_INITIAL_PROMPT=hello world"}) {
+		t.Errorf("args %v do not contain [-e PRISM_INITIAL_PROMPT=hello world]", args)
+	}
+}
+
+// TestNewWindow_EnvVar_Empty verifies that NewWindow does NOT emit any "-e"
+// flag when envVars is nil.
+func TestNewWindow_EnvVar_Empty(t *testing.T) {
+	argsFile := spyTmux(t)
+
+	err := tmux.NewWindow("mysession", 1, "agent", "/tmp", "echo hi", nil)
+	if err != nil {
+		t.Fatalf("NewWindow: %v", err)
+	}
+
+	args := readArgs(argsFile)
+	for _, a := range args {
+		if a == "-e" {
+			t.Errorf("args %v contain -e flag, expected none when envVars is nil", args)
+			break
+		}
+	}
+}
+
+// TestNewWindow_EnvVar_EmptyMap verifies that NewWindow does NOT emit any "-e"
+// flag when envVars is an empty (non-nil) map.
+func TestNewWindow_EnvVar_EmptyMap(t *testing.T) {
+	argsFile := spyTmux(t)
+
+	err := tmux.NewWindow("mysession", 1, "agent", "/tmp", "echo hi", map[string]string{})
+	if err != nil {
+		t.Fatalf("NewWindow: %v", err)
+	}
+
+	args := readArgs(argsFile)
+	for _, a := range args {
+		if a == "-e" {
+			t.Errorf("args %v contain -e flag, expected none when envVars is empty", args)
+			break
+		}
+	}
+}
+
+// TestNewWindow_EnvVar_MultipleKeys verifies that multiple env vars each
+// produce their own "-e KEY=VALUE" pair, in sorted key order.
+func TestNewWindow_EnvVar_MultipleKeys(t *testing.T) {
+	argsFile := spyTmux(t)
+
+	err := tmux.NewWindow("mysession", 1, "agent", "/tmp", "", map[string]string{
+		"ZEBRA": "z",
+		"ALPHA": "a",
+	})
+	if err != nil {
+		t.Fatalf("NewWindow: %v", err)
+	}
+
+	args := readArgs(argsFile)
+	// Both env vars must be present.
+	if !containsSequence(args, []string{"-e", "ALPHA=a"}) {
+		t.Errorf("args %v do not contain [-e ALPHA=a]", args)
+	}
+	if !containsSequence(args, []string{"-e", "ZEBRA=z"}) {
+		t.Errorf("args %v do not contain [-e ZEBRA=z]", args)
+	}
+	// ALPHA must appear before ZEBRA (sorted key order).
+	alphaIdx := -1
+	zebraIdx := -1
+	for i, a := range args {
+		if a == "ALPHA=a" {
+			alphaIdx = i
+		}
+		if a == "ZEBRA=z" {
+			zebraIdx = i
+		}
+	}
+	if alphaIdx == -1 || zebraIdx == -1 {
+		t.Fatalf("ALPHA or ZEBRA not found in args: %v", args)
+	}
+	if alphaIdx > zebraIdx {
+		t.Errorf("ALPHA (idx %d) must come before ZEBRA (idx %d) in args: %v", alphaIdx, zebraIdx, args)
+	}
+}
+
+// TestNewWindow_EnvVar_EqualInValue verifies that a prompt containing '='
+// characters is passed verbatim — the env var is split on the FIRST '=' only.
+func TestNewWindow_EnvVar_EqualInValue(t *testing.T) {
+	argsFile := spyTmux(t)
+
+	err := tmux.NewWindow("mysession", 1, "agent", "/tmp", "", map[string]string{
+		"PRISM_INITIAL_PROMPT": "KEY=value is part of the message",
+	})
+	if err != nil {
+		t.Fatalf("NewWindow: %v", err)
+	}
+
+	args := readArgs(argsFile)
+	if !containsSequence(args, []string{"-e", "PRISM_INITIAL_PROMPT=KEY=value is part of the message"}) {
+		t.Errorf("args %v do not contain expected env var with = in value", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the silent prompt drop in `prism spawn --isolation bwrap --prompt '<text>'`. The session spawned, opencode started inside bwrap, but the TUI's input field was empty because both delivery paths (sidecar HTTP and bwrap CLI-append) were disabled.

**Root cause:** `bwrap.go` BuildArgs already has the correct `--prompt` append at lines 466–468, but `cfg.InitialPrompt` was always empty when it ran because the DB row doesn't persist `InitialPrompt` and `agent-run` never read it from anywhere.

**Fix:** Zero new persistent state. `session.go` sets `PRISM_INITIAL_PROMPT` on the agent tmux pane via `tmux new-window -e KEY=VALUE` at window-creation time. `agent-run` reads `os.Getenv("PRISM_INITIAL_PROMPT")` and assigns it to `ctrCfg.InitialPrompt` before calling `m.PrepareBwrap()`, activating the existing `--prompt` append.

## Changes

- **`internal/tmux/tmux.go`** — `NewWindow` gains a `envVars map[string]string` parameter; each entry produces one `-e K=V` flag in sorted key order. Existing callers pass `nil` (no change in behaviour).
- **`internal/session/session.go`** — `agentPaneEnvVars(opts)` builds the env-var map; sets `PRISM_INITIAL_PROMPT` when `opts.Prompt` is non-empty. `setupFullLayout` calls `tmux.NewWindow` with this map.
- **`cmd/agent_run.go`** — `applyInitialPromptEnvVar(&ctrCfg)` reads `PRISM_INITIAL_PROMPT` and sets `ctrCfg.InitialPrompt`, feeding the existing bwrap `--prompt` path.
- **`internal/review/review.go`** — Updated sole other `NewWindow` caller to pass `nil`.
- **Tests** — `tmux_test.go`: `NewWindow` env-var flag emission; `session_test.go`: `agentPaneEnvVars` and spy-based tmux invocation tests; `cmd/agent_run_test.go` (new): `applyInitialPromptEnvVar` with set/unset/special-char cases.

## Scope

Podman and host isolation modes are untouched. The sidecar's `DeliverInitialPrompt` path is untouched. `bwrap.go` is untouched. `container.go` is untouched.

## Manual verification (post-merge on navi)

After `sudo nixos-rebuild switch --flake ~/code/nixos-config`:

1. `prism spawn --isolation bwrap --branch smoke-prompt --prompt 'kia ora from the sandbox'`
2. Attach (C-f). Expect opencode TUI to show `kia ora from the sandbox` as the first user message.
3. `prism cleanup --yes --session nixos-config@smoke-prompt`
4. `prism spawn --isolation bwrap --branch smoke-noprompt` (no `--prompt`)
5. Attach. Expect empty input field, no initial message.
6. `prism cleanup --yes --session nixos-config@smoke-noprompt`

Closes #897