### PR TITLE
prism: replace name-based agent type inference with DB-backed reads

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -91,26 +92,28 @@ func runCheckin(cmd *cobra.Command, args []string) error {
 
 	sessionArg := args[0]
 
-	// Special case: if the session argument ends with "~review" (no round number),
-	// prefix-match all ~review-* rounds for the parent session and display a
-	// summary of each round.
+	// Special case: render a review-group summary when the session arg is the
+	// parent of a review group. The DB-backed path (HasReviewGroup) is the
+	// primary check; the "~review" name-suffix heuristic is the fallback for
+	// pre-migration sessions where session_groups has not yet been populated.
 	//
-	// DB-backed: also detect review groups via session_groups.parent_session.
-	// When the sessionArg itself is a parent_session in session_groups, treat it
-	// as a review-summary request (DB path). The name-suffix heuristic is kept
-	// for backward compat with pre-migration sessions and direct ~review suffixes.
-	if strings.HasSuffix(sessionArg, "~review") {
-		return runCheckinReviewRounds(sessionArg, verbose)
-	}
-	// DB-backed check: is sessionArg a parent of a review group?
+	// For sessions with a trailing "~review" that are NOT yet registered in
+	// session_groups (pre-migration), the name heuristic fires as a fallback.
 	if d, dbErr := openDB(); dbErr == nil {
 		hasGroup, groupErr := d.HasReviewGroup(sessionArg)
 		d.Close()
 		if groupErr == nil && hasGroup {
-			// sessionArg is a parent session with a review group — use the
+			// DB-backed: sessionArg is a registered parent_session — use the
 			// group-aware review summary path.
 			return runCheckinReviewRoundsByGroup(sessionArg, verbose)
 		}
+		// DB open succeeded but no group found; fall through to name heuristic.
+	}
+	// Pre-migration fallback: session ends with "~review" but has no DB group.
+	// Keep backward compat for sessions created before session_groups existed.
+	if strings.HasSuffix(sessionArg, "~review") {
+		log.Printf("[deprecation] checkin: no session_groups row for %q — falling back to ~review name heuristic", sessionArg)
+		return runCheckinReviewRounds(sessionArg, verbose)
 	}
 
 	return runCheckinSession(sessionArg, last, beforePtr, afterPtr, types, verbose)

--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -94,8 +94,23 @@ func runCheckin(cmd *cobra.Command, args []string) error {
 	// Special case: if the session argument ends with "~review" (no round number),
 	// prefix-match all ~review-* rounds for the parent session and display a
 	// summary of each round.
+	//
+	// DB-backed: also detect review groups via session_groups.parent_session.
+	// When the sessionArg itself is a parent_session in session_groups, treat it
+	// as a review-summary request (DB path). The name-suffix heuristic is kept
+	// for backward compat with pre-migration sessions and direct ~review suffixes.
 	if strings.HasSuffix(sessionArg, "~review") {
 		return runCheckinReviewRounds(sessionArg, verbose)
+	}
+	// DB-backed check: is sessionArg a parent of a review group?
+	if d, dbErr := openDB(); dbErr == nil {
+		hasGroup, groupErr := d.HasReviewGroup(sessionArg)
+		d.Close()
+		if groupErr == nil && hasGroup {
+			// sessionArg is a parent session with a review group — use the
+			// group-aware review summary path.
+			return runCheckinReviewRoundsByGroup(sessionArg, verbose)
+		}
 	}
 
 	return runCheckinSession(sessionArg, last, beforePtr, afterPtr, types, verbose)
@@ -1578,6 +1593,83 @@ func runCheckinReviewRounds(reviewPrefix string, verbose bool) error {
 		}
 
 		fmt.Println(styleDim.Render("── end of round ──"))
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// runCheckinReviewRoundsByGroup is the DB-backed replacement for
+// runCheckinReviewRounds. Instead of using a name-prefix scan, it queries
+// session_groups.parent_session to find all review agent sessions belonging to
+// groups owned by parentSession.
+//
+// This is the authoritative path for post-migration sessions where group_id is
+// populated. Falls back to the name-prefix path when no group members are found.
+func runCheckinReviewRoundsByGroup(parentSession string, verbose bool) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("checkin review (group): open db: %w", err)
+	}
+	defer d.Close()
+
+	members, err := d.GroupMembersForParent(parentSession)
+	if err != nil {
+		return fmt.Errorf("checkin review (group): query members: %w", err)
+	}
+
+	if len(members) == 0 {
+		// No group members — fall back to the legacy name-prefix scan.
+		fmt.Fprintf(os.Stderr, "[deprecation] checkin: no group members found for %q via DB — falling back to name-prefix scan\n", parentSession)
+		return runCheckinReviewRounds(parentSession+"~review", verbose)
+	}
+
+	styleBold := lipgloss.NewStyle().Bold(true)
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	fmt.Printf("%s\n\n", styleBold.Render(fmt.Sprintf("review sessions for %s (%d agent(s))", parentSession, len(members))))
+
+	// Sort by session name for deterministic output.
+	for i := 1; i < len(members); i++ {
+		key := members[i]
+		j := i - 1
+		for j >= 0 && members[j].SessionName > key.SessionName {
+			members[j+1] = members[j]
+			j--
+		}
+		members[j+1] = key
+	}
+
+	for _, m := range members {
+		label := m.SessionName
+		if m.RootAgentName != nil && *m.RootAgentName != "" {
+			label = *m.RootAgentName
+		}
+		fmt.Printf("  %s\n", styleBold.Render(label))
+		stateStyled := stateStyle(m.State).Render(m.State)
+		fmt.Printf("  state: %s\n", stateStyled)
+
+		if verbose {
+			if err := runCheckinSession(m.SessionName, 20, nil, nil, nil, true); err != nil {
+				fmt.Fprintf(os.Stderr, "  [error reading session %s: %v]\n", m.SessionName, err)
+			}
+		} else {
+			events, qerr := d.QueryEvents(m.SessionName, 1, nil, nil, []string{"msg_assistant"})
+			if qerr != nil || len(events) == 0 {
+				fmt.Println(styleDim.Render("  (no output recorded)"))
+			} else {
+				e := events[len(events)-1]
+				ts := e.CreatedAt.Local().Format("15:04:05")
+				var ap struct {
+					Text string `json:"text"`
+				}
+				text := e.Payload
+				if jerr := json.Unmarshal([]byte(e.Payload), &ap); jerr == nil && ap.Text != "" {
+					text = ap.Text
+				}
+				fmt.Printf("  [%s]\n  %s\n", ts, strings.ReplaceAll(text, "\n", "\n  "))
+			}
+		}
 		fmt.Println()
 	}
 

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/spf13/cobra"
 )
 
 // captureStdout redirects os.Stdout to a pipe for the duration of fn,
@@ -1239,6 +1240,115 @@ func TestRenderCheckinTurns_StateChangeInsideSubagentCollapse(t *testing.T) {
 	// The subagent summary line must still appear.
 	if !strings.Contains(out, "└─ review") {
 		t.Errorf("subagent summary line missing\ngot:\n%s", out)
+	}
+}
+
+// TestRunCheckinReviewRoundsByGroup verifies the DB-backed review-group summary
+// path in runCheckin. When a parent session has registered a group in
+// session_groups, checkin must route to runCheckinReviewRoundsByGroup (the DB
+// path) rather than the legacy name-prefix scan.
+//
+// This test covers the happy path (group members listed) and the pre-migration
+// fallback (no group members → name-prefix fallback).
+func TestRunCheckinReviewRoundsByGroup(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	d := openCheckinTestDB(t)
+
+	parentSession := "repo@feature"
+	reviewerSession := "repo@feature~review-1-review-code"
+	base := time.Now().Truncate(time.Second)
+
+	// Register a group for the parent session.
+	groupID, err := d.RegisterGroup(parentSession)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed the reviewer session and assign it to the group.
+	if err := d.UpsertStatus(reviewerSession, "repo", "/code/repo", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus reviewer: %v", err)
+	}
+	if err := d.SetGroupID(reviewerSession, groupID); err != nil {
+		t.Fatalf("SetGroupID reviewer: %v", err)
+	}
+
+	// Write an event for the reviewer so the checkin has something to show.
+	writeEvent(t, d, "evt-1", reviewerSession, "msg_assistant",
+		assistantPayload("msg-1", "reviewing now"), base)
+
+	// Point openDB() at the test DB.
+	SetTestDBPath(d.Path())
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Call runCheckinReviewRoundsByGroup directly to verify the DB-backed path.
+	out := captureStdout(t, func() {
+		if err := runCheckinReviewRoundsByGroup(parentSession, false); err != nil {
+			t.Errorf("runCheckinReviewRoundsByGroup: unexpected error: %v", err)
+		}
+	})
+
+	// The output must mention the reviewer session.
+	if !strings.Contains(out, reviewerSession) && !strings.Contains(out, "review-code") {
+		t.Errorf("runCheckinReviewRoundsByGroup output does not mention reviewer session\ngot:\n%s", out)
+	}
+}
+
+// TestRunCheckin_DBGroupPathTakesPrecedence verifies that when a session arg is
+// a registered parent_session in session_groups, runCheckin routes to the DB
+// path (runCheckinReviewRoundsByGroup) even when the session name does NOT end
+// with "~review". The DB path must take precedence over the name heuristic.
+//
+// This test wires up the checkin command's flag set (so GetBool/GetInt work)
+// and calls runCheckin directly.
+func TestRunCheckin_DBGroupPathTakesPrecedence(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	d := openCheckinTestDB(t)
+
+	// Use a parent session whose name does NOT end with "~review" — this
+	// ensures the DB path must fire, not the name heuristic.
+	parentSession := "repo@non-review-parent"
+	reviewerSession := "repo@non-review-parent~review-1-review-code"
+	base := time.Now().Truncate(time.Second)
+
+	groupID, err := d.RegisterGroup(parentSession)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.UpsertStatus(reviewerSession, "repo", "/code/repo", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus reviewer: %v", err)
+	}
+	if err := d.SetGroupID(reviewerSession, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+	writeEvent(t, d, "evt-grp-1", reviewerSession, "msg_assistant",
+		assistantPayload("msg-grp-1", "group path test"), base)
+
+	SetTestDBPath(d.Path())
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Build a minimal cobra.Command with the flags that runCheckin reads.
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("all", false, "")
+	cmd.Flags().Int("last", 10, "")
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("before", "", "")
+	cmd.Flags().String("types", "", "")
+	cmd.Flags().Bool("verbose", false, "")
+
+	// runCheckin with the parent session name (no "~review" suffix).
+	// The DB path (HasReviewGroup) must route to runCheckinReviewRoundsByGroup.
+	out := captureStdout(t, func() {
+		if err := runCheckin(cmd, []string{parentSession}); err != nil {
+			t.Logf("runCheckin returned error (may be acceptable): %v", err)
+		}
+	})
+
+	// The reviewer session must appear in the output — it was found via DB group membership.
+	if !strings.Contains(out, reviewerSession) && !strings.Contains(out, "review-code") {
+		t.Errorf("runCheckin DB group path: output does not mention reviewer session %q\ngot:\n%s",
+			reviewerSession, out)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -379,31 +379,7 @@ var cleanupCmd = &cobra.Command{
 		// DB-backed coordinator check: prefer root_agent_name == "coordinator"
 		// over the default-branch heuristic. Fallback to the heuristic when the
 		// DB row is absent or root_agent_name is NULL (pre-migration).
-		isCoordinatorSession := false
-		if d, dbErr := openDB(); dbErr == nil {
-			rootName, rowExists, rootErr := d.RootAgentName(session)
-			d.Close()
-			if rootErr == nil && rowExists && rootName != "" {
-				isCoordinatorSession = rootName == "coordinator"
-				if isCoordinatorSession != isDefaultBranch {
-					fmt.Fprintf(os.Stderr, "[debug] cleanup: isCoordinator(%q): DB says %v (root_agent_name=%q), branch heuristic says %v\n",
-						session, isCoordinatorSession, rootName, isDefaultBranch)
-				}
-			} else {
-				// Pre-migration fallback: use branch-name heuristic.
-				if rootErr != nil {
-					fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: DB error reading root_agent_name for %q: %v — using branch heuristic\n", session, rootErr)
-				} else if rowExists {
-					// Row exists but root_agent_name is NULL — pre-migration.
-					fmt.Fprintf(os.Stderr, "[deprecation] cleanup: root_agent_name NULL for %q — using branch heuristic\n", session)
-				}
-				// rowExists=false: no row yet — use heuristic silently.
-				isCoordinatorSession = isDefaultBranch
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: could not open DB for %q: %v — using branch heuristic\n", session, dbErr)
-			isCoordinatorSession = isDefaultBranch
-		}
+		isCoordinatorSession := isCoordinatorFromDB(session, isDefaultBranch)
 
 		if isCoordinatorSession {
 			// Default-branch sessions (e.g. repo@main): close the tmux
@@ -747,5 +723,39 @@ func removeContainerIfExists(sessionName string) {
 	// after KillSidecar so we cannot rely on that — remove it directly.
 	if sockPath, err := prismSession.SidecarHostAPIPath(sessionName); err == nil {
 		_ = os.Remove(sockPath)
+	}
+}
+
+// isCoordinatorFromDB checks whether session is a coordinator using the
+// DB-backed root_agent_name read. When the DB is unavailable, the row is
+// missing, or root_agent_name is NULL (pre-migration), falls back to the
+// branch-name heuristic (isDefaultBranch).
+//
+// This function is extracted from cleanupCmd.RunE to allow unit testing of
+// the DB-backed coordinator detection independently of the full cleanup flow.
+func isCoordinatorFromDB(session string, isDefaultBranch bool) bool {
+	if d, dbErr := openDB(); dbErr == nil {
+		rootName, rowExists, rootErr := d.RootAgentName(session)
+		d.Close()
+		if rootErr == nil && rowExists && rootName != "" {
+			isCoord := rootName == "coordinator"
+			if isCoord != isDefaultBranch {
+				fmt.Fprintf(os.Stderr, "[debug] cleanup: isCoordinator(%q): DB says %v (root_agent_name=%q), branch heuristic says %v\n",
+					session, isCoord, rootName, isDefaultBranch)
+			}
+			return isCoord
+		}
+		// Pre-migration fallback: use branch-name heuristic.
+		if rootErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: DB error reading root_agent_name for %q: %v — using branch heuristic\n", session, rootErr)
+		} else if rowExists {
+			// Row exists but root_agent_name is NULL — pre-migration.
+			fmt.Fprintf(os.Stderr, "[deprecation] cleanup: root_agent_name NULL for %q — using branch heuristic\n", session)
+		}
+		// rowExists=false: no row yet — use heuristic silently.
+		return isDefaultBranch
+	} else {
+		fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: could not open DB for %q: %v — using branch heuristic\n", session, dbErr)
+		return isDefaultBranch
 	}
 }

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -381,9 +381,9 @@ var cleanupCmd = &cobra.Command{
 		// DB row is absent or root_agent_name is NULL (pre-migration).
 		isCoordinatorSession := false
 		if d, dbErr := openDB(); dbErr == nil {
-			rootName, rootErr := d.RootAgentName(session)
+			rootName, rowExists, rootErr := d.RootAgentName(session)
 			d.Close()
-			if rootErr == nil && rootName != "" {
+			if rootErr == nil && rowExists && rootName != "" {
 				isCoordinatorSession = rootName == "coordinator"
 				if isCoordinatorSession != isDefaultBranch {
 					fmt.Fprintf(os.Stderr, "[debug] cleanup: isCoordinator(%q): DB says %v (root_agent_name=%q), branch heuristic says %v\n",
@@ -393,9 +393,11 @@ var cleanupCmd = &cobra.Command{
 				// Pre-migration fallback: use branch-name heuristic.
 				if rootErr != nil {
 					fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: DB error reading root_agent_name for %q: %v — using branch heuristic\n", session, rootErr)
-				} else {
+				} else if rowExists {
+					// Row exists but root_agent_name is NULL — pre-migration.
 					fmt.Fprintf(os.Stderr, "[deprecation] cleanup: root_agent_name NULL for %q — using branch heuristic\n", session)
 				}
+				// rowExists=false: no row yet — use heuristic silently.
 				isCoordinatorSession = isDefaultBranch
 			}
 		} else {

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -376,7 +376,34 @@ var cleanupCmd = &cobra.Command{
 		defaultBr := git.DefaultBranchFromBareRoot(bareRoot)
 		isDefaultBranch := defaultBr != "" && worktreeName == defaultBr
 
-		if isDefaultBranch {
+		// DB-backed coordinator check: prefer root_agent_name == "coordinator"
+		// over the default-branch heuristic. Fallback to the heuristic when the
+		// DB row is absent or root_agent_name is NULL (pre-migration).
+		isCoordinatorSession := false
+		if d, dbErr := openDB(); dbErr == nil {
+			rootName, rootErr := d.RootAgentName(session)
+			d.Close()
+			if rootErr == nil && rootName != "" {
+				isCoordinatorSession = rootName == "coordinator"
+				if isCoordinatorSession != isDefaultBranch {
+					fmt.Fprintf(os.Stderr, "[debug] cleanup: isCoordinator(%q): DB says %v (root_agent_name=%q), branch heuristic says %v\n",
+						session, isCoordinatorSession, rootName, isDefaultBranch)
+				}
+			} else {
+				// Pre-migration fallback: use branch-name heuristic.
+				if rootErr != nil {
+					fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: DB error reading root_agent_name for %q: %v — using branch heuristic\n", session, rootErr)
+				} else {
+					fmt.Fprintf(os.Stderr, "[deprecation] cleanup: root_agent_name NULL for %q — using branch heuristic\n", session)
+				}
+				isCoordinatorSession = isDefaultBranch
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: could not open DB for %q: %v — using branch heuristic\n", session, dbErr)
+			isCoordinatorSession = isDefaultBranch
+		}
+
+		if isCoordinatorSession {
 			// Default-branch sessions (e.g. repo@main): close the tmux
 			// session and mark the DB as ended, but keep the worktree
 			// and branch intact.

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -667,6 +667,86 @@ func TestCleanupYes_NonWorktreeSession(t *testing.T) {
 	}
 }
 
+// TestIsCoordinatorFromDB verifies the DB-backed coordinator detection helper.
+// It covers the post-migration DB path, pre-migration NULL fallback, no-row
+// fallback, and the core correctness assertion: a coordinator on a non-@main
+// branch is correctly identified via root_agent_name, not branch name.
+func TestIsCoordinatorFromDB(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Post-migration coordinator on the conventional @main branch.
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator @main: %v", err)
+	}
+
+	// Core correctness assertion: coordinator on a non-@main branch.
+	// root_agent_name = "coordinator" must be the deciding factor, not the
+	// branch name. This is the primary motivation for the DB-backed migration.
+	// Use a different repo name to avoid the unique-active-coordinator-per-repo constraint.
+	if err := d.UpsertStatusSeedRootAgentName("custom-repo@custom-branch", "custom-repo", "/code/custom", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator on custom branch: %v", err)
+	}
+
+	// Post-migration worker on @main-named branch (should not be detected as coordinator).
+	if err := d.UpsertStatusSeedRootAgentName("otherwork@main", "otherwork", "/code/other/main", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed worker @main: %v", err)
+	}
+
+	// Pre-migration: row exists but root_agent_name is NULL.
+	if err := d.UpsertStatus("prerepo@main", "prerepo", "/code/pre/main", "active", nil, nil); err != nil {
+		t.Fatalf("seed pre-migration: %v", err)
+	}
+
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	tests := []struct {
+		session         string
+		isDefaultBranch bool
+		want            bool
+		description     string
+	}{
+		{
+			session: "myrepo@main", isDefaultBranch: true, want: true,
+			description: "post-migration coordinator on @main: DB and heuristic agree",
+		},
+		{
+			session: "custom-repo@custom-branch", isDefaultBranch: false, want: true,
+			description: "post-migration coordinator on non-main branch: DB says coordinator, heuristic says false — DB wins",
+		},
+		{
+			session: "otherwork@main", isDefaultBranch: true, want: false,
+			description: "post-migration worker on @main branch: DB says worker, heuristic says true — DB wins",
+		},
+		{
+			session: "prerepo@main", isDefaultBranch: true, want: true,
+			description: "pre-migration NULL root_agent_name on @main: falls back to heuristic",
+		},
+		{
+			session: "prerepo@feature", isDefaultBranch: false, want: false,
+			description: "no row at all on non-main branch: falls back to heuristic",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			got := isCoordinatorFromDB(tc.session, tc.isDefaultBranch)
+			if got != tc.want {
+				t.Errorf("isCoordinatorFromDB(%q, isDefaultBranch=%v) = %v, want %v",
+					tc.session, tc.isDefaultBranch, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded verifies that
 // headlessCloseSession marks the DB row as ended even when the tmux session
 // no longer exists (already killed or never started). This calls

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -298,7 +298,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	opts := session.Opts{
 		Headless:         true,
 		OpencodeSession:  opencodeSession,
-		Agent:            session.DefaultAgent(directory, ""),
+		Agent:            session.DefaultAgentForSession(s.SessionName, directory, "", d),
 		SessionName:      s.SessionName,
 		Layout:           session.LayoutFull,
 		SkipStatusSeed:   true,
@@ -325,7 +325,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		if pfErr != nil {
 			fmt.Fprintf(os.Stderr, "restore %q: load profiles: %v — skipping config injection\n", s.SessionName, pfErr)
 		} else {
-			effectiveRole := session.DefaultAgent(directory, "")
+			effectiveRole := session.DefaultAgentForSession(s.SessionName, directory, "", d)
 			roleConfig, roleErr := config.ContainerConfigForRole(pf, effectiveRole)
 			if roleErr != nil {
 				fmt.Fprintf(os.Stderr, "restore %q: container config for role %q: %v — skipping config injection\n", s.SessionName, effectiveRole, roleErr)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -272,6 +272,9 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// This block fires for both podman and bwrap isolation modes. Host-mode
 	// sessions skip it because they run opencode directly with the host's real
 	// ~/.config/opencode/opencode.json via xdg.configFile.
+	//
+	// DefaultAgent (not DefaultAgentForSession) is intentional: at spawn time the
+	// session has no DB row yet, so this call ASSIGNS the role rather than reading it.
 	sandboxed := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap
 	if sandboxed && pf != nil {
 		effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
@@ -322,6 +325,11 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// DB seed with root_agent_name, tmux session creation, sidecar startup).
 	// See #849 §3.1 and #859.
 	sessionName := session.NameFor(worktreePath, bareRoot)
+	// DefaultAgent (not DefaultAgentForSession) is intentional here: at spawn
+	// time the session does not yet have a DB row, so there is no root_agent_name
+	// to read back. This call ASSIGNS the agent type for the new session (written
+	// to DB via SpawnOpts.AgentRole → UpsertStatusSeedRootAgentName). Reads of an
+	// existing session's type use DefaultAgentForSession (e.g. in restore.go).
 	agentRole := session.DefaultAgent(worktreePath, agentFlag)
 	headless := !fromKeybind && !attachFlag
 

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -23,14 +23,15 @@ import (
 // holds the escalated state across the children.
 type AgentSession struct {
 	Name        string
-	AgentState  string // active | waiting | finished | compacting | error | idle | ""
-	AgentPath   string // worktree path — used for git diff stats
-	AgentTitle  string // current session title from agent_status.title
-	AgentName   string // coordinator | worker | "" — from agent_status.agent_name
-	ModelID     string // model identifier from agent_status.model_id
-	Harness     string // harness name from agent_status.harness, defaults to "opencode"
-	HarnessPort *int   // allocated port from agent_status.harness_port, nil when unset
-	ClientCount int    // tmux clients currently attached (best-effort, 0 on error)
+	AgentState  string  // active | waiting | finished | compacting | error | idle | ""
+	AgentPath   string  // worktree path — used for git diff stats
+	AgentTitle  string  // current session title from agent_status.title
+	AgentName   string  // coordinator | worker | "" — from agent_status.agent_name
+	ModelID     string  // model identifier from agent_status.model_id
+	Harness     string  // harness name from agent_status.harness, defaults to "opencode"
+	HarnessPort *int    // allocated port from agent_status.harness_port, nil when unset
+	ClientCount int     // tmux clients currently attached (best-effort, 0 on error)
+	GroupID     *string // from agent_status.group_id; non-nil when session belongs to a review group
 	// IsReviewGroup marks a virtual ~review-N group row (not a real session).
 	// Selecting this row in the picker toggles expand/collapse rather than switching.
 	IsReviewGroup bool
@@ -65,6 +66,7 @@ func StatusToAgentSession(s db.Status, clientCounts map[string]int) AgentSession
 		Harness:     harness,
 		HarnessPort: s.HarnessPort,
 		ClientCount: clientCounts[s.SessionName],
+		GroupID:     s.GroupID,
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -184,7 +184,11 @@ CREATE TABLE IF NOT EXISTS schema_version (
 // v10→v11 drops the legacy opencode_port and opencode_sid columns from
 // agent_status (harness-agnostic equivalents harness_port and harness_session_id
 // have been the canonical columns since v8; the legacy names were dual-written
-// for back-compat and are now removed).
+// for back-compat and are now removed);
+// v11→v12 adds a partial unique index to enforce at most one active coordinator
+// per repo (§6.1 from #849): UNIQUE (repo) WHERE root_agent_name='coordinator'
+// AND ended_at IS NULL. The IF NOT EXISTS guard makes this idempotent so that
+// databases already at v12 (e.g. from a re-run) do not fail.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -226,8 +230,9 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("db: apply schema: %w", err)
 	}
 
-	// Set schema_version=11 if the table is empty (fresh database already has
-	// all columns including the v2–v11 additions, so no migration is needed).
+	// Set schema_version=11 if the table is empty. Fresh databases have all
+	// current columns from the schema above. The v11→v12 migration (partial
+	// unique index for coordinator-per-repo) runs immediately below.
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
@@ -489,6 +494,28 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 11
+	}
+	if version == 11 {
+		// Migration v11 → v12: add a partial unique index enforcing at most one
+		// active coordinator per repo (§6.1 from #849). The index is partial so
+		// that:
+		//   - ended coordinators (ended_at IS NOT NULL) are excluded, allowing
+		//     a new coordinator to start for the same repo after the previous one ends.
+		//   - sessions without root_agent_name='coordinator' are unaffected.
+		// CREATE INDEX IF NOT EXISTS makes this idempotent.
+		migrations := []string{
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+			   ON agent_status (repo)
+			   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL`,
+			"UPDATE schema_version SET version = 12",
+		}
+		for _, m := range migrations {
+			if _, err := conn.Exec(m); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v11→v12: %w", err)
+			}
+		}
+		version = 12
 	}
 
 	return &DB{conn: conn, path: path}, nil

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1919,19 +1919,23 @@ LIMIT 1`
 
 // RootAgentName returns the root_agent_name for sessionName, or "" when the
 // row does not exist or root_agent_name is NULL (pre-migration row).
-func (d *DB) RootAgentName(sessionName string) (string, error) {
-	var name sql.NullString
+// The second return value (rowExists) distinguishes the two empty cases:
+//   - ("", false, nil)  — no agent_status row found (new/unknown session)
+//   - ("", true, nil)   — row found but root_agent_name is NULL (pre-migration)
+//   - (name, true, nil) — row found with a populated root_agent_name
+func (d *DB) RootAgentName(sessionName string) (name string, rowExists bool, err error) {
+	var ns sql.NullString
 	const q = `SELECT root_agent_name FROM agent_status WHERE session_name = ?`
-	if err := d.conn.QueryRow(q, sessionName).Scan(&name); err != nil {
-		if err == sql.ErrNoRows {
-			return "", nil
+	if scanErr := d.conn.QueryRow(q, sessionName).Scan(&ns); scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			return "", false, nil
 		}
-		return "", fmt.Errorf("db: root agent name: %w", err)
+		return "", false, fmt.Errorf("db: root agent name: %w", scanErr)
 	}
-	if !name.Valid {
-		return "", nil
+	if !ns.Valid {
+		return "", true, nil
 	}
-	return name.String, nil
+	return ns.String, true, nil
 }
 
 // IsGroupMember returns true when sessionName has a non-NULL group_id in

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1893,3 +1893,80 @@ func scanBusMessage(s scanner) (BusMessage, error) {
 	}
 	return m, nil
 }
+
+// CoordinatorForRepo returns the agent_status row for the active coordinator
+// session of repo (i.e. the row where repo = repo AND root_agent_name =
+// "coordinator" AND ended_at IS NULL). Returns nil when no coordinator exists.
+// When multiple rows match (schema violation), the most-recently-seen row is
+// returned and a duplicate is silently tolerated.
+func (d *DB) CoordinatorForRepo(repo string) (*Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE repo = ? AND root_agent_name = 'coordinator' AND ended_at IS NULL
+ORDER BY last_seen DESC
+LIMIT 1`
+	row := d.conn.QueryRow(q, repo)
+	s, err := scanStatus(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: coordinator for repo: %w", err)
+	}
+	return s, nil
+}
+
+// RootAgentName returns the root_agent_name for sessionName, or "" when the
+// row does not exist or root_agent_name is NULL (pre-migration row).
+func (d *DB) RootAgentName(sessionName string) (string, error) {
+	var name sql.NullString
+	const q = `SELECT root_agent_name FROM agent_status WHERE session_name = ?`
+	if err := d.conn.QueryRow(q, sessionName).Scan(&name); err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("db: root agent name: %w", err)
+	}
+	if !name.Valid {
+		return "", nil
+	}
+	return name.String, nil
+}
+
+// IsGroupMember returns true when sessionName has a non-NULL group_id in
+// agent_status (i.e. it belongs to a session group). Returns false for
+// pre-migration rows where group_id is NULL.
+func (d *DB) IsGroupMember(sessionName string) (bool, error) {
+	var groupID sql.NullString
+	const q = `SELECT group_id FROM agent_status WHERE session_name = ?`
+	if err := d.conn.QueryRow(q, sessionName).Scan(&groupID); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("db: is group member: %w", err)
+	}
+	return groupID.Valid && groupID.String != "", nil
+}
+
+// HasReviewGroup returns true when sessionName is the parent_session of at
+// least one row in session_groups. This is the DB-backed way to detect whether
+// a session has spawned a review group (replacing the "~review" name heuristic).
+func (d *DB) HasReviewGroup(parentSession string) (bool, error) {
+	var count int
+	const q = `SELECT COUNT(*) FROM session_groups WHERE parent_session = ?`
+	if err := d.conn.QueryRow(q, parentSession).Scan(&count); err != nil {
+		return false, fmt.Errorf("db: has review group: %w", err)
+	}
+	return count > 0, nil
+}
+
+// GroupMembersForParent returns all agent_status rows whose group_id belongs
+// to a session_groups row with parent_session = parentSession.
+func (d *DB) GroupMembersForParent(parentSession string) ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
+	return d.queryStatuses(q, parentSession)
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1901,7 +1901,7 @@ func scanBusMessage(s scanner) (BusMessage, error) {
 // returned and a duplicate is silently tolerated.
 func (d *DB) CoordinatorForRepo(repo string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE repo = ? AND root_agent_name = 'coordinator' AND ended_at IS NULL
 ORDER BY last_seen DESC
@@ -1969,7 +1969,7 @@ func (d *DB) HasReviewGroup(parentSession string) (bool, error) {
 // to a session_groups row with parent_session = parentSession.
 func (d *DB) GroupMembersForParent(parentSession string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, opencode_sid, agent_name, model_id, root_agent_name, root_model_id, opencode_port, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
 	return d.queryStatuses(q, parentSession)

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -3627,6 +3627,58 @@ func TestIsGroupMember(t *testing.T) {
 	}
 }
 
+// TestGroupMembersForParent verifies the GroupMembersForParent DB helper.
+func TestGroupMembersForParent(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	// Empty result when no groups exist.
+	rows, err := d.GroupMembersForParent("repo@worker")
+	if err != nil {
+		t.Fatalf("GroupMembersForParent (no groups): %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("GroupMembersForParent (no groups): got %d rows, want 0", len(rows))
+	}
+
+	// Seed a worker session and register a group.
+	if err := d.UpsertStatus("repo@worker", "repo", "/code/worker", "active", nil, nil); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+	groupID, err := d.RegisterGroup("repo@worker")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed two reviewer sessions and assign them to the group.
+	for _, name := range []string{"repo@worker~review-1-code", "repo@worker~review-2-goal"} {
+		if err := d.UpsertStatus(name, "repo", "/code/"+name, "active", nil, nil); err != nil {
+			t.Fatalf("seed reviewer %q: %v", name, err)
+		}
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID %q: %v", name, err)
+		}
+	}
+
+	// GroupMembersForParent should return both reviewer rows.
+	members, err := d.GroupMembersForParent("repo@worker")
+	if err != nil {
+		t.Fatalf("GroupMembersForParent (with members): %v", err)
+	}
+	if len(members) != 2 {
+		t.Errorf("GroupMembersForParent (with members): got %d rows, want 2", len(members))
+	}
+
+	// Different parent session returns empty.
+	other, err := d.GroupMembersForParent("repo@other")
+	if err != nil {
+		t.Fatalf("GroupMembersForParent (other parent): %v", err)
+	}
+	if len(other) != 0 {
+		t.Errorf("GroupMembersForParent (other parent): got %d rows, want 0", len(other))
+	}
+}
+
 // TestHasReviewGroup verifies the HasReviewGroup DB helper.
 func TestHasReviewGroup(t *testing.T) {
 	d := openTestDB(t)

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,21 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=11 (migrations are applied on Open).
+	// Verify schema_version=12 (migrations are applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version: got %d, want 12", version)
+	}
+
+	// Verify the partial unique index for coordinator-per-repo was created (v12).
+	var indexName string
+	if err := d.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_active_coordinator_per_repo'",
+	).Scan(&indexName); err != nil {
+		t.Errorf("idx_active_coordinator_per_repo index not found: %v", err)
 	}
 
 	// Verify WAL mode.
@@ -773,13 +781,13 @@ func TestMigration_V1ToV2(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Verify schema_version=11.
+	// Verify schema_version=12.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -853,8 +861,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1354,8 +1362,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1420,8 +1428,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1490,8 +1498,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1585,8 +1593,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1678,8 +1686,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2263,8 +2271,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2352,8 +2360,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 11 {
-		t.Errorf("schema_version after migration: got %d, want 11", version)
+	if version != 12 {
+		t.Errorf("schema_version after migration: got %d, want 12", version)
 	}
 
 	// isolation_mode column must exist (NULL for pre-migration rows).

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -3531,37 +3531,46 @@ func TestRootAgentName(t *testing.T) {
 	d := openTestDB(t)
 	defer d.Close()
 
-	// Non-existent session returns "".
-	name, err := d.RootAgentName("nonexistent@session")
+	// Non-existent session returns ("", false, nil).
+	name, rowExists, err := d.RootAgentName("nonexistent@session")
 	if err != nil {
 		t.Fatalf("RootAgentName(nonexistent): %v", err)
 	}
 	if name != "" {
 		t.Errorf("RootAgentName(nonexistent): got %q, want empty", name)
 	}
+	if rowExists {
+		t.Error("RootAgentName(nonexistent): got rowExists=true, want false")
+	}
 
-	// Pre-migration row: root_agent_name is NULL.
+	// Pre-migration row: root_agent_name is NULL — returns ("", true, nil).
 	if err := d.UpsertStatus("repo@old", "repo", "/code", "active", nil, nil); err != nil {
 		t.Fatalf("seed pre-migration: %v", err)
 	}
-	nameNull, err := d.RootAgentName("repo@old")
+	nameNull, rowExistsNull, err := d.RootAgentName("repo@old")
 	if err != nil {
 		t.Fatalf("RootAgentName(pre-migration): %v", err)
 	}
 	if nameNull != "" {
 		t.Errorf("RootAgentName(pre-migration): got %q, want empty for NULL", nameNull)
 	}
+	if !rowExistsNull {
+		t.Error("RootAgentName(pre-migration): got rowExists=false, want true")
+	}
 
-	// Post-migration row: root_agent_name is populated.
+	// Post-migration row: root_agent_name is populated — returns (name, true, nil).
 	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
-	nameCoord, err := d.RootAgentName("repo@main")
+	nameCoord, rowExistsCoord, err := d.RootAgentName("repo@main")
 	if err != nil {
 		t.Fatalf("RootAgentName(coordinator): %v", err)
 	}
 	if nameCoord != "coordinator" {
 		t.Errorf("RootAgentName(coordinator): got %q, want \"coordinator\"", nameCoord)
+	}
+	if !rowExistsCoord {
+		t.Error("RootAgentName(coordinator): got rowExists=false, want true")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -3464,3 +3464,208 @@ func TestUpsertStatusSeedRootAgentName_SidecarWriteIdempotent(t *testing.T) {
 		t.Errorf("State after sidecar write: got %q, want \"active\"", s2.State)
 	}
 }
+
+// TestCoordinatorForRepo verifies the DB-backed coordinator lookup by repo.
+func TestCoordinatorForRepo(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	// Seed a coordinator row with root_agent_name = "coordinator".
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/myrepo/main", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+	// Seed a worker row.
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@feature", "myrepo", "/code/myrepo/feature", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+
+	// Happy path: find the coordinator for the repo.
+	coord, err := d.CoordinatorForRepo("myrepo")
+	if err != nil {
+		t.Fatalf("CoordinatorForRepo: %v", err)
+	}
+	if coord == nil {
+		t.Fatal("CoordinatorForRepo: got nil, want coordinator row")
+	}
+	if coord.SessionName != "myrepo@main" {
+		t.Errorf("CoordinatorForRepo: SessionName = %q, want %q", coord.SessionName, "myrepo@main")
+	}
+
+	// No coordinator for an unknown repo returns nil.
+	none, err := d.CoordinatorForRepo("other-repo")
+	if err != nil {
+		t.Fatalf("CoordinatorForRepo(other-repo): %v", err)
+	}
+	if none != nil {
+		t.Errorf("CoordinatorForRepo(other-repo): got %v, want nil", none)
+	}
+
+	// Pre-migration row: a session named "oldrepo@main" with NULL root_agent_name
+	// is NOT returned by CoordinatorForRepo (it requires the DB field).
+	if err := d.UpsertStatus("oldrepo@main", "oldrepo", "/code/oldrepo/main", "active", nil, nil); err != nil {
+		t.Fatalf("seed pre-migration coordinator: %v", err)
+	}
+	noPreMig, err := d.CoordinatorForRepo("oldrepo")
+	if err != nil {
+		t.Fatalf("CoordinatorForRepo(oldrepo): %v", err)
+	}
+	if noPreMig != nil {
+		t.Errorf("CoordinatorForRepo(oldrepo): expected nil for pre-migration row (NULL root_agent_name), got %v", noPreMig)
+	}
+
+	// Ended coordinator should not be returned.
+	if err := d.SetEnded("myrepo@main"); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+	ended, err := d.CoordinatorForRepo("myrepo")
+	if err != nil {
+		t.Fatalf("CoordinatorForRepo after SetEnded: %v", err)
+	}
+	if ended != nil {
+		t.Errorf("CoordinatorForRepo after SetEnded: got %v, want nil", ended)
+	}
+}
+
+// TestRootAgentName verifies the RootAgentName DB helper.
+func TestRootAgentName(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	// Non-existent session returns "".
+	name, err := d.RootAgentName("nonexistent@session")
+	if err != nil {
+		t.Fatalf("RootAgentName(nonexistent): %v", err)
+	}
+	if name != "" {
+		t.Errorf("RootAgentName(nonexistent): got %q, want empty", name)
+	}
+
+	// Pre-migration row: root_agent_name is NULL.
+	if err := d.UpsertStatus("repo@old", "repo", "/code", "active", nil, nil); err != nil {
+		t.Fatalf("seed pre-migration: %v", err)
+	}
+	nameNull, err := d.RootAgentName("repo@old")
+	if err != nil {
+		t.Fatalf("RootAgentName(pre-migration): %v", err)
+	}
+	if nameNull != "" {
+		t.Errorf("RootAgentName(pre-migration): got %q, want empty for NULL", nameNull)
+	}
+
+	// Post-migration row: root_agent_name is populated.
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+	nameCoord, err := d.RootAgentName("repo@main")
+	if err != nil {
+		t.Fatalf("RootAgentName(coordinator): %v", err)
+	}
+	if nameCoord != "coordinator" {
+		t.Errorf("RootAgentName(coordinator): got %q, want \"coordinator\"", nameCoord)
+	}
+}
+
+// TestIsGroupMember verifies the IsGroupMember DB helper.
+func TestIsGroupMember(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	// Seed a session and a group.
+	if err := d.UpsertStatusSeedRootAgentName("repo@worker", "repo", "/code/worker", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+	groupID, err := d.RegisterGroup("repo@worker")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed a review agent session and assign it to the group.
+	if err := d.UpsertStatusSeedRootAgentName("repo@worker~review-1-review-goal", "repo", "/code/worker", "active", nil, nil, "review-goal"); err != nil {
+		t.Fatalf("seed review agent: %v", err)
+	}
+	if err := d.SetGroupID("repo@worker~review-1-review-goal", groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+
+	// The review agent IS a group member.
+	isMember, err := d.IsGroupMember("repo@worker~review-1-review-goal")
+	if err != nil {
+		t.Fatalf("IsGroupMember(review agent): %v", err)
+	}
+	if !isMember {
+		t.Error("IsGroupMember(review agent): got false, want true")
+	}
+
+	// The parent worker is NOT a group member (it is the parent, not a member).
+	isParentMember, err := d.IsGroupMember("repo@worker")
+	if err != nil {
+		t.Fatalf("IsGroupMember(parent): %v", err)
+	}
+	if isParentMember {
+		t.Error("IsGroupMember(parent worker): got true, want false (parent is not in a group)")
+	}
+
+	// Pre-migration row (NULL group_id) is not a group member.
+	if err := d.UpsertStatus("repo@old-worker", "repo", "/code", "active", nil, nil); err != nil {
+		t.Fatalf("seed pre-migration: %v", err)
+	}
+	isOldMember, err := d.IsGroupMember("repo@old-worker")
+	if err != nil {
+		t.Fatalf("IsGroupMember(pre-migration): %v", err)
+	}
+	if isOldMember {
+		t.Error("IsGroupMember(pre-migration NULL group_id): got true, want false")
+	}
+
+	// Non-existent session returns false.
+	isNone, err := d.IsGroupMember("nonexistent@session")
+	if err != nil {
+		t.Fatalf("IsGroupMember(nonexistent): %v", err)
+	}
+	if isNone {
+		t.Error("IsGroupMember(nonexistent): got true, want false")
+	}
+}
+
+// TestHasReviewGroup verifies the HasReviewGroup DB helper.
+func TestHasReviewGroup(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	// Seed a worker session.
+	if err := d.UpsertStatus("repo@worker", "repo", "/code/worker", "active", nil, nil); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+
+	// Before registering any group, HasReviewGroup returns false.
+	has, err := d.HasReviewGroup("repo@worker")
+	if err != nil {
+		t.Fatalf("HasReviewGroup (before group): %v", err)
+	}
+	if has {
+		t.Error("HasReviewGroup (before group): got true, want false")
+	}
+
+	// Register a group for the worker.
+	if _, err := d.RegisterGroup("repo@worker"); err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Now HasReviewGroup returns true.
+	hasAfter, err := d.HasReviewGroup("repo@worker")
+	if err != nil {
+		t.Fatalf("HasReviewGroup (after group): %v", err)
+	}
+	if !hasAfter {
+		t.Error("HasReviewGroup (after group): got false, want true")
+	}
+
+	// Different session returns false.
+	hasOther, err := d.HasReviewGroup("repo@other")
+	if err != nil {
+		t.Fatalf("HasReviewGroup (other session): %v", err)
+	}
+	if hasOther {
+		t.Error("HasReviewGroup (other session): got true, want false")
+	}
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -1128,20 +1128,67 @@ func IsPerAgentSession(sessionName, parentSession string) bool {
 	return agentPart != "" && !strings.Contains(agentPart, "~")
 }
 
-// KillReviewSessionsForParent kills all ~review-* tmux sessions for the given parent.
+// KillReviewSessionsForParent kills all review sessions for the given parent.
+// Uses DB group membership (GroupMembersForParent) as the primary source, with
+// a name-prefix fallback for pre-migration rows where group_id is not set.
 // This is the public API used by cleanup.go for cascading parent cleanup.
 // It kills ALL review sessions across all rounds (for prism cleanup --yes --session <parent>).
 func KillReviewSessionsForParent(parentSession string) {
+	KillReviewSessionsForParentWithDB(nil, parentSession)
+}
+
+// KillReviewSessionsForParentWithDB is like KillReviewSessionsForParent but
+// uses the DB for group membership when available.
+func KillReviewSessionsForParentWithDB(d *db.DB, parentSession string) {
 	prefix := parentSession + "~review-"
+
+	// Try DB-backed group membership first (post-migration rows).
+	if d != nil {
+		members, err := d.GroupMembersForParent(parentSession)
+		if err == nil && len(members) > 0 {
+			names := make([]string, 0, len(members))
+			for _, m := range members {
+				names = append(names, m.SessionName)
+			}
+			KillSessionsByNames(names)
+			return
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[prism] warning: KillReviewSessionsForParentWithDB: DB error for %q: %v — using name-prefix fallback\n", parentSession, err)
+		}
+		// len(members) == 0: fall through to name-prefix for pre-migration rows.
+	}
+
+	// Pre-migration fallback: kill by name prefix.
 	KillSessionPrefix(prefix)
 }
 
-// CleanupReviewSessionsForParent kills all ~review-* tmux sessions for the
+// CleanupReviewSessionsForParent kills all review sessions for the
 // given parent AND cleans up their DB rows (port allocations, ended state,
 // bus messages). Called by prism cleanup --yes --session <parent> to cascade
 // the cleanup to all review sessions.
+// Uses DB group membership (GroupMembersForParent) as the primary source, with
+// a name-prefix fallback for pre-migration rows where group_id is not set.
 func CleanupReviewSessionsForParent(d *db.DB, parentSession string) {
 	prefix := parentSession + "~review-"
+
+	// Try DB-backed group membership first (post-migration rows).
+	members, err := d.GroupMembersForParent(parentSession)
+	if err == nil && len(members) > 0 {
+		// DB-backed: clean up only the actual group members.
+		names := make([]string, 0, len(members))
+		for _, row := range members {
+			cleanupAgentSession(d, row.SessionName)
+			names = append(names, row.SessionName)
+		}
+		// Kill the tmux sessions (best effort, idempotent).
+		KillSessionsByNames(names)
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[prism] warning: CleanupReviewSessionsForParent: DB group error for %q: %v — using name-prefix fallback\n", parentSession, err)
+	}
+	// Pre-migration fallback: find rows by name prefix and kill by prefix.
 
 	// Find all review session rows in the DB.
 	rows, err := d.AllStatusesWithPrefix(prefix)

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2198,3 +2198,114 @@ func TestGroupWiring_PollWithGroupCompleted(t *testing.T) {
 		t.Errorf("expected 2 progress lines, got %d: %v", len(lines), lines)
 	}
 }
+
+// ── CleanupReviewSessionsForParent / KillReviewSessionsForParentWithDB ────────
+
+// TestCleanupReviewSessionsForParent_DBBacked verifies that when group members
+// exist in the DB (post-migration), CleanupReviewSessionsForParent marks them
+// as ended via the DB-backed path.
+func TestCleanupReviewSessionsForParent_DBBacked(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@main"
+	member1 := parent + "~review-1-review-goal"
+	member2 := parent + "~review-1-review-code"
+
+	// Seed parent row with root_agent_name = "coordinator".
+	if err := d.UpsertStatusSeedRootAgentName(parent, "nixos-config", "/wt/main", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+
+	// Register a group and seed member rows.
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	for _, m := range []string{member1, member2} {
+		if err := d.UpsertStatus(m, "nixos-config", "/wt/"+m, "running", nil, nil); err != nil {
+			t.Fatalf("seed member %q: %v", m, err)
+		}
+		if err := d.SetGroupID(m, groupID); err != nil {
+			t.Fatalf("SetGroupID %q: %v", m, err)
+		}
+	}
+
+	// Call the function under test (KillSessionsByNames will fail silently — no tmux).
+	review.CleanupReviewSessionsForParent(d, parent)
+
+	// Verify both member rows have ended_at set (SetEnded was called).
+	for _, m := range []string{member1, member2} {
+		s, err := d.CurrentStatus(m)
+		if err != nil {
+			t.Fatalf("CurrentStatus(%q): %v", m, err)
+		}
+		if s == nil {
+			t.Fatalf("CurrentStatus(%q): no row found", m)
+		}
+		if s.EndedAt == nil {
+			t.Errorf("session %q: EndedAt is nil, want non-nil (SetEnded should have been called)", m)
+		}
+	}
+}
+
+// TestCleanupReviewSessionsForParent_PreMigrationFallback verifies that when no
+// group members exist in the DB (pre-migration), the function falls back to the
+// name-prefix scan.
+func TestCleanupReviewSessionsForParent_PreMigrationFallback(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@legacy"
+	member := parent + "~review-1-review-goal"
+
+	// Seed member row WITHOUT group_id (pre-migration shape).
+	if err := d.UpsertStatus(member, "nixos-config", "/wt/"+member, "running", nil, nil); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+
+	// No group registered — GroupMembersForParent returns empty slice.
+	review.CleanupReviewSessionsForParent(d, parent)
+
+	// Verify the member row had ended_at set via the prefix-scan fallback path.
+	s, err := d.CurrentStatus(member)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatalf("CurrentStatus: no row found")
+	}
+	if s.EndedAt == nil {
+		t.Errorf("session %q: EndedAt is nil, want non-nil (prefix-scan fallback should have called SetEnded)", member)
+	}
+}
+
+// TestKillReviewSessionsForParentWithDB_DBBacked verifies that when group
+// members exist, KillReviewSessionsForParentWithDB uses the DB-backed path
+// (returns without calling KillSessionPrefix — no tmux panic for nonexistent sessions).
+func TestKillReviewSessionsForParentWithDB_DBBacked(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@main"
+	member := parent + "~review-1-review-goal"
+
+	if err := d.UpsertStatusSeedRootAgentName(parent, "nixos-config", "/wt/main", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.UpsertStatus(member, "nixos-config", "/wt/"+member, "running", nil, nil); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+	if err := d.SetGroupID(member, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+
+	// Should not panic even though tmux is not running (KillSessionsByNames is best-effort).
+	review.KillReviewSessionsForParentWithDB(d, parent)
+}
+
+// TestKillReviewSessionsForParentWithDB_NilDB verifies that when d is nil,
+// KillReviewSessionsForParentWithDB delegates to KillSessionPrefix (name-prefix path).
+func TestKillReviewSessionsForParentWithDB_NilDB(t *testing.T) {
+	// With nil DB the function falls through to KillSessionPrefix.
+	// KillSessionPrefix calls tmux (best-effort, non-fatal). Verify no panic.
+	review.KillReviewSessionsForParentWithDB(nil, "nixos-config@main")
+}

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -207,20 +207,21 @@ func DefaultAgentForSession(sessionName, directory, explicit string, d *db.DB) s
 		return explicit
 	}
 	if d != nil {
-		rootName, err := d.RootAgentName(sessionName)
+		rootName, rowExists, err := d.RootAgentName(sessionName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[prism] warning: DefaultAgentForSession: DB error reading root_agent_name for %q: %v — using directory heuristic\n", sessionName, err)
-		} else if rootName != "" {
+		} else if rowExists && rootName != "" {
 			// DB-backed: return the stored root_agent_name.
 			dirBased := DefaultAgent(directory, "")
 			if rootName != dirBased {
 				fmt.Fprintf(os.Stderr, "[debug] DefaultAgentForSession(%q): DB says %q, directory heuristic says %q\n", sessionName, rootName, dirBased)
 			}
 			return rootName
-		} else {
-			// NULL root_agent_name — pre-migration row.
+		} else if rowExists {
+			// Row exists but root_agent_name is NULL — pre-migration row.
 			fmt.Fprintf(os.Stderr, "[deprecation] DefaultAgentForSession(%q): root_agent_name is NULL — using directory heuristic\n", sessionName)
 		}
+		// rowExists=false: no row yet — use directory heuristic silently.
 	}
 	return DefaultAgent(directory, "")
 }

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -195,6 +195,36 @@ func DefaultAgent(directory, explicit string) string {
 	return "worker"
 }
 
+// DefaultAgentForSession returns the agent to use for the given session,
+// using a DB-backed read of root_agent_name when available.
+// If explicit is non-empty it is returned unchanged.
+// Otherwise it reads root_agent_name from the DB; if the row has a non-NULL
+// root_agent_name it is returned directly. Falls back to DefaultAgent (directory
+// heuristic) for pre-migration rows where root_agent_name is NULL.
+// When d is nil, falls back to DefaultAgent unconditionally.
+func DefaultAgentForSession(sessionName, directory, explicit string, d *db.DB) string {
+	if explicit != "" {
+		return explicit
+	}
+	if d != nil {
+		rootName, err := d.RootAgentName(sessionName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[prism] warning: DefaultAgentForSession: DB error reading root_agent_name for %q: %v — using directory heuristic\n", sessionName, err)
+		} else if rootName != "" {
+			// DB-backed: return the stored root_agent_name.
+			dirBased := DefaultAgent(directory, "")
+			if rootName != dirBased {
+				fmt.Fprintf(os.Stderr, "[debug] DefaultAgentForSession(%q): DB says %q, directory heuristic says %q\n", sessionName, rootName, dirBased)
+			}
+			return rootName
+		} else {
+			// NULL root_agent_name — pre-migration row.
+			fmt.Fprintf(os.Stderr, "[deprecation] DefaultAgentForSession(%q): root_agent_name is NULL — using directory heuristic\n", sessionName)
+		}
+	}
+	return DefaultAgent(directory, "")
+}
+
 // effectiveIsolationMode returns the resolved isolation mode for opts,
 // falling back to ContainerMode for back-compat.
 func effectiveIsolationMode(opts Opts) string {

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -490,3 +490,99 @@ func TestSpawnSession_PromptEnvVar_NoPrompt(t *testing.T) {
 		}
 	}
 }
+
+// TestDefaultAgentForSession_DBHappyPath verifies that when root_agent_name is
+// set in the DB, DefaultAgentForSession returns it regardless of directory.
+func TestDefaultAgentForSession_DBHappyPath(t *testing.T) {
+	const sessionName = "testrepo@main"
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	got := DefaultAgentForSession(sessionName, "/worktrees/main", "", d)
+	if got != "coordinator" {
+		t.Errorf("DefaultAgentForSession = %q, want %q", got, "coordinator")
+	}
+}
+
+// TestDefaultAgentForSession_ExplicitOverridesDB verifies that an explicit
+// agent value is returned as-is, bypassing the DB.
+func TestDefaultAgentForSession_ExplicitOverridesDB(t *testing.T) {
+	const sessionName = "testrepo@main"
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	got := DefaultAgentForSession(sessionName, "/worktrees/main", "worker", d)
+	if got != "worker" {
+		t.Errorf("DefaultAgentForSession = %q, want %q (explicit should win)", got, "worker")
+	}
+}
+
+// TestDefaultAgentForSession_PreMigrationNULL verifies that when the DB row
+// exists but root_agent_name is NULL (pre-migration), DefaultAgentForSession
+// falls back to the directory heuristic.
+func TestDefaultAgentForSession_PreMigrationNULL(t *testing.T) {
+	const sessionName = "testrepo@main"
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	// Seed a row WITHOUT root_agent_name (NULL).
+	if err := d.UpsertStatus(sessionName, "testrepo", "/worktrees/nixos-config", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Directory heuristic for /worktrees/nixos-config returns "coordinator".
+	got := DefaultAgentForSession(sessionName, "/worktrees/nixos-config", "", d)
+	want := DefaultAgent("/worktrees/nixos-config", "")
+	if got != want {
+		t.Errorf("DefaultAgentForSession = %q, want directory heuristic %q", got, want)
+	}
+}
+
+// TestDefaultAgentForSession_NilDB verifies that when d is nil,
+// DefaultAgentForSession falls back to the directory heuristic unconditionally.
+func TestDefaultAgentForSession_NilDB(t *testing.T) {
+	got := DefaultAgentForSession("testrepo@main", "/worktrees/nixos-config", "", nil)
+	want := DefaultAgent("/worktrees/nixos-config", "")
+	if got != want {
+		t.Errorf("DefaultAgentForSession (nil DB) = %q, want %q", got, want)
+	}
+}
+
+// TestDefaultAgentForSession_NoRow verifies that when no DB row exists for the
+// session (new session, not yet seeded), DefaultAgentForSession silently falls
+// back to the directory heuristic (no deprecation warning emitted).
+func TestDefaultAgentForSession_NoRow(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	// No row seeded — rowExists=false path.
+	got := DefaultAgentForSession("testrepo@main", "/worktrees/nixos-config", "", d)
+	want := DefaultAgent("/worktrees/nixos-config", "")
+	if got != want {
+		t.Errorf("DefaultAgentForSession (no row) = %q, want %q", got, want)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1913,22 +1913,25 @@ func isCoordinator(sessionName string) bool {
 // When d is nil, the name heuristic is used unconditionally.
 func isCoordinatorSession(sessionName string, d *db.DB) bool {
 	if d != nil {
-		name, err := d.RootAgentName(sessionName)
-		if err == nil && name != "" {
-			nameBased := strings.HasSuffix(sessionName, "@main")
-			dbBased := name == "coordinator"
-			if dbBased != nameBased {
-				log.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v",
-					sessionName, dbBased, name, nameBased)
+		name, rowExists, err := d.RootAgentName(sessionName)
+		if err == nil && rowExists {
+			if name != "" {
+				nameBased := strings.HasSuffix(sessionName, "@main")
+				dbBased := name == "coordinator"
+				if dbBased != nameBased {
+					log.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v",
+						sessionName, dbBased, name, nameBased)
+				}
+				return dbBased
 			}
-			return dbBased
-		}
-		if err != nil {
+			// Row exists but root_agent_name is NULL — pre-migration row.
+			log.Printf("[deprecation] sidecar: isCoordinatorSession(%q): root_agent_name is NULL — pre-migration row, using name heuristic", sessionName)
+		} else if err != nil {
 			log.Printf("sidecar: isCoordinatorSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
 		}
+		// rowExists=false means no row — no log needed, just use heuristic.
 	}
 	// Pre-migration fallback or DB unavailable: use name-suffix heuristic.
-	log.Printf("[deprecation] sidecar: isCoordinatorSession(%q): using name heuristic — session may predate root_agent_name migration", sessionName)
 	return strings.HasSuffix(sessionName, "@main")
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1534,12 +1534,19 @@ func (s *Sidecar) notifyCoordinator() {
 		// No coordinator with root_agent_name='coordinator' found — fall back to
 		// the name-based convention for pre-migration rows.
 		fallbackName := s.cfg.Repo + "@main"
-		log.Printf("[deprecation] sidecar: notifyCoordinator: no DB-backed coordinator found for %q — falling back to name convention %q", s.cfg.Repo, fallbackName)
-		coordStatus, err = s.cfg.DB.CurrentStatus(fallbackName)
+		var fallbackStatus *db.Status
+		fallbackStatus, err = s.cfg.DB.CurrentStatus(fallbackName)
 		if err != nil {
 			log.Printf("sidecar: notifyCoordinator: fallback look up coordinator: %v", err)
 			return
 		}
+		if fallbackStatus != nil {
+			// Name-based fallback succeeded: a pre-migration coordinator row was
+			// found via the @main name convention. Log deprecation only here,
+			// not when no coordinator is running at all (which is a normal state).
+			log.Printf("[deprecation] sidecar: notifyCoordinator: no DB-backed coordinator found for %q — falling back to name convention %q (pre-migration row)", s.cfg.Repo, fallbackName)
+		}
+		coordStatus = fallbackStatus
 	}
 	if coordStatus == nil {
 		// No coordinator session at all — silent skip.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2113,10 +2113,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		return true
 	}
 
-	// requireCoordinator checks that the calling sidecar's AgentRole is
-	// "coordinator". Returns false and writes HTTP 403 if not.
+	// requireCoordinator checks that the calling sidecar is a coordinator
+	// session. Uses the DB-backed isCoordinatorSession check (same helper as
+	// isCoordinator) which reads root_agent_name and falls back to AgentRole
+	// for pre-migration rows. Returns false and writes HTTP 403 if not.
 	requireCoordinator := func(w http.ResponseWriter, operation string) bool {
-		if s.cfg.AgentRole != "coordinator" {
+		if !isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("workers cannot perform %s", operation))
 			return false

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1451,8 +1451,37 @@ func touchDashboardSentinel() {
 // These sessions are short-lived internal helpers; their finish events are
 // consumed by the parent worker's pollAgents DB loop and must not propagate
 // further up the chain as coordinator notifications.
-func isReviewAgentSession(sessionName string) bool {
-	return strings.Contains(sessionName, "~review")
+//
+// DB-backed check: a session is a review agent if it belongs to a session group
+// (non-NULL group_id). The name-match heuristic is used as a fallback when the
+// DB is unavailable or the row has no group_id (pre-migration rows).
+func isReviewAgentSession(sessionName string, d *db.DB) bool {
+	nameBased := strings.Contains(sessionName, "~review")
+	if d != nil {
+		isMember, err := d.IsGroupMember(sessionName)
+		if err != nil {
+			log.Printf("sidecar: isReviewAgentSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
+			return nameBased
+		}
+		if isMember {
+			// DB-backed: confirmed group member.
+			if !nameBased {
+				log.Printf("[debug] sidecar: isReviewAgentSession(%q): DB says group member, name heuristic says false",
+					sessionName)
+			}
+			return true
+		}
+		// DB says not a group member. If the name heuristic says it IS a review
+		// agent, this is likely a pre-migration row (group_id not yet set).
+		// Fall back to the name heuristic.
+		if nameBased {
+			log.Printf("[deprecation] sidecar: isReviewAgentSession(%q): group_id not set but name heuristic matches — pre-migration row, using name heuristic", sessionName)
+			return true
+		}
+		return false
+	}
+	// No DB available — use name heuristic.
+	return nameBased
 }
 
 // notifyCoordinator sends a "finished" notification to the coordinator session
@@ -1480,9 +1509,10 @@ func isReviewAgentSession(sessionName string) bool {
 // returns an empty list, delivery fails immediately (no retry). If GET /session
 // fails with a network or non-200 error, the retry policy applies.
 func (s *Sidecar) notifyCoordinator() {
-	// Self-notification guard: if this session is the coordinator, skip.
-	coordinatorName := s.cfg.Repo + "@main"
-	if s.cfg.SessionName == coordinatorName {
+	// Self-notification guard: if this session IS the coordinator, skip.
+	// DB-backed: check root_agent_name == "coordinator" for self.
+	// Fallback to name heuristic for pre-migration rows.
+	if isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
 		return
 	}
 
@@ -1490,25 +1520,37 @@ func (s *Sidecar) notifyCoordinator() {
 	// prism review invocation. Their finish events are discovered by the
 	// worker's pollAgents DB poll and must not be forwarded to the coordinator
 	// as noise notifications.
-	if isReviewAgentSession(s.cfg.SessionName) {
+	if isReviewAgentSession(s.cfg.SessionName, s.cfg.DB) {
 		log.Printf("sidecar: notifyCoordinator: suppressed for review-agent session %s", s.cfg.SessionName)
 		return
 	}
 
-	// Look up coordinator status.
-	coordStatus, err := s.cfg.DB.CurrentStatus(coordinatorName)
+	// DB-backed coordinator lookup: find the active coordinator for this repo.
+	coordStatus, err := s.cfg.DB.CoordinatorForRepo(s.cfg.Repo)
 	if err != nil {
-		log.Printf("sidecar: notifyCoordinator: look up coordinator: %v", err)
-		return
+		log.Printf("sidecar: notifyCoordinator: DB lookup coordinator for repo %q: %v — falling back to name-based lookup", s.cfg.Repo, err)
 	}
 	if coordStatus == nil {
-		// No coordinator session — silent skip.
+		// No coordinator with root_agent_name='coordinator' found — fall back to
+		// the name-based convention for pre-migration rows.
+		fallbackName := s.cfg.Repo + "@main"
+		log.Printf("[deprecation] sidecar: notifyCoordinator: no DB-backed coordinator found for %q — falling back to name convention %q", s.cfg.Repo, fallbackName)
+		coordStatus, err = s.cfg.DB.CurrentStatus(fallbackName)
+		if err != nil {
+			log.Printf("sidecar: notifyCoordinator: fallback look up coordinator: %v", err)
+			return
+		}
+	}
+	if coordStatus == nil {
+		// No coordinator session at all — silent skip.
 		return
 	}
 	if coordStatus.EndedAt != nil {
 		// Coordinator has ended — silent skip.
 		return
 	}
+
+	coordinatorName := coordStatus.SessionName
 
 	notifyText := fmt.Sprintf("Agent %s has finished its current task", s.cfg.SessionName)
 
@@ -1859,8 +1901,34 @@ func repoFromSession(sessionName string) (string, error) {
 }
 
 // isCoordinator returns true when the session name ends with "@main", which is
-// the convention for coordinator sessions in the prism model.
+// the legacy convention for coordinator sessions in the prism model.
+// Deprecated: prefer isCoordinatorSession which also checks the DB.
 func isCoordinator(sessionName string) bool {
+	return strings.HasSuffix(sessionName, "@main")
+}
+
+// isCoordinatorSession returns true when the session is a coordinator, using
+// a DB-backed read of root_agent_name when available. Falls back to the
+// name-suffix heuristic for pre-migration rows (NULL root_agent_name).
+// When d is nil, the name heuristic is used unconditionally.
+func isCoordinatorSession(sessionName string, d *db.DB) bool {
+	if d != nil {
+		name, err := d.RootAgentName(sessionName)
+		if err == nil && name != "" {
+			nameBased := strings.HasSuffix(sessionName, "@main")
+			dbBased := name == "coordinator"
+			if dbBased != nameBased {
+				log.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v",
+					sessionName, dbBased, name, nameBased)
+			}
+			return dbBased
+		}
+		if err != nil {
+			log.Printf("sidecar: isCoordinatorSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
+		}
+	}
+	// Pre-migration fallback or DB unavailable: use name-suffix heuristic.
+	log.Printf("[deprecation] sidecar: isCoordinatorSession(%q): using name heuristic — session may predate root_agent_name migration", sessionName)
 	return strings.HasSuffix(sessionName, "@main")
 }
 
@@ -2146,7 +2214,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		crossRepo := targetRepo != ownRepo
-		if crossRepo && !isCoordinator(targetSession) {
+		if crossRepo && !isCoordinatorSession(targetSession, s.cfg.DB) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("cross-repo checkin can only target coordinators (<repo>@main), got %q", targetSession))
 			return
@@ -2312,7 +2380,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
 			return
 		}
-		if targetRepo != ownRepo && !isCoordinator(targetSession) {
+		if targetRepo != ownRepo && !isCoordinatorSession(targetSession, s.cfg.DB) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("cross-repo logs can only target coordinators (<repo>@main), got %q", targetSession))
 			return
@@ -2405,14 +2473,27 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		if s.cfg.AgentRole == "coordinator" {
 			// Coordinator: own repo any session allowed; cross-repo only @main.
-			if crossRepo && !isCoordinator(req.Session) {
+			if crossRepo && !isCoordinatorSession(req.Session, s.cfg.DB) {
 				writeError(w, http.StatusForbidden,
 					fmt.Sprintf("cross-repo prompts can only target coordinators (<repo>@main), got %q", req.Session))
 				return
 			}
 		} else {
-			// Worker: only own coordinator (@main) allowed.
-			ownCoordinator := ownRepo + "@main"
+			// Worker: only own coordinator allowed.
+			// DB-backed: look up the coordinator for this repo.
+			coordStatus, coordErr := s.cfg.DB.CoordinatorForRepo(ownRepo)
+			if coordErr != nil {
+				log.Printf("sidecar: /prompt worker check: DB error looking up coordinator for %q: %v — falling back to name heuristic", ownRepo, coordErr)
+				coordStatus = nil
+			}
+			var ownCoordinator string
+			if coordStatus != nil {
+				ownCoordinator = coordStatus.SessionName
+			} else {
+				// Pre-migration fallback or no coordinator in DB.
+				ownCoordinator = ownRepo + "@main"
+				log.Printf("[deprecation] sidecar: /prompt worker check: no coordinator found in DB for %q — using name convention %q", ownRepo, ownCoordinator)
+			}
 			if req.Session != ownCoordinator {
 				writeError(w, http.StatusForbidden,
 					fmt.Sprintf("workers can only prompt their own coordinator (%s), got %q", ownCoordinator, req.Session))

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2502,9 +2502,19 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			if coordStatus != nil {
 				ownCoordinator = coordStatus.SessionName
 			} else {
-				// Pre-migration fallback or no coordinator in DB.
-				ownCoordinator = ownRepo + "@main"
-				log.Printf("[deprecation] sidecar: /prompt worker check: no coordinator found in DB for %q — using name convention %q", ownRepo, ownCoordinator)
+				// No coordinator with root_agent_name='coordinator' in DB.
+				// Fall back to name convention for pre-migration rows.
+				fallbackCoord := ownRepo + "@main"
+				fallbackStatus, _ := s.cfg.DB.CurrentStatus(fallbackCoord)
+				if fallbackStatus != nil {
+					// Pre-migration row found via name convention — log deprecation
+					// only when the fallback actually finds a row.
+					log.Printf("[deprecation] sidecar: /prompt worker check: no DB-backed coordinator for %q — using name convention %q (pre-migration row)", ownRepo, fallbackCoord)
+					ownCoordinator = fallbackCoord
+				} else {
+					// Normal "no coordinator running" state — silent fallback.
+					ownCoordinator = fallbackCoord
+				}
 			}
 			if req.Session != ownCoordinator {
 				writeError(w, http.StatusForbidden,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5030,6 +5030,10 @@ func TestHostAPI_Cleanup_WorkerForbidden(t *testing.T) {
 
 func TestHostAPI_SessionNameNoAt_NoCheckinPanic(t *testing.T) {
 	d := openTestDB(t)
+	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
+	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed DB: %v", err)
+	}
 	// Session name without "@" — edge case for repoFromSession.
 	sc := newSidecarWithRole(t, "no-at-sign", "", "coordinator", d)
 	// The sidecar's own session has no "@", which will fail repoFromSession.
@@ -5291,6 +5295,10 @@ func TestHostAPI_Spawn_EmptyBranchReturns400(t *testing.T) {
 // message indicating the repo cannot be derived, and no spawn is attempted.
 func TestHostAPI_Spawn_SidecarNoAtSign_Returns500(t *testing.T) {
 	d := openTestDB(t)
+	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
+	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed DB: %v", err)
+	}
 	// Session name without "@" — repoFromSession will fail.
 	sc := newSidecarWithRole(t, "no-at-sign", "", "coordinator", d)
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"branch":"some-branch"}`)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -1573,6 +1573,8 @@ func newWorkerSidecar(t *testing.T, d *db.DB, httpClient *http.Client) (*Sidecar
 
 // seedCoordinatorWithPort inserts a coordinator row with a specific known port
 // and harness_session_id using a SQL exec via db.QueryRow (for testing).
+// root_agent_name is also set to "coordinator" so that isCoordinatorSession
+// and CoordinatorForRepo exercise the DB-backed path rather than the name heuristic.
 func seedCoordinatorWithPort(t *testing.T, d *db.DB, repo string, port int, sid string) {
 	t.Helper()
 	coordName := repo + "@main"
@@ -1580,6 +1582,14 @@ func seedCoordinatorWithPort(t *testing.T, d *db.DB, repo string, port int, sid 
 	modelID := "anthropic/claude-sonnet-4-5"
 	if err := d.UpsertStatusWithAgent(coordName, repo, "/tmp/coord-worktree", "active", nil, &sid, &agentName, &modelID); err != nil {
 		t.Fatalf("seed coordinator: UpsertStatusWithAgent: %v", err)
+	}
+	// Set root_agent_name = 'coordinator' so the DB-backed coordinator detection
+	// path is exercised by tests that call notifyCoordinator / CoordinatorForRepo.
+	if err := d.QueryRow(
+		"UPDATE agent_status SET root_agent_name = 'coordinator' WHERE session_name = ? RETURNING session_name",
+		coordName,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("seed coordinator: set root_agent_name: %v", err)
 	}
 	// Set the port directly via a UPDATE … RETURNING to verify it applied.
 	var got int
@@ -2580,17 +2590,91 @@ func TestIsReviewAgentSession(t *testing.T) {
 	}
 }
 
+// TestIsReviewAgentSession_DBBackedPath verifies that isReviewAgentSession
+// returns true via the DB-backed group_id path even when the session name
+// does NOT contain "~review". This is the core correctness assertion for the
+// DB migration: a review agent on any session-name shape is identified by
+// group membership, not by name.
+func TestIsReviewAgentSession_DBBackedPath(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	parentSession := "repo@feature"
+	reviewSession := "repo@feature~review-1-review-code"
+	// A reviewer with an unconventional name (post-migration; group_id set but
+	// no "~review" in the name — verifies the DB path is primary).
+	unconventionalReviewer := "repo@feature-review-agent-custom"
+
+	// Register a group for the parent session.
+	groupID, err := d.RegisterGroup(parentSession)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed the conventional reviewer and assign it to the group.
+	if err := d.UpsertStatus(reviewSession, "repo", "/code/repo", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus reviewer: %v", err)
+	}
+	if err := d.SetGroupID(reviewSession, groupID); err != nil {
+		t.Fatalf("SetGroupID reviewer: %v", err)
+	}
+
+	// Seed an unconventional reviewer (no "~review" in name) and assign to group.
+	if err := d.UpsertStatus(unconventionalReviewer, "repo", "/code/repo", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus unconventional: %v", err)
+	}
+	if err := d.SetGroupID(unconventionalReviewer, groupID); err != nil {
+		t.Fatalf("SetGroupID unconventional: %v", err)
+	}
+
+	// Conventional reviewer: DB group membership takes precedence over name check.
+	if !isReviewAgentSession(reviewSession, d) {
+		t.Error("isReviewAgentSession(conventional, DB group set): got false, want true")
+	}
+
+	// Unconventional reviewer: DB identifies it without relying on the name heuristic.
+	if !isReviewAgentSession(unconventionalReviewer, d) {
+		t.Errorf("isReviewAgentSession(%q, DB group set, no ~review in name): got false, want true — DB path must identify group members regardless of name", unconventionalReviewer)
+	}
+
+	// Parent session itself: NOT a group member.
+	if isReviewAgentSession(parentSession, d) {
+		t.Error("isReviewAgentSession(parent session): got true, want false — parent is not a group member")
+	}
+
+	// Pre-migration: session with "~review" in name but no group_id set.
+	// Falls back to name heuristic.
+	preMigrationReviewer := "repo@pre-migration~review-1"
+	if err := d.UpsertStatus(preMigrationReviewer, "repo", "/code/repo", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus pre-migration: %v", err)
+	}
+	// group_id is NOT set — simulates pre-migration row.
+	if !isReviewAgentSession(preMigrationReviewer, d) {
+		t.Errorf("isReviewAgentSession(pre-migration ~review name, no group_id): got false, want true — name heuristic fallback must fire")
+	}
+}
+
 // TestIsCoordinatorSession verifies the DB-backed isCoordinatorSession helper.
 func TestIsCoordinatorSession(t *testing.T) {
 	d := openTestDB(t)
 	defer d.Close()
 
-	// Happy path: post-migration coordinator row.
+	// Happy path: post-migration coordinator row on the conventional @main branch.
 	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	if !isCoordinatorSession("repo@main", d) {
-		t.Error("isCoordinatorSession(post-migration coordinator): got false, want true")
+		t.Error("isCoordinatorSession(post-migration coordinator @main): got false, want true")
+	}
+
+	// Core value of the change: coordinator on a non-@main branch name.
+	// The DB read must identify it correctly regardless of branch name.
+	// Use a different repo name to avoid the unique-coordinator-per-repo constraint.
+	if err := d.UpsertStatusSeedRootAgentName("other-repo@custom-branch", "other-repo", "/code/custom", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator on custom branch: %v", err)
+	}
+	if !isCoordinatorSession("other-repo@custom-branch", d) {
+		t.Error("isCoordinatorSession(post-migration coordinator on non-main branch): got false, want true — this is the core correctness assertion of the DB-backed migration")
 	}
 
 	// Post-migration worker row: DB says false.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2571,7 +2571,8 @@ func TestIsReviewAgentSession(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isReviewAgentSession(tc.sessionName)
+			// Pass nil DB to exercise the name-heuristic fallback path.
+			got := isReviewAgentSession(tc.sessionName, nil)
 			if got != tc.want {
 				t.Errorf("isReviewAgentSession(%q) = %v, want %v", tc.sessionName, got, tc.want)
 			}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2580,6 +2580,53 @@ func TestIsReviewAgentSession(t *testing.T) {
 	}
 }
 
+// TestIsCoordinatorSession verifies the DB-backed isCoordinatorSession helper.
+func TestIsCoordinatorSession(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	// Happy path: post-migration coordinator row.
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+	if !isCoordinatorSession("repo@main", d) {
+		t.Error("isCoordinatorSession(post-migration coordinator): got false, want true")
+	}
+
+	// Post-migration worker row: DB says false.
+	if err := d.UpsertStatusSeedRootAgentName("repo@feature", "repo", "/code/feature", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+	if isCoordinatorSession("repo@feature", d) {
+		t.Error("isCoordinatorSession(post-migration worker): got true, want false")
+	}
+
+	// Pre-migration NULL root_agent_name: row exists but NULL — falls back to name heuristic.
+	if err := d.UpsertStatus("repo@main-old", "repo", "/code/main-old", "active", nil, nil); err != nil {
+		t.Fatalf("seed pre-migration coordinator: %v", err)
+	}
+	// repo@main-old does NOT end with "@main", so heuristic returns false.
+	if isCoordinatorSession("repo@main-old", d) {
+		t.Error("isCoordinatorSession(pre-migration non-main): got true, want false")
+	}
+	// Create a session that ends with @main but has NULL root_agent_name.
+	if err := d.UpsertStatus("other@main", "other", "/code/other/main", "active", nil, nil); err != nil {
+		t.Fatalf("seed other@main: %v", err)
+	}
+	// Pre-migration row with @main suffix: heuristic returns true.
+	if !isCoordinatorSession("other@main", d) {
+		t.Error("isCoordinatorSession(pre-migration @main): got false, want true (name heuristic)")
+	}
+
+	// No DB row: falls back to name heuristic.
+	if !isCoordinatorSession("newrepo@main", nil) {
+		t.Error("isCoordinatorSession(nil DB, @main): got false, want true")
+	}
+	if isCoordinatorSession("newrepo@feature", nil) {
+		t.Error("isCoordinatorSession(nil DB, non-main): got true, want false")
+	}
+}
+
 // TestNotifyCoordinator_ParentWorkerStillNotifies verifies that the parent
 // worker's own finish event (the session that ran `prism review`) continues to
 // propagate to the coordinator after its review-cycle completes. The parent


### PR DESCRIPTION
## Summary

- Adds 5 DB helper functions (`CoordinatorForRepo`, `RootAgentName`, `IsGroupMember`, `HasReviewGroup`, `GroupMembersForParent`) to `internal/db/db.go`
- Updates 8 call sites in `sidecar.go`, `cleanup.go`, and `checkin.go` to read `root_agent_name` / `group_id` from the DB instead of pattern-matching on session names (`@main`, `~review`, etc.)
- Pre-migration sessions with NULL `root_agent_name` fall back to the existing name-match heuristic with a deprecation warning logged

Closes #861