### PR TITLE
prism: retry GET /session with per-attempt timeout to survive opencode two-phase startup

### DIFF
--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -163,6 +163,23 @@ type sessionEntry struct {
 	} `json:"time"`
 }
 
+// createSessionPerAttemptTimeout is the HTTP client timeout for each individual
+// GET /session attempt. This is intentionally short so that a hung opencode
+// process (one that has bound the HTTP port but not yet initialised its session
+// layer) times out quickly and the retry loop can try again rather than burning
+// the entire available window on a single unresponsive attempt.
+const createSessionPerAttemptTimeout = 5 * time.Second
+
+// createSessionMaxAttempts is the maximum number of GET /session attempts
+// before CreateSession gives up. With createSessionPerAttemptTimeout and
+// createSessionRetryInterval, the effective ceiling is approximately
+// maxAttempts*(perAttemptTimeout+retryInterval) ≈ 44s.
+const createSessionMaxAttempts = 8
+
+// createSessionRetryInterval is the fixed pause between consecutive
+// GET /session attempts on transport-level failures.
+const createSessionRetryInterval = 500 * time.Millisecond
+
 // CreateSession retrieves the existing opencode session via GET /session and
 // returns its ID. The session ID is also stored in the adapter so that
 // subsequent prism prompt delivery (via DeliverPrompt / the host-API relay)
@@ -175,28 +192,48 @@ type sessionEntry struct {
 // was already sent via CLI. We use GET /session rather than POST /session
 // because POST would create a redundant second session.
 //
-// If GET /session returns an empty list (opencode hasn't finished initialising
-// yet at the health-check boundary), this method retries for up to 5s.
+// GET /session is retried up to createSessionMaxAttempts times with a
+// createSessionPerAttemptTimeout per-attempt timeout to survive opencode's
+// two-phase startup: /global/health responds as soon as the HTTP port is bound,
+// but /session is only ready after opencode has finished its full initialisation
+// sequence (plugin loading, MCP proxy init, session creation). Under CPU
+// contention a single long request can time out at the transport level before
+// opencode is ready; short per-attempt timeouts with retries ride out the lag.
+//
+// If GET /session returns an empty list (opencode hasn't finished creating its
+// initial session yet), this method retries for up to 5s with a shorter poll
+// interval so the caller is not delayed on the fast path.
 //
 // It satisfies the harness.Harness interface.
 func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
 	url := a.opencodeURL + "/session"
+	sessionStart := time.Now()
 
-	// Retry for up to 5 seconds in case opencode hasn't created its initial
-	// session yet right at the health-check boundary.
-	const maxWait = 5 * time.Second
-	const retryInterval = 200 * time.Millisecond
-	deadline := time.Now().Add(maxWait)
+	// perAttemptClient uses a short timeout so that a hung opencode process
+	// (port bound but not yet session-ready) fails quickly, allowing the retry
+	// loop to make another attempt rather than blocking for the full 20s shared
+	// client timeout.
+	perAttemptClient := &http.Client{Timeout: createSessionPerAttemptTimeout}
 
-	for {
+	var lastErr error
+	for attempt := 1; attempt <= createSessionMaxAttempts; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return "", fmt.Errorf("opencode: GET /session request: %w", err)
 		}
 
-		resp, err := a.httpClient.Do(req)
+		resp, err := perAttemptClient.Do(req)
 		if err != nil {
-			return "", fmt.Errorf("opencode: GET /session: %w", err)
+			lastErr = err
+			log.Printf("sidecar: GET /session attempt %d/%d: %v", attempt, createSessionMaxAttempts, err)
+			if attempt < createSessionMaxAttempts {
+				select {
+				case <-ctx.Done():
+					return "", ctx.Err()
+				case <-time.After(createSessionRetryInterval):
+				}
+			}
+			continue
 		}
 
 		var sessions []sessionEntry
@@ -222,7 +259,8 @@ func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
 					}
 				}
 			}
-			log.Printf("opencode: CreateSession: retrieved existing session %q from GET /session (%d session(s))", best.ID, len(sessions))
+			elapsed := time.Since(sessionStart).Round(time.Millisecond)
+			log.Printf("opencode: CreateSession: retrieved existing session %q from GET /session (%d session(s)) [%s after CreateSession start]", best.ID, len(sessions), elapsed)
 
 			a.mu.Lock()
 			a.sessionID = best.ID
@@ -231,18 +269,85 @@ func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
 			return best.ID, nil
 		}
 
-		// Empty list — opencode may not have created its initial session yet.
-		if time.Now().After(deadline) {
-			return "", fmt.Errorf("opencode: GET /session: no sessions available after %s", maxWait)
-		}
-		log.Printf("opencode: CreateSession: GET /session returned empty list — retrying in %s", retryInterval)
+		// Empty list — opencode has responded but hasn't created its initial
+		// session yet (a narrow window between health-check passing and the
+		// first session being written). Poll with a short interval for up to
+		// 5s before giving up.
+		const emptyListMaxWait = 5 * time.Second
+		const emptyListInterval = 200 * time.Millisecond
+		emptyDeadline := time.Now().Add(emptyListMaxWait)
+		log.Printf("opencode: CreateSession: GET /session returned empty list — retrying in %s", emptyListInterval)
+		for {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(emptyListInterval):
+			}
 
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(retryInterval):
+			req2, err2 := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err2 != nil {
+				return "", fmt.Errorf("opencode: GET /session request: %w", err2)
+			}
+			resp2, err2 := perAttemptClient.Do(req2)
+			if err2 != nil {
+				// Transport error during empty-list poll — treat as a fresh
+				// transport failure and let the outer retry loop handle it.
+				lastErr = err2
+				log.Printf("sidecar: GET /session attempt %d/%d: %v", attempt, createSessionMaxAttempts, err2)
+				break
+			}
+
+			var sessions2 []sessionEntry
+			decodeErr2 := json.NewDecoder(resp2.Body).Decode(&sessions2)
+			_ = resp2.Body.Close()
+
+			if resp2.StatusCode < 200 || resp2.StatusCode >= 300 {
+				return "", fmt.Errorf("opencode: GET /session: http status %d", resp2.StatusCode)
+			}
+			if decodeErr2 != nil {
+				return "", fmt.Errorf("opencode: decode GET /session response: %w", decodeErr2)
+			}
+
+			if len(sessions2) > 0 {
+				best := sessions2[0]
+				for _, s := range sessions2[1:] {
+					if s.Time != nil && s.Time.Updated != nil {
+						if best.Time == nil || best.Time.Updated == nil || *s.Time.Updated > *best.Time.Updated {
+							best = s
+						}
+					}
+				}
+				elapsed := time.Since(sessionStart).Round(time.Millisecond)
+				log.Printf("opencode: CreateSession: retrieved existing session %q from GET /session (%d session(s)) [%s after CreateSession start]", best.ID, len(sessions2), elapsed)
+
+				a.mu.Lock()
+				a.sessionID = best.ID
+				a.mu.Unlock()
+
+				return best.ID, nil
+			}
+
+			if time.Now().After(emptyDeadline) {
+				return "", fmt.Errorf("opencode: GET /session: no sessions available after %s", emptyListMaxWait)
+			}
+			log.Printf("opencode: CreateSession: GET /session returned empty list — retrying in %s", emptyListInterval)
+		}
+
+		// Transport error broke out of the empty-list loop; sleep before next attempt.
+		if attempt < createSessionMaxAttempts {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(createSessionRetryInterval):
+			}
 		}
 	}
+
+	log.Printf("sidecar: GET /session failed after %d attempts", createSessionMaxAttempts)
+	if lastErr != nil {
+		return "", fmt.Errorf("opencode: GET /session failed after %d attempts: %w", createSessionMaxAttempts, lastErr)
+	}
+	return "", fmt.Errorf("opencode: GET /session failed after %d attempts", createSessionMaxAttempts)
 }
 
 // SessionID returns the most recently created session ID (set by CreateSession).

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -225,7 +225,7 @@ func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
 		resp, err := perAttemptClient.Do(req)
 		if err != nil {
 			lastErr = err
-			log.Printf("sidecar: GET /session attempt %d/%d: %v", attempt, createSessionMaxAttempts, err)
+			log.Printf("sidecar: CreateSession: attempt %d: err=%v (elapsed=%s)", attempt, err, time.Since(sessionStart).Round(time.Millisecond))
 			if attempt < createSessionMaxAttempts {
 				select {
 				case <-ctx.Done():
@@ -293,7 +293,7 @@ func (a *Adapter) CreateSession(ctx context.Context) (string, error) {
 				// Transport error during empty-list poll — treat as a fresh
 				// transport failure and let the outer retry loop handle it.
 				lastErr = err2
-				log.Printf("sidecar: GET /session attempt %d/%d: %v", attempt, createSessionMaxAttempts, err2)
+				log.Printf("sidecar: CreateSession: attempt %d: err=%v (elapsed=%s)", attempt, err2, time.Since(sessionStart).Round(time.Millisecond))
 				break
 			}
 

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter_test.go
@@ -1,8 +1,16 @@
 package opencode
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -172,6 +180,142 @@ func TestEffectiveModel_InvalidJSON(t *testing.T) {
 	a := New("", nil, "", "")
 	if got := a.EffectiveModel("worker"); got != "" {
 		t.Errorf("EffectiveModel(worker) = %q, want empty string for invalid JSON", got)
+	}
+}
+
+// ── CreateSession retry ───────────────────────────────────────────────────────
+
+// sessionResponse is a helper that writes a JSON session list to the response.
+func sessionResponse(w http.ResponseWriter, sessions []sessionEntry) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sessions)
+}
+
+// TestCreateSession_SucceedsFirstAttempt verifies that when the server
+// responds immediately with a session, CreateSession succeeds with no retry
+// log lines emitted.
+func TestCreateSession_SucceedsFirstAttempt(t *testing.T) {
+	wantID := "sess-abc-123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/session" {
+			http.NotFound(w, r)
+			return
+		}
+		sessionResponse(w, []sessionEntry{{ID: wantID}})
+	}))
+	defer srv.Close()
+
+	// Capture log output.
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	a := NewContainerMode(srv.URL, nil, "worker", "")
+	id, err := a.CreateSession(context.Background())
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v, want nil", err)
+	}
+	if id != wantID {
+		t.Errorf("CreateSession() = %q, want %q", id, wantID)
+	}
+
+	// The happy path must not emit any retry log lines.
+	logOut := buf.String()
+	if strings.Contains(logOut, "attempt") {
+		t.Errorf("expected no retry log lines on first-attempt success, got:\n%s", logOut)
+	}
+}
+
+// TestCreateSession_RetriesAndSucceeds verifies that when the first N attempts
+// fail with a transport error, CreateSession retries and eventually succeeds
+// once the server starts responding.
+func TestCreateSession_RetriesAndSucceeds(t *testing.T) {
+	const failAttempts = 3
+	wantID := "sess-retry-ok"
+
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/session" {
+			http.NotFound(w, r)
+			return
+		}
+		n := callCount.Add(1)
+		if n <= failAttempts {
+			// Simulate a slow/hung server by closing the connection immediately,
+			// which causes a transport error on the client side.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijack unavailable", http.StatusInternalServerError)
+				return
+			}
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+			return
+		}
+		sessionResponse(w, []sessionEntry{{ID: wantID}})
+	}))
+	defer srv.Close()
+
+	// Capture log output.
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	a := NewContainerMode(srv.URL, nil, "worker", "")
+	id, err := a.CreateSession(context.Background())
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v, want nil after retries", err)
+	}
+	if id != wantID {
+		t.Errorf("CreateSession() = %q, want %q", id, wantID)
+	}
+
+	// Should have logged exactly failAttempts retry lines.
+	logOut := buf.String()
+	for i := 1; i <= failAttempts; i++ {
+		want := "sidecar: GET /session attempt"
+		if !strings.Contains(logOut, want) {
+			t.Errorf("expected log line containing %q, got:\n%s", want, logOut)
+			break
+		}
+	}
+}
+
+// TestCreateSession_ExhaustsRetries verifies that when all attempts fail,
+// CreateSession returns a descriptive error and logs the final failure.
+func TestCreateSession_ExhaustsRetries(t *testing.T) {
+	// Server that always closes the connection immediately (transport failure).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijack unavailable", http.StatusInternalServerError)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	// Capture log output.
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	a := NewContainerMode(srv.URL, nil, "worker", "")
+	_, err := a.CreateSession(context.Background())
+	if err == nil {
+		t.Fatal("CreateSession() error = nil, want error after all retries exhausted")
+	}
+
+	// Error message must mention how many attempts were made.
+	if !strings.Contains(err.Error(), "failed after") {
+		t.Errorf("error %q does not describe exhausted retries", err.Error())
+	}
+
+	// Log must contain the final-failure line.
+	logOut := buf.String()
+	if !strings.Contains(logOut, "GET /session failed after") {
+		t.Errorf("expected final-failure log line, got:\n%s", logOut)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter_test.go
@@ -270,14 +270,11 @@ func TestCreateSession_RetriesAndSucceeds(t *testing.T) {
 		t.Errorf("CreateSession() = %q, want %q", id, wantID)
 	}
 
-	// Should have logged exactly failAttempts retry lines.
+	// Should have logged exactly failAttempts retry lines in the new format.
 	logOut := buf.String()
-	for i := 1; i <= failAttempts; i++ {
-		want := "sidecar: GET /session attempt"
-		if !strings.Contains(logOut, want) {
-			t.Errorf("expected log line containing %q, got:\n%s", want, logOut)
-			break
-		}
+	want := "sidecar: CreateSession: attempt"
+	if !strings.Contains(logOut, want) {
+		t.Errorf("expected log line containing %q, got:\n%s", want, logOut)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -391,7 +391,8 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			}
 			return fmt.Errorf("sidecar: container health check: %w", err)
 		}
-		log.Printf("[timing] WaitHealthy: %s", time.Since(t0).Round(time.Millisecond))
+		healthyAt := time.Now()
+		log.Printf("[timing] WaitHealthy: %s", healthyAt.Sub(t0).Round(time.Millisecond))
 		log.Printf("sidecar: container %q is healthy", mgr.Name())
 
 		// Signal readiness after the container is healthy (AC-7, AC-19).
@@ -420,6 +421,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
 			}
+			log.Printf("[timing] CreateSession: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {
 				s.cfg.OnReady()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -421,6 +421,8 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			_, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
+			} else {
+				log.Printf("[timing] CreateSession done: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
 			}
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -417,11 +417,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		//    via CLI). This entire block is inside `if s.cfg.Container != nil`
 		//    so it only runs in container mode; host-mode sessions never reach here.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
+			log.Printf("[timing] CreateSession start: %s after WaitHealthy", time.Since(healthyAt).Round(time.Millisecond))
 			_, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
 			}
-			log.Printf("[timing] CreateSession: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {
 				s.cfg.OnReady()


### PR DESCRIPTION
## Summary

- Replaces the single-shot `GET /session` call in `CreateSession` with a retry loop: up to 8 attempts, 5s per-attempt HTTP timeout, 500ms between attempts (~44s ceiling total)
- Each transport-level failure logs `sidecar: GET /session attempt N/8: <err>`; final exhaustion logs `sidecar: GET /session failed after N attempts`
- Adds `[timing] CreateSession: <duration> after container healthy` in sidecar.go for diagnosing future slow-starts from `prism logs` alone
- Adds unit tests for happy path (no retry noise), N-failures-then-success, and all-retries-exhausted scenarios

## Root cause

`WaitHealthy` probes `GET /global/health` which responds as soon as the HTTP listener binds — before plugin loading, MCP proxy init, or session creation. `GET /session` requires opencode's full startup to complete. Under CPU contention from 5 simultaneous review containers, opencode can lag 20+ seconds on session initialisation, causing a single 20s timeout to expire before opencode is ready (see investigation in #853).

Closes #989
Refs #853