### PR TITLE
nix: pin opencode to 1.4.6 via dedicated flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -133,6 +133,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-opencode": {
+      "locked": {
+        "lastModified": 1776485399,
+        "narHash": "sha256-4Cmxz15i5qn3HZFbyxf6hRyeb7huOJgW2+c1GCQ0J4U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5230db4d0c546b5b7594aa978e6e8aa560351748",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5230db4d0c546b5b7594aa978e6e8aa560351748",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1776434932,
@@ -173,6 +189,7 @@
         "impermanence": "impermanence",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-master": "nixpkgs-master",
+        "nixpkgs-opencode": "nixpkgs-opencode",
         "nixpkgs-stable": "nixpkgs-stable",
         "sops-nix": "sops-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-master.url = "github:nixos/nixpkgs/master";
+    nixpkgs-opencode.url = "github:nixos/nixpkgs/5230db4d0c546b5b7594aa978e6e8aa560351748";
     disko = {
       url = "github:nix-community/disko";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -21,13 +21,24 @@ rec {
         system = final.stdenv.hostPlatform.system;
         config.allowUnfree = true;
       };
+      opencodePkgs = import inputs.nixpkgs-opencode {
+        system = final.stdenv.hostPlatform.system;
+        config.allowUnfree = true;
+      };
     in
     {
       # packages where we use master by default for bleeding edge
 
       claude-code = masterPkgs.claude-code;
       discord = masterPkgs.discord;
-      opencode = masterPkgs.opencode;
+      # Pinned to nixpkgs-opencode (opencode 1.4.6). Upstream 1.4.11 regressed
+      # the --prompt TUI flag (pre-fills instead of auto-submitting), breaking
+      # prism's headless workflows. Unpin when either:
+      #   (a) upstream opencode fixes the --prompt regression, or
+      #   (b) we land the HTTP-submit path in the opencode harness adapter
+      #       (decouples us from --prompt CLI semantics entirely).
+      # See: https://github.com/prismatic-koi/nixos-config/issues/901
+      opencode = opencodePkgs.opencode;
       pi-coding-agent = masterPkgs.pi-coding-agent;
 
       # packages not yet in nixpkgs; use local definitions


### PR DESCRIPTION
## Summary

- Adds a dedicated `nixpkgs-opencode` flake input pinned to nixpkgs revision `5230db4d0c546b5b7594aa978e6e8aa560351748` (the revision that packages opencode 1.4.6, already validated on navi by the user)
- Shifts `opencode` in `overlays/default.nix` from `masterPkgs.opencode` to `opencodePkgs.opencode` with a comment naming the pin reason and unpin criteria
- All other `nixpkgs-master` packages (`claude-code`, `discord`, `pi-coding-agent`) are unaffected and continue to track master

## Context

Opencode 1.4.11 regressed the `--prompt` TUI flag: it pre-fills the prompt but no longer auto-submits it. This breaks prism's headless workflows (`prism spawn`, `prism pr`, etc.) which rely on `--prompt` auto-submitting to start the agent without human intervention.

This fix pins opencode to 1.4.6 via a dedicated flake input rather than reverting the entire `nixpkgs-master` lock, keeping other packages current.

## Runtime ACs requiring coordinator action post-merge

Two acceptance criteria require a live `sudo nixos-rebuild switch --flake .` on navi:
- `opencode --version` should return `1.4.6` (not `1.4.11`)
- `opencode --prompt 'ping'` should auto-submit (the agent begins processing without a manual Enter press)

Please run the switch on navi after merging and verify these two behaviours.

## Build note

`nix build .#nixosConfigurations.navi.config.system.build.toplevel` fails in this sandbox environment due to a pre-existing issue fetching `nixpkgs-stable` (nixos-25.11, not yet released/accessible in this sandbox). The same failure occurs on the unmodified base branch, confirming this is not caused by these changes. The change is purely additive (new input, updated overlay line) and is structurally correct.

Closes #901