### PR TITLE
prism: remove bwrap from concurrency cap — cap applies to podman only

### DIFF
--- a/modules/programs/prism/prism/cmd/concurrency.go
+++ b/modules/programs/prism/prism/cmd/concurrency.go
@@ -22,8 +22,8 @@ import (
 //
 // cmd is the cobra.Command that owns the --ignore-concurrency-cap flag.
 // callerName is used in warning/error messages (e.g. "spawn", "pr", "review").
-// conCapped must be true for modes that consume a container/sandbox slot —
-// currently "podman" and "bwrap". Pass false for "host" mode (no cap needed).
+// conCapped must be true for modes that consume a container slot —
+// currently "podman" only. Pass false for "host" and "bwrap" modes (no cap needed).
 func checkConcurrencyCap(cmd *cobra.Command, callerName string, conCapped bool) error {
 	if !conCapped {
 		return nil

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -73,7 +73,8 @@ var prCmd = &cobra.Command{
 		cfg := config.Load()
 		isoMode := cfg.EffectiveIsolationMode()
 		effectiveContainerMode := isoMode == config.IsolationPodman
-		conCapped := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
+		// bwrap sessions are plain host processes — only podman triggers the cap.
+		conCapped := isoMode == config.IsolationPodman
 
 		// Concurrency cap check: BEFORE any container-creation side effects
 		// (no worktree, no tmux session, no DB row on refusal).

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -104,7 +104,8 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// Load cfg now for the cap check; it is re-used below for ContainerMode.
 	cfg := config.Load()
 	isoMode := cfg.EffectiveIsolationMode()
-	conCapped := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
+	// bwrap sessions are plain host processes — only podman triggers the cap.
+	conCapped := isoMode == config.IsolationPodman
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL == "" {
 		// Running on host — check the cap before spawning review containers.
 		if err := checkConcurrencyCap(cmd, "review", conCapped); err != nil {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -211,9 +211,10 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 
 	// Concurrency cap check: BEFORE any container-creation side effects
 	// (no worktree, no tmux session, no DB row on refusal).
-	// Skipped in host-mode — host-mode sessions don't consume a container slot.
-	// bwrap sessions are treated as concurrency-capped (same as podman).
-	conCapped := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap
+	// Skipped in host-mode and bwrap-mode — the cap exists to guard host memory
+	// against podman container overhead; bwrap sessions are plain host processes
+	// with no per-session memory cap, so they do not count against it.
+	conCapped := isolationMode == config.IsolationPodman
 	if err := checkConcurrencyCap(cmd, "spawn", conCapped); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Remove `IsolationBwrap` from the concurrency cap condition in `spawn`, `pr`, and `review`. The cap exists to protect host memory from podman container overhead (each container gets a 5 GB `--memory` limit); bwrap sessions are plain host processes with no per-session memory cap and no container overhead, so they should not count against it.

## Changes

- `cmd/spawn.go`: `conCapped := isolationMode == config.IsolationPodman` (removed `|| isolationMode == config.IsolationBwrap`)
- `cmd/pr.go`: same change
- `cmd/review.go`: same change
- `cmd/concurrency.go`: updated comment to say "currently podman only" instead of "podman and bwrap"

## Testing

- `go build ./...` passes
- `go test ./...` — same pre-existing tmux multi-client test failures as on `main` (require live tmux sessions); all other packages pass
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes

Closes #969