### PR TITLE
db: populate agent_status.last_seen on WriteEvent and backfill (fixes #824)

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -197,6 +197,12 @@ CREATE TABLE IF NOT EXISTS schema_version (
 // zero, or older than 7 days are touched. The 7-day threshold is also expressed
 // in milliseconds ((unixepoch('now') - 604800) * 1000) to match the column unit.
 // Rows already with ended_at set are left alone (idempotent).
+// v13→v14 is a one-shot backfill that populates agent_status.last_seen from
+// MAX(agent_events.created_at) for sessions where last_seen IS NULL or 0 (i.e.
+// the column was never populated by a live WriteEvent call). It is idempotent:
+// sessions that already have a non-zero last_seen are left untouched. Rows with
+// no matching agent_events remain at 0 (COALESCE preserves the NOT NULL
+// constraint). This fixes the gap described in issue #824 for pre-existing rows.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -239,8 +245,10 @@ func Open(path string) (*DB, error) {
 	}
 
 	// Set schema_version=11 if the table is empty. Fresh databases have all
-	// current columns from the schema above. The v11→v12 migration (partial
-	// unique index for coordinator-per-repo) runs immediately below.
+	// current columns from the schema above. The v11→v12, v12→v13, and
+	// v13→v14 migrations run immediately below; on a fresh DB they are
+	// effectively no-ops (the index already exists and there are no rows to
+	// backfill), so starting at 11 rather than 14 is safe.
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
@@ -572,6 +580,32 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 13
+	}
+	if version == 13 {
+		// Migration v13 → v14: one-shot backfill of agent_status.last_seen for
+		// rows where last_seen is NULL or 0 (column was never populated by a live
+		// WriteEvent call). We set last_seen = MAX(agent_events.created_at) for
+		// the owning session. The WHERE guard (last_seen IS NULL OR last_seen = 0)
+		// makes this idempotent — sessions that already have a real last_seen
+		// value are left untouched. Rows with no matching agent_events get NULL
+		// from the subquery; COALESCE(..., 0) keeps them at 0 so the NOT NULL
+		// constraint is satisfied.
+		migrations := []string{
+			`UPDATE agent_status
+			   SET last_seen = COALESCE(
+			         (SELECT MAX(created_at) FROM agent_events
+			           WHERE agent_events.session_name = agent_status.session_name),
+			         0)
+			 WHERE last_seen IS NULL OR last_seen = 0`,
+			"UPDATE schema_version SET version = 14",
+		}
+		for _, m := range migrations {
+			if _, err := conn.Exec(m); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v13→v14: %w", err)
+			}
+		}
+		version = 14
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -1064,18 +1098,43 @@ func (d *DB) RefreshWorktree(sessionName, repo, worktree string) error {
 	return nil
 }
 
-// WriteEvent inserts an event row into agent_events.
+// WriteEvent inserts an event row into agent_events and, when a matching
+// agent_status row exists for e.SessionName, bumps last_seen to
+// MAX(last_seen, e.CreatedAt) in the same transaction. Writing an event for
+// an unknown session_name (no agent_status row) is not an error — the event
+// is still recorded and no last_seen update is attempted.
 func (d *DB) WriteEvent(e Event) error {
 	if e.CreatedAt.IsZero() {
 		e.CreatedAt = time.Now()
 	}
 	createdAt := e.CreatedAt.UnixMilli()
-	const q = `
+
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("db: write event: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	const insertQ = `
 INSERT INTO agent_events (id, session_name, repo, worktree, opencode_sid, type, payload, created_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-	_, err := d.conn.Exec(q, e.ID, e.SessionName, e.Repo, e.Worktree, e.OpencodeSID, e.Type, e.Payload, createdAt)
-	if err != nil {
-		return fmt.Errorf("db: write event: %w", err)
+	if _, err := tx.Exec(insertQ, e.ID, e.SessionName, e.Repo, e.Worktree, e.OpencodeSID, e.Type, e.Payload, createdAt); err != nil {
+		return fmt.Errorf("db: write event: insert: %w", err)
+	}
+
+	// Bump last_seen only when a matching agent_status row exists. The MAX
+	// guard ensures we never move last_seen backward (e.g. for out-of-order
+	// event replays or backfill writes with old timestamps).
+	const updateQ = `
+UPDATE agent_status
+   SET last_seen = MAX(last_seen, ?)
+ WHERE session_name = ?`
+	if _, err := tx.Exec(updateQ, createdAt, e.SessionName); err != nil {
+		return fmt.Errorf("db: write event: update last_seen: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("db: write event: commit: %w", err)
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -49,8 +49,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version: got %d, want 14", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -786,8 +786,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -861,8 +861,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1362,8 +1362,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1428,8 +1428,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1498,8 +1498,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1593,8 +1593,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1686,8 +1686,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2271,8 +2271,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2360,8 +2360,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	// isolation_mode column must exist (NULL for pre-migration rows).
@@ -3963,8 +3963,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("schema_version after migration: got %d, want 13", version)
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
 	}
 
 	// Check each row.
@@ -4140,6 +4140,450 @@ func TestMigration_V12ToV13_Idempotent(t *testing.T) {
 	}
 	if s2Valid.EndedAt != nil {
 		t.Errorf("second pass: valid-shape row incorrectly ended (ended_at = %v)", s2Valid.EndedAt)
+	}
+}
+
+// ── WriteEvent last_seen tests (issue #824) ───────────────────────────────────
+
+// TestWriteEvent_BumpsLastSeen verifies that WriteEvent updates
+// agent_status.last_seen for the owning session to the event's created_at
+// value (AC from #824).
+func TestWriteEvent_BumpsLastSeen(t *testing.T) {
+	d := openTestDB(t)
+
+	// Create a status row — last_seen is set to time.Now() by UpsertStatus.
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Capture the initial last_seen.
+	s0, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus (initial): %v", err)
+	}
+	initialLastSeen := s0.LastSeen
+
+	// Write an event with a created_at that is strictly in the future relative
+	// to the initial last_seen. Use a fixed offset so the assertion is stable.
+	eventTime := initialLastSeen.Add(5 * time.Second)
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+		CreatedAt:   eventTime,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	s1, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus (after WriteEvent): %v", err)
+	}
+
+	// last_seen must have been bumped to the event's created_at (within
+	// millisecond rounding — both are stored as UnixMilli).
+	wantMs := eventTime.UnixMilli()
+	gotMs := s1.LastSeen.UnixMilli()
+	if gotMs != wantMs {
+		t.Errorf("LastSeen after WriteEvent: got %d ms, want %d ms (event created_at)",
+			gotMs, wantMs)
+	}
+}
+
+// TestWriteEvent_LastSeen_MaxGuard verifies that writing an event with a
+// created_at OLDER than the current last_seen does NOT move last_seen backward
+// (MAX semantics from issue #824).
+func TestWriteEvent_LastSeen_MaxGuard(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Read the current last_seen so we can build a definitely-older timestamp.
+	s0, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus (initial): %v", err)
+	}
+	currentLastSeen := s0.LastSeen
+
+	// Write an event with created_at 10 seconds in the past.
+	oldTime := currentLastSeen.Add(-10 * time.Second)
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+		CreatedAt:   oldTime,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent (old event): %v", err)
+	}
+
+	s1, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus (after WriteEvent old): %v", err)
+	}
+
+	// last_seen must not have gone backward.
+	if s1.LastSeen.UnixMilli() < currentLastSeen.UnixMilli() {
+		t.Errorf("LastSeen moved backward: was %d ms, now %d ms (old event must not decrease last_seen)",
+			currentLastSeen.UnixMilli(), s1.LastSeen.UnixMilli())
+	}
+}
+
+// TestWriteEvent_UnknownSession_NoError verifies the edge-case AC from #824:
+// writing an event for a session_name that has no agent_status row does not
+// produce an error — the event is still recorded.
+func TestWriteEvent_UnknownSession_NoError(t *testing.T) {
+	d := openTestDB(t)
+
+	// No UpsertStatus call — the session does not exist in agent_status.
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "repo@nonexistent",
+		Repo:        "repo",
+		Worktree:    "/code/repo/main",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+		CreatedAt:   time.Now(),
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent for unknown session: %v (want nil)", err)
+	}
+
+	// The event must be retrievable.
+	events, err := d.QueryEvents("repo@nonexistent", 10, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count: got %d, want 1", len(events))
+	}
+	if events[0].ID != e.ID {
+		t.Errorf("event ID: got %q, want %q", events[0].ID, e.ID)
+	}
+}
+
+// TestUpsertStatus_SetsLastSeenOnInsert verifies that a newly created
+// agent_status row has a non-zero last_seen set to approximately now (#824 AC).
+func TestUpsertStatus_SetsLastSeenOnInsert(t *testing.T) {
+	d := openTestDB(t)
+
+	before := time.Now().Add(-time.Second) // give 1s slack for slow systems
+	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	after := time.Now().Add(time.Second)
+
+	s, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s == nil {
+		t.Fatal("CurrentStatus: got nil")
+	}
+
+	if s.LastSeen.IsZero() {
+		t.Error("LastSeen: got zero, want non-zero timestamp")
+	}
+	if s.LastSeen.Before(before) {
+		t.Errorf("LastSeen (%v) is before expected window start (%v)", s.LastSeen, before)
+	}
+	if s.LastSeen.After(after) {
+		t.Errorf("LastSeen (%v) is after expected window end (%v)", s.LastSeen, after)
+	}
+}
+
+// TestMigration_V13ToV14_BackfillsLastSeen verifies the one-shot backfill
+// migration (v13→v14): agent_status rows with last_seen=0 are populated from
+// MAX(agent_events.created_at) for the owning session, while rows that already
+// have a real last_seen are left untouched (#824 AC).
+func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v13_backfill.db")
+
+	// Seed a v13 database with:
+	//   - "repo@stale"  — last_seen=0, has agent_events → should be backfilled
+	//   - "repo@noevts" — last_seen=0, no agent_events  → should stay 0
+	//   - "repo@live"   — last_seen=already_set         → must not be overwritten
+	const alreadySet = int64(9_000_000_000_000) // ms, some past date
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY,
+		  repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL,
+		  state TEXT NOT NULL,
+		  title TEXT,
+		  agent_name TEXT,
+		  model_id TEXT,
+		  root_agent_name TEXT,
+		  root_model_id TEXT,
+		  host_mode INTEGER NOT NULL DEFAULT 0,
+		  isolation_mode TEXT,
+		  instance_id TEXT,
+		  last_seen INTEGER NOT NULL,
+		  ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT,
+		  harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+		INSERT INTO schema_version (version) VALUES (13);
+
+		INSERT INTO agent_status (session_name, repo, worktree, state, last_seen)
+		  VALUES ('repo@stale',  'repo', '/wt', 'active', 0);
+		INSERT INTO agent_status (session_name, repo, worktree, state, last_seen)
+		  VALUES ('repo@noevts', 'repo', '/wt', 'active', 0);
+		INSERT INTO agent_status (session_name, repo, worktree, state, last_seen)
+		  VALUES ('repo@live',   'repo', '/wt', 'active', 9000000000000);
+
+		-- Two events for repo@stale, different timestamps.
+		INSERT INTO agent_events (id, session_name, repo, worktree, type, payload, created_at)
+		  VALUES ('evt-stale-1', 'repo@stale', 'repo', '/wt', 'state_change', '{}', 1000);
+		INSERT INTO agent_events (id, session_name, repo, worktree, type, payload, created_at)
+		  VALUES ('evt-stale-2', 'repo@stale', 'repo', '/wt', 'state_change', '{}', 5000);
+		-- No events for repo@noevts.
+		-- No events for repo@live (its last_seen is already set).
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v13 db: %v", err)
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v13 db: %v", err)
+	}
+	defer d.Close()
+
+	// Schema version must advance to 14.
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 14 {
+		t.Errorf("schema_version after migration: got %d, want 14", version)
+	}
+
+	// repo@stale: last_seen must be MAX(created_at) = 5000.
+	stale, err := d.CurrentStatus("repo@stale")
+	if err != nil {
+		t.Fatalf("CurrentStatus(repo@stale): %v", err)
+	}
+	if stale == nil {
+		t.Fatal("CurrentStatus(repo@stale): got nil")
+	}
+	if stale.LastSeen.UnixMilli() != 5000 {
+		t.Errorf("repo@stale last_seen: got %d ms, want 5000 (MAX of events)", stale.LastSeen.UnixMilli())
+	}
+
+	// repo@noevts: last_seen stays 0 (COALESCE returns 0 for NULL subquery result).
+	noevts, err := d.CurrentStatus("repo@noevts")
+	if err != nil {
+		t.Fatalf("CurrentStatus(repo@noevts): %v", err)
+	}
+	if noevts == nil {
+		t.Fatal("CurrentStatus(repo@noevts): got nil")
+	}
+	if noevts.LastSeen.UnixMilli() != 0 {
+		t.Errorf("repo@noevts last_seen: got %d ms, want 0 (no events)", noevts.LastSeen.UnixMilli())
+	}
+
+	// repo@live: last_seen must not be overwritten (already had a non-zero value).
+	live, err := d.CurrentStatus("repo@live")
+	if err != nil {
+		t.Fatalf("CurrentStatus(repo@live): %v", err)
+	}
+	if live == nil {
+		t.Fatal("CurrentStatus(repo@live): got nil")
+	}
+	if live.LastSeen.UnixMilli() != alreadySet {
+		t.Errorf("repo@live last_seen: got %d ms, want %d ms (must not overwrite existing value)", live.LastSeen.UnixMilli(), alreadySet)
+	}
+}
+
+// TestMigration_V13ToV14_Idempotent verifies that running the v13→v14 backfill
+// a second time (by opening an already-migrated DB) does not overwrite
+// last_seen values that were set by the first migration pass (#824 AC:
+// idempotent backfill).
+func TestMigration_V13ToV14_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v13_backfill_idempotent.db")
+
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY,
+		  repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL,
+		  state TEXT NOT NULL,
+		  title TEXT,
+		  agent_name TEXT,
+		  model_id TEXT,
+		  root_agent_name TEXT,
+		  root_model_id TEXT,
+		  host_mode INTEGER NOT NULL DEFAULT 0,
+		  isolation_mode TEXT,
+		  instance_id TEXT,
+		  last_seen INTEGER NOT NULL,
+		  ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT,
+		  harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+		INSERT INTO schema_version (version) VALUES (13);
+		INSERT INTO agent_status (session_name, repo, worktree, state, last_seen)
+		  VALUES ('repo@stale', 'repo', '/wt', 'active', 0);
+		INSERT INTO agent_events (id, session_name, repo, worktree, type, payload, created_at)
+		  VALUES ('evt-1', 'repo@stale', 'repo', '/wt', 'state_change', '{}', 7777);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v13 db: %v", err)
+	}
+
+	// First open: applies the backfill.
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first db.Open: %v", err)
+	}
+	s1, err := d1.CurrentStatus("repo@stale")
+	if err != nil {
+		t.Fatalf("first CurrentStatus: %v", err)
+	}
+	if s1 == nil || s1.LastSeen.UnixMilli() != 7777 {
+		t.Fatalf("first pass: expected last_seen=7777, got %v", s1)
+	}
+	d1.Close()
+
+	// Second open: migration is at v14; the backfill WHERE guard means rows with
+	// last_seen != 0 are not touched.
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	s2, err := d2.CurrentStatus("repo@stale")
+	if err != nil {
+		t.Fatalf("second CurrentStatus: %v", err)
+	}
+	if s2 == nil || s2.LastSeen.UnixMilli() != 7777 {
+		t.Errorf("second pass: last_seen changed (want 7777, got %v); backfill is not idempotent", s2.LastSeen.UnixMilli())
+	}
+}
+
+// TestLastSeen_ActivityQuery verifies the functional AC from #824: a query
+//
+//	SELECT session_name FROM agent_status WHERE last_seen >= unixepoch('now', '-1 day') * 1000
+//
+// returns only sessions that have had recent event activity.
+func TestLastSeen_ActivityQuery(t *testing.T) {
+	d := openTestDB(t)
+
+	// Create two sessions.
+	if err := d.UpsertStatus("repo@recent", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus recent: %v", err)
+	}
+	if err := d.UpsertStatus("repo@old", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus old: %v", err)
+	}
+
+	// Force repo@old's last_seen to a timestamp more than 24h ago via SQL directly,
+	// so that the query below can discriminate. Use a timestamp 2 days in the past.
+	twoDaysAgo := time.Now().Add(-48 * time.Hour).UnixMilli()
+	if err := d.QueryRow(
+		"UPDATE agent_status SET last_seen = ? WHERE session_name = 'repo@old' RETURNING 1",
+		twoDaysAgo,
+	).Scan(new(int)); err != nil {
+		t.Fatalf("force-set old last_seen: %v", err)
+	}
+
+	// Write a recent event for repo@recent to bump its last_seen.
+	if err := d.WriteEvent(db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "repo@recent",
+		Repo:        "repo",
+		Worktree:    "/wt",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteEvent recent: %v", err)
+	}
+
+	// Check that only 'repo@recent' qualifies for the last-24h query from #824.
+	// last_seen is stored in milliseconds; unixepoch() returns seconds.
+	var recentCount, oldCount int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM agent_status WHERE last_seen >= (unixepoch('now') - 86400) * 1000 AND session_name = 'repo@recent'",
+	).Scan(&recentCount); err != nil {
+		t.Fatalf("count recent: %v", err)
+	}
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM agent_status WHERE last_seen >= (unixepoch('now') - 86400) * 1000 AND session_name = 'repo@old'",
+	).Scan(&oldCount); err != nil {
+		t.Fatalf("count old: %v", err)
+	}
+
+	if recentCount != 1 {
+		t.Errorf("repo@recent should appear in last-24h query: got count %d, want 1", recentCount)
+	}
+	if oldCount != 0 {
+		t.Errorf("repo@old should NOT appear in last-24h query: got count %d, want 0", oldCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `WriteEvent` now updates `agent_status.last_seen = MAX(last_seen, event.created_at)` in the same transaction as the event insert, so every recorded event bumps the owning session's activity timestamp.
- Migration v13→v14 backfills `last_seen` from `MAX(agent_events.created_at)` for any existing rows where `last_seen IS NULL OR last_seen = 0` — safe to run multiple times (idempotent).
- `UpsertStatus` already set `last_seen = now` correctly; confirmed and tested explicitly.
- Seven new unit tests covering all ACs from the issue.

Closes #824