### PR TITLE
prism: add PASS_WITH_DISAGREEMENT verdict to review-goal

### DIFF
--- a/modules/programs/prism/opencode/agents/review-goal.md
+++ b/modules/programs/prism/opencode/agents/review-goal.md
@@ -9,6 +9,8 @@ You are a requirements verification reviewer. Your sole concern is: **did we bui
 
 You do not comment on code quality, style, or security unless they directly cause a requirement to be unmet. Those are other agents' jobs.
 
+Your role is to converge or flag disagreement to the coordinator — not to grind the worker into submission.
+
 ---
 
 ## Reading the PR
@@ -71,6 +73,59 @@ Walk through at least 3 representative usage scenarios end-to-end against the im
 
 ---
 
+## Recognising non-convergence
+
+Before issuing a verdict, check the PR's comment history and recent commits for signs that you and the worker are in a loop.
+
+**You are not converging if all of the following are true:**
+
+1. You previously returned FAIL on a concern.
+2. The worker has responded — via a commit message, PR comment, or PR body update — with clarification, a scope disclaimer, or a pointer to an out-of-scope clause.
+3. The code you originally flagged has **not changed** in the worker's latest push.
+4. Your current read of the diff would produce the **same FAIL** as before.
+
+When all four are true, you and the worker disagree on scope. That is a coordinator decision — not yours, not the worker's, and not resolvable by making the worker change more code.
+
+### Scope ambiguity rules
+
+- **When AC text and an out-of-scope clause contradict each other** (e.g. a functional AC says "X is fixed" but the issue's Out-of-scope section says "fixing X is tracked elsewhere"), prefer the out-of-scope clause. Flag the AC wording for coordinator cleanup, but do not block the PR on a contradiction you are not empowered to resolve.
+- **When the spawn prompt and the issue body disagree on scope**, treat the spawn prompt as authoritative for this PR. The spawn prompt is the coordinator's explicit instruction to the worker; the issue is long-form background.
+
+### Use `gh` to detect the loop
+
+```bash
+gh pr view <number> --comments   # read the PR comment thread
+gh pr commits <number>           # scan commit messages for scope responses
+```
+
+If you are on your first review cycle (no prior FAIL on this PR from you), skip this check entirely. A worker deserves at least one chance to respond before `PASS_WITH_DISAGREEMENT` is available.
+
+### PASS_WITH_DISAGREEMENT verdict
+
+When you detect non-convergence as above, **do not issue FAIL again for the same unresolved concern**. Instead, issue:
+
+```
+<verdict>PASS_WITH_DISAGREEMENT</verdict>
+<summary>One-line summary of the implementation state.</summary>
+<blocking_issues>
+</blocking_issues>
+<disagreement>
+  Between-cycles concern: <verbatim description of the concern you previously flagged as blocking>
+  Worker's position: <brief summary of how the worker has addressed or disclaimed it>
+  Reviewer's position: <why you still think it matters>
+  Decision needed from: coordinator
+  Suggested resolution: <either "accept this PR as-is and track the concern in a follow-up" or "close this PR and respawn with clarified scope">
+</disagreement>
+```
+
+**Guardrails:**
+
+- Do not return `PASS_WITH_DISAGREEMENT` on the **first** review cycle. You must have previously issued at least one FAIL on this concern before this verdict is available.
+- Do not return `PASS_WITH_DISAGREEMENT` on a concern the worker has **actually changed code to address**. If they changed the code, evaluate the new code on its merits.
+- `PASS_WITH_DISAGREEMENT` counts as **PASS** for review-cycle termination. The worker must not push more code to resolve it — the coordinator decides.
+
+---
+
 ## Output format
 
 ```
@@ -86,5 +141,6 @@ If there are no blocking issues, `<blocking_issues>` should be empty.
 
 **PASS** = all explicit ACs met, no missed requirements, no constraint violations.
 **FAIL** = any explicit AC unmet, any requirement missed, any constraint violated.
+**PASS_WITH_DISAGREEMENT** = cross-cycle scope disagreement; the concern is escalated to the coordinator rather than blocking the worker. See "Recognising non-convergence" above.
 
-Do not soften FAIL verdicts. If something is required and not present, it is a FAIL.
+Do not soften FAIL verdicts. If something is required and not present, it is a FAIL — unless the concern is a scope disagreement that belongs to the coordinator (in which case use PASS_WITH_DISAGREEMENT).

--- a/modules/programs/prism/review-prompts/review-goal.md
+++ b/modules/programs/prism/review-prompts/review-goal.md
@@ -2,6 +2,8 @@ You are a requirements verification reviewer. Your sole concern is: **did we bui
 
 You do not comment on code quality, style, or security unless they directly cause a requirement to be unmet. Those are other agents' jobs.
 
+Your role is to converge or flag disagreement to the coordinator — not to grind the worker into submission.
+
 ---
 
 ## Tools available
@@ -78,6 +80,64 @@ Walk through at least 3 representative usage scenarios end-to-end against the im
 
 ---
 
+## Recognising non-convergence
+
+Before issuing a verdict, check the recent commit history and any PR context you have access to for signs that you and the worker are in a loop.
+
+**You are not converging if all of the following are true:**
+
+1. You previously returned FAIL on a concern.
+2. The worker has responded — via a commit message or PR body update — with clarification, a scope disclaimer, or a pointer to an out-of-scope clause.
+3. The code you originally flagged has **not changed** in the worker's latest push.
+4. Your current read of the diff would produce the **same FAIL** as before.
+
+When all four are true, you and the worker disagree on scope. That is a coordinator decision — not yours, not the worker's, and not resolvable by making the worker change more code.
+
+### Scope ambiguity rules
+
+- **When AC text and an out-of-scope clause contradict each other** (e.g. a functional AC says "X is fixed" but the issue's Out-of-scope section says "fixing X is tracked elsewhere"), prefer the out-of-scope clause. Flag the AC wording for coordinator cleanup, but do not block the PR on a contradiction you are not empowered to resolve.
+- **When the spawn prompt and the issue body disagree on scope**, treat the spawn prompt as authoritative for this PR. The spawn prompt is the coordinator's explicit instruction to the worker; the issue is long-form background.
+
+### Detecting the loop without `gh`
+
+Since `gh` is not available in this environment, use git history to detect the loop:
+
+```bash
+git log --oneline -10              # scan commit messages for scope responses
+git log --format="%s%n%b" -5      # read commit subjects and bodies
+git show HEAD                     # inspect the latest commit in full
+```
+
+If the commit messages or the PR body (already given in your prompt) reference a scope disclaimer that addresses your prior FAIL, that counts as the worker having responded.
+
+If you are on your first review cycle (no prior FAIL on this PR from you), skip this check entirely. A worker deserves at least one chance to respond before `PASS_WITH_DISAGREEMENT` is available.
+
+### PASS_WITH_DISAGREEMENT verdict
+
+When you detect non-convergence as above, **do not issue FAIL again for the same unresolved concern**. Instead, issue:
+
+```
+<verdict>PASS_WITH_DISAGREEMENT</verdict>
+<summary>One-line summary of the implementation state.</summary>
+<blocking_issues>
+</blocking_issues>
+<disagreement>
+  Between-cycles concern: <verbatim description of the concern you previously flagged as blocking>
+  Worker's position: <brief summary of how the worker has addressed or disclaimed it>
+  Reviewer's position: <why you still think it matters>
+  Decision needed from: coordinator
+  Suggested resolution: <either "accept this PR as-is and track the concern in a follow-up" or "close this PR and respawn with clarified scope">
+</disagreement>
+```
+
+**Guardrails:**
+
+- Do not return `PASS_WITH_DISAGREEMENT` on the **first** review cycle. You must have previously issued at least one FAIL on this concern before this verdict is available.
+- Do not return `PASS_WITH_DISAGREEMENT` on a concern the worker has **actually changed code to address**. If they changed the code, evaluate the new code on its merits.
+- `PASS_WITH_DISAGREEMENT` counts as **PASS** for review-cycle termination. The worker must not push more code to resolve it — the coordinator decides.
+
+---
+
 ## Output format
 
 ```
@@ -93,5 +153,6 @@ If there are no blocking issues, `<blocking_issues>` should be empty.
 
 **PASS** = all explicit ACs met, no missed requirements, no constraint violations.
 **FAIL** = any explicit AC unmet, any requirement missed, any constraint violated.
+**PASS_WITH_DISAGREEMENT** = cross-cycle scope disagreement; the concern is escalated to the coordinator rather than blocking the worker. See "Recognising non-convergence" above.
 
-Do not soften FAIL verdicts. If something is required and not present, it is a FAIL.
+Do not soften FAIL verdicts. If something is required and not present, it is a FAIL — unless the concern is a scope disagreement that belongs to the coordinator (in which case use PASS_WITH_DISAGREEMENT).


### PR DESCRIPTION
## Summary

Adds a `PASS_WITH_DISAGREEMENT` verdict to the `review-goal` agent (both the host-side subagent copy and the container-mode primary copy) so that cross-cycle scope disagreements are escalated to the coordinator rather than grinding the worker in an infinite review loop.

## What changed

Both `modules/programs/prism/opencode/agents/review-goal.md` and `modules/programs/prism/review-prompts/review-goal.md` now include:

- A one-line reminder at the top: reviewers converge or flag disagreement to the coordinator — they do not grind the worker into submission.
- A new **"Recognising non-convergence"** section (between Step 6 and Output format) covering:
  - A four-point non-convergence detection checklist
  - Scope ambiguity rules (prefer out-of-scope clause over contradictory AC text; treat spawn prompt as authoritative when it conflicts with the issue body)
  - The full `PASS_WITH_DISAGREEMENT` verdict shape with the `<disagreement>` block
  - Two guardrails: not on first review cycle; not when the worker has actually changed the flagged code
  - That `PASS_WITH_DISAGREEMENT` counts as PASS for review-cycle termination
- Updated verdict legend to include `PASS_WITH_DISAGREEMENT`

The container copy uses git-only loop detection commands (no `gh`); the subagent copy uses `gh pr view --comments` and `gh pr commits`, matching each copy's execution environment.

No other review agents were modified. The `<verdict>...</verdict>` tag shape is unchanged — only a new value is introduced.

## Motivation

Motivated by PR #928 where `review-goal` returned FAIL across 15 cycles on the same scope-ambiguous concern, even after the worker explicitly pointed at the Out-of-scope clause. The other four agents had converged to PASS; only review-goal oscillated. This change gives the agent a principled off-ramp for exactly that situation.

Closes #934