### PR TITLE
sidecar: drop agent override from notify prompt body (#848)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1718,10 +1718,15 @@ func deliverNotificationViaHTTP(port int, opencodeSID string, text string, statu
 }
 
 // buildNotifyPromptBody constructs the request body for the coordinator
-// notification prompt_async call. When root_agent_name and root_model_id are
-// known, they are included so the session continues using its root agent/model.
-// Falls back to agent_name/model_id for sessions created before the root fields
-// migration. Mirrors the buildPromptBody logic in cmd/prompt.go.
+// notification prompt_async call. When root_model_id is known, it is included
+// so the session continues using its root model. Falls back to model_id for
+// sessions created before the root fields migration.
+//
+// The receiving session's active-turn agent context is deliberately NOT
+// overridden: the notification is processed by whichever agent the session is
+// configured to run. Setting an "agent" field here would let an incoming
+// notification switch a subagent's context to the notifier's agent — a real
+// bug that caused subagent context-switch incidents. See issue #848.
 func buildNotifyPromptBody(text string, status *db.Status) map[string]any {
 	body := map[string]any{
 		"parts": []map[string]string{
@@ -1729,18 +1734,12 @@ func buildNotifyPromptBody(text string, status *db.Status) map[string]any {
 		},
 	}
 
-	agentName := status.RootAgentName
-	if agentName == nil {
-		agentName = status.AgentName
-	}
 	modelID := status.RootModelID
 	if modelID == nil {
 		modelID = status.ModelID
 	}
 
-	if agentName != nil && modelID != nil {
-		body["agent"] = *agentName
-
+	if modelID != nil {
 		// Split model_id on the first "/" to get providerID and modelID.
 		slashIdx := strings.Index(*modelID, "/")
 		providerID := *modelID

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6640,3 +6640,120 @@ exit 0
 		t.Errorf("PRISM_SESSION_NAME = %q, want %q (must be injected by sidecar)", got, "nixos-config@741-fix")
 	}
 }
+
+// ── buildNotifyPromptBody tests (issue #848) ────────────────────────────────
+
+// TestBuildNotifyPromptBody_OmitsAgentField verifies that the outgoing
+// notification body never carries an "agent" field. Setting this field lets an
+// incoming notification switch the receiving session's active-turn agent
+// context (e.g. a subagent gets promoted to the coordinator's agent). See
+// issue #848 — the "agent" override was a host-mode-era workaround that is no
+// longer needed and causes a real context-switch bug.
+func TestBuildNotifyPromptBody_OmitsAgentField(t *testing.T) {
+	rootAgent := "coordinator"
+	agentName := "explore"
+	rootModel := "anthropic/claude-opus-4"
+	modelID := "anthropic/claude-sonnet-4"
+
+	cases := []struct {
+		name   string
+		status *db.Status
+	}{
+		{
+			name: "root fields present",
+			status: &db.Status{
+				RootAgentName: &rootAgent,
+				RootModelID:   &rootModel,
+				AgentName:     &agentName,
+				ModelID:       &modelID,
+			},
+		},
+		{
+			name: "only legacy fields present",
+			status: &db.Status{
+				AgentName: &agentName,
+				ModelID:   &modelID,
+			},
+		},
+		{
+			name: "only root fields present",
+			status: &db.Status{
+				RootAgentName: &rootAgent,
+				RootModelID:   &rootModel,
+			},
+		},
+		{
+			name:   "no fields present",
+			status: &db.Status{},
+		},
+		{
+			name: "agent known but no model",
+			status: &db.Status{
+				RootAgentName: &rootAgent,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := buildNotifyPromptBody("hello", tc.status)
+			if _, ok := body["agent"]; ok {
+				t.Errorf("body must not contain \"agent\" field (got %v); setting it switches the receiving session's agent context — see issue #848", body["agent"])
+			}
+		})
+	}
+}
+
+// TestBuildNotifyPromptBody_IncludesTextAndModel verifies that the notification
+// body still carries the prompt text and, when a model is known, the split
+// provider/model identifiers. Model is preferred from RootModelID, falling
+// back to ModelID for pre-migration sessions.
+func TestBuildNotifyPromptBody_IncludesTextAndModel(t *testing.T) {
+	rootModel := "anthropic/claude-opus-4"
+	legacyModel := "openai/gpt-4o"
+
+	t.Run("root model preferred", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{
+			RootModelID: &rootModel,
+			ModelID:     &legacyModel,
+		})
+
+		parts, ok := body["parts"].([]map[string]string)
+		if !ok || len(parts) != 1 || parts[0]["text"] != "hello" {
+			t.Errorf("parts = %v, want single text part with \"hello\"", body["parts"])
+		}
+
+		model, ok := body["model"].(map[string]string)
+		if !ok {
+			t.Fatalf("model = %v, want map[string]string", body["model"])
+		}
+		if model["providerID"] != "anthropic" || model["modelID"] != "claude-opus-4" {
+			t.Errorf("model = %v, want providerID=anthropic modelID=claude-opus-4", model)
+		}
+	})
+
+	t.Run("legacy model fallback", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{
+			ModelID: &legacyModel,
+		})
+		model, ok := body["model"].(map[string]string)
+		if !ok {
+			t.Fatalf("model = %v, want map[string]string", body["model"])
+		}
+		if model["providerID"] != "openai" || model["modelID"] != "gpt-4o" {
+			t.Errorf("model = %v, want providerID=openai modelID=gpt-4o", model)
+		}
+	})
+
+	t.Run("no model omits model field", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{})
+		if _, ok := body["model"]; ok {
+			t.Errorf("model field must be absent when no model known, got %v", body["model"])
+		}
+		// text must still be present
+		parts, ok := body["parts"].([]map[string]string)
+		if !ok || len(parts) != 1 || parts[0]["text"] != "hello" {
+			t.Errorf("parts = %v, want single text part with \"hello\"", body["parts"])
+		}
+	})
+}


### PR DESCRIPTION
Closes #848

## Summary

`buildNotifyPromptBody` was setting `body["agent"] = *agentName` in the HTTP body sent to `POST /session/<sid>/prompt_async` for bus notifications. This was a host-mode-era workaround that is no longer needed under the current per-session-per-container architecture, and it has a live side-effect: an incoming notification switches the receiving session's active-turn agent context to whatever the notifier picked.

That side-effect caused a real subagent context-switch incident: an `@explore` subagent running in a coordinator pane was promoted to the coordinator agent's context by an incoming notification and began executing coordinator tool calls.

## Change

- Delete `body["agent"] = *agentName` from `buildNotifyPromptBody` in `internal/sidecar/sidecar.go`.
- Drop the now-dead `agentName` lookup (`status.RootAgentName` → `status.AgentName` fallback) that existed only to feed that field.
- Simplify the guard on the model block from `if agentName != nil && modelID != nil` to just `if modelID != nil`.
- Update the function doc comment to explain why the `agent` field is deliberately omitted, referencing this issue.
- Add unit tests:
  - `TestBuildNotifyPromptBody_OmitsAgentField` — asserts the `agent` field is absent across five status combinations (root fields present, legacy fields present, only root, none, agent-but-no-model).
  - `TestBuildNotifyPromptBody_IncludesTextAndModel` — verifies the text parts and model split still work, including the `RootModelID` preference and `ModelID` fallback.

## Out of scope

- Other fields in `buildNotifyPromptBody` (`text`, `urgency`, `from_session`) — untouched.
- The non-notification `prism prompt` path (`cmd/prompt.go`) — already doesn't set `agent` for the subagent case; out of scope per the issue.
- The broader #849 session uniformity refactor and the bus message schema.

## Verification

Quality gates:

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./internal/sidecar/...` — passes (including the two new tests)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — passes

The new `TestBuildNotifyPromptBody_OmitsAgentField` is the primary regression guard: it would fail if the `agent` field ever returned to the outgoing body. The PR body is a straightforward map literal — the unit test is a complete verification that the field does not appear for any representative status shape.

Manual verification of the live subagent context-switch path (spawning `@explore` in a coordinator pane and sending a labelled notification) is impractical to reproduce inside the branch sandbox without a full prism runtime. The HTTP body no longer carrying the `agent` field is sufficient on its own: opencode only switches agent context when the field is present, so removing it removes the mechanism.

## Coordination with parallel work

- #916 — touches `tmux.nix` only. No overlap.
- #859 — may touch `sidecar.go` (SpawnSession extraction). No overlap at the function I changed (`buildNotifyPromptBody` ~L1720); the worker for #859 was told to route around it. If #859 lands first, a trivial rebase should be all that is needed.
- #844 — different file. No overlap.