### PR TITLE
prism db: cascade SetEnded to review-agent child rows

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -891,8 +891,15 @@ WHERE session_name = ?
 // session_name matches the pattern "<sessionName>~review-%", setting
 // ended_at only on rows where it is not already set (idempotent).
 // Both the parent and child updates are performed in a single transaction.
+//
+// The session name is escaped for SQL LIKE wildcards before being used as a
+// pattern prefix (using the same escaping as AllStatusesWithPrefix) so that
+// session names containing `%`, `_`, or `\` are handled correctly.
 func (d *DB) SetEnded(sessionName string) error {
 	now := time.Now().UnixMilli()
+	// Escape LIKE special characters in sessionName so that literal `%`, `_`,
+	// and `\` in the name are matched exactly, not as wildcards.
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(sessionName)
 	tx, err := d.conn.Begin()
 	if err != nil {
 		return fmt.Errorf("db: set ended: begin tx: %w", err)
@@ -902,9 +909,9 @@ func (d *DB) SetEnded(sessionName string) error {
 	const q = `
 UPDATE agent_status
 SET    ended_at = ?
-WHERE  (session_name = ? OR session_name LIKE ? || '~review-%')
+WHERE  (session_name = ? OR session_name LIKE ? || '~review-%' ESCAPE '\')
   AND  ended_at IS NULL`
-	if _, err := tx.Exec(q, now, sessionName, sessionName); err != nil {
+	if _, err := tx.Exec(q, now, sessionName, escaped); err != nil {
 		return fmt.Errorf("db: set ended: %w", err)
 	}
 

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -887,14 +887,29 @@ WHERE session_name = ?
 }
 
 // SetEnded marks the session as ended by setting ended_at to now.
+// It also cascades the ended_at to any child review-agent rows whose
+// session_name matches the pattern "<sessionName>~review-%", setting
+// ended_at only on rows where it is not already set (idempotent).
+// Both the parent and child updates are performed in a single transaction.
 func (d *DB) SetEnded(sessionName string) error {
 	now := time.Now().UnixMilli()
-	_, err := d.conn.Exec(
-		"UPDATE agent_status SET ended_at = ? WHERE session_name = ?",
-		now, sessionName,
-	)
+	tx, err := d.conn.Begin()
 	if err != nil {
+		return fmt.Errorf("db: set ended: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	const q = `
+UPDATE agent_status
+SET    ended_at = ?
+WHERE  (session_name = ? OR session_name LIKE ? || '~review-%')
+  AND  ended_at IS NULL`
+	if _, err := tx.Exec(q, now, sessionName, sessionName); err != nil {
 		return fmt.Errorf("db: set ended: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("db: set ended: commit: %w", err)
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -201,6 +201,149 @@ func TestSetEnded(t *testing.T) {
 	}
 }
 
+// TestSetEnded_CascadesToReviewChildren verifies that SetEnded on a parent
+// session also ends all child review-agent rows matching <parent>~review-%,
+// while leaving unrelated rows untouched. It also asserts the idempotency
+// guarantee: children with ended_at already set are not re-touched.
+func TestSetEnded_CascadesToReviewChildren(t *testing.T) {
+	d := openTestDB(t)
+
+	parent := "nixos-config@feat"
+
+	// Child rows that should be cascaded.
+	children := []string{
+		parent + "~review-1-review-goal",
+		parent + "~review-1-review-code",
+		parent + "~review-1-review-security",
+		parent + "~review-2-review-qa",
+		parent + "~review-2-review-context",
+	}
+
+	// A child that already has ended_at set — must not be re-touched.
+	alreadyEndedChild := parent + "~review-1-review-qa"
+
+	// An unrelated session that must not be affected.
+	unrelated := "other-repo@main"
+
+	// Another session whose name starts similarly but does NOT match the
+	// ~review- pattern — must not be affected.
+	notReview := "nixos-config@feat-other"
+
+	// Insert the parent row.
+	if err := d.UpsertStatus(parent, "nixos-config", "/wt/feat", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus parent: %v", err)
+	}
+
+	// Insert child rows (active).
+	for _, c := range children {
+		if err := d.UpsertStatus(c, "nixos-config", "/wt/feat", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus child %q: %v", c, err)
+		}
+	}
+
+	// Insert the already-ended child row.
+	if err := d.UpsertStatus(alreadyEndedChild, "nixos-config", "/wt/feat", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus alreadyEndedChild: %v", err)
+	}
+	if err := d.SetEnded(alreadyEndedChild); err != nil {
+		t.Fatalf("SetEnded alreadyEndedChild (pre-condition): %v", err)
+	}
+	// Record the ended_at value so we can assert it was not changed.
+	preStatus, err := d.CurrentStatus(alreadyEndedChild)
+	if err != nil || preStatus == nil || preStatus.EndedAt == nil {
+		t.Fatalf("pre-condition: alreadyEndedChild must have ended_at set")
+	}
+	preEndedAt := *preStatus.EndedAt
+
+	// Insert the unrelated session.
+	if err := d.UpsertStatus(unrelated, "other-repo", "/wt/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus unrelated: %v", err)
+	}
+
+	// Insert the not-review session (shares the same prefix but no ~review-).
+	if err := d.UpsertStatus(notReview, "nixos-config", "/wt/feat-other", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus notReview: %v", err)
+	}
+
+	// Call SetEnded on the parent.
+	if err := d.SetEnded(parent); err != nil {
+		t.Fatalf("SetEnded parent: %v", err)
+	}
+
+	// Parent must be ended.
+	s, err := d.CurrentStatus(parent)
+	if err != nil || s == nil {
+		t.Fatalf("CurrentStatus parent: %v", err)
+	}
+	if s.EndedAt == nil {
+		t.Error("parent: EndedAt is nil, want non-nil")
+	}
+
+	// All children must be ended.
+	for _, c := range children {
+		sc, err := d.CurrentStatus(c)
+		if err != nil || sc == nil {
+			t.Fatalf("CurrentStatus child %q: %v", c, err)
+		}
+		if sc.EndedAt == nil {
+			t.Errorf("child %q: EndedAt is nil, want non-nil", c)
+		}
+	}
+
+	// The already-ended child must still be ended, with the same timestamp
+	// (not re-touched by the cascade).
+	postStatus, err := d.CurrentStatus(alreadyEndedChild)
+	if err != nil || postStatus == nil {
+		t.Fatalf("CurrentStatus alreadyEndedChild post: %v", err)
+	}
+	if postStatus.EndedAt == nil {
+		t.Error("alreadyEndedChild: EndedAt became nil after cascade")
+	} else if !(*postStatus.EndedAt).Equal(preEndedAt) {
+		t.Errorf("alreadyEndedChild: ended_at changed: got %v, want %v", *postStatus.EndedAt, preEndedAt)
+	}
+
+	// Unrelated session must not be ended.
+	su, err := d.CurrentStatus(unrelated)
+	if err != nil || su == nil {
+		t.Fatalf("CurrentStatus unrelated: %v", err)
+	}
+	if su.EndedAt != nil {
+		t.Errorf("unrelated session: EndedAt is non-nil, want nil")
+	}
+
+	// Not-review session (shares prefix but no ~review-) must not be ended.
+	sn, err := d.CurrentStatus(notReview)
+	if err != nil || sn == nil {
+		t.Fatalf("CurrentStatus notReview: %v", err)
+	}
+	if sn.EndedAt != nil {
+		t.Errorf("notReview session: EndedAt is non-nil, want nil")
+	}
+}
+
+// TestSetEnded_NoChildrenIsNoop verifies that SetEnded on a session with no
+// review children still works correctly (no regression for the common case).
+func TestSetEnded_NoChildrenIsNoop(t *testing.T) {
+	d := openTestDB(t)
+
+	session := "myrepo@feat"
+	if err := d.UpsertStatus(session, "myrepo", "/wt/feat", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	if err := d.SetEnded(session); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	s, err := d.CurrentStatus(session)
+	if err != nil || s == nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s.EndedAt == nil {
+		t.Error("EndedAt: got nil, want non-nil")
+	}
+}
+
 // TestAllActiveStatus_ExcludesEnded verifies that ended sessions are not returned.
 func TestAllActiveStatus_ExcludesEnded(t *testing.T) {
 	d := openTestDB(t)

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -344,6 +344,60 @@ func TestSetEnded_NoChildrenIsNoop(t *testing.T) {
 	}
 }
 
+// TestSetEnded_LikeWildcardsInSessionName verifies that session names containing
+// SQL LIKE wildcard characters (%, _, \) are handled correctly and do not
+// cause the cascade to match unintended sibling rows.
+func TestSetEnded_LikeWildcardsInSessionName(t *testing.T) {
+	d := openTestDB(t)
+
+	// A session name containing an underscore (produced by NameFor when the
+	// repo name contains a dot, e.g. "my.repo" → "my_repo").
+	parent := "my_repo@feat"
+	child := parent + "~review-1-review-goal"
+
+	// A session that would be matched if _ acted as a wildcard:
+	// "myXrepo@feat~review-1-review-goal" — the X can be any character.
+	decoy := "myXrepo@feat~review-1-review-goal"
+
+	for _, sess := range []string{parent, child, decoy} {
+		if err := d.UpsertStatus(sess, "myrepo", "/wt", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", sess, err)
+		}
+	}
+
+	// End the parent. Only the parent and its exact-prefix child should be ended.
+	if err := d.SetEnded(parent); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	// Parent must be ended.
+	sp, err := d.CurrentStatus(parent)
+	if err != nil || sp == nil {
+		t.Fatalf("CurrentStatus parent: %v", err)
+	}
+	if sp.EndedAt == nil {
+		t.Error("parent: EndedAt is nil, want non-nil")
+	}
+
+	// Child must be ended.
+	sc, err := d.CurrentStatus(child)
+	if err != nil || sc == nil {
+		t.Fatalf("CurrentStatus child: %v", err)
+	}
+	if sc.EndedAt == nil {
+		t.Error("child: EndedAt is nil, want non-nil")
+	}
+
+	// Decoy (different repo prefix) must NOT be ended.
+	sd, err := d.CurrentStatus(decoy)
+	if err != nil || sd == nil {
+		t.Fatalf("CurrentStatus decoy: %v", err)
+	}
+	if sd.EndedAt != nil {
+		t.Errorf("decoy session %q: EndedAt is non-nil; _ was treated as wildcard", decoy)
+	}
+}
+
 // TestAllActiveStatus_ExcludesEnded verifies that ended sessions are not returned.
 func TestAllActiveStatus_ExcludesEnded(t *testing.T) {
 	d := openTestDB(t)


### PR DESCRIPTION
## Summary

- Extends `SetEnded` in `internal/db/db.go` so that ending a parent session also sets `ended_at` on all matching `<parent>~review-%` child rows in the same transaction.
- The cascade uses `AND ended_at IS NULL` so already-ended children are not re-touched (idempotent).
- Adds two unit tests: `TestSetEnded_CascadesToReviewChildren` (cascade + idempotency + no effect on unrelated rows) and `TestSetEnded_NoChildrenIsNoop` (regression for the common no-children case).

## Why

Review-agent `agent_status` rows were never ended when a parent worker session was merged or cleaned up. Every merged PR left 5–25 stale rows with `ended_at = NULL`, which `prism restore` then treated as active sessions to restore on next boot — contributing to the thundering-herd crash described in #825.

The fix is applied at the `SetEnded` layer so every code path that ends a parent session (cleanup, sidecar shutdown, switch, restore, event tmux-session-end) automatically cascades to children, with no changes needed in callers.

`prism cleanup` already called `review.CleanupReviewSessionsForParent` before `SetEnded`, so children were getting individual `SetEnded` calls there. The new cascade makes the invariant hold for all other paths (e.g. when a coordinator session is ended by the sidecar or via the merge path without a full cleanup).

Closes #825