### PR TITLE
prism: isolate cmd/ tests from live tmux server and DB

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup_container_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_container_test.go
@@ -188,6 +188,9 @@ func TestRemoveContainerIfExists_NoSuchContainer(t *testing.T) {
 // Covers the host_mode short-circuit added in #471.
 func TestHeadlessCleanup_HostMode_SkipsPodman(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCleanup's scratchpad-ensure
+	// path does not reach the live tmux server.
+	withNoopTmux(t)
 	logFile := installFakePodman(t, "ok")
 
 	// Seed a temp DB with a host-mode row.
@@ -246,6 +249,9 @@ func TestHeadlessCleanup_HostMode_SkipsPodman(t *testing.T) {
 // Covers AC-2 (headlessCleanup path) directly.
 func TestHeadlessCleanup_ContainerMode_StopsAndRemoves(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCleanup's scratchpad-ensure
+	// path does not reach the live tmux server.
+	withNoopTmux(t)
 	logFile := installFakePodman(t, "ok")
 
 	dbFile := filepath.Join(t.TempDir(), "prism.db")

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -92,6 +92,10 @@ func TestWorktreePathFromSession_DBFallback(t *testing.T) {
 // Runs without tmux, so it exercises only the DB-update path.
 func TestHeadlessCleanup_EmptyWorktreePath(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCleanup's scratchpad-ensure
+	// path does not reach the live tmux server. The test only verifies DB
+	// side-effects, so a stub that always exits 0 is correct.
+	withNoopTmux(t)
 	// Seed a temp DB.
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
@@ -138,6 +142,10 @@ func TestHeadlessCleanup_EmptyWorktreePath(t *testing.T) {
 // headlessCleanup warns and continues rather than returning an error.
 func TestHeadlessCleanup_InvalidWorktreePath(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCleanup's scratchpad-ensure
+	// path does not reach the live tmux server. The test only verifies DB
+	// side-effects and git error handling.
+	withNoopTmux(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found in PATH — skipping integration test")
 	}
@@ -513,6 +521,10 @@ func TestCleanupYes_DefaultBranch(t *testing.T) {
 // Runs without tmux, so it exercises only the DB-update path.
 func TestHeadlessCloseSession_NonWorktree_MarksEnded(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCloseSession's scratchpad-ensure
+	// path does not reach the live tmux server. The test only verifies DB
+	// side-effects, so a stub that always exits 0 is correct.
+	withNoopTmux(t)
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {
@@ -552,6 +564,9 @@ func TestHeadlessCloseSession_NonWorktree_MarksEnded(t *testing.T) {
 // exits 0 even when no DB row exists for the session (never recorded).
 func TestHeadlessCloseSession_NonWorktree_NoDB(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCloseSession's scratchpad-ensure
+	// path does not reach the live tmux server.
+	withNoopTmux(t)
 	// Point openDB at an empty temp DB (no row for the session).
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
@@ -756,6 +771,11 @@ func TestIsCoordinatorFromDB(t *testing.T) {
 // headlessCloseSession directly — it does not exercise cleanupCmd routing.
 func TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
+	// Redirect TmuxBin to a no-op so headlessCloseSession's scratchpad-ensure
+	// path does not reach the live tmux server. The test verifies DB-update
+	// behaviour when the tmux session is absent; tmux isolation is necessary
+	// but not the focus of this test.
+	withNoopTmux(t)
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {

--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -149,6 +149,65 @@ func withCmdServer(t *testing.T, s *cmdTestServer) {
 	t.Cleanup(func() { tmux.TmuxBin = orig })
 }
 
+// withNoopTmux redirects tmux.TmuxBin to a stub that accepts any arguments
+// and exits 0 without contacting any real tmux server. The stub returns exit 0
+// for all commands — including has-session — so callers see every session as
+// "already existing" and skip session creation. Use this for tests that call
+// code paths which invoke tmux (e.g. headlessCleanup) but do not actually need
+// a tmux server to be present — only the non-tmux side effects (DB writes,
+// return values) are under test.
+//
+// Only call this from non-parallel tests — TmuxBin is a package-level global.
+func withNoopTmux(t *testing.T) {
+	t.Helper()
+	wrapperPath := t.TempDir() + "/tmux"
+	// The stub exits 0 for every invocation, returning empty output.
+	// Commands like has-session will return 0 (session "exists"), which
+	// prevents code that calls HasSession before NewSessionDetached from
+	// creating new sessions.
+	script := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write noop tmux: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+}
+
+// withSpyTmux redirects tmux.TmuxBin to a stub that records all invocations
+// and allows controlling per-command exit codes. By default every command exits
+// 0 EXCEPT has-session which exits 1 (session does not exist), allowing code
+// that checks HasSession before calling NewSessionDetached to proceed with
+// session creation without touching a real tmux server.
+//
+// Returns the path to the log file where each invocation's arguments are written
+// (one argument per line, invocations separated by a blank line).
+//
+// Only call this from non-parallel tests — TmuxBin is a package-level global.
+func withSpyTmux(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	logFile := dir + "/tmux-args"
+	wrapperPath := dir + "/tmux"
+	// has-session exits 1 (not found); all other commands exit 0 (success).
+	// This lets code that checks HasSession fall through to session creation
+	// while keeping all tmux operations isolated from any real server.
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do printf '%s\\n' \"$a\" >> " + logFile + "; done\n" +
+		"printf '\\n' >> " + logFile + "\n" +
+		"case \"$1\" in\n" +
+		"  has-session) exit 1 ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write spy tmux: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+	return logFile
+}
+
 // randCmdHex returns n random bytes as a hex string using crypto/rand.
 func randCmdHex(n int) string {
 	b := make([]byte, n)

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -514,6 +514,9 @@ func TestProxyToHostAPI_NotCalledWhenEnvUnset(t *testing.T) {
 
 	// Ensure PRISM_HOST_API is explicitly unset.
 	t.Setenv("PRISM_HOST_API", "")
+	// Redirect TmuxBin to a no-op so headlessCleanup's scratchpad-ensure
+	// path does not reach the live tmux server.
+	withNoopTmux(t)
 
 	// headlessCleanup with no PRISM_HOST_API should NOT contact the server.
 	// We use a temp DB to avoid touching production state.

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -463,6 +463,10 @@ func TestRestoreSession_AllThreeWindows(t *testing.T) {
 	// Redirect XDG_STATE_HOME so StartSidecar writes its PID file to an
 	// isolated temp dir rather than the production ~/.local/state/prism/.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// PRISM_CMD_TEST_STUB=1 makes the test binary exit immediately when
+	// re-invoked as a sidecar subprocess, preventing it from calling tmux
+	// commands (e.g. has-session scratchpad) against the live tmux server.
+	t.Setenv("PRISM_CMD_TEST_STUB", "1")
 	s := newCmdTestServer(t)
 	withCmdServer(t, s)
 
@@ -918,6 +922,16 @@ func TestCircuitBreaker_NFailures_SessionSkipped(t *testing.T) {
 // fail, but we want to confirm it does NOT return restoreOutcomeCircuitOpen.
 func TestCircuitBreaker_NMinusOneFailures_SessionRestored(t *testing.T) {
 	const threshold = 3
+	// Redirect TmuxBin to a spy that exits 1 for has-session (session absent)
+	// and 0 for all other commands. This prevents real session creation while
+	// allowing the circuit-breaker code path to run normally.
+	withSpyTmux(t)
+	// Isolate session.openDB() calls (from setupFullLayout) from the live DB.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// PRISM_CMD_TEST_STUB=1 makes the test binary exit immediately when
+	// re-invoked as a sidecar subprocess, preventing it from calling tmux
+	// commands against the live server.
+	t.Setenv("PRISM_CMD_TEST_STUB", "1")
 	d := openRestoreTestDB(t)
 
 	worktreeDir := t.TempDir()
@@ -943,6 +957,11 @@ func TestCircuitBreaker_NMinusOneFailures_SessionRestored(t *testing.T) {
 // the circuit breaker (only 1 consecutive failure since the last success).
 func TestCircuitBreaker_SuccessBetweenFailures_Restored(t *testing.T) {
 	const threshold = 3
+	// Redirect TmuxBin to a spy that exits 1 for has-session and 0 for all
+	// other commands. Isolate session.openDB() from the live DB via XDG_STATE_HOME.
+	withSpyTmux(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_CMD_TEST_STUB", "1")
 	d := openRestoreTestDB(t)
 
 	worktreeDir := t.TempDir()
@@ -968,6 +987,11 @@ func TestCircuitBreaker_SuccessBetweenFailures_Restored(t *testing.T) {
 // recorded sidecar history is always restored (zero failures).
 func TestCircuitBreaker_NoHistory_Restored(t *testing.T) {
 	const threshold = 3
+	// Redirect TmuxBin to a spy that exits 1 for has-session and 0 for all
+	// other commands. Isolate session.openDB() from the live DB via XDG_STATE_HOME.
+	withSpyTmux(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_CMD_TEST_STUB", "1")
 	d := openRestoreTestDB(t)
 
 	worktreeDir := t.TempDir()
@@ -989,6 +1013,11 @@ func TestCircuitBreaker_NoHistory_Restored(t *testing.T) {
 // marked ended and the restore must not return a circuit-open outcome.
 func TestCircuitBreaker_QueryError_FallsThrough(t *testing.T) {
 	const threshold = 3
+	// Redirect TmuxBin to a spy that exits 1 for has-session and 0 for all
+	// other commands. Isolate session.openDB() from the live DB via XDG_STATE_HOME.
+	withSpyTmux(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_CMD_TEST_STUB", "1")
 	d := openRestoreTestDB(t)
 
 	worktreeDir := t.TempDir()


### PR DESCRIPTION
## Summary

- Adds `withNoopTmux()` and `withSpyTmux()` helpers to the `cmd` test harness so tests that call cleanup/restore functions directly no longer touch the live tmux server
- Fixes all identified `cmd/` tests that were creating `scratchpad` in the live tmux server or writing rows to `~/.local/state/prism/prism.db` when `go test ./...` runs
- Adds `PRISM_CMD_TEST_STUB=1` environment isolation to prevent sidecar subprocesses started during restore tests from calling `tmux` commands against the live default socket

Closes #976