### PR TITLE
fix: @main heuristic wins over stale root_agent_name in coordinator detection

### DIFF
--- a/modules/programs/prism/prism/internal/session/meta.go
+++ b/modules/programs/prism/prism/internal/session/meta.go
@@ -44,10 +44,10 @@ func IsCoordinatorSession(sessionName string, d *db.DB) bool {
 				dbBased := name == "coordinator"
 				nameBased := strings.HasSuffix(sessionName, "@main")
 				if dbBased != nameBased {
-					log.Printf("[debug] session: IsCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v",
+					log.Printf("[debug] session: IsCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v — heuristic wins",
 						sessionName, dbBased, name, nameBased)
 				}
-				return dbBased
+				return dbBased || nameBased
 			}
 			// Row exists but root_agent_name is NULL — pre-migration row.
 			log.Printf("[deprecation] session: IsCoordinatorSession(%q): root_agent_name is NULL — pre-migration row, falling back to name heuristic", sessionName)

--- a/modules/programs/prism/prism/internal/session/meta.go
+++ b/modules/programs/prism/prism/internal/session/meta.go
@@ -24,15 +24,18 @@ func IsMetaSession(name string) bool {
 
 // IsCoordinatorSession reports whether the named session is a coordinator.
 //
-// Detection strategy (in order):
+// Detection strategy:
 //  1. DB-backed: if d is non-nil and the session has a row with a non-NULL
-//     root_agent_name, return root_agent_name == "coordinator". This is the
-//     primary signal introduced by PR #928 (Issue F / #861).
+//     root_agent_name, compute dbBased = (root_agent_name == "coordinator") and
+//     nameBased = sessionName ends with "@main". Return dbBased || nameBased —
+//     meaning the @main heuristic wins when it disagrees with the DB value (e.g.
+//     stale "worker" from an SSE inference race). A [debug] log is emitted when
+//     the two signals disagree.
 //  2. NULL root_agent_name (pre-migration row): log a deprecation warning and
 //     fall through to the name-suffix heuristic.
 //  3. No DB, DB error, or no row: fall back to the name-suffix heuristic
 //     (session name ends with "@main"), which matches the convention used by
-//     isCoordinator() in sidecar.go.
+//     isCoordinatorSession() in sidecar.go.
 //
 // The d parameter may be nil; when nil the DB-backed lookup is skipped and
 // only the heuristic is used.

--- a/modules/programs/prism/prism/internal/session/meta_test.go
+++ b/modules/programs/prism/prism/internal/session/meta_test.go
@@ -67,17 +67,18 @@ func TestIsCoordinatorSession_DBBackedCoordinator(t *testing.T) {
 }
 
 // TestIsCoordinatorSession_DBBackedWorker verifies that a session with
-// root_agent_name == "worker" returns false, even though its name ends with @main
-// (pathological edge-case: a worker named with @main suffix).
+// root_agent_name == "worker" returns false when it does NOT end with @main.
+// NOTE: if the session name ends with @main, the heuristic wins and returns
+// true (see TestIsCoordinatorSession_StaleRootAgentName_MainHeuristicWins).
 func TestIsCoordinatorSession_DBBackedWorker(t *testing.T) {
 	d := openTestDB(t)
-	// A worker session that happens to end with @main — DB must win over heuristic.
-	const sess = "nixos-config@main"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "worker"); err != nil {
+	// A worker session on a non-@main branch — DB value must cause false.
+	const sess = "nixos-config@feature-worker"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-worker", "idle", nil, nil, "worker"); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if IsCoordinatorSession(sess, d) {
-		t.Errorf("IsCoordinatorSession(%q) = true, want false (DB says worker)", sess)
+		t.Errorf("IsCoordinatorSession(%q) = true, want false (DB says worker, non-@main)", sess)
 	}
 }
 
@@ -143,5 +144,40 @@ func TestIsCoordinatorSession_NilDB_FallsBackToHeuristic(t *testing.T) {
 	// Edge case: empty session name should not be considered coordinator.
 	if IsCoordinatorSession("", nil) {
 		t.Error("IsCoordinatorSession(\"\", nil) = true, want false")
+	}
+}
+
+// TestIsCoordinatorSession_StaleRootAgentName_MainHeuristicWins verifies the
+// fix for the bug where a coordinator session with root_agent_name="worker"
+// (stale/incorrect DB value) would incorrectly return false, allowing
+// self-notification to proceed.
+func TestIsCoordinatorSession_StaleRootAgentName_MainHeuristicWins(t *testing.T) {
+	d := openTestDB(t)
+
+	sess := "nixos-config@main"
+	// Seed the session with a stale root_agent_name of "worker".
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/main", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed stale worker: %v", err)
+	}
+
+	// Despite DB saying "worker", @main heuristic must win → true.
+	if !IsCoordinatorSession(sess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = false, want true (@main heuristic must win over stale DB value)", sess)
+	}
+}
+
+// TestIsCoordinatorSession_StaleRootAgentName_NonMain verifies that the fix
+// does not accidentally promote a genuine worker session with a non-@main name.
+func TestIsCoordinatorSession_StaleRootAgentName_NonMain(t *testing.T) {
+	d := openTestDB(t)
+
+	sess := "nixos-config@feature"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/feature", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+
+	// DB says worker, name does not end in @main → must return false.
+	if IsCoordinatorSession(sess, d) {
+		t.Errorf("IsCoordinatorSession(%q) = true, want false (non-@main worker must not be promoted)", sess)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1914,10 +1914,14 @@ func isCoordinator(sessionName string) bool {
 	return strings.HasSuffix(sessionName, "@main")
 }
 
-// isCoordinatorSession returns true when the session is a coordinator, using
-// a DB-backed read of root_agent_name when available. Falls back to the
-// name-suffix heuristic for pre-migration rows (NULL root_agent_name).
-// When d is nil, the name heuristic is used unconditionally.
+// isCoordinatorSession returns true when the session is a coordinator. When d
+// is non-nil and the session has a row with a non-NULL root_agent_name, it
+// computes dbBased = (root_agent_name == "coordinator") and nameBased =
+// (sessionName ends with "@main") and returns dbBased || nameBased. This means
+// the @main heuristic wins when it disagrees with a stale or incorrect DB value
+// (e.g. "worker" written during an SSE inference race); a [debug] log is emitted
+// on mismatch. Falls back to the name-suffix heuristic for pre-migration rows
+// (NULL root_agent_name) and when d is nil.
 func isCoordinatorSession(sessionName string, d *db.DB) bool {
 	if d != nil {
 		name, rowExists, err := d.RootAgentName(sessionName)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1926,10 +1926,10 @@ func isCoordinatorSession(sessionName string, d *db.DB) bool {
 				nameBased := strings.HasSuffix(sessionName, "@main")
 				dbBased := name == "coordinator"
 				if dbBased != nameBased {
-					log.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v",
+					log.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v — heuristic wins",
 						sessionName, dbBased, name, nameBased)
 				}
-				return dbBased
+				return dbBased || nameBased
 			}
 			// Row exists but root_agent_name is NULL — pre-migration row.
 			log.Printf("[deprecation] sidecar: isCoordinatorSession(%q): root_agent_name is NULL — pre-migration row, using name heuristic", sessionName)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2711,6 +2711,79 @@ func TestIsCoordinatorSession(t *testing.T) {
 	}
 }
 
+// TestNotifyCoordinator_SelfNotificationSkipped_StaleRootAgentName verifies
+// that a coordinator session with a stale root_agent_name="worker" in the DB
+// (e.g. from an SSE inference race) does NOT receive a self-notification when
+// transitioning to finished. The @main heuristic must win over the stale value.
+func TestNotifyCoordinator_SelfNotificationSkipped_StaleRootAgentName(t *testing.T) {
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: "test-repo@main",
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-coord-stale-worktree",
+		OpencodeURL: "http://localhost:14000",
+		DB:          d,
+		Clock:       clk,
+		Harness:     opencode.New("http://localhost:14000", nil, "", ""),
+	}
+	coordinator := New(cfg)
+
+	// Seed with stale root_agent_name="worker" — simulates the bug scenario.
+	if err := d.UpsertStatusSeedRootAgentName(coordinator.cfg.SessionName, coordinator.cfg.Repo, coordinator.cfg.Worktree, "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed stale worker: %v", err)
+	}
+
+	// Trigger idle debounce → finished.
+	coordinator.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	if state := getState(t, d, coordinator.cfg.SessionName); state != "finished" {
+		t.Errorf("coordinator state = %q, want finished", state)
+	}
+
+	// Give a brief window for any spurious goroutines to write.
+	time.Sleep(50 * time.Millisecond)
+
+	// No bus messages should have been written (self-notification skipped).
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	if totalMsgs != 0 {
+		t.Errorf("expected no bus messages for self-notification (stale DB value), got %d", totalMsgs)
+	}
+}
+
+// TestIsCoordinatorSession_StaleRootAgentName_MainWins verifies the low-level
+// helper directly: @main session with root_agent_name="worker" must return true.
+func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	sess := "myrepo@main"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "myrepo", "/code/main", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed stale worker: %v", err)
+	}
+
+	if !isCoordinatorSession(sess, d) {
+		t.Errorf("isCoordinatorSession(%q) = false, want true (@main heuristic must win over stale root_agent_name)", sess)
+	}
+
+	// Worker on a non-@main branch must still return false.
+	workerSess := "myrepo@feature"
+	if err := d.UpsertStatusSeedRootAgentName(workerSess, "myrepo", "/code/feature", "active", nil, nil, "worker"); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+	if isCoordinatorSession(workerSess, d) {
+		t.Errorf("isCoordinatorSession(%q) = true, want false (non-@main worker must not be promoted)", workerSess)
+	}
+}
+
 // TestNotifyCoordinator_ParentWorkerStillNotifies verifies that the parent
 // worker's own finish event (the session that ran `prism review`) continues to
 // propagate to the coordinator after its review-cycle completes. The parent


### PR DESCRIPTION
## Summary

- Fixes the self-notification bug where a coordinator session with a stale `root_agent_name="worker"` in the DB would incorrectly receive a self-notification on transition to `finished`.
- Changed `return dbBased` to `return dbBased || nameBased` in both `isCoordinatorSession` (sidecar.go) and `IsCoordinatorSession` (session/meta.go), so the `@main` name heuristic always wins when it indicates coordinator, regardless of DB value.
- Updated the debug log message to say "heuristic wins" on mismatch.
- Added tests: `TestNotifyCoordinator_SelfNotificationSkipped_StaleRootAgentName`, `TestIsCoordinatorSession_StaleRootAgentName_MainWins` (sidecar), and `TestIsCoordinatorSession_StaleRootAgentName_MainHeuristicWins` / `TestIsCoordinatorSession_StaleRootAgentName_NonMain` (session/meta).
- Updated `TestIsCoordinatorSession_DBBackedWorker` to use a non-`@main` session name (the old test was asserting the now-fixed buggy behavior).

Closes #944