### PR TITLE
prism: per-incarnation stats + prism archive + prism sessions commands

### DIFF
--- a/modules/programs/prism/prism/cmd/archive.go
+++ b/modules/programs/prism/prism/cmd/archive.go
@@ -1,0 +1,111 @@
+package cmd
+
+// prism archive — resolve the archive directory for a session incarnation.
+//
+// Usage:
+//
+//	prism archive <instance-id>                  print archive_path and exit 0
+//	prism archive <session-name>                 print archive_path for most recent incarnation
+//	prism archive <session-name> --all           print one archive_path per line, newest first
+//	prism archive --instance <full-uuid>         force UUID lookup (disambiguate from session name)
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var archiveCmd = &cobra.Command{
+	Use:   "archive <instance-id|session-name>",
+	Short: "Print the archive path for a session incarnation",
+	Long: `Print sessions.archive_path for the specified incarnation and exit 0.
+
+The argument may be a full 36-character UUID (instance_id), an unambiguous
+UUID prefix, or a session name (resolves to the most recent incarnation).
+
+Use --instance to force UUID lookup even when the argument could also match a
+session name.
+
+Use --all with a session name to print one archive_path per line for every
+incarnation of that name, newest first.
+
+Exits non-zero when the incarnation is unknown or archive_path IS NULL
+(session not yet archived).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runArchive,
+}
+
+func init() {
+	archiveCmd.Flags().Bool("all", false, "Print archive_path for every incarnation of the session name, newest first")
+	archiveCmd.Flags().String("instance", "", "Force UUID instance_id lookup for this full UUID (alternative to positional arg)")
+	rootCmd.AddCommand(archiveCmd)
+}
+
+func runArchive(cmd *cobra.Command, args []string) error {
+	all, _ := cmd.Flags().GetBool("all")
+	instanceFlag, _ := cmd.Flags().GetString("instance")
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("archive: %w", err)
+	}
+	defer d.Close()
+
+	// --instance flag takes precedence over the positional arg.
+	if instanceFlag != "" {
+		return printArchivePath(d, instanceFlag, true, false)
+	}
+
+	arg := args[0]
+
+	// --all: iterate all incarnations of the session name.
+	if all {
+		return printArchivePathAll(d, arg)
+	}
+
+	// Disambiguate: full UUID or session name.
+	forceInstance := len(arg) == 36
+	return printArchivePath(d, arg, forceInstance, false)
+}
+
+// printArchivePath resolves arg to a single sessions row and prints its archive_path.
+// If forceInstance is true, arg is treated as an instance_id (UUID lookup).
+// Returns a non-zero exit code (via error) when archive_path IS NULL.
+func printArchivePath(d *db.DB, arg string, forceInstance bool, silent bool) error {
+	sess, err := resolveSessionArg(d, arg, forceInstance)
+	if err != nil {
+		return fmt.Errorf("archive: %w", err)
+	}
+
+	if sess.ArchivePath == nil || *sess.ArchivePath == "" {
+		return fmt.Errorf("archive: session not yet archived")
+	}
+
+	fmt.Println(*sess.ArchivePath)
+	return nil
+}
+
+// printArchivePathAll prints one archive_path per line for every incarnation of
+// session_name = arg, ordered by started_at DESC (newest first).
+// Exits non-zero when no incarnations exist for that name.
+func printArchivePathAll(d *db.DB, sessionName string) error {
+	sessions, err := d.SessionsByName(sessionName)
+	if err != nil {
+		return fmt.Errorf("archive: %w", err)
+	}
+
+	if len(sessions) == 0 {
+		return fmt.Errorf("archive: no incarnations found for session %q", sessionName)
+	}
+
+	for _, s := range sessions {
+		if s.ArchivePath != nil && *s.ArchivePath != "" {
+			fmt.Println(*s.ArchivePath)
+		} else {
+			fmt.Println("(not yet archived)")
+		}
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/archive.go
+++ b/modules/programs/prism/prism/cmd/archive.go
@@ -18,22 +18,23 @@ import (
 )
 
 var archiveCmd = &cobra.Command{
-	Use:   "archive <instance-id|session-name>",
+	Use:   "archive [instance-id|session-name]",
 	Short: "Print the archive path for a session incarnation",
 	Long: `Print sessions.archive_path for the specified incarnation and exit 0.
 
 The argument may be a full 36-character UUID (instance_id), an unambiguous
 UUID prefix, or a session name (resolves to the most recent incarnation).
 
-Use --instance to force UUID lookup even when the argument could also match a
-session name.
+Use --instance <full-uuid> as an alternative to the positional argument when
+you want to force UUID lookup regardless of any session_name that could collide.
+With --instance, the positional argument is optional and ignored if provided.
 
 Use --all with a session name to print one archive_path per line for every
 incarnation of that name, newest first.
 
 Exits non-zero when the incarnation is unknown or archive_path IS NULL
 (session not yet archived).`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runArchive,
 }
 
@@ -53,9 +54,15 @@ func runArchive(cmd *cobra.Command, args []string) error {
 	}
 	defer d.Close()
 
-	// --instance flag takes precedence over the positional arg.
+	// --instance flag takes precedence over the positional arg and does not
+	// require one. This is the disambiguator for collisions between an
+	// instance_id and a session_name.
 	if instanceFlag != "" {
-		return printArchivePath(d, instanceFlag, true, false)
+		return printArchivePath(d, instanceFlag, true)
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("archive: requires an argument (instance-id or session-name) or --instance <uuid>")
 	}
 
 	arg := args[0]
@@ -67,13 +74,13 @@ func runArchive(cmd *cobra.Command, args []string) error {
 
 	// Disambiguate: full UUID or session name.
 	forceInstance := len(arg) == 36
-	return printArchivePath(d, arg, forceInstance, false)
+	return printArchivePath(d, arg, forceInstance)
 }
 
 // printArchivePath resolves arg to a single sessions row and prints its archive_path.
 // If forceInstance is true, arg is treated as an instance_id (UUID lookup).
 // Returns a non-zero exit code (via error) when archive_path IS NULL.
-func printArchivePath(d *db.DB, arg string, forceInstance bool, silent bool) error {
+func printArchivePath(d *db.DB, arg string, forceInstance bool) error {
 	sess, err := resolveSessionArg(d, arg, forceInstance)
 	if err != nil {
 		return fmt.Errorf("archive: %w", err)

--- a/modules/programs/prism/prism/cmd/archive_test.go
+++ b/modules/programs/prism/prism/cmd/archive_test.go
@@ -28,7 +28,7 @@ func TestRunArchive_ByInstanceID(t *testing.T) {
 		base.Add(-1*time.Hour), base, "finished", "/archive/testrepo/path")
 
 	out := captureStdout(t, func() {
-		if err := printArchivePath(d, iid, true, false); err != nil {
+		if err := printArchivePath(d, iid, true); err != nil {
 			t.Errorf("printArchivePath: %v", err)
 		}
 	})
@@ -53,7 +53,7 @@ func TestRunArchive_BySessionName(t *testing.T) {
 		base.Add(-1*time.Hour), base, "finished", "/archive/new")
 
 	out := captureStdout(t, func() {
-		if err := printArchivePath(d, "testrepo@main", false, false); err != nil {
+		if err := printArchivePath(d, "testrepo@main", false); err != nil {
 			t.Errorf("printArchivePath: %v", err)
 		}
 	})
@@ -76,7 +76,7 @@ func TestRunArchive_NullArchivePath(t *testing.T) {
 	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
 		base.Add(-1*time.Hour), base, "finished", "")
 
-	err := printArchivePath(d, iid, true, false)
+	err := printArchivePath(d, iid, true)
 	if err == nil {
 		t.Fatal("expected error for NULL archive_path, got nil")
 	}
@@ -90,7 +90,7 @@ func TestRunArchive_UnknownID(t *testing.T) {
 	d := openIncarnationTestDB(t)
 
 	unknownID := uuid.New().String()
-	err := printArchivePath(d, unknownID, true, false)
+	err := printArchivePath(d, unknownID, true)
 	if err == nil {
 		t.Fatal("expected error for unknown instance_id, got nil")
 	}

--- a/modules/programs/prism/prism/cmd/archive_test.go
+++ b/modules/programs/prism/prism/cmd/archive_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+// Tests for prism archive (issue #999 ACs):
+//   - prism archive <instance-id> → prints archive_path
+//   - prism archive <session-name> → most recent incarnation's archive_path
+//   - prism archive <session-name> --all → all paths, newest first
+//   - prism archive --instance <uuid> → force UUID lookup
+//   - prism archive <id> where archive_path IS NULL → "session not yet archived" + exit non-zero
+//   - prism archive <unknown> → exit non-zero with error
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// --- archive_path tests ---
+
+// TestRunArchive_ByInstanceID verifies that a full UUID returns the archive_path.
+func TestRunArchive_ByInstanceID(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "/archive/testrepo/path")
+
+	out := captureStdout(t, func() {
+		if err := printArchivePath(d, iid, true, false); err != nil {
+			t.Errorf("printArchivePath: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "/archive/testrepo/path") {
+		t.Errorf("expected archive path in output\ngot:\n%s", out)
+	}
+}
+
+// TestRunArchive_BySessionName verifies that a session name resolves to the
+// most recent incarnation's archive_path.
+func TestRunArchive_BySessionName(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Two incarnations — most recent should win.
+	iid1 := uuid.New().String()
+	iid2 := uuid.New().String()
+	insertTestSession(t, d, iid1, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-3*time.Hour), base.Add(-2*time.Hour), "finished", "/archive/old")
+	insertTestSession(t, d, iid2, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "/archive/new")
+
+	out := captureStdout(t, func() {
+		if err := printArchivePath(d, "testrepo@main", false, false); err != nil {
+			t.Errorf("printArchivePath: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "/archive/new") {
+		t.Errorf("expected most recent archive path '/archive/new'\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "/archive/old") {
+		t.Errorf("expected old archive path to NOT appear\ngot:\n%s", out)
+	}
+}
+
+// TestRunArchive_NullArchivePath verifies that a NULL archive_path returns an error.
+func TestRunArchive_NullArchivePath(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	// No archive path (empty string treated as unarchived).
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	err := printArchivePath(d, iid, true, false)
+	if err == nil {
+		t.Fatal("expected error for NULL archive_path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not yet archived") {
+		t.Errorf("expected 'not yet archived' in error\ngot: %v", err)
+	}
+}
+
+// TestRunArchive_UnknownID verifies that an unknown instance_id returns an error.
+func TestRunArchive_UnknownID(t *testing.T) {
+	d := openIncarnationTestDB(t)
+
+	unknownID := uuid.New().String()
+	err := printArchivePath(d, unknownID, true, false)
+	if err == nil {
+		t.Fatal("expected error for unknown instance_id, got nil")
+	}
+}
+
+// TestRunArchive_AllFlag verifies that --all prints one path per incarnation,
+// newest first.
+func TestRunArchive_AllFlag(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid1 := uuid.New().String()
+	iid2 := uuid.New().String()
+	iid3 := uuid.New().String()
+	// Insert in chronological order; --all should return newest first.
+	insertTestSession(t, d, iid1, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-3*time.Hour), base.Add(-2*time.Hour), "finished", "/archive/1")
+	insertTestSession(t, d, iid2, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-2*time.Hour), base.Add(-1*time.Hour), "finished", "/archive/2")
+	insertTestSession(t, d, iid3, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "/archive/3")
+
+	out := captureStdout(t, func() {
+		if err := printArchivePathAll(d, "testrepo@main"); err != nil {
+			t.Errorf("printArchivePathAll: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d\n%s", len(lines), out)
+	}
+	// Newest first: /archive/3, /archive/2, /archive/1.
+	if !strings.Contains(lines[0], "/archive/3") {
+		t.Errorf("first line should be newest (/archive/3)\ngot: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "/archive/2") {
+		t.Errorf("second line should be /archive/2\ngot: %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "/archive/1") {
+		t.Errorf("third line should be oldest (/archive/1)\ngot: %q", lines[2])
+	}
+}
+
+// TestRunArchive_AllFlag_NotYetArchived verifies that --all shows "(not yet archived)"
+// for incarnations with NULL archive_path.
+func TestRunArchive_AllFlag_NotYetArchived(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "") // no archive path
+
+	out := captureStdout(t, func() {
+		if err := printArchivePathAll(d, "testrepo@main"); err != nil {
+			t.Errorf("printArchivePathAll: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "not yet archived") {
+		t.Errorf("expected '(not yet archived)' for NULL archive_path\ngot:\n%s", out)
+	}
+}
+
+// TestRunArchive_AllFlag_UnknownSession verifies that --all with an unknown session
+// name returns an error.
+func TestRunArchive_AllFlag_UnknownSession(t *testing.T) {
+	d := openIncarnationTestDB(t)
+
+	err := printArchivePathAll(d, "nonexistent@branch")
+	if err == nil {
+		t.Fatal("expected error for unknown session name, got nil")
+	}
+}

--- a/modules/programs/prism/prism/cmd/incarnation_stats_test.go
+++ b/modules/programs/prism/prism/cmd/incarnation_stats_test.go
@@ -1,0 +1,488 @@
+package cmd
+
+// Tests for the per-incarnation stats rework (issue #999):
+//   - prism stats (no args) → runStatsIncarnations
+//   - prism stats <instance-id|session-name> → runStatsDetail / resolveSessionArg
+//   - prism stats --repo / --since filtering
+//   - prism stats --aggregate-by-name flag removed (produces unknown-flag error)
+//   - prism stats --since with unparseable date
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// insertTestSession inserts a sessions row directly via InsertSession + UpdateSessionEnded.
+// startedAt is required; endedAt may be zero (live session).
+func insertTestSession(t *testing.T, d *db.DB, instanceID, sessionName, repo, worktree, harness string,
+	startedAt time.Time, endedAt time.Time, endState string, archivePath string) {
+	t.Helper()
+	s := db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    worktree,
+		Harness:     harness,
+		StartedAt:   startedAt,
+	}
+	agentRole := "coordinator"
+	s.AgentRole = &agentRole
+	rootAgent := "coordinator"
+	s.RootAgentName = &rootAgent
+	if err := d.InsertSession(s); err != nil {
+		t.Fatalf("InsertSession(%s): %v", instanceID, err)
+	}
+	if !endedAt.IsZero() {
+		// UpdateSessionEnded uses time.Now() internally; we need to test with custom times.
+		// For tests we call the DB method directly which sets ended_at = now.
+		// Instead we use a direct SQL approach via the QueryRow accessor.
+		// The DB exposes QueryRow for tests — use it to set ended_at directly.
+		d.QueryRow(`UPDATE sessions SET ended_at = ?, end_state = ?, archive_path = ? WHERE instance_id = ?`,
+			endedAt.UnixMilli(), endState, archivePath, instanceID)
+	}
+}
+
+// writeSessionEvent writes a msg_assistant event linked to the given instance_id.
+func writeSessionEvent(t *testing.T, d *db.DB, instanceID, sessionName, model string,
+	inputTokens, outputTokens int, ts time.Time) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"messageId":"msg-%s","text":"reply","agent":"coordinator","model":%q,"inputTokens":%d,"outputTokens":%d,"durationMs":5000}`,
+		uuid.New().String()[:8], model, inputTokens, outputTokens)
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sessionName,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/main",
+		Type:        "msg_assistant",
+		Payload:     payload,
+		CreatedAt:   ts,
+		InstanceID:  &instanceID,
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+// openIncarnationTestDB opens a temp DB and registers cleanup. Also sets testDBPath.
+func openIncarnationTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+	return d
+}
+
+// --- prism stats (no args): per-incarnation table ---
+
+// TestRunStatsIncarnations_EmptyTable verifies graceful output for empty sessions table.
+func TestRunStatsIncarnations_EmptyTable(t *testing.T) {
+	_ = openIncarnationTestDB(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("", 0); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no sessions yet") {
+		t.Errorf("expected 'no sessions yet' for empty table\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsIncarnations_OneRow verifies a single incarnation row is shown.
+func TestRunStatsIncarnations_OneRow(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code/testrepo/main", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("", 0); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	// Should show the short instance_id (first 8 chars).
+	if !strings.Contains(out, iid[:8]) {
+		t.Errorf("output missing short instance_id %q\ngot:\n%s", iid[:8], out)
+	}
+	// Should show session name.
+	if !strings.Contains(out, "testrepo@main") {
+		t.Errorf("output missing session name 'testrepo@main'\ngot:\n%s", out)
+	}
+	// Should show column headers.
+	if !strings.Contains(out, "INSTANCE") {
+		t.Errorf("output missing 'INSTANCE' column header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "SESSION_NAME") {
+		t.Errorf("output missing 'SESSION_NAME' column header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "DURATION") {
+		t.Errorf("output missing 'DURATION' column header\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsIncarnations_ActiveSession verifies that live sessions (ended_at IS NULL)
+// show STATE=active.
+func TestRunStatsIncarnations_ActiveSession(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	// No end time — live session.
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code/testrepo/main", "opencode",
+		base.Add(-30*time.Minute), time.Time{}, "", "")
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("", 0); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "active") {
+		t.Errorf("expected 'active' state for live session\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsIncarnations_TokensAndCost verifies token/cost totals are shown
+// when agent_events are linked to the instance_id.
+func TestRunStatsIncarnations_TokensAndCost(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code/testrepo/main", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	// 100K input at $3/M = $0.30, 10K output at $15/M = $0.15 → ~$0.45
+	writeSessionEvent(t, d, iid, "testrepo@main", "anthropic/claude-sonnet-4-6",
+		100000, 10000, base.Add(-30*time.Minute))
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("", 0); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	// 110K total tokens.
+	if !strings.Contains(out, "110K") {
+		t.Errorf("expected '110K' total tokens\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsIncarnations_RepoFilter verifies --repo filtering.
+func TestRunStatsIncarnations_RepoFilter(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid1 := uuid.New().String()
+	iid2 := uuid.New().String()
+	insertTestSession(t, d, iid1, "repo-a@main", "repo-a", "/code/repo-a/main", "opencode",
+		base.Add(-2*time.Hour), base, "finished", "")
+	insertTestSession(t, d, iid2, "repo-b@main", "repo-b", "/code/repo-b/main", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("repo-a", 0); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "repo-a@main") {
+		t.Errorf("expected 'repo-a@main' in filtered output\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "repo-b@main") {
+		t.Errorf("expected 'repo-b@main' to be filtered out\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsIncarnations_SinceFilter verifies --since filtering.
+func TestRunStatsIncarnations_SinceFilter(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iidOld := uuid.New().String()
+	iidNew := uuid.New().String()
+	// Old session: started 30 days ago.
+	insertTestSession(t, d, iidOld, "repo@old", "testrepo", "/code/testrepo/main", "opencode",
+		base.Add(-30*24*time.Hour), base.Add(-29*24*time.Hour), "finished", "")
+	// New session: started 1 hour ago.
+	insertTestSession(t, d, iidNew, "repo@new", "testrepo", "/code/testrepo/main", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	// Filter to the last 7 days.
+	sinceMs := base.Add(-7 * 24 * time.Hour).UnixMilli()
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("", sinceMs); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "repo@old") {
+		t.Errorf("expected old session to be filtered out\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "repo@new") {
+		t.Errorf("expected new session to be shown\ngot:\n%s", out)
+	}
+}
+
+// --- prism stats <arg>: detail view ---
+
+// TestRunStatsDetail_ByFullUUID verifies detail view with a full 36-char UUID.
+func TestRunStatsDetail_ByFullUUID(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code/testrepo/main", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "/archive/path")
+
+	out := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, iid) {
+		t.Errorf("expected full instance_id %q in output\ngot:\n%s", iid, out)
+	}
+	if !strings.Contains(out, "testrepo@main") {
+		t.Errorf("expected session name 'testrepo@main'\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "/archive/path") {
+		t.Errorf("expected archive path '/archive/path'\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDetail_BySessionName verifies detail view with a session name.
+func TestRunStatsDetail_BySessionName(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Two incarnations of the same session name; most recent should be returned.
+	iid1 := uuid.New().String()
+	iid2 := uuid.New().String()
+	insertTestSession(t, d, iid1, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-3*time.Hour), base.Add(-2*time.Hour), "finished", "")
+	insertTestSession(t, d, iid2, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	out := captureStdout(t, func() {
+		if err := runStatsDetail("testrepo@main", false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+
+	// Should show the most recent incarnation (iid2).
+	if !strings.Contains(out, iid2) {
+		t.Errorf("expected most recent instance_id %q\ngot:\n%s", iid2, out)
+	}
+}
+
+// TestRunStatsDetail_ByUUIDPrefix verifies detail view with an unambiguous UUID prefix.
+func TestRunStatsDetail_ByUUIDPrefix(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	out := captureStdout(t, func() {
+		// Use first 8 chars as prefix.
+		if err := runStatsDetail("aaaabbbb", false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, iid) {
+		t.Errorf("expected instance_id %q in output from prefix lookup\ngot:\n%s", iid, out)
+	}
+}
+
+// TestRunStatsDetail_AmbiguousPrefix verifies that an ambiguous UUID prefix returns an error.
+func TestRunStatsDetail_AmbiguousPrefix(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	// Two instance IDs sharing the same first 8 chars.
+	iid1 := "aaaabbbb-0000-0000-0000-000000000001"
+	iid2 := "aaaabbbb-0000-0000-0000-000000000002"
+	insertTestSession(t, d, iid1, "s1@main", "r1", "/code/r1", "opencode",
+		base.Add(-2*time.Hour), base, "finished", "")
+	insertTestSession(t, d, iid2, "s2@main", "r2", "/code/r2", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	err := runStatsDetail("aaaabbbb", false, false)
+	if err == nil {
+		t.Fatal("expected error for ambiguous prefix, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("expected 'ambiguous' in error\ngot: %v", err)
+	}
+}
+
+// TestRunStatsDetail_Unknown verifies that an unknown arg returns a clear error.
+func TestRunStatsDetail_Unknown(t *testing.T) {
+	_ = openIncarnationTestDB(t)
+
+	err := runStatsDetail("totally-unknown-session", false, false)
+	if err == nil {
+		t.Fatal("expected error for unknown arg, got nil")
+	}
+}
+
+// TestRunStatsDetail_NotYetArchived verifies "(not yet archived)" output when
+// archive_path IS NULL.
+func TestRunStatsDetail_NotYetArchived(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	// No archive path.
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	out := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "not yet archived") {
+		t.Errorf("expected 'not yet archived' when archive_path IS NULL\ngot:\n%s", out)
+	}
+}
+
+// --- --aggregate-by-name flag: must be removed ---
+
+// TestRunStats_AggregateByNameFlagRemoved verifies that --aggregate-by-name is NOT
+// registered on statsCmd (flag is explicitly removed per issue #999).
+func TestRunStats_AggregateByNameFlagRemoved(t *testing.T) {
+	f := statsCmd.Flags().Lookup("aggregate-by-name")
+	if f != nil {
+		t.Error("statsCmd should NOT have an --aggregate-by-name flag (it was removed), but it is still registered")
+	}
+}
+
+// TestRunStats_AggregateByNameProducesError verifies that passing --aggregate-by-name
+// to the cobra root command produces an error (unknown flag).
+func TestRunStats_AggregateByNameProducesError(t *testing.T) {
+	_ = openIncarnationTestDB(t)
+
+	// Execute with the flag through cobra — should return an unknown flag error.
+	rootCmd.SetArgs([]string{"stats", "--aggregate-by-name"})
+	err := rootCmd.Execute()
+	rootCmd.SetArgs(nil) // reset
+	if err == nil {
+		t.Fatal("expected error for unknown flag --aggregate-by-name, got nil")
+	}
+}
+
+// --- --since flag parsing ---
+
+// TestParseSinceFlag_ValidDate verifies ISO 8601 date parsing.
+func TestParseSinceFlag_ValidDate(t *testing.T) {
+	cases := []struct {
+		input string
+		valid bool
+	}{
+		{"2026-04-01", true},
+		{"2026-04-01T00:00:00Z", true},
+		{"2026-04-01T15:04:05Z", true},
+		{"", true},                          // empty is valid (means no filter)
+		{"not-a-date", false},
+		{"2026/04/01", false},
+	}
+
+	for _, tc := range cases {
+		ms, err := parseSinceFlag(tc.input)
+		if tc.valid {
+			if err != nil {
+				t.Errorf("parseSinceFlag(%q) returned unexpected error: %v", tc.input, err)
+			}
+			if tc.input == "" && ms != 0 {
+				t.Errorf("parseSinceFlag(\"\") should return 0, got %d", ms)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("parseSinceFlag(%q) should have returned an error", tc.input)
+			}
+		}
+	}
+}
+
+// TestRunStats_SinceUnparseable verifies that a bad --since value produces an error.
+func TestRunStats_SinceUnparseable(t *testing.T) {
+	_ = openIncarnationTestDB(t)
+
+	statsCmd.Flags().Set("since", "not-a-date") //nolint:errcheck
+	defer statsCmd.Flags().Set("since", "")     //nolint:errcheck
+
+	err := runStats(statsCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for unparseable --since, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot parse") {
+		t.Errorf("expected 'cannot parse' in error\ngot: %v", err)
+	}
+}
+
+// --- token/cost aggregation: NULL instance_id excluded ---
+
+// TestRunStatsIncarnations_NullInstanceIDExcluded verifies that events with
+// NULL instance_id (pre-migration) are NOT counted in incarnation totals.
+func TestRunStatsIncarnations_NullInstanceIDExcluded(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	// Write an event with NULL instance_id (legacy — should NOT be counted).
+	legacyPayload := `{"messageId":"msg-legacy","text":"old reply","agent":"coordinator","model":"anthropic/claude-sonnet-4-6","inputTokens":500000,"outputTokens":100000,"durationMs":5000}`
+	e := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "testrepo@main",
+		Repo:        "testrepo",
+		Worktree:    "/code",
+		Type:        "msg_assistant",
+		Payload:     legacyPayload,
+		CreatedAt:   base.Add(-45 * time.Minute),
+		InstanceID:  nil, // NULL — should NOT be counted
+	}
+	if err := d.WriteEvent(e); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runStatsIncarnations("", 0); err != nil {
+			t.Errorf("runStatsIncarnations: %v", err)
+		}
+	})
+
+	// 500K+100K = 600K tokens — should NOT appear (NULL instance_id excluded).
+	if strings.Contains(out, "600K") {
+		t.Errorf("NULL instance_id events should be excluded from incarnation totals\ngot:\n%s", out)
+	}
+	// Token column should show "—" (no events with this instance_id).
+	if !strings.Contains(out, "—") {
+		t.Errorf("expected '—' for tokens when no instance-linked events\ngot:\n%s", out)
+	}
+}

--- a/modules/programs/prism/prism/cmd/incarnation_stats_test.go
+++ b/modules/programs/prism/prism/cmd/incarnation_stats_test.go
@@ -253,7 +253,7 @@ func TestRunStatsDetail_ByFullUUID(t *testing.T) {
 		base.Add(-1*time.Hour), base, "finished", "/archive/path")
 
 	out := captureStdout(t, func() {
-		if err := runStatsDetail(iid, false, false); err != nil {
+		if err := runStatsDetail(iid, false); err != nil {
 			t.Errorf("runStatsDetail: %v", err)
 		}
 	})
@@ -283,7 +283,7 @@ func TestRunStatsDetail_BySessionName(t *testing.T) {
 		base.Add(-1*time.Hour), base, "finished", "")
 
 	out := captureStdout(t, func() {
-		if err := runStatsDetail("testrepo@main", false, false); err != nil {
+		if err := runStatsDetail("testrepo@main", false); err != nil {
 			t.Errorf("runStatsDetail: %v", err)
 		}
 	})
@@ -305,7 +305,7 @@ func TestRunStatsDetail_ByUUIDPrefix(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		// Use first 8 chars as prefix.
-		if err := runStatsDetail("aaaabbbb", false, false); err != nil {
+		if err := runStatsDetail("aaaabbbb", false); err != nil {
 			t.Errorf("runStatsDetail: %v", err)
 		}
 	})
@@ -328,7 +328,7 @@ func TestRunStatsDetail_AmbiguousPrefix(t *testing.T) {
 	insertTestSession(t, d, iid2, "s2@main", "r2", "/code/r2", "opencode",
 		base.Add(-1*time.Hour), base, "finished", "")
 
-	err := runStatsDetail("aaaabbbb", false, false)
+	err := runStatsDetail("aaaabbbb", false)
 	if err == nil {
 		t.Fatal("expected error for ambiguous prefix, got nil")
 	}
@@ -341,7 +341,7 @@ func TestRunStatsDetail_AmbiguousPrefix(t *testing.T) {
 func TestRunStatsDetail_Unknown(t *testing.T) {
 	_ = openIncarnationTestDB(t)
 
-	err := runStatsDetail("totally-unknown-session", false, false)
+	err := runStatsDetail("totally-unknown-session", false)
 	if err == nil {
 		t.Fatal("expected error for unknown arg, got nil")
 	}
@@ -359,7 +359,7 @@ func TestRunStatsDetail_NotYetArchived(t *testing.T) {
 		base.Add(-1*time.Hour), base, "finished", "")
 
 	out := captureStdout(t, func() {
-		if err := runStatsDetail(iid, false, false); err != nil {
+		if err := runStatsDetail(iid, false); err != nil {
 			t.Errorf("runStatsDetail: %v", err)
 		}
 	})

--- a/modules/programs/prism/prism/cmd/sessions.go
+++ b/modules/programs/prism/prism/cmd/sessions.go
@@ -1,0 +1,226 @@
+package cmd
+
+// prism sessions — general query surface over the sessions table.
+//
+// Usage:
+//
+//	prism sessions list                  tabular listing of all sessions rows
+//	prism sessions list --repo <name>    filter by repo
+//	prism sessions list --since <date>   filter by started_at
+//	prism sessions list --json           emit one JSON object per line (JSONL)
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "Query the sessions table",
+	Long:  `General query surface over the sessions table. Use subcommands to list sessions.`,
+}
+
+var sessionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all session incarnations",
+	Long: `List all rows in the sessions table as a tabular display.
+
+Use --repo to filter by repo name, --since to filter by start date, and
+--json to emit one JSON object per line (JSONL) for scripting.`,
+	Args: cobra.NoArgs,
+	RunE: runSessionsList,
+}
+
+func init() {
+	sessionsListCmd.Flags().String("repo", "", "Filter by repo name")
+	sessionsListCmd.Flags().String("since", "", "Filter by started_at >= date (ISO 8601 or YYYY-MM-DD)")
+	sessionsListCmd.Flags().Bool("json", false, "Emit one JSON object per line (JSONL)")
+	sessionsCmd.AddCommand(sessionsListCmd)
+	rootCmd.AddCommand(sessionsCmd)
+}
+
+// sessionJSONRow is the JSONL schema for one sessions row.
+type sessionJSONRow struct {
+	InstanceID       string  `json:"instanceId"`
+	SessionName      string  `json:"sessionName"`
+	AgentRole        *string `json:"agentRole"`
+	RootAgentName    *string `json:"rootAgentName"`
+	Repo             string  `json:"repo"`
+	Worktree         string  `json:"worktree"`
+	Harness          string  `json:"harness"`
+	HarnessSessionID *string `json:"harnessSessionId,omitempty"`
+	GroupID          *string `json:"groupId,omitempty"`
+	StartedAt        string  `json:"startedAt"` // RFC3339
+	EndedAt          *string `json:"endedAt,omitempty"`
+	EndState         *string `json:"endState,omitempty"`
+	ArchivePath      *string `json:"archivePath,omitempty"`
+	PrismVersion     *string `json:"prismVersion,omitempty"`
+}
+
+func runSessionsList(cmd *cobra.Command, _ []string) error {
+	repoFilter, _ := cmd.Flags().GetString("repo")
+	sinceStr, _ := cmd.Flags().GetString("since")
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	sinceMs, err := parseSinceFlag(sinceStr)
+	if err != nil {
+		return err
+	}
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("sessions list: %w", err)
+	}
+	defer d.Close()
+
+	var sessions []db.Session
+	switch {
+	case repoFilter != "" && sinceMs > 0:
+		sessions, err = d.SessionsForRepoSince(repoFilter, sinceMs)
+	case repoFilter != "":
+		sessions, err = d.SessionsForRepo(repoFilter)
+	case sinceMs > 0:
+		sessions, err = d.SessionsSince(sinceMs)
+	default:
+		sessions, err = d.AllSessions()
+	}
+	if err != nil {
+		return fmt.Errorf("sessions list: %w", err)
+	}
+
+	if jsonMode {
+		return renderSessionsListJSON(sessions)
+	}
+
+	return renderSessionsListTable(sessions)
+}
+
+func renderSessionsListJSON(sessions []db.Session) error {
+	for _, s := range sessions {
+		row := sessionJSONRow{
+			InstanceID:       s.InstanceID,
+			SessionName:      s.SessionName,
+			AgentRole:        s.AgentRole,
+			RootAgentName:    s.RootAgentName,
+			Repo:             s.Repo,
+			Worktree:         s.Worktree,
+			Harness:          s.Harness,
+			HarnessSessionID: s.HarnessSessionID,
+			GroupID:          s.GroupID,
+			StartedAt:        s.StartedAt.UTC().Format(time.RFC3339),
+			EndState:         s.EndState,
+			ArchivePath:      s.ArchivePath,
+			PrismVersion:     s.PrismVersion,
+		}
+		if s.EndedAt != nil {
+			endedStr := s.EndedAt.UTC().Format(time.RFC3339)
+			row.EndedAt = &endedStr
+		}
+		b, err := json.Marshal(row)
+		if err != nil {
+			return fmt.Errorf("sessions list: marshal: %w", err)
+		}
+		fmt.Println(string(b))
+	}
+	return nil
+}
+
+func renderSessionsListTable(sessions []db.Session) error {
+	if len(sessions) == 0 {
+		fmt.Println("no sessions yet")
+		return nil
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	now := time.Now()
+
+	const (
+		wID      = 8
+		wName    = 32
+		wRepo    = 20
+		wAgent   = 14
+		wState   = 10
+		wStarted = 19
+		wDur     = 10
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s",
+		wID, "INSTANCE",
+		wName, "SESSION_NAME",
+		wRepo, "REPO",
+		wAgent, "AGENT",
+		wState, "STATE",
+		wStarted, "STARTED",
+		wDur, "DURATION",
+	)
+	fmt.Println(styleHeader.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, s := range sessions {
+		shortID := s.InstanceID
+		if len(shortID) > wID {
+			shortID = shortID[:wID]
+		}
+
+		sessionName := s.SessionName
+		if len(sessionName) > wName {
+			sessionName = sessionName[:wName-3] + "..."
+		}
+
+		repoStr := s.Repo
+		if len(repoStr) > wRepo {
+			repoStr = repoStr[:wRepo-3] + "..."
+		}
+
+		agentName := "—"
+		if s.RootAgentName != nil && *s.RootAgentName != "" {
+			agentName = *s.RootAgentName
+		} else if s.AgentRole != nil && *s.AgentRole != "" {
+			agentName = *s.AgentRole
+		}
+		if len(agentName) > wAgent {
+			agentName = agentName[:wAgent-3] + "..."
+		}
+
+		state := "active"
+		if s.EndState != nil && *s.EndState != "" {
+			state = *s.EndState
+		} else if s.EndedAt != nil {
+			state = "ended"
+		}
+
+		startedStr := s.StartedAt.Format("2006-01-02 15:04:05")
+
+		var dur time.Duration
+		if s.EndedAt != nil {
+			dur = s.EndedAt.Sub(s.StartedAt)
+		} else {
+			dur = now.Sub(s.StartedAt)
+		}
+		durStr := formatDurationLong(dur)
+
+		stateStyled := stateStyle(state).Render(fmt.Sprintf("%-*s", wState, truncateStr(state, wState)))
+
+		fmt.Printf("%-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s\n",
+			wID, shortID,
+			wName, sessionName,
+			wRepo, repoStr,
+			wAgent, agentName,
+			stateStyled,
+			wStarted, startedStr,
+			wDur, durStr,
+		)
+	}
+
+	fmt.Println()
+	fmt.Println(styleDim.Render("run `prism stats <instance-id>` for full metrics on a specific incarnation"))
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/sessions_test.go
+++ b/modules/programs/prism/prism/cmd/sessions_test.go
@@ -1,0 +1,216 @@
+package cmd
+
+// Tests for prism sessions list (issue #999 ACs):
+//   - prism sessions list → tabular listing of all rows
+//   - prism sessions list --repo <name> → filter by repo
+//   - prism sessions list --since <date> → filter by started_at
+//   - prism sessions list --json → JSONL output (every line independently parseable)
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestRunSessionsList_Empty verifies graceful output for an empty sessions table.
+func TestRunSessionsList_Empty(t *testing.T) {
+	_ = openIncarnationTestDB(t)
+
+	out := captureStdout(t, func() {
+		if err := renderSessionsListTable(nil); err != nil {
+			t.Errorf("renderSessionsListTable: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no sessions yet") {
+		t.Errorf("expected 'no sessions yet' for empty list\ngot:\n%s", out)
+	}
+}
+
+// TestRunSessionsList_TabularOutput verifies that the tabular listing contains
+// the expected column headers and rows.
+func TestRunSessionsList_TabularOutput(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	sessions, err := d.AllSessions()
+	if err != nil {
+		t.Fatalf("AllSessions: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderSessionsListTable(sessions); err != nil {
+			t.Errorf("renderSessionsListTable: %v", err)
+		}
+	})
+
+	// Check headers.
+	for _, hdr := range []string{"INSTANCE", "SESSION_NAME", "REPO", "AGENT", "STATE", "STARTED", "DURATION"} {
+		if !strings.Contains(out, hdr) {
+			t.Errorf("output missing column header %q\ngot:\n%s", hdr, out)
+		}
+	}
+	// Check data.
+	if !strings.Contains(out, iid[:8]) {
+		t.Errorf("output missing short instance_id %q\ngot:\n%s", iid[:8], out)
+	}
+	if !strings.Contains(out, "testrepo@main") {
+		t.Errorf("output missing session name 'testrepo@main'\ngot:\n%s", out)
+	}
+}
+
+// TestRunSessionsList_RepoFilter verifies --repo filtering.
+func TestRunSessionsList_RepoFilter(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid1 := uuid.New().String()
+	iid2 := uuid.New().String()
+	insertTestSession(t, d, iid1, "repo-a@main", "repo-a", "/code/repo-a", "opencode",
+		base.Add(-2*time.Hour), base, "finished", "")
+	insertTestSession(t, d, iid2, "repo-b@main", "repo-b", "/code/repo-b", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	sessions, err := d.SessionsForRepo("repo-a")
+	if err != nil {
+		t.Fatalf("SessionsForRepo: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderSessionsListTable(sessions); err != nil {
+			t.Errorf("renderSessionsListTable: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "repo-a@main") {
+		t.Errorf("expected 'repo-a@main' in filtered output\ngot:\n%s", out)
+	}
+	if strings.Contains(out, "repo-b@main") {
+		t.Errorf("'repo-b@main' should be filtered out\ngot:\n%s", out)
+	}
+}
+
+// TestRunSessionsList_SinceFilter verifies --since filtering.
+func TestRunSessionsList_SinceFilter(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iidOld := uuid.New().String()
+	iidNew := uuid.New().String()
+	insertTestSession(t, d, iidOld, "repo@old", "testrepo", "/code", "opencode",
+		base.Add(-30*24*time.Hour), base.Add(-29*24*time.Hour), "finished", "")
+	insertTestSession(t, d, iidNew, "repo@new", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	sinceMs := base.Add(-7 * 24 * time.Hour).UnixMilli()
+	sessions, err := d.SessionsSince(sinceMs)
+	if err != nil {
+		t.Fatalf("SessionsSince: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderSessionsListTable(sessions); err != nil {
+			t.Errorf("renderSessionsListTable: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "repo@old") {
+		t.Errorf("old session should be filtered out\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "repo@new") {
+		t.Errorf("expected 'repo@new' in output\ngot:\n%s", out)
+	}
+}
+
+// TestRunSessionsList_JSONOutput verifies that --json emits valid JSONL.
+func TestRunSessionsList_JSONOutput(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid1 := uuid.New().String()
+	iid2 := uuid.New().String()
+	insertTestSession(t, d, iid1, "repo@main", "testrepo", "/code", "opencode",
+		base.Add(-2*time.Hour), base.Add(-1*time.Hour), "finished", "/archive/1")
+	insertTestSession(t, d, iid2, "repo@feature", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	sessions, err := d.AllSessions()
+	if err != nil {
+		t.Fatalf("AllSessions: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderSessionsListJSON(sessions); err != nil {
+			t.Errorf("renderSessionsListJSON: %v", err)
+		}
+	})
+
+	// Every line must be independently parseable as a JSON object.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 JSONL lines, got %d\n%s", len(lines), out)
+	}
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Errorf("line %d is not valid JSON: %v\nline: %s", i, err, line)
+		}
+		// Required fields must be present.
+		for _, field := range []string{"instanceId", "sessionName", "repo", "harness", "startedAt"} {
+			if _, ok := obj[field]; !ok {
+				t.Errorf("line %d missing required JSON field %q\n%s", i, field, line)
+			}
+		}
+	}
+}
+
+// TestRunSessionsList_JSONOutput_Empty verifies that --json with no sessions
+// produces no output (empty JSONL is valid).
+func TestRunSessionsList_JSONOutput_Empty(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := renderSessionsListJSON(nil); err != nil {
+			t.Errorf("renderSessionsListJSON: %v", err)
+		}
+	})
+
+	// Should produce no output (valid empty JSONL).
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output for empty sessions list, got: %q", out)
+	}
+}
+
+// TestRunSessionsList_JSONOutput_ArchivePath verifies that archive_path is
+// included in JSON output when non-nil.
+func TestRunSessionsList_JSONOutput_ArchivePath(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "/some/archive/path")
+
+	sessions, err := d.AllSessions()
+	if err != nil {
+		t.Fatalf("AllSessions: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderSessionsListJSON(sessions); err != nil {
+			t.Errorf("renderSessionsListJSON: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "/some/archive/path") {
+		t.Errorf("expected archive path in JSON output\ngot:\n%s", out)
+	}
+}

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -62,20 +62,24 @@ var modelCosts = map[string]struct {
 }
 
 var statsCmd = &cobra.Command{
-	Use:   "stats [session]",
+	Use:   "stats [instance-id|session-name]",
 	Short: "Session metrics and statistics",
-	Long: `Display metrics and statistics for agent sessions.
+	Long: `Display metrics and statistics for agent session incarnations.
 
-With no arguments, shows a summary table of all active sessions across all repos.
+With no arguments, shows one row per incarnation in the sessions table,
+ordered by started_at DESC (most recent first).
 
-With a session name argument, shows per-session metrics. Long-lived sessions
-(e.g. nixos-config@main) that contain multiple opencode sessions are shown as
-a compact table — one row per opencode session. Short-lived worktree sessions
-with a single opencode session are shown as a detailed block.
+With an argument that is a full 36-character UUID (or an unambiguous prefix),
+shows detail for the matching incarnation. Use --instance to force UUID lookup
+even when the argument might also match a session name.
 
-Use --detail to force the detailed block format even for multi-session tmux sessions.
+With a session-name argument, shows detail for the most recent incarnation of
+that session name.
 
-Use --days N to show aggregate statistics over the last N days.
+Filter flags:
+  --repo <name>     only show incarnations where sessions.repo matches
+  --since <date>    only show incarnations started on or after <date>
+                    (ISO 8601 or YYYY-MM-DD, e.g. 2026-04-01)
 
 Use --doomloops to show doom_loop_detected events. Defaults to the last 7 days
 cross-session; combine with --days N to change the window; combine with a
@@ -89,18 +93,45 @@ Use --asks to show permission_ask events aggregated by (session, tool, pattern).
 Defaults to the last 7 days cross-session; combine with --days N to change the
 window; combine with a session name argument to filter to a specific session.
 
+Use --days N to show historical aggregate statistics over the last N days.
+
 Use the 'model' subcommand for a per-provider/model performance breakdown.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStats,
 }
 
 func init() {
-	statsCmd.Flags().Int("days", 0, "Show aggregate statistics over the last N days")
+	statsCmd.Flags().Int("days", 0, "Show aggregate statistics over the last N days (historical view)")
 	statsCmd.Flags().Bool("detail", false, "Force detailed block format even for multi-session tmux sessions")
 	statsCmd.Flags().Bool("doomloops", false, "Show doom_loop_detected events (last 7 days by default)")
 	statsCmd.Flags().Bool("denials", false, "Show permission_denied events aggregated by (session, tool) (last 7 days by default)")
 	statsCmd.Flags().Bool("asks", false, "Show permission_ask events aggregated by (session, tool, pattern) (last 7 days by default)")
+	statsCmd.Flags().String("repo", "", "Filter rows to those where sessions.repo equals this value")
+	statsCmd.Flags().String("since", "", "Filter rows to those started on or after this date (ISO 8601 or YYYY-MM-DD)")
+	statsCmd.Flags().Bool("instance", false, "Treat the argument as a full instance_id (UUID) even if it might match a session name")
 	rootCmd.AddCommand(statsCmd)
+}
+
+// parseSinceFlag parses the --since flag value into a Unix millisecond timestamp.
+// Returns (0, nil) when since is empty. Returns an error when unparseable.
+func parseSinceFlag(since string) (int64, error) {
+	if since == "" {
+		return 0, nil
+	}
+	// Try common date formats.
+	formats := []string{
+		"2006-01-02",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05",
+		time.RFC3339,
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, since); err == nil {
+			return t.UnixMilli(), nil
+		}
+	}
+	return 0, fmt.Errorf("cannot parse --since value %q: expected ISO 8601 date (e.g. 2026-04-01)", since)
 }
 
 func runStats(cmd *cobra.Command, args []string) error {
@@ -109,8 +140,11 @@ func runStats(cmd *cobra.Command, args []string) error {
 	doomloops, _ := cmd.Flags().GetBool("doomloops")
 	denials, _ := cmd.Flags().GetBool("denials")
 	asks, _ := cmd.Flags().GetBool("asks")
+	repoFilter, _ := cmd.Flags().GetString("repo")
+	sinceStr, _ := cmd.Flags().GetString("since")
+	forceInstance, _ := cmd.Flags().GetBool("instance")
 
-	// --doomloops, --denials, and --asks bypass the --days+session guard.
+	// --doomloops, --denials, and --asks bypass the per-incarnation view.
 	// They each have their own session-filter path and --days is additive.
 	if doomloops || denials || asks {
 		// Default window is 7 days; --days N overrides it.
@@ -141,22 +175,323 @@ func runStats(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// --days: historical aggregate view.
 	if days > 0 && len(args) > 0 {
 		return fmt.Errorf("--days is mutually exclusive with a session name")
 	}
-
 	if days > 0 {
 		return runStatsHistorical(days)
 	}
 
-	if len(args) == 1 {
-		return runStatsSession(args[0], detail)
+	// Parse --since before doing anything else so we fail-fast on bad input.
+	sinceMs, err := parseSinceFlag(sinceStr)
+	if err != nil {
+		return err
 	}
 
-	return runStatsSummary()
+	// With an argument: detail view for a specific incarnation or session name.
+	if len(args) == 1 {
+		return runStatsDetail(args[0], forceInstance, detail)
+	}
+
+	// No argument: per-incarnation summary table.
+	return runStatsIncarnations(repoFilter, sinceMs)
 }
 
-// ---------- per-session detail ----------
+// ---------- per-incarnation summary table ----------
+
+// runStatsIncarnations shows one row per row in the sessions table, ordered by
+// started_at DESC. Filtered by repo and/or sinceMs when provided.
+func runStatsIncarnations(repoFilter string, sinceMs int64) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats: %w", err)
+	}
+	defer d.Close()
+
+	var sessions []db.Session
+	switch {
+	case repoFilter != "" && sinceMs > 0:
+		sessions, err = d.SessionsForRepoSince(repoFilter, sinceMs)
+	case repoFilter != "":
+		sessions, err = d.SessionsForRepo(repoFilter)
+	case sinceMs > 0:
+		sessions, err = d.SessionsSince(sinceMs)
+	default:
+		sessions, err = d.AllSessions()
+	}
+	if err != nil {
+		return fmt.Errorf("stats: %w", err)
+	}
+
+	if len(sessions) == 0 {
+		fmt.Println("no sessions yet")
+		return nil
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	now := time.Now()
+
+	const (
+		wID      = 8
+		wName    = 32
+		wAgent   = 14
+		wState   = 10
+		wDur     = 10
+		wTokens  = 8
+		wCost    = 8
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %*s  %*s",
+		wID, "INSTANCE",
+		wName, "SESSION_NAME",
+		wAgent, "AGENT",
+		wState, "STATE",
+		wDur, "DURATION",
+		wTokens, "TOKENS",
+		wCost, "COST",
+	)
+	fmt.Println(styleHeader.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, s := range sessions {
+		shortID := s.InstanceID
+		if len(shortID) > wID {
+			shortID = shortID[:wID]
+		}
+
+		sessionName := s.SessionName
+		if len(sessionName) > wName {
+			sessionName = sessionName[:wName-3] + "..."
+		}
+
+		agentName := "—"
+		if s.RootAgentName != nil && *s.RootAgentName != "" {
+			agentName = agentShortName(*s.RootAgentName)
+		} else if s.AgentRole != nil && *s.AgentRole != "" {
+			agentName = agentShortName(*s.AgentRole)
+		}
+		if len(agentName) > wAgent {
+			agentName = agentName[:wAgent-3] + "..."
+		}
+
+		state := "active"
+		if s.EndState != nil && *s.EndState != "" {
+			state = *s.EndState
+		} else if s.EndedAt != nil {
+			state = "ended"
+		}
+
+		var dur time.Duration
+		if s.EndedAt != nil {
+			dur = s.EndedAt.Sub(s.StartedAt)
+		} else {
+			dur = now.Sub(s.StartedAt)
+		}
+		durStr := formatDurationLong(dur)
+
+		// Compute token/cost totals from agent_events for this instance_id.
+		turns, terr := d.SessionTurnTokens(s.InstanceID)
+		var totalTokens int
+		var totalCost float64
+		if terr == nil {
+			for _, t := range turns {
+				totalTokens += t.Input + t.Output
+				totalCost += computeTurnCost(t)
+			}
+		}
+
+		tokStr := "—"
+		if totalTokens > 0 {
+			tokStr = formatTokenCount(totalTokens)
+		}
+		costStr := "—"
+		if totalCost > 0 {
+			costStr = formatCost(totalCost)
+		}
+
+		stateStyled := stateStyle(state).Render(fmt.Sprintf("%-*s", wState, truncateStr(state, wState)))
+
+		fmt.Printf("%-*s  %-*s  %-*s  %s  %-*s  %*s  %*s\n",
+			wID, shortID,
+			wName, sessionName,
+			wAgent, agentName,
+			stateStyled,
+			wDur, durStr,
+			wTokens, tokStr,
+			wCost, costStr,
+		)
+	}
+
+	fmt.Println()
+	fmt.Println(styleDim.Render("run `prism stats <instance-id>` or `prism stats <session-name>` for detail"))
+	return nil
+}
+
+// computeTurnCost computes the cost for a single msg_assistant turn.
+// Uses the local pricing table when the model is known; falls back to
+// the event-reported cost for unknown models (e.g. openrouter/*).
+func computeTurnCost(t db.TokenTurn) float64 {
+	costs, ok := modelCosts[t.Model]
+	if !ok {
+		return t.EventCost
+	}
+	return (float64(t.Input)*costs.Input +
+		float64(t.Output)*costs.Output +
+		float64(t.CacheRead)*costs.CacheRead +
+		float64(t.CacheWrite)*costs.CacheWrite) / 1_000_000
+}
+
+// ---------- per-incarnation detail view ----------
+
+// runStatsDetail resolves an argument to a specific sessions row and renders
+// detail for it. The argument may be a full UUID, a UUID prefix (when
+// unambiguous), or a session name.
+func runStatsDetail(arg string, forceInstance bool, detail bool) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats: %w", err)
+	}
+	defer d.Close()
+
+	sess, err := resolveSessionArg(d, arg, forceInstance)
+	if err != nil {
+		return err
+	}
+
+	renderIncarnationDetail(d, sess)
+	return nil
+}
+
+// resolveSessionArg resolves an argument to a single sessions row.
+// Disambiguation rules (from issue #999):
+//  1. Full 36-char UUID (or --instance flag) → SessionByInstanceID
+//  2. Exact match in sessions.session_name → MostRecentSessionForName
+//  3. UUID prefix → SessionsByInstanceIDPrefix (must be unambiguous)
+//  4. Not found → error
+func resolveSessionArg(d *db.DB, arg string, forceInstance bool) (*db.Session, error) {
+	// Step 1: full UUID (36 chars) or --instance flag.
+	if forceInstance || len(arg) == 36 {
+		sess, err := d.SessionByInstanceID(arg)
+		if err != nil {
+			return nil, fmt.Errorf("stats: lookup instance %q: %w", arg, err)
+		}
+		if sess != nil {
+			return sess, nil
+		}
+		return nil, fmt.Errorf("stats: instance %q not found", arg)
+	}
+
+	// Step 2: try exact session_name match first.
+	sess, err := d.MostRecentSessionForName(arg)
+	if err != nil {
+		return nil, fmt.Errorf("stats: lookup session name %q: %w", arg, err)
+	}
+	if sess != nil {
+		return sess, nil
+	}
+
+	// Step 3: try UUID prefix match.
+	matches, err := d.SessionsByInstanceIDPrefix(arg)
+	if err != nil {
+		return nil, fmt.Errorf("stats: lookup instance prefix %q: %w", arg, err)
+	}
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+	if len(matches) > 1 {
+		var candidates []string
+		for _, m := range matches {
+			candidates = append(candidates, m.InstanceID)
+		}
+		return nil, fmt.Errorf("stats: %q is ambiguous — multiple incarnations match:\n  %s\nuse the full instance_id to disambiguate",
+			arg, strings.Join(candidates, "\n  "))
+	}
+
+	return nil, fmt.Errorf("stats: %q is not a known instance_id or session_name", arg)
+}
+
+// renderIncarnationDetail renders the full detail block for a single sessions row.
+func renderIncarnationDetail(d *db.DB, sess *db.Session) {
+	styleHeader := lipgloss.NewStyle().Bold(true)
+	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	now := time.Now()
+
+	fmt.Println(styleHeader.Render("incarnation: " + sess.InstanceID))
+	fmt.Println()
+
+	fmt.Printf("%s %s\n", styleLabel.Render("session:"), sess.SessionName)
+	fmt.Printf("%s %s\n", styleLabel.Render("repo:"), sess.Repo)
+
+	if sess.RootAgentName != nil && *sess.RootAgentName != "" {
+		fmt.Printf("%s %s\n", styleLabel.Render("agent:"), *sess.RootAgentName)
+	} else if sess.AgentRole != nil && *sess.AgentRole != "" {
+		fmt.Printf("%s %s\n", styleLabel.Render("agent:"), *sess.AgentRole)
+	}
+
+	state := "active"
+	if sess.EndState != nil && *sess.EndState != "" {
+		state = *sess.EndState
+	} else if sess.EndedAt != nil {
+		state = "ended"
+	}
+	fmt.Printf("%s %s\n", styleLabel.Render("state:"), stateStyle(state).Render(state))
+
+	fmt.Printf("%s %s\n", styleLabel.Render("started:"), sess.StartedAt.Format("2006-01-02 15:04:05"))
+	if sess.EndedAt != nil {
+		fmt.Printf("%s %s\n", styleLabel.Render("ended:"), sess.EndedAt.Format("2006-01-02 15:04:05"))
+		dur := sess.EndedAt.Sub(sess.StartedAt)
+		fmt.Printf("%s %s\n", styleLabel.Render("duration:"), formatDurationLong(dur))
+	} else {
+		dur := now.Sub(sess.StartedAt)
+		fmt.Printf("%s %s\n", styleLabel.Render("duration:"), formatDurationLong(dur))
+	}
+
+	// Archive path.
+	if sess.ArchivePath != nil && *sess.ArchivePath != "" {
+		fmt.Printf("%s %s\n", styleLabel.Render("archive:"), *sess.ArchivePath)
+	} else {
+		fmt.Printf("%s %s\n", styleLabel.Render("archive:"), styleDim.Render("(not yet archived)"))
+	}
+	fmt.Println()
+
+	// Token/cost totals from agent_events.
+	fmt.Println(styleHeader.Render("Token Usage"))
+	turns, err := d.SessionTurnTokens(sess.InstanceID)
+	if err != nil || len(turns) == 0 {
+		fmt.Println(styleDim.Render("  no token data (pre-migration events excluded)"))
+	} else {
+		var totalInput, totalOutput, totalCacheRead, totalCacheWrite int
+		var totalCost float64
+		for _, t := range turns {
+			totalInput += t.Input
+			totalOutput += t.Output
+			totalCacheRead += t.CacheRead
+			totalCacheWrite += t.CacheWrite
+			totalCost += computeTurnCost(t)
+		}
+		if totalInput+totalOutput > 0 {
+			fmt.Printf("  %s %s\n", styleLabel.Render("input:"), formatTokenCount(totalInput))
+			fmt.Printf("  %s %s\n", styleLabel.Render("output:"), formatTokenCount(totalOutput))
+			if totalCacheRead > 0 {
+				fmt.Printf("  %s %s\n", styleLabel.Render("cache read:"), formatTokenCount(totalCacheRead))
+			}
+			if totalCacheWrite > 0 {
+				fmt.Printf("  %s %s\n", styleLabel.Render("cache write:"), formatTokenCount(totalCacheWrite))
+			}
+			if totalCost > 0 {
+				fmt.Printf("  %s %s\n", styleLabel.Render("est. cost:"), formatCost(totalCost))
+			}
+		} else {
+			fmt.Println(styleDim.Render("  no token data"))
+		}
+	}
+}
+
+// ---------- legacy per-session detail (kept for --doomloops/denials/asks) ----------
 
 // sessionMetrics holds aggregated metrics for a single opencode session.
 type sessionMetrics struct {

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -136,7 +136,6 @@ func parseSinceFlag(since string) (int64, error) {
 
 func runStats(cmd *cobra.Command, args []string) error {
 	days, _ := cmd.Flags().GetInt("days")
-	detail, _ := cmd.Flags().GetBool("detail")
 	doomloops, _ := cmd.Flags().GetBool("doomloops")
 	denials, _ := cmd.Flags().GetBool("denials")
 	asks, _ := cmd.Flags().GetBool("asks")
@@ -191,7 +190,7 @@ func runStats(cmd *cobra.Command, args []string) error {
 
 	// With an argument: detail view for a specific incarnation or session name.
 	if len(args) == 1 {
-		return runStatsDetail(args[0], forceInstance, detail)
+		return runStatsDetail(args[0], forceInstance)
 	}
 
 	// No argument: per-incarnation summary table.
@@ -348,7 +347,7 @@ func computeTurnCost(t db.TokenTurn) float64 {
 // runStatsDetail resolves an argument to a specific sessions row and renders
 // detail for it. The argument may be a full UUID, a UUID prefix (when
 // unambiguous), or a session name.
-func runStatsDetail(arg string, forceInstance bool, detail bool) error {
+func runStatsDetail(arg string, forceInstance bool) error {
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats: %w", err)

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -2478,3 +2478,211 @@ FROM agent_status
 WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
 	return d.queryStatuses(q, parentSession)
 }
+
+// scanSession scans a sessions row from the given scanner into a Session value.
+func scanSession(s scanner) (*Session, error) {
+	var sess Session
+	var startedAt int64
+	var endedAt sql.NullInt64
+	var agentRole sql.NullString
+	var rootAgentName sql.NullString
+	var harnessSessionID sql.NullString
+	var groupID sql.NullString
+	var endState sql.NullString
+	var archivePath sql.NullString
+	var prismVersion sql.NullString
+
+	err := s.Scan(
+		&sess.InstanceID, &sess.SessionName, &agentRole, &rootAgentName,
+		&sess.Repo, &sess.Worktree, &sess.Harness, &harnessSessionID, &groupID,
+		&startedAt, &endedAt, &endState, &archivePath, &prismVersion,
+	)
+	if err != nil {
+		return nil, err
+	}
+	sess.StartedAt = time.UnixMilli(startedAt)
+	if endedAt.Valid {
+		t := time.UnixMilli(endedAt.Int64)
+		sess.EndedAt = &t
+	}
+	if agentRole.Valid {
+		sess.AgentRole = &agentRole.String
+	}
+	if rootAgentName.Valid {
+		sess.RootAgentName = &rootAgentName.String
+	}
+	if harnessSessionID.Valid {
+		sess.HarnessSessionID = &harnessSessionID.String
+	}
+	if groupID.Valid {
+		sess.GroupID = &groupID.String
+	}
+	if endState.Valid {
+		sess.EndState = &endState.String
+	}
+	if archivePath.Valid {
+		sess.ArchivePath = &archivePath.String
+	}
+	if prismVersion.Valid {
+		sess.PrismVersion = &prismVersion.String
+	}
+	return &sess, nil
+}
+
+const sessionsSelectCols = `
+SELECT instance_id, session_name, agent_role, root_agent_name,
+       repo, worktree, harness, harness_session_id, group_id,
+       started_at, ended_at, end_state, archive_path, prism_version
+  FROM sessions`
+
+// querySessions is a helper that runs a SELECT on sessions and scans rows.
+func (d *DB) querySessions(q string, args ...any) ([]Session, error) {
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []Session
+	for rows.Next() {
+		sess, err := scanSession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("db: scan session: %w", err)
+		}
+		sessions = append(sessions, *sess)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate sessions: %w", err)
+	}
+	return sessions, nil
+}
+
+// AllSessions returns all rows in the sessions table, ordered by started_at DESC.
+func (d *DB) AllSessions() ([]Session, error) {
+	return d.querySessions(sessionsSelectCols + ` ORDER BY started_at DESC`)
+}
+
+// SessionsForRepo returns all sessions rows for the given repo, ordered by
+// started_at DESC.
+func (d *DB) SessionsForRepo(repo string) ([]Session, error) {
+	return d.querySessions(sessionsSelectCols+` WHERE repo = ? ORDER BY started_at DESC`, repo)
+}
+
+// SessionsSince returns all sessions rows where started_at >= sinceMs (Unix
+// milliseconds), ordered by started_at DESC.
+func (d *DB) SessionsSince(sinceMs int64) ([]Session, error) {
+	return d.querySessions(sessionsSelectCols+` WHERE started_at >= ? ORDER BY started_at DESC`, sinceMs)
+}
+
+// SessionsForRepoSince returns all sessions rows for repo where started_at >=
+// sinceMs, ordered by started_at DESC.
+func (d *DB) SessionsForRepoSince(repo string, sinceMs int64) ([]Session, error) {
+	return d.querySessions(sessionsSelectCols+` WHERE repo = ? AND started_at >= ? ORDER BY started_at DESC`, repo, sinceMs)
+}
+
+// SessionByInstanceID returns the sessions row with the given instance_id, or
+// nil when not found.
+func (d *DB) SessionByInstanceID(instanceID string) (*Session, error) {
+	row := d.conn.QueryRow(sessionsSelectCols+` WHERE instance_id = ?`, instanceID)
+	sess, err := scanSession(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: session by instance_id: %w", err)
+	}
+	return sess, nil
+}
+
+// SessionsByInstanceIDPrefix returns all sessions rows whose instance_id starts
+// with the given prefix. Used for short-form UUID lookup.
+func (d *DB) SessionsByInstanceIDPrefix(prefix string) ([]Session, error) {
+	return d.querySessions(sessionsSelectCols+` WHERE instance_id LIKE ? ORDER BY started_at DESC`, prefix+"%")
+}
+
+// MostRecentSessionForName returns the most recent sessions row whose
+// session_name equals name (ordered by started_at DESC, take first), or nil.
+func (d *DB) MostRecentSessionForName(name string) (*Session, error) {
+	row := d.conn.QueryRow(sessionsSelectCols+` WHERE session_name = ? ORDER BY started_at DESC LIMIT 1`, name)
+	sess, err := scanSession(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: most recent session for name: %w", err)
+	}
+	return sess, nil
+}
+
+// SessionsByName returns all sessions rows where session_name = name, ordered
+// by started_at DESC.
+func (d *DB) SessionsByName(name string) ([]Session, error) {
+	return d.querySessions(sessionsSelectCols+` WHERE session_name = ? ORDER BY started_at DESC`, name)
+}
+
+// SessionTokenTotals returns the sum of input+output tokens from agent_events
+// for the given instance_id. Only events with a non-NULL instance_id matching
+// instanceID are counted (pre-migration NULL rows are excluded).
+// Returns (inputTokens, outputTokens, totalCost, error).
+func (d *DB) SessionTokenTotals(instanceID string) (inputTokens, outputTokens int, totalCost float64, err error) {
+	const q = `
+SELECT COALESCE(SUM(JSON_EXTRACT(payload, '$.inputTokens')), 0),
+       COALESCE(SUM(JSON_EXTRACT(payload, '$.outputTokens')), 0),
+       COALESCE(SUM(JSON_EXTRACT(payload, '$.cacheReadTokens')), 0),
+       COALESCE(SUM(JSON_EXTRACT(payload, '$.cacheWriteTokens')), 0)
+  FROM agent_events
+ WHERE instance_id = ?
+   AND type = 'msg_assistant'`
+	var input, output, cacheRead, cacheWrite int
+	if scanErr := d.conn.QueryRow(q, instanceID).Scan(&input, &output, &cacheRead, &cacheWrite); scanErr != nil {
+		return 0, 0, 0, fmt.Errorf("db: session token totals: %w", scanErr)
+	}
+	return input, output, 0, nil
+}
+
+// SessionTokensAndCostPerTurn returns (inputTokens, outputTokens, cacheRead,
+// cacheWrite, eventCost) as separate per-turn slices for the given instance_id,
+// along with the model seen on each turn. The returned slices are parallel —
+// index i corresponds to the same msg_assistant event in all slices. Only events
+// with instance_id = instanceID are returned (NULL rows excluded).
+type TokenTurn struct {
+	Model       string
+	Input       int
+	Output      int
+	CacheRead   int
+	CacheWrite  int
+	EventCost   float64
+}
+
+// SessionTurnTokens returns per-turn token data for the given instance_id.
+func (d *DB) SessionTurnTokens(instanceID string) ([]TokenTurn, error) {
+	const q = `
+SELECT COALESCE(JSON_EXTRACT(payload, '$.model'), ''),
+       COALESCE(JSON_EXTRACT(payload, '$.inputTokens'), 0),
+       COALESCE(JSON_EXTRACT(payload, '$.outputTokens'), 0),
+       COALESCE(JSON_EXTRACT(payload, '$.cacheReadTokens'), 0),
+       COALESCE(JSON_EXTRACT(payload, '$.cacheWriteTokens'), 0),
+       COALESCE(JSON_EXTRACT(payload, '$.cost'), 0.0)
+  FROM agent_events
+ WHERE instance_id = ?
+   AND type = 'msg_assistant'
+ ORDER BY created_at ASC`
+	rows, err := d.conn.Query(q, instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("db: session turn tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var turns []TokenTurn
+	for rows.Next() {
+		var t TokenTurn
+		if scanErr := rows.Scan(&t.Model, &t.Input, &t.Output, &t.CacheRead, &t.CacheWrite, &t.EventCost); scanErr != nil {
+			return nil, fmt.Errorf("db: session turn tokens: scan: %w", scanErr)
+		}
+		turns = append(turns, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: session turn tokens: iterate: %w", err)
+	}
+	return turns, nil
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -2596,8 +2596,11 @@ func (d *DB) SessionByInstanceID(instanceID string) (*Session, error) {
 
 // SessionsByInstanceIDPrefix returns all sessions rows whose instance_id starts
 // with the given prefix. Used for short-form UUID lookup.
+// The prefix is escaped for SQL LIKE metacharacters (`%`, `_`, `\`) so that
+// literal characters in the prefix are matched exactly, not as wildcards.
 func (d *DB) SessionsByInstanceIDPrefix(prefix string) ([]Session, error) {
-	return d.querySessions(sessionsSelectCols+` WHERE instance_id LIKE ? ORDER BY started_at DESC`, prefix+"%")
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
+	return d.querySessions(sessionsSelectCols+` WHERE instance_id LIKE ? ESCAPE '\' ORDER BY started_at DESC`, escaped+"%")
 }
 
 // MostRecentSessionForName returns the most recent sessions row whose
@@ -2620,31 +2623,8 @@ func (d *DB) SessionsByName(name string) ([]Session, error) {
 	return d.querySessions(sessionsSelectCols+` WHERE session_name = ? ORDER BY started_at DESC`, name)
 }
 
-// SessionTokenTotals returns the sum of input+output tokens from agent_events
-// for the given instance_id. Only events with a non-NULL instance_id matching
-// instanceID are counted (pre-migration NULL rows are excluded).
-// Returns (inputTokens, outputTokens, totalCost, error).
-func (d *DB) SessionTokenTotals(instanceID string) (inputTokens, outputTokens int, totalCost float64, err error) {
-	const q = `
-SELECT COALESCE(SUM(JSON_EXTRACT(payload, '$.inputTokens')), 0),
-       COALESCE(SUM(JSON_EXTRACT(payload, '$.outputTokens')), 0),
-       COALESCE(SUM(JSON_EXTRACT(payload, '$.cacheReadTokens')), 0),
-       COALESCE(SUM(JSON_EXTRACT(payload, '$.cacheWriteTokens')), 0)
-  FROM agent_events
- WHERE instance_id = ?
-   AND type = 'msg_assistant'`
-	var input, output, cacheRead, cacheWrite int
-	if scanErr := d.conn.QueryRow(q, instanceID).Scan(&input, &output, &cacheRead, &cacheWrite); scanErr != nil {
-		return 0, 0, 0, fmt.Errorf("db: session token totals: %w", scanErr)
-	}
-	return input, output, 0, nil
-}
-
-// SessionTokensAndCostPerTurn returns (inputTokens, outputTokens, cacheRead,
-// cacheWrite, eventCost) as separate per-turn slices for the given instance_id,
-// along with the model seen on each turn. The returned slices are parallel —
-// index i corresponds to the same msg_assistant event in all slices. Only events
-// with instance_id = instanceID are returned (NULL rows excluded).
+// TokenTurn holds per-turn token and cost data for a single msg_assistant event.
+// Used by SessionTurnTokens to return per-turn data for cost calculation.
 type TokenTurn struct {
 	Model       string
 	Input       int


### PR DESCRIPTION
## Summary

Implements issue #999 — the final CLI/stats piece of the session-archive design from #995.

- **`prism stats` rework**: default view is now one row per incarnation in the `sessions` table (ordered by `started_at DESC`), replacing the legacy `session_name`-aggregated view. Adds `--repo` and `--since <date>` filter flags.
- **`prism stats <instance-id|session-name>`**: detail view for a specific incarnation. Argument disambiguation: full 36-char UUID → instance_id lookup; shorter string → session_name lookup (most recent incarnation); unambiguous prefix → prefix match. Use `--instance` to force UUID mode.
- **`prism archive`**: new subcommand — prints `sessions.archive_path` for an incarnation. Returns "session not yet archived" (non-zero exit) when `archive_path IS NULL`. Supports `--all` for all incarnations of a session name.
- **`prism sessions list`**: new subcommand — tabular listing of all `sessions` rows. Supports `--repo`, `--since`, and `--json` (JSONL) flags.
- **`--aggregate-by-name` explicitly removed**: produces the standard Go flag parser's unknown-flag error (as required by AC).
- **Token/cost aggregation**: computed from `agent_events WHERE instance_id = ?`; NULL `instance_id` rows (pre-migration) excluded per #995 design.

### Migration note
`prism stats` (no args) no longer shows the session_name-aggregated view. It now shows one row per incarnation. Use `prism stats --days N` for the historical aggregate, or `prism stats <session-name>` for the most recent incarnation of a named session.

## Changes

- `internal/db/db.go`: adds `AllSessions`, `SessionsForRepo`, `SessionsSince`, `SessionsForRepoSince`, `SessionByInstanceID`, `SessionsByInstanceIDPrefix`, `MostRecentSessionForName`, `SessionsByName`, `SessionTurnTokens`, `scanSession`, `querySessions`
- `cmd/stats.go`: reworked default/detail handlers; adds `--repo`, `--since`, `--instance` flags; removes `--aggregate-by-name`
- `cmd/archive.go`: new `prism archive` command
- `cmd/sessions.go`: new `prism sessions list` command with JSONL support

Closes #999