### PR TITLE
prism review: return full agent findings to worker, not just pass/fail summary

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -349,7 +349,10 @@
           `prism review <pr>` is **async** — it spawns 5 review agents, registers a group, and returns immediately with an acknowledgement.
           Results are delivered to you via a follow-up `prism prompt` when all agents complete.
           **Do NOT commit, merge, or announce completion** until the review-complete prompt arrives.
-          When the review-complete prompt arrives, handle PASS/FAIL per the worker agent instructions.
+          The review-complete prompt includes a one-line summary header followed by full per-agent findings (verdict, blocking issues, non-blocking observations).
+          When findings exceed the inline budget, a file pointer appears — read the file with `cat /tmp/prism-review-<pr>-round-<N>.md` to see the full output.
+          On FAIL: fix all blocking issues, commit, push, and re-run. Non-blocking observations on a failed round MAY be actioned alongside the fix.
+          On PASS: non-blocking observations MAY be actioned if they align with repo conventions or add defence-in-depth at low cost. You are NOT required to action them — shipping the PR is not gated on non-blocking observations.
           If no review-complete prompt arrives within 30 minutes, investigate with `prism checkin <session>~review-<N>-review-goal`.
           After 3 full review cycles without convergence, stop and escalate — do not run a 4th cycle.
           Invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` as parallel Task calls (all five in a single response) as a fallback when `prism review` is unavailable.

--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -73,18 +73,46 @@ delivered to you via a follow-up `prism prompt` when all agents complete.
 
 ### Handling review results
 
-When the review-complete prompt arrives:
+`prism review` returns full reviewer output for each agent: verdict, summary,
+blocking issues, and non-blocking observations. The review-complete prompt
+includes a one-line summary header followed by a `## Per-agent findings` section
+with the full output.
+
+When findings exceed the inline budget (default 20 KB), a file pointer appears:
+
+```
+Full findings: `/tmp/prism-review-<pr>-round-<N>.md` (N KB) — read with `cat` or `rg` as needed.
+```
+
+Read the file with `cat /tmp/prism-review-<pr>-round-<N>.md` to see the full
+per-agent findings when the pointer is present.
 
 **ALL 5 must pass** for the review to pass.
 
-If ANY agent returns `<verdict>FAIL</verdict>`:
+**On FAIL:**
 
-1. Read each agent's `<blocking_issues>` carefully
-2. Fix every blocking issue identified
-3. Commit and push your fixes
+1. Read each agent's `<blocking_issues>` carefully — they are mandatory.
+2. Fix every blocking issue identified.
+3. Commit and push your fixes.
 4. Re-run `prism review <pr>` — not just the failed agents (a fix in one area
    can create issues in another, so the full set must re-run every cycle).
    Use `prism review <pr> --only review-goal,review-code` for targeted reruns.
+5. Non-blocking observations on a failed round MAY also be actioned alongside
+   the mandatory fix — the worker decides what to include.
+
+**On PASS:**
+
+Non-blocking observations MAY be actioned if they represent a genuine
+improvement. You are **not required** to action them — shipping the PR is not
+gated on non-blocking observations.
+
+Prefer actioning observations that:
+- Align the change with repo conventions already present in sibling files
+- Add defence-in-depth at low cost (permissions blocks, input validation)
+- Would otherwise require a dedicated follow-up PR
+
+Avoid cosmetic bikeshedding that invites another full review round for no
+substantive gain. When in doubt, ship the PR as-is — review rounds aren't free.
 
 ### Fallback: Task-call subagents
 

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -56,6 +56,7 @@ func init() {
 	reviewCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	reviewCmd.Flags().Int("diff-inline-max", 0,
 		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
+	reviewCmd.Flags().Int("size-budget", 0, "Max inline size (bytes) for full per-agent findings before overflow-to-file (default 20480; overridden by PRISM_REVIEW_SIZE_BUDGET env var)")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -78,6 +79,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	onlyFlag, _ := cmd.Flags().GetString("only")
 	onlyChanged := cmd.Flags().Changed("only")
 	diffInlineMaxFlag, _ := cmd.Flags().GetInt("diff-inline-max")
+	sizeBudgetFlag, _ := cmd.Flags().GetInt("size-budget")
 
 	// Resolve the full agent list and apply --only filtering up-front.
 	// This is done before the container-mode branch so that validation
@@ -244,6 +246,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,
 		RuntimeEnvVars: h.RuntimeEnv(),
+		SizeBudget:     sizeBudgetFlag,
 	}
 
 	// Load profiles for container mode — passed through to review.RunAsync so

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -157,7 +157,7 @@ func MonitorFunc(opts MonitorOpts) error {
 	deliverErr := deliverWithRetry(opts.WorkerSession, deliveryText, maxRetries, retryBackoff, dbPath)
 	if deliverErr != nil {
 		// Delivery failed after all retries — write fallback file.
-		fallbackPath := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", opts.PRNumber, opts.Round)
+		fallbackPath := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", sanitisePRNumber(opts.PRNumber), opts.Round)
 		fmt.Fprintf(os.Stderr, "[prism monitor-review] delivery failed after %d retries — writing fallback to %s\n", maxRetries, fallbackPath)
 		writeErr := os.WriteFile(fallbackPath, []byte(deliveryText), 0o644)
 		if writeErr != nil {
@@ -431,7 +431,7 @@ func StartMonitorProcess(opts MonitorOpts, prismBinary string) error {
 	// Detach the process: use setsid so it survives the parent process exiting.
 	detachProcess(cmd)
 	// Redirect stdout/stderr to log file for diagnostics.
-	logPath := fmt.Sprintf("/tmp/prism-monitor-review-%s-round-%d.log", opts.PRNumber, opts.Round)
+	logPath := fmt.Sprintf("/tmp/prism-monitor-review-%s-round-%d.log", sanitisePRNumber(opts.PRNumber), opts.Round)
 	logFile, logErr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if logErr == nil {
 		cmd.Stdout = logFile
@@ -521,9 +521,10 @@ func ReviewRoundForGroup(members []db.Status) int {
 }
 
 // WriteFallbackResult writes the review result to the standard fallback file
-// when delivery fails. Exported for testing.
+// when delivery fails. prNumber is sanitised to prevent path traversal.
+// Exported for testing.
 func WriteFallbackResult(prNumber string, round int, content string) (string, error) {
-	path := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", prNumber, round)
+	path := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", sanitisePRNumber(prNumber), round)
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		return "", fmt.Errorf("write fallback result: %w", err)
 	}
@@ -546,8 +547,9 @@ func LoadMonitorOptsFromFile(path string) (MonitorOpts, error) {
 }
 
 // fallbackFilePath returns the standard fallback result file path.
+// prNumber is sanitised to prevent path traversal.
 func fallbackFilePath(prNumber string, round int) string {
-	return filepath.Join("/tmp", fmt.Sprintf("prism-review-%s-round-%d-result.md", prNumber, round))
+	return filepath.Join("/tmp", fmt.Sprintf("prism-review-%s-round-%d-result.md", sanitisePRNumber(prNumber), round))
 }
 
 // BuildMonitorResultsForTest is an exported wrapper around buildMonitorResults

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -58,6 +58,11 @@ type MonitorOpts struct {
 	// Timeout is the maximum time to wait for the group to complete. Zero means
 	// no timeout (monitor runs until the group is complete).
 	Timeout time.Duration
+	// SizeBudget is the maximum inline size (bytes) for full per-agent findings.
+	// When the total findings exceed this budget they are written to a temp file
+	// and a pointer is included inline. Zero uses the default (20 KB).
+	// Can also be overridden via the PRISM_REVIEW_SIZE_BUDGET environment variable.
+	SizeBudget int
 }
 
 // defaultPollInterval is how often the monitor polls GroupCompleted.
@@ -143,8 +148,9 @@ func MonitorFunc(opts MonitorOpts) error {
 	// Build AgentResult slice, handling "missing" sessions (row deleted mid-review).
 	results := buildMonitorResults(opts.Agents, opts.AgentSessions, groupData)
 
-	// Format the delivery message.
-	output, allPassed := FormatResults(results, opts.PRNumber)
+	// Format the delivery message. Pass round and sizeBudget so that
+	// overflow-to-file is handled when the total findings exceed the budget.
+	output, allPassed := FormatResults(results, opts.PRNumber, opts.Round, opts.SizeBudget)
 	deliveryText := buildDeliveryMessage(opts.PRNumber, opts.Round, output, allPassed, groupData, opts.AgentSessions)
 
 	// Deliver to worker via prism prompt with bounded retry.

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -560,6 +560,12 @@ type Opts struct {
 	// agents are productive from turn 1. When nil or FetchFailed is true, a
 	// minimal fallback prompt is used instead.
 	PRCtx *PRContext
+	// SizeBudget is the maximum inline size (bytes) for full per-agent findings
+	// in the formatted output. When the total findings exceed this budget they
+	// are written to /tmp/prism-review-<pr>-round-<N>.md and a pointer is
+	// included inline. Zero uses the default (20 KB). Can also be overridden
+	// via the PRISM_REVIEW_SIZE_BUDGET environment variable.
+	SizeBudget int
 }
 
 // FormatAgentDisplayName converts an agent name like "review-goal" to a
@@ -950,6 +956,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		AgentSessions: liveSessions,
 		DBPath:        dbPath,
 		Timeout:       opts.Timeout * 2, // 2x per-agent timeout as group monitor limit
+		SizeBudget:    opts.SizeBudget,
 	}
 	if startErr := StartMonitorProcess(monitorOpts, prismBinary); startErr != nil {
 		// Monitor failed to start — not fatal for spawning, but warn loudly.
@@ -1529,38 +1536,122 @@ func cleanupAgentSession(d *db.DB, agentSession string) {
 	_ = d.PurgeBusMessages(agentSession)
 }
 
+// DefaultFindingsSizeBudget is the default maximum inline size (in bytes) for
+// full per-agent findings. When the total findings exceed this budget, they are
+// written to a file and a pointer is included instead.
+const DefaultFindingsSizeBudget = 20 * 1024 // 20 KB
+
+// FindingsSizeBudgetEnvVar is the environment variable that overrides the
+// default findings size budget. Set to an integer byte count (e.g. "10240").
+const FindingsSizeBudgetEnvVar = "PRISM_REVIEW_SIZE_BUDGET"
+
+// FindingsFilePath returns the path where full findings are written when the
+// size budget is exceeded. prNumber and round identify the review run.
+func FindingsFilePath(prNumber string, round int) string {
+	return fmt.Sprintf("/tmp/prism-review-%s-round-%d.md", prNumber, round)
+}
+
+// resolveSizeBudget returns the effective size budget. sizeBudget ≤ 0 means use
+// the default (or the env-var override, if set).
+func resolveSizeBudget(sizeBudget int) int {
+	if sizeBudget > 0 {
+		return sizeBudget
+	}
+	if v := os.Getenv(FindingsSizeBudgetEnvVar); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultFindingsSizeBudget
+}
+
 // FormatResults formats the aggregated results as a human-readable report.
+// It always includes a one-line-per-agent summary header for terse scanning,
+// followed by full per-agent findings (verdict, summary, blocking issues, and
+// non-blocking observations).
+//
+// When total output exceeds sizeBudget bytes (default 20 KB when ≤ 0), the
+// full findings are written to /tmp/prism-review-<pr>-round-<round>.md and the
+// inline output contains only summaries + blocking issues with a file pointer.
+// Pass round=0 to omit the file-overflow path (used in unit tests).
+//
 // Returns the formatted string and a boolean indicating whether all passed.
-func FormatResults(results []AgentResult, prNumber string) (string, bool) {
-	var sb strings.Builder
+func FormatResults(results []AgentResult, prNumber string, round int, sizeBudget int) (string, bool) {
+	budget := resolveSizeBudget(sizeBudget)
+
+	var header strings.Builder
+	var findings strings.Builder
 	allPassed := true
 	var failed []string
 
 	for _, r := range results {
+		// ── Summary header line ──────────────────────────────────────────
 		if r.Passed {
-			sb.WriteString(fmt.Sprintf("✓ %-20s passed\n", r.Agent.Name))
+			header.WriteString(fmt.Sprintf("✓ %-20s passed\n", r.Agent.Name))
 		} else {
 			allPassed = false
 			failed = append(failed, r.Agent.Name)
 			if r.IsError {
-				sb.WriteString(fmt.Sprintf("✗ %-20s %s\n", r.Agent.Name, r.Output))
+				header.WriteString(fmt.Sprintf("✗ %-20s error\n", r.Agent.Name))
 			} else {
-				// Content failure: include the output.
-				sb.WriteString(fmt.Sprintf("✗ %-20s\n", r.Agent.Name))
-				// Indent the output.
-				for _, line := range strings.Split(r.Output, "\n") {
-					sb.WriteString("  " + line + "\n")
-				}
+				header.WriteString(fmt.Sprintf("✗ %-20s failed\n", r.Agent.Name))
+			}
+		}
+
+		// ── Full per-agent findings ──────────────────────────────────────
+		findings.WriteString(fmt.Sprintf("\n### %s\n\n", r.Agent.Name))
+		if r.Passed {
+			findings.WriteString("**Verdict:** PASS\n\n")
+		} else if r.IsError {
+			findings.WriteString("**Verdict:** ERROR\n\n")
+		} else {
+			findings.WriteString("**Verdict:** FAIL\n\n")
+		}
+		if r.Output != "" {
+			findings.WriteString(r.Output)
+			if !strings.HasSuffix(r.Output, "\n") {
+				findings.WriteString("\n")
 			}
 		}
 	}
 
 	if !allPassed {
-		sb.WriteString(fmt.Sprintf("\n%d agent(s) failed. Retry: prism review %s --only %s\n",
+		header.WriteString(fmt.Sprintf("\n%d agent(s) failed. Retry: prism review %s --only %s\n",
 			len(failed), prNumber, strings.Join(failed, ",")))
 	}
 
-	return sb.String(), allPassed
+	findingsStr := findings.String()
+	headerStr := header.String()
+
+	// ── Size budget check ────────────────────────────────────────────────
+	totalSize := len(headerStr) + len(findingsStr)
+	if round > 0 && totalSize > budget {
+		// Overflow: write full findings to file and inline a pointer.
+		filePath := FindingsFilePath(prNumber, round)
+		fullContent := headerStr + "\n## Per-agent findings\n" + findingsStr
+		writeErr := os.WriteFile(filePath, []byte(fullContent), 0o644)
+
+		var result strings.Builder
+		result.WriteString(headerStr)
+		if writeErr == nil {
+			result.WriteString(fmt.Sprintf(
+				"\nFull findings: `%s` (%d KB) — read with `cat` or `rg` as needed.\n",
+				filePath, totalSize/1024,
+			))
+		} else {
+			// File write failed — inline the findings anyway rather than losing them.
+			result.WriteString("\n## Per-agent findings\n")
+			result.WriteString(findingsStr)
+		}
+		return result.String(), allPassed
+	}
+
+	// Findings fit within budget — inline them.
+	var result strings.Builder
+	result.WriteString(headerStr)
+	result.WriteString("\n## Per-agent findings\n")
+	result.WriteString(findingsStr)
+	return result.String(), allPassed
 }
 
 // LookupParentSession looks up the parent session from the environment or DB.

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -1545,10 +1545,28 @@ const DefaultFindingsSizeBudget = 20 * 1024 // 20 KB
 // default findings size budget. Set to an integer byte count (e.g. "10240").
 const FindingsSizeBudgetEnvVar = "PRISM_REVIEW_SIZE_BUDGET"
 
+// sanitisePRNumber returns a version of prNumber safe for use in a filename by
+// retaining only alphanumeric characters and hyphens. This prevents path
+// traversal when prNumber comes from user-supplied CLI input.
+func sanitisePRNumber(prNumber string) string {
+	var b strings.Builder
+	for _, r := range prNumber {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	safe := b.String()
+	if safe == "" {
+		safe = "unknown"
+	}
+	return safe
+}
+
 // FindingsFilePath returns the path where full findings are written when the
-// size budget is exceeded. prNumber and round identify the review run.
+// size budget is exceeded. prNumber is sanitised before use to prevent path
+// traversal; round identifies the review round.
 func FindingsFilePath(prNumber string, round int) string {
-	return fmt.Sprintf("/tmp/prism-review-%s-round-%d.md", prNumber, round)
+	return fmt.Sprintf("/tmp/prism-review-%s-round-%d.md", sanitisePRNumber(prNumber), round)
 }
 
 // resolveSizeBudget returns the effective size budget. sizeBudget ≤ 0 means use

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -192,7 +192,7 @@ func TestFormatResults_AllPassed(t *testing.T) {
 	results := []review.AgentResult{
 		{Agent: review.Agent{Name: "review"}, Passed: true, Output: "LGTM, no issues found."},
 	}
-	output, allPassed := review.FormatResults(results, "42")
+	output, allPassed := review.FormatResults(results, "42", 0, 0)
 	if !allPassed {
 		t.Errorf("allPassed = false, want true")
 	}
@@ -213,7 +213,7 @@ func TestFormatResults_SomeFailed(t *testing.T) {
 	results := []review.AgentResult{
 		{Agent: review.Agent{Name: "review"}, Passed: false, Output: "Please fix the above before this PR is merged.", IsError: false},
 	}
-	output, allPassed := review.FormatResults(results, "42")
+	output, allPassed := review.FormatResults(results, "42", 0, 0)
 	if allPassed {
 		t.Errorf("allPassed = true, want false")
 	}
@@ -229,7 +229,7 @@ func TestFormatResults_InfraError(t *testing.T) {
 	results := []review.AgentResult{
 		{Agent: review.Agent{Name: "review"}, Passed: false, Output: "ERROR: timed out after 10m", IsError: true},
 	}
-	output, allPassed := review.FormatResults(results, "42")
+	output, allPassed := review.FormatResults(results, "42", 0, 0)
 	if allPassed {
 		t.Errorf("allPassed = true, want false")
 	}
@@ -247,7 +247,7 @@ func TestFormatResults_PassFailResults(t *testing.T) {
 	results := []review.AgentResult{
 		{Agent: review.Agent{Name: "review"}, Passed: false, Output: "Please fix the above before this PR is merged."},
 	}
-	_, allPassed := review.FormatResults(results, "1")
+	_, allPassed := review.FormatResults(results, "1", 0, 0)
 	if allPassed {
 		t.Errorf("FormatResults with Passed=false: allPassed=true, want false")
 	}
@@ -256,7 +256,7 @@ func TestFormatResults_PassFailResults(t *testing.T) {
 	results = []review.AgentResult{
 		{Agent: review.Agent{Name: "review"}, Passed: true, Output: "<verdict>PASS</verdict>"},
 	}
-	_, allPassed = review.FormatResults(results, "1")
+	_, allPassed = review.FormatResults(results, "1", 0, 0)
 	if !allPassed {
 		t.Errorf("FormatResults with Passed=true: allPassed=false, want true")
 	}
@@ -818,7 +818,7 @@ func TestFormatResults_TwoAgentSubset(t *testing.T) {
 		{Agent: review.Agent{Name: "review-code"}, Passed: true, Output: "LGTM"},
 		{Agent: review.Agent{Name: "review-qa"}, Passed: true, Output: "All tests pass"},
 	}
-	output, allPassed := review.FormatResults(results, "42")
+	output, allPassed := review.FormatResults(results, "42", 0, 0)
 	if !allPassed {
 		t.Errorf("allPassed = false, want true")
 	}
@@ -856,7 +856,7 @@ func TestFormatResults_RetryHintNamesOnlyFailedAgents(t *testing.T) {
 		{Agent: review.Agent{Name: "review-code"}, Passed: true, Output: "LGTM"},
 		{Agent: review.Agent{Name: "review-qa"}, Passed: false, Output: "Please fix the test coverage.", IsError: false},
 	}
-	output, allPassed := review.FormatResults(results, "99")
+	output, allPassed := review.FormatResults(results, "99", 0, 0)
 	if allPassed {
 		t.Errorf("allPassed = true, want false")
 	}
@@ -886,7 +886,7 @@ func TestFormatResults_RetryHintMultipleFailed(t *testing.T) {
 		{Agent: review.Agent{Name: "review-qa"}, Passed: true, Output: "All tests pass"},
 		{Agent: review.Agent{Name: "review-context"}, Passed: true, Output: "Context OK"},
 	}
-	output, allPassed := review.FormatResults(results, "55")
+	output, allPassed := review.FormatResults(results, "55", 0, 0)
 	if allPassed {
 		t.Errorf("allPassed = true, want false")
 	}
@@ -926,7 +926,7 @@ func TestFormatResults_ExactlyNResultLines(t *testing.T) {
 					Output: "LGTM",
 				})
 			}
-			output, allPassed := review.FormatResults(results, "1")
+			output, allPassed := review.FormatResults(results, "1", 0, 0)
 			if !allPassed {
 				t.Errorf("allPassed = false, want true")
 			}
@@ -936,6 +936,235 @@ func TestFormatResults_ExactlyNResultLines(t *testing.T) {
 					tc.n, got, tc.n, output)
 			}
 		})
+	}
+}
+
+// ── FormatResults: full findings ─────────────────────────────────────────────
+
+// TestFormatResults_FullFindingsIncluded verifies that FormatResults includes
+// the full per-agent findings (verdict, full output text) below the summary
+// header, not just the one-line summary.
+func TestFormatResults_FullFindingsIncluded(t *testing.T) {
+	longOutput := "This is the full reviewer output.\n" +
+		"It includes blocking issues, non-blocking observations,\n" +
+		"and a structured analysis of each acceptance criterion.\n" +
+		"<verdict>PASS</verdict>"
+	results := []review.AgentResult{
+		{
+			Agent:  review.Agent{Name: "review-goal"},
+			Passed: true,
+			Output: longOutput,
+		},
+	}
+	output, allPassed := review.FormatResults(results, "123", 0, 0)
+	if !allPassed {
+		t.Errorf("allPassed = false, want true")
+	}
+	// Summary header must still be present.
+	if !findSubstring(output, "✓") {
+		t.Errorf("output missing ✓ summary header: %q", output)
+	}
+	if !findSubstring(output, "review-goal") {
+		t.Errorf("output missing agent name in summary: %q", output)
+	}
+	// Full output text must appear in the findings section.
+	if !findSubstring(output, "full reviewer output") {
+		t.Errorf("output missing full reviewer text: %q", output)
+	}
+	if !findSubstring(output, "non-blocking observations") {
+		t.Errorf("output missing non-blocking observations: %q", output)
+	}
+	// Findings section header must be present.
+	if !findSubstring(output, "Per-agent findings") {
+		t.Errorf("output missing 'Per-agent findings' section: %q", output)
+	}
+}
+
+// TestFormatResults_FullFindingsOnFail verifies that full findings are included
+// for FAIL results including blocking issues in the output.
+func TestFormatResults_FullFindingsOnFail(t *testing.T) {
+	failOutput := "<blocking_issues>\n- Missing error handling in foo()\n</blocking_issues>\n\n" +
+		"Non-blocking: consider renaming bar to baz for clarity.\n" +
+		"<verdict>FAIL</verdict>"
+	results := []review.AgentResult{
+		{
+			Agent:   review.Agent{Name: "review-code"},
+			Passed:  false,
+			Output:  failOutput,
+			IsError: false,
+		},
+	}
+	output, allPassed := review.FormatResults(results, "456", 0, 0)
+	if allPassed {
+		t.Errorf("allPassed = true, want false")
+	}
+	// Blocking issues must be surfaced.
+	if !findSubstring(output, "blocking_issues") {
+		t.Errorf("output missing blocking issues: %q", output)
+	}
+	// Non-blocking observations must also appear.
+	if !findSubstring(output, "Non-blocking") {
+		t.Errorf("output missing non-blocking observations: %q", output)
+	}
+	// FAIL verdict section must be present.
+	if !findSubstring(output, "FAIL") {
+		t.Errorf("output missing FAIL verdict in findings: %q", output)
+	}
+}
+
+// TestFormatResults_OverflowToFile verifies that when total findings exceed the
+// size budget, the full findings are written to a file and a file pointer is
+// returned inline instead.
+func TestFormatResults_OverflowToFile(t *testing.T) {
+	// Build a result with very large output that will exceed a tiny budget.
+	largeOutput := strings.Repeat("x", 500) + "\n<verdict>PASS</verdict>"
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-goal"}, Passed: true, Output: largeOutput},
+		{Agent: review.Agent{Name: "review-code"}, Passed: true, Output: largeOutput},
+	}
+
+	// Use a small budget (100 bytes) and a non-zero round so overflow fires.
+	prNumber := "overflow-test-001"
+	round := 7
+	budget := 100 // tiny budget to force overflow
+
+	// Clean up the expected file before and after.
+	expectedPath := review.FindingsFilePath(prNumber, round)
+	_ = os.Remove(expectedPath)
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	output, allPassed := review.FormatResults(results, prNumber, round, budget)
+	if !allPassed {
+		t.Errorf("allPassed = false, want true")
+	}
+
+	// Inline output must contain a file pointer.
+	if !findSubstring(output, expectedPath) {
+		t.Errorf("inline output missing file pointer %q: %q", expectedPath, output)
+	}
+	// Inline output must still contain the summary header.
+	if !findSubstring(output, "✓") {
+		t.Errorf("inline output missing summary header ✓: %q", output)
+	}
+	// Full findings must NOT be inlined (they went to the file).
+	// The large 'x' block should be in the file, not in inline output.
+	if findSubstring(output, strings.Repeat("x", 100)) {
+		t.Errorf("inline output should not contain large findings when overflowing to file: %q", output[:200])
+	}
+
+	// The file must exist and contain the full findings.
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("overflow file not written at %q: %v", expectedPath, err)
+	}
+	fileContent := string(data)
+	if !findSubstring(fileContent, strings.Repeat("x", 100)) {
+		t.Errorf("overflow file missing full findings: (first 200 bytes) %q", fileContent[:min(200, len(fileContent))])
+	}
+}
+
+// TestFormatResults_NoOverflowWithinBudget verifies that when total findings
+// are within the budget, findings are inlined and no file is written.
+func TestFormatResults_NoOverflowWithinBudget(t *testing.T) {
+	output := "Short output.\n<verdict>PASS</verdict>"
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-goal"}, Passed: true, Output: output},
+	}
+
+	prNumber := "no-overflow-test-002"
+	round := 1
+	budget := 1024 * 1024 // 1 MB — way above the short output
+
+	// Clean up any leftover file.
+	expectedPath := review.FindingsFilePath(prNumber, round)
+	_ = os.Remove(expectedPath)
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	formatted, allPassed := review.FormatResults(results, prNumber, round, budget)
+	if !allPassed {
+		t.Errorf("allPassed = false, want true")
+	}
+
+	// Full findings must be inlined.
+	if !findSubstring(formatted, "Short output") {
+		t.Errorf("findings not inlined within budget: %q", formatted)
+	}
+	// No file pointer should appear.
+	if findSubstring(formatted, expectedPath) {
+		t.Errorf("unexpected file pointer in inline output: %q", formatted)
+	}
+	// File must not be written.
+	if _, err := os.Stat(expectedPath); err == nil {
+		t.Errorf("overflow file was written when findings fit within budget: %s", expectedPath)
+	}
+}
+
+// TestFormatResults_OverflowThresholdEnvVar verifies that the overflow
+// threshold can be overridden via the PRISM_REVIEW_SIZE_BUDGET environment
+// variable without a rebuild.
+func TestFormatResults_OverflowThresholdEnvVar(t *testing.T) {
+	// Set env var to a very small budget.
+	t.Setenv(review.FindingsSizeBudgetEnvVar, "50")
+
+	largeOutput := strings.Repeat("y", 200) + "\n<verdict>PASS</verdict>"
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-security"}, Passed: true, Output: largeOutput},
+	}
+
+	prNumber := "envvar-test-003"
+	round := 2
+
+	expectedPath := review.FindingsFilePath(prNumber, round)
+	_ = os.Remove(expectedPath)
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	// sizeBudget=0 → uses env var (50 bytes).
+	output, allPassed := review.FormatResults(results, prNumber, round, 0)
+	if !allPassed {
+		t.Errorf("allPassed = false, want true")
+	}
+
+	// With budget=50, the large output must overflow to file.
+	if !findSubstring(output, expectedPath) {
+		t.Errorf("expected file pointer in output when env var budget=50: %q", output)
+	}
+
+	// File must exist.
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("overflow file not written when budget=50 via env var: %v", err)
+	}
+}
+
+// TestFormatResults_FilePointerFormat verifies the file pointer format matches
+// the documented shape: "Full findings: `<path>` (N KB) — read with `cat` or
+// `rg` as needed."
+func TestFormatResults_FilePointerFormat(t *testing.T) {
+	// Force overflow with a tiny budget.
+	largeOutput := strings.Repeat("z", 300) + "\n<verdict>PASS</verdict>"
+	results := []review.AgentResult{
+		{Agent: review.Agent{Name: "review-context"}, Passed: true, Output: largeOutput},
+	}
+	prNumber := "pointer-format-004"
+	round := 3
+
+	expectedPath := review.FindingsFilePath(prNumber, round)
+	_ = os.Remove(expectedPath)
+	t.Cleanup(func() { _ = os.Remove(expectedPath) })
+
+	output, _ := review.FormatResults(results, prNumber, round, 10 /* tiny budget */)
+
+	// The pointer line must match the documented format.
+	if !findSubstring(output, "Full findings:") {
+		t.Errorf("missing 'Full findings:' prefix in pointer line: %q", output)
+	}
+	if !findSubstring(output, expectedPath) {
+		t.Errorf("missing file path in pointer line: %q", output)
+	}
+	if !findSubstring(output, "KB") {
+		t.Errorf("missing KB size in pointer line: %q", output)
+	}
+	if !findSubstring(output, "cat") {
+		t.Errorf("missing 'cat' usage hint in pointer line: %q", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `FormatResults` now includes full per-agent findings (verdict + complete output including blocking issues and non-blocking observations) below the one-line summary header, so workers see everything reviewers produced.
- When total findings exceed a configurable budget (default 20 KB), full findings are written to `/tmp/prism-review-<pr>-round-<N>.md` and a file pointer with size hint is included inline instead.
- Budget is configurable via `--size-budget` flag or `PRISM_REVIEW_SIZE_BUDGET` env var without a rebuild.
- `worker.md` updated with explicit On FAIL / On PASS guidance including the "prefer actioning observations that align with repo conventions" direction from the issue.
- `opencode.nix` container-mode worker instructions updated to match.
- Tests added covering: full findings in output, overflow-to-file threshold, file pointer format, env-var override, no-overflow happy path.

Closes #854