### PR TITLE
prism: pi-mono v3 JSONL translator (piexport) — emit session.jsonl from archive at cleanup

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/piexport"
 	"github.com/prismatic-koi/prism/internal/review"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -823,6 +824,13 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	if updErr := d.UpdateSessionArchivePath(instanceID, archivePath); updErr != nil {
 		fmt.Fprintf(os.Stderr, "[prism] archive: update archive_path for %q: %v\n", instanceID, updErr)
 	}
+
+	// Translate the raw archive to pi-mono v3 JSONL. Failure is non-fatal:
+	// the raw archive remains intact for re-translation later.
+	if translateErr := piexport.Translate(archivePath); translateErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism] piexport: translate failed for session %q: %v\n", sessionName, translateErr)
+	}
+
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/piexport/piexport.go
+++ b/modules/programs/prism/prism/internal/piexport/piexport.go
@@ -1,0 +1,802 @@
+// Package piexport translates an opencode raw session archive into a pi-mono
+// v3 JSONL trace file.
+//
+// # Input layout (archive raw/ subtree)
+//
+//	raw/
+//	  session.json                          — opencode session metadata
+//	  messages/msg_*.json                   — per-message records
+//	  parts/msg_<id>/prt_*.json             — per-part records
+//	  tool-output/tool_*                    — truncated tool output sidecars
+//
+// # Output
+//
+//	<archiveDir>/session.jsonl             — pi-mono v3 JSONL trace
+//
+// The translator is a pure library function: no running opencode server is
+// required. It reads the archived files, maps them to pi-mono v3 entries, and
+// writes the JSONL atomically (temp file + rename).
+package piexport
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+// Translate reads the raw opencode archive at archiveDir/raw/ and writes
+// archiveDir/session.jsonl. On error the partial output is discarded and no
+// session.jsonl is left behind. An existing session.jsonl is overwritten
+// atomically.
+func Translate(archiveDir string) error {
+	rawDir := filepath.Join(archiveDir, "raw")
+
+	// Read session.json.
+	sessData, err := os.ReadFile(filepath.Join(rawDir, "session.json"))
+	if err != nil {
+		return fmt.Errorf("piexport: read session.json: %w", err)
+	}
+	var sess ocSession
+	if err := json.Unmarshal(sessData, &sess); err != nil {
+		return fmt.Errorf("piexport: parse session.json: %w", err)
+	}
+
+	// Read all message files.
+	rawMsgs, err := readMessages(filepath.Join(rawDir, "messages"))
+	if err != nil {
+		return fmt.Errorf("piexport: read messages: %w", err)
+	}
+
+	// For each message read its parts.
+	var allMsgs []msgWithParts
+	for _, msg := range rawMsgs {
+		parts, partErr := readParts(filepath.Join(rawDir, "parts", msg.ID))
+		if partErr != nil {
+			return fmt.Errorf("piexport: read parts for %s: %w", msg.ID, partErr)
+		}
+		allMsgs = append(allMsgs, msgWithParts{msg: msg, parts: parts})
+	}
+
+	// Build the JSONL entries.
+	entries, err := buildEntries(sess, allMsgs, rawDir)
+	if err != nil {
+		return fmt.Errorf("piexport: build entries: %w", err)
+	}
+
+	// Atomic write: temp file → rename.
+	if err := writeJSONL(archiveDir, entries); err != nil {
+		return fmt.Errorf("piexport: write session.jsonl: %w", err)
+	}
+	return nil
+}
+
+// ── opencode on-disk types ────────────────────────────────────────────────────
+
+type ocSession struct {
+	ID        string `json:"id"`
+	Directory string `json:"directory"`
+	Slug      string `json:"slug"`
+	Time      struct {
+		Created int64 `json:"created"` // unix ms
+	} `json:"time"`
+}
+
+type ocMessage struct {
+	ID         string   `json:"id"`
+	SessionID  string   `json:"sessionID"`
+	Role       string   `json:"role"`       // "user" | "assistant"
+	ParentID   string   `json:"parentID"`   // assistant messages have a parentID
+	System     []string `json:"system"`     // per-message system prompts (may be nil)
+	ModelID    string   `json:"modelID"`    // assistant only
+	ProviderID string   `json:"providerID"` // assistant only
+	Cost       float64  `json:"cost"`
+	Tokens     struct {
+		Input     int64 `json:"input"`
+		Output    int64 `json:"output"`
+		Reasoning int64 `json:"reasoning"`
+		Cache     struct {
+			Read  int64 `json:"read"`
+			Write int64 `json:"write"`
+		} `json:"cache"`
+	} `json:"tokens"`
+	Finish string `json:"finish"` // assistant: the finish reason from the message level
+	Time   struct {
+		Created   int64 `json:"created"`
+		Completed int64 `json:"completed"`
+	} `json:"time"`
+}
+
+type ocPart struct {
+	ID        string          `json:"id"`
+	MessageID string          `json:"messageID"`
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`     // type=text, type=reasoning
+	Snapshot  string          `json:"snapshot"` // type=step-start, step-finish
+	CallID    string          `json:"callID"`   // type=tool
+	Tool      string          `json:"tool"`     // type=tool
+	Asset     string          `json:"asset"`    // legacy type=tool sidecar ref
+	State     json.RawMessage `json:"state"`    // type=tool: ToolState JSON
+	Reason    string          `json:"reason"`   // type=step-finish
+	Cost      float64         `json:"cost"`     // type=step-finish
+	Tokens    struct {
+		Input     int64 `json:"input"`
+		Output    int64 `json:"output"`
+		Reasoning int64 `json:"reasoning"`
+		Cache     struct {
+			Read  int64 `json:"read"`
+			Write int64 `json:"write"`
+		} `json:"cache"`
+	} `json:"tokens"` // type=step-finish
+	Time struct {
+		Start int64 `json:"start"`
+		End   int64 `json:"end"`
+	} `json:"time"` // type=text, reasoning, tool state
+	// File parts.
+	Mime     string `json:"mime"`
+	Filename string `json:"filename"`
+	URL      string `json:"url"` // data: URI or file path
+}
+
+type ocToolState struct {
+	Status string          `json:"status"` // "pending" | "running" | "completed" | "error"
+	Input  json.RawMessage `json:"input"`
+	Output string          `json:"output"` // completed status: tool output text
+	Error  string          `json:"error"`  // error status
+	Title  string          `json:"title"`
+	Time   struct {
+		Start int64 `json:"start"`
+		End   int64 `json:"end"`
+	} `json:"time"`
+}
+
+// msgWithParts bundles an opencode message with its ordered parts.
+type msgWithParts struct {
+	msg   ocMessage
+	parts []ocPart
+}
+
+// ── pi-mono v3 entry types ────────────────────────────────────────────────────
+
+type piSessionHeader struct {
+	Type      string `json:"type"`
+	Version   int    `json:"version"`
+	ID        string `json:"id"`
+	Timestamp string `json:"timestamp"`
+	CWD       string `json:"cwd"`
+}
+
+type piEntryBase struct {
+	Type      string  `json:"type"`
+	ID        string  `json:"id"`
+	ParentID  *string `json:"parentId"`
+	Timestamp string  `json:"timestamp"`
+}
+
+type piMessageEntry struct {
+	piEntryBase
+	Message piMessage `json:"message"`
+}
+
+type piMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	API        string          `json:"api,omitempty"`
+	Provider   string          `json:"provider,omitempty"`
+	Model      string          `json:"model,omitempty"`
+	Usage      *piUsage        `json:"usage,omitempty"`
+	StopReason string          `json:"stopReason,omitempty"`
+	Timestamp  int64           `json:"timestamp"` // unix ms
+	ToolCallID string          `json:"toolCallId,omitempty"`
+	ToolName   string          `json:"toolName,omitempty"`
+	IsError    bool            `json:"isError,omitempty"`
+}
+
+type piUsage struct {
+	Input       int64   `json:"input"`
+	Output      int64   `json:"output"`
+	CacheRead   int64   `json:"cacheRead"`
+	CacheWrite  int64   `json:"cacheWrite"`
+	TotalTokens int64   `json:"totalTokens"`
+	Cost        piCost  `json:"cost"`
+}
+
+type piCost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cacheRead"`
+	CacheWrite float64 `json:"cacheWrite"`
+	Total      float64 `json:"total"`
+}
+
+type piCustomEntry struct {
+	piEntryBase
+	CustomType string          `json:"customType"`
+	Data       json.RawMessage `json:"data"`
+}
+
+// Content block types.
+
+type piTextContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type piThinkingContent struct {
+	Type     string `json:"type"`
+	Thinking string `json:"thinking"`
+}
+
+type piImageContent struct {
+	Type     string `json:"type"`
+	Data     string `json:"data"`     // base64
+	MimeType string `json:"mimeType"` // e.g. "image/png"
+}
+
+type piToolCallContent struct {
+	Type      string         `json:"type"`
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// ── ID generation ─────────────────────────────────────────────────────────────
+
+// newID returns an 8-character lowercase hex string from 4 random bytes.
+func newID() (string, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func mustID() string {
+	id, err := newID()
+	if err != nil {
+		panic("piexport: crypto/rand failed: " + err.Error())
+	}
+	return id
+}
+
+// ── file I/O helpers ──────────────────────────────────────────────────────────
+
+func readMessages(dir string) ([]ocMessage, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var msgs []ocMessage
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", e.Name(), readErr)
+		}
+		var m ocMessage
+		if parseErr := json.Unmarshal(data, &m); parseErr != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), parseErr)
+		}
+		msgs = append(msgs, m)
+	}
+	// Sort messages by ID (ULID-sortable — time-ordered).
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].ID < msgs[j].ID
+	})
+	return msgs, nil
+}
+
+func readParts(dir string) ([]ocPart, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var parts []ocPart
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", e.Name(), readErr)
+		}
+		var p ocPart
+		if parseErr := json.Unmarshal(data, &p); parseErr != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), parseErr)
+		}
+		parts = append(parts, p)
+	}
+	// Sort parts by ID (ULID-sortable). Tiebreak by time.start.
+	sort.Slice(parts, func(i, j int) bool {
+		if parts[i].ID == parts[j].ID {
+			return parts[i].Time.Start < parts[j].Time.Start
+		}
+		return parts[i].ID < parts[j].ID
+	})
+	return parts, nil
+}
+
+// msToISO converts unix milliseconds to ISO 8601 / RFC3339Nano.
+func msToISO(ms int64) string {
+	if ms == 0 {
+		return time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339Nano)
+}
+
+// ── main translation logic ────────────────────────────────────────────────────
+
+func buildEntries(sess ocSession, allMsgs []msgWithParts, rawDir string) ([]any, error) {
+	var entries []any
+
+	// Session header.
+	ts := msToISO(sess.Time.Created)
+	header := piSessionHeader{
+		Type:      "session",
+		Version:   3,
+		ID:        sess.ID,
+		Timestamp: ts,
+		CWD:       sess.Directory,
+	}
+	entries = append(entries, header)
+
+	// Linear id/parentId chain state.
+	var prevID *string
+
+	// emit appends an entry and returns its ID for chaining.
+	emit := func(e any) {
+		entries = append(entries, e)
+	}
+
+	// Track the last emitted system prompts to detect changes.
+	var lastSystem []string
+
+	for _, mp := range allMsgs {
+		msg := mp.msg
+		parts := mp.parts
+
+		msgTS := msToISO(msg.Time.Created)
+
+		switch msg.Role {
+		case "user":
+			// Emit system custom entry before this user message when system changes.
+			if len(msg.System) > 0 && !stringSliceEqual(msg.System, lastSystem) {
+				sysEntry, err := buildSystemEntry(msg.System, prevID, msgTS)
+				if err != nil {
+					return nil, fmt.Errorf("build system entry for %s: %w", msg.ID, err)
+				}
+				sysID := sysEntry.ID
+				emit(sysEntry)
+				prevID = &sysID
+				lastSystem = append([]string(nil), msg.System...)
+			}
+
+			// Build user content blocks.
+			content, err := buildUserContent(parts, rawDir)
+			if err != nil {
+				return nil, fmt.Errorf("build user content for %s: %w", msg.ID, err)
+			}
+			contentJSON, err := json.Marshal(content)
+			if err != nil {
+				return nil, fmt.Errorf("marshal user content for %s: %w", msg.ID, err)
+			}
+
+			entryID := mustID()
+			entry := piMessageEntry{
+				piEntryBase: piEntryBase{
+					Type:      "message",
+					ID:        entryID,
+					ParentID:  prevID,
+					Timestamp: msgTS,
+				},
+				Message: piMessage{
+					Role:      "user",
+					Content:   contentJSON,
+					Timestamp: msg.Time.Created,
+				},
+			}
+			emit(entry)
+			prevID = &entryID
+
+		case "assistant":
+			// Check for a step-start part with a snapshot — emit before the assistant entry.
+			for _, p := range parts {
+				if p.Type == "step-start" && p.Snapshot != "" {
+					snapEntry, err := buildSnapshotEntry(p.Snapshot, prevID, msgTS)
+					if err != nil {
+						return nil, fmt.Errorf("build snapshot entry for %s: %w", p.ID, err)
+					}
+					snapID := snapEntry.ID
+					emit(snapEntry)
+					prevID = &snapID
+					break // one snapshot per message
+				}
+			}
+
+			// Emit system entry if system changed.
+			if len(msg.System) > 0 && !stringSliceEqual(msg.System, lastSystem) {
+				sysEntry, err := buildSystemEntry(msg.System, prevID, msgTS)
+				if err != nil {
+					return nil, fmt.Errorf("build system entry for assistant %s: %w", msg.ID, err)
+				}
+				sysID := sysEntry.ID
+				emit(sysEntry)
+				prevID = &sysID
+				lastSystem = append([]string(nil), msg.System...)
+			}
+
+			// Build assistant content + aggregate usage from step-finish parts.
+			content, toolInfos, usage, stopReason, err := buildAssistantContent(parts, rawDir)
+			if err != nil {
+				return nil, fmt.Errorf("build assistant content for %s: %w", msg.ID, err)
+			}
+			contentJSON, err := json.Marshal(content)
+			if err != nil {
+				return nil, fmt.Errorf("marshal assistant content for %s: %w", msg.ID, err)
+			}
+
+			entryID := mustID()
+			entry := piMessageEntry{
+				piEntryBase: piEntryBase{
+					Type:      "message",
+					ID:        entryID,
+					ParentID:  prevID,
+					Timestamp: msgTS,
+				},
+				Message: piMessage{
+					Role:       "assistant",
+					Content:    contentJSON,
+					Provider:   msg.ProviderID,
+					Model:      msg.ModelID,
+					Usage:      usage,
+					StopReason: stopReason,
+					Timestamp:  msg.Time.Created,
+				},
+			}
+			emit(entry)
+			prevID = &entryID
+
+			// Emit one toolResult entry per tool call.
+			for i := range toolInfos {
+				toolResultEntry, trErr := buildToolResultEntry(toolInfos[i], prevID, rawDir)
+				if trErr != nil {
+					return nil, fmt.Errorf("build toolResult for callID %s: %w", toolInfos[i].callID, trErr)
+				}
+				trID := toolResultEntry.ID
+				emit(toolResultEntry)
+				prevID = &trID
+			}
+		}
+	}
+
+	return entries, nil
+}
+
+// ── user message content ──────────────────────────────────────────────────────
+
+func buildUserContent(parts []ocPart, rawDir string) ([]any, error) {
+	var content []any
+	for _, p := range parts {
+		switch p.Type {
+		case "text":
+			if p.Text != "" {
+				content = append(content, piTextContent{Type: "text", Text: p.Text})
+			}
+		case "file":
+			if isImageMIME(p.Mime) {
+				imgContent, err := filePartToImage(p)
+				if err != nil {
+					slog.Warn("piexport: could not convert file part to image", "part", p.ID, "err", err)
+					continue
+				}
+				content = append(content, imgContent)
+			}
+			// Non-image file parts (text/plain, dirs) are skipped for user content.
+		}
+		// Ignore step-start, step-finish, tool, reasoning, etc. for user messages.
+	}
+	if len(content) == 0 {
+		content = append(content, piTextContent{Type: "text", Text: ""})
+	}
+	return content, nil
+}
+
+// ── assistant message content ─────────────────────────────────────────────────
+
+type toolPartInfo struct {
+	callID string
+	tool   string
+	state  ocToolState
+	asset  string // legacy sidecar ref
+}
+
+func buildAssistantContent(parts []ocPart, rawDir string) (content []any, toolInfos []toolPartInfo, usage *piUsage, stopReason string, err error) {
+	var aggUsage piUsage
+	var hasStepFinish bool
+
+	for _, p := range parts {
+		switch p.Type {
+		case "text":
+			if p.Text != "" {
+				content = append(content, piTextContent{Type: "text", Text: p.Text})
+			}
+		case "reasoning":
+			if p.Text != "" {
+				content = append(content, piThinkingContent{Type: "thinking", Thinking: p.Text})
+			}
+		case "tool":
+			var state ocToolState
+			if len(p.State) > 0 {
+				if parseErr := json.Unmarshal(p.State, &state); parseErr != nil {
+					return nil, nil, nil, "", fmt.Errorf("parse tool state for part %s: %w", p.ID, parseErr)
+				}
+			}
+
+			var args map[string]any
+			if len(state.Input) > 0 {
+				if parseErr := json.Unmarshal(state.Input, &args); parseErr != nil {
+					args = map[string]any{"raw": string(state.Input)}
+				}
+			}
+
+			callID := p.CallID
+			if callID == "" {
+				callID = p.ID
+			}
+			content = append(content, piToolCallContent{
+				Type:      "toolCall",
+				ID:        callID,
+				Name:      p.Tool,
+				Arguments: args,
+			})
+			toolInfos = append(toolInfos, toolPartInfo{
+				callID: callID,
+				tool:   p.Tool,
+				state:  state,
+				asset:  p.Asset,
+			})
+
+		case "step-finish":
+			hasStepFinish = true
+			aggUsage.Input += p.Tokens.Input
+			aggUsage.Output += p.Tokens.Output
+			aggUsage.CacheRead += p.Tokens.Cache.Read
+			aggUsage.CacheWrite += p.Tokens.Cache.Write
+			aggUsage.Cost.Total += p.Cost
+			stopReason = mapStopReason(p.Reason)
+		}
+		// step-start is handled by the caller before this function.
+	}
+
+	if !hasStepFinish {
+		stopReason = "aborted"
+	}
+	aggUsage.TotalTokens = aggUsage.Input + aggUsage.Output + aggUsage.CacheRead
+
+	return content, toolInfos, &aggUsage, stopReason, nil
+}
+
+func mapStopReason(reason string) string {
+	switch reason {
+	case "stop", "end_turn":
+		return "stop"
+	case "length", "max_tokens":
+		return "length"
+	case "tool-calls", "tool_use":
+		return "toolUse"
+	case "error":
+		return "error"
+	default:
+		if reason == "" {
+			return "stop"
+		}
+		return reason
+	}
+}
+
+// ── tool result entries ───────────────────────────────────────────────────────
+
+func buildToolResultEntry(tp toolPartInfo, prevID *string, rawDir string) (piMessageEntry, error) {
+	isError := tp.state.Status == "error"
+
+	var outputText string
+	switch tp.state.Status {
+	case "completed":
+		outputText = tp.state.Output
+	case "error":
+		outputText = tp.state.Error
+	case "pending", "running":
+		outputText = "[Tool execution was interrupted]"
+		isError = true
+	}
+
+	// If there's a legacy sidecar asset reference, prefer that content.
+	if tp.asset != "" && strings.HasPrefix(tp.asset, "tool_") {
+		if tp.asset == filepath.Base(tp.asset) && !strings.ContainsRune(tp.asset, os.PathSeparator) {
+			sidecarPath := filepath.Join(rawDir, "tool-output", tp.asset)
+			if data, readErr := os.ReadFile(sidecarPath); readErr == nil {
+				outputText = string(data)
+			}
+		}
+	}
+
+	resultContent := []any{piTextContent{Type: "text", Text: outputText}}
+	contentJSON, err := json.Marshal(resultContent)
+	if err != nil {
+		return piMessageEntry{}, err
+	}
+
+	endTime := tp.state.Time.End
+	entryID := mustID()
+	return piMessageEntry{
+		piEntryBase: piEntryBase{
+			Type:      "message",
+			ID:        entryID,
+			ParentID:  prevID,
+			Timestamp: msToISO(endTime),
+		},
+		Message: piMessage{
+			Role:       "toolResult",
+			Content:    contentJSON,
+			ToolCallID: tp.callID,
+			ToolName:   tp.tool,
+			IsError:    isError,
+			Timestamp:  endTime,
+		},
+	}, nil
+}
+
+// ── system and snapshot custom entries ───────────────────────────────────────
+
+func buildSystemEntry(system []string, prevID *string, ts string) (piCustomEntry, error) {
+	type systemData struct {
+		Prompts []string `json:"prompts"`
+	}
+	data, err := json.Marshal(systemData{Prompts: system})
+	if err != nil {
+		return piCustomEntry{}, err
+	}
+	entryID := mustID()
+	return piCustomEntry{
+		piEntryBase: piEntryBase{
+			Type:      "custom",
+			ID:        entryID,
+			ParentID:  prevID,
+			Timestamp: ts,
+		},
+		CustomType: "opencode.system",
+		Data:       data,
+	}, nil
+}
+
+func buildSnapshotEntry(sha string, prevID *string, ts string) (piCustomEntry, error) {
+	type snapData struct {
+		SHA string `json:"sha"`
+	}
+	data, err := json.Marshal(snapData{SHA: sha})
+	if err != nil {
+		return piCustomEntry{}, err
+	}
+	entryID := mustID()
+	return piCustomEntry{
+		piEntryBase: piEntryBase{
+			Type:      "custom",
+			ID:        entryID,
+			ParentID:  prevID,
+			Timestamp: ts,
+		},
+		CustomType: "opencode.snapshot.start",
+		Data:       data,
+	}, nil
+}
+
+// ── image helpers ─────────────────────────────────────────────────────────────
+
+func isImageMIME(m string) bool {
+	return strings.HasPrefix(m, "image/")
+}
+
+func filePartToImage(p ocPart) (piImageContent, error) {
+	mimeType := p.Mime
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	if strings.HasPrefix(p.URL, "data:") {
+		comma := strings.Index(p.URL, ",")
+		if comma < 0 {
+			return piImageContent{}, fmt.Errorf("malformed data URI for part %s", p.ID)
+		}
+		// Extract mime from the data URI header.
+		header := p.URL[5:comma] // strip "data:"
+		if semi := strings.Index(header, ";"); semi > 0 {
+			mimeType = header[:semi]
+		}
+		return piImageContent{Type: "image", Data: p.URL[comma+1:], MimeType: mimeType}, nil
+	}
+
+	// Treat as a file path.
+	data, err := os.ReadFile(p.URL)
+	if err != nil {
+		return piImageContent{}, fmt.Errorf("read image file %s: %w", p.URL, err)
+	}
+	if mimeType == "" || mimeType == "application/octet-stream" {
+		detected := http.DetectContentType(data)
+		if parsedMime, _, parseErr := mime.ParseMediaType(detected); parseErr == nil {
+			mimeType = parsedMime
+		}
+	}
+	return piImageContent{
+		Type:     "image",
+		Data:     base64.StdEncoding.EncodeToString(data),
+		MimeType: mimeType,
+	}, nil
+}
+
+// ── JSONL writer ──────────────────────────────────────────────────────────────
+
+func writeJSONL(archiveDir string, entries []any) error {
+	finalPath := filepath.Join(archiveDir, "session.jsonl")
+	tmpPath := finalPath + ".tmp"
+
+	// Remove stale temp file if present.
+	_ = os.Remove(tmpPath)
+
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if encErr := enc.Encode(e); encErr != nil {
+			f.Close()
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("encode entry: %w", encErr)
+		}
+	}
+
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename to final: %w", err)
+	}
+	return nil
+}
+
+// ── string slice equality ─────────────────────────────────────────────────────
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/programs/prism/prism/internal/piexport/piexport_test.go
+++ b/modules/programs/prism/prism/internal/piexport/piexport_test.go
@@ -1,0 +1,907 @@
+package piexport
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── fixture builders ──────────────────────────────────────────────────────────
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+func mustWriteJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal for %s: %v", path, err)
+	}
+	mustWriteFile(t, path, data)
+}
+
+// buildArchiveDir creates a self-contained archive directory under t.TempDir()
+// with the given raw/ subtree and returns the archive root path.
+func buildArchiveDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "raw", "messages"))
+	mustMkdir(t, filepath.Join(dir, "raw", "parts"))
+	return dir
+}
+
+// ── shared session JSON ───────────────────────────────────────────────────────
+
+func makeSession(id, directory string, createdMS int64) map[string]any {
+	return map[string]any{
+		"id":        id,
+		"directory": directory,
+		"slug":      "test-session",
+		"time":      map[string]any{"created": createdMS},
+	}
+}
+
+// ── helpers for parsing output ───────────────────────────────────────────────
+
+type rawEntry map[string]json.RawMessage
+
+func parseJSONL(t *testing.T, path string) []rawEntry {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", path, err)
+	}
+	var entries []rawEntry
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var e rawEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v\nline: %s", lineNum, err, line)
+		}
+		entries = append(entries, e)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+	return entries
+}
+
+func entryType(t *testing.T, e rawEntry) string {
+	t.Helper()
+	var v string
+	if err := json.Unmarshal(e["type"], &v); err != nil {
+		t.Fatalf("entry.type: %v", err)
+	}
+	return v
+}
+
+func entryID(t *testing.T, e rawEntry) string {
+	t.Helper()
+	var v string
+	if err := json.Unmarshal(e["id"], &v); err != nil {
+		t.Fatalf("entry.id: %v", err)
+	}
+	return v
+}
+
+func entryParentID(t *testing.T, e rawEntry) *string {
+	t.Helper()
+	raw, ok := e["parentId"]
+	if !ok {
+		return nil
+	}
+	if string(raw) == "null" {
+		return nil
+	}
+	var v string
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("entry.parentId: %v", err)
+	}
+	return &v
+}
+
+func entryMessage(t *testing.T, e rawEntry) map[string]json.RawMessage {
+	t.Helper()
+	var v map[string]json.RawMessage
+	if err := json.Unmarshal(e["message"], &v); err != nil {
+		t.Fatalf("entry.message: %v", err)
+	}
+	return v
+}
+
+func messageRole(t *testing.T, msg map[string]json.RawMessage) string {
+	t.Helper()
+	var v string
+	if err := json.Unmarshal(msg["role"], &v); err != nil {
+		t.Fatalf("message.role: %v", err)
+	}
+	return v
+}
+
+// ── fixture 1: simple linear text conversation ────────────────────────────────
+
+// TestFixtureLinearText covers a simple user→assistant text-only exchange.
+// It also validates the linear id/parentId chain and round-trip stability.
+func TestFixtureLinearText(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	sessionID := "ses_lineartest"
+	createdMS := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC).UnixMilli()
+
+	// session.json
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession(sessionID, "/home/user/project", createdMS))
+
+	// User message.
+	userMsgID := "msg_aaa0000001user"
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", userMsgID+".json"), map[string]any{
+		"id":        userMsgID,
+		"sessionID": sessionID,
+		"role":      "user",
+		"time":      map[string]any{"created": createdMS + 1000},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", userMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", userMsgID, "prt_aaa0000001text.json"), map[string]any{
+		"id":        "prt_aaa0000001text",
+		"messageID": userMsgID,
+		"type":      "text",
+		"text":      "What is 2 + 2?",
+	})
+
+	// Assistant message.
+	asstMsgID := "msg_bbb0000001asst"
+	asstCreated := createdMS + 2000
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", asstMsgID+".json"), map[string]any{
+		"id":         asstMsgID,
+		"sessionID":  sessionID,
+		"role":       "assistant",
+		"parentID":   userMsgID,
+		"modelID":    "claude-sonnet-4-5",
+		"providerID": "anthropic",
+		"time":       map[string]any{"created": asstCreated, "completed": asstCreated + 500},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", asstMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_bbb0000001step.json"), map[string]any{
+		"id":        "prt_bbb0000001step",
+		"messageID": asstMsgID,
+		"type":      "step-start",
+		"snapshot":  "abc123def456abc123def456abc123def456abc1",
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_bbb0000002text.json"), map[string]any{
+		"id":        "prt_bbb0000002text",
+		"messageID": asstMsgID,
+		"type":      "text",
+		"text":      "4",
+		"time":      map[string]any{"start": asstCreated + 100, "end": asstCreated + 200},
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_bbb0000003fin.json"), map[string]any{
+		"id":        "prt_bbb0000003fin",
+		"messageID": asstMsgID,
+		"type":      "step-finish",
+		"reason":    "stop",
+		"cost":      0.001,
+		"tokens": map[string]any{
+			"input": 10, "output": 5, "reasoning": 0,
+			"cache": map[string]any{"read": 0, "write": 0},
+		},
+	})
+
+	// Run translator.
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+
+	jsonlPath := filepath.Join(archDir, "session.jsonl")
+	entries := parseJSONL(t, jsonlPath)
+
+	// Must have at least: header + snapshot + user-msg + asst-msg = 4 entries.
+	if len(entries) < 4 {
+		t.Fatalf("expected ≥4 entries, got %d", len(entries))
+	}
+
+	// First entry: session header.
+	hdr := entries[0]
+	if entryType(t, hdr) != "session" {
+		t.Errorf("entries[0].type = %q, want %q", entryType(t, hdr), "session")
+	}
+	var hdrVersion int
+	if err := json.Unmarshal(hdr["version"], &hdrVersion); err != nil || hdrVersion != 3 {
+		t.Errorf("header.version = %v, want 3", hdrVersion)
+	}
+	var hdrID string
+	if err := json.Unmarshal(hdr["id"], &hdrID); err != nil || hdrID != sessionID {
+		t.Errorf("header.id = %q, want %q", hdrID, sessionID)
+	}
+
+	// Validate linear chain for non-header entries.
+	validateLinearChain(t, entries[1:])
+
+	// Round-trip stability: parse the JSONL into raw maps, re-serialize each
+	// line, and verify byte-equality with the original.
+	checkRoundTrip(t, jsonlPath)
+}
+
+// validateLinearChain checks that entries (excluding the session header) form
+// a valid linear parentId chain and that all IDs are unique 8-char hex.
+func validateLinearChain(t *testing.T, entries []rawEntry) {
+	t.Helper()
+	seen := map[string]bool{}
+	var prevID *string
+	for i, e := range entries {
+		if entryType(t, e) == "session" {
+			continue // header has no id/parentId
+		}
+		id := entryID(t, e)
+		if len(id) != 8 {
+			t.Errorf("entry[%d].id = %q, want 8-char hex", i, id)
+		}
+		// Validate hex characters.
+		for _, c := range id {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Errorf("entry[%d].id = %q contains non-hex character %c", i, id, c)
+			}
+		}
+		if seen[id] {
+			t.Errorf("entry[%d].id = %q is duplicate", i, id)
+		}
+		seen[id] = true
+
+		parentID := entryParentID(t, e)
+		if i == 0 {
+			if parentID != nil {
+				t.Errorf("first non-header entry has parentId = %q, want null", *parentID)
+			}
+		} else {
+			if parentID == nil {
+				t.Errorf("entry[%d] has parentId = null, want %q", i, *prevID)
+			} else if *parentID != *prevID {
+				t.Errorf("entry[%d].parentId = %q, want %q", i, *parentID, *prevID)
+			}
+		}
+		prevID = &id
+	}
+}
+
+// ── fixture 2: tool calls with sidecar ───────────────────────────────────────
+
+// TestFixtureToolCalls covers an assistant message with tool calls, including
+// the tool-output sidecar file.
+func TestFixtureToolCalls(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	sessionID := "ses_tooltest001"
+	createdMS := time.Date(2026, 2, 10, 8, 0, 0, 0, time.UTC).UnixMilli()
+
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession(sessionID, "/home/user/repo", createdMS))
+
+	// User message asking to run a bash command.
+	userMsgID := "msg_tooluser0001"
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", userMsgID+".json"), map[string]any{
+		"id":        userMsgID,
+		"sessionID": sessionID,
+		"role":      "user",
+		"time":      map[string]any{"created": createdMS + 500},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", userMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", userMsgID, "prt_tooluser0001text.json"), map[string]any{
+		"id":        "prt_tooluser0001text",
+		"messageID": userMsgID,
+		"type":      "text",
+		"text":      "Run ls in the current directory",
+	})
+
+	// Assistant message with tool call.
+	asstMsgID := "msg_toolasst0001"
+	asstCreated := createdMS + 2000
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", asstMsgID+".json"), map[string]any{
+		"id":         asstMsgID,
+		"sessionID":  sessionID,
+		"role":       "assistant",
+		"parentID":   userMsgID,
+		"modelID":    "claude-opus-4",
+		"providerID": "anthropic",
+		"time":       map[string]any{"created": asstCreated, "completed": asstCreated + 3000},
+	})
+
+	toolCallID := "toolu_01ExampleBashCall"
+	toolOutputContent := strings.Repeat("file\n", 3000) // large enough to simulate sidecar
+	sidecarID := "tool_01SidecarULIDxyz"
+	mustMkdir(t, filepath.Join(rawDir, "tool-output"))
+	mustWriteFile(t, filepath.Join(rawDir, "tool-output", sidecarID), []byte(toolOutputContent))
+
+	mustMkdir(t, filepath.Join(rawDir, "parts", asstMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_toolasst0001step.json"), map[string]any{
+		"id":        "prt_toolasst0001step",
+		"messageID": asstMsgID,
+		"type":      "step-start",
+		"snapshot":  "",
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_toolasst0001text.json"), map[string]any{
+		"id":        "prt_toolasst0001text",
+		"messageID": asstMsgID,
+		"type":      "text",
+		"text":      "I'll run ls for you.",
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_toolasst0001tool.json"), map[string]any{
+		"id":        "prt_toolasst0001tool",
+		"messageID": asstMsgID,
+		"type":      "tool",
+		"callID":    toolCallID,
+		"tool":      "bash",
+		"asset":     sidecarID, // legacy sidecar reference
+		"state": map[string]any{
+			"status": "completed",
+			"input":  map[string]any{"command": "ls"},
+			"output": "truncated output...", // will be replaced by sidecar
+			"title":  "ls",
+			"time":   map[string]any{"start": asstCreated + 500, "end": asstCreated + 1500},
+		},
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_toolasst0001fin.json"), map[string]any{
+		"id":        "prt_toolasst0001fin",
+		"messageID": asstMsgID,
+		"type":      "step-finish",
+		"reason":    "tool-calls",
+		"cost":      0.005,
+		"tokens": map[string]any{
+			"input": 50, "output": 30, "reasoning": 0,
+			"cache": map[string]any{"read": 10, "write": 5},
+		},
+	})
+
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+
+	jsonlPath := filepath.Join(archDir, "session.jsonl")
+	entries := parseJSONL(t, jsonlPath)
+
+	// Expected entries: header + user-msg + asst-msg + toolResult-msg
+	// The step-start has no snapshot so no custom entry.
+	if len(entries) < 4 {
+		t.Fatalf("expected ≥4 entries, got %d", len(entries))
+	}
+
+	validateLinearChain(t, entries[1:])
+
+	// Find the toolResult entry.
+	var toolResultEntry rawEntry
+	for _, e := range entries {
+		if entryType(t, e) == "message" {
+			msg := entryMessage(t, e)
+			if messageRole(t, msg) == "toolResult" {
+				toolResultEntry = e
+				break
+			}
+		}
+	}
+	if toolResultEntry == nil {
+		t.Fatal("no toolResult entry found")
+	}
+
+	// Verify the toolResult references the correct toolCallId.
+	msg := entryMessage(t, toolResultEntry)
+	var toolCallIDGot string
+	if err := json.Unmarshal(msg["toolCallId"], &toolCallIDGot); err != nil {
+		t.Fatalf("toolResult.toolCallId: %v", err)
+	}
+	if toolCallIDGot != toolCallID {
+		t.Errorf("toolResult.toolCallId = %q, want %q", toolCallIDGot, toolCallID)
+	}
+
+	// Verify sidecar content appears in the toolResult.
+	var content []map[string]json.RawMessage
+	if err := json.Unmarshal(msg["content"], &content); err != nil {
+		t.Fatalf("toolResult.content: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("toolResult.content is empty")
+	}
+	var textVal string
+	if err := json.Unmarshal(content[0]["text"], &textVal); err != nil {
+		t.Fatalf("toolResult.content[0].text: %v", err)
+	}
+	if textVal != toolOutputContent {
+		t.Errorf("toolResult sidecar content mismatch: got %q, want sidecar content", textVal[:min(50, len(textVal))])
+	}
+
+	// Round-trip stability.
+	checkRoundTrip(t, jsonlPath)
+}
+
+// ── fixture 3: thinking blocks ────────────────────────────────────────────────
+
+// TestFixtureThinkingBlocks covers an assistant message with reasoning parts
+// (mapped to pi ThinkingContent blocks).
+func TestFixtureThinkingBlocks(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	sessionID := "ses_thinktest001"
+	createdMS := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC).UnixMilli()
+
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession(sessionID, "/home/user/think-project", createdMS))
+
+	// User message.
+	userMsgID := "msg_thinkuser0001"
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", userMsgID+".json"), map[string]any{
+		"id":        userMsgID,
+		"sessionID": sessionID,
+		"role":      "user",
+		"time":      map[string]any{"created": createdMS + 1000},
+		"system":    []string{"You are a helpful assistant.", "Think carefully before responding."},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", userMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", userMsgID, "prt_thinkuser0001t.json"), map[string]any{
+		"id":        "prt_thinkuser0001t",
+		"messageID": userMsgID,
+		"type":      "text",
+		"text":      "What is the meaning of life?",
+	})
+
+	// Assistant message with thinking block.
+	asstMsgID := "msg_thinkasst0001"
+	asstCreated := createdMS + 5000
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", asstMsgID+".json"), map[string]any{
+		"id":         asstMsgID,
+		"sessionID":  sessionID,
+		"role":       "assistant",
+		"parentID":   userMsgID,
+		"modelID":    "claude-opus-4-5",
+		"providerID": "anthropic",
+		"time":       map[string]any{"created": asstCreated, "completed": asstCreated + 4000},
+		"system":     []string{"You are a helpful assistant.", "Think carefully before responding."},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", asstMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_thinkasst0001s.json"), map[string]any{
+		"id":        "prt_thinkasst0001s",
+		"messageID": asstMsgID,
+		"type":      "step-start",
+		"snapshot":  "deadbeefdeadbeefdeadbeefdeadbeef01234567",
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_thinkasst0001r.json"), map[string]any{
+		"id":        "prt_thinkasst0001r",
+		"messageID": asstMsgID,
+		"type":      "reasoning",
+		"text":      "The question asks about the meaning of life. This is a philosophical question...",
+		"time":      map[string]any{"start": asstCreated + 100, "end": asstCreated + 2000},
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_thinkasst0001t.json"), map[string]any{
+		"id":        "prt_thinkasst0001t",
+		"messageID": asstMsgID,
+		"type":      "text",
+		"text":      "The meaning of life is 42.",
+		"time":      map[string]any{"start": asstCreated + 2000, "end": asstCreated + 3000},
+	})
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_thinkasst0001f.json"), map[string]any{
+		"id":        "prt_thinkasst0001f",
+		"messageID": asstMsgID,
+		"type":      "step-finish",
+		"reason":    "end_turn",
+		"cost":      0.01,
+		"tokens": map[string]any{
+			"input": 100, "output": 50, "reasoning": 200,
+			"cache": map[string]any{"read": 20, "write": 10},
+		},
+	})
+
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+
+	jsonlPath := filepath.Join(archDir, "session.jsonl")
+	entries := parseJSONL(t, jsonlPath)
+
+	// Expected: header + system-custom + snapshot-custom + user-msg + asst-msg
+	// (system is on user msg, snapshot is on asst msg)
+	if len(entries) < 5 {
+		t.Fatalf("expected ≥5 entries, got %d", len(entries))
+	}
+
+	validateLinearChain(t, entries[1:])
+
+	// Find the assistant message entry.
+	var asstEntry rawEntry
+	for _, e := range entries {
+		if entryType(t, e) == "message" {
+			msg := entryMessage(t, e)
+			if messageRole(t, msg) == "assistant" {
+				asstEntry = e
+				break
+			}
+		}
+	}
+	if asstEntry == nil {
+		t.Fatal("no assistant message entry found")
+	}
+
+	// Verify thinking block appears in content.
+	msg := entryMessage(t, asstEntry)
+	var content []map[string]json.RawMessage
+	if err := json.Unmarshal(msg["content"], &content); err != nil {
+		t.Fatalf("assistant.content: %v", err)
+	}
+
+	hasThinking := false
+	for _, block := range content {
+		var blockType string
+		if err := json.Unmarshal(block["type"], &blockType); err == nil && blockType == "thinking" {
+			hasThinking = true
+			break
+		}
+	}
+	if !hasThinking {
+		t.Error("assistant message content has no thinking block")
+	}
+
+	// Verify a snapshot custom entry exists.
+	hasSnapshot := false
+	for _, e := range entries {
+		if entryType(t, e) == "custom" {
+			var ct string
+			if err := json.Unmarshal(e["customType"], &ct); err == nil && ct == "opencode.snapshot.start" {
+				hasSnapshot = true
+				break
+			}
+		}
+	}
+	if !hasSnapshot {
+		t.Error("no opencode.snapshot.start custom entry found")
+	}
+
+	// Verify system custom entry.
+	hasSystem := false
+	for _, e := range entries {
+		if entryType(t, e) == "custom" {
+			var ct string
+			if err := json.Unmarshal(e["customType"], &ct); err == nil && ct == "opencode.system" {
+				hasSystem = true
+				break
+			}
+		}
+	}
+	if !hasSystem {
+		t.Error("no opencode.system custom entry found")
+	}
+
+	// Verify stopReason is "stop" (mapped from "end_turn").
+	var stopReason string
+	if err := json.Unmarshal(msg["stopReason"], &stopReason); err != nil {
+		t.Fatalf("assistant.stopReason: %v", err)
+	}
+	if stopReason != "stop" {
+		t.Errorf("assistant.stopReason = %q, want %q", stopReason, "stop")
+	}
+
+	// Verify usage.
+	var usage piUsage
+	if err := json.Unmarshal(msg["usage"], &usage); err != nil {
+		t.Fatalf("assistant.usage: %v", err)
+	}
+	if usage.Input != 100 || usage.Output != 50 || usage.CacheRead != 20 || usage.CacheWrite != 10 {
+		t.Errorf("assistant.usage = %+v, want input=100 output=50 cacheRead=20 cacheWrite=10", usage)
+	}
+
+	// Round-trip stability.
+	checkRoundTrip(t, jsonlPath)
+}
+
+// ── edge case tests ───────────────────────────────────────────────────────────
+
+// TestZeroMessages verifies a session with no messages produces only the header.
+func TestZeroMessages(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession("ses_empty001", "/home/user/empty", 0))
+
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+
+	entries := parseJSONL(t, filepath.Join(archDir, "session.jsonl"))
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry (header only), got %d", len(entries))
+	}
+	if entryType(t, entries[0]) != "session" {
+		t.Errorf("entries[0].type = %q, want %q", entryType(t, entries[0]), "session")
+	}
+}
+
+// TestAbortedAssistant verifies that an interrupted assistant message (no
+// step-finish) produces a valid entry with stopReason "aborted" and zero usage.
+func TestAbortedAssistant(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	sessionID := "ses_aborted001"
+	createdMS := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC).UnixMilli()
+
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession(sessionID, "/home/user/proj", createdMS))
+
+	userMsgID := "msg_abortuser0001"
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", userMsgID+".json"), map[string]any{
+		"id":        userMsgID,
+		"sessionID": sessionID,
+		"role":      "user",
+		"time":      map[string]any{"created": createdMS + 100},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", userMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", userMsgID, "prt_abortuser0001t.json"), map[string]any{
+		"id":        "prt_abortuser0001t",
+		"messageID": userMsgID,
+		"type":      "text",
+		"text":      "Do something slow",
+	})
+
+	// Assistant message with NO step-finish part (interrupted mid-stream).
+	asstMsgID := "msg_abortasst0001"
+	mustWriteJSON(t, filepath.Join(rawDir, "messages", asstMsgID+".json"), map[string]any{
+		"id":         asstMsgID,
+		"sessionID":  sessionID,
+		"role":       "assistant",
+		"parentID":   userMsgID,
+		"modelID":    "claude-sonnet-4-5",
+		"providerID": "anthropic",
+		"time":       map[string]any{"created": createdMS + 500},
+	})
+	mustMkdir(t, filepath.Join(rawDir, "parts", asstMsgID))
+	mustWriteJSON(t, filepath.Join(rawDir, "parts", asstMsgID, "prt_abortasst0001t.json"), map[string]any{
+		"id":        "prt_abortasst0001t",
+		"messageID": asstMsgID,
+		"type":      "text",
+		"text":      "I was going to say something but I got interrupted",
+	})
+	// No step-finish part — simulates abort mid-stream.
+
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+
+	entries := parseJSONL(t, filepath.Join(archDir, "session.jsonl"))
+	validateLinearChain(t, entries[1:])
+
+	// Find the assistant entry.
+	var asstEntry rawEntry
+	for _, e := range entries {
+		if entryType(t, e) == "message" {
+			msg := entryMessage(t, e)
+			if messageRole(t, msg) == "assistant" {
+				asstEntry = e
+				break
+			}
+		}
+	}
+	if asstEntry == nil {
+		t.Fatal("no assistant entry found")
+	}
+
+	msg := entryMessage(t, asstEntry)
+
+	// stopReason must be "aborted".
+	var stopReason string
+	if err := json.Unmarshal(msg["stopReason"], &stopReason); err != nil {
+		t.Fatalf("assistant.stopReason: %v", err)
+	}
+	if stopReason != "aborted" {
+		t.Errorf("stopReason = %q, want %q", stopReason, "aborted")
+	}
+
+	// usage must be present with zero values.
+	var usage piUsage
+	if err := json.Unmarshal(msg["usage"], &usage); err != nil {
+		t.Fatalf("assistant.usage: %v", err)
+	}
+	if usage.Input != 0 || usage.Output != 0 {
+		t.Errorf("expected zero usage for aborted message, got %+v", usage)
+	}
+}
+
+// TestAtomicWrite verifies that translator failure leaves no partial session.jsonl.
+func TestAtomicWrite(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	// Write a malformed session.json to trigger an error.
+	mustWriteFile(t, filepath.Join(rawDir, "session.json"), []byte("not valid json"))
+
+	err := Translate(archDir)
+	if err == nil {
+		t.Fatal("expected error from malformed session.json, got nil")
+	}
+
+	// No partial session.jsonl should exist.
+	if _, statErr := os.Stat(filepath.Join(archDir, "session.jsonl")); !os.IsNotExist(statErr) {
+		t.Error("session.jsonl exists after failed Translate() — should have been cleaned up")
+	}
+}
+
+// TestOverwriteAtomic verifies that a second Translate() call overwrites an
+// existing session.jsonl atomically.
+func TestOverwriteAtomic(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession("ses_overwrite001", "/home/user/proj", 1000000))
+
+	// First run.
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("first Translate(): %v", err)
+	}
+	// Second run — must succeed and overwrite.
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("second Translate(): %v", err)
+	}
+	entries := parseJSONL(t, filepath.Join(archDir, "session.jsonl"))
+	if len(entries) == 0 {
+		t.Error("session.jsonl is empty after overwrite")
+	}
+}
+
+// TestIDUniqueness verifies that all entry IDs in a multi-message session are unique.
+func TestIDUniqueness(t *testing.T) {
+	archDir := buildArchiveDir(t)
+	rawDir := filepath.Join(archDir, "raw")
+
+	sessionID := "ses_iduniq0001"
+	createdMS := time.Now().UnixMilli()
+	mustWriteJSON(t, filepath.Join(rawDir, "session.json"),
+		makeSession(sessionID, "/home/user/proj", createdMS))
+
+	// Create 10 user+assistant message pairs.
+	prevUserID := ""
+	for i := 0; i < 10; i++ {
+		userID := "msg_iduniq" + strings.Repeat("0", 6-len(strings.Repeat("", i))) + strings.Repeat("u", i+1)
+		asstID := "msg_iduniq" + strings.Repeat("0", 6-len(strings.Repeat("", i))) + strings.Repeat("a", i+1)
+		_ = prevUserID
+
+		mustWriteJSON(t, filepath.Join(rawDir, "messages", userID+".json"), map[string]any{
+			"id":        userID,
+			"sessionID": sessionID,
+			"role":      "user",
+			"time":      map[string]any{"created": createdMS + int64(i*1000)},
+		})
+		mustMkdir(t, filepath.Join(rawDir, "parts", userID))
+		mustWriteJSON(t, filepath.Join(rawDir, "parts", userID, "prt_"+userID[:min(len(userID), 8)]+"t.json"), map[string]any{
+			"id":        "prt_" + userID[:min(len(userID), 8)] + "t",
+			"messageID": userID,
+			"type":      "text",
+			"text":      "Question " + userID,
+		})
+
+		mustWriteJSON(t, filepath.Join(rawDir, "messages", asstID+".json"), map[string]any{
+			"id":         asstID,
+			"sessionID":  sessionID,
+			"role":       "assistant",
+			"parentID":   userID,
+			"modelID":    "claude-sonnet-4-5",
+			"providerID": "anthropic",
+			"time":       map[string]any{"created": createdMS + int64(i*1000) + 100},
+		})
+		mustMkdir(t, filepath.Join(rawDir, "parts", asstID))
+		mustWriteJSON(t, filepath.Join(rawDir, "parts", asstID, "prt_"+asstID[:min(len(asstID), 8)]+"t.json"), map[string]any{
+			"id":        "prt_" + asstID[:min(len(asstID), 8)] + "t",
+			"messageID": asstID,
+			"type":      "text",
+			"text":      "Answer " + asstID,
+		})
+		mustWriteJSON(t, filepath.Join(rawDir, "parts", asstID, "prt_"+asstID[:min(len(asstID), 8)]+"f.json"), map[string]any{
+			"id":        "prt_" + asstID[:min(len(asstID), 8)] + "f",
+			"messageID": asstID,
+			"type":      "step-finish",
+			"reason":    "stop",
+			"cost":      0.0,
+			"tokens": map[string]any{
+				"input": 5, "output": 3, "reasoning": 0,
+				"cache": map[string]any{"read": 0, "write": 0},
+			},
+		})
+		prevUserID = userID
+	}
+
+	if err := Translate(archDir); err != nil {
+		t.Fatalf("Translate(): %v", err)
+	}
+
+	entries := parseJSONL(t, filepath.Join(archDir, "session.jsonl"))
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if entryType(t, e) == "session" {
+			continue
+		}
+		id := entryID(t, e)
+		if seen[id] {
+			t.Errorf("duplicate entry ID: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// checkRoundTrip verifies that each line of the JSONL at path can be
+// round-tripped: parsed into a generic map and re-serialized to a canonical
+// (alphabetically sorted) form, and that the canonical form equals the
+// canonical form of the original line. This ensures emitted JSON is valid and
+// structurally stable — both the original and re-encoded use canonical key order.
+func checkRoundTrip(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("checkRoundTrip ReadFile: %v", err)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Increase scanner buffer for large tool outputs.
+	buf := make([]byte, 0, 512*1024)
+	scanner.Buffer(buf, 4*1024*1024)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// Parse into generic value (maps get alphabetically sorted on re-encode).
+		var v any
+		if err := json.Unmarshal([]byte(line), &v); err != nil {
+			t.Fatalf("line %d: json.Unmarshal: %v", lineNum, err)
+		}
+		// Re-serialize to canonical form.
+		canonical, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("line %d: json.Marshal: %v", lineNum, err)
+		}
+		// Re-parse the canonical form and re-serialize again — must be identical
+		// (i.e. the canonical form is a fixed point of json.Marshal).
+		var v2 any
+		if err := json.Unmarshal(canonical, &v2); err != nil {
+			t.Fatalf("line %d: second json.Unmarshal: %v", lineNum, err)
+		}
+		canonical2, err := json.Marshal(v2)
+		if err != nil {
+			t.Fatalf("line %d: second json.Marshal: %v", lineNum, err)
+		}
+		if !bytes.Equal(canonical, canonical2) {
+			t.Errorf("line %d: canonical form is not a fixed point of json.Marshal", lineNum)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("checkRoundTrip scanner error: %v", err)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Closes #998.

## Summary

Adds `internal/piexport` package with a `Translate(archiveDir string) error` entrypoint that reads the raw opencode archive subtree written by #997 and emits `<archiveDir>/session.jsonl` in pi-mono v3 format. The translator is wired into `prism cleanup` after a successful archive copy; failure is non-fatal (logs a warning, raw archive remains intact).

## Revert investigation (AC edge-case)

Opencode's `SessionRevert.cleanup()` in `revert.ts` calls `SyncEvent.run(MessageV2.Event.Removed, ...)` for each reverted message, which deletes the message from storage. This cleanup runs at the start of the next prompt (before `prompt.loop`), not at session archive time — but because sessions are only archived at `prism cleanup` (after the session ends), any reverts that occurred during the session will have their messages deleted by that point.

**Finding: reverted messages are deleted on disk before the archive is written. Linear-only emission is correct and sufficient.** No branch tree logic is needed.

## Mapping implemented

| opencode | pi-mono v3 |
|---|---|
| `session.json` | `{type:"session", version:3, id, timestamp, cwd}` header |
| user message + parts | `{type:"message", message:{role:"user", content:[text\|image]}}` |
| assistant message + parts | `{type:"message", message:{role:"assistant", content:[thinking\|text\|toolCall], provider, model, usage, stopReason}}` |
| `part.type:"tool"` (call side) | `toolCall` block in assistant entry |
| `part.type:"tool"` (result side) | separate `toolResult` message entry |
| `step-finish` tokens/cost | summed into `usage` on assistant entry |
| last `step-finish.reason` | mapped to pi `stopReason` (stop/length/toolUse/error/aborted) |
| no `step-finish` (interrupted) | `stopReason: "aborted"`, zero usage |
| per-message `system[]` | `{type:"custom", customType:"opencode.system", data:{prompts:[...]}}` on first message and on change |
| `step-start.snapshot` | `{type:"custom", customType:"opencode.snapshot.start", data:{sha}}` before assistant entry |
| legacy sidecar `asset: "tool_*"` | full sidecar content inlined into `toolResult.content` |
| `part.type:"reasoning"` | `{type:"thinking", thinking:...}` block in assistant content |
| `part.type:"file"` with image MIME | `{type:"image", data:base64, mimeType:...}` in user content |
| flat timeline | linear `id`/`parentId` chain (8-char hex from `crypto/rand`) |

## Tests

Three fixture tests in `internal/piexport/piexport_test.go`:
- `TestFixtureLinearText` — simple user→assistant text exchange with snapshot
- `TestFixtureToolCalls` — tool call with legacy sidecar (`asset: "tool_*"`)
- `TestFixtureThinkingBlocks` — assistant with reasoning parts, system prompts, snapshot

Edge case tests:
- `TestZeroMessages` — header-only output for empty session
- `TestAbortedAssistant` — no step-finish → aborted + zero usage
- `TestAtomicWrite` — malformed input leaves no partial `session.jsonl`
- `TestOverwriteAtomic` — second run overwrites atomically
- `TestIDUniqueness` — 10-message session has no duplicate entry IDs

All tests validate the linear `id`/`parentId` chain and JSON round-trip stability (canonical fixed-point: `json.Marshal(json.Unmarshal(line)) == json.Marshal(json.Unmarshal(canonical))`).