### PR TITLE
fix: update repo and worktree on upsert conflict

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -579,9 +579,8 @@ func (d *DB) checkTransition(sessionName string, toState agent.AgentState, calle
 }
 
 // UpsertStatus inserts or updates the agent_status row for sessionName.
-// repo and worktree are only set on initial insert — they do not change on
-// conflict. title, harnessSessionID, agentName, and modelID are updated only when
-// non-nil (COALESCE).
+// repo and worktree are always overwritten on conflict. title, harnessSessionID,
+// agentName, and modelID are updated only when non-nil (COALESCE).
 func (d *DB) UpsertStatus(sessionName, repo, worktree, state string, title *string, harnessSessionID *string) error {
 	return d.UpsertStatusWithAgent(sessionName, repo, worktree, state, title, harnessSessionID, nil, nil)
 }
@@ -984,10 +983,10 @@ func portAvailable(port int) bool {
 }
 
 // RefreshWorktree unconditionally updates the repo and worktree columns for an
-// existing agent_status row. Unlike UpsertStatus, which only writes repo and
-// worktree on the initial INSERT, this corrects any previously-corrupted values
-// (e.g. from the session-created hook race described in issue #380) and also
-// resets state to idle and refreshes last_seen.
+// existing agent_status row. It also resets state to idle and refreshes
+// last_seen, making it useful for prism restore (which needs a clean idle state
+// regardless of what the prior session left behind). Unlike UpsertStatus, this
+// does not insert a new row when none exists — it is a no-op for unknown sessions.
 //
 // It is a no-op when no row exists for sessionName (returns nil).
 func (d *DB) RefreshWorktree(sessionName, repo, worktree string) error {

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -598,6 +598,8 @@ INSERT INTO agent_status (session_name, repo, worktree, state, title, agent_name
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'opencode', ?)
 ON CONFLICT(session_name) DO UPDATE SET
   state              = excluded.state,
+  repo               = excluded.repo,
+  worktree           = excluded.worktree,
   title              = COALESCE(excluded.title, title),
   agent_name         = COALESCE(excluded.agent_name, agent_name),
   model_id           = COALESCE(excluded.model_id, model_id),
@@ -658,6 +660,8 @@ INSERT INTO agent_status (session_name, repo, worktree, state, title, root_agent
 VALUES (?, ?, ?, ?, ?, ?, ?, 'opencode', ?)
 ON CONFLICT(session_name) DO UPDATE SET
   state              = excluded.state,
+  repo               = excluded.repo,
+  worktree           = excluded.worktree,
   title              = COALESCE(excluded.title, title),
   root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
   last_seen          = excluded.last_seen,
@@ -689,6 +693,8 @@ INSERT INTO agent_status (session_name, repo, worktree, state, title, agent_name
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'opencode', ?)
 ON CONFLICT(session_name) DO UPDATE SET
   state              = excluded.state,
+  repo               = excluded.repo,
+  worktree           = excluded.worktree,
   title              = COALESCE(excluded.title, title),
   agent_name         = COALESCE(excluded.agent_name, agent_name),
   model_id           = COALESCE(excluded.model_id, model_id),

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -3738,3 +3738,85 @@ func TestHasReviewGroup(t *testing.T) {
 		t.Error("HasReviewGroup (other session): got true, want false")
 	}
 }
+
+// TestUpsertStatusWithAgent_WorktreeUpdatedOnConflict verifies that a second
+// call to UpsertStatusWithAgent with the same session name but a different
+// worktree overwrites the stored worktree rather than silently keeping the old
+// value.
+func TestUpsertStatusWithAgent_WorktreeUpdatedOnConflict(t *testing.T) {
+	d := openTestDB(t)
+
+	agentName := "opencode"
+	modelID := "gpt-4o"
+
+	if err := d.UpsertStatusWithAgent("repo@main", "repo", "/old/worktree", "idle", nil, nil, &agentName, &modelID); err != nil {
+		t.Fatalf("first UpsertStatusWithAgent: %v", err)
+	}
+	if err := d.UpsertStatusWithAgent("repo@main", "repo", "/new/worktree", "active", nil, nil, &agentName, &modelID); err != nil {
+		t.Fatalf("second UpsertStatusWithAgent: %v", err)
+	}
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil, want a row")
+	}
+	if s.Worktree != "/new/worktree" {
+		t.Errorf("Worktree: got %q, want %q", s.Worktree, "/new/worktree")
+	}
+}
+
+// TestUpsertStatusSeedRootAgentName_WorktreeUpdatedOnConflict verifies that a
+// second call to UpsertStatusSeedRootAgentName with the same session name but a
+// different worktree overwrites the stored worktree.
+func TestUpsertStatusSeedRootAgentName_WorktreeUpdatedOnConflict(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/old/worktree", "idle", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("first UpsertStatusSeedRootAgentName: %v", err)
+	}
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/new/worktree", "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil, want a row")
+	}
+	if s.Worktree != "/new/worktree" {
+		t.Errorf("Worktree: got %q, want %q", s.Worktree, "/new/worktree")
+	}
+}
+
+// TestUpsertStatusWithRootAgent_WorktreeUpdatedOnConflict verifies that a
+// second call to UpsertStatusWithRootAgent with the same session name but a
+// different worktree overwrites the stored worktree.
+func TestUpsertStatusWithRootAgent_WorktreeUpdatedOnConflict(t *testing.T) {
+	d := openTestDB(t)
+
+	agentName := "opencode"
+	modelID := "gpt-4o"
+
+	if err := d.UpsertStatusWithRootAgent("repo@main", "repo", "/old/worktree", "idle", nil, nil, &agentName, &modelID); err != nil {
+		t.Fatalf("first UpsertStatusWithRootAgent: %v", err)
+	}
+	if err := d.UpsertStatusWithRootAgent("repo@main", "repo", "/new/worktree", "active", nil, nil, &agentName, &modelID); err != nil {
+		t.Fatalf("second UpsertStatusWithRootAgent: %v", err)
+	}
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil, want a row")
+	}
+	if s.Worktree != "/new/worktree" {
+		t.Errorf("Worktree: got %q, want %q", s.Worktree, "/new/worktree")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `repo = excluded.repo, worktree = excluded.worktree` to the ON CONFLICT DO UPDATE SET clause in `UpsertStatusWithAgent`, `UpsertStatusSeedRootAgentName`, and `UpsertStatusWithRootAgent`
- Add regression tests for all three methods verifying the worktree is overwritten on conflict

Closes #950