### PR TITLE
fix: DefaultAgent returns empty string for non-worktree paths

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -1,27 +1,52 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
+// makeBareWorktree creates a temporary directory layout simulating a prism
+// bare+worktree project:
+//
+//	<tmp>/
+//	  .bare     ← IsBareRepo marker
+//	  main/     ← coordinator worktree
+//	  <branch>/ ← worker worktree
+//
+// Returns the project root path. The caller's t.TempDir() is used so cleanup
+// is automatic.
+func makeBareWorktree(t *testing.T, branches ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range append([]string{"main"}, branches...) {
+		if err := os.MkdirAll(filepath.Join(root, b), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
 func TestDefaultAgent_CoordinatorForMain(t *testing.T) {
-	got := session.DefaultAgent("/home/user/repos/project/main", "")
+	root := makeBareWorktree(t)
+	mainDir := filepath.Join(root, "main")
+	got := session.DefaultAgent(mainDir, "")
 	if got != "coordinator" {
-		t.Errorf("DefaultAgent(%q, %q) = %q, want %q", "/home/user/repos/project/main", "", got, "coordinator")
+		t.Errorf("DefaultAgent(%q, %q) = %q, want %q", mainDir, "", got, "coordinator")
 	}
 }
 
 func TestDefaultAgent_WorkerForNonMain(t *testing.T) {
+	root := makeBareWorktree(t, "feature-foo", "maintain", "main-branch")
 	cases := []string{
-		"/home/user/repos/project/feature-foo",
-		"/home/user/repos/project/maintain",
-		"/home/user/repos/project/main-branch",
-		"/home/user/repos/project/MAIN",
-		"/home/user/repos/project/Main",
-		"/home/user",
+		filepath.Join(root, "feature-foo"),
+		filepath.Join(root, "maintain"),
+		filepath.Join(root, "main-branch"),
 	}
 	for _, dir := range cases {
 		t.Run(filepath.Base(dir), func(t *testing.T) {
@@ -33,14 +58,36 @@ func TestDefaultAgent_WorkerForNonMain(t *testing.T) {
 	}
 }
 
+// TestDefaultAgent_NonWorktreePath verifies that directories whose parent does
+// NOT contain a .bare entry return "" (non-worktree path).
+func TestDefaultAgent_NonWorktreePath(t *testing.T) {
+	tmp := t.TempDir()
+	cases := []string{
+		tmp,
+		filepath.Join(tmp, "regular-repo"),
+		filepath.Join(tmp, "main"), // named "main" but parent has no .bare
+	}
+	for _, dir := range cases {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			got := session.DefaultAgent(dir, "")
+			if got != "" {
+				t.Errorf("DefaultAgent(%q, %q) = %q, want %q (empty)", dir, "", got, "")
+			}
+		})
+	}
+}
+
 func TestDefaultAgent_ExplicitOverridesDefault(t *testing.T) {
+	root := makeBareWorktree(t, "feature")
+	tmp := t.TempDir()
 	cases := []struct {
 		dir   string
 		agent string
 	}{
-		{"/home/user/repos/project/main", "custom-agent"},
-		{"/home/user/repos/project/feature", "custom-agent"},
-		{"/home/user/repos/project/main", "worker"},
+		{filepath.Join(root, "main"), "custom-agent"},
+		{filepath.Join(root, "feature"), "custom-agent"},
+		{filepath.Join(root, "main"), "worker"},
+		{tmp, "coordinator"}, // non-worktree, explicit wins
 	}
 	for _, tc := range cases {
 		got := session.DefaultAgent(tc.dir, tc.agent)
@@ -77,9 +124,9 @@ func TestBuildOpencodeCmd_UsesAgent(t *testing.T) {
 		{session.Opts{Agent: "worker", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
 		// Fresh=true suppresses the stored session ID even if set.
 		{session.Opts{Agent: "worker", Fresh: true, OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
-		// Safety-net fallback: empty agent still yields "worker".
-		{session.Opts{OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker -s ses_abc123"},
-		{session.Opts{RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker"},
+		// Empty agent (non-worktree path) — no --agent flag at all.
+		{session.Opts{OpencodeSession: "ses_abc123", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode -s ses_abc123"},
+		{session.Opts{RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode"},
 		// Prompt with no special characters.
 		{session.Opts{Agent: "worker", Prompt: "fix the login bug", RuntimeEnvVars: re}, bashTimeoutPrefix + "opencode --agent worker --prompt 'fix the login bug'"},
 		// Prompt containing a single quote — exercises shellQuote escaping.

--- a/modules/programs/prism/prism/cmd/inject_container_config_test.go
+++ b/modules/programs/prism/prism/cmd/inject_container_config_test.go
@@ -6,13 +6,15 @@ package cmd
 // looks up the role's config blob from the profiles file, and sets
 // opts.ConfigContent. These tests exercise:
 //
-//   - Worker role (non-"main" directory base) receives ContainerWorkerConfig.
-//   - Coordinator role ("main" directory base) receives ContainerCoordinatorConfig.
+//   - Worker role (non-"main" directory base, parent has .bare) receives ContainerWorkerConfig.
+//   - Coordinator role ("main" directory base, parent has .bare) receives ContainerCoordinatorConfig.
+//   - Non-worktree path (parent has no .bare) receives ContainerCoordinatorConfig (fallback).
 //   - An explicit Agent override is respected over the DefaultAgent derivation.
 //   - Empty config blob (role present but no config set) leaves ConfigContent empty
 //     and does not return an error.
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,12 +31,29 @@ func makeInjectTestProfile() *config.ProfilesFile {
 	}
 }
 
+// makeBareRoot creates a temp dir with a .bare marker and the given subdirs.
+// Returns the root path.
+func makeBareRoot(t *testing.T, subdirs ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range subdirs {
+		if err := os.MkdirAll(filepath.Join(root, s), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
 // TestInjectContainerConfig_WorkerRole verifies that a non-"main" worktree
-// directory causes injectContainerConfig to select ContainerWorkerConfig.
+// directory (parent has .bare) causes injectContainerConfig to select ContainerWorkerConfig.
 func TestInjectContainerConfig_WorkerRole(t *testing.T) {
+	root := makeBareRoot(t, "feature-branch")
 	pf := makeInjectTestProfile()
 	opts := session.Opts{}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+	worktreePath := filepath.Join(root, "feature-branch")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig: %v", err)
@@ -47,11 +66,12 @@ func TestInjectContainerConfig_WorkerRole(t *testing.T) {
 }
 
 // TestInjectContainerConfig_CoordinatorRole verifies that a worktree directory
-// named "main" causes injectContainerConfig to select ContainerCoordinatorConfig.
+// named "main" (parent has .bare) causes injectContainerConfig to select ContainerCoordinatorConfig.
 func TestInjectContainerConfig_CoordinatorRole(t *testing.T) {
+	root := makeBareRoot(t, "main")
 	pf := makeInjectTestProfile()
 	opts := session.Opts{}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "main")
+	worktreePath := filepath.Join(root, "main")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig: %v", err)
@@ -63,13 +83,33 @@ func TestInjectContainerConfig_CoordinatorRole(t *testing.T) {
 	}
 }
 
+// TestInjectContainerConfig_NonWorktreePath verifies that a non-worktree path
+// (parent directory has no .bare) receives the coordinator config blob so that
+// build and plan mode agents are available.
+func TestInjectContainerConfig_NonWorktreePath(t *testing.T) {
+	// Plain temp dir — no .bare parent.
+	worktreePath := t.TempDir()
+	pf := makeInjectTestProfile()
+	opts := session.Opts{}
+
+	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
+		t.Fatalf("injectContainerConfig: %v", err)
+	}
+
+	if opts.ConfigContent != pf.ContainerCoordinatorConfig {
+		t.Errorf("ConfigContent = %q, want %q (coordinator blob for non-worktree path)",
+			opts.ConfigContent, pf.ContainerCoordinatorConfig)
+	}
+}
+
 // TestInjectContainerConfig_ExplicitAgentOverride verifies that an explicit
 // opts.Agent override is respected: when opts.Agent is "coordinator", the
 // coordinator blob is selected even for a non-"main" directory.
 func TestInjectContainerConfig_ExplicitAgentOverride(t *testing.T) {
+	root := makeBareRoot(t, "feature-branch")
 	pf := makeInjectTestProfile()
 	opts := session.Opts{Agent: "coordinator"}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+	worktreePath := filepath.Join(root, "feature-branch")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig: %v", err)
@@ -86,6 +126,7 @@ func TestInjectContainerConfig_ExplicitAgentOverride(t *testing.T) {
 // file exists but the relevant role config blob is empty, ConfigContent is left
 // empty and no error is returned.
 func TestInjectContainerConfig_EmptyBlobNoError(t *testing.T) {
+	root := makeBareRoot(t, "feature-branch")
 	pf := &config.ProfilesFile{
 		// Both blobs are intentionally empty to simulate a profiles.json that
 		// was generated without container configs.
@@ -93,7 +134,7 @@ func TestInjectContainerConfig_EmptyBlobNoError(t *testing.T) {
 		ContainerCoordinatorConfig: "",
 	}
 	opts := session.Opts{}
-	worktreePath := filepath.Join("/some/repo/.bare/worktrees", "feature-branch")
+	worktreePath := filepath.Join(root, "feature-branch")
 
 	if err := injectContainerConfig(worktreePath, pf, &opts, "test"); err != nil {
 		t.Fatalf("injectContainerConfig returned error on empty blob: %v", err)
@@ -103,3 +144,4 @@ func TestInjectContainerConfig_EmptyBlobNoError(t *testing.T) {
 		t.Errorf("ConfigContent = %q, want empty (no blob for role)", opts.ConfigContent)
 	}
 }
+

--- a/modules/programs/prism/prism/cmd/inject_container_config_test.go
+++ b/modules/programs/prism/prism/cmd/inject_container_config_test.go
@@ -144,4 +144,3 @@ func TestInjectContainerConfig_EmptyBlobNoError(t *testing.T) {
 		t.Errorf("ConfigContent = %q, want empty (no blob for role)", opts.ConfigContent)
 	}
 }
-

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -107,16 +107,22 @@ var prCmd = &cobra.Command{
 			if pfErr != nil {
 				return pfErr
 			}
-			effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
-			roleConfig, roleErr := config.ContainerConfigForRole(pf, effectiveRole)
-			if roleErr != nil {
-				return roleErr
-			}
-			if roleConfig != "" {
-				configContent = roleConfig
-			} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
-				fmt.Fprintf(os.Stderr, "[prism pr] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
-			}
+		effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
+		// Non-worktree paths (effectiveRole == "") use the coordinator config blob
+		// so that build/plan agents are available, but pass no --agent flag.
+		lookupRole := effectiveRole
+		if lookupRole == "" {
+			lookupRole = "coordinator"
+		}
+		roleConfig, roleErr := config.ContainerConfigForRole(pf, lookupRole)
+		if roleErr != nil {
+			return roleErr
+		}
+		if roleConfig != "" {
+			configContent = roleConfig
+		} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
+			fmt.Fprintf(os.Stderr, "[prism pr] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
+		}
 		}
 
 		// For bwrap sessions, write the opencode.json config file to disk now

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -107,22 +107,22 @@ var prCmd = &cobra.Command{
 			if pfErr != nil {
 				return pfErr
 			}
-		effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
-		// Non-worktree paths (effectiveRole == "") use the coordinator config blob
-		// so that build/plan agents are available, but pass no --agent flag.
-		lookupRole := effectiveRole
-		if lookupRole == "" {
-			lookupRole = "coordinator"
-		}
-		roleConfig, roleErr := config.ContainerConfigForRole(pf, lookupRole)
-		if roleErr != nil {
-			return roleErr
-		}
-		if roleConfig != "" {
-			configContent = roleConfig
-		} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
-			fmt.Fprintf(os.Stderr, "[prism pr] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
-		}
+			effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
+			// Non-worktree paths (effectiveRole == "") use the coordinator config blob
+			// so that build/plan agents are available, but pass no --agent flag.
+			lookupRole := effectiveRole
+			if lookupRole == "" {
+				lookupRole = "coordinator"
+			}
+			roleConfig, roleErr := config.ContainerConfigForRole(pf, lookupRole)
+			if roleErr != nil {
+				return roleErr
+			}
+			if roleConfig != "" {
+				configContent = roleConfig
+			} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
+				fmt.Fprintf(os.Stderr, "[prism pr] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
+			}
 		}
 
 		// For bwrap sessions, write the opencode.json config file to disk now

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -326,7 +326,13 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 			fmt.Fprintf(os.Stderr, "restore %q: load profiles: %v — skipping config injection\n", s.SessionName, pfErr)
 		} else {
 			effectiveRole := session.DefaultAgentForSession(s.SessionName, directory, "", d)
-			roleConfig, roleErr := config.ContainerConfigForRole(pf, effectiveRole)
+			// Non-worktree paths (effectiveRole == "") use the coordinator config blob
+			// so that build/plan agents are available, but pass no --agent flag.
+			lookupRole := effectiveRole
+			if lookupRole == "" {
+				lookupRole = "coordinator"
+			}
+			roleConfig, roleErr := config.ContainerConfigForRole(pf, lookupRole)
 			if roleErr != nil {
 				fmt.Fprintf(os.Stderr, "restore %q: container config for role %q: %v — skipping config injection\n", s.SessionName, effectiveRole, roleErr)
 			} else if roleConfig != "" {

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -616,10 +616,12 @@ func TestRestoreSession_HostModeOverride(t *testing.T) {
 		t.Fatalf("session %q was not created", sessionName)
 	}
 
-	// Agent pane start command must contain "opencode --agent ...", not "podman attach".
+	// Agent pane start command must contain "opencode" but NOT "podman attach".
+	// For a non-worktree path (no .bare parent), no --agent flag is added,
+	// but the command is still opencode directly (host mode).
 	pane := agentPaneStartCmd(t, s, sessionName)
-	if !strings.Contains(pane, "opencode --agent") {
-		t.Errorf("agent pane missing 'opencode --agent' — captured:\n%s", pane)
+	if !strings.Contains(pane, "opencode") {
+		t.Errorf("agent pane missing 'opencode' — captured:\n%s", pane)
 	}
 	if strings.Contains(pane, "podman attach") {
 		t.Errorf("agent pane contains 'podman attach' but should be in host mode — captured:\n%s", pane)
@@ -728,8 +730,12 @@ func TestRestoreSession_ContainerMode_WorkerConfigContent(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	// Use a non-main worktree directory so DefaultAgent returns "worker".
-	worktreeDir := filepath.Join(t.TempDir(), "feature-branch")
+	// Use a non-main worktree directory in a bare-root so DefaultAgent returns "worker".
+	bareRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bareRoot, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatalf("write .bare: %v", err)
+	}
+	worktreeDir := filepath.Join(bareRoot, "feature-branch")
 	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -776,8 +782,12 @@ func TestRestoreSession_ContainerMode_CoordinatorConfigContent(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	// "main" as the base name causes DefaultAgent to return "coordinator".
-	worktreeDir := filepath.Join(t.TempDir(), "main")
+	// "main" as the base name in a bare-root causes DefaultAgent to return "coordinator".
+	bareRoot2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bareRoot2, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatalf("write .bare: %v", err)
+	}
+	worktreeDir := filepath.Join(bareRoot2, "main")
 	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -1211,8 +1221,12 @@ func TestRestoreSession_BwrapMode_WorkerConfigContent(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	// Non-main worktree → DefaultAgent returns "worker".
-	worktreeDir := filepath.Join(t.TempDir(), "feature-branch")
+	// Non-main worktree in a bare-root → DefaultAgent returns "worker".
+	bareRoot3 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bareRoot3, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatalf("write .bare: %v", err)
+	}
+	worktreeDir := filepath.Join(bareRoot3, "feature-branch")
 	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -1275,7 +1289,11 @@ func TestRestoreSession_BwrapMode_TempFileWritten(t *testing.T) {
 
 	d := openRestoreTestDB(t)
 
-	worktreeDir := filepath.Join(t.TempDir(), "feature-x")
+	bareRoot4 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bareRoot4, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatalf("write .bare: %v", err)
+	}
+	worktreeDir := filepath.Join(bareRoot4, "feature-x")
 	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -278,7 +278,13 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	sandboxed := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap
 	if sandboxed && pf != nil {
 		effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
-		roleConfig, roleErr := config.ContainerConfigForRole(pf, effectiveRole)
+		// Non-worktree paths (effectiveRole == "") use the coordinator config blob
+		// so that build/plan agents are available, but pass no --agent flag.
+		lookupRole := effectiveRole
+		if lookupRole == "" {
+			lookupRole = "coordinator"
+		}
+		roleConfig, roleErr := config.ContainerConfigForRole(pf, lookupRole)
 		if roleErr != nil {
 			return roleErr
 		}

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -432,7 +432,13 @@ func promptBranchInput(prompt string) string {
 // the effective isolation mode is podman or bwrap.
 func injectContainerConfig(path string, pf *config.ProfilesFile, opts *session.Opts, cmdName string) error {
 	effectiveRole := session.DefaultAgent(path, opts.Agent)
-	roleConfig, err := config.ContainerConfigForRole(pf, effectiveRole)
+	// Non-worktree paths (effectiveRole == "") use the coordinator config blob
+	// so that build/plan agents are available, but pass no --agent flag.
+	lookupRole := effectiveRole
+	if lookupRole == "" {
+		lookupRole = "coordinator"
+	}
+	roleConfig, err := config.ContainerConfigForRole(pf, lookupRole)
 	if err != nil {
 		return err
 	}

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -183,16 +183,24 @@ const (
 
 // DefaultAgent returns the agent to use for the given directory.
 // If explicit is non-empty it is returned unchanged.
-// Otherwise "coordinator" is returned for the "main" worktree and "worker" for
-// everything else.
+// Otherwise the parent directory is checked for a .bare entry (prism
+// bare+worktree layout):
+//   - parent has .bare AND basename == "main"  → "coordinator"
+//   - parent has .bare AND basename ≠ "main"   → "worker"
+//   - parent does NOT have .bare               → "" (non-worktree path)
+//
+// Callers must treat "" as "no --agent flag, but use coordinator config blob".
 func DefaultAgent(directory, explicit string) string {
 	if explicit != "" {
 		return explicit
 	}
-	if filepath.Base(directory) == "main" {
-		return "coordinator"
+	if git.IsBareRepo(filepath.Dir(directory)) {
+		if filepath.Base(directory) == "main" {
+			return "coordinator"
+		}
+		return "worker"
 	}
-	return "worker"
+	return ""
 }
 
 // DefaultAgentForSession returns the agent to use for the given session,
@@ -285,10 +293,12 @@ func BuildOpencodeCmd(opts Opts) string {
 // buildDirectOpencodeCmd returns the opencode direct-launch command (pre-container mode).
 func buildDirectOpencodeCmd(opts Opts) string {
 	agent := opts.Agent
-	if agent == "" {
-		agent = "worker"
+	var cmd string
+	if agent != "" {
+		cmd = "opencode --agent " + agent
+	} else {
+		cmd = "opencode"
 	}
-	cmd := "opencode --agent " + agent
 	if opts.Port != 0 {
 		cmd += fmt.Sprintf(" --port %d --hostname 127.0.0.1", opts.Port)
 	}

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -71,7 +71,6 @@ func TestDefaultAgent(t *testing.T) {
 	}
 }
 
-
 // prepended to the command string before PRISM_SESSION_NAME in host-mode
 // (ContainerMode = false) sessions.
 func TestBuildDirectOpencodeCmd_AgentEnvVars(t *testing.T) {

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -10,7 +10,68 @@ import (
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
-// TestBuildDirectOpencodeCmd_AgentEnvVars verifies that AgentEnvVars are
+// TestDefaultAgent covers the three cases described in issue #952:
+//  1. main worktree (parent has .bare, basename == "main") → "coordinator"
+//  2. non-main worktree (parent has .bare, basename ≠ "main") → "worker"
+//  3. non-worktree path (parent does NOT have .bare) → ""
+//
+// It also verifies that an explicit non-empty value always wins regardless of
+// directory type.
+func TestDefaultAgent(t *testing.T) {
+	// Set up a temporary directory structure:
+	//   <tmp>/
+	//     bare-root/       ← acts as the bare+worktree project root
+	//       .bare          ← signals prism bare layout to IsBareRepo
+	//       main/          ← worktree at "main"
+	//       feature-branch/ ← non-main worktree
+	//     regular-repo/    ← plain directory (no .bare in parent)
+
+	tmp := t.TempDir()
+	bareRoot := filepath.Join(tmp, "bare-root")
+	if err := os.MkdirAll(filepath.Join(bareRoot, "main"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(bareRoot, "feature-branch"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create .bare marker so IsBareRepo(bareRoot) returns true.
+	if err := os.WriteFile(filepath.Join(bareRoot, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	regularRepo := filepath.Join(tmp, "regular-repo")
+	if err := os.MkdirAll(regularRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mainWorktree := filepath.Join(bareRoot, "main")
+	featureWorktree := filepath.Join(bareRoot, "feature-branch")
+
+	tests := []struct {
+		name      string
+		directory string
+		explicit  string
+		want      string
+	}{
+		{"main worktree → coordinator", mainWorktree, "", "coordinator"},
+		{"feature worktree → worker", featureWorktree, "", "worker"},
+		{"regular repo → empty", regularRepo, "", ""},
+		{"non-git dir → empty", filepath.Join(tmp, "documents"), "", ""},
+		{"explicit overrides main", mainWorktree, "worker", "worker"},
+		{"explicit overrides feature", featureWorktree, "coordinator", "coordinator"},
+		{"explicit overrides regular", regularRepo, "worker", "worker"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DefaultAgent(tc.directory, tc.explicit)
+			if got != tc.want {
+				t.Errorf("DefaultAgent(%q, %q) = %q, want %q", tc.directory, tc.explicit, got, tc.want)
+			}
+		})
+	}
+}
+
+
 // prepended to the command string before PRISM_SESSION_NAME in host-mode
 // (ContainerMode = false) sessions.
 func TestBuildDirectOpencodeCmd_AgentEnvVars(t *testing.T) {


### PR DESCRIPTION
## Summary

- `DefaultAgent` now uses `git.IsBareRepo(filepath.Dir(directory))` to distinguish worktree paths from regular dirs: returns `"coordinator"` (main), `"worker"` (non-main worktree), or `""` (non-worktree).
- Callers in `spawn.go`, `switch.go`, and `restore.go` treat `""` as: no `--agent` flag, but mount the coordinator config blob.
- `buildDirectOpencodeCmd` now omits `--agent` entirely when `opts.Agent` is empty.
- All affected tests updated to use real filesystem layouts with `.bare` markers.

Closes #952