### PR TITLE
ix: improve statusCmd grep for battery-notifier

### DIFF
--- a/modules/services/battery-notifier.nix
+++ b/modules/services/battery-notifier.nix
@@ -448,7 +448,7 @@ in
         enable = true;
         udevTrigger = false; # The mouse doesn't have a standard udev event
         levelCmd = "${pkgs.polychromatic}/bin/polychromatic-cli -d mouse -k | grep Battery | sed 's/[^0-9]*//g' || echo 100";
-        statusCmd = "if ${pkgs.polychromatic}/bin/polychromatic-cli -d mouse -k | grep -q '[(]charging[)]'; then echo 'Charging'; else echo 'Discharging'; fi";
+        statusCmd = "if ${pkgs.polychromatic}/bin/polychromatic-cli -d mouse -k | grep -qF \"(charging)\"; then echo Charging; else echo Discharging; fi";
         lowThreshold = 20;
         dismissThreshold = 50;
         ignoreZero = true;


### PR DESCRIPTION
Updates the `statusCmd` in `battery-notifier.nix` to use `grep -qF` for literal string matching of "(charging)". This prevents potential regex interpretation issues and cleans up the output formatting.