### PR TITLE
dashboard: pass agent_name through as the type label

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/agent_type_label_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/agent_type_label_test.go
@@ -1,0 +1,44 @@
+package dashboard
+
+import "testing"
+
+// TestAgentTypeLabel verifies that agentTypeLabel is a pass-through:
+// every agent_name value renders as itself, including agent types beyond the
+// old hard-coded coordinator/worker allowlist. See #844 / #849.
+func TestAgentTypeLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		// [functional] Previously-supported types still render as themselves.
+		{"coordinator passes through", "coordinator", "coordinator"},
+		{"worker passes through", "worker", "worker"},
+
+		// [functional] Review subagents — the central bug from #844.
+		{"review-goal passes through", "review-goal", "review-goal"},
+		{"review-code passes through", "review-code", "review-code"},
+		{"review-security passes through", "review-security", "review-security"},
+		{"review-qa passes through", "review-qa", "review-qa"},
+		{"review-context passes through", "review-context", "review-context"},
+
+		// [functional] Other known agent types.
+		{"ac passes through", "ac", "ac"},
+		{"retro passes through", "retro", "retro"},
+
+		// [functional] Future / unknown agent types must not be silently dropped.
+		{"unknown agent type passes through", "some-future-agent", "some-future-agent"},
+
+		// [edge-case] Defensive: empty input yields empty output.
+		{"empty string yields empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := agentTypeLabel(tc.agentName)
+			if got != tc.want {
+				t.Errorf("agentTypeLabel(%q) = %q, want %q", tc.agentName, got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -353,15 +353,14 @@ func SortDisplayed(ss []AgentSession) {
 }
 
 // agentTypeLabel returns a display label for the agent_name value.
+//
+// This is a pass-through: every agent type (coordinator, worker, review-goal,
+// review-code, review-security, review-qa, review-context, ac, retro, and any
+// future type) renders as its own name. An empty input yields an empty label.
+// See #849 for the session-uniformity rationale behind the flat-allowlist
+// removal.
 func agentTypeLabel(agentName string) string {
-	switch agentName {
-	case "coordinator":
-		return "coordinator"
-	case "worker":
-		return "worker"
-	default:
-		return ""
-	}
+	return agentName
 }
 
 // SessionColumnWidth computes the session column width (sessionW) from the

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -117,7 +117,7 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	// treePrefixW=10 sets the total reserved width (prefix + branch) so column
 	// alignment is preserved across all depths.
 	const treePrefixW = 10
-	const agentTypeW = 12 // "coordinator " or "worker      " or "            "
+	const agentTypeW = 15 // widest: "review-security" (15 chars); other types right-pad.
 	const stateW = 10
 	const dotW = 2
 	const sessionWCap = 40  // maximum session width before the rest goes to title


### PR DESCRIPTION
## Summary

`internal/dashboard/sessions.go` had an `agentTypeLabel` function with a
hard-coded switch that only returned labels for `coordinator` and
`worker` — every other agent type (`review-goal`, `review-code`,
`review-security`, `review-qa`, `review-context`, `ac`, `retro`, and any
future type) rendered as a blank string in the dashboard's type column.
This is a flat-allowlist leak that the session-uniformity design (#849)
wants to eliminate.

- Replace the switch with a pass-through: `agentTypeLabel` now returns
  `agentName` directly, so every type renders as itself.
- Bump `agentTypeW` in `view.go` from 12 → 15 so the column accommodates
  the widest current label (`review-security`, 15 chars) without
  clipping adjacent columns. The existing dynamic layout (shed-columns
  loop + `growSession`) still handles narrow terminals gracefully — the
  type column is shed before session growth when width is tight.
- Add a package-internal test `agent_type_label_test.go` asserting the
  pass-through behaviour for all known agent names, a future/unknown
  type, and the empty-input defensive case.

This is Issue G from the session-uniformity migration plan (#849) —
small, mechanical, no dependencies.

## Verification

- `go build ./...` and `go test ./internal/dashboard/...` pass locally
  (all dashboard tests, including the new `TestAgentTypeLabel`, pass).
- Pre-existing flaky tmux multi-client tests fail on `main` as well —
  unrelated to this change.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`
  completes successfully.
- Live visual check: not run in this worktree (no live dashboard with a
  review round active here). The layout logic is unchanged other than
  the width bump, and `SessionColumnWidth` / column shedding are driven
  by session-name lengths rather than the type column, so the type
  column simply renders wider by 3 chars when visible.

Closes #844.