### PR TITLE
container: suppress KUBECONFIG and AWS_CONFIG_FILE in bwrap/podman env injection

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -457,15 +457,27 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--setenv", k, v)
 	}
 
-	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true, KUBECONFIG,
-	// AWS_CONFIG_FILE). These come from profiles.json agent_env_vars (written
-	// by Nix). Emitted in sorted key order for determinism. bwrap --setenv
-	// takes KEY and VALUE as distinct argv elements so no shell quoting is
-	// needed — special characters in values are passed verbatim.
+	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true). These come
+	// from profiles.json agent_env_vars (written by Nix). Emitted in sorted
+	// key order for determinism. bwrap --setenv takes KEY and VALUE as distinct
+	// argv elements so no shell quoting is needed — special characters in
+	// values are passed verbatim.
+	//
+	// KUBECONFIG and AWS_CONFIG_FILE are intentionally suppressed here: both
+	// files are already bind-mounted at their canonical default paths
+	// (~/.kube/config and ~/.aws/config respectively), so the host XDG paths
+	// held in AgentEnvVars do not exist inside the sandbox and would only
+	// override the correctly-mounted locations.
+	sandboxMountedByDefault := map[string]bool{
+		"KUBECONFIG":      true,
+		"AWS_CONFIG_FILE": true,
+	}
 	if len(cfg.AgentEnvVars) > 0 {
 		keys := make([]string, 0, len(cfg.AgentEnvVars))
 		for k := range cfg.AgentEnvVars {
-			keys = append(keys, k)
+			if !sandboxMountedByDefault[k] {
+				keys = append(keys, k)
+			}
 		}
 		sort.Strings(keys)
 		for _, k := range keys {

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -1280,9 +1280,10 @@ func TestBwrapBuildArgs_ColortermOmittedWhenUnset(t *testing.T) {
 
 // ── AgentEnvVars (--setenv K V) ───────────────────────────────────────────────
 
-// TestBwrapBuildArgs_AgentEnvVarsInjected verifies that entries in
-// Config.AgentEnvVars (e.g. GIT_EDITOR, KUBECONFIG, AWS_CONFIG_FILE) are
-// emitted as --setenv K V in the bwrap arg list.
+// TestBwrapBuildArgs_AgentEnvVarsInjected verifies that plain entries in
+// Config.AgentEnvVars (e.g. GIT_EDITOR) are emitted as --setenv K V in the
+// bwrap arg list, while KUBECONFIG and AWS_CONFIG_FILE are suppressed because
+// those files are bind-mounted at their canonical default paths.
 func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
 	m, _, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
@@ -1299,14 +1300,141 @@ func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	cases := [][2]string{
-		{"GIT_EDITOR", "true"},
-		{"KUBECONFIG", "/home/ben/.config/kube/agents-config"},
-		{"AWS_CONFIG_FILE", "/home/ben/.config/aws/readonly-config"},
+	// GIT_EDITOR must be injected.
+	if !hasSetenv(args, "GIT_EDITOR", "true") {
+		t.Errorf("--setenv GIT_EDITOR true not found in args: %v", args)
 	}
-	for _, c := range cases {
-		if !hasSetenv(args, c[0], c[1]) {
-			t.Errorf("--setenv %s %q not found in args: %v", c[0], c[1], args)
+
+	// KUBECONFIG and AWS_CONFIG_FILE must NOT be injected — the files are
+	// already bind-mounted at their canonical default paths inside the sandbox.
+	for i, arg := range args {
+		if arg == "--setenv" && i+1 < len(args) {
+			key := args[i+1]
+			if key == "KUBECONFIG" {
+				t.Errorf("KUBECONFIG must not be injected in bwrap mode; found in args: %v", args)
+			}
+			if key == "AWS_CONFIG_FILE" {
+				t.Errorf("AWS_CONFIG_FILE must not be injected in bwrap mode; found in args: %v", args)
+			}
+		}
+	}
+}
+
+// TestBwrapBuildArgs_KubeconfigNotInjectedWhenAbsent verifies that KUBECONFIG
+// is suppressed even when ~/.config/kube/agents-config does not exist (mount
+// is skipped but the host path is still wrong inside the sandbox).
+func TestBwrapBuildArgs_KubeconfigNotInjectedWhenAbsent(t *testing.T) {
+	fakeHome := t.TempDir()
+	// Do NOT create kube dir — file absent.
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", fakeHome); err != nil {
+		t.Fatalf("Setenv HOME: %v", err)
+	}
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	// Minimal fixture: create the dirs/files required by BuildArgs.
+	for _, d := range []string{
+		filepath.Join(fakeHome, ".claude"),
+		filepath.Join(fakeHome, ".mcp-auth"),
+		filepath.Join(fakeHome, ".local", "share", "opencode"),
+		filepath.Join(fakeHome, ".cache", "nix"),
+		filepath.Join(fakeHome, ".ssh"),
+		filepath.Join(fakeHome, ".config", "aws"),
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("MkdirAll %q: %v", d, err)
+		}
+	}
+	for _, f := range []string{
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"),
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey"),
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey.pub"),
+		filepath.Join(fakeHome, ".ssh", "known_hosts"),
+		filepath.Join(fakeHome, ".config", "aws", "readonly-config"),
+	} {
+		if err := os.WriteFile(f, []byte("fake"), 0o600); err != nil {
+			t.Fatalf("WriteFile %q: %v", f, err)
+		}
+	}
+
+	m := newBwrapManager(Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentEnvVars:  map[string]string{"KUBECONFIG": "/home/ben/.config/kube/agents-config"},
+	})
+	if err := os.WriteFile(m.sshConfigFilePath(), []byte("fake"), 0o600); err != nil {
+		t.Fatalf("WriteFile ssh config: %v", err)
+	}
+	if err := os.WriteFile(m.gitconfigFilePath(), []byte("fake"), 0o600); err != nil {
+		t.Fatalf("WriteFile gitconfig: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for i, arg := range args {
+		if arg == "--setenv" && i+1 < len(args) && args[i+1] == "KUBECONFIG" {
+			t.Errorf("KUBECONFIG must not be injected even when kube file is absent; found in args: %v", args)
+		}
+	}
+}
+
+// TestBwrapBuildArgs_AwsConfigFileNotInjectedWhenAbsent verifies that
+// AWS_CONFIG_FILE is suppressed even when ~/.config/aws/readonly-config does
+// not exist.
+func TestBwrapBuildArgs_AwsConfigFileNotInjectedWhenAbsent(t *testing.T) {
+	fakeHome := t.TempDir()
+	// Do NOT create aws dir — file absent.
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", fakeHome); err != nil {
+		t.Fatalf("Setenv HOME: %v", err)
+	}
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	for _, d := range []string{
+		filepath.Join(fakeHome, ".claude"),
+		filepath.Join(fakeHome, ".mcp-auth"),
+		filepath.Join(fakeHome, ".local", "share", "opencode"),
+		filepath.Join(fakeHome, ".cache", "nix"),
+		filepath.Join(fakeHome, ".ssh"),
+		filepath.Join(fakeHome, ".config", "kube"),
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("MkdirAll %q: %v", d, err)
+		}
+	}
+	for _, f := range []string{
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"),
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey"),
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey.pub"),
+		filepath.Join(fakeHome, ".ssh", "known_hosts"),
+		filepath.Join(fakeHome, ".config", "kube", "agents-config"),
+	} {
+		if err := os.WriteFile(f, []byte("fake"), 0o600); err != nil {
+			t.Fatalf("WriteFile %q: %v", f, err)
+		}
+	}
+
+	m := newBwrapManager(Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		AgentEnvVars:  map[string]string{"AWS_CONFIG_FILE": "/home/ben/.config/aws/readonly-config"},
+	})
+	if err := os.WriteFile(m.sshConfigFilePath(), []byte("fake"), 0o600); err != nil {
+		t.Fatalf("WriteFile ssh config: %v", err)
+	}
+	if err := os.WriteFile(m.gitconfigFilePath(), []byte("fake"), 0o600); err != nil {
+		t.Fatalf("WriteFile gitconfig: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for i, arg := range args {
+		if arg == "--setenv" && i+1 < len(args) && args[i+1] == "AWS_CONFIG_FILE" {
+			t.Errorf("AWS_CONFIG_FILE must not be injected even when aws file is absent; found in args: %v", args)
 		}
 	}
 }

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -1399,13 +1399,25 @@ func (m *Manager) buildRunArgs() []string {
 		args = append(args, "--env", kv)
 	}
 
-	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true, KUBECONFIG,
-	// AWS_CONFIG_FILE). These come from profiles.json agent_env_vars (written
-	// by Nix). Emitted in sorted key order for determinism.
+	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true). These come
+	// from profiles.json agent_env_vars (written by Nix). Emitted in sorted
+	// key order for determinism.
+	//
+	// KUBECONFIG and AWS_CONFIG_FILE are intentionally suppressed here: both
+	// files are already bind-mounted at their canonical default paths
+	// (/root/.kube/config and /root/.aws/config respectively), so the host
+	// XDG paths held in AgentEnvVars do not exist inside the container and
+	// would only override the correctly-mounted locations.
+	sandboxMountedByDefault := map[string]bool{
+		"KUBECONFIG":      true,
+		"AWS_CONFIG_FILE": true,
+	}
 	if len(cfg.AgentEnvVars) > 0 {
 		keys := make([]string, 0, len(cfg.AgentEnvVars))
 		for k := range cfg.AgentEnvVars {
-			keys = append(keys, k)
+			if !sandboxMountedByDefault[k] {
+				keys = append(keys, k)
+			}
 		}
 		sort.Strings(keys)
 		for _, k := range keys {

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -3267,9 +3267,10 @@ func TestOpencodeConfigFilePath_MatchesManagerMethod(t *testing.T) {
 
 // ── AgentEnvVars (--env K=V) ──────────────────────────────────────────────────
 
-// TestBuildRunArgs_AgentEnvVarsInjected verifies that entries in
-// Config.AgentEnvVars (e.g. GIT_EDITOR, KUBECONFIG, AWS_CONFIG_FILE) are
-// emitted as --env KEY=VALUE in the podman run arg list.
+// TestBuildRunArgs_AgentEnvVarsInjected verifies that plain entries in
+// Config.AgentEnvVars (e.g. GIT_EDITOR) are emitted as --env KEY=VALUE in the
+// podman run arg list, while KUBECONFIG and AWS_CONFIG_FILE are suppressed
+// because those files are bind-mounted at their canonical default paths.
 func TestBuildRunArgs_AgentEnvVarsInjected(t *testing.T) {
 	m := New(Config{
 		SessionName:   "repo@feat",
@@ -3282,22 +3283,65 @@ func TestBuildRunArgs_AgentEnvVarsInjected(t *testing.T) {
 	})
 	args := m.buildRunArgs()
 
-	cases := [][2]string{
-		{"GIT_EDITOR", "true"},
-		{"KUBECONFIG", "/home/ben/.config/kube/agents-config"},
-		{"AWS_CONFIG_FILE", "/home/ben/.config/aws/readonly-config"},
+	// GIT_EDITOR must be injected.
+	want := "GIT_EDITOR=true"
+	found := false
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && args[i+1] == want {
+			found = true
+			break
+		}
 	}
-	for _, c := range cases {
-		want := c[0] + "=" + c[1]
-		found := false
-		for i, arg := range args {
-			if arg == "--env" && i+1 < len(args) && args[i+1] == want {
-				found = true
-				break
+	if !found {
+		t.Errorf("--env %q not found in podman args: %v", want, args)
+	}
+
+	// KUBECONFIG and AWS_CONFIG_FILE must NOT be injected — the files are
+	// already bind-mounted at their canonical default paths inside the container.
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) {
+			val := args[i+1]
+			if strings.HasPrefix(val, "KUBECONFIG=") {
+				t.Errorf("KUBECONFIG must not be injected in podman mode; found %q in args: %v", val, args)
+			}
+			if strings.HasPrefix(val, "AWS_CONFIG_FILE=") {
+				t.Errorf("AWS_CONFIG_FILE must not be injected in podman mode; found %q in args: %v", val, args)
 			}
 		}
-		if !found {
-			t.Errorf("--env %q not found in podman args: %v", want, args)
+	}
+}
+
+// TestBuildRunArgs_KubeconfigNotInjectedWhenAbsent verifies that KUBECONFIG is
+// suppressed even when ~/.config/kube/agents-config does not exist on the host.
+func TestBuildRunArgs_KubeconfigNotInjectedWhenAbsent(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentEnvVars:  map[string]string{"KUBECONFIG": "/home/ben/.config/kube/agents-config"},
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && strings.HasPrefix(args[i+1], "KUBECONFIG=") {
+			t.Errorf("KUBECONFIG must not be injected even when kube file is absent; found %q in args: %v", args[i+1], args)
+		}
+	}
+}
+
+// TestBuildRunArgs_AwsConfigFileNotInjectedWhenAbsent verifies that
+// AWS_CONFIG_FILE is suppressed even when ~/.config/aws/readonly-config does
+// not exist on the host.
+func TestBuildRunArgs_AwsConfigFileNotInjectedWhenAbsent(t *testing.T) {
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+		AgentEnvVars:  map[string]string{"AWS_CONFIG_FILE": "/home/ben/.config/aws/readonly-config"},
+	})
+	args := m.buildRunArgs()
+
+	for i, arg := range args {
+		if arg == "--env" && i+1 < len(args) && strings.HasPrefix(args[i+1], "AWS_CONFIG_FILE=") {
+			t.Errorf("AWS_CONFIG_FILE must not be injected even when aws file is absent; found %q in args: %v", args[i+1], args)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- In bwrap and podman isolation modes, `KUBECONFIG` and `AWS_CONFIG_FILE` were being injected from `AgentEnvVars` despite both files already being bind-mounted at their canonical default paths inside the sandbox
- The host XDG paths (`~/.config/kube/agents-config`, `~/.config/aws/readonly-config`) don't exist inside the sandbox and were overriding the correctly-mounted locations
- Added a filter in both injection loops to suppress these two vars; all other `AgentEnvVars` (including `GIT_EDITOR`) continue to be injected unchanged
- Host mode is unaffected — the filter only applies in the bwrap and podman code paths

## Tests

- Updated `TestBwrapBuildArgs_AgentEnvVarsInjected` and `TestBuildRunArgs_AgentEnvVarsInjected` to assert suppression
- Added edge-case tests for both vars when the underlying files are absent (suppression still applies)

Closes #957