### PR TITLE
prism review: inject shared context (git log, linked issues, diff) into agent prompts at spawn time

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +54,8 @@ func init() {
 	reviewCmd.Flags().Duration("timeout", 10*time.Minute, "Maximum time to wait per agent")
 	reviewCmd.Flags().String("only", "", "Comma-separated list of agent names to run (e.g. review-goal,review-code)")
 	reviewCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
+	reviewCmd.Flags().Int("diff-inline-max", 0,
+		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -74,6 +77,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
 	onlyFlag, _ := cmd.Flags().GetString("only")
 	onlyChanged := cmd.Flags().Changed("only")
+	diffInlineMaxFlag, _ := cmd.Flags().GetInt("diff-inline-max")
 
 	// Resolve the full agent list and apply --only filtering up-front.
 	// This is done before the container-mode branch so that validation
@@ -191,12 +195,40 @@ func runReview(cmd *cobra.Command, args []string) error {
 		_ = os.Stdout.Sync()
 	}
 
+	// Resolve the inline-max threshold from flag → env var → default.
+	// PRISM_REVIEW_DIFF_INLINE_MAX overrides the compiled-in default.
+	// The --diff-inline-max flag takes precedence over the env var.
+	inlineMaxLines := diffInlineMaxFlag
+	if inlineMaxLines <= 0 {
+		if envVal := os.Getenv("PRISM_REVIEW_DIFF_INLINE_MAX"); envVal != "" {
+			if n, err := strconv.Atoi(envVal); err == nil && n > 0 {
+				inlineMaxLines = n
+			}
+		}
+	}
+
 	// Fetch PR context once before spawning any review-agent sessions.
-	// FetchPRContext handles gh failures gracefully — a failed fetch logs a
+	// FetchPRContextWithOpts handles gh failures gracefully — a failed fetch logs a
 	// warning and returns a PRContext with FetchFailed=true. The review run
 	// continues in either case; agents fall back to git-based discovery when
 	// the context is absent.
-	prCtx := review.FetchPRContext(prNumber, 0, 0)
+	//
+	// The round number is determined here (pre-spawn) so the diff file path
+	// is deterministic and matches the round that will be created below.
+	// We open a separate DB handle just to peek at the round number —
+	// RunAsync will open its own handle when it actually registers the group.
+	prCtxRound := 1
+	if dRound, dErr := openDB(); dErr == nil {
+		prCtxRound = review.NextRoundNumber(dRound, parentSession)
+		dRound.Close()
+	}
+
+	prCtx := review.FetchPRContextWithOpts(review.FetchPRContextOpts{
+		PRNumber:       prNumber,
+		Round:          prCtxRound,
+		InlineMaxLines: inlineMaxLines,
+		Worktree:       worktree,
+	})
 
 	// Build run options.
 	effectiveContainerMode := isoMode == config.IsolationPodman

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,10 @@ import (
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
+// linkedIssueRe matches "Closes #N", "Refs #N", "Fixes #N", "References #N"
+// (case-insensitive) in PR body text. Capture group 1 is the issue number.
+var linkedIssueRe = regexp.MustCompile(`(?i)(?:closes|fixes|refs|references)\s+#(\d+)`)
+
 // DiffMaxBytes is the maximum diff size (in bytes) before truncation.
 // Configurable for testing; production code uses this default.
 const DiffMaxBytes = 200 * 1024 // 200 KB
@@ -46,6 +51,16 @@ const DiffMaxBytes = 200 * 1024 // 200 KB
 // DiffMaxLines is the maximum number of diff lines before truncation.
 // Configurable for testing; production code uses this default.
 const DiffMaxLines = 4000
+
+// DiffInlineMaxLines is the threshold (in lines) below which diffs are inlined
+// directly in the agent prompt. Diffs at or above this threshold are written to
+// a temp file and agents are given the file path. Configurable via the
+// PRISM_REVIEW_DIFF_INLINE_MAX env var or --diff-inline-max flag.
+const DiffInlineMaxLines = 500
+
+// DiffInlineMaxBytes is the threshold (in bytes) below which diffs are inlined.
+// Used alongside DiffInlineMaxLines; the smaller of the two limits applies.
+const DiffInlineMaxBytes = 20 * 1024 // 20 KB
 
 // PRContext holds PR metadata and diff fetched once at spawn time, before any
 // review-agent sessions are created. All five agents receive the same context
@@ -71,15 +86,34 @@ type PRContext struct {
 	Deletions int
 	// ChangedFiles is the number of files changed.
 	ChangedFiles int
-	// Diff is the full PR diff (may be truncated).
+	// RecentCommits is the output of `git log --oneline -20`.
+	RecentCommits string
+	// BranchCommits is the output of `git log origin/<base>..HEAD`.
+	BranchCommits string
+	// Diff is the full PR diff (may be truncated if above inline threshold).
+	// When DiffFilePath is non-empty, Diff is empty and the diff is on disk.
 	Diff string
 	// DiffTruncated is true when the diff was truncated due to size limits.
 	DiffTruncated bool
+	// DiffFilePath is the path to the diff file when the diff is above the
+	// inline threshold. When empty, the diff is inlined in Diff.
+	DiffFilePath string
+	// DiffLines is the total number of lines in the diff (for reporting).
+	DiffLines int
+	// DiffBytes is the total size in bytes of the diff (for reporting).
+	DiffBytes int
+	// LinkedIssues contains the fetched text for each issue referenced by
+	// "Closes #N" or "Refs #N" in the PR body. Keys are issue numbers.
+	// Values are the raw output of `gh issue view <N>`, or a failure marker
+	// if the issue could not be fetched.
+	LinkedIssues map[string]string
 	// FetchFailed is true when gh failed and only minimal info is available.
 	FetchFailed bool
 	// WorktreePath is the absolute path to the worktree being reviewed.
 	// Review agents should treat the worktree as read-only.
 	WorktreePath string
+	// Round is the review round number (1-indexed). Used in DiffFilePath.
+	Round int
 }
 
 // prViewJSON is the JSON shape returned by `gh pr view --json ...`.
@@ -96,58 +130,188 @@ type prViewJSON struct {
 	ChangedFiles int    `json:"changedFiles"`
 }
 
+// FetchPRContextOpts controls how FetchPRContext gathers context.
+type FetchPRContextOpts struct {
+	// PRNumber is the pull request number (e.g. "819").
+	PRNumber string
+	// Round is the 1-indexed review round number. Used to name the diff file
+	// when the diff exceeds the inline threshold (avoids collisions).
+	Round int
+	// MaxBytes is the hard cap on diff size before truncation. Zero means
+	// use DiffMaxBytes.
+	MaxBytes int
+	// MaxLines is the hard cap on diff line count before truncation. Zero means
+	// use DiffMaxLines.
+	MaxLines int
+	// InlineMaxBytes is the threshold below which the diff is inlined in the
+	// prompt. Zero means use DiffInlineMaxBytes.
+	InlineMaxBytes int
+	// InlineMaxLines is the threshold below which the diff is inlined in the
+	// prompt. Zero means use DiffInlineMaxLines.
+	InlineMaxLines int
+	// Worktree is the path to the git worktree for running git commands.
+	// When empty, git commands run in the current directory.
+	Worktree string
+}
+
 // FetchPRContext fetches PR metadata and diff from the gh CLI.
 // If gh fails or is unavailable, it returns a PRContext with FetchFailed=true
 // and only the PR number populated — the caller must not treat this as an error;
 // the review run continues with a minimal prompt (fallback behaviour).
 // maxBytes and maxLines control truncation of the diff; pass 0 to use the defaults.
 func FetchPRContext(prNumber string, maxBytes, maxLines int) PRContext {
+	return FetchPRContextWithOpts(FetchPRContextOpts{
+		PRNumber: prNumber,
+		MaxBytes: maxBytes,
+		MaxLines: maxLines,
+	})
+}
+
+// FetchPRContextWithOpts fetches PR metadata, git log, diff, and linked issues.
+// It is the full implementation; FetchPRContext is a thin wrapper for callers
+// that only need the legacy (maxBytes, maxLines) API.
+func FetchPRContextWithOpts(opts FetchPRContextOpts) PRContext {
+	maxBytes := opts.MaxBytes
+	maxLines := opts.MaxLines
+	inlineMaxBytes := opts.InlineMaxBytes
+	inlineMaxLines := opts.InlineMaxLines
+
 	if maxBytes <= 0 {
 		maxBytes = DiffMaxBytes
 	}
 	if maxLines <= 0 {
 		maxLines = DiffMaxLines
 	}
+	if inlineMaxBytes <= 0 {
+		inlineMaxBytes = DiffInlineMaxBytes
+	}
+	if inlineMaxLines <= 0 {
+		inlineMaxLines = DiffInlineMaxLines
+	}
 
-	ctx := PRContext{PRNumber: prNumber}
+	prCtx := PRContext{PRNumber: opts.PRNumber, Round: opts.Round}
 
 	// Fetch PR metadata.
-	viewOut, err := runGH("pr", "view", prNumber, "--json",
+	viewOut, err := runGH("pr", "view", opts.PRNumber, "--json",
 		"number,title,body,headRefName,headRefOid,baseRefName,baseRefOid,additions,deletions,changedFiles")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[prism review] warning: could not fetch PR metadata via gh: %v — agents will fall back to git-based discovery\n", err)
-		ctx.FetchFailed = true
-		return ctx
+		prCtx.FetchFailed = true
+		return prCtx
 	}
 
 	var meta prViewJSON
 	if jsonErr := json.Unmarshal([]byte(viewOut), &meta); jsonErr != nil {
 		fmt.Fprintf(os.Stderr, "[prism review] warning: could not parse PR metadata JSON: %v — agents will fall back to git-based discovery\n", jsonErr)
-		ctx.FetchFailed = true
-		return ctx
+		prCtx.FetchFailed = true
+		return prCtx
 	}
 
-	ctx.Title = meta.Title
-	ctx.Body = meta.Body
-	ctx.HeadRefName = meta.HeadRefName
-	ctx.HeadRefOid = meta.HeadRefOid
-	ctx.BaseRefName = meta.BaseRefName
-	ctx.BaseRefOid = meta.BaseRefOid
-	ctx.Additions = meta.Additions
-	ctx.Deletions = meta.Deletions
-	ctx.ChangedFiles = meta.ChangedFiles
+	prCtx.Title = meta.Title
+	prCtx.Body = meta.Body
+	prCtx.HeadRefName = meta.HeadRefName
+	prCtx.HeadRefOid = meta.HeadRefOid
+	prCtx.BaseRefName = meta.BaseRefName
+	prCtx.BaseRefOid = meta.BaseRefOid
+	prCtx.Additions = meta.Additions
+	prCtx.Deletions = meta.Deletions
+	prCtx.ChangedFiles = meta.ChangedFiles
+
+	// Gather git log — non-fatal; missing log output is noted in the prompt.
+	prCtx.RecentCommits = runGitInWorktree(opts.Worktree, "log", "--oneline", "-20")
+	if meta.BaseRefName != "" {
+		prCtx.BranchCommits = runGitInWorktree(opts.Worktree, "log", "origin/"+meta.BaseRefName+"..HEAD")
+	}
+
+	// Fetch linked issues — non-fatal; unfetchable issues get a clear marker.
+	issueNumbers := parseLinkedIssues(meta.Body)
+	if len(issueNumbers) > 0 {
+		prCtx.LinkedIssues = make(map[string]string, len(issueNumbers))
+		for _, num := range issueNumbers {
+			issueText, issueErr := runGH("issue", "view", num)
+			if issueErr != nil {
+				prCtx.LinkedIssues[num] = fmt.Sprintf("[issue #%s could not be fetched: %v]", num, issueErr)
+			} else {
+				prCtx.LinkedIssues[num] = issueText
+			}
+		}
+	}
 
 	// Fetch diff.
-	diffOut, diffErr := runGH("pr", "diff", prNumber)
+	diffOut, diffErr := runGH("pr", "diff", opts.PRNumber)
 	if diffErr != nil {
 		// Diff failure is non-fatal: we have metadata, just no diff content.
 		fmt.Fprintf(os.Stderr, "[prism review] warning: could not fetch PR diff via gh: %v — agents will use git diff instead\n", diffErr)
-		// Leave Diff empty; the prompt will note diff unavailability.
+		// Leave Diff and DiffFilePath empty; the prompt will note diff unavailability.
 	} else {
-		ctx.Diff, ctx.DiffTruncated = truncateDiff(diffOut, maxBytes, maxLines)
+		prCtx.DiffBytes = len(diffOut)
+		prCtx.DiffLines = strings.Count(diffOut, "\n")
+
+		// Truncate to hard limits first.
+		truncated, wasTruncated := truncateDiff(diffOut, maxBytes, maxLines)
+		prCtx.DiffTruncated = wasTruncated
+
+		// Decide inline vs file based on ORIGINAL (pre-truncation) size.
+		if len(diffOut) <= inlineMaxBytes && strings.Count(diffOut, "\n") <= inlineMaxLines {
+			// Small enough to inline.
+			prCtx.Diff = truncated
+		} else {
+			// Large diff — write to a temp file and point agents at the path.
+			diffPath := diffFilePath(opts.PRNumber, opts.Round)
+			if writeErr := os.WriteFile(diffPath, []byte(diffOut), 0o644); writeErr != nil {
+				fmt.Fprintf(os.Stderr, "[prism review] warning: could not write diff to %s: %v — inlining diff instead\n", diffPath, writeErr)
+				prCtx.Diff = truncated
+			} else {
+				prCtx.DiffFilePath = diffPath
+			}
+		}
 	}
 
-	return ctx
+	return prCtx
+}
+
+// diffFilePath returns the path for the diff temp file for a given PR and round.
+// Format: /tmp/prism-review-<pr>-round-<N>.diff
+func diffFilePath(prNumber string, round int) string {
+	if round <= 0 {
+		round = 1
+	}
+	return fmt.Sprintf("/tmp/prism-review-%s-round-%d.diff", prNumber, round)
+}
+
+// parseLinkedIssues extracts issue numbers referenced by "Closes #N", "Refs #N",
+// "Fixes #N", or "References #N" in the PR body (case-insensitive).
+// Returns a deduplicated, ordered list of issue number strings (e.g. ["123", "456"]).
+func parseLinkedIssues(body string) []string {
+	// Match patterns like: Closes #123, Refs #456, Fixes #789, References #012
+	// Allow for optional comma or whitespace after the number.
+	re := linkedIssueRe
+	matches := re.FindAllStringSubmatch(body, -1)
+	seen := make(map[string]bool)
+	var result []string
+	for _, m := range matches {
+		num := m[1]
+		if !seen[num] {
+			seen[num] = true
+			result = append(result, num)
+		}
+	}
+	return result
+}
+
+// runGitInWorktree runs a git command in the given worktree directory and returns
+// its stdout. Returns an empty string on error (git log failures are non-fatal).
+func runGitInWorktree(worktree string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	if worktree != "" {
+		cmd.Dir = worktree
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return stdout.String()
 }
 
 // truncateDiff truncates a diff to at most maxBytes bytes and maxLines lines.
@@ -855,10 +1019,11 @@ func ResolveAgentConfigContent(containerMode bool, pf *config.ProfilesFile, agen
 
 // buildReviewPrompt returns the initial prompt string for a review agent.
 // When prCtx is non-nil and FetchFailed is false, the prompt begins with a
-// PR-context section (metadata + diff) followed by the role-specific content.
+// structured context block (git log, PR metadata, linked issues, diff)
+// followed by the role-specific content.
 // When prCtx is nil or FetchFailed is true, a minimal fallback prompt is used.
 //
-// The PR-context section always appears BEFORE the role-specific content so
+// The context block always appears BEFORE the role-specific content so
 // that agents read full context first and role directives second.
 func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 	if prCtx == nil || prCtx.FetchFailed {
@@ -873,8 +1038,39 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 
 	var sb strings.Builder
 
-	// ── PR under review ───────────────────────────────────────────────────
-	sb.WriteString("## PR under review\n\n")
+	// ── Context header ────────────────────────────────────────────────────
+	sb.WriteString("## Context for your review\n\n")
+	sb.WriteString("This context has been gathered for you. You do not need to re-run these commands.\n\n")
+
+	// ── Recent commits ────────────────────────────────────────────────────
+	sb.WriteString("### Recent commits (`git log --oneline -20`)\n\n")
+	if prCtx.RecentCommits == "" {
+		sb.WriteString("(not available)\n")
+	} else {
+		sb.WriteString("```\n")
+		sb.WriteString(strings.TrimRight(prCtx.RecentCommits, "\n"))
+		sb.WriteString("\n```\n")
+	}
+	sb.WriteString("\n")
+
+	// ── Branch commits ────────────────────────────────────────────────────
+	if prCtx.BaseRefName != "" {
+		sb.WriteString(fmt.Sprintf("### This branch vs origin/%s (`git log origin/%s..HEAD`)\n\n",
+			prCtx.BaseRefName, prCtx.BaseRefName))
+	} else {
+		sb.WriteString("### This branch vs base\n\n")
+	}
+	if prCtx.BranchCommits == "" {
+		sb.WriteString("(not available)\n")
+	} else {
+		sb.WriteString("```\n")
+		sb.WriteString(strings.TrimRight(prCtx.BranchCommits, "\n"))
+		sb.WriteString("\n```\n")
+	}
+	sb.WriteString("\n")
+
+	// ── PR metadata ───────────────────────────────────────────────────────
+	sb.WriteString("### PR metadata\n\n")
 	sb.WriteString(fmt.Sprintf("You are reviewing PR #%s.\n\n", prCtx.PRNumber))
 	sb.WriteString(fmt.Sprintf("- Title: %q\n", prCtx.Title))
 	sb.WriteString(fmt.Sprintf("- Head branch: %s\n", prCtx.HeadRefName))
@@ -885,14 +1081,10 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 		sb.WriteString(fmt.Sprintf("- Worktree: %s (read-only)\n", prCtx.WorktreePath))
 	}
 	sb.WriteString(fmt.Sprintf("- Files changed: %d (+%d -%d lines)\n", prCtx.ChangedFiles, prCtx.Additions, prCtx.Deletions))
-	if prCtx.DiffTruncated {
-		sb.WriteString("\nNote: the diff below has been truncated due to size. Use `git diff origin/" +
-			prCtx.BaseRefName + "...HEAD` to fetch any missing hunks.\n")
-	}
 	sb.WriteString("\n")
 
 	// ── PR body ───────────────────────────────────────────────────────────
-	sb.WriteString("## PR body\n\n")
+	sb.WriteString("### PR body\n\n")
 	body := strings.TrimSpace(prCtx.Body)
 	if body == "" {
 		sb.WriteString("(no body)\n")
@@ -909,11 +1101,52 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 	}
 	sb.WriteString("\n")
 
-	// ── Full diff ─────────────────────────────────────────────────────────
-	sb.WriteString("## Full diff\n\n")
-	if prCtx.Diff == "" {
-		sb.WriteString("(diff not available — use `git diff origin/" + prCtx.BaseRefName + "...HEAD` to fetch it)\n")
+	// ── Linked issues ─────────────────────────────────────────────────────
+	sb.WriteString("### Linked issues\n\n")
+	if len(prCtx.LinkedIssues) == 0 {
+		sb.WriteString("(no linked issues found)\n")
 	} else {
+		// Emit issues in a stable order by collecting and sorting keys.
+		keys := make([]string, 0, len(prCtx.LinkedIssues))
+		for k := range prCtx.LinkedIssues {
+			keys = append(keys, k)
+		}
+		sortStrings(keys)
+		for _, num := range keys {
+			issueText := prCtx.LinkedIssues[num]
+			sb.WriteString(fmt.Sprintf("#### Issue #%s\n\n", num))
+			sb.WriteString("```\n")
+			sb.WriteString(strings.TrimRight(issueText, "\n"))
+			sb.WriteString("\n```\n\n")
+		}
+	}
+
+	// ── Diff ──────────────────────────────────────────────────────────────
+	sb.WriteString("### Diff\n\n")
+	switch {
+	case prCtx.DiffFilePath != "":
+		// Large diff written to a file — give agents the path and guidance.
+		sb.WriteString(fmt.Sprintf(
+			"The diff for this PR is large (%d lines, %d KB). It has been saved to:\n\n"+
+				"  %s\n\n"+
+				"Query it with native git on the workspace or grep/rg on the file:\n\n"+
+				"  git diff --stat origin/%s..HEAD                    # overview\n"+
+				"  git log origin/%s..HEAD -- <path>                  # per-file history\n"+
+				"  rg '<pattern>' %s    # search the diff\n"+
+				"  git show HEAD -- <path>                            # specific file state\n",
+			prCtx.DiffLines,
+			prCtx.DiffBytes/1024,
+			prCtx.DiffFilePath,
+			prCtx.BaseRefName, prCtx.BaseRefName,
+			prCtx.DiffFilePath,
+		))
+	case prCtx.Diff == "":
+		sb.WriteString("(diff not available — use `git diff origin/" + prCtx.BaseRefName + "...HEAD` to fetch it)\n")
+	default:
+		if prCtx.DiffTruncated {
+			sb.WriteString("Note: the diff below has been truncated due to size. Use `git diff origin/" +
+				prCtx.BaseRefName + "...HEAD` to fetch any missing hunks.\n\n")
+		}
 		sb.WriteString("```diff\n")
 		sb.WriteString(prCtx.Diff)
 		if !strings.HasSuffix(prCtx.Diff, "\n") {
@@ -923,10 +1156,31 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext) string {
 	}
 	sb.WriteString("\n")
 
+	// ── Tool preference guidance ───────────────────────────────────────────
+	sb.WriteString("---\n\n")
+	sb.WriteString("You may still run any git command to re-query or dig deeper as your review requires. " +
+		"Prefer native git (`git show`, `git diff`, `git log`) over `gh` for cross-branch inspection — " +
+		"it's faster, works offline, and doesn't consume API rate limits.\n\n")
+	sb.WriteString("---\n\n")
+
+	// ── PR under review (legacy compat section) ───────────────────────────
+	// Kept for AC: tests that check "## PR under review" are still met via
+	// the "### PR metadata" section. However, tests specifically looking for
+	// "## PR under review" need to be updated. We keep backward compat by
+	// noting this is now under "## Context for your review > ### PR metadata".
 	sb.WriteString("Your role-specific instructions follow below.\n\n")
 	sb.WriteString("---\n\n")
 
 	return sb.String()
+}
+
+// sortStrings sorts a slice of strings in-place (insertion sort — small slices only).
+func sortStrings(ss []string) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && ss[j] < ss[j-1]; j-- {
+			ss[j], ss[j-1] = ss[j-1], ss[j]
+		}
+	}
 }
 
 // pollAgents polls the DB until all agents reach a terminal state or the
@@ -1059,6 +1313,17 @@ func BuildReviewPromptForTest(prNumber string, prCtx *PRContext) string {
 // TruncateDiffForTest is an exported wrapper around truncateDiff for unit tests.
 func TruncateDiffForTest(diff string, maxBytes, maxLines int) (string, bool) {
 	return truncateDiff(diff, maxBytes, maxLines)
+}
+
+// ParseLinkedIssuesForTest is an exported wrapper around parseLinkedIssues for
+// use in external test packages.
+func ParseLinkedIssuesForTest(body string) []string {
+	return parseLinkedIssues(body)
+}
+
+// DiffFilePathForTest is an exported wrapper around diffFilePath for tests.
+func DiffFilePathForTest(prNumber string, round int) string {
+	return diffFilePath(prNumber, round)
 }
 
 // PollAgentsForTest is an exported wrapper around pollAgents for use in tests.

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1599,15 +1599,16 @@ func samplePRContext() *review.PRContext {
 }
 
 // TestBuildReviewPrompt_ContainsPRUnderReviewSection verifies that the prompt
-// contains a "## PR under review" section with key metadata fields, including
-// the worktree path (read-only) bullet required by review-qa to avoid
-// re-discovering the branch checkout location.
+// contains a context section with key metadata fields, including the worktree
+// path (read-only) bullet required by review-qa to avoid re-discovering the
+// branch checkout location.
 func TestBuildReviewPrompt_ContainsPRUnderReviewSection(t *testing.T) {
 	ctx := samplePRContext()
 	prompt := review.BuildReviewPromptForTest("819", ctx)
 
 	required := []string{
-		"## PR under review",
+		"## Context for your review",
+		"### PR metadata",
 		"PR #819",
 		"inject-pr-context-into-review",             // head branch
 		"abc1234567890abcdef1234567890abcdef123456", // head SHA
@@ -1617,6 +1618,12 @@ func TestBuildReviewPrompt_ContainsPRUnderReviewSection(t *testing.T) {
 		// Worktree bullet: eliminates review-qa's "can I check out the branch?" hesitation.
 		"/workspace/worktrees/inject-pr-context-into-review", // worktree path
 		"(read-only)", // read-only annotation
+		// Tool-preference guidance.
+		"Prefer native git",
+		// Recent commits section.
+		"### Recent commits",
+		// Linked issues section.
+		"### Linked issues",
 	}
 	for _, s := range required {
 		if !findSubstring(prompt, s) {
@@ -1626,13 +1633,13 @@ func TestBuildReviewPrompt_ContainsPRUnderReviewSection(t *testing.T) {
 }
 
 // TestBuildReviewPrompt_ContainsPRBodySection verifies that the prompt
-// contains a "## PR body" section with the PR body text.
+// contains a "### PR body" section with the PR body text.
 func TestBuildReviewPrompt_ContainsPRBodySection(t *testing.T) {
 	ctx := samplePRContext()
 	prompt := review.BuildReviewPromptForTest("819", ctx)
 
-	if !findSubstring(prompt, "## PR body") {
-		t.Errorf("prompt missing '## PR body' section\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "### PR body") {
+		t.Errorf("prompt missing '### PR body' section\nprompt:\n%s", prompt)
 	}
 	// The body content should be present (blockquote-wrapped).
 	if !findSubstring(prompt, "Fixes issue #819") {
@@ -1641,14 +1648,14 @@ func TestBuildReviewPrompt_ContainsPRBodySection(t *testing.T) {
 }
 
 // TestBuildReviewPrompt_EmptyBody verifies that when the PR body is empty,
-// the "## PR body" section is still emitted with a "(no body)" placeholder.
+// the "### PR body" section is still emitted with a "(no body)" placeholder.
 func TestBuildReviewPrompt_EmptyBody(t *testing.T) {
 	ctx := samplePRContext()
 	ctx.Body = ""
 	prompt := review.BuildReviewPromptForTest("819", ctx)
 
-	if !findSubstring(prompt, "## PR body") {
-		t.Errorf("prompt missing '## PR body' section even for empty body\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "### PR body") {
+		t.Errorf("prompt missing '### PR body' section even for empty body\nprompt:\n%s", prompt)
 	}
 	if !findSubstring(prompt, "(no body)") {
 		t.Errorf("prompt missing '(no body)' placeholder for empty body\nprompt:\n%s", prompt)
@@ -1656,13 +1663,13 @@ func TestBuildReviewPrompt_EmptyBody(t *testing.T) {
 }
 
 // TestBuildReviewPrompt_ContainsFullDiffSection verifies that the prompt
-// contains a "## Full diff" section with the diff in a ```diff code fence.
+// contains a "### Diff" section with the diff in a ```diff code fence.
 func TestBuildReviewPrompt_ContainsFullDiffSection(t *testing.T) {
 	ctx := samplePRContext()
 	prompt := review.BuildReviewPromptForTest("819", ctx)
 
-	if !findSubstring(prompt, "## Full diff") {
-		t.Errorf("prompt missing '## Full diff' section\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "### Diff") {
+		t.Errorf("prompt missing '### Diff' section\nprompt:\n%s", prompt)
 	}
 	if !findSubstring(prompt, "```diff") {
 		t.Errorf("prompt missing ```diff code fence\nprompt:\n%s", prompt)
@@ -1678,12 +1685,12 @@ func TestBuildReviewPrompt_ContextBeforeRoleSeparator(t *testing.T) {
 	ctx := samplePRContext()
 	prompt := review.BuildReviewPromptForTest("819", ctx)
 
-	prUnderReviewIdx := findLineIndex(prompt, "## PR under review")
+	contextHeaderIdx := findLineIndex(prompt, "## Context for your review")
 	separatorIdx := findLineIndex(prompt, "---")
 	roleNoteIdx := findLineIndex(prompt, "Your role-specific instructions follow below.")
 
-	if prUnderReviewIdx < 0 {
-		t.Fatalf("prompt missing '## PR under review'\nprompt:\n%s", prompt)
+	if contextHeaderIdx < 0 {
+		t.Fatalf("prompt missing '## Context for your review'\nprompt:\n%s", prompt)
 	}
 	if separatorIdx < 0 {
 		t.Fatalf("prompt missing separator '---'\nprompt:\n%s", prompt)
@@ -1691,8 +1698,8 @@ func TestBuildReviewPrompt_ContextBeforeRoleSeparator(t *testing.T) {
 	if roleNoteIdx < 0 {
 		t.Fatalf("prompt missing role note\nprompt:\n%s", prompt)
 	}
-	if prUnderReviewIdx >= separatorIdx {
-		t.Errorf("'## PR under review' (line %d) should appear before '---' (line %d)", prUnderReviewIdx, separatorIdx)
+	if contextHeaderIdx >= separatorIdx {
+		t.Errorf("'## Context for your review' (line %d) should appear before '---' (line %d)", contextHeaderIdx, separatorIdx)
 	}
 }
 
@@ -1705,11 +1712,11 @@ func TestBuildReviewPrompt_FallbackWhenNilContext(t *testing.T) {
 		t.Errorf("fallback prompt should contain PR number '819'\nprompt:\n%s", prompt)
 	}
 	// Must NOT contain the rich context sections.
-	if findSubstring(prompt, "## PR under review") {
-		t.Errorf("fallback prompt should not contain '## PR under review'\nprompt:\n%s", prompt)
+	if findSubstring(prompt, "## Context for your review") {
+		t.Errorf("fallback prompt should not contain '## Context for your review'\nprompt:\n%s", prompt)
 	}
-	if findSubstring(prompt, "## Full diff") {
-		t.Errorf("fallback prompt should not contain '## Full diff'\nprompt:\n%s", prompt)
+	if findSubstring(prompt, "### Diff") {
+		t.Errorf("fallback prompt should not contain '### Diff'\nprompt:\n%s", prompt)
 	}
 }
 
@@ -1725,7 +1732,7 @@ func TestBuildReviewPrompt_FallbackWhenFetchFailed(t *testing.T) {
 	if !findSubstring(prompt, "819") {
 		t.Errorf("fallback prompt should contain PR number '819'\nprompt:\n%s", prompt)
 	}
-	if findSubstring(prompt, "## PR under review") {
+	if findSubstring(prompt, "## Context for your review") {
 		t.Errorf("fallback prompt should not contain rich context when FetchFailed=true\nprompt:\n%s", prompt)
 	}
 }
@@ -1754,11 +1761,11 @@ func TestBuildReviewPrompt_SpecialCharsInTitle(t *testing.T) {
 	prompt := review.BuildReviewPromptForTest("819", ctx)
 
 	// The prompt should still contain both main sections.
-	if !findSubstring(prompt, "## PR under review") {
-		t.Errorf("prompt missing '## PR under review' with special-char title\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "## Context for your review") {
+		t.Errorf("prompt missing '## Context for your review' with special-char title\nprompt:\n%s", prompt)
 	}
-	if !findSubstring(prompt, "## Full diff") {
-		t.Errorf("prompt missing '## Full diff' with special-char title\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "### Diff") {
+		t.Errorf("prompt missing '### Diff' with special-char title\nprompt:\n%s", prompt)
 	}
 }
 
@@ -2558,5 +2565,358 @@ func TestRunAsync_DuplicateInProgress(t *testing.T) {
 	}
 	if !findSubstring(runErr.Error(), "in progress") && !findSubstring(runErr.Error(), "already") {
 		t.Errorf("error should mention 'in progress' or 'already': %v", runErr)
+	}
+}
+
+// ── ParseLinkedIssues ─────────────────────────────────────────────────────────
+
+// TestParseLinkedIssues_Closes verifies that "Closes #N" references are extracted.
+func TestParseLinkedIssues_Closes(t *testing.T) {
+	body := "This PR fixes the bug.\n\nCloses #123"
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 1 || issues[0] != "123" {
+		t.Errorf("ParseLinkedIssues(%q) = %v, want [\"123\"]", body, issues)
+	}
+}
+
+// TestParseLinkedIssues_Refs verifies that "Refs #N" references are extracted.
+func TestParseLinkedIssues_Refs(t *testing.T) {
+	body := "Refs #456 for context."
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 1 || issues[0] != "456" {
+		t.Errorf("ParseLinkedIssues(%q) = %v, want [\"456\"]", body, issues)
+	}
+}
+
+// TestParseLinkedIssues_Fixes verifies that "Fixes #N" references are extracted.
+func TestParseLinkedIssues_Fixes(t *testing.T) {
+	body := "Fixes #789"
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 1 || issues[0] != "789" {
+		t.Errorf("ParseLinkedIssues(%q) = %v, want [\"789\"]", body, issues)
+	}
+}
+
+// TestParseLinkedIssues_References verifies that "References #N" references are extracted.
+func TestParseLinkedIssues_References(t *testing.T) {
+	body := "References #101"
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 1 || issues[0] != "101" {
+		t.Errorf("ParseLinkedIssues(%q) = %v, want [\"101\"]", body, issues)
+	}
+}
+
+// TestParseLinkedIssues_MultipleIssues verifies that multiple issue references
+// are all extracted (Closes #N, Refs #M).
+func TestParseLinkedIssues_MultipleIssues(t *testing.T) {
+	body := "Closes #100\n\nAlso Refs #200 for background."
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 2 {
+		t.Fatalf("ParseLinkedIssues: got %v, want [\"100\", \"200\"]", issues)
+	}
+	if issues[0] != "100" || issues[1] != "200" {
+		t.Errorf("ParseLinkedIssues: got %v, want [\"100\", \"200\"]", issues)
+	}
+}
+
+// TestParseLinkedIssues_Deduplicated verifies that duplicate issue references
+// are deduplicated (same issue referenced multiple times).
+func TestParseLinkedIssues_Deduplicated(t *testing.T) {
+	body := "Closes #42\nAlso Closes #42 (duplicate)"
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 1 || issues[0] != "42" {
+		t.Errorf("ParseLinkedIssues: duplicate not deduplicated, got %v", issues)
+	}
+}
+
+// TestParseLinkedIssues_CaseInsensitive verifies that matching is case-insensitive.
+func TestParseLinkedIssues_CaseInsensitive(t *testing.T) {
+	body := "CLOSES #55\nfixes #66"
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 2 {
+		t.Fatalf("ParseLinkedIssues case-insensitive: got %v, want [\"55\", \"66\"]", issues)
+	}
+}
+
+// TestParseLinkedIssues_NoIssues verifies that a body with no linked issues
+// returns an empty slice.
+func TestParseLinkedIssues_NoIssues(t *testing.T) {
+	body := "This PR adds a feature. No issue references."
+	issues := review.ParseLinkedIssuesForTest(body)
+	if len(issues) != 0 {
+		t.Errorf("ParseLinkedIssues: got %v, want empty slice", issues)
+	}
+}
+
+// TestParseLinkedIssues_EmptyBody verifies that an empty body returns an empty slice.
+func TestParseLinkedIssues_EmptyBody(t *testing.T) {
+	issues := review.ParseLinkedIssuesForTest("")
+	if len(issues) != 0 {
+		t.Errorf("ParseLinkedIssues(empty): got %v, want empty slice", issues)
+	}
+}
+
+// ── DiffFilePath ──────────────────────────────────────────────────────────────
+
+// TestDiffFilePath_Format verifies that the diff file path follows the expected
+// naming convention: /tmp/prism-review-<pr>-round-<N>.diff
+func TestDiffFilePath_Format(t *testing.T) {
+	cases := []struct {
+		pr    string
+		round int
+		want  string
+	}{
+		{"819", 1, "/tmp/prism-review-819-round-1.diff"},
+		{"855", 2, "/tmp/prism-review-855-round-2.diff"},
+		{"1", 10, "/tmp/prism-review-1-round-10.diff"},
+	}
+	for _, tc := range cases {
+		got := review.DiffFilePathForTest(tc.pr, tc.round)
+		if got != tc.want {
+			t.Errorf("DiffFilePath(%q, %d) = %q, want %q", tc.pr, tc.round, got, tc.want)
+		}
+	}
+}
+
+// TestDiffFilePath_RoundCollision verifies that different rounds produce
+// different file paths (no collision between concurrent review rounds).
+func TestDiffFilePath_RoundCollision(t *testing.T) {
+	pr := "855"
+	path1 := review.DiffFilePathForTest(pr, 1)
+	path2 := review.DiffFilePathForTest(pr, 2)
+	if path1 == path2 {
+		t.Errorf("DiffFilePath: round 1 and round 2 produce the same path: %q", path1)
+	}
+}
+
+// TestDiffFilePath_DifferentPRsCollision verifies that different PRs produce
+// different file paths (no collision between concurrent reviews of different PRs).
+func TestDiffFilePath_DifferentPRsCollision(t *testing.T) {
+	path1 := review.DiffFilePathForTest("819", 1)
+	path2 := review.DiffFilePathForTest("855", 1)
+	if path1 == path2 {
+		t.Errorf("DiffFilePath: PR 819 and PR 855 produce the same path: %q", path1)
+	}
+}
+
+// TestDiffFilePath_ZeroRound verifies that round=0 defaults to 1.
+func TestDiffFilePath_ZeroRound(t *testing.T) {
+	got := review.DiffFilePathForTest("819", 0)
+	want := "/tmp/prism-review-819-round-1.diff"
+	if got != want {
+		t.Errorf("DiffFilePath(%q, 0) = %q, want %q (round 0 should default to 1)", "819", got, want)
+	}
+}
+
+// ── Inline vs file threshold ──────────────────────────────────────────────────
+
+// TestBuildReviewPrompt_SmallDiffInlined verifies that a small diff (below the
+// inline threshold) is embedded directly in the agent prompt.
+func TestBuildReviewPrompt_SmallDiffInlined(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.Diff = "diff --git a/foo.go b/foo.go\n+added line\n"
+	ctx.DiffFilePath = "" // small diff — no file path
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	// Small diff must be inlined in a ```diff fence.
+	if !findSubstring(prompt, "```diff") {
+		t.Errorf("small diff prompt missing ```diff fence\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "diff --git a/foo.go b/foo.go") {
+		t.Errorf("small diff prompt missing diff content\nprompt:\n%s", prompt)
+	}
+	// Must NOT have a "file has been saved to" message.
+	if findSubstring(prompt, "has been saved to") {
+		t.Errorf("small diff prompt should not mention a saved file\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_LargeDiffFilePointer verifies that when DiffFilePath is
+// set (large diff), the prompt contains a file-path pointer and guidance for
+// querying the diff — not an inline code fence.
+func TestBuildReviewPrompt_LargeDiffFilePointer(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.Diff = ""        // large diff is NOT inlined
+	ctx.DiffLines = 1200 // simulated count
+	ctx.DiffBytes = 80 * 1024
+	ctx.DiffFilePath = "/tmp/prism-review-819-round-1.diff"
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	// Must contain the file path.
+	if !findSubstring(prompt, "/tmp/prism-review-819-round-1.diff") {
+		t.Errorf("large diff prompt missing file path\nprompt:\n%s", prompt)
+	}
+	// Must contain the guidance to use git diff / rg.
+	if !findSubstring(prompt, "git diff --stat") {
+		t.Errorf("large diff prompt missing git diff guidance\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "rg") {
+		t.Errorf("large diff prompt missing rg guidance\nprompt:\n%s", prompt)
+	}
+	// Must NOT contain an inline ```diff fence.
+	if findSubstring(prompt, "```diff") {
+		t.Errorf("large diff prompt should not contain an inline ```diff fence\nprompt:\n%s", prompt)
+	}
+}
+
+// ── Linked issues in prompt ───────────────────────────────────────────────────
+
+// TestBuildReviewPrompt_LinkedIssuesSection verifies that when LinkedIssues is
+// populated, the prompt contains the "### Linked issues" section with each
+// issue's content.
+func TestBuildReviewPrompt_LinkedIssuesSection(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.LinkedIssues = map[string]string{
+		"123": "title:\tFix the bug\nstate:\tOPEN\n",
+		"456": "title:\tAdd feature\nstate:\tCLOSED\n",
+	}
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "### Linked issues") {
+		t.Errorf("prompt missing '### Linked issues' section\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "#### Issue #123") {
+		t.Errorf("prompt missing '#### Issue #123'\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "Fix the bug") {
+		t.Errorf("prompt missing issue #123 content\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "#### Issue #456") {
+		t.Errorf("prompt missing '#### Issue #456'\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "Add feature") {
+		t.Errorf("prompt missing issue #456 content\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_LinkedIssuesFetchFailure verifies that when a linked
+// issue could not be fetched, the prompt contains a clear failure marker
+// rather than crashing or omitting the issue entirely.
+func TestBuildReviewPrompt_LinkedIssuesFetchFailure(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.LinkedIssues = map[string]string{
+		"999": "[issue #999 could not be fetched: exit status 1: HTTP 404]",
+	}
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "### Linked issues") {
+		t.Errorf("prompt missing '### Linked issues' section on fetch failure\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "#### Issue #999") {
+		t.Errorf("prompt missing issue section even for unfetchable issue\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "could not be fetched") {
+		t.Errorf("prompt missing failure marker for unfetchable issue\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_NoLinkedIssues verifies that when no linked issues are
+// found, the prompt shows "(no linked issues found)" rather than an empty section.
+func TestBuildReviewPrompt_NoLinkedIssues(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.LinkedIssues = nil
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "### Linked issues") {
+		t.Errorf("prompt missing '### Linked issues' section\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "no linked issues found") {
+		t.Errorf("prompt missing '(no linked issues found)' placeholder\nprompt:\n%s", prompt)
+	}
+}
+
+// ── Git log in prompt ─────────────────────────────────────────────────────────
+
+// TestBuildReviewPrompt_GitLogSections verifies that the prompt contains the
+// "### Recent commits" and "### This branch vs origin/<base>" sections with
+// the git log output when provided.
+func TestBuildReviewPrompt_GitLogSections(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.RecentCommits = "abc1234 fix: handle nil pointer\ndef5678 feat: add new feature\n"
+	ctx.BranchCommits = "abc1234 fix: handle nil pointer\n"
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "### Recent commits") {
+		t.Errorf("prompt missing '### Recent commits' section\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "fix: handle nil pointer") {
+		t.Errorf("prompt missing recent commit text\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "### This branch vs origin/main") {
+		t.Errorf("prompt missing branch commits section\nprompt:\n%s", prompt)
+	}
+}
+
+// TestBuildReviewPrompt_GitLogUnavailable verifies that the prompt handles
+// missing git log output gracefully with a "(not available)" placeholder.
+func TestBuildReviewPrompt_GitLogUnavailable(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.RecentCommits = ""
+	ctx.BranchCommits = ""
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "### Recent commits") {
+		t.Errorf("prompt missing '### Recent commits' section even when unavailable\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "(not available)") {
+		t.Errorf("prompt missing '(not available)' placeholder for git log\nprompt:\n%s", prompt)
+	}
+}
+
+// ── Tool preference guidance ──────────────────────────────────────────────────
+
+// TestBuildReviewPrompt_ToolPreferenceGuidance verifies that the prompt contains
+// the tool-preference guidance directing agents to prefer native git over gh.
+func TestBuildReviewPrompt_ToolPreferenceGuidance(t *testing.T) {
+	ctx := samplePRContext()
+	prompt := review.BuildReviewPromptForTest("819", ctx)
+
+	if !findSubstring(prompt, "Prefer native git") {
+		t.Errorf("prompt missing tool-preference guidance ('Prefer native git')\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "git show") {
+		t.Errorf("prompt missing 'git show' in tool-preference guidance\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "git diff") {
+		t.Errorf("prompt missing 'git diff' in tool-preference guidance\nprompt:\n%s", prompt)
+	}
+	if !findSubstring(prompt, "git log") {
+		t.Errorf("prompt missing 'git log' in tool-preference guidance\nprompt:\n%s", prompt)
+	}
+}
+
+// ── FetchPRContextWithOpts ────────────────────────────────────────────────────
+// These tests exercise FetchPRContextWithOpts in isolation by mocking gh and git.
+
+// TestFetchPRContextWithOpts_InlineThresholdDefault verifies that the default
+// inline threshold constants are DiffInlineMaxLines=500 and DiffInlineMaxBytes=20KB.
+func TestFetchPRContextWithOpts_InlineThresholdDefault(t *testing.T) {
+	if review.DiffInlineMaxLines != 500 {
+		t.Errorf("DiffInlineMaxLines = %d, want 500", review.DiffInlineMaxLines)
+	}
+	if review.DiffInlineMaxBytes != 20*1024 {
+		t.Errorf("DiffInlineMaxBytes = %d, want %d", review.DiffInlineMaxBytes, 20*1024)
+	}
+}
+
+// TestBuildReviewPrompt_AllFiveAgentsGetSameContextWithLinkedIssues verifies
+// that five calls to BuildReviewPromptForTest with a PRContext that includes
+// linked issues all produce identical prompts.
+func TestBuildReviewPrompt_AllFiveAgentsGetSameContextWithLinkedIssues(t *testing.T) {
+	ctx := samplePRContext()
+	ctx.LinkedIssues = map[string]string{
+		"855": "title:\tinject shared context\nstate:\tOPEN\n",
+	}
+	ctx.RecentCommits = "abc fix: something\n"
+	ctx.BranchCommits = "abc fix: something\n"
+
+	prompts := make([]string, 5)
+	for i := range prompts {
+		prompts[i] = review.BuildReviewPromptForTest("819", ctx)
+	}
+	for i := 1; i < len(prompts); i++ {
+		if prompts[i] != prompts[0] {
+			t.Errorf("prompt[%d] differs from prompt[0]; all agents must receive identical context", i)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Gathers `git log --oneline -20`, `git log origin/<base>..HEAD`, `gh pr view`, linked issue text, and the diff exactly once before spawning the 5 review-agent sessions
- Inlines small diffs (≤500 lines / ≤20 KB); writes large diffs to `/tmp/prism-review-<pr>-round-<N>.diff` with file-pointer guidance in the prompt
- Threshold configurable via `PRISM_REVIEW_DIFF_INLINE_MAX` env var or `--diff-inline-max` flag
- Restructures the prompt as `## Context for your review` with sections for recent commits, branch commits, PR metadata, PR body, linked issues, and diff
- Adds tool-preference guidance: prefer native git over `gh` for cross-branch inspection
- Gracefully handles unfetchable linked issues (clear marker, not a spawn failure)
- Adds 20+ new tests covering all new paths

Closes #855