### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776721614,
-        "narHash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U=",
+        "lastModified": 1776904464,
+        "narHash": "sha256-sBUCj7/4d3Hoevpu3oQp8ccJNA1EDeVmFi1F8O6VJro=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c555a4a34a260493be5adb795c54e013c58f2d34",
+        "rev": "667b3c47325441e6a444faaf405bba76ec70338a",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1776746178,
-        "narHash": "sha256-9UIeN1ps3EqeOj/BaSLIIrknikTxKYA4U3s8Cxo9LSo=",
+        "lastModified": 1776920365,
+        "narHash": "sha256-+tOsjH7+7Gg08KXlmvb+l+TDjDzGKsGf93pjiby50bo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5223754a980187d21c9b2302ce6a665d6903f1bb",
+        "rev": "760cd162a3b8e1a655c39750e045811437156b77",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1776434932,
-        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776119890,
-        "narHash": "sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M=",
+        "lastModified": 1776771786,
+        "narHash": "sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "d4971dd58c6627bfee52a1ad4237637c0a2fb0cd",
+        "rev": "bef289e2248991f7afeb95965c82fbcd8ff72598",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/24818135747

## Closure diff: navi

```
abseil-cpp: 3.3 MiB
acl: 125.2 KiB
ada: ∅ → 3.4.4, 1.3 MiB
alsa-lib: 1.8 MiB
alsa-topology-conf: 336.1 KiB
alsa-ucm-conf: 841.8 KiB
at-spi2-core: 2.2 MiB
attr: 90.5 KiB
audit: 420.4 KiB
avahi: 1.6 MiB
bash: 1.8 MiB
bash-interactive: 7.1 MiB
bluez: ∅ → 5.86, 10.1 MiB
brotli: 1.0 MiB
bubblewrap: ∅ → 0.11.1, 107.1 KiB
bzip2: 86.9 KiB
c-ares: 787.5 KiB
cairo: 2.1 MiB
cdparanoia-iii: 366.9 KiB
cjson: 72.3 KiB
coreutils: 1.6 MiB
cracklib: 803.0 KiB
cryptsetup: ∅ → 2.8.6, 2.7 MiB
cups: 4.7 MiB
curl: ∅ → 8.19.0, 1.2 MiB
dav1d: 2.5 MiB
db: 3.5 MiB
dbus: 461.6 KiB
dconf: 324.5 KiB
dejavu-fonts-minimal: 742.6 KiB
elfutils: 4.0 MiB
ell: ∅ → 0.83, 658.7 KiB
expat: ∅ → 2.7.5, 302.2 KiB
fdk-aac: 1.6 MiB
ffado: 3.1 MiB
ffmpeg-headless: 33.1 MiB
fftw-double: 3.9 MiB
fftw-single: 4.1 MiB
file: 8.3 MiB
flac: 778.8 KiB
fontconfig: 1.6 MiB
freetype: ∅ → 2.14.2, 2.2 MiB
fribidi: 162.5 KiB
gcc: 10.0 MiB
gdbm: 448.6 KiB
gdk-pixbuf: 2.8 MiB
giflib: 407.5 KiB
glib: 15.1 MiB
glibc: ∅ → 2.42-61, 33.5 MiB
glibmm: 4.2 MiB
gmp-with-cxx: 1.5 MiB
gnugrep: 932.4 KiB
gnum4: ∅ → 1.4.21, 1.1 MiB
gnupg: 1.2 MiB
gnutar: 2.7 MiB
gnutls: 3.4 MiB
gobject-introspection: 1.2 MiB
graphene: 182.5 KiB
graphite2: 228.0 KiB
gsettings-desktop-schemas: 5.8 MiB
gst-plugins-base: ∅ → 1.26.11, 8.8 MiB
gstreamer: ∅ → 1.26.11, 5.9 MiB
gtest: 842.0 KiB
gtk+3: ∅ → 3.24.52, 41.6 MiB
harfbuzz: 3.6 MiB
hm_kittydiff.conf: ∅ → ε
home-configuration-reference: 10.8 KiB
hwdata: ∅ → 0.406, 9.9 MiB
icu4c: 44.0 MiB
iso-codes: 22.6 MiB
json-c: 244.8 KiB
json-glib: 662.9 KiB
kbd: 2.7 MiB
kexec-tools: 262.5 KiB
keyutils: 41.8 KiB
kmod: 325.6 KiB
krb5: 2.7 MiB
lame: 348.7 KiB
lcms2: 484.3 KiB
ldacBT: 88.7 KiB
lerc: ∅ → 4.1.0, 842.4 KiB
libao: 123.7 KiB
libaom: 8.4 MiB
libapparmor: ∅ → 4.1.7, 590.5 KiB
libappindicator-gtk3: 89.7 KiB
libarchive: ∅ → 3.8.6, 950.0 KiB
libass: 253.1 KiB
libassuan: 101.9 KiB
libavc1394: 145.7 KiB
libbluray: 1.1 MiB
libbpf: 2.1 MiB
libcamera: 6.1 MiB
libcanberra: 251.2 KiB
libcap: 73.4 KiB
libcap-ng: ∅ → 0.9.2, 161.8 KiB
libcbor: 83.6 KiB
libconfig: 398.1 KiB
libdaemon: 41.0 KiB
libdatrie: 42.2 KiB
libdbusmenu-gtk3: 632.5 KiB
libdeflate: 458.6 KiB
libdrm: 1.8 MiB
libebur128: 54.2 KiB
libepoxy: 1.7 MiB
libev: 225.9 KiB
libevent: 861.7 KiB
libffi: 72.1 KiB
libfido2: 1.1 MiB
libfreeaptx: 55.5 KiB
libgcrypt: 1.8 MiB
libglvnd: 2.5 MiB
libgpg-error: ∅ → 1.59, 885.0 KiB
libical: 3.9 MiB
libidn2: 368.3 KiB
libiec61883: 154.8 KiB
libjack2: 420.7 KiB
libjpeg-turbo: ∅ → 3.1.4, 2.0 MiB
liblc3: 175.1 KiB
libmad: 142.5 KiB
libmicrohttpd: 260.4 KiB
libmpg123: 1.1 MiB
libmysofa: 1.3 MiB
libnotify: 111.2 KiB
libogg: 47.0 KiB
libopenmpt: ∅ → 0.8.6, 2.9 MiB
libopus: 501.2 KiB
libpciaccess: ∅ → 0.19, 172.0 KiB
libpng-apng: ∅ → 1.6.56, 273.3 KiB
libpsl: 114.9 KiB
libpulseaudio: 4.7 MiB
libpwquality: 382.5 KiB
libraw1394: 196.5 KiB
librist: 422.9 KiB
libsamplerate: 1.5 MiB
libseccomp: 193.8 KiB
libselinux: 690.2 KiB
libsigc++: 42.0 KiB
libsndfile: 644.6 KiB
libsoup: 1.2 MiB
libssh: ∅ → 0.12.0, 682.3 KiB
libssh2: 326.6 KiB
libtasn1: 95.8 KiB
libthai: 637.0 KiB
libtheora: 675.4 KiB
libtiff: 739.2 KiB
libtool: 57.0 KiB
libtpms: 1.1 MiB
libunistring: ∅ → 1.4.2, 2.0 MiB
libunwind: 267.6 KiB
libusb: 158.0 KiB
libuv: ∅ → 1.52.1, 381.6 KiB
libva: 353.6 KiB
libva-minimal: 254.3 KiB
libvmaf: 2.7 MiB
libvorbis: 1.1 MiB
libvpx: 8.9 MiB
libwebp: 3.4 MiB
libx11: 2.6 MiB
libxau: 27.1 KiB
libxcb: 1.4 MiB
libxcomposite: 25.1 KiB
libxcrypt: 141.0 KiB
libxcursor: 78.0 KiB
libxdamage: 17.9 KiB
libxdmcp: 31.2 KiB
libxext: 93.7 KiB
libxfixes: 33.9 KiB
libxft: 151.0 KiB
libxi: 87.7 KiB
libxinerama: 21.7 KiB
libxkbcommon: 1.0 MiB
libxml++: 299.8 KiB
libxml2: 1.4 MiB
libxrandr: 62.6 KiB
libxrender: 53.2 KiB
libxscrnsaver: 32.9 KiB
libxtst: 117.6 KiB
libxv: 31.4 KiB
libyaml: 143.9 KiB
lilv: ∅ → 0.26.4, 380.8 KiB
linux-pam: 1.8 MiB
llhttp: 126.6 KiB
lttng-ust: 1.8 MiB
lvm2: 418.0 KiB
lz4: 256.0 KiB
lzo: 159.7 KiB
mailcap: 116.6 KiB
mbedtls: 12.5 MiB
mesa-libgbm: ∅ → 26.0.3, 58.2 KiB
mpdecimal: 220.9 KiB
mpg123: 1.1 MiB
ncurses: 3.7 MiB
nettle: 723.5 KiB
nghttp2: ∅ → 1.68.1, 3.2 MiB
nghttp3: ∅ → 1.15.0, 345.9 KiB
ngtcp2: ∅ → 1.22.0, 766.4 KiB
nodejs: ∅ → 24.14.1, 771.4 KiB
nodejs-slim: ∅ → 24.14.1, 92.7 MiB
npth: 56.0 KiB
nspr: 349.8 KiB
nss: 4.0 MiB
numactl: 269.9 KiB
ocl-icd: 609.3 KiB
openapv: ∅ → 0.2.1.2, 719.7 KiB
openfec: 204.4 KiB
openjpeg: 1.6 MiB
openssl: 12.1 MiB
opusfile: 124.6 KiB
orc: 844.3 KiB
p11-kit: ∅ → 0.26.2, 5.7 MiB
pango: 907.9 KiB
pcre2: 2.0 MiB
pcsclite: 107.3 KiB
pipewire: ∅ → 1.6.3, 16.6 MiB
pixman: 858.3 KiB
procps: 3.0 MiB
publicsuffix-list: ∅ → 0-unstable-2026-03-26, 328.2 KiB
python3: 126.7 MiB
qrencode: 62.6 KiB
readline: 494.5 KiB
ripgrep: 6.4 MiB
roc-toolkit: 7.9 MiB
sbc: 276.9 KiB
serd: ∅ → 0.32.8, 137.3 KiB
simdjson: ∅ → 4.6.0, 7.6 MiB
simdutf: ∅ → 8.1.0, 2.3 MiB
socat: 860.2 KiB
sord: 99.5 KiB
sox-unstable: 701.6 KiB
soxr: 298.4 KiB
spandsp: 983.9 KiB
speech-dispatcher: 488.3 KiB
speex: 133.7 KiB
speexdsp: 78.5 KiB
sqlite: 8.4 MiB
sratom: ∅ → 0.6.22, 47.2 KiB
srt: 6.8 MiB
svt-av1: 8.1 MiB
systemd: ∅ → 260.1, 59.9 MiB
systemd-minimal: ∅ → 260.1, 20.1 MiB
systemd-minimal-libs: ∅ → 260.1, 4.0 MiB
tinysparql: 4.7 MiB
tpm2-tss: 3.2 MiB
tremor-unstable: 132.7 KiB
tzdata: 2.0 MiB
unbound: 1.1 MiB
util-linux-minimal: ∅ → 2.42, 2.5 MiB
uvwasi: 238.0 KiB
v4l-utils: 782.0 KiB
vid.stab: 552.5 KiB
vulkan-loader: 683.8 KiB
wavpack: 547.0 KiB
wayland: 259.5 KiB
webrtc-audio-processing: 1.2 MiB
x264: 2.4 MiB
x265: 23.7 MiB
xgcc: 193.0 KiB
xkeyboard-config: 10.3 MiB
xorgproto: 1.6 MiB
xvidcore: 786.7 KiB
xz: ∅ → 5.8.3, 837.8 KiB
zimg: 758.8 KiB
zix: 142.0 KiB
zlib: 398.8 KiB
zstd: 1.7 MiB
zvbi: 1.0 MiB
```

## Closure diff: tui

```
abseil-cpp: 3.3 MiB
acl: 125.2 KiB
ada: ∅ → 3.4.4, 1.3 MiB
alsa-lib: 1.8 MiB
alsa-topology-conf: 336.1 KiB
alsa-ucm-conf: 841.8 KiB
at-spi2-core: 2.2 MiB
attr: 90.5 KiB
audit: 420.4 KiB
avahi: 1.6 MiB
bash: 1.8 MiB
bash-interactive: 7.1 MiB
bluez: ∅ → 5.86, 10.1 MiB
brotli: 1.0 MiB
bubblewrap: ∅ → 0.11.1, 107.1 KiB
bzip2: 86.9 KiB
c-ares: 787.5 KiB
cairo: 2.1 MiB
cdparanoia-iii: 366.9 KiB
cjson: 72.3 KiB
coreutils: 1.6 MiB
cracklib: 803.0 KiB
cryptsetup: ∅ → 2.8.6, 2.7 MiB
cups: 4.7 MiB
curl: ∅ → 8.19.0, 1.2 MiB
dav1d: 2.5 MiB
db: 3.5 MiB
dbus: 461.6 KiB
dconf: 324.5 KiB
dejavu-fonts-minimal: 742.6 KiB
elfutils: 4.0 MiB
ell: ∅ → 0.83, 658.7 KiB
expat: ∅ → 2.7.5, 302.2 KiB
fdk-aac: 1.6 MiB
ffado: 3.1 MiB
ffmpeg-headless: 33.1 MiB
fftw-double: 3.9 MiB
fftw-single: 4.1 MiB
file: 8.3 MiB
flac: 778.8 KiB
fontconfig: 1.6 MiB
freetype: ∅ → 2.14.2, 2.2 MiB
fribidi: 162.5 KiB
gcc: 10.0 MiB
gdbm: 448.6 KiB
gdk-pixbuf: 2.8 MiB
giflib: 407.5 KiB
glib: 15.1 MiB
glibc: ∅ → 2.42-61, 33.5 MiB
glibmm: 4.2 MiB
gmp-with-cxx: 1.5 MiB
gnugrep: 932.4 KiB
gnum4: ∅ → 1.4.21, 1.1 MiB
gnupg: 1.2 MiB
gnutar: 2.7 MiB
gnutls: 3.4 MiB
gobject-introspection: 1.2 MiB
graphene: 182.5 KiB
graphite2: 228.0 KiB
gsettings-desktop-schemas: 5.8 MiB
gst-plugins-base: ∅ → 1.26.11, 8.8 MiB
gstreamer: ∅ → 1.26.11, 5.9 MiB
gtest: 842.0 KiB
gtk+3: ∅ → 3.24.52, 41.6 MiB
harfbuzz: 3.6 MiB
hm_kittydiff.conf: ∅ → ε
home-configuration-reference: 10.8 KiB
hwdata: ∅ → 0.406, 9.9 MiB
icu4c: 44.0 MiB
iso-codes: 22.6 MiB
json-c: 244.8 KiB
json-glib: 662.9 KiB
kbd: 2.7 MiB
kexec-tools: 262.5 KiB
keyutils: 41.8 KiB
kmod: 325.6 KiB
krb5: 2.7 MiB
lame: 348.7 KiB
lcms2: 484.3 KiB
ldacBT: 88.7 KiB
lerc: ∅ → 4.1.0, 842.4 KiB
libao: 123.7 KiB
libaom: 8.4 MiB
libapparmor: ∅ → 4.1.7, 590.5 KiB
libappindicator-gtk3: 89.7 KiB
libarchive: ∅ → 3.8.6, 950.0 KiB
libass: 253.1 KiB
libassuan: 101.9 KiB
libavc1394: 145.7 KiB
libbluray: 1.1 MiB
libbpf: 2.1 MiB
libcamera: 6.1 MiB
libcanberra: 251.2 KiB
libcap: 73.4 KiB
libcap-ng: ∅ → 0.9.2, 161.8 KiB
libcbor: 83.6 KiB
libconfig: 398.1 KiB
libdaemon: 41.0 KiB
libdatrie: 42.2 KiB
libdbusmenu-gtk3: 632.5 KiB
libdeflate: 458.6 KiB
libdrm: 1.8 MiB
libebur128: 54.2 KiB
libepoxy: 1.7 MiB
libev: 225.9 KiB
libevent: 861.7 KiB
libffi: 72.1 KiB
libfido2: 1.1 MiB
libfreeaptx: 55.5 KiB
libgcrypt: 1.8 MiB
libglvnd: 2.5 MiB
libgpg-error: ∅ → 1.59, 885.0 KiB
libical: 3.9 MiB
libidn2: 368.3 KiB
libiec61883: 154.8 KiB
libjack2: 420.7 KiB
libjpeg-turbo: ∅ → 3.1.4, 2.0 MiB
liblc3: 175.1 KiB
libmad: 142.5 KiB
libmicrohttpd: 260.4 KiB
libmpg123: 1.1 MiB
libmysofa: 1.3 MiB
libnotify: 111.2 KiB
libogg: 47.0 KiB
libopenmpt: ∅ → 0.8.6, 2.9 MiB
libopus: 501.2 KiB
libpciaccess: ∅ → 0.19, 172.0 KiB
libpng-apng: ∅ → 1.6.56, 273.3 KiB
libpsl: 114.9 KiB
libpulseaudio: 4.7 MiB
libpwquality: 382.5 KiB
libraw1394: 196.5 KiB
librist: 422.9 KiB
libsamplerate: 1.5 MiB
libseccomp: 193.8 KiB
libselinux: 690.2 KiB
libsigc++: 42.0 KiB
libsndfile: 644.6 KiB
libsoup: 1.2 MiB
libssh: ∅ → 0.12.0, 682.3 KiB
libssh2: 326.6 KiB
libtasn1: 95.8 KiB
libthai: 637.0 KiB
libtheora: 675.4 KiB
libtiff: 739.2 KiB
libtool: 57.0 KiB
libtpms: 1.1 MiB
libunistring: ∅ → 1.4.2, 2.0 MiB
libunwind: 267.6 KiB
libusb: 158.0 KiB
libuv: ∅ → 1.52.1, 381.6 KiB
libva: 353.6 KiB
libva-minimal: 254.3 KiB
libvmaf: 2.7 MiB
libvorbis: 1.1 MiB
libvpx: 8.9 MiB
libwebp: 3.4 MiB
libx11: 2.6 MiB
libxau: 27.1 KiB
libxcb: 1.4 MiB
libxcomposite: 25.1 KiB
libxcrypt: 141.0 KiB
libxcursor: 78.0 KiB
libxdamage: 17.9 KiB
libxdmcp: 31.2 KiB
libxext: 93.7 KiB
libxfixes: 33.9 KiB
libxft: 151.0 KiB
libxi: 87.7 KiB
libxinerama: 21.7 KiB
libxkbcommon: 1.0 MiB
libxml++: 299.8 KiB
libxml2: 1.4 MiB
libxrandr: 62.6 KiB
libxrender: 53.2 KiB
libxscrnsaver: 32.9 KiB
libxtst: 117.6 KiB
libxv: 31.4 KiB
libyaml: 143.9 KiB
lilv: ∅ → 0.26.4, 380.8 KiB
linux-pam: 1.8 MiB
llhttp: 126.6 KiB
lttng-ust: 1.8 MiB
lvm2: 418.0 KiB
lz4: 256.0 KiB
lzo: 159.7 KiB
mailcap: 116.6 KiB
mbedtls: 12.5 MiB
mesa-libgbm: ∅ → 26.0.3, 58.2 KiB
mpdecimal: 220.9 KiB
mpg123: 1.1 MiB
ncurses: 3.7 MiB
nettle: 723.5 KiB
nghttp2: ∅ → 1.68.1, 3.2 MiB
nghttp3: ∅ → 1.15.0, 345.9 KiB
ngtcp2: ∅ → 1.22.0, 766.4 KiB
nodejs: ∅ → 24.14.1, 771.4 KiB
nodejs-slim: ∅ → 24.14.1, 92.7 MiB
npth: 56.0 KiB
nspr: 349.8 KiB
nss: 4.0 MiB
numactl: 269.9 KiB
ocl-icd: 609.3 KiB
openapv: ∅ → 0.2.1.2, 719.7 KiB
openfec: 204.4 KiB
openjpeg: 1.6 MiB
openssl: 12.1 MiB
opusfile: 124.6 KiB
orc: 844.3 KiB
p11-kit: ∅ → 0.26.2, 5.7 MiB
pango: 907.9 KiB
pcre2: 2.0 MiB
pcsclite: 107.3 KiB
pipewire: ∅ → 1.6.3, 16.6 MiB
pixman: 858.3 KiB
procps: 3.0 MiB
publicsuffix-list: ∅ → 0-unstable-2026-03-26, 328.2 KiB
python3: 126.7 MiB
qrencode: 62.6 KiB
readline: 494.5 KiB
ripgrep: 6.4 MiB
roc-toolkit: 7.9 MiB
sbc: 276.9 KiB
serd: ∅ → 0.32.8, 137.3 KiB
simdjson: ∅ → 4.6.0, 7.6 MiB
simdutf: ∅ → 8.1.0, 2.3 MiB
socat: 860.2 KiB
sord: 99.5 KiB
sox-unstable: 701.6 KiB
soxr: 298.4 KiB
spandsp: 983.9 KiB
speech-dispatcher: 488.3 KiB
speex: 133.7 KiB
speexdsp: 78.5 KiB
sqlite: 8.4 MiB
sratom: ∅ → 0.6.22, 47.2 KiB
srt: 6.8 MiB
svt-av1: 8.1 MiB
systemd: ∅ → 260.1, 59.9 MiB
systemd-minimal: ∅ → 260.1, 20.1 MiB
systemd-minimal-libs: ∅ → 260.1, 4.0 MiB
tinysparql: 4.7 MiB
tpm2-tss: 3.2 MiB
tremor-unstable: 132.7 KiB
tzdata: 2.0 MiB
unbound: 1.1 MiB
util-linux-minimal: ∅ → 2.42, 2.5 MiB
uvwasi: 238.0 KiB
v4l-utils: 782.0 KiB
vid.stab: 552.5 KiB
vulkan-loader: 683.8 KiB
wavpack: 547.0 KiB
wayland: 259.5 KiB
webrtc-audio-processing: 1.2 MiB
x264: 2.4 MiB
x265: 23.7 MiB
xgcc: 193.0 KiB
xkeyboard-config: 10.3 MiB
xorgproto: 1.6 MiB
xvidcore: 786.7 KiB
xz: ∅ → 5.8.3, 837.8 KiB
zimg: 758.8 KiB
zix: 142.0 KiB
zlib: 398.8 KiB
zstd: 1.7 MiB
zvbi: 1.0 MiB
```