### PR TITLE
prism switch: migrate from cfg.ContainerMode to cfg.EffectiveIsolationMode()

### DIFF
--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/dashboard"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -422,12 +423,12 @@ func promptBranchInput(prompt string) string {
 // ── session management ────────────────────────────────────────────────────────
 
 // injectContainerConfig loads the role-specific opencode.json blob from
-// profiles.json and sets opts.ConfigContent when container mode is active.
+// profiles.json and sets opts.ConfigContent when sandboxed mode is active.
 // This mirrors the pattern in spawn.go and must be called after the final
 // worktree path is known (path is the directory passed to ensureAndSwitch).
 //
 // pf must be non-nil when called; callers are responsible for loading it when
-// cfg.ContainerMode is true.
+// the effective isolation mode is podman or bwrap.
 func injectContainerConfig(path string, pf *config.ProfilesFile, opts *session.Opts, cmdName string) error {
 	effectiveRole := session.DefaultAgent(path, opts.Agent)
 	roleConfig, err := config.ContainerConfigForRole(pf, effectiveRole)
@@ -617,7 +618,7 @@ func allocatePortForSession(sessionName, directory string) (int, error) {
 
 // ── worktree second-level picker ──────────────────────────────────────────────
 
-func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Opts) error {
+func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Opts, isoMode config.IsolationMode, sandboxed bool) error {
 	worktrees := git.Worktrees(projectPath)
 	createNew := entry{display: "[+ create new worktree]", special: "[+ create new worktree]"}
 
@@ -670,17 +671,31 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 		if err != nil {
 			return fmt.Errorf("create worktree: %w", err)
 		}
-		if opts.ContainerMode && pf != nil {
+		if sandboxed && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
+			}
+		}
+		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+			tmuxSessionName := session.NameFor(worktreePath, projectPath)
+			containerName := container.NameForSession(tmuxSessionName)
+			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+				return fmt.Errorf("switch: %w", err)
 			}
 		}
 		return ensureAndSwitch(worktreePath, projectPath, opts)
 	}
 
-	if opts.ContainerMode && pf != nil {
+	if sandboxed && pf != nil {
 		if err := injectContainerConfig(chosen.path, pf, &opts, "prism switch"); err != nil {
 			return err
+		}
+	}
+	if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		tmuxSessionName := session.NameFor(chosen.path, projectPath)
+		containerName := container.NameForSession(tmuxSessionName)
+		if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+			return fmt.Errorf("switch: %w", err)
 		}
 	}
 	return ensureAndSwitch(chosen.path, projectPath, opts)
@@ -858,12 +873,19 @@ func handleReviewGroupPick(groupKey string) error {
 	return err
 }
 
-func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts) error {
+func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, isoMode config.IsolationMode, sandboxed bool) error {
 	exclude := switchWorktreeExcludeSet()
 	if exclude[filepath.Base(path)] {
-		if opts.ContainerMode && pf != nil {
+		if sandboxed && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
+			}
+		}
+		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+			tmuxSessionName := session.NameFor(path, "")
+			containerName := container.NameForSession(tmuxSessionName)
+			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+				return fmt.Errorf("switch: %w", err)
 			}
 		}
 		return ensureAndSwitch(path, "", opts)
@@ -886,9 +908,16 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts) 
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "conversion failed: %v\nopening directly\n", err)
-			if opts.ContainerMode && pf != nil {
+			if sandboxed && pf != nil {
 				if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 					return err
+				}
+			}
+			if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+				tmuxSessionName := session.NameFor(path, "")
+				containerName := container.NameForSession(tmuxSessionName)
+				if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+					return fmt.Errorf("switch: %w", err)
 				}
 			}
 			return ensureAndSwitch(path, "", opts)
@@ -920,16 +949,30 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts) 
 			removeContainerIfExists(oldSessionName)
 		}
 
-		if opts.ContainerMode && pf != nil {
+		if sandboxed && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
+		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+			tmuxSessionName := session.NameFor(worktreePath, path)
+			containerName := container.NameForSession(tmuxSessionName)
+			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+				return fmt.Errorf("switch: %w", err)
+			}
+		}
 		return ensureAndSwitch(worktreePath, path, opts)
 	default:
-		if opts.ContainerMode && pf != nil {
+		if sandboxed && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
+			}
+		}
+		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+			tmuxSessionName := session.NameFor(path, "")
+			containerName := container.NameForSession(tmuxSessionName)
+			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+				return fmt.Errorf("switch: %w", err)
 			}
 		}
 		return ensureAndSwitch(path, "", opts)
@@ -938,7 +981,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts) 
 
 // ── clone repo ────────────────────────────────────────────────────────────────
 
-func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts) error {
+func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoMode config.IsolationMode, sandboxed bool) error {
 	repoURL := promptInput("clone url> ")
 	if repoURL == "" {
 		return nil
@@ -969,9 +1012,16 @@ func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts) error {
 	if len(worktrees) == 0 {
 		return fmt.Errorf("clone succeeded but no worktrees found in %s", targetDir)
 	}
-	if opts.ContainerMode && pf != nil {
+	if sandboxed && pf != nil {
 		if err := injectContainerConfig(worktrees[0], pf, &opts, "prism switch"); err != nil {
 			return err
+		}
+	}
+	if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		tmuxSessionName := session.NameFor(worktrees[0], targetDir)
+		containerName := container.NameForSession(tmuxSessionName)
+		if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+			return fmt.Errorf("switch: %w", err)
 		}
 	}
 	return ensureAndSwitch(worktrees[0], targetDir, opts)
@@ -1006,15 +1056,21 @@ var switchCmd = &cobra.Command{
 		fresh, _ := cmd.Flags().GetBool("fresh")
 		cfg := config.Load()
 
-		// Load profiles.json for container config injection (container mode)
-		// and agent env var injection (host mode). Always attempt to load;
-		// treat missing file as fatal only in container mode.
+		// Derive the effective isolation mode from config, mirroring the pattern
+		// in spawn.go. switch has no --isolation flag — the machine default is used.
+		isoMode := cfg.EffectiveIsolationMode()
+		effectiveContainerMode := isoMode == config.IsolationPodman
+
+		// Load profiles.json for container/bwrap config injection and agent env
+		// var injection (host mode). Always attempt to load; treat missing file as
+		// fatal when sandboxed (podman or bwrap), since those paths require the
+		// role config blob.
 		var pf *config.ProfilesFile
 		{
 			var pfErr error
 			pf, pfErr = config.LoadProfiles()
 			if pfErr != nil {
-				if cfg.ContainerMode {
+				if effectiveContainerMode || isoMode == config.IsolationBwrap {
 					return pfErr
 				}
 				fmt.Fprintf(os.Stderr, "[prism switch] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
@@ -1024,14 +1080,20 @@ var switchCmd = &cobra.Command{
 
 		opts := session.Opts{
 			Fresh:          fresh,
-			ContainerMode:  cfg.ContainerMode,
+			ContainerMode:  effectiveContainerMode,
+			IsolationMode:  string(isoMode),
 			PluginHostPath: cfg.SidecarPluginPath,
 		}
-		// AgentEnvVars only applies to host-mode sessions; container sessions
-		// receive env vars via podman --env flags in the sidecar.
-		if pf != nil && !cfg.ContainerMode {
+		// AgentEnvVars only applies to host-mode sessions; sandboxed sessions
+		// receive env vars via podman --env flags in the sidecar (podman) or
+		// via the bwrap environment pass-through.
+		if pf != nil && isoMode == config.IsolationHost {
 			opts.AgentEnvVars = pf.AgentEnvVars
 		}
+
+		// sandboxed is true for both podman and bwrap isolation modes —
+		// both require container config injection.
+		sandboxed := effectiveContainerMode || isoMode == config.IsolationBwrap
 
 		// --path: open a specific path directly.
 		if pathArg != "" {
@@ -1046,26 +1108,47 @@ var switchCmd = &cobra.Command{
 					return fmt.Errorf("no worktrees found in %s", p)
 				}
 				o := opts
-				if cfg.ContainerMode && pf != nil {
+				if sandboxed && pf != nil {
 					if err := injectContainerConfig(worktrees[0], pf, &o, "prism switch"); err != nil {
 						return err
+					}
+				}
+				if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+					tmuxSessionName := session.NameFor(worktrees[0], p)
+					containerName := container.NameForSession(tmuxSessionName)
+					if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
+						return fmt.Errorf("switch: %w", err)
 					}
 				}
 				return ensureAndSwitch(worktrees[0], p, o)
 			}
 			if bareRoot := git.BareRoot(p); bareRoot != "" {
 				o := opts
-				if cfg.ContainerMode && pf != nil {
+				if sandboxed && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
+					}
+				}
+				if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+					tmuxSessionName := session.NameFor(p, bareRoot)
+					containerName := container.NameForSession(tmuxSessionName)
+					if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
+						return fmt.Errorf("switch: %w", err)
 					}
 				}
 				return ensureAndSwitch(p, bareRoot, o)
 			}
 			o := opts
-			if cfg.ContainerMode && pf != nil {
+			if sandboxed && pf != nil {
 				if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 					return err
+				}
+			}
+			if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+				tmuxSessionName := session.NameFor(p, "")
+				containerName := container.NameForSession(tmuxSessionName)
+				if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
+					return fmt.Errorf("switch: %w", err)
 				}
 			}
 			return ensureAndSwitch(p, "", o)
@@ -1098,20 +1181,27 @@ var switchCmd = &cobra.Command{
 			return ensureAndSwitch("[scratchpad]", "", opts)
 
 		case "[+ clone repo]":
-			return handleCloneRepo(pf, opts)
+			return handleCloneRepo(pf, opts, isoMode, sandboxed)
 
 		default:
 			p := chosen.path
 			switch {
 			case git.IsBareRepo(p):
-				return handleBareRepo(p, pf, opts)
+				return handleBareRepo(p, pf, opts, isoMode, sandboxed)
 			case git.IsRegularRepo(p):
-				return handleRegularRepo(p, pf, opts)
+				return handleRegularRepo(p, pf, opts, isoMode, sandboxed)
 			default:
 				o := opts
-				if cfg.ContainerMode && pf != nil {
+				if sandboxed && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
+					}
+				}
+				if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+					tmuxSessionName := session.NameFor(p, "")
+					containerName := container.NameForSession(tmuxSessionName)
+					if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
+						return fmt.Errorf("switch: %w", err)
 					}
 				}
 				return ensureAndSwitch(p, "", o)


### PR DESCRIPTION
## Summary

- Replace all `cfg.ContainerMode` references in `cmd/switch.go` with a locally-derived `isoMode`/`effectiveContainerMode` pair, mirroring the pattern already used in `spawn.go`
- Add `WriteOpencodeConfig` calls for bwrap sessions at every `ensureAndSwitch` call site so the role-specific `opencode.json` is on disk before the agent pane opens
- Fix `AgentEnvVars` injection to use `isoMode == IsolationHost` and profiles.json load error to be fatal for bwrap (same as podman)

## What changed

- `isoMode = cfg.EffectiveIsolationMode()` derived at the top of the handler; `effectiveContainerMode = isoMode == IsolationPodman`
- `opts.IsolationMode = string(isoMode)` so the correct mode is written to the DB
- All `if cfg.ContainerMode && pf != nil` guards replaced with `if sandboxed && pf != nil` (sandboxed = podman || bwrap)
- `container.WriteOpencodeConfig` added for bwrap sessions at all `ensureAndSwitch` call sites (bare repo, regular repo, clone, `--path`, non-repo picker default)
- Profiles load error is now fatal when `isoMode == IsolationBwrap` (previously only fatal for podman)
- `AgentEnvVars` now injected only when `isoMode == IsolationHost` (was `!cfg.ContainerMode`, which incorrectly included bwrap)
- `handleBareRepo`, `handleRegularRepo`, `handleCloneRepo` updated to accept `isoMode` and `sandboxed` params
- `container` package imported

Closes #905