### PR TITLE
prism stats: rename stats vocabulary opencode_sid→harness_session_id (Class B of #927)

### DIFF
--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -34,7 +34,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/payload"
 )
 
-// legacySentinel is the key used to group events that have a NULL opencode_sid.
+// legacySentinel is the key used to group events that have a NULL harness_session_id.
 // These are pre-sidecar "legacy" events that predate opencode session tracking.
 const legacySentinel = ""
 
@@ -161,7 +161,7 @@ func runStats(cmd *cobra.Command, args []string) error {
 // sessionMetrics holds aggregated metrics for a single opencode session.
 type sessionMetrics struct {
 	SessionName string
-	OpencodeSID string // empty string = legacy sentinel (NULL opencode_sid)
+	HarnessSessionID string // empty string = legacy sentinel (NULL harness_session_id)
 	AgentName   string
 	ModelID     string
 	State       string
@@ -258,19 +258,19 @@ func (m *sessionMetrics) totalToolCalls() int {
 // isLegacy reports whether this sessionMetrics represents the legacy NULL-sid
 // sentinel group.
 func (m *sessionMetrics) isLegacy() bool {
-	return m.OpencodeSID == legacySentinel
+	return m.HarnessSessionID == legacySentinel
 }
 
 // collectMetrics builds a sessionMetrics from a slice of events that all belong
-// to the same opencode session (or the legacy sentinel group). The opencodeSID
+// to the same harness session (or the legacy sentinel group). The harnessSessionID
 // parameter is the key used for this group (legacySentinel for NULL-sid events).
 //
 // The model field is set to the coordinator/root agent's model if one is present
 // (agent field == "coordinator"), falling back to the most-frequently-seen model.
 // This gives a more meaningful "session model" than first-seen.
-func collectMetrics(events []db.Event, opencodeSID string) *sessionMetrics {
+func collectMetrics(events []db.Event, harnessSessionID string) *sessionMetrics {
 	m := &sessionMetrics{
-		OpencodeSID:   opencodeSID,
+		HarnessSessionID: harnessSessionID,
 		ToolCalls:     make(map[string]int),
 		ToolDurations: make(map[string][]time.Duration),
 	}
@@ -368,11 +368,11 @@ func collectMetrics(events []db.Event, opencodeSID string) *sessionMetrics {
 	return m
 }
 
-// groupEventsByOpencodeSID partitions events by opencode_sid, preserving
+// groupEventsByHarnessSessionID partitions events by harness_session_id, preserving
 // insertion order for the first occurrence of each key.
-// Events with a NULL opencode_sid are grouped under legacySentinel ("").
+// Events with a NULL harness_session_id are grouped under legacySentinel ("").
 // Returns the grouped map and the ordered list of keys.
-func groupEventsByOpencodeSID(events []db.Event) (map[string][]db.Event, []string) {
+func groupEventsByHarnessSessionID(events []db.Event) (map[string][]db.Event, []string) {
 	grouped := make(map[string][]db.Event)
 	var order []string
 
@@ -416,8 +416,8 @@ func runStatsSession(session string, detail bool) error {
 		return nil
 	}
 
-	// Group events by opencode_sid.
-	grouped, order := groupEventsByOpencodeSID(events)
+	// Group events by harness_session_id.
+	grouped, order := groupEventsByHarnessSessionID(events)
 
 	// Build a sessionMetrics per opencode session.
 	var allMetrics []*sessionMetrics
@@ -688,7 +688,7 @@ func renderSessionCompactTable(sessionName string, metrics []*sessionMetrics, st
 					m.ModelID = "(legacy)"
 				}
 			} else {
-				fmt.Printf("%s %s\n", styleLabel.Render("opencode session:"), styleDim.Render(m.OpencodeSID))
+				fmt.Printf("%s %s\n", styleLabel.Render("opencode session:"), styleDim.Render(m.HarnessSessionID))
 			}
 			fmt.Println()
 			renderSessionDetail(m)
@@ -810,7 +810,7 @@ func runStatsSummary() error {
 	var rows []summaryRow
 	for _, s := range statuses {
 		events, _ := d.AllSessionEvents(s.SessionName)
-		grouped, order := groupEventsByOpencodeSID(events)
+		grouped, order := groupEventsByHarnessSessionID(events)
 		// For the summary table, accumulate tokens, cost, and duration across
 		// all opencode sessions within the tmux session. Cost is summed per-session
 		// (each session uses its own model's pricing) rather than applying a single
@@ -933,7 +933,7 @@ func runStatsHistorical(days int) error {
 	for session, evts := range bySession {
 		totalSessions++
 		// Sum across all opencode sessions within this tmux session.
-		grouped, order := groupEventsByOpencodeSID(evts)
+		grouped, order := groupEventsByHarnessSessionID(evts)
 		// Hoist status lookup outside the inner loop to avoid N+1 queries when
 		// multiple opencode SID groups have no model data.
 		st, _ := d.CurrentStatus(session)
@@ -1511,9 +1511,9 @@ func splitModel(modelID string) (provider, model string) {
 // per-model metrics. Turns with durationMs == 0 are excluded from latency and
 // throughput calculations.
 //
-// Sessions are counted by distinct opencode_sid (not session_name) so that
+// Sessions are counted by distinct harness_session_id (not session_name) so that
 // long-lived tmux sessions with multiple opencode sessions are counted correctly.
-// Events with a NULL opencode_sid are counted as distinct sessions only if the
+// Events with a NULL harness_session_id are counted as distinct sessions only if the
 // session_name is distinct — they're bucketed by session_name as a fallback.
 func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 	metrics := make(map[string]*modelMetrics)
@@ -1546,7 +1546,7 @@ func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 
 		m.Turns++
 
-		// Count sessions by opencode_sid when available; fall back to session_name
+		// Count sessions by harness_session_id when available; fall back to session_name
 		// for NULL-sid (legacy) events so they still contribute a session count.
 		if e.OpencodeSID != nil && *e.OpencodeSID != "" {
 			m.Sessions[*e.OpencodeSID] = struct{}{}

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -45,7 +45,7 @@ func writeStatsEvent(t *testing.T, d *db.DB, session, typ, payload string, ts ti
 	}
 }
 
-// writeStatsEventWithSID writes an event with an explicit opencode_sid.
+// writeStatsEventWithSID writes an event with an explicit harness_session_id.
 func writeStatsEventWithSID(t *testing.T, d *db.DB, session, sid, typ, payload string, ts time.Time) {
 	t.Helper()
 	e := db.Event{
@@ -545,7 +545,7 @@ func TestRunStatsSession_SingleSessionUnchanged(t *testing.T) {
 }
 
 // TestRunStatsSession_NullSidLegacySentinel verifies that events with NULL
-// opencode_sid are grouped under the legacy sentinel and displayed as "(legacy)".
+// harness_session_id are grouped under the legacy sentinel and displayed as "(legacy)".
 func TestRunStatsSession_NullSidLegacySentinel(t *testing.T) {
 	d := openStatsTestDB(t)
 	const session = "testrepo@main"
@@ -555,7 +555,7 @@ func TestRunStatsSession_NullSidLegacySentinel(t *testing.T) {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
 
-	// Write events with NULL opencode_sid (no SID — uses writeStatsEvent which doesn't set SID).
+	// Write events with NULL harness_session_id (no SID — uses writeStatsEvent which doesn't set SID).
 	writeStatsEvent(t, d, session, "msg_assistant",
 		`{"messageId":"msg-old","text":"old reply","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":500,"outputTokens":200,"durationMs":3000}`,
 		base)
@@ -586,7 +586,7 @@ func TestRunStatsSession_NullSidLegacySentinel(t *testing.T) {
 }
 
 // TestRunStatsSession_AllNullSidSingleLegacy verifies that a session where ALL
-// events have NULL opencode_sid renders as a detailed block labelled "(legacy)".
+// events have NULL harness_session_id renders as a detailed block labelled "(legacy)".
 func TestRunStatsSession_AllNullSidSingleLegacy(t *testing.T) {
 	d := openStatsTestDB(t)
 	const session = "testrepo@old"
@@ -596,7 +596,7 @@ func TestRunStatsSession_AllNullSidSingleLegacy(t *testing.T) {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
 
-	// All events have NULL opencode_sid.
+	// All events have NULL harness_session_id.
 	writeStatsEvent(t, d, session, "msg_assistant",
 		`{"messageId":"msg-1","text":"reply","agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":500,"outputTokens":200,"durationMs":3000}`,
 		base)
@@ -658,8 +658,8 @@ func TestRunStatsSession_DetailFlag(t *testing.T) {
 	}
 }
 
-// TestGroupEventsByOpencodeSID verifies event grouping by opencode_sid.
-func TestGroupEventsByOpencodeSID(t *testing.T) {
+// TestGroupEventsByHarnessSessionID verifies event grouping by harness_session_id.
+func TestGroupEventsByHarnessSessionID(t *testing.T) {
 	sid1 := "ses_aaa"
 	sid2 := "ses_bbb"
 
@@ -670,7 +670,7 @@ func TestGroupEventsByOpencodeSID(t *testing.T) {
 		{ID: "4", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid1, Payload: `{}`, CreatedAt: time.Now()}, // same as id=1
 	}
 
-	grouped, order := groupEventsByOpencodeSID(events)
+	grouped, order := groupEventsByHarnessSessionID(events)
 
 	if len(order) != 3 {
 		t.Errorf("expected 3 groups (sid1, sid2, sentinel), got %d: %v", len(order), order)
@@ -755,8 +755,8 @@ func TestCollectMetrics_NullSidLegacy(t *testing.T) {
 	if !m.isLegacy() {
 		t.Errorf("expected m.isLegacy() == true for legacySentinel key")
 	}
-	if m.OpencodeSID != legacySentinel {
-		t.Errorf("OpencodeSID should be legacySentinel %q, got %q", legacySentinel, m.OpencodeSID)
+	if m.HarnessSessionID != legacySentinel {
+		t.Errorf("HarnessSessionID should be legacySentinel %q, got %q", legacySentinel, m.HarnessSessionID)
 	}
 }
 
@@ -1165,10 +1165,10 @@ func TestRunStatsModel_BasicOutput(t *testing.T) {
 	}
 }
 
-// TestRunStatsModel_SessionCountByOpencodeSID verifies that sessions are counted
-// by opencode_sid (not session_name) so that multi-session tmux sessions are
+// TestRunStatsModel_SessionCountByHarnessSessionID verifies that sessions are counted
+// by harness_session_id (not session_name) so that multi-session tmux sessions are
 // counted correctly.
-func TestRunStatsModel_SessionCountByOpencodeSID(t *testing.T) {
+func TestRunStatsModel_SessionCountByHarnessSessionID(t *testing.T) {
 	sid1 := "ses_opencode_aaa"
 	sid2 := "ses_opencode_bbb"
 	sid3 := "ses_opencode_ccc"
@@ -1193,16 +1193,16 @@ func TestRunStatsModel_SessionCountByOpencodeSID(t *testing.T) {
 		t.Fatal("missing entry for anthropic/claude-sonnet-4-6")
 	}
 
-	// Should count 3 sessions (one per opencode_sid), NOT 1 (session_name).
+	// Should count 3 sessions (one per harness_session_id), NOT 1 (session_name).
 	if len(entry.Sessions) != 3 {
 		t.Errorf("expected 3 distinct opencode sessions, got %d", len(entry.Sessions))
 	}
 }
 
-// TestRunStatsModel_NullSidFallbackSessionName verifies that NULL opencode_sid
+// TestRunStatsModel_NullSidFallbackSessionName verifies that NULL harness_session_id
 // events fall back to counting by session_name as a legacy bucket.
 func TestRunStatsModel_NullSidFallbackSessionName(t *testing.T) {
-	// Two different sessions, both with NULL opencode_sid, same model.
+	// Two different sessions, both with NULL harness_session_id, same model.
 	events := []db.Event{
 		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: nil,
 			Payload:   `{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,


### PR DESCRIPTION
## Summary

Renames the internal stats vocabulary in `cmd/stats.go` and `cmd/stats_test.go` from the legacy `opencode_sid` naming to the harness-agnostic `harness_session_id` naming (Class B of #927).

### Changes

**`cmd/stats.go`**
- Renamed `groupEventsByOpencodeSID` → `groupEventsByHarnessSessionID` (function + all call sites)
- Renamed `sessionMetrics.OpencodeSID` struct field → `HarnessSessionID` (field definition + all references within this file)
- Updated comments referring to "NULL opencode_sid" → "NULL harness_session_id"
- Updated `collectMetrics` parameter name `opencodeSID` → `harnessSessionID` and its doc comment

**`cmd/stats_test.go`**
- Renamed `TestGroupEventsByOpencodeSID` → `TestGroupEventsByHarnessSessionID`
- Renamed `TestRunStatsModel_SessionCountByOpencodeSID` → `TestRunStatsModel_SessionCountByHarnessSessionID`
- Updated all `m.OpencodeSID` → `m.HarnessSessionID` test assertions (for the `sessionMetrics` struct field)
- Updated all comments referring to "opencode_sid" → "harness_session_id"

### Out of scope (intentionally not changed)

- `db.Event.OpencodeSID` field references (`e.OpencodeSID`) — these are Class A (agent_events schema) and belong in a separate risky PR
- The user-facing label `"opencode session:"` shown in `prism stats` output (line 686/691) — **kept as-is** per the spawn prompt. The issue says to default to keeping the user-facing string as opencode-specific until a second harness exists. This decision is documented here.

### Quality gates

- `go build ./...` ✓
- `go test ./...` ✓ (all packages pass)

Refs #927