### PR TITLE
prism: propagate agent.envVars and fix TERM/COLORTERM in bwrap sandbox

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -123,6 +123,14 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		hostAPISockPath = sockPath
 	}
 
+	// Load profiles.json for agent env vars (e.g. GIT_EDITOR, KUBECONFIG,
+	// AWS_CONFIG_FILE). Non-fatal if missing — agent env vars are injected on
+	// a best-effort basis.
+	var agentEnvVars map[string]string
+	if pf, pfErr := config.LoadProfiles(); pfErr == nil && pf != nil {
+		agentEnvVars = pf.AgentEnvVars
+	}
+
 	// Populate harness-specific runtime env vars for the bwrap sandbox.
 	agentRunHarness := opencode.New("", nil, "", "")
 	ctrCfg := container.Config{
@@ -138,6 +146,7 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		SshSigningKeyName: cfg.SshSigningKeyName,
 		HostAPISockPath:   hostAPISockPath,
 		RuntimeEnv:        agentRunHarness.RuntimeEnv(),
+		AgentEnvVars:      agentEnvVars,
 	}
 
 	// Read the initial prompt from the pane env var set by session.go at
@@ -192,13 +201,14 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 // other secret a prism coordinator might export — is dropped.
 func minimalBwrapExecEnv(hostEnv []string) []string {
 	allow := map[string]bool{
-		"PATH":    true,
-		"HOME":    true,
-		"USER":    true,
-		"LOGNAME": true,
-		"TERM":    true,
-		"LANG":    true,
-		"LC_ALL":  true,
+		"PATH":      true,
+		"HOME":      true,
+		"USER":      true,
+		"LOGNAME":   true,
+		"TERM":      true,
+		"COLORTERM": true,
+		"LANG":      true,
+		"LC_ALL":    true,
 	}
 	out := make([]string, 0, len(allow))
 	for _, kv := range hostEnv {

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -177,13 +177,15 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// adapter with the resolved model is constructed below for the sidecar.
 	agentModel := opencode.New("", nil, agentRole, "").EffectiveModel(agentRole)
 
-	// Load profiles to extract container resource caps. Non-fatal if missing
-	// (e.g. running without the nix module) — resource fields remain at their
-	// zero values and no resource flags are emitted.
+	// Load profiles to extract container resource caps and agent env vars.
+	// Non-fatal if missing (e.g. running without the nix module) — resource
+	// fields remain at their zero values and no resource flags are emitted.
 	var containerResources config.ContainerResources
+	var agentEnvVars map[string]string
 	if podmanMode {
 		if pf, pfErr := config.LoadProfiles(); pfErr == nil {
 			containerResources = pf.ContainerResources
+			agentEnvVars = pf.AgentEnvVars
 		}
 	}
 
@@ -222,6 +224,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 			MemoryMax:         containerResources.MemoryMax,
 			MemorySwapMax:     containerResources.MemorySwapMax,
 			PidsLimit:         containerResources.PidsLimit,
+			AgentEnvVars:      agentEnvVars,
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -100,8 +100,9 @@ func fallbackPATH() string {
 //     $SHELL (opencode's bash tool, most TUIs) gets a clean shell that
 //     doesn't wipe credentials.
 //
-// TERM is NOT included here — it is handled separately by BuildArgs so that
-// its fixed value ("xterm-256color") is always used regardless of the host.
+// TERM is NOT included here — it is handled separately by BuildArgs, where
+// the host's TERM is passed through verbatim (falling back to xterm-256color
+// only when TERM is unset on the host). COLORTERM is similarly handled there.
 func standardSandboxEnvArgs() []string {
 	var args []string
 

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -455,11 +456,47 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--setenv", k, v)
 	}
 
+	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true, KUBECONFIG,
+	// AWS_CONFIG_FILE). These come from profiles.json agent_env_vars (written
+	// by Nix). Emitted in sorted key order for determinism. bwrap --setenv
+	// takes KEY and VALUE as distinct argv elements so no shell quoting is
+	// needed — special characters in values are passed verbatim.
+	if len(cfg.AgentEnvVars) > 0 {
+		keys := make([]string, 0, len(cfg.AgentEnvVars))
+		for k := range cfg.AgentEnvVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "--setenv", k, cfg.AgentEnvVars[k])
+		}
+	}
+
 	// NIX_CONFIG: tell nix to use the host daemon for store operations.
 	args = append(args, "--setenv", "NIX_CONFIG", "store = daemon")
 
-	// TERM: xterm-256color for full SGR mouse support in the TUI.
-	args = append(args, "--setenv", "TERM", "xterm-256color")
+	// TERM: pass through the host's TERM so that the sandbox sees the same
+	// terminal type as the tmux pane (e.g. tmux-256color). In bwrap mode the
+	// host terminfo tree is already bind-mounted (/etc, /nix, /run/current-system),
+	// so any terminfo entry the host has is resolvable inside the sandbox.
+	// This is intentionally different from the podman path, which hardcodes
+	// xterm-256color because the container image may not ship tmux-256color.
+	// Fallback to xterm-256color only if TERM is unset on the host (shouldn't
+	// happen from a tmux pane, but guard anyway).
+	{
+		termVal := os.Getenv("TERM")
+		if termVal == "" {
+			termVal = "xterm-256color"
+		}
+		args = append(args, "--setenv", "TERM", termVal)
+	}
+
+	// COLORTERM: pass through the host's COLORTERM when set so that TUI
+	// libraries receive the truecolor signal. Only injected when the host
+	// has it set — no fabricated value is inserted when it is absent.
+	if colorterm := os.Getenv("COLORTERM"); colorterm != "" {
+		args = append(args, "--setenv", "COLORTERM", colorterm)
+	}
 
 	// Standard env vars: PATH (with fallback), HOME, USER, LOGNAME, LANG,
 	// LC_ALL, SHELL. These ensure that binaries resolve correctly inside the
@@ -581,13 +618,14 @@ func (b *bwrapIsolator) Run(ctx context.Context, args []string) error {
 // call site. Both filters use the same allow-list; keep them in sync.
 func minimalBwrapExecEnv(hostEnv []string) []string {
 	allow := map[string]bool{
-		"PATH":    true,
-		"HOME":    true,
-		"USER":    true,
-		"LOGNAME": true,
-		"TERM":    true,
-		"LANG":    true,
-		"LC_ALL":  true,
+		"PATH":      true,
+		"HOME":      true,
+		"USER":      true,
+		"LOGNAME":   true,
+		"TERM":      true,
+		"COLORTERM": true,
+		"LANG":      true,
+		"LC_ALL":    true,
 	}
 	out := make([]string, 0, len(allow))
 	for _, kv := range hostEnv {

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -244,7 +244,8 @@ func TestMinimalBwrapExecEnv_DropsSecrets(t *testing.T) {
 		"HOME=/home/ben",
 		"USER=ben",
 		"LOGNAME=ben",
-		"TERM=xterm-256color",
+		"TERM=tmux-256color",
+		"COLORTERM=truecolor",
 		"LANG=en_NZ.UTF-8",
 		"LC_ALL=en_NZ.UTF-8",
 
@@ -270,7 +271,8 @@ func TestMinimalBwrapExecEnv_DropsSecrets(t *testing.T) {
 		"HOME=/home/ben",
 		"USER=ben",
 		"LOGNAME=ben",
-		"TERM=xterm-256color",
+		"TERM=tmux-256color",
+		"COLORTERM=truecolor",
 		"LANG=en_NZ.UTF-8",
 		"LC_ALL=en_NZ.UTF-8",
 	}
@@ -287,7 +289,7 @@ func TestMinimalBwrapExecEnv_DropsSecrets(t *testing.T) {
 	// Every output pair must be on the allow-list — nothing else should leak.
 	allowedKeys := map[string]bool{
 		"PATH": true, "HOME": true, "USER": true, "LOGNAME": true,
-		"TERM": true, "LANG": true, "LC_ALL": true,
+		"TERM": true, "COLORTERM": true, "LANG": true, "LC_ALL": true,
 	}
 	for _, kv := range out {
 		eq := -1
@@ -963,7 +965,33 @@ func TestBwrapBuildArgs_NixConfigSetenv(t *testing.T) {
 	}
 }
 
-func TestBwrapBuildArgs_TermSetenv(t *testing.T) {
+// TestBwrapBuildArgs_TermPassthrough verifies that the host TERM value is
+// passed through verbatim into the sandbox (e.g. tmux-256color). bwrap mode
+// bind-mounts the host terminfo tree so any host TERM entry is resolvable
+// inside the sandbox.
+func TestBwrapBuildArgs_TermPassthrough(t *testing.T) {
+	t.Setenv("TERM", "tmux-256color")
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "TERM", "tmux-256color") {
+		t.Errorf("--setenv TERM tmux-256color not found in args: %v", args)
+	}
+}
+
+// TestBwrapBuildArgs_TermFallbackWhenUnset verifies that when TERM is unset on
+// the host, the sandbox receives the safe fallback value xterm-256color.
+func TestBwrapBuildArgs_TermFallbackWhenUnset(t *testing.T) {
+	t.Setenv("TERM", "")
+
 	m, _, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -975,7 +1003,29 @@ func TestBwrapBuildArgs_TermSetenv(t *testing.T) {
 	args := b.BuildArgs(m)
 
 	if !hasSetenv(args, "TERM", "xterm-256color") {
-		t.Errorf("--setenv TERM xterm-256color not found in args: %v", args)
+		t.Errorf("--setenv TERM xterm-256color (fallback) not found when TERM is empty, args: %v", args)
+	}
+}
+
+// TestBwrapBuildArgs_TermUnusualValue verifies that unusual TERM values
+// (e.g. alacritty-direct) are passed through verbatim without any shell
+// interpretation, since bwrap --setenv takes KEY and VALUE as distinct argv
+// elements.
+func TestBwrapBuildArgs_TermUnusualValue(t *testing.T) {
+	t.Setenv("TERM", "alacritty-direct")
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "TERM", "alacritty-direct") {
+		t.Errorf("--setenv TERM alacritty-direct not found in args: %v", args)
 	}
 }
 
@@ -1143,9 +1193,14 @@ func TestBwrapBuildArgs_PathFallbackInBuildArgs(t *testing.T) {
 	}
 }
 
-// TestBwrapBuildArgs_TermRegression guards the existing TERM=xterm-256color
-// behaviour from #876 — it must still be present after adding standard env vars.
+// TestBwrapBuildArgs_TermRegression guards that TERM is always injected into
+// the sandbox. When TERM is set on the host it is passed through; when unset
+// it falls back to xterm-256color (the previous hardcoded value, now a safe
+// default rather than an override).
 func TestBwrapBuildArgs_TermRegression(t *testing.T) {
+	// Simulate a normal tmux pane with TERM set.
+	t.Setenv("TERM", "tmux-256color")
+
 	m, _, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -1156,8 +1211,8 @@ func TestBwrapBuildArgs_TermRegression(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	if !hasSetenv(args, "TERM", "xterm-256color") {
-		t.Errorf("regression: --setenv TERM xterm-256color missing from args: %v", args)
+	if !hasSetenv(args, "TERM", "tmux-256color") {
+		t.Errorf("regression: --setenv TERM tmux-256color missing from args: %v", args)
 	}
 }
 
@@ -1174,6 +1229,137 @@ func TestBwrapBuildArgs_PrismSessionNameSetenv(t *testing.T) {
 
 	if !hasSetenv(args, "PRISM_SESSION_NAME", "myrepo@feat") {
 		t.Errorf("--setenv PRISM_SESSION_NAME myrepo@feat not found in args: %v", args)
+	}
+}
+
+// ── COLORTERM pass-through ────────────────────────────────────────────────────
+
+// TestBwrapBuildArgs_ColortermPassthrough verifies that when COLORTERM is set
+// on the host, it is injected into the sandbox so TUI libraries receive the
+// truecolor signal.
+func TestBwrapBuildArgs_ColortermPassthrough(t *testing.T) {
+	t.Setenv("COLORTERM", "truecolor")
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "COLORTERM", "truecolor") {
+		t.Errorf("--setenv COLORTERM truecolor not found in args: %v", args)
+	}
+}
+
+// TestBwrapBuildArgs_ColortermOmittedWhenUnset verifies that when COLORTERM is
+// not set on the host, no COLORTERM is injected into the sandbox (no fabricated
+// value).
+func TestBwrapBuildArgs_ColortermOmittedWhenUnset(t *testing.T) {
+	t.Setenv("COLORTERM", "")
+
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == "--setenv" && args[i+1] == "COLORTERM" {
+			t.Errorf("COLORTERM should be omitted when unset but found --setenv COLORTERM %q in args: %v", args[i+2], args)
+		}
+	}
+}
+
+// ── AgentEnvVars (--setenv K V) ───────────────────────────────────────────────
+
+// TestBwrapBuildArgs_AgentEnvVarsInjected verifies that entries in
+// Config.AgentEnvVars (e.g. GIT_EDITOR, KUBECONFIG, AWS_CONFIG_FILE) are
+// emitted as --setenv K V in the bwrap arg list.
+func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentEnvVars: map[string]string{
+			"GIT_EDITOR":      "true",
+			"KUBECONFIG":      "/home/ben/.config/kube/agents-config",
+			"AWS_CONFIG_FILE": "/home/ben/.config/aws/readonly-config",
+		},
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	cases := [][2]string{
+		{"GIT_EDITOR", "true"},
+		{"KUBECONFIG", "/home/ben/.config/kube/agents-config"},
+		{"AWS_CONFIG_FILE", "/home/ben/.config/aws/readonly-config"},
+	}
+	for _, c := range cases {
+		if !hasSetenv(args, c[0], c[1]) {
+			t.Errorf("--setenv %s %q not found in args: %v", c[0], c[1], args)
+		}
+	}
+}
+
+// TestBwrapBuildArgs_AgentEnvVarsEmptyNoExtra verifies that an empty
+// AgentEnvVars map produces no extra --setenv flags.
+func TestBwrapBuildArgs_AgentEnvVarsEmptyNoExtra(t *testing.T) {
+	// Collect baseline arg count with nil AgentEnvVars.
+	mNil, _, cleanupNil := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentEnvVars:  nil,
+	})
+	defer cleanupNil()
+	bNil := &bwrapIsolator{name: mNil.name}
+	argsNil := bNil.BuildArgs(mNil)
+
+	// Empty map should produce the same args as nil.
+	mEmpty, _, cleanupEmpty := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentEnvVars:  map[string]string{},
+	})
+	defer cleanupEmpty()
+	bEmpty := &bwrapIsolator{name: mEmpty.name}
+	argsEmpty := bEmpty.BuildArgs(mEmpty)
+
+	if len(argsEmpty) != len(argsNil) {
+		t.Errorf("empty AgentEnvVars should produce same arg count as nil: nil=%d, empty=%d", len(argsNil), len(argsEmpty))
+	}
+}
+
+// TestBwrapBuildArgs_AgentEnvVarsSpecialChars verifies that values containing
+// spaces and single quotes are passed through verbatim, since bwrap --setenv
+// takes VALUE as a distinct argv element and does no shell interpretation.
+func TestBwrapBuildArgs_AgentEnvVarsSpecialChars(t *testing.T) {
+	m, _, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentEnvVars: map[string]string{
+			"TRICKY_VAR": "value with spaces and 'quotes'",
+		},
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "TRICKY_VAR", "value with spaces and 'quotes'") {
+		t.Errorf("--setenv TRICKY_VAR with special chars not found verbatim in args: %v", args)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -32,6 +32,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 )
@@ -225,6 +226,14 @@ type Config struct {
 	// harness.Harness.RuntimeEnv() by the sidecar at container creation
 	// time. When nil, no harness-specific env vars are injected.
 	RuntimeEnv map[string]string
+
+	// AgentEnvVars holds the profile-level environment variables to inject
+	// into the agent shell. Each entry is emitted as --env KEY=VALUE (podman)
+	// or --setenv KEY VALUE (bwrap). Sourced from profiles.json agent_env_vars
+	// (written by Nix). These carry entries such as GIT_EDITOR=true,
+	// KUBECONFIG, and AWS_CONFIG_FILE into the sandboxed agent.
+	// When nil or empty, no profile env vars are injected.
+	AgentEnvVars map[string]string
 }
 
 // NameForSession returns the stable podman container name for a session.
@@ -1388,6 +1397,20 @@ func (m *Manager) buildRunArgs() []string {
 	// Inject credentials as environment variables (AC-10, AC-11).
 	for _, kv := range m.credentialEnvVars() {
 		args = append(args, "--env", kv)
+	}
+
+	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true, KUBECONFIG,
+	// AWS_CONFIG_FILE). These come from profiles.json agent_env_vars (written
+	// by Nix). Emitted in sorted key order for determinism.
+	if len(cfg.AgentEnvVars) > 0 {
+		keys := make([]string, 0, len(cfg.AgentEnvVars))
+		for k := range cfg.AgentEnvVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "--env", k+"="+cfg.AgentEnvVars[k])
+		}
 	}
 
 	// opencode.json: mount the generated config file when ConfigContent is set.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -3264,3 +3264,88 @@ func TestOpencodeConfigFilePath_MatchesManagerMethod(t *testing.T) {
 			m.name, exported, unexported)
 	}
 }
+
+// ── AgentEnvVars (--env K=V) ──────────────────────────────────────────────────
+
+// TestBuildRunArgs_AgentEnvVarsInjected verifies that entries in
+// Config.AgentEnvVars (e.g. GIT_EDITOR, KUBECONFIG, AWS_CONFIG_FILE) are
+// emitted as --env KEY=VALUE in the podman run arg list.
+func TestBuildRunArgs_AgentEnvVarsInjected(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentEnvVars: map[string]string{
+			"GIT_EDITOR":      "true",
+			"KUBECONFIG":      "/home/ben/.config/kube/agents-config",
+			"AWS_CONFIG_FILE": "/home/ben/.config/aws/readonly-config",
+		},
+	})
+	args := m.buildRunArgs()
+
+	cases := [][2]string{
+		{"GIT_EDITOR", "true"},
+		{"KUBECONFIG", "/home/ben/.config/kube/agents-config"},
+		{"AWS_CONFIG_FILE", "/home/ben/.config/aws/readonly-config"},
+	}
+	for _, c := range cases {
+		want := c[0] + "=" + c[1]
+		found := false
+		for i, arg := range args {
+			if arg == "--env" && i+1 < len(args) && args[i+1] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("--env %q not found in podman args: %v", want, args)
+		}
+	}
+}
+
+// TestBuildRunArgs_AgentEnvVarsEmptyNoExtra verifies that a nil or empty
+// AgentEnvVars map does not emit extra --env flags beyond the credential vars.
+func TestBuildRunArgs_AgentEnvVarsEmptyNoExtra(t *testing.T) {
+	mNil := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentEnvVars:  nil,
+	})
+	argsNil := mNil.buildRunArgs()
+
+	mEmpty := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentEnvVars:  map[string]string{},
+	})
+	argsEmpty := mEmpty.buildRunArgs()
+
+	if len(argsEmpty) != len(argsNil) {
+		t.Errorf("empty AgentEnvVars should produce same arg count as nil: nil=%d, empty=%d", len(argsNil), len(argsEmpty))
+	}
+}
+
+// TestBuildRunArgs_AgentEnvVarsSpecialChars verifies that values containing
+// spaces and single quotes are passed through verbatim as --env KEY=VALUE since
+// podman --env takes the value as a distinct argv element without shell parsing.
+func TestBuildRunArgs_AgentEnvVarsSpecialChars(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentEnvVars: map[string]string{
+			"TRICKY_VAR": "value with spaces and 'quotes'",
+		},
+	})
+	args := m.buildRunArgs()
+
+	want := "TRICKY_VAR=value with spaces and 'quotes'"
+	found := false
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && args[i+1] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("--env %q not found verbatim in podman args: %v", want, args)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two related env-propagation gaps in the bwrap (and podman) sandboxes.

### #931 — agent.envVars not reaching bwrap/container agent shells

`agent.envVars` from `profiles.json` (e.g. `GIT_EDITOR=true`, `KUBECONFIG`, `AWS_CONFIG_FILE`) was only injected for host-mode sessions. Container and bwrap sessions were silently missing them, causing failures like:

```
error: cannot run vi: No such file or directory
error: unable to start editor 'vi'
```

**Fix:**
- Add `AgentEnvVars map[string]string` to `container.Config`
- In `buildRunArgs` (podman): emit `--env KEY=VALUE` for each entry
- In `BuildArgs` (bwrap): emit `--setenv KEY VALUE` for each entry, in sorted key order
- In `cmd/sidecar.go`: load `profiles.json` and populate `AgentEnvVars` when in podman mode
- In `cmd/agent_run.go`: load `profiles.json` and populate `AgentEnvVars` when in bwrap mode

### #932 — bwrap hardcodes TERM=xterm-256color, clobbering tmux's TERM

`bwrap.go` was hardcoding `TERM=xterm-256color`, clobbering the tmux pane's actual `TERM=tmux-256color`. This was inherited from podman (container image may not have matching terminfo), which does not apply in bwrap since the host terminfo is bind-mounted.

**Fix:**
- Replace hardcoded `xterm-256color` with pass-through of host `$TERM`, falling back to `xterm-256color` only if unset
- Add conditional `COLORTERM` injection: inject only when the host has it set, never fabricate
- Add `COLORTERM` to both `minimalBwrapExecEnv` allowlists (`bwrap.go` and `cmd/agent_run.go`)
- Podman mode `TERM` handling unchanged (container image constraint still applies)

## Changes

- `internal/container/container.go`: Add `AgentEnvVars` to `Config`; emit `--env` for podman mode; add `sort` import
- `internal/container/bwrap.go`: Add `AgentEnvVars` injection; fix TERM pass-through; add COLORTERM; add `COLORTERM` to allowlist; add `sort` import
- `cmd/agent_run.go`: Load profiles.json for `AgentEnvVars`; add `COLORTERM` to allowlist
- `cmd/sidecar.go`: Load `AgentEnvVars` from profiles when in podman mode
- `internal/container/bwrap_test.go`: Replace hardcoded-TERM test with pass-through tests; add COLORTERM tests; add AgentEnvVars tests; update `TestMinimalBwrapExecEnv_DropsSecrets`
- `internal/container/container_test.go`: Add AgentEnvVars tests for podman mode

## Quality gates

- `go build ./...` ✅
- `go test ./internal/container/... ./internal/session/... ./cmd/...` ✅ (pre-existing flaky tests in `TestSwitchPath_OnlyMovesTargetClient` and tmux package excluded — they fail on main too)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

## Scope

- Only touches the two file groups specified: `internal/container/bwrap.go` (+ test), `internal/container/container.go` (+ test), `cmd/agent_run.go`, `cmd/sidecar.go`
- Does NOT DRY the two `minimalBwrapExecEnv` copies (follow-up concern, out of scope)
- Podman TERM handling unchanged

Closes #931
Closes #932