### PR TITLE
fix: non-worktree sessions incorrectly pass --agent worker and mount worker config blob

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -111,41 +111,41 @@ func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 		want string
 	}{
 		// With a stored opencode session ID — should use -s <id>.
-		{session.Opts{Agent: "coordinator", OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent coordinator -s ses_abc123"},
-		{session.Opts{Agent: "worker", OpencodeSession: "ses_xyz789", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker -s ses_xyz789"},
+		{session.Opts{Agent: "coordinator", OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'coordinator' -s ses_abc123"},
+		{session.Opts{Agent: "worker", OpencodeSession: "ses_xyz789", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' -s ses_xyz789"},
 		// No stored session — no session flag.
-		{session.Opts{Agent: "coordinator", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent coordinator"},
-		{session.Opts{Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		{session.Opts{Agent: "coordinator", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'coordinator'"},
+		{session.Opts{Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker'"},
 		// Fresh=true suppresses the stored session ID even if set.
-		{session.Opts{Agent: "worker", Fresh: true, OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		{session.Opts{Agent: "worker", Fresh: true, OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker'"},
 		// Empty agent means no --agent flag (non-worktree path case).
 		{session.Opts{OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode -s ses_abc123"},
 		{session.Opts{RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode"},
 		// Prompt with no special characters.
-		{session.Opts{Agent: "worker", Prompt: "fix the login bug", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --prompt 'fix the login bug'"},
+		{session.Opts{Agent: "worker", Prompt: "fix the login bug", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' --prompt 'fix the login bug'"},
 		// Prompt containing a single quote — exercises shellQuote escaping.
-		{session.Opts{Agent: "worker", Prompt: "it's broken", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --prompt 'it'\\''s broken'"},
+		{session.Opts{Agent: "worker", Prompt: "it's broken", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' --prompt 'it'\\''s broken'"},
 		// Prompt with shell metacharacters that are safe inside single quotes.
-		{session.Opts{Agent: "worker", Prompt: "run `make test` and fix $ERRORS", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --prompt 'run `make test` and fix $ERRORS'"},
+		{session.Opts{Agent: "worker", Prompt: "run `make test` and fix $ERRORS", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' --prompt 'run `make test` and fix $ERRORS'"},
 		// Prompt + session ID — both flags present.
-		{session.Opts{Agent: "coordinator", OpencodeSession: "ses_abc", Prompt: "review pr", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent coordinator -s ses_abc --prompt 'review pr'"},
+		{session.Opts{Agent: "coordinator", OpencodeSession: "ses_abc", Prompt: "review pr", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'coordinator' -s ses_abc --prompt 'review pr'"},
 		// SessionName set — PRISM_SESSION_NAME is prepended (after the timeout prefix).
-		{session.Opts{Agent: "worker", SessionName: "myrepo@main", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent worker"},
-		{session.Opts{Agent: "coordinator", OpencodeSession: "ses_abc123", SessionName: "myrepo@main", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent coordinator -s ses_abc123"},
+		{session.Opts{Agent: "worker", SessionName: "myrepo@main", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent 'worker'"},
+		{session.Opts{Agent: "coordinator", OpencodeSession: "ses_abc123", SessionName: "myrepo@main", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent 'coordinator' -s ses_abc123"},
 		// SessionName with special characters (dots and dashes are common).
-		{session.Opts{Agent: "worker", SessionName: "nixos_config@feature--my-branch", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='nixos_config@feature--my-branch' opencode --agent worker"},
+		{session.Opts{Agent: "worker", SessionName: "nixos_config@feature--my-branch", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='nixos_config@feature--my-branch' opencode --agent 'worker'"},
 		// SessionName + Prompt — env var prefix appears before the prompt flag.
-		{session.Opts{Agent: "worker", SessionName: "myrepo@main", Prompt: "do the thing", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent worker --prompt 'do the thing'"},
+		{session.Opts{Agent: "worker", SessionName: "myrepo@main", Prompt: "do the thing", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent 'worker' --prompt 'do the thing'"},
 		// No SessionName — no PRISM_SESSION_NAME, only the timeout prefix.
-		{session.Opts{Agent: "worker", SessionName: "", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		{session.Opts{Agent: "worker", SessionName: "", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker'"},
 		// Port set — includes --port and --hostname.
-		{session.Opts{Agent: "worker", Port: 14000, RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --port 14000 --hostname 127.0.0.1"},
+		{session.Opts{Agent: "worker", Port: 14000, RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' --port 14000 --hostname 127.0.0.1"},
 		// Port + session ID + SessionName — all flags together.
-		{session.Opts{Agent: "coordinator", Port: 14042, OpencodeSession: "ses_abc", SessionName: "myrepo@main", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent coordinator --port 14042 --hostname 127.0.0.1 -s ses_abc"},
+		{session.Opts{Agent: "coordinator", Port: 14042, OpencodeSession: "ses_abc", SessionName: "myrepo@main", RuntimeEnvVars: re}, bashTimeoutPrefix + "PRISM_SESSION_NAME='myrepo@main' opencode --agent 'coordinator' --port 14042 --hostname 127.0.0.1 -s ses_abc"},
 		// Port + Prompt.
-		{session.Opts{Agent: "worker", Port: 14001, Prompt: "fix it", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --port 14001 --hostname 127.0.0.1 --prompt 'fix it'"},
+		{session.Opts{Agent: "worker", Port: 14001, Prompt: "fix it", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' --port 14001 --hostname 127.0.0.1 --prompt 'fix it'"},
 		// Port zero — no port flags.
-		{session.Opts{Agent: "worker", Port: 0, RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		{session.Opts{Agent: "worker", Port: 0, RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker'"},
 	}
 	for _, tc := range cases {
 		got := session.BuildOpencodeCmd(tc.opts)
@@ -173,9 +173,9 @@ func TestBuildOpencodeCmd_ContainerMode(t *testing.T) {
 		{session.Opts{ContainerMode: true, SessionName: "repo@branch", Port: 14001, Agent: "coordinator"}, "podman attach --sig-proxy=false 'prism-repo-branch'"},
 		// Container mode with no SessionName falls back to direct launch (safety net).
 		// The fallback calls buildDirectOpencodeCmd, which prepends RuntimeEnvVars.
-		{session.Opts{ContainerMode: true, SessionName: "", Port: 0, Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		{session.Opts{ContainerMode: true, SessionName: "", Port: 0, Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker'"},
 		// Non-container mode includes the timeout prefix (via RuntimeEnvVars).
-		{session.Opts{ContainerMode: false, Port: 14000, Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --port 14000 --hostname 127.0.0.1"},
+		{session.Opts{ContainerMode: false, Port: 14000, Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent 'worker' --port 14000 --hostname 127.0.0.1"},
 	}
 	for _, tc := range cases {
 		got := session.BuildOpencodeCmd(tc.opts)

--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -8,26 +9,66 @@ import (
 )
 
 func TestDefaultAgent_CoordinatorForMain(t *testing.T) {
-	got := session.DefaultAgent("/home/user/repos/project/main", "")
+	// Create a temporary bare repo structure for testing.
+	tmpDir := t.TempDir()
+	bareRoot := filepath.Join(tmpDir, "project")
+	mainWorktree := filepath.Join(bareRoot, "main")
+
+	// Create bare repo structure with .bare marker.
+	if err := os.MkdirAll(mainWorktree, 0755); err != nil {
+		t.Fatalf("mkdir main worktree: %v", err)
+	}
+	// Create .bare marker in parent directory to simulate a prism bare repo.
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0755); err != nil {
+		t.Fatalf("mkdir .bare: %v", err)
+	}
+
+	got := session.DefaultAgent(mainWorktree, "")
 	if got != "coordinator" {
-		t.Errorf("DefaultAgent(%q, %q) = %q, want %q", "/home/user/repos/project/main", "", got, "coordinator")
+		t.Errorf("DefaultAgent(%q, %q) = %q, want %q", mainWorktree, "", got, "coordinator")
 	}
 }
 
 func TestDefaultAgent_WorkerForNonMain(t *testing.T) {
-	cases := []string{
-		"/home/user/repos/project/feature-foo",
-		"/home/user/repos/project/maintain",
-		"/home/user/repos/project/main-branch",
-		"/home/user/repos/project/MAIN",
-		"/home/user/repos/project/Main",
-		"/home/user",
+	// Create a temporary bare repo structure for testing.
+	tmpDir := t.TempDir()
+	bareRoot := filepath.Join(tmpDir, "project")
+
+	// Create bare repo structure with .bare marker.
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0755); err != nil {
+		t.Fatalf("mkdir .bare: %v", err)
 	}
-	for _, dir := range cases {
-		t.Run(filepath.Base(dir), func(t *testing.T) {
+
+	// Create worktree branches.
+	worktrees := []string{"feature-foo", "maintain", "main-branch", "feature-branch"}
+	for _, branch := range worktrees {
+		if err := os.MkdirAll(filepath.Join(bareRoot, branch), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", branch, err)
+		}
+	}
+
+	// Test that non-main worktrees return "worker".
+	for _, branch := range worktrees {
+		t.Run(branch, func(t *testing.T) {
+			dir := filepath.Join(bareRoot, branch)
 			got := session.DefaultAgent(dir, "")
 			if got != "worker" {
 				t.Errorf("DefaultAgent(%q, %q) = %q, want %q", dir, "", got, "worker")
+			}
+		})
+	}
+
+	// Test that paths that are NOT worktrees (no .bare in parent) return "".
+	nonWorktreePaths := []string{
+		"/home/user/repos/project/MAIN",   // Not under a bare repo
+		"/home/user/repos/project/Main",   // Not under a bare repo
+		"/home/user",                      // Not under a bare repo
+	}
+	for _, dir := range nonWorktreePaths {
+		t.Run(filepath.Base(dir)+"_nonworktree", func(t *testing.T) {
+			got := session.DefaultAgent(dir, "")
+			if got != "" {
+				t.Errorf("DefaultAgent(%q, %q) = %q, want %q (empty string for non-worktree)", dir, "", got, "")
 			}
 		})
 	}
@@ -77,9 +118,9 @@ func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 		{session.Opts{Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
 		// Fresh=true suppresses the stored session ID even if set.
 		{session.Opts{Agent: "worker", Fresh: true, OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
-		// Safety-net fallback: empty agent still yields "worker".
-		{session.Opts{OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker -s ses_abc123"},
-		{session.Opts{RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		// Empty agent means no --agent flag (non-worktree path case).
+		{session.Opts{OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode -s ses_abc123"},
+		{session.Opts{RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode"},
 		// Prompt with no special characters.
 		{session.Opts{Agent: "worker", Prompt: "fix the login bug", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --prompt 'fix the login bug'"},
 		// Prompt containing a single quote — exercises shellQuote escaping.

--- a/modules/programs/prism/prism/cmd/inject_container_config_test.go
+++ b/modules/programs/prism/prism/cmd/inject_container_config_test.go
@@ -6,13 +6,15 @@ package cmd
 // looks up the role's config blob from the profiles file, and sets
 // opts.ConfigContent. These tests exercise:
 //
-//   - Worker role (non-"main" directory base) receives ContainerWorkerConfig.
-//   - Coordinator role ("main" directory base) receives ContainerCoordinatorConfig.
+//   - Worker role (non-"main" worktree under a bare repo) receives ContainerWorkerConfig.
+//   - Coordinator role ("main" worktree under a bare repo) receives ContainerCoordinatorConfig.
+//   - Non-worktree path receives ContainerCoordinatorConfig but with no --agent flag.
 //   - An explicit Agent override is respected over the DefaultAgent derivation.
 //   - Empty config blob (role present but no config set) leaves ConfigContent empty
 //     and does not return an error.
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,12 +31,32 @@ func makeInjectTestProfile() *config.ProfilesFile {
 	}
 }
 
+// setupBareWorktree creates a temporary bare repo with a worktree for testing.
+// Returns the bare repo path and the worktree path.
+func setupBareWorktree(t *testing.T, branchName string) (bareRoot, worktreePath string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	bareRoot = filepath.Join(tmpDir, "myrepo")
+	worktreePath = filepath.Join(bareRoot, branchName)
+
+	// Create bare repo structure with .bare marker.
+	if err := os.MkdirAll(worktreePath, 0755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	// Create .bare marker in parent directory to simulate a prism bare repo.
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0755); err != nil {
+		t.Fatalf("mkdir .bare: %v", err)
+	}
+
+	return bareRoot, worktreePath
+}
+
 // TestInjectContainerConfig_WorkerRole verifies that a non-"main" worktree
-// directory causes injectContainerConfig to select ContainerWorkerConfig.
+// directory under a bare repo causes injectContainerConfig to select ContainerWorkerConfig.
 func TestInjectContainerConfig_WorkerRole(t *testing.T) {
 	pf := makeInjectTestProfile()
 	opts := session.Opts{}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+	_, worktreePath := setupBareWorktree(t, "feature-branch")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig: %v", err)
@@ -47,11 +69,11 @@ func TestInjectContainerConfig_WorkerRole(t *testing.T) {
 }
 
 // TestInjectContainerConfig_CoordinatorRole verifies that a worktree directory
-// named "main" causes injectContainerConfig to select ContainerCoordinatorConfig.
+// named "main" under a bare repo causes injectContainerConfig to select ContainerCoordinatorConfig.
 func TestInjectContainerConfig_CoordinatorRole(t *testing.T) {
 	pf := makeInjectTestProfile()
 	opts := session.Opts{}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "main")
+	_, worktreePath := setupBareWorktree(t, "main")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig: %v", err)
@@ -63,13 +85,36 @@ func TestInjectContainerConfig_CoordinatorRole(t *testing.T) {
 	}
 }
 
+// TestInjectContainerConfig_NonWorktreePath verifies that a non-worktree path
+// (no .bare in parent) receives the coordinator blob but no --agent flag.
+func TestInjectContainerConfig_NonWorktreePath(t *testing.T) {
+	pf := makeInjectTestProfile()
+	opts := session.Opts{}
+	// Use a path that is not under a bare repo (no .bare in parent).
+	worktreePath := "/some/regular/repo"
+
+	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
+		t.Fatalf("injectContainerConfig: %v", err)
+	}
+
+	// Non-worktree paths should receive coordinator config.
+	if opts.ConfigContent != pf.ContainerCoordinatorConfig {
+		t.Errorf("ConfigContent = %q, want %q (coordinator blob for non-worktree)",
+			opts.ConfigContent, pf.ContainerCoordinatorConfig)
+	}
+	// Agent should be empty (no --agent flag passed).
+	if opts.Agent != "" {
+		t.Errorf("Agent = %q, want %q (no --agent flag for non-worktree)", opts.Agent, "")
+	}
+}
+
 // TestInjectContainerConfig_ExplicitAgentOverride verifies that an explicit
 // opts.Agent override is respected: when opts.Agent is "coordinator", the
 // coordinator blob is selected even for a non-"main" directory.
 func TestInjectContainerConfig_ExplicitAgentOverride(t *testing.T) {
 	pf := makeInjectTestProfile()
 	opts := session.Opts{Agent: "coordinator"}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+	_, worktreePath := setupBareWorktree(t, "feature-branch")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig: %v", err)
@@ -93,7 +138,7 @@ func TestInjectContainerConfig_EmptyBlobNoError(t *testing.T) {
 		ContainerCoordinatorConfig: "",
 	}
 	opts := session.Opts{}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+	_, worktreePath := setupBareWorktree(t, "feature-branch")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig returned error on empty blob: %v", err)

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -329,10 +329,16 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 			roleConfig, roleErr := config.ContainerConfigForRole(pf, effectiveRole)
 			if roleErr != nil {
 				fmt.Fprintf(os.Stderr, "restore %q: container config for role %q: %v — skipping config injection\n", s.SessionName, effectiveRole, roleErr)
-			} else if roleConfig != "" {
-				opts.ConfigContent = roleConfig
-			} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
-				fmt.Fprintf(os.Stderr, "[prism restore] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
+			} else {
+				// When effectiveRole is "" (non-worktree path), use the coordinator config blob.
+				if effectiveRole == "" {
+					roleConfig = pf.ContainerCoordinatorConfig
+				}
+				if roleConfig != "" {
+					opts.ConfigContent = roleConfig
+				} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
+					fmt.Fprintf(os.Stderr, "[prism restore] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
+				}
 			}
 		}
 

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -584,7 +584,7 @@ func TestRestoreSession_HostModeOverride(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	worktreeDir := t.TempDir()
+	_, worktreeDir := setupBareWorktree(t, "host-mode")
 	sessionName := "myrepo@host-mode"
 	// Seed the row first, then mark it as host_mode=true. Re-read so the
 	// Status passed to restoreSession has the correct HostMode value.
@@ -728,11 +728,8 @@ func TestRestoreSession_ContainerMode_WorkerConfigContent(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	// Use a non-main worktree directory so DefaultAgent returns "worker".
-	worktreeDir := filepath.Join(t.TempDir(), "feature-branch")
-	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	// Use a non-main worktree directory under a bare repo so DefaultAgent returns "worker".
+	_, worktreeDir := setupBareWorktree(t, "feature-branch")
 	sessionName := "myrepo@feature"
 	status := seedStatus(t, d, sessionName, worktreeDir, nil)
 
@@ -776,11 +773,8 @@ func TestRestoreSession_ContainerMode_CoordinatorConfigContent(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	// "main" as the base name causes DefaultAgent to return "coordinator".
-	worktreeDir := filepath.Join(t.TempDir(), "main")
-	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	// "main" as the base name under a bare repo causes DefaultAgent to return "coordinator".
+	_, worktreeDir := setupBareWorktree(t, "main")
 	sessionName := "myrepo@main"
 	status := seedStatus(t, d, sessionName, worktreeDir, nil)
 
@@ -1211,11 +1205,8 @@ func TestRestoreSession_BwrapMode_WorkerConfigContent(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	// Non-main worktree → DefaultAgent returns "worker".
-	worktreeDir := filepath.Join(t.TempDir(), "feature-branch")
-	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	// Non-main worktree under a bare repo → DefaultAgent returns "worker".
+	_, worktreeDir := setupBareWorktree(t, "feature-branch")
 	sessionName := "myrepo@bwrap-worker"
 	status := seedStatus(t, d, sessionName, worktreeDir, nil)
 
@@ -1275,10 +1266,7 @@ func TestRestoreSession_BwrapMode_TempFileWritten(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	worktreeDir := filepath.Join(t.TempDir(), "feature-x")
-	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	_, worktreeDir := setupBareWorktree(t, "feature-x")
 	sessionName := "myrepo@bwrap-file"
 	status := seedStatus(t, d, sessionName, worktreeDir, nil)
 	if err := d.SetIsolationMode(sessionName, string(config.IsolationBwrap)); err != nil {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -265,7 +265,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// determined by Nix config, not by the project file.
 	//
 	// effectiveRole is derived the same way the session uses: explicit --agent
-	// flag wins; otherwise "coordinator" on the main branch, "worker" elsewhere.
+	// flag wins; otherwise "coordinator" on the main branch, "worker" elsewhere,
+	// or "" for non-worktree paths (regular git repos, non-git dirs).
 	// This must run after worktreePath is known so that DefaultAgent can inspect
 	// the directory name (e.g. "main").
 	//
@@ -281,6 +282,12 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		roleConfig, roleErr := config.ContainerConfigForRole(pf, effectiveRole)
 		if roleErr != nil {
 			return roleErr
+		}
+		// When effectiveRole is "" (non-worktree path), use the coordinator config blob
+		// but do not pass --agent flag (opts.Agent will be "" and buildDirectOpencodeCmd
+		// will not add --agent). This ensures build/plan mode agents are available.
+		if effectiveRole == "" {
+			roleConfig = pf.ContainerCoordinatorConfig
 		}
 		if roleConfig != "" {
 			// Role config supersedes profile/model overrides for identity &

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -10,7 +10,7 @@ package cmd
 //	--repo <name>         repo shorthand name or absolute path (default: inferred from current pane)
 //	--prompt <text>       pass an initial prompt to opencode on launch
 //	--prompt-file <path>  read the initial prompt from a file
-//	--agent <name>        opencode agent to use (default: "coordinator" on main, "worker" otherwise)
+//	--agent <name>        opencode agent to use (default: "coordinator" on main worktree, "worker" on other worktrees, no flag for non-worktree paths)
 //	--profile <name>      model profile to use from ~/.config/prism/profiles.json
 //	--model <name>        model identifier override (overrides profile's primary model)
 //	--variant <name>      model variant override (overrides all agents' variant)
@@ -86,7 +86,7 @@ func init() {
 	spawnCmd.Flags().String("pr", "", "PR number — check out its branch")
 	spawnCmd.Flags().String("repo", "", "Repo shorthand name or absolute path (default: inferred from current pane)")
 	addPromptFlags(spawnCmd)
-	spawnCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main, "worker" otherwise)`)
+	spawnCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main worktree, "worker" on other worktrees, no flag for non-worktree paths)`)
 	spawnCmd.Flags().Bool("attach", false, "Switch the current tmux client to the new session")
 	spawnCmd.Flags().String("profile", "", "Model profile name from ~/.config/prism/profiles.json (e.g. anthropic, gemini-hybrid)")
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -436,6 +436,12 @@ func injectContainerConfig(path string, pf *config.ProfilesFile, opts *session.O
 	if err != nil {
 		return err
 	}
+	// When effectiveRole is "" (non-worktree path), use the coordinator config blob
+	// but do not pass --agent flag (opts.Agent will be "" and buildDirectOpencodeCmd
+	// will not add --agent). This ensures build/plan mode agents are available.
+	if effectiveRole == "" {
+		roleConfig = pf.ContainerCoordinatorConfig
+	}
 	if roleConfig != "" {
 		opts.ConfigContent = roleConfig
 	} else if effectiveRole == "worker" || effectiveRole == "coordinator" {

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -183,16 +183,25 @@ const (
 
 // DefaultAgent returns the agent to use for the given directory.
 // If explicit is non-empty it is returned unchanged.
-// Otherwise "coordinator" is returned for the "main" worktree and "worker" for
-// everything else.
+// Otherwise:
+//   - For prism bare+worktree sessions (parent dir contains .bare), returns
+//     "coordinator" for the "main" worktree and "worker" for other branches.
+//   - For non-worktree paths (regular git repos, non-git dirs), returns ""
+//     (empty string) so no --agent flag is passed to opencode.
 func DefaultAgent(directory, explicit string) string {
 	if explicit != "" {
 		return explicit
 	}
-	if filepath.Base(directory) == "main" {
-		return "coordinator"
+	// Only apply the coordinator/worker split for prism bare+worktree sessions.
+	// A path whose parent contains .bare is a linked worktree; everything else
+	// (regular git repo, non-git dir) is a plain project and gets no role assigned.
+	if git.IsBareRepo(filepath.Dir(directory)) {
+		if filepath.Base(directory) == "main" {
+			return "coordinator"
+		}
+		return "worker"
 	}
-	return "worker"
+	return "" // non-worktree: caller must not pass --agent
 }
 
 // DefaultAgentForSession returns the agent to use for the given session,
@@ -284,11 +293,12 @@ func BuildOpencodeCmd(opts Opts) string {
 
 // buildDirectOpencodeCmd returns the opencode direct-launch command (pre-container mode).
 func buildDirectOpencodeCmd(opts Opts) string {
-	agent := opts.Agent
-	if agent == "" {
-		agent = "worker"
+	cmd := "opencode"
+	// Only add --agent flag if opts.Agent is non-empty. Empty string means
+	// "let opencode fall back to its own config" (used for non-worktree paths).
+	if opts.Agent != "" {
+		cmd += " --agent " + opts.Agent
 	}
-	cmd := "opencode --agent " + agent
 	if opts.Port != 0 {
 		cmd += fmt.Sprintf(" --port %d --hostname 127.0.0.1", opts.Port)
 	}

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -297,7 +297,7 @@ func buildDirectOpencodeCmd(opts Opts) string {
 	// Only add --agent flag if opts.Agent is non-empty. Empty string means
 	// "let opencode fall back to its own config" (used for non-worktree paths).
 	if opts.Agent != "" {
-		cmd += " --agent " + opts.Agent
+		cmd += " --agent " + shellQuote(opts.Agent)
 	}
 	if opts.Port != 0 {
 		cmd += fmt.Sprintf(" --port %d --hostname 127.0.0.1", opts.Port)

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -586,3 +586,78 @@ func TestDefaultAgentForSession_NoRow(t *testing.T) {
 		t.Errorf("DefaultAgentForSession (no row) = %q, want %q", got, want)
 	}
 }
+
+// ── DefaultAgent tests ──────────────────────────────────────────────────────────
+
+// TestDefaultAgent_ExplicitAgent verifies that an explicit agent value is
+// returned as-is, bypassing all directory heuristics.
+func TestDefaultAgent_ExplicitAgent(t *testing.T) {
+	got := DefaultAgent("/any/path", "my-custom-agent")
+	if got != "my-custom-agent" {
+		t.Errorf("DefaultAgent with explicit agent = %q, want %q", got, "my-custom-agent")
+	}
+}
+
+// TestDefaultAgent_ThreeWayLogic verifies the three-way logic:
+// 1. main worktree (parent contains .bare, basename is "main") → "coordinator"
+// 2. Non-main worktree branch (parent contains .bare, basename ≠ "main") → "worker"
+// 3. Non-worktree path (parent does NOT contain .bare) → ""
+func TestDefaultAgent_ThreeWayLogic(t *testing.T) {
+	// Create a temporary directory structure for testing.
+	tmpDir := t.TempDir()
+	bareRoot := filepath.Join(tmpDir, "myrepo")
+	mainWorktree := filepath.Join(bareRoot, "main")
+	featureWorktree := filepath.Join(bareRoot, "feature-branch")
+	regularRepo := filepath.Join(tmpDir, "regular-repo")
+	nonGitDir := filepath.Join(tmpDir, "non-git-dir")
+
+	// Create bare repo structure.
+	if err := os.MkdirAll(mainWorktree, 0755); err != nil {
+		t.Fatalf("mkdir main worktree: %v", err)
+	}
+	if err := os.MkdirAll(featureWorktree, 0755); err != nil {
+		t.Fatalf("mkdir feature worktree: %v", err)
+	}
+	// Create .bare marker in parent directory to simulate a prism bare repo.
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0755); err != nil {
+		t.Fatalf("mkdir .bare: %v", err)
+	}
+
+	// Create regular git repo.
+	if err := os.MkdirAll(regularRepo, 0755); err != nil {
+		t.Fatalf("mkdir regular repo: %v", err)
+	}
+	// Create .git directory to simulate a regular git repo.
+	if err := os.MkdirAll(filepath.Join(regularRepo, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+
+	// Create non-git directory.
+	if err := os.MkdirAll(nonGitDir, 0755); err != nil {
+		t.Fatalf("mkdir non-git dir: %v", err)
+	}
+
+	// Test case 1: main worktree → "coordinator"
+	got1 := DefaultAgent(mainWorktree, "")
+	if got1 != "coordinator" {
+		t.Errorf("DefaultAgent(main worktree) = %q, want %q", got1, "coordinator")
+	}
+
+	// Test case 2: non-main worktree branch → "worker"
+	got2 := DefaultAgent(featureWorktree, "")
+	if got2 != "worker" {
+		t.Errorf("DefaultAgent(feature worktree) = %q, want %q", got2, "worker")
+	}
+
+	// Test case 3: regular git repo → ""
+	got3 := DefaultAgent(regularRepo, "")
+	if got3 != "" {
+		t.Errorf("DefaultAgent(regular git repo) = %q, want %q (empty string)", got3, "")
+	}
+
+	// Test case 4: non-git directory → ""
+	got4 := DefaultAgent(nonGitDir, "")
+	if got4 != "" {
+		t.Errorf("DefaultAgent(non-git dir) = %q, want %q (empty string)", got4, "")
+	}
+}


### PR DESCRIPTION
Fixes #952

DefaultAgent in session.go now returns empty string for non-worktree paths
(regular git repos, non-git dirs) instead of defaulting to "worker". The
detection uses git.IsBareRepo(filepath.Dir(directory)) to distinguish
between:

1. main worktree (parent contains .bare, basename is "main") → "coordinator"
2. non-main worktree (parent contains .bare, basename ≠ "main") → "worker"
3. non-worktree path (parent does NOT contain .bare) → "" (no --agent flag)

When DefaultAgent returns "", callers:
- Pass no --agent flag to opencode
- Still mount the coordinator config blob

Changes:
- session.go: DefaultAgent updated with three-way logic using git.IsBareRepo
- session.go: buildDirectOpencodeCmd handles empty Agent (no --agent flag)
- switch.go: injectContainerConfig uses coordinator blob when role is ""
- switch.go: ensureAndSwitch handles empty opts.Agent correctly
- spawn.go: effectiveRole derivation uses coordinator blob when role is ""
- Updated tests for DefaultAgent three-way logic
- Updated agent_default_test.go tests to use proper bare repo structures
- Updated inject_container_config_test.go to use proper bare repo structures
- Added TestDefaultAgent_ThreeWayLogic and TestDefaultAgent_ExplicitAgent

All Go tests pass. Nix build succeeds.