### PR TITLE
prism: add bwrap concurrency cap (default 20, navi override 50)

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -29,6 +29,7 @@
       prism = {
         opencode.provider = "anthropic";
         agent.isolation.default = "bwrap";
+        bwrapConcurrencyCap = 50;
       };
       anki.enable = false; # build broken as of 2025-08-30
       calibre.enable = true;

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -57,6 +57,7 @@ let
     ssh_signing_key_name = config.nx.programs.prism.sshSigningKeyName;
     restore_stagger_delay_ms = config.nx.programs.prism.restoreStaggerDelayMs;
     sidecar_circuit_breaker_threshold = config.nx.programs.prism.sidecarCircuitBreakerThreshold;
+    bwrap_concurrency_cap = config.nx.programs.prism.bwrapConcurrencyCap;
   };
 in
 {
@@ -103,6 +104,17 @@ in
         `prism restore` to skip re-spawning a session. 0 means use the
         compiled-in default (3). Set to a negative value to disable the
         circuit breaker entirely.
+      '';
+    };
+
+    nx.programs.prism.bwrapConcurrencyCap = lib.mkOption {
+      type = lib.types.int;
+      default = 20;
+      description = ''
+        Maximum number of concurrent bwrap sessions (agent_status rows with
+        ended_at IS NULL AND isolation_mode = 'bwrap') before new bwrap spawns
+        are refused. 0 means uncapped. Default of 20 is conservative enough for
+        any machine without an explicit per-machine override.
       '';
     };
   };

--- a/modules/programs/prism/prism/cmd/concurrency.go
+++ b/modules/programs/prism/prism/cmd/concurrency.go
@@ -1,14 +1,21 @@
 package cmd
 
-// concurrency.go — shared concurrency-cap check used by spawn, pr, and review.
+// concurrency.go — shared concurrency-cap checks used by spawn, pr, and review.
+//
+// checkConcurrencyCap enforces the podman container cap.
+// checkBwrapConcurrencyCap enforces the bwrap session cap.
+// Both honour the --ignore-concurrency-cap flag on the supplied cobra.Command.
 
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/db"
 )
 
 // checkConcurrencyCap checks the soft container concurrency cap.
@@ -46,4 +53,87 @@ func checkConcurrencyCap(cmd *cobra.Command, callerName string, conCapped bool) 
 	}
 
 	return fmt.Errorf("%s", container.FormatExceededError(res))
+}
+
+// checkBwrapConcurrencyCap checks the soft bwrap session concurrency cap.
+// Returns a non-nil error when the cap is exceeded and --ignore-concurrency-cap
+// is not set. When the flag is set and the cap is exceeded, writes a warning to
+// stderr and returns nil.
+//
+// The cap value is read from config.Load().BwrapConcurrencyCap. A value of 0
+// means uncapped — the check always passes.
+//
+// Must be called BEFORE any session-creation side effects (no worktree, no DB
+// row, no tmux session on refusal).
+//
+// cmd is the cobra.Command that owns the --ignore-concurrency-cap flag.
+// callerName is used in warning/error messages (e.g. "spawn", "pr", "review").
+func checkBwrapConcurrencyCap(cmd *cobra.Command, callerName string) error {
+	cap := config.Load().BwrapConcurrencyCap
+	if cap == 0 {
+		// 0 means uncapped.
+		return nil
+	}
+
+	d, err := db.Open(dbPath())
+	if err != nil {
+		// Non-fatal: if we can't open the DB we skip the cap check rather than
+		// blocking spawn on a DB error.
+		fmt.Fprintf(os.Stderr, "[prism %s] warning: could not open DB for bwrap cap check: %v\n", callerName, err)
+		return nil
+	}
+	defer d.Close()
+
+	count, err := d.ActiveBwrapSessionCount()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[prism %s] warning: could not count active bwrap sessions: %v\n", callerName, err)
+		return nil
+	}
+
+	if count < cap {
+		return nil
+	}
+
+	// Cap exceeded — fetch session list for the error/warning message.
+	sessions, listErr := d.ActiveBwrapSessions()
+
+	ignoreCap, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
+	if ignoreCap {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "[prism] warning: bwrap concurrency cap exceeded (%d/%d bwrap sessions in flight) — proceeding because --ignore-concurrency-cap was passed\n", count, cap)
+		if listErr == nil {
+			sb.WriteString("[prism] active bwrap sessions:\n")
+			for _, s := range sessions {
+				role := s.RootAgentName
+				roleStr := "unknown"
+				if role != nil && *role != "" {
+					roleStr = *role
+				} else if strings.HasSuffix(s.SessionName, "@main") {
+					roleStr = "coordinator"
+				}
+				fmt.Fprintf(&sb, "[prism]   %-40s (%s)\n", s.SessionName, roleStr)
+			}
+		}
+		fmt.Fprint(os.Stderr, sb.String())
+		return nil
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "error: prism bwrap concurrency cap reached (%d bwrap sessions already in flight)\n", count)
+	if listErr == nil {
+		sb.WriteString("\nActive bwrap sessions:\n")
+		for _, s := range sessions {
+			role := s.RootAgentName
+			roleStr := "unknown"
+			if role != nil && *role != "" {
+				roleStr = *role
+			} else if strings.HasSuffix(s.SessionName, "@main") {
+				roleStr = "coordinator"
+			}
+			fmt.Fprintf(&sb, "  %-40s (%s)\n", s.SessionName, roleStr)
+		}
+	}
+	sb.WriteString("\nHint: wait for a worker to finish and be cleaned up, or re-run with\n")
+	sb.WriteString("      --ignore-concurrency-cap to bypass this guard.")
+	return fmt.Errorf("%s", sb.String())
 }

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -75,13 +75,18 @@ var prCmd = &cobra.Command{
 		cfg := config.Load()
 		isoMode := cfg.EffectiveIsolationMode()
 		effectiveContainerMode := isoMode == config.IsolationPodman
-		// bwrap sessions are plain host processes — only podman triggers the cap.
+		// bwrap sessions are plain host processes — only podman triggers the container cap.
 		conCapped := isoMode == config.IsolationPodman
 
-		// Concurrency cap check: BEFORE any container-creation side effects
+		// Concurrency cap checks: BEFORE any container-creation side effects
 		// (no worktree, no tmux session, no DB row on refusal).
 		if err := checkConcurrencyCap(cmd, "pr", conCapped); err != nil {
 			return err
+		}
+		if isoMode == config.IsolationBwrap {
+			if err := checkBwrapConcurrencyCap(cmd, "pr"); err != nil {
+				return err
+			}
 		}
 
 		branch, err := resolveBranch(bareRoot, "", prNumber)

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -103,19 +103,24 @@ func runReview(cmd *cobra.Command, args []string) error {
 		agents = allAgents
 	}
 
-	// Concurrency cap check: BEFORE any container-creation side effects.
+	// Concurrency cap checks: BEFORE any container-creation side effects.
 	// We check inside the container-mode guard below (PRISM_HOST_API set
 	// means we're already inside a container; the host sidecar handles the cap
-	// for the actual spawn). Only apply the check on the host path.
+	// for the actual spawn). Only apply the checks on the host path.
 	// Load cfg now for the cap check; it is re-used below for ContainerMode.
 	cfg := config.Load()
 	isoMode := cfg.EffectiveIsolationMode()
-	// bwrap sessions are plain host processes — only podman triggers the cap.
+	// bwrap sessions are plain host processes — only podman triggers the container cap.
 	conCapped := isoMode == config.IsolationPodman
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL == "" {
-		// Running on host — check the cap before spawning review containers.
+		// Running on host — check the caps before spawning review sessions.
 		if err := checkConcurrencyCap(cmd, "review", conCapped); err != nil {
 			return err
+		}
+		if isoMode == config.IsolationBwrap {
+			if err := checkBwrapConcurrencyCap(cmd, "review"); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -216,14 +216,19 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Concurrency cap check: BEFORE any container-creation side effects
+	// Concurrency cap checks: BEFORE any container-creation side effects
 	// (no worktree, no tmux session, no DB row on refusal).
-	// Skipped in host-mode and bwrap-mode — the cap exists to guard host memory
-	// against podman container overhead; bwrap sessions are plain host processes
-	// with no per-session memory cap, so they do not count against it.
+	// The podman cap guards host memory against container overhead.
+	// The bwrap cap guards against process-count exhaustion from uncapped
+	// bwrap sessions (each is a host process with no per-session memory ceil).
 	conCapped := isolationMode == config.IsolationPodman
 	if err := checkConcurrencyCap(cmd, "spawn", conCapped); err != nil {
 		return err
+	}
+	if isolationMode == config.IsolationBwrap {
+		if err := checkBwrapConcurrencyCap(cmd, "spawn"); err != nil {
+			return err
+		}
 	}
 
 	// Load the profiles file. It carries container role configs, model profile

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -103,6 +103,13 @@ type Config struct {
 	// session. Zero means use the compiled-in default (3).
 	SidecarCircuitBreakerThreshold int `json:"sidecar_circuit_breaker_threshold"`
 
+	// BwrapConcurrencyCap is the maximum number of active bwrap sessions
+	// (agent_status rows with ended_at IS NULL AND isolation_mode = 'bwrap')
+	// before new bwrap spawns are refused. Zero means uncapped (not "cap of
+	// zero"). The default of 20 is conservative enough for any machine without
+	// an explicit per-machine override.
+	BwrapConcurrencyCap int `json:"bwrap_concurrency_cap"`
+
 	// Project layout (JSON arrays).
 	WorktreeExclude  []string `json:"worktree_exclude"`
 	ProjectLocations []string `json:"project_locations"`
@@ -131,30 +138,39 @@ type parsedConfig struct {
 	SshSigningKeyName              string    `json:"ssh_signing_key_name"`
 	RestoreStaggerDelayMs          *int      `json:"restore_stagger_delay_ms"`
 	SidecarCircuitBreakerThreshold *int      `json:"sidecar_circuit_breaker_threshold"`
+	BwrapConcurrencyCap            *int      `json:"bwrap_concurrency_cap"`
 	WorktreeExclude                *[]string `json:"worktree_exclude"`
 	ProjectLocations               *[]string `json:"project_locations"`
 	ProjectSpecific                *[]string `json:"project_specific"`
 }
 
+// DefaultBwrapConcurrencyCap is the compiled-in default maximum number of
+// concurrent bwrap sessions. A value of 20 is conservative enough for any
+// machine without an explicit override. The cap can be raised per-machine
+// via the Nix bwrapConcurrencyCap option (written to config.json).
+// Zero means uncapped.
+const DefaultBwrapConcurrencyCap = 20
+
 // defaults returns the compiled-in fallback Config (gruvbox-dark palette,
 // standard paths). These values are used whenever no config file is found.
 func defaults() Config {
 	return Config{
-		ColorPrimary:      "#d4be98",
-		ColorSecondary:    "#a89984",
-		ColorPurple:       "#d3869b",
-		ColorYellow:       "#d8a657",
-		ColorGreen:        "#a9b665",
-		ColorBlue:         "#7daea3",
-		ColorRed:          "#ea6962",
-		ColorForeground:   "#d3c6aa",
-		ColorBg0:          "#2d353b",
-		KittyBin:          "kitty",
-		SshAccessKeyName:  "prismatic-koi-ed25519",
-		SshSigningKeyName: "prismatic-koi-ed25519-signingkey",
-		WorktreeExclude:   []string{"obsidian"},
-		ProjectLocations:  []string{"~/code"},
-		ProjectSpecific:   []string{"~/documents/obsidian"},
+		ColorPrimary:        "#d4be98",
+		ColorSecondary:      "#a89984",
+		ColorPurple:         "#d3869b",
+		ColorYellow:         "#d8a657",
+		ColorGreen:          "#a9b665",
+		ColorBlue:           "#7daea3",
+		ColorRed:            "#ea6962",
+		ColorForeground:     "#d3c6aa",
+		ColorBg0:            "#2d353b",
+		KittyBin:            "kitty",
+		SshAccessKeyName:    "prismatic-koi-ed25519",
+		SshSigningKeyName:   "prismatic-koi-ed25519-signingkey",
+		BwrapConcurrencyCap: DefaultBwrapConcurrencyCap,
+		WorktreeExclude:     []string{"obsidian"},
+		ProjectLocations:    []string{"~/code"},
+		ProjectSpecific:     []string{"~/documents/obsidian"},
 	}
 }
 
@@ -267,6 +283,9 @@ func load() Config {
 	}
 	if parsed.SidecarCircuitBreakerThreshold != nil {
 		cfg.SidecarCircuitBreakerThreshold = *parsed.SidecarCircuitBreakerThreshold
+	}
+	if parsed.BwrapConcurrencyCap != nil {
+		cfg.BwrapConcurrencyCap = *parsed.BwrapConcurrencyCap
 	}
 
 	// For slice fields: nil pointer means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1546,6 +1546,31 @@ WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
 }
 
+// ActiveBwrapSessionCount returns the number of agent_status rows where
+// ended_at IS NULL AND isolation_mode = 'bwrap'. Used by the bwrap
+// concurrency cap check in cmd/concurrency.go.
+func (d *DB) ActiveBwrapSessionCount() (int, error) {
+	var n int
+	err := d.conn.QueryRow(
+		"SELECT COUNT(*) FROM agent_status WHERE ended_at IS NULL AND isolation_mode = 'bwrap'",
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("db: active bwrap session count: %w", err)
+	}
+	return n, nil
+}
+
+// ActiveBwrapSessions returns the agent_status rows for all active bwrap
+// sessions (ended_at IS NULL AND isolation_mode = 'bwrap'). Used to build
+// the session list in the bwrap concurrency cap error message.
+func (d *DB) ActiveBwrapSessions() ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE ended_at IS NULL AND isolation_mode = 'bwrap'`
+	return d.queryStatuses(q)
+}
+
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `


### PR DESCRIPTION
## Summary

- Adds a soft bwrap session concurrency cap to prevent OOM incidents from uncapped bwrap process proliferation (motivated by the 2026-04-25 incident where 55 concurrent bwrap opencode processes saturated RAM).
- Default cap: 20 sessions. Navi override: 50. Cap = 0 means uncapped.
- The existing podman cap and host-mode behaviour are unchanged.

## Changes

- **`internal/config/config.go`**: `BwrapConcurrencyCap int` field (default 20, `DefaultBwrapConcurrencyCap = 20`), pointer field in `parsedConfig`, merge logic — 0 in config means uncapped.
- **`internal/db/db.go`**: `ActiveBwrapSessionCount()` and `ActiveBwrapSessions()` — count/list `agent_status` rows where `ended_at IS NULL AND isolation_mode = 'bwrap'`.
- **`cmd/concurrency.go`**: `checkBwrapConcurrencyCap` helper — reads cap from config, queries DB, formats error/warning matching the existing podman cap style, honours `--ignore-concurrency-cap`.
- **`cmd/spawn.go`**, **`cmd/pr.go`**, **`cmd/review.go`**: wire in `checkBwrapConcurrencyCap` when `isoMode == IsolationBwrap` (before any side effects).
- **`modules/programs/prism/prism-tui.nix`**: `nx.programs.prism.bwrapConcurrencyCap` option (default 20); `bwrap_concurrency_cap` key written to `config.json`.
- **`machines/navi/configuration.nix`**: `bwrapConcurrencyCap = 50`.

Closes #1007