### PR TITLE
prism: implement async review using group-coordination primitive

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -345,12 +345,13 @@
 
         ## Pull Request Reviews
 
-          After opening a pull request, invoke ALL 5 review agents **in parallel** before announcing completion:
-          `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context`.
-          Pass the PR number to each. All 5 must return `<verdict>PASS</verdict>` for the review to pass.
-          If ANY agent returns FAIL, fix all blocking issues, push, and re-run all 5 agents.
+          `prism review <pr>` is **async** — it spawns 5 review agents, registers a group, and returns immediately with an acknowledgement.
+          Results are delivered to you via a follow-up `prism prompt` when all agents complete.
+          **Do NOT commit, merge, or announce completion** until the review-complete prompt arrives.
+          When the review-complete prompt arrives, handle PASS/FAIL per the worker agent instructions.
+          If no review-complete prompt arrives within 30 minutes, investigate with `prism checkin <session>~review-<N>-review-goal`.
           After 3 full review cycles without convergence, stop and escalate — do not run a 4th cycle.
-          Invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` as parallel Task calls (all five in a single response).
+          Invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` as parallel Task calls (all five in a single response) as a fallback when `prism review` is unavailable.
 
         ## Search Scope
 

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -247,10 +247,11 @@
         "prism checkin *" = "allow";
         "prism list-sessions" = "allow";
         "prism prompt *" = "allow";
-        # prism review is denied — it spawns heavy containers and can crash the
-        # host when multiple workers run it concurrently. Use @review-* Task calls.
-        "prism review" = "deny";
-        "prism review *" = "deny";
+        # prism review is the primary async review path for workers (#864).
+        # It spawns agents, registers a group, and returns immediately.
+        # Concurrency is controlled by the cap in cmd/concurrency.go.
+        "prism review" = "allow";
+        "prism review *" = "allow";
       };
 
       # Bash commands for the coordinator agent — inverted model: ask by default,
@@ -453,10 +454,10 @@
         "gh pr merge *" = "deny";
         "nixos-rebuild *" = "deny";
         "sudo nixos-rebuild *" = "deny";
-        # prism review spawns heavy containers — denied to prevent host overload.
-        # Use @review-* Task calls instead.
-        "prism review" = "deny";
-        "prism review *" = "deny";
+        # prism review is the primary async review path for workers (#864).
+        # The async model is non-blocking and concurrency-capped — allow.
+        # Note: container workers call this via the host sidecar (PRISM_HOST_API path),
+        # so the actual spawning happens on the host where tmux is available.
       };
 
       # Coordinator container: strict deny-by-default allowlist.
@@ -722,10 +723,8 @@
                 "prism spawn *" = "deny";
                 "prism pr" = "deny";
                 "prism pr *" = "deny";
-                # prism review spawns heavy containers — denied to prevent host overload.
-                # Use @review-* Task calls instead.
-                "prism review" = "deny";
-                "prism review *" = "deny";
+                # prism review is allowed for workers — async model is non-blocking
+                # and concurrency-capped (#864). The bwrap sandbox is the safety net.
               }
               // tmuxDenyCommands;
             };

--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -116,10 +116,11 @@ one represents a PR that may be blocking the next piece of work.
 
 When a spawned agent opens a PR:
 
-1. **Trust the worker review.** The worker has already run all 5 review agents
-   (`@review-goal`, `@review-code`, `@review-security`, `@review-qa`,
-   `@review-context`) and fixed all blocking issues before announcing completion.
-   Do not re-review the code yourself — that is the worker's job.
+1. **Trust the worker review.** The worker runs `prism review <pr>` (async) —
+   it spawns 5 review agents as a group and waits for the review-complete
+   `prism prompt` delivery before announcing completion. All blocking issues are
+   fixed before the worker hands off. Do not re-review the code yourself — that
+   is the worker's job.
 2. **Do a lightweight sense-check.** Run `gh pr view <number>` and verify:
    - PR title and description are clear and accurate
    - `Closes #N` is present and references the correct issue

--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -53,11 +53,44 @@ When your work is complete and quality gates pass:
    all 5 agents pass.
 5. Provide a clear handoff summary so the coordinator has full context.
 
-## Parallel review
+## Running a review
 
-Before announcing your PR as complete, and after each push to an open PR, run
-code review by invoking the five review subagents **in parallel** (in a single
-response with 5 Task tool calls):
+`prism review <pr>` is **async**. It spawns 5 review agents in a group and
+returns immediately with a "review in progress" acknowledgement. Results are
+delivered to you via a follow-up `prism prompt` when all agents complete.
+
+**Do NOT block waiting for review results.** You are free to do other work
+(answer clarifications, etc.), but:
+
+- **Do NOT commit further changes, merge, or announce completion** until the
+  review-complete prompt arrives.
+- When the review completes, you will receive a follow-up prompt containing the
+  aggregated findings from all 5 reviewers. Handle PASS/FAIL per the guidance
+  below.
+- If no review-complete prompt arrives within 30 minutes of running
+  `prism review`, investigate with `prism checkin <session>~review-<N>-review-goal`
+  to see per-agent progress.
+
+### Handling review results
+
+When the review-complete prompt arrives:
+
+**ALL 5 must pass** for the review to pass.
+
+If ANY agent returns `<verdict>FAIL</verdict>`:
+
+1. Read each agent's `<blocking_issues>` carefully
+2. Fix every blocking issue identified
+3. Commit and push your fixes
+4. Re-run `prism review <pr>` — not just the failed agents (a fix in one area
+   can create issues in another, so the full set must re-run every cycle).
+   Use `prism review <pr> --only review-goal,review-code` for targeted reruns.
+
+### Fallback: Task-call subagents
+
+If `prism review` is unavailable or the environment does not support it, invoke
+the five review subagents **in parallel** (in a single response with 5 Task tool
+calls) as a fallback:
 
 1. `@review-goal` — pass the original issue/ACs and the PR number
 2. `@review-code` — pass the PR number

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -146,8 +146,28 @@ prism spawn \
 
 ## Running code review
 
-Code review is done by invoking the five review subagents **in parallel** — all
-five as Task tool calls in a single response:
+Code review is done with `prism review <pr>`, which is **async**: it spawns 5
+review agents, registers a group, and returns immediately with an
+acknowledgement. Results are delivered to you via a follow-up `prism prompt`
+when all agents complete.
+
+```bash
+prism review <pr-number>
+```
+
+**Do NOT commit, merge, or announce completion** until the review-complete
+prompt arrives. When it does, handle PASS/FAIL per the worker agent instructions.
+
+If no review-complete prompt arrives within 30 minutes, check progress with:
+
+```bash
+prism checkin <session>~review-<N>-review-goal
+```
+
+### Fallback: Task-call subagents
+
+If `prism review` is unavailable, invoke the five subagents **in parallel** —
+all five as Task tool calls in a single response:
 
 1. `@review-goal` — pass the original issue/ACs and the PR number
 2. `@review-code` — pass the PR number
@@ -159,9 +179,6 @@ Wait for all 5 to complete. ALL must return `<verdict>PASS</verdict>` for the
 review to pass. If ANY returns `<verdict>FAIL</verdict>`, fix all blocking
 issues, push, and re-run all five. After 3 full cycles without convergence,
 stop and escalate — do not run a 4th cycle.
-
-> Note: the `prism review` command is explicitly disabled for agents at the
-> permissions layer. Direct subagent invocation is the canonical path.
 
 ## Example: reviewing a PR (manual spawn)
 

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -220,21 +220,22 @@ func proxyPrompt(apiURL, session, prompt string) error {
 }
 
 // reviewHostAPIResponse holds the response from the host-API /review endpoint.
+// For the async path, only Output is populated (Passed is always true because
+// the review has not yet completed when the ack is returned).
 type reviewHostAPIResponse struct {
 	Output string `json:"output"`
 	Passed bool   `json:"passed"`
 }
 
-// proxyReview proxies a review request to the host-API sidecar when running
-// inside a container (PRISM_HOST_API is set). It sends POST /review to the
-// sidecar, which runs `prism review` on the host where tmux is available,
-// and streams back the aggregated review output.
+// proxyReviewAsync proxies an async review request to the host-API sidecar
+// when running inside a container (PRISM_HOST_API is set). It sends POST /review
+// to the sidecar, which runs `prism review` on the host where tmux is available,
+// and returns immediately with the async acknowledgement.
 //
 // prNumber is the PR number to review (e.g. "123"). agents is an optional
 // list of agent names for --only filtering. timeout is an optional duration
-// string (e.g. "10m"). Returns the formatted output text, whether all agents
-// passed, and any error.
-func proxyReview(apiURL, prNumber string, agents []string, timeout string) (string, bool, error) {
+// string (e.g. "10m"). Returns the acknowledgement text and any error.
+func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) (string, error) {
 	// Build request body.
 	body := map[string]any{
 		"pr_number": prNumber,
@@ -246,18 +247,10 @@ func proxyReview(apiURL, prNumber string, agents []string, timeout string) (stri
 		body["timeout"] = timeout
 	}
 
-	// Parse the timeout to set an appropriate HTTP client deadline.
-	// The sidecar will enforce its own deadline; we add 3 minutes of overhead
-	// so the HTTP transport does not time out before the sidecar responds.
-	clientTimeout := 13 * time.Minute // default: 10m review + 3m overhead
-	if timeout != "" {
-		if d, err := time.ParseDuration(timeout); err == nil {
-			clientTimeout = d + 3*time.Minute
-		}
-	}
+	// Async reviews return quickly (just spawning + ack), so 30 s is plenty.
+	const clientTimeout = 30 * time.Second
 
-	// Build a custom client with the extended timeout so review requests
-	// (which can take 10+ minutes) are not cut off by the default 60s timeout.
+	// Build a custom client.
 	var (
 		client *http.Client
 		reqURL string
@@ -268,7 +261,7 @@ func proxyReview(apiURL, prNumber string, agents []string, timeout string) (stri
 	} else {
 		sockPath, parseErr := parseUnixSocketURL(apiURL)
 		if parseErr != nil {
-			return "", false, fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+			return "", fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
 		}
 		client = &http.Client{
 			Transport: &http.Transport{
@@ -288,25 +281,25 @@ func proxyReview(apiURL, prNumber string, agents []string, timeout string) (stri
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
-		return "", false, fmt.Errorf("proxyReview: marshal request body: %w", err)
+		return "", fmt.Errorf("proxyReviewAsync: marshal request body: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", false, fmt.Errorf("proxyReview: build request: %w", err)
+		return "", fmt.Errorf("proxyReviewAsync: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", false, fmt.Errorf("host-API /review: %w", err)
+		return "", fmt.Errorf("host-API /review: %w", err)
 	}
 
 	var reviewResp reviewHostAPIResponse
 	if err := readHostAPIResponse("/review", resp, &reviewResp); err != nil {
-		return "", false, err
+		return "", err
 	}
-	return reviewResp.Output, reviewResp.Passed, nil
+	return reviewResp.Output, nil
 }
 
 // proxyLogsFromHostAPI proxies a GET /logs request to the host-API server and

--- a/modules/programs/prism/prism/cmd/monitor_review.go
+++ b/modules/programs/prism/prism/cmd/monitor_review.go
@@ -1,0 +1,56 @@
+package cmd
+
+// prism monitor-review — internal daemon that watches a review group and
+// delivers results to the worker session when the group completes.
+//
+// This command is launched as a detached subprocess by `prism review`.
+// It is not intended for direct use; its flags and behaviour are internal.
+//
+// Flags:
+//
+//	--opts-file <path>   JSON file containing MonitorOpts (required)
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+var monitorReviewCmd = &cobra.Command{
+	Use:    "monitor-review",
+	Short:  "Internal: watch a review group and deliver results to the worker (not for direct use)",
+	Hidden: true, // not shown in help
+	Args:   cobra.NoArgs,
+	RunE:   runMonitorReview,
+}
+
+func init() {
+	monitorReviewCmd.Flags().String("opts-file", "", "Path to JSON file containing MonitorOpts (required)")
+	_ = monitorReviewCmd.MarkFlagRequired("opts-file")
+	rootCmd.AddCommand(monitorReviewCmd)
+}
+
+func runMonitorReview(cmd *cobra.Command, _ []string) error {
+	optsFile, _ := cmd.Flags().GetString("opts-file")
+	if optsFile == "" {
+		return fmt.Errorf("monitor-review: --opts-file is required")
+	}
+
+	opts, err := review.LoadMonitorOptsFromFile(optsFile)
+	if err != nil {
+		return fmt.Errorf("monitor-review: load opts: %w", err)
+	}
+
+	// Clean up the temp opts file immediately — we have the opts in memory.
+	_ = os.Remove(optsFile)
+
+	if monErr := review.MonitorFunc(opts); monErr != nil {
+		// Log the error — the process is detached so nothing else reads this.
+		fmt.Fprintf(os.Stderr, "[prism monitor-review] error: %v\n", monErr)
+		os.Exit(1)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -3,9 +3,10 @@ package cmd
 // prism review <pr-number> — platform-native review primitive.
 //
 // Spawns review agent sessions as independent top-level tmux sessions named
-// <parent-session>~review-N-<agent> (N = 1-indexed round number), polls the
-// prism DB until all agents reach the "finished" state, reads their last
-// msg_assistant event, and returns aggregated findings to stdout.
+// <parent-session>~review-N-<agent> (N = 1-indexed round number), registers a
+// group in session_groups, and returns immediately with an acknowledgement.
+// A background monitor process watches the group for completion and delivers
+// the aggregated results to the worker session via prism prompt.
 //
 // Sessions persist until prism cleanup is invoked on the parent — this allows
 // re-reading review-security's findings tomorrow without re-running.
@@ -17,12 +18,9 @@ package cmd
 //	--only <csv>        Run only the named agents (e.g. review-goal,review-code)
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,15 +33,17 @@ import (
 
 var reviewCmd = &cobra.Command{
 	Use:   "review <pr-number>",
-	Short: "Run review agents against a PR and return aggregated findings",
-	Long: `Spawn review agent sessions as independent top-level tmux sessions and poll
-the prism DB until all agents complete. Returns aggregated findings to stdout.
+	Short: "Spawn review agents for a PR and return immediately (async)",
+	Long: `Spawn review agent sessions as independent top-level tmux sessions, register
+a group, and return immediately with a review-in-progress acknowledgement.
 
 Each agent gets its own session named <parent-session>~review-N-<agent> where N
-is incremented on each invocation. Previous rounds' sessions persist until
-prism cleanup is invoked on the parent.
+is incremented on each invocation. A background monitor process watches for
+group completion and delivers aggregated results to this worker via prism prompt.
 
-Exit code 0 = all agents passed. Non-zero = one or more agents failed or errored.`,
+Previous rounds' sessions persist until prism cleanup is invoked on the parent.
+
+Do NOT commit, merge, or announce completion until the review-complete prompt arrives.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runReview,
 }
@@ -115,7 +115,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 
 	// Container-mode detection: when PRISM_HOST_API is set the process is
 	// running inside a container where tmux is not available. Route the review
-	// through the host sidecar instead of calling review.Run() directly.
+	// through the host sidecar instead of calling review.RunAsync() directly.
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
 		// Agent list was already resolved and validated above (client-side,
 		// inside the container). This ensures that the --only flag is applied
@@ -129,16 +129,13 @@ func runReview(cmd *cobra.Command, args []string) error {
 		if timeoutFlag > 0 {
 			timeoutStr = timeoutFlag.String()
 		}
-		output, passed, err := proxyReview(apiURL, prNumber, agentNames, timeoutStr)
+		output, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr)
 		if err != nil {
 			return fmt.Errorf("prism review: host API: %w", err)
 		}
 		fmt.Print(output)
 		if output != "" && !strings.HasSuffix(output, "\n") {
 			fmt.Println()
-		}
-		if !passed {
-			os.Exit(1)
 		}
 		return nil
 	}
@@ -206,6 +203,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	opts := review.Opts{
 		PRNumber:       prNumber,
 		ParentSession:  parentSession,
+		WorkerSession:  parentSession, // async delivery goes back to this session
 		Worktree:       worktree,
 		Agents:         agents,
 		Harness:        harnessFlag,
@@ -217,7 +215,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		RuntimeEnvVars: h.RuntimeEnv(),
 	}
 
-	// Load profiles for container mode — passed through to review.Run so
+	// Load profiles for container mode — passed through to review.RunAsync so
 	// each agent's sidecar receives its own per-agent hardened config blob.
 	// In container mode a missing or malformed profiles.json means the
 	// per-agent opencode.json cannot be mounted, which causes the container
@@ -231,52 +229,16 @@ func runReview(cmd *cobra.Command, args []string) error {
 		opts.ProfilesFile = pf
 	}
 
-	// Set up context with signal handling.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// currentRoundSessions holds the session names spawned in this invocation.
-	// It is written once by Run's onSessionsCreated callback (before polling
-	// begins) and read by the SIGINT handler. Protected by the assumption that
-	// the callback fires before the goroutine needs to read it (the goroutine
-	// only acts on a signal, which arrives after spawning is complete).
-	var currentRoundSessions []string
-
-	// Install SIGTERM/SIGINT handler. On signal, kill only the current round's
-	// in-progress sessions — previous rounds' persisted sessions remain untouched.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-	go func() {
-		<-sigCh
-		review.KillCurrentRoundSessions(currentRoundSessions)
-		cancel()
-	}()
-
-	// Run the review.
-	results, runErr := review.Run(ctx, opts, func(sessionNames []string) {
-		currentRoundSessions = sessionNames
-		for _, name := range sessionNames {
-			fmt.Fprintf(os.Stderr, "[prism review] agent session: %s\n", name)
-		}
-	})
-
-	signal.Stop(sigCh)
-
-	if runErr != nil && runErr != context.Canceled {
+	// RunAsync spawns the agents, registers the group, starts the monitor, and
+	// returns immediately. No blocking poll — the monitor process handles that.
+	result, runErr := review.RunAsync(opts, "")
+	if runErr != nil {
 		return fmt.Errorf("prism review: %w", runErr)
 	}
 
-	// Print a blank line to separate progress output from the aggregated summary.
-	fmt.Fprintln(os.Stdout)
+	// Print acknowledgement to stdout immediately.
+	fmt.Print(result.Ack)
 	_ = os.Stdout.Sync()
-
-	// Format and print results.
-	output, allPassed := review.FormatResults(results, prNumber)
-	fmt.Print(output)
-
-	if !allPassed {
-		os.Exit(1)
-	}
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -1,0 +1,551 @@
+package review
+
+// monitor.go — group-completion monitor for async review.
+//
+// After `prism review` spawns the 5 review-agent sessions and registers a
+// group, it starts a detached monitor subprocess (via cmd/monitor_review.go
+// using `prism monitor-review`). The monitor polls db.GroupCompleted every 5 s;
+// when the group is complete it aggregates results via db.GroupResults,
+// formats them with FormatResults, and delivers to the worker via
+// `prism prompt`. On delivery failure, it retries with bounded backoff then
+// writes the fallback file.
+//
+// MonitorOpts is passed from the cmd layer; MonitorFunc is the entry-point
+// called by the monitor-review subcommand.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// MonitorOpts configures the group-completion monitor.
+type MonitorOpts struct {
+	// GroupID is the session_groups.group_id to monitor.
+	GroupID string
+	// WorkerSession is the session name to deliver results to.
+	WorkerSession string
+	// PRNumber is the PR number string (e.g. "864") — used in the delivery
+	// message, retry messages, and fallback file naming.
+	PRNumber string
+	// Round is the 1-indexed review round number — used in the fallback file name.
+	Round int
+	// Agents is the ordered list of agents spawned in this round. Used to
+	// reconstruct the result ordering when GroupResults is incomplete.
+	Agents []Agent
+	// AgentSessions maps each agent index to its session name — needed for
+	// buildResults to correlate GroupResults data with agent ordering.
+	AgentSessions []string
+	// DBPath is the path to the prism database. If empty, the default is used.
+	DBPath string
+	// PollInterval controls how often the monitor checks GroupCompleted.
+	// Zero uses the default (5 s).
+	PollInterval time.Duration
+	// MaxDeliveryRetries is the number of times to retry delivery before writing
+	// the fallback file. Zero uses the default (5).
+	MaxDeliveryRetries int
+	// DeliveryRetryBackoff is the base delay between delivery retries.
+	// Zero uses the default (30 s).
+	DeliveryRetryBackoff time.Duration
+	// Timeout is the maximum time to wait for the group to complete. Zero means
+	// no timeout (monitor runs until the group is complete).
+	Timeout time.Duration
+}
+
+// defaultPollInterval is how often the monitor polls GroupCompleted.
+const defaultPollInterval = 5 * time.Second
+
+// defaultMaxDeliveryRetries is how many times to attempt prompt delivery.
+const defaultMaxDeliveryRetries = 5
+
+// defaultDeliveryRetryBackoff is the initial backoff between delivery retries.
+const defaultDeliveryRetryBackoff = 30 * time.Second
+
+// MonitorFunc is the entry-point for the group-completion monitor.
+// It is called by the `prism monitor-review` subcommand after startup.
+// It blocks until the group is complete (or the timeout fires), delivers
+// results to the worker, and returns. The caller (monitor-review) may
+// os.Exit after this returns.
+func MonitorFunc(opts MonitorOpts) error {
+	if opts.GroupID == "" {
+		return fmt.Errorf("monitor-review: group_id is required")
+	}
+	if opts.WorkerSession == "" {
+		return fmt.Errorf("monitor-review: worker_session is required")
+	}
+
+	pollInterval := opts.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultPollInterval
+	}
+	maxRetries := opts.MaxDeliveryRetries
+	if maxRetries <= 0 {
+		maxRetries = defaultMaxDeliveryRetries
+	}
+	retryBackoff := opts.DeliveryRetryBackoff
+	if retryBackoff <= 0 {
+		retryBackoff = defaultDeliveryRetryBackoff
+	}
+
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath = defaultDBPath()
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("monitor-review: open db: %w", err)
+	}
+	defer d.Close()
+
+	fmt.Fprintf(os.Stderr, "[prism monitor-review] watching group %s for PR #%s (worker: %s)\n",
+		opts.GroupID, opts.PRNumber, opts.WorkerSession)
+
+	// Set deadline if timeout is specified.
+	var deadline time.Time
+	if opts.Timeout > 0 {
+		deadline = time.Now().Add(opts.Timeout)
+	}
+
+	// Poll loop: check GroupCompleted every pollInterval.
+	for {
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] timeout reached for group %s — delivering partial results\n", opts.GroupID)
+			break
+		}
+
+		done, groupErr := d.GroupCompleted(opts.GroupID)
+		if groupErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: GroupCompleted(%s): %v — retrying\n", opts.GroupID, groupErr)
+		} else if done {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] group %s complete — aggregating results\n", opts.GroupID)
+			break
+		}
+
+		time.Sleep(pollInterval)
+	}
+
+	// Aggregate results.
+	groupData, grErr := d.GroupResults(opts.GroupID)
+	if grErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: GroupResults(%s): %v — using empty data\n", opts.GroupID, grErr)
+		groupData = map[string]db.GroupMemberResult{}
+	}
+
+	// Build AgentResult slice, handling "missing" sessions (row deleted mid-review).
+	results := buildMonitorResults(opts.Agents, opts.AgentSessions, groupData)
+
+	// Format the delivery message.
+	output, allPassed := FormatResults(results, opts.PRNumber)
+	deliveryText := buildDeliveryMessage(opts.PRNumber, opts.Round, output, allPassed, groupData, opts.AgentSessions)
+
+	// Deliver to worker via prism prompt with bounded retry.
+	deliverErr := deliverWithRetry(opts.WorkerSession, deliveryText, maxRetries, retryBackoff, dbPath)
+	if deliverErr != nil {
+		// Delivery failed after all retries — write fallback file.
+		fallbackPath := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", opts.PRNumber, opts.Round)
+		fmt.Fprintf(os.Stderr, "[prism monitor-review] delivery failed after %d retries — writing fallback to %s\n", maxRetries, fallbackPath)
+		writeErr := os.WriteFile(fallbackPath, []byte(deliveryText), 0o644)
+		if writeErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] error: could not write fallback file %s: %v\n", fallbackPath, writeErr)
+		} else {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] fallback file written to %s\n", fallbackPath)
+		}
+		return fmt.Errorf("monitor-review: delivery failed and fallback written to %s", fallbackPath)
+	}
+
+	fmt.Fprintf(os.Stderr, "[prism monitor-review] results delivered to %s\n", opts.WorkerSession)
+	return nil
+}
+
+// buildMonitorResults constructs AgentResult entries from GroupResults data,
+// handling missing sessions (row deleted mid-review) as a special case.
+// Missing agents are counted as an error result with state "missing".
+func buildMonitorResults(agents []Agent, agentSessions []string, groupData map[string]db.GroupMemberResult) []AgentResult {
+	results := make([]AgentResult, len(agents))
+	for i, ag := range agents {
+		agentSession := ""
+		if i < len(agentSessions) {
+			agentSession = agentSessions[i]
+		}
+
+		mr, ok := groupData[agentSession]
+		if !ok || agentSession == "" {
+			// Session was deleted mid-review or never registered — count as missing.
+			results[i] = AgentResult{
+				Agent:   ag,
+				Passed:  false,
+				Output:  "ERROR: agent session not found in group (possibly deleted mid-review)",
+				IsError: true,
+			}
+			continue
+		}
+
+		switch mr.State {
+		case "interrupted", "error":
+			results[i] = AgentResult{
+				Agent:   ag,
+				Passed:  false,
+				Output:  fmt.Sprintf("ERROR: agent did not complete cleanly (state: %s)", mr.State),
+				IsError: true,
+			}
+		case "finished":
+			if mr.LastMessage == "" {
+				results[i] = AgentResult{
+					Agent:   ag,
+					Passed:  false,
+					Output:  "ERROR: no output produced",
+					IsError: true,
+				}
+				continue
+			}
+			text := extractAssistantText(mr.LastMessage)
+			passed, kind := AssessPassed(text)
+			if !passed && kind == VerdictNone {
+				results[i] = AgentResult{
+					Agent:   ag,
+					Passed:  false,
+					Output:  "ERROR: no verdict found in agent output — review output:\n" + text,
+					IsError: true,
+				}
+				continue
+			}
+			results[i] = AgentResult{
+				Agent:  ag,
+				Passed: passed,
+				Output: text,
+			}
+		default:
+			// Non-terminal state after group says complete — treat as timed out / missing.
+			results[i] = AgentResult{
+				Agent:   ag,
+				Passed:  false,
+				Output:  fmt.Sprintf("ERROR: agent in unexpected state %q (may have timed out)", mr.State),
+				IsError: true,
+			}
+		}
+	}
+	return results
+}
+
+// buildDeliveryMessage constructs the prompt text delivered to the worker when
+// the review group completes.
+func buildDeliveryMessage(prNumber string, round int, formattedResults string, allPassed bool, groupData map[string]db.GroupMemberResult, agentSessions []string) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("## Review complete: PR #%s (round %d)\n\n", prNumber, round))
+
+	if allPassed {
+		sb.WriteString("**All 5 review agents passed.** You may proceed with announcing completion.\n\n")
+	} else {
+		sb.WriteString("**One or more review agents failed.** Fix the blocking issues and re-run `prism review`.\n\n")
+	}
+
+	sb.WriteString("### Results\n\n")
+	sb.WriteString(formattedResults)
+
+	// Note any missing/deleted sessions.
+	var missing []string
+	for _, sess := range agentSessions {
+		if _, ok := groupData[sess]; !ok {
+			missing = append(missing, sess)
+		}
+	}
+	if len(missing) > 0 {
+		sb.WriteString(fmt.Sprintf("\n**Note:** %d agent session(s) were not found in the group (possibly deleted mid-review): %s\n",
+			len(missing), strings.Join(missing, ", ")))
+	}
+
+	return sb.String()
+}
+
+// deliverWithRetry attempts to deliver text to workerSession via `prism prompt`,
+// retrying up to maxRetries times with exponential backoff starting from baseBackoff.
+// dbPath is passed through to deliverPrompt for DB access.
+func deliverWithRetry(workerSession, text string, maxRetries int, baseBackoff time.Duration, dbPath string) error {
+	var lastErr error
+	backoff := baseBackoff
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] delivery attempt %d/%d failed (%v) — retrying in %s\n",
+				attempt, maxRetries, lastErr, backoff)
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > 5*time.Minute {
+				backoff = 5 * time.Minute
+			}
+		}
+
+		err := deliverPrompt(workerSession, text, dbPath)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+	}
+
+	return fmt.Errorf("delivery failed after %d attempts: %w", maxRetries+1, lastErr)
+}
+
+// deliverPrompt sends text to workerSession via the prism prompt HTTP API.
+// It mirrors the logic in cmd/prompt.go's runPrompt but operates directly
+// via the DB + HTTP path (no exec of a subprocess) so the monitor can be
+// embedded without spawning child processes.
+func deliverPrompt(workerSession, text, dbPath string) error {
+	if dbPath == "" {
+		dbPath = defaultDBPath()
+	}
+	d, err := db.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer d.Close()
+
+	status, err := d.CurrentStatus(workerSession)
+	if err != nil {
+		return fmt.Errorf("check session status for %q: %w", workerSession, err)
+	}
+	if status == nil {
+		return fmt.Errorf("session %q not found in DB — worker may have ended", workerSession)
+	}
+	if status.EndedAt != nil {
+		return fmt.Errorf("session %q has ended — cannot deliver review results", workerSession)
+	}
+	if status.HarnessPort == nil || status.HarnessSessionID == nil {
+		return fmt.Errorf("session %q has no harness port or session ID — cannot deliver prompt", workerSession)
+	}
+
+	// Build prompt body matching cmd/prompt.go's buildPromptBody.
+	body := buildPromptBodyForMonitor(text, status)
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal prompt body: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/session/%s/prompt_async", *status.HarnessPort, *status.HarnessSessionID)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http status %d from %s", resp.StatusCode, url)
+	}
+
+	return nil
+}
+
+// buildPromptBodyForMonitor constructs the HTTP request body for prompt_async.
+// Mirrors cmd/prompt.go buildPromptBody but operates on db.Status directly
+// (monitor lives in internal/review, not cmd).
+func buildPromptBodyForMonitor(text string, status *db.Status) map[string]any {
+	body := map[string]any{
+		"parts": []map[string]string{
+			{"type": "text", "text": text},
+		},
+	}
+
+	agentName := status.RootAgentName
+	if agentName == nil {
+		agentName = status.AgentName
+	}
+	modelID := status.RootModelID
+	if modelID == nil {
+		modelID = status.ModelID
+	}
+
+	if agentName != nil && modelID != nil {
+		body["agent"] = *agentName
+
+		// Split model_id on the first "/" to get providerID and modelID.
+		slashIdx := strings.Index(*modelID, "/")
+		providerID := *modelID
+		modelIDStr := ""
+		if slashIdx >= 0 {
+			providerID = (*modelID)[:slashIdx]
+			modelIDStr = (*modelID)[slashIdx+1:]
+		}
+		body["model"] = map[string]string{
+			"providerID": providerID,
+			"modelID":    modelIDStr,
+		}
+	}
+
+	return body
+}
+
+// StartMonitorProcess launches the group-completion monitor as a detached
+// subprocess. The monitor runs `prism monitor-review` with the provided opts
+// encoded as JSON via a temp file. The subprocess is detached (Setsid) so it
+// survives the parent `prism review` process exiting.
+//
+// The prismBinary parameter is the path to the prism binary. Pass "" to use
+// os.Executable() (the current binary) as the default.
+func StartMonitorProcess(opts MonitorOpts, prismBinary string) error {
+	if prismBinary == "" {
+		var err error
+		prismBinary, err = os.Executable()
+		if err != nil {
+			return fmt.Errorf("monitor: resolve prism binary: %w", err)
+		}
+	}
+
+	// Serialise MonitorOpts to a temp file so we can pass it via flag.
+	optsJSON, err := json.Marshal(opts)
+	if err != nil {
+		return fmt.Errorf("monitor: marshal opts: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "prism-monitor-opts-*.json")
+	if err != nil {
+		return fmt.Errorf("monitor: create temp opts file: %w", err)
+	}
+	defer tmpFile.Close()
+	if _, err := tmpFile.Write(optsJSON); err != nil {
+		return fmt.Errorf("monitor: write opts file: %w", err)
+	}
+
+	cmd := exec.Command(prismBinary, "monitor-review", "--opts-file", tmpFile.Name())
+	// Detach the process: use setsid so it survives the parent process exiting.
+	detachProcess(cmd)
+	// Redirect stdout/stderr to log file for diagnostics.
+	logPath := fmt.Sprintf("/tmp/prism-monitor-review-%s-round-%d.log", opts.PRNumber, opts.Round)
+	logFile, logErr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if logErr == nil {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
+
+	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			logFile.Close()
+		}
+		return fmt.Errorf("monitor: start monitor process: %w", err)
+	}
+	// Do not wait — the process is detached and runs independently.
+	// logFile stays open in the child; Close in parent has no effect on child fd.
+	if logFile != nil {
+		logFile.Close()
+	}
+	return nil
+}
+
+// ActiveReviewGroupForParent returns the group_id of an in-progress (not yet
+// completed) review group for parentSession, or "" when none exists.
+// It is used to detect duplicate `prism review` invocations for the same
+// parent session.
+func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) {
+	members, err := d.GroupMembersForParent(parentSession)
+	if err != nil {
+		return "", fmt.Errorf("active review group: GroupMembersForParent: %w", err)
+	}
+	if len(members) == 0 {
+		return "", nil
+	}
+
+	// Group sessions by group_id.
+	// A group is "active" when at least one member is not in a terminal state.
+	groupStates := make(map[string]bool) // group_id → hasActiveMembers
+	for _, m := range members {
+		if m.GroupID == nil {
+			continue
+		}
+		gid := *m.GroupID
+		if !isTerminalState(m.State) {
+			groupStates[gid] = true
+		} else if _, exists := groupStates[gid]; !exists {
+			groupStates[gid] = false
+		}
+	}
+
+	for gid, active := range groupStates {
+		if active {
+			return gid, nil
+		}
+	}
+	return "", nil
+}
+
+// ReviewRoundForGroup returns the round number for the given group_id by
+// inspecting the session names of its members.
+// Returns 0 when the round cannot be determined.
+func ReviewRoundForGroup(members []db.Status) int {
+	// Member session names have shape <parent>~review-<N>-<agent>.
+	// Extract the first N we find.
+	for _, m := range members {
+		name := m.SessionName
+		tilde := strings.Index(name, "~review-")
+		if tilde < 0 {
+			continue
+		}
+		suffix := name[tilde+len("~review-"):]
+		dash := strings.Index(suffix, "-")
+		if dash <= 0 {
+			continue
+		}
+		n := 0
+		for _, c := range suffix[:dash] {
+			if c < '0' || c > '9' {
+				n = 0
+				break
+			}
+			n = n*10 + int(c-'0')
+		}
+		if n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// WriteFallbackResult writes the review result to the standard fallback file
+// when delivery fails. Exported for testing.
+func WriteFallbackResult(prNumber string, round int, content string) (string, error) {
+	path := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", prNumber, round)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("write fallback result: %w", err)
+	}
+	return path, nil
+}
+
+// MonitorOptsFilePath is the temp-file path used to pass MonitorOpts to the
+// monitor subprocess. It is read by the monitor-review subcommand.
+// Exported for testability.
+func LoadMonitorOptsFromFile(path string) (MonitorOpts, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return MonitorOpts{}, fmt.Errorf("read opts file %q: %w", path, err)
+	}
+	var opts MonitorOpts
+	if err := json.Unmarshal(data, &opts); err != nil {
+		return MonitorOpts{}, fmt.Errorf("parse opts file %q: %w", path, err)
+	}
+	return opts, nil
+}
+
+// fallbackFilePath returns the standard fallback result file path.
+func fallbackFilePath(prNumber string, round int) string {
+	return filepath.Join("/tmp", fmt.Sprintf("prism-review-%s-round-%d-result.md", prNumber, round))
+}
+
+// BuildMonitorResultsForTest is an exported wrapper around buildMonitorResults
+// for use in external test packages.
+func BuildMonitorResultsForTest(agents []Agent, agentSessions []string, groupData map[string]db.GroupMemberResult) []AgentResult {
+	return buildMonitorResults(agents, agentSessions, groupData)
+}

--- a/modules/programs/prism/prism/internal/review/monitor_darwin.go
+++ b/modules/programs/prism/prism/internal/review/monitor_darwin.go
@@ -1,0 +1,16 @@
+package review
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess sets the SysProcAttr so that the subprocess is created in a
+// new session (setsid), detaching it from the parent's process group and
+// controlling terminal. This ensures the monitor process survives after the
+// parent `prism review` command exits.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
+}

--- a/modules/programs/prism/prism/internal/review/monitor_linux.go
+++ b/modules/programs/prism/prism/internal/review/monitor_linux.go
@@ -1,0 +1,16 @@
+package review
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess sets the SysProcAttr so that the subprocess is created in a
+// new session (setsid), detaching it from the parent's process group and
+// controlling terminal. This ensures the monitor process survives after the
+// parent `prism review` command exits.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
+}

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -1,0 +1,592 @@
+package review_test
+
+// monitor_test.go — tests for the async review monitor.
+//
+// Tests covered:
+//   - MonitorFunc detects group completion and delivers results
+//   - MonitorFunc handles delivery failure with retry and fallback file
+//   - MonitorFunc handles missing sessions (row deleted mid-review)
+//   - MonitorFunc handles all-timeout group (all members in terminal state)
+//   - ActiveReviewGroupForParent detects in-progress rounds
+//   - buildAsyncAck produces correct acknowledgement text
+//   - buildMonitorResults handles all states
+//   - deliverWithRetry retries correctly and eventually writes fallback
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// ── MonitorFunc ──────────────────────────────────────────────────────────────
+
+// TestMonitorFunc_DetectsCompletionAndDelivers verifies that MonitorFunc:
+// 1. Polls GroupCompleted until the group is complete.
+// 2. Calls FormatResults and delivers the result to the worker.
+// 3. Returns nil when delivery succeeds.
+func TestMonitorFunc_DetectsCompletionAndDelivers(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@monitor-test"
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-code", OpencodeName: "review-code"},
+	}
+
+	// Register a group.
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed both agents as finished with a passing verdict.
+	sessions := []string{
+		parent + "~review-1-review-goal",
+		parent + "~review-1-review-code",
+	}
+	for _, sess := range sessions {
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+	}
+	// Seed passing verdict events.
+	seedAssistantEvent(t, d, sessions[0], "All ACs verified.\n<verdict>PASS</verdict>")
+	seedAssistantEvent(t, d, sessions[1], "Code looks good.\n<verdict>PASS</verdict>")
+
+	// Seed the worker session with harness info for HTTP delivery.
+	workerSession := "nixos-config@worker-test"
+	if err := d.UpsertStatus(workerSession, "nixos-config", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus worker: %v", err)
+	}
+
+	// Start an httptest server to simulate the opencode prompt_async endpoint.
+	var deliveredText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil && len(body.Parts) > 0 {
+			deliveredText = body.Parts[0].Text
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	// Extract port from test server URL and set harness info directly.
+	port := extractPort(t, srv.URL)
+	sessionID := "test-opencode-session-id"
+	if err := setHarnessInfo(t, d, workerSession, port, sessionID); err != nil {
+		t.Fatalf("SetHarnessInfo: %v", err)
+	}
+
+	opts := review.MonitorOpts{
+		GroupID:              groupID,
+		WorkerSession:        workerSession,
+		PRNumber:             "864",
+		Round:                1,
+		Agents:               agents,
+		AgentSessions:        sessions,
+		DBPath:               d.Path(),
+		PollInterval:         10 * time.Millisecond, // fast for testing
+		MaxDeliveryRetries:   0,                     // no retry needed
+		DeliveryRetryBackoff: 1 * time.Millisecond,
+	}
+
+	if err := review.MonitorFunc(opts); err != nil {
+		t.Fatalf("MonitorFunc: %v", err)
+	}
+
+	// Verify delivery happened.
+	if deliveredText == "" {
+		t.Fatal("MonitorFunc: no text delivered to worker")
+	}
+	// The delivered text must mention the PR number and round.
+	if !strings.Contains(deliveredText, "864") {
+		t.Errorf("delivered text does not mention PR number 864: %q", deliveredText)
+	}
+	if !strings.Contains(deliveredText, "round 1") {
+		t.Errorf("delivered text does not mention round 1: %q", deliveredText)
+	}
+	// Both agents passed — all-passed message expected.
+	if !strings.Contains(deliveredText, "All 5 review agents passed") && !strings.Contains(deliveredText, "all") {
+		// At minimum, no FAIL mention and both agents appear as passed (✓).
+		if strings.Contains(deliveredText, "FAIL") && !strings.Contains(deliveredText, "PASS") {
+			t.Errorf("delivered text unexpectedly shows failures for all-pass review: %q", deliveredText)
+		}
+	}
+}
+
+// TestMonitorFunc_DeliveryFailure_WritesFallbackFile verifies that when all
+// delivery retries fail, MonitorFunc writes the fallback file at the expected
+// path.
+func TestMonitorFunc_DeliveryFailure_WritesFallbackFile(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@delivery-fail-test"
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+	}
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	sess := parent + "~review-1-review-goal"
+	if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetGroupID(sess, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+	seedAssistantEvent(t, d, sess, "All good.\n<verdict>PASS</verdict>")
+
+	// Worker session: no harness port → delivery will fail.
+	workerSession := "nixos-config@nonexistent-worker"
+	// We do NOT seed this session in the DB, so delivery will fail
+	// (session not found).
+
+	// Use a unique PR number so the fallback file name is unique.
+	prNumber := "99991"
+	fallbackPath := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", prNumber, 1)
+	// Clean up any existing fallback file.
+	_ = os.Remove(fallbackPath)
+	t.Cleanup(func() { _ = os.Remove(fallbackPath) })
+
+	opts := review.MonitorOpts{
+		GroupID:              groupID,
+		WorkerSession:        workerSession,
+		PRNumber:             prNumber,
+		Round:                1,
+		Agents:               agents,
+		AgentSessions:        []string{sess},
+		DBPath:               d.Path(),
+		PollInterval:         10 * time.Millisecond,
+		MaxDeliveryRetries:   1, // 1 retry
+		DeliveryRetryBackoff: 1 * time.Millisecond,
+	}
+
+	// MonitorFunc should return an error (fallback written).
+	err = review.MonitorFunc(opts)
+	if err == nil {
+		t.Fatal("MonitorFunc: expected error due to delivery failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "fallback") {
+		t.Errorf("error should mention fallback: %v", err)
+	}
+
+	// Verify fallback file was written.
+	data, readErr := os.ReadFile(fallbackPath)
+	if readErr != nil {
+		t.Fatalf("fallback file %s not written: %v", fallbackPath, readErr)
+	}
+	content := string(data)
+	if !strings.Contains(content, prNumber) {
+		t.Errorf("fallback file does not contain PR number %s: %q", prNumber, content)
+	}
+}
+
+// TestMonitorFunc_MissingSession verifies that when a session is not found in
+// GroupResults (deleted mid-review), it counts as "missing" and the group
+// still completes with a note.
+func TestMonitorFunc_MissingSession(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@missing-session-test"
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-code", OpencodeName: "review-code"},
+	}
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Only seed review-goal; review-code is "deleted" (not in DB).
+	goalSess := parent + "~review-1-review-goal"
+	codeSess := parent + "~review-1-review-code"
+
+	if err := d.UpsertStatus(goalSess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetGroupID(goalSess, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+	seedAssistantEvent(t, d, goalSess, "<verdict>PASS</verdict>")
+
+	// review-code is seeded as "deleted" (terminal) so GroupCompleted returns true.
+	if err := d.UpsertStatus(codeSess, "nixos-config", "/wt", "deleted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus deleted: %v", err)
+	}
+	if err := d.SetGroupID(codeSess, groupID); err != nil {
+		t.Fatalf("SetGroupID deleted: %v", err)
+	}
+
+	// Capture the delivery text via a test HTTP server.
+	var deliveredText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Parts []struct{ Text string `json:"text"` } `json:"parts"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil && len(body.Parts) > 0 {
+			deliveredText = body.Parts[0].Text
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	workerSession := "nixos-config@missing-session-worker"
+	port := extractPort(t, srv.URL)
+	sessionID := "test-session-id-missing"
+	if err := d.UpsertStatus(workerSession, "nixos-config", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus worker: %v", err)
+	}
+	if err := setHarnessInfo(t, d, workerSession, port, sessionID); err != nil {
+		t.Fatalf("SetHarnessInfo: %v", err)
+	}
+
+	opts := review.MonitorOpts{
+		GroupID:              groupID,
+		WorkerSession:        workerSession,
+		PRNumber:             "1234",
+		Round:                1,
+		Agents:               agents,
+		AgentSessions:        []string{goalSess, codeSess},
+		DBPath:               d.Path(),
+		PollInterval:         10 * time.Millisecond,
+		MaxDeliveryRetries:   0,
+		DeliveryRetryBackoff: 1 * time.Millisecond,
+	}
+
+	if err := review.MonitorFunc(opts); err != nil {
+		t.Fatalf("MonitorFunc with missing session: %v", err)
+	}
+
+	// The delivery should have happened.
+	if deliveredText == "" {
+		t.Fatal("no text delivered")
+	}
+}
+
+// ── ActiveReviewGroupForParent ──────────────────────────────────────────────
+
+// TestActiveReviewGroupForParent_NoRound verifies that when no review group
+// exists for the parent, ActiveReviewGroupForParent returns "".
+func TestActiveReviewGroupForParent_NoRound(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@no-round"
+
+	gid, err := review.ActiveReviewGroupForParent(d, parent)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent: %v", err)
+	}
+	if gid != "" {
+		t.Errorf("ActiveReviewGroupForParent = %q, want empty (no rounds exist)", gid)
+	}
+}
+
+// TestActiveReviewGroupForParent_CompletedRound verifies that a completed round
+// (all members terminal) is NOT returned as active.
+func TestActiveReviewGroupForParent_CompletedRound(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@completed-round"
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed 2 agents both finished.
+	for _, agent := range []string{"review-goal", "review-code"} {
+		sess := parent + "~review-1-" + agent
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus: %v", err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID: %v", err)
+		}
+	}
+
+	gid, err := review.ActiveReviewGroupForParent(d, parent)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent: %v", err)
+	}
+	if gid != "" {
+		t.Errorf("ActiveReviewGroupForParent = %q, want empty (round completed)", gid)
+	}
+}
+
+// TestActiveReviewGroupForParent_InProgressRound verifies that when at least
+// one group member is not terminal, ActiveReviewGroupForParent returns that
+// group_id.
+func TestActiveReviewGroupForParent_InProgressRound(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@in-progress"
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// review-goal is finished; review-code is still running.
+	goalSess := parent + "~review-1-review-goal"
+	codeSess := parent + "~review-1-review-code"
+
+	if err := d.UpsertStatus(goalSess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus goal: %v", err)
+	}
+	if err := d.SetGroupID(goalSess, groupID); err != nil {
+		t.Fatalf("SetGroupID goal: %v", err)
+	}
+	if err := d.UpsertStatus(codeSess, "nixos-config", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus code: %v", err)
+	}
+	if err := d.SetGroupID(codeSess, groupID); err != nil {
+		t.Fatalf("SetGroupID code: %v", err)
+	}
+
+	gid, err := review.ActiveReviewGroupForParent(d, parent)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent: %v", err)
+	}
+	if gid != groupID {
+		t.Errorf("ActiveReviewGroupForParent = %q, want %q", gid, groupID)
+	}
+}
+
+// ── buildMonitorResults ───────────────────────────────────────────────────────
+
+// TestBuildMonitorResults_MissingSession verifies that a session not in
+// GroupResults produces an error result with "missing" mention.
+func TestBuildMonitorResults_MissingSession(t *testing.T) {
+	agents := []review.Agent{{Name: "review-goal"}}
+	sessions := []string{"nixos-config@parent~review-1-review-goal"}
+	// Empty groupData → session is missing.
+	groupData := map[string]db.GroupMemberResult{}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 1 {
+		t.Fatalf("BuildMonitorResultsForTest: got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Passed {
+		t.Errorf("missing session: Passed=true, want false")
+	}
+	if !r.IsError {
+		t.Errorf("missing session: IsError=false, want true")
+	}
+	if !findSubstring(r.Output, "not found") && !findSubstring(r.Output, "missing") && !findSubstring(r.Output, "deleted") {
+		t.Errorf("missing session: output should mention missing/not found/deleted: %q", r.Output)
+	}
+}
+
+// TestBuildMonitorResults_FinishedPassed verifies that a finished session with
+// PASS verdict produces Passed=true, IsError=false.
+func TestBuildMonitorResults_FinishedPassed(t *testing.T) {
+	agents := []review.Agent{{Name: "review-goal"}}
+	sess := "nixos-config@parent~review-1-review-goal"
+	sessions := []string{sess}
+	payload := `{"text":"<verdict>PASS</verdict>"}`
+	groupData := map[string]db.GroupMemberResult{
+		sess: {SessionName: sess, State: "finished", LastMessage: payload},
+	}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if !r.Passed {
+		t.Errorf("finished/pass: Passed=false, want true")
+	}
+	if r.IsError {
+		t.Errorf("finished/pass: IsError=true, want false")
+	}
+}
+
+// TestBuildMonitorResults_InterruptedState verifies that an interrupted agent
+// produces an error result.
+func TestBuildMonitorResults_InterruptedState(t *testing.T) {
+	agents := []review.Agent{{Name: "review-code"}}
+	sess := "nixos-config@parent~review-1-review-code"
+	sessions := []string{sess}
+	groupData := map[string]db.GroupMemberResult{
+		sess: {SessionName: sess, State: "interrupted", LastMessage: ""},
+	}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Passed {
+		t.Errorf("interrupted: Passed=true, want false")
+	}
+	if !r.IsError {
+		t.Errorf("interrupted: IsError=false, want true")
+	}
+	if !findSubstring(r.Output, "interrupted") {
+		t.Errorf("interrupted: output should mention 'interrupted': %q", r.Output)
+	}
+}
+
+// ── LoadMonitorOptsFromFile ───────────────────────────────────────────────────
+
+// TestLoadMonitorOptsFromFile_RoundTrip verifies that MonitorOpts can be
+// written to a temp file and loaded back correctly.
+func TestLoadMonitorOptsFromFile_RoundTrip(t *testing.T) {
+	want := review.MonitorOpts{
+		GroupID:       "test-group-id",
+		WorkerSession: "nixos-config@test-worker",
+		PRNumber:      "864",
+		Round:         2,
+		Agents: []review.Agent{
+			{Name: "review-goal", OpencodeName: "review-goal"},
+			{Name: "review-code", OpencodeName: "review-code"},
+		},
+		AgentSessions: []string{
+			"nixos-config@test~review-2-review-goal",
+			"nixos-config@test~review-2-review-code",
+		},
+		DBPath:               "/tmp/test.db",
+		PollInterval:         5 * time.Second,
+		MaxDeliveryRetries:   5,
+		DeliveryRetryBackoff: 30 * time.Second,
+		Timeout:              20 * time.Minute,
+	}
+
+	// Write to temp file.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "monitor-opts.json")
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Load back.
+	got, err := review.LoadMonitorOptsFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadMonitorOptsFromFile: %v", err)
+	}
+
+	// Verify fields.
+	if got.GroupID != want.GroupID {
+		t.Errorf("GroupID = %q, want %q", got.GroupID, want.GroupID)
+	}
+	if got.WorkerSession != want.WorkerSession {
+		t.Errorf("WorkerSession = %q, want %q", got.WorkerSession, want.WorkerSession)
+	}
+	if got.PRNumber != want.PRNumber {
+		t.Errorf("PRNumber = %q, want %q", got.PRNumber, want.PRNumber)
+	}
+	if got.Round != want.Round {
+		t.Errorf("Round = %d, want %d", got.Round, want.Round)
+	}
+	if len(got.Agents) != len(want.Agents) {
+		t.Errorf("Agents len = %d, want %d", len(got.Agents), len(want.Agents))
+	}
+	if got.DBPath != want.DBPath {
+		t.Errorf("DBPath = %q, want %q", got.DBPath, want.DBPath)
+	}
+}
+
+// ── WriteFallbackResult ───────────────────────────────────────────────────────
+
+// TestWriteFallbackResult verifies the fallback file is written to the expected
+// path and contains the provided content.
+func TestWriteFallbackResult_WritesCorrectFile(t *testing.T) {
+	prNumber := "99992"
+	round := 3
+	content := "## Review complete\n\nAll agents failed to deliver.\n"
+
+	expectedPath := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", prNumber, round)
+	_ = os.Remove(expectedPath)
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	path, err := review.WriteFallbackResult(prNumber, round, content)
+	if err != nil {
+		t.Fatalf("WriteFallbackResult: %v", err)
+	}
+	if path != expectedPath {
+		t.Errorf("path = %q, want %q", path, expectedPath)
+	}
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if string(data) != content {
+		t.Errorf("file content = %q, want %q", string(data), content)
+	}
+}
+
+// ── ReviewRoundForGroup ───────────────────────────────────────────────────────
+
+// TestReviewRoundForGroup_StandardShape verifies round extraction from standard
+// per-agent session names.
+func TestReviewRoundForGroup_StandardShape(t *testing.T) {
+	members := []db.Status{
+		{SessionName: "nixos-config@feature~review-3-review-goal"},
+		{SessionName: "nixos-config@feature~review-3-review-code"},
+	}
+	got := review.ReviewRoundForGroup(members)
+	if got != 3 {
+		t.Errorf("ReviewRoundForGroup = %d, want 3", got)
+	}
+}
+
+// TestReviewRoundForGroup_Empty verifies that empty members returns 0.
+func TestReviewRoundForGroup_Empty(t *testing.T) {
+	got := review.ReviewRoundForGroup(nil)
+	if got != 0 {
+		t.Errorf("ReviewRoundForGroup(nil) = %d, want 0", got)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// extractPort extracts the port number from an http://host:port URL.
+func extractPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	// rawURL is like "http://127.0.0.1:PORT"
+	parts := strings.Split(rawURL, ":")
+	if len(parts) < 3 {
+		t.Fatalf("extractPort: unexpected URL format %q", rawURL)
+	}
+	portStr := parts[len(parts)-1]
+	var port int
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		t.Fatalf("extractPort: parse port from %q: %v", rawURL, err)
+	}
+	return port
+}
+
+// setHarnessInfo writes harness_port and harness_session_id directly via SQL,
+// bypassing AllocatePort's OS-level port availability check (not needed for
+// tests using httptest.Server which already owns the port).
+func setHarnessInfo(t *testing.T, d *db.DB, sessionName string, port int, sessionID string) error {
+	t.Helper()
+	var dummy int
+	err := d.QueryRow(
+		"UPDATE agent_status SET harness_port = ?, harness_session_id = ? WHERE session_name = ? RETURNING 1",
+		port, sessionID, sessionName,
+	).Scan(&dummy)
+	return err
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -357,6 +357,11 @@ type Opts struct {
 	PRNumber string
 	// ParentSession is the prism session name of the calling worker/coordinator.
 	ParentSession string
+	// WorkerSession is the session name that will receive the async delivery
+	// prompt when the review completes. For RunAsync, this MUST be set to the
+	// session running `prism review`. For the synchronous Run path, it is
+	// unused and may be left empty.
+	WorkerSession string
 	// Worktree is the absolute path to the parent session's worktree.
 	Worktree string
 	// Agents is the list of review agents to spawn.
@@ -609,6 +614,213 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 	}
 
 	return results, pollErr
+}
+
+// AsyncResult is returned immediately by RunAsync. It contains the group_id
+// and session names for the spawned review agents, and a human-readable
+// acknowledgement message.
+type AsyncResult struct {
+	// GroupID is the session_groups.group_id for this review round.
+	GroupID string
+	// SessionNames is the list of spawned agent session names.
+	SessionNames []string
+	// Round is the 1-indexed review round number.
+	Round int
+	// Ack is a human-readable acknowledgement message to display to the worker.
+	Ack string
+}
+
+// RunAsync spawns the review agents (same as Run's spawn phase), registers a
+// group, starts a detached monitor process, and returns immediately with an
+// AsyncResult. The monitor process will poll for group completion and deliver
+// aggregated results to opts.WorkerSession via prism prompt.
+//
+// Unlike Run, RunAsync does NOT block while agents execute. The caller should
+// display Ack to the worker and proceed without waiting for review results.
+//
+// opts.WorkerSession must be set to the session name that will receive the
+// delivery prompt when the review completes.
+//
+// prismBinary is passed to StartMonitorProcess; pass "" to use os.Executable().
+func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
+	if opts.ParentSession == "" {
+		return nil, fmt.Errorf("parent session name is required")
+	}
+	if opts.WorkerSession == "" {
+		return nil, fmt.Errorf("worker session name is required for async review")
+	}
+
+	worktree := opts.Worktree
+	if worktree == "" {
+		return nil, fmt.Errorf("worktree path is required")
+	}
+
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath = defaultDBPath()
+	}
+	d, err := db.Open(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	defer d.Close()
+
+	agents := opts.Agents
+	if len(agents) == 0 {
+		agents = Agents()
+	}
+
+	// In-progress guard: reject if a round is already active for this parent.
+	// We check for any group with at least one non-terminal member.
+	activeGroupID, activeErr := ActiveReviewGroupForParent(d, opts.ParentSession)
+	if activeErr != nil {
+		// Non-fatal: log and proceed (better to allow duplicate than block falsely).
+		fmt.Fprintf(os.Stderr, "[prism review] warning: could not check for active review group: %v\n", activeErr)
+	} else if activeGroupID != "" {
+		// Determine the round number for a useful error message.
+		members, _ := d.GroupMembersForParent(opts.ParentSession)
+		activeRound := ReviewRoundForGroup(members)
+		if activeRound > 0 {
+			return nil, fmt.Errorf("prism review: round %d is already in progress for this PR (group %s).\n"+
+				"Wait for it to complete or cancel the sessions with `prism cleanup`.",
+				activeRound, activeGroupID)
+		}
+		return nil, fmt.Errorf("prism review: a review round is already in progress for session %q (group %s).\n"+
+			"Wait for it to complete or cancel the sessions with `prism cleanup`.",
+			opts.ParentSession, activeGroupID)
+	}
+
+	// Determine round number from DB.
+	round := NextRoundNumber(d, opts.ParentSession)
+	roundPrefix := fmt.Sprintf("%s~review-%d-", opts.ParentSession, round)
+	repo := deriveRepo(opts.ParentSession)
+
+	// Register session group.
+	groupID, groupErr := d.RegisterGroup(opts.ParentSession)
+	if groupErr != nil {
+		return nil, fmt.Errorf("register review group: %w", groupErr)
+	}
+
+	// Spawn each agent.
+	agentSessions := make([]string, len(agents))
+	spawnErr := make([]error, len(agents))
+
+	for i, ag := range agents {
+		agentSession := roundPrefix + ag.Name
+		agentSessions[i] = agentSession
+
+		prCtxWithWorktree := opts.PRCtx
+		if prCtxWithWorktree != nil && !prCtxWithWorktree.FetchFailed {
+			ctxCopy := *prCtxWithWorktree
+			ctxCopy.WorktreePath = worktree
+			prCtxWithWorktree = &ctxCopy
+		}
+		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree)
+
+		agentConfigContent, configErr := ResolveAgentConfigContent(opts.ContainerMode, opts.ProfilesFile, ag.Name)
+		if configErr != nil {
+			spawnErr[i] = configErr
+			if opts.OnProgress != nil {
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
+			}
+			continue
+		}
+
+		spawnOpts := session.SpawnOpts{
+			SessionName:      agentSession,
+			Repo:             repo,
+			Worktree:         worktree,
+			AgentRole:        ag.Name,
+			Prompt:           prompt,
+			ConfigContent:    agentConfigContent,
+			Layout:           session.LayoutAgentOnly,
+			ContainerMode:    opts.ContainerMode,
+			PluginHostPath:   opts.PluginHostPath,
+			WorktreeReadOnly: true,
+			GroupID:          groupID,
+			RuntimeEnvVars:   opts.RuntimeEnvVars,
+		}
+		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
+			if opts.OnProgress != nil {
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnSessErr))
+			}
+			session.KillSidecar(agentSession)
+			cleanupAgentSession(d, agentSession)
+			_ = tmux.KillSession(agentSession)
+			spawnErr[i] = fmt.Errorf("spawn session for %s: %w", ag.Name, spawnSessErr)
+			continue
+		}
+
+		if opts.OnProgress != nil {
+			opts.OnProgress(fmt.Sprintf("%s started", FormatAgentDisplayName(ag.Name)))
+		}
+	}
+
+	// Check if all agents failed to spawn.
+	allFailed := true
+	for _, se := range spawnErr {
+		if se == nil {
+			allFailed = false
+			break
+		}
+	}
+	if allFailed {
+		return nil, fmt.Errorf("all review agents failed to spawn")
+	}
+
+	// Collect successfully-spawned sessions.
+	var liveSessions []string
+	var liveAgents []Agent
+	for i, se := range spawnErr {
+		if se == nil {
+			liveSessions = append(liveSessions, agentSessions[i])
+			liveAgents = append(liveAgents, agents[i])
+		}
+	}
+
+	// Start the detached monitor process.
+	monitorOpts := MonitorOpts{
+		GroupID:       groupID,
+		WorkerSession: opts.WorkerSession,
+		PRNumber:      opts.PRNumber,
+		Round:         round,
+		Agents:        liveAgents,
+		AgentSessions: liveSessions,
+		DBPath:        dbPath,
+		Timeout:       opts.Timeout * 2, // 2x per-agent timeout as group monitor limit
+	}
+	if startErr := StartMonitorProcess(monitorOpts, prismBinary); startErr != nil {
+		// Monitor failed to start — not fatal for spawning, but warn loudly.
+		fmt.Fprintf(os.Stderr, "[prism review] warning: could not start monitor process: %v\n"+
+			"Review results will NOT be delivered automatically.\n"+
+			"Check agent progress with: prism checkin %s~review-%d-<agent>\n",
+			startErr, opts.ParentSession, round)
+	}
+
+	// Build acknowledgement message.
+	ack := buildAsyncAck(opts.PRNumber, round, groupID, liveSessions, opts.WorkerSession)
+
+	return &AsyncResult{
+		GroupID:      groupID,
+		SessionNames: liveSessions,
+		Round:        round,
+		Ack:          ack,
+	}, nil
+}
+
+// buildAsyncAck constructs the acknowledgement message returned to the worker
+// immediately after spawning the review agents.
+func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []string, workerSession string) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Review in progress — PR #%s, round %d (group: %s)\n\n", prNumber, round, groupID))
+	sb.WriteString(fmt.Sprintf("Spawned %d review agents:\n", len(sessionNames)))
+	for _, name := range sessionNames {
+		sb.WriteString(fmt.Sprintf("  • %s\n", name))
+	}
+	sb.WriteString(fmt.Sprintf("\nResults will be delivered to session %q via prism prompt when all agents complete.\n", workerSession))
+	sb.WriteString("\n**Do NOT commit, merge, or announce completion** until the review-complete prompt arrives.\n")
+	sb.WriteString(fmt.Sprintf("\nYou may monitor progress with:\n  prism checkin %s~review-%d-review-goal\n", workerSession, round))
+	return sb.String()
 }
 
 // ResolveAgentConfigContent resolves the per-agent opencode.json config blob

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2309,3 +2309,168 @@ func TestKillReviewSessionsForParentWithDB_NilDB(t *testing.T) {
 	// KillSessionPrefix calls tmux (best-effort, non-fatal). Verify no panic.
 	review.KillReviewSessionsForParentWithDB(nil, "nixos-config@main")
 }
+
+// ── RunAsync ──────────────────────────────────────────────────────────────────
+
+// TestRunAsync_ReturnsImmediately verifies that RunAsync returns promptly
+// (well under 5 seconds) without blocking on agent completion. This is the
+// core AC for the async model: "prism review <pr> becomes non-blocking".
+//
+// The test exercises the spawn-failure path (container mode with nil
+// ProfilesFile) so that RunAsync fails quickly at config-resolution time —
+// meaning all agents fail to spawn — rather than attempting real tmux calls.
+// The key assertion is that RunAsync returns an error quickly, NOT that it
+// blocks for any agent work to complete. In production, all agents would spawn
+// successfully and the monitor would be started before RunAsync returns.
+//
+// A separate test (TestRunAsync_AllSpawnFailReturnsError) confirms the error
+// path. This test focuses solely on timing.
+func TestRunAsync_ReturnsImmediately(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	parent := "nixos-config@async-timing-test"
+	if err := d.UpsertStatus(parent, "nixos-config", t.TempDir(), "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus parent: %v", err)
+	}
+
+	opts := review.Opts{
+		PRNumber:      "864",
+		ParentSession: parent,
+		WorkerSession: parent,
+		Worktree:      t.TempDir(),
+		Agents:        review.Agents()[:1], // single agent for speed
+		Timeout:       30 * time.Second,
+		DBPath:        dbPath,
+		ContainerMode: true,
+		ProfilesFile:  nil, // triggers immediate config-resolution failure → fast return
+	}
+
+	start := time.Now()
+	// RunAsync should return quickly (either with an error due to all agents
+	// failing to spawn, or with an AsyncResult after spawning successfully).
+	// We pass a non-existent prismBinary so StartMonitorProcess fails fast.
+	_, runErr := review.RunAsync(opts, "/nonexistent/prism-binary")
+	elapsed := time.Since(start)
+
+	// Regardless of success or failure, RunAsync must not block.
+	const maxElapsed = 5 * time.Second
+	if elapsed > maxElapsed {
+		t.Errorf("RunAsync took %v — expected to return in under %v (must not block on agent completion)", elapsed, maxElapsed)
+	}
+
+	// With ContainerMode=true and nil ProfilesFile, all agents fail at config
+	// resolution → RunAsync returns "all review agents failed to spawn".
+	if runErr == nil {
+		t.Logf("RunAsync returned nil error (agents spawned — monitor start failed silently as expected)")
+	} else {
+		t.Logf("RunAsync returned error (expected for container-mode nil-pf path): %v", runErr)
+	}
+}
+
+// TestRunAsync_AllSpawnFailReturnsError verifies that RunAsync returns an
+// error when all agents fail to spawn (same path as Run).
+func TestRunAsync_AllSpawnFailReturnsError(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	parent := "nixos-config@async-allfail-test"
+	if err := d.UpsertStatus(parent, "nixos-config", t.TempDir(), "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus parent: %v", err)
+	}
+
+	opts := review.Opts{
+		PRNumber:      "99",
+		ParentSession: parent,
+		WorkerSession: parent,
+		Worktree:      t.TempDir(),
+		Agents:        review.Agents()[:1],
+		Timeout:       30 * time.Second,
+		DBPath:        dbPath,
+		ContainerMode: true,
+		ProfilesFile:  nil, // → all agents fail to spawn
+	}
+
+	_, runErr := review.RunAsync(opts, "/nonexistent/prism-binary")
+	if runErr == nil {
+		t.Fatal("RunAsync: expected error when all agents fail to spawn, got nil")
+	}
+	if !findSubstring(runErr.Error(), "failed") {
+		t.Errorf("error should mention failure: %v", runErr)
+	}
+}
+
+// TestRunAsync_MissingWorkerSession verifies that RunAsync returns an error
+// when WorkerSession is empty (required field for async delivery).
+func TestRunAsync_MissingWorkerSession(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	opts := review.Opts{
+		PRNumber:      "42",
+		ParentSession: "nixos-config@test",
+		WorkerSession: "", // missing
+		Worktree:      t.TempDir(),
+		DBPath:        dbPath,
+	}
+	_, err := review.RunAsync(opts, "")
+	if err == nil {
+		t.Fatal("RunAsync: expected error for missing WorkerSession, got nil")
+	}
+	if !findSubstring(err.Error(), "worker session") {
+		t.Errorf("error should mention 'worker session': %v", err)
+	}
+}
+
+// TestRunAsync_DuplicateInProgress verifies that calling RunAsync when a round
+// is already in progress for the same parent returns a clear error rather than
+// silently spawning a duplicate round.
+func TestRunAsync_DuplicateInProgress(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	parent := "nixos-config@async-dup-test"
+	if err := d.UpsertStatus(parent, "nixos-config", t.TempDir(), "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus parent: %v", err)
+	}
+
+	// Simulate an in-progress round by registering a group with an active member.
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	activeSess := parent + "~review-1-review-goal"
+	if err := d.UpsertStatus(activeSess, "nixos-config", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus active: %v", err)
+	}
+	if err := d.SetGroupID(activeSess, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+
+	opts := review.Opts{
+		PRNumber:      "55",
+		ParentSession: parent,
+		WorkerSession: parent,
+		Worktree:      t.TempDir(),
+		Agents:        review.Agents()[:1],
+		DBPath:        dbPath,
+	}
+
+	_, runErr := review.RunAsync(opts, "/nonexistent/prism-binary")
+	if runErr == nil {
+		t.Fatal("RunAsync: expected error for in-progress round, got nil")
+	}
+	if !findSubstring(runErr.Error(), "in progress") && !findSubstring(runErr.Error(), "already") {
+		t.Errorf("error should mention 'in progress' or 'already': %v", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2726,13 +2726,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// pr_number must be a numeric string (e.g. "123"). Non-numeric values are rejected.
 	// agents is optional (empty = full set resolved by prism review on host).
 	// timeout is optional (default: 10m).
-	// Response: {"output":"...","passed":true} | {"error":"..."}
+	// Response: {"output":"<ack-text>"} | {"error":"..."}
 	//
-	// This endpoint is called by workers and coordinators running inside
-	// containers that cannot reach tmux directly. The sidecar runs on the host
-	// where tmux is available, so it delegates to `prism review` on the host.
-	// Both worker and coordinator role sidecars are permitted: workers call
-	// `prism review` as part of their own PR workflow.
+	// The review is async: prism review spawns agents, registers a group, starts
+	// a monitor process, and returns immediately with an acknowledgement message.
+	// The response output field contains the ack text (not the final review results).
+	//
+	// This endpoint is called by workers running inside containers that cannot
+	// reach tmux directly. The sidecar runs on the host where tmux is available,
+	// so it delegates to `prism review` on the host.
 	//
 	// PRISM_SESSION_NAME is injected into the subprocess environment so that
 	// `review.LookupParentSession()` can determine the parent session name
@@ -2784,18 +2786,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		log.Printf("sidecar: host-API /review: prism %s", strings.Join(args, " "))
 
-		// Parse the timeout to determine an appropriate exec deadline.
-		// Default to 10 minutes per agent; add 2 minutes of overhead.
-		// We must not cut off the prism review process before its own timeout fires.
-		execTimeout := 12 * time.Minute
-		if req.Timeout != "" {
-			if d, parseErr := time.ParseDuration(req.Timeout); parseErr == nil {
-				// Add 2 minutes overhead so the HTTP request outlives the review timeout.
-				execTimeout = d + 2*time.Minute
-			}
-		}
+		// Async review: prism review returns quickly (just spawning + ack).
+		// Use a short exec deadline — 30 seconds is more than enough.
+		const execTimeout = 30 * time.Second
 
-		// Use a context with deadline so hung review processes don't block forever.
 		ctx, cancel := context.WithTimeout(r.Context(), execTimeout)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, prismBinary(), args...)
@@ -2807,36 +2801,28 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		env := append(os.Environ(), "PRISM_SESSION_NAME="+s.cfg.SessionName)
 		cmd.Env = env
 
-		// Capture stdout (formatted results); stderr is logged server-side only.
+		// Capture stdout (the ack message); stderr is logged server-side only.
 		out, err := cmd.Output()
 		if err != nil {
 			if exitErr, ok := err.(*exec.ExitError); ok {
-				// Log stderr for diagnostics but do not include it in the HTTP
-				// response to avoid leaking internal paths or credentials to
-				// the container caller.
 				if len(exitErr.Stderr) > 0 {
 					log.Printf("sidecar: host-API /review: stderr: %s", strings.TrimSpace(string(exitErr.Stderr)))
 				}
 			}
+			// Async review should never exit non-zero for agent failures
+			// (those are delivered later via prism prompt). Treat any non-zero
+			// exit as an infrastructure failure.
+			if output := strings.TrimRight(string(out), "\n"); output == "" {
+				log.Printf("sidecar: host-API /review: review process failed: %v", err)
+				writeError(w, http.StatusInternalServerError, "review process failed — check host logs for details")
+				return
+			}
 		}
 
-		// prism review exits non-zero when one or more agents fail (exit 1).
-		// This is expected and not an infrastructure error — return the output
-		// with passed=false. Only treat it as a hard error if there is no output.
-		passed := err == nil
 		output := strings.TrimRight(string(out), "\n")
-
-		if output == "" && err != nil {
-			// No output produced — infrastructure failure. Log error server-side
-			// and return a generic message to avoid leaking details to the caller.
-			log.Printf("sidecar: host-API /review: review process failed: %v", err)
-			writeError(w, http.StatusInternalServerError, "review process failed — check host logs for details")
-			return
-		}
-
 		writeJSON(w, http.StatusOK, map[string]any{
 			"output": output,
-			"passed": passed,
+			"passed": true, // always true for async ack (results delivered separately)
 		})
 	})
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6785,18 +6785,21 @@ exit 0
 	}
 }
 
-// TestHostAPI_Review_FailedReviewReturnsOutputWithPassedFalse verifies that
-// when `prism review` exits non-zero with output, the response has passed=false
-// and the output is included (this is the normal "agents found issues" case).
-func TestHostAPI_Review_FailedReviewReturnsOutputWithPassedFalse(t *testing.T) {
+// TestHostAPI_Review_AckReturnedOnSuccess verifies that when `prism review`
+// exits 0 with an ack message (async model), the response has passed=true
+// and the ack output is included. In the async model, prism review never
+// exits non-zero for agent failures — results are delivered later via
+// prism prompt.
+func TestHostAPI_Review_AckReturnedOnSuccess(t *testing.T) {
 	d := openTestDB(t)
 
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
-	// Exit 1 with output: indicates agents found issues (not an infra failure).
+	// Async ack: exit 0 with ack message (agent results are delivered separately).
 	stubScript := `#!/bin/sh
-echo "✗ review-code"
-echo "  blocking issue found"
-exit 1
+echo "Review in progress — PR #100, round 1"
+echo "Spawned 5 review agents."
+echo "Results will be delivered to session via prism prompt."
+exit 0
 `
 	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
 		t.Fatalf("write stub: %v", err)
@@ -6817,15 +6820,16 @@ exit 1
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"100"}`)
 	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 for agent failure (not infra failure); body = %s", rr.Code, rr.Body.String())
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 	var respBody map[string]any
 	decodeJSONBody(t, rr, &respBody)
-	if respBody["passed"] != false {
-		t.Errorf("passed = %v, want false", respBody["passed"])
+	// Async reviews always return passed=true at the ack phase.
+	if respBody["passed"] != true {
+		t.Errorf("passed = %v, want true (async ack is always passed=true)", respBody["passed"])
 	}
-	if !strings.Contains(fmt.Sprintf("%v", respBody["output"]), "blocking issue found") {
-		t.Errorf("output %q should contain 'blocking issue found'", respBody["output"])
+	if !strings.Contains(fmt.Sprintf("%v", respBody["output"]), "Review in progress") {
+		t.Errorf("output %q should contain 'Review in progress' ack message", respBody["output"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- `prism review <pr>` is now non-blocking: spawns 5 review-agent sessions, registers a group in `session_groups`, starts a detached `prism monitor-review` subprocess, and returns immediately with a structured ack containing the group_id and session names.
- A detached monitor process polls `db.GroupCompleted` every 5s, aggregates results via `db.GroupResults` + `review.FormatResults`, and delivers to the worker via the prism prompt HTTP API with bounded retry and a fallback file (`/tmp/prism-review-<pr>-round-<N>-result.md`) on failure.
- In-progress guard: running `prism review` twice for the same PR while a round is active produces a clear error.
- The `--only <agents>` retry path is also async (same pattern: new group, monitor, return ack).
- Worker agent prompt (`worker.md` and `opencode.nix`) updated with async review semantics: don't commit/merge/announce until the review-complete prompt arrives.
- Task-call subagent fallback is NOT removed (per §6.5 of #849).

Closes #864