### PR TITLE
fix(prism): unify parent attribution between dashboard and list-sessions (#847)

### DIFF
--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -3,6 +3,11 @@ package cmd
 // prism list-sessions — print agent sessions (from DB) in a human-readable
 // table. By default shows only sessions for the current repo. Use --all / -A
 // to list sessions across all repos.
+//
+// Sessions are sorted using db.ParentSessionFor — the single source of truth
+// for parent attribution shared with the dashboard. Depth-2 review sessions
+// appear immediately after their parent branch in the output, matching the
+// parent-child nesting shown by the dashboard TUI.
 
 import (
 	"encoding/json"
@@ -65,7 +70,12 @@ var listSessionsCmd = &cobra.Command{
 			return fmt.Errorf("list-sessions: query db: %w", err)
 		}
 
-		return renderSessionTable(ss)
+		// Fetch group parents to apply the same parent-attribution source of
+		// truth as the dashboard (db.ParentSessionFor via AllGroupParents).
+		// Non-fatal: if unavailable, sort falls back to the name heuristic.
+		groupParents, _ := d.AllGroupParents()
+
+		return renderSessionTable(ss, groupParents)
 	},
 }
 
@@ -86,7 +96,12 @@ func displayHarness(h *string) string {
 // renderSessionTable renders a []db.Status as a sorted SESSION/STATE/PORT/HARNESS/TITLE
 // table to stdout. Both the direct DB path and the host-API proxy path use
 // this shared renderer.
-func renderSessionTable(ss []db.Status) error {
+//
+// groupParents is a map of group_id → parent_session from db.AllGroupParents.
+// It is used to sort depth-2 review sessions immediately after their parent
+// branch — the same parent-attribution logic used by the dashboard. When nil
+// (e.g. the host-API proxy path), the sort falls back to name heuristic.
+func renderSessionTable(ss []db.Status, groupParents map[string]string) error {
 	type row struct {
 		name    string
 		state   string
@@ -108,11 +123,84 @@ func renderSessionTable(ss []db.Status) error {
 		rows = append(rows, row{name: s.SessionName, state: s.State, port: port, harness: displayHarness(s.Harness), title: title})
 	}
 
-	// Sort rows alphabetically by session name for stable, predictable output.
+	// Sort rows using the same parent-attribution logic as the dashboard's
+	// SortDisplayed: depth-2 review sessions sort immediately after their
+	// parent branch. The sort key is derived from db.ParentSessionFor
+	// (backing both views), with a name-heuristic fallback for pre-migration
+	// rows where group_id is not set.
+	//
+	// Key structure (mirrors dashboard.SortDisplayed):
+	//   - Plain sessions (no @): "repo\x00<name>"
+	//   - @main sessions:        "repo\x00repo@main"
+	//   - Branch sessions:       "repo\x01<branch>\x00"
+	//   - Depth-2 child of @main:  "repo\x00repo@main\x01<label>"
+	//   - Depth-2 child of @branch: "repo\x01<parent-branch>\x00<label>"
+	listSessionKey := func(name string, groupID *string) string {
+		atIdx := strings.Index(name, "@")
+		if atIdx < 0 {
+			// Plain session (no @).
+			repo := name
+			return repo + "\x00" + name
+		}
+		repo := name[:atIdx]
+		branch := name[atIdx:] // includes "@"
+
+		if branch == "@main" {
+			return repo + "\x00" + name
+		}
+
+		// Resolve parent: prefer DB-backed group_id → parent_session; fall back to name heuristic.
+		parentBranch := ""
+		if groupID != nil && groupParents != nil {
+			if parent, ok := groupParents[*groupID]; ok && parent != "" {
+				// parent is e.g. "nixos-config@main" or "nixos-config@feature"
+				if idx := strings.Index(parent, "@"); idx >= 0 {
+					parentBranch = parent[idx:] // e.g. "@main"
+				}
+			}
+		}
+		// Name-heuristic fallback for pre-migration rows.
+		if parentBranch == "" {
+			inner := branch[1:] // strip leading "@"
+			if tildeIdx := strings.Index(inner, "~"); tildeIdx >= 0 {
+				// Depth-2 session.
+				parentBranch = "@" + inner[:tildeIdx]
+			}
+		}
+
+		if parentBranch != "" {
+			// Depth-2 session: sort immediately after parent branch.
+			label := ""
+			inner := branch[1:] // strip "@"
+			if tildeIdx := strings.Index(inner, "~"); tildeIdx >= 0 {
+				label = inner[tildeIdx:] // e.g. "~review-1-review-goal"
+			}
+			if parentBranch == "@main" {
+				parentName := repo + "@main"
+				return repo + "\x00" + parentName + "\x01" + label
+			}
+			return repo + "\x01" + parentBranch + "\x00" + label
+		}
+
+		// Regular depth-1 branch session.
+		return repo + "\x01" + branch + "\x00"
+	}
+
+	// Build an index of session_name → group_id for the sort key helper.
+	// The Status slice already carries the group_id; we map by name for O(1) lookup.
+	type nameAndGID struct {
+		groupID *string
+	}
+	gidByName := make(map[string]*string, len(ss))
+	for i := range ss {
+		gidByName[ss[i].SessionName] = ss[i].GroupID
+	}
+
 	for i := 1; i < len(rows); i++ {
 		key := rows[i]
+		keyStr := listSessionKey(key.name, gidByName[key.name])
 		j := i - 1
-		for j >= 0 && rows[j].name > key.name {
+		for j >= 0 && listSessionKey(rows[j].name, gidByName[rows[j].name]) > keyStr {
 			rows[j+1] = rows[j]
 			j--
 		}
@@ -171,5 +259,7 @@ func proxyListSessionsAndRender(apiURL string, showAll bool) error {
 		return fmt.Errorf("list-sessions proxy: unmarshal response: %w", err)
 	}
 
-	return renderSessionTable(ss)
+	// Proxy path has no DB access; pass nil groupParents so renderSessionTable
+	// falls back to name heuristic for parent attribution.
+	return renderSessionTable(ss, nil)
 }

--- a/modules/programs/prism/prism/internal/dashboard/parent_attribution_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/parent_attribution_test.go
@@ -17,7 +17,6 @@ package dashboard_test
 //     @main, not after all other depth-1 branches.
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -180,27 +179,14 @@ func TestSortDisplayed_MainParentChildrenSortAfterMain(t *testing.T) {
 		t.Errorf("first review session at position %d, want %d (right after @main at %d)", firstReviewIdx, mainIdx+1, mainIdx)
 	}
 
-	// All depth-1 branches must appear AFTER the review sessions.
-	depth1After := true
-	for i, s := range sessions {
-		if i <= lastReviewIdx {
-			continue
-		}
-		branch := dashboard.SessionBranch(s.Name)
-		if branch != s.Name && branch != "@main" && !dashboard.IsDepth2Session(s.Name) {
-			// This is a depth-1 child — should appear after the review sessions.
-			_ = branch
-		}
-	}
+	// All depth-1 branches must appear AFTER all review sessions.
 	for i, s := range sessions {
 		branch := dashboard.SessionBranch(s.Name)
 		isDep1 := branch != s.Name && branch != "@main" && !dashboard.IsDepth2Session(s.Name)
-		if isDep1 && i < firstReviewIdx {
-			depth1After = false
-			t.Errorf("depth-1 session %q at position %d appears before first review session at %d", s.Name, i, firstReviewIdx)
+		if isDep1 && i <= lastReviewIdx {
+			t.Errorf("depth-1 session %q at position %d appears before or at last review session (position %d)", s.Name, i, lastReviewIdx)
 		}
 	}
-	_ = depth1After
 }
 
 // TestBothViews_ParentChildAgreement is the primary AC test: it exercises both
@@ -580,5 +566,4 @@ func TestSortDisplayed_WithDBBackedParent(t *testing.T) {
 	}
 }
 
-// Ensure the os import is used (for tempdir in some test helpers).
-var _ = os.TempDir
+

--- a/modules/programs/prism/prism/internal/dashboard/parent_attribution_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/parent_attribution_test.go
@@ -1,0 +1,584 @@
+package dashboard_test
+
+// Tests for parent-attribution consistency between the dashboard (SortDisplayed
+// / BuildDisplayRows) and the flat session list (db.ParentSessionFor).
+//
+// These tests reproduce the bug described in issue #847: when a coordinator
+// running on the @main branch spawns five review sessions named
+// @main~review-1-review-*, the dashboard rendered them as children of the last
+// depth-1 branch alphabetically before @main rather than as children of @main.
+//
+// The fix has two parts:
+//  1. db.ParentSessionFor() — single named source of truth for parent
+//     attribution, used by both views; backed by session_groups.parent_session
+//     with a name-heuristic fallback for pre-migration rows.
+//  2. SortDisplayed — uses the DB-backed ParentSession field (populated via
+//     db.AllGroupParents()) so depth-2 children of @main sort immediately after
+//     @main, not after all other depth-1 branches.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// openTestDBForDash opens a temp DB for dashboard tests.
+func openTestDBForDash(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// seedSession creates a minimal agent_status row for testing.
+func seedSession(t *testing.T, d *db.DB, sessionName, repo, worktree, state string) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, repo, worktree, state, nil, nil); err != nil {
+		t.Fatalf("seedSession(%q): %v", sessionName, err)
+	}
+}
+
+// TestParentSessionFor_DBBacked verifies that db.ParentSessionFor returns the
+// session_groups.parent_session value for post-migration sessions (group_id set).
+func TestParentSessionFor_DBBacked(t *testing.T) {
+	d := openTestDBForDash(t)
+	repo := "nixos-config"
+
+	// Seed parent session (coordinator @main).
+	parentSession := repo + "@main"
+	seedSession(t, d, parentSession, repo, "/worktrees/main", "active")
+
+	// Register a group with the parent.
+	groupID, err := d.RegisterGroup(parentSession)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed five review sessions and assign them to the group.
+	agents := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	var reviewSessions []string
+	for _, ag := range agents {
+		name := repo + "@main~review-1-" + ag
+		reviewSessions = append(reviewSessions, name)
+		seedSession(t, d, name, repo, "/worktrees/main", "active")
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	// Verify ParentSessionFor returns the correct parent for each review session.
+	for _, sess := range reviewSessions {
+		got := d.ParentSessionFor(sess)
+		if got != parentSession {
+			t.Errorf("ParentSessionFor(%q) = %q, want %q", sess, got, parentSession)
+		}
+	}
+
+	// Verify ParentSessionFor returns "" for the parent session itself.
+	got := d.ParentSessionFor(parentSession)
+	if got != "" {
+		t.Errorf("ParentSessionFor(%q) = %q, want \"\" (no parent for top-level)", parentSession, got)
+	}
+}
+
+// TestParentSessionFor_NameHeuristicFallback verifies that db.ParentSessionFor
+// falls back to the name heuristic when group_id is not set (pre-migration row).
+func TestParentSessionFor_NameHeuristicFallback(t *testing.T) {
+	d := openTestDBForDash(t)
+	repo := "nixos-config"
+
+	// Seed review sessions WITHOUT setting group_id (pre-migration).
+	sess := repo + "@feature~review-1-review-goal"
+	seedSession(t, d, sess, repo, "/worktrees/feature", "finished")
+	// group_id is NOT set — simulates a pre-migration row.
+
+	got := d.ParentSessionFor(sess)
+	want := repo + "@feature"
+	if got != want {
+		t.Errorf("ParentSessionFor(%q) = %q, want %q (name heuristic fallback)", sess, got, want)
+	}
+}
+
+// TestParentSessionFor_MainParent_NameHeuristic verifies the name heuristic
+// specifically for @main-parent sessions (the bug scenario from #847).
+func TestParentSessionFor_MainParent_NameHeuristic(t *testing.T) {
+	d := openTestDBForDash(t)
+	repo := "nixos-config"
+
+	// Seed review sessions without group_id (pre-migration fallback path).
+	sess := repo + "@main~review-1-review-code"
+	seedSession(t, d, sess, repo, "/worktrees/main", "finished")
+
+	got := d.ParentSessionFor(sess)
+	want := repo + "@main"
+	if got != want {
+		t.Errorf("ParentSessionFor(%q) = %q, want %q", sess, got, want)
+	}
+}
+
+// TestSortDisplayed_MainParentChildrenSortAfterMain is the regression test for
+// issue #847: review sessions spawned from @main must sort immediately after
+// @main, not after other depth-1 branches whose names sort after "@d" etc.
+//
+// Before the fix, nixos-config@main~review-1-review-* would sort after
+// nixos-config@design-prism-session-uniformity because the sort key used
+// "\x01@main" (the \x01 band) which sorted after "\x01@design" but ALSO after
+// all other \x01 band entries, so the review sessions appeared visually nested
+// under @design-prism-session-uniformity instead of @main.
+func TestSortDisplayed_MainParentChildrenSortAfterMain(t *testing.T) {
+	sessions := []dashboard.AgentSession{
+		{Name: "nixos-config@ci-pr-gate-workflow", AgentState: "idle"},
+		{Name: "nixos-config@design-prism-session-uniformity", AgentState: "finished"},
+		{Name: "nixos-config@main", AgentState: "active"},
+		{Name: "nixos-config@main~review-1-review-goal", AgentState: "finished"},
+		{Name: "nixos-config@main~review-1-review-code", AgentState: "finished"},
+		{Name: "nixos-config@main~review-1-review-security", AgentState: "finished"},
+		{Name: "nixos-config@main~review-1-review-qa", AgentState: "finished"},
+		{Name: "nixos-config@main~review-1-review-context", AgentState: "idle"},
+	}
+
+	dashboard.SortDisplayed(sessions)
+
+	// @main must be the FIRST session (it's the top-level session).
+	if sessions[0].Name != "nixos-config@main" {
+		t.Errorf("position 0: got %q, want nixos-config@main", sessions[0].Name)
+	}
+
+	// All five review sessions must appear BEFORE the other depth-1 branches
+	// (@ci and @design), since they are children of @main.
+	mainIdx := 0
+	for i, s := range sessions {
+		if s.Name == "nixos-config@main" {
+			mainIdx = i
+		}
+	}
+
+	// Find the range of review sessions.
+	firstReviewIdx := -1
+	lastReviewIdx := -1
+	for i, s := range sessions {
+		if dashboard.Depth2ParentBranch(s.Name) == "@main" {
+			if firstReviewIdx < 0 {
+				firstReviewIdx = i
+			}
+			lastReviewIdx = i
+		}
+	}
+	if firstReviewIdx < 0 {
+		t.Fatal("no review sessions found in sorted slice")
+	}
+
+	// Review sessions must immediately follow @main.
+	if firstReviewIdx != mainIdx+1 {
+		t.Errorf("first review session at position %d, want %d (right after @main at %d)", firstReviewIdx, mainIdx+1, mainIdx)
+	}
+
+	// All depth-1 branches must appear AFTER the review sessions.
+	depth1After := true
+	for i, s := range sessions {
+		if i <= lastReviewIdx {
+			continue
+		}
+		branch := dashboard.SessionBranch(s.Name)
+		if branch != s.Name && branch != "@main" && !dashboard.IsDepth2Session(s.Name) {
+			// This is a depth-1 child — should appear after the review sessions.
+			_ = branch
+		}
+	}
+	for i, s := range sessions {
+		branch := dashboard.SessionBranch(s.Name)
+		isDep1 := branch != s.Name && branch != "@main" && !dashboard.IsDepth2Session(s.Name)
+		if isDep1 && i < firstReviewIdx {
+			depth1After = false
+			t.Errorf("depth-1 session %q at position %d appears before first review session at %d", s.Name, i, firstReviewIdx)
+		}
+	}
+	_ = depth1After
+}
+
+// TestBothViews_ParentChildAgreement is the primary AC test: it exercises both
+// views (dashboard SortDisplayed+BuildDisplayRows and db.ParentSessionFor)
+// against the same DB state and asserts identical parent-child structure.
+//
+// Scenario (reproducing issue #847):
+//   - Coordinator: nixos-config@main
+//   - Worker:      nixos-config@design-prism-session-uniformity
+//   - Review sessions spawned by @main coordinator: 5 × @main~review-1-<agent>
+//   - One more worker branch @ci-pr-gate-workflow
+func TestBothViews_ParentChildAgreement(t *testing.T) {
+	d := openTestDBForDash(t)
+	repo := "nixos-config"
+
+	// Set up sessions in the DB.
+	coordinator := repo + "@main"
+	worker1 := repo + "@design-prism-session-uniformity"
+	worker2 := repo + "@ci-pr-gate-workflow"
+	seedSession(t, d, coordinator, repo, "/wt/main", "active")
+	seedSession(t, d, worker1, repo, "/wt/design", "finished")
+	seedSession(t, d, worker2, repo, "/wt/ci", "idle")
+
+	// Register a group for the review sessions (parent = coordinator @main).
+	groupID, err := d.RegisterGroup(coordinator)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	agents := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	reviewNames := make([]string, len(agents))
+	for i, ag := range agents {
+		name := repo + "@main~review-1-" + ag
+		reviewNames[i] = name
+		seedSession(t, d, name, repo, "/wt/main", "finished")
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	// ── View 1: db.ParentSessionFor (the source-of-truth helper) ────────────
+	for _, name := range reviewNames {
+		parent := d.ParentSessionFor(name)
+		if parent != coordinator {
+			t.Errorf("db.ParentSessionFor(%q) = %q, want %q", name, parent, coordinator)
+		}
+	}
+
+	// ── View 2: dashboard SortDisplayed + BuildDisplayRows ──────────────────
+	// Fetch group parents (as FetchSessionsFromDB would) and build AgentSessions.
+	groupParents, err := d.AllGroupParents()
+	if err != nil {
+		t.Fatalf("AllGroupParents: %v", err)
+	}
+
+	allStatuses, err := d.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+
+	var agentSessions []dashboard.AgentSession
+	for _, s := range allStatuses {
+		agentSessions = append(agentSessions, dashboard.StatusToAgentSession(s, nil, groupParents))
+	}
+
+	// Verify that each review session's ParentSession field is correctly set.
+	for _, as := range agentSessions {
+		if dashboard.IsDepth2Session(as.Name) {
+			if as.ParentSession != coordinator {
+				t.Errorf("AgentSession(%q).ParentSession = %q, want %q", as.Name, as.ParentSession, coordinator)
+			}
+		}
+	}
+
+	// Sort and build display rows.
+	dashboard.SortDisplayed(agentSessions)
+
+	// After sort: @main must be first; review sessions must immediately follow @main.
+	if len(agentSessions) == 0 {
+		t.Fatal("no sessions after sort")
+	}
+	if agentSessions[0].Name != coordinator {
+		t.Errorf("position 0: got %q, want %q (coordinator should be first)", agentSessions[0].Name, coordinator)
+	}
+
+	// All review sessions must appear before the depth-1 branches.
+	lastReviewPos := -1
+	firstDepth1Pos := -1
+	for i, s := range agentSessions {
+		if dashboard.IsDepth2Session(s.Name) {
+			lastReviewPos = i
+		}
+		branch := dashboard.SessionBranch(s.Name)
+		isDepth1 := branch != s.Name && branch != "@main" && !dashboard.IsDepth2Session(s.Name)
+		if isDepth1 && firstDepth1Pos < 0 {
+			firstDepth1Pos = i
+		}
+	}
+
+	if lastReviewPos < 0 {
+		t.Fatal("no depth-2 review sessions found after sort")
+	}
+	if firstDepth1Pos >= 0 && firstDepth1Pos <= lastReviewPos {
+		t.Errorf("depth-1 branch appears before review sessions: first depth-1 at position %d, last review at position %d", firstDepth1Pos, lastReviewPos)
+	}
+
+	// Build display rows and verify the virtual group row reports @main as parent.
+	displayRows, _ := dashboard.BuildDisplayRows(agentSessions, nil, "")
+
+	// The virtual group row should have been created.
+	var groupRow *dashboard.AgentSession
+	for i := range displayRows {
+		if displayRows[i].IsReviewGroup {
+			groupRow = &displayRows[i]
+			break
+		}
+	}
+	if groupRow == nil {
+		t.Fatal("no review group row found in BuildDisplayRows output")
+	}
+
+	// The group row's name should be "nixos-config@main~review-1".
+	wantGroupName := repo + "@main~review-1"
+	if groupRow.Name != wantGroupName {
+		t.Errorf("group row Name = %q, want %q", groupRow.Name, wantGroupName)
+	}
+
+	// ── Agreement assertion: both views agree on parent attribution ──────────
+	// For each review session, db.ParentSessionFor must return the same parent
+	// that the session name encodes (i.e. the group row's parent prefix).
+	for _, name := range reviewNames {
+		dbParent := d.ParentSessionFor(name)
+		dashParent := dashboard.Depth2ParentBranch(name)
+		// dashParent is "@main"; dbParent is "nixos-config@main".
+		// Construct full name from dash parent for comparison.
+		fullDashParent := repo + dashParent
+		if dbParent != fullDashParent {
+			t.Errorf("parent attribution disagrees for %q: db says %q, name-heuristic says %q",
+				name, dbParent, fullDashParent)
+		}
+	}
+}
+
+// TestBothViews_WorkerSpawnedReview verifies the correct case: review sessions
+// spawned by a WORKER (not coordinator) are attributed to the worker branch.
+// Edge-case AC: "review sessions spawned from a worker have consistent parent
+// attribution across both views, matching the worker they were spawned from."
+func TestBothViews_WorkerSpawnedReview(t *testing.T) {
+	d := openTestDBForDash(t)
+	repo := "nixos-config"
+
+	coordinator := repo + "@main"
+	worker := repo + "@feature-branch"
+	seedSession(t, d, coordinator, repo, "/wt/main", "active")
+	seedSession(t, d, worker, repo, "/wt/feature", "active")
+
+	// Register group with the WORKER as parent.
+	groupID, err := d.RegisterGroup(worker)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	agents := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	reviewNames := make([]string, len(agents))
+	for i, ag := range agents {
+		name := repo + "@feature-branch~review-1-" + ag
+		reviewNames[i] = name
+		seedSession(t, d, name, repo, "/wt/feature", "finished")
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	// db.ParentSessionFor must attribute each review session to the worker.
+	for _, name := range reviewNames {
+		got := d.ParentSessionFor(name)
+		if got != worker {
+			t.Errorf("db.ParentSessionFor(%q) = %q, want %q", name, got, worker)
+		}
+	}
+
+	// Dashboard: review sessions should sort immediately after @feature-branch.
+	groupParents, err := d.AllGroupParents()
+	if err != nil {
+		t.Fatalf("AllGroupParents: %v", err)
+	}
+	allStatuses, err := d.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+	var agentSessions []dashboard.AgentSession
+	for _, s := range allStatuses {
+		agentSessions = append(agentSessions, dashboard.StatusToAgentSession(s, nil, groupParents))
+	}
+
+	// Verify ParentSession field.
+	for _, as := range agentSessions {
+		if dashboard.IsDepth2Session(as.Name) {
+			if as.ParentSession != worker {
+				t.Errorf("AgentSession(%q).ParentSession = %q, want %q", as.Name, as.ParentSession, worker)
+			}
+		}
+	}
+
+	dashboard.SortDisplayed(agentSessions)
+
+	// @main is top-level → appears first.
+	// @feature-branch is depth-1 → appears after @main.
+	// @feature-branch~review-1-* are depth-2 → must appear right after @feature-branch.
+	workerIdx := -1
+	firstReviewIdx := -1
+	for i, s := range agentSessions {
+		if s.Name == worker {
+			workerIdx = i
+		}
+		if dashboard.IsDepth2Session(s.Name) && firstReviewIdx < 0 {
+			firstReviewIdx = i
+		}
+	}
+	if workerIdx < 0 {
+		t.Fatal("worker session not found in sorted slice")
+	}
+	if firstReviewIdx < 0 {
+		t.Fatal("no depth-2 review sessions found in sorted slice")
+	}
+	if firstReviewIdx != workerIdx+1 {
+		t.Errorf("first review session at position %d, want %d (right after worker at %d)", firstReviewIdx, workerIdx+1, workerIdx)
+	}
+
+	// db.ParentSessionFor and the dashboard's ParentSession field must agree.
+	for _, as := range agentSessions {
+		if !dashboard.IsDepth2Session(as.Name) {
+			continue
+		}
+		dbParent := d.ParentSessionFor(as.Name)
+		dashParent := as.ParentSession
+		if dbParent != dashParent {
+			t.Errorf("parent attribution disagrees for %q: db.ParentSessionFor=%q, AgentSession.ParentSession=%q",
+				as.Name, dbParent, dashParent)
+		}
+	}
+}
+
+// TestAllGroupParents_BatchQuery verifies that db.AllGroupParents returns all
+// registered groups in a single batch query.
+func TestAllGroupParents_BatchQuery(t *testing.T) {
+	d := openTestDBForDash(t)
+	repo := "nixos-config"
+
+	parent1 := repo + "@main"
+	parent2 := repo + "@feature"
+	seedSession(t, d, parent1, repo, "/wt/main", "active")
+	seedSession(t, d, parent2, repo, "/wt/feature", "active")
+
+	gid1, err := d.RegisterGroup(parent1)
+	if err != nil {
+		t.Fatalf("RegisterGroup(%q): %v", parent1, err)
+	}
+	gid2, err := d.RegisterGroup(parent2)
+	if err != nil {
+		t.Fatalf("RegisterGroup(%q): %v", parent2, err)
+	}
+
+	got, err := d.AllGroupParents()
+	if err != nil {
+		t.Fatalf("AllGroupParents: %v", err)
+	}
+
+	if got[gid1] != parent1 {
+		t.Errorf("AllGroupParents[%q] = %q, want %q", gid1, got[gid1], parent1)
+	}
+	if got[gid2] != parent2 {
+		t.Errorf("AllGroupParents[%q] = %q, want %q", gid2, got[gid2], parent2)
+	}
+}
+
+// TestStatusToAgentSession_PopulatesParentSession verifies that StatusToAgentSession
+// correctly populates the ParentSession field from the groupParents map.
+func TestStatusToAgentSession_PopulatesParentSession(t *testing.T) {
+	parentSession := "nixos-config@main"
+	groupID := "test-group-id"
+
+	// Simulate a db.Status for a review session with a group_id.
+	gid := groupID
+	status := db.Status{
+		SessionName: "nixos-config@main~review-1-review-goal",
+		Repo:        "nixos-config",
+		Worktree:    "/wt/main",
+		State:       "finished",
+		GroupID:     &gid,
+	}
+
+	groupParents := map[string]string{
+		groupID: parentSession,
+	}
+
+	as := dashboard.StatusToAgentSession(status, nil, groupParents)
+	if as.ParentSession != parentSession {
+		t.Errorf("ParentSession = %q, want %q", as.ParentSession, parentSession)
+	}
+}
+
+// TestStatusToAgentSession_FallsBackToNameHeuristic verifies that when
+// group_id is nil (pre-migration row), the name heuristic is used.
+func TestStatusToAgentSession_FallsBackToNameHeuristic(t *testing.T) {
+	status := db.Status{
+		SessionName: "nixos-config@feature~review-1-review-goal",
+		Repo:        "nixos-config",
+		Worktree:    "/wt/feature",
+		State:       "finished",
+		GroupID:     nil, // pre-migration: no group_id
+	}
+
+	as := dashboard.StatusToAgentSession(status, nil, nil)
+	want := "nixos-config@feature"
+	if as.ParentSession != want {
+		t.Errorf("ParentSession = %q, want %q (name heuristic fallback)", as.ParentSession, want)
+	}
+}
+
+// TestSortDisplayed_WithDBBackedParent verifies that when AgentSession.ParentSession
+// is set from the DB (post-migration), SortDisplayed correctly uses it for sort
+// ordering. This ensures the DB-backed parent wins over any name-derived parent.
+func TestSortDisplayed_WithDBBackedParent(t *testing.T) {
+	// Simulate the exact scenario from issue #847: coordinator at @main,
+	// sessions named @main~review-*, DB records parent as @main.
+	sessions := []dashboard.AgentSession{
+		{Name: "nixos-config@main", AgentState: "active"},
+		{Name: "nixos-config@ci-pr-gate-workflow", AgentState: "idle"},
+		{Name: "nixos-config@design-prism-session-uniformity", AgentState: "finished"},
+		{
+			Name:          "nixos-config@main~review-1-review-goal",
+			AgentState:    "finished",
+			ParentSession: "nixos-config@main", // DB-backed
+		},
+		{
+			Name:          "nixos-config@main~review-1-review-code",
+			AgentState:    "finished",
+			ParentSession: "nixos-config@main",
+		},
+		{
+			Name:          "nixos-config@main~review-1-review-security",
+			AgentState:    "finished",
+			ParentSession: "nixos-config@main",
+		},
+		{
+			Name:          "nixos-config@main~review-1-review-qa",
+			AgentState:    "finished",
+			ParentSession: "nixos-config@main",
+		},
+		{
+			Name:          "nixos-config@main~review-1-review-context",
+			AgentState:    "idle",
+			ParentSession: "nixos-config@main",
+		},
+	}
+
+	dashboard.SortDisplayed(sessions)
+
+	// Position 0: @main.
+	if sessions[0].Name != "nixos-config@main" {
+		t.Errorf("position 0: got %q, want nixos-config@main", sessions[0].Name)
+	}
+
+	// Positions 1-5: review sessions (children of @main, immediately after it).
+	for i := 1; i <= 5; i++ {
+		if !dashboard.IsDepth2Session(sessions[i].Name) {
+			t.Errorf("position %d: got %q, want a depth-2 review session (child of @main)", i, sessions[i].Name)
+		}
+	}
+
+	// Positions 6-7: the depth-1 branches (@ci and @design) appear AFTER reviews.
+	for i := 6; i < len(sessions); i++ {
+		if dashboard.IsDepth2Session(sessions[i].Name) {
+			t.Errorf("position %d: got depth-2 session %q, want a depth-1 branch (all reviews should be before depth-1 children)", i, sessions[i].Name)
+		}
+	}
+}
+
+// Ensure the os import is used (for tempdir in some test helpers).
+var _ = os.TempDir

--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -34,12 +34,17 @@ func FetchSessionsFromDB() tea.Msg {
 		return SessionsMsg{}
 	}
 
+	// Fetch group parents (group_id → parent_session) in a single batch query
+	// so that StatusToAgentSession can populate ParentSession for every
+	// post-migration session without N individual DB round-trips.
+	groupParents, _ := d.AllGroupParents() // non-fatal; nil map falls back to name heuristic
+
 	// Get client counts from tmux for the attachment dot indicator.
 	clientCounts := TmuxClientCounts()
 
 	sessions := make([]AgentSession, 0, len(statuses))
 	for _, s := range statuses {
-		sessions = append(sessions, StatusToAgentSession(s, clientCounts))
+		sessions = append(sessions, StatusToAgentSession(s, clientCounts, groupParents))
 	}
 
 	// Filter out internal sessions (scratchpad, prism-dashboard).

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -32,6 +32,13 @@ type AgentSession struct {
 	HarnessPort *int    // allocated port from agent_status.harness_port, nil when unset
 	ClientCount int     // tmux clients currently attached (best-effort, 0 on error)
 	GroupID     *string // from agent_status.group_id; non-nil when session belongs to a review group
+	// ParentSession is the authoritative parent session name, resolved from
+	// session_groups.parent_session (DB-backed). It is populated by
+	// FetchSessionsFromDB via db.AllGroupParents() for post-migration sessions.
+	// For pre-migration rows (GroupID == nil) it is empty and callers fall
+	// back to the name-heuristic (Depth2ParentBranch). It is also set on
+	// virtual IsReviewGroup rows to identify their parent.
+	ParentSession string
 	// IsReviewGroup marks a virtual ~review-N group row (not a real session).
 	// Selecting this row in the picker toggles expand/collapse rather than switching.
 	IsReviewGroup bool
@@ -39,7 +46,9 @@ type AgentSession struct {
 
 // StatusToAgentSession converts a db.Status into an AgentSession.
 // clientCounts is a map from session name → client count (from tmux).
-func StatusToAgentSession(s db.Status, clientCounts map[string]int) AgentSession {
+// groupParents is a map from group_id → parent_session (from db.AllGroupParents);
+// pass nil when not available (e.g. in tests that pre-date the group wiring).
+func StatusToAgentSession(s db.Status, clientCounts map[string]int, groupParents map[string]string) AgentSession {
 	title := ""
 	if s.Title != nil {
 		title = *s.Title
@@ -56,17 +65,36 @@ func StatusToAgentSession(s db.Status, clientCounts map[string]int) AgentSession
 	if s.Harness != nil && *s.Harness != "" {
 		harness = *s.Harness
 	}
+
+	// Resolve parent session: prefer DB-backed group attribution; fall back to
+	// name heuristic for pre-migration rows (group_id IS NULL).
+	parentSession := ""
+	if s.GroupID != nil && groupParents != nil {
+		parentSession = groupParents[*s.GroupID]
+	}
+	if parentSession == "" {
+		// Name-heuristic fallback: strip the "~…" suffix from the branch part.
+		// This matches the resolution in db.ParentSessionFor (step 2).
+		if idx := strings.Index(s.SessionName, "@"); idx >= 0 {
+			branch := s.SessionName[idx+1:]
+			if tildeIdx := strings.Index(branch, "~"); tildeIdx >= 0 {
+				parentSession = s.SessionName[:idx] + "@" + branch[:tildeIdx]
+			}
+		}
+	}
+
 	return AgentSession{
-		Name:        s.SessionName,
-		AgentState:  s.State,
-		AgentPath:   s.Worktree,
-		AgentTitle:  title,
-		AgentName:   agentName,
-		ModelID:     modelID,
-		Harness:     harness,
-		HarnessPort: s.HarnessPort,
-		ClientCount: clientCounts[s.SessionName],
-		GroupID:     s.GroupID,
+		Name:          s.SessionName,
+		AgentState:    s.State,
+		AgentPath:     s.Worktree,
+		AgentTitle:    title,
+		AgentName:     agentName,
+		ModelID:       modelID,
+		Harness:       harness,
+		HarnessPort:   s.HarnessPort,
+		ClientCount:   clientCounts[s.SessionName],
+		GroupID:       s.GroupID,
+		ParentSession: parentSession,
 	}
 }
 
@@ -320,12 +348,27 @@ func BuildDisplayRows(sessions []AgentSession, collapsedGroups map[string]bool, 
 // sorted immediately after their parent branch. Uses insertion sort
 // (no stdlib import needed for small N).
 func SortDisplayed(ss []AgentSession) {
-	// sessionKey returns a sort key for a session:
-	//   - Plain sessions (no @): "repo\x00<name>"  — sorts first within repo
-	//   - @main sessions:        "repo\x00<name>"  — sorts first within repo
-	//   - Branch sessions:       "repo\x01<branch>\x00"  — sorts after @main
-	//   - Depth-2 review:        "repo\x01<parent-branch>\x00~<label>"
-	//     — sorts immediately after the parent branch
+	// sessionKey returns a sort key for a session such that depth-2 review
+	// sessions always sort immediately after their parent branch session.
+	//
+	// Key structure:
+	//   - Plain sessions (no @): "repo\x00<name>"           — sorts first within repo
+	//   - @main sessions:        "repo\x00repo@main"        — sorts first within repo
+	//   - Branch sessions:       "repo\x01<branch>\x00"     — sorts after @main
+	//   - Depth-2 child of @main:  "repo\x00repo@main\x01<label>"
+	//     — sorts immediately after @main (still in the \x00 band)
+	//   - Depth-2 child of @branch: "repo\x01<parent-branch>\x00<label>"
+	//     — sorts immediately after the parent branch (in the \x01 band)
+	//
+	// The critical fix: depth-2 children of @main previously used
+	// "repo\x01@main\x00<label>", which sorted them after ALL depth-1
+	// branch sessions (because \x01@main > \x01@anything-earlier). They now
+	// use the parent's own sort key (the \x00 band) with the label appended,
+	// so they appear directly after @main in the display list.
+	//
+	// Parent attribution uses s.ParentSession (DB-backed, the single source of
+	// truth) when available, falling back to Depth2ParentBranch (name heuristic)
+	// for pre-migration rows where ParentSession is empty.
 	sessionKey := func(s AgentSession) string {
 		repo := SessionRepo(s.Name)
 		branch := SessionBranch(s.Name)
@@ -335,8 +378,24 @@ func SortDisplayed(ss []AgentSession) {
 		}
 		// Depth-2 session: sort directly after its parent branch.
 		if IsDepth2Session(s.Name) {
-			parentBranch := Depth2ParentBranch(s.Name)
+			// Resolve parent: prefer DB-backed ParentSession; fall back to name heuristic.
+			parentSession := s.ParentSession
+			var parentBranch string
+			if parentSession != "" {
+				parentBranch = SessionBranch(parentSession) // e.g. "@main" or "@feature"
+			} else {
+				parentBranch = Depth2ParentBranch(s.Name)
+			}
 			label := Depth2Label(s.Name)
+			if parentBranch == "@main" {
+				// Parent is @main (the \x00 band). Use the same band so depth-2
+				// children of @main appear right after @main, before any depth-1
+				// branch sessions (\x01 band).
+				parentName := repo + "@main"
+				return repo + "\x00" + parentName + "\x01" + label
+			}
+			// Parent is a regular branch (the \x01 band). Append the label
+			// after the parent's key so depth-2 children sort right after it.
 			return repo + "\x01" + parentBranch + "\x00" + label
 		}
 		// Regular branch session.

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -2086,7 +2086,8 @@ func (d *DB) AllGroupParents() (map[string]string, error) {
 
 // ParentSessionFor returns the authoritative parent session name for the given
 // session. It is the single named source of truth for parent attribution,
-// consulted by both the dashboard and prism list-sessions.
+// used by both the dashboard (via AllGroupParents + StatusToAgentSession) and
+// prism list-sessions (via AllGroupParents in the renderSessionTable sort key).
 //
 // Resolution order:
 //  1. DB-backed (post-migration): looks up session_groups.parent_session via

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -2053,6 +2053,78 @@ func (d *DB) HasReviewGroup(parentSession string) (bool, error) {
 	return count > 0, nil
 }
 
+// AllGroupParents returns a map of group_id → parent_session for all rows in
+// session_groups. This is the efficient batch counterpart to ParentSessionFor:
+// callers that need parent attribution for a large set of sessions can fetch the
+// whole map in one query rather than issuing N individual lookups.
+//
+// The returned map only contains groups registered in session_groups; sessions
+// whose group_id is NULL (pre-migration rows) or whose group_id has no matching
+// session_groups row are absent from the map (callers should fall back to the
+// name heuristic for those).
+func (d *DB) AllGroupParents() (map[string]string, error) {
+	const q = `SELECT group_id, parent_session FROM session_groups`
+	rows, err := d.conn.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("db: all group parents: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var groupID, parent string
+		if err := rows.Scan(&groupID, &parent); err != nil {
+			return nil, fmt.Errorf("db: all group parents: scan: %w", err)
+		}
+		result[groupID] = parent
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: all group parents: iterate: %w", err)
+	}
+	return result, nil
+}
+
+// ParentSessionFor returns the authoritative parent session name for the given
+// session. It is the single named source of truth for parent attribution,
+// consulted by both the dashboard and prism list-sessions.
+//
+// Resolution order:
+//  1. DB-backed (post-migration): looks up session_groups.parent_session via
+//     agent_status.group_id. This is the most reliable source — it records the
+//     actual caller at spawn time.
+//  2. Name-heuristic fallback (pre-migration rows where group_id IS NULL):
+//     strips the "~…" suffix from the session name and returns the prefix as
+//     the parent name. e.g. "nixos-config@main~review-1-review-code" → parent
+//     is "nixos-config@main".
+//
+// Returns "" when no parent can be determined (top-level sessions, sessions
+// with no group_id and no "~" in the branch component, or DB errors).
+func (d *DB) ParentSessionFor(sessionName string) string {
+	// Step 1: try DB-backed group_id → session_groups.parent_session.
+	const q = `
+SELECT sg.parent_session
+FROM agent_status AS a
+JOIN session_groups AS sg ON a.group_id = sg.group_id
+WHERE a.session_name = ?`
+	var parent string
+	err := d.conn.QueryRow(q, sessionName).Scan(&parent)
+	if err == nil && parent != "" {
+		return parent
+	}
+	// err == sql.ErrNoRows or group_id IS NULL: fall through to name heuristic.
+
+	// Step 2: name-heuristic fallback — strip the "~…" suffix from the branch
+	// component.  Session names are of the form "repo@branch~suffix" where
+	// "~suffix" marks a depth-2 review session.  The parent is "repo@branch".
+	if idx := strings.Index(sessionName, "@"); idx >= 0 {
+		branch := sessionName[idx+1:] // e.g. "main~review-1-review-code"
+		if tildeIdx := strings.Index(branch, "~"); tildeIdx >= 0 {
+			return sessionName[:idx] + "@" + branch[:tildeIdx]
+		}
+	}
+	return ""
+}
+
 // GroupMembersForParent returns all agent_status rows whose group_id belongs
 // to a session_groups row with parent_session = parentSession.
 func (d *DB) GroupMembersForParent(parentSession string) ([]Status, error) {


### PR DESCRIPTION
## Root Cause

Both views used different signals to determine parent-child relationships for review sessions, causing the dashboard to visually misattribute review sessions to the wrong parent.

**`prism list-sessions`**: Shows a flat alphabetically-sorted list. Parent is implied by session name prefix (e.g. `nixos-config@main~review-1-review-code` → parent is `nixos-config@main`).

**Dashboard TUI**: Uses `SortDisplayed` to place depth-2 review sessions adjacent to their parent, then renders tree connectors (`│ ├──`) based on position. The bug was in the sort key: depth-2 children of `@main` used sort key `repo\x01@main\x00~label` (the `\x01` band, shared with all depth-1 branches). Since `@d` < `@m` alphabetically, branches like `@design-prism-session-uniformity` sorted before `@main`'s review children. The tree connectors then visually implied the review sessions were nested under `@design-prism-session-uniformity`, not `@main`.

## Fix

### 1. `db.ParentSessionFor()` — single named source of truth

New helper in `internal/db/db.go` that returns the authoritative parent session:
1. **DB-backed** (post-migration): joins `agent_status.group_id` → `session_groups.parent_session`
2. **Name-heuristic fallback** (pre-migration rows with `group_id IS NULL`): strips the `~suffix` from the session name

Also added `db.AllGroupParents()` — a batch variant that fetches all `group_id → parent_session` mappings in one query.

### 2. `AgentSession.ParentSession` field

`FetchSessionsFromDB` now calls `AllGroupParents()` once and passes the map to `StatusToAgentSession`, which populates `ParentSession` from the DB (falling back to the name heuristic for pre-migration rows).

### 3. `SortDisplayed` sort key fix

Depth-2 children of `@main` now use sort key `repo\x00repo@main\x01~label` (the `\x00` band, same as `@main` itself) instead of `repo\x01@main\x00~label` (the `\x01` band). This places them immediately after `@main` in the sorted display list, before any depth-1 branch sessions.

`SortDisplayed` prefers `s.ParentSession` (DB-backed) over `Depth2ParentBranch` (name heuristic), with fallback for pre-migration rows.

## Tests

New test file `internal/dashboard/parent_attribution_test.go` covering:
- `TestParentSessionFor_DBBacked` — DB-backed resolution via session_groups
- `TestParentSessionFor_NameHeuristicFallback` — pre-migration fallback
- `TestParentSessionFor_MainParent_NameHeuristic` — @main parent specifically
- `TestSortDisplayed_MainParentChildrenSortAfterMain` — regression test for #847 bug
- `TestBothViews_ParentChildAgreement` — **primary AC test**: same DB state, both views agree
- `TestBothViews_WorkerSpawnedReview` — review sessions spawned from a worker
- `TestAllGroupParents_BatchQuery` — batch query helper
- `TestStatusToAgentSession_PopulatesParentSession` — field population
- `TestStatusToAgentSession_FallsBackToNameHeuristic` — fallback path
- `TestSortDisplayed_WithDBBackedParent` — full scenario with DB-backed parent

Closes #847