### PR TITLE
flip navi default to bwrap isolation for prism

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -26,7 +26,10 @@
       wallpaper.variant = "enso-6colour";
     };
     programs = {
-      prism.opencode.provider = "anthropic";
+      prism = {
+        opencode.provider = "anthropic";
+        agent.isolation.default = "bwrap";
+      };
       anki.enable = false; # build broken as of 2025-08-30
       calibre.enable = true;
       corectrl.enable = true;


### PR DESCRIPTION
## Summary

One-line flip (expanded to a nested block): set `nx.programs.prism.agent.isolation.default = "bwrap"` on navi.

Module-level default in `default.nix` stays conservative (`"podman"` on Linux); only navi opts in. Darwin unaffected (m4mac stays on `"host"`).

Pre-flip criteria from the issue were satisfied before opening this PR (bwrap soak on navi, no regressions, #904 merged so `prism pr` and `prism restore` no longer lose `opencode.json` for bwrap sessions).

Closes #878