### PR TITLE
Update Prism configuration and suppress anthropic warning

### DIFF
--- a/.github/workflows/update-flakes.yml
+++ b/.github/workflows/update-flakes.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.FLAKE_UPDATE_TOKEN }}
           add-paths: flake.lock
           body: ${{ steps.pr-body.outputs.body }}
           branch: flake-updates

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -60,7 +60,7 @@
       piSettings = {
         steeringMode = "one-at-a-time";
         transport = "sse";
-        theme = "dark";
+        theme = config.theme.name;
         treeFilterMode = "default";
         quietStartup = true;
         enableInstallTelemetry = false;
@@ -108,7 +108,7 @@
             mdHeading = orange;
             mdLink = blue;
             mdLinkUrl = grey0;
-            mdCode = aqua;
+            mdCode = green;
             mdCodeBlock = "";
             mdCodeBlockBorder = grey0;
             mdQuote = grey0;
@@ -131,10 +131,10 @@
             syntaxPunctuation = grey1;
             # Thinking Level Borders
             thinkingOff = grey0;
-            thinkingMinimal = primary;
-            thinkingLow = blue;
-            thinkingMedium = aqua;
-            thinkingHigh = purple;
+            thinkingMinimal = grey1;
+            thinkingLow = aqua;
+            thinkingMedium = green;
+            thinkingHigh = orange;
             thinkingXhigh = red;
             # Bash Mode
             bashMode = orange;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -120,7 +120,14 @@ rec {
           jsonschema = "${placeholder "out"}/share/opencode/schema.json";
         };
       });
-      pi-coding-agent = masterPkgs.pi-coding-agent;
+      pi-coding-agent = masterPkgs.pi-coding-agent.overrideAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          substituteInPlace packages/coding-agent/src/modes/interactive/interactive-mode.ts \
+            --replace-fail \
+              'this.showWarning(ANTHROPIC_SUBSCRIPTION_AUTH_WARNING);' \
+              '/* anthropic subscription warning suppressed */'
+        '';
+      });
 
       # packages not yet in nixpkgs; use local definitions
       # playwright-cli depends on chromium which is Linux-only


### PR DESCRIPTION
This update dynamically sets the Prism theme to match the system configuration and adjusts the syntax highlighting colors for better consistency. It also adds a custom patch to pi-coding-agent to suppress the anthropic subscription warning. Finally, the flake update workflow is configured to use a dedicated secret token for creating pull requests.