### PR TITLE
prism: fix review-agent startup failure state and parent notification

### DIFF
--- a/modules/programs/prism/prism/internal/agent/machine.go
+++ b/modules/programs/prism/prism/internal/agent/machine.go
@@ -11,6 +11,9 @@ import "fmt"
 //     session.created fires active in the plugin).
 //   - idle → interrupted: pane-died before the session was ever active (rare but
 //     possible if the opencode process crashes before session.created fires).
+//   - idle → error: container startup failure (WaitHealthy timeout or CreateSession
+//     failure) before the session became active. The sidecar writes error directly
+//     to avoid relying on the pane-died tmux hook for state cleanup.
 //   - finished → interrupted: explicitly allowed for the pane-died hook when the
 //     pane exits with a non-zero code — a crash overrides a cleanly-written
 //     "finished" (see UpsertStatusInterruptedOverrideFinished).
@@ -29,6 +32,7 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 	StateIdle: {
 		StateActive:      true,
 		StateInterrupted: true,
+		StateError:       true, // container startup failure before session.created
 		StateDeleted:     true,
 	},
 	StateActive: {

--- a/modules/programs/prism/prism/internal/agent/machine_test.go
+++ b/modules/programs/prism/prism/internal/agent/machine_test.go
@@ -31,6 +31,9 @@ func TestTransition_ValidPairs(t *testing.T) {
 		{StateCompacting, StateInterrupted, "pane-died during compaction"},
 		{StateError, StateInterrupted, "pane-died after error"},
 
+		// Container startup failure path (issue #994)
+		{StateIdle, StateError, "container startup failure before session.created (WaitHealthy/CreateSession)"},
+
 		// Edge cases from acceptance criteria
 		{StateFinished, StateInterrupted, "non-zero exit overrides finished (pane-died)"},
 		{StateFinished, StateActive, "session resumed after prior close"},
@@ -71,7 +74,6 @@ func TestTransition_InvalidPairs(t *testing.T) {
 		{StateIdle, StateWaiting, "idle → waiting (no permission before active)"},
 		{StateIdle, StateFinished, "idle → finished (nothing happened)"},
 		{StateIdle, StateCompacting, "idle → compacting (nothing happened)"},
-		{StateIdle, StateError, "idle → error (nothing happened)"},
 
 		// Compacting resumes to active; finished is no longer a valid direct transition
 		{StateCompacting, StateFinished, "compacting → finished (compaction ≠ task completion)"},

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -992,15 +992,16 @@ ON CONFLICT(session_name) DO UPDATE SET
 }
 
 // UpsertStatusIfNotTerminal upserts the state for sessionName only when the
-// current state is not already a terminal state (finished, interrupted, or
-// deleted) and the session has not yet been ended (ended_at IS NULL). Returns
+// current state is not already a terminal state (error, finished, interrupted,
+// or deleted) and the session has not yet been ended (ended_at IS NULL). Returns
 // (true, nil) if the update was applied, (false, nil) if the session was
 // already in a terminal state, has been ended, or did not exist, or
 // (false, err) on a database error.
 //
 // This is used by the pane-died hook to transition active sessions to
-// "interrupted" without clobbering a clean "finished" that was written first,
-// and without acting on sessions that have already been ended by cleanup.
+// "interrupted" without clobbering a clean "finished" or an "error" state
+// written directly by the sidecar on startup failure, and without acting on
+// sessions that have already been ended by cleanup.
 func (d *DB) UpsertStatusIfNotTerminal(sessionName, state string) (bool, error) {
 	// Snapshot the current state before the write so that the advisory
 	// transition check (below) sees the from-state rather than the newly
@@ -1012,7 +1013,7 @@ UPDATE agent_status
 SET state = ?, last_seen = ?
 WHERE session_name = ?
   AND ended_at IS NULL
-  AND state NOT IN ('finished', 'interrupted', 'deleted')`
+  AND state NOT IN ('error', 'finished', 'interrupted', 'deleted')`
 	res, err := d.conn.Exec(q, state, now, sessionName)
 	if err != nil {
 		return false, fmt.Errorf("db: upsert status if not terminal: %w", err)
@@ -1040,11 +1041,14 @@ WHERE session_name = ?
 // exit means the process was killed or crashed, so even a prior "finished" that
 // the plugin wrote should be corrected to "interrupted".
 //
+// "error" is left intact — a startup failure that wrote "error" directly (via
+// writeStartupError in sidecar.go) must not be overwritten to "interrupted" by
+// the pane-died hook, since "error" is the correct terminal state in that case.
 // "deleted" is still left intact — a deleted session should not be resurrected.
 // "interrupted" is also left alone to avoid a no-op double-write.
 //
 // Returns (true, nil) if the update was applied, (false, nil) if the row did
-// not exist, was already interrupted or deleted, or has ended_at set.
+// not exist, was already error/interrupted/deleted, or has ended_at set.
 func (d *DB) UpsertStatusInterruptedOverrideFinished(sessionName string) (bool, error) {
 	// Snapshot the current state before the write so that the advisory
 	// transition check (below) sees the from-state rather than the newly
@@ -1056,7 +1060,7 @@ UPDATE agent_status
 SET state = 'interrupted', last_seen = ?
 WHERE session_name = ?
   AND ended_at IS NULL
-  AND state NOT IN ('interrupted', 'deleted')`
+  AND state NOT IN ('error', 'interrupted', 'deleted')`
 	res, err := d.conn.Exec(q, now, sessionName)
 	if err != nil {
 		return false, fmt.Errorf("db: upsert status interrupted override finished: %w", err)

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -618,6 +618,23 @@ func TestUpsertStatusIfNotTerminal(t *testing.T) {
 	if sEnded.State != "active" {
 		t.Errorf("State after ended no-op: got %q, want \"active\" (unchanged)", sEnded.State)
 	}
+
+	// Should be a no-op when already in "error" (terminal state — startup failure).
+	// The pane-died hook must not overwrite a startup-failure "error" with "interrupted".
+	if err := d.UpsertStatus("repo@errored", "repo", "/code/repo/errored", "error", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (error): %v", err)
+	}
+	updated7, err := d.UpsertStatusIfNotTerminal("repo@errored", "interrupted")
+	if err != nil {
+		t.Fatalf("UpsertStatusIfNotTerminal (error): %v", err)
+	}
+	if updated7 {
+		t.Error("UpsertStatusIfNotTerminal (error): got updated=true, want false (no-op — error is terminal)")
+	}
+	sErrored, _ := d.CurrentStatus("repo@errored")
+	if sErrored.State != "error" {
+		t.Errorf("State after error no-op: got %q, want \"error\" (must not be overwritten)", sErrored.State)
+	}
 }
 
 // TestUpsertStatusInterruptedOverrideFinished verifies that the method
@@ -702,6 +719,24 @@ func TestUpsertStatusInterruptedOverrideFinished(t *testing.T) {
 	}
 	if updated6 {
 		t.Error("UpsertStatusInterruptedOverrideFinished (nonexistent): got updated=true, want false (no-op)")
+	}
+
+	// "error" should be a no-op — the pane-died hook must not overwrite a startup-
+	// failure "error" with "interrupted". writeStartupError sets StateError
+	// directly before the sidecar exits; the hook must leave it intact.
+	if err := d.UpsertStatus("repo@errored", "repo", "/code/repo/errored", "error", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus (error): %v", err)
+	}
+	updated7, err := d.UpsertStatusInterruptedOverrideFinished("repo@errored")
+	if err != nil {
+		t.Fatalf("UpsertStatusInterruptedOverrideFinished (error): %v", err)
+	}
+	if updated7 {
+		t.Error("UpsertStatusInterruptedOverrideFinished (error): got updated=true, want false (no-op — error is terminal)")
+	}
+	sErr, _ := d.CurrentStatus("repo@errored")
+	if sErr.State != "error" {
+		t.Errorf("State after error no-op: got %q, want \"error\" (pane-died must not overwrite startup-failure error)", sErr.State)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -2259,7 +2259,7 @@ func TestCheckTransition_SameState(t *testing.T) {
 }
 
 // TestCheckTransition_InvalidTransition verifies that a genuinely invalid
-// transition (e.g. idle → error, idle → finished) still logs a warning to
+// transition (e.g. idle → finished) still logs a warning to
 // stderr after the same-state early-return fix is in place.
 func TestCheckTransition_InvalidTransition(t *testing.T) {
 	// "error → active" is valid per ValidTransitions; use only pairs that are
@@ -2268,7 +2268,6 @@ func TestCheckTransition_InvalidTransition(t *testing.T) {
 		from string
 		to   string
 	}{
-		{"idle", "error"},
 		{"idle", "finished"},
 		{"deleted", "active"},
 		{"idle", "waiting"},

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -383,16 +383,24 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// When SIGTERM arrives, the signal goroutine calls Shutdown() (which
 			// sets shuttingDown=true and stops the container) then cancel(). In
 			// that case ctx may still be non-nil here (cancel fires after Shutdown),
-			// but we check ctx.Err() to distinguish a context-cancelled WaitHealthy
-			// (SIGTERM path where Shutdown already ran) from a genuine probe timeout
-			// (no Shutdown yet), avoiding a double-Shutdown with spurious log lines.
+			// but we check shuttingDown to distinguish a SIGTERM-cancelled WaitHealthy
+			// (Shutdown already ran) from a genuine probe timeout (no Shutdown yet),
+			// avoiding a double-Shutdown with spurious log lines.
+			//
+			// shuttingDown is the reliable SIGTERM gate: Shutdown() sets it before
+			// calling ctr.mgr.Shutdown(), so even when the container exits early
+			// (WaitHealthy returns via hasExited before cancel fires), shuttingDown
+			// is already true. ctx.Err() is set only after Shutdown() returns, which
+			// is too late.
+			s.mu.Lock()
+			alreadyShutdown := s.shuttingDown
+			s.mu.Unlock()
 			startupErr := fmt.Errorf("sidecar: container health check: %w", err)
-			if ctx.Err() == nil {
+			if !alreadyShutdown {
 				// Genuine probe timeout (not SIGTERM): clean up the container
 				// ourselves (Shutdown() has not run yet) and write StateError
 				// directly so the DB row is in the correct terminal state.
-				// On SIGTERM, Shutdown() has already run (and will write
-				// StateInterrupted), so we skip both actions to avoid a race.
+				// On SIGTERM, Shutdown() handles cleanup and writes StateInterrupted.
 				mgr.Shutdown()
 				closeTCPListenerOnError()
 				// Gap 1 fix: write StateError directly so the DB row transitions
@@ -433,10 +441,15 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
 				startupErr := fmt.Errorf("sidecar: create session: %w", createErr)
-				if ctx.Err() == nil {
-					// Genuine CreateSession failure (not a SIGTERM-induced context
-					// cancellation). Write StateError directly so the DB row is in
-					// the correct terminal state, regardless of tmux hook timing.
+				// Use shuttingDown (not ctx.Err()) as the SIGTERM guard — same
+				// rationale as the WaitHealthy path above. The outer isShuttingDown
+				// snapshot predates CreateSession, so re-read under the lock here.
+				s.mu.Lock()
+				alreadyShutdown := s.shuttingDown
+				s.mu.Unlock()
+				if !alreadyShutdown {
+					// Genuine CreateSession failure. Write StateError so the DB row
+					// is in the correct terminal state, regardless of tmux hook timing.
 					// On SIGTERM, Shutdown() handles the state write.
 					s.writeStartupError(startupErr)
 				}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -390,7 +390,12 @@ func (s *Sidecar) Run(ctx context.Context) error {
 				mgr.Shutdown()
 				closeTCPListenerOnError()
 			}
-			return fmt.Errorf("sidecar: container health check: %w", err)
+			// Gap 1 fix: write StateError directly so the DB row transitions to
+			// "error" (not "interrupted" via the pane-died hook). This is reliable
+			// regardless of tmux hook timing.
+			startupErr := fmt.Errorf("sidecar: container health check: %w", err)
+			s.writeStartupError(startupErr)
+			return startupErr
 		}
 		healthyAt := time.Now()
 		log.Printf("[timing] WaitHealthy: %s", healthyAt.Sub(t0).Round(time.Millisecond))
@@ -422,22 +427,24 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			_, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
-			} else {
-				log.Printf("[timing] CreateSession done: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
+				// Gap 1 fix: write StateError directly so the DB row transitions to
+				// "error" on CreateSession failure. Also notify the parent worker.
+				startupErr := fmt.Errorf("sidecar: create session: %w", createErr)
+				s.writeStartupError(startupErr)
+				return startupErr
 			}
+			log.Printf("[timing] CreateSession done: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {
 				s.cfg.OnReady()
 			}
-			if createErr == nil {
-				initialPrompt := s.cfg.InitialPrompt
-				go func() {
-					if err := s.harness.DeliverInitialPrompt(ctx, initialPrompt, s.cfg.AgentRole); err != nil {
-						log.Printf("sidecar: deliverInitialPrompt: %v", err)
-					}
-					log.Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
-				}()
-			}
+			initialPrompt := s.cfg.InitialPrompt
+			go func() {
+				if err := s.harness.DeliverInitialPrompt(ctx, initialPrompt, s.cfg.AgentRole); err != nil {
+					log.Printf("sidecar: deliverInitialPrompt: %v", err)
+				}
+				log.Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
+			}()
 		} else if !isShuttingDown {
 			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if s.cfg.OnReady != nil {
@@ -1641,6 +1648,129 @@ func isReviewAgentSession(sessionName string, d *db.DB) bool {
 	}
 	// No DB available — use name heuristic.
 	return nameBased
+}
+
+// writeStartupError writes StateError to the DB and, when this session is a
+// review agent, sends a notification to the parent worker session. It must be
+// called WITHOUT s.mu held (it acquires the mutex internally via upsertState,
+// and the notification goroutine also runs without the lock).
+//
+// This is the Gap 1 + Gap 2 fix for startup failures (WaitHealthy timeout,
+// CreateSession failure). Calling it ensures:
+//   - The DB row transitions to "error" immediately in the sidecar, not via the
+//     fragile pane-died tmux hook.
+//   - The parent worker is notified when a review-agent container fails to start.
+func (s *Sidecar) writeStartupError(startupErr error) {
+	s.mu.Lock()
+	log.Printf("sidecar: startup failure — writing error state: %v", startupErr)
+	s.upsertState(agent.StateError, nil, nil)
+	s.writeStateChange(agent.StateError)
+	s.mu.Unlock()
+
+	// Gap 2 fix: notify the parent worker when this is a review-agent session.
+	// Normal finish notifications for review agents remain suppressed in
+	// notifyCoordinator — this is an exception only for the startup-failure path.
+	go s.notifyParentWorkerOnStartupFailure(startupErr)
+}
+
+// reviewAgentParentSession derives the parent worker session name from a
+// review-agent session name. Review-agent sessions follow the naming convention:
+//
+//	<parent>~review-<N>-<role>   e.g. nixos-config@feature~review-2-review-goal
+//
+// The parent session name is the prefix before "~review".
+// Returns ("", false) when the session name does not contain "~review".
+func reviewAgentParentSession(sessionName string) (string, bool) {
+	idx := strings.Index(sessionName, "~review")
+	if idx < 0 {
+		return "", false
+	}
+	return sessionName[:idx], true
+}
+
+// notifyParentWorkerOnStartupFailure sends a notification to the parent worker
+// when a review-agent container fails to start. It is called asynchronously via
+// go from writeStartupError, so s.mu must NOT be held.
+//
+// If the parent worker session cannot be found or has ended, the failure is
+// logged and the sidecar exits cleanly (the notification failure is not fatal).
+//
+// Normal finish notifications for review agents (on the success path) remain
+// suppressed via the isReviewAgentSession guard in notifyCoordinator. This
+// function is an exception only for the startup-failure path.
+func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
+	// Only apply to review-agent sessions.
+	parentSession, isReview := reviewAgentParentSession(s.cfg.SessionName)
+	if !isReview {
+		return
+	}
+
+	// Look up the parent worker in the DB.
+	parentStatus, err := s.cfg.DB.CurrentStatus(parentSession)
+	if err != nil {
+		log.Printf("sidecar: notifyParentWorker: DB lookup for parent %q: %v — skipping notification", parentSession, err)
+		return
+	}
+	if parentStatus == nil {
+		log.Printf("sidecar: notifyParentWorker: parent session %q not found in DB — skipping notification", parentSession)
+		return
+	}
+	if parentStatus.EndedAt != nil {
+		log.Printf("sidecar: notifyParentWorker: parent session %q has ended — skipping notification", parentSession)
+		return
+	}
+	if parentStatus.HarnessPort == nil {
+		log.Printf("sidecar: notifyParentWorker: parent session %q has no harness port — cannot deliver notification", parentSession)
+		return
+	}
+	port := *parentStatus.HarnessPort
+
+	notifyText := fmt.Sprintf("review agent %s failed to start: %v", s.cfg.SessionName, startupErr)
+
+	storedSID := ""
+	if parentStatus.HarnessSessionID != nil {
+		storedSID = *parentStatus.HarnessSessionID
+	}
+
+	const maxAttempts = 3
+	backoff := []time.Duration{500 * time.Millisecond, 1 * time.Second}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			time.Sleep(backoff[attempt-2])
+		}
+
+		targetSID, validationErr := validateOrRefreshCoordinatorSID(
+			port, storedSID, parentSession, s.cfg.DB, s.cfg.HTTPClient,
+		)
+		if validationErr != nil {
+			lastErr = fmt.Errorf("attempt %d: SID validation failed: %w", attempt, validationErr)
+			log.Printf("sidecar: notifyParentWorker: %v (parent=%s)", lastErr, parentSession)
+			if errors.Is(validationErr, errEmptySessionList) {
+				break
+			}
+			continue
+		}
+		storedSID = targetSID
+
+		log.Printf("sidecar: notifyParentWorker: attempt %d/%d POST to parent=%s sid=%s",
+			attempt, maxAttempts, parentSession, targetSID)
+
+		httpErr := deliverNotificationViaHTTP(port, targetSID, notifyText, parentStatus, s.cfg.HTTPClient)
+		if httpErr != nil {
+			lastErr = fmt.Errorf("attempt %d: HTTP delivery failed: %w", attempt, httpErr)
+			log.Printf("sidecar: notifyParentWorker: %v (parent=%s sid=%s)", lastErr, parentSession, targetSID)
+			continue
+		}
+
+		log.Printf("sidecar: notifyParentWorker: delivered to parent=%s sid=%s", parentSession, targetSID)
+		return
+	}
+
+	// All retries exhausted — log and exit cleanly (notification failure is not fatal).
+	log.Printf("sidecar: notifyParentWorker: FAILED after %d attempts — parent=%s reason=%v",
+		maxAttempts, parentSession, lastErr)
 }
 
 // notifyCoordinator sends a "finished" notification to the coordinator session

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -696,7 +696,11 @@ func (s *Sidecar) Shutdown() {
 
 	if s.lastState != agent.StateFinished &&
 		s.lastState != agent.StateDeleted &&
-		s.lastState != agent.StateInterrupted {
+		s.lastState != agent.StateInterrupted &&
+		s.lastState != agent.StateError {
+		// Note: StateError is excluded because writeStartupError may have already
+		// written it before Run() returned on the startup-failure path. Overwriting
+		// error with interrupted here would clobber the correct terminal state.
 		log.Printf("sidecar: transition -> interrupted (cause=sigterm)")
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
@@ -1674,8 +1678,11 @@ func isReviewAgentSession(sessionName string, d *db.DB) bool {
 
 // writeStartupError writes StateError to the DB and, when this session is a
 // review agent, sends a notification to the parent worker session. It must be
-// called WITHOUT s.mu held (it acquires the mutex internally via upsertState,
-// and the notification goroutine also runs without the lock).
+// called WITHOUT s.mu held — it acquires s.mu itself to call upsertState and
+// writeStateChange (which require the lock), then releases it before launching
+// the notification goroutine. upsertState's own doc says "called with s.mu held"
+// — that contract is satisfied here because writeStartupError holds the lock for
+// the entire upsertState + writeStateChange block.
 //
 // This is the Gap 1 + Gap 2 fix for startup failures (WaitHealthy timeout,
 // CreateSession failure). Calling it ensures:

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -386,15 +386,20 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// but we check ctx.Err() to distinguish a context-cancelled WaitHealthy
 			// (SIGTERM path where Shutdown already ran) from a genuine probe timeout
 			// (no Shutdown yet), avoiding a double-Shutdown with spurious log lines.
+			startupErr := fmt.Errorf("sidecar: container health check: %w", err)
 			if ctx.Err() == nil {
+				// Genuine probe timeout (not SIGTERM): clean up the container
+				// ourselves (Shutdown() has not run yet) and write StateError
+				// directly so the DB row is in the correct terminal state.
+				// On SIGTERM, Shutdown() has already run (and will write
+				// StateInterrupted), so we skip both actions to avoid a race.
 				mgr.Shutdown()
 				closeTCPListenerOnError()
+				// Gap 1 fix: write StateError directly so the DB row transitions
+				// to "error" (not relying on the fragile pane-died tmux hook).
+				// This is skipped on SIGTERM to avoid racing with Shutdown().
+				s.writeStartupError(startupErr)
 			}
-			// Gap 1 fix: write StateError directly so the DB row transitions to
-			// "error" (not "interrupted" via the pane-died hook). This is reliable
-			// regardless of tmux hook timing.
-			startupErr := fmt.Errorf("sidecar: container health check: %w", err)
-			s.writeStartupError(startupErr)
 			return startupErr
 		}
 		healthyAt := time.Now()
@@ -427,10 +432,14 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			_, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
 				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
-				// Gap 1 fix: write StateError directly so the DB row transitions to
-				// "error" on CreateSession failure. Also notify the parent worker.
 				startupErr := fmt.Errorf("sidecar: create session: %w", createErr)
-				s.writeStartupError(startupErr)
+				if ctx.Err() == nil {
+					// Genuine CreateSession failure (not a SIGTERM-induced context
+					// cancellation). Write StateError directly so the DB row is in
+					// the correct terminal state, regardless of tmux hook timing.
+					// On SIGTERM, Shutdown() handles the state write.
+					s.writeStartupError(startupErr)
+				}
 				return startupErr
 			}
 			log.Printf("[timing] CreateSession done: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7782,3 +7782,358 @@ func TestBuildNotifyPromptBody_IncludesTextAndModel(t *testing.T) {
 		}
 	})
 }
+
+// ── Startup failure tests (issue #994) ──────────────────────────────────────
+
+// newReviewAgentSidecar creates a review-agent sidecar whose session name
+// follows the <parent>~review-<N>-<role> convention. It shares the given DB
+// and HTTP client with the parent worker.
+func newReviewAgentSidecar(t *testing.T, parentSession string, d *db.DB, httpClient *http.Client) (*Sidecar, *testClock) {
+	t.Helper()
+	clk := newTestClock()
+	reviewSession := parentSession + "~review-1-review-goal"
+	cfg := Config{
+		SessionName: reviewSession,
+		Repo:        "test-repo",
+		Worktree:    "/tmp/" + reviewSession,
+		OpencodeURL: "http://localhost:14003",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  httpClient,
+		AgentRole:   "review-goal",
+		Harness:     opencode.New("http://localhost:14003", httpClient, "review-goal", ""),
+	}
+	return New(cfg), clk
+}
+
+// seedParentWorkerWithPort seeds a parent worker session in the DB with a
+// harness port and session ID, so notifyParentWorkerOnStartupFailure can
+// deliver notifications.
+func seedParentWorkerWithPort(t *testing.T, d *db.DB, sessionName, repo string, port int, sid string) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, repo, "/tmp/"+sessionName, "active", nil, &sid); err != nil {
+		t.Fatalf("seed parent worker: UpsertStatus: %v", err)
+	}
+	if err := d.QueryRow(
+		"UPDATE agent_status SET harness_port = ? WHERE session_name = ? RETURNING harness_port",
+		port, sessionName,
+	).Scan(new(int)); err != nil {
+		t.Fatalf("seed parent worker: set port: %v", err)
+	}
+}
+
+// waitForHTTPPromptCalls polls until the given counter reaches the expected
+// value (for async HTTP delivery).
+func waitForHTTPPromptCalls(t *testing.T, counter *int, mu *sync.Mutex, want int) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := *counter
+		mu.Unlock()
+		if got >= want {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// TestWriteStartupError_WritesErrorState verifies Gap 1: when writeStartupError
+// is called (simulating WaitHealthy or CreateSession failure), the DB row
+// transitions directly to "error" state — not via the pane-died tmux hook.
+func TestWriteStartupError_WritesErrorState(t *testing.T) {
+	d := openTestDB(t)
+	sc, _ := newReviewAgentSidecar(t, "test-repo@feature", d, nil)
+
+	// Seed an idle row (as tmux-session-start would write it).
+	_ = d.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "idle", nil, nil)
+
+	// Call writeStartupError directly (simulates WaitHealthy timeout).
+	startupErr := fmt.Errorf("container health check: context deadline exceeded")
+	sc.writeStartupError(startupErr)
+
+	// The DB row must be "error", not "idle" or "interrupted".
+	state := getState(t, d, sc.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q after writeStartupError, want %q", state, agent.StateError)
+	}
+}
+
+// TestWriteStartupError_WritesStateChangeEvent verifies that writeStartupError
+// writes a state_change event to the DB, providing a visible audit trail.
+func TestWriteStartupError_WritesStateChangeEvent(t *testing.T) {
+	d := openTestDB(t)
+	sc, _ := newReviewAgentSidecar(t, "test-repo@feature", d, nil)
+
+	_ = d.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "idle", nil, nil)
+
+	sc.writeStartupError(fmt.Errorf("container health check: timeout"))
+
+	events := getEvents(t, d, sc.cfg.SessionName)
+	found := false
+	for _, e := range events {
+		if e.Type == "state_change" {
+			found = true
+			var payload map[string]string
+			if err := json.Unmarshal([]byte(e.Payload), &payload); err == nil {
+				if payload["state"] != string(agent.StateError) {
+					t.Errorf("state_change event state = %q, want %q", payload["state"], agent.StateError)
+				}
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected state_change event after writeStartupError")
+	}
+}
+
+// TestWriteStartupError_NonReviewAgent_NoParentNotification verifies that
+// writeStartupError on a non-review-agent session does NOT attempt to notify
+// a parent (it returns silently from notifyParentWorkerOnStartupFailure).
+func TestWriteStartupError_NonReviewAgent_NoParentNotification(t *testing.T) {
+	d := openTestDB(t)
+
+	// A regular worker session (no "~review" in name).
+	worker, _ := newWorkerSidecar(t, d, nil)
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, "idle", nil, nil)
+
+	worker.writeStartupError(fmt.Errorf("container health check: timeout"))
+
+	// State should still be "error".
+	state := getState(t, d, worker.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q, want %q", state, agent.StateError)
+	}
+
+	// Give a brief window for any spurious goroutines to complete.
+	time.Sleep(50 * time.Millisecond)
+
+	// No bus messages should have been written (no coordinator or parent notification).
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	if totalMsgs != 0 {
+		t.Errorf("non-review-agent writeStartupError must not write bus messages, got %d", totalMsgs)
+	}
+}
+
+// TestWriteStartupError_ReviewAgent_NotifiesParentWorker verifies Gap 2:
+// when a review-agent container fails to start, the parent worker session
+// receives a notification via HTTP POST to its harness port.
+func TestWriteStartupError_ReviewAgent_NotifiesParentWorker(t *testing.T) {
+	d := openTestDB(t)
+
+	parentSession := "test-repo@feature"
+	parentSID := "parent-sid-startup-failure"
+
+	// Set up a test HTTP server that simulates the parent worker's opencode process.
+	// It must serve GET /session (for SID validation) and POST prompt_async.
+	var promptCallCount int
+	var promptMu sync.Mutex
+	var capturedText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": parentSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		if r.Method == http.MethodPost {
+			body, _ := io.ReadAll(r.Body)
+			promptMu.Lock()
+			promptCallCount++
+			var bodyMap map[string]any
+			if err := json.Unmarshal(body, &bodyMap); err == nil {
+				if parts, ok := bodyMap["parts"].([]any); ok && len(parts) > 0 {
+					if part, ok := parts[0].(map[string]any); ok {
+						capturedText, _ = part["text"].(string)
+					}
+				}
+			}
+			promptMu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+
+	// Seed the parent worker with a port and SID.
+	seedParentWorkerWithPort(t, d, parentSession, "test-repo", srvPort, parentSID)
+
+	// Create review-agent sidecar with the test server's HTTP client.
+	reviewAgent, _ := newReviewAgentSidecar(t, parentSession, d, srv.Client())
+	_ = d.UpsertStatus(reviewAgent.cfg.SessionName, reviewAgent.cfg.Repo, reviewAgent.cfg.Worktree, "idle", nil, nil)
+
+	// Simulate WaitHealthy timeout.
+	startupErrMsg := "container health check: context deadline exceeded (120s)"
+	reviewAgent.writeStartupError(fmt.Errorf("%s", startupErrMsg))
+
+	// Gap 1: DB state must be "error".
+	if state := getState(t, d, reviewAgent.cfg.SessionName); state != string(agent.StateError) {
+		t.Errorf("state = %q after startup failure, want %q (Gap 1 fix)", state, agent.StateError)
+	}
+
+	// Gap 2: wait for the parent worker notification to arrive.
+	if !waitForHTTPPromptCalls(t, &promptCallCount, &promptMu, 1) {
+		t.Fatal("timed out waiting for parent worker notification (Gap 2 fix) — expected HTTP POST to parent's harness port")
+	}
+
+	// Verify the notification text mentions the review agent session name.
+	promptMu.Lock()
+	text := capturedText
+	promptMu.Unlock()
+	if !strings.Contains(text, reviewAgent.cfg.SessionName) {
+		t.Errorf("notification text %q does not mention review agent session name %q", text, reviewAgent.cfg.SessionName)
+	}
+	if !strings.Contains(text, "failed to start") {
+		t.Errorf("notification text %q does not mention 'failed to start'", text)
+	}
+}
+
+// TestWriteStartupError_ReviewAgent_ParentEnded_LogsAndExitsCleanly verifies
+// the edge case: if the parent worker session has ended (ended_at set), the
+// notification failure is logged and the sidecar exits cleanly without panic.
+func TestWriteStartupError_ReviewAgent_ParentEnded_LogsAndExitsCleanly(t *testing.T) {
+	d := openTestDB(t)
+
+	parentSession := "test-repo@feature"
+	parentSID := "parent-sid-ended"
+
+	// Seed the parent worker, then mark it as ended.
+	if err := d.UpsertStatus(parentSession, "test-repo", "/tmp/"+parentSession, "finished", nil, &parentSID); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	if err := d.SetEnded(parentSession); err != nil {
+		t.Fatalf("SetEnded parent: %v", err)
+	}
+
+	reviewAgent, _ := newReviewAgentSidecar(t, parentSession, d, nil)
+	_ = d.UpsertStatus(reviewAgent.cfg.SessionName, reviewAgent.cfg.Repo, reviewAgent.cfg.Worktree, "idle", nil, nil)
+
+	// writeStartupError should not panic even when parent has ended.
+	reviewAgent.writeStartupError(fmt.Errorf("container health check: timeout"))
+
+	// State must still transition to "error".
+	if state := getState(t, d, reviewAgent.cfg.SessionName); state != string(agent.StateError) {
+		t.Errorf("state = %q, want %q", state, agent.StateError)
+	}
+
+	// Give a brief window to ensure no panics or unexpected goroutine behaviour.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestWriteStartupError_ReviewAgent_ParentNoPort_LogsAndExitsCleanly verifies
+// the edge case: if the parent worker has no harness port, the notification
+// failure is logged and the sidecar exits cleanly.
+func TestWriteStartupError_ReviewAgent_ParentNoPort_LogsAndExitsCleanly(t *testing.T) {
+	d := openTestDB(t)
+
+	parentSession := "test-repo@feature"
+	// Seed parent without a harness port.
+	if err := d.UpsertStatus(parentSession, "test-repo", "/tmp/"+parentSession, "active", nil, nil); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+
+	reviewAgent, _ := newReviewAgentSidecar(t, parentSession, d, nil)
+	_ = d.UpsertStatus(reviewAgent.cfg.SessionName, reviewAgent.cfg.Repo, reviewAgent.cfg.Worktree, "idle", nil, nil)
+
+	// Should not panic — notification is skipped with a log message.
+	reviewAgent.writeStartupError(fmt.Errorf("container health check: timeout"))
+
+	if state := getState(t, d, reviewAgent.cfg.SessionName); state != string(agent.StateError) {
+		t.Errorf("state = %q, want %q", state, agent.StateError)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestWriteStartupError_NormalFinish_NotSuppressed verifies that the existing
+// review-agent suppress-coordinator-notification behaviour on the normal finish
+// path is not affected by the new writeStartupError function. When a review
+// agent finishes normally (via session.idle), notifyCoordinator is still
+// suppressed and the parent worker notification path is NOT triggered.
+func TestWriteStartupError_NormalFinish_NotSuppressed(t *testing.T) {
+	d := openTestDB(t)
+
+	coordSID := "coord-sid-normal-finish"
+	srv, promptCalls := makeSessionListServer(t, []string{coordSID}, http.StatusOK)
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	// Review agent session (normal finish path).
+	reviewAgent, clk := newReviewAgentSidecar(t, "test-repo@feature", d, srv.Client())
+	_ = d.UpsertStatus(reviewAgent.cfg.SessionName, reviewAgent.cfg.Repo, reviewAgent.cfg.Worktree, "active", nil, nil)
+
+	// Normal finish: session.idle → debounce → finished.
+	reviewAgent.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	if state := getState(t, d, reviewAgent.cfg.SessionName); state != string(agent.StateFinished) {
+		t.Errorf("state = %q, want finished", state)
+	}
+
+	// Give time for any async goroutines.
+	time.Sleep(100 * time.Millisecond)
+
+	// The coordinator must NOT have received a notification (review-agent suppression preserved).
+	if *promptCalls != 0 {
+		t.Errorf("coordinator received %d notification(s) from review-agent normal finish, want 0 (suppression must be preserved)", *promptCalls)
+	}
+
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	if totalMsgs != 0 {
+		t.Errorf("expected no bus messages from review-agent normal finish, got %d", totalMsgs)
+	}
+}
+
+// TestReviewAgentParentSession verifies the reviewAgentParentSession helper
+// correctly derives the parent session name from various review-agent session
+// name shapes.
+func TestReviewAgentParentSession(t *testing.T) {
+	cases := []struct {
+		session    string
+		wantParent string
+		wantOK     bool
+	}{
+		// Current shape: <parent>~review-<N>-<role>
+		{"nixos-config@feature~review-1-review-goal", "nixos-config@feature", true},
+		{"nixos-config@feature~review-2-review-code", "nixos-config@feature", true},
+		// Old shape: <parent>~review-<N>~<role>
+		{"nixos-config@feature~review-1~review", "nixos-config@feature", true},
+		// Round session: <parent>~review-<N>
+		{"nixos-config@feature~review-3", "nixos-config@feature", true},
+		// Normal worker — no "~review" in name.
+		{"nixos-config@feature", "", false},
+		{"nixos-config@main", "", false},
+		// Empty string
+		{"", "", false},
+	}
+
+	for _, tc := range cases {
+		got, ok := reviewAgentParentSession(tc.session)
+		if ok != tc.wantOK {
+			t.Errorf("reviewAgentParentSession(%q): ok = %v, want %v", tc.session, ok, tc.wantOK)
+			continue
+		}
+		if ok && got != tc.wantParent {
+			t.Errorf("reviewAgentParentSession(%q) = %q, want %q", tc.session, got, tc.wantParent)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -8103,6 +8103,31 @@ func TestWriteStartupError_NormalFinish_NotSuppressed(t *testing.T) {
 	}
 }
 
+// TestShutdown_DoesNotOverrideError verifies that Shutdown() does not overwrite
+// a StateError that was written by writeStartupError — the narrow-window race
+// where SIGTERM arrives after writeStartupError sets lastState=StateError but
+// before Run() returns.
+func TestShutdown_DoesNotOverrideError(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Simulate writeStartupError having already run: set lastState to StateError
+	// as writeStartupError would do.
+	sc.mu.Lock()
+	sc.lastState = agent.StateError
+	sc.mu.Unlock()
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "error", nil, nil)
+
+	// Shutdown() must not overwrite the error state.
+	sc.Shutdown()
+
+	state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if state != string(agent.StateError) {
+		t.Errorf("state = %q after Shutdown on error, want %q (Shutdown must not clobber startup-failure error)", state, agent.StateError)
+	}
+}
+
 // TestReviewAgentParentSession verifies the reviewAgentParentSession helper
 // correctly derives the parent session name from various review-agent session
 // name shapes.


### PR DESCRIPTION
## Summary

- **Gap 1**: When `WaitHealthy` times out or `CreateSession` fails, the sidecar now calls `writeStartupError()` which writes `StateError` directly to `agent_status` before exiting — not relying on the fragile `pane-died` tmux hook which writes `interrupted` instead.
- **Gap 2**: On startup failure, a targeted notification is delivered to the parent worker session (the session that spawned the review round). The existing suppression of normal finish notifications for review agents is preserved.
- **State machine**: Added `idle → error` as a valid transition to cover the startup-failure path (container fails before `session.created` fires).

## Changes

- `internal/sidecar/sidecar.go`: Added `writeStartupError()`, `reviewAgentParentSession()`, and `notifyParentWorkerOnStartupFailure()`. Updated `WaitHealthy` and `CreateSession` error paths to call `writeStartupError()` and return early.
- `internal/agent/machine.go`: Added `idle → error` transition with explanatory comment.
- `internal/agent/machine_test.go`: Updated to reflect the new valid transition.
- `internal/db/db_test.go`: Removed `idle → error` from the invalid transition test.
- `internal/sidecar/sidecar_test.go`: Added 7 new tests covering both gaps and edge cases.

Closes #994