### PR TITLE
sidecar: fix error state overwrite by immediate session.updated (#923)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -62,6 +62,18 @@ const IdleDebounce = 2 * time.Second
 // this timer.
 const ReconnectRecoveryDelay = 60 * time.Second
 
+// ErrorResumeDebounce is the window after a non-MessageAbortedError session.error
+// during which a session.updated event is treated as post-error churn and does NOT
+// transition the session from error to active. After this window, a genuine
+// user-initiated resume (session.updated) transitions normally.
+//
+// The opencode runtime emits a rapid burst of events in the same millisecond
+// after an error (session.error → session.status → session.updated → session.idle),
+// and the session.updated is internal housekeeping, not a user action. Without
+// this guard, the false resume would erase the error state and the coordinator
+// would see a spurious "finished" notification.
+const ErrorResumeDebounce = 5 * time.Second
+
 // Clock abstracts time and timer operations for testing.
 type Clock interface {
 	Now() time.Time
@@ -220,6 +232,11 @@ type Sidecar struct {
 	// can update the title display immediately without a DB round-trip.
 	// Protected by s.mu.
 	lastTitle string
+	// lastErrorAt records the time when handleSessionError last wrote StateError
+	// for a non-MessageAbortedError. Used by handleSessionUpdated to suppress
+	// false resumes caused by the post-error session.updated churn that opencode
+	// emits in the same millisecond as session.error. Protected by s.mu.
+	lastErrorAt time.Time
 }
 
 // New creates a Sidecar with the given configuration.
@@ -783,7 +800,26 @@ func (s *Sidecar) handleSessionUpdated(evt harness.HarnessEvent) {
 		// No prior row — treat as session creation.
 		s.upsertState(agent.StateActive, title, sid)
 		s.writeStateChange(agent.StateActive)
-	case agent.StateInterrupted, agent.StateError, agent.StateFinished:
+	case agent.StateError:
+		// Resume from error: only transition to active if we are outside the
+		// post-error debounce window. Within ErrorResumeDebounce of the last
+		// session.error, this event is treated as post-error churn that opencode
+		// emits in the same millisecond burst (session.error → session.updated),
+		// not as a genuine user-initiated resume. After the window, genuine
+		// resumes (e.g. user presses Enter) transition normally.
+		if !s.lastErrorAt.IsZero() && s.cfg.Clock.Now().Sub(s.lastErrorAt) < ErrorResumeDebounce {
+			// Within debounce window: treat as churn. Update metadata only.
+			log.Printf("sidecar: session.updated within error-resume debounce window (%v since error) — suppressing resume", s.cfg.Clock.Now().Sub(s.lastErrorAt))
+			s.upsertState(currentState, title, sid)
+			return
+		}
+		// Outside debounce window (or no error recorded): genuine resume.
+		if err := s.cfg.DB.ClearEnded(s.cfg.SessionName); err != nil {
+			log.Printf("sidecar: ClearEnded failed on resume: %v", err)
+		}
+		s.upsertState(agent.StateActive, title, sid)
+		s.writeStateChange(agent.StateActive)
+	case agent.StateInterrupted, agent.StateFinished:
 		// Resume: transition back to active. Clear ended_at so the session
 		// becomes visible again in AllActiveStatus / dashboard filters
 		// (both query WHERE ended_at IS NULL).
@@ -825,7 +861,12 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
 	} else {
+		s.cancelIdleTimer()
 		s.cancelRecoveryTimer()
+		// Record the error time so handleSessionUpdated can suppress the
+		// post-error session.updated churn that opencode emits in the same
+		// millisecond as session.error (see ErrorResumeDebounce).
+		s.lastErrorAt = s.cfg.Clock.Now()
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 		s.writeEvent("error", map[string]string{"name": errorName}, nil)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -672,7 +672,13 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 			s.writeStateChange(agent.StateActive)
 		}
 	case "retry":
+		s.cancelIdleTimer()
 		s.cancelRecoveryTimer()
+		// Record lastErrorAt so that handleSessionUpdated's error-resume debounce
+		// also protects this path. session.status{retry} independently writes
+		// StateError; without this, an immediate session.updated would bypass the
+		// debounce guard and false-resume.
+		s.lastErrorAt = s.cfg.Clock.Now()
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7029,6 +7029,39 @@ func TestSessionError_DelayedSessionUpdated_DoesResume(t *testing.T) {
 	}
 }
 
+// TestSessionStatusRetry_ImmediateUpdated_DoesNotResume verifies that the
+// error-resume debounce also protects the session.status{retry} path.
+// session.status{retry} writes StateError independently of session.error; a
+// immediately-following session.updated must NOT transition back to active
+// within the debounce window.
+func TestSessionStatusRetry_ImmediateUpdated_DoesNotResume(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// session.status{retry} → StateError + lastErrorAt set.
+	sc.HandleEvent(makeSSE("session.status", map[string]any{
+		"status": map[string]string{"type": "retry"},
+	}))
+	if state := getState(t, sc.cfg.DB, sc.cfg.SessionName); state != string(agent.StateError) {
+		t.Fatalf("state = %q after session.status{retry}, want %q", state, agent.StateError)
+	}
+
+	// session.updated arrives immediately (within debounce window). Clock has not advanced.
+	sc.HandleEvent(makeSSE("session.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "oc-session-retry-churn",
+			"title": "Post-retry churn",
+		},
+	}))
+
+	// State must remain error — the false resume must be suppressed.
+	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q after immediate session.updated following retry, want %q (debounce must also protect session.status{retry} path)", state, agent.StateError)
+	}
+}
+
 // TestSessionError_MessageAbortedError_PathUnchanged verifies edge-case: the
 // MessageAbortedError path (user pressed Escape) is unchanged by the fix.
 // It must still write interrupted (not error) and NOT set lastErrorAt, so the

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -93,6 +93,13 @@ func (c *testClock) TimerCount() int {
 	return len(c.timers)
 }
 
+// Advance moves the clock forward by d.
+func (c *testClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
 // ── test helpers ────────────────────────────────────────────────────────────
 
 func openTestDB(t *testing.T) *db.DB {
@@ -6914,6 +6921,152 @@ func TestBuildNotifyPromptBody_OmitsAgentField(t *testing.T) {
 				t.Errorf("body must not contain \"agent\" field (got %v); setting it switches the receiving session's agent context — see issue #848", body["agent"])
 			}
 		})
+	}
+}
+
+// ── error-state debounce tests (issue #923) ─────────────────────────────────
+
+// TestSessionError_NonAbort_CancelsIdleTimer verifies Fix 1: when session.error
+// fires with a non-MessageAbortedError name, any in-flight idle timer is
+// cancelled. Without this fix, the idle timer could fire after the false resume
+// rewrites active state and produce a spurious finished transition.
+func TestSessionError_NonAbort_CancelsIdleTimer(t *testing.T) {
+	sc, clk := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Start an idle timer first.
+	sc.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer to be created")
+	}
+
+	// Fire session.error with a non-MessageAbortedError — must cancel the idle timer.
+	sc.HandleEvent(makeSSE("session.error", map[string]any{
+		"error": map[string]string{"name": "APIError"},
+	}))
+
+	// State must be error.
+	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q, want %q", state, agent.StateError)
+	}
+
+	// Try to fire the now-stopped timer — state must NOT change to finished.
+	timer.Fire()
+
+	state = getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q after cancelled idle timer fired, want %q (idle timer must have been cancelled)", state, agent.StateError)
+	}
+}
+
+// TestSessionError_ImmediateSessionUpdated_DoesNotResume verifies Fix 2
+// (debounce window): when session.updated arrives within ErrorResumeDebounce
+// after session.error, the session must NOT transition from error to active.
+// This is the core regression test for the bug described in issue #923.
+func TestSessionError_ImmediateSessionUpdated_DoesNotResume(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// session.error arrives — state becomes error.
+	sc.HandleEvent(makeSSE("session.error", map[string]any{
+		"error": map[string]string{"name": "InvalidPromptError"},
+	}))
+	if state := getState(t, sc.cfg.DB, sc.cfg.SessionName); state != string(agent.StateError) {
+		t.Fatalf("state = %q after session.error, want %q", state, agent.StateError)
+	}
+
+	// session.updated arrives in the same millisecond (within debounce window).
+	// Clock has not advanced — time.Since(lastErrorAt) ≈ 0, well within 5 s.
+	sc.HandleEvent(makeSSE("session.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "oc-session-post-error",
+			"title": "Post-error churn",
+		},
+	}))
+
+	// State must remain error — the false resume must be suppressed.
+	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q after immediate session.updated, want %q (resume must be suppressed within debounce window)", state, agent.StateError)
+	}
+}
+
+// TestSessionError_DelayedSessionUpdated_DoesResume verifies that after the
+// ErrorResumeDebounce window has elapsed, a genuine session.updated correctly
+// transitions the session from error to active.
+func TestSessionError_DelayedSessionUpdated_DoesResume(t *testing.T) {
+	sc, clk := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// session.error fires.
+	sc.HandleEvent(makeSSE("session.error", map[string]any{
+		"error": map[string]string{"name": "APIError"},
+	}))
+	if state := getState(t, sc.cfg.DB, sc.cfg.SessionName); state != string(agent.StateError) {
+		t.Fatalf("state = %q after session.error, want %q", state, agent.StateError)
+	}
+
+	// Advance the clock past the debounce window.
+	clk.Advance(ErrorResumeDebounce + time.Second)
+
+	// session.updated arrives after the debounce window — genuine user resume.
+	sc.HandleEvent(makeSSE("session.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "oc-session-genuine-resume",
+			"title": "User resumed after error",
+		},
+	}))
+
+	// State must transition to active — the genuine resume must proceed.
+	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateActive) {
+		t.Errorf("state = %q after delayed session.updated, want %q (genuine resume after debounce window must proceed)", state, agent.StateActive)
+	}
+}
+
+// TestSessionError_MessageAbortedError_PathUnchanged verifies edge-case: the
+// MessageAbortedError path (user pressed Escape) is unchanged by the fix.
+// It must still write interrupted (not error) and NOT set lastErrorAt, so the
+// debounce does not affect subsequent session.updated events.
+func TestSessionError_MessageAbortedError_PathUnchanged(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// MessageAbortedError → interrupted.
+	sc.HandleEvent(makeSSE("session.error", map[string]any{
+		"error": map[string]string{"name": "MessageAbortedError"},
+	}))
+	if state := getState(t, sc.cfg.DB, sc.cfg.SessionName); state != string(agent.StateInterrupted) {
+		t.Fatalf("state = %q after MessageAbortedError, want %q", state, agent.StateInterrupted)
+	}
+
+	// lastErrorAt must NOT be set (MessageAbortedError takes the other branch).
+	sc.mu.Lock()
+	lastErrorAt := sc.lastErrorAt
+	sc.mu.Unlock()
+	if !lastErrorAt.IsZero() {
+		t.Errorf("lastErrorAt = %v, want zero (MessageAbortedError must not set lastErrorAt)", lastErrorAt)
+	}
+
+	// A session.updated after MessageAbortedError (interrupted state) must
+	// resume normally — the error debounce must not interfere.
+	sc.HandleEvent(makeSSE("session.updated", map[string]any{
+		"info": map[string]any{
+			"id":    "oc-session-abort-resume",
+			"title": "Resumed after abort",
+		},
+	}))
+
+	// State must transition to active (resume from interrupted is unaffected).
+	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateActive) {
+		t.Errorf("state = %q after session.updated following MessageAbortedError, want %q (abort path must not be affected by error debounce)", state, agent.StateActive)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a state-machine bug where a `session.error` event is silently overwritten by an immediately-following `session.updated` event, causing errors to appear as clean finished completions to the coordinator (~43% hit rate on 2026-04-20).

## Root cause

opencode emits a rapid burst of events in the same millisecond after an error:
```
session.error    → handleSessionError writes StateError
session.updated  → handleSessionUpdated sees StateError in DB, treats as "resume", writes StateActive
session.idle     → idle debounce fires → writes StateFinished
```

Two contributing bugs:

1. `handleSessionError`'s non-`MessageAbortedError` branch was missing `s.cancelIdleTimer()` — any in-flight idle debounce could fire after the false resume.

2. `handleSessionUpdated`'s resume logic fired for **any** `session.updated` while in error state, including opencode's internal post-error housekeeping churn.

## Changes

**Fix 1 — cancel idle timer on non-abort errors** (`sidecar.go`):
Added `s.cancelIdleTimer()` to the `else` branch of `handleSessionError`, matching the `MessageAbortedError` branch. Prevents in-flight idle timers from surviving an error.

**Fix 2 — debounce window on error-to-active resume** (`sidecar.go`):
- Added `ErrorResumeDebounce = 5 * time.Second` constant
- Added `lastErrorAt time.Time` field to `Sidecar` struct
- `handleSessionError` records `lastErrorAt = clock.Now()` when writing `StateError`
- `handleSessionUpdated` suppresses the error→active transition when `time.Since(lastErrorAt) < ErrorResumeDebounce` — treating it as post-error churn
- After the window, genuine user-initiated resumes proceed normally

**Tests added** (`sidecar_test.go`):
- `TestSessionError_NonAbort_CancelsIdleTimer` — Fix 1 regression test
- `TestSessionError_ImmediateSessionUpdated_DoesNotResume` — immediate churn is suppressed
- `TestSessionError_DelayedSessionUpdated_DoesResume` — genuine resume after window proceeds
- `TestSessionError_MessageAbortedError_PathUnchanged` — abort path is unaffected
- Also added `Advance(d time.Duration)` method to `testClock` to enable time-travel in tests

## Notes

- Issue #920 (sidecar logging) is sequenced AFTER this and also touches `sidecar.go`. Merge this first.
- The `MessageAbortedError` path is unchanged: it writes `StateInterrupted` (not `StateError`), does not set `lastErrorAt`, and its existing `cancelIdleTimer()` is untouched.
- The debounce does not affect sessions never in error state, or resumes from `interrupted`/`finished`.

## Testing

- `go build ./...` ✓
- `go test ./internal/sidecar/...` ✓ (all existing + 4 new tests pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✓

Closes #923