### PR TITLE
prism tmux: fix sandboxed-pane keybinds under bwrap isolation

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -11,8 +11,40 @@ let
   prismPkg = pkgs.callPackage ../../../pkgs/prism.nix { };
   prism = "${prismPkg}/bin/prism";
 
-  # Host-side clipboard paste bridge script for container-mode opencode panes.
-  # Invoked by the tmux Ctrl-V keybind when pane_current_command is "podman".
+  # Sandboxed-pane guard for tmux if-shell.
+  #
+  # Returns 0 when the pane's current command indicates a prism agent pane
+  # running under a supported isolation mode, 1 otherwise. The five
+  # container-mode keybinds below (C-v paste bridge + C-u/C-d/C-g/C-M-g
+  # opencode scrolling) call this script via if-shell to decide whether to
+  # fire the agent-specific action or fall through to a pass-through.
+  #
+  # The single argument is the value of tmux's #{pane_current_command} format
+  # variable, expanded by tmux before the shell receives it.
+  #
+  # Matched values:
+  #   podman   — legacy podman isolation (`podman attach` is the pane command).
+  #   bwrap    — bwrap isolation: `prism agent-run` execs bwrap directly, so
+  #              the pane's direct child is the bwrap process.
+  #   opencode — defensive fallback for bwrap cases where tmux reports the
+  #              foregrounded descendant rather than bwrap itself, and for
+  #              host-mode panes that run opencode directly (Linux legacy /
+  #              Darwin). Opencode is only ever launched in agent panes by
+  #              prism, so matching it here does not affect plain shells,
+  #              editors, or dashboard panes.
+  #
+  # Extracting this guard into a script keeps the five call sites consistent —
+  # no binding keeps a hand-rolled pane_current_command equality check.
+  sandboxedPaneGuard = pkgs.writeShellScript "prism-tmux-sandboxed-pane" ''
+    case "$1" in
+      podman|bwrap|opencode) exit 0 ;;
+      *) exit 1 ;;
+    esac
+  '';
+
+  # Host-side clipboard paste bridge script for sandboxed opencode panes.
+  # Invoked by the tmux Ctrl-V keybind when the pane is running a prism
+  # agent (see sandboxedPaneGuard above for the matching rules).
   # Argument $1 is the tmux pane ID (e.g. "%3") to inject the paste into.
   #
   # Two cases:
@@ -39,7 +71,8 @@ let
     # No image: fall back to text clipboard paste.
     # This preserves pre-PR behaviour: before this keybind existed, the terminal
     # emulator's own bracketed-paste handled text Ctrl-V transparently through
-    # the podman attach PTY. Since we now intercept C-v we must replicate this.
+    # the sandbox (podman attach PTY / bwrap PTY). Since we now intercept C-v
+    # we must replicate this.
     if [ -n "$WAYLAND_DISPLAY" ]; then
       txt="$(wl-paste --no-newline 2>/dev/null)"
     elif [ -n "$DISPLAY" ]; then
@@ -100,8 +133,9 @@ in
               # sensible debugging behavior
               set -g remain-on-exit on
               # Enable OSC 52 clipboard passthrough so opencode running inside a
-              # container can write to the host clipboard via the podman attach PTY bridge.
-              # Without this, tmux drops OSC 52 sequences and clipboard is silently broken.
+              # sandbox (podman or bwrap) can write to the host clipboard via the
+              # sandbox PTY bridge. Without this, tmux drops OSC 52 sequences and
+              # clipboard is silently broken.
               set -g set-clipboard on
               # pane switching
               bind -r h select-pane -L
@@ -191,17 +225,21 @@ in
               bind a display-popup -E -d "#{pane_current_path}" -w 60% -h 20% -b single \
                 "${prism} spawn --attach"
 
-              # opencode scrolling keybinds (only active when opencode is running inside podman)
-              # Note: after the podman-attach migration, the agent pane command is "podman"
-              bind -n C-u if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys C-M-u' 'send-keys C-u'
-              bind -n C-d if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys C-M-d' 'send-keys C-d'
-              bind -n C-g if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys Home'
-              bind -n C-M-g if-shell '[ "#{pane_current_command}" = "podman" ]' 'send-keys End'
+              # opencode scrolling keybinds — active when the pane is a prism agent
+              # running under either supported isolation mode (podman or bwrap),
+              # or hosting opencode directly. See sandboxedPaneGuard above for the
+              # matching rules. In any other pane (plain shell, editor, dashboard)
+              # the literal keystroke is sent through unchanged.
+              bind -n C-u if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' 'send-keys C-M-u' 'send-keys C-u'
+              bind -n C-d if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' 'send-keys C-M-d' 'send-keys C-d'
+              bind -n C-g if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' 'send-keys Home'
+              bind -n C-M-g if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' 'send-keys End'
 
-              # Clipboard paste bridge for container-mode opencode panes (issue #752).
+              # Clipboard paste bridge for sandboxed opencode panes (issue #752).
               #
-              # When Ctrl-V is pressed in a pane whose current command is "podman"
-              # (i.e. `podman attach` is running the container's opencode TUI):
+              # When Ctrl-V is pressed in a pane whose current command is one of
+              # the sandboxed-agent values matched by sandboxedPaneGuard (podman
+              # attach / bwrap / direct opencode):
               #
               #   Image path: `prism clipboard paste-image` reads the host clipboard,
               #   stages the PNG to ~/.cache/prism/clipboard/<uuid>.png, and prints
@@ -211,20 +249,21 @@ in
               #   Text fallback path: if paste-image exits non-zero (no image in
               #   clipboard), read text from the host clipboard and inject it as a
               #   bracketed-paste sequence. This ensures text Ctrl-V continues to
-              #   work in container panes even though tmux has intercepted C-v.
-              #   Without this fallback, text paste would be silently dropped.
+              #   work in agent panes even though tmux has intercepted C-v. Without
+              #   this fallback, text paste would be silently dropped.
               #
-              # Guard: if-shell checks pane_current_command and only intercepts when
-              # it equals "podman". All other panes (plain shell, editor, non-container
-              # windows) are unaffected — Ctrl-V reaches them via the else branch
-              # which sends a literal Ctrl-V (standard bracketed-paste passthrough).
+              # Guard: if-shell runs sandboxedPaneGuard against #{pane_current_command}
+              # and only intercepts when the pane is a sandboxed agent pane. All
+              # other panes (plain shell, editor, non-agent windows) are unaffected —
+              # Ctrl-V reaches them via the else branch which sends a literal Ctrl-V
+              # (standard bracketed-paste passthrough).
               #
               # The script is written to the Nix store via writeShellScript to avoid
               # complex quoting of ESC bytes and printf format strings inside the
               # tmux bind-key string. #{pane_id} is expanded by tmux before the
               # shell receives it as $1.
               bind -n C-v \
-                if-shell '[ "#{pane_current_command}" = "podman" ]' \
+                if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' \
                   'run-shell "${clipboardPasteScript} #{pane_id}"' \
                   'send-keys C-v'
 


### PR DESCRIPTION
## Summary

Five tmux keybinds in `modules/programs/prism/tmux.nix` stopped firing for bwrap-isolated agent panes after #915 flipped navi's default isolation to bwrap. Each guarded on `pane_current_command = "podman"`, which only matches the legacy podman-attach path. Under bwrap, prism runs `bwrap <args...> -- opencode ...` directly, so the guard falls through:

- **C-v**: image paste bridge is silently dropped (text paste only keeps working because the literal `send-keys C-v` fallback triggers the terminal emulator's native bracketed-paste passthrough).
- **C-u / C-d / C-g / C-M-g**: opencode scrolling sequences (`C-M-u`, `C-M-d`, `Home`, `End`) never fire; literal `C-u` / `C-d` / no-op reaches the pane instead.

## Fix

Extracted a shared `sandboxedPaneGuard` helper (`pkgs.writeShellScript`) that returns 0 when `#{pane_current_command}` matches any of:

- `podman` — legacy podman isolation
- `bwrap` — bwrap isolation (the pane's direct child is the bwrap process)
- `opencode` — defensive fallback for bwrap cases where tmux reports the foregrounded descendant rather than bwrap itself, and for host-mode panes that run opencode directly

All five bindings now invoke `if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' ...`; no binding keeps a hand-rolled equality check. Stale comments in the same file that described podman as the only sandboxed mode are updated to describe both modes.

## Preflight — worker-observable constraints

The issue asked the worker to run `tmux display-message -p '#{pane_current_command}'` inside a live bwrap-mode agent pane and a podman-mode pane, then match on the observed value. **This worker is itself running inside the bwrap sandbox** (self-spawned via prism on branch `issue-916`) and cannot reach the host's tmux socket — `/tmp` inside the sandbox is a fresh `--tmpfs`, the host-API socket does not expose a tmux query endpoint, and no other channel back to the host tmux server is available from within the sandbox.

To satisfy the intent of the preflight without being able to execute the command directly, the guard matches **all three plausible values** (`podman`, `bwrap`, `opencode`) instead of gambling on one. This is why the fix extracts a script rather than expanding the inline equality to `= podman || = bwrap`: a shell `case` statement makes the set of matched values explicit, and the defensive `opencode` arm absorbs whichever of `bwrap` or `opencode` tmux actually reports without having to pin down which one. Non-agent panes (plain shells, editors, dashboard) report values like `zsh`, `bash`, `nvim`, `sh`, none of which match — their behaviour is unchanged.

### Manual verification the user should run before merging

```bash
# Expected: one of bwrap, opencode, or (if tmux reports the shell) the shell's name.
tmux display-message -p '#{pane_current_command}'   # in a bwrap agent pane
tmux display-message -p '#{pane_current_command}'   # in a podman agent pane (should still be "podman")
tmux display-message -p '#{pane_current_command}'   # in a plain term pane (should be "zsh"/"bash")
```

Keybinds to exercise in each pane type (both isolation modes, plus a plain term pane):

| Keybind | Expected in agent pane | Expected in non-agent pane |
|---|---|---|
| `C-v` (with PNG in clipboard) | opencode attaches the image | terminal's native paste |
| `C-v` (with text in clipboard) | text appears as bracketed-paste | terminal's native paste |
| `C-u` | opencode scrolls up half a page | literal `C-u` (clear line) |
| `C-d` | opencode scrolls down half a page | literal `C-d` (EOF) |
| `C-g` | opencode jumps to top of scrollback | no-op |
| `C-M-g` | opencode jumps to end of scrollback | no-op |

## Unit-tested

The generated guard script was exercised directly:

```
$ for v in podman bwrap opencode zsh nvim bash sh; do
    /nix/store/.../prism-tmux-sandboxed-pane "$v"; echo "$v -> $?"
  done
podman -> 0
bwrap -> 0
opencode -> 0
zsh -> 1
nvim -> 1
bash -> 1
sh -> 1
```

## Build

`nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds. The rendered tmux.conf shows the five bindings all sharing `/nix/store/<hash>-prism-tmux-sandboxed-pane "#{pane_current_command}"` as the if-shell guard.

`nixfmt .` produced no additional changes beyond what's in the diff.

## Out of scope (per the issue)

- Automated end-to-end integration tests for the paste bridge (flagged as a follow-up).
- Darwin / sandbox-exec support.
- Changes to the clipboard staging directory.
- Broader refactor of the container-mode keybind block.

Closes #916