### PR TITLE
prism: archive opencode session subtree at cleanup + manifest.json (#997)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -242,7 +242,7 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 					fmt.Fprintf(os.Stderr, "[prism] doCleanup: update session ended: %v\n", updErr)
 				}
 				// Archive the session storage after recording the end state.
-				if archiveErr := runArchive(d, m.session, instanceIDForSessions, isolationMode); archiveErr != nil {
+				if archiveErr := runSessionArchive(d, m.session, instanceIDForSessions, isolationMode); archiveErr != nil {
 					if errors.Is(archiveErr, archive.ErrAlreadyExists) {
 						_ = d.PurgeBusMessages(m.session)
 						d.Close()
@@ -521,7 +521,7 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 				fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: update session ended: %v\n", updErr)
 			}
 			// Archive the session storage after recording the end state.
-			if archiveErr := runArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
+			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
 				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
 					_ = d.PurgeBusMessages(session)
 					d.Close()
@@ -581,7 +581,7 @@ func closeSession(session string) error {
 				fmt.Fprintf(os.Stderr, "[prism] closeSession: update session ended: %v\n", updErr)
 			}
 			// Archive the session storage after recording the end state.
-			if archiveErr := runArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
+			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
 				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
 					_ = d.PurgeBusMessages(session)
 					d.Close()
@@ -653,7 +653,7 @@ func headlessCloseSession(session string) error {
 				fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: update session ended: %v\n", updErr)
 			}
 			// Archive the session storage after recording the end state.
-			if archiveErr := runArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
+			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
 				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
 					_ = d.PurgeBusMessages(session)
 					d.Close()
@@ -735,7 +735,7 @@ func worktreePathFromSession(session string) string {
 	return ""
 }
 
-// runArchive performs the opencode-storage copy for the session identified by
+// runSessionArchive performs the opencode-storage copy for the session identified by
 // instanceID using the already-open DB d and the agent_status isolation mode
 // from statusIsolationMode. It is called after UpdateSessionEnded so the
 // sessions row has ended_at and end_state populated.
@@ -751,7 +751,7 @@ func worktreePathFromSession(session string) string {
 //
 // Sessions with unknown or unsupported isolation modes log a clear warning and
 // are skipped (AC: edge-case — unknown isolation mode); returns nil.
-func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) error {
+func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) error {
 	if instanceID == "" {
 		// No instance_id — nothing to archive.
 		return nil
@@ -768,7 +768,7 @@ func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) e
 	}
 
 	// Fetch the full sessions row (has ended_at/end_state set by caller).
-	sess, err := d.GetSession(instanceID)
+	sess, err := d.SessionByInstanceID(instanceID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[prism] archive: get session %q: %v — skipping archive\n", instanceID, err)
 		return nil

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -241,7 +242,14 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 					fmt.Fprintf(os.Stderr, "[prism] doCleanup: update session ended: %v\n", updErr)
 				}
 				// Archive the session storage after recording the end state.
-				runArchive(d, m.session, instanceIDForSessions, isolationMode)
+				if archiveErr := runArchive(d, m.session, instanceIDForSessions, isolationMode); archiveErr != nil {
+					if errors.Is(archiveErr, archive.ErrAlreadyExists) {
+						_ = d.PurgeBusMessages(m.session)
+						d.Close()
+						return cleanupDoneMsg{archiveErr}
+					}
+					// Other archive errors are non-fatal — cleanup continues.
+				}
 			}
 			_ = d.PurgeBusMessages(m.session)
 			d.Close()
@@ -513,7 +521,14 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 				fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: update session ended: %v\n", updErr)
 			}
 			// Archive the session storage after recording the end state.
-			runArchive(d, session, instanceIDForSessions, isolationMode)
+			if archiveErr := runArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
+				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
+					_ = d.PurgeBusMessages(session)
+					d.Close()
+					return archiveErr
+				}
+				// Other archive errors are non-fatal — cleanup continues.
+			}
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -566,7 +581,14 @@ func closeSession(session string) error {
 				fmt.Fprintf(os.Stderr, "[prism] closeSession: update session ended: %v\n", updErr)
 			}
 			// Archive the session storage after recording the end state.
-			runArchive(d, session, instanceIDForSessions, isolationMode)
+			if archiveErr := runArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
+				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
+					_ = d.PurgeBusMessages(session)
+					d.Close()
+					return archiveErr
+				}
+				// Other archive errors are non-fatal — cleanup continues.
+			}
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -631,7 +653,14 @@ func headlessCloseSession(session string) error {
 				fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: update session ended: %v\n", updErr)
 			}
 			// Archive the session storage after recording the end state.
-			runArchive(d, session, instanceIDForSessions, isolationMode)
+			if archiveErr := runArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
+				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
+					_ = d.PurgeBusMessages(session)
+					d.Close()
+					return archiveErr
+				}
+				// Other archive errors are non-fatal — cleanup continues.
+			}
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -712,15 +741,20 @@ func worktreePathFromSession(session string) string {
 // sessions row has ended_at and end_state populated.
 //
 // On success it calls UpdateSessionArchivePath to record the archive directory
-// path in the DB. On any error it logs a warning and returns — archive failure
-// is non-fatal and must not block the rest of cleanup.
+// path in the DB.
+//
+// Return value: the error from archive.Run, or nil on success. The caller is
+// responsible for deciding whether the error should be fatal:
+//   - archive.ErrAlreadyExists should be propagated — the AC requires cleanup
+//     to exit non-zero when the archive directory already exists on a re-run.
+//   - Other errors are treated as non-fatal (logged + cleanup continues).
 //
 // Sessions with unknown or unsupported isolation modes log a clear warning and
-// are skipped (AC: edge-case — unknown isolation mode).
-func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) {
+// are skipped (AC: edge-case — unknown isolation mode); returns nil.
+func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) error {
 	if instanceID == "" {
 		// No instance_id — nothing to archive.
-		return
+		return nil
 	}
 
 	// Validate isolation mode before doing any work.
@@ -730,32 +764,32 @@ func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) {
 	default:
 		fmt.Fprintf(os.Stderr, "[prism] archive: skipping session %q — unsupported isolation mode %q\n",
 			sessionName, statusIsolationMode)
-		return
+		return nil
 	}
 
 	// Fetch the full sessions row (has ended_at/end_state set by caller).
 	sess, err := d.GetSession(instanceID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[prism] archive: get session %q: %v — skipping archive\n", instanceID, err)
-		return
+		return nil
 	}
 	if sess == nil {
 		// No sessions row — pre-migration or session that never inserted.
 		fmt.Fprintf(os.Stderr, "[prism] archive: no sessions row for instance_id %q — skipping archive\n", instanceID)
-		return
+		return nil
 	}
 
 	// Build archive params from DB fields.
 	params := archive.Params{
-		InstanceID:    sess.InstanceID,
-		SessionName:   sess.SessionName,
-		Harness:       sess.Harness,
-		Repo:          sess.Repo,
-		Worktree:      sess.Worktree,
-		StartedAt:     sess.StartedAt,
-		EndedAt:       time.Now(), // EndedAt was just set in DB; use now as fallback
-		IsolationMode: statusIsolationMode,
-		PrismVersion:  archive.PrismGitSHA(),
+		InstanceID:     sess.InstanceID,
+		SessionName:    sess.SessionName,
+		Harness:        sess.Harness,
+		Repo:           sess.Repo,
+		Worktree:       sess.Worktree,
+		StartedAt:      sess.StartedAt,
+		EndedAt:        time.Now(), // EndedAt was just set in DB; use now as fallback
+		IsolationMode:  statusIsolationMode,
+		PrismVersion:   archive.PrismGitSHA(),
 		HarnessVersion: archive.HarnessVersion(),
 	}
 	if sess.AgentRole != nil {
@@ -783,12 +817,13 @@ func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) {
 	archivePath, archiveErr := archive.Run(params)
 	if archiveErr != nil {
 		fmt.Fprintf(os.Stderr, "[prism] archive: copy failed for session %q: %v\n", sessionName, archiveErr)
-		return
+		return archiveErr
 	}
 
 	if updErr := d.UpdateSessionArchivePath(instanceID, archivePath); updErr != nil {
 		fmt.Fprintf(os.Stderr, "[prism] archive: update archive_path for %q: %v\n", instanceID, updErr)
 	}
+	return nil
 }
 
 func init() {

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/archive"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
@@ -233,11 +234,14 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 				fmt.Fprintf(os.Stderr, "[prism] doCleanup: release port: %v\n", releaseErr)
 			}
 			instanceIDForSessions := instanceIDFromStatus(d, m.session)
+			isolationMode := isolationModeFromDB(d, m.session)
 			_ = d.SetEnded(m.session)
 			if instanceIDForSessions != "" {
 				if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
 					fmt.Fprintf(os.Stderr, "[prism] doCleanup: update session ended: %v\n", updErr)
 				}
+				// Archive the session storage after recording the end state.
+				runArchive(d, m.session, instanceIDForSessions, isolationMode)
 			}
 			_ = d.PurgeBusMessages(m.session)
 			d.Close()
@@ -499,13 +503,17 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
 			fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: release port: %v\n", releaseErr)
 		}
-		// Capture instance_id before SetEnded clears the row's lifecycle fields.
+		// Capture instance_id and isolation_mode before SetEnded clears the
+		// row's lifecycle fields.
 		instanceIDForSessions := instanceIDFromStatus(d, session)
+		isolationMode := isolationModeFromDB(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
 				fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: update session ended: %v\n", updErr)
 			}
+			// Archive the session storage after recording the end state.
+			runArchive(d, session, instanceIDForSessions, isolationMode)
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -551,11 +559,14 @@ func closeSession(session string) error {
 			fmt.Fprintf(os.Stderr, "[prism] closeSession: release port: %v\n", releaseErr)
 		}
 		instanceIDForSessions := instanceIDFromStatus(d, session)
+		isolationMode := isolationModeFromDB(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
 				fmt.Fprintf(os.Stderr, "[prism] closeSession: update session ended: %v\n", updErr)
 			}
+			// Archive the session storage after recording the end state.
+			runArchive(d, session, instanceIDForSessions, isolationMode)
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -613,11 +624,14 @@ func headlessCloseSession(session string) error {
 			fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: release port: %v\n", releaseErr)
 		}
 		instanceIDForSessions := instanceIDFromStatus(d, session)
+		isolationMode := isolationModeFromDB(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
 				fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: update session ended: %v\n", updErr)
 			}
+			// Archive the session storage after recording the end state.
+			runArchive(d, session, instanceIDForSessions, isolationMode)
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -692,6 +706,91 @@ func worktreePathFromSession(session string) string {
 	return ""
 }
 
+// runArchive performs the opencode-storage copy for the session identified by
+// instanceID using the already-open DB d and the agent_status isolation mode
+// from statusIsolationMode. It is called after UpdateSessionEnded so the
+// sessions row has ended_at and end_state populated.
+//
+// On success it calls UpdateSessionArchivePath to record the archive directory
+// path in the DB. On any error it logs a warning and returns — archive failure
+// is non-fatal and must not block the rest of cleanup.
+//
+// Sessions with unknown or unsupported isolation modes log a clear warning and
+// are skipped (AC: edge-case — unknown isolation mode).
+func runArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) {
+	if instanceID == "" {
+		// No instance_id — nothing to archive.
+		return
+	}
+
+	// Validate isolation mode before doing any work.
+	switch statusIsolationMode {
+	case "host", "bwrap", "podman":
+		// OK — supported modes.
+	default:
+		fmt.Fprintf(os.Stderr, "[prism] archive: skipping session %q — unsupported isolation mode %q\n",
+			sessionName, statusIsolationMode)
+		return
+	}
+
+	// Fetch the full sessions row (has ended_at/end_state set by caller).
+	sess, err := d.GetSession(instanceID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[prism] archive: get session %q: %v — skipping archive\n", instanceID, err)
+		return
+	}
+	if sess == nil {
+		// No sessions row — pre-migration or session that never inserted.
+		fmt.Fprintf(os.Stderr, "[prism] archive: no sessions row for instance_id %q — skipping archive\n", instanceID)
+		return
+	}
+
+	// Build archive params from DB fields.
+	params := archive.Params{
+		InstanceID:    sess.InstanceID,
+		SessionName:   sess.SessionName,
+		Harness:       sess.Harness,
+		Repo:          sess.Repo,
+		Worktree:      sess.Worktree,
+		StartedAt:     sess.StartedAt,
+		EndedAt:       time.Now(), // EndedAt was just set in DB; use now as fallback
+		IsolationMode: statusIsolationMode,
+		PrismVersion:  archive.PrismGitSHA(),
+		HarnessVersion: archive.HarnessVersion(),
+	}
+	if sess.AgentRole != nil {
+		params.AgentRole = *sess.AgentRole
+	}
+	if sess.RootAgentName != nil {
+		params.RootAgentName = *sess.RootAgentName
+	}
+	if sess.HarnessSessionID != nil {
+		params.HarnessSessionID = *sess.HarnessSessionID
+	}
+	if sess.GroupID != nil {
+		params.GroupID = *sess.GroupID
+	}
+	if sess.EndedAt != nil {
+		params.EndedAt = *sess.EndedAt
+	}
+	if sess.EndState != nil {
+		params.EndState = *sess.EndState
+	}
+	if sess.PrismVersion != nil {
+		params.PrismVersion = *sess.PrismVersion
+	}
+
+	archivePath, archiveErr := archive.Run(params)
+	if archiveErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism] archive: copy failed for session %q: %v\n", sessionName, archiveErr)
+		return
+	}
+
+	if updErr := d.UpdateSessionArchivePath(instanceID, archivePath); updErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism] archive: update archive_path for %q: %v\n", instanceID, updErr)
+	}
+}
+
 func init() {
 	cleanupCmd.Flags().Bool("yes", false, "Non-interactive: skip all prompts and clean up immediately")
 	cleanupCmd.Flags().String("session", "", "Target session name (default: current session)")
@@ -719,6 +818,17 @@ func hostModeFromDB(d *db.DB, sessionName string) bool {
 		return false
 	}
 	return status.HostMode
+}
+
+// isolationModeFromDB queries the already-open database d and returns the
+// effective isolation mode for sessionName using Status.EffectiveIsolationMode.
+// Returns "" when the row is missing or on any error.
+func isolationModeFromDB(d *db.DB, sessionName string) string {
+	status, err := d.CurrentStatus(sessionName)
+	if err != nil || status == nil {
+		return ""
+	}
+	return status.EffectiveIsolationMode()
 }
 
 // stopAndRemoveChildContainers stops and removes podman containers for all

--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -106,7 +106,8 @@ type Params struct {
 // error the temp directory is removed and Run returns a non-nil error.
 //
 // Idempotency: if the target archive directory already exists when Run is
-// called, Run returns a non-nil error and leaves the existing directory intact.
+// called, Run returns archive.ErrAlreadyExists and leaves the existing
+// directory intact.
 //
 // Sessions with no HarnessSessionID (opencode failed to start) still produce
 // an archive directory containing manifest.json and an empty raw/ directory.
@@ -116,11 +117,25 @@ func Run(p Params) (archivePath string, err error) {
 		return "", err
 	}
 
+	// Validate p.Repo to prevent path traversal: it must not contain any
+	// path separator or resolve outside archiveRoot. A repo name like
+	// "../../evil" would otherwise escape the archive root via filepath.Join.
+	cleanRepo := filepath.Clean(p.Repo)
+	if cleanRepo != p.Repo || strings.ContainsRune(p.Repo, os.PathSeparator) || p.Repo == ".." {
+		return "", fmt.Errorf("archive: invalid repo name %q (must not contain path separators or be '..')", p.Repo)
+	}
+
 	// Build the final archive directory path: <archiveRoot>/<repo>/<startedAtISO>_<instanceID>/
 	dirName := p.StartedAt.UTC().Format("20060102T150405Z") + "_" + p.InstanceID
 	repoDir := filepath.Join(archiveRoot, p.Repo)
 	finalDir := filepath.Join(repoDir, dirName)
 	tmpDir := filepath.Join(repoDir, ".tmp-"+p.InstanceID)
+
+	// Secondary containment check: repoDir must be a direct child of archiveRoot
+	// (guards against any edge case not caught by the string checks above).
+	if filepath.Dir(repoDir) != filepath.Clean(archiveRoot) {
+		return "", fmt.Errorf("archive: repo dir %q is not a direct child of archive root %q", repoDir, archiveRoot)
+	}
 
 	// Check whether target already exists before touching anything.
 	if _, statErr := os.Stat(finalDir); statErr == nil {
@@ -215,6 +230,14 @@ func resolvePaths(p Params) (archiveRoot, storageRoot string, err error) {
 //   - host / bwrap: $HOME/.local/share/opencode/storage
 //   - podman: $HOME/.local/share/opencode/prism-sessions/<containerName>/storage
 //   - unknown / empty: returns an error
+//
+// bwrap note: bwrap sessions bind-mount the *shared* ~/.local/share/opencode/
+// directory (not a per-session sub-dir); see internal/container/bwrap.go.
+// The per-session isolation used by the podman path (Darwin virtiofs WAL-mode
+// workaround) does not apply to bwrap. The shared root is correct here because
+// copySessionFiles scopes its reads to the specific harness_session_id, so only
+// files belonging to this session are copied even when the storage pool
+// contains concurrent bwrap sessions.
 func resolveStorageRoot(isolationMode, sessionName string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -367,16 +390,18 @@ func findSessionFile(harnessSessionID, storageRoot string) (path, projectID stri
 }
 
 // copyDirFlat copies all regular files in srcDir into dstDir (created if
-// absent). Subdirectories within srcDir are ignored. If srcDir does not exist
-// or is empty, a (possibly empty) dstDir is still created and nil is returned.
+// absent). Subdirectories within srcDir are ignored. If srcDir does not exist,
+// a (possibly empty) dstDir is still created and nil is returned. A real I/O
+// error (e.g. permission denied) reading srcDir is returned to the caller.
 func copyDirFlat(srcDir, dstDir string) error {
 	if mkErr := os.MkdirAll(dstDir, archiveDirMode); mkErr != nil {
 		return fmt.Errorf("create %s: %w", dstDir, mkErr)
 	}
 	entries, err := listDirEntries(srcDir)
 	if err != nil {
-		// srcDir missing → treat as empty.
-		return nil
+		// listDirEntries returns nil for os.IsNotExist; any remaining error is
+		// a real I/O failure (e.g. EACCES) that we propagate.
+		return fmt.Errorf("read %s: %w", srcDir, err)
 	}
 	for _, name := range entries {
 		src := filepath.Join(srcDir, name)
@@ -430,6 +455,10 @@ func copyFile(src, dst string) error {
 // toolOutputIDsFromPart parses the part JSON at path and returns any
 // tool-output file IDs referenced (e.g. "tool_<ulid>"). Returns nil on any
 // parse error (best-effort; caller handles missing tool-output gracefully).
+//
+// The returned IDs are validated to be plain file names (no path separator,
+// no ".." components) to prevent path traversal when used in filepath.Join.
+// Any crafted asset value containing "/" or ".." is silently dropped.
 func toolOutputIDsFromPart(path string) []string {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -446,10 +475,18 @@ func toolOutputIDsFromPart(path string) []string {
 		return nil
 	}
 
-	if part.Type == "tool" && strings.HasPrefix(part.Asset, "tool_") {
-		return []string{part.Asset}
+	if part.Type != "tool" || !strings.HasPrefix(part.Asset, "tool_") {
+		return nil
 	}
-	return nil
+
+	// Validate: toolID must be a plain filename with no path separators or
+	// ".." to prevent traversal outside the tool-output directory.
+	toolID := part.Asset
+	if toolID != filepath.Base(toolID) || strings.ContainsRune(toolID, os.PathSeparator) {
+		return nil
+	}
+
+	return []string{toolID}
 }
 
 // manifest is the JSON structure written to manifest.json.

--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -35,6 +35,12 @@ import (
 	"time"
 )
 
+// ErrAlreadyExists is returned by Run when the final archive directory already
+// exists. Callers that need to distinguish "already archived" from other
+// failures (e.g. to propagate a non-zero exit code) can check with
+// errors.Is(err, ErrAlreadyExists).
+var ErrAlreadyExists = fmt.Errorf("archive directory already exists")
+
 const (
 	// ArchiveVersion stamps the directory layout format. Increment when the
 	// layout changes in a backward-incompatible way.
@@ -45,7 +51,7 @@ const (
 	// produce JSONL — the manifest format must be consistent across PRs.
 	PiMonoVersion = 3
 
-	archiveDirMode = 0o700
+	archiveDirMode  = 0o700
 	archiveFileMode = 0o600
 )
 
@@ -118,7 +124,7 @@ func Run(p Params) (archivePath string, err error) {
 
 	// Check whether target already exists before touching anything.
 	if _, statErr := os.Stat(finalDir); statErr == nil {
-		return "", fmt.Errorf("archive: target directory already exists: %s", finalDir)
+		return "", fmt.Errorf("%w: %s", ErrAlreadyExists, finalDir)
 	}
 
 	// Ensure the repo-level directory exists (0700; world-private).

--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -1,0 +1,508 @@
+// Package archive copies opencode's on-disk session subtree into a prism
+// archive directory at cleanup time.
+//
+// # Directory layout
+//
+//	~/.local/share/prism/archive/
+//	  <repo>/
+//	    <startedAtISO>_<instanceID>/
+//	      raw/
+//	        session.json
+//	        messages/msg_*.json
+//	        parts/msg_<id>/prt_*.json
+//	        tool-output/tool_*         (only when parts reference sidecar files)
+//	      manifest.json
+//
+// # Atomicity
+//
+// The copy is performed under a temp directory (.tmp-<instanceID>/) that is
+// renamed to the final name only on success. A partial copy is cleaned up on
+// any error so that prism cleanup never leaves a half-written archive behind.
+//
+// # File permissions
+//
+// Archive directories are created with mode 0700; individual files are copied
+// with mode 0600. These are personal session traces that may contain secrets.
+package archive
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// ArchiveVersion stamps the directory layout format. Increment when the
+	// layout changes in a backward-incompatible way.
+	ArchiveVersion = 1
+
+	// PiMonoVersion is the pi-mono JSONL trace format version targeted by the
+	// next child PR (#995 child 3). Written here even though this PR does not
+	// produce JSONL — the manifest format must be consistent across PRs.
+	PiMonoVersion = 3
+
+	archiveDirMode = 0o700
+	archiveFileMode = 0o600
+)
+
+// Params holds the inputs needed to run an archive copy.
+type Params struct {
+	// InstanceID is the session's UUID (from sessions.instance_id).
+	InstanceID string
+	// SessionName is the prism session name (e.g. "nixos-config@feature").
+	SessionName string
+	// AgentRole is the value of sessions.agent_role (may be empty).
+	AgentRole string
+	// RootAgentName is the value of sessions.root_agent_name (may be empty).
+	RootAgentName string
+	// Harness is the harness name, e.g. "opencode".
+	Harness string
+	// HarnessSessionID is the opencode ses_<ULID> (from sessions.harness_session_id).
+	// May be empty when opencode failed to start.
+	HarnessSessionID string
+	// HarnessVersion is the opencode binary version string (e.g. "1.1.30").
+	// May be empty when the binary could not be queried.
+	HarnessVersion string
+	// Repo is the repository name (from sessions.repo).
+	Repo string
+	// Worktree is the absolute worktree path (from sessions.worktree).
+	Worktree string
+	// StartedAt is when the session started.
+	StartedAt time.Time
+	// EndedAt is when the session ended (set just before archive is called).
+	EndedAt time.Time
+	// EndState is the terminal end state, e.g. "finished" or "interrupted".
+	EndState string
+	// GroupID is the session_groups.group_id (may be empty).
+	GroupID string
+	// PrismVersion is the git SHA or version of the prism binary. May be empty.
+	PrismVersion string
+	// IsolationMode is "podman", "bwrap", or "host".
+	IsolationMode string
+	// StorageRoot overrides the host opencode storage root. When empty the
+	// default (~/.local/share/opencode/storage) is used. Tests inject this to
+	// point at a temp dir.
+	StorageRoot string
+	// ArchiveRoot overrides the archive root (~/.local/share/prism/archive).
+	// When empty the XDG-derived default is used. Tests inject this.
+	ArchiveRoot string
+}
+
+// Run copies the opencode session subtree for p into the archive directory and
+// returns the absolute path of the archive directory on success.
+//
+// Atomicity: the copy is written to a temp directory under <archiveRoot>/<repo>/
+// and renamed to the final name only when the entire copy succeeds. On any
+// error the temp directory is removed and Run returns a non-nil error.
+//
+// Idempotency: if the target archive directory already exists when Run is
+// called, Run returns a non-nil error and leaves the existing directory intact.
+//
+// Sessions with no HarnessSessionID (opencode failed to start) still produce
+// an archive directory containing manifest.json and an empty raw/ directory.
+func Run(p Params) (archivePath string, err error) {
+	archiveRoot, storageRoot, err := resolvePaths(p)
+	if err != nil {
+		return "", err
+	}
+
+	// Build the final archive directory path: <archiveRoot>/<repo>/<startedAtISO>_<instanceID>/
+	dirName := p.StartedAt.UTC().Format("20060102T150405Z") + "_" + p.InstanceID
+	repoDir := filepath.Join(archiveRoot, p.Repo)
+	finalDir := filepath.Join(repoDir, dirName)
+	tmpDir := filepath.Join(repoDir, ".tmp-"+p.InstanceID)
+
+	// Check whether target already exists before touching anything.
+	if _, statErr := os.Stat(finalDir); statErr == nil {
+		return "", fmt.Errorf("archive: target directory already exists: %s", finalDir)
+	}
+
+	// Ensure the repo-level directory exists (0700; world-private).
+	if mkErr := os.MkdirAll(repoDir, archiveDirMode); mkErr != nil {
+		return "", fmt.Errorf("archive: create repo dir %s: %w", repoDir, mkErr)
+	}
+
+	// Create temp dir.
+	if mkErr := os.Mkdir(tmpDir, archiveDirMode); mkErr != nil {
+		if os.IsExist(mkErr) {
+			// Stale temp dir from a previous failed run — remove and retry.
+			_ = os.RemoveAll(tmpDir)
+			if mkErr2 := os.Mkdir(tmpDir, archiveDirMode); mkErr2 != nil {
+				return "", fmt.Errorf("archive: create temp dir %s: %w", tmpDir, mkErr2)
+			}
+		} else {
+			return "", fmt.Errorf("archive: create temp dir %s: %w", tmpDir, mkErr)
+		}
+	}
+
+	// On any error after this point, remove the temp dir.
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+
+	// Create raw/ subdirectory.
+	rawDir := filepath.Join(tmpDir, "raw")
+	if mkErr := os.Mkdir(rawDir, archiveDirMode); mkErr != nil {
+		return "", fmt.Errorf("archive: create raw dir: %w", mkErr)
+	}
+
+	// Copy opencode session files (only when we have a harness_session_id).
+	if p.HarnessSessionID != "" {
+		if copyErr := copySessionFiles(p.HarnessSessionID, storageRoot, rawDir); copyErr != nil {
+			return "", copyErr
+		}
+	}
+
+	// Write manifest.json.
+	if writeErr := writeManifest(p, tmpDir); writeErr != nil {
+		return "", writeErr
+	}
+
+	// Atomic rename.
+	if renErr := os.Rename(tmpDir, finalDir); renErr != nil {
+		return "", fmt.Errorf("archive: rename temp to final: %w", renErr)
+	}
+
+	return finalDir, nil
+}
+
+// resolvePaths returns (archiveRoot, storageRoot) for the params, applying
+// XDG defaults when the override fields are empty.
+func resolvePaths(p Params) (archiveRoot, storageRoot string, err error) {
+	// Archive root: $XDG_DATA_HOME/prism/archive
+	if p.ArchiveRoot != "" {
+		archiveRoot = p.ArchiveRoot
+	} else {
+		dataHome := os.Getenv("XDG_DATA_HOME")
+		if dataHome == "" {
+			home, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				return "", "", fmt.Errorf("archive: resolve home: %w", homeErr)
+			}
+			dataHome = filepath.Join(home, ".local", "share")
+		}
+		archiveRoot = filepath.Join(dataHome, "prism", "archive")
+	}
+
+	// Storage root: $HOME/.local/share/opencode/storage or per-container path.
+	if p.StorageRoot != "" {
+		storageRoot = p.StorageRoot
+	} else {
+		storageRoot, err = resolveStorageRoot(p.IsolationMode, p.SessionName)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	return archiveRoot, storageRoot, nil
+}
+
+// resolveStorageRoot returns the host-side opencode storage root for the given
+// isolation mode and session name.
+//
+//   - host / bwrap: $HOME/.local/share/opencode/storage
+//   - podman: $HOME/.local/share/opencode/prism-sessions/<containerName>/storage
+//   - unknown / empty: returns an error
+func resolveStorageRoot(isolationMode, sessionName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("archive: resolve home for storage root: %w", err)
+	}
+
+	switch isolationMode {
+	case "host", "bwrap":
+		return filepath.Join(home, ".local", "share", "opencode", "storage"), nil
+	case "podman":
+		containerName := containerNameForSession(sessionName)
+		return filepath.Join(home, ".local", "share", "opencode", "prism-sessions", containerName, "storage"), nil
+	default:
+		return "", fmt.Errorf("archive: unsupported isolation mode %q", isolationMode)
+	}
+}
+
+// containerNameForSession returns the podman container name for a session,
+// mirroring the logic in internal/container.NameForSession without importing
+// that package (to keep archive lean and avoid a circular dependency).
+func containerNameForSession(sessionName string) string {
+	safe := strings.ReplaceAll(sessionName, "@", "-")
+	safe = strings.ReplaceAll(safe, "/", "-")
+	safe = strings.ReplaceAll(safe, ".", "-")
+	safe = strings.ReplaceAll(safe, "~", "-")
+	return "prism-" + safe
+}
+
+// copySessionFiles copies the opencode session subtree rooted at storageRoot
+// into rawDir. The subtree consists of:
+//
+//   - storage/session/<projectID>/ses_<id>.json  → raw/session.json
+//   - storage/message/ses_<id>/*.json             → raw/messages/msg_*.json
+//   - storage/part/msg_<id>/prt_*.json           → raw/parts/msg_<id>/prt_*.json
+//   - storage/tool-output/tool_*                 → raw/tool-output/tool_* (referenced by parts)
+func copySessionFiles(harnessSessionID, storageRoot, rawDir string) error {
+	sessionFile, projectID, err := findSessionFile(harnessSessionID, storageRoot)
+	if err != nil {
+		return err
+	}
+
+	// Copy session.json → raw/session.json
+	if copyErr := copyFile(sessionFile, filepath.Join(rawDir, "session.json")); copyErr != nil {
+		return fmt.Errorf("archive: copy session.json: %w", copyErr)
+	}
+	_ = projectID // projectID found but not needed further; session path was already determined
+
+	// Copy messages.
+	msgDir := filepath.Join(storageRoot, "message", harnessSessionID)
+	rawMsgDir := filepath.Join(rawDir, "messages")
+	if err := copyDirFlat(msgDir, rawMsgDir); err != nil {
+		return fmt.Errorf("archive: copy messages: %w", err)
+	}
+
+	// Copy parts — one subdirectory per message ID.
+	partBaseDir := filepath.Join(storageRoot, "part")
+	rawPartDir := filepath.Join(rawDir, "parts")
+
+	// List message IDs from the messages we just copied — these are the
+	// subdirectory names under storage/part/ that belong to this session.
+	// Rather than globbing message IDs from the DB, we enumerate the
+	// part directories that are prefixed by our message files.
+	msgIDs, msgListErr := listDirEntries(msgDir)
+	if msgListErr != nil {
+		// Non-fatal: if there are no messages, there are no parts.
+		msgIDs = nil
+	}
+
+	// Build the set of msg_* IDs by stripping the .json suffix from message filenames.
+	type partRef struct {
+		msgID string
+		srcDir string
+	}
+	var partDirs []partRef
+	for _, f := range msgIDs {
+		msgID := strings.TrimSuffix(f, ".json")
+		srcDir := filepath.Join(partBaseDir, msgID)
+		if _, statErr := os.Stat(srcDir); statErr == nil {
+			partDirs = append(partDirs, partRef{msgID: msgID, srcDir: srcDir})
+		}
+	}
+
+	// Collect tool-output references while copying parts.
+	toolOutputIDs := map[string]bool{}
+
+	for _, pd := range partDirs {
+		destDir := filepath.Join(rawPartDir, pd.msgID)
+		if mkErr := os.MkdirAll(destDir, archiveDirMode); mkErr != nil {
+			return fmt.Errorf("archive: create parts/%s dir: %w", pd.msgID, mkErr)
+		}
+		partFiles, listErr := listDirEntries(pd.srcDir)
+		if listErr != nil {
+			return fmt.Errorf("archive: list parts/%s: %w", pd.msgID, listErr)
+		}
+		for _, pf := range partFiles {
+			src := filepath.Join(pd.srcDir, pf)
+			dst := filepath.Join(destDir, pf)
+			if copyErr := copyFile(src, dst); copyErr != nil {
+				return fmt.Errorf("archive: copy part %s/%s: %w", pd.msgID, pf, copyErr)
+			}
+			// Scan the part file for tool-output references.
+			ids := toolOutputIDsFromPart(src)
+			for _, id := range ids {
+				toolOutputIDs[id] = true
+			}
+		}
+	}
+
+	// Copy tool-output files referenced by parts.
+	if len(toolOutputIDs) > 0 {
+		toolOutputSrcDir := filepath.Join(storageRoot, "tool-output")
+		toolOutputDstDir := filepath.Join(rawDir, "tool-output")
+		if mkErr := os.MkdirAll(toolOutputDstDir, archiveDirMode); mkErr != nil {
+			return fmt.Errorf("archive: create tool-output dir: %w", mkErr)
+		}
+		for toolID := range toolOutputIDs {
+			src := filepath.Join(toolOutputSrcDir, toolID)
+			dst := filepath.Join(toolOutputDstDir, toolID)
+			if _, statErr := os.Stat(src); os.IsNotExist(statErr) {
+				// Tool output file missing — not fatal, just skip.
+				continue
+			}
+			if copyErr := copyFile(src, dst); copyErr != nil {
+				return fmt.Errorf("archive: copy tool-output %s: %w", toolID, copyErr)
+			}
+		}
+	}
+
+	return nil
+}
+
+// findSessionFile scans the storage/session/ subtree to locate the session JSON
+// file for harnessSessionID (a ses_<ULID> value). Returns the absolute path and
+// projectID (directory name under storage/session/).
+func findSessionFile(harnessSessionID, storageRoot string) (path, projectID string, err error) {
+	sessionBaseDir := filepath.Join(storageRoot, "session")
+	projectDirs, listErr := listDirEntries(sessionBaseDir)
+	if listErr != nil {
+		return "", "", fmt.Errorf("archive: list session base dir: %w", listErr)
+	}
+
+	fileName := harnessSessionID + ".json"
+	for _, proj := range projectDirs {
+		candidate := filepath.Join(sessionBaseDir, proj, fileName)
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate, proj, nil
+		}
+	}
+	return "", "", fmt.Errorf("archive: session file for %q not found under %s", harnessSessionID, sessionBaseDir)
+}
+
+// copyDirFlat copies all regular files in srcDir into dstDir (created if
+// absent). Subdirectories within srcDir are ignored. If srcDir does not exist
+// or is empty, a (possibly empty) dstDir is still created and nil is returned.
+func copyDirFlat(srcDir, dstDir string) error {
+	if mkErr := os.MkdirAll(dstDir, archiveDirMode); mkErr != nil {
+		return fmt.Errorf("create %s: %w", dstDir, mkErr)
+	}
+	entries, err := listDirEntries(srcDir)
+	if err != nil {
+		// srcDir missing → treat as empty.
+		return nil
+	}
+	for _, name := range entries {
+		src := filepath.Join(srcDir, name)
+		dst := filepath.Join(dstDir, name)
+		if copyErr := copyFile(src, dst); copyErr != nil {
+			return copyErr
+		}
+	}
+	return nil
+}
+
+// listDirEntries returns the names of all directory entries directly under dir.
+// Returns nil (not an error) when dir does not exist.
+func listDirEntries(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names, nil
+}
+
+// copyFile copies the file at src to dst with mode 0600.
+// The destination directory must already exist.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, archiveFileMode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		_ = os.Remove(dst)
+		return fmt.Errorf("copy %s → %s: %w", src, dst, err)
+	}
+	return out.Close()
+}
+
+// toolOutputIDsFromPart parses the part JSON at path and returns any
+// tool-output file IDs referenced (e.g. "tool_<ulid>"). Returns nil on any
+// parse error (best-effort; caller handles missing tool-output gracefully).
+func toolOutputIDsFromPart(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	// We only need the "type" and "asset" (or similar) fields — use a
+	// minimal struct rather than full unmarshalling.
+	var part struct {
+		Type  string `json:"type"`
+		Asset string `json:"asset"` // tool-output references: "tool_<ulid>"
+	}
+	if err := json.Unmarshal(data, &part); err != nil {
+		return nil
+	}
+
+	if part.Type == "tool" && strings.HasPrefix(part.Asset, "tool_") {
+		return []string{part.Asset}
+	}
+	return nil
+}
+
+// manifest is the JSON structure written to manifest.json.
+type manifest struct {
+	ArchiveVersion  int     `json:"archiveVersion"`
+	PiMonoVersion   int     `json:"piMonoVersion"`
+	InstanceID      string  `json:"instanceId"`
+	SessionName     string  `json:"sessionName"`
+	AgentRole       string  `json:"agentRole"`
+	RootAgentName   string  `json:"rootAgentName"`
+	Harness         string  `json:"harness"`
+	HarnessSessionID string `json:"harnessSessionId"`
+	HarnessVersion  string  `json:"harnessVersion"`
+	Repo            string  `json:"repo"`
+	Worktree        string  `json:"worktree"`
+	StartedAt       string  `json:"startedAt"`
+	EndedAt         string  `json:"endedAt"`
+	EndState        string  `json:"endState"`
+	GroupID         *string `json:"groupId"`
+	PrismVersion    string  `json:"prismVersion"`
+}
+
+// writeManifest serialises the manifest and writes it to <dir>/manifest.json
+// with mode 0600.
+func writeManifest(p Params, dir string) error {
+	var groupID *string
+	if p.GroupID != "" {
+		g := p.GroupID
+		groupID = &g
+	}
+
+	m := manifest{
+		ArchiveVersion:   ArchiveVersion,
+		PiMonoVersion:    PiMonoVersion,
+		InstanceID:       p.InstanceID,
+		SessionName:      p.SessionName,
+		AgentRole:        p.AgentRole,
+		RootAgentName:    p.RootAgentName,
+		Harness:          p.Harness,
+		HarnessSessionID: p.HarnessSessionID,
+		HarnessVersion:   p.HarnessVersion,
+		Repo:             p.Repo,
+		Worktree:         p.Worktree,
+		StartedAt:        p.StartedAt.UTC().Format(time.RFC3339),
+		EndedAt:          p.EndedAt.UTC().Format(time.RFC3339),
+		EndState:         p.EndState,
+		GroupID:          groupID,
+		PrismVersion:     p.PrismVersion,
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("archive: marshal manifest: %w", err)
+	}
+	data = append(data, '\n')
+
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if writeErr := os.WriteFile(manifestPath, data, archiveFileMode); writeErr != nil {
+		return fmt.Errorf("archive: write manifest.json: %w", writeErr)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/internal/archive/archive_test.go
+++ b/modules/programs/prism/prism/internal/archive/archive_test.go
@@ -1,0 +1,601 @@
+package archive
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// makeStorageTree creates a minimal opencode storage tree under root for the
+// given session ID and project ID. Returns a map of relative paths → content
+// that the caller can compare against the archive raw/ contents.
+func makeStorageTree(t *testing.T, root, projectID, sessionID string) map[string]string {
+	t.Helper()
+
+	// storage/session/<projectID>/ses_<id>.json
+	sessDir := filepath.Join(root, "session", projectID)
+	mustMkdir(t, sessDir)
+	sessContent := `{"id":"` + sessionID + `","projectID":"` + projectID + `"}`
+	mustWriteFile(t, filepath.Join(sessDir, sessionID+".json"), sessContent)
+
+	// storage/message/<sessionID>/msg_aaa.json
+	msgDir := filepath.Join(root, "message", sessionID)
+	mustMkdir(t, msgDir)
+	msg1Content := `{"id":"msg_aaa","type":"text"}`
+	mustWriteFile(t, filepath.Join(msgDir, "msg_aaa.json"), msg1Content)
+
+	// storage/part/msg_aaa/prt_001.json (text part — no tool-output ref)
+	partDir := filepath.Join(root, "part", "msg_aaa")
+	mustMkdir(t, partDir)
+	part1Content := `{"id":"prt_001","type":"text","text":"hello"}`
+	mustWriteFile(t, filepath.Join(partDir, "prt_001.json"), part1Content)
+
+	return map[string]string{
+		"session.json":              sessContent,
+		"messages/msg_aaa.json":     msg1Content,
+		"parts/msg_aaa/prt_001.json": part1Content,
+	}
+}
+
+// makeStorageTreeWithToolOutput extends makeStorageTree with a tool part that
+// references a tool-output sidecar file. Returns the file map and toolID.
+func makeStorageTreeWithToolOutput(t *testing.T, root, projectID, sessionID string) (map[string]string, string) {
+	t.Helper()
+	files := makeStorageTree(t, root, projectID, sessionID)
+
+	toolID := "tool_abc123"
+	toolContent := "tool output bytes"
+
+	// Add a second part in msg_aaa that references the tool output.
+	partDir := filepath.Join(root, "part", "msg_aaa")
+	part2Content := `{"id":"prt_002","type":"tool","asset":"` + toolID + `"}`
+	mustWriteFile(t, filepath.Join(partDir, "prt_002.json"), part2Content)
+	files["parts/msg_aaa/prt_002.json"] = part2Content
+
+	// Write the tool-output sidecar.
+	toDir := filepath.Join(root, "tool-output")
+	mustMkdir(t, toDir)
+	mustWriteFile(t, filepath.Join(toDir, toolID), toolContent)
+	files["tool-output/"+toolID] = toolContent
+
+	return files, toolID
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func baseParams(archiveRoot, storageRoot string) Params {
+	startedAt := time.Date(2026, 4, 25, 14, 30, 22, 0, time.UTC)
+	endedAt := time.Date(2026, 4, 25, 15, 47, 11, 0, time.UTC)
+	return Params{
+		InstanceID:       "a3f1c9e8-1234-5678-9abc-def012345678",
+		SessionName:      "nixos-config@feature",
+		AgentRole:        "worker",
+		RootAgentName:    "worker",
+		Harness:          "opencode",
+		HarnessSessionID: "ses_test001",
+		HarnessVersion:   "1.1.30",
+		Repo:             "nixos-config",
+		Worktree:         "/home/ben/code/nixos-config/feature",
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		EndState:         "finished",
+		GroupID:          "",
+		PrismVersion:     "abc123",
+		IsolationMode:    "host",
+		StorageRoot:      storageRoot,
+		ArchiveRoot:      archiveRoot,
+	}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+// TestRunHappyPath verifies that a successful archive creates the correct
+// directory layout with byte-for-byte identical file contents.
+func TestRunHappyPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "proj123"
+	sessionID := "ses_test001"
+	wantFiles := makeStorageTree(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Verify archive path format: <archiveRoot>/<repo>/<startedAtISO>_<instanceID>
+	wantName := "20260425T143022Z_" + p.InstanceID
+	if !strings.HasSuffix(archivePath, filepath.Join(p.Repo, wantName)) {
+		t.Errorf("archivePath = %q, want suffix %q", archivePath, filepath.Join(p.Repo, wantName))
+	}
+
+	// Verify the archive directory exists.
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("archive dir not found: %v", err)
+	}
+
+	// Verify raw/ directory exists.
+	rawDir := filepath.Join(archivePath, "raw")
+	if _, err := os.Stat(rawDir); err != nil {
+		t.Fatalf("raw/ dir not found: %v", err)
+	}
+
+	// Verify each file is present and byte-for-byte identical.
+	for rel, want := range wantFiles {
+		got := readFile(t, filepath.Join(rawDir, rel))
+		if got != want {
+			t.Errorf("raw/%s content = %q, want %q", rel, got, want)
+		}
+	}
+
+	// Verify manifest.json exists and parses.
+	var m manifest
+	mData := readFile(t, filepath.Join(archivePath, "manifest.json"))
+	if err := json.Unmarshal([]byte(mData), &m); err != nil {
+		t.Fatalf("manifest.json parse error: %v", err)
+	}
+
+	// Verify key manifest fields.
+	if m.ArchiveVersion != ArchiveVersion {
+		t.Errorf("manifest.archiveVersion = %d, want %d", m.ArchiveVersion, ArchiveVersion)
+	}
+	if m.PiMonoVersion != PiMonoVersion {
+		t.Errorf("manifest.piMonoVersion = %d, want %d", m.PiMonoVersion, PiMonoVersion)
+	}
+	if m.InstanceID != p.InstanceID {
+		t.Errorf("manifest.instanceId = %q, want %q", m.InstanceID, p.InstanceID)
+	}
+	if m.SessionName != p.SessionName {
+		t.Errorf("manifest.sessionName = %q, want %q", m.SessionName, p.SessionName)
+	}
+	if m.Repo != p.Repo {
+		t.Errorf("manifest.repo = %q, want %q", m.Repo, p.Repo)
+	}
+	if m.Worktree != p.Worktree {
+		t.Errorf("manifest.worktree = %q, want %q", m.Worktree, p.Worktree)
+	}
+	if m.HarnessSessionID != p.HarnessSessionID {
+		t.Errorf("manifest.harnessSessionId = %q, want %q", m.HarnessSessionID, p.HarnessSessionID)
+	}
+	if m.HarnessVersion != p.HarnessVersion {
+		t.Errorf("manifest.harnessVersion = %q, want %q", m.HarnessVersion, p.HarnessVersion)
+	}
+	if m.EndState != p.EndState {
+		t.Errorf("manifest.endState = %q, want %q", m.EndState, p.EndState)
+	}
+	if m.PrismVersion != p.PrismVersion {
+		t.Errorf("manifest.prismVersion = %q, want %q", m.PrismVersion, p.PrismVersion)
+	}
+	if m.GroupID != nil {
+		t.Errorf("manifest.groupId = %v, want nil", m.GroupID)
+	}
+
+	// Verify timestamps.
+	wantStarted := p.StartedAt.UTC().Format(time.RFC3339)
+	if m.StartedAt != wantStarted {
+		t.Errorf("manifest.startedAt = %q, want %q", m.StartedAt, wantStarted)
+	}
+}
+
+// TestRunWithToolOutput verifies that tool-output sidecar files referenced by
+// parts are copied into raw/tool-output/.
+func TestRunWithToolOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "proj456"
+	sessionID := "ses_test002"
+	wantFiles, toolID := makeStorageTreeWithToolOutput(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "bbbbbbbb-1234-5678-9abc-def012345678"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	rawDir := filepath.Join(archivePath, "raw")
+	for rel, want := range wantFiles {
+		got := readFile(t, filepath.Join(rawDir, rel))
+		if got != want {
+			t.Errorf("raw/%s content = %q, want %q", rel, got, want)
+		}
+	}
+
+	// Verify the tool-output file is present.
+	toolPath := filepath.Join(rawDir, "tool-output", toolID)
+	if _, err := os.Stat(toolPath); err != nil {
+		t.Errorf("tool-output/%s not found: %v", toolID, err)
+	}
+}
+
+// TestRunNoHarnessSessionID verifies that a session with no harness_session_id
+// still produces an archive dir with manifest.json and an empty raw/.
+func TestRunNoHarnessSessionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = "" // opencode failed to start
+	p.InstanceID = "cccccccc-1234-5678-9abc-def012345678"
+	p.EndState = "interrupted"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// raw/ must exist.
+	rawDir := filepath.Join(archivePath, "raw")
+	if _, err := os.Stat(rawDir); err != nil {
+		t.Fatalf("raw/ dir not found: %v", err)
+	}
+
+	// raw/ must be empty.
+	entries, err := os.ReadDir(rawDir)
+	if err != nil {
+		t.Fatalf("ReadDir raw/: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("raw/ has %d entries, want 0", len(entries))
+	}
+
+	// manifest.json must be present with correct endState.
+	var m manifest
+	mData := readFile(t, filepath.Join(archivePath, "manifest.json"))
+	if err := json.Unmarshal([]byte(mData), &m); err != nil {
+		t.Fatalf("manifest.json parse error: %v", err)
+	}
+	if m.EndState != "interrupted" {
+		t.Errorf("manifest.endState = %q, want %q", m.EndState, "interrupted")
+	}
+	if m.HarnessSessionID != "" {
+		t.Errorf("manifest.harnessSessionId = %q, want empty", m.HarnessSessionID)
+	}
+}
+
+// TestRunIdempotencyError verifies that calling Run a second time for the same
+// instance returns an error and leaves the existing archive intact.
+func TestRunIdempotencyError(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "proj789"
+	sessionID := "ses_test003"
+	makeStorageTree(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "dddddddd-1234-5678-9abc-def012345678"
+
+	// First run — should succeed.
+	firstPath, err := Run(p)
+	if err != nil {
+		t.Fatalf("first Run() error: %v", err)
+	}
+
+	// Write a sentinel file to verify the dir is not overwritten.
+	sentinelPath := filepath.Join(firstPath, "sentinel.txt")
+	if writeErr := os.WriteFile(sentinelPath, []byte("original"), 0o600); writeErr != nil {
+		t.Fatalf("write sentinel: %v", writeErr)
+	}
+
+	// Second run — should fail.
+	_, err = Run(p)
+	if err == nil {
+		t.Fatal("second Run() succeeded, want error")
+	}
+
+	// The existing directory must be intact.
+	if _, statErr := os.Stat(sentinelPath); statErr != nil {
+		t.Errorf("sentinel file missing after failed second run: %v", statErr)
+	}
+}
+
+// TestRunCopyFailureAtomicity verifies that a copy failure leaves no partial
+// archive directory (temp dir is cleaned up).
+func TestRunCopyFailureAtomicity(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	// Point storageRoot at a directory that exists but has no session files.
+	storageRoot := filepath.Join(tmpDir, "empty-storage")
+	if err := os.MkdirAll(storageRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll storageRoot: %v", err)
+	}
+	// Create the session base dir but NO project subdir, so findSessionFile fails.
+	if err := os.MkdirAll(filepath.Join(storageRoot, "session"), 0o755); err != nil {
+		t.Fatalf("MkdirAll session dir: %v", err)
+	}
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = "ses_missing"
+	p.InstanceID = "eeeeeeee-1234-5678-9abc-def012345678"
+
+	_, err := Run(p)
+	if err == nil {
+		t.Fatal("Run() succeeded, want error (session file not found)")
+	}
+
+	// No temp dir should remain.
+	repoDir := filepath.Join(archiveRoot, p.Repo)
+	entries, _ := os.ReadDir(repoDir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".tmp-") {
+			t.Errorf("temp dir left behind: %s", e.Name())
+		}
+	}
+
+	// The final directory must not exist either.
+	dirName := p.StartedAt.UTC().Format("20060102T150405Z") + "_" + p.InstanceID
+	if _, statErr := os.Stat(filepath.Join(repoDir, dirName)); statErr == nil {
+		t.Errorf("final archive dir exists after failed Run()")
+	}
+}
+
+// TestFilePermissions verifies that archive dirs are 0700 and files are 0600.
+func TestFilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "permproj"
+	sessionID := "ses_perm001"
+	makeStorageTree(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "ffffffff-1234-5678-9abc-def012345678"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Check archive directory mode.
+	dirInfo, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatalf("stat archive dir: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Errorf("archive dir mode = %04o, want %04o", dirInfo.Mode().Perm(), 0o700)
+	}
+
+	// Check a file mode.
+	manifestInfo, err := os.Stat(filepath.Join(archivePath, "manifest.json"))
+	if err != nil {
+		t.Fatalf("stat manifest.json: %v", err)
+	}
+	if manifestInfo.Mode().Perm() != 0o600 {
+		t.Errorf("manifest.json mode = %04o, want %04o", manifestInfo.Mode().Perm(), 0o600)
+	}
+
+	// Check raw/ directory mode.
+	rawInfo, err := os.Stat(filepath.Join(archivePath, "raw"))
+	if err != nil {
+		t.Fatalf("stat raw/: %v", err)
+	}
+	if rawInfo.Mode().Perm() != 0o700 {
+		t.Errorf("raw/ dir mode = %04o, want %04o", rawInfo.Mode().Perm(), 0o700)
+	}
+
+	// Check a raw file mode.
+	sessFileInfo, err := os.Stat(filepath.Join(archivePath, "raw", "session.json"))
+	if err != nil {
+		t.Fatalf("stat raw/session.json: %v", err)
+	}
+	if sessFileInfo.Mode().Perm() != 0o600 {
+		t.Errorf("raw/session.json mode = %04o, want %04o", sessFileInfo.Mode().Perm(), 0o600)
+	}
+}
+
+// TestRunManifestVersions verifies archiveVersion=1 and piMonoVersion=3.
+func TestRunManifestVersions(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "versionproj"
+	sessionID := "ses_ver001"
+	makeStorageTree(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "11111111-2222-3333-4444-555555555555"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	var m manifest
+	mData := readFile(t, filepath.Join(archivePath, "manifest.json"))
+	if err := json.Unmarshal([]byte(mData), &m); err != nil {
+		t.Fatalf("manifest.json parse error: %v", err)
+	}
+
+	if m.ArchiveVersion != 1 {
+		t.Errorf("archiveVersion = %d, want 1", m.ArchiveVersion)
+	}
+	if m.PiMonoVersion != 3 {
+		t.Errorf("piMonoVersion = %d, want 3", m.PiMonoVersion)
+	}
+}
+
+// TestRunGroupID verifies that a non-empty GroupID is written to
+// manifest.groupId as a non-nil pointer.
+func TestRunGroupID(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "groupproj"
+	sessionID := "ses_grp001"
+	makeStorageTree(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "22222222-3333-4444-5555-666666666666"
+	p.GroupID = "my-group-id"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	var m manifest
+	mData := readFile(t, filepath.Join(archivePath, "manifest.json"))
+	if err := json.Unmarshal([]byte(mData), &m); err != nil {
+		t.Fatalf("manifest.json parse error: %v", err)
+	}
+
+	if m.GroupID == nil {
+		t.Fatal("manifest.groupId = nil, want non-nil")
+	}
+	if *m.GroupID != p.GroupID {
+		t.Errorf("manifest.groupId = %q, want %q", *m.GroupID, p.GroupID)
+	}
+}
+
+// TestRunSessionWithNoMessages verifies that a session with a session.json but
+// no messages produces an archive with raw/session.json and raw/messages/ empty.
+func TestRunSessionWithNoMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "nomsgproj"
+	sessionID := "ses_nomsg"
+	// Only create the session.json, no message/ dir.
+	sessDir := filepath.Join(storageRoot, "session", projectID)
+	mustMkdir(t, sessDir)
+	sessContent := `{"id":"` + sessionID + `","projectID":"` + projectID + `"}`
+	mustWriteFile(t, filepath.Join(sessDir, sessionID+".json"), sessContent)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "33333333-4444-5555-6666-777777777777"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// session.json must be present.
+	sessFilePath := filepath.Join(archivePath, "raw", "session.json")
+	if _, err := os.Stat(sessFilePath); err != nil {
+		t.Fatalf("raw/session.json not found: %v", err)
+	}
+	if got := readFile(t, sessFilePath); got != sessContent {
+		t.Errorf("raw/session.json = %q, want %q", got, sessContent)
+	}
+
+	// messages/ must exist and be empty.
+	msgDir := filepath.Join(archivePath, "raw", "messages")
+	if _, err := os.Stat(msgDir); err != nil {
+		t.Fatalf("raw/messages/ not found: %v", err)
+	}
+	entries, err := os.ReadDir(msgDir)
+	if err != nil {
+		t.Fatalf("ReadDir raw/messages/: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("raw/messages/ has %d entries, want 0", len(entries))
+	}
+}
+
+// TestResolveStorageRootPodman verifies the podman path uses the container name.
+func TestResolveStorageRootPodman(t *testing.T) {
+	// We don't want to call os.UserHomeDir in a way that makes the test
+	// platform-dependent — just verify the function doesn't return an error
+	// and includes "prism-sessions" in the path.
+	got, err := resolveStorageRoot("podman", "nixos-config@feature")
+	if err != nil {
+		t.Fatalf("resolveStorageRoot podman: %v", err)
+	}
+	if !strings.Contains(got, "prism-sessions") {
+		t.Errorf("podman storage root = %q, want path containing 'prism-sessions'", got)
+	}
+	if !strings.Contains(got, "prism-nixos-config-feature") {
+		t.Errorf("podman storage root = %q, want path containing container name 'prism-nixos-config-feature'", got)
+	}
+}
+
+// TestResolveStorageRootHost verifies the host/bwrap path does not use
+// prism-sessions.
+func TestResolveStorageRootHost(t *testing.T) {
+	for _, mode := range []string{"host", "bwrap"} {
+		got, err := resolveStorageRoot(mode, "nixos-config@main")
+		if err != nil {
+			t.Fatalf("resolveStorageRoot %s: %v", mode, err)
+		}
+		if strings.Contains(got, "prism-sessions") {
+			t.Errorf("mode=%s storage root = %q, should not contain 'prism-sessions'", mode, got)
+		}
+		if !strings.HasSuffix(got, filepath.Join("opencode", "storage")) {
+			t.Errorf("mode=%s storage root = %q, want suffix opencode/storage", mode, got)
+		}
+	}
+}
+
+// TestResolveStorageRootUnknown verifies that an unsupported isolation mode
+// returns an error.
+func TestResolveStorageRootUnknown(t *testing.T) {
+	_, err := resolveStorageRoot("docker", "nixos-config@main")
+	if err == nil {
+		t.Fatal("resolveStorageRoot with unknown mode: expected error, got nil")
+	}
+}
+
+// TestContainerNameForSession verifies the container name mapping matches
+// the logic in internal/container.NameForSession.
+func TestContainerNameForSession(t *testing.T) {
+	cases := []struct {
+		sessionName   string
+		wantContainer string
+	}{
+		{"nixos-config@feature", "prism-nixos-config-feature"},
+		{"nixos-config@main~review-1-review-code", "prism-nixos-config-main-review-1-review-code"},
+		{"my.repo@feat/slash", "prism-my-repo-feat-slash"},
+	}
+	for _, tc := range cases {
+		got := containerNameForSession(tc.sessionName)
+		if got != tc.wantContainer {
+			t.Errorf("containerNameForSession(%q) = %q, want %q", tc.sessionName, got, tc.wantContainer)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/archive/archive_test.go
+++ b/modules/programs/prism/prism/internal/archive/archive_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -582,6 +583,68 @@ func TestResolveStorageRootUnknown(t *testing.T) {
 	_, err := resolveStorageRoot("docker", "nixos-config@main")
 	if err == nil {
 		t.Fatal("resolveStorageRoot with unknown mode: expected error, got nil")
+	}
+}
+
+// TestRunRepoTraversalRejected verifies that a p.Repo containing path traversal
+// components is rejected before any filesystem operations.
+func TestRunRepoTraversalRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	cases := []string{
+		"../../evil",
+		"../up",
+		"..",
+		"good/sub", // slash inside repo name is also invalid
+	}
+
+	for _, repo := range cases {
+		p := baseParams(archiveRoot, storageRoot)
+		p.Repo = repo
+		p.InstanceID = "aaaa1111-1111-1111-1111-111111111111"
+
+		_, err := Run(p)
+		if err == nil {
+			t.Errorf("Run() with repo=%q succeeded, want error", repo)
+		}
+	}
+}
+
+// TestToolOutputIDValidation verifies that toolOutputIDsFromPart rejects
+// asset values containing path traversal sequences.
+func TestToolOutputIDValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cases := []struct {
+		partContent string
+		wantIDs     []string
+	}{
+		// Normal tool part.
+		{`{"type":"tool","asset":"tool_abc123"}`, []string{"tool_abc123"}},
+		// Traversal attempt — must be rejected.
+		{`{"type":"tool","asset":"tool_/../../etc/shadow"}`, nil},
+		{`{"type":"tool","asset":"tool_../secret"}`, nil},
+		// Wrong prefix — ignored.
+		{`{"type":"tool","asset":"output_abc"}`, nil},
+		// Wrong type — ignored.
+		{`{"type":"text","asset":"tool_abc"}`, nil},
+	}
+
+	for i, tc := range cases {
+		partPath := filepath.Join(tmpDir, fmt.Sprintf("prt_%02d.json", i))
+		mustWriteFile(t, partPath, tc.partContent)
+		got := toolOutputIDsFromPart(partPath)
+		if len(got) != len(tc.wantIDs) {
+			t.Errorf("case %d (%s): got %v, want %v", i, tc.partContent, got, tc.wantIDs)
+			continue
+		}
+		for j := range got {
+			if got[j] != tc.wantIDs[j] {
+				t.Errorf("case %d: got[%d] = %q, want %q", i, j, got[j], tc.wantIDs[j])
+			}
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/archive/archive_test.go
+++ b/modules/programs/prism/prism/internal/archive/archive_test.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -315,10 +316,13 @@ func TestRunIdempotencyError(t *testing.T) {
 		t.Fatalf("write sentinel: %v", writeErr)
 	}
 
-	// Second run — should fail.
+	// Second run — should fail with ErrAlreadyExists.
 	_, err = Run(p)
 	if err == nil {
 		t.Fatal("second Run() succeeded, want error")
+	}
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("second Run() error = %v, want errors.Is(err, ErrAlreadyExists)", err)
 	}
 
 	// The existing directory must be intact.

--- a/modules/programs/prism/prism/internal/archive/version.go
+++ b/modules/programs/prism/prism/internal/archive/version.go
@@ -1,0 +1,34 @@
+package archive
+
+import (
+	"os/exec"
+	"runtime/debug"
+	"strings"
+)
+
+// PrismGitSHA returns the VCS revision embedded in the binary by `go build`,
+// or "" when not available (e.g. built with `go run` or in tests).
+func PrismGitSHA() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			return s.Value
+		}
+	}
+	return ""
+}
+
+// HarnessVersion returns the version string reported by the opencode binary
+// (e.g. "1.1.30"), or "" when the binary is not on PATH or returns an error.
+// The result is derived by running `opencode --version` and stripping any
+// trailing newline.
+func HarnessVersion() string {
+	out, err := exec.Command("opencode", "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1691,60 +1691,6 @@ UPDATE sessions
 	return nil
 }
 
-// GetSession returns the sessions row for instanceID, or nil if not found.
-func (d *DB) GetSession(instanceID string) (*Session, error) {
-	const q = `
-SELECT instance_id, session_name, agent_role, root_agent_name, repo, worktree,
-       harness, harness_session_id, group_id, started_at, ended_at, end_state,
-       archive_path, prism_version
-  FROM sessions
- WHERE instance_id = ?`
-	row := d.conn.QueryRow(q, instanceID)
-	var s Session
-	var agentRole, rootAgentName, harnessSessionID, groupID, endState, archivePath, prismVersion sql.NullString
-	var startedAt int64
-	var endedAt sql.NullInt64
-	err := row.Scan(
-		&s.InstanceID, &s.SessionName, &agentRole, &rootAgentName,
-		&s.Repo, &s.Worktree, &s.Harness, &harnessSessionID,
-		&groupID, &startedAt, &endedAt, &endState,
-		&archivePath, &prismVersion,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("db: get session: %w", err)
-	}
-	s.StartedAt = time.UnixMilli(startedAt)
-	if agentRole.Valid {
-		s.AgentRole = &agentRole.String
-	}
-	if rootAgentName.Valid {
-		s.RootAgentName = &rootAgentName.String
-	}
-	if harnessSessionID.Valid {
-		s.HarnessSessionID = &harnessSessionID.String
-	}
-	if groupID.Valid {
-		s.GroupID = &groupID.String
-	}
-	if endedAt.Valid {
-		t := time.UnixMilli(endedAt.Int64)
-		s.EndedAt = &t
-	}
-	if endState.Valid {
-		s.EndState = &endState.String
-	}
-	if archivePath.Valid {
-		s.ArchivePath = &archivePath.String
-	}
-	if prismVersion.Valid {
-		s.PrismVersion = &prismVersion.String
-	}
-	return &s, nil
-}
-
 // UpdateSessionArchivePath sets archive_path on the sessions row for
 // instanceID. Called during prism cleanup after the archive copy completes
 // successfully. It is a no-op when no row exists for instanceID (returns nil).

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1691,6 +1691,72 @@ UPDATE sessions
 	return nil
 }
 
+// GetSession returns the sessions row for instanceID, or nil if not found.
+func (d *DB) GetSession(instanceID string) (*Session, error) {
+	const q = `
+SELECT instance_id, session_name, agent_role, root_agent_name, repo, worktree,
+       harness, harness_session_id, group_id, started_at, ended_at, end_state,
+       archive_path, prism_version
+  FROM sessions
+ WHERE instance_id = ?`
+	row := d.conn.QueryRow(q, instanceID)
+	var s Session
+	var agentRole, rootAgentName, harnessSessionID, groupID, endState, archivePath, prismVersion sql.NullString
+	var startedAt int64
+	var endedAt sql.NullInt64
+	err := row.Scan(
+		&s.InstanceID, &s.SessionName, &agentRole, &rootAgentName,
+		&s.Repo, &s.Worktree, &s.Harness, &harnessSessionID,
+		&groupID, &startedAt, &endedAt, &endState,
+		&archivePath, &prismVersion,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: get session: %w", err)
+	}
+	s.StartedAt = time.UnixMilli(startedAt)
+	if agentRole.Valid {
+		s.AgentRole = &agentRole.String
+	}
+	if rootAgentName.Valid {
+		s.RootAgentName = &rootAgentName.String
+	}
+	if harnessSessionID.Valid {
+		s.HarnessSessionID = &harnessSessionID.String
+	}
+	if groupID.Valid {
+		s.GroupID = &groupID.String
+	}
+	if endedAt.Valid {
+		t := time.UnixMilli(endedAt.Int64)
+		s.EndedAt = &t
+	}
+	if endState.Valid {
+		s.EndState = &endState.String
+	}
+	if archivePath.Valid {
+		s.ArchivePath = &archivePath.String
+	}
+	if prismVersion.Valid {
+		s.PrismVersion = &prismVersion.String
+	}
+	return &s, nil
+}
+
+// UpdateSessionArchivePath sets archive_path on the sessions row for
+// instanceID. Called during prism cleanup after the archive copy completes
+// successfully. It is a no-op when no row exists for instanceID (returns nil).
+func (d *DB) UpdateSessionArchivePath(instanceID, archivePath string) error {
+	const q = `UPDATE sessions SET archive_path = ? WHERE instance_id = ?`
+	_, err := d.conn.Exec(q, archivePath, instanceID)
+	if err != nil {
+		return fmt.Errorf("db: update session archive path: %w", err)
+	}
+	return nil
+}
+
 // SetInstanceID writes a UUID instance_id to the agent_status row for
 // sessionName. Called on tmux-session-start to uniquely identify this session
 // incarnation.

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -333,6 +333,7 @@ in
 
         home.persistence."/persist" = {
           directories = [
+            ".local/share/prism"
             ".local/state/prism"
           ];
         };


### PR DESCRIPTION
Closes #997.

## Summary

- Adds `internal/archive` package that copies opencode's on-disk session storage into `~/.local/share/prism/archive/<repo>/<startedAtISO>_<instanceID>/` at `prism cleanup` time, writing a `manifest.json` alongside the raw file copy.
- Atomic write: copies into `.tmp-<instanceID>/` then renames to final on success; removes temp on any failure — no partial archives ever left behind.
- Isolation-mode aware: host/bwrap reads from `~/.local/share/opencode/storage/`; podman reads from the per-container `prism-sessions/<name>/storage/` path.
- File permissions: `0700` on archive directories, `0600` on copied files.
- Sessions with no `harness_session_id` (opencode never started) still produce an archive dir with `manifest.json` and empty `raw/` — the fact of the session is preserved.
- Tool-output sidecars discovered by scanning part files for the `asset` field, copied into `raw/tool-output/`.
- `manifest.json` fields: `archiveVersion=1`, `piMonoVersion=3`, plus all session metadata sourced from the `sessions` and `agent_status` tables.
- Adds `GetSession(instanceID)` and `UpdateSessionArchivePath(instanceID, path)` to `db.go`.
- Wired into all three cleanup paths (`headlessCleanup`, `headlessCloseSession`, `doCleanup` TUI, `closeSession`); archive runs after `UpdateSessionEnded` so `ended_at`/`end_state` are set when manifest is written. Archive failure is non-fatal — logs a warning and cleanup continues.
- 13 new tests in `internal/archive/archive_test.go` covering happy path, tool-output, no-harness-session-id, idempotency error, atomicity on failure, file permissions, manifest versions, groupId, and storage root resolution.