### PR TITLE
prism: rename agent_events.opencode_sid → harness_session_id (Class A, #927)

### DIFF
--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -378,8 +378,8 @@ func groupEventsByHarnessSessionID(events []db.Event) (map[string][]db.Event, []
 
 	for _, e := range events {
 		key := legacySentinel
-		if e.OpencodeSID != nil {
-			key = *e.OpencodeSID
+		if e.HarnessSessionID != nil {
+			key = *e.HarnessSessionID
 		}
 		if _, exists := grouped[key]; !exists {
 			order = append(order, key)
@@ -1548,8 +1548,8 @@ func collectModelMetrics(events []db.Event) map[string]*modelMetrics {
 
 		// Count sessions by harness_session_id when available; fall back to session_name
 		// for NULL-sid (legacy) events so they still contribute a session count.
-		if e.OpencodeSID != nil && *e.OpencodeSID != "" {
-			m.Sessions[*e.OpencodeSID] = struct{}{}
+		if e.HarnessSessionID != nil && *e.HarnessSessionID != "" {
+			m.Sessions[*e.HarnessSessionID] = struct{}{}
 		} else {
 			m.Sessions["legacy:"+e.SessionName] = struct{}{}
 		}

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -53,7 +53,7 @@ func writeStatsEventWithSID(t *testing.T, d *db.DB, session, sid, typ, payload s
 		SessionName: session,
 		Repo:        "testrepo",
 		Worktree:    "/code/testrepo/main",
-		OpencodeSID: &sid,
+		HarnessSessionID: &sid,
 		Type:        typ,
 		Payload:     payload,
 		CreatedAt:   ts,
@@ -253,7 +253,7 @@ func TestCollectMetrics_OpenrouterEventCostAccumulated(t *testing.T) {
 			Type:        "msg_assistant",
 			Payload:     `{"messageId":"msg-1","agent":"coordinator","model":"openrouter/z-ai/glm-4.7","inputTokens":622000,"outputTokens":14000,"cost":1.96}`,
 			CreatedAt:   time.Now(),
-			OpencodeSID: &sid,
+			HarnessSessionID: &sid,
 		},
 		{
 			ID:          "e2",
@@ -261,7 +261,7 @@ func TestCollectMetrics_OpenrouterEventCostAccumulated(t *testing.T) {
 			Type:        "msg_assistant",
 			Payload:     `{"messageId":"msg-2","agent":"coordinator","model":"openrouter/z-ai/glm-4.7","inputTokens":1000,"outputTokens":500,"cost":0.04}`,
 			CreatedAt:   time.Now().Add(time.Minute),
-			OpencodeSID: &sid,
+			HarnessSessionID: &sid,
 		},
 	}
 
@@ -288,7 +288,7 @@ func TestCollectMetrics_EventCostZeroDisplaysDash(t *testing.T) {
 			Type:        "msg_assistant",
 			Payload:     `{"messageId":"msg-1","agent":"coordinator","model":"openrouter/some/model","inputTokens":1000,"outputTokens":500}`,
 			CreatedAt:   time.Now(),
-			OpencodeSID: &sid,
+			HarnessSessionID: &sid,
 		},
 	}
 
@@ -664,10 +664,10 @@ func TestGroupEventsByHarnessSessionID(t *testing.T) {
 	sid2 := "ses_bbb"
 
 	events := []db.Event{
-		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid1, Payload: `{}`, CreatedAt: time.Now()},
-		{ID: "2", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid2, Payload: `{}`, CreatedAt: time.Now()},
-		{ID: "3", SessionName: "s", Type: "msg_assistant", OpencodeSID: nil, Payload: `{}`, CreatedAt: time.Now()},   // NULL → sentinel
-		{ID: "4", SessionName: "s", Type: "msg_assistant", OpencodeSID: &sid1, Payload: `{}`, CreatedAt: time.Now()}, // same as id=1
+		{ID: "1", SessionName: "s", Type: "msg_assistant", HarnessSessionID: &sid1, Payload: `{}`, CreatedAt: time.Now()},
+		{ID: "2", SessionName: "s", Type: "msg_assistant", HarnessSessionID: &sid2, Payload: `{}`, CreatedAt: time.Now()},
+		{ID: "3", SessionName: "s", Type: "msg_assistant", HarnessSessionID: nil, Payload: `{}`, CreatedAt: time.Now()},   // NULL → sentinel
+		{ID: "4", SessionName: "s", Type: "msg_assistant", HarnessSessionID: &sid1, Payload: `{}`, CreatedAt: time.Now()}, // same as id=1
 	}
 
 	grouped, order := groupEventsByHarnessSessionID(events)
@@ -702,13 +702,13 @@ func TestCollectMetrics_CoordinatorModelPreferred(t *testing.T) {
 	// 3 turns on opus (build/review), 1 turn on sonnet (coordinator).
 	// Coordinator model should win despite being less frequent.
 	events := []db.Event{
-		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "1", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"build","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
-		{ID: "2", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "2", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"review","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
-		{ID: "3", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "3", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"build","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
-		{ID: "4", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "4", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
 	}
 
@@ -726,11 +726,11 @@ func TestCollectMetrics_CoordinatorModelPreferred(t *testing.T) {
 // turn exists, the most-frequent model is used.
 func TestCollectMetrics_FallbackToMostFrequent(t *testing.T) {
 	events := []db.Event{
-		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "1", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"build","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
-		{ID: "2", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "2", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"review","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
-		{ID: "3", SessionName: "s", Type: "msg_assistant", OpencodeSID: strPtr("ses_abc"),
+		{ID: "3", SessionName: "s", Type: "msg_assistant", HarnessSessionID: strPtr("ses_abc"),
 			Payload: `{"agent":"explore","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
 	}
 
@@ -746,7 +746,7 @@ func TestCollectMetrics_FallbackToMostFrequent(t *testing.T) {
 // correctly for NULL-sid events.
 func TestCollectMetrics_NullSidLegacy(t *testing.T) {
 	events := []db.Event{
-		{ID: "1", SessionName: "s", Type: "msg_assistant", OpencodeSID: nil,
+		{ID: "1", SessionName: "s", Type: "msg_assistant", HarnessSessionID: nil,
 			Payload: `{"agent":"coordinator","model":"anthropic/claude-opus-4-6","inputTokens":100,"outputTokens":50}`, CreatedAt: time.Now()},
 	}
 
@@ -1176,13 +1176,13 @@ func TestRunStatsModel_SessionCountByHarnessSessionID(t *testing.T) {
 	// Three distinct opencode sessions all within the same tmux session "repo@main",
 	// all using the same model.
 	events := []db.Event{
-		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: &sid1,
+		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", HarnessSessionID: &sid1,
 			Payload:   `{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
 			CreatedAt: time.Now()},
-		{ID: "2", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: &sid2,
+		{ID: "2", SessionName: "repo@main", Type: "msg_assistant", HarnessSessionID: &sid2,
 			Payload:   `{"messageId":"m2","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
 			CreatedAt: time.Now()},
-		{ID: "3", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: &sid3,
+		{ID: "3", SessionName: "repo@main", Type: "msg_assistant", HarnessSessionID: &sid3,
 			Payload:   `{"messageId":"m3","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50,"durationMs":5000}`,
 			CreatedAt: time.Now()},
 	}
@@ -1204,14 +1204,14 @@ func TestRunStatsModel_SessionCountByHarnessSessionID(t *testing.T) {
 func TestRunStatsModel_NullSidFallbackSessionName(t *testing.T) {
 	// Two different sessions, both with NULL harness_session_id, same model.
 	events := []db.Event{
-		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: nil,
+		{ID: "1", SessionName: "repo@main", Type: "msg_assistant", HarnessSessionID: nil,
 			Payload:   `{"messageId":"m1","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,
 			CreatedAt: time.Now()},
-		{ID: "2", SessionName: "repo@feature", Type: "msg_assistant", OpencodeSID: nil,
+		{ID: "2", SessionName: "repo@feature", Type: "msg_assistant", HarnessSessionID: nil,
 			Payload:   `{"messageId":"m2","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,
 			CreatedAt: time.Now()},
 		// Same session_name as first but different event — should NOT add another session count.
-		{ID: "3", SessionName: "repo@main", Type: "msg_assistant", OpencodeSID: nil,
+		{ID: "3", SessionName: "repo@main", Type: "msg_assistant", HarnessSessionID: nil,
 			Payload:   `{"messageId":"m3","text":"r","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":100,"outputTokens":50}`,
 			CreatedAt: time.Now()},
 	}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -44,14 +44,14 @@ func (d *DB) QueryRow(query string, args ...any) *sql.Row {
 
 // Event represents a row in the agent_events table.
 type Event struct {
-	ID          string
-	SessionName string
-	Repo        string
-	Worktree    string
-	OpencodeSID *string
-	Type        string
-	Payload     string // raw JSON
-	CreatedAt   time.Time
+	ID                string
+	SessionName       string
+	Repo              string
+	Worktree          string
+	HarnessSessionID  *string
+	Type              string
+	Payload           string // raw JSON
+	CreatedAt         time.Time
 }
 
 // Status represents a row in the agent_status table.
@@ -109,14 +109,14 @@ type BusMessage struct {
 
 const schema = `
 CREATE TABLE IF NOT EXISTS agent_events (
-  id           TEXT PRIMARY KEY,
-  session_name TEXT NOT NULL,
-  repo         TEXT NOT NULL,
-  worktree     TEXT NOT NULL,
-  opencode_sid TEXT,
-  type         TEXT NOT NULL,
-  payload      TEXT NOT NULL,
-  created_at   INTEGER NOT NULL
+  id                 TEXT PRIMARY KEY,
+  session_name       TEXT NOT NULL,
+  repo               TEXT NOT NULL,
+  worktree           TEXT NOT NULL,
+  harness_session_id TEXT,
+  type               TEXT NOT NULL,
+  payload            TEXT NOT NULL,
+  created_at         INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
@@ -203,6 +203,11 @@ CREATE TABLE IF NOT EXISTS schema_version (
 // sessions that already have a non-zero last_seen are left untouched. Rows with
 // no matching agent_events remain at 0 (COALESCE preserves the NOT NULL
 // constraint). This fixes the gap described in issue #824 for pre-existing rows.
+// v14→v15 renames the agent_events.opencode_sid column to harness_session_id
+// to match the harness-agnostic naming convention used on agent_status. SQLite
+// supports ALTER TABLE ... RENAME COLUMN ... since 3.25 (2018). The migration
+// is idempotent: it checks whether opencode_sid still exists before acting, so
+// running it twice against an already-migrated DB is safe.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -245,10 +250,11 @@ func Open(path string) (*DB, error) {
 	}
 
 	// Set schema_version=11 if the table is empty. Fresh databases have all
-	// current columns from the schema above. The v11→v12, v12→v13, and
-	// v13→v14 migrations run immediately below; on a fresh DB they are
-	// effectively no-ops (the index already exists and there are no rows to
-	// backfill), so starting at 11 rather than 14 is safe.
+	// current columns from the schema above. The v11→v12, v12→v13, v13→v14,
+	// and v14→v15 migrations run immediately below; on a fresh DB they are
+	// effectively no-ops (the index already exists, there are no rows to
+	// backfill, and the column is already named harness_session_id), so
+	// starting at 11 rather than 15 is safe.
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
@@ -606,6 +612,37 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 14
+	}
+	if version == 14 {
+		// Migration v14 → v15: rename agent_events.opencode_sid to
+		// harness_session_id to match the harness-agnostic naming convention
+		// already used on agent_status. SQLite supports ALTER TABLE ... RENAME
+		// COLUMN ... since 3.25 (2018); the modernc.org/sqlite driver embeds a
+		// recent enough SQLite version.
+		//
+		// Idempotency: the migration first checks whether the opencode_sid column
+		// still exists using pragma_table_info. If the column is already named
+		// harness_session_id (i.e. the migration ran before), the RENAME is
+		// skipped and only the schema_version bump is applied. This makes it safe
+		// to run twice against the same database without error.
+		var colExists int
+		if err := conn.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('agent_events') WHERE name = 'opencode_sid'`,
+		).Scan(&colExists); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v14→v15: check column: %w", err)
+		}
+		if colExists > 0 {
+			if _, err := conn.Exec(`ALTER TABLE agent_events RENAME COLUMN opencode_sid TO harness_session_id`); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v14→v15: rename column: %w", err)
+			}
+		}
+		if _, err := conn.Exec("UPDATE schema_version SET version = 15"); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v14→v15: bump version: %w", err)
+		}
+		version = 15
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -1138,9 +1175,9 @@ func (d *DB) WriteEvent(e Event) error {
 	defer tx.Rollback() //nolint:errcheck
 
 	const insertQ = `
-INSERT INTO agent_events (id, session_name, repo, worktree, opencode_sid, type, payload, created_at)
+INSERT INTO agent_events (id, session_name, repo, worktree, harness_session_id, type, payload, created_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-	if _, err := tx.Exec(insertQ, e.ID, e.SessionName, e.Repo, e.Worktree, e.OpencodeSID, e.Type, e.Payload, createdAt); err != nil {
+	if _, err := tx.Exec(insertQ, e.ID, e.SessionName, e.Repo, e.Worktree, e.HarnessSessionID, e.Type, e.Payload, createdAt); err != nil {
 		return fmt.Errorf("db: write event: insert: %w", err)
 	}
 
@@ -1234,7 +1271,7 @@ func (d *DB) QueryEvents(sessionName string, limit int, before, after *string, t
 		reverseResult = true
 	}
 
-	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+	q := "SELECT id, session_name, repo, worktree, harness_session_id, type, payload, created_at FROM agent_events" +
 		where + " ORDER BY created_at " + orderDir
 	if limit > 0 {
 		q += fmt.Sprintf(" LIMIT %d", limit)
@@ -1250,7 +1287,7 @@ func (d *DB) QueryEvents(sessionName string, limit int, before, after *string, t
 	for rows.Next() {
 		var e Event
 		var createdAt int64
-		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.HarnessSessionID, &e.Type, &e.Payload, &createdAt); err != nil {
 			return nil, fmt.Errorf("db: scan event: %w", err)
 		}
 		e.CreatedAt = time.UnixMilli(createdAt)
@@ -1302,7 +1339,7 @@ func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, ty
 		conditions = append(conditions, "type IN ("+strings.Join(typePlaceholders, ",")+")")
 	}
 
-	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+	q := "SELECT id, session_name, repo, worktree, harness_session_id, type, payload, created_at FROM agent_events" +
 		" WHERE " + strings.Join(conditions, " AND ") +
 		" ORDER BY created_at ASC"
 
@@ -1316,7 +1353,7 @@ func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, ty
 	for rows.Next() {
 		var e Event
 		var createdAt int64
-		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.HarnessSessionID, &e.Type, &e.Payload, &createdAt); err != nil {
 			return nil, fmt.Errorf("db: scan event: %w", err)
 		}
 		e.CreatedAt = time.UnixMilli(createdAt)
@@ -1391,7 +1428,7 @@ func (d *DB) AllSessionEvents(sessionName string) ([]Event, error) {
 // (Unix milliseconds), ordered by created_at ASC. Used by `prism stats --days`.
 func (d *DB) EventsSince(sinceMs int64) ([]Event, error) {
 	const q = `
-SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at
+SELECT id, session_name, repo, worktree, harness_session_id, type, payload, created_at
 FROM agent_events
 WHERE created_at >= ?
 ORDER BY created_at ASC`
@@ -1405,7 +1442,7 @@ ORDER BY created_at ASC`
 	for rows.Next() {
 		var e Event
 		var createdAt int64
-		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.HarnessSessionID, &e.Type, &e.Payload, &createdAt); err != nil {
 			return nil, fmt.Errorf("db: scan event: %w", err)
 		}
 		e.CreatedAt = time.UnixMilli(createdAt)
@@ -1616,7 +1653,7 @@ func (d *DB) QueryDoomLoopEvents(sessionName string, sinceMs int64) ([]Event, er
 
 	where := " WHERE " + strings.Join(conditions, " AND ")
 
-	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+	q := "SELECT id, session_name, repo, worktree, harness_session_id, type, payload, created_at FROM agent_events" +
 		where + " ORDER BY created_at DESC"
 
 	rows, err := d.conn.Query(q, args...)
@@ -1629,7 +1666,7 @@ func (d *DB) QueryDoomLoopEvents(sessionName string, sinceMs int64) ([]Event, er
 	for rows.Next() {
 		var e Event
 		var createdAt int64
-		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.HarnessSessionID, &e.Type, &e.Payload, &createdAt); err != nil {
 			return nil, fmt.Errorf("db: scan doom loop event: %w", err)
 		}
 		e.CreatedAt = time.UnixMilli(createdAt)
@@ -1662,7 +1699,7 @@ func (d *DB) QueryPermissionEvents(eventType, sessionName string, sinceMs int64)
 
 	where := " WHERE " + strings.Join(conditions, " AND ")
 
-	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+	q := "SELECT id, session_name, repo, worktree, harness_session_id, type, payload, created_at FROM agent_events" +
 		where + " ORDER BY created_at ASC"
 
 	rows, err := d.conn.Query(q, args...)
@@ -1675,7 +1712,7 @@ func (d *DB) QueryPermissionEvents(eventType, sessionName string, sinceMs int64)
 	for rows.Next() {
 		var e Event
 		var createdAt int64
-		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.HarnessSessionID, &e.Type, &e.Payload, &createdAt); err != nil {
 			return nil, fmt.Errorf("db: scan permission event: %w", err)
 		}
 		e.CreatedAt = time.UnixMilli(createdAt)
@@ -1720,7 +1757,7 @@ func (d *DB) QueryAuditEvents(sessionName string, sinceMs int64, pattern string,
 
 	where := " WHERE " + strings.Join(conditions, " AND ")
 
-	q := "SELECT id, session_name, repo, worktree, opencode_sid, type, payload, created_at FROM agent_events" +
+	q := "SELECT id, session_name, repo, worktree, harness_session_id, type, payload, created_at FROM agent_events" +
 		where + " ORDER BY created_at DESC"
 
 	if limit > 0 {
@@ -1740,7 +1777,7 @@ func (d *DB) QueryAuditEvents(sessionName string, sinceMs int64, pattern string,
 	for rows.Next() {
 		var e Event
 		var createdAt int64
-		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.OpencodeSID, &e.Type, &e.Payload, &createdAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionName, &e.Repo, &e.Worktree, &e.HarnessSessionID, &e.Type, &e.Payload, &createdAt); err != nil {
 			return nil, fmt.Errorf("db: scan audit event: %w", err)
 		}
 		e.CreatedAt = time.UnixMilli(createdAt)

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -49,8 +49,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version: got %d, want 15", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -983,8 +983,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1058,8 +1058,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1559,8 +1559,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1625,8 +1625,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1695,8 +1695,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1790,8 +1790,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1883,8 +1883,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2468,8 +2468,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2557,8 +2557,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// isolation_mode column must exist (NULL for pre-migration rows).
@@ -4160,8 +4160,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// Check each row.
@@ -4583,13 +4583,13 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must advance to 14.
+	// Schema version must advance to 15.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 14 {
-		t.Errorf("schema_version after migration: got %d, want 14", version)
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4706,7 +4706,7 @@ func TestMigration_V13ToV14_Idempotent(t *testing.T) {
 	}
 	d1.Close()
 
-	// Second open: migration is at v14; the backfill WHERE guard means rows with
+	// Second open: migration is at v15; the backfill WHERE guard means rows with
 	// last_seen != 0 are not touched.
 	d2, err := db.Open(dbPath)
 	if err != nil {
@@ -4781,6 +4781,152 @@ func TestLastSeen_ActivityQuery(t *testing.T) {
 	}
 	if oldCount != 0 {
 		t.Errorf("repo@old should NOT appear in last-24h query: got count %d, want 0", oldCount)
+	}
+}
+
+// TestMigration_V14ToV15_RenamesColumn verifies the v14→v15 migration:
+// agent_events.opencode_sid is renamed to harness_session_id, existing
+// non-NULL values are preserved under the new name, and the migration is
+// idempotent (running it twice does not error or corrupt data).
+func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v14_rename.db")
+
+	// Seed a v14 database: agent_events still has opencode_sid, not harness_session_id.
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	sid := "ses_abc123"
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, opencode_sid TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY,
+		  repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL,
+		  state TEXT NOT NULL,
+		  title TEXT,
+		  agent_name TEXT,
+		  model_id TEXT,
+		  root_agent_name TEXT,
+		  root_model_id TEXT,
+		  host_mode INTEGER NOT NULL DEFAULT 0,
+		  isolation_mode TEXT,
+		  instance_id TEXT,
+		  last_seen INTEGER NOT NULL,
+		  ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT,
+		  harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+		INSERT INTO schema_version (version) VALUES (14);
+
+		-- One event with a non-NULL opencode_sid, one with NULL.
+		INSERT INTO agent_events (id, session_name, repo, worktree, opencode_sid, type, payload, created_at)
+		  VALUES ('evt-1', 'repo@main', 'repo', '/wt', 'ses_abc123', 'state_change', '{}', 1000);
+		INSERT INTO agent_events (id, session_name, repo, worktree, opencode_sid, type, payload, created_at)
+		  VALUES ('evt-2', 'repo@main', 'repo', '/wt', NULL, 'state_change', '{}', 2000);
+	`)
+	rawConn.Close()
+	if err != nil {
+		t.Fatalf("seed v14 db: %v", err)
+	}
+
+	// First open: applies v14→v15 migration.
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v14 db: %v", err)
+	}
+	defer d.Close()
+
+	// Schema version must advance to 15.
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 15 {
+		t.Errorf("schema_version after migration: got %d, want 15", version)
+	}
+
+	// harness_session_id column must now exist in agent_events.
+	var hsiExists int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('agent_events') WHERE name = 'harness_session_id'`,
+	).Scan(&hsiExists); err != nil {
+		t.Fatalf("pragma_table_info harness_session_id: %v", err)
+	}
+	if hsiExists == 0 {
+		t.Error("harness_session_id column does not exist in agent_events after migration")
+	}
+
+	// opencode_sid column must no longer exist.
+	var oldColExists int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('agent_events') WHERE name = 'opencode_sid'`,
+	).Scan(&oldColExists); err != nil {
+		t.Fatalf("pragma_table_info opencode_sid: %v", err)
+	}
+	if oldColExists != 0 {
+		t.Error("opencode_sid column still exists in agent_events after migration")
+	}
+
+	// Non-NULL value is preserved: evt-1 must have harness_session_id = sid.
+	var got *string
+	if err := d.QueryRow(
+		`SELECT harness_session_id FROM agent_events WHERE id = 'evt-1'`,
+	).Scan(&got); err != nil {
+		t.Fatalf("read evt-1 harness_session_id: %v", err)
+	}
+	if got == nil || *got != sid {
+		t.Errorf("evt-1 harness_session_id: got %v, want %q", got, sid)
+	}
+
+	// NULL value is preserved: evt-2 must have harness_session_id = NULL.
+	var gotNull *string
+	if err := d.QueryRow(
+		`SELECT harness_session_id FROM agent_events WHERE id = 'evt-2'`,
+	).Scan(&gotNull); err != nil {
+		t.Fatalf("read evt-2 harness_session_id: %v", err)
+	}
+	if gotNull != nil {
+		t.Errorf("evt-2 harness_session_id: got %v, want nil", gotNull)
+	}
+
+	// Idempotency: opening the same (now v15) DB a second time must not error.
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open on already-migrated db: %v", err)
+	}
+	defer d2.Close()
+
+	// harness_session_id value must still be intact after second open.
+	var got2 *string
+	if err := d2.QueryRow(
+		`SELECT harness_session_id FROM agent_events WHERE id = 'evt-1'`,
+	).Scan(&got2); err != nil {
+		t.Fatalf("read evt-1 after second open: %v", err)
+	}
+	if got2 == nil || *got2 != sid {
+		t.Errorf("evt-1 after second open: got %v, want %q", got2, sid)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -187,16 +187,16 @@ type DoomLoopDetected struct {
 // they survive worktree cleanup.
 //
 // The Command field contains the full command string as passed to the bash tool.
-// SessionName, OpencodeSID, and MessageID provide forensic attribution.
+// SessionName, HarnessSessionID, and MessageID provide forensic attribution.
 //
 // Note: an instanceId field (per issue #641) is intentionally absent until
 // the instance-ID feature lands. Once #641 is implemented, add an InstanceID
 // field here and populate it from the sidecar's instance ID so that audit
 // events can be attributed to a specific sidecar process invocation.
 type Audit struct {
-	Tool        string `json:"tool"`
-	Command     string `json:"command"`
-	SessionName string `json:"sessionName"`
-	OpencodeSID string `json:"opencodeSID,omitempty"`
-	MessageID   string `json:"messageId,omitempty"`
+	Tool             string `json:"tool"`
+	Command          string `json:"command"`
+	SessionName      string `json:"sessionName"`
+	HarnessSessionID string `json:"harnessSessionID,omitempty"`
+	MessageID        string `json:"messageId,omitempty"`
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1377,11 +1377,11 @@ func (s *Sidecar) handleMessagePartUpdated(evt harness.HarnessEvent) {
 			if part.Tool == "bash" {
 				if cmd := extractBashCommand(part.State.Input); isHighImpactCommand(cmd) {
 					s.writeEvent("audit", map[string]any{
-						"tool":        "bash",
-						"command":     cmd,
-						"sessionName": s.cfg.SessionName,
-						"opencodeSID": s.opencodeSID,
-						"messageId":   part.MessageID,
+						"tool":             "bash",
+						"command":          cmd,
+						"sessionName":      s.cfg.SessionName,
+						"harnessSessionID": s.opencodeSID,
+						"messageId":        part.MessageID,
 					}, nil)
 					log.Printf("sidecar: audit: high-impact command recorded: %s", truncate(cmd, 120))
 				}
@@ -1517,14 +1517,14 @@ func (s *Sidecar) writeEvent(eventType string, payload any, opencodeSID *string)
 	}
 
 	e := db.Event{
-		ID:          uuid.New().String(),
-		SessionName: s.cfg.SessionName,
-		Repo:        s.cfg.Repo,
-		Worktree:    s.cfg.Worktree,
-		OpencodeSID: sid,
-		Type:        eventType,
-		Payload:     string(data),
-		CreatedAt:   s.cfg.Clock.Now(),
+		ID:               uuid.New().String(),
+		SessionName:      s.cfg.SessionName,
+		Repo:             s.cfg.Repo,
+		Worktree:         s.cfg.Worktree,
+		HarnessSessionID: sid,
+		Type:             eventType,
+		Payload:          string(data),
+		CreatedAt:        s.cfg.Clock.Now(),
 	}
 	if err := s.cfg.DB.WriteEvent(e); err != nil {
 		log.Printf("sidecar: WriteEvent(%s) failed: %v", eventType, err)


### PR DESCRIPTION
## Summary

Implements Class A of issue #927: the `agent_events` schema migration, `db.Event` struct field rename, and payload JSON tag rename.

### Changes

- **Schema migration (v14→v15)**: Renames `agent_events.opencode_sid` column to `harness_session_id` via `ALTER TABLE ... RENAME COLUMN` (SQLite 3.25+). The migration is idempotent — it checks `pragma_table_info('agent_events')` before acting, so running it twice against an already-migrated DB is a safe no-op.
- **Schema constant**: Updated the `CREATE TABLE agent_events` DDL in `db.go` so fresh databases use `harness_session_id` from the start.
- **`db.Event` struct**: `OpencodeSID *string` → `HarnessSessionID *string`. All INSERT, SELECT, and `rows.Scan` call sites in `db.go` updated.
- **`cmd/stats.go`**: Updated the two `e.OpencodeSID` accesses at ~line 381 and ~line 1551 (explicitly deferred from Class B).
- **`payload.Audit`**: `OpencodeSID string \`json:"opencodeSID,omitempty"\`` → `HarnessSessionID string \`json:"harnessSessionID,omitempty"\``. This is the wire-observable JSON tag change.
- **`sidecar.go`**: Updated the `db.Event` struct literal (`OpencodeSID: sid` → `HarnessSessionID: sid`) and the audit event map key (`"opencodeSID"` → `"harnessSessionID"`).
- **Tests**: Updated all `db.Event` struct literal field names in test files; updated schema version assertions (v14 → v15); added `TestMigration_V14ToV15_RenamesColumn` covering: column rename, data preservation for non-NULL values, NULL preservation, column name verification, and double-run idempotency.

### Quality gates

- `go build ./...` ✓
- `go test ./...` ✓ (all 19 packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✓

### Wire-compat note

The `opencodeSID` JSON tag in `payload.Audit` is wire-observable (emitted in forensic/audit events). Renaming it to `harnessSessionID` is the forward-compatible direction. A grep across the full repo found no other consumers of this tag outside `internal/payload/` and `internal/sidecar/`.

Closes #927