### PR TITLE
prism: fix bwrap sessions losing opencode.json for prism pr and prism restore

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/session"
 )
@@ -94,8 +95,13 @@ var prCmd = &cobra.Command{
 		// In container/bwrap mode, inject the role-specific opencode.json blob
 		// as OPENCODE_CONFIG_CONTENT so it takes precedence (level 6) over any
 		// project-level opencode.jsonc. This mirrors the pattern in spawn.go.
+		//
+		// This block fires for both podman and bwrap isolation modes. Host-mode
+		// sessions skip it because they run opencode directly with the host's
+		// real ~/.config/opencode/opencode.json via xdg.configFile.
+		sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
 		var configContent string
-		if effectiveContainerMode {
+		if sandboxed {
 			pf, pfErr := config.LoadProfiles()
 			if pfErr != nil {
 				return pfErr
@@ -109,6 +115,31 @@ var prCmd = &cobra.Command{
 				configContent = roleConfig
 			} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
 				fmt.Fprintf(os.Stderr, "[prism pr] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
+			}
+		}
+
+		// For bwrap sessions, write the opencode.json config file to disk now
+		// so it is present before the agent pane opens. prism agent-run
+		// reconstructs a container.Manager from DB state (which does not carry
+		// ConfigContent), so the file must be written here via the deterministic
+		// temp path. The bwrap.go mount-emission block checks file existence
+		// (os.Stat) rather than cfg.ConfigContent, so it picks this up correctly.
+		//
+		// Podman mode does NOT need this write — the sidecar's Create() path
+		// already writes the file before the container starts. Host mode does
+		// NOT need this write — it uses ~/.config/opencode/opencode.json
+		// directly via xdg.configFile.
+		//
+		// IMPORTANT: the path key used here must match the one used by Manager
+		// internally. Manager.name = container.NameForSession(tmuxSessionName),
+		// and Manager.opencodeConfigFilePath() calls OpencodeConfigFilePath(m.name).
+		// So we must pass the container name (not the raw tmux session name) to
+		// WriteOpencodeConfig. This mirrors the pattern in spawn.go.
+		if isoMode == config.IsolationBwrap && configContent != "" {
+			tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+			containerName := container.NameForSession(tmuxSessionName)
+			if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
+				return fmt.Errorf("prism pr: %w", err)
 			}
 		}
 

--- a/modules/programs/prism/prism/cmd/pr_config_write_test.go
+++ b/modules/programs/prism/prism/cmd/pr_config_write_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+// Tests for the bwrap opencode.json config file write added to prCmd
+// (issue #904). These mirror the contract tests in spawn_config_write_test.go
+// and verify that:
+//
+//	1. The "sandboxed" gate (isoMode == IsolationPodman || isoMode == IsolationBwrap)
+//	   correctly admits bwrap and podman, and rejects host.
+//	2. The WriteOpencodeConfig write path used by pr.go
+//	   (container.OpencodeConfigFilePath(container.NameForSession(tmuxSession)))
+//	   matches the Manager's read path, so prism agent-run's reconstructed
+//	   Manager can find the file at the path bwrap expects.
+//	3. The gate for calling WriteOpencodeConfig
+//	   (isoMode == IsolationBwrap && configContent != "") is reflected in the
+//	   actual write behaviour — bwrap with content writes; host does not; bwrap
+//	   with empty content does not.
+//
+// Calling the prCmd RunE directly is not safe: it invokes git, tmux, and
+// filesystem side effects. These tests exercise the pure logic pieces and the
+// write helper instead.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// TestPrBwrapSandboxedGate asserts that the boolean gate widening the
+// configContent generation block matches the post-#898 spec:
+//   - IsolationPodman → sandboxed = true
+//   - IsolationBwrap  → sandboxed = true  (new in #904 for pr.go)
+//   - IsolationHost   → sandboxed = false
+func TestPrBwrapSandboxedGate(t *testing.T) {
+	cases := []struct {
+		mode      config.IsolationMode
+		sandboxed bool
+	}{
+		{config.IsolationPodman, true},
+		{config.IsolationBwrap, true},
+		{config.IsolationHost, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			got := tc.mode == config.IsolationPodman || tc.mode == config.IsolationBwrap
+			if got != tc.sandboxed {
+				t.Errorf("sandboxed gate for mode %q = %v, want %v", tc.mode, got, tc.sandboxed)
+			}
+		})
+	}
+}
+
+// TestPrBwrapWritePathMatchesManagerPath guards against the path mismatch
+// where pr.go passes the raw tmux session name and the Manager uses the
+// transformed container name. Both must resolve to the same OpencodeConfigFilePath.
+func TestPrBwrapWritePathMatchesManagerPath(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	// Simulate the path derivation in pr.go:
+	//   tmuxSessionName = session.NameFor(worktreePath, bareRoot)
+	//   containerName   = container.NameForSession(tmuxSessionName)
+	//   writePath       = container.OpencodeConfigFilePath(containerName)
+	const branchName = "pr-1234"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
+
+	writePath := container.OpencodeConfigFilePath(containerName)
+
+	// Read path: Manager.opencodeConfigFilePath() calls
+	// OpencodeConfigFilePath(m.name) where m.name = NameForSession(cfg.SessionName).
+	readPath := container.OpencodeConfigFilePath(container.NameForSession(tmuxSessionName))
+
+	if writePath != readPath {
+		t.Errorf("write path %q != read path %q — pr.go will write to a path that agent-run's Manager can never find",
+			writePath, readPath)
+	}
+	if strings.Contains(writePath, "@") {
+		t.Errorf("write path %q contains '@' — pr.go must use the container name (NameForSession), not the raw tmux session name",
+			writePath)
+	}
+}
+
+// TestPrBwrapWritesConfigFileWhenContentPresent simulates the pr.go guard:
+//
+//	if isoMode == config.IsolationBwrap && configContent != "" {
+//	    container.WriteOpencodeConfig(containerName, configContent)
+//	}
+//
+// When the gate passes, the file must exist with the expected content.
+func TestPrBwrapWritesConfigFileWhenContentPresent(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	t.Setenv("TMPDIR", t.TempDir())
+
+	const branchName = "pr-5678"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
+
+	const configContent = `{"model":"pr-worker-model","agents":[]}`
+
+	// Simulate the gate and the write.
+	isoMode := config.IsolationBwrap
+	if isoMode == config.IsolationBwrap && configContent != "" {
+		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
+			t.Fatalf("WriteOpencodeConfig: %v", err)
+		}
+	}
+	t.Cleanup(func() { _ = os.Remove(container.OpencodeConfigFilePath(containerName)) })
+
+	data, err := os.ReadFile(container.OpencodeConfigFilePath(containerName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != configContent {
+		t.Errorf("file content = %q, want %q", string(data), configContent)
+	}
+}
+
+// TestPrBwrapNoWriteWhenConfigContentEmpty asserts that pr.go's conditional
+// skips WriteOpencodeConfig when configContent is empty — even though the
+// isolation mode is bwrap. This matches the spec's `configContent != ""`
+// guard and prevents an empty opencode.json from being mounted.
+func TestPrBwrapNoWriteWhenConfigContentEmpty(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	t.Setenv("TMPDIR", t.TempDir())
+
+	const branchName = "pr-empty"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
+
+	isoMode := config.IsolationBwrap
+	configContent := ""
+
+	// Simulate the pr.go guard.
+	if isoMode == config.IsolationBwrap && configContent != "" {
+		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
+			t.Fatalf("WriteOpencodeConfig: %v", err)
+		}
+	}
+
+	// File must NOT exist.
+	path := container.OpencodeConfigFilePath(containerName)
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("opencode temp file %q must not exist when configContent is empty, but it does", path)
+		_ = os.Remove(path)
+	}
+}
+
+// TestPrHostModeNoWrite asserts that host mode does NOT write the opencode
+// temp file. The pr.go guard `isoMode == config.IsolationBwrap && ...` must
+// reject IsolationHost.
+func TestPrHostModeNoWrite(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	t.Setenv("TMPDIR", t.TempDir())
+
+	const branchName = "pr-host"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
+
+	isoMode := config.IsolationHost
+	configContent := `{"model":"pr-worker-model"}`
+
+	// Simulate the pr.go guard. For host mode it must not fire regardless of
+	// whether configContent is populated.
+	if isoMode == config.IsolationBwrap && configContent != "" {
+		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
+			t.Fatalf("WriteOpencodeConfig: %v", err)
+		}
+	}
+
+	path := container.OpencodeConfigFilePath(containerName)
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("host-mode pr must not write opencode temp file %q, but it exists", path)
+		_ = os.Remove(path)
+	}
+}
+
+// TestPrPodmanModeNoWriteFromPrCmd asserts that podman mode does NOT write
+// the opencode temp file from pr.go. The podman sidecar's Create() flow
+// handles the file itself — writing it in pr.go for podman would be a no-op
+// at best and a source of drift at worst.
+func TestPrPodmanModeNoWriteFromPrCmd(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("bwrap mode is Linux-only")
+	}
+
+	t.Setenv("TMPDIR", t.TempDir())
+
+	const branchName = "pr-podman"
+	bareRoot := filepath.Join(t.TempDir(), "myrepo")
+	worktreePath := filepath.Join(bareRoot, branchName)
+	tmuxSessionName := session.NameFor(worktreePath, bareRoot)
+	containerName := container.NameForSession(tmuxSessionName)
+
+	isoMode := config.IsolationPodman
+	configContent := `{"model":"pr-worker-model"}`
+
+	// Simulate the pr.go guard — podman mode must NOT fire it.
+	if isoMode == config.IsolationBwrap && configContent != "" {
+		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
+			t.Fatalf("WriteOpencodeConfig: %v", err)
+		}
+	}
+
+	path := container.OpencodeConfigFilePath(containerName)
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("podman pr must not write opencode temp file %q (sidecar handles it), but it exists", path)
+		_ = os.Remove(path)
+	}
+}

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/dashboard"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -304,12 +305,18 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	}
 	if containerMode {
 		opts.PluginHostPath = cfg.SidecarPluginPath
+	}
 
-		// In container mode, inject the role-specific opencode.json blob as
-		// OPENCODE_CONFIG_CONTENT. This mirrors the pattern in spawn.go.
-		// Profile load errors are non-fatal for restore: log and skip
-		// config injection so the session is still recreated without it,
-		// rather than aborting the entire restore run.
+	// In sandboxed mode (podman or bwrap), inject the role-specific opencode.json
+	// blob as OPENCODE_CONFIG_CONTENT. This mirrors the pattern in spawn.go.
+	// Profile load errors are non-fatal for restore: log and skip config
+	// injection so the session is still recreated without it, rather than
+	// aborting the entire restore run.
+	//
+	// Host-mode sessions skip this entirely because they run opencode directly
+	// with the host's real ~/.config/opencode/opencode.json via xdg.configFile.
+	sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
+	if sandboxed {
 		pf, pfErr := loadRestoreProfiles()
 		if pfErr != nil {
 			fmt.Fprintf(os.Stderr, "restore %q: load profiles: %v — skipping config injection\n", s.SessionName, pfErr)
@@ -322,6 +329,33 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 				opts.ConfigContent = roleConfig
 			} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
 				fmt.Fprintf(os.Stderr, "[prism restore] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
+			}
+		}
+
+		// For bwrap sessions, write the opencode.json config file to disk now
+		// so it is present before the agent pane opens. prism agent-run
+		// reconstructs a container.Manager from DB state (which does not carry
+		// ConfigContent), so the file must be written here at restore time via
+		// the deterministic temp path. The bwrap.go mount-emission block checks
+		// file existence (os.Stat) rather than cfg.ConfigContent, so it picks
+		// this up correctly.
+		//
+		// Podman mode does NOT need this write — the sidecar's Create() path
+		// already writes the file before the container starts.
+		//
+		// IMPORTANT: the path key used here must match the one used by Manager
+		// internally. Manager.name = container.NameForSession(s.SessionName),
+		// and Manager.opencodeConfigFilePath() calls OpencodeConfigFilePath(m.name).
+		// So we must pass the container name (not the raw tmux session name) to
+		// WriteOpencodeConfig. This mirrors the pattern in spawn.go.
+		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+			containerName := container.NameForSession(s.SessionName)
+			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
+				// Non-fatal: log and continue with restore. The session will
+				// still be re-spawned; it just won't have the opencode.json
+				// mounted. This matches the general "restore is best-effort"
+				// posture (profile load errors are also non-fatal above).
+				fmt.Fprintf(os.Stderr, "restore %q: write opencode config: %v — session will spawn without opencode.json mounted\n", s.SessionName, err)
 			}
 		}
 	}

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
 )
@@ -1168,5 +1169,246 @@ func TestRestoreSession_CircuitBreakerSkipsNotEnded_IdempotentRestore(t *testing
 	}
 	if isEnded(t, d, sessionName) {
 		t.Error("second call: session was marked ended — must not be")
+	}
+}
+
+// ─── bwrap restore tests (issue #904) ─────────────────────────────────────────
+//
+// These tests cover the fix for issue #904: when restoring a session whose
+// recorded isolation mode is bwrap, restoreProjectSession must:
+//
+//  1. Run the configContent generation block (widened "sandboxed" gate), so
+//     the worker/coordinator opencode.json blob ends up in opts.ConfigContent.
+//  2. Write the opencode.json temp file to disk via
+//     container.WriteOpencodeConfig(container.NameForSession(s.SessionName), …)
+//     so the bwrap sandbox can bind-mount it at
+//     $HOME/.config/opencode/opencode.json.
+//
+// The tests exercise restoreProjectSession with a DB row whose isolation_mode
+// column is set to "bwrap" (the authoritative source of truth post-v10), and
+// assert both the opts.ConfigContent and the temp file contents.
+
+// TestRestoreSession_BwrapMode_WorkerConfigContent verifies that a bwrap
+// session (IsolationMode="bwrap" recorded in the DB) flows the worker
+// opencode.json blob into opts.ConfigContent — the same way container mode
+// does. This is the widened "sandboxed" gate behaviour.
+func TestRestoreSession_BwrapMode_WorkerConfigContent(t *testing.T) {
+	// Uses withCmdServer — must not run in parallel.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	// Isolate the temp dir so the opencode temp file written by the restore
+	// path lands in t.TempDir() and does not pollute /tmp.
+	t.Setenv("TMPDIR", t.TempDir())
+
+	withRestoreConfig(t, config.Config{
+		// ContainerMode is intentionally false — bwrap is the session's
+		// recorded isolation mode, not the global default.
+	})
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	// Non-main worktree → DefaultAgent returns "worker".
+	worktreeDir := filepath.Join(t.TempDir(), "feature-branch")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@bwrap-worker"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+
+	// Record bwrap as the authoritative isolation mode for this session.
+	if err := d.SetIsolationMode(sessionName, string(config.IsolationBwrap)); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	status.IsolationMode = string(config.IsolationBwrap)
+
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	if err := callRestoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+	t.Cleanup(func() {
+		_ = os.Remove(container.OpencodeConfigFilePath(container.NameForSession(sessionName)))
+	})
+
+	if !s.hasSession(sessionName) {
+		t.Fatalf("session %q was not created", sessionName)
+	}
+
+	// The worker blob must be in ConfigContent — the widened "sandboxed" gate
+	// must fire for bwrap too.
+	if capturedOpts.ConfigContent != pf.ContainerWorkerConfig {
+		t.Errorf("opts.ConfigContent = %q, want %q (worker blob)",
+			capturedOpts.ConfigContent, pf.ContainerWorkerConfig)
+	}
+
+	// IsolationMode must be recorded as bwrap on the opts, so session.Create
+	// downstream routes the session through the bwrap path.
+	if capturedOpts.IsolationMode != string(config.IsolationBwrap) {
+		t.Errorf("opts.IsolationMode = %q, want %q",
+			capturedOpts.IsolationMode, config.IsolationBwrap)
+	}
+}
+
+// TestRestoreSession_BwrapMode_TempFileWritten verifies that when a bwrap
+// session is restored, the opencode.json temp file is written to the
+// deterministic container path via container.WriteOpencodeConfig. The content
+// on disk must match the worker blob injected into opts.ConfigContent, and
+// the path must match what the Manager will look up via
+// OpencodeConfigFilePath(NameForSession(sessionName)).
+func TestRestoreSession_BwrapMode_TempFileWritten(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+	t.Setenv("TMPDIR", t.TempDir())
+
+	withRestoreConfig(t, config.Config{})
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	worktreeDir := filepath.Join(t.TempDir(), "feature-x")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@bwrap-file"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+	if err := d.SetIsolationMode(sessionName, string(config.IsolationBwrap)); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	status.IsolationMode = string(config.IsolationBwrap)
+
+	// Ensure the temp file does not exist beforehand — we want to confirm the
+	// restore path creates it.
+	expectedPath := container.OpencodeConfigFilePath(container.NameForSession(sessionName))
+	_ = os.Remove(expectedPath)
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	withCreateSessionHook(t, func(opts session.Opts) {})
+
+	if err := callRestoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	// The temp file must exist and contain the worker blob.
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("opencode temp file %q not written for bwrap restore: %v", expectedPath, err)
+	}
+	if string(data) != pf.ContainerWorkerConfig {
+		t.Errorf("opencode temp file content = %q, want %q (worker blob)",
+			string(data), pf.ContainerWorkerConfig)
+	}
+}
+
+// TestRestoreSession_HostMode_NoTempFileWritten verifies that host-mode
+// restore does NOT write the opencode temp file — host sessions use the real
+// ~/.config/opencode/opencode.json directly and must not leak a stray file
+// into TMPDIR.
+func TestRestoreSession_HostMode_NoTempFileWritten(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+	t.Setenv("TMPDIR", t.TempDir())
+
+	withRestoreConfig(t, config.Config{
+		// Force EffectiveIsolationMode() → IsolationHost for pre-v10 rows.
+		DefaultIsolationMode: config.IsolationHost,
+	})
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	worktreeDir := filepath.Join(t.TempDir(), "feature-host")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@host-worker"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+	if err := d.SetIsolationMode(sessionName, string(config.IsolationHost)); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	status.IsolationMode = string(config.IsolationHost)
+
+	expectedPath := container.OpencodeConfigFilePath(container.NameForSession(sessionName))
+	_ = os.Remove(expectedPath) // precondition: file absent
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	if err := callRestoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	// Host mode: configContent must be empty (the sandboxed gate must not fire).
+	if capturedOpts.ConfigContent != "" {
+		t.Errorf("opts.ConfigContent = %q, want empty (host mode must skip injection)",
+			capturedOpts.ConfigContent)
+	}
+
+	// Temp file must NOT exist.
+	if _, err := os.Stat(expectedPath); err == nil {
+		t.Errorf("host-mode restore leaked opencode temp file at %q — must not write for host isolation",
+			expectedPath)
+	}
+}
+
+// TestRestoreSession_PodmanMode_NoTempFileWritten verifies that podman-mode
+// restore does NOT write the opencode temp file via the new code path — the
+// podman sidecar's Create() flow handles that file itself. Writing it in
+// restore.go for podman would be a no-op at best and a source of drift at worst.
+func TestRestoreSession_PodmanMode_NoTempFileWritten(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+	t.Setenv("TMPDIR", t.TempDir())
+
+	withRestoreConfig(t, config.Config{ContainerMode: true})
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	worktreeDir := filepath.Join(t.TempDir(), "feature-pod")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@podman-worker"
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+	if err := d.SetIsolationMode(sessionName, string(config.IsolationPodman)); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	status.IsolationMode = string(config.IsolationPodman)
+
+	expectedPath := container.OpencodeConfigFilePath(container.NameForSession(sessionName))
+	_ = os.Remove(expectedPath) // precondition
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	withCreateSessionHook(t, func(opts session.Opts) {})
+
+	if err := callRestoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	// Podman mode: restore.go must NOT preemptively write the temp file.
+	// The sidecar's own Create() path writes it just before container start.
+	if _, err := os.Stat(expectedPath); err == nil {
+		t.Errorf("podman restore wrote opencode temp file at %q — must not write for podman (sidecar handles it)",
+			expectedPath)
 	}
 }


### PR DESCRIPTION
## Summary

Mirrors the spawn.go fixes from #898 and #903 into \`cmd/pr.go\` and \`cmd/restore.go\`:

- Widens the gate from \`effectiveContainerMode\` (podman-only) to \`sandboxed := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap\` so the role-specific \`opencode.json\` blob is generated for bwrap sessions too.
- For bwrap sessions, writes the opencode.json temp file via \`container.WriteOpencodeConfig(container.NameForSession(sessionName), configContent)\` before the agent pane opens — so \`prism agent-run\` (which reconstructs the \`Manager\` from DB state without \`ConfigContent\`) finds the file at the deterministic path bwrap expects, and the bwrap bind-mount emits the correct \`--ro-bind\` for \`\$HOME/.config/opencode/opencode.json\`.

Without this, \`prism pr\` and \`prism restore\` of a bwrap session produced a sandbox with no \`opencode.json\` mounted, causing opencode to fall back to built-in defaults (no agent, copilot-only, \`Agent not found: worker\`).

## Changes

- \`cmd/pr.go\` — widened \`sandboxed\` gate; added \`WriteOpencodeConfig\` call for \`IsolationBwrap\` before \`ensureAndSwitch\`.
- \`cmd/restore.go\` — widened \`sandboxed\` gate; added \`WriteOpencodeConfig\` call for \`IsolationBwrap\` before \`session.Create\`. Write failure is non-fatal (logged) to match restore's existing best-effort posture for profile load errors.
- \`cmd/pr_config_write_test.go\` — new file; mirrors \`spawn_config_write_test.go\`. Covers: sandboxed-gate truth table (podman/bwrap true, host false); write path matches Manager read path; write fires for bwrap+content; no write for empty content, host, or podman.
- \`cmd/restore_test.go\` — four new tests: bwrap ConfigContent injection, bwrap temp file written with correct content, host mode writes nothing, podman mode writes nothing (sidecar handles it).

## Quality gates

- \`go build ./...\` — passes
- \`go test ./...\` — passes for changed packages. Two pre-existing flakes in \`internal/tmux\` (\`TestAPI_TwoClientsGlobalStampIsolation\`, \`TestCleanupRedirectMultiClient_Direct\`, \`TestThreeClientsDirectSwitch_Direct\`, \`TestTwoClientsCallerClientBug_Direct\`) and \`cmd/TestSwitchPath_OnlyMovesTargetClient\` are unrelated to these changes (verified by running them against the base branch with the changes stashed).
- \`nix build .#nixosConfigurations.navi.config.system.build.toplevel\` — succeeds.

## Manual verification (post-merge on navi — for the coordinator)

Cannot be run from a branch worker. After \`sudo nixos-rebuild switch --flake ~/code/nixos-config\`:

1. \`prism pr <some-open-pr-number> --isolation bwrap\`. Attach (C-f). Expect the worker TUI with no \`Agent not found\` error and Anthropic provider visible.
2. Inside the PR session, quit cleanly with \`/exit\`.
3. Force a restart simulating reboot: \`systemctl --user restart prism-restore.service\` (or \`prism reset\` followed by re-attach).
4. Confirm the session is re-spawned with bwrap isolation and the opencode TUI renders with the correct worker agent.
5. Cleanup: \`prism cleanup --yes --session nixos-config@<pr-branch>\`.

## Notes

- No changes to \`spawn.go\`, the bwrap/podman isolation machinery, the sidecar, or \`internal/container/container.go\` helpers — pattern mirroring only, as per the issue scope.
- Parallel PR \`nixos-config@upgrade-opencode-1-14-18\` touches \`overlays/default.nix\`, \`flake.nix\`, and \`flake.lock\` — no file overlap with this PR.

Closes #904