### PR TITLE
prism: block coordinator sessions from invoking `prism review`

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 var reviewCmd = &cobra.Command{
@@ -57,6 +58,17 @@ func init() {
 
 func runReview(cmd *cobra.Command, args []string) error {
 	prNumber := args[0]
+
+	// Coordinator guard: prism review is a worker-only command.
+	// Check before spawning any sessions so that a coordinator hitting this
+	// guard does not create orphaned review-agent sessions.
+	// Detection: DB-backed (root_agent_name == "coordinator") with a name-suffix
+	// heuristic fallback for pre-migration rows (session ends with "@main").
+	// A NULL root_agent_name row (pre-migration) falls back to the heuristic
+	// with a deprecation log — not a hard failure.
+	if err := rejectIfCoordinator(); err != nil {
+		return err
+	}
 
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
@@ -325,4 +337,45 @@ func agentNameStrings(agents []review.Agent) []string {
 		names[i] = a.Name
 	}
 	return names
+}
+
+// rejectIfCoordinator returns an error if the invoking session is a coordinator.
+// It resolves the current session name from PRISM_SESSION_NAME (set inside
+// containers/agents) or the current tmux session, then uses a DB-backed lookup
+// (root_agent_name == "coordinator") with a name-suffix heuristic fallback
+// for pre-migration rows. When no session can be identified, the check is
+// skipped (no error) so that ad-hoc invocations outside any session are not
+// blocked.
+func rejectIfCoordinator() error {
+	// Resolve the caller's session name.
+	callerSession := review.LookupParentSession()
+	if callerSession == "" {
+		// Cannot determine session — skip the guard to avoid blocking
+		// ad-hoc (non-tmux) invocations.
+		return nil
+	}
+
+	// Open the DB for the lookup. A DB open failure is non-fatal: we fall
+	// back to the name-suffix heuristic inside IsCoordinatorSession.
+	d, dbErr := openDB()
+	if dbErr != nil {
+		d = nil
+	}
+	if d != nil {
+		defer d.Close()
+	}
+
+	if session.IsCoordinatorSession(callerSession, d) {
+		return fmt.Errorf(`prism review: this command is for worker sessions only.
+
+Coordinators do not run review directly. To review a PR, delegate to a worker:
+
+  prism spawn --pr <number> --prompt 'read the PR and linked issue, run prism review <number>, and report findings'
+
+The worker will run the review agents as children of its own session, which is
+the correct parent for review attribution.
+
+See: modules/programs/prism/opencode/agents/coordinator.md`)
+	}
+	return nil
 }

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -383,3 +383,130 @@ func TestAgentNameStrings(t *testing.T) {
 		}
 	}
 }
+
+// ── rejectIfCoordinator tests ─────────────────────────────────────────────────
+//
+// These tests cover the coordinator guard added by issue #846.
+// All tests set PRISM_SESSION_NAME (and TMUX="" to avoid tmux look-ups) to
+// control which session is detected, and set testDBPath to an isolated temp DB.
+
+// TestRejectIfCoordinator_BlocksCoordinatorSession verifies that a session
+// whose root_agent_name is "coordinator" in the DB causes rejectIfCoordinator
+// to return a non-nil error. This is the primary functional AC: a coordinator
+// session running prism review must be rejected before any sessions spawn.
+func TestRejectIfCoordinator_BlocksCoordinatorSession(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const coordSession = "nixos-config@main"
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	// Make review.LookupParentSession return the coordinator session.
+	t.Setenv("PRISM_SESSION_NAME", coordSession)
+	t.Setenv("TMUX", "") // ensure no tmux fallback
+
+	err := rejectIfCoordinator()
+	if err == nil {
+		t.Fatal("rejectIfCoordinator: expected error for coordinator session, got nil — coordinator must be blocked")
+	}
+	if !strings.Contains(err.Error(), "worker sessions only") {
+		t.Errorf("rejectIfCoordinator error %q does not mention 'worker sessions only'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "prism spawn") {
+		t.Errorf("rejectIfCoordinator error %q does not mention 'prism spawn'", err.Error())
+	}
+}
+
+// TestRejectIfCoordinator_AllowsWorkerSession verifies that a session whose
+// root_agent_name is "worker" in the DB is NOT blocked by rejectIfCoordinator.
+// This is the regression AC: worker sessions must continue to work as before.
+func TestRejectIfCoordinator_AllowsWorkerSession(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const workerSession = "nixos-config@feature-branch"
+	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	t.Setenv("PRISM_SESSION_NAME", workerSession)
+	t.Setenv("TMUX", "")
+
+	if err := rejectIfCoordinator(); err != nil {
+		t.Errorf("rejectIfCoordinator: unexpected error for worker session: %v", err)
+	}
+}
+
+// TestRejectIfCoordinator_NullRootAgentName_MainFallback verifies that a
+// pre-migration row with NULL root_agent_name and a @main session name causes
+// rejectIfCoordinator to fall back to the name-suffix heuristic and return an
+// error (the @main heuristic identifies it as a coordinator).
+func TestRejectIfCoordinator_NullRootAgentName_MainFallback(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	// UpsertStatus leaves root_agent_name NULL (pre-migration path).
+	const coordSession = "nixos-config@main"
+	if err := d.UpsertStatus(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	t.Setenv("PRISM_SESSION_NAME", coordSession)
+	t.Setenv("TMUX", "")
+
+	// The heuristic should identify nixos-config@main as a coordinator.
+	err := rejectIfCoordinator()
+	if err == nil {
+		t.Fatal("rejectIfCoordinator: expected error for @main session with NULL root_agent_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "worker sessions only") {
+		t.Errorf("rejectIfCoordinator error %q does not mention 'worker sessions only'", err.Error())
+	}
+}
+
+// TestRejectIfCoordinator_NullRootAgentName_WorkerFallback verifies that a
+// pre-migration row with NULL root_agent_name and a non-@main session name
+// does NOT cause rejectIfCoordinator to block (heuristic: not @main → worker).
+func TestRejectIfCoordinator_NullRootAgentName_WorkerFallback(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const workerSession = "nixos-config@feature-branch"
+	if err := d.UpsertStatus(workerSession, "nixos-config", "/worktree/feature-branch", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	t.Setenv("PRISM_SESSION_NAME", workerSession)
+	t.Setenv("TMUX", "")
+
+	if err := rejectIfCoordinator(); err != nil {
+		t.Errorf("rejectIfCoordinator: unexpected error for non-@main session with NULL root_agent_name: %v", err)
+	}
+}
+
+// TestRejectIfCoordinator_NoSession_NoError verifies that when no session can
+// be determined (PRISM_SESSION_NAME unset, TMUX unset), rejectIfCoordinator
+// returns nil — ad-hoc (non-tmux) invocations must not be blocked.
+func TestRejectIfCoordinator_NoSession_NoError(t *testing.T) {
+	openReviewTestDB(t) // use isolated DB even though we don't query it
+
+	t.Setenv("PRISM_SESSION_NAME", "")
+	t.Setenv("TMUX", "")
+
+	if err := rejectIfCoordinator(); err != nil {
+		t.Errorf("rejectIfCoordinator: unexpected error when no session can be determined: %v", err)
+	}
+}
+
+// TestRejectIfCoordinator_NameHeuristicMainBlocked verifies that a @main
+// session blocks even when the DB has no row for it (no migration yet).
+// This covers the pure heuristic path for unregistered sessions.
+func TestRejectIfCoordinator_NameHeuristicMainBlocked(t *testing.T) {
+	openReviewTestDB(t) // empty DB — no rows
+
+	t.Setenv("PRISM_SESSION_NAME", "nixos-config@main")
+	t.Setenv("TMUX", "")
+
+	err := rejectIfCoordinator()
+	if err == nil {
+		t.Fatal("rejectIfCoordinator: expected error for @main session with no DB row, got nil")
+	}
+}

--- a/modules/programs/prism/prism/internal/session/meta.go
+++ b/modules/programs/prism/prism/internal/session/meta.go
@@ -1,5 +1,12 @@
 package session
 
+import (
+	"log"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
 // ScratchpadSession is the canonical name of the prism scratchpad tmux session.
 const ScratchpadSession = "scratchpad"
 
@@ -13,4 +20,42 @@ func IsMetaSession(name string) bool {
 		return true
 	}
 	return false
+}
+
+// IsCoordinatorSession reports whether the named session is a coordinator.
+//
+// Detection strategy (in order):
+//  1. DB-backed: if d is non-nil and the session has a row with a non-NULL
+//     root_agent_name, return root_agent_name == "coordinator". This is the
+//     primary signal introduced by PR #928 (Issue F / #861).
+//  2. NULL root_agent_name (pre-migration row): log a deprecation warning and
+//     fall through to the name-suffix heuristic.
+//  3. No DB, DB error, or no row: fall back to the name-suffix heuristic
+//     (session name ends with "@main"), which matches the convention used by
+//     isCoordinator() in sidecar.go.
+//
+// The d parameter may be nil; when nil the DB-backed lookup is skipped and
+// only the heuristic is used.
+func IsCoordinatorSession(sessionName string, d *db.DB) bool {
+	if d != nil {
+		name, rowExists, err := d.RootAgentName(sessionName)
+		if err == nil && rowExists {
+			if name != "" {
+				dbBased := name == "coordinator"
+				nameBased := strings.HasSuffix(sessionName, "@main")
+				if dbBased != nameBased {
+					log.Printf("[debug] session: IsCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v",
+						sessionName, dbBased, name, nameBased)
+				}
+				return dbBased
+			}
+			// Row exists but root_agent_name is NULL — pre-migration row.
+			log.Printf("[deprecation] session: IsCoordinatorSession(%q): root_agent_name is NULL — pre-migration row, falling back to name heuristic", sessionName)
+		} else if err != nil {
+			log.Printf("session: IsCoordinatorSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
+		}
+		// rowExists=false: no row yet — fall through to heuristic silently.
+	}
+	// Pre-migration fallback or DB unavailable: use name-suffix heuristic.
+	return strings.HasSuffix(sessionName, "@main")
 }

--- a/modules/programs/prism/prism/internal/session/meta_test.go
+++ b/modules/programs/prism/prism/internal/session/meta_test.go
@@ -1,6 +1,11 @@
 package session
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
 
 func TestIsMetaSession(t *testing.T) {
 	t.Parallel()
@@ -31,5 +36,112 @@ func TestIsMetaSession(t *testing.T) {
 				t.Errorf("IsMetaSession(%q) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+// openTestDB opens a fresh temp SQLite DB for session tests and registers cleanup.
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// ── IsCoordinatorSession tests ───────────────────────────────────────────────
+
+// TestIsCoordinatorSession_DBBackedCoordinator verifies the primary DB-backed
+// path: a session with root_agent_name == "coordinator" returns true.
+func TestIsCoordinatorSession_DBBackedCoordinator(t *testing.T) {
+	d := openTestDB(t)
+	const sess = "nixos-config@main"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	if !IsCoordinatorSession(sess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = false, want true (coordinator in DB)", sess)
+	}
+}
+
+// TestIsCoordinatorSession_DBBackedWorker verifies that a session with
+// root_agent_name == "worker" returns false, even though its name ends with @main
+// (pathological edge-case: a worker named with @main suffix).
+func TestIsCoordinatorSession_DBBackedWorker(t *testing.T) {
+	d := openTestDB(t)
+	// A worker session that happens to end with @main — DB must win over heuristic.
+	const sess = "nixos-config@main"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "worker"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	if IsCoordinatorSession(sess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = true, want false (DB says worker)", sess)
+	}
+}
+
+// TestIsCoordinatorSession_DBBackedWorkerBranch verifies a normal worker
+// session (non-@main branch) with root_agent_name == "worker" returns false.
+func TestIsCoordinatorSession_DBBackedWorkerBranch(t *testing.T) {
+	d := openTestDB(t)
+	const sess = "nixos-config@feature-branch"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	if IsCoordinatorSession(sess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = true, want false (worker on feature branch)", sess)
+	}
+}
+
+// TestIsCoordinatorSession_NullRootAgentName_FallsBackToHeuristic verifies
+// that a pre-migration row with NULL root_agent_name falls back to the
+// name-suffix heuristic rather than returning a hard error.
+// A @main-suffixed session should return true; a non-@main session false.
+func TestIsCoordinatorSession_NullRootAgentName_FallsBackToHeuristic(t *testing.T) {
+	d := openTestDB(t)
+	// UpsertStatus leaves root_agent_name NULL (pre-migration path).
+	const coordSess = "nixos-config@main"
+	const workerSess = "nixos-config@feature-branch"
+	if err := d.UpsertStatus(coordSess, "nixos-config", "/worktree/main", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (coordinator): %v", err)
+	}
+	if err := d.UpsertStatus(workerSess, "nixos-config", "/worktree/feature", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (worker): %v", err)
+	}
+
+	if !IsCoordinatorSession(coordSess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = false, want true (NULL root_agent_name, @main heuristic)", coordSess)
+	}
+	if IsCoordinatorSession(workerSess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = true, want false (NULL root_agent_name, non-@main)", workerSess)
+	}
+}
+
+// TestIsCoordinatorSession_NoRow_FallsBackToHeuristic verifies that when there
+// is no DB row at all, the name-suffix heuristic is used.
+func TestIsCoordinatorSession_NoRow_FallsBackToHeuristic(t *testing.T) {
+	d := openTestDB(t) // empty DB — no rows seeded
+
+	if !IsCoordinatorSession("nixos-config@main", d) {
+		t.Error("IsCoordinatorSession(nixos-config@main, emptyDB) = false, want true (no row → heuristic)")
+	}
+	if IsCoordinatorSession("nixos-config@feature", d) {
+		t.Error("IsCoordinatorSession(nixos-config@feature, emptyDB) = true, want false (no row → heuristic)")
+	}
+}
+
+// TestIsCoordinatorSession_NilDB_FallsBackToHeuristic verifies that when d is
+// nil (DB unavailable), the name-suffix heuristic is used unconditionally.
+func TestIsCoordinatorSession_NilDB_FallsBackToHeuristic(t *testing.T) {
+	if !IsCoordinatorSession("nixos-config@main", nil) {
+		t.Error("IsCoordinatorSession(nixos-config@main, nil) = false, want true (nil DB → heuristic)")
+	}
+	if IsCoordinatorSession("nixos-config@feature", nil) {
+		t.Error("IsCoordinatorSession(nixos-config@feature, nil) = true, want false (nil DB → heuristic)")
+	}
+	// Edge case: empty session name should not be considered coordinator.
+	if IsCoordinatorSession("", nil) {
+		t.Error("IsCoordinatorSession(\"\", nil) = true, want false")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a coordinator guard at the entry point of `runReview` in `cmd/review.go` that fires **before any review-agent sessions are spawned**. When a coordinator session invokes `prism review`, it exits non-zero with a clear error message pointing to the correct `prism spawn --pr` delegation pattern.
- Adds an exported `session.IsCoordinatorSession(sessionName string, d *db.DB) bool` helper in `internal/session/meta.go` using the same DB-backed + heuristic strategy as `sidecar.go`'s existing `isCoordinatorSession` (PR #928), but in a package that `cmd/` can import without a cycle.
- 6 new tests for `IsCoordinatorSession` and 6 new tests for `rejectIfCoordinator`.

## Detection strategy

1. **DB-backed** (`root_agent_name == "coordinator"` — primary signal from PR #928/#861)
2. **Pre-migration fallback**: NULL `root_agent_name` → name-suffix heuristic (session ends with `@main`) + deprecation log
3. **No row / DB error / nil DB**: name-suffix heuristic
4. **No session name** (outside tmux, `PRISM_SESSION_NAME` unset): guard is skipped — ad-hoc invocations are not blocked

## Error message shown to coordinator

```
prism review: this command is for worker sessions only.

Coordinators do not run review directly. To review a PR, delegate to a worker:

  prism spawn --pr <number> --prompt 'read the PR and linked issue, run prism review <number>, and report findings'

The worker will run the review agents as children of its own session, which is
the correct parent for review attribution.

See: modules/programs/prism/opencode/agents/coordinator.md
```

## Quality gates

- `go build ./...` ✅
- `go test ./internal/session/...` ✅ (all pass including 6 new `IsCoordinatorSession` tests)
- `go test ./cmd/... -run TestRejectIfCoordinator|TestResolveReviewWorktree|...` ✅ (all pass including 6 new `rejectIfCoordinator` tests)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Pre-existing unrelated tmux/multi-client test failures (`TestSwitchPath_OnlyMovesTargetClient`, `TestCleanupYes_*`, dashboard timeout tests) were already failing on `main` before this change.

Closes #846