### PR TITLE
prism: extract session.SpawnSession as single shared spawn primitive

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -316,29 +316,52 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	opts := session.Opts{
+	// Build SpawnOpts and call session.SpawnSession — the single shared
+	// primitive for creating a prism session end-to-end (port allocation,
+	// DB seed with root_agent_name, tmux session creation, sidecar startup).
+	// See #849 §3.1 and #859.
+	sessionName := session.NameFor(worktreePath, bareRoot)
+	agentRole := session.DefaultAgent(worktreePath, agentFlag)
+	headless := !fromKeybind && !attachFlag
+
+	spawnOpts := session.SpawnOpts{
+		SessionName:    sessionName,
+		Repo:           deriveRepo(worktreePath),
+		Worktree:       worktreePath,
+		AgentRole:      agentRole,
 		Prompt:         promptFlag,
-		Agent:          agentFlag,
 		ConfigContent:  configContent,
-		Headless:       !fromKeybind && !attachFlag,
+		Layout:         session.LayoutFull,
 		ContainerMode:  effectiveContainerMode,
 		IsolationMode:  string(isolationMode),
 		PluginHostPath: cfg.SidecarPluginPath,
-		// ForceFresh=true: spawn always wants a new instance. If a session with
-		// the same name already exists it is a stale zombie and should be killed.
+		// ForceFresh=true: spawn always wants a new instance. If a session
+		// with the same name already exists it is a stale zombie and should
+		// be killed.
 		ForceFresh: true,
+		Headless:   headless,
 	}
 	// AgentEnvVars only applies to host-mode sessions; container sessions
 	// receive env vars via podman --env flags in the sidecar.
 	if pf != nil && !effectiveContainerMode {
-		opts.AgentEnvVars = pf.AgentEnvVars
+		spawnOpts.AgentEnvVars = pf.AgentEnvVars
 	}
 
-	if err := ensureAndSwitch(worktreePath, bareRoot, opts); err != nil {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("spawn: open db: %w", dbErr)
+	}
+	defer d.Close()
+
+	if err := session.SpawnSession(d, spawnOpts); err != nil {
 		return err
 	}
 
-	return nil
+	if headless {
+		fmt.Printf("session %q created\n", sessionName)
+		return nil
+	}
+	return session.Attach(sessionName)
 }
 
 // resolveBareRoot returns the bare repo root to operate on.

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -75,6 +75,10 @@ type Status struct {
 	Harness          *string
 	HarnessSessionID *string
 	HarnessPort      *int
+	// GroupID is the session_groups.group_id this session belongs to, or nil
+	// when this session is not part of a group. Populated by SpawnSession
+	// when opts.GroupID is non-empty (see #849 §3.1 and #859).
+	GroupID *string
 }
 
 // EffectiveIsolationMode returns the effective isolation mode for this session.
@@ -1137,7 +1141,7 @@ func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, ty
 // CurrentStatus returns the agent_status row for sessionName, or nil if not found.
 func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE session_name = ?`
 	row := d.conn.QueryRow(q, sessionName)
@@ -1154,7 +1158,7 @@ WHERE session_name = ?`
 // AllActiveStatus returns all agent_status rows where ended_at IS NULL.
 func (d *DB) AllActiveStatus() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
@@ -1163,7 +1167,7 @@ WHERE ended_at IS NULL`
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
@@ -1181,7 +1185,7 @@ func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
 	// percent signs in session names are matched exactly, not as wildcards.
 	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE session_name LIKE ? ESCAPE '\'`
 	return d.queryStatuses(q, escaped+"%")
@@ -1245,6 +1249,23 @@ func (d *DB) SetInstanceID(sessionName, instanceID string) error {
 	)
 	if err != nil {
 		return fmt.Errorf("db: set instance_id: %w", err)
+	}
+	return nil
+}
+
+// SetGroupID writes a group_id to the agent_status row for sessionName. Called
+// by SpawnSession when opts.GroupID is non-empty to associate the new session
+// with a session_groups entry (Issue E hook — see #849 §3.1 and #860).
+//
+// No-op when sessionName has no agent_status row (the UPDATE affects zero rows
+// and returns nil).
+func (d *DB) SetGroupID(sessionName, groupID string) error {
+	_, err := d.conn.Exec(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = ?",
+		groupID, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("db: set group_id: %w", err)
 	}
 	return nil
 }
@@ -1609,14 +1630,19 @@ func scanStatus(s scanner) (*Status, error) {
 	var harnessSessionID sql.NullString
 	var harnessPort sql.NullInt64
 	var isolationMode sql.NullString
+	var groupID sql.NullString
 	err := s.Scan(
 		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
 		&st.Title, &st.OpencodeSID, &st.AgentName, &st.ModelID,
 		&st.RootAgentName, &st.RootModelID, &port, &hostMode, &isolationMode, &instanceID, &lastSeen, &endedAt,
-		&harness, &harnessSessionID, &harnessPort,
+		&harness, &harnessSessionID, &harnessPort, &groupID,
 	)
 	if err != nil {
 		return nil, err
+	}
+	if groupID.Valid {
+		g := groupID.String
+		st.GroupID = &g
 	}
 	st.LastSeen = time.UnixMilli(lastSeen)
 	if endedAt.Valid {

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/config"
-	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -470,28 +469,6 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		agentSession := roundPrefix + ag.Name
 		agentSessions[i] = agentSession
 
-		// Seed agent_status for the agent session, including root_agent_name so
-		// the DB reflects the reviewer type from the first moment (closes the
-		// capture gap referenced in #844).
-		if err := d.UpsertStatusSeedRootAgentName(agentSession, repo, worktree, "idle", nil, nil, ag.Name); err != nil {
-			spawnErr[i] = fmt.Errorf("seed status for %s: %w", ag.Name, err)
-			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), err))
-			}
-			continue
-		}
-
-		// Allocate a port for this agent session.
-		port, portErr := d.AllocatePort(agentSession)
-		if portErr != nil {
-			_ = d.SetEnded(agentSession)
-			spawnErr[i] = fmt.Errorf("allocate port for %s: %w", ag.Name, portErr)
-			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), portErr))
-			}
-			continue
-		}
-
 		// Build the prompt for the review agent.
 		// Inject the worktree path into PRCtx so agents know where the
 		// branch is checked out (and that it is read-only).
@@ -512,7 +489,6 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// surfaces this as an explicit error to prevent silent build-agent spawns.
 		agentConfigContent, configErr := ResolveAgentConfigContent(opts.ContainerMode, opts.ProfilesFile, ag.Name)
 		if configErr != nil {
-			_ = d.SetEnded(agentSession)
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
 				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
@@ -520,35 +496,38 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			continue
 		}
 
-		// Start the sidecar for this agent.
+		// Spawn the per-agent session via the shared primitive. SpawnSession
+		// handles DB seed (with root_agent_name from AgentRole), port
+		// allocation, tmux session creation, and sidecar startup — keeping
+		// review.go free of direct db/tmux/sidecar machinery (#859).
+		//
 		// WorktreeReadOnly=true ensures review containers cannot modify the
 		// branch under review (satisfies the [security] acceptance criterion).
-		sidecarOpts := session.StartSidecarOpts{
-			Port:             port,
-			ContainerMode:    opts.ContainerMode,
-			AgentRole:        ag.Name,
+		spawnOpts := session.SpawnOpts{
+			SessionName:      agentSession,
+			Repo:             repo,
 			Worktree:         worktree,
-			PluginHostPath:   opts.PluginHostPath,
-			InitialPrompt:    prompt,
+			AgentRole:        ag.Name,
+			Prompt:           prompt,
 			ConfigContent:    agentConfigContent,
+			Layout:           session.LayoutAgentOnly,
+			ContainerMode:    opts.ContainerMode,
+			PluginHostPath:   opts.PluginHostPath,
 			WorktreeReadOnly: true,
+			// GroupID intentionally left empty — Issue E (#860) will wire
+			// review rounds to session_groups once this primitive lands.
 		}
-		if sidecarErr := session.StartSidecarWithOpts(agentSession, sidecarOpts); sidecarErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism review] warning: could not start sidecar for %s: %v\n", ag.Name, sidecarErr)
-		}
-
-		// Create the independent top-level tmux session for this agent.
-		agentCmd := buildAgentCommand(ag, agentSession, port, prompt, opts.ContainerMode)
-		if err := createAgentSession(agentSession, worktree, agentCmd, port, opts.ContainerMode); err != nil {
-			// Emit spawn-failure progress line immediately.
+		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), err))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnSessErr))
 			}
 			// Clean up this agent's resources (sidecar, DB row, tmux session).
+			// SpawnSession may have partially progressed; be defensive so a
+			// second spawn attempt with the same name doesn't see stale state.
 			session.KillSidecar(agentSession)
 			cleanupAgentSession(d, agentSession)
 			_ = tmux.KillSession(agentSession)
-			spawnErr[i] = fmt.Errorf("create session for %s: %w", ag.Name, err)
+			spawnErr[i] = fmt.Errorf("spawn session for %s: %w", ag.Name, spawnSessErr)
 			continue
 		}
 
@@ -724,71 +703,6 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 	sb.WriteString("---\n\n")
 
 	return sb.String()
-}
-
-// buildAgentCommand returns the command string for a review agent session.
-// agentSession is the full session name (e.g. "nixos-config@feature~review-1-review-goal"),
-// used as PRISM_SESSION_NAME so the plugin correctly identifies the DB row.
-func buildAgentCommand(ag Agent, agentSession string, port int, prompt string, containerMode bool) string {
-	if containerMode {
-		// Use podman attach to bridge the tmux pane to the container's PTY.
-		// The container runs opencode in combined TUI + HTTP mode (RFC #691, Phase 1a).
-		// --sig-proxy=false prevents podman from forwarding signals (e.g. SIGINT from
-		// Ctrl-C) to the container process; instead the ^C byte reaches opencode's TUI
-		// as literal stdin input, which it handles as an interrupt keystroke — matching
-		// host-mode behaviour where Ctrl-C interrupts the current turn, not the process.
-		// The container name is shell-quoted so that any unexpected characters in
-		// the session name cannot be interpreted as shell metacharacters when
-		// buildReadinessWaitCmd embeds this string in the readiness shell script.
-		return "podman attach --sig-proxy=false " + shellQuote(container.NameForSession(agentSession))
-	}
-	escapedPrompt := shellQuote(prompt)
-	// Prepend the experimental bash-tool timeout env var so review agents also
-	// get the 15-min default. Scoped to opencode only — not pi or other harnesses.
-	return fmt.Sprintf("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=900000 PRISM_SESSION_NAME=%s opencode --agent %s --port %d --hostname 127.0.0.1 --prompt %s",
-		shellQuote(agentSession), ag.OpencodeName, port, escapedPrompt)
-}
-
-// createAgentSession creates a new independent top-level tmux session for a
-// review agent. In container mode it prepends a readiness wait like the
-// standard session setup. The session is created with a single "agent" window
-// that runs the given command.
-func createAgentSession(agentSession, worktree, agentCmd string, port int, containerMode bool) error {
-	cmd := agentCmd
-	if containerMode && port != 0 {
-		readyPath, pathErr := session.SidecarReadyPath(agentSession)
-		if pathErr == nil {
-			// Remove any stale ready file from a previous lifecycle.
-			_ = os.Remove(readyPath)
-			cmd = buildReadinessWaitCmd(readyPath, agentCmd)
-		}
-	}
-	// Create the session (starts with a bare shell in window 0).
-	if err := tmux.NewSessionDetached(agentSession, worktree); err != nil {
-		return fmt.Errorf("new-session %q: %w", agentSession, err)
-	}
-	// Create window 1 with the agent command. Window 0 remains as a shell.
-	// Using NewWindow ensures the command runs via "sh -c" and semicolons in
-	// the readiness wait script are not consumed by tmux's command parser.
-	if err := tmux.NewWindow(agentSession, 1, "agent", worktree, cmd, nil); err != nil {
-		return fmt.Errorf("new-window for %q: %w", agentSession, err)
-	}
-	// Select the agent window (1) as the default.
-	_ = tmux.SelectWindow(agentSession, 1)
-	return nil
-}
-
-// buildReadinessWaitCmd mirrors session.buildReadinessWaitCmd (unexported).
-// Polls for the readiness file and runs the attach command directly once ready.
-func buildReadinessWaitCmd(readyPath, attachCmd string) string {
-	return fmt.Sprintf(
-		`i=0; while [ ! -f %s ] && [ $i -lt 240 ]; do sleep 0.5; i=$((i+1)); done; `+
-			`if [ ! -f %s ]; then `+
-			`echo "prism: container did not become ready within 120s" >&2; exit 1; `+
-			`fi; `+
-			`%s`,
-		shellQuote(readyPath), shellQuote(readyPath), attachCmd,
-	)
 }
 
 // pollAgents polls the DB until all agents reach "finished" or the timeout expires.
@@ -1192,11 +1106,6 @@ func deriveRepo(sessionName string) string {
 		return sessionName[:idx]
 	}
 	return sessionName
-}
-
-// shellQuote wraps s in single quotes, escaping any single quotes within.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // formatDuration formats a duration as "Xm" or "Xs" for display.

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -157,6 +157,12 @@ const (
 	// LayoutFull sets up the standard three-window layout:
 	// window 0 "edit" (nvim), window 1 "agent" (opencode), window 2 "term".
 	LayoutFull
+
+	// LayoutAgentOnly sets up a minimal two-window layout: window 0 is a
+	// bare shell, window 1 runs the agent command. Used by review-style
+	// sessions (spawned via SpawnSession) that do not need an editor or
+	// terminal window — the worktree is read-only for them.
+	LayoutAgentOnly
 )
 
 // DefaultAgent returns the agent to use for the given directory.

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -1,0 +1,308 @@
+package session
+
+// SpawnSession is the single shared primitive for creating a prism session
+// end-to-end. Both `prism spawn` (cmd/spawn.go → ensureAndSwitch) and
+// `prism review` (internal/review/review.go per-agent loop) compose over it.
+//
+// Design (see #849 §3.1 and #859):
+//
+//   - A prism session is the fundamental primitive. A spawn-style command is
+//     an abstraction over the primitive. The primitive is uniform; the
+//     abstractions are allowed to be rich and divergent.
+//
+//   - SpawnSession contains NO branching on session-type strings. All variant
+//     behaviour flows through SpawnOpts fields (Layout, WorktreeReadOnly,
+//     ContainerMode, GroupID, …). If a branch here feels unavoidable, first
+//     ask whether it should be a new SpawnOpts field.
+//
+//   - root_agent_name is written at spawn time from opts.AgentRole — no NULL
+//     window (relies on #857 / Issue B).
+//
+//   - group_id is written from opts.GroupID when non-empty. It is a no-op for
+//     single-session spawns (spawn/pr); Issue E (#860) will wire it into
+//     review.go once this primitive lands.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// SpawnOpts describes a single session to create end-to-end.
+// All fields are available regardless of agent type — SpawnSession does not
+// branch on the value of AgentRole (or any other string identifier).
+type SpawnOpts struct {
+	// SessionName is the canonical tmux/prism session name. Required.
+	SessionName string
+
+	// Repo is the short repo name, e.g. "nixos-config". Written to
+	// agent_status.repo on initial insert only. May be empty for sessions
+	// outside a worktree.
+	Repo string
+
+	// Worktree is the absolute path to the directory the session should run
+	// in. Required.
+	Worktree string
+
+	// AgentRole is the agent identity (e.g. "coordinator", "worker",
+	// "review-code"). Written to agent_status.root_agent_name at spawn time
+	// so the DB row reflects the agent type from the first moment.
+	AgentRole string
+
+	// Prompt is the initial prompt delivered to the agent on startup.
+	// Passed via opencode's --prompt CLI flag (host mode) or via the sidecar
+	// (container/bwrap mode).
+	Prompt string
+
+	// ConfigContent is the JSON blob injected as OPENCODE_CONFIG_CONTENT.
+	// Generated upstream from --profile/--model/--variant or from per-role
+	// container profiles. Empty string means no override.
+	ConfigContent string
+
+	// Layout selects the tmux window layout created for this session.
+	//   - LayoutFull:       3-window layout (edit / agent / term) — spawn path
+	//   - LayoutAgentOnly:  2-window layout (shell / agent)       — review path
+	Layout Layout
+
+	// ContainerMode, when true, runs opencode inside a podman container.
+	// Deprecated alias for IsolationMode == "podman"; both are accepted for
+	// back-compat.
+	ContainerMode bool
+
+	// IsolationMode is the resolved isolation mode for this session.
+	// Valid values: "podman", "bwrap", "host". When non-empty it overrides
+	// ContainerMode.
+	IsolationMode string
+
+	// PluginHostPath is the host-side path to the opencode plugin bind-mounted
+	// into the container.
+	PluginHostPath string
+
+	// InstanceID is the UUID for this session incarnation. When empty,
+	// callers that need a stable instance_id should generate one and
+	// populate this field before calling SpawnSession; otherwise the sidecar
+	// / tmux-session-start hook will generate one.
+	InstanceID string
+
+	// WorktreeReadOnly, when true, mounts the worktree read-only inside the
+	// container. Set for review agents so they cannot modify the branch
+	// under review.
+	WorktreeReadOnly bool
+
+	// GroupID, when non-empty, associates this session with a SessionGroup
+	// (see db.RegisterGroup). Written to agent_status.group_id. This is the
+	// hook for Issue E (#860) — SpawnSession writes it when present but does
+	// not create the group itself.
+	GroupID string
+
+	// AgentEnvVars are additional env vars prefixed to the opencode command
+	// in host-mode sessions (see profiles.json agent_env_vars). Ignored in
+	// container/bwrap mode — those paths deliver env vars via podman --env
+	// in the sidecar.
+	AgentEnvVars map[string]string
+
+	// ForceFresh controls the startup guard for LayoutFull. When true, any
+	// existing tmux session with the same name is killed before the new
+	// session is created. When false, a live existing session is preserved
+	// and SpawnSession is a no-op. For LayoutAgentOnly this field is ignored
+	// — review agent sessions always create fresh.
+	ForceFresh bool
+
+	// Headless, when true, signals to callers that no tmux client switch
+	// should happen after the session is created. SpawnSession itself does
+	// not call Attach; this field is carried through for composition with
+	// higher-level wrappers.
+	Headless bool
+}
+
+// SpawnSession creates a single prism session end-to-end: seeds the
+// agent_status row (including root_agent_name and, when set, group_id),
+// allocates a port, creates the tmux session, and starts the sidecar.
+//
+// This is the single entry point for session creation. Both `prism spawn` and
+// `prism review`'s per-agent loop compose over it; no other callers should
+// call db.AllocatePort + tmux.NewSessionDetached + StartSidecarWithOpts
+// directly.
+//
+// Ordering is preserved from the pre-extraction call sites:
+//
+//  1. DB seed (UpsertStatusSeedRootAgentName) — writes root_agent_name
+//     immediately so the DB row reflects agent identity from the first
+//     moment.
+//  2. Group-id write (when opts.GroupID != "") — SetGroupID on the same row.
+//  3. Port allocation (db.AllocatePort).
+//  4. Tmux session + agent window creation (via Create for LayoutFull, or
+//     inline for LayoutAgentOnly).
+//  5. Sidecar startup — handled inside setupFullLayout for LayoutFull, and
+//     called directly here for LayoutAgentOnly.
+func SpawnSession(d *db.DB, opts SpawnOpts) error {
+	if d == nil {
+		return fmt.Errorf("spawn session: db handle is required")
+	}
+	if opts.SessionName == "" {
+		return fmt.Errorf("spawn session: SessionName is required")
+	}
+	if opts.Worktree == "" {
+		return fmt.Errorf("spawn session: Worktree is required")
+	}
+
+	// Step 1: Seed agent_status with root_agent_name. Idempotent; later
+	// writes by the sidecar and by tmux-session-start COALESCE-preserve the
+	// value written here.
+	if err := d.UpsertStatusSeedRootAgentName(
+		opts.SessionName, opts.Repo, opts.Worktree, "idle", nil, nil, opts.AgentRole,
+	); err != nil {
+		return fmt.Errorf("spawn session: seed status: %w", err)
+	}
+
+	// Step 2: Write group_id when set (hook for Issue E — single-session
+	// spawns leave GroupID empty and this is a no-op).
+	if opts.GroupID != "" {
+		if err := d.SetGroupID(opts.SessionName, opts.GroupID); err != nil {
+			return fmt.Errorf("spawn session: set group_id: %w", err)
+		}
+	}
+
+	// Generate an instance_id if the caller did not pre-populate one. The
+	// sidecar needs it via --instance-id to tag container labels and bus
+	// messages; writing it to the DB here keeps the DB row in sync before
+	// the tmux-session-start hook fires.
+	if opts.InstanceID == "" && opts.Layout == LayoutFull {
+		opts.InstanceID = uuid.New().String()
+		if err := d.SetInstanceID(opts.SessionName, opts.InstanceID); err != nil {
+			// Non-fatal: instance isolation degrades gracefully. Log and
+			// continue — the sidecar will read back an empty instance_id
+			// from the DB (which is the pre-instance-id behaviour).
+			fmt.Fprintf(os.Stderr,
+				"warning: could not set instance_id for %q: %v\n",
+				opts.SessionName, err)
+			opts.InstanceID = ""
+		}
+	}
+
+	// Step 3: Allocate a port from the configured range. Fails fast if the
+	// allocation fails — a session with no port cannot start opencode.
+	port, err := d.AllocatePort(opts.SessionName)
+	if err != nil {
+		return fmt.Errorf("spawn session: allocate port: %w", err)
+	}
+
+	// Step 4 & 5: Create the tmux session and start the sidecar. Both
+	// layouts share the same responsibilities — only the window shape and
+	// the ownership of the sidecar-start call differ.
+	switch opts.Layout {
+	case LayoutFull:
+		return spawnFullLayout(d, opts, port)
+	case LayoutAgentOnly:
+		return spawnAgentOnlyLayout(opts, port)
+	default:
+		return fmt.Errorf("spawn session: unsupported layout %d", opts.Layout)
+	}
+}
+
+// spawnFullLayout delegates to Create, which handles the 3-window spawn-path
+// layout: edit (nvim), agent (opencode), and term. Create also fires the
+// tmux-session-start hook (which idempotently re-seeds root_agent_name) and
+// starts the sidecar from inside setupFullLayout.
+func spawnFullLayout(d *db.DB, opts SpawnOpts, port int) error {
+	createOpts := Opts{
+		Prompt:           opts.Prompt,
+		Agent:            opts.AgentRole,
+		ConfigContent:    opts.ConfigContent,
+		SessionName:      opts.SessionName,
+		Port:             port,
+		ContainerMode:    opts.ContainerMode,
+		IsolationMode:    opts.IsolationMode,
+		PluginHostPath:   opts.PluginHostPath,
+		InstanceID:       opts.InstanceID,
+		AgentEnvVars:     opts.AgentEnvVars,
+		Layout:           LayoutFull,
+		ForceFresh:       opts.ForceFresh,
+		Headless:         opts.Headless,
+		DB:               d,
+	}
+	return Create(opts.SessionName, opts.Worktree, createOpts)
+}
+
+// spawnAgentOnlyLayout creates a 2-window tmux session for a review-style
+// agent: window 0 is a bare shell, window 1 runs the agent command. The
+// sidecar is started directly (it is owned by the session, not by a tmux
+// hook — review sessions do not run the tmux-session-start seeding hook).
+//
+// No nvim/term windows — review agents do not need an editor or terminal;
+// the worktree is read-only for them.
+func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
+	mode := opts.IsolationMode
+	if mode == "" && opts.ContainerMode {
+		mode = "podman"
+	}
+
+	// Start the sidecar BEFORE creating the agent window so that the
+	// readiness file (in podman mode) exists by the time the pane polls for
+	// it. For bwrap / host modes the sidecar still handles SSE, state, and
+	// host-API, and starting it up-front keeps the ordering consistent.
+	sidecarOpts := StartSidecarOpts{
+		Port:             port,
+		ContainerMode:    opts.ContainerMode,
+		IsolationMode:    mode,
+		AgentRole:        opts.AgentRole,
+		Worktree:         opts.Worktree,
+		PluginHostPath:   opts.PluginHostPath,
+		InitialPrompt:    opts.Prompt,
+		ConfigContent:    opts.ConfigContent,
+		InstanceID:       opts.InstanceID,
+		WorktreeReadOnly: opts.WorktreeReadOnly,
+	}
+	if err := StartSidecarWithOpts(opts.SessionName, sidecarOpts); err != nil {
+		// Non-fatal: log and continue, matching the LayoutFull behaviour
+		// inside setupFullLayout. The session still gets created.
+		fmt.Fprintf(os.Stderr,
+			"warning: could not start sidecar for %q: %v\n",
+			opts.SessionName, err)
+	}
+
+	// Build the agent command. BuildOpencodeCmd produces the right shape
+	// for the resolved isolation mode (podman attach / prism agent-run /
+	// direct opencode). For podman mode, wrap it in the readiness-wait
+	// script so the pane blocks until the sidecar has health-checked the
+	// container.
+	buildOpts := Opts{
+		Prompt:         opts.Prompt,
+		Agent:          opts.AgentRole,
+		ConfigContent:  opts.ConfigContent,
+		SessionName:    opts.SessionName,
+		Port:           port,
+		ContainerMode:  opts.ContainerMode,
+		IsolationMode:  mode,
+		PluginHostPath: opts.PluginHostPath,
+		// AgentEnvVars intentionally omitted: review sessions don't inject
+		// profile env vars in host mode today.
+	}
+	agentCmd := BuildOpencodeCmd(buildOpts)
+	if mode == "podman" && port != 0 {
+		readyPath, pathErr := SidecarReadyPath(opts.SessionName)
+		if pathErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not determine ready path for %q, skipping readiness wait: %v\n",
+				opts.SessionName, pathErr)
+		} else {
+			_ = os.Remove(readyPath)
+			agentCmd = buildReadinessWaitCmd(readyPath, agentCmd)
+		}
+	}
+
+	// Create the tmux session (window 0 = bare shell) and the agent window
+	// (window 1).
+	if err := tmux.NewSessionDetached(opts.SessionName, opts.Worktree); err != nil {
+		return fmt.Errorf("spawn session: new tmux session %q: %w", opts.SessionName, err)
+	}
+	if err := tmux.NewWindow(opts.SessionName, 1, "agent", opts.Worktree, agentCmd, nil); err != nil {
+		return fmt.Errorf("spawn session: new agent window for %q: %w", opts.SessionName, err)
+	}
+	_ = tmux.SelectWindow(opts.SessionName, 1)
+	return nil
+}

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -82,10 +82,11 @@ type SpawnOpts struct {
 	// into the container.
 	PluginHostPath string
 
-	// InstanceID is the UUID for this session incarnation. When empty,
-	// callers that need a stable instance_id should generate one and
-	// populate this field before calling SpawnSession; otherwise the sidecar
-	// / tmux-session-start hook will generate one.
+	// InstanceID is the UUID for this session incarnation. For LayoutFull,
+	// SpawnSession auto-generates one when this field is empty and writes it
+	// to agent_status before the sidecar starts. For LayoutAgentOnly, the
+	// field is passed through verbatim — the sidecar and tmux-session-start
+	// hook will generate one downstream if it remains empty.
 	InstanceID string
 
 	// WorktreeReadOnly, when true, mounts the worktree read-only inside the
@@ -210,20 +211,20 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 // starts the sidecar from inside setupFullLayout.
 func spawnFullLayout(d *db.DB, opts SpawnOpts, port int) error {
 	createOpts := Opts{
-		Prompt:           opts.Prompt,
-		Agent:            opts.AgentRole,
-		ConfigContent:    opts.ConfigContent,
-		SessionName:      opts.SessionName,
-		Port:             port,
-		ContainerMode:    opts.ContainerMode,
-		IsolationMode:    opts.IsolationMode,
-		PluginHostPath:   opts.PluginHostPath,
-		InstanceID:       opts.InstanceID,
-		AgentEnvVars:     opts.AgentEnvVars,
-		Layout:           LayoutFull,
-		ForceFresh:       opts.ForceFresh,
-		Headless:         opts.Headless,
-		DB:               d,
+		Prompt:         opts.Prompt,
+		Agent:          opts.AgentRole,
+		ConfigContent:  opts.ConfigContent,
+		SessionName:    opts.SessionName,
+		Port:           port,
+		ContainerMode:  opts.ContainerMode,
+		IsolationMode:  opts.IsolationMode,
+		PluginHostPath: opts.PluginHostPath,
+		InstanceID:     opts.InstanceID,
+		AgentEnvVars:   opts.AgentEnvVars,
+		Layout:         LayoutFull,
+		ForceFresh:     opts.ForceFresh,
+		Headless:       opts.Headless,
+		DB:             d,
 	}
 	return Create(opts.SessionName, opts.Worktree, createOpts)
 }

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
-	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
 // openSpawnTestDB creates a fresh temp DB and registers cleanup.
@@ -334,8 +333,3 @@ func TestSpawnSession_UnsupportedLayout_ReturnsError(t *testing.T) {
 		t.Errorf("error %q does not mention layout", err.Error())
 	}
 }
-
-// sentinel to ensure the tmux spy package import is retained even if the
-// signature of tmux changes — the _ reference prevents a "declared and not
-// used" error if all in-line uses are removed by a refactor.
-var _ = tmux.TmuxBin

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -1,0 +1,341 @@
+package session
+
+// Tests for SpawnSession — the shared primitive that powers both `prism spawn`
+// and `prism review`'s per-agent spawn loop. See #849 §3.1 and #859.
+//
+// SpawnSession's responsibilities, in order:
+//   1. Seed agent_status with root_agent_name (via UpsertStatusSeedRootAgentName).
+//   2. Write group_id when opts.GroupID is non-empty (hook for Issue E).
+//   3. Allocate a port from the DB range.
+//   4. Create the tmux session and (for LayoutAgentOnly) start the sidecar.
+//
+// These tests exercise the behaviour that belongs to SpawnSession specifically:
+// the DB side-effects (step 1–3) and the fail-fast path when port allocation
+// fails. The tmux/sidecar mechanics in step 4 are covered separately by the
+// existing session.Create, sidecar_test.go, and createAgentSession-equivalent
+// tests — SpawnSession composes those helpers without adding new logic.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// openSpawnTestDB creates a fresh temp DB and registers cleanup.
+func openSpawnTestDB(t *testing.T) (*db.DB, string) {
+	t.Helper()
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() {
+		d.Close()
+		SetTestDBPath("")
+	})
+	return d, dbFile
+}
+
+// TestSpawnSession_AgentOnly_SeedsRootAgentName verifies that, after a
+// successful LayoutAgentOnly spawn, the agent_status row has the expected
+// root_agent_name, repo, worktree, and a non-zero allocated port — all written
+// by SpawnSession before the sidecar and tmux session were created.
+func TestSpawnSession_AgentOnly_SeedsRootAgentName(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+
+	// Redirect tmux to a spy so we don't need a real tmux server.
+	_ = spyTmuxBin(t)
+	// Make the sidecar stub exit quickly (see TestMain in sidecar_test.go).
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	// Route sidecar state files to a temp dir.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~review-1-review-code"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-code",
+		Prompt:      "review this PR",
+		Layout:      LayoutAgentOnly,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want row")
+	}
+	if st.RootAgentName == nil || *st.RootAgentName != "review-code" {
+		got := "<nil>"
+		if st.RootAgentName != nil {
+			got = *st.RootAgentName
+		}
+		t.Errorf("root_agent_name = %q, want %q", got, "review-code")
+	}
+	if st.Repo != "myrepo" {
+		t.Errorf("repo = %q, want %q", st.Repo, "myrepo")
+	}
+	if st.Worktree != "/worktrees/myrepo-branch" {
+		t.Errorf("worktree = %q, want %q", st.Worktree, "/worktrees/myrepo-branch")
+	}
+	if st.OpencodePort == nil || *st.OpencodePort == 0 {
+		t.Error("expected non-zero opencode_port; got nil or 0")
+	}
+	if st.GroupID != nil {
+		t.Errorf("group_id = %q, want nil (GroupID was not set in opts)", *st.GroupID)
+	}
+}
+
+// TestSpawnSession_AgentOnly_WritesGroupID verifies that when opts.GroupID is
+// non-empty, SpawnSession writes it to agent_status.group_id. This is the hook
+// Issue E (#860) will use to wire review rounds into session_groups.
+func TestSpawnSession_AgentOnly_WritesGroupID(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	// RegisterGroup first so the FK (or future FK) is satisfied. The
+	// group_id column references session_groups(group_id) ON DELETE SET NULL.
+	groupID, err := d.RegisterGroup("myrepo@branch")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	const sessionName = "myrepo@branch~review-1-review-goal"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-goal",
+		Layout:      LayoutAgentOnly,
+		GroupID:     groupID,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want row")
+	}
+	if st.GroupID == nil {
+		t.Fatal("group_id is nil; want it to be populated from opts.GroupID")
+	}
+	if *st.GroupID != groupID {
+		t.Errorf("group_id = %q, want %q", *st.GroupID, groupID)
+	}
+}
+
+// TestSpawnSession_AgentOnly_CreatesTmuxSession verifies that SpawnSession
+// invokes tmux.NewSessionDetached and tmux.NewWindow for the agent window —
+// i.e. SpawnSession produces the tmux-side shape that previously lived in
+// review.go's createAgentSession helper.
+func TestSpawnSession_AgentOnly_CreatesTmuxSession(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~review-1-review-qa"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-qa",
+		Layout:      LayoutAgentOnly,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	args := readSpyArgs(argsFile)
+	joined := strings.Join(args, " ")
+
+	// new-session arguments go through tmux.NewSessionDetached.
+	if !strings.Contains(joined, "new-session") {
+		t.Errorf("expected tmux new-session invocation, got args: %v", args)
+	}
+	if !strings.Contains(joined, sessionName) {
+		t.Errorf("expected session name %q in tmux args, got: %v", sessionName, args)
+	}
+	// new-window for the agent pane.
+	if !strings.Contains(joined, "new-window") {
+		t.Errorf("expected tmux new-window invocation for agent pane, got args: %v", args)
+	}
+}
+
+// TestSpawnSession_NoAgentRole_LeavesRootAgentNameNull verifies that when
+// opts.AgentRole is empty, SpawnSession does NOT write a root_agent_name value
+// — the UpsertStatusSeedRootAgentName helper preserves NULL in that case. This
+// matches the pre-spawn-time seeding semantics (see Issue B / #857).
+func TestSpawnSession_NoAgentRole_LeavesRootAgentNameNull(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch-no-role"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		// AgentRole intentionally left empty.
+		Layout: LayoutAgentOnly,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want row")
+	}
+	if st.RootAgentName != nil {
+		t.Errorf("root_agent_name = %q, want nil when AgentRole is empty", *st.RootAgentName)
+	}
+}
+
+// TestSpawnSession_AllocatePortFails_ReturnsError verifies SpawnSession's
+// fail-fast path when port allocation fails. We force failure by closing the
+// DB before the call so the subsequent AllocatePort query errors out.
+//
+// The error must be wrapped so callers can inspect it, and no tmux session
+// must be created (tmux spy should see zero new-session args).
+func TestSpawnSession_AllocatePortFails_ReturnsError(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	// Close the DB so AllocatePort fails with "sql: database is closed".
+	// UpsertStatusSeedRootAgentName also fails on a closed DB, which is
+	// fine — SpawnSession must surface that as an error too.
+	d.Close()
+
+	const sessionName = "myrepo@branch-alloc-fail"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-security",
+		Layout:      LayoutAgentOnly,
+	}
+
+	err := SpawnSession(d, opts)
+	if err == nil {
+		t.Fatal("SpawnSession: got nil error, want an error (DB is closed)")
+	}
+	// The error message must clearly identify this as a SpawnSession
+	// failure so callers can tell it apart from downstream errors.
+	if !strings.Contains(err.Error(), "spawn session:") {
+		t.Errorf("error %q does not begin with 'spawn session:' prefix", err.Error())
+	}
+
+	// The tmux spy must not see any new-session calls — a failure before
+	// tmux creation must not leak a zombie tmux session.
+	args := readSpyArgs(argsFile)
+	for _, a := range args {
+		if a == "new-session" {
+			t.Errorf("tmux new-session was invoked despite early DB failure; args: %v", args)
+			break
+		}
+	}
+}
+
+// TestSpawnSession_Validation_RequiresSessionName verifies the argument guard.
+func TestSpawnSession_Validation_RequiresSessionName(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+
+	err := SpawnSession(d, SpawnOpts{
+		Worktree:  "/tmp",
+		AgentRole: "worker",
+		Layout:    LayoutAgentOnly,
+	})
+	if err == nil {
+		t.Fatal("expected error when SessionName is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "SessionName") {
+		t.Errorf("error %q does not mention SessionName", err.Error())
+	}
+}
+
+// TestSpawnSession_Validation_RequiresWorktree verifies the argument guard.
+func TestSpawnSession_Validation_RequiresWorktree(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+
+	err := SpawnSession(d, SpawnOpts{
+		SessionName: "myrepo@branch",
+		AgentRole:   "worker",
+		Layout:      LayoutAgentOnly,
+	})
+	if err == nil {
+		t.Fatal("expected error when Worktree is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "Worktree") {
+		t.Errorf("error %q does not mention Worktree", err.Error())
+	}
+}
+
+// TestSpawnSession_Validation_RequiresDB verifies the argument guard.
+func TestSpawnSession_Validation_RequiresDB(t *testing.T) {
+	err := SpawnSession(nil, SpawnOpts{
+		SessionName: "myrepo@branch",
+		Worktree:    "/tmp",
+		AgentRole:   "worker",
+		Layout:      LayoutAgentOnly,
+	})
+	if err == nil {
+		t.Fatal("expected error when db is nil, got nil")
+	}
+	if !strings.Contains(err.Error(), "db") {
+		t.Errorf("error %q does not mention db", err.Error())
+	}
+}
+
+// TestSpawnSession_UnsupportedLayout_ReturnsError verifies that Layout values
+// outside the supported set (LayoutFull / LayoutAgentOnly) surface a clear
+// error rather than silently falling through.
+func TestSpawnSession_UnsupportedLayout_ReturnsError(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	err := SpawnSession(d, SpawnOpts{
+		SessionName: "myrepo@branch-bad-layout",
+		Worktree:    "/tmp",
+		AgentRole:   "worker",
+		Layout:      LayoutScratchpad, // not supported by SpawnSession
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported layout, got nil")
+	}
+	if !strings.Contains(err.Error(), "layout") {
+		t.Errorf("error %q does not mention layout", err.Error())
+	}
+}
+
+// sentinel to ensure the tmux spy package import is retained even if the
+// signature of tmux changes — the _ reference prevents a "declared and not
+// used" error if all in-line uses are removed by a refactor.
+var _ = tmux.TmuxBin


### PR DESCRIPTION
## Summary

- Extract `session.SpawnSession(db, opts)` in `internal/session` as the end-to-end primitive for creating a prism session: port allocation, DB seed with `root_agent_name` (and optional `group_id`), tmux session creation, and sidecar startup — all in one place.
- Refactor `cmd/spawn.go` and `internal/review/review.go`'s per-agent spawn loop to compose over `SpawnSession` instead of calling `db.AllocatePort`, `tmux.NewSessionDetached`, and `session.StartSidecarWithOpts` directly.
- Variant behaviour flows through \`SpawnOpts\` fields — no session-type string matching inside the primitive. \`Layout\` (LayoutFull vs LayoutAgentOnly) selects the tmux window shape; \`WorktreeReadOnly\`, \`ContainerMode\`, \`IsolationMode\` are passthroughs; \`GroupID\` is written to \`agent_status.group_id\` when set (hook for Issue E / #860).

## Why

This is **Issue D** of the session-uniformity migration (#849). Today, \`prism spawn\` and \`prism review\` each reimplement parts of the spawn pipeline independently with subtle differences. Issue D extracts the shared core so that the remainder of the #849 chain (issues E, F, H, I, J) has one well-defined primitive to compose over, rather than two divergent paths to keep in sync.

## Scope

- \`internal/session/spawn.go\` (new): \`SpawnOpts\` + \`SpawnSession\`.
- \`internal/session/session.go\`: new \`LayoutAgentOnly\` layout value.
- \`internal/db/db.go\`: new \`SetGroupID\` helper; \`Status\` struct gains a \`GroupID\` field; row-scan queries include \`group_id\`.
- \`cmd/spawn.go\`: builds \`SpawnOpts\` and calls \`SpawnSession\` + \`Attach\` directly (no longer goes via \`ensureAndSwitch\`).
- \`internal/review/review.go\`: per-agent spawn loop calls \`SpawnSession\`; orphan helpers (\`createAgentSession\`, \`buildAgentCommand\`, \`buildReadinessWaitCmd\`, \`shellQuote\`) removed.
- \`internal/session/spawn_test.go\` (new): happy path, port-allocation-failure path, \`group_id\` hook, empty \`AgentRole\` preserves NULL, and argument-validation guards.

## Out of scope (per #859)

- Wiring \`prism review\` to actually pass \`GroupID\` — Issue E (#860).
- \`prism pr\` refactor — still calls \`ensureAndSwitch\`; tracked separately.
- Harness interface changes — Issue H (#862).
- Removing session-name pattern matching — Issue F (#861).

## Verification

From \`modules/programs/prism/prism/\`:

- \`go build ./...\` — passes.
- \`go test ./...\` — all tests pass except two pre-existing tmux flakes (\`TestCleanupRedirectMultiClient_Direct\`, \`TestSwitchPath_OnlyMovesTargetClient\` and related) that also fail on \`main\` with the same \"client never appeared in list-clients (timeout)\" message.
- \`nix build .#nixosConfigurations.navi.config.system.build.toplevel\` — passes.
- \`go vet ./...\` — clean.

Closes #859