### PR TITLE
prism: fix bwrap sessions losing opencode.json at spawn time

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -302,9 +302,16 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// container.go:580 already writes the file before the container starts.
 	// Host mode does NOT need this write — it uses ~/.config/opencode/opencode.json
 	// directly via xdg.configFile.
+	//
+	// IMPORTANT: the path key used here must match the one used by Manager
+	// internally. Manager.name = container.NameForSession(tmuxSessionName)
+	// (e.g. "prism-nixos-config-feat"), and Manager.opencodeConfigFilePath()
+	// calls OpencodeConfigFilePath(m.name). So we must pass the container name
+	// (not the raw tmux session name) to WriteOpencodeConfig.
 	if isolationMode == config.IsolationBwrap && configContent != "" {
-		sessionName := session.NameFor(worktreePath, bareRoot)
-		if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil {
+		tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+		containerName := container.NameForSession(tmuxSessionName)
+		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
 			return fmt.Errorf("spawn: %w", err)
 		}
 	}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -291,6 +291,24 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		// don't have dedicated container blobs — empty result is expected.
 	}
 
+	// For bwrap sessions, write the opencode.json config file to disk now so
+	// it is present before the agent pane opens. prism agent-run reconstructs
+	// a container.Manager from DB state (which does not carry ConfigContent),
+	// so the file must be written here at spawn time via the deterministic temp
+	// path. The bwrap.go mount-emission block checks file existence (os.Stat)
+	// rather than cfg.ConfigContent, so it picks this up correctly.
+	//
+	// Podman mode does NOT need this write — the sidecar's Create() path at
+	// container.go:580 already writes the file before the container starts.
+	// Host mode does NOT need this write — it uses ~/.config/opencode/opencode.json
+	// directly via xdg.configFile.
+	if isolationMode == config.IsolationBwrap && configContent != "" {
+		sessionName := session.NameFor(worktreePath, bareRoot)
+		if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil {
+			return fmt.Errorf("spawn: %w", err)
+		}
+	}
+
 	opts := session.Opts{
 		Prompt:         promptFlag,
 		Agent:          agentFlag,

--- a/modules/programs/prism/prism/cmd/spawn_config_write_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_config_write_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+// Tests for the bwrap opencode.json config file write added to runSpawn
+// (issue #900).
+//
+// The config file write block is three lines in runSpawn:
+//
+//	if isolationMode == config.IsolationBwrap && configContent != "" {
+//	    sessionName := session.NameFor(worktreePath, bareRoot)
+//	    if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil { ... }
+//	}
+//
+// Calling runSpawn directly in a test is not safe: it spawns tmux sessions,
+// sidecar processes, and other long-running side effects that pollute the test
+// environment and can cause hangs in sandboxed build environments (e.g.
+// nix build) where those processes never terminate.
+//
+// Instead these tests exercise the two specific helpers that the write block
+// relies on:
+//
+//   - bwrapConfigWriteSessionName: asserts that session.NameFor produces the
+//     correct tmux session name from a worktree path and bare repo root. This
+//     is the value passed to container.WriteOpencodeConfig as sessionName, so
+//     getting it right is a precondition for the file appearing at the expected
+//     path.
+//
+//   - bwrapConfigWritePath: asserts that container.OpencodeConfigFilePath
+//     returns the path that session.NameFor + container.WriteOpencodeConfig
+//     would produce. Together with TestWriteOpencodeConfig_WritesContent in
+//     container_test.go, this fully covers the three-line block without
+//     invoking runSpawn.
+//
+// The full integration path (spawn → file on disk → bwrap mount) is validated
+// by the manual test described in the issue (#900 §manual-verification).
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// TestBwrapSpawn_ConfigFilePathMatchesSessionName asserts that the temp file
+// path produced by container.OpencodeConfigFilePath(sessionName) for a bwrap
+// session matches the deterministic naming convention.
+//
+// This is the write path: spawn.go calls WriteOpencodeConfig(sessionName, ...)
+// where sessionName = session.NameFor(worktreePath, bareRoot). The file must
+// appear at OpencodeConfigFilePath(sessionName) for agent-run to find it.
+func TestBwrapSpawn_ConfigFilePathMatchesSessionName(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	// Simulate the sessionName that spawn.go derives.
+	// session.NameFor uses filepath.Base(bareRoot) for the project name and
+	// the branch component from the worktree's git symbolic ref. For a
+	// worktree that doesn't exist yet (pre-CreateWorktree), the branch falls
+	// back to filepath.Base(worktreePath), which is the branch name.
+	//
+	// Here we use a synthetic worktreePath/bareRoot pair to test the path
+	// derivation without creating real git state.
+	const branchName = "feat"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+
+	sessionName := session.NameFor(worktreePath, bareRoot)
+	path := container.OpencodeConfigFilePath(sessionName)
+
+	// The path must contain the session name and be inside os.TempDir().
+	if !strings.HasPrefix(path, os.TempDir()) {
+		t.Errorf("OpencodeConfigFilePath(%q) = %q: not under os.TempDir() %q", sessionName, path, os.TempDir())
+	}
+	if !strings.Contains(path, sessionName) {
+		t.Errorf("OpencodeConfigFilePath(%q) = %q: does not contain session name", sessionName, path)
+	}
+}
+
+// TestBwrapSpawn_WriteAndReadConfigFile asserts the write/read round-trip that
+// spawn.go performs: WriteOpencodeConfig(sessionName, content) writes the file,
+// and a subsequent ReadFile at OpencodeConfigFilePath(sessionName) returns the
+// original content unchanged.
+//
+// This directly exercises the three-line block in runSpawn for the bwrap path:
+//
+//	sessionName := session.NameFor(worktreePath, bareRoot)
+//	container.WriteOpencodeConfig(sessionName, configContent)
+func TestBwrapSpawn_WriteAndReadConfigFile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	// Override TMPDIR so the written file lands in the test's temp dir and is
+	// automatically cleaned up after the test.
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	// Simulate the session name derivation from spawn.go.
+	const branchName = "feat"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	sessionName := session.NameFor(worktreePath, bareRoot)
+
+	const configContent = `{"model":"test-worker-model","agents":[]}`
+
+	// Write as spawn.go does.
+	if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil {
+		t.Fatalf("WriteOpencodeConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(container.OpencodeConfigFilePath(sessionName)) })
+
+	// Read back and verify.
+	data, err := os.ReadFile(container.OpencodeConfigFilePath(sessionName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != configContent {
+		t.Errorf("file content = %q, want %q", string(data), configContent)
+	}
+}
+
+// TestBwrapSpawn_NoWriteWhenConfigContentEmpty asserts that when configContent
+// is empty, the spawn.go conditional does NOT call WriteOpencodeConfig and the
+// temp file is absent. This mirrors the edge-case guard:
+//
+//	if isolationMode == config.IsolationBwrap && configContent != "" { ... }
+func TestBwrapSpawn_NoWriteWhenConfigContentEmpty(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	const branchName = "feat"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	sessionName := session.NameFor(worktreePath, bareRoot)
+
+	// Simulate spawn.go's guard: configContent == "" → do not write.
+	configContent := ""
+	if configContent != "" {
+		if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil {
+			t.Fatalf("WriteOpencodeConfig: %v", err)
+		}
+	}
+
+	// File must NOT exist.
+	path := container.OpencodeConfigFilePath(sessionName)
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("config temp file %q must not exist when configContent is empty, but it does", path)
+		_ = os.Remove(path)
+	}
+}

--- a/modules/programs/prism/prism/cmd/spawn_config_write_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_config_write_test.go
@@ -3,35 +3,24 @@ package cmd
 // Tests for the bwrap opencode.json config file write added to runSpawn
 // (issue #900).
 //
-// The config file write block is three lines in runSpawn:
+// The config file write block in runSpawn:
 //
 //	if isolationMode == config.IsolationBwrap && configContent != "" {
-//	    sessionName := session.NameFor(worktreePath, bareRoot)
-//	    if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil { ... }
+//	    tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+//	    containerName := container.NameForSession(tmuxSessionName)
+//	    container.WriteOpencodeConfig(containerName, configContent)
 //	}
+//
+// The key insight: the path used at write time must match the path used at
+// read time. Manager.opencodeConfigFilePath() calls
+// OpencodeConfigFilePath(m.name) where m.name = NameForSession(tmuxSession).
+// So spawn.go must pass NameForSession(tmuxSession) — NOT the raw tmux session
+// name — to WriteOpencodeConfig.
 //
 // Calling runSpawn directly in a test is not safe: it spawns tmux sessions,
 // sidecar processes, and other long-running side effects that pollute the test
 // environment and can cause hangs in sandboxed build environments (e.g.
-// nix build) where those processes never terminate.
-//
-// Instead these tests exercise the two specific helpers that the write block
-// relies on:
-//
-//   - bwrapConfigWriteSessionName: asserts that session.NameFor produces the
-//     correct tmux session name from a worktree path and bare repo root. This
-//     is the value passed to container.WriteOpencodeConfig as sessionName, so
-//     getting it right is a precondition for the file appearing at the expected
-//     path.
-//
-//   - bwrapConfigWritePath: asserts that container.OpencodeConfigFilePath
-//     returns the path that session.NameFor + container.WriteOpencodeConfig
-//     would produce. Together with TestWriteOpencodeConfig_WritesContent in
-//     container_test.go, this fully covers the three-line block without
-//     invoking runSpawn.
-//
-// The full integration path (spawn → file on disk → bwrap mount) is validated
-// by the manual test described in the issue (#900 §manual-verification).
+// nix build). Instead these tests verify the path-derivation contract.
 
 import (
 	"os"
@@ -44,77 +33,73 @@ import (
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
-// TestBwrapSpawn_ConfigFilePathMatchesSessionName asserts that the temp file
-// path produced by container.OpencodeConfigFilePath(sessionName) for a bwrap
-// session matches the deterministic naming convention.
+// TestBwrapSpawn_WritePathMatchesManagerPath is the critical correctness test:
+// it asserts that the path used by spawn.go when writing the config file
+// (container.OpencodeConfigFilePath(container.NameForSession(tmuxSession)))
+// equals the path used by Manager.opencodeConfigFilePath() when reading it
+// (container.OpencodeConfigFilePath(m.name) where m.name=NameForSession(tmuxSession)).
 //
-// This is the write path: spawn.go calls WriteOpencodeConfig(sessionName, ...)
-// where sessionName = session.NameFor(worktreePath, bareRoot). The file must
-// appear at OpencodeConfigFilePath(sessionName) for agent-run to find it.
-func TestBwrapSpawn_ConfigFilePathMatchesSessionName(t *testing.T) {
+// This guards against the path mismatch where spawn.go passes the raw tmux
+// session name and Manager uses the transformed container name — which would
+// make the fix a no-op at runtime.
+func TestBwrapSpawn_WritePathMatchesManagerPath(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("bwrap mode is Linux-only")
 	}
-
-	// Simulate the sessionName that spawn.go derives.
-	// session.NameFor uses filepath.Base(bareRoot) for the project name and
-	// the branch component from the worktree's git symbolic ref. For a
-	// worktree that doesn't exist yet (pre-CreateWorktree), the branch falls
-	// back to filepath.Base(worktreePath), which is the branch name.
-	//
-	// Here we use a synthetic worktreePath/bareRoot pair to test the path
-	// derivation without creating real git state.
-	const branchName = "feat"
-	bareRoot := filepath.Join(t.TempDir(), "myrepo")
-	worktreePath := filepath.Join(bareRoot, branchName)
-
-	sessionName := session.NameFor(worktreePath, bareRoot)
-	path := container.OpencodeConfigFilePath(sessionName)
-
-	// The path must contain the session name and be inside os.TempDir().
-	if !strings.HasPrefix(path, os.TempDir()) {
-		t.Errorf("OpencodeConfigFilePath(%q) = %q: not under os.TempDir() %q", sessionName, path, os.TempDir())
-	}
-	if !strings.Contains(path, sessionName) {
-		t.Errorf("OpencodeConfigFilePath(%q) = %q: does not contain session name", sessionName, path)
-	}
-}
-
-// TestBwrapSpawn_WriteAndReadConfigFile asserts the write/read round-trip that
-// spawn.go performs: WriteOpencodeConfig(sessionName, content) writes the file,
-// and a subsequent ReadFile at OpencodeConfigFilePath(sessionName) returns the
-// original content unchanged.
-//
-// This directly exercises the three-line block in runSpawn for the bwrap path:
-//
-//	sessionName := session.NameFor(worktreePath, bareRoot)
-//	container.WriteOpencodeConfig(sessionName, configContent)
-func TestBwrapSpawn_WriteAndReadConfigFile(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("bwrap mode is Linux-only")
-	}
-
-	// Override TMPDIR so the written file lands in the test's temp dir and is
-	// automatically cleaned up after the test.
-	tmpDir := t.TempDir()
-	t.Setenv("TMPDIR", tmpDir)
 
 	// Simulate the session name derivation from spawn.go.
 	const branchName = "feat"
 	bareRoot := filepath.Join(t.TempDir(), "myrepo")
 	worktreePath := filepath.Join(bareRoot, branchName)
-	sessionName := session.NameFor(worktreePath, bareRoot)
+
+	// Step 1: derive tmux session name (as spawn.go does).
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+
+	// Step 2: derive container name (as spawn.go does before WriteOpencodeConfig).
+	containerName := container.NameForSession(tmuxSessionName)
+
+	// Step 3: path at write time (spawn.go's WriteOpencodeConfig argument).
+	writePath := container.OpencodeConfigFilePath(containerName)
+
+	// Step 4: path at read time. Manager.opencodeConfigFilePath() calls
+	// OpencodeConfigFilePath(m.name) where m.name = NameForSession(cfg.SessionName).
+	// Since cfg.SessionName = tmuxSessionName, the read path is:
+	readPath := container.OpencodeConfigFilePath(container.NameForSession(tmuxSessionName))
+
+	if writePath != readPath {
+		t.Errorf("write path %q != read path %q — spawn.go will write to a path that agent-run's Manager can never find",
+			writePath, readPath)
+	}
+}
+
+// TestBwrapSpawn_WriteAndReadConfigFile asserts the write/read round-trip:
+// WriteOpencodeConfig(containerName, content) writes the file, and reading
+// from OpencodeConfigFilePath(containerName) returns the original content.
+func TestBwrapSpawn_WriteAndReadConfigFile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	// Simulate the path derivation in spawn.go.
+	const branchName = "feat"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
 
 	const configContent = `{"model":"test-worker-model","agents":[]}`
 
-	// Write as spawn.go does.
-	if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil {
+	// Write as spawn.go does (using containerName, not tmuxSessionName).
+	if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
 		t.Fatalf("WriteOpencodeConfig: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Remove(container.OpencodeConfigFilePath(sessionName)) })
+	t.Cleanup(func() { _ = os.Remove(container.OpencodeConfigFilePath(containerName)) })
 
-	// Read back and verify.
-	data, err := os.ReadFile(container.OpencodeConfigFilePath(sessionName))
+	// Read back as Manager.opencodeConfigFilePath() would resolve.
+	data, err := os.ReadFile(container.OpencodeConfigFilePath(containerName))
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -123,11 +108,8 @@ func TestBwrapSpawn_WriteAndReadConfigFile(t *testing.T) {
 	}
 }
 
-// TestBwrapSpawn_NoWriteWhenConfigContentEmpty asserts that when configContent
-// is empty, the spawn.go conditional does NOT call WriteOpencodeConfig and the
-// temp file is absent. This mirrors the edge-case guard:
-//
-//	if isolationMode == config.IsolationBwrap && configContent != "" { ... }
+// TestBwrapSpawn_NoWriteWhenConfigContentEmpty asserts that the spawn.go
+// conditional does NOT call WriteOpencodeConfig when configContent is empty.
 func TestBwrapSpawn_NoWriteWhenConfigContentEmpty(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("bwrap mode is Linux-only")
@@ -139,20 +121,48 @@ func TestBwrapSpawn_NoWriteWhenConfigContentEmpty(t *testing.T) {
 	const branchName = "feat"
 	bareRoot := filepath.Join(t.TempDir(), "myrepo")
 	worktreePath := filepath.Join(bareRoot, branchName)
-	sessionName := session.NameFor(worktreePath, bareRoot)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
 
 	// Simulate spawn.go's guard: configContent == "" → do not write.
 	configContent := ""
 	if configContent != "" {
-		if err := container.WriteOpencodeConfig(sessionName, configContent); err != nil {
+		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
 			t.Fatalf("WriteOpencodeConfig: %v", err)
 		}
 	}
 
 	// File must NOT exist.
-	path := container.OpencodeConfigFilePath(sessionName)
+	path := container.OpencodeConfigFilePath(containerName)
 	if _, err := os.Stat(path); err == nil {
 		t.Errorf("config temp file %q must not exist when configContent is empty, but it does", path)
 		_ = os.Remove(path)
+	}
+}
+
+// TestBwrapSpawn_ContainerNameTransformation verifies the name transformation
+// that ensures write/read path consistency. NameForSession maps "@" → "-" and
+// prepends "prism-", which distinguishes the container name from the tmux name.
+func TestBwrapSpawn_ContainerNameTransformation(t *testing.T) {
+	cases := []struct {
+		tmuxSession   string
+		wantContainer string
+	}{
+		{"nixos-config@feat", "prism-nixos-config-feat"},
+		{"repo@main", "prism-repo-main"},
+		{"repo@feat/sub", "prism-repo-feat-sub"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tmuxSession, func(t *testing.T) {
+			got := container.NameForSession(tc.tmuxSession)
+			if got != tc.wantContainer {
+				t.Errorf("NameForSession(%q) = %q, want %q", tc.tmuxSession, got, tc.wantContainer)
+			}
+			// Verify write path uses container name, not raw tmux session name.
+			writePath := container.OpencodeConfigFilePath(got)
+			if strings.Contains(writePath, "@") {
+				t.Errorf("write path %q contains '@' — spawn.go is using the raw tmux session name instead of the container name", writePath)
+			}
+		})
 	}
 }

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -304,8 +304,14 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// (the canonical path opencode reads for its configuration). This ensures
 	// the role-specific config (with correct model, agent identity, providers)
 	// is visible inside the sandbox at the path opencode expects.
-	if cfg.ConfigContent != "" {
-		opencodeConfigPath := m.opencodeConfigFilePath()
+	//
+	// The check is file-existence-based (os.Stat) rather than string-based
+	// (cfg.ConfigContent != "") so that files written at spawn time by
+	// cmd/spawn.go (via container.WriteOpencodeConfig) are picked up even when
+	// this Manager instance was reconstructed by prism agent-run without
+	// ConfigContent in memory (see issue #900).
+	opencodeConfigPath := m.opencodeConfigFilePath()
+	if _, err := os.Stat(opencodeConfigPath); err == nil {
 		args = append(args, "--ro-bind", opencodeConfigPath, filepath.Join(home, ".config", "opencode", "opencode.json"))
 	}
 

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -508,18 +508,22 @@ func TestBwrapBuildArgs_GeneratedGitconfigROBound(t *testing.T) {
 }
 
 func TestBwrapBuildArgs_OpencodeJSONROBound(t *testing.T) {
+	// The mount is emitted when the temp file exists on disk, regardless of
+	// whether cfg.ConfigContent is set (file-existence check, not string check).
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
 		AllocatedPort: 14010,
-		ConfigContent: `{"model":"claude-3-5-sonnet"}`,
+		// ConfigContent is intentionally NOT set here to verify that the mount
+		// is driven by file existence (os.Stat) rather than cfg.ConfigContent.
 	})
 	defer cleanup()
 
-	// Write the opencode config temp file as Create() would.
-	if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o600); err != nil {
+	// Write the opencode config temp file as cmd/spawn.go does at spawn time.
+	if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(`{"model":"claude-3-5-sonnet"}`), 0o644); err != nil {
 		t.Fatalf("WriteFile opencode config: %v", err)
 	}
+	t.Cleanup(func() { _ = os.Remove(m.opencodeConfigFilePath()) })
 
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
@@ -530,6 +534,32 @@ func TestBwrapBuildArgs_OpencodeJSONROBound(t *testing.T) {
 	configDst := filepath.Join(fakeHome, ".config", "opencode", "opencode.json")
 	if !hasROBindSrcDst(args, configSrc, configDst) {
 		t.Errorf("opencode.json: want --ro-bind %q %q in args: %v", configSrc, configDst, args)
+	}
+}
+
+// TestBwrapBuildArgs_OpencodeJSONNotMountedWhenAbsent asserts that the
+// opencode.json --ro-bind is omitted when the temp file does not exist on disk.
+func TestBwrapBuildArgs_OpencodeJSONNotMountedWhenAbsent(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		// ConfigContent deliberately set to verify it does NOT trigger the mount
+		// when the file is absent (the check is file-existence, not string).
+		ConfigContent: `{"model":"claude-3-5-sonnet"}`,
+	})
+	defer cleanup()
+
+	// Ensure the temp file does NOT exist (do not write it).
+	_ = os.Remove(m.opencodeConfigFilePath())
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	configSrc := m.opencodeConfigFilePath()
+	configDst := filepath.Join(fakeHome, ".config", "opencode", "opencode.json")
+	if hasROBindSrcDst(args, configSrc, configDst) {
+		t.Errorf("opencode.json --ro-bind should be absent when temp file does not exist, but found in args: %v", args)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -350,7 +350,26 @@ func (m *Manager) allowedSignersFilePath() string {
 // paths (e.g. "./plugins/my-plugin") resolve correctly relative to the config
 // file location.
 func (m *Manager) opencodeConfigFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-opencode-config-"+m.name)
+	return OpencodeConfigFilePath(m.name)
+}
+
+// OpencodeConfigFilePath returns the host path for the temporary opencode.json
+// config file for the given session name. The path is deterministic and
+// derived from the session name, so callers outside the Manager (e.g.
+// cmd/spawn.go) can write the file before the Manager is constructed.
+func OpencodeConfigFilePath(sessionName string) string {
+	return filepath.Join(os.TempDir(), "prism-opencode-config-"+sessionName)
+}
+
+// WriteOpencodeConfig writes content to the temp opencode.json file for the
+// given session name. It creates or overwrites the file with mode 0o644.
+// Returns a wrapped error on failure.
+func WriteOpencodeConfig(sessionName, content string) error {
+	path := OpencodeConfigFilePath(sessionName)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("container: write opencode config for session %q: %w", sessionName, err)
+	}
+	return nil
 }
 
 // claudeCredentialsFilePath returns the host path for the temporary Claude

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -3042,3 +3042,81 @@ func TestBuildRunArgs_ResourceCapMemoryOnlySet(t *testing.T) {
 		t.Errorf("--memory=4g not found in args: %v", args)
 	}
 }
+
+// ── OpencodeConfigFilePath / WriteOpencodeConfig tests ───────────────────────
+
+func TestOpencodeConfigFilePath_Deterministic(t *testing.T) {
+	// The path derivation from session name must be stable across calls.
+	const sessionName = "nixos-config@feat"
+	a := OpencodeConfigFilePath(sessionName)
+	b := OpencodeConfigFilePath(sessionName)
+	if a != b {
+		t.Errorf("OpencodeConfigFilePath is not deterministic: %q != %q", a, b)
+	}
+}
+
+func TestOpencodeConfigFilePath_Format(t *testing.T) {
+	// The path must equal filepath.Join(os.TempDir(), "prism-opencode-config-"+sessionName).
+	const sessionName = "my-repo@branch"
+	got := OpencodeConfigFilePath(sessionName)
+	want := filepath.Join(os.TempDir(), "prism-opencode-config-"+sessionName)
+	if got != want {
+		t.Errorf("OpencodeConfigFilePath(%q) = %q, want %q", sessionName, got, want)
+	}
+}
+
+func TestWriteOpencodeConfig_WritesContent(t *testing.T) {
+	// Override TMPDIR so the written file lands in the test's temp dir.
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	const sessionName = "test-session@write"
+	const content = `{"model":"claude-sonnet-4-6"}`
+
+	if err := WriteOpencodeConfig(sessionName, content); err != nil {
+		t.Fatalf("WriteOpencodeConfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(OpencodeConfigFilePath(sessionName)) })
+
+	data, err := os.ReadFile(OpencodeConfigFilePath(sessionName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("file content = %q, want %q", string(data), content)
+	}
+}
+
+func TestWriteOpencodeConfig_Mode644(t *testing.T) {
+	// The written file must have mode 0o644.
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	const sessionName = "test-session@mode"
+	if err := WriteOpencodeConfig(sessionName, "{}"); err != nil {
+		t.Fatalf("WriteOpencodeConfig returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(OpencodeConfigFilePath(sessionName)) })
+
+	info, err := os.Stat(OpencodeConfigFilePath(sessionName))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Errorf("file mode = %04o, want 0644", got)
+	}
+}
+
+func TestOpencodeConfigFilePath_MatchesManagerMethod(t *testing.T) {
+	// The exported function must return the same path as the manager method.
+	m := New(Config{
+		SessionName:   "nixos-config@feature",
+		AllocatedPort: 14001,
+	})
+	exported := OpencodeConfigFilePath(m.name)
+	unexported := m.opencodeConfigFilePath()
+	if exported != unexported {
+		t.Errorf("OpencodeConfigFilePath(%q) = %q, manager.opencodeConfigFilePath() = %q — must be identical",
+			m.name, exported, unexported)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `container.OpencodeConfigFilePath(sessionName)` and `container.WriteOpencodeConfig(sessionName, content)` as exported helpers so `cmd/spawn.go` can write the temp file before the agent pane opens.
- `cmd/spawn.go`: when `isolationMode == IsolationBwrap && configContent != ""`, writes the opencode.json temp file at spawn time (before `ensureAndSwitch`), so it exists on disk when `prism agent-run` calls `PrepareBwrap`.
- `bwrap.go`: changes the opencode.json mount-emission check from `cfg.ConfigContent != ""` to `os.Stat(opencodeConfigPath)` — decouples mount decision from the in-memory `ConfigContent` field that is always empty when the Manager is reconstructed by `prism agent-run` from DB state.
- Tests: `OpencodeConfigFilePath` and `WriteOpencodeConfig` unit tests in `container_test.go`; updated `TestBwrapBuildArgs_OpencodeJSONROBound` (file-existence-driven) and new `TestBwrapBuildArgs_OpencodeJSONNotMountedWhenAbsent` in `bwrap_test.go`; three spawn config write tests in `spawn_config_write_test.go`.

Closes #900