### PR TITLE
prism bwrap: fix spawn hangs caused by cache EROFS and port collision

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -397,16 +397,26 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		}
 	}
 
-	// ── opencode plugin cache (read-only, conditional) ───────────────────────
+	// ── opencode plugin cache (read-write, conditional) ─────────────────────
+	// Must be writable: opencode refreshes ~/.cache/opencode/models.json from
+	// models.dev on startup and writes back to disk. A read-only mount causes
+	// EROFS, which opencode swallows into a silent "Failed to start server"
+	// error (logged to ~/.local/share/opencode/log/*.log, NOT to stderr), so
+	// the sidecar loops on connection-refused and the pane stays blank. See
+	// the bwrap-spawn-hangs investigation for the full signature.
 	opencodeCacheDir := filepath.Join(home, ".cache", "opencode")
 	if _, err := os.Stat(opencodeCacheDir); err == nil {
-		args = append(args, "--ro-bind", opencodeCacheDir, opencodeCacheDir)
+		args = append(args, "--bind", opencodeCacheDir, opencodeCacheDir)
 	}
 
-	// ── bun transpiler cache (read-only, conditional) ───────────────────────
+	// ── bun transpiler cache (read-write, conditional) ──────────────────────
+	// Must be writable alongside the opencode cache: bun writes transpile
+	// outputs and lockfile updates here on plugin load. Mirrors the opencode
+	// cache treatment above for the same reason — EROFS on write would also
+	// manifest as a silent startup hang.
 	bunCacheDir := filepath.Join(home, ".cache", "bun")
 	if _, err := os.Stat(bunCacheDir); err == nil {
-		args = append(args, "--ro-bind", bunCacheDir, bunCacheDir)
+		args = append(args, "--bind", bunCacheDir, bunCacheDir)
 	}
 
 	// ── Additional AWS mounts (read-only, conditional) ───────────────────────
@@ -500,9 +510,23 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// ── Terminator: -- opencode --port <port> --hostname 127.0.0.1 ──────────
 	// bwrap uses 127.0.0.1 (not 0.0.0.0): the host network namespace is shared
 	// (no --unshare-net), so binding to 0.0.0.0 would be overly broad.
+	//
+	// The port is cfg.AllocatedPort (the per-session host port picked by prism)
+	// rather than the fixed ContainerPort. Because bwrap shares the host network
+	// namespace, every sandbox binds directly to a host port — two sessions both
+	// trying to bind ContainerPort (4096) would collide with EADDRINUSE and the
+	// second would silently fail with "Failed to start server on port 4096" in
+	// the opencode log. ContainerPort is retained as a fallback for the
+	// theoretical case where AllocatedPort is unset (e.g. a malformed session
+	// row); in normal operation cfg.AllocatedPort is always populated by
+	// agent-run from the DB's opencode_port column.
+	opencodePort := cfg.AllocatedPort
+	if opencodePort == 0 {
+		opencodePort = ContainerPort
+	}
 	args = append(args, "--",
 		"opencode",
-		"--port", fmt.Sprintf("%d", ContainerPort),
+		"--port", fmt.Sprintf("%d", opencodePort),
 		"--hostname", "127.0.0.1",
 	)
 

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1265,7 +1264,12 @@ func TestBwrapBuildArgs_Terminator(t *testing.T) {
 	if tail[1] != "--port" {
 		t.Errorf("tail[1] = %q, want --port", tail[1])
 	}
-	wantPort := fmt.Sprintf("%d", ContainerPort)
+	// bwrap binds directly to the per-session AllocatedPort (shared host
+	// network namespace — no --publish remap). The fixture sets AllocatedPort
+	// = 14010 above; asserting that value confirms the opencode --port flag
+	// tracks it rather than the fixed ContainerPort (which would cause every
+	// second bwrap session to fail with EADDRINUSE).
+	wantPort := "14010"
 	if tail[2] != wantPort {
 		t.Errorf("tail[2] = %q, want %q", tail[2], wantPort)
 	}
@@ -1275,6 +1279,67 @@ func TestBwrapBuildArgs_Terminator(t *testing.T) {
 	if tail[4] != "127.0.0.1" {
 		t.Errorf("tail[4] = %q, want 127.0.0.1", tail[4])
 	}
+}
+
+// TestBwrapBuildArgs_PortTracksAllocatedPort verifies that the opencode --port
+// flag in the bwrap argv reflects cfg.AllocatedPort rather than being
+// hardcoded. Two distinct AllocatedPort values must produce two distinct --port
+// values in the resulting argv. Regression guard for the bug where every bwrap
+// session bound the fixed ContainerPort and the second session silently failed
+// with EADDRINUSE (because bwrap shares the host network namespace).
+func TestBwrapBuildArgs_PortTracksAllocatedPort(t *testing.T) {
+	portOf := func(t *testing.T, allocated int) string {
+		t.Helper()
+		m, _, cleanup := bwrapFixture(t, Config{
+			SessionName:   "repo@main",
+			Worktree:      t.TempDir(),
+			AllocatedPort: allocated,
+		})
+		defer cleanup()
+		b := &bwrapIsolator{name: m.name}
+		args := b.BuildArgs(m)
+		// Locate the terminator and return the --port value.
+		for i, a := range args {
+			if a == "--" && i+3 < len(args) && args[i+1] == "opencode" && args[i+2] == "--port" {
+				return args[i+3]
+			}
+		}
+		t.Fatalf("did not find '-- opencode --port <value>' in args: %v", args)
+		return ""
+	}
+
+	if got := portOf(t, 14010); got != "14010" {
+		t.Errorf("AllocatedPort=14010: --port = %q, want \"14010\"", got)
+	}
+	if got := portOf(t, 14020); got != "14020" {
+		t.Errorf("AllocatedPort=14020: --port = %q, want \"14020\"", got)
+	}
+}
+
+// TestBwrapBuildArgs_PortFallbackWhenUnset verifies that when AllocatedPort is
+// 0 (unset — e.g. a malformed session row with no opencode_port in the DB), the
+// argv falls back to ContainerPort rather than emitting "--port 0" which would
+// make opencode bind to an arbitrary ephemeral port the sidecar can't locate.
+func TestBwrapBuildArgs_PortFallbackWhenUnset(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName: "repo@main",
+		Worktree:    t.TempDir(),
+		// AllocatedPort intentionally left as zero-value.
+	})
+	defer cleanup()
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	want := "4096" // ContainerPort — keep in sync with container.ContainerPort.
+	for i, a := range args {
+		if a == "--" && i+3 < len(args) && args[i+1] == "opencode" && args[i+2] == "--port" {
+			if args[i+3] != want {
+				t.Errorf("fallback --port = %q, want %q (ContainerPort)", args[i+3], want)
+			}
+			return
+		}
+	}
+	t.Fatalf("did not find '-- opencode --port <value>' in args: %v", args)
 }
 
 func TestBwrapBuildArgs_AgentRoleAndPromptInTail(t *testing.T) {
@@ -1715,7 +1780,7 @@ func TestBwrapBuildArgs_FullFixture(t *testing.T) {
 		t.Errorf("-- separator missing from args")
 	}
 
-	// Tail: opencode --port 4096 --hostname 127.0.0.1 --agent worker --prompt ...
+	// Tail: opencode --port <AllocatedPort> --hostname 127.0.0.1 --agent worker --prompt ...
 	n := len(args)
 	if args[n-4] != "--agent" || args[n-3] != "worker" {
 		t.Errorf("expected --agent worker near end, got %q %q", args[n-4], args[n-3])


### PR DESCRIPTION
## Summary

Two bugs in the bwrap isolation path caused spawned worker sessions to hang silently on startup. Both produce the same swallowed log signature so fixing one in isolation was insufficient.

### Bug 1: cache mounted read-only

`~/.cache/opencode` and `~/.cache/bun` were bind-mounted with `--ro-bind`. opencode 1.4.6 writes a refreshed `models.json` to the opencode cache on startup; the write fails with `EROFS`, opencode swallows it into `Failed to start server on port 4096` in its log file (not stderr), and the sidecar loops forever on connection-refused.

**Fix:** mount both caches read-write (`--bind`), matching host-mode semantics.

### Bug 2: hardcoded `--port 4096` in opencode invocation

The opencode argv passed `ContainerPort` (4096) for the `--port` flag. Because bwrap shares the host network namespace (no `--unshare-net`), every second bwrap session collided on host port 4096 with `EADDRINUSE` — producing the same swallowed `Failed to start server` signature.

**Fix:** use `cfg.AllocatedPort` (populated by `prism agent-run` from the DB's `opencode_port` column) with `ContainerPort` as a defensive fallback for the case where `AllocatedPort` is unset.

## How this manifested

- Worker spawned via `prism spawn` → tmux pane stays blank
- Sidecar log: `sse: connection refused` retrying forever
- Opencode log: `service=models.dev error=EROFS …` (cache bug) or `Failed to start server on port 4096` (port bug)
- Pane never produces output because errors land in the log file, not stderr

## Verification

- `go build ./...` and `go test ./internal/container/...` pass locally
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds
- Confirmed end-to-end after switch: bwrap worker spawned, came up on its allocated port, accepted initial prompt, accepted follow-up via `prism prompt`, transitioned to `finished`
- Confirmed independently with a second bwrap session spawned alongside the working coordinator and worker

## Tests added

- `TestBwrapBuildArgs_PortTracksAllocatedPort` — two distinct `AllocatedPort` values produce two distinct `--port` argv values
- `TestBwrapBuildArgs_PortFallbackWhenUnset` — falls back to `ContainerPort` when `AllocatedPort` is zero
- Existing `TestBwrapBuildArgs_Terminator` updated to assert `AllocatedPort` rather than `ContainerPort`

## Out of scope

- The `prism spawn --isolation` flag is silently dropped by `proxySpawn` on the host-API path (only `--host-mode` is forwarded). Separate bug, separate fix; will file as a follow-up issue.