### PR TITLE
migrate f/t motions to leap.nvim and add openrouter provider

### DIFF
--- a/modules/programs/prism/neovim/plugins/leap.nix
+++ b/modules/programs/prism/neovim/plugins/leap.nix
@@ -9,15 +9,30 @@
         ''
           vim.keymap.set({'n', 'x', 'o'}, 's', '<Plug>(leap)')
           vim.keymap.set('n',             'S', '<Plug>(leap-from-window)')
-        '';
-    }
-    {
-      plugin = pkgs.vimPlugins.flit-nvim;
-      type = "lua";
-      config =
-        # lua
-        ''
-          require("flit").setup()
+
+          -- f/F/t/T via leap (replaces flit.nvim)
+          do
+            local function ft(key_specific_args)
+              require('leap').leap(
+                vim.tbl_deep_extend('keep', key_specific_args, {
+                  inputlen = 1,
+                  inclusive = true,
+                  opts = {
+                    labels = "",
+                    safe_labels = vim.fn.mode(1):match('o') and "" or nil,
+                  },
+                })
+              )
+            end
+
+            local clever_f = require('leap.user').with_traversal_keys('f', 'F')
+            local clever_t = require('leap.user').with_traversal_keys('t', 'T')
+
+            vim.keymap.set({'n', 'x', 'o'}, 'f', function() ft { opts = clever_f } end)
+            vim.keymap.set({'n', 'x', 'o'}, 'F', function() ft { backward = true,  opts = clever_f } end)
+            vim.keymap.set({'n', 'x', 'o'}, 't', function() ft { offset = -1,      opts = clever_t } end)
+            vim.keymap.set({'n', 'x', 'o'}, 'T', function() ft { backward = true, offset = 1, opts = clever_t } end)
+          end
         '';
     }
     pkgs.vimPlugins.vim-repeat

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -431,6 +431,7 @@
         anthropic = { };
         github-copilot = { };
         google = { };
+        openrouter = { };
       };
       hmUser = config.home-manager.users.${config.nx.username};
 
@@ -534,6 +535,7 @@
         "anthropic"
         "github-copilot"
         "google"
+        "openrouter"
       ];
 
       # Relative paths resolve from the opencode.json config file location


### PR DESCRIPTION
This change replaces flit.nvim by configuring native leap.nvim motions for f, F, t, and T to provide a more consistent experience. Additionally, the openrouter provider is added to the opencode configuration to expand available AI service options.