### PR TITLE
prism sidecar: add log coverage for silent-stall, error-finish, and opencode event-type drift

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -158,6 +158,10 @@ type Config struct {
 	PrismBinaryPath string
 }
 
+// seenUnknownCap is the maximum number of unique unknown event types tracked
+// in seenUnknown before the cap-reached message fires and tracking stops.
+const seenUnknownCap = 50
+
 // Sidecar is the core event processor. It consumes events from the agent
 // runtime's event stream (via the Harness interface) and drives state
 // transitions in the prism DB.
@@ -237,6 +241,20 @@ type Sidecar struct {
 	// false resumes caused by the post-error session.updated churn that opencode
 	// emits in the same millisecond as session.error. Protected by s.mu.
 	lastErrorAt time.Time
+	// spawnTime records when the sidecar Run() began; used to compute elapsed
+	// time for the "first event received" log line (Gap 1b).
+	// Set at the top of Run(), read under s.mu in HandleEvent.
+	spawnTime time.Time
+	// firstEventLogged is set to true after the "first event received" log
+	// line has been emitted. Prevents duplicate lines on reconnect.
+	// Protected by s.mu.
+	firstEventLogged bool
+	// seenUnknown tracks event types that have hit the default switch case
+	// and been logged once. Capped at seenUnknownCap entries. Protected by s.mu.
+	seenUnknown map[string]bool
+	// seenUnknownCapReached is set to true when seenUnknown reaches seenUnknownCap.
+	// Prevents repeated "cap reached" log lines. Protected by s.mu.
+	seenUnknownCapReached bool
 }
 
 // New creates a Sidecar with the given configuration.
@@ -258,6 +276,7 @@ func New(cfg Config) *Sidecar {
 		textByMessage:   make(map[string]string),
 		msgCreatedAtMs:  make(map[string]float64),
 		ttftByMessage:   make(map[string]int64),
+		seenUnknown:     make(map[string]bool),
 	}
 	// Pre-set rootAgent from the configured agent role so that subagent user
 	// messages (which have a non-empty agent field in SSE events) do not
@@ -284,6 +303,11 @@ type containerMgr struct {
 // health-checks the podman container before subscribing to the SSE stream.
 // The container is stopped and removed by Shutdown().
 func (s *Sidecar) Run(ctx context.Context) error {
+	// Record spawn time for "first event received" log line (Gap 1b).
+	s.mu.Lock()
+	s.spawnTime = time.Now()
+	s.mu.Unlock()
+
 	// Container mode: create and health-check the container before connecting.
 	if s.cfg.Container != nil {
 		sessionStart := time.Now()
@@ -518,6 +542,13 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 
 	log.Printf("sidecar: event: %s", eventType)
 
+	// Gap 1b: log the first event received from opencode (once per session).
+	if !s.firstEventLogged {
+		s.firstEventLogged = true
+		elapsed := time.Since(s.spawnTime)
+		log.Printf("sidecar: first event received from opencode (%s after spawn)", elapsed.Round(time.Millisecond))
+	}
+
 	switch eventType {
 	case "server.connected":
 		s.handleServerConnected()
@@ -550,6 +581,19 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 		s.handleMessageUpdated(evt)
 	case "message.part.updated":
 		s.handleMessagePartUpdated(evt)
+	default:
+		// Gap 6: log unknown event types once per unique type.
+		if !s.seenUnknown[eventType] {
+			if len(s.seenUnknown) >= seenUnknownCap {
+				if !s.seenUnknownCapReached {
+					s.seenUnknownCapReached = true
+					log.Printf("sidecar: unknown-event log cap reached")
+				}
+			} else {
+				s.seenUnknown[eventType] = true
+				log.Printf("sidecar: event: %s (unhandled — opencode may have added a new event type)", eventType)
+			}
+		}
 	}
 }
 
@@ -608,6 +652,7 @@ func (s *Sidecar) Shutdown() {
 	if s.lastState != agent.StateFinished &&
 		s.lastState != agent.StateDeleted &&
 		s.lastState != agent.StateInterrupted {
+		log.Printf("sidecar: transition -> interrupted (cause=sigterm)")
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
 	}
@@ -642,6 +687,7 @@ func (s *Sidecar) handleServerConnected() {
 			return
 		}
 		log.Printf("sidecar: recovery timer fired, writing finished (session.idle likely missed on reconnect)")
+		log.Printf("sidecar: transition -> finished (cause=recovery_timer)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
@@ -679,6 +725,7 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 		// StateError; without this, an immediate session.updated would bypass the
 		// debounce guard and false-resume.
 		s.lastErrorAt = s.cfg.Clock.Now()
+		log.Printf("sidecar: transition -> error (cause=error_finish)")
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 	}
@@ -709,6 +756,7 @@ func (s *Sidecar) handleSessionIdle() {
 		// If the user manually denied a permission, write interrupted not finished.
 		if s.manualDenial {
 			s.manualDenial = false
+			log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
 			return
@@ -720,6 +768,7 @@ func (s *Sidecar) handleSessionIdle() {
 			return
 		}
 
+		log.Printf("sidecar: transition -> finished (cause=idle_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
@@ -846,7 +895,8 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 	var payload struct {
 		Properties struct {
 			Error *struct {
-				Name string `json:"name"`
+				Name    string `json:"name"`
+				Message string `json:"message"`
 			} `json:"error"`
 		} `json:"properties"`
 	}
@@ -856,14 +906,27 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 	}
 
 	errorName := ""
+	errorMessage := ""
 	if payload.Properties.Error != nil {
 		errorName = payload.Properties.Error.Name
+		errorMessage = payload.Properties.Error.Message
+	}
+
+	// Gap 2: log the error name and truncated message.
+	// MessageAbortedError is visually distinguishable — it is a known/expected
+	// condition (user pressed Escape/Ctrl-C) whereas other errors are unexpected.
+	truncatedMsg := truncate(errorMessage, 200)
+	if errorName == "MessageAbortedError" {
+		log.Printf("sidecar: session.error: name=%q message=%s [MessageAbortedError — user-initiated]", errorName, truncatedMsg)
+	} else {
+		log.Printf("sidecar: session.error: name=%q message=%s", errorName, truncatedMsg)
 	}
 
 	if errorName == "MessageAbortedError" {
 		// User pressed Escape/Ctrl-C — record as interrupted.
 		s.cancelIdleTimer()
 		s.cancelRecoveryTimer()
+		log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
 	} else {
@@ -873,6 +936,7 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		// post-error session.updated churn that opencode emits in the same
 		// millisecond as session.error (see ErrorResumeDebounce).
 		s.lastErrorAt = s.cfg.Clock.Now()
+		log.Printf("sidecar: transition -> error (cause=error_finish)")
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 		s.writeEvent("error", map[string]string{"name": errorName}, nil)
@@ -1100,6 +1164,15 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 		// here ensures the session always reaches finished even when no
 		// second idle event is emitted (#538).
 		if agentName != "" && agentName == s.rootAgent {
+			// Gap 4: emit assistant turn summary before the internal state lines.
+			isRoot := agentName == s.rootAgent
+			totalTokens := 0
+			if info.Tokens != nil {
+				totalTokens = info.Tokens.Input + info.Tokens.Output
+			}
+			log.Printf("sidecar: assistant turn complete (agent=%s root=%t model=%s messageId=%s tokens=%d)",
+				agentName, isRoot, model, info.ID, totalTokens)
+
 			log.Printf("sidecar: lastAssistantAgent cleared (root agent completed)")
 			s.lastAssistantAgent = ""
 
@@ -1136,6 +1209,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 
 				if s.manualDenial {
 					s.manualDenial = false
+					log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 					s.upsertState(agent.StateInterrupted, nil, nil)
 					s.writeStateChange(agent.StateInterrupted)
 					return
@@ -1146,6 +1220,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 					return
 				}
 
+				log.Printf("sidecar: transition -> finished (cause=root_agent_idle_debounce)")
 				s.upsertState(agent.StateFinished, nil, nil)
 				s.writeStateChange(agent.StateFinished)
 				go s.notifyCoordinator()
@@ -1299,6 +1374,15 @@ func (s *Sidecar) handleMessagePartUpdated(evt harness.HarnessEvent) {
 					log.Printf("sidecar: audit: high-impact command recorded: %s", truncate(cmd, 120))
 				}
 			}
+		} else if part.State != nil && part.State.Status == "error" {
+			// Gap 5: log tool call failures and write a tool_error DB event.
+			errStr := truncate(fmt.Sprintf("%v", part.State.Output), 200)
+			log.Printf("sidecar: tool call failed (tool=%s messageId=%s err=%s)", part.Tool, part.MessageID, errStr)
+			s.writeEvent("tool_error", map[string]string{
+				"tool":      part.Tool,
+				"err":       errStr,
+				"messageId": part.MessageID,
+			}, nil)
 		}
 
 	case "reasoning":

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -7198,6 +7199,362 @@ func TestSessionError_MessageAbortedError_PathUnchanged(t *testing.T) {
 	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
 	if state != string(agent.StateActive) {
 		t.Errorf("state = %q after session.updated following MessageAbortedError, want %q (abort path must not be affected by error debounce)", state, agent.StateActive)
+	}
+}
+
+// ── Gap 3: finish-cause annotation ──────────────────────────────────────────
+
+// captureLog redirects the standard logger to a buffer for the duration of the
+// test and returns a function that reads everything logged so far.
+func captureLog(t *testing.T) func() string {
+	t.Helper()
+	var buf strings.Builder
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return func() string { return buf.String() }
+}
+
+// TestTransitionCause_IdleDebounce verifies that transitioning to finished via
+// the session.idle debounce emits cause=idle_debounce.
+func TestTransitionCause_IdleDebounce(t *testing.T) {
+	sc, clk := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+	sc.HandleEvent(makeSSE("session.idle", map[string]any{}))
+
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer to be created")
+	}
+	timer.Fire()
+
+	logs := getLogs()
+	if !strings.Contains(logs, "cause=idle_debounce") {
+		t.Errorf("expected cause=idle_debounce in log; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "transition -> finished") {
+		t.Errorf("expected 'transition -> finished' in log; got:\n%s", logs)
+	}
+}
+
+// TestTransitionCause_RootAgentIdleDebounce verifies that the root-agent
+// message debounce path emits cause=root_agent_idle_debounce.
+func TestTransitionCause_RootAgentIdleDebounce(t *testing.T) {
+	sc, clk := newTestSidecar(t)
+	sc.rootAgent = "worker"
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Build a message.updated event for the root agent with time.completed set.
+	evt := makeSSE("message.updated", map[string]any{
+		"info": map[string]any{
+			"id":   "msg-001",
+			"role": "assistant",
+			"agent": "worker",
+			"time": map[string]any{
+				"created":   float64(1000),
+				"completed": float64(2000),
+			},
+		},
+	})
+	// Seed text so the message write proceeds.
+	sc.textByMessage["msg-001"] = "hello"
+	sc.HandleEvent(evt)
+
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected root-agent idle debounce timer to be created")
+	}
+	timer.Fire()
+
+	logs := getLogs()
+	if !strings.Contains(logs, "cause=root_agent_idle_debounce") {
+		t.Errorf("expected cause=root_agent_idle_debounce in log; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "transition -> finished") {
+		t.Errorf("expected 'transition -> finished' in log; got:\n%s", logs)
+	}
+}
+
+// TestTransitionCause_ErrorFinish verifies that session.error emits
+// cause=error_finish.
+func TestTransitionCause_ErrorFinish(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	evt := makeSSE("session.error", map[string]any{
+		"error": map[string]string{
+			"name":    "ModelMessageSchemaError",
+			"message": "Invalid prompt: The messages do not match the ModelMessage[] schema",
+		},
+	})
+	sc.HandleEvent(evt)
+
+	logs := getLogs()
+	if !strings.Contains(logs, "cause=error_finish") {
+		t.Errorf("expected cause=error_finish in log; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "transition -> error") {
+		t.Errorf("expected 'transition -> error' in log; got:\n%s", logs)
+	}
+}
+
+// TestTransitionCause_InterruptedByDenial verifies that MessageAbortedError
+// emits cause=interrupted_by_denial.
+func TestTransitionCause_InterruptedByDenial(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	evt := makeSSE("session.error", map[string]any{
+		"error": map[string]string{
+			"name":    "MessageAbortedError",
+			"message": "user cancelled",
+		},
+	})
+	sc.HandleEvent(evt)
+
+	logs := getLogs()
+	if !strings.Contains(logs, "cause=interrupted_by_denial") {
+		t.Errorf("expected cause=interrupted_by_denial in log; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "transition -> interrupted") {
+		t.Errorf("expected 'transition -> interrupted' in log; got:\n%s", logs)
+	}
+}
+
+// TestTransitionCause_RecoveryTimer verifies that the reconnect recovery timer
+// emits cause=recovery_timer.
+func TestTransitionCause_RecoveryTimer(t *testing.T) {
+	sc, clk := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	// Pre-set to active so handleServerConnected starts the recovery timer.
+	sc.lastState = agent.StateActive
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected recovery timer to be created")
+	}
+	timer.Fire()
+
+	logs := getLogs()
+	if !strings.Contains(logs, "cause=recovery_timer") {
+		t.Errorf("expected cause=recovery_timer in log; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "transition -> finished") {
+		t.Errorf("expected 'transition -> finished' in log; got:\n%s", logs)
+	}
+}
+
+// ── Gap 5: tool_error DB event ───────────────────────────────────────────────
+
+// TestToolCallFailed_WritesToolErrorEvent verifies that a tool part with
+// status=error writes a tool_error event to the DB and logs the failure.
+func TestToolCallFailed_WritesToolErrorEvent(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+	sc.opencodeSID = "sid-abc"
+
+	evt := makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "tool",
+			"messageID": "msg-001",
+			"tool":      "bash",
+			"state": map[string]any{
+				"status": "error",
+				"output": "exit status 1: command not found",
+			},
+		},
+	})
+	sc.HandleEvent(evt)
+
+	// Verify log line.
+	logs := getLogs()
+	if !strings.Contains(logs, "sidecar: tool call failed") {
+		t.Errorf("expected 'sidecar: tool call failed' in log; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "tool=bash") {
+		t.Errorf("expected tool=bash in log; got:\n%s", logs)
+	}
+
+	// Verify DB event.
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var toolErrorEvents []db.Event
+	for _, e := range events {
+		if e.Type == "tool_error" {
+			toolErrorEvents = append(toolErrorEvents, e)
+		}
+	}
+	if len(toolErrorEvents) != 1 {
+		t.Fatalf("expected 1 tool_error event, got %d (all events: %v)", len(toolErrorEvents), events)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(toolErrorEvents[0].Payload), &payload); err != nil {
+		t.Fatalf("unmarshal tool_error payload: %v", err)
+	}
+	if payload["tool"] != "bash" {
+		t.Errorf("tool_error payload tool = %q, want %q", payload["tool"], "bash")
+	}
+	if payload["messageId"] != "msg-001" {
+		t.Errorf("tool_error payload messageId = %q, want %q", payload["messageId"], "msg-001")
+	}
+	if !strings.Contains(payload["err"], "exit status 1") {
+		t.Errorf("tool_error payload err = %q, want to contain 'exit status 1'", payload["err"])
+	}
+}
+
+// TestToolCallFailed_ErrTruncated verifies that tool call error strings longer
+// than 200 chars are truncated using the existing truncate() helper.
+func TestToolCallFailed_ErrTruncated(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	longErr := strings.Repeat("x", 300)
+
+	evt := makeSSE("message.part.updated", map[string]any{
+		"part": map[string]any{
+			"type":      "tool",
+			"messageID": "msg-002",
+			"tool":      "read",
+			"state": map[string]any{
+				"status": "error",
+				"output": longErr,
+			},
+		},
+	})
+	sc.HandleEvent(evt)
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var toolErrorEvents []db.Event
+	for _, e := range events {
+		if e.Type == "tool_error" {
+			toolErrorEvents = append(toolErrorEvents, e)
+		}
+	}
+	if len(toolErrorEvents) != 1 {
+		t.Fatalf("expected 1 tool_error event, got %d", len(toolErrorEvents))
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(toolErrorEvents[0].Payload), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload["err"]) > 200 {
+		t.Errorf("err field length = %d, want ≤ 200 (should be truncated)", len(payload["err"]))
+	}
+}
+
+// ── Gap 6: unknown event type deduplication ──────────────────────────────────
+
+// TestUnknownEventType_LoggedOnce verifies that an unknown event type is
+// logged exactly once, not on every occurrence.
+func TestUnknownEventType_LoggedOnce(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Send the same unknown event type 5 times.
+	for range 5 {
+		sc.HandleEvent(makeSSE("new.event.type", map[string]any{}))
+	}
+
+	logs := getLogs()
+
+	// Count occurrences of the "unhandled" marker.
+	count := strings.Count(logs, "unhandled — opencode may have added a new event type")
+	if count != 1 {
+		t.Errorf("expected exactly 1 'unhandled' log line for duplicate event type, got %d; logs:\n%s", count, logs)
+	}
+
+	// Verify seenUnknown was set.
+	if !sc.seenUnknown["new.event.type"] {
+		t.Error("expected new.event.type in seenUnknown map")
+	}
+}
+
+// TestUnknownEventType_MultipleTypes verifies that each unique unknown event
+// type is logged once.
+func TestUnknownEventType_MultipleTypes(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	unknownTypes := []string{"alpha.event", "beta.event", "gamma.event"}
+	for _, typ := range unknownTypes {
+		sc.HandleEvent(makeSSE(typ, map[string]any{}))
+		sc.HandleEvent(makeSSE(typ, map[string]any{})) // duplicate
+	}
+
+	logs := getLogs()
+
+	count := strings.Count(logs, "unhandled — opencode may have added a new event type")
+	if count != len(unknownTypes) {
+		t.Errorf("expected %d 'unhandled' log lines (one per unique type), got %d; logs:\n%s",
+			len(unknownTypes), count, logs)
+	}
+}
+
+// TestUnknownEventType_CapReached verifies that the seenUnknown map is capped
+// at seenUnknownCap and a "cap reached" log line fires once.
+func TestUnknownEventType_CapReached(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Send seenUnknownCap + 10 unique unknown types.
+	for i := range seenUnknownCap + 10 {
+		sc.HandleEvent(makeSSE(fmt.Sprintf("unknown.event.%d", i), map[string]any{}))
+	}
+
+	logs := getLogs()
+
+	// Cap-reached line should appear exactly once.
+	capCount := strings.Count(logs, "sidecar: unknown-event log cap reached")
+	if capCount != 1 {
+		t.Errorf("expected exactly 1 'cap reached' log line, got %d; logs:\n%s", capCount, logs)
+	}
+
+	// seenUnknown should not exceed seenUnknownCap.
+	if len(sc.seenUnknown) > seenUnknownCap {
+		t.Errorf("seenUnknown map has %d entries, want ≤ %d", len(sc.seenUnknown), seenUnknownCap)
+	}
+
+	// Types beyond the cap should NOT have been logged as "unhandled".
+	unhandledCount := strings.Count(logs, "unhandled — opencode may have added a new event type")
+	if unhandledCount > seenUnknownCap {
+		t.Errorf("expected ≤ %d 'unhandled' log lines (cap), got %d", seenUnknownCap, unhandledCount)
+	}
+}
+
+// TestUnknownEventType_CapReachedOnce verifies that once the cap is reached,
+// sending more unique unknown types does not emit additional "cap reached" lines.
+func TestUnknownEventType_CapReachedOnce(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(t)
+
+	// Fill to cap.
+	for i := range seenUnknownCap + 20 {
+		sc.HandleEvent(makeSSE(fmt.Sprintf("cap.test.%d", i), map[string]any{}))
+	}
+
+	logs := getLogs()
+	capCount := strings.Count(logs, "sidecar: unknown-event log cap reached")
+	if capCount != 1 {
+		t.Errorf("expected exactly 1 cap-reached line (idempotent), got %d", capCount)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sse/client.go
+++ b/modules/programs/prism/prism/internal/sse/client.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -21,6 +22,10 @@ import (
 // exceed 64 KiB for long assistant responses. 10 MiB is generous but still
 // bounded.
 const maxScanTokenSize = 10 * 1024 * 1024 // 10 MiB
+
+// heartbeatInterval is how often the SSE client logs a "still waiting for
+// first event" message when the stream is open but no events have arrived yet.
+const heartbeatInterval = 30 * time.Second
 
 // Event represents a single SSE event parsed from the stream.
 type Event struct {
@@ -98,33 +103,36 @@ func (c *Client) Connect(ctx context.Context, url string) (<-chan Event, error) 
 
 	// Retry the initial connection with backoff — the server may not be ready
 	// yet (e.g. opencode is still starting up from a tmux send-keys command).
-	resp := c.connectWithRetry(ctx, url)
+	connectStart := time.Now()
+	resp, attempt := c.connectWithRetry(ctx, url)
 	if resp == nil {
 		close(ch)
 		return ch, fmt.Errorf("sse: connection cancelled: %w", ctx.Err())
 	}
+	log.Printf("sse: connected to %s (attempt %d, waited %s)", url, attempt, time.Since(connectStart).Round(time.Millisecond))
 
-	go c.readLoop(ctx, url, resp, ch)
+	go c.readLoop(ctx, url, resp, ch, attempt)
 	return ch, nil
 }
 
 // connectWithRetry attempts the initial SSE connection. It tries once
 // immediately — the common case where the server is already up — then falls
 // into the same exponential backoff loop as reconnect() if that fails.
-// Returns nil if ctx is cancelled before a connection is established.
-func (c *Client) connectWithRetry(ctx context.Context, url string) *http.Response {
+// Returns (nil, 0) if ctx is cancelled before a connection is established.
+// Returns (*http.Response, attempt) on success.
+func (c *Client) connectWithRetry(ctx context.Context, url string) (*http.Response, int) {
 	// Try immediately first.
 	resp, err := c.doRequest(ctx, url)
 	if err == nil {
-		return resp
+		return resp, 1
 	}
 	if ctx.Err() != nil {
-		return nil
+		return nil, 0
 	}
 	log.Printf("sse: initial connection failed, retrying: %v", err)
 
 	// Fall into the same backoff loop used for reconnection.
-	return c.reconnect(ctx, url)
+	return c.reconnect(ctx, url, err, 2)
 }
 
 // doRequest performs a single SSE connection attempt.
@@ -149,50 +157,95 @@ func (c *Client) doRequest(ctx context.Context, url string) (*http.Response, err
 
 // readLoop reads events from the response body, reconnecting on failure.
 // It closes ch when ctx is done.
-func (c *Client) readLoop(ctx context.Context, url string, resp *http.Response, ch chan<- Event) {
+func (c *Client) readLoop(ctx context.Context, url string, resp *http.Response, ch chan<- Event, attempt int) {
 	defer close(ch)
 
+	// firstEventReceived is shared between the heartbeat goroutine and the
+	// stream consumer. When the first event arrives, close this channel to
+	// signal the heartbeat to stop.
+	firstEventReceived := make(chan struct{})
+	firstEventOnce := &sync.Once{}
+	signalFirstEvent := func() {
+		firstEventOnce.Do(func() { close(firstEventReceived) })
+	}
+
+	// Start heartbeat goroutine: logs every 30s while no events have arrived.
+	go func() {
+		streamStart := time.Now()
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-firstEventReceived:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				log.Printf("sse: stream open for %s, no events received yet (attempt %d)",
+					time.Since(streamStart).Round(time.Second), attempt)
+			}
+		}
+	}()
+
 	for {
-		reason := c.consumeStream(ctx, resp, ch)
+		reason, gotEvent := c.consumeStream(ctx, resp, ch)
 		resp.Body.Close()
+
+		// Signal first-event on any event received (so heartbeat stops on reconnect too).
+		if gotEvent {
+			signalFirstEvent()
+		}
 
 		// If the context is done, stop reconnecting.
 		if ctx.Err() != nil {
+			signalFirstEvent() // ensure heartbeat goroutine exits
 			return
 		}
 
 		log.Printf("sse: disconnected (reason: %s)", reason)
 
 		// Reconnect with exponential backoff.
-		resp = c.reconnect(ctx, url)
+		var lastErr error
+		if reason != "EOF" {
+			lastErr = fmt.Errorf("%s", reason)
+		}
+		reconnectStart := time.Now()
+		// attempt is incremented inside reconnect for each failed attempt.
+		// Pass next attempt number (current + 1) as starting point.
+		resp, attempt = c.reconnect(ctx, url, lastErr, attempt+1)
 		if resp == nil {
 			// Context cancelled during reconnection.
+			signalFirstEvent() // ensure heartbeat goroutine exits
 			return
 		}
+		log.Printf("sse: connected to %s (attempt %d, waited %s)", url, attempt, time.Since(reconnectStart).Round(time.Millisecond))
 	}
 }
 
 // reconnect attempts to re-establish the SSE connection with exponential
-// backoff. Returns nil if ctx is cancelled before a connection is established.
-func (c *Client) reconnect(ctx context.Context, url string) *http.Response {
+// backoff. Returns (nil, attempt) if ctx is cancelled before a connection
+// is established. The attempt parameter is the attempt number to start at.
+func (c *Client) reconnect(ctx context.Context, url string, lastErr error, attempt int) (*http.Response, int) {
 	delay := c.initialRetryDelay()
 	maxDelay := c.maxRetryDelay()
 
 	for {
-		log.Printf("sse: reconnecting in %v", delay)
+		log.Printf("sse: reconnecting in %v (attempt %d, last err: %v)", delay, attempt, lastErr)
 
 		select {
 		case <-ctx.Done():
-			return nil
+			return nil, attempt
 		case <-time.After(delay):
 		}
 
 		resp, err := c.doRequest(ctx, url)
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil
+				return nil, attempt
 			}
 			log.Printf("sse: reconnection failed: %v", err)
+			lastErr = err
+			attempt++
 			delay *= 2
 			if delay > maxDelay {
 				delay = maxDelay
@@ -200,13 +253,14 @@ func (c *Client) reconnect(ctx context.Context, url string) *http.Response {
 			continue
 		}
 
-		return resp
+		return resp, attempt
 	}
 }
 
 // consumeStream reads from a single response body until EOF or error. It
-// returns a human-readable reason string describing why the stream ended.
-func (c *Client) consumeStream(ctx context.Context, resp *http.Response, ch chan<- Event) string {
+// returns a human-readable reason string describing why the stream ended,
+// and a bool indicating whether at least one event was delivered.
+func (c *Client) consumeStream(ctx context.Context, resp *http.Response, ch chan<- Event) (string, bool) {
 	scanner := bufio.NewScanner(resp.Body)
 	// Use a large buffer to handle big SSE data: lines (e.g. message.part.updated
 	// events that embed full LLM response text). The default 64 KiB limit causes
@@ -215,10 +269,11 @@ func (c *Client) consumeStream(ctx context.Context, resp *http.Response, ch chan
 
 	var eventType string
 	var dataLines []string
+	var gotEvent bool
 
 	for scanner.Scan() {
 		if ctx.Err() != nil {
-			return "context cancelled"
+			return "context cancelled", gotEvent
 		}
 
 		line := scanner.Text()
@@ -234,6 +289,7 @@ func (c *Client) consumeStream(ctx context.Context, resp *http.Response, ch chan
 					evt.Type = "message"
 				}
 				c.send(ch, evt)
+				gotEvent = true
 			}
 			eventType = ""
 			dataLines = nil
@@ -271,9 +327,9 @@ func (c *Client) consumeStream(ctx context.Context, resp *http.Response, ch chan
 	// when an empty line is encountered.
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Sprintf("read error: %v", err)
+		return fmt.Sprintf("read error: %v", err), gotEvent
 	}
-	return "EOF"
+	return "EOF", gotEvent
 }
 
 // send delivers an event to the channel, dropping it with a log warning if the


### PR DESCRIPTION
## Summary

Fills six observability gaps identified in issue #920 after a morning session where three distinct silent-failure classes could not be diagnosed from the sidecar log alone.

- **Gap 1 (SSE connection heartbeat)**: `sse/client.go` now logs `sse: connected to <url> (attempt N, waited Ns)` on every connection, emits a heartbeat every 30s while no events have been received, and extends the reconnect log to include attempt number and last error.
- **Gap 1b (first event)**: `sidecar.go` logs `sidecar: first event received from opencode (N.Ns after spawn)` on the first HandleEvent call per session.
- **Gap 2 (session.error payload)**: `handleSessionError` now logs the error name and truncated message; `MessageAbortedError` is visually distinguished from real failures.
- **Gap 3 (finish-cause annotation)**: Every transition to `StateFinished`, `StateError`, or `StateInterrupted` is preceded by `sidecar: transition -> <state> (cause=<cause>)`. Causes: `idle_debounce`, `root_agent_idle_debounce`, `recovery_timer`, `error_finish`, `interrupted_by_denial`, `sigterm`.
- **Gap 4 (assistant turn summary)**: Logs `sidecar: assistant turn complete (agent=%s root=%t model=%s messageId=%s tokens=%d)` in the root-agent-completed branch.
- **Gap 5 (tool call failures)**: Logs `sidecar: tool call failed (tool=%s messageId=%s err=%s)` and writes a `tool_error` DB event when `part.State.Status == "error"`.
- **Gap 6 (unhandled event types)**: Unknown event types log once per unique type via a `seenUnknown` map capped at 50 entries.

Tests added for Gap 3 cause-string enum, Gap 5 `tool_error` DB event write, and Gap 6 dedup/cap behaviour.

Closes #920