### PR TITLE
prism spawn: fix error messages and flag forwarding in proxy mode

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -312,6 +312,63 @@ func TestProxySpawn_SendsCorrectPayload(t *testing.T) {
 	}
 }
 
+// TestProxySpawn_IgnoreConcurrencyCapForwarded verifies that when
+// --ignore-concurrency-cap is set, proxySpawn includes ignore_concurrency_cap:true
+// in the JSON body sent to the host-API sidecar.
+func TestProxySpawn_IgnoreConcurrencyCapForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch               string `json:"branch"`
+		IgnoreConcurrencyCap bool   `json:"ignore_concurrency_cap"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spawn" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@cap-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "cap-branch")
+	_ = cmd.Flags().Set("ignore-concurrency-cap", "true")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Branch != "cap-branch" {
+			t.Errorf("branch = %q, want %q", req.Branch, "cap-branch")
+		}
+		if !req.IgnoreConcurrencyCap {
+			t.Errorf("ignore_concurrency_cap = false, want true")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
 // ── cleanup proxy tests (AC-2, AC-11) ─────────────────────────────────────────
 
 // TestHeadlessCleanup_Proxy verifies AC-11 for cleanup: when PRISM_HOST_API is

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -54,15 +54,17 @@ var prCmd = &cobra.Command{
 			if branchErr != nil {
 				return branchErr
 			}
+			ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 			repo := filepath.Base(bareRoot)
 			var resp struct {
 				SessionName string `json:"session_name"`
 			}
 			if proxyErr := proxyToHostAPI(apiURL, "/spawn", map[string]any{
-				"repo":   repo,
-				"branch": branch,
-				"prompt": promptFlag,
-				"agent":  agentFlag,
+				"repo":                   repo,
+				"branch":                 branch,
+				"prompt":                 promptFlag,
+				"agent":                  agentFlag,
+				"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 			}, &resp); proxyErr != nil {
 				return proxyErr
 			}

--- a/modules/programs/prism/prism/cmd/root.go
+++ b/modules/programs/prism/prism/cmd/root.go
@@ -5,9 +5,8 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:          "prism",
-	Short:        "Prism — tmux-based AI development environment",
-	SilenceUsage: true,
+	Use:   "prism",
+	Short: "Prism — tmux-based AI development environment",
 }
 
 func Execute() error {

--- a/modules/programs/prism/prism/cmd/root.go
+++ b/modules/programs/prism/prism/cmd/root.go
@@ -5,8 +5,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "prism",
-	Short: "Prism — tmux-based AI development environment",
+	Use:          "prism",
+	Short:        "Prism — tmux-based AI development environment",
+	SilenceUsage: true,
 }
 
 func Execute() error {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -162,6 +162,11 @@ func checkBwrapPlatform(mode config.IsolationMode) error {
 }
 
 func runSpawn(cmd *cobra.Command, args []string) error {
+	// Silence the cobra usage block for runtime errors. Flag parse errors
+	// (unknown flags, wrong argument count) are handled before RunE is called
+	// and still print usage — this only silences errors returned from RunE.
+	cmd.SilenceUsage = true
+
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
 		return proxySpawn(apiURL, cmd)
 	}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -52,6 +52,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
+	ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 	promptFlag, err := resolvePrompt(cmd)
 	if err != nil {
 		return err
@@ -60,14 +61,15 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		SessionName string `json:"session_name"`
 	}
 	if err := proxyToHostAPI(apiURL, "/spawn", map[string]any{
-		"branch":    branchFlag,
-		"prompt":    promptFlag,
-		"agent":     agentFlag,
-		"profile":   profileFlag,
-		"model":     modelFlag,
-		"variant":   variantFlag,
-		"host_mode": hostModeFlag,
-		"harness":   harnessFlag,
+		"branch":                 branchFlag,
+		"prompt":                 promptFlag,
+		"agent":                  agentFlag,
+		"profile":                profileFlag,
+		"model":                  modelFlag,
+		"variant":                variantFlag,
+		"host_mode":              hostModeFlag,
+		"harness":                harnessFlag,
+		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 	}, &resp); err != nil {
 		return err
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2560,17 +2560,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if !requireCoordinator(w, "spawn") {
 			return
 		}
-		var req struct {
-			Repo     string `json:"repo"` // accepted but ignored — ownRepo is always used
-			Branch   string `json:"branch"`
-			Prompt   string `json:"prompt"`
-			Agent    string `json:"agent"`
-			Profile  string `json:"profile"`
-			Model    string `json:"model"`
-			Variant  string `json:"variant"`
-			HostMode bool   `json:"host_mode"`
-			Harness  string `json:"harness"`
-		}
+	var req struct {
+		Repo                 string `json:"repo"` // accepted but ignored — ownRepo is always used
+		Branch               string `json:"branch"`
+		Prompt               string `json:"prompt"`
+		Agent                string `json:"agent"`
+		Profile              string `json:"profile"`
+		Model                string `json:"model"`
+		Variant              string `json:"variant"`
+		HostMode             bool   `json:"host_mode"`
+		Harness              string `json:"harness"`
+		IgnoreConcurrencyCap bool   `json:"ignore_concurrency_cap"`
+	}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
@@ -2619,6 +2620,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			args = append(args, "--host-mode")
 		}
+		if req.IgnoreConcurrencyCap {
+			args = append(args, "--ignore-concurrency-cap")
+		}
 		args = append(args, "--harness", req.Harness)
 		args = append(args, "--repo", ownRepo)
 
@@ -2642,6 +2646,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			logArgs = append(logArgs, "--host-mode")
 		}
+		if req.IgnoreConcurrencyCap {
+			logArgs = append(logArgs, "--ignore-concurrency-cap")
+		}
 		logArgs = append(logArgs, "--harness", req.Harness)
 		logArgs = append(logArgs, "--repo", ownRepo)
 		log.Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
@@ -2649,7 +2656,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Printf("sidecar: host-API /spawn: %v: %s", err, out)
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("spawn failed: %v", err))
+			msg := fmt.Sprintf("spawn failed: %v", err)
+			if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+				msg = fmt.Sprintf("spawn failed: %v\n%s", err, trimmed)
+			}
+			writeError(w, http.StatusInternalServerError, msg)
 			return
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2560,18 +2560,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if !requireCoordinator(w, "spawn") {
 			return
 		}
-	var req struct {
-		Repo                 string `json:"repo"` // accepted but ignored — ownRepo is always used
-		Branch               string `json:"branch"`
-		Prompt               string `json:"prompt"`
-		Agent                string `json:"agent"`
-		Profile              string `json:"profile"`
-		Model                string `json:"model"`
-		Variant              string `json:"variant"`
-		HostMode             bool   `json:"host_mode"`
-		Harness              string `json:"harness"`
-		IgnoreConcurrencyCap bool   `json:"ignore_concurrency_cap"`
-	}
+		var req struct {
+			Repo                 string `json:"repo"` // accepted but ignored — ownRepo is always used
+			Branch               string `json:"branch"`
+			Prompt               string `json:"prompt"`
+			Agent                string `json:"agent"`
+			Profile              string `json:"profile"`
+			Model                string `json:"model"`
+			Variant              string `json:"variant"`
+			HostMode             bool   `json:"host_mode"`
+			Harness              string `json:"harness"`
+			IgnoreConcurrencyCap bool   `json:"ignore_concurrency_cap"`
+		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5616,6 +5616,104 @@ echo "session \"${last}@host-mode-branch\" created"
 	}
 }
 
+// TestHostAPI_Spawn_IgnoreConcurrencyCapForwarded verifies that when a client
+// sends {"ignore_concurrency_cap":true}, the sidecar includes
+// "--ignore-concurrency-cap" in the args passed to the prism binary.
+func TestHostAPI_Spawn_IgnoreConcurrencyCapForwarded(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@cap-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"cap-branch","ignore_concurrency_cap":true}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "--ignore-concurrency-cap") {
+		t.Errorf("captured args %q do not contain --ignore-concurrency-cap; ignore_concurrency_cap:true was not forwarded", string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Spawn_SubprocessOutputIncludedInError verifies that when the
+// host-side prism spawn subprocess exits non-zero, the error response includes
+// the subprocess stdout/stderr output (not just "exit status 1").
+func TestHostAPI_Spawn_SubprocessOutputIncludedInError(t *testing.T) {
+	d := openTestDB(t)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "error: prism concurrency cap reached (6 agent containers already in flight)"
+echo ""
+echo "Active containers:"
+echo "  nixos-config@main   (coordinator)"
+exit 1
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"cap-branch"}`)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", rr.Code, rr.Body.String())
+	}
+
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	errMsg := errResp["error"]
+	if !strings.Contains(errMsg, "concurrency cap reached") {
+		t.Errorf("error %q should include subprocess output (concurrency cap message)", errMsg)
+	}
+	if !strings.Contains(errMsg, "nixos-config@main") {
+		t.Errorf("error %q should include subprocess output (active container list)", errMsg)
+	}
+	// Verify trailing whitespace/newlines are trimmed.
+	if strings.HasSuffix(errMsg, "\n") || strings.HasSuffix(errMsg, " ") {
+		t.Errorf("error %q has trailing whitespace/newline — should be trimmed", errMsg)
+	}
+}
+
 func TestHostAPI_Cleanup_CoordinatorCrossRepoForbidden(t *testing.T) {
 	d := openTestDB(t)
 	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)


### PR DESCRIPTION
## Summary

Three fixes for `prism spawn` in proxy mode (`PRISM_HOST_API` is set — inside a bwrap/podman container):

- **Fix 1**: When the host-side `prism spawn` subprocess exits non-zero, include its combined stdout/stderr in the HTTP error response body. Previously only `exit status 1` was returned to the client; now the full error (e.g. the concurrency cap message with session list and `--ignore-concurrency-cap` hint) reaches the user. Trailing whitespace/newlines are trimmed.

- **Fix 2**: Forward `--ignore-concurrency-cap` through proxy mode. `proxySpawn()` in `cmd/spawn.go` now includes `ignore_concurrency_cap` in the JSON request body, and the sidecar `/spawn` handler reads the field and passes `--ignore-concurrency-cap` to the host-side `prism spawn` subprocess when set.

- **Fix 3**: Set `SilenceUsage: true` on the root command so cobra's usage block is not printed when any command fails at runtime (cap exceeded, git error, tmux error, etc.). The usage block was misleadingly suggesting the user had passed wrong flags.

## Changes

- `modules/programs/prism/prism/internal/sidecar/sidecar.go` — Fixes 1 and 2 (server side)
- `modules/programs/prism/prism/cmd/spawn.go` — Fix 2 (client side)
- `modules/programs/prism/prism/cmd/root.go` — Fix 3
- `modules/programs/prism/prism/internal/sidecar/sidecar_test.go` — Tests for fixes 1 and 2
- `modules/programs/prism/prism/cmd/hostapi_test.go` — Test for fix 2 (client side)

Closes #964