### PR TITLE
feat(prism): extend Harness interface with ConfigEnvVar, RuntimeEnv, ValidateAgentRole, EffectiveModel

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -52,7 +52,7 @@ func TestDefaultAgent_ExplicitOverridesDefault(t *testing.T) {
 
 // bashTimeoutPrefix is the env-var prefix injected into all host-mode opencode commands
 // when RuntimeEnvVars is populated from the opencode harness adapter.
-const bashTimeoutPrefix = "OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=900000 "
+const bashTimeoutPrefix = "OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS='900000' "
 
 // opencodeRuntimeEnv returns the RuntimeEnvVars map matching what the opencode
 // harness adapter provides. Used by tests that exercise buildDirectOpencodeCmd

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
+	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -122,6 +123,8 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		hostAPISockPath = sockPath
 	}
 
+	// Populate harness-specific runtime env vars for the bwrap sandbox.
+	agentRunHarness := opencode.New("", nil, "", "")
 	ctrCfg := container.Config{
 		SessionName:       sessionName,
 		Worktree:          worktree,
@@ -134,6 +137,7 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		SshAccessKeyName:  cfg.SshAccessKeyName,
 		SshSigningKeyName: cfg.SshSigningKeyName,
 		HostAPISockPath:   hostAPISockPath,
+		RuntimeEnv:        agentRunHarness.RuntimeEnv(),
 	}
 
 	// Read the initial prompt from the pane env var set by session.go at

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -201,6 +201,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		ContainerMode:  effectiveContainerMode,
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,
+		RuntimeEnvVars: h.RuntimeEnv(),
 	}
 
 	// Load profiles for container mode — passed through to review.Run so

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -290,6 +290,13 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		h = opencode.New(opencodeURL, nil, agentRole, agentModel)
 	}
 
+	// Inject harness-specific runtime env vars into the container config.
+	// This replaces the previously hard-coded OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS
+	// in container.go and bwrap.go with values from the harness adapter.
+	if ctrCfg != nil {
+		ctrCfg.RuntimeEnv = h.RuntimeEnv()
+	}
+
 	cfg := sidecar.Config{
 		SessionName:     sessionName,
 		Repo:            repo,

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -488,8 +488,12 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	}
 	args = append(args, "--setenv", "PRISM_SESSION_NAME", cfg.SessionName)
 
-	// OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: 15-minute bash timeout.
-	args = append(args, "--setenv", "OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS", "900000")
+	// Inject harness-specific runtime env vars. For opencode, this includes
+	// the experimental bash-tool timeout (15 min). Populated from
+	// harness.Harness.RuntimeEnv() via the container Config.
+	for k, v := range cfg.RuntimeEnv {
+		args = append(args, "--setenv", k, v)
+	}
 
 	// Host-API env var.
 	if cfg.HostAPITCPPort != 0 {

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -218,6 +218,13 @@ type Config struct {
 	// PidsLimit is the value for podman run --pids-limit.
 	// When zero, no --pids-limit flag is emitted.
 	PidsLimit int
+
+	// RuntimeEnv holds harness-specific environment variables to inject
+	// into the container. Each entry is emitted as --env KEY=VALUE (podman)
+	// or --setenv KEY VALUE (bwrap). Populated from
+	// harness.Harness.RuntimeEnv() by the sidecar at container creation
+	// time. When nil, no harness-specific env vars are injected.
+	RuntimeEnv map[string]string
 }
 
 // NameForSession returns the stable podman container name for a session.
@@ -1413,13 +1420,14 @@ func (m *Manager) buildRunArgs() []string {
 	// connects to the SSE endpoint on the mapped host port exactly as before.
 	// The tmux agent window uses "podman attach" to bridge the PTY (RFC #691,
 	// Phase 1a / Issue #715).
-	// Raise the bash-tool default timeout inside the container to 15 min
-	// (same value used for host-mode sessions). Scoped to opencode only —
-	// this env var is not forwarded to any other process in the container.
-	// Precedence: podman --env overrides any same-named ENV instruction baked
-	// into the image, so 900000 is what opencode inside the container sees
-	// regardless of the image's default. Currently no image default is set.
-	args = append(args, "--env", "OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=900000")
+	// Inject harness-specific runtime env vars into the container. These are
+	// populated from harness.Harness.RuntimeEnv() by the sidecar. For opencode,
+	// this includes the experimental bash-tool timeout (15 min). Precedence:
+	// podman --env overrides any same-named ENV instruction baked into the
+	// image, so the harness values are what the agent runtime sees.
+	for k, v := range cfg.RuntimeEnv {
+		args = append(args, "--env", k+"="+v)
+	}
 
 	args = append(args, Image,
 		"opencode",

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -363,6 +363,12 @@ type Opts struct {
 	Agents []Agent
 	// Harness is the runtime harness to use ("opencode").
 	Harness string
+	// RuntimeEnvVars holds harness-specific environment variables to inject
+	// into each spawned agent session (host-mode only; container-mode sessions
+	// receive env vars via the container runtime). Populated from
+	// harness.Harness.RuntimeEnv() by the caller. When nil, no harness-specific
+	// env vars are injected.
+	RuntimeEnvVars map[string]string
 	// Timeout is the per-agent maximum wait time.
 	Timeout time.Duration
 	// DBPath is the path to the prism database. If empty, the default is used.
@@ -522,6 +528,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			PluginHostPath:   opts.PluginHostPath,
 			WorktreeReadOnly: true,
 			GroupID:          groupID,
+			RuntimeEnvVars:   opts.RuntimeEnvVars,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -309,7 +309,7 @@ func buildDirectOpencodeCmd(opts Opts) string {
 		for _, k := range keys {
 			prefix.WriteString(k)
 			prefix.WriteString("=")
-			prefix.WriteString(opts.RuntimeEnvVars[k])
+			prefix.WriteString(shellQuote(opts.RuntimeEnvVars[k]))
 			prefix.WriteString(" ")
 		}
 		cmd = prefix.String() + cmd


### PR DESCRIPTION
## Summary

- Adds four new methods to the `Harness` interface (`ConfigEnvVar`, `RuntimeEnv`, `ValidateAgentRole`, `EffectiveModel`) to hide opencode-specific string literals behind an adapter boundary
- Implements all four in the opencode adapter; `FakeHarness` updated for compile-time interface compliance
- Moves hardcoded `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` out of `container.go`/`bwrap.go` into the adapter's `RuntimeEnv()` map, threaded through `container.Config.RuntimeEnv`
- Restores group-id wiring (RegisterGroup, GroupCompleted, GroupResults) that was accidentally dropped while rebasing — including the full `TestGroupWiring_*` test suite (~430 lines)

Closes #862