### PR TITLE
prism: fix stale opencode_port comments (Class C of #927)

### DIFF
--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -554,7 +554,7 @@ func ensureAndSwitch(path string, projectRoot string, opts session.Opts) error {
 	}
 
 	// Allocate a port for full-layout sessions. The agent_status row must
-	// exist before we can write opencode_port to it, so we allocate after
+	// exist before we can write harness_port to it, so we allocate after
 	// session.Create (which seeds agent_status via `prism event
 	// tmux-session-start`). However, BuildOpencodeCmd needs the port at
 	// session creation time (it's called inside setupFullLayout). To break

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -523,7 +523,7 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// the opencode log. ContainerPort is retained as a fallback for the
 	// theoretical case where AllocatedPort is unset (e.g. a malformed session
 	// row); in normal operation cfg.AllocatedPort is always populated by
-	// agent-run from the DB's opencode_port column.
+	// agent-run from the DB's harness_port column.
 	opencodePort := cfg.AllocatedPort
 	if opencodePort == 0 {
 		opencodePort = ContainerPort


### PR DESCRIPTION
## Summary

Fix two stale doc comments that referred to the old `opencode_port` column name. The code already reads/writes the correct `harness_port` field; only the comments were behind.

### Changes

- `internal/container/bwrap.go:526` — `"DB's opencode_port column"` → `"DB's harness_port column"`
- `cmd/switch.go:557` — `"write opencode_port to it"` → `"write harness_port to it"`

### Scope

This is **PR 1 of 3** for #927 (Class C: comment-only cleanup). PRs 2 and 3 (Class B stats rename and Class A schema/payload migration) remain outstanding under the same issue.

Refs #927