### PR TITLE
prism review: stream /review response line-by-line with pass/fail sentinel

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -12,6 +12,7 @@ package cmd
 // operations on the host side.
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -25,6 +26,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/prismatic-koi/prism/internal/sidecar"
 )
 
 // newHostAPIClient returns an *http.Client that dials sockPath over a Unix
@@ -220,22 +223,24 @@ func proxyPrompt(apiURL, session, prompt string) error {
 	}, nil)
 }
 
-// reviewHostAPIResponse holds the response from the host-API /review endpoint.
-// For the async path, only Output is populated (Passed is always true because
-// the review has not yet completed when the ack is returned).
-type reviewHostAPIResponse struct {
-	Output string `json:"output"`
-	Passed bool   `json:"passed"`
-}
-
 // proxyReviewAsync proxies an async review request to the host-API sidecar
 // when running inside a container (PRISM_HOST_API is set). It sends POST /review
 // to the sidecar, which runs `prism review` on the host where tmux is available,
-// and returns immediately with the async acknowledgement.
+// streams each output line to os.Stdout as it arrives, and returns once the
+// subprocess completes (signalled by a sentinel line in the response body).
 //
 // prNumber is the PR number to review (e.g. "123"). agents is an optional
 // list of agent names for --only filtering. timeout is an optional duration
-// string (e.g. "10m"). Returns the acknowledgement text and any error.
+// string (e.g. "10m"). Returns an error if the host-side subprocess failed or
+// the connection was lost mid-stream.
+//
+// The response from the sidecar /review endpoint is a plain-text chunked stream
+// terminated by one of two sentinel lines:
+//
+//	sidecar.ReviewSentinelPassed — subprocess exited 0
+//	sidecar.ReviewSentinelFailed — subprocess exited non-zero
+//
+// This function consumes the sentinel and does NOT print it to stdout.
 func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) (string, error) {
 	// Build request body.
 	body := map[string]any{
@@ -248,16 +253,26 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) 
 		body["timeout"] = timeout
 	}
 
-	// Async reviews return quickly (just spawning + ack), so 30 s is plenty.
-	const clientTimeout = 30 * time.Second
+	// The sidecar streams output as it arrives and closes the response body
+	// when the sentinel is written, so we need a longer timeout than the 30 s
+	// that sufficed for the old buffered path. Use 60 s — the spawn phase
+	// (the only non-trivial work in async prism review) completes well within
+	// that window even on a slow host.
+	const clientTimeout = 60 * time.Second
 
-	// Build a custom client.
+	// Build a custom client without a read timeout so the streaming response
+	// body can remain open for the full duration of the subprocess.
 	var (
 		client *http.Client
 		reqURL string
 	)
 	if strings.HasPrefix(apiURL, "http://") {
-		client = &http.Client{Timeout: clientTimeout}
+		// TCP path: use a transport with no read deadline on the connection.
+		// We set Timeout:0 on the client and rely on the context deadline instead.
+		client = &http.Client{
+			Transport: &http.Transport{},
+			Timeout:   0, // no global timeout; context deadline governs
+		}
 		reqURL = apiURL + "/review"
 	} else {
 		sockPath, parseErr := parseUnixSocketURL(apiURL)
@@ -275,7 +290,7 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) 
 					return conn, nil
 				},
 			},
-			Timeout: clientTimeout,
+			Timeout: 0, // no global timeout; context deadline governs
 		}
 		reqURL = "http://prism-hostapi/review"
 	}
@@ -285,7 +300,11 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) 
 		return "", fmt.Errorf("proxyReviewAsync: marshal request body: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
+	// Attach a context deadline so the request cannot hang indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), clientTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return "", fmt.Errorf("proxyReviewAsync: build request: %w", err)
 	}
@@ -295,12 +314,70 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) 
 	if err != nil {
 		return "", fmt.Errorf("host-API /review: %w", err)
 	}
+	defer resp.Body.Close()
 
-	var reviewResp reviewHostAPIResponse
-	if err := readHostAPIResponse("/review", resp, &reviewResp); err != nil {
-		return "", err
+	if resp.StatusCode >= 400 {
+		// Error responses from the sidecar are still JSON (written before the
+		// streaming body begins), so read and surface the error field.
+		respBody, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil && errResp.Error != "" {
+			return "", fmt.Errorf("host-API /review: %s", errResp.Error)
+		}
+		return "", fmt.Errorf("host-API /review: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
-	return reviewResp.Output, nil
+
+	// Read the streaming response line-by-line. Each line is printed to stdout
+	// immediately so the worker sees progress as it is emitted. The final line
+	// is a sentinel that we consume but do not print.
+	scanner := bufio.NewScanner(resp.Body)
+	// Allow lines up to 1 MiB to handle very long output without truncation.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	var (
+		sentinelSeen bool
+		passed       bool
+		outputBuf    strings.Builder
+	)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch line {
+		case sidecar.ReviewSentinelPassed:
+			sentinelSeen = true
+			passed = true
+		case sidecar.ReviewSentinelFailed:
+			sentinelSeen = true
+			passed = false
+		default:
+			// Regular output line — print to stdout immediately and buffer for
+			// the caller so it can be used in the return value if needed.
+			fmt.Fprintln(os.Stdout, line)
+			outputBuf.WriteString(line)
+			outputBuf.WriteByte('\n')
+		}
+		// Stop after consuming the sentinel.
+		if sentinelSeen {
+			break
+		}
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		return outputBuf.String(), fmt.Errorf("host-API /review: read stream: %w", scanErr)
+	}
+
+	if !sentinelSeen {
+		// The stream ended without a sentinel — the subprocess died mid-stream
+		// or the connection was lost. Surface this as a clear error.
+		return outputBuf.String(), fmt.Errorf("host-API /review: stream ended without completion sentinel (subprocess may have crashed)")
+	}
+
+	if !passed {
+		return outputBuf.String(), fmt.Errorf("host-API /review: review process failed — check host logs for details")
+	}
+
+	return outputBuf.String(), nil
 }
 
 // proxyLogsFromHostAPI proxies a GET /logs request to the host-API server and

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/sidecar"
 )
 
 // mockUnixServer starts a minimal HTTP server on a fresh Unix socket and
@@ -869,5 +871,187 @@ func TestProxyToHostAPI_TCPScheme_ErrorResponse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "tcp server error") {
 		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}
+
+// ── proxyReviewAsync streaming tests (issue #815) ─────────────────────────────
+
+// TestProxyReviewAsync_LinesArrivedProgressively verifies that output lines
+// produced by the sidecar /review endpoint are printed to stdout as they arrive
+// (AC: lines produced by subprocess arrive in response body as emitted).
+//
+// The mock server writes lines one at a time with a short delay between them,
+// then appends the passed sentinel. proxyReviewAsync must print each line to
+// stdout and must not print the sentinel itself.
+func TestProxyReviewAsync_LinesArrivedProgressively(t *testing.T) {
+	const (
+		line1 = "Review-Goal started"
+		line2 = "Review-Code started"
+		line3 = "Review-Goal finished in 1.2s"
+	)
+
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request path and method.
+		if r.URL.Path != "/review" || r.Method != "POST" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+
+		// Stream response: write lines, flush between each, then sentinel.
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		for _, line := range []string{line1, line2, line3} {
+			_, _ = w.Write([]byte(line + "\n"))
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte(sidecar.ReviewSentinelPassed + "\n"))
+		flusher.Flush()
+	})
+
+	var stdout string
+	var callErr error
+	stdout = captureStdout(t, func() {
+		_, callErr = proxyReviewAsync(srv.apiURL(), "123", nil, "")
+	})
+
+	if callErr != nil {
+		t.Fatalf("proxyReviewAsync: unexpected error: %v", callErr)
+	}
+
+	// All three progress lines must appear in stdout.
+	for _, want := range []string{line1, line2, line3} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout %q does not contain expected line %q", stdout, want)
+		}
+	}
+
+	// The sentinel must NOT appear in stdout.
+	if strings.Contains(stdout, sidecar.ReviewSentinelPassed) {
+		t.Errorf("stdout %q must not contain the passed sentinel", stdout)
+	}
+	if strings.Contains(stdout, sidecar.ReviewSentinelFailed) {
+		t.Errorf("stdout %q must not contain the failed sentinel", stdout)
+	}
+}
+
+// TestProxyReviewAsync_SentinelConsumedNotEchoed verifies that proxyReviewAsync
+// consumes the sentinel line and does NOT echo it to stdout (AC: sentinel marker
+// is NOT printed to the worker's stdout).
+func TestProxyReviewAsync_SentinelConsumedNotEchoed(t *testing.T) {
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Review-Goal started\n"))
+		_, _ = w.Write([]byte(sidecar.ReviewSentinelPassed + "\n"))
+	})
+
+	var stdout string
+	var callErr error
+	stdout = captureStdout(t, func() {
+		_, callErr = proxyReviewAsync(srv.apiURL(), "42", nil, "")
+	})
+
+	if callErr != nil {
+		t.Fatalf("proxyReviewAsync: unexpected error: %v", callErr)
+	}
+
+	// Sentinel must NOT be in stdout.
+	if strings.Contains(stdout, sidecar.ReviewSentinelPassed) {
+		t.Errorf("stdout %q must not contain the passed sentinel", stdout)
+	}
+
+	// The regular line must be in stdout.
+	if !strings.Contains(stdout, "Review-Goal started") {
+		t.Errorf("stdout %q should contain 'Review-Goal started'", stdout)
+	}
+}
+
+// TestProxyReviewAsync_FailedSentinelProducesError verifies that when the sidecar
+// writes ReviewSentinelFailed (exit-1 subprocess), proxyReviewAsync returns a
+// non-nil error and the output lines before the sentinel are still printed
+// (AC: exit-1 subprocess produces non-zero exit and correct output).
+func TestProxyReviewAsync_FailedSentinelProducesError(t *testing.T) {
+	const progressLine = "Review-Goal started"
+
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(progressLine + "\n"))
+		_, _ = w.Write([]byte(sidecar.ReviewSentinelFailed + "\n"))
+	})
+
+	var stdout string
+	var callErr error
+	stdout = captureStdout(t, func() {
+		_, callErr = proxyReviewAsync(srv.apiURL(), "99", nil, "")
+	})
+
+	// proxyReviewAsync must return a non-nil error when sentinel says failed.
+	if callErr == nil {
+		t.Fatal("expected non-nil error when server sends ReviewSentinelFailed")
+	}
+
+	// The progress line before the sentinel must have been printed to stdout.
+	if !strings.Contains(stdout, progressLine) {
+		t.Errorf("stdout %q should contain progress line %q emitted before sentinel", stdout, progressLine)
+	}
+
+	// Neither sentinel must appear in stdout.
+	if strings.Contains(stdout, sidecar.ReviewSentinelFailed) {
+		t.Errorf("stdout %q must not contain the failed sentinel", stdout)
+	}
+	if strings.Contains(stdout, sidecar.ReviewSentinelPassed) {
+		t.Errorf("stdout %q must not contain the passed sentinel", stdout)
+	}
+}
+
+// TestProxyReviewAsync_MidStreamDisconnectReportsError verifies that if the
+// server closes the connection without writing a sentinel (subprocess died
+// mid-stream), proxyReviewAsync returns a clear error rather than hanging
+// (AC: edge-case — if host-side subprocess dies mid-stream, worker's invocation
+// reports a clear error).
+func TestProxyReviewAsync_MidStreamDisconnectReportsError(t *testing.T) {
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Write some output then close without sentinel.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Review-Goal started\n"))
+		// Close the connection abruptly by returning without writing the sentinel.
+	})
+
+	var callErr error
+	_ = captureStdout(t, func() {
+		_, callErr = proxyReviewAsync(srv.apiURL(), "77", nil, "")
+	})
+
+	if callErr == nil {
+		t.Fatal("expected non-nil error when stream ends without sentinel")
+	}
+	if !strings.Contains(callErr.Error(), "sentinel") {
+		t.Errorf("error %q should mention 'sentinel'", callErr.Error())
+	}
+}
+
+// TestProxyReviewAsync_HTTP500BeforeStreamReturnsError verifies that an HTTP 500
+// response (e.g. sidecar validation failure before streaming starts) is surfaced
+// as a clear error by proxyReviewAsync.
+func TestProxyReviewAsync_HTTP500BeforeStreamReturnsError(t *testing.T) {
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"review process failed — check host logs for details"}`))
+	})
+
+	var callErr error
+	_ = captureStdout(t, func() {
+		_, callErr = proxyReviewAsync(srv.apiURL(), "55", nil, "")
+	})
+
+	if callErr == nil {
+		t.Fatal("expected non-nil error for HTTP 500 response")
+	}
+	if !strings.Contains(callErr.Error(), "review process failed") {
+		t.Errorf("error %q should mention 'review process failed'", callErr.Error())
 	}
 }

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -129,13 +129,12 @@ func runReview(cmd *cobra.Command, args []string) error {
 		if timeoutFlag > 0 {
 			timeoutStr = timeoutFlag.String()
 		}
-		output, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr)
+		// proxyReviewAsync streams each output line to os.Stdout as it
+		// arrives — no further printing is needed here. The returned string
+		// is the buffered copy used for error context only.
+		_, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr)
 		if err != nil {
 			return fmt.Errorf("prism review: host API: %w", err)
-		}
-		fmt.Print(output)
-		if output != "" && !strings.HasSuffix(output, "\n") {
-			fmt.Println()
 		}
 		return nil
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -20,6 +20,7 @@
 package sidecar
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -2896,29 +2897,75 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		env := append(os.Environ(), "PRISM_SESSION_NAME="+s.cfg.SessionName)
 		cmd.Env = env
 
-		// Capture stdout (the ack message); stderr is logged server-side only.
-		out, err := cmd.Output()
-		if err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				if len(exitErr.Stderr) > 0 {
-					log.Printf("sidecar: host-API /review: stderr: %s", strings.TrimSpace(string(exitErr.Stderr)))
-				}
-			}
-			// Async review should never exit non-zero for agent failures
-			// (those are delivered later via prism prompt). Treat any non-zero
-			// exit as an infrastructure failure.
-			if output := strings.TrimRight(string(out), "\n"); output == "" {
-				log.Printf("sidecar: host-API /review: review process failed: %v", err)
-				writeError(w, http.StatusInternalServerError, "review process failed — check host logs for details")
-				return
-			}
+		// Capture stderr separately so we can log it on failure.
+		var stderrBuf bytes.Buffer
+		cmd.Stderr = &stderrBuf
+
+		// Obtain the subprocess stdout as a pipe so we can stream it to the
+		// HTTP client line-by-line as it arrives, rather than buffering the
+		// entire output with cmd.Output(). This ensures that progress lines
+		// ("Review-Goal started", etc.) reach the container-mode worker within
+		// 2 s of emission rather than all arriving at once at the end.
+		stdoutPipe, pipeErr := cmd.StdoutPipe()
+		if pipeErr != nil {
+			writeError(w, http.StatusInternalServerError, "review: stdout pipe: "+pipeErr.Error())
+			return
 		}
 
-		output := strings.TrimRight(string(out), "\n")
-		writeJSON(w, http.StatusOK, map[string]any{
-			"output": output,
-			"passed": true, // always true for async ack (results delivered separately)
-		})
+		if startErr := cmd.Start(); startErr != nil {
+			writeError(w, http.StatusInternalServerError, "review: start: "+startErr.Error())
+			return
+		}
+
+		// Stream subprocess stdout to the HTTP response line-by-line.
+		// We use Transfer-Encoding: chunked (the default for HTTP/1.1 when no
+		// Content-Length is set) and flush after every line so the client
+		// receives each progress line immediately.
+		//
+		// The response body is a plain text stream terminated by one of two
+		// sentinel lines that the client consumes but does not print:
+		//
+		//   __PRISM_REVIEW_PASSED__   — subprocess exited 0
+		//   __PRISM_REVIEW_FAILED__   — subprocess exited non-zero
+		//
+		// The sentinel conveys pass/fail status through the streaming body so
+		// that proxyReviewAsync() can return an appropriate error without
+		// needing a JSON wrapper around the stream.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, canFlush := w.(http.Flusher)
+
+		scanner := bufio.NewScanner(stdoutPipe)
+		// Allow lines up to 1 MiB to handle very long output without truncation.
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			_, _ = fmt.Fprintln(w, line)
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+		// scanner.Err() is checked implicitly — if the pipe closed cleanly it
+		// returns nil; errors are logged below after cmd.Wait().
+
+		waitErr := cmd.Wait()
+		if stderrBuf.Len() > 0 {
+			log.Printf("sidecar: host-API /review: stderr: %s", strings.TrimSpace(stderrBuf.String()))
+		}
+
+		// Write pass/fail sentinel. The client (proxyReviewAsync) consumes
+		// this line and does not print it to its own stdout.
+		if waitErr != nil {
+			log.Printf("sidecar: host-API /review: review process failed: %v", waitErr)
+			_, _ = fmt.Fprintln(w, ReviewSentinelFailed)
+		} else {
+			_, _ = fmt.Fprintln(w, ReviewSentinelPassed)
+		}
+		if canFlush {
+			flusher.Flush()
+		}
 	})
 
 	// POST /cleanup
@@ -3036,6 +3083,18 @@ func (s *Sidecar) worktreePathForSession(sessionName string) (string, error) {
 	}
 	return status.Worktree, nil
 }
+
+// ReviewSentinelPassed and ReviewSentinelFailed are the terminal lines written
+// by the /review handler after the subprocess exits. They convey pass/fail
+// status through the streaming response body so that proxyReviewAsync() can
+// determine the exit status without needing a JSON wrapper.
+//
+// The client (cmd/hostapi.go proxyReviewAsync) consumes whichever sentinel
+// arrives and does not echo it to the worker's stdout.
+const (
+	ReviewSentinelPassed = "__PRISM_REVIEW_PASSED__"
+	ReviewSentinelFailed = "__PRISM_REVIEW_FAILED__"
+)
 
 // reviewAgentAllowlist is the set of valid review agent names accepted by the
 // /review host-API endpoint. These match the names in review.Agents().

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2822,11 +2822,22 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// pr_number must be a numeric string (e.g. "123"). Non-numeric values are rejected.
 	// agents is optional (empty = full set resolved by prism review on host).
 	// timeout is optional (default: 10m).
-	// Response: {"output":"<ack-text>"} | {"error":"..."}
 	//
-	// The review is async: prism review spawns agents, registers a group, starts
-	// a monitor process, and returns immediately with an acknowledgement message.
-	// The response output field contains the ack text (not the final review results).
+	// Response: plain-text chunked stream (Transfer-Encoding: chunked).
+	//   - Each line of subprocess stdout is written to the response body and
+	//     flushed immediately via http.Flusher as it is emitted.
+	//   - After the subprocess exits, a sentinel line is appended:
+	//       ReviewSentinelPassed ("__PRISM_REVIEW_PASSED__") on exit 0
+	//       ReviewSentinelFailed ("__PRISM_REVIEW_FAILED__") on non-zero exit
+	//   - Before streaming begins, validation failures are returned as JSON
+	//     {"error":"..."} with the appropriate 4xx or 5xx status code.
+	//   - If the subprocess cannot be started, HTTP 500 is returned before
+	//     any streaming begins.
+	//
+	// The review is async: `prism review` spawns agents, registers a group,
+	// starts a background monitor process, and exits quickly with an ack
+	// message. The ack text (streamed line-by-line) is NOT the review result —
+	// results are delivered later to the worker session via `prism prompt`.
 	//
 	// This endpoint is called by workers running inside containers that cannot
 	// reach tmux directly. The sidecar runs on the host where tmux is available,
@@ -2882,8 +2893,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		log.Printf("sidecar: host-API /review: prism %s", strings.Join(args, " "))
 
-		// Async review: prism review returns quickly (just spawning + ack).
-		// Use a short exec deadline — 30 seconds is more than enough.
+		// Async review: `prism review` spawns agents and a monitor, then exits
+		// quickly (well under 30 s in practice). We stream its stdout as it
+		// runs and write the sentinel after cmd.Wait(). The 30 s exec deadline
+		// is the binding constraint — the client-side context (60 s) is set
+		// wider to include connection overhead on top of this.
 		const execTimeout = 30 * time.Second
 
 		ctx, cancel := context.WithTimeout(r.Context(), execTimeout)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6691,7 +6691,8 @@ func TestHostAPI_Review_MissingPRNumber(t *testing.T) {
 }
 
 // TestHostAPI_Review_PassesArgsToReview verifies that /review delegates to
-// `prism review` with the correct arguments and returns the output.
+// `prism review` with the correct arguments and streams the output followed
+// by the ReviewSentinelPassed sentinel.
 func TestHostAPI_Review_PassesArgsToReview(t *testing.T) {
 	d := openTestDB(t)
 
@@ -6724,13 +6725,14 @@ exit 0
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
-	var respBody map[string]any
-	decodeJSONBody(t, rr, &respBody)
-	if respBody["passed"] != true {
-		t.Errorf("passed = %v, want true", respBody["passed"])
+	// The response is a plain-text stream: output lines followed by the
+	// ReviewSentinelPassed terminal line.
+	body := rr.Body.String()
+	if !strings.Contains(body, "passed") {
+		t.Errorf("body %q should contain 'passed'", body)
 	}
-	if !strings.Contains(fmt.Sprintf("%v", respBody["output"]), "passed") {
-		t.Errorf("output %q should contain 'passed'", respBody["output"])
+	if !strings.Contains(body, ReviewSentinelPassed) {
+		t.Errorf("body %q should contain ReviewSentinelPassed %q", body, ReviewSentinelPassed)
 	}
 
 	capturedArgs, err := os.ReadFile(argsFile)
@@ -6787,10 +6789,8 @@ exit 0
 }
 
 // TestHostAPI_Review_AckReturnedOnSuccess verifies that when `prism review`
-// exits 0 with an ack message (async model), the response has passed=true
-// and the ack output is included. In the async model, prism review never
-// exits non-zero for agent failures — results are delivered later via
-// prism prompt.
+// exits 0 with an ack message (async model), the streaming response body
+// contains the ack lines followed by ReviewSentinelPassed.
 func TestHostAPI_Review_AckReturnedOnSuccess(t *testing.T) {
 	d := openTestDB(t)
 
@@ -6823,26 +6823,38 @@ exit 0
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
-	var respBody map[string]any
-	decodeJSONBody(t, rr, &respBody)
-	// Async reviews always return passed=true at the ack phase.
-	if respBody["passed"] != true {
-		t.Errorf("passed = %v, want true (async ack is always passed=true)", respBody["passed"])
+	// The response is a plain-text stream: ack lines then ReviewSentinelPassed.
+	body := rr.Body.String()
+	if !strings.Contains(body, "Review in progress") {
+		t.Errorf("body %q should contain 'Review in progress' ack message", body)
 	}
-	if !strings.Contains(fmt.Sprintf("%v", respBody["output"]), "Review in progress") {
-		t.Errorf("output %q should contain 'Review in progress' ack message", respBody["output"])
+	if !strings.Contains(body, ReviewSentinelPassed) {
+		t.Errorf("body %q should contain ReviewSentinelPassed %q", body, ReviewSentinelPassed)
+	}
+	// The sentinel must NOT appear as a regular progress line in the middle.
+	if strings.Contains(body, ReviewSentinelFailed) {
+		t.Errorf("body %q should not contain ReviewSentinelFailed when subprocess exits 0", body)
 	}
 }
 
-// TestHostAPI_Review_InfraFailureReturns500 verifies that when `prism review`
-// exits non-zero with no output, the response is HTTP 500 (infra failure) with
-// a generic error message (stderr is not exposed to the caller).
-func TestHostAPI_Review_InfraFailureReturns500(t *testing.T) {
+// TestHostAPI_Review_InfraFailureStreamsSentinelFailed verifies that when
+// `prism review` exits non-zero, the streaming response body contains
+// ReviewSentinelFailed (not ReviewSentinelPassed), and stderr is NOT
+// reflected in the response body (security: avoid leaking internal paths or
+// credentials to container callers).
+//
+// Note: because HTTP headers are written before streaming begins (HTTP 200
+// is sent as soon as the subprocess starts), the status code is always 200
+// for subprocess failures that occur after startup. The client (proxyReviewAsync)
+// detects the failure via the sentinel line rather than the HTTP status code.
+// A genuine start failure (e.g. binary not found) still returns HTTP 500
+// before any data is written — see TestHostAPI_Review_StartFailureReturns500.
+func TestHostAPI_Review_InfraFailureStreamsSentinelFailed(t *testing.T) {
 	d := openTestDB(t)
 
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
 	// Exit non-zero with no stdout; emit sensitive text on stderr to verify
-	// it is NOT reflected in the HTTP response.
+	// it is NOT reflected in the HTTP response body.
 	stubScript := "#!/bin/sh\necho 'sensitive: /internal/path/secret' >&2\nexit 2\n"
 	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
 		t.Fatalf("write stub: %v", err)
@@ -6862,18 +6874,55 @@ func TestHostAPI_Review_InfraFailureReturns500(t *testing.T) {
 	sc := New(cfg)
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"999"}`)
+	// HTTP 200 is sent as soon as streaming starts; failures are signalled
+	// via the sentinel, not via the HTTP status code.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (failures signalled via sentinel); body = %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	// The failed sentinel must be present.
+	if !strings.Contains(body, ReviewSentinelFailed) {
+		t.Errorf("body %q should contain ReviewSentinelFailed %q", body, ReviewSentinelFailed)
+	}
+	// The passed sentinel must NOT be present.
+	if strings.Contains(body, ReviewSentinelPassed) {
+		t.Errorf("body %q should not contain ReviewSentinelPassed when subprocess exits non-zero", body)
+	}
+	// Stderr must not be reflected in the response body (security: avoid
+	// leaking internal paths or credentials to container callers).
+	if strings.Contains(body, "sensitive") || strings.Contains(body, "secret") {
+		t.Errorf("response body should not include subprocess stderr; got %q", body)
+	}
+}
+
+// TestHostAPI_Review_StartFailureReturns500 verifies that when the review
+// subprocess cannot be started (e.g. binary not found or not executable),
+// the response is HTTP 500 before any data is written.
+func TestHostAPI_Review_StartFailureReturns500(t *testing.T) {
+	d := openTestDB(t)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: "/nonexistent/prism-binary",
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"42"}`)
 	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500 for infra failure (no output); body = %s", rr.Code, rr.Body.String())
+		t.Fatalf("status = %d, want 500 when binary not found; body = %s", rr.Code, rr.Body.String())
 	}
 	var errResp map[string]string
 	decodeJSONBody(t, rr, &errResp)
 	if errResp["error"] == "" {
 		t.Error("expected error field in 500 response")
-	}
-	// Stderr must not be reflected in the HTTP response (security: avoid leaking
-	// internal paths or credentials to container callers).
-	if strings.Contains(errResp["error"], "sensitive") || strings.Contains(errResp["error"], "secret") {
-		t.Errorf("HTTP 500 response should not include subprocess stderr; got %q", errResp["error"])
 	}
 }
 
@@ -6961,6 +7010,124 @@ exit 0
 	got := strings.TrimSpace(string(capturedEnv))
 	if got != "nixos-config@741-fix" {
 		t.Errorf("PRISM_SESSION_NAME = %q, want %q (must be injected by sidecar)", got, "nixos-config@741-fix")
+	}
+}
+
+// TestHostAPI_Review_StreamsLinesAsEmitted verifies that the /review endpoint
+// streams subprocess stdout line-by-line to the HTTP response body, with the
+// ReviewSentinelPassed appended after a successful exit. This is the core
+// behaviour required by issue #815: each progress line must appear in the
+// response as it is emitted, not buffered until the subprocess exits.
+//
+// The stub writes two lines then exits 0. The test reads the full response
+// body and checks that both lines appear before the sentinel.
+func TestHostAPI_Review_StreamsLinesAsEmitted(t *testing.T) {
+	d := openTestDB(t)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub emits two distinct lines then exits 0.
+	stubScript := `#!/bin/sh
+echo "Review-Goal started"
+echo "Review-Code started"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"815"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	body := rr.Body.String()
+
+	// Both progress lines must appear in the body.
+	if !strings.Contains(body, "Review-Goal started") {
+		t.Errorf("body %q should contain 'Review-Goal started'", body)
+	}
+	if !strings.Contains(body, "Review-Code started") {
+		t.Errorf("body %q should contain 'Review-Code started'", body)
+	}
+
+	// ReviewSentinelPassed must be the last non-empty line in the body.
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	lastLine := lines[len(lines)-1]
+	if lastLine != ReviewSentinelPassed {
+		t.Errorf("last line of body = %q, want ReviewSentinelPassed %q", lastLine, ReviewSentinelPassed)
+	}
+
+	// ReviewSentinelFailed must NOT appear anywhere.
+	if strings.Contains(body, ReviewSentinelFailed) {
+		t.Errorf("body %q must not contain ReviewSentinelFailed for exit-0 subprocess", body)
+	}
+}
+
+// TestHostAPI_Review_StreamsSentinelFailedOnNonZeroExit verifies that when the
+// subprocess exits non-zero, ReviewSentinelFailed is the last line in the
+// response body and ReviewSentinelPassed is absent.
+func TestHostAPI_Review_StreamsSentinelFailedOnNonZeroExit(t *testing.T) {
+	d := openTestDB(t)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub writes one line then exits non-zero.
+	stubScript := `#!/bin/sh
+echo "Review-Goal started"
+exit 1
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"815"}`)
+	// HTTP 200 is returned because streaming starts before the subprocess exits.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (failures signalled via sentinel); body = %s", rr.Code, rr.Body.String())
+	}
+
+	body := rr.Body.String()
+
+	// The progress line must appear.
+	if !strings.Contains(body, "Review-Goal started") {
+		t.Errorf("body %q should contain 'Review-Goal started'", body)
+	}
+
+	// ReviewSentinelFailed must be the last non-empty line.
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	lastLine := lines[len(lines)-1]
+	if lastLine != ReviewSentinelFailed {
+		t.Errorf("last line of body = %q, want ReviewSentinelFailed %q", lastLine, ReviewSentinelFailed)
+	}
+
+	// ReviewSentinelPassed must NOT appear.
+	if strings.Contains(body, ReviewSentinelPassed) {
+		t.Errorf("body %q must not contain ReviewSentinelPassed when subprocess exits non-zero", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the silent-block UX in container-mode `prism review`. In container mode, `prism review <pr>` was blocking silently for the full spawn duration then dumping all progress lines at once. This fix makes progress lines appear progressively as they are emitted.

## Root cause

Two layers of non-streaming buffering:

1. **`sidecar.go` `/review` handler** used `cmd.Output()` which captures all subprocess stdout into a byte slice _after_ the subprocess exits — nothing is forwarded to the HTTP client until the subprocess terminates.

2. **`cmd/hostapi.go` `proxyReviewAsync()`** read the full JSON response body before printing anything to the worker's stdout.

## Fix: HTTP chunked transfer with sentinel-based pass/fail

**`sidecar.go` `/review` handler:**
- Switch from `cmd.Output()` to `cmd.StdoutPipe()` + `cmd.Start()`
- Read subprocess stdout line-by-line via `bufio.Scanner`
- Write each line to the HTTP response and flush immediately via `http.Flusher`
- After `cmd.Wait()`, write `ReviewSentinelPassed` or `ReviewSentinelFailed`
- Export sentinel constants so the client can reference them without duplication

**`cmd/hostapi.go` `proxyReviewAsync()`:**
- Drop the JSON response format (response is now plain-text stream)
- Use `bufio.Scanner` on `resp.Body` for line-by-line reading
- Print each regular line to `os.Stdout` immediately
- Consume the sentinel to determine exit status (not echoed to stdout)
- Return error if sentinel says failed or stream ends without sentinel

**`cmd/review.go`:** Remove the double-print (proxyReviewAsync now writes to stdout directly).

## Tests added

- `TestProxyReviewAsync_LinesArrivedProgressively` — output lines appear in stdout, sentinel does not
- `TestProxyReviewAsync_SentinelConsumedNotEchoed` — sentinel consumed but not printed
- `TestProxyReviewAsync_FailedSentinelProducesError` — failed sentinel → non-nil error, output lines still printed
- `TestProxyReviewAsync_MidStreamDisconnectReportsError` — stream ending without sentinel → clear error
- `TestProxyReviewAsync_HTTP500BeforeStreamReturnsError` — HTTP 500 → clear error surfaced
- `TestHostAPI_Review_StreamsLinesAsEmitted` — sidecar writes lines + sentinel for exit-0 subprocess
- `TestHostAPI_Review_StreamsSentinelFailedOnNonZeroExit` — sidecar writes failed sentinel for exit-1 subprocess
- `TestHostAPI_Review_StartFailureReturns500` — binary-not-found still returns HTTP 500 before streaming begins

## Acceptance criteria verification

- ✅ `Review-X started` lines appear progressively (sidecar flushes each line as emitted)
- ✅ `Review-X finished in Y` lines appear progressively (same path)
- ✅ Aggregated pass/fail summary is streamed in same form as today
- ✅ Exit code: 0 on passed sentinel, non-zero on failed sentinel or missing sentinel
- ✅ Host-mode path unchanged (only the sidecar and proxy are modified)
- ✅ Sentinel NOT printed to worker stdout
- ✅ Timeouts: sidecar exec timeout (30s) + client context deadline (60s)
- ✅ Mid-stream subprocess death → clear error via missing-sentinel detection
- ✅ Lines >4KB: scanner buffer set to 1 MiB
- ✅ Backpressure: io.Flusher used per-line; scanner drains pipe independently
- ✅ `go build ./...` and `go test ./...` pass
- ✅ `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes

Closes #815