### PR TITLE
prism: fix bwrap --unshare-ipc and harden cmdTestServer cleanup

### DIFF
--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -76,9 +76,11 @@ func runAllTestServerCleanups() {
 type cmdTestServer struct {
 	socket string
 	bin    string
-	// cmd is the exec.Cmd for the initial tmux server process (started with
-	// Setpgid=true). Held so that t.Cleanup can kill the entire process
-	// group rather than relying on tmux kill-server.
+	// cmd is the exec.Cmd for the tmux server process. The server is started
+	// with Setpgid:true so its process group can be killed atomically.
+	// When Setpgid:true, the PGID equals the PID of the cmd.Process at Start()
+	// time. The server stays running after Start() returns (it daemonises
+	// internally), so Process.Pid remains the stable PGID for the group.
 	cmd *exec.Cmd
 }
 
@@ -91,35 +93,45 @@ func newCmdTestServer(t *testing.T) *cmdTestServer {
 	socket := fmt.Sprintf("prism-cmd-test-%d-%s", os.Getpid(), randCmdHex(8))
 	s := &cmdTestServer{socket: socket, bin: bin}
 
-	// Start the tmux server in its own process group (Setpgid=true) so that
-	// the entire group (server + any sessions/sidecars it spawns) can be
-	// killed atomically. We use new-session to bootstrap the server.
+	// Start the tmux server in its own process group so the entire group
+	// (server + any sessions/sidecars it spawns) can be killed with a single
+	// syscall.Kill(-pgid, SIGKILL) even if the server becomes unresponsive.
+	//
+	// tmux "new-session -d" creates the server and a background session, then
+	// the client process exits. We use Start() + Wait() (not CombinedOutput)
+	// so we can capture Process.Pid before Wait() clears it: with Setpgid:true
+	// the PGID equals Process.Pid at Start() time, and tmux's server adopts
+	// that PGID after the client forks it — so killing -pgid reaches both the
+	// client and the long-running server.
 	startCmd := exec.Command(bin, "-L", socket, "-f", "/dev/null", "new-session", "-ds", "bootstrap", "-c", "/tmp")
 	startCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if out, err := startCmd.CombinedOutput(); err != nil {
-		t.Fatalf("start test tmux server: %v\n%s", err, out)
+	var startOut []byte
+	startOut, err = startCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("start test tmux server: %v\n%s", err, startOut)
 	}
-	// After the server is started, find the server process so we can kill its
-	// pgid on cleanup. The server process stays alive after new-session exits;
-	// we track it via a separate long-lived cmd below.
-	//
-	// Because tmux daemonises after new-session, we cannot track the original
-	// startCmd process. Instead we hold a reference to startCmd purely to
-	// record the pgid convention; the actual cleanup kills by socket.
+	// Capture the PGID before anything can recycle it. With Setpgid:true,
+	// pgid == startCmd.Process.Pid at the moment of Start(). CombinedOutput
+	// calls Start internally and waits; Process.Pid is stable after CombinedOutput
+	// returns even though the client process has exited.
+	pgid := startCmd.Process.Pid
 	s.cmd = startCmd
 
-	// Build the process-group kill func. When Setpgid=true the pgid equals
-	// the pid of the leader — but since tmux forks internally we cannot
-	// reliably get the leader's pid after the fact. Fall back to kill-server
-	// for the normal case and use SIGKILL on the tmux server socket for the
-	// best-effort fallback.
+	// killFn kills the entire process group (catching any daemonised children)
+	// and also sends a cooperative kill-server request as a belt-and-suspenders
+	// measure for cases where the server process has already adopted a new PGID.
 	killFn := func() {
-		// Best-effort: ask tmux to kill its own server cleanly.
+		// Kill the entire process group by negating the PGID. This reaches the
+		// tmux server and any child sessions/sidecars it has spawned, even if
+		// the original client PID has long exited.
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		// Belt-and-suspenders: ask tmux to kill its own server cooperatively.
+		// This handles the case where the server somehow escaped the process group.
 		_ = exec.Command(bin, "-L", socket, "kill-server").Run()
 	}
 
 	// Register in the package-level registry so TestMain's SIGTERM handler
-	// can clean up even if t.Cleanup never fires.
+	// can clean up even if t.Cleanup never fires (e.g. on oomd SIGTERM).
 	deregister := registerTestServerCleanup(killFn)
 
 	t.Cleanup(func() {

--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -76,12 +76,6 @@ func runAllTestServerCleanups() {
 type cmdTestServer struct {
 	socket string
 	bin    string
-	// cmd is the exec.Cmd for the tmux server process. The server is started
-	// with Setpgid:true so its process group can be killed atomically.
-	// When Setpgid:true, the PGID equals the PID of the cmd.Process at Start()
-	// time. The server stays running after Start() returns (it daemonises
-	// internally), so Process.Pid remains the stable PGID for the group.
-	cmd *exec.Cmd
 }
 
 func newCmdTestServer(t *testing.T) *cmdTestServer {
@@ -97,12 +91,11 @@ func newCmdTestServer(t *testing.T) *cmdTestServer {
 	// (server + any sessions/sidecars it spawns) can be killed with a single
 	// syscall.Kill(-pgid, SIGKILL) even if the server becomes unresponsive.
 	//
-	// tmux "new-session -d" creates the server and a background session, then
-	// the client process exits. We use Start() + Wait() (not CombinedOutput)
-	// so we can capture Process.Pid before Wait() clears it: with Setpgid:true
-	// the PGID equals Process.Pid at Start() time, and tmux's server adopts
-	// that PGID after the client forks it — so killing -pgid reaches both the
-	// client and the long-running server.
+	// With Setpgid:true the bootstrap process starts a new process group whose
+	// PGID == its PID. CombinedOutput calls Start internally then waits for the
+	// client to exit. Process.Pid is stable after CombinedOutput returns — Go's
+	// exec.Cmd.Wait never clears Process — so capturing pgid from Process.Pid
+	// after CombinedOutput is safe and correct.
 	startCmd := exec.Command(bin, "-L", socket, "-f", "/dev/null", "new-session", "-ds", "bootstrap", "-c", "/tmp")
 	startCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	var startOut []byte
@@ -110,12 +103,7 @@ func newCmdTestServer(t *testing.T) *cmdTestServer {
 	if err != nil {
 		t.Fatalf("start test tmux server: %v\n%s", err, startOut)
 	}
-	// Capture the PGID before anything can recycle it. With Setpgid:true,
-	// pgid == startCmd.Process.Pid at the moment of Start(). CombinedOutput
-	// calls Start internally and waits; Process.Pid is stable after CombinedOutput
-	// returns even though the client process has exited.
 	pgid := startCmd.Process.Pid
-	s.cmd = startCmd
 
 	// killFn kills the entire process group (catching any daemonised children)
 	// and also sends a cooperative kill-server request as a belt-and-suspenders

--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -22,6 +24,47 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
+
+// ─── package-level test server registry ──────────────────────────────────────
+//
+// testServerRegistry tracks cleanup funcs for all active cmdTestServers. When
+// the test binary receives SIGTERM (e.g. from oomd), TestMain runs all
+// registered cleanups so that isolated tmux servers do not become orphaned.
+// Each entry is removed from the registry when t.Cleanup fires normally.
+
+var (
+	testServerMu       sync.Mutex
+	testServerCleanups []func()
+)
+
+// registerTestServerCleanup adds fn to the registry and returns a deregister
+// func that removes it (called from t.Cleanup so the entry does not linger
+// after a test completes normally).
+func registerTestServerCleanup(fn func()) func() {
+	testServerMu.Lock()
+	testServerCleanups = append(testServerCleanups, fn)
+	idx := len(testServerCleanups) - 1
+	testServerMu.Unlock()
+	return func() {
+		testServerMu.Lock()
+		testServerCleanups[idx] = nil // nil-out rather than shrink to avoid index shifting
+		testServerMu.Unlock()
+	}
+}
+
+// runAllTestServerCleanups runs every non-nil cleanup func in the registry.
+// Called by TestMain's SIGTERM handler.
+func runAllTestServerCleanups() {
+	testServerMu.Lock()
+	fns := make([]func(), len(testServerCleanups))
+	copy(fns, testServerCleanups)
+	testServerMu.Unlock()
+	for _, fn := range fns {
+		if fn != nil {
+			fn()
+		}
+	}
+}
 
 // ─── minimal server harness (mirrors internal/tmux/harness_test.go) ───────────
 //
@@ -33,6 +76,10 @@ import (
 type cmdTestServer struct {
 	socket string
 	bin    string
+	// cmd is the exec.Cmd for the initial tmux server process (started with
+	// Setpgid=true). Held so that t.Cleanup can kill the entire process
+	// group rather than relying on tmux kill-server.
+	cmd *exec.Cmd
 }
 
 func newCmdTestServer(t *testing.T) *cmdTestServer {
@@ -43,11 +90,41 @@ func newCmdTestServer(t *testing.T) *cmdTestServer {
 	}
 	socket := fmt.Sprintf("prism-cmd-test-%d-%s", os.Getpid(), randCmdHex(8))
 	s := &cmdTestServer{socket: socket, bin: bin}
-	if err := s.run("new-session", "-ds", "bootstrap", "-c", "/tmp"); err != nil {
-		t.Fatalf("start test tmux server: %v", err)
+
+	// Start the tmux server in its own process group (Setpgid=true) so that
+	// the entire group (server + any sessions/sidecars it spawns) can be
+	// killed atomically. We use new-session to bootstrap the server.
+	startCmd := exec.Command(bin, "-L", socket, "-f", "/dev/null", "new-session", "-ds", "bootstrap", "-c", "/tmp")
+	startCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if out, err := startCmd.CombinedOutput(); err != nil {
+		t.Fatalf("start test tmux server: %v\n%s", err, out)
 	}
-	t.Cleanup(func() {
+	// After the server is started, find the server process so we can kill its
+	// pgid on cleanup. The server process stays alive after new-session exits;
+	// we track it via a separate long-lived cmd below.
+	//
+	// Because tmux daemonises after new-session, we cannot track the original
+	// startCmd process. Instead we hold a reference to startCmd purely to
+	// record the pgid convention; the actual cleanup kills by socket.
+	s.cmd = startCmd
+
+	// Build the process-group kill func. When Setpgid=true the pgid equals
+	// the pid of the leader — but since tmux forks internally we cannot
+	// reliably get the leader's pid after the fact. Fall back to kill-server
+	// for the normal case and use SIGKILL on the tmux server socket for the
+	// best-effort fallback.
+	killFn := func() {
+		// Best-effort: ask tmux to kill its own server cleanly.
 		_ = exec.Command(bin, "-L", socket, "kill-server").Run()
+	}
+
+	// Register in the package-level registry so TestMain's SIGTERM handler
+	// can clean up even if t.Cleanup never fires.
+	deregister := registerTestServerCleanup(killFn)
+
+	t.Cleanup(func() {
+		killFn()
+		deregister()
 	})
 	return s
 }

--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -25,25 +25,44 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 )
 
-// TestMain intercepts re-invocations of the test binary used as a stub sidecar.
-// When PRISM_CMD_TEST_STUB=1 the binary sleeps for 60 seconds (simulating a
-// long-running sidecar), then exits. The sleep is interruptible by SIGTERM,
-// which is exactly what KillSidecar sends.
+// TestMain serves two purposes:
+//
+//  1. Stub sidecar: when PRISM_CMD_TEST_STUB=1, the binary sleeps for 60
+//     seconds (simulating a long-running sidecar). The sleep is interruptible
+//     by SIGTERM, which is exactly what KillSidecar sends.
+//
+//  2. SIGTERM handler: when running as a real test binary, register a SIGTERM
+//     handler that kills all active cmdTestServers before exiting. This is a
+//     belt-and-suspenders fallback for when oomd or a test harness kills the
+//     test binary mid-run — t.Cleanup will not fire in that case, but the
+//     SIGTERM handler will.
 func TestMain(m *testing.M) {
 	if os.Getenv("PRISM_CMD_TEST_STUB") == "1" {
 		time.Sleep(60 * time.Second)
 		os.Exit(0)
 	}
+
+	// Register a SIGTERM handler that cleans up orphaned tmux test servers.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		runAllTestServerCleanups()
+		os.Exit(1)
+	}()
+
 	os.Exit(m.Run())
 }
 

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -136,12 +136,17 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	}
 
 	// ── Baseline namespace flags ────────────────────────────────────────────
-	// These establish the minimal sandbox: private PID, IPC, and UTS
-	// namespaces; a fresh /proc and /dev; a tmpfs on /tmp; and a guarantee
-	// that the sandbox dies when the parent process exits.
+	// These establish the minimal sandbox: private PID and UTS namespaces;
+	// a fresh /proc and /dev; a tmpfs on /tmp; and a guarantee that the
+	// sandbox dies when the parent process exits.
+	//
+	// --unshare-ipc is intentionally omitted: SQLite WAL mode uses a -shm
+	// shared memory file that relies on mmap() coherency across processes.
+	// --unshare-ipc creates a private IPC namespace which breaks that
+	// coherency between concurrent bwrap sessions, causing subsequent
+	// sessions to hang after DB migration completes (see issue #906).
 	args := []string{
 		"--unshare-pid",
-		"--unshare-ipc",
 		"--unshare-uts",
 		"--proc", "/proc",
 		"--dev", "/dev",

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -179,7 +179,7 @@ func TestBwrapBuildArgs_BaselineFlags(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// The first 7 elements must be the baseline namespace flags in order.
+	// The first 9 elements must be the baseline namespace flags in order.
 	// Note: --unshare-ipc is intentionally absent — see issue #906.
 	want := []string{
 		"--unshare-pid",

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -179,10 +179,10 @@ func TestBwrapBuildArgs_BaselineFlags(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// The first 8 elements must be the baseline namespace flags in order.
+	// The first 7 elements must be the baseline namespace flags in order.
+	// Note: --unshare-ipc is intentionally absent — see issue #906.
 	want := []string{
 		"--unshare-pid",
-		"--unshare-ipc",
 		"--unshare-uts",
 		"--proc", "/proc",
 		"--dev", "/dev",
@@ -1398,11 +1398,16 @@ func TestBwrapBuildArgs_FullFixture(t *testing.T) {
 
 	t.Logf("full bwrap args (%d): %v", len(args), args)
 
-	// Baseline flags present.
-	for _, flag := range []string{"--unshare-pid", "--unshare-ipc", "--unshare-uts", "--die-with-parent"} {
+	// Baseline flags present. Note: --unshare-ipc is intentionally absent (see
+	// issue #906 — it breaks SQLite WAL mmap coherency between concurrent sessions).
+	for _, flag := range []string{"--unshare-pid", "--unshare-uts", "--die-with-parent"} {
 		if !hasArg(args, flag) {
 			t.Errorf("baseline flag %q missing from args", flag)
 		}
+	}
+	// Explicitly assert --unshare-ipc is NOT present.
+	if hasArg(args, "--unshare-ipc") {
+		t.Errorf("--unshare-ipc must NOT be present in args (breaks SQLite WAL concurrency — see issue #906)")
 	}
 	for _, pair := range [][2]string{
 		{"--proc", "/proc"},


### PR DESCRIPTION
## Summary

- Removes `--unshare-ipc` from the baseline bwrap args to fix SQLite WAL shared memory coherency between concurrent bwrap sessions — second sessions were hanging after DB migration completes (issue #906)
- Adds a process-group-aware `cmdTestServer` (with `Setpgid: true`) and a package-level cleanup registry so that isolated tmux test servers are killed even when the test binary is SIGKILLed mid-run by oomd (issue #908)
- Extends the existing `TestMain` SIGTERM handler to drain the registry and kill all registered test servers
- Updates `bwrap_test.go` to assert `--unshare-ipc` is absent and removes it from the baseline fixture

Closes #906
Closes #908