### PR TITLE
prism: wire group_id into prism review spawn loop

### DIFF
--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -457,6 +457,16 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		agents = Agents()
 	}
 
+	// Register a session group for this review round. Every spawned agent
+	// session will carry this group_id, enabling GroupCompleted-based
+	// termination detection and GroupResults-based result aggregation.
+	// Fail fast if RegisterGroup fails — no sessions are spawned without a
+	// group to belong to (AC: edge-case).
+	groupID, groupErr := d.RegisterGroup(opts.ParentSession)
+	if groupErr != nil {
+		return nil, fmt.Errorf("register review group: %w", groupErr)
+	}
+
 	// Spawn each agent as its own independent top-level tmux session.
 	// spawnErr[i] is non-nil if agent i failed to spawn. Agents that fail to
 	// spawn are excluded from polling; they receive an error AgentResult.
@@ -514,8 +524,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			ContainerMode:    opts.ContainerMode,
 			PluginHostPath:   opts.PluginHostPath,
 			WorktreeReadOnly: true,
-			// GroupID intentionally left empty — Issue E (#860) will wire
-			// review rounds to session_groups once this primitive lands.
+			GroupID:          groupID,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -568,8 +577,9 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		onSessionsCreated(liveSessions)
 	}
 
-	// Poll DB until all live agents finish or timeout.
-	liveResults, pollErr := pollAgents(ctx, d, liveAgents, liveSessions, opts.Timeout, liveSpawnTimes, opts.OnProgress)
+	// Poll DB until all live agents finish or timeout. Uses GroupCompleted
+	// for termination detection instead of per-session name-based polling.
+	liveResults, pollErr := pollAgents(ctx, d, liveAgents, liveSessions, opts.Timeout, liveSpawnTimes, opts.OnProgress, groupID)
 
 	// Sessions persist — do NOT kill them here. The user can re-read them later.
 	// Sidecar processes are cleaned up since the agents have finished.
@@ -705,11 +715,17 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 	return sb.String()
 }
 
-// pollAgents polls the DB until all agents reach "finished" or the timeout expires.
-// spawnTimes[i] is the time agent i was spawned; used to compute durations for
-// progress output. onProgress is called for each "finished" or "timed out" event;
-// it may be nil.
-func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string)) ([]AgentResult, error) {
+// pollAgents polls the DB until all agents reach a terminal state or the
+// timeout expires. Uses db.GroupCompleted(groupID) as the primary termination
+// signal — this replaces the prior name-prefix-based approach (#860, Issue E).
+//
+// Per-agent progress tracking (onProgress callbacks for "finished" and "timed
+// out" events) still checks individual session states so that progress lines
+// are emitted at the right moment.
+//
+// spawnTimes[i] is the time agent i was spawned; used to compute durations.
+// onProgress may be nil.
+func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string), groupID string) ([]AgentResult, error) {
 	if timeout <= 0 {
 		timeout = 10 * time.Minute
 	}
@@ -721,45 +737,56 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 	const pollInterval = 2 * time.Second
 
 	for {
-		allDone := true
+		// Primary termination check: ask the DB whether all group members
+		// have reached a terminal state. This is the group-id-based path
+		// introduced by #860 (Issue E).
+		groupDone, groupErr := d.GroupCompleted(groupID)
+		if groupErr != nil {
+			// DB error — log and fall through to per-agent checks below
+			// so progress tracking still works.
+			fmt.Fprintf(os.Stderr, "[prism review] warning: GroupCompleted(%s): %v\n", groupID, groupErr)
+		}
+
+		// Even when groupDone is true, scan agents once more to emit any
+		// remaining progress lines for agents whose terminal transition
+		// hasn't been reported yet.
 		for i, agentSession := range agentSessions {
 			if finished[i] || timedOut[i] {
 				continue
 			}
 			status, err := d.CurrentStatus(agentSession)
 			if err != nil {
-				// DB error — treat as still running.
-				allDone = false
 				continue
 			}
 			if status != nil && isTerminalState(status.State) {
 				finished[i] = true
-				// Emit "finished" progress line.
 				if onProgress != nil {
 					elapsed := time.Since(spawnTimes[i])
 					onProgress(fmt.Sprintf("%s finished in %s", FormatAgentDisplayName(agents[i].Name), FormatProgressDuration(elapsed)))
 				}
 			} else if time.Now().After(deadline) {
 				timedOut[i] = true
-				// Emit "timed out" progress line.
 				if onProgress != nil {
 					elapsed := time.Since(spawnTimes[i])
 					onProgress(fmt.Sprintf("%s timed out after %s", FormatAgentDisplayName(agents[i].Name), FormatProgressDuration(elapsed)))
 				}
-			} else {
-				allDone = false
 			}
 		}
 
 		// Check context cancellation.
 		select {
 		case <-ctx.Done():
-			// Build partial results with all non-finished agents as timed out.
-			return buildResults(agents, agentSessions, d, finished, timedOut, timeout, true), ctx.Err()
+			for i := range agents {
+				if !finished[i] && !timedOut[i] {
+					timedOut[i] = true
+				}
+			}
+			return buildResults(agents, agentSessions, d, finished, timedOut, timeout, true, groupID), ctx.Err()
 		default:
 		}
 
-		if allDone {
+		// If the group is completed (all members terminal), we're done.
+		if groupDone && groupErr == nil {
 			break
 		}
 
@@ -785,12 +812,12 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 					timedOut[i] = true
 				}
 			}
-			return buildResults(agents, agentSessions, d, finished, timedOut, timeout, true), ctx.Err()
+			return buildResults(agents, agentSessions, d, finished, timedOut, timeout, true, groupID), ctx.Err()
 		case <-time.After(pollInterval):
 		}
 	}
 
-	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, false), nil
+	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, false, groupID), nil
 }
 
 // isTerminalState returns true if the state is considered terminal (finished or error).
@@ -804,8 +831,8 @@ func isTerminalState(state string) bool {
 
 // BuildResults is the exported entry point for tests. See buildResults.
 // Production code calls buildResults directly (via pollAgents).
-func BuildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
-	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, cancelled)
+func BuildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool, groupID string) []AgentResult {
+	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, cancelled, groupID)
 }
 
 // BuildReviewPromptForTest is an exported wrapper around buildReviewPrompt for
@@ -823,14 +850,24 @@ func TruncateDiffForTest(diff string, maxBytes, maxLines int) (string, bool) {
 // PollAgentsForTest is an exported wrapper around pollAgents for use in tests.
 // It accepts pre-seeded DB rows and returns both results and the progress lines
 // emitted via onProgress.
-func PollAgentsForTest(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string)) ([]AgentResult, error) {
-	return pollAgents(ctx, d, agents, agentSessions, timeout, spawnTimes, onProgress)
+//
+// groupID is the session_groups.group_id for the poll loop's GroupCompleted
+// termination check. When empty, the caller must ensure the group has been
+// registered via db.RegisterGroup before calling this function — passing ""
+// will cause GroupCompleted to return true immediately (zero members).
+func PollAgentsForTest(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string), groupID string) ([]AgentResult, error) {
+	return pollAgents(ctx, d, agents, agentSessions, timeout, spawnTimes, onProgress, groupID)
 }
 
 // buildResults constructs AgentResult entries from polling outcomes.
 // finished[i] is true when agent i reached a terminal DB state; timedOut[i] is
 // true when it did not finish before the deadline; cancelled is true on context
 // cancellation (e.g. SIGINT).
+//
+// When groupID is non-empty, result data (terminal state and last assistant
+// message) is fetched via db.GroupResults(groupID) in a single batch query.
+// When groupID is empty (tests that pre-date the group wiring), per-session
+// individual queries are used as a fallback.
 //
 // Layer 3 (fail-safe): when cancelled is true, no result may have Passed=true.
 // Every result is either IsError=true or annotated as incomplete. This prevents
@@ -839,7 +876,21 @@ func PollAgentsForTest(ctx context.Context, d *db.DB, agents []Agent, agentSessi
 // Layer 2: agents whose DB terminal state is "interrupted" or "error" always
 // produce an error result, regardless of any msg_assistant events they may have.
 // Only agents that reached the "finished" state cleanly proceed to AssessPassed.
-func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool) []AgentResult {
+func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool, groupID string) []AgentResult {
+	// Pre-fetch group member data when a group_id is available. This replaces
+	// individual per-session CurrentStatus + QueryEvents calls with a single
+	// batch query via GroupResults (#860, Issue E).
+	var groupData map[string]db.GroupMemberResult
+	if groupID != "" {
+		var grErr error
+		groupData, grErr = d.GroupResults(groupID)
+		if grErr != nil {
+			// Non-fatal: fall back to per-session queries below.
+			fmt.Fprintf(os.Stderr, "[prism review] warning: GroupResults(%s): %v — falling back to per-session queries\n", groupID, grErr)
+			groupData = nil
+		}
+	}
+
 	results := make([]AgentResult, len(agents))
 	for i, ag := range agents {
 		agentSession := agentSessions[i]
@@ -878,23 +929,40 @@ func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 			continue
 		}
 
+		// Resolve state and last message: prefer GroupResults batch data when
+		// available, fall back to individual DB queries.
+		var agentState string
+		var lastPayload string
+		if mr, ok := groupData[agentSession]; ok {
+			agentState = mr.State
+			lastPayload = mr.LastMessage
+		} else {
+			// Fallback: individual per-session queries.
+			status, stErr := d.CurrentStatus(agentSession)
+			if stErr == nil && status != nil {
+				agentState = status.State
+			}
+			events, evtErr := d.QueryEvents(agentSession, 1, nil, nil, []string{"msg_assistant"})
+			if evtErr == nil && len(events) > 0 {
+				lastPayload = events[len(events)-1].Payload
+			}
+		}
+
 		// Layer 2: check the agent's actual DB terminal state. Only "finished"
 		// is considered a clean completion; "interrupted" and "error" are errors
 		// regardless of what msg_assistant events may exist.
-		status, stErr := d.CurrentStatus(agentSession)
-		if stErr == nil && status != nil && (status.State == "interrupted" || status.State == "error") {
+		if agentState == "interrupted" || agentState == "error" {
 			results[i] = AgentResult{
 				Agent:   ag,
 				Passed:  false,
-				Output:  fmt.Sprintf("ERROR: agent did not complete cleanly (state: %s)", status.State),
+				Output:  fmt.Sprintf("ERROR: agent did not complete cleanly (state: %s)", agentState),
 				IsError: true,
 			}
 			continue
 		}
 
 		// Read last msg_assistant event.
-		events, err := d.QueryEvents(agentSession, 1, nil, nil, []string{"msg_assistant"})
-		if err != nil || len(events) == 0 {
+		if lastPayload == "" {
 			results[i] = AgentResult{
 				Agent:   ag,
 				Passed:  false,
@@ -906,7 +974,7 @@ func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 
 		// Extract text from the last msg_assistant event.
 		// Layer 1 applies here: AssessPassed requires an explicit positive marker.
-		text := extractAssistantText(events[len(events)-1].Payload)
+		text := extractAssistantText(lastPayload)
 		passed, kind := AssessPassed(text)
 
 		if !passed && kind == VerdictNone {

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -412,7 +412,7 @@ func TestBuildResults_InterruptedState(t *testing.T) {
 
 	finished := []bool{true} // "interrupted" was a terminal state → finished=true
 	timedOut := []bool{false}
-	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false)
+	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
 
 	if len(results) != 1 {
 		t.Fatalf("BuildResults returned %d results, want 1", len(results))
@@ -441,7 +441,7 @@ func TestBuildResults_ErrorState(t *testing.T) {
 
 	finished := []bool{true}
 	timedOut := []bool{false}
-	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false)
+	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
 
 	r := results[0]
 	if r.Passed {
@@ -477,7 +477,7 @@ func TestBuildResults_CancelledAllFinished(t *testing.T) {
 
 	finished := []bool{true, true}
 	timedOut := []bool{false, false}
-	results := review.BuildResults(agents, sessions, d, finished, timedOut, 10*time.Minute, true)
+	results := review.BuildResults(agents, sessions, d, finished, timedOut, 10*time.Minute, true, "")
 
 	for _, r := range results {
 		if r.Passed {
@@ -507,7 +507,7 @@ func TestBuildResults_CancelledMixed(t *testing.T) {
 
 	finished := []bool{true, false}
 	timedOut := []bool{false, false}
-	results := review.BuildResults(agents, sessions, d, finished, timedOut, 10*time.Minute, true)
+	results := review.BuildResults(agents, sessions, d, finished, timedOut, 10*time.Minute, true, "")
 
 	for _, r := range results {
 		if r.Passed {
@@ -531,7 +531,7 @@ func TestBuildResults_HappyPathPass(t *testing.T) {
 
 	finished := []bool{true}
 	timedOut := []bool{false}
-	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false)
+	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
 
 	r := results[0]
 	if !r.Passed {
@@ -554,7 +554,7 @@ func TestBuildResults_HappyPathFail(t *testing.T) {
 
 	finished := []bool{true}
 	timedOut := []bool{false}
-	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false)
+	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
 
 	r := results[0]
 	if r.Passed {
@@ -579,7 +579,7 @@ func TestBuildResults_NoVerdictIsError(t *testing.T) {
 
 	finished := []bool{true}
 	timedOut := []bool{false}
-	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false)
+	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
 
 	r := results[0]
 	if r.Passed {
@@ -1149,10 +1149,19 @@ func TestPollAgents_ProgressCallback_HappyPath(t *testing.T) {
 		"test@parent~review-1-review-code",
 	}
 
-	// Pre-seed both agents as finished.
+	// Register a group and associate sessions with it.
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Pre-seed both agents as finished with group_id.
 	for _, sess := range sessions {
 		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
 			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
 		}
 	}
 
@@ -1161,7 +1170,7 @@ func TestPollAgents_ProgressCallback_HappyPath(t *testing.T) {
 
 	results, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Minute, spawnTimes, func(line string) {
 		lines = append(lines, line)
-	})
+	}, groupID)
 	if err != nil {
 		t.Fatalf("PollAgentsForTest: %v", err)
 	}
@@ -1205,18 +1214,28 @@ func TestPollAgents_ProgressCallback_OnlySubset(t *testing.T) {
 		"test@parent~review-1-review-code",
 		"test@parent~review-1-review-qa",
 	}
+
+	// Register a group and associate sessions with it.
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
 	for _, sess := range sessions {
 		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
 			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
 		}
 	}
 
 	var lines []string
 	spawnTimes := []time.Time{time.Now(), time.Now()}
 
-	_, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Minute, spawnTimes, func(line string) {
+	_, err = review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Minute, spawnTimes, func(line string) {
 		lines = append(lines, line)
-	})
+	}, groupID)
 	if err != nil {
 		t.Fatalf("PollAgentsForTest: %v", err)
 	}
@@ -1257,21 +1276,33 @@ func TestPollAgents_ProgressCallback_Timeout(t *testing.T) {
 		"test@parent~review-5-review-code",
 	}
 
+	// Register a group and associate sessions with it.
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
 	// review-goal is finished; review-code stays idle (will time out).
 	if err := d.UpsertStatus(sessions[0], "nixos-config", "/wt", "finished", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
+	if err := d.SetGroupID(sessions[0], groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
 	if err := d.UpsertStatus(sessions[1], "nixos-config", "/wt", "idle", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetGroupID(sessions[1], groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
 	}
 
 	var lines []string
 	spawnTimes := []time.Time{time.Now(), time.Now()}
 
 	// Very short timeout so review-code times out quickly.
-	_, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Millisecond, spawnTimes, func(line string) {
+	_, err = review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Millisecond, spawnTimes, func(line string) {
 		lines = append(lines, line)
-	})
+	}, groupID)
 	if err != nil {
 		t.Fatalf("PollAgentsForTest: %v", err)
 	}
@@ -1736,5 +1767,429 @@ func TestTruncateDiff_TruncatesByByteCount(t *testing.T) {
 	if len(result) > 200 { // well under the original 999 bytes
 		// Sanity check that we actually truncated substantially.
 		// The marker adds ~70 bytes; total should be << 999.
+	}
+}
+
+// ── Group-id wiring (#860, Issue E) ──────────────────────────────────────────
+
+// TestGroupWiring_RegisterGroupCalledOncePerRound verifies that each review
+// round creates exactly one session_groups row with the correct parent_session.
+// AC: "Every prism review invocation creates exactly one new row in
+// session_groups per round, with parent_session correctly set."
+func TestGroupWiring_RegisterGroupCalledOncePerRound(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@worker-branch"
+
+	// Simulate what review.Run does: register one group per round.
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if groupID == "" {
+		t.Fatal("RegisterGroup returned empty group_id")
+	}
+
+	// Verify the session_groups row exists with the correct parent.
+	var storedParent string
+	err = d.QueryRow(
+		"SELECT parent_session FROM session_groups WHERE group_id = ?", groupID,
+	).Scan(&storedParent)
+	if err != nil {
+		t.Fatalf("query session_groups: %v", err)
+	}
+	if storedParent != parent {
+		t.Errorf("session_groups.parent_session = %q, want %q", storedParent, parent)
+	}
+}
+
+// TestGroupWiring_AllMembersHaveGroupID verifies that when SpawnSession writes
+// group_id via SetGroupID, all 5 agent_status rows have the same group_id.
+// AC: "Every one of the 5 per-round reviewer sessions has agent_status.group_id
+// set to the round's group_id."
+func TestGroupWiring_AllMembersHaveGroupID(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@worker-branch"
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	agents := review.Agents()
+	round := 1
+	roundPrefix := fmt.Sprintf("%s~review-%d-", parent, round)
+
+	// Simulate what review.Run does: seed each agent and set group_id.
+	for _, ag := range agents {
+		sess := roundPrefix + ag.Name
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "idle", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+	}
+
+	// Verify every agent_status row has the correct group_id.
+	for _, ag := range agents {
+		sess := roundPrefix + ag.Name
+		s, err := d.CurrentStatus(sess)
+		if err != nil {
+			t.Fatalf("CurrentStatus(%q): %v", sess, err)
+		}
+		if s == nil {
+			t.Errorf("agent %q: expected agent_status row, got nil", ag.Name)
+			continue
+		}
+		if s.GroupID == nil {
+			t.Errorf("agent %q: GroupID is nil, want %q", ag.Name, groupID)
+			continue
+		}
+		if *s.GroupID != groupID {
+			t.Errorf("agent %q: GroupID = %q, want %q", ag.Name, *s.GroupID, groupID)
+		}
+	}
+}
+
+// TestGroupWiring_GroupCompletedIsTerminationSignal verifies that
+// GroupCompleted returns false while agents are running and true once all
+// reach a terminal state. This is the core AC:
+// "The review orchestrator's termination check uses db.GroupCompleted(group_id)."
+func TestGroupWiring_GroupCompletedIsTerminationSignal(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	sessions := []string{"test@parent~review-1-review-goal", "test@parent~review-1-review-code"}
+	for _, sess := range sessions {
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "idle", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+	}
+
+	// Initially: both idle → GroupCompleted should return false.
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted (initial): %v", err)
+	}
+	if done {
+		t.Error("GroupCompleted returned true while agents are still idle")
+	}
+
+	// Transition first agent to finished → still not complete (second is idle).
+	_ = d.UpsertStatus(sessions[0], "nixos-config", "/wt", "finished", nil, nil)
+	done, err = d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted (one finished): %v", err)
+	}
+	if done {
+		t.Error("GroupCompleted returned true with only one of two agents finished")
+	}
+
+	// Transition second agent to finished → now complete.
+	_ = d.UpsertStatus(sessions[1], "nixos-config", "/wt", "finished", nil, nil)
+	done, err = d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted (all finished): %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted returned false after all agents finished")
+	}
+}
+
+// TestGroupWiring_GroupResultsMatchesPerSessionAggregation verifies that
+// GroupResults produces the same terminal state and last message data as
+// individual per-session queries. This is the AC:
+// "GroupResults output matches what name-prefix aggregation produced."
+func TestGroupWiring_GroupResultsMatchesPerSessionAggregation(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	agents := review.Agents()
+	roundPrefix := "test@parent~review-1-"
+	sessions := make([]string, len(agents))
+
+	for i, ag := range agents {
+		sess := roundPrefix + ag.Name
+		sessions[i] = sess
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+		// Seed a root_agent_name via the seed helper.
+		if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/wt", "finished", nil, nil, ag.Name); err != nil {
+			t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
+		}
+		seedAssistantEvent(t, d, sess, fmt.Sprintf("Review from %s. <verdict>PASS</verdict>", ag.Name))
+	}
+
+	// Fetch via GroupResults.
+	groupData, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+
+	if len(groupData) != 5 {
+		t.Fatalf("GroupResults returned %d members, want 5", len(groupData))
+	}
+
+	// Verify each member matches individual per-session queries.
+	for _, sess := range sessions {
+		gr, ok := groupData[sess]
+		if !ok {
+			t.Errorf("GroupResults missing session %q", sess)
+			continue
+		}
+
+		// Compare state with CurrentStatus.
+		status, sErr := d.CurrentStatus(sess)
+		if sErr != nil {
+			t.Fatalf("CurrentStatus(%q): %v", sess, sErr)
+		}
+		if gr.State != status.State {
+			t.Errorf("session %q: GroupResults.State = %q, CurrentStatus.State = %q", sess, gr.State, status.State)
+		}
+
+		// Compare last message with QueryEvents.
+		events, eErr := d.QueryEvents(sess, 1, nil, nil, []string{"msg_assistant"})
+		if eErr != nil {
+			t.Fatalf("QueryEvents(%q): %v", sess, eErr)
+		}
+		if len(events) > 0 && gr.LastMessage != events[len(events)-1].Payload {
+			t.Errorf("session %q: GroupResults.LastMessage differs from QueryEvents payload", sess)
+		}
+	}
+}
+
+// TestGroupWiring_DistinctGroupsPerRound verifies that two review invocations
+// create distinct group_ids with no cross-contamination.
+// AC: "A second prism review invocation creates a distinct group_id with
+// distinct member rows."
+func TestGroupWiring_DistinctGroupsPerRound(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@worker-branch"
+
+	// Round 1.
+	g1, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup round 1: %v", err)
+	}
+	// Round 2.
+	g2, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup round 2: %v", err)
+	}
+
+	if g1 == g2 {
+		t.Errorf("two RegisterGroup calls returned the same group_id: %q", g1)
+	}
+
+	// Seed members for each group.
+	sess1 := parent + "~review-1-review-goal"
+	sess2 := parent + "~review-2-review-goal"
+
+	_ = d.UpsertStatus(sess1, "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.SetGroupID(sess1, g1)
+	_ = d.UpsertStatus(sess2, "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.SetGroupID(sess2, g2)
+
+	// GroupResults for g1 must not include sess2 and vice versa.
+	gr1, err := d.GroupResults(g1)
+	if err != nil {
+		t.Fatalf("GroupResults(g1): %v", err)
+	}
+	if _, ok := gr1[sess2]; ok {
+		t.Errorf("GroupResults(g1) unexpectedly includes session from round 2: %q", sess2)
+	}
+
+	gr2, err := d.GroupResults(g2)
+	if err != nil {
+		t.Fatalf("GroupResults(g2): %v", err)
+	}
+	if _, ok := gr2[sess1]; ok {
+		t.Errorf("GroupResults(g2) unexpectedly includes session from round 1: %q", sess1)
+	}
+}
+
+// TestGroupWiring_OnlyRetryRegistersNewGroup verifies that the --only retry
+// path also creates a new group_id for the retry round. Existing prior rounds'
+// session_groups rows remain untouched.
+// AC: "The --only retry path also registers a new group (new round)."
+func TestGroupWiring_OnlyRetryRegistersNewGroup(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@worker-branch"
+
+	// First round (full 5 agents).
+	g1, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup round 1: %v", err)
+	}
+	for _, ag := range review.Agents() {
+		sess := parent + "~review-1-" + ag.Name
+		_ = d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil)
+		_ = d.SetGroupID(sess, g1)
+	}
+
+	// Retry round (only 2 agents — simulating --only review-code,review-qa).
+	g2, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup retry round: %v", err)
+	}
+	if g1 == g2 {
+		t.Fatal("retry round got same group_id as first round")
+	}
+
+	retryAgents := []string{"review-code", "review-qa"}
+	for _, name := range retryAgents {
+		sess := parent + "~review-2-" + name
+		_ = d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil)
+		_ = d.SetGroupID(sess, g2)
+	}
+
+	// Original group still has 5 members.
+	gr1, err := d.GroupResults(g1)
+	if err != nil {
+		t.Fatalf("GroupResults(g1): %v", err)
+	}
+	if len(gr1) != 5 {
+		t.Errorf("GroupResults(g1): got %d members, want 5", len(gr1))
+	}
+
+	// Retry group has 2 members.
+	gr2, err := d.GroupResults(g2)
+	if err != nil {
+		t.Fatalf("GroupResults(g2): %v", err)
+	}
+	if len(gr2) != 2 {
+		t.Errorf("GroupResults(g2): got %d members, want 2", len(gr2))
+	}
+}
+
+// TestGroupWiring_BuildResultsUsesGroupResults verifies that buildResults (via
+// BuildResults) uses GroupResults data when a valid groupID is provided, and
+// the output matches the per-session fallback path exactly.
+func TestGroupWiring_BuildResultsUsesGroupResults(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	agents := []review.Agent{
+		{Name: "review-goal"},
+		{Name: "review-code"},
+	}
+	sessions := []string{
+		"test@parent~review-1-review-goal",
+		"test@parent~review-1-review-code",
+	}
+
+	// review-goal: PASS. review-code: FAIL.
+	_ = d.UpsertStatus(sessions[0], "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.SetGroupID(sessions[0], groupID)
+	seedAssistantEvent(t, d, sessions[0], "All good. <verdict>PASS</verdict>")
+
+	_ = d.UpsertStatus(sessions[1], "nixos-config", "/wt", "finished", nil, nil)
+	_ = d.SetGroupID(sessions[1], groupID)
+	seedAssistantEvent(t, d, sessions[1], "Blocking issue found. <verdict>FAIL</verdict>")
+
+	finished := []bool{true, true}
+	timedOut := []bool{false, false}
+
+	// With groupID → uses GroupResults batch path.
+	resultsWithGroup := review.BuildResults(agents, sessions, d, finished, timedOut, 10*time.Minute, false, groupID)
+	// Without groupID → uses per-session fallback.
+	resultsWithoutGroup := review.BuildResults(agents, sessions, d, finished, timedOut, 10*time.Minute, false, "")
+
+	// Both paths must produce the same Passed/IsError/Output for each agent.
+	for i, ag := range agents {
+		rg := resultsWithGroup[i]
+		rf := resultsWithoutGroup[i]
+		if rg.Passed != rf.Passed {
+			t.Errorf("agent %q: group path Passed=%v, fallback path Passed=%v", ag.Name, rg.Passed, rf.Passed)
+		}
+		if rg.IsError != rf.IsError {
+			t.Errorf("agent %q: group path IsError=%v, fallback path IsError=%v", ag.Name, rg.IsError, rf.IsError)
+		}
+		if rg.Output != rf.Output {
+			t.Errorf("agent %q: group path Output differs from fallback path\ngroup:    %q\nfallback: %q", ag.Name, rg.Output, rf.Output)
+		}
+	}
+
+	// Verify specific results.
+	if !resultsWithGroup[0].Passed {
+		t.Error("review-goal should have passed")
+	}
+	if resultsWithGroup[1].Passed {
+		t.Error("review-code should have failed")
+	}
+}
+
+// TestGroupWiring_PollWithGroupCompleted verifies the full poll loop with group
+// termination: agents transition from idle → finished, and the poll loop
+// terminates via GroupCompleted. This exercises the integration between
+// RegisterGroup, SetGroupID, GroupCompleted, and GroupResults.
+func TestGroupWiring_PollWithGroupCompleted(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-code", OpencodeName: "review-code"},
+	}
+	sessions := []string{
+		"test@parent~review-1-review-goal",
+		"test@parent~review-1-review-code",
+	}
+
+	// Pre-seed as finished with group_id.
+	for _, sess := range sessions {
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+		seedAssistantEvent(t, d, sess, "<verdict>PASS</verdict>")
+	}
+
+	var lines []string
+	spawnTimes := []time.Time{time.Now(), time.Now()}
+
+	results, err := review.PollAgentsForTest(ctx, d, agents, sessions, 10*time.Minute, spawnTimes, func(line string) {
+		lines = append(lines, line)
+	}, groupID)
+	if err != nil {
+		t.Fatalf("PollAgentsForTest: %v", err)
+	}
+
+	// Both agents should have passed.
+	for i, r := range results {
+		if !r.Passed {
+			t.Errorf("agent %q: Passed=false, want true (output: %q)", agents[i].Name, r.Output)
+		}
+	}
+
+	// Progress lines should be emitted.
+	if len(lines) != 2 {
+		t.Errorf("expected 2 progress lines, got %d: %v", len(lines), lines)
 	}
 }


### PR DESCRIPTION
## Summary

Wire `group_id` into `prism review` so that each review round registers a session group and all reviewer sessions are associated with it via `agent_status.group_id`. This is Issue E of the session-uniformity migration plan (#849).

### Changes

- **RegisterGroup before spawn loop**: `review.Run()` calls `db.RegisterGroup(parentSession)` once at the start of each review round, creating a `session_groups` row. If this fails, the review fails fast — no sessions are spawned without a group.
- **GroupID on every SpawnOpts**: The resulting `group_id` is passed via `SpawnOpts.GroupID` to each `session.SpawnSession()` call, so all 5 (or fewer with `--only`) reviewer sessions carry the same `group_id` in `agent_status`.
- **GroupCompleted for termination**: The poll loop uses `db.GroupCompleted(groupID)` as the primary termination signal instead of per-session name-prefix polling. Per-agent progress callbacks still check individual session states for timing accuracy.
- **GroupResults for aggregation**: `buildResults` uses `db.GroupResults(groupID)` for batch result fetching instead of individual `CurrentStatus` + `QueryEvents` calls per session. Falls back to per-session queries when `groupID` is empty.
- **8 new tests**: RegisterGroup called once per round, all members have matching group_id, GroupCompleted as termination signal, GroupResults matches per-session aggregation, distinct groups per round, --only retry registers new group, BuildResults uses GroupResults, full poll loop with GroupCompleted.

### What's unchanged

- End-to-end `prism review` behaviour: same 5 agents, same verdict aggregation, same output format.
- Name-match detection in other parts of the codebase (sidecar, cleanup, checkin) — those are Issue F (#861).
- `prism spawn` (single-session spawns don't use groups).

Closes #860