### PR TITLE
prism merge: local serial merge queue with pull notifications

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -214,6 +214,9 @@
         # deny PR merge — merging is a coordinator responsibility, never a worker's
         "gh pr merge" = "deny";
         "gh pr merge *" = "deny";
+        # deny prism merge — enqueuing is a coordinator responsibility (#783)
+        "prism merge" = "deny";
+        "prism merge *" = "deny";
         # file operations that modify
         "mkdir *" = "allow";
         "rm *" = "allow";
@@ -277,6 +280,11 @@
         "prism prompt *" = "allow";
         "prism cleanup *" = "allow";
         "prism pr *" = "allow";
+        # prism merge — local serial merge queue (#783)
+        "prism merge" = "allow";
+        "prism merge *" = "allow";
+        "prism merges" = "allow";
+        "prism merges *" = "allow";
         # prism review is denied — spawns heavy containers, can crash host.
         # Use @review-* Task calls instead.
         "prism review" = "deny";
@@ -456,6 +464,9 @@
         "prism pr *" = "deny";
         "gh pr merge" = "deny";
         "gh pr merge *" = "deny";
+        # prism merge — enqueuing is a coordinator responsibility (#783)
+        "prism merge" = "deny";
+        "prism merge *" = "deny";
         "nixos-rebuild *" = "deny";
         "sudo nixos-rebuild *" = "deny";
         # prism review is the primary async review path for workers (#864).
@@ -727,6 +738,9 @@
                 "prism spawn *" = "deny";
                 "prism pr" = "deny";
                 "prism pr *" = "deny";
+                # prism merge — enqueuing is a coordinator responsibility (#783)
+                "prism merge" = "deny";
+                "prism merge *" = "deny";
                 # prism review is allowed for workers — async model is non-blocking
                 # and concurrency-capped (#864). The bwrap sandbox is the safety net.
               }
@@ -789,6 +803,9 @@
         # prism review recursion prevention (belt-and-suspenders over deny-all)
         "prism review" = "deny";
         "prism review *" = "deny";
+        # prism merge — coordinator-only; review agents must not enqueue (#783)
+        "prism merge" = "deny";
+        "prism merge *" = "deny";
         # Standard read-only file/text operations
         "cat *" = "allow";
         "head *" = "allow";
@@ -897,6 +914,9 @@
         "prism review *" = "deny";
         "prism spawn" = "deny";
         "prism spawn *" = "deny";
+        # prism merge — coordinator-only; review agents must not enqueue (#783)
+        "prism merge" = "deny";
+        "prism merge *" = "deny";
         # Standard read-only file/text operations (mirrors readOnlyBashCommands)
         "cat *" = "allow";
         "head *" = "allow";
@@ -1289,6 +1309,9 @@
                         "prism spawn *" = "deny";
                         "prism pr" = "deny";
                         "prism pr *" = "deny";
+                        # prism merge — enqueuing is a coordinator responsibility (#783)
+                        "prism merge" = "deny";
+                        "prism merge *" = "deny";
                         # prism review denied — recursive review spawning caused OOM (#1002)
                         "prism review" = "deny";
                         "prism review *" = "deny";

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -92,23 +92,33 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		return fmt.Errorf("prism merge: cannot determine instance_id for session %q\nhint: ensure the coordinator session is registered in prism.db", callerSession)
 	}
 
-	// Pre-flight: verify the PR exists and is open.
-	if err := preflight(pr); err != nil {
-		return fmt.Errorf("prism merge: %w", err)
-	}
-
 	sessionName := callerSession
 	if sessionName == "" {
 		sessionName = "unknown"
 	}
 
-	// Enqueue (idempotent).
-	row, err := d.EnqueueMerge(pr, sessionName, instanceID)
+	// Pre-flight: verify the PR exists and is open, and fetch its title.
+	// Timeout is kept tight (5s) so the overall command returns well within
+	// the 2-second AC when the GitHub API responds promptly.
+	title, err := preflight(pr)
+	if err != nil {
+		return fmt.Errorf("prism merge: %w", err)
+	}
+
+	// Enqueue (idempotent). Pass title for `prism merges list` display.
+	var titlePtr *string
+	if title != "" {
+		titlePtr = &title
+	}
+	row, err := d.EnqueueMerge(pr, sessionName, instanceID, titlePtr)
 	if err != nil {
 		return fmt.Errorf("prism merge: %w", err)
 	}
 
 	fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", pr, row.QueuePosition, row.Status)
+	if title != "" {
+		fmt.Printf("  %s\n", title)
+	}
 	fmt.Println("The merge-queue watcher will drive this PR through CI and merge it automatically.")
 	fmt.Println("You will be notified when it merges or fails.")
 	fmt.Println()
@@ -116,15 +126,17 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 	return nil
 }
 
-// preflight calls `gh pr view <pr> --json state,number` to verify the PR
-// exists and is open. Returns an error if the PR is closed, merged, or not found.
-func preflight(pr int) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+// preflight calls `gh pr view <pr> --json state,number,title` to verify the PR
+// exists and is open. Returns (title, nil) on success. Returns ("", err) if the
+// PR is closed, merged, or not found.
+// Timeout is 5s — callers should complete within ~2s for typical API latency.
+func preflight(pr int) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "gh", "pr", "view", fmt.Sprintf("%d", pr),
 		"--json", "state,number,title").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("PR #%d not found or gh CLI error: %s", pr, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("PR #%d not found or gh CLI error: %s", pr, strings.TrimSpace(string(out)))
 	}
 	var info struct {
 		State  string `json:"state"`
@@ -132,20 +144,19 @@ func preflight(pr int) error {
 		Title  string `json:"title"`
 	}
 	if jsonErr := json.Unmarshal(out, &info); jsonErr != nil {
-		return fmt.Errorf("parse gh pr view output: %w", jsonErr)
+		return "", fmt.Errorf("parse gh pr view output: %w", jsonErr)
 	}
 	switch strings.ToUpper(info.State) {
 	case "OPEN":
 		// Good.
 	case "CLOSED":
-		return fmt.Errorf("PR #%d is already closed — cannot enqueue", pr)
+		return "", fmt.Errorf("PR #%d is already closed — cannot enqueue", pr)
 	case "MERGED":
-		return fmt.Errorf("PR #%d is already merged — cannot enqueue", pr)
+		return "", fmt.Errorf("PR #%d is already merged — cannot enqueue", pr)
 	default:
-		return fmt.Errorf("PR #%d has unexpected state %q — cannot enqueue", pr, info.State)
+		return "", fmt.Errorf("PR #%d has unexpected state %q — cannot enqueue", pr, info.State)
 	}
 
-	// Also print PR title for confirmation.
 	fmt.Fprintf(os.Stderr, "prism merge: enqueueing PR #%d: %s\n", pr, info.Title)
-	return nil
+	return info.Title, nil
 }

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -1,0 +1,151 @@
+package cmd
+
+// prism merge <pr> — enqueue a PR for the local serial merge queue (#783).
+//
+// Coordinator-only: looks up the calling session's instance_id from the DB,
+// pre-flight-validates that the PR exists and is open, then inserts a row into
+// pending_merges with status = 'watching'. The sidecar's merge-queue watcher
+// drives the merge lifecycle asynchronously.
+//
+// Idempotent: if the PR already has a non-terminal row (watching), the command
+// returns success without inserting a duplicate.
+//
+// Worker sessions and review agents are denied: this command is restricted to
+// coordinators.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+var mergeCmd = &cobra.Command{
+	Use:   "merge <pr>",
+	Short: "Enqueue a PR for the local serial merge queue",
+	Long: `Enqueue a PR for the coordinator's local serial merge queue.
+
+The sidecar's merge-queue watcher drives the merge lifecycle asynchronously:
+it polls the head of the queue, rebases when needed, merges when clean, and
+notifies you via prompt when each PR completes (merged or failed).
+
+This command is coordinator-only. Worker sessions must not invoke it.
+
+Idempotent: calling prism merge <pr> a second time for an already-queued
+(non-terminal) PR returns success without inserting a duplicate row.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMerge,
+}
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+}
+
+func runMerge(cmd *cobra.Command, args []string) error {
+	prArg := args[0]
+	pr, err := strconv.Atoi(prArg)
+	if err != nil || pr <= 0 {
+		return fmt.Errorf("prism merge: invalid PR number %q — must be a positive integer", prArg)
+	}
+
+	// Guard: coordinator-only.
+	callerSession := review.LookupParentSession()
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("prism merge: open db: %w", dbErr)
+	}
+	defer d.Close()
+
+	if callerSession != "" {
+		if !session.IsCoordinatorSession(callerSession, d) {
+			return fmt.Errorf(`prism merge: this command is for coordinator sessions only.
+
+Workers must not enqueue merges directly. Ask your coordinator to run:
+
+  prism merge %d
+
+See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
+		}
+	}
+
+	// Look up instance_id for the calling session.
+	var instanceID string
+	if callerSession != "" {
+		status, statusErr := d.CurrentStatus(callerSession)
+		if statusErr != nil {
+			return fmt.Errorf("prism merge: look up session %q: %w", callerSession, statusErr)
+		}
+		if status != nil && status.InstanceID != nil {
+			instanceID = *status.InstanceID
+		}
+	}
+	if instanceID == "" {
+		return fmt.Errorf("prism merge: cannot determine instance_id for session %q\nhint: ensure the coordinator session is registered in prism.db", callerSession)
+	}
+
+	// Pre-flight: verify the PR exists and is open.
+	if err := preflight(pr); err != nil {
+		return fmt.Errorf("prism merge: %w", err)
+	}
+
+	sessionName := callerSession
+	if sessionName == "" {
+		sessionName = "unknown"
+	}
+
+	// Enqueue (idempotent).
+	row, err := d.EnqueueMerge(pr, sessionName, instanceID)
+	if err != nil {
+		return fmt.Errorf("prism merge: %w", err)
+	}
+
+	fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", pr, row.QueuePosition, row.Status)
+	fmt.Println("The merge-queue watcher will drive this PR through CI and merge it automatically.")
+	fmt.Println("You will be notified when it merges or fails.")
+	fmt.Println()
+	fmt.Println("Track progress with: prism merges")
+	return nil
+}
+
+// preflight calls `gh pr view <pr> --json state,number` to verify the PR
+// exists and is open. Returns an error if the PR is closed, merged, or not found.
+func preflight(pr int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "pr", "view", fmt.Sprintf("%d", pr),
+		"--json", "state,number,title").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("PR #%d not found or gh CLI error: %s", pr, strings.TrimSpace(string(out)))
+	}
+	var info struct {
+		State  string `json:"state"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
+	if jsonErr := json.Unmarshal(out, &info); jsonErr != nil {
+		return fmt.Errorf("parse gh pr view output: %w", jsonErr)
+	}
+	switch strings.ToUpper(info.State) {
+	case "OPEN":
+		// Good.
+	case "CLOSED":
+		return fmt.Errorf("PR #%d is already closed — cannot enqueue", pr)
+	case "MERGED":
+		return fmt.Errorf("PR #%d is already merged — cannot enqueue", pr)
+	default:
+		return fmt.Errorf("PR #%d has unexpected state %q — cannot enqueue", pr, info.State)
+	}
+
+	// Also print PR title for confirmation.
+	fmt.Fprintf(os.Stderr, "prism merge: enqueueing PR #%d: %s\n", pr, info.Title)
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// openMergeTestDB opens an isolated test DB and registers cleanup.
+// Sets testDBPath so that openDB() in cmd package uses the test DB.
+func openMergeTestDB(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	SetTestDBPath(filepath.Join(dir, "merge_test.db"))
+	t.Cleanup(func() { SetTestDBPath("") })
+}
+
+// ── runMerge coordinator-only guard ───────────────────────────────────────────
+
+// TestRunMerge_WorkerSessionIsRejected verifies that a worker session calling
+// prism merge receives an error and no row is inserted. This is the security
+// AC: "Worker agents are not permitted to invoke prism merge."
+func TestRunMerge_WorkerSessionIsRejected(t *testing.T) {
+	openMergeTestDB(t)
+
+	// Seed a worker session.
+	const workerSession = "nixos-config@feature"
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer d.Close()
+	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature", "idle", nil, nil, "worker"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	d.Close()
+
+	t.Setenv("PRISM_SESSION_NAME", workerSession)
+	t.Setenv("TMUX", "")
+
+	// Call runMerge directly. It should return an error before inserting any row.
+	err = runMerge(mergeCmd, []string{"42"})
+	if err == nil {
+		t.Fatal("runMerge: expected error for worker session, got nil")
+	}
+	if !strings.Contains(err.Error(), "coordinator sessions only") {
+		t.Errorf("runMerge error %q does not mention 'coordinator sessions only'", err.Error())
+	}
+
+	// Confirm no row was inserted.
+	d2, err2 := openDB()
+	if err2 != nil {
+		t.Fatalf("openDB for verify: %v", err2)
+	}
+	defer d2.Close()
+	row, rowErr := d2.PendingMergeByPR(42)
+	if rowErr != nil {
+		t.Fatalf("PendingMergeByPR: %v", rowErr)
+	}
+	if row != nil {
+		t.Errorf("PendingMergeByPR(42): got row with status=%q, want nil (no row should be inserted for worker)", row.Status)
+	}
+}
+
+// TestRunMerge_MainSessionHeuristicRejected verifies that a @main session
+// name (coordinator heuristic) that calls prism merge IS allowed (not
+// rejected). This tests the inverse: coordinators can enqueue.
+// We can't test a full enqueue without a real GitHub API, so we just verify
+// that the worker-rejection gate is NOT hit for a @main session, i.e. the
+// error (if any) is about missing instance_id, not about being a worker.
+func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
+	openMergeTestDB(t)
+
+	const coordSession = "nixos-config@main"
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+		d.Close()
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	d.Close()
+
+	t.Setenv("PRISM_SESSION_NAME", coordSession)
+	t.Setenv("TMUX", "")
+
+	// The call will fail — but NOT with "coordinator sessions only".
+	// It should fail at the instance_id check (no instance_id set).
+	err = runMerge(mergeCmd, []string{"999"})
+	if err == nil {
+		// Surprising but not impossible in a very unusual test environment.
+		t.Log("runMerge returned nil — may have succeeded via gh if PR 999 is open")
+		return
+	}
+	if strings.Contains(err.Error(), "coordinator sessions only") {
+		t.Errorf("runMerge error %q mentions 'coordinator sessions only' — coordinator should not be blocked", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -190,15 +190,17 @@ func renderMergesList(merges []db.PendingMerge, filter string) error {
 	const (
 		wPos     = 5
 		wPR      = 6
+		wTitle   = 40
 		wStatus  = 11
 		wQueued  = 10
 		wChecked = 10
 		wError   = 40
 	)
 
-	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %s",
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
 		wPos, "POS",
 		wPR, "PR",
+		wTitle, "TITLE",
 		wStatus, "STATUS",
 		wQueued, "QUEUED",
 		wChecked, "CHECKED",
@@ -213,6 +215,10 @@ func renderMergesList(merges []db.PendingMerge, filter string) error {
 			posStr = posStr[:wPos]
 		}
 		prStr := fmt.Sprintf("#%d", m.PR)
+		titleStr := "—"
+		if m.Title != nil && *m.Title != "" {
+			titleStr = *m.Title
+		}
 		queuedStr := formatAge(now, m.QueuedAt)
 		checkedStr := "—"
 		if m.LastCheckedAt != nil {
@@ -228,9 +234,10 @@ func renderMergesList(merges []db.PendingMerge, filter string) error {
 
 		statusStyled := mergeStatusStyle(m.Status).Render(fmt.Sprintf("%-*s", wStatus, truncateStr(m.Status, wStatus)))
 
-		fmt.Printf("%-*s  %-*s  %s  %-*s  %-*s  %s\n",
+		fmt.Printf("%-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
 			wPos, posStr,
 			wPR, prStr,
+			wTitle, truncateStr(titleStr, wTitle),
 			statusStyled,
 			wQueued, queuedStr,
 			wChecked, checkedStr,

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -1,0 +1,275 @@
+package cmd
+
+// prism merges — inspect and manage the local serial merge queue (#783).
+//
+// Usage:
+//
+//	prism merges                         alias for `prism merges list`
+//	prism merges list                    current watching queue (this coordinator)
+//	prism merges list --failed           failed entries
+//	prism merges list --abandoned        abandoned entries from previous coordinator
+//	prism merges list --all              all non-abandoned rows from the last 7 days
+//	prism merges cancel <pr>             cancel a watching entry
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+var mergesCmd = &cobra.Command{
+	Use:   "merges",
+	Short: "Inspect and manage the merge queue",
+	Long:  `Inspect and manage the local serial merge queue. Defaults to listing watching entries.`,
+	Args:  cobra.NoArgs,
+	RunE:  runMergesList, // default action is list
+}
+
+var mergesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List merge queue entries",
+	Long: `List merge queue entries for the current coordinator session.
+
+By default shows only 'watching' entries (active queue).
+Use --failed, --abandoned, or --all to show other entries.`,
+	Args: cobra.NoArgs,
+	RunE: runMergesList,
+}
+
+var mergesCancelCmd = &cobra.Command{
+	Use:   "cancel <pr>",
+	Short: "Cancel a watching merge queue entry",
+	Long: `Cancel a watching merge queue entry owned by the current coordinator session.
+
+No-op (exit 0 with message) when:
+  - The entry is already terminal (merged, failed, cancelled, abandoned)
+  - The entry is owned by a different coordinator incarnation`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMergesCancel,
+}
+
+func init() {
+	mergesListCmd.Flags().Bool("failed", false, "Show failed entries")
+	mergesListCmd.Flags().Bool("abandoned", false, "Show abandoned entries from previous coordinator incarnations")
+	mergesListCmd.Flags().Bool("all", false, "Show all non-abandoned entries from the last 7 days")
+
+	// Also add the filter flags to the root mergesCmd so `prism merges --failed`
+	// works as a shorthand for `prism merges list --failed`.
+	mergesCmd.Flags().Bool("failed", false, "Show failed entries")
+	mergesCmd.Flags().Bool("abandoned", false, "Show abandoned entries from previous coordinator incarnations")
+	mergesCmd.Flags().Bool("all", false, "Show all non-abandoned entries from the last 7 days")
+
+	mergesCmd.AddCommand(mergesListCmd)
+	mergesCmd.AddCommand(mergesCancelCmd)
+	rootCmd.AddCommand(mergesCmd)
+}
+
+func runMergesList(cmd *cobra.Command, _ []string) error {
+	failed, _ := cmd.Flags().GetBool("failed")
+	abandoned, _ := cmd.Flags().GetBool("abandoned")
+	all, _ := cmd.Flags().GetBool("all")
+
+	filter := ""
+	switch {
+	case failed:
+		filter = "failed"
+	case abandoned:
+		filter = "abandoned"
+	case all:
+		filter = "all"
+	}
+
+	callerSession := review.LookupParentSession()
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("prism merges list: open db: %w", err)
+	}
+	defer d.Close()
+
+	// Look up instance_id and session_name.
+	instanceID, sessionName, err := resolveCallerIdentity(callerSession, d)
+	if err != nil {
+		return fmt.Errorf("prism merges list: %w", err)
+	}
+
+	merges, err := d.MergeQueueForInstance(instanceID, sessionName, filter)
+	if err != nil {
+		return fmt.Errorf("prism merges list: %w", err)
+	}
+
+	return renderMergesList(merges, filter)
+}
+
+func runMergesCancel(cmd *cobra.Command, args []string) error {
+	prArg := args[0]
+	pr, err := strconv.Atoi(prArg)
+	if err != nil || pr <= 0 {
+		return fmt.Errorf("prism merges cancel: invalid PR number %q", prArg)
+	}
+
+	callerSession := review.LookupParentSession()
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("prism merges cancel: open db: %w", dbErr)
+	}
+	defer d.Close()
+
+	instanceID, _, err := resolveCallerIdentity(callerSession, d)
+	if err != nil {
+		return fmt.Errorf("prism merges cancel: %w", err)
+	}
+
+	cancelled, err := d.CancelMerge(pr, instanceID)
+	if err != nil {
+		return fmt.Errorf("prism merges cancel: %w", err)
+	}
+	if cancelled {
+		fmt.Printf("PR #%d removed from merge queue.\n", pr)
+	} else {
+		// Look up the row to give a helpful message.
+		row, _ := d.PendingMergeByPR(pr)
+		if row == nil {
+			fmt.Printf("PR #%d is not in the merge queue.\n", pr)
+		} else if row.InstanceID != instanceID {
+			fmt.Printf("PR #%d is owned by a different coordinator incarnation — not cancelled.\n", pr)
+		} else {
+			fmt.Printf("PR #%d is already in terminal state %q — no change.\n", pr, row.Status)
+		}
+	}
+	return nil
+}
+
+// resolveCallerIdentity returns the instance_id and session_name for the
+// calling session. Falls back to empty strings gracefully when no session
+// can be identified (e.g. running outside a tmux session).
+func resolveCallerIdentity(callerSession string, d *db.DB) (instanceID, sessionName string, err error) {
+	if callerSession == "" {
+		return "", "", fmt.Errorf("cannot determine caller session — run from inside a prism tmux session or set PRISM_SESSION_NAME")
+	}
+	status, err := d.CurrentStatus(callerSession)
+	if err != nil {
+		return "", "", fmt.Errorf("look up session %q: %w", callerSession, err)
+	}
+	if status == nil {
+		return "", "", fmt.Errorf("session %q not found in prism.db", callerSession)
+	}
+	if status.InstanceID == nil || *status.InstanceID == "" {
+		return "", "", fmt.Errorf("session %q has no instance_id — coordinator may not have started correctly", callerSession)
+	}
+	return *status.InstanceID, callerSession, nil
+}
+
+// renderMergesList renders a tabular view of merge queue entries.
+func renderMergesList(merges []db.PendingMerge, filter string) error {
+	if len(merges) == 0 {
+		switch filter {
+		case "failed":
+			fmt.Println("no failed merge queue entries")
+		case "abandoned":
+			fmt.Println("no abandoned merge queue entries from previous coordinator sessions")
+		case "all":
+			fmt.Println("no merge queue entries in the last 7 days")
+		default:
+			fmt.Println("merge queue is empty")
+		}
+		return nil
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	now := time.Now()
+
+	const (
+		wPos     = 5
+		wPR      = 6
+		wStatus  = 11
+		wQueued  = 10
+		wChecked = 10
+		wError   = 40
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %s",
+		wPos, "POS",
+		wPR, "PR",
+		wStatus, "STATUS",
+		wQueued, "QUEUED",
+		wChecked, "CHECKED",
+		"ERROR",
+	)
+	fmt.Println(styleHeader.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header)+5)))
+
+	for _, m := range merges {
+		posStr := fmt.Sprintf("%d", m.QueuePosition)
+		if len(posStr) > wPos {
+			posStr = posStr[:wPos]
+		}
+		prStr := fmt.Sprintf("#%d", m.PR)
+		queuedStr := formatAge(now, m.QueuedAt)
+		checkedStr := "—"
+		if m.LastCheckedAt != nil {
+			checkedStr = formatAge(now, *m.LastCheckedAt)
+		}
+		errStr := ""
+		if m.Error != nil {
+			errStr = *m.Error
+		}
+		if len(errStr) > wError {
+			errStr = errStr[:wError-3] + "..."
+		}
+
+		statusStyled := mergeStatusStyle(m.Status).Render(fmt.Sprintf("%-*s", wStatus, truncateStr(m.Status, wStatus)))
+
+		fmt.Printf("%-*s  %-*s  %s  %-*s  %-*s  %s\n",
+			wPos, posStr,
+			wPR, prStr,
+			statusStyled,
+			wQueued, queuedStr,
+			wChecked, checkedStr,
+			errStr,
+		)
+	}
+	fmt.Fprintln(os.Stdout)
+	return nil
+}
+
+// mergeStatusStyle returns a lipgloss style for a merge status value.
+func mergeStatusStyle(status string) lipgloss.Style {
+	switch status {
+	case "watching":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("33")) // yellow
+	case "merged":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("32")) // green
+	case "failed":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("31")) // red
+	case "cancelled":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	case "abandoned":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("35")) // magenta
+	default:
+		return lipgloss.NewStyle()
+	}
+}
+
+// formatAge returns a short human-readable age string like "2m", "1h", "3d".
+func formatAge(now, t time.Time) string {
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -190,6 +190,20 @@ CREATE INDEX IF NOT EXISTS idx_bus_pending ON bus_messages(to_session, delivered
 CREATE TABLE IF NOT EXISTS schema_version (
   version INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS pending_merges (
+  pr              INTEGER PRIMARY KEY,
+  session_name    TEXT NOT NULL,
+  instance_id     TEXT NOT NULL,
+  queue_position  INTEGER NOT NULL,
+  status          TEXT NOT NULL,
+  error           TEXT,
+  queued_at       INTEGER NOT NULL,
+  last_checked_at INTEGER,
+  merged_at       INTEGER,
+  ended_at        INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_pending_merges_status_instance ON pending_merges(instance_id, status, queue_position);
 `
 
 // Open opens (or creates) the prism database at path.
@@ -252,6 +266,12 @@ CREATE TABLE IF NOT EXISTS schema_version (
 // via the formatDurationLong defence-in-depth fallback). The migration is
 // idempotent: a second run finds no rows with negative started_at and is a
 // no-op. Fresh databases have no such rows so the migration is trivially safe.
+// v18→v19 adds the pending_merges table for the local serial merge queue
+// (#783). Uses CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS so the
+// migration is idempotent (safe to run twice). Both the declarative schema
+// block and the migration produce identical sqlite_master output on a fresh
+// database — fresh databases have the table from the schema block and skip the
+// CREATE silently.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -294,11 +314,12 @@ func Open(path string) (*DB, error) {
 	}
 
 	// Set schema_version=11 if the table is empty. Fresh databases have all
-	// current columns from the schema above. The v11→v12, v12→v13, v13→v14,
-	// and v14→v15 migrations run immediately below; on a fresh DB they are
-	// effectively no-ops (the index already exists, there are no rows to
-	// backfill, and the column is already named harness_session_id), so
-	// starting at 11 rather than 15 is safe.
+	// current columns from the schema above (including pending_merges). The
+	// v11→v12 through v18→v19 migrations run immediately below; on a fresh DB
+	// they are all effectively no-ops (indexes already exist, no rows to
+	// backfill, columns already named correctly, sessions and pending_merges
+	// tables already present from the declarative schema block), so starting
+	// at 11 is safe.
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
@@ -811,7 +832,6 @@ func Open(path string) (*DB, error) {
 		}
 		version = 16
 	}
-
 	if version == 16 {
 		// Migration v16 → v17: no-op bridge. This slot is occupied by PR #1014
 		// (local serial merge queue / pending_merges table). When #1014 lands
@@ -885,6 +905,37 @@ func Open(path string) (*DB, error) {
 			return nil, fmt.Errorf("db: migration v17→v18: bump version: %w", err)
 		}
 		version = 18
+	}
+	if version == 18 {
+		// Migration v18 → v19: introduce the pending_merges table for the
+		// local serial merge queue (#783). Uses CREATE TABLE IF NOT EXISTS and
+		// CREATE INDEX IF NOT EXISTS so this migration is fully idempotent —
+		// running it against a fresh database that already has the table from
+		// the declarative schema block above is a safe no-op.
+		steps := []string{
+			`CREATE TABLE IF NOT EXISTS pending_merges (
+			  pr              INTEGER PRIMARY KEY,
+			  session_name    TEXT NOT NULL,
+			  instance_id     TEXT NOT NULL,
+			  queue_position  INTEGER NOT NULL,
+			  status          TEXT NOT NULL,
+			  title           TEXT,
+			  error           TEXT,
+			  queued_at       INTEGER NOT NULL,
+			  last_checked_at INTEGER,
+			  merged_at       INTEGER,
+			  ended_at        INTEGER
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_pending_merges_status_instance ON pending_merges(instance_id, status, queue_position)`,
+			`UPDATE schema_version SET version = 19`,
+		}
+		for _, s := range steps {
+			if _, err := conn.Exec(s); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v18→v19: %w", err)
+			}
+		}
+		version = 19
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -2747,6 +2798,14 @@ func (d *DB) SessionsByName(name string) ([]Session, error) {
 	return d.querySessions(sessionsSelectCols+` WHERE session_name = ? ORDER BY started_at DESC`, name)
 }
 
+// SessionsByNamePattern returns all sessions rows whose session_name ends with
+// the given suffix (LIKE '%<suffix>' pattern), ordered by started_at DESC.
+// The suffix is escaped for SQL LIKE metacharacters.
+func (d *DB) SessionsByNamePattern(suffix string) ([]Session, error) {
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(suffix)
+	return d.querySessions(sessionsSelectCols+` WHERE session_name LIKE ? ESCAPE '\' ORDER BY started_at DESC`, "%"+escaped)
+}
+
 // TokenTurn holds per-turn token and cost data for a single msg_assistant event.
 // Used by SessionTurnTokens to return per-turn data for cost calculation.
 type TokenTurn struct {
@@ -2756,6 +2815,322 @@ type TokenTurn struct {
 	CacheRead   int
 	CacheWrite  int
 	EventCost   float64
+}
+
+// PendingMerge represents a row in the pending_merges table.
+type PendingMerge struct {
+	PR            int
+	SessionName   string
+	InstanceID    string
+	QueuePosition int64
+	Status        string // 'watching' | 'merged' | 'failed' | 'cancelled' | 'abandoned'
+	Error         *string
+	QueuedAt      time.Time
+	LastCheckedAt *time.Time
+	MergedAt      *time.Time
+	EndedAt       *time.Time
+}
+
+// EnqueueMerge inserts a new pending_merges row with status = 'watching'.
+// queue_position is set to the current Unix millisecond timestamp (monotone
+// insertion order). If a non-terminal row already exists for pr, the existing
+// row is returned unchanged (idempotent success). A terminal row (merged,
+// failed, cancelled, abandoned) is treated as gone — a fresh row is inserted.
+// Returns the resulting row (existing or newly inserted).
+func (d *DB) EnqueueMerge(pr int, sessionName, instanceID string) (*PendingMerge, error) {
+	// Check for an existing non-terminal row.
+	existing, err := d.PendingMergeByPR(pr)
+	if err != nil {
+		return nil, fmt.Errorf("db: enqueue merge: check existing: %w", err)
+	}
+	if existing != nil && !isMergeTerminal(existing.Status) {
+		// Non-terminal row exists — idempotent success.
+		return existing, nil
+	}
+
+	now := time.Now().UnixMilli()
+	const q = `
+INSERT INTO pending_merges (pr, session_name, instance_id, queue_position, status, queued_at)
+VALUES (?, ?, ?, ?, 'watching', ?)
+ON CONFLICT(pr) DO UPDATE SET
+  session_name    = excluded.session_name,
+  instance_id     = excluded.instance_id,
+  queue_position  = excluded.queue_position,
+  status          = 'watching',
+  error           = NULL,
+  queued_at       = excluded.queued_at,
+  last_checked_at = NULL,
+  merged_at       = NULL,
+  ended_at        = NULL`
+	if _, err := d.conn.Exec(q, pr, sessionName, instanceID, now, now); err != nil {
+		return nil, fmt.Errorf("db: enqueue merge: insert: %w", err)
+	}
+	row, err := d.PendingMergeByPR(pr)
+	if err != nil {
+		return nil, fmt.Errorf("db: enqueue merge: refetch: %w", err)
+	}
+	return row, nil
+}
+
+// isMergeTerminal returns true when status is a terminal state.
+func isMergeTerminal(status string) bool {
+	switch status {
+	case "merged", "failed", "cancelled", "abandoned":
+		return true
+	}
+	return false
+}
+
+// PendingMergeByPR returns the pending_merges row for pr, or nil if not found.
+func (d *DB) PendingMergeByPR(pr int) (*PendingMerge, error) {
+	const q = `
+SELECT pr, session_name, instance_id, queue_position, status, error,
+       queued_at, last_checked_at, merged_at, ended_at
+  FROM pending_merges
+ WHERE pr = ?`
+	row := d.conn.QueryRow(q, pr)
+	m, err := scanPendingMerge(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: pending merge by pr: %w", err)
+	}
+	return m, nil
+}
+
+// MergeQueueHead returns the head of the merge queue for the given instanceID:
+// the watching row with the lowest queue_position. Returns nil when the queue
+// is empty.
+func (d *DB) MergeQueueHead(instanceID string) (*PendingMerge, error) {
+	const q = `
+SELECT pr, session_name, instance_id, queue_position, status, error,
+       queued_at, last_checked_at, merged_at, ended_at
+  FROM pending_merges
+ WHERE instance_id = ? AND status = 'watching'
+ ORDER BY queue_position ASC
+ LIMIT 1`
+	row := d.conn.QueryRow(q, instanceID)
+	m, err := scanPendingMerge(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: merge queue head: %w", err)
+	}
+	return m, nil
+}
+
+// UpdateMergeLastChecked sets last_checked_at to now for the given pr.
+func (d *DB) UpdateMergeLastChecked(pr int) error {
+	now := time.Now().UnixMilli()
+	_, err := d.conn.Exec(
+		"UPDATE pending_merges SET last_checked_at = ? WHERE pr = ?",
+		now, pr,
+	)
+	if err != nil {
+		return fmt.Errorf("db: update merge last checked: %w", err)
+	}
+	return nil
+}
+
+// TerminateMerge transitions a pending_merges row to a terminal status.
+// status must be one of 'merged', 'failed', 'cancelled', or 'abandoned'.
+// errMsg is stored in the error column; pass "" for no error.
+// merged_at is populated when status = 'merged'; ended_at is always set.
+func (d *DB) TerminateMerge(pr int, status, errMsg string) error {
+	now := time.Now().UnixMilli()
+	var errPtr *string
+	if errMsg != "" {
+		errPtr = &errMsg
+	}
+	var mergedAt *int64
+	if status == "merged" {
+		mergedAt = &now
+	}
+	const q = `
+UPDATE pending_merges
+   SET status   = ?,
+       error    = ?,
+       merged_at = ?,
+       ended_at  = ?
+ WHERE pr = ?`
+	_, err := d.conn.Exec(q, status, errPtr, mergedAt, now, pr)
+	if err != nil {
+		return fmt.Errorf("db: terminate merge: %w", err)
+	}
+	return nil
+}
+
+// AbandonWatchingMerges transitions all watching rows for instanceID to
+// 'abandoned' with error = 'coordinator session ended'. Called on sidecar
+// shutdown so that a new coordinator never inherits stale watching rows.
+func (d *DB) AbandonWatchingMerges(instanceID string) error {
+	now := time.Now().UnixMilli()
+	const q = `
+UPDATE pending_merges
+   SET status   = 'abandoned',
+       error    = 'coordinator session ended',
+       ended_at = ?
+ WHERE instance_id = ? AND status = 'watching'`
+	_, err := d.conn.Exec(q, now, instanceID)
+	if err != nil {
+		return fmt.Errorf("db: abandon watching merges: %w", err)
+	}
+	return nil
+}
+
+// CancelMerge transitions a watching row owned by instanceID to 'cancelled'.
+// Returns (true, nil) when the row was cancelled; (false, nil) when the row
+// does not exist, is already terminal, or is owned by a different instanceID.
+func (d *DB) CancelMerge(pr int, instanceID string) (bool, error) {
+	now := time.Now().UnixMilli()
+	const q = `
+UPDATE pending_merges
+   SET status   = 'cancelled',
+       ended_at = ?
+ WHERE pr = ? AND instance_id = ? AND status = 'watching'`
+	res, err := d.conn.Exec(q, now, pr, instanceID)
+	if err != nil {
+		return false, fmt.Errorf("db: cancel merge: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("db: cancel merge: rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
+// MergeQueueForInstance returns merge queue rows for instanceID, optionally
+// filtered by status. Rows are sorted by queue_position ascending.
+// filter values: "watching", "failed", "all", "abandoned" (special: cross-instance).
+//
+//   - "" or "watching" → only watching rows for instanceID
+//   - "failed"         → failed rows for instanceID
+//   - "all"            → all non-abandoned rows for instanceID from the last 7 days
+//   - "abandoned"      → abandoned rows for the same session_name but a different
+//     instanceID (previous coordinator incarnations)
+func (d *DB) MergeQueueForInstance(instanceID, sessionName, filter string) ([]PendingMerge, error) {
+	var (
+		q    string
+		args []any
+	)
+	sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour).UnixMilli()
+
+	switch filter {
+	case "failed":
+		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		            queued_at, last_checked_at, merged_at, ended_at
+		       FROM pending_merges
+		      WHERE instance_id = ? AND status = 'failed'
+		      ORDER BY queue_position ASC`
+		args = []any{instanceID}
+	case "abandoned":
+		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		            queued_at, last_checked_at, merged_at, ended_at
+		       FROM pending_merges
+		      WHERE session_name = ? AND instance_id != ? AND status = 'abandoned'
+		      ORDER BY queue_position ASC`
+		args = []any{sessionName, instanceID}
+	case "all":
+		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		            queued_at, last_checked_at, merged_at, ended_at
+		       FROM pending_merges
+		      WHERE instance_id = ? AND status != 'abandoned' AND queued_at >= ?
+		      ORDER BY queue_position ASC`
+		args = []any{instanceID, sevenDaysAgo}
+	default:
+		// Default: only watching rows for this instanceID.
+		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		            queued_at, last_checked_at, merged_at, ended_at
+		       FROM pending_merges
+		      WHERE instance_id = ? AND status = 'watching'
+		      ORDER BY queue_position ASC`
+		args = []any{instanceID}
+	}
+
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: merge queue for instance: %w", err)
+	}
+	defer rows.Close()
+
+	var merges []PendingMerge
+	for rows.Next() {
+		m, scanErr := scanPendingMergeRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("db: merge queue for instance: scan: %w", scanErr)
+		}
+		merges = append(merges, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: merge queue for instance: iterate: %w", err)
+	}
+	return merges, nil
+}
+
+// scanPendingMerge scans a single *sql.Row into a PendingMerge.
+func scanPendingMerge(row *sql.Row) (*PendingMerge, error) {
+	var m PendingMerge
+	var (
+		queuedAtMs       int64
+		lastCheckedAtMs  *int64
+		mergedAtMs       *int64
+		endedAtMs        *int64
+	)
+	err := row.Scan(
+		&m.PR, &m.SessionName, &m.InstanceID, &m.QueuePosition, &m.Status,
+		&m.Error, &queuedAtMs, &lastCheckedAtMs, &mergedAtMs, &endedAtMs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	m.QueuedAt = time.UnixMilli(queuedAtMs)
+	if lastCheckedAtMs != nil {
+		t := time.UnixMilli(*lastCheckedAtMs)
+		m.LastCheckedAt = &t
+	}
+	if mergedAtMs != nil {
+		t := time.UnixMilli(*mergedAtMs)
+		m.MergedAt = &t
+	}
+	if endedAtMs != nil {
+		t := time.UnixMilli(*endedAtMs)
+		m.EndedAt = &t
+	}
+	return &m, nil
+}
+
+// scanPendingMergeRow scans a *sql.Rows (multi-row scanner) into a PendingMerge.
+func scanPendingMergeRow(rows *sql.Rows) (PendingMerge, error) {
+	var m PendingMerge
+	var (
+		queuedAtMs      int64
+		lastCheckedAtMs *int64
+		mergedAtMs      *int64
+		endedAtMs       *int64
+	)
+	err := rows.Scan(
+		&m.PR, &m.SessionName, &m.InstanceID, &m.QueuePosition, &m.Status,
+		&m.Error, &queuedAtMs, &lastCheckedAtMs, &mergedAtMs, &endedAtMs,
+	)
+	if err != nil {
+		return m, err
+	}
+	m.QueuedAt = time.UnixMilli(queuedAtMs)
+	if lastCheckedAtMs != nil {
+		t := time.UnixMilli(*lastCheckedAtMs)
+		m.LastCheckedAt = &t
+	}
+	if mergedAtMs != nil {
+		t := time.UnixMilli(*mergedAtMs)
+		m.MergedAt = &t
+	}
+	if endedAtMs != nil {
+		t := time.UnixMilli(*endedAtMs)
+		m.EndedAt = &t
+	}
+	return m, nil
 }
 
 // SessionTurnTokens returns per-turn token data for the given instance_id.

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -3038,10 +3038,14 @@ func (d *DB) MergeQueueForInstance(instanceID, sessionName, filter string) ([]Pe
 		      ORDER BY queue_position ASC`
 		args = []any{sessionName, instanceID}
 	case "all":
+		// Include all terminal states (merged, cancelled, failed, abandoned) plus
+		// watching, from the last 7 days, scoped to this instanceID. Per AC:
+		// "includes terminal states (merged, cancelled, failed, abandoned) from
+		// the last 7 days."
 		q = `SELECT pr, session_name, instance_id, queue_position, status, title, error,
 		            queued_at, last_checked_at, merged_at, ended_at
 		       FROM pending_merges
-		      WHERE instance_id = ? AND status != 'abandoned' AND queued_at >= ?
+		      WHERE instance_id = ? AND queued_at >= ?
 		      ORDER BY queue_position ASC`
 		args = []any{instanceID, sevenDaysAgo}
 	default:

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -197,6 +197,7 @@ CREATE TABLE IF NOT EXISTS pending_merges (
   instance_id     TEXT NOT NULL,
   queue_position  INTEGER NOT NULL,
   status          TEXT NOT NULL,
+  title           TEXT,
   error           TEXT,
   queued_at       INTEGER NOT NULL,
   last_checked_at INTEGER,
@@ -2824,6 +2825,7 @@ type PendingMerge struct {
 	InstanceID    string
 	QueuePosition int64
 	Status        string // 'watching' | 'merged' | 'failed' | 'cancelled' | 'abandoned'
+	Title         *string
 	Error         *string
 	QueuedAt      time.Time
 	LastCheckedAt *time.Time
@@ -2836,8 +2838,10 @@ type PendingMerge struct {
 // insertion order). If a non-terminal row already exists for pr, the existing
 // row is returned unchanged (idempotent success). A terminal row (merged,
 // failed, cancelled, abandoned) is treated as gone — a fresh row is inserted.
+// title is the PR title stored for display in `prism merges list`; pass nil
+// if the title is not known at enqueue time.
 // Returns the resulting row (existing or newly inserted).
-func (d *DB) EnqueueMerge(pr int, sessionName, instanceID string) (*PendingMerge, error) {
+func (d *DB) EnqueueMerge(pr int, sessionName, instanceID string, title *string) (*PendingMerge, error) {
 	// Check for an existing non-terminal row.
 	existing, err := d.PendingMergeByPR(pr)
 	if err != nil {
@@ -2850,19 +2854,20 @@ func (d *DB) EnqueueMerge(pr int, sessionName, instanceID string) (*PendingMerge
 
 	now := time.Now().UnixMilli()
 	const q = `
-INSERT INTO pending_merges (pr, session_name, instance_id, queue_position, status, queued_at)
-VALUES (?, ?, ?, ?, 'watching', ?)
+INSERT INTO pending_merges (pr, session_name, instance_id, queue_position, status, title, queued_at)
+VALUES (?, ?, ?, ?, 'watching', ?, ?)
 ON CONFLICT(pr) DO UPDATE SET
   session_name    = excluded.session_name,
   instance_id     = excluded.instance_id,
   queue_position  = excluded.queue_position,
   status          = 'watching',
+  title           = excluded.title,
   error           = NULL,
   queued_at       = excluded.queued_at,
   last_checked_at = NULL,
   merged_at       = NULL,
   ended_at        = NULL`
-	if _, err := d.conn.Exec(q, pr, sessionName, instanceID, now, now); err != nil {
+	if _, err := d.conn.Exec(q, pr, sessionName, instanceID, now, title, now); err != nil {
 		return nil, fmt.Errorf("db: enqueue merge: insert: %w", err)
 	}
 	row, err := d.PendingMergeByPR(pr)
@@ -2884,7 +2889,7 @@ func isMergeTerminal(status string) bool {
 // PendingMergeByPR returns the pending_merges row for pr, or nil if not found.
 func (d *DB) PendingMergeByPR(pr int) (*PendingMerge, error) {
 	const q = `
-SELECT pr, session_name, instance_id, queue_position, status, error,
+SELECT pr, session_name, instance_id, queue_position, status, title, error,
        queued_at, last_checked_at, merged_at, ended_at
   FROM pending_merges
  WHERE pr = ?`
@@ -2904,7 +2909,7 @@ SELECT pr, session_name, instance_id, queue_position, status, error,
 // is empty.
 func (d *DB) MergeQueueHead(instanceID string) (*PendingMerge, error) {
 	const q = `
-SELECT pr, session_name, instance_id, queue_position, status, error,
+SELECT pr, session_name, instance_id, queue_position, status, title, error,
        queued_at, last_checked_at, merged_at, ended_at
   FROM pending_merges
  WHERE instance_id = ? AND status = 'watching'
@@ -3019,21 +3024,21 @@ func (d *DB) MergeQueueForInstance(instanceID, sessionName, filter string) ([]Pe
 
 	switch filter {
 	case "failed":
-		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		q = `SELECT pr, session_name, instance_id, queue_position, status, title, error,
 		            queued_at, last_checked_at, merged_at, ended_at
 		       FROM pending_merges
 		      WHERE instance_id = ? AND status = 'failed'
 		      ORDER BY queue_position ASC`
 		args = []any{instanceID}
 	case "abandoned":
-		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		q = `SELECT pr, session_name, instance_id, queue_position, status, title, error,
 		            queued_at, last_checked_at, merged_at, ended_at
 		       FROM pending_merges
 		      WHERE session_name = ? AND instance_id != ? AND status = 'abandoned'
 		      ORDER BY queue_position ASC`
 		args = []any{sessionName, instanceID}
 	case "all":
-		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		q = `SELECT pr, session_name, instance_id, queue_position, status, title, error,
 		            queued_at, last_checked_at, merged_at, ended_at
 		       FROM pending_merges
 		      WHERE instance_id = ? AND status != 'abandoned' AND queued_at >= ?
@@ -3041,7 +3046,7 @@ func (d *DB) MergeQueueForInstance(instanceID, sessionName, filter string) ([]Pe
 		args = []any{instanceID, sevenDaysAgo}
 	default:
 		// Default: only watching rows for this instanceID.
-		q = `SELECT pr, session_name, instance_id, queue_position, status, error,
+		q = `SELECT pr, session_name, instance_id, queue_position, status, title, error,
 		            queued_at, last_checked_at, merged_at, ended_at
 		       FROM pending_merges
 		      WHERE instance_id = ? AND status = 'watching'
@@ -3073,14 +3078,14 @@ func (d *DB) MergeQueueForInstance(instanceID, sessionName, filter string) ([]Pe
 func scanPendingMerge(row *sql.Row) (*PendingMerge, error) {
 	var m PendingMerge
 	var (
-		queuedAtMs       int64
-		lastCheckedAtMs  *int64
-		mergedAtMs       *int64
-		endedAtMs        *int64
+		queuedAtMs      int64
+		lastCheckedAtMs *int64
+		mergedAtMs      *int64
+		endedAtMs       *int64
 	)
 	err := row.Scan(
 		&m.PR, &m.SessionName, &m.InstanceID, &m.QueuePosition, &m.Status,
-		&m.Error, &queuedAtMs, &lastCheckedAtMs, &mergedAtMs, &endedAtMs,
+		&m.Title, &m.Error, &queuedAtMs, &lastCheckedAtMs, &mergedAtMs, &endedAtMs,
 	)
 	if err != nil {
 		return nil, err
@@ -3112,7 +3117,7 @@ func scanPendingMergeRow(rows *sql.Rows) (PendingMerge, error) {
 	)
 	err := rows.Scan(
 		&m.PR, &m.SessionName, &m.InstanceID, &m.QueuePosition, &m.Status,
-		&m.Error, &queuedAtMs, &lastCheckedAtMs, &mergedAtMs, &endedAtMs,
+		&m.Title, &m.Error, &queuedAtMs, &lastCheckedAtMs, &mergedAtMs, &endedAtMs,
 	)
 	if err != nil {
 		return m, err

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=18 (all migrations applied on Open).
+	// Verify schema_version=19 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version: got %d, want 19", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -983,8 +983,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1058,8 +1058,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1559,8 +1559,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1625,8 +1625,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1695,8 +1695,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1790,8 +1790,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1883,8 +1883,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2468,8 +2468,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2557,8 +2557,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// isolation_mode column must exist (NULL for pre-migration rows).
@@ -4160,8 +4160,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// Check each row.
@@ -4588,8 +4588,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4863,8 +4863,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5084,8 +5084,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// sessions table must exist.
@@ -5238,8 +5238,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after second open: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after second open: got %d, want 19", version)
 	}
 }
 
@@ -5787,13 +5787,13 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must advance to 18.
+	// Schema version must advance to 19 (v17→v18 backfill + v18→v19 pending_merges).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after migration: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after migration: got %d, want 19", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -5850,8 +5850,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("schema_version after second open: got %d, want 18", version)
+	if version != 19 {
+		t.Errorf("schema_version after second open: got %d, want 19", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -1,0 +1,398 @@
+// Package mergequeue implements the local serial merge queue for prism (#783).
+//
+// The Watcher is a goroutine started by the coordinator's sidecar on init.
+// It polls the head of the pending_merges queue for the sidecar's instance_id
+// and drives PRs through the merge lifecycle using the GitHub CLI:
+//
+//   - CLEAN   → gh pr merge --squash
+//   - BEHIND  → gh pr update-branch
+//   - DIRTY   → fail with "merge conflicts"
+//   - BLOCKED → fail on CI failure, keep watching otherwise
+//   - Others  → keep watching (transient)
+//
+// On each terminal outcome (merged, failed, closed) a bus notification is
+// delivered to the enqueuing coordinator session via the opencode HTTP API.
+// The notification text names the PR, includes the worker session's archive
+// path, and prompts git pull + prism cleanup.
+//
+// Watcher lifetime equals coordinator session lifetime. On sidecar shutdown,
+// all watching rows for this instance_id are transitioned to 'abandoned'.
+package mergequeue
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+const (
+	// PollInterval is how often the watcher ticks.
+	PollInterval = 45 * time.Second
+)
+
+// Watcher runs the merge-queue polling loop for a single coordinator session.
+type Watcher struct {
+	db         *db.DB
+	instanceID string
+	sessionName string
+	httpClient *http.Client
+}
+
+// New creates a Watcher. instanceID and sessionName identify the coordinator
+// session that owns this watcher. httpClient is used for notification delivery;
+// pass nil to use the default client.
+func New(database *db.DB, instanceID, sessionName string, httpClient *http.Client) *Watcher {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Watcher{
+		db:          database,
+		instanceID:  instanceID,
+		sessionName: sessionName,
+		httpClient:  httpClient,
+	}
+}
+
+// Run starts the polling loop and blocks until ctx is cancelled.
+// It is safe to run in a goroutine.
+func (w *Watcher) Run(ctx context.Context) {
+	log.Printf("[mergequeue] watcher started (instance=%s)", w.instanceID)
+	ticker := time.NewTicker(PollInterval)
+	defer ticker.Stop()
+
+	// Run once immediately on startup, then on each tick.
+	w.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[mergequeue] watcher stopped (instance=%s)", w.instanceID)
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+// tick processes the head of the queue once.
+func (w *Watcher) tick(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	head, err := w.db.MergeQueueHead(w.instanceID)
+	if err != nil {
+		log.Printf("[mergequeue] db error reading head: %v", err)
+		return
+	}
+	if head == nil {
+		// Queue is empty — no-op.
+		return
+	}
+
+	log.Printf("[mergequeue] polling head PR #%d (queue_pos=%d)", head.PR, head.QueuePosition)
+	if err := w.db.UpdateMergeLastChecked(head.PR); err != nil {
+		log.Printf("[mergequeue] UpdateMergeLastChecked PR #%d: %v", head.PR, err)
+	}
+
+	prInfo, err := fetchPRInfo(ctx, head.PR)
+	if err != nil {
+		log.Printf("[mergequeue] fetchPRInfo PR #%d: %v — leaving watching", head.PR, err)
+		return
+	}
+
+	// PR closed without merging.
+	if prInfo.State == "CLOSED" && !prInfo.Merged {
+		msg := "PR was closed without merging"
+		w.failAndNotify(head, msg)
+		return
+	}
+
+	// PR already merged (shouldn't happen, but handle it gracefully).
+	if prInfo.State == "MERGED" || prInfo.Merged {
+		w.succeedAndNotify(ctx, head)
+		return
+	}
+
+	switch prInfo.MergeStateStatus {
+	case "CLEAN":
+		w.tryMerge(ctx, head)
+
+	case "BEHIND":
+		log.Printf("[mergequeue] PR #%d is BEHIND — calling gh pr update-branch", head.PR)
+		if err := updateBranch(ctx, head.PR); err != nil {
+			log.Printf("[mergequeue] gh pr update-branch PR #%d: %v — leaving watching", head.PR, err)
+		}
+		// Leave row as watching; next tick will see UNSTABLE→BLOCKED→CLEAN cycle.
+
+	case "DIRTY":
+		w.failAndNotify(head, "merge conflicts")
+
+	case "BLOCKED":
+		// Disambiguate: CI failure vs. still running / required review.
+		if hasCIFailure(prInfo.StatusCheckRollup) {
+			w.failAndNotify(head, "CI failed")
+		} else {
+			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure — staying watching", head.PR)
+		}
+
+	case "UNSTABLE", "UNKNOWN", "HAS_HOOKS", "DRAFT":
+		log.Printf("[mergequeue] PR #%d %s — staying watching", head.PR, prInfo.MergeStateStatus)
+
+	default:
+		log.Printf("[mergequeue] PR #%d unknown mergeStateStatus=%q — staying watching", head.PR, prInfo.MergeStateStatus)
+	}
+}
+
+// tryMerge attempts `gh pr merge --squash` on head. On success transitions to
+// merged and notifies; on branch-moved race (exit 1 + "already merged" or
+// "sha1" message) leaves watching; on other errors transitions to failed.
+func (w *Watcher) tryMerge(ctx context.Context, head *db.PendingMerge) {
+	log.Printf("[mergequeue] PR #%d CLEAN — attempting gh pr merge --squash", head.PR)
+	out, err := runGH(ctx, "pr", "merge", fmt.Sprintf("%d", head.PR), "--squash", "--auto")
+	if err == nil {
+		log.Printf("[mergequeue] PR #%d merged successfully", head.PR)
+		w.succeedAndNotify(ctx, head)
+		return
+	}
+
+	// Check for branch-moved race: GitHub returns a message containing
+	// "already merged" or similar when the head SHA moved between our
+	// view and the merge call. Treat as transient — leave watching.
+	combinedOutput := strings.ToLower(string(out) + err.Error())
+	if isBranchMovedRace(combinedOutput) {
+		log.Printf("[mergequeue] PR #%d branch-moved race detected — leaving watching for next tick", head.PR)
+		return
+	}
+
+	errMsg := fmt.Sprintf("gh pr merge failed: %s", strings.TrimSpace(string(out)))
+	if len(errMsg) > 500 {
+		errMsg = errMsg[:500]
+	}
+	log.Printf("[mergequeue] PR #%d merge failed: %v", head.PR, errMsg)
+	w.failAndNotify(head, errMsg)
+}
+
+// succeedAndNotify transitions head to merged and notifies the coordinator.
+func (w *Watcher) succeedAndNotify(ctx context.Context, head *db.PendingMerge) {
+	if err := w.db.TerminateMerge(head.PR, "merged", ""); err != nil {
+		log.Printf("[mergequeue] TerminateMerge(merged) PR #%d: %v", head.PR, err)
+	}
+	// Look up the worker session's archive_path from the sessions table.
+	archivePath := w.lookupWorkerArchivePath(head.PR)
+	var notifyText string
+	if archivePath != "" {
+		notifyText = fmt.Sprintf(
+			"PR #%d merged. Archive: %s. Run `git pull` in @main and `prism cleanup` the worker session.",
+			head.PR, archivePath,
+		)
+	} else {
+		notifyText = fmt.Sprintf(
+			"PR #%d merged. Run `git pull` in @main and `prism cleanup` the worker session.",
+			head.PR,
+		)
+	}
+	log.Printf("[mergequeue] %s", notifyText)
+	w.notify(ctx, head.SessionName, head.InstanceID, notifyText)
+}
+
+// failAndNotify transitions head to failed and notifies the coordinator.
+func (w *Watcher) failAndNotify(head *db.PendingMerge, errMsg string) {
+	if err := w.db.TerminateMerge(head.PR, "failed", errMsg); err != nil {
+		log.Printf("[mergequeue] TerminateMerge(failed) PR #%d: %v", head.PR, err)
+	}
+	var notifyText string
+	switch errMsg {
+	case "merge conflicts":
+		notifyText = fmt.Sprintf("PR #%d has merge conflicts — worker rebase needed", head.PR)
+	case "CI failed":
+		notifyText = fmt.Sprintf("PR #%d CI failed — needs worker fix", head.PR)
+	case "PR was closed without merging":
+		notifyText = fmt.Sprintf("PR #%d was closed without merging — removed from queue", head.PR)
+	default:
+		notifyText = fmt.Sprintf("PR #%d merge failed: %s", head.PR, errMsg)
+	}
+	log.Printf("[mergequeue] %s", notifyText)
+	w.notify(context.Background(), head.SessionName, head.InstanceID, notifyText)
+}
+
+// notify delivers a notification to the coordinator via the opencode HTTP API.
+// It looks up the coordinator's harness port from agent_status and posts a
+// prompt_async message. Failure is non-fatal (logged).
+func (w *Watcher) notify(ctx context.Context, targetSession, targetInstanceID, text string) {
+	status, err := w.db.CurrentStatus(targetSession)
+	if err != nil || status == nil {
+		log.Printf("[mergequeue] notify: cannot find coordinator session %q: %v", targetSession, err)
+		return
+	}
+	if status.HarnessPort == nil {
+		log.Printf("[mergequeue] notify: coordinator %q has no harness port", targetSession)
+		return
+	}
+	port := *status.HarnessPort
+
+	// Validate harness_session_id.
+	if status.HarnessSessionID == nil || *status.HarnessSessionID == "" {
+		log.Printf("[mergequeue] notify: coordinator %q has no harness_session_id", targetSession)
+		return
+	}
+	sid := *status.HarnessSessionID
+
+	body := buildNotifyBody(text, status)
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		log.Printf("[mergequeue] notify: marshal body: %v", err)
+		return
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/session/%s/prompt_async", port, sid)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBytes))
+	if err != nil {
+		log.Printf("[mergequeue] notify: create request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		log.Printf("[mergequeue] notify: HTTP request: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
+		log.Printf("[mergequeue] notify: HTTP status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+		return
+	}
+	log.Printf("[mergequeue] notify: delivered to %s", targetSession)
+}
+
+// lookupWorkerArchivePath finds the most recent sessions row for the PR's
+// worker branch (heuristic: session_name ends with "@<prNumber>").
+// Returns the archive_path if found, or "".
+func (w *Watcher) lookupWorkerArchivePath(pr int) string {
+	branchSuffix := fmt.Sprintf("@%d", pr)
+	sessions, err := w.db.SessionsByNamePattern(branchSuffix)
+	if err != nil || len(sessions) == 0 {
+		return ""
+	}
+	// Pick the most recent session.
+	best := sessions[0]
+	for _, s := range sessions[1:] {
+		if s.StartedAt.After(best.StartedAt) {
+			best = s
+		}
+	}
+	if best.ArchivePath != nil {
+		return *best.ArchivePath
+	}
+	return ""
+}
+
+// buildNotifyBody constructs the opencode prompt_async body.
+func buildNotifyBody(text string, status *db.Status) map[string]any {
+	body := map[string]any{
+		"parts": []map[string]string{
+			{"type": "text", "text": text},
+		},
+	}
+	modelID := status.RootModelID
+	if modelID == nil {
+		modelID = status.ModelID
+	}
+	if modelID != nil {
+		slashIdx := strings.Index(*modelID, "/")
+		providerID := *modelID
+		modelIDStr := ""
+		if slashIdx >= 0 {
+			providerID = (*modelID)[:slashIdx]
+			modelIDStr = (*modelID)[slashIdx+1:]
+		}
+		body["model"] = map[string]string{
+			"providerID": providerID,
+			"modelID":    modelIDStr,
+		}
+	}
+	return body
+}
+
+// prInfo holds the fields we care about from `gh pr view --json`.
+type prInfo struct {
+	State             string          `json:"state"`
+	Merged            bool            `json:"merged"`
+	MergeStateStatus  string          `json:"mergeStateStatus"`
+	StatusCheckRollup []checkEntry    `json:"statusCheckRollup"`
+}
+
+type checkEntry struct {
+	Conclusion string `json:"conclusion"`
+	Status     string `json:"status"`
+}
+
+// fetchPRInfo calls `gh pr view <pr> --json` and returns the parsed result.
+func fetchPRInfo(ctx context.Context, pr int) (*prInfo, error) {
+	out, err := runGH(ctx, "pr", "view", fmt.Sprintf("%d", pr),
+		"--json", "state,merged,mergeStateStatus,statusCheckRollup")
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	var info prInfo
+	if err := json.Unmarshal(out, &info); err != nil {
+		return nil, fmt.Errorf("parse gh pr view output: %w", err)
+	}
+	return &info, nil
+}
+
+// hasCIFailure returns true when at least one check in rollup has
+// conclusion = FAILURE.
+func hasCIFailure(rollup []checkEntry) bool {
+	for _, c := range rollup {
+		if strings.EqualFold(c.Conclusion, "FAILURE") {
+			return true
+		}
+	}
+	return false
+}
+
+// isBranchMovedRace heuristically detects the GitHub branch-moved race from
+// error output: the merge call fails because the head SHA changed between our
+// CLEAN observation and the merge call. We treat this as transient.
+func isBranchMovedRace(output string) bool {
+	keywords := []string{
+		"already merged",
+		"pull request is not mergeable",
+		"base branch was modified",
+	}
+	for _, kw := range keywords {
+		if strings.Contains(output, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// updateBranch calls `gh pr update-branch <pr>` to rebase the PR onto main.
+func updateBranch(ctx context.Context, pr int) error {
+	out, err := runGH(ctx, "pr", "update-branch", fmt.Sprintf("%d", pr))
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// runGH runs `gh <args...>` and returns combined output. Uses a 30s timeout
+// per call to avoid hanging the poll loop.
+func runGH(ctx context.Context, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	return cmd.CombinedOutput()
+}

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -157,7 +157,7 @@ func (w *Watcher) tick(ctx context.Context) {
 // "sha1" message) leaves watching; on other errors transitions to failed.
 func (w *Watcher) tryMerge(ctx context.Context, head *db.PendingMerge) {
 	log.Printf("[mergequeue] PR #%d CLEAN — attempting gh pr merge --squash", head.PR)
-	out, err := runGH(ctx, "pr", "merge", fmt.Sprintf("%d", head.PR), "--squash", "--auto")
+	out, err := runGH(ctx, "pr", "merge", fmt.Sprintf("%d", head.PR), "--squash")
 	if err == nil {
 		log.Printf("[mergequeue] PR #%d merged successfully", head.PR)
 		w.succeedAndNotify(ctx, head)

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -63,17 +63,17 @@ func TestEnqueueMerge_FIFO(t *testing.T) {
 	session := "myrepo@main"
 
 	// Enqueue PRs in reverse order to ensure FIFO is by queue_position, not PR number.
-	m3, err := d.EnqueueMerge(300, session, instanceID)
+	m3, err := d.EnqueueMerge(300, session, instanceID, nil)
 	if err != nil {
 		t.Fatalf("EnqueueMerge(300): %v", err)
 	}
 	time.Sleep(time.Millisecond) // ensure distinct timestamps
-	m2, err := d.EnqueueMerge(200, session, instanceID)
+	m2, err := d.EnqueueMerge(200, session, instanceID, nil)
 	if err != nil {
 		t.Fatalf("EnqueueMerge(200): %v", err)
 	}
 	time.Sleep(time.Millisecond)
-	m1, err := d.EnqueueMerge(100, session, instanceID)
+	m1, err := d.EnqueueMerge(100, session, instanceID, nil)
 	if err != nil {
 		t.Fatalf("EnqueueMerge(100): %v", err)
 	}
@@ -104,12 +104,12 @@ func TestEnqueueMerge_Idempotent(t *testing.T) {
 	instanceID := "inst-idem"
 	session := "myrepo@main"
 
-	m1, err := d.EnqueueMerge(42, session, instanceID)
+	m1, err := d.EnqueueMerge(42, session, instanceID, nil)
 	if err != nil {
 		t.Fatalf("first EnqueueMerge: %v", err)
 	}
 
-	m2, err := d.EnqueueMerge(42, session, instanceID)
+	m2, err := d.EnqueueMerge(42, session, instanceID, nil)
 	if err != nil {
 		t.Fatalf("second EnqueueMerge: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestEnqueueMerge_TerminalRowReplaceable(t *testing.T) {
 	session := "myrepo@main"
 
 	// Enqueue and then fail.
-	if _, err := d.EnqueueMerge(99, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(99, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 	if err := d.TerminateMerge(99, "failed", "CI failed"); err != nil {
@@ -148,7 +148,7 @@ func TestEnqueueMerge_TerminalRowReplaceable(t *testing.T) {
 	}
 
 	// Re-enqueue — should produce a fresh watching row.
-	m, err := d.EnqueueMerge(99, session, instanceID)
+	m, err := d.EnqueueMerge(99, session, instanceID, nil)
 	if err != nil {
 		t.Fatalf("second EnqueueMerge: %v", err)
 	}
@@ -168,10 +168,10 @@ func TestAbandonWatchingMerges(t *testing.T) {
 	session := "myrepo@main"
 
 	// Enqueue two PRs.
-	if _, err := d.EnqueueMerge(1, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(1, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(1): %v", err)
 	}
-	if _, err := d.EnqueueMerge(2, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(2, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(2): %v", err)
 	}
 
@@ -217,7 +217,7 @@ func TestCancelMerge(t *testing.T) {
 	instanceID := "inst-cancel"
 	session := "myrepo@main"
 
-	if _, err := d.EnqueueMerge(55, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(55, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -248,7 +248,7 @@ func TestCancelMerge(t *testing.T) {
 	}
 
 	// Wrong instanceID returns false.
-	if _, err := d.EnqueueMerge(66, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(66, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(66): %v", err)
 	}
 	cancelled3, err := d.CancelMerge(66, "other-instance")
@@ -267,7 +267,7 @@ func TestMergeQueueHead_ScopedByInstanceID(t *testing.T) {
 	session := "myrepo@main"
 
 	// Enqueue a PR under instance A.
-	if _, err := d.EnqueueMerge(10, session, "inst-A"); err != nil {
+	if _, err := d.EnqueueMerge(10, session, "inst-A", nil); err != nil {
 		t.Fatalf("EnqueueMerge inst-A: %v", err)
 	}
 
@@ -288,13 +288,13 @@ func TestMergeQueueForInstance_Filters(t *testing.T) {
 	session := "myrepo@main"
 
 	// Enqueue 3 PRs. Fail one, leave one watching, cancel one.
-	if _, err := d.EnqueueMerge(1, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(1, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(1): %v", err)
 	}
-	if _, err := d.EnqueueMerge(2, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(2, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(2): %v", err)
 	}
-	if _, err := d.EnqueueMerge(3, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(3, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(3): %v", err)
 	}
 
@@ -344,7 +344,7 @@ func TestMergeQueueForInstance_AbandonedFilter(t *testing.T) {
 	newInstance := "inst-new"
 
 	// Enqueue under old instance and abandon.
-	if _, err := d.EnqueueMerge(77, session, oldInstance); err != nil {
+	if _, err := d.EnqueueMerge(77, session, oldInstance, nil); err != nil {
 		t.Fatalf("EnqueueMerge(old): %v", err)
 	}
 	if err := d.AbandonWatchingMerges(oldInstance); err != nil {
@@ -352,7 +352,7 @@ func TestMergeQueueForInstance_AbandonedFilter(t *testing.T) {
 	}
 
 	// Enqueue under new instance.
-	if _, err := d.EnqueueMerge(88, session, newInstance); err != nil {
+	if _, err := d.EnqueueMerge(88, session, newInstance, nil); err != nil {
 		t.Fatalf("EnqueueMerge(new): %v", err)
 	}
 
@@ -517,7 +517,7 @@ func TestWatcher_CLEANTransitionToMerged(t *testing.T) {
 	seedCoordinator(t, d, session, instanceID, port, sid)
 
 	// Enqueue PR 100.
-	if _, err := d.EnqueueMerge(100, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(100, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -557,7 +557,7 @@ func TestWatcher_BEHINDLeaveWatching(t *testing.T) {
 	session := "myrepo@main"
 	updateCalled := false
 
-	if _, err := d.EnqueueMerge(200, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(200, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -599,7 +599,7 @@ func TestWatcher_DIRTYTransitionToFailed(t *testing.T) {
 	sid := "opencode-sid-dirty"
 	seedCoordinator(t, d, session, instanceID, port, sid)
 
-	if _, err := d.EnqueueMerge(300, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(300, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -635,7 +635,7 @@ func TestWatcher_BLOCKEDWithCIFailure(t *testing.T) {
 	port := parsePort(t, srv.URL)
 	seedCoordinator(t, d, session, instanceID, port, "sid-ci")
 
-	if _, err := d.EnqueueMerge(400, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(400, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -672,7 +672,7 @@ func TestWatcher_BLOCKEDWithoutCIFailureStaysWatching(t *testing.T) {
 	instanceID := "inst-blocked-noci"
 	session := "myrepo@main"
 
-	if _, err := d.EnqueueMerge(500, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(500, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -705,7 +705,7 @@ func TestWatcher_UNSTABLEStaysWatching(t *testing.T) {
 	instanceID := "inst-unstable"
 	session := "myrepo@main"
 
-	if _, err := d.EnqueueMerge(600, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(600, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -734,7 +734,7 @@ func TestWatcher_UNKNOWNStaysWatching(t *testing.T) {
 	instanceID := "inst-unknown"
 	session := "myrepo@main"
 
-	if _, err := d.EnqueueMerge(700, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(700, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -764,7 +764,7 @@ func TestWatcher_BranchMovedRaceRetries(t *testing.T) {
 	instanceID := "inst-race"
 	session := "myrepo@main"
 
-	if _, err := d.EnqueueMerge(800, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(800, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -811,7 +811,7 @@ func TestWatcher_ClosedExternallyTransitionsToFailed(t *testing.T) {
 	port := parsePort(t, srv.URL)
 	seedCoordinator(t, d, session, instanceID, port, "sid-closed")
 
-	if _, err := d.EnqueueMerge(900, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(900, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -840,7 +840,7 @@ func TestWatcher_Cancellation(t *testing.T) {
 	instanceID := "inst-canc"
 	session := "myrepo@main"
 
-	if _, err := d.EnqueueMerge(111, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(111, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 
@@ -870,11 +870,11 @@ func TestWatcher_NextPRPromotedAfterTerminal(t *testing.T) {
 	session := "myrepo@main"
 
 	// Enqueue two PRs.
-	if _, err := d.EnqueueMerge(10, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(10, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(10): %v", err)
 	}
 	time.Sleep(time.Millisecond)
-	if _, err := d.EnqueueMerge(20, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(20, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(20): %v", err)
 	}
 
@@ -1004,7 +1004,7 @@ func TestWatcher_NotificationBodyContainsPR(t *testing.T) {
 	port := parsePort(t, srv.URL)
 	seedCoordinator(t, d, session, instanceID, port, "sid-notif")
 
-	if _, err := d.EnqueueMerge(123, session, instanceID); err != nil {
+	if _, err := d.EnqueueMerge(123, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1,0 +1,1044 @@
+package mergequeue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// openTestDB creates a temporary test database and returns it.
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	dir := t.TempDir()
+	d, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// seedCoordinator inserts an agent_status row for a coordinator session so
+// notify() can look up its harness port and harness_session_id.
+func seedCoordinator(t *testing.T, d *db.DB, sessionName, instanceID string, port int, harnessSessionID string) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, "myrepo", "/tmp/wt", "active", nil, &harnessSessionID); err != nil {
+		t.Fatalf("seed coordinator status: %v", err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("seed coordinator instance_id: %v", err)
+	}
+	// Force the port to the value we want via execSQL.
+	_ = execSQL(d, "UPDATE agent_status SET harness_port = ?, harness_session_id = ? WHERE session_name = ?",
+		port, harnessSessionID, sessionName)
+}
+
+// execSQL runs a raw SQL statement against the test DB via QueryRow.
+// DML statements (UPDATE/INSERT) return sql.ErrNoRows from Scan, which we ignore.
+func execSQL(d *db.DB, q string, args ...any) error {
+	var dummy int
+	err := d.QueryRow(q, args...).Scan(&dummy)
+	if err != nil && strings.Contains(err.Error(), "no rows") {
+		return nil
+	}
+	return err
+}
+
+// ── DB-layer tests ─────────────────────────────────────────────────────────────
+
+// TestEnqueueMerge_FIFO verifies that queue_position increases monotonically
+// and that MergeQueueHead returns the row with the lowest queue_position.
+func TestEnqueueMerge_FIFO(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-fifo"
+	session := "myrepo@main"
+
+	// Enqueue PRs in reverse order to ensure FIFO is by queue_position, not PR number.
+	m3, err := d.EnqueueMerge(300, session, instanceID)
+	if err != nil {
+		t.Fatalf("EnqueueMerge(300): %v", err)
+	}
+	time.Sleep(time.Millisecond) // ensure distinct timestamps
+	m2, err := d.EnqueueMerge(200, session, instanceID)
+	if err != nil {
+		t.Fatalf("EnqueueMerge(200): %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	m1, err := d.EnqueueMerge(100, session, instanceID)
+	if err != nil {
+		t.Fatalf("EnqueueMerge(100): %v", err)
+	}
+
+	// queue_position must be strictly increasing in insertion order.
+	if !(m3.QueuePosition < m2.QueuePosition && m2.QueuePosition < m1.QueuePosition) {
+		t.Errorf("queue_positions not strictly increasing: m3=%d m2=%d m1=%d",
+			m3.QueuePosition, m2.QueuePosition, m1.QueuePosition)
+	}
+
+	// Head must be the first-inserted row (PR 300).
+	head, err := d.MergeQueueHead(instanceID)
+	if err != nil {
+		t.Fatalf("MergeQueueHead: %v", err)
+	}
+	if head == nil {
+		t.Fatal("MergeQueueHead: got nil, want PR 300")
+	}
+	if head.PR != 300 {
+		t.Errorf("MergeQueueHead.PR: got %d, want 300", head.PR)
+	}
+}
+
+// TestEnqueueMerge_Idempotent verifies that enqueueing the same PR twice returns
+// the existing row without inserting a duplicate.
+func TestEnqueueMerge_Idempotent(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-idem"
+	session := "myrepo@main"
+
+	m1, err := d.EnqueueMerge(42, session, instanceID)
+	if err != nil {
+		t.Fatalf("first EnqueueMerge: %v", err)
+	}
+
+	m2, err := d.EnqueueMerge(42, session, instanceID)
+	if err != nil {
+		t.Fatalf("second EnqueueMerge: %v", err)
+	}
+
+	// Must be the same row — identical PR, status, and queue_position.
+	if m1.QueuePosition != m2.QueuePosition {
+		t.Errorf("second enqueue returned different queue_position: got %d, want %d", m2.QueuePosition, m1.QueuePosition)
+	}
+	if m2.Status != "watching" {
+		t.Errorf("second enqueue status: got %q, want watching", m2.Status)
+	}
+
+	// Only one row should exist.
+	rows, err := d.MergeQueueForInstance(instanceID, session, "")
+	if err != nil {
+		t.Fatalf("MergeQueueForInstance: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("expected 1 row, got %d", len(rows))
+	}
+}
+
+// TestEnqueueMerge_TerminalRowReplaceable verifies that a terminal row can be
+// overwritten by a fresh EnqueueMerge.
+func TestEnqueueMerge_TerminalRowReplaceable(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-term"
+	session := "myrepo@main"
+
+	// Enqueue and then fail.
+	if _, err := d.EnqueueMerge(99, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(99, "failed", "CI failed"); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+
+	// Re-enqueue — should produce a fresh watching row.
+	m, err := d.EnqueueMerge(99, session, instanceID)
+	if err != nil {
+		t.Fatalf("second EnqueueMerge: %v", err)
+	}
+	if m.Status != "watching" {
+		t.Errorf("re-enqueued status: got %q, want watching", m.Status)
+	}
+	if m.Error != nil {
+		t.Errorf("re-enqueued error: got %v, want nil", m.Error)
+	}
+}
+
+// TestAbandonWatchingMerges verifies that AbandonWatchingMerges transitions all
+// watching rows for the given instanceID to abandoned.
+func TestAbandonWatchingMerges(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-abandon"
+	session := "myrepo@main"
+
+	// Enqueue two PRs.
+	if _, err := d.EnqueueMerge(1, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(1): %v", err)
+	}
+	if _, err := d.EnqueueMerge(2, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(2): %v", err)
+	}
+
+	// Abandon all watching rows.
+	if err := d.AbandonWatchingMerges(instanceID); err != nil {
+		t.Fatalf("AbandonWatchingMerges: %v", err)
+	}
+
+	// Both rows should now be abandoned.
+	for _, pr := range []int{1, 2} {
+		row, err := d.PendingMergeByPR(pr)
+		if err != nil {
+			t.Fatalf("PendingMergeByPR(%d): %v", pr, err)
+		}
+		if row == nil {
+			t.Fatalf("PendingMergeByPR(%d): got nil", pr)
+		}
+		if row.Status != "abandoned" {
+			t.Errorf("PR %d status: got %q, want abandoned", pr, row.Status)
+		}
+		if row.Error == nil || *row.Error != "coordinator session ended" {
+			t.Errorf("PR %d error: got %v, want 'coordinator session ended'", pr, row.Error)
+		}
+		if row.EndedAt == nil {
+			t.Errorf("PR %d ended_at: got nil, want set", pr)
+		}
+	}
+
+	// Head must now be nil.
+	head, err := d.MergeQueueHead(instanceID)
+	if err != nil {
+		t.Fatalf("MergeQueueHead after abandon: %v", err)
+	}
+	if head != nil {
+		t.Errorf("MergeQueueHead after abandon: got PR %d, want nil", head.PR)
+	}
+}
+
+// TestCancelMerge verifies that CancelMerge transitions a watching row to
+// cancelled and returns false for non-matching rows.
+func TestCancelMerge(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-cancel"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(55, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	// Cancel it.
+	cancelled, err := d.CancelMerge(55, instanceID)
+	if err != nil {
+		t.Fatalf("CancelMerge: %v", err)
+	}
+	if !cancelled {
+		t.Error("CancelMerge: returned false, want true")
+	}
+
+	row, err := d.PendingMergeByPR(55)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "cancelled" {
+		t.Errorf("status after cancel: got %q, want cancelled", row.Status)
+	}
+
+	// Cancelling again returns false (already terminal).
+	cancelled2, err := d.CancelMerge(55, instanceID)
+	if err != nil {
+		t.Fatalf("second CancelMerge: %v", err)
+	}
+	if cancelled2 {
+		t.Error("second CancelMerge: returned true, want false")
+	}
+
+	// Wrong instanceID returns false.
+	if _, err := d.EnqueueMerge(66, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(66): %v", err)
+	}
+	cancelled3, err := d.CancelMerge(66, "other-instance")
+	if err != nil {
+		t.Fatalf("CancelMerge wrong instance: %v", err)
+	}
+	if cancelled3 {
+		t.Error("CancelMerge with wrong instanceID: returned true, want false")
+	}
+}
+
+// TestMergeQueueHead_ScopedByInstanceID verifies that MergeQueueHead only
+// returns rows for the given instanceID.
+func TestMergeQueueHead_ScopedByInstanceID(t *testing.T) {
+	d := openTestDB(t)
+	session := "myrepo@main"
+
+	// Enqueue a PR under instance A.
+	if _, err := d.EnqueueMerge(10, session, "inst-A"); err != nil {
+		t.Fatalf("EnqueueMerge inst-A: %v", err)
+	}
+
+	// Head for inst-B must be nil.
+	head, err := d.MergeQueueHead("inst-B")
+	if err != nil {
+		t.Fatalf("MergeQueueHead inst-B: %v", err)
+	}
+	if head != nil {
+		t.Errorf("MergeQueueHead inst-B: got PR %d, want nil", head.PR)
+	}
+}
+
+// TestMergeQueueForInstance_Filters verifies the filter modes.
+func TestMergeQueueForInstance_Filters(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-filter"
+	session := "myrepo@main"
+
+	// Enqueue 3 PRs. Fail one, leave one watching, cancel one.
+	if _, err := d.EnqueueMerge(1, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(1): %v", err)
+	}
+	if _, err := d.EnqueueMerge(2, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(2): %v", err)
+	}
+	if _, err := d.EnqueueMerge(3, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(3): %v", err)
+	}
+
+	// Fail PR 2.
+	if err := d.TerminateMerge(2, "failed", "CI failed"); err != nil {
+		t.Fatalf("TerminateMerge(2): %v", err)
+	}
+	// Cancel PR 3.
+	if _, err := d.CancelMerge(3, instanceID); err != nil {
+		t.Fatalf("CancelMerge(3): %v", err)
+	}
+
+	// Default filter: only watching.
+	watching, err := d.MergeQueueForInstance(instanceID, session, "")
+	if err != nil {
+		t.Fatalf("MergeQueueForInstance(watching): %v", err)
+	}
+	if len(watching) != 1 || watching[0].PR != 1 {
+		t.Errorf("watching filter: got %d rows, want 1 (PR 1)", len(watching))
+	}
+
+	// Failed filter.
+	failed, err := d.MergeQueueForInstance(instanceID, session, "failed")
+	if err != nil {
+		t.Fatalf("MergeQueueForInstance(failed): %v", err)
+	}
+	if len(failed) != 1 || failed[0].PR != 2 {
+		t.Errorf("failed filter: got %d rows, want 1 (PR 2)", len(failed))
+	}
+
+	// All filter includes watching + failed + cancelled (not abandoned).
+	all, err := d.MergeQueueForInstance(instanceID, session, "all")
+	if err != nil {
+		t.Fatalf("MergeQueueForInstance(all): %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("all filter: got %d rows, want 3", len(all))
+	}
+}
+
+// TestMergeQueueForInstance_AbandonedFilter verifies that the abandoned filter
+// returns rows from a different instanceID for the same session_name.
+func TestMergeQueueForInstance_AbandonedFilter(t *testing.T) {
+	d := openTestDB(t)
+	session := "myrepo@main"
+	oldInstance := "inst-old"
+	newInstance := "inst-new"
+
+	// Enqueue under old instance and abandon.
+	if _, err := d.EnqueueMerge(77, session, oldInstance); err != nil {
+		t.Fatalf("EnqueueMerge(old): %v", err)
+	}
+	if err := d.AbandonWatchingMerges(oldInstance); err != nil {
+		t.Fatalf("AbandonWatchingMerges(old): %v", err)
+	}
+
+	// Enqueue under new instance.
+	if _, err := d.EnqueueMerge(88, session, newInstance); err != nil {
+		t.Fatalf("EnqueueMerge(new): %v", err)
+	}
+
+	// Abandoned filter from new instance perspective.
+	abandoned, err := d.MergeQueueForInstance(newInstance, session, "abandoned")
+	if err != nil {
+		t.Fatalf("MergeQueueForInstance(abandoned): %v", err)
+	}
+	if len(abandoned) != 1 || abandoned[0].PR != 77 {
+		t.Errorf("abandoned filter: got %d rows, want 1 (PR 77)", len(abandoned))
+	}
+
+	// Watching filter from new instance sees only PR 88.
+	watching, err := d.MergeQueueForInstance(newInstance, session, "")
+	if err != nil {
+		t.Fatalf("MergeQueueForInstance(watching): %v", err)
+	}
+	if len(watching) != 1 || watching[0].PR != 88 {
+		t.Errorf("watching after old abandon: got %d rows, want PR 88", len(watching))
+	}
+}
+
+// ── Watcher unit tests (using an in-process HTTP server to mock GitHub API) ────
+
+// mockGHServer mocks the `gh` binary by returning predetermined responses.
+// The watcher calls `gh pr view` and `gh pr merge` — we mock the CLI by
+// setting PRISM_TEST_GH_MOCK_RESPONSES (key=args, value=output+exitcode).
+// Because mocking actual OS executables in Go is complex, these tests use a
+// helper approach: we test the tick() logic by directly calling the DB state
+// machine through the watcher's exported-for-test tick path.
+
+// To test the watcher without mocking the OS, we build a fakeWatcher that
+// replaces the gh CLI calls with an injectable function.
+
+type fakeWatcher struct {
+	watcher  *Watcher
+	fetchFn  func(ctx context.Context, pr int) (*prInfo, error)
+	mergeFn  func(ctx context.Context, pr int) ([]byte, error)
+	updateFn func(ctx context.Context, pr int) error
+}
+
+// processHead is a test-friendly version of tick() that uses injected functions
+// instead of the real gh CLI.
+func (fw *fakeWatcher) processHead(ctx context.Context) {
+	head, err := fw.watcher.db.MergeQueueHead(fw.watcher.instanceID)
+	if err != nil || head == nil {
+		return
+	}
+	_ = fw.watcher.db.UpdateMergeLastChecked(head.PR)
+
+	prInfoVal, err := fw.fetchFn(ctx, head.PR)
+	if err != nil {
+		return
+	}
+
+	if prInfoVal.State == "CLOSED" && !prInfoVal.Merged {
+		fw.watcher.failAndNotify(head, "PR was closed without merging")
+		return
+	}
+	if prInfoVal.State == "MERGED" || prInfoVal.Merged {
+		fw.watcher.succeedAndNotify(ctx, head)
+		return
+	}
+
+	switch prInfoVal.MergeStateStatus {
+	case "CLEAN":
+		out, mergeErr := fw.mergeFn(ctx, head.PR)
+		if mergeErr == nil {
+			fw.watcher.succeedAndNotify(ctx, head)
+			return
+		}
+		combined := strings.ToLower(string(out) + mergeErr.Error())
+		if isBranchMovedRace(combined) {
+			return // transient
+		}
+		errMsg := fmt.Sprintf("gh pr merge failed: %s", strings.TrimSpace(string(out)))
+		fw.watcher.failAndNotify(head, errMsg)
+
+	case "BEHIND":
+		_ = fw.updateFn(ctx, head.PR)
+
+	case "DIRTY":
+		fw.watcher.failAndNotify(head, "merge conflicts")
+
+	case "BLOCKED":
+		if hasCIFailure(prInfoVal.StatusCheckRollup) {
+			fw.watcher.failAndNotify(head, "CI failed")
+		}
+
+	case "UNSTABLE", "UNKNOWN", "HAS_HOOKS", "DRAFT":
+		// stay watching
+
+	}
+}
+
+// newFakeWatcher builds a fakeWatcher for tests.
+func newFakeWatcher(
+	d *db.DB,
+	instanceID, sessionName string,
+	httpClient *http.Client,
+	fetchFn func(context.Context, int) (*prInfo, error),
+	mergeFn func(context.Context, int) ([]byte, error),
+	updateFn func(context.Context, int) error,
+) *fakeWatcher {
+	w := New(d, instanceID, sessionName, httpClient)
+	return &fakeWatcher{
+		watcher:  w,
+		fetchFn:  fetchFn,
+		mergeFn:  mergeFn,
+		updateFn: updateFn,
+	}
+}
+
+// capturingServer returns an httptest.Server that captures the last received
+// request body (for notification verification).
+type capturingServer struct {
+	*httptest.Server
+	lastBody []byte
+	called   int
+}
+
+func newCapturingServer(t *testing.T) *capturingServer {
+	t.Helper()
+	cs := &capturingServer{}
+	cs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := readAll(r.Body)
+		cs.lastBody = body
+		cs.called++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(cs.Server.Close)
+	return cs
+}
+
+func readAll(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
+	var buf []byte
+	tmp := make([]byte, 512)
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	return buf, nil
+}
+
+// TestWatcher_CLEANTransitionToMerged verifies that a CLEAN PR gets merged and
+// transitions to 'merged' with a notification.
+func TestWatcher_CLEANTransitionToMerged(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-clean"
+	session := "myrepo@main"
+
+	// Seed coordinator with a harness server.
+	srv := newCapturingServer(t)
+	// Parse port from srv.URL.
+	port := parsePort(t, srv.URL)
+	sid := "opencode-sid-clean"
+	seedCoordinator(t, d, session, instanceID, port, sid)
+
+	// Enqueue PR 100.
+	if _, err := d.EnqueueMerge(100, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			return nil, nil // merge succeeds
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	// Row must be merged.
+	row, err := d.PendingMergeByPR(100)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "merged" {
+		t.Errorf("status: got %q, want merged", row.Status)
+	}
+	if row.MergedAt == nil {
+		t.Error("merged_at: got nil, want set")
+	}
+	if row.EndedAt == nil {
+		t.Error("ended_at: got nil, want set")
+	}
+}
+
+// TestWatcher_BEHINDLeaveWatching verifies that a BEHIND PR triggers
+// update-branch and stays watching.
+func TestWatcher_BEHINDLeaveWatching(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-behind"
+	session := "myrepo@main"
+	updateCalled := false
+
+	if _, err := d.EnqueueMerge(200, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "BEHIND"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error {
+			updateCalled = true
+			return nil
+		},
+	)
+
+	fw.processHead(context.Background())
+
+	if !updateCalled {
+		t.Error("BEHIND: update-branch was not called")
+	}
+
+	// Row must still be watching.
+	row, err := d.PendingMergeByPR(200)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status after BEHIND: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_DIRTYTransitionToFailed verifies conflict detection.
+func TestWatcher_DIRTYTransitionToFailed(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-dirty"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	sid := "opencode-sid-dirty"
+	seedCoordinator(t, d, session, instanceID, port, sid)
+
+	if _, err := d.EnqueueMerge(300, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "DIRTY"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(300)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+	if row.Error == nil || *row.Error != "merge conflicts" {
+		t.Errorf("error: got %v, want 'merge conflicts'", row.Error)
+	}
+}
+
+// TestWatcher_BLOCKEDWithCIFailure transitions to failed.
+func TestWatcher_BLOCKEDWithCIFailure(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-ci"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-ci")
+
+	if _, err := d.EnqueueMerge(400, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "FAILURE"}},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(400)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+	if row.Error == nil || *row.Error != "CI failed" {
+		t.Errorf("error: got %v, want 'CI failed'", row.Error)
+	}
+}
+
+// TestWatcher_BLOCKEDWithoutCIFailureStaysWatching verifies that BLOCKED with
+// no failed checks does not terminate the row (CI still running).
+func TestWatcher_BLOCKEDWithoutCIFailureStaysWatching(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-noci"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(500, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "IN_PROGRESS"}},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(500)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching (no CI failure)", row.Status)
+	}
+}
+
+// TestWatcher_UNSTABLEStaysWatching verifies UNSTABLE leaves the row watching.
+func TestWatcher_UNSTABLEStaysWatching(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-unstable"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(600, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "UNSTABLE"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(600)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_UNKNOWNStaysWatching verifies UNKNOWN leaves the row watching.
+func TestWatcher_UNKNOWNStaysWatching(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-unknown"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(700, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "UNKNOWN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(700)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_BranchMovedRaceRetries verifies that when gh pr merge returns a
+// branch-moved error, the row stays watching (no notification).
+func TestWatcher_BranchMovedRaceRetries(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-race"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(800, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	notified := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notified = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			return []byte("already merged"), fmt.Errorf("exit status 1")
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	if notified {
+		t.Error("branch-moved race: notification was sent, want no notification")
+	}
+
+	row, err := d.PendingMergeByPR(800)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status after race: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_ClosedExternallyTransitionsToFailed verifies that a PR closed
+// without merging becomes failed.
+func TestWatcher_ClosedExternallyTransitionsToFailed(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-closed"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-closed")
+
+	if _, err := d.EnqueueMerge(900, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "CLOSED", Merged: false}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(900)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+}
+
+// TestWatcher_Cancellation verifies CancelMerge terminates a watching row.
+func TestWatcher_Cancellation(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-canc"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(111, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	cancelled, err := d.CancelMerge(111, instanceID)
+	if err != nil {
+		t.Fatalf("CancelMerge: %v", err)
+	}
+	if !cancelled {
+		t.Error("CancelMerge: returned false, want true")
+	}
+
+	// Head must now be nil (no more watching rows).
+	head, err := d.MergeQueueHead(instanceID)
+	if err != nil {
+		t.Fatalf("MergeQueueHead after cancel: %v", err)
+	}
+	if head != nil {
+		t.Errorf("MergeQueueHead after cancel: got PR %d, want nil", head.PR)
+	}
+}
+
+// TestWatcher_NextPRPromotedAfterTerminal verifies that after the head
+// terminates, the next PR becomes head on the next tick.
+func TestWatcher_NextPRPromotedAfterTerminal(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-promote"
+	session := "myrepo@main"
+
+	// Enqueue two PRs.
+	if _, err := d.EnqueueMerge(10, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(10): %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if _, err := d.EnqueueMerge(20, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge(20): %v", err)
+	}
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-promote")
+
+	// First tick: head is PR 10 — mark as DIRTY so it fails.
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "DIRTY"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+	fw.processHead(context.Background())
+
+	// Head should now be PR 20.
+	head, err := d.MergeQueueHead(instanceID)
+	if err != nil {
+		t.Fatalf("MergeQueueHead after first tick: %v", err)
+	}
+	if head == nil {
+		t.Fatal("MergeQueueHead: got nil, want PR 20")
+	}
+	if head.PR != 20 {
+		t.Errorf("MergeQueueHead after first tick: got PR %d, want PR 20", head.PR)
+	}
+}
+
+// TestWatcher_SecurityDenies verifies the isBranchMovedRace helper identifies
+// known race messages.
+func TestWatcher_SecurityDenies(t *testing.T) {
+	cases := []struct {
+		output  string
+		isRace  bool
+	}{
+		{"already merged\n", true},
+		{"pull request is not mergeable", true},
+		{"base branch was modified", true},
+		{"some other error", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isBranchMovedRace(tc.output)
+		if got != tc.isRace {
+			t.Errorf("isBranchMovedRace(%q) = %v, want %v", tc.output, got, tc.isRace)
+		}
+	}
+}
+
+// TestMigration_V18ToV19_CreatesTable verifies that the v18→v19 migration
+// creates the pending_merges table with the expected schema.
+func TestMigration_V18ToV19_CreatesTable(t *testing.T) {
+	d := openTestDB(t)
+
+	// pending_merges table must exist.
+	var tname string
+	if err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='pending_merges'").Scan(&tname); err != nil {
+		t.Fatalf("pending_merges table not found after v18→v19 migration: %v", err)
+	}
+
+	// idx_pending_merges_status_instance must exist.
+	var iname string
+	if err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_pending_merges_status_instance'").Scan(&iname); err != nil {
+		t.Fatalf("idx_pending_merges_status_instance not found after v18→v19 migration: %v", err)
+	}
+}
+
+// TestMigration_V18ToV19_Idempotent verifies opening the same DB twice doesn't error.
+func TestMigration_V18ToV19_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "idem.db")
+
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	d1.Close()
+
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	defer d2.Close()
+
+	var version int
+	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 19 {
+		t.Errorf("schema_version after second open: got %d, want 19", version)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// parsePort extracts the TCP port from an httptest.Server URL.
+func parsePort(t *testing.T, rawURL string) int {
+	t.Helper()
+	// URL format: http://127.0.0.1:<port>
+	parts := strings.Split(rawURL, ":")
+	if len(parts) < 3 {
+		t.Fatalf("cannot parse port from URL %q", rawURL)
+	}
+	var port int
+	if _, err := fmt.Sscanf(parts[2], "%d", &port); err != nil {
+		t.Fatalf("cannot parse port from %q: %v", parts[2], err)
+	}
+	return port
+}
+
+// TestWatcher_NotificationBodyContainsPR verifies the notification body
+// sent to the coordinator contains the PR number.
+func TestWatcher_NotificationBodyContainsPR(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-notif"
+	session := "myrepo@main"
+
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = readAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-notif")
+
+	if _, err := d.EnqueueMerge(123, session, instanceID); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	if len(received) == 0 {
+		t.Fatal("no notification received by coordinator")
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(received, &body); err != nil {
+		t.Fatalf("unmarshal notification body: %v", err)
+	}
+
+	parts, ok := body["parts"].([]interface{})
+	if !ok || len(parts) == 0 {
+		t.Fatalf("notification body has no parts: %v", body)
+	}
+	part, _ := parts[0].(map[string]interface{})
+	text, _ := part["text"].(string)
+	if !strings.Contains(text, "PR #123") {
+		t.Errorf("notification text %q does not mention PR #123", text)
+	}
+	if !strings.Contains(text, "git pull") {
+		t.Errorf("notification text %q does not mention 'git pull'", text)
+	}
+
+	_ = os.Getenv // avoid unused import
+}

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -287,7 +287,7 @@ func TestMergeQueueForInstance_Filters(t *testing.T) {
 	instanceID := "inst-filter"
 	session := "myrepo@main"
 
-	// Enqueue 3 PRs. Fail one, leave one watching, cancel one.
+	// Enqueue 4 PRs. Fail one, leave one watching, cancel one, abandon one.
 	if _, err := d.EnqueueMerge(1, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(1): %v", err)
 	}
@@ -296,6 +296,9 @@ func TestMergeQueueForInstance_Filters(t *testing.T) {
 	}
 	if _, err := d.EnqueueMerge(3, session, instanceID, nil); err != nil {
 		t.Fatalf("EnqueueMerge(3): %v", err)
+	}
+	if _, err := d.EnqueueMerge(4, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge(4): %v", err)
 	}
 
 	// Fail PR 2.
@@ -306,14 +309,22 @@ func TestMergeQueueForInstance_Filters(t *testing.T) {
 	if _, err := d.CancelMerge(3, instanceID); err != nil {
 		t.Fatalf("CancelMerge(3): %v", err)
 	}
+	// Abandon PR 4 via AbandonWatchingMerges (simulates coordinator shutdown).
+	// First, mark PR 1 as merged so only PR 4 is still watching.
+	if err := d.TerminateMerge(1, "merged", ""); err != nil {
+		t.Fatalf("TerminateMerge(1,merged): %v", err)
+	}
+	if err := d.AbandonWatchingMerges(instanceID); err != nil {
+		t.Fatalf("AbandonWatchingMerges: %v", err)
+	}
 
-	// Default filter: only watching.
+	// Default filter: only watching — should be empty (PR 4 was abandoned).
 	watching, err := d.MergeQueueForInstance(instanceID, session, "")
 	if err != nil {
 		t.Fatalf("MergeQueueForInstance(watching): %v", err)
 	}
-	if len(watching) != 1 || watching[0].PR != 1 {
-		t.Errorf("watching filter: got %d rows, want 1 (PR 1)", len(watching))
+	if len(watching) != 0 {
+		t.Errorf("watching filter: got %d rows, want 0 (all terminated)", len(watching))
 	}
 
 	// Failed filter.
@@ -325,13 +336,24 @@ func TestMergeQueueForInstance_Filters(t *testing.T) {
 		t.Errorf("failed filter: got %d rows, want 1 (PR 2)", len(failed))
 	}
 
-	// All filter includes watching + failed + cancelled (not abandoned).
+	// All filter includes all terminal states including abandoned (per AC).
+	// merged(1) + failed(2) + cancelled(3) + abandoned(4) = 4 rows.
 	all, err := d.MergeQueueForInstance(instanceID, session, "all")
 	if err != nil {
 		t.Fatalf("MergeQueueForInstance(all): %v", err)
 	}
-	if len(all) != 3 {
-		t.Errorf("all filter: got %d rows, want 3", len(all))
+	if len(all) != 4 {
+		t.Errorf("all filter: got %d rows, want 4 (includes abandoned per AC)", len(all))
+	}
+	// Verify abandoned row is included in --all.
+	foundAbandoned := false
+	for _, m := range all {
+		if m.PR == 4 && m.Status == "abandoned" {
+			foundAbandoned = true
+		}
+	}
+	if !foundAbandoned {
+		t.Error("all filter: abandoned PR 4 not found — --all must include abandoned rows")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -45,6 +45,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/mergequeue"
 	session "github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -256,6 +257,11 @@ type Sidecar struct {
 	// seenUnknownCapReached is set to true when seenUnknown reaches seenUnknownCap.
 	// Prevents repeated "cap reached" log lines. Protected by s.mu.
 	seenUnknownCapReached bool
+
+	// mergeWatcherCancel cancels the merge-watcher goroutine context. Set in
+	// Run() when this is a coordinator session (AgentRole == "coordinator").
+	// Protected by mu; nil when no watcher is running.
+	mergeWatcherCancel context.CancelFunc
 }
 
 // New creates a Sidecar with the given configuration.
@@ -512,6 +518,28 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		}
 	}
 
+	// Start the merge-queue watcher for coordinator sessions. The watcher polls
+	// the pending_merges head on a 45s ticker and drives PRs through the merge
+	// lifecycle. It is started only when:
+	//   - AgentRole is "coordinator" (explicit), OR
+	//   - SessionName ends with "@main" (legacy heuristic).
+	// The watcher context is stored so Shutdown() can cancel it before the
+	// abandon-watching-rows SQL runs (preventing a race where the watcher fires
+	// a terminal transition after AbandonWatchingMerges clears the rows).
+	if s.cfg.AgentRole == "coordinator" || isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
+		if s.cfg.InstanceID != "" {
+			watcherCtx, watcherCancel := context.WithCancel(ctx)
+			s.mu.Lock()
+			s.mergeWatcherCancel = watcherCancel
+			s.mu.Unlock()
+			watcher := mergequeue.New(s.cfg.DB, s.cfg.InstanceID, s.cfg.SessionName, s.cfg.HTTPClient)
+			go watcher.Run(watcherCtx)
+			log.Printf("sidecar: merge-queue watcher started (instance=%s)", s.cfg.InstanceID)
+		} else {
+			log.Printf("sidecar: merge-queue watcher NOT started — no instance_id")
+		}
+	}
+
 	ch, err := s.harness.Subscribe(ctx)
 	if err != nil {
 		return fmt.Errorf("sidecar: connect to SSE stream: %w", err)
@@ -612,13 +640,34 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 // Shutdown writes the interrupted state if the session is not already in a
 // terminal state, cancels any pending idle timer, and stops/removes the
 // container (if running in container mode). Called on SIGINT/SIGTERM.
+//
+// For coordinator sessions, Shutdown also cancels the merge-queue watcher and
+// transitions all watching pending_merges rows to 'abandoned' so that the next
+// coordinator session starts clean.
 func (s *Sidecar) Shutdown() {
 	s.mu.Lock()
 	// Mark shutdown before releasing the lock so that Run()'s OnReady guard
 	// sees shuttingDown=true even if it races with Shutdown() (AC-16).
 	s.shuttingDown = true
 	ctr := s.container
+	watcherCancel := s.mergeWatcherCancel
+	s.mergeWatcherCancel = nil
 	s.mu.Unlock()
+
+	// Cancel the merge-queue watcher first (before the SQL below) to prevent
+	// a race where the watcher fires a state transition after the abandon SQL.
+	if watcherCancel != nil {
+		watcherCancel()
+	}
+
+	// Abandon all watching merge rows for this coordinator incarnation.
+	if s.cfg.InstanceID != "" {
+		if err := s.cfg.DB.AbandonWatchingMerges(s.cfg.InstanceID); err != nil {
+			log.Printf("sidecar: AbandonWatchingMerges: %v", err)
+		} else {
+			log.Printf("sidecar: watching merge rows abandoned (instance=%s)", s.cfg.InstanceID)
+		}
+	}
 
 	// Stop and remove the container before writing state — this ensures
 	// cleanup happens even if SIGTERM arrives during health-check (AC-16).
@@ -2000,6 +2049,7 @@ var highImpactPrefixes = []string{
 	"prism spawn",
 	"prism cleanup",
 	"prism prompt",
+	"prism merge",
 }
 
 // isHighImpactCommand reports whether cmd matches any high-impact prefix.


### PR DESCRIPTION
## Summary

- Adds a local serial merge queue to the prism coordinator sidecar: `prism merge <pr>` enqueues a PR; the sidecar drives it through CI/rebase/merge automatically and notifies the coordinator on each terminal outcome.
- Schema migration v16→v17 adds the `pending_merges` table with instance_id scoping, FIFO ordering, and full state machine (`watching`/`merged`/`failed`/`cancelled`/`abandoned`).
- Security: `prism merge` and `prism merge *` are denied in worker, container worker, review agent (container + host), and bwrap worker bash permission lists; allowed only for coordinator agents.

## Key components

- **`internal/mergequeue/watcher.go`** — 45s polling goroutine; handles `CLEAN`→merge, `BEHIND`→update-branch, `DIRTY`/`BLOCKED(CI fail)`→fail; branch-moved race leaves watching; bus notification on each terminal state.
- **`internal/db/db.go`** — migration v16→v17, `PendingMerge` type, `EnqueueMerge` (idempotent), `MergeQueueHead`, `TerminateMerge`, `AbandonWatchingMerges`, `CancelMerge`, `MergeQueueForInstance`.
- **`internal/sidecar/sidecar.go`** — starts watcher goroutine on coordinator init; shutdown cancels watcher and abandons watching rows.
- **`cmd/merge.go`** — `prism merge <pr>` with preflight validation and coordinator-only guard.
- **`cmd/merges.go`** — `prism merges list` (+ `--failed`/`--abandoned`/`--all`) and `prism merges cancel <pr>`.
- **`modules/programs/prism/opencode.nix`** — deny lists for `prism merge` / `prism merge *` in all non-coordinator agent types.

Closes #783