### PR TITLE
fix: thread IsolationMode through review path to prevent host fallback

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -243,6 +243,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		Timeout:        timeoutFlag,
 		PluginHostPath: cfg.SidecarPluginPath,
 		ContainerMode:  effectiveContainerMode,
+		IsolationMode:  string(isoMode),
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,
 		RuntimeEnvVars: h.RuntimeEnv(),

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -566,6 +566,12 @@ type Opts struct {
 	// included inline. Zero uses the default (20 KB). Can also be overridden
 	// via the PRISM_REVIEW_SIZE_BUDGET environment variable.
 	SizeBudget int
+	// IsolationMode is the resolved isolation mode to use when spawning review
+	// agent sessions. Valid values: "podman", "bwrap", "host". When set, it is
+	// forwarded to session.SpawnOpts.IsolationMode for every spawned agent.
+	// When empty, spawnAgentOnlyLayout will call cfg.EffectiveIsolationMode()
+	// to resolve the machine default rather than silently falling back to host.
+	IsolationMode string
 }
 
 // FormatAgentDisplayName converts an agent name like "review-goal" to a
@@ -700,6 +706,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			ConfigContent:    agentConfigContent,
 			Layout:           session.LayoutAgentOnly,
 			ContainerMode:    opts.ContainerMode,
+			IsolationMode:    opts.IsolationMode,
 			PluginHostPath:   opts.PluginHostPath,
 			WorktreeReadOnly: true,
 			GroupID:          groupID,
@@ -903,6 +910,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			ConfigContent:    agentConfigContent,
 			Layout:           session.LayoutAgentOnly,
 			ContainerMode:    opts.ContainerMode,
+			IsolationMode:    opts.IsolationMode,
 			PluginHostPath:   opts.PluginHostPath,
 			WorktreeReadOnly: true,
 			GroupID:          groupID,

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -255,6 +256,15 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	mode := opts.IsolationMode
 	if mode == "" && opts.ContainerMode {
 		mode = "podman"
+	}
+	// When IsolationMode is still empty (neither field set), resolve the
+	// machine default from config rather than silently falling back to host.
+	// A silent host fallback breaks bwrap sessions: review agents would run
+	// without the sandbox, pick up the host opencode.json (which only defines
+	// the build agent), and trigger the recursive review explosion described
+	// in issue #1001.
+	if mode == "" {
+		mode = string(config.Load().EffectiveIsolationMode())
 	}
 
 	// Start the sidecar BEFORE creating the agent window so that the


### PR DESCRIPTION
## Summary

Fixes the root cause of the recursive review explosion that caused the OOM event on 2026-04-25 (#1001).

When `prism review` was invoked from a bwrap-isolated worker session, review agent sessions were silently spawned in host mode. The host `opencode.json` only defines the `build` agent, so opencode fell back to `build`. The `build` agent has the Task tool enabled and reads the AGENTS.md fallback instructions which direct it to spawn 5 review subagents as parallel Task calls — producing a 5×5×N recursive session explosion.

## Changes

- **`internal/review/review.go`**: Add `IsolationMode string` field to `review.Opts`. Thread `opts.IsolationMode` through to `session.SpawnOpts.IsolationMode` in both `Run` and `RunAsync`.
- **`cmd/review.go`**: Set `opts.IsolationMode = string(isoMode)` (using the already-resolved `cfg.EffectiveIsolationMode()`) before calling `review.RunAsync`.
- **`internal/session/spawn.go`**: In `spawnAgentOnlyLayout`, when `IsolationMode` is empty and `ContainerMode` is false, resolve the machine default via `config.Load().EffectiveIsolationMode()` instead of silently falling back to host mode.

## Acceptance criteria coverage

- ✅ When the machine's configured isolation mode is `bwrap`, review agent sessions are spawned with `IsolationMode="bwrap"`
- ✅ When the machine's configured isolation mode is `podman`, review agent sessions are spawned with `IsolationMode="podman"` (existing behaviour, not regressed)
- ✅ When the machine's configured isolation mode is `host`, review agent sessions are spawned with `IsolationMode="host"` (explicit opt-in, not silent fallback)
- ✅ `review.Opts` exposes an `IsolationMode` field threaded through to `session.SpawnOpts.IsolationMode` for every agent in both `Run` and `RunAsync`
- ✅ `cmd/review.go` sets `opts.IsolationMode` from `cfg.EffectiveIsolationMode()` before calling `review.RunAsync`
- ✅ When `IsolationMode` is empty in `review.Opts`, `spawnAgentOnlyLayout` now calls `cfg.EffectiveIsolationMode()` instead of silently falling back to host

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all 18 packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #1001