### PR TITLE
Add 1password-cli and update kubetools package list

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -59,6 +59,7 @@ in
   environment.systemPackages =
     with pkgs;
     [
+      _1password-cli
       arping
       gnutar
       mysql84

--- a/modules/programs/kubetools.nix
+++ b/modules/programs/kubetools.nix
@@ -24,12 +24,13 @@ in
       {
         home-manager.users.${username} = {
           home.packages = with pkgs; [
-            kubectl
-            kubernetes-helm
-            kubelogin-oidc
-            kubelogin
             fluxcd
             krew
+            kubectl
+            kubelogin
+            kubelogin-oidc
+            kubernetes-helm
+            kustomize
           ];
           home.sessionVariables = {
             KUBECONFIG = "${kubeDir}/config";


### PR DESCRIPTION
Added _1password-cli to the system packages for m4mac to enable command-line secret management. Revised the kubetools module package list to include kustomize and sorted the existing items for better maintainability.