### PR TITLE
prism: bring bwrap isolation to full parity with podman

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -157,9 +157,63 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("agent-run: %w", err)
 	}
 
-	// exec replaces the current process with bwrap. argv[0] must be the binary path.
+	// exec replaces the current process with bwrap. argv[0] must be the binary
+	// path. The child env is filtered to a minimal allow-list so that nothing
+	// from the invoking shell leaks into bwrap's own process environment.
+	// This is defence-in-depth: bwrap itself will also run with --clearenv
+	// (see internal/container/bwrap.go) so the sandbox interior is wiped
+	// regardless. Stripping here ensures secrets never appear in bwrap's
+	// own /proc/<pid>/environ either, and means "ps aux" / "bwrap --help"
+	// style debugging can't accidentally expose them.
 	argv := append([]string{bwrapBin}, bwrapArgs...)
-	return syscall.Exec(bwrapBin, argv, os.Environ())
+	return syscall.Exec(bwrapBin, argv, minimalBwrapExecEnv(os.Environ()))
+}
+
+// minimalBwrapExecEnv filters a hostEnv slice (K=V pairs, as returned by
+// os.Environ()) down to a minimal allow-list that bwrap itself needs to run.
+// The returned env is what the bwrap *process* sees; it is NOT the sandbox
+// interior env (bwrap starts the sandbox with --clearenv and rebuilds the
+// interior env from explicit --setenv pairs).
+//
+// Allow-list rationale:
+//
+//   - PATH:     bwrap uses PATH to locate interpreters when parsing some
+//     arguments, and tools that bwrap itself spawns during setup rely on it.
+//   - HOME, USER, LOGNAME: used in default paths, error messages, and (more
+//     importantly) by any subcommand bwrap shells out to internally.
+//   - TERM, LANG, LC_ALL: avoid bwrap logging locale/terminal warnings.
+//
+// Everything else — including PRISM_GITHUB_TOKEN_*, GITHUB_TOKEN,
+// GITHUB_PACKAGES_TOKEN, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, and any
+// other secret a prism coordinator might export — is dropped.
+func minimalBwrapExecEnv(hostEnv []string) []string {
+	allow := map[string]bool{
+		"PATH":    true,
+		"HOME":    true,
+		"USER":    true,
+		"LOGNAME": true,
+		"TERM":    true,
+		"LANG":    true,
+		"LC_ALL":  true,
+	}
+	out := make([]string, 0, len(allow))
+	for _, kv := range hostEnv {
+		// Split once on '='; malformed pairs (no '=') are skipped.
+		eq := -1
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				eq = i
+				break
+			}
+		}
+		if eq <= 0 {
+			continue
+		}
+		if allow[kv[:eq]] {
+			out = append(out, kv)
+		}
+	}
+	return out
 }
 
 // applyInitialPromptEnvVar reads PRISM_INITIAL_PROMPT from the process

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -223,8 +223,16 @@ func setupMinimalBareRepo(t *testing.T) (bareRoot, worktreePath, branchName stri
 		"add", "--orphan", "-b", "main", initDir).CombinedOutput(); err != nil {
 		t.Fatalf("git worktree add (orphan): %v\n%s", err, out)
 	}
-	// Stage an empty commit.
-	cfgArgs := []string{"-C", initDir, "-c", "user.email=test@test.com", "-c", "user.name=Test"}
+	// Stage an empty commit. Disable signing explicitly: host gitconfig may
+	// enable gpgsign globally (via home-manager), which would break this
+	// commit in a test env with no signing key.
+	cfgArgs := []string{
+		"-C", initDir,
+		"-c", "user.email=test@test.com",
+		"-c", "user.name=Test",
+		"-c", "commit.gpgsign=false",
+		"-c", "tag.gpgsign=false",
+	}
 	if out, err := exec.Command("git", append(cfgArgs,
 		"commit", "--allow-empty", "-m", "init")...).CombinedOutput(); err != nil {
 		t.Fatalf("git commit (init): %v\n%s", err, out)
@@ -273,6 +281,16 @@ func TestCleanupYes_RedirectsClientsAndKillsSession(t *testing.T) {
 	// sidecar state dir instead of the production ~/.local/state/prism/ path.
 	// Must be set before newCmdTestServer starts the tmux server.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Clear PRISM_HOST_API so the spawned binary runs its host-side cleanup
+	// path directly rather than proxying to a sidecar that doesn't know
+	// about the test's isolated tmux server. This env var is inherited when
+	// the test itself runs inside a prism-managed session.
+	t.Setenv("PRISM_HOST_API", "")
+	// Ignore the host's global gitconfig so the spawned prism binary is not
+	// affected by host-level signing config (gpgsign=true without a key
+	// available would break any git commit it runs).
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
 
 	prismBin := buildPrismBinary(t)
 
@@ -383,6 +401,16 @@ func TestCleanupYes_DefaultBranch(t *testing.T) {
 	// sidecar state dir instead of the production ~/.local/state/prism/ path.
 	// Must be set before newCmdTestServer starts the tmux server.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Clear PRISM_HOST_API so the spawned binary runs its host-side cleanup
+	// path directly rather than proxying to a sidecar that doesn't know
+	// about the test's isolated tmux server. This env var is inherited when
+	// the test itself runs inside a prism-managed session.
+	t.Setenv("PRISM_HOST_API", "")
+	// Ignore the host's global gitconfig so the spawned prism binary is not
+	// affected by host-level signing config (gpgsign=true without a key
+	// available would break any git commit it runs).
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
 
 	prismBin := buildPrismBinary(t)
 
@@ -558,6 +586,16 @@ func TestCleanupYes_NonWorktreeSession(t *testing.T) {
 	// Uses withCmdServer which mutates TmuxBin — must not be parallel.
 
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Ignore the host's global gitconfig so the spawned prism binary is not
+	// affected by host-level signing config (gpgsign=true without a key
+	// available would break any git commit it runs).
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	// Clear PRISM_HOST_API so the spawned binary runs its host-side cleanup
+	// path directly rather than proxying to a sidecar that doesn't know
+	// about the test's isolated tmux server. This env var is inherited when
+	// the test itself runs inside a prism-managed session.
+	t.Setenv("PRISM_HOST_API", "")
 
 	prismBin := buildPrismBinary(t)
 

--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -14,12 +14,14 @@ package cmd
 //   - Missing PID file: function returns silently without error.
 //   - Corrupt PID file: non-integer content, file removed.
 //   - PID recycled to unrelated process: /proc/<pid>/cmdline doesn't contain
-//     "prism", kill is skipped, PID file removed.
+//     the sidecar invariant ("sidecar" + "--session"), kill is skipped,
+//     PID file removed.
 //
 // TestKillSidecar_NormalOperation re-invokes the test binary itself as a stub
-// sidecar subprocess. When PRISM_CMD_TEST_STUB=1 the binary sleeps briefly so
-// its /proc/<pid>/cmdline contains the test binary path (which includes "prism"
-// because the test binary is named after the package). See TestMain below.
+// sidecar subprocess with argv "sidecar --session stub-session". When
+// PRISM_CMD_TEST_STUB=1 TestMain short-circuits into a sleep-and-exit loop
+// so the stub acts as a long-running sidecar whose cmdline matches the
+// invariant KillSidecar looks for. See TestMain below.
 
 import (
 	"fmt"
@@ -104,14 +106,13 @@ func processExists(pid int) bool {
 }
 
 // startStubProcess re-invokes the current test binary with PRISM_CMD_TEST_STUB=1
-// so it acts as a long-running sidecar stub whose cmdline contains the word
-// "prism" (the test binary is typically named cmd.test or similar, but the
-// full path goes through os.Executable which may contain the project name).
+// so it acts as a long-running sidecar stub whose /proc/<pid>/cmdline matches
+// the real-sidecar invariant that KillSidecar checks for: it contains both
+// "sidecar" and "--session".
 //
-// To guarantee the cmdline check passes, the stub binary is invoked via a
-// symlink named "prism-stub" placed in a temp dir and added to PATH. Since the
-// test binary is already a real binary with a path that may or may not contain
-// "prism", we instead copy/symlink to a path that explicitly contains "prism".
+// We pass "sidecar --session <name>" on the argv so the cmdline matches. The
+// PRISM_CMD_TEST_STUB env var forces TestMain to short-circuit into a
+// sleep-and-exit loop instead of running the real sidecar command.
 func startStubProcess(t *testing.T) (pid int, cleanup func()) {
 	t.Helper()
 
@@ -121,15 +122,9 @@ func startStubProcess(t *testing.T) (pid int, cleanup func()) {
 		t.Fatalf("os.Executable: %v", err)
 	}
 
-	// Create a symlink named "prism" → current test binary in a temp dir.
-	// This ensures /proc/<pid>/cmdline will contain the path "…/prism".
-	binDir := t.TempDir()
-	prismLink := filepath.Join(binDir, "prism")
-	if err := os.Symlink(self, prismLink); err != nil {
-		t.Fatalf("symlink prism → test binary: %v", err)
-	}
-
-	cmd := exec.Command(prismLink)
+	// Invoke the test binary with stub-matching argv so cmdline contains
+	// both "sidecar" and "--session" (the invariant KillSidecar checks).
+	cmd := exec.Command(self, "sidecar", "--session", "stub-session")
 	cmd.Env = append(os.Environ(), "PRISM_CMD_TEST_STUB=1")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start stub process: %v", err)
@@ -147,14 +142,15 @@ func TestKillSidecar_NormalOperation(t *testing.T) {
 	pid, cleanupProc := startStubProcess(t)
 	t.Cleanup(cleanupProc)
 
-	// Verify cmdline contains "prism" before we proceed (skip if not).
+	// Verify cmdline matches the sidecar invariant KillSidecar checks for.
 	time.Sleep(30 * time.Millisecond) // Let the process start.
 	cmdlineData, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
 		t.Skipf("could not read /proc/%d/cmdline: %v (process may have exited already)", pid, err)
 	}
-	if !strings.Contains(string(cmdlineData), "prism") {
-		t.Fatalf("stub process cmdline does not contain 'prism': %q — startStubProcess setup is broken", string(cmdlineData))
+	cmdlineStr := string(cmdlineData)
+	if !strings.Contains(cmdlineStr, "sidecar") || !strings.Contains(cmdlineStr, "--session") {
+		t.Fatalf("stub process cmdline does not contain 'sidecar' and '--session': %q — startStubProcess setup is broken", cmdlineStr)
 	}
 
 	stateDir := t.TempDir()

--- a/modules/programs/prism/prism/cmd/session_name_test.go
+++ b/modules/programs/prism/prism/cmd/session_name_test.go
@@ -18,6 +18,11 @@ func initGitRepo(t *testing.T, dir, branchName string) string {
 		{"git", "init", "-b", branchName},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
+		// Disable signing in the test repo: host gitconfig may enable
+		// gpgsign globally (via home-manager), which would make `git commit`
+		// fail here because no signing key is available in the test env.
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "config", "tag.gpgsign", "false"},
 	}
 	for _, args := range cmds {
 		c := exec.Command(args[0], args[1:]...)

--- a/modules/programs/prism/prism/cmd/switch_test.go
+++ b/modules/programs/prism/prism/cmd/switch_test.go
@@ -85,6 +85,16 @@ func TestSwitchPath_SwitchesClientToNewSession(t *testing.T) {
 	// production ~/.local/state/prism/ path.  Must be set before newCmdTestServer
 	// starts the tmux server (which inherits the environment).
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Ignore the host's global gitconfig so the spawned prism binary is not
+	// affected by host-level signing config (gpgsign=true without a key
+	// available would break any git commit it runs).
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	// Clear PRISM_HOST_API so the spawned binary runs the host-side switch
+	// path directly rather than proxying to a sidecar that doesn't know
+	// about the test's isolated tmux server. This env var is inherited when
+	// the test itself runs inside a prism-managed session.
+	t.Setenv("PRISM_HOST_API", "")
 
 	prismBin := buildPrismBinary(t)
 
@@ -151,6 +161,12 @@ func TestSwitchPath_OnlyMovesTargetClient(t *testing.T) {
 	// production ~/.local/state/prism/ path.  Must be set before newCmdTestServer
 	// starts the tmux server (which inherits the environment).
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Ignore the host's global gitconfig and unset PRISM_HOST_API for the
+	// same reasons as the first test in this file — see
+	// TestSwitchPath_SwitchesClientToNewSession.
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	t.Setenv("PRISM_HOST_API", "")
 
 	prismBin := buildPrismBinary(t)
 

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -81,9 +81,23 @@ func fallbackPATH() string {
 // Rules:
 //   - PATH: always emitted; falls back to fallbackPATH when the host value is
 //     empty (e.g. in a stripped environment).
-//   - HOME, USER, LOGNAME, LANG, LC_ALL, SHELL: forwarded when the host has
-//     them set; omitted entirely when unset, so the sandbox does not receive a
+//   - HOME, USER, LOGNAME, LANG, LC_ALL: forwarded when the host has them
+//     set; omitted entirely when unset, so the sandbox does not receive a
 //     spurious empty string.
+//   - SHELL: forced to /bin/sh regardless of the host value. The host's
+//     SHELL is typically zsh, and NixOS' /etc/zshenv unconditionally sources
+//     set-environment which runs `cat /run/secrets/...` for every sops secret.
+//     Inside bwrap those paths don't exist, so the cat fails AND (critically)
+//     overwrites any --setenv'd GITHUB_TOKEN with an empty string — breaking
+//     every `git push` and `gh` call the agent tries. /bin/sh on NixOS is a
+//     symlink to bash; bash's non-interactive -c invocation does not source
+//     /etc/profile (login-shell only) or /etc/bashrc (interactive-only), so
+//     the injected env survives. We pin /bin/sh (not /bin/bash) because
+//     /bin/ inside the sandbox only contains the NixOS-provided /bin/sh
+//     symlink — bash itself lives in the Nix store at a hash-prefixed path,
+//     not at /bin/bash. Pinning SHELL to /bin/sh means any tool that uses
+//     $SHELL (opencode's bash tool, most TUIs) gets a clean shell that
+//     doesn't wipe credentials.
 //
 // TERM is NOT included here — it is handled separately by BuildArgs so that
 // its fixed value ("xterm-256color") is always used regardless of the host.
@@ -98,11 +112,17 @@ func standardSandboxEnvArgs() []string {
 	args = append(args, "--setenv", "PATH", pathVal)
 
 	// Optional vars — only emitted when the host has them set.
-	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "SHELL"} {
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL"} {
 		if val := os.Getenv(key); val != "" {
 			args = append(args, "--setenv", key, val)
 		}
 	}
+
+	// SHELL — forced to /bin/sh. See godoc above for the zsh/set-environment
+	// reason. /bin/sh is always available inside the sandbox (NixOS ships
+	// /bin/sh as a symlink to bash) because BuildArgs ro-binds /bin from
+	// the host.
+	args = append(args, "--setenv", "SHELL", "/bin/sh")
 
 	return args
 }
@@ -140,12 +160,23 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// a fresh /proc and /dev; a tmpfs on /tmp; and a guarantee that the
 	// sandbox dies when the parent process exits.
 	//
+	// --clearenv (first) wipes the inherited environment so that nothing from
+	// the invoking shell leaks into the sandbox. Every var the sandbox needs
+	// must be re-introduced via an explicit --setenv below (see
+	// standardSandboxEnvArgs and credentialEnvVars). Without --clearenv, bwrap
+	// forwards the full host environment — which on a prism coordinator
+	// includes role-specific GitHub tokens (PRISM_GITHUB_TOKEN_*) and other
+	// credentials that must never reach a sandboxed agent. Podman does not
+	// have this problem because its default is to pass nothing from the host;
+	// --clearenv gives bwrap the same baseline.
+	//
 	// --unshare-ipc is intentionally omitted: SQLite WAL mode uses a -shm
 	// shared memory file that relies on mmap() coherency across processes.
 	// --unshare-ipc creates a private IPC namespace which breaks that
 	// coherency between concurrent bwrap sessions, causing subsequent
 	// sessions to hang after DB migration completes (see issue #906).
 	args := []string{
+		"--clearenv",
 		"--unshare-pid",
 		"--unshare-uts",
 		"--proc", "/proc",
@@ -225,9 +256,16 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--bind", mcpAuthDir, mcpAuthDir)
 	}
 
-	// ── opencode session state dir (read-write) ─────────────────────────────
-	opencodeSessionDir := filepath.Join(home, ".local", "share", "opencode", "prism-sessions", m.name)
-	args = append(args, "--bind", opencodeSessionDir, opencodeSessionDir)
+	// ── opencode shared state dir (read-write) ─────────────────────────────
+	// bwrap sessions share the host's ~/.local/share/opencode/ directly: a
+	// single SQLite DB across all sessions (host mode, bwrap mode, and the
+	// non-prism opencode CLI). The per-session isolation used by the podman
+	// path exists solely to work around a virtiofs WAL-mode locking issue on
+	// Darwin — that path doesn't apply here because bwrap is Linux-only and
+	// SQLite WAL works correctly across concurrent processes on a shared
+	// filesystem.
+	opencodeDataDir := filepath.Join(home, ".local", "share", "opencode")
+	args = append(args, "--bind", opencodeDataDir, opencodeDataDir)
 
 	// ── Nix daemon socket dir (read-write) ──────────────────────────────────
 	// Mount the parent directory, not the socket file directly (same pattern
@@ -258,6 +296,13 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	}
 
 	// ── SSH keys (read-only, conditional) ───────────────────────────────────
+	// All SSH artefacts are remapped to canonical generic paths under
+	// $HOME/.ssh/ inside the sandbox. Agents inside both bwrap and podman
+	// sandboxes see the same filenames (access-key, signing-key, signing-key.pub,
+	// allowed_signers, known_hosts) — only the $HOME prefix differs (/root for
+	// podman, <hostHome> for bwrap). The generated ~/.ssh/config and
+	// ~/.gitconfig (see writeSshConfig and writeGitconfig) reference these
+	// canonical paths using the same prefix via sandboxHome().
 	sshDir := filepath.Join(home, ".ssh")
 
 	accessKeyName := cfg.SshAccessKeyName
@@ -265,7 +310,7 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		accessKeyName = "prismatic-koi-ed25519"
 	}
 	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, accessKeyName)); err == nil {
-		args = append(args, "--ro-bind", resolved, resolved)
+		args = append(args, "--ro-bind", resolved, filepath.Join(sshDir, "access-key"))
 	}
 
 	signingKeyName := cfg.SshSigningKeyName
@@ -276,18 +321,17 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName+".pub"))
 	if errPriv == nil && errPub == nil {
 		args = append(args,
-			"--ro-bind", signingKeyResolved, signingKeyResolved,
-			"--ro-bind", signingKeyPubResolved, signingKeyPubResolved,
+			"--ro-bind", signingKeyResolved, filepath.Join(sshDir, "signing-key"),
+			"--ro-bind", signingKeyPubResolved, filepath.Join(sshDir, "signing-key.pub"),
 		)
 		if m.allowedSignersReady {
-			allowedSignersPath := m.allowedSignersFilePath()
-			args = append(args, "--ro-bind", allowedSignersPath, allowedSignersPath)
+			args = append(args, "--ro-bind", m.allowedSignersFilePath(), filepath.Join(sshDir, "allowed_signers"))
 		}
 	}
 
 	// ── known_hosts (read-only, conditional) ────────────────────────────────
 	if resolved, err := filepath.EvalSymlinks(filepath.Join(sshDir, "known_hosts")); err == nil {
-		args = append(args, "--ro-bind", resolved, resolved)
+		args = append(args, "--ro-bind", resolved, filepath.Join(sshDir, "known_hosts"))
 	}
 
 	// ── Generated SSH config (read-only) ────────────────────────────────────
@@ -351,15 +395,6 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		if _, err := os.Stat(p); err == nil {
 			args = append(args, "--ro-bind", p, p)
 		}
-	}
-
-	// ── auth.json overlay (read-write, conditional) ──────────────────────────
-	// Share the host's OAuth token file across sessions. The opencode-claude-auth
-	// plugin writes back refreshed credentials, so it must be read-write.
-	// Mounted at the exact host path (Dst==Src).
-	opencodeAuthJSON := filepath.Join(home, ".local", "share", "opencode", "auth.json")
-	if _, err := os.Stat(opencodeAuthJSON); err == nil {
-		args = append(args, "--bind", opencodeAuthJSON, opencodeAuthJSON)
 	}
 
 	// ── opencode plugin cache (read-only, conditional) ───────────────────────
@@ -484,10 +519,19 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 // Run launches "bwrap <args...>" and waits for it to complete. Stdout and
 // stderr are forwarded to the sidecar's stderr log. Returns a wrapped error
 // on failure.
+//
+// The bwrap child process runs with a filtered environment (see
+// minimalBwrapExecEnv) so that secrets from the invoking process do not
+// appear in the bwrap process's own /proc/<pid>/environ. This pairs with
+// the --clearenv flag in the baseline args (see BuildArgs) which wipes
+// the sandbox interior env. Defence-in-depth: either layer alone would
+// block the leak; both are kept so regressions in one layer are caught
+// by the other.
 func (b *bwrapIsolator) Run(ctx context.Context, args []string) error {
 	cmd := exec.CommandContext(ctx, "bwrap", args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
+	cmd.Env = minimalBwrapExecEnv(os.Environ())
 
 	b.mu.Lock()
 	b.cmd = cmd
@@ -497,6 +541,43 @@ func (b *bwrapIsolator) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("container: bwrap run %q: %w", b.name, err)
 	}
 	return nil
+}
+
+// minimalBwrapExecEnv filters a hostEnv slice (K=V pairs, as returned by
+// os.Environ()) down to a minimal allow-list that the bwrap process itself
+// needs. The returned env is what bwrap's /proc/<pid>/environ contains; it
+// is NOT the sandbox interior env (bwrap starts the sandbox with --clearenv
+// and rebuilds the interior env from explicit --setenv pairs in BuildArgs).
+//
+// See cmd/agent_run.go for the corresponding filter at the syscall.Exec
+// call site. Both filters use the same allow-list; keep them in sync.
+func minimalBwrapExecEnv(hostEnv []string) []string {
+	allow := map[string]bool{
+		"PATH":    true,
+		"HOME":    true,
+		"USER":    true,
+		"LOGNAME": true,
+		"TERM":    true,
+		"LANG":    true,
+		"LC_ALL":  true,
+	}
+	out := make([]string, 0, len(allow))
+	for _, kv := range hostEnv {
+		eq := -1
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				eq = i
+				break
+			}
+		}
+		if eq <= 0 {
+			continue
+		}
+		if allow[kv[:eq]] {
+			out = append(out, kv)
+		}
+	}
+	return out
 }
 
 // Shutdown sends SIGTERM to the bwrap process if it is still running. It uses

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -92,20 +92,14 @@ func bwrapFixture(t *testing.T, cfg Config) (m *Manager, fakeHome string, cleanu
 	dirs := []string{
 		filepath.Join(fakeHome, ".claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
-		filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions"),
+		// Shared opencode data dir — bound directly into the bwrap sandbox.
+		filepath.Join(fakeHome, ".local", "share", "opencode"),
 		filepath.Join(fakeHome, ".cache", "nix"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			t.Fatalf("fixture: MkdirAll %q: %v", d, err)
 		}
-	}
-
-	// Ensure the opencode session dir exists (named after the container).
-	containerN := containerName(cfg.SessionName)
-	sessionDir := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", containerN)
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		t.Fatalf("fixture: MkdirAll session dir: %v", err)
 	}
 
 	// Create fake SSH keys (regular files, so EvalSymlinks resolves them).
@@ -179,9 +173,13 @@ func TestBwrapBuildArgs_BaselineFlags(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// The first 9 elements must be the baseline namespace flags in order.
+	// The first baseline flags must appear in order, with --clearenv first.
+	// --clearenv wipes the inherited environment so host-shell secrets (e.g.
+	// PRISM_GITHUB_TOKEN_*) do not leak into the sandbox interior; every var
+	// the sandbox needs is added back via explicit --setenv pairs.
 	// Note: --unshare-ipc is intentionally absent — see issue #906.
 	want := []string{
+		"--clearenv",
 		"--unshare-pid",
 		"--unshare-uts",
 		"--proc", "/proc",
@@ -195,6 +193,157 @@ func TestBwrapBuildArgs_BaselineFlags(t *testing.T) {
 		}
 		if args[i] != w {
 			t.Errorf("args[%d] = %q, want %q", i, args[i], w)
+		}
+	}
+}
+
+// TestBwrapBuildArgs_ClearenvBeforeAllSetenv verifies that --clearenv appears
+// before the first --setenv pair. bwrap applies flags left-to-right, so
+// --clearenv MUST come first — any --setenv emitted before it would be wiped.
+func TestBwrapBuildArgs_ClearenvBeforeAllSetenv(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	clearenvIdx := -1
+	firstSetenvIdx := -1
+	for i, a := range args {
+		if a == "--clearenv" && clearenvIdx == -1 {
+			clearenvIdx = i
+		}
+		if a == "--setenv" && firstSetenvIdx == -1 {
+			firstSetenvIdx = i
+		}
+	}
+
+	if clearenvIdx == -1 {
+		t.Fatalf("--clearenv missing from args: %v", args)
+	}
+	if firstSetenvIdx == -1 {
+		t.Fatalf("expected at least one --setenv, got none: %v", args)
+	}
+	if clearenvIdx >= firstSetenvIdx {
+		t.Errorf("--clearenv at index %d must precede first --setenv at index %d (otherwise the setenv is wiped)",
+			clearenvIdx, firstSetenvIdx)
+	}
+}
+
+// TestMinimalBwrapExecEnv_DropsSecrets verifies that minimalBwrapExecEnv
+// strips every env var except the small allow-list bwrap itself needs. This
+// is the second layer of the token-leak defence (the first being --clearenv
+// on the bwrap command line): even the bwrap process's own /proc/<pid>/environ
+// must not contain secrets that could be read by anyone with ptrace rights.
+func TestMinimalBwrapExecEnv_DropsSecrets(t *testing.T) {
+	input := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/home/ben",
+		"USER=ben",
+		"LOGNAME=ben",
+		"TERM=xterm-256color",
+		"LANG=en_NZ.UTF-8",
+		"LC_ALL=en_NZ.UTF-8",
+
+		// All the secret shapes we've observed leaking.
+		"GITHUB_TOKEN=github_pat_secret",
+		"GITHUB_PACKAGES_TOKEN=ghp_secret",
+		"PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR=github_pat_role",
+		"PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER=github_pat_role",
+		"ANTHROPIC_API_KEY=sk-anth",
+		"OPENAI_API_KEY=sk-openai",
+		"OPENROUTER_API_KEY=sk-or",
+
+		// Arbitrary non-secret noise that should also be dropped.
+		"PRISM_SESSION_NAME=leaky",
+		"XDG_RUNTIME_DIR=/run/user/1000",
+		"SSH_AUTH_SOCK=/tmp/ssh-xxx",
+	}
+
+	out := minimalBwrapExecEnv(input)
+
+	wantPresent := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/home/ben",
+		"USER=ben",
+		"LOGNAME=ben",
+		"TERM=xterm-256color",
+		"LANG=en_NZ.UTF-8",
+		"LC_ALL=en_NZ.UTF-8",
+	}
+	gotSet := map[string]bool{}
+	for _, kv := range out {
+		gotSet[kv] = true
+	}
+	for _, kv := range wantPresent {
+		if !gotSet[kv] {
+			t.Errorf("allow-listed pair %q missing from output: %v", kv, out)
+		}
+	}
+
+	// Every output pair must be on the allow-list — nothing else should leak.
+	allowedKeys := map[string]bool{
+		"PATH": true, "HOME": true, "USER": true, "LOGNAME": true,
+		"TERM": true, "LANG": true, "LC_ALL": true,
+	}
+	for _, kv := range out {
+		eq := -1
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				eq = i
+				break
+			}
+		}
+		if eq <= 0 {
+			t.Errorf("output pair %q is malformed (no '=')", kv)
+			continue
+		}
+		key := kv[:eq]
+		if !allowedKeys[key] {
+			t.Errorf("key %q leaked through minimalBwrapExecEnv (pair: %q)", key, kv)
+		}
+	}
+
+	// Explicitly guard against the specific secret env var shapes.
+	for _, kv := range out {
+		for _, forbidden := range []string{
+			"GITHUB_TOKEN",
+			"GITHUB_PACKAGES_TOKEN",
+			"PRISM_GITHUB_TOKEN_",
+			"ANTHROPIC_API_KEY",
+			"OPENAI_API_KEY",
+			"OPENROUTER_API_KEY",
+		} {
+			if strings.HasPrefix(kv, forbidden) {
+				t.Errorf("forbidden key %q leaked: %q", forbidden, kv)
+			}
+		}
+	}
+}
+
+// TestMinimalBwrapExecEnv_IgnoresMalformed verifies that entries without '='
+// (which should never appear in os.Environ() output but are possible in
+// synthetic inputs) are silently skipped rather than panicking or producing
+// bogus pairs.
+func TestMinimalBwrapExecEnv_IgnoresMalformed(t *testing.T) {
+	out := minimalBwrapExecEnv([]string{
+		"PATH=/usr/bin",
+		"malformed-no-equals",
+		"=starts-with-equals",
+		"HOME=/home/ben",
+	})
+
+	want := []string{"PATH=/usr/bin", "HOME=/home/ben"}
+	if len(out) != len(want) {
+		t.Fatalf("len(out) = %d, want %d: %v", len(out), len(want), out)
+	}
+	for i, w := range want {
+		if out[i] != w {
+			t.Errorf("out[%d] = %q, want %q", i, out[i], w)
 		}
 	}
 }
@@ -252,7 +401,12 @@ func TestBwrapBuildArgs_McpAuthBound(t *testing.T) {
 	}
 }
 
-func TestBwrapBuildArgs_OpencodeSessionDirBound(t *testing.T) {
+func TestBwrapBuildArgs_OpencodeSharedDirBound(t *testing.T) {
+	// bwrap mode binds the shared host opencode data dir
+	// (~/.local/share/opencode/) directly into the sandbox so all sessions
+	// share a single SQLite DB. The per-session prism-sessions/<name>/
+	// isolation used by the podman path is not needed on Linux (no virtiofs
+	// WAL-mode locking issue) and is intentionally omitted here.
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -263,9 +417,16 @@ func TestBwrapBuildArgs_OpencodeSessionDirBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	sessionDir := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", m.name)
-	if !hasBind(args, sessionDir) {
-		t.Errorf("opencode session dir %q not found as --bind SRC SRC in args: %v", sessionDir, args)
+	sharedDir := filepath.Join(fakeHome, ".local", "share", "opencode")
+	if !hasBind(args, sharedDir) {
+		t.Errorf("opencode shared data dir %q not found as --bind SRC SRC in args: %v", sharedDir, args)
+	}
+
+	// Confirm the per-session prism-sessions path is NOT bound — bwrap
+	// must use the shared dir, not the per-session one.
+	perSessionDir := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", m.name)
+	if hasBind(args, perSessionDir) {
+		t.Errorf("per-session opencode dir %q should NOT be bound in bwrap mode, but was: %v", perSessionDir, args)
 	}
 }
 
@@ -412,7 +573,10 @@ func TestBwrapBuildArgs_KubeAgentsConfigROBound(t *testing.T) {
 	}
 }
 
-func TestBwrapBuildArgs_SSHAccessKeyROBound(t *testing.T) {
+func TestBwrapBuildArgs_SSHAccessKeyRemapped(t *testing.T) {
+	// The access key is mounted at the host path but exposed inside the
+	// sandbox at the canonical generic path $HOME/.ssh/access-key so that
+	// the generated ~/.ssh/config's IdentityFile line resolves correctly.
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -423,13 +587,23 @@ func TestBwrapBuildArgs_SSHAccessKeyROBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	accessKey := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519")
-	if !hasROBind(args, accessKey) {
-		t.Errorf("SSH access key %q not found as --ro-bind SRC SRC in args: %v", accessKey, args)
+	accessKeySrc := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519")
+	accessKeyDst := filepath.Join(fakeHome, ".ssh", "access-key")
+	if !hasROBindSrcDst(args, accessKeySrc, accessKeyDst) {
+		t.Errorf("SSH access key: want --ro-bind %q %q in args: %v", accessKeySrc, accessKeyDst, args)
+	}
+	// Must NOT be bound at the host-name path (Dst==Src form was replaced
+	// by the canonical-name remap in the signing-key parity fix).
+	if hasROBindSrcDst(args, accessKeySrc, accessKeySrc) {
+		t.Errorf("SSH access key: --ro-bind %q %q (Dst==Src) should not be emitted; args: %v",
+			accessKeySrc, accessKeySrc, args)
 	}
 }
 
-func TestBwrapBuildArgs_SSHSigningKeyROBound(t *testing.T) {
+func TestBwrapBuildArgs_SSHSigningKeyRemapped(t *testing.T) {
+	// Both halves of the signing key pair are remapped to canonical generic
+	// paths under $HOME/.ssh/ so the generated ~/.gitconfig's signingKey
+	// line resolves to the same path the agent sees at runtime.
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -440,17 +614,71 @@ func TestBwrapBuildArgs_SSHSigningKeyROBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	signingKey := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey")
-	signingKeyPub := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey.pub")
-	if !hasROBind(args, signingKey) {
-		t.Errorf("SSH signing key (private) %q not found as --ro-bind SRC SRC in args: %v", signingKey, args)
+	signingKeySrc := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey")
+	signingKeyDst := filepath.Join(fakeHome, ".ssh", "signing-key")
+	signingKeyPubSrc := filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey.pub")
+	signingKeyPubDst := filepath.Join(fakeHome, ".ssh", "signing-key.pub")
+
+	if !hasROBindSrcDst(args, signingKeySrc, signingKeyDst) {
+		t.Errorf("SSH signing key (private): want --ro-bind %q %q in args: %v",
+			signingKeySrc, signingKeyDst, args)
 	}
-	if !hasROBind(args, signingKeyPub) {
-		t.Errorf("SSH signing key (public) %q not found as --ro-bind SRC SRC in args: %v", signingKeyPub, args)
+	if !hasROBindSrcDst(args, signingKeyPubSrc, signingKeyPubDst) {
+		t.Errorf("SSH signing key (public): want --ro-bind %q %q in args: %v",
+			signingKeyPubSrc, signingKeyPubDst, args)
+	}
+	// Must NOT be bound at the host-name paths.
+	if hasROBindSrcDst(args, signingKeySrc, signingKeySrc) {
+		t.Errorf("SSH signing key (private): --ro-bind %q %q (Dst==Src) should not be emitted",
+			signingKeySrc, signingKeySrc)
+	}
+	if hasROBindSrcDst(args, signingKeyPubSrc, signingKeyPubSrc) {
+		t.Errorf("SSH signing key (public): --ro-bind %q %q (Dst==Src) should not be emitted",
+			signingKeyPubSrc, signingKeyPubSrc)
 	}
 }
 
-func TestBwrapBuildArgs_KnownHostsROBound(t *testing.T) {
+func TestBwrapBuildArgs_AllowedSignersRemapped(t *testing.T) {
+	// When writeGitconfig has successfully written the allowed_signers file,
+	// BuildArgs must mount it at the canonical $HOME/.ssh/allowed_signers
+	// path so that `git verify-commit` (which reads the path from gitconfig)
+	// resolves it inside the sandbox.
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		GitUserName:   "test-user",
+		GitUserEmail:  "test@example.com",
+	})
+	defer cleanup()
+
+	// writeGitconfig(isolationBwrap) both writes the gitconfig and, as a
+	// side effect, writes the allowed_signers file and sets
+	// allowedSignersReady — which is what gates the mount below.
+	if err := m.writeGitconfig(isolationBwrap); err != nil {
+		t.Fatalf("writeGitconfig: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(m.gitconfigFilePath())
+		_ = os.Remove(m.allowedSignersFilePath())
+	})
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	allowedSrc := m.allowedSignersFilePath()
+	allowedDst := filepath.Join(fakeHome, ".ssh", "allowed_signers")
+	if !hasROBindSrcDst(args, allowedSrc, allowedDst) {
+		t.Errorf("allowed_signers: want --ro-bind %q %q in args: %v",
+			allowedSrc, allowedDst, args)
+	}
+}
+
+func TestBwrapBuildArgs_KnownHostsRemapped(t *testing.T) {
+	// known_hosts is mounted with Dst = $HOME/.ssh/known_hosts, matching the
+	// canonical-name pattern used by the other SSH artefacts. This is
+	// functionally identical to Dst==Src because host sshDir already equals
+	// $HOME/.ssh, but the explicit form reads uniformly with the siblings.
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -461,9 +689,11 @@ func TestBwrapBuildArgs_KnownHostsROBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	knownHosts := filepath.Join(fakeHome, ".ssh", "known_hosts")
-	if !hasROBind(args, knownHosts) {
-		t.Errorf("known_hosts %q not found as --ro-bind SRC SRC in args: %v", knownHosts, args)
+	knownHostsSrc := filepath.Join(fakeHome, ".ssh", "known_hosts")
+	knownHostsDst := filepath.Join(fakeHome, ".ssh", "known_hosts")
+	if !hasROBindSrcDst(args, knownHostsSrc, knownHostsDst) {
+		t.Errorf("known_hosts: want --ro-bind %q %q in args: %v",
+			knownHostsSrc, knownHostsDst, args)
 	}
 }
 
@@ -776,14 +1006,13 @@ func TestStandardSandboxEnvArgs_PathFromHostWhenSet(t *testing.T) {
 }
 
 // TestStandardSandboxEnvArgs_OptionalVarsPresentWhenSet verifies that HOME,
-// USER, LOGNAME, LANG, LC_ALL, and SHELL are forwarded when set on the host.
+// USER, LOGNAME, LANG, and LC_ALL are forwarded when set on the host.
 func TestStandardSandboxEnvArgs_OptionalVarsPresentWhenSet(t *testing.T) {
 	t.Setenv("HOME", "/home/testuser")
 	t.Setenv("USER", "testuser")
 	t.Setenv("LOGNAME", "testuser")
 	t.Setenv("LANG", "en_US.UTF-8")
 	t.Setenv("LC_ALL", "en_US.UTF-8")
-	t.Setenv("SHELL", "/bin/bash")
 
 	args := standardSandboxEnvArgs()
 
@@ -793,7 +1022,6 @@ func TestStandardSandboxEnvArgs_OptionalVarsPresentWhenSet(t *testing.T) {
 		{"LOGNAME", "testuser"},
 		{"LANG", "en_US.UTF-8"},
 		{"LC_ALL", "en_US.UTF-8"},
-		{"SHELL", "/bin/bash"},
 	}
 	for _, c := range cases {
 		if !hasSetenv(args, c[0], c[1]) {
@@ -803,20 +1031,48 @@ func TestStandardSandboxEnvArgs_OptionalVarsPresentWhenSet(t *testing.T) {
 }
 
 // TestStandardSandboxEnvArgs_OptionalVarsOmittedWhenUnset verifies that
-// optional vars (HOME, USER, LOGNAME, LANG, LC_ALL, SHELL) are NOT emitted
-// when they are not set on the host.
+// optional vars (HOME, USER, LOGNAME, LANG, LC_ALL) are NOT emitted when
+// they are not set on the host. SHELL is not in this list because it is
+// forced to /bin/sh unconditionally (see TestStandardSandboxEnvArgs_ShellPinnedToBinSh).
 func TestStandardSandboxEnvArgs_OptionalVarsOmittedWhenUnset(t *testing.T) {
-	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "SHELL"} {
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL"} {
 		t.Setenv(key, "")
 	}
 	args := standardSandboxEnvArgs()
 
-	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "SHELL"} {
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL"} {
 		for i := 0; i+2 < len(args); i++ {
 			if args[i] == "--setenv" && args[i+1] == key {
 				t.Errorf("optional var %s should be omitted when unset but found in args: %v", key, args)
 			}
 		}
+	}
+}
+
+// TestStandardSandboxEnvArgs_ShellPinnedToBinSh verifies that SHELL is always
+// set to /bin/sh, regardless of the host value. On NixOS /bin/sh is a symlink
+// to bash; using /bin/sh (not zsh) avoids NixOS' /etc/zshenv sourcing
+// set-environment, which cats sops paths that don't exist inside the sandbox
+// and silently overwrites GITHUB_TOKEN with an empty string. bash -c does
+// not source /etc/profile or /etc/bashrc for non-interactive invocations, so
+// injected env vars survive intact. We pin /bin/sh (not /bin/bash) because
+// /bin/ inside the sandbox only contains the NixOS /bin/sh symlink — bash
+// itself lives in the Nix store at a hash-prefixed path.
+func TestStandardSandboxEnvArgs_ShellPinnedToBinSh(t *testing.T) {
+	for _, hostShell := range []string{
+		"", // unset host SHELL
+		"/run/current-system/sw/bin/zsh",
+		"/usr/bin/fish",
+		"/bin/bash",
+	} {
+		t.Run("host_SHELL="+hostShell, func(t *testing.T) {
+			t.Setenv("SHELL", hostShell)
+			args := standardSandboxEnvArgs()
+			if !hasSetenv(args, "SHELL", "/bin/sh") {
+				t.Errorf("expected --setenv SHELL /bin/sh regardless of host value %q; got args: %v",
+					hostShell, args)
+			}
+		})
 	}
 }
 
@@ -1400,7 +1656,7 @@ func TestBwrapBuildArgs_FullFixture(t *testing.T) {
 
 	// Baseline flags present. Note: --unshare-ipc is intentionally absent (see
 	// issue #906 — it breaks SQLite WAL mmap coherency between concurrent sessions).
-	for _, flag := range []string{"--unshare-pid", "--unshare-uts", "--die-with-parent"} {
+	for _, flag := range []string{"--clearenv", "--unshare-pid", "--unshare-uts", "--die-with-parent"} {
 		if !hasArg(args, flag) {
 			t.Errorf("baseline flag %q missing from args", flag)
 		}

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -54,6 +54,44 @@ const (
 	healthCheckInterval = 500 * time.Millisecond
 )
 
+// isolationMode identifies which sandbox layer will consume the temp files
+// (gitconfig, ssh config) that writeGitconfig / writeSshConfig generate.
+//
+// The two sandboxes mount the SSH artefacts at different in-sandbox paths:
+//
+//   - podman runs as root, so canonical paths are /root/.ssh/{access-key,
+//     signing-key,signing-key.pub,allowed_signers} — the agent's $HOME is /root.
+//   - bwrap runs as the host user, so canonical paths are
+//     $HOME/.ssh/{access-key,signing-key,signing-key.pub,allowed_signers}
+//     where $HOME is the host user's home directory.
+//
+// Agents inside both sandboxes see the same generic filenames (access-key,
+// signing-key, …); only the $HOME prefix differs. The isolation mode lets the
+// generators substitute the correct prefix into the config files they write.
+type isolationMode int
+
+const (
+	isolationPodman isolationMode = iota
+	isolationBwrap
+)
+
+// sandboxHome returns the in-sandbox $HOME directory for the given isolation
+// mode. For podman this is always /root (the image's user). For bwrap this is
+// the host user's home directory, because bwrap shares the host user namespace
+// and does not switch to root.
+func sandboxHome(mode isolationMode) string {
+	switch mode {
+	case isolationBwrap:
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			home = os.Getenv("HOME")
+		}
+		return home
+	default:
+		return "/root"
+	}
+}
+
 // Config holds the parameters for creating and managing a container.
 type Config struct {
 	// SessionName is the prism session name (e.g. "nixos-config@feature").
@@ -419,8 +457,30 @@ func (m *Manager) writeClaudeCredentials() {
 	m.claudeCredentialsReady = true
 }
 
+// writeSshConfig generates a minimal ~/.ssh/config for the sandbox and writes
+// it to a temp file. The file is later mounted at $HOME/.ssh/config:ro inside
+// the sandbox, where $HOME depends on the isolation mode (see isolationMode).
+//
+// The config only needs to handle GitHub; other SSH hosts are not expected
+// inside agent sandboxes. The IdentityFile path is $HOME/.ssh/access-key
+// using the sandbox-specific $HOME prefix, which matches the generic name
+// used by both the podman volume mount (/root/.ssh/access-key) and the bwrap
+// bind-mount (<hostHome>/.ssh/access-key).
+func (m *Manager) writeSshConfig(mode isolationMode) error {
+	identityFile := filepath.Join(sandboxHome(mode), ".ssh", "access-key")
+	sshConfig := "Host github.com\n" +
+		"  StrictHostKeyChecking accept-new\n" +
+		"  IdentityFile " + identityFile + "\n" +
+		"  IdentitiesOnly yes\n"
+	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
+		return fmt.Errorf("container: write ssh config: %w", err)
+	}
+	return nil
+}
+
 // writeGitconfig generates a minimal .gitconfig for the container and writes
-// it to a temp file. The file is later mounted at /root/.gitconfig:ro.
+// it to a temp file. The file is later mounted at $HOME/.gitconfig:ro inside
+// the sandbox, where $HOME depends on the isolation mode (see isolationMode).
 //
 // Sections included:
 //   - [user] — only when GitUserName and GitUserEmail are both non-empty;
@@ -431,7 +491,20 @@ func (m *Manager) writeClaudeCredentials() {
 //
 // Missing identity → [user] section omitted, warning logged (AC-14).
 // Missing signing keys → signing sections omitted, warning logged (AC-13).
-func (m *Manager) writeGitconfig() error {
+//
+// The mode argument controls the paths embedded in the generated file:
+//
+//   - isolationPodman: signingKey = /root/.ssh/signing-key.pub,
+//     allowedSignersFile = /root/.ssh/allowed_signers (paths inside the
+//     podman container, where the agent runs as root).
+//   - isolationBwrap: signingKey = <hostHome>/.ssh/signing-key.pub,
+//     allowedSignersFile = <hostHome>/.ssh/allowed_signers (paths inside
+//     the bwrap sandbox, where the agent runs as the host user).
+//
+// Both sandboxes mount the same underlying host key files — only the $HOME
+// prefix differs. Generic filenames (signing-key.pub, allowed_signers, …)
+// are used in both cases so agents see a uniform layout regardless of mode.
+func (m *Manager) writeGitconfig(mode isolationMode) error {
 	// Reset allowedSignersReady so that a retry or second call doesn't carry
 	// stale state from a previous successful write into a new call that may fail.
 	m.allowedSignersReady = false
@@ -465,13 +538,22 @@ func (m *Manager) writeGitconfig() error {
 
 	var sb strings.Builder
 
+	// Canonical in-sandbox paths for the signing artefacts. Both paths live
+	// at $HOME/.ssh/<generic-name> where $HOME depends on the isolation mode
+	// (see sandboxHome). Agents inside the sandbox see generic filenames —
+	// signing-key.pub / allowed_signers — regardless of which sandbox layer
+	// they're running under.
+	sandboxSshDir := filepath.Join(sandboxHome(mode), ".ssh")
+	sandboxSigningKeyPub := filepath.Join(sandboxSshDir, "signing-key.pub")
+	sandboxAllowedSigners := filepath.Join(sandboxSshDir, "allowed_signers")
+
 	// [user] section — only when identity is present.
 	if m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
 		sb.WriteString("[user]\n")
 		sb.WriteString("    name = " + m.cfg.GitUserName + "\n")
 		sb.WriteString("    email = " + m.cfg.GitUserEmail + "\n")
 		if hasSigning {
-			sb.WriteString("    signingKey = /root/.ssh/signing-key.pub\n")
+			sb.WriteString("    signingKey = " + sandboxSigningKeyPub + "\n")
 		}
 	} else {
 		log.Printf("container: git identity (name=%q, email=%q) missing; omitting [user] section from gitconfig",
@@ -507,7 +589,7 @@ func (m *Manager) writeGitconfig() error {
 			sb.WriteString("\n[gpg]\n")
 			sb.WriteString("    format = ssh\n")
 			sb.WriteString("\n[gpg \"ssh\"]\n")
-			sb.WriteString("    allowedSignersFile = /root/.ssh/allowed_signers\n")
+			sb.WriteString("    allowedSignersFile = " + sandboxAllowedSigners + "\n")
 		}
 	}
 
@@ -573,12 +655,9 @@ func (m *Manager) Create(ctx context.Context) error {
 	}
 
 	// Write a minimal SSH config for the container. The host's ~/.ssh/config
-	// is a nix store symlink with wrong ownership that SSH rejects. This
-	// config only needs to handle GitHub; other SSH hosts are not expected
-	// inside agent containers.
-	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile /root/.ssh/access-key\n  IdentitiesOnly yes\n"
-	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
-		return fmt.Errorf("container: write ssh config: %w", err)
+	// is a nix store symlink with wrong ownership that SSH rejects.
+	if err := m.writeSshConfig(isolationPodman); err != nil {
+		return err
 	}
 
 	// Write a minimal .gitconfig for the container. The host's git config lives
@@ -586,7 +665,7 @@ func (m *Manager) Create(ctx context.Context) error {
 	// containers. We generate a minimal config with identity, signing, and
 	// convenience settings.
 	t0 := time.Now()
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		return fmt.Errorf("container: write gitconfig: %w", err)
 	}
 	log.Printf("[timing] writeGitconfig: %s", time.Since(t0).Round(time.Millisecond))
@@ -611,7 +690,7 @@ func (m *Manager) Create(ctx context.Context) error {
 	// container and exits 125 if any are absent, so we create them eagerly here.
 	// Failures are logged and non-fatal — podman will surface the real error if
 	// the directory is still absent after this attempt.
-	if err := m.prepareVolumeDirs(); err != nil {
+	if err := m.prepareVolumeDirs(true); err != nil {
 		// prepareVolumeDirs logs individual failures; a non-nil error means
 		// multiple dirs failed and is logged here for observability only.
 		log.Printf("container: prepareVolumeDirs partial failure: %v", err)
@@ -746,32 +825,19 @@ func (m *Manager) Shutdown() {
 // missing sources — it simply fails to bind. Eagerly creating the directories
 // avoids confusing "No such file or directory" errors at bwrap startup.
 func (m *Manager) PrepareBwrap() ([]string, error) {
-	// Write a minimal SSH config for bwrap. Unlike the podman path, which uses
-	// the in-container path "/root/.ssh/access-key" (where the key is mounted),
-	// bwrap uses Dst==Src mounts — the key is visible at its resolved host path
-	// inside the sandbox. Resolve the symlink to get the absolute path that
-	// BuildArgs mounts with --ro-bind.
-	accessKeyName := m.cfg.SshAccessKeyName
-	if accessKeyName == "" {
-		accessKeyName = "prismatic-koi-ed25519"
-	}
-	home, _ := os.UserHomeDir()
-	if home == "" {
-		home = os.Getenv("HOME")
-	}
-	sshDir := filepath.Join(home, ".ssh")
-	accessKeyPath := filepath.Join(sshDir, accessKeyName)
-	if resolved, err := filepath.EvalSymlinks(accessKeyPath); err == nil {
-		// Use the resolved path — that's what BuildArgs mounts with --ro-bind.
-		accessKeyPath = resolved
-	}
-	sshConfig := "Host github.com\n  StrictHostKeyChecking accept-new\n  IdentityFile " + accessKeyPath + "\n  IdentitiesOnly yes\n"
-	if err := os.WriteFile(m.sshConfigFilePath(), []byte(sshConfig), 0o600); err != nil {
-		return nil, fmt.Errorf("container: bwrap: write ssh config: %w", err)
+	// Write a minimal SSH config for bwrap. The bwrap SSH key mount remaps
+	// the host signing/access keys to canonical generic paths under
+	// $HOME/.ssh/ inside the sandbox (see bwrap.go), so the IdentityFile path
+	// is $HOME/.ssh/access-key — same generic name as the podman path, just
+	// rooted at the host user's $HOME instead of /root.
+	if err := m.writeSshConfig(isolationBwrap); err != nil {
+		return nil, fmt.Errorf("container: bwrap: %w", err)
 	}
 
-	// Write the gitconfig. Mirrors the Create() path.
-	if err := m.writeGitconfig(); err != nil {
+	// Write the gitconfig. Mirrors the Create() path, but with bwrap-mode
+	// paths (signingKey and allowedSignersFile rooted at <hostHome>/.ssh/
+	// rather than /root/.ssh/).
+	if err := m.writeGitconfig(isolationBwrap); err != nil {
 		return nil, fmt.Errorf("container: bwrap: write gitconfig: %w", err)
 	}
 
@@ -785,7 +851,7 @@ func (m *Manager) PrepareBwrap() ([]string, error) {
 	// Pre-create directories that BuildArgs will reference as bind-mount
 	// sources. bwrap silently fails rather than printing a clear error, so
 	// we create eagerly here.
-	if err := m.prepareVolumeDirs(); err != nil {
+	if err := m.prepareVolumeDirs(false); err != nil {
 		log.Printf("container: bwrap: prepareVolumeDirs partial failure: %v", err)
 	}
 
@@ -803,7 +869,12 @@ func (m *Manager) PrepareBwrap() ([]string, error) {
 // Individual MkdirAll failures are logged and treated as non-fatal: if the
 // directory is still absent when podman runs, podman will produce the real
 // error. Returns a non-nil error only when multiple dirs fail.
-func (m *Manager) prepareVolumeDirs() error {
+//
+// perSessionOpencode controls whether the per-session opencode state directory
+// (~/.local/share/opencode/prism-sessions/<name>/) is created. The podman path
+// requires it (Darwin virtiofs WAL-mode locking workaround); the bwrap path
+// shares ~/.local/share/opencode/ directly and does not need a per-session dir.
+func (m *Manager) prepareVolumeDirs(perSessionOpencode bool) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = os.Getenv("HOME")
@@ -811,11 +882,13 @@ func (m *Manager) prepareVolumeDirs() error {
 
 	var errs []string
 
-	// Per-session opencode state directory.
-	opencodeSessionDir := filepath.Join(home, ".local", "share", "opencode", "prism-sessions", m.name)
-	if err := os.MkdirAll(opencodeSessionDir, 0o755); err != nil {
-		log.Printf("container: failed to create per-session opencode state dir %q: %v", opencodeSessionDir, err)
-		errs = append(errs, err.Error())
+	// Per-session opencode state directory (podman only).
+	if perSessionOpencode {
+		opencodeSessionDir := filepath.Join(home, ".local", "share", "opencode", "prism-sessions", m.name)
+		if err := os.MkdirAll(opencodeSessionDir, 0o755); err != nil {
+			log.Printf("container: failed to create per-session opencode state dir %q: %v", opencodeSessionDir, err)
+			errs = append(errs, err.Error())
+		}
 	}
 
 	// opencode plugin/model cache.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1542,7 +1542,7 @@ func TestWriteGitconfig_IncludesPushAndInit(t *testing.T) {
 		AllocatedPort: 14000,
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
@@ -1584,7 +1584,7 @@ func TestWriteGitconfig_NoSigningSectionsWhenKeysUnavailable(t *testing.T) {
 		GitUserEmail:  "test@example.com",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
@@ -1630,7 +1630,7 @@ func TestWriteGitconfig_SigningSectionsWhenKeysAndIdentityPresent(t *testing.T) 
 		GitUserEmail:  "test@example.com",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() {
@@ -1661,6 +1661,118 @@ func TestWriteGitconfig_SigningSectionsWhenKeysAndIdentityPresent(t *testing.T) 
 	}
 }
 
+// TestWriteGitconfig_BwrapMode_UsesHostHomePaths verifies that writeGitconfig
+// in bwrap mode writes signingKey and allowedSignersFile paths rooted at the
+// host user's $HOME (not /root). The bwrap sandbox runs as the host user, so
+// the canonical $HOME/.ssh/<generic-name> paths resolve to the host user's
+// home — not the image root — and must match what bwrap.go mounts.
+func TestWriteGitconfig_BwrapMode_UsesHostHomePaths(t *testing.T) {
+	fakeHome := t.TempDir()
+	sshDir := fakeHome + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll .ssh: %v", err)
+	}
+	for _, name := range []string{"prismatic-koi-ed25519-signingkey", "prismatic-koi-ed25519-signingkey.pub"} {
+		if err := os.WriteFile(sshDir+"/"+name, []byte("stub"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		GitUserName:   "test-user",
+		GitUserEmail:  "test@example.com",
+	})
+
+	if err := m.writeGitconfig(isolationBwrap); err != nil {
+		t.Fatalf("writeGitconfig(isolationBwrap) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(m.gitconfigFilePath())
+		_ = os.Remove(m.allowedSignersFilePath())
+	})
+
+	data, err := os.ReadFile(m.gitconfigFilePath())
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	content := string(data)
+
+	wantSigning := "signingKey = " + fakeHome + "/.ssh/signing-key.pub"
+	if !strings.Contains(content, wantSigning) {
+		t.Errorf("bwrap gitconfig missing %q; content:\n%s", wantSigning, content)
+	}
+	wantAllowed := "allowedSignersFile = " + fakeHome + "/.ssh/allowed_signers"
+	if !strings.Contains(content, wantAllowed) {
+		t.Errorf("bwrap gitconfig missing %q; content:\n%s", wantAllowed, content)
+	}
+	// Must NOT contain the podman-only /root/.ssh/... paths.
+	if strings.Contains(content, "/root/.ssh/signing-key.pub") {
+		t.Errorf("bwrap gitconfig must not contain /root/.ssh/signing-key.pub; content:\n%s", content)
+	}
+	if strings.Contains(content, "/root/.ssh/allowed_signers") {
+		t.Errorf("bwrap gitconfig must not contain /root/.ssh/allowed_signers; content:\n%s", content)
+	}
+}
+
+// TestWriteSshConfig_PodmanMode_UsesRootPath verifies that writeSshConfig in
+// podman mode embeds IdentityFile = /root/.ssh/access-key (the path where
+// buildRunArgs mounts the access key inside the podman container).
+func TestWriteSshConfig_PodmanMode_UsesRootPath(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+
+	if err := m.writeSshConfig(isolationPodman); err != nil {
+		t.Fatalf("writeSshConfig(isolationPodman): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.sshConfigFilePath()) })
+
+	data, err := os.ReadFile(m.sshConfigFilePath())
+	if err != nil {
+		t.Fatalf("read ssh config: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "IdentityFile /root/.ssh/access-key") {
+		t.Errorf("podman ssh config missing IdentityFile /root/.ssh/access-key; content:\n%s", content)
+	}
+}
+
+// TestWriteSshConfig_BwrapMode_UsesHostHomePath verifies that writeSshConfig
+// in bwrap mode embeds IdentityFile = <hostHome>/.ssh/access-key rather than
+// /root/.ssh/access-key. bwrap mounts the access key at the host user's
+// $HOME/.ssh/ so the generated SSH config must reference the same path.
+func TestWriteSshConfig_BwrapMode_UsesHostHomePath(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+
+	if err := m.writeSshConfig(isolationBwrap); err != nil {
+		t.Fatalf("writeSshConfig(isolationBwrap): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(m.sshConfigFilePath()) })
+
+	data, err := os.ReadFile(m.sshConfigFilePath())
+	if err != nil {
+		t.Fatalf("read ssh config: %v", err)
+	}
+	content := string(data)
+	want := "IdentityFile " + fakeHome + "/.ssh/access-key"
+	if !strings.Contains(content, want) {
+		t.Errorf("bwrap ssh config missing %q; content:\n%s", want, content)
+	}
+	if strings.Contains(content, "IdentityFile /root/.ssh/access-key") {
+		t.Errorf("bwrap ssh config must not contain /root/.ssh/access-key; content:\n%s", content)
+	}
+}
+
 func TestWriteGitconfig_UserSectionWhenIdentityPresent(t *testing.T) {
 	// AC-2, AC-14: [user] section present only when both name and email are set.
 	m := New(Config{
@@ -1670,7 +1782,7 @@ func TestWriteGitconfig_UserSectionWhenIdentityPresent(t *testing.T) {
 		GitUserEmail:  "test@example.com",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
@@ -1720,7 +1832,7 @@ func TestWriteGitconfig_NoSigningWithoutIdentity(t *testing.T) {
 		// GitUserName and GitUserEmail intentionally left empty.
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
@@ -1763,7 +1875,7 @@ func TestWriteGitconfig_NoUserSectionWhenIdentityMissing(t *testing.T) {
 				GitUserEmail:  tc.email,
 			})
 
-			if err := m.writeGitconfig(); err != nil {
+			if err := m.writeGitconfig(isolationPodman); err != nil {
 				t.Fatalf("writeGitconfig returned error: %v", err)
 			}
 			t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
@@ -1889,7 +2001,7 @@ func TestWriteGitconfig_CustomSigningKeyName(t *testing.T) {
 		SshSigningKeyName: "my-custom-signingkey",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() {
@@ -1936,7 +2048,7 @@ func TestWriteGitconfig_FallbackWhenSigningKeyNameEmpty(t *testing.T) {
 		// SshSigningKeyName intentionally left empty — must fall back to default.
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() {
@@ -1988,7 +2100,7 @@ func TestWriteGitconfig_AllowedSignersFileInGitconfigWhenSigningAvailable(t *tes
 		GitUserEmail:  "test@example.com",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() {
@@ -2023,7 +2135,7 @@ func TestWriteGitconfig_AllowedSignersAbsentWhenSigningUnavailable(t *testing.T)
 		GitUserEmail:  "test@example.com",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(m.gitconfigFilePath()) })
@@ -2066,7 +2178,7 @@ func TestWriteGitconfig_AllowedSignersFileContent(t *testing.T) {
 		GitUserEmail:  "test@example.com",
 	})
 
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig returned error: %v", err)
 	}
 	t.Cleanup(func() {
@@ -2115,7 +2227,7 @@ func TestBuildRunArgs_AllowedSignersMountedWhenSigningAvailable(t *testing.T) {
 
 	// writeGitconfig must be called first — it sets allowedSignersReady which
 	// buildRunArgs uses to gate the bind-mount.
-	if err := m.writeGitconfig(); err != nil {
+	if err := m.writeGitconfig(isolationPodman); err != nil {
 		t.Fatalf("writeGitconfig: %v", err)
 	}
 	t.Cleanup(func() {
@@ -2599,7 +2711,7 @@ func TestPrepareVolumeDirs_CreatesSessionDir(t *testing.T) {
 	t.Setenv("HOME", fakeHome)
 
 	m := New(Config{SessionName: "my-repo@feat", AllocatedPort: 14000})
-	if err := m.prepareVolumeDirs(); err != nil {
+	if err := m.prepareVolumeDirs(true); err != nil {
 		t.Fatalf("prepareVolumeDirs: %v", err)
 	}
 
@@ -2611,6 +2723,38 @@ func TestPrepareVolumeDirs_CreatesSessionDir(t *testing.T) {
 	wantClipboard := filepath.Join(fakeHome, ".cache", "prism", "clipboard")
 
 	for _, dir := range []string{wantSession, wantOpencode, wantBun, wantClipboard} {
+		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+			t.Errorf("expected directory to exist: %s (err: %v)", dir, err)
+		}
+	}
+}
+
+// TestPrepareVolumeDirs_BwrapSkipsSessionDir verifies that when called with
+// perSessionOpencode=false (the bwrap path), the per-session opencode state
+// directory under prism-sessions/ is NOT created. bwrap mode shares the host's
+// ~/.local/share/opencode/ directly, so a per-session subdir would just be
+// dead state on disk.
+func TestPrepareVolumeDirs_BwrapSkipsSessionDir(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := New(Config{SessionName: "my-repo@feat", AllocatedPort: 14000})
+	if err := m.prepareVolumeDirs(false); err != nil {
+		t.Fatalf("prepareVolumeDirs(false): %v", err)
+	}
+
+	// Per-session dir must NOT exist.
+	perSession := filepath.Join(fakeHome, ".local", "share", "opencode", "prism-sessions", m.Name())
+	if _, err := os.Stat(perSession); !os.IsNotExist(err) {
+		t.Errorf("per-session dir %q should not exist for bwrap mode (stat err: %v)", perSession, err)
+	}
+
+	// Other shared dirs that bwrap also relies on should still be created.
+	for _, dir := range []string{
+		filepath.Join(fakeHome, ".cache", "opencode"),
+		filepath.Join(fakeHome, ".cache", "bun"),
+		filepath.Join(fakeHome, ".cache", "prism", "clipboard"),
+	} {
 		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
 			t.Errorf("expected directory to exist: %s (err: %v)", dir, err)
 		}

--- a/modules/programs/prism/prism/internal/git/git_test.go
+++ b/modules/programs/prism/prism/internal/git/git_test.go
@@ -15,6 +15,11 @@ func initRepo(t *testing.T, dir, branchName string) {
 		{"git", "init", "-b", branchName},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
+		// Disable signing in the test repo: host gitconfig may enable
+		// gpgsign globally (via home-manager), which would make `git commit`
+		// fail here because no signing key is available in the test env.
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "config", "tag.gpgsign", "false"},
 	}
 	for _, args := range cmds {
 		c := exec.Command(args[0], args[1:]...)
@@ -562,9 +567,14 @@ func TestCloneWorktree_EmptyRepo(t *testing.T) {
 		t.Errorf("no bootstrap instructions in progress messages; got: %v", progressMsgs)
 	}
 
-	// User must be able to make a commit in the orphan worktree.
+	// User must be able to make a commit in the orphan worktree. Disable
+	// signing in the test repo: host gitconfig may enable gpgsign globally
+	// (via home-manager), which would make `git commit` fail here because no
+	// signing key is available in the test env.
 	runGitIn(t, worktreeDir, "config", "user.email", "test@test.com")
 	runGitIn(t, worktreeDir, "config", "user.name", "Test")
+	runGitIn(t, worktreeDir, "config", "commit.gpgsign", "false")
+	runGitIn(t, worktreeDir, "config", "tag.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(worktreeDir, "README"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatalf("write README: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -111,14 +111,26 @@ func KillSidecar(sessionName string) {
 	}
 
 	// Guard against same-user PID recycling: verify the PID belongs to a
-	// prism process by checking /proc/<pid>/cmdline before sending SIGTERM.
-	// This is Linux-specific (codebase targets NixOS), so if the file is
-	// unreadable (e.g. the process is already gone) we fall through and let
-	// the subsequent Kill handle ESRCH gracefully.
+	// prism sidecar process by checking /proc/<pid>/cmdline before sending
+	// SIGTERM. This is Linux-specific (codebase targets NixOS), so if the
+	// file is unreadable (e.g. the process is already gone) we fall through
+	// and let the subsequent Kill handle ESRCH gracefully.
+	//
+	// The check matches the invariant argv shape of a prism-spawned sidecar:
+	//
+	//   <binary> sidecar --session <name> ...
+	//
+	// We require both "sidecar" and "--session" to appear in the cmdline.
+	// A previous implementation checked for "prism" in the binary path, but
+	// that produced false negatives under `go test`, where the sidecar is
+	// spawned by re-invoking the test binary (e.g. "cmd.test sidecar …") —
+	// the cmdline does not contain "prism" at all, so KillSidecar skipped
+	// the kill and sidecars leaked after every test run.
 	if cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid)); err == nil {
-		if !strings.Contains(string(cmdline), "prism") {
+		cmdlineStr := string(cmdline)
+		if !strings.Contains(cmdlineStr, "sidecar") || !strings.Contains(cmdlineStr, "--session") {
 			// PID has been recycled to an unrelated process — do not kill it.
-			fmt.Fprintf(os.Stderr, "warning: sidecar pid %d does not appear to be a prism process — skipping kill\n", pid)
+			fmt.Fprintf(os.Stderr, "warning: sidecar pid %d does not appear to be a prism sidecar process — skipping kill\n", pid)
 			_ = os.Remove(pidPath)
 			return
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -398,57 +398,64 @@ func (s *Sidecar) Run(ctx context.Context) error {
 				s.cfg.OnReady()
 			}
 		}
+	}
 
-		// Start the host-API servers (AC-1, AC-9).
-		// Guard with !isShuttingDown: if SIGTERM arrived between WaitHealthy
-		// and here, Shutdown() will have already run and we must not create
-		// listeners that would never be closed.
-		if !isShuttingDown && s.cfg.HostAPISockPath != "" {
-			// Unix socket server — always started when HostAPISockPath is set,
-			// regardless of platform. On Darwin the container uses TCP
-			// (HostAPITCPPort), but the Unix socket is still available for
-			// host-side tooling.
-			_ = os.Remove(s.cfg.HostAPISockPath)
-			ln, listenErr := net.Listen("unix", s.cfg.HostAPISockPath)
-			if listenErr != nil {
-				log.Printf("sidecar: host-API server: listen unix: %v", listenErr)
-			} else {
-				srv := &http.Server{Handler: s.hostAPIHandler()}
-				s.mu.Lock()
-				s.hostAPIListener = ln
-				s.hostAPISrv = srv
-				s.mu.Unlock()
-				go func() {
-					if err := srv.Serve(ln); err != nil &&
-						!errors.Is(err, http.ErrServerClosed) &&
-						!errors.Is(err, net.ErrClosed) {
-						log.Printf("sidecar: host-API server (unix): %v", err)
-					}
-				}()
-			}
-
-			// TCP server — Darwin only, when the TCP listener was bound before
-			// container creation. Uses a separate http.Server with the same handler
-			// so both transports serve identical API endpoints.
+	// Start the host-API servers (AC-1, AC-9).
+	// This runs for BOTH podman and bwrap isolation modes — any session with
+	// HostAPISockPath set needs the Unix socket so the sandboxed agent can
+	// proxy prism CLI calls back to the host. Previously this block was nested
+	// inside the Container!=nil branch, which meant bwrap coordinators (where
+	// Container is nil) never got a socket.
+	//
+	// Guard with !shuttingDown: if SIGTERM arrived before we reach here,
+	// Shutdown() will have already run and we must not create listeners that
+	// would never be closed.
+	s.mu.Lock()
+	alreadyShuttingDown := s.shuttingDown
+	s.mu.Unlock()
+	if !alreadyShuttingDown && s.cfg.HostAPISockPath != "" {
+		// Unix socket server — always started when HostAPISockPath is set,
+		// regardless of platform. On Darwin the container uses TCP
+		// (HostAPITCPPort), but the Unix socket is still available for
+		// host-side tooling.
+		_ = os.Remove(s.cfg.HostAPISockPath)
+		ln, listenErr := net.Listen("unix", s.cfg.HostAPISockPath)
+		if listenErr != nil {
+			log.Printf("sidecar: host-API server: listen unix: %v", listenErr)
+		} else {
+			srv := &http.Server{Handler: s.hostAPIHandler()}
 			s.mu.Lock()
-			tcpLn := s.hostAPITCPListener
+			s.hostAPIListener = ln
+			s.hostAPISrv = srv
 			s.mu.Unlock()
-			if tcpLn != nil {
-				tcpSrv := &http.Server{Handler: s.hostAPIHandler()}
-				s.mu.Lock()
-				s.hostAPITCPSrv = tcpSrv
-				s.mu.Unlock()
-				go func() {
-					if err := tcpSrv.Serve(tcpLn); err != nil &&
-						!errors.Is(err, http.ErrServerClosed) &&
-						!errors.Is(err, net.ErrClosed) {
-						log.Printf("sidecar: host-API server (tcp): %v", err)
-					}
-				}()
-				log.Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
-			}
-		} else if s.cfg.HostAPISockPath == "" {
-			log.Printf("sidecar: host-API server: HostAPISockPath is empty — skipping (container mode active but no socket path configured)")
+			go func() {
+				if err := srv.Serve(ln); err != nil &&
+					!errors.Is(err, http.ErrServerClosed) &&
+					!errors.Is(err, net.ErrClosed) {
+					log.Printf("sidecar: host-API server (unix): %v", err)
+				}
+			}()
+		}
+
+		// TCP server — Darwin only, when the TCP listener was bound before
+		// container creation. Uses a separate http.Server with the same handler
+		// so both transports serve identical API endpoints.
+		s.mu.Lock()
+		tcpLn := s.hostAPITCPListener
+		s.mu.Unlock()
+		if tcpLn != nil {
+			tcpSrv := &http.Server{Handler: s.hostAPIHandler()}
+			s.mu.Lock()
+			s.hostAPITCPSrv = tcpSrv
+			s.mu.Unlock()
+			go func() {
+				if err := tcpSrv.Serve(tcpLn); err != nil &&
+					!errors.Is(err, http.ErrServerClosed) &&
+					!errors.Is(err, net.ErrClosed) {
+					log.Printf("sidecar: host-API server (tcp): %v", err)
+				}
+			}()
+			log.Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Bring bwrap isolation to production parity with podman. Before this PR:

- bwrap sandboxes couldn't sign commits (gitconfig hardcoded `/root/...` paths that only exist in podman containers)
- bwrap coordinators had no host-API socket
- every host env var leaked into the sandbox (including every `PRISM_GITHUB_TOKEN_*` role token)
- NixOS' zsh init wiped the injected `GITHUB_TOKEN` to empty on every shell spawn inside the sandbox, breaking `git push` and `gh`
- the Go test suite leaked ~12 sidecar processes per run, eventually starving the box

All of those gaps are closed here.

## What changed

### Bwrap ↔ podman signing-key + SSH-config parity
`writeGitconfig` / `writeSshConfig` take an `isolationMode` and substitute the correct `$HOME` prefix (`/root` for podman, host user's `$HOME` for bwrap). Bwrap SSH mounts remapped to canonical generic paths under `$HOME/.ssh/` — `access-key`, `signing-key`, `signing-key.pub`, `allowed_signers`, `known_hosts`. Agents see identical filenames in both sandboxes.

### Host env leak into bwrap closed (two-layer defence)
1. `--clearenv` is now the first flag in the bwrap baseline args — wipes inherited env so every var must come via explicit `--setenv`.
2. The bwrap child process itself runs with a minimal allow-list env (`minimalBwrapExecEnv`) applied at `syscall.Exec` and `exec.Command` call sites, so nothing secret appears in bwrap's own `/proc/<pid>/environ` either.

### `SHELL` pinned to `/bin/sh` inside bwrap
Forces non-interactive bash behaviour. NixOS' `/etc/zshenv` sources `set-environment`, which `cat`s every sops secret path and exports the result — inside bwrap those paths don't exist, so the sandbox would silently wipe `GITHUB_TOKEN`. bash `-c` does not source `/etc/profile` or `/etc/bashrc`, so the injected env survives.

### Host-API socket works for bwrap coordinators
Sidecar's Unix-socket (and Darwin TCP) server lifted out of the `Container != nil` branch. Bwrap coordinators now get a socket and can proxy prism CLI calls from inside the sandbox.

### Shared opencode data dir for bwrap
bwrap sessions share `~/.local/share/opencode/` directly — single SQLite DB across host / bwrap / plain-opencode. Per-session isolation is podman-only (Darwin virtiofs WAL workaround). `prepareVolumeDirs` takes a `perSessionOpencode bool`.

### Sidecar process leak fixed
`KillSidecar`'s PID-recycling guard required `"prism"` in `/proc/<pid>/cmdline`. Test-spawned sidecars (`cmd.test sidecar --session …`) don't contain `"prism"` so cleanup silently skipped the kill and the `Setsid`-detached sidecar survived as a PID-1 orphan. Guard replaced: now matches the invariant sidecar argv shape (both `"sidecar"` and `"--session"` must be present).

### Host-side test hygiene
Tests now run from inside prism sandboxes where `gpgsign=true` is the norm and `PRISM_HOST_API` is inherited. Added per-repo `commit.gpgsign=false` to test helpers and `GIT_CONFIG_GLOBAL=/dev/null` + `PRISM_HOST_API=""` to the integration tests that spawn a fresh prism binary.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test ./...` | all packages green (previously: 24 failures + leaked sidecars per run) |
| `ps -ef \| rg 'cmd.test sidecar'` after `go test ./...` | zero matches |
| `nix build .#nixosConfigurations.navi.config.system.build.toplevel` | exit 0 |
| Live bwrap verification on navi (post-switch) | `SHELL=/bin/sh`, exactly one `GITHUB_TOKEN` present, no other secret env vars, no `cat: /run/secrets/…` noise, this very PR's commit is signed + correctly attributed |

## Acceptance criteria

- AC-1 Inside bwrap, `git commit -S` succeeds when host signing keys exist.
- AC-2 Inside bwrap, `git push` over SSH to github.com succeeds.
- AC-3 `git verify-commit` resolves `allowed_signers` correctly.
- AC-4 `writeGitconfig(isolationPodman)` output unchanged from before.
- AC-5 `writeGitconfig(isolationBwrap)` paths rooted at host user's `$HOME`.
- AC-6 bwrap mounts the five SSH artefacts at `$HOME/.ssh/<generic-name>`.
- AC-7 Bwrap coordinators resolve `PRISM_HOST_API` via the sidecar socket.
- AC-8 Bwrap sandbox env contains at most one `GITHUB_TOKEN`; no other secret-shaped env vars leak from the host.
- AC-9 The injected `GITHUB_TOKEN` survives arbitrary shell invocations inside the sandbox.
- AC-10 `go test ./...` passes with zero leaked sidecar or tmux processes.
- AC-11 `nix build` for navi succeeds.

## Files changed

- `cmd/agent_run.go` — minimal allow-list env for `syscall.Exec`
- `cmd/cleanup_test.go` — gpgsign=false in helper, env hygiene in 3 integration tests
- `cmd/killsidecar_test.go` — stub process argv + assertion updated for new cmdline invariant
- `cmd/session_name_test.go` — gpgsign=false in helper
- `cmd/switch_test.go` — env hygiene in 2 integration tests
- `internal/container/bwrap.go` — `--clearenv`, SHELL pin, SSH mount remap, shared opencode dir, `minimalBwrapExecEnv`
- `internal/container/bwrap_test.go` — rewritten SSH/baseline assertions, new tests for clearenv + env filter + SHELL pin
- `internal/container/container.go` — `isolationMode` enum, `writeGitconfig(mode)`, `writeSshConfig(mode)`, `prepareVolumeDirs(bool)`
- `internal/container/container_test.go` — 12 existing sites updated, 4 new tests
- `internal/git/git_test.go` — gpgsign=false in `initRepo` + `TestCloneWorktree_EmptyRepo`
- `internal/session/sidecar.go` — KillSidecar cmdline guard
- `internal/sidecar/sidecar.go` — host-API socket lifted out of container branch