### PR TITLE
doc: teach coordinators about the prism merge queue (skill + coordinator agent)

### DIFF
--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -136,12 +136,26 @@ When a spawned agent opens a PR:
 
 ## Merge and cleanup
 
-Once the sense-check passes, merge the PR and sync main before cleaning up:
+Once the sense-check passes, enqueue the PR in the merge queue and continue with other work. The queue handles CI waits, rebases, and the merge itself; you act on the bus notification when the merge lands or fails.
 
-1. Wait for CI checks to finish before merging. An `IN_PROGRESS` status means come back later when the finish notification arrives — do not retry in a loop.
+1. `prism merge <number>` — enqueue. Returns within ~2 seconds. Continue with other coordinator work while the queue progresses.
+2. When a merge-queue notification arrives via the bus, action it as a high-priority todo (same handling as a worker finished-notification):
+   - **`PR #N merged...`** — `git pull` in @main, then `prism cleanup --yes --session <worker-session>`.
+   - **`PR #N has merge conflicts...`** — `prism prompt <worker-session>` to rebase and push, then `prism merge <number>` again.
+   - **`PR #N CI failed...`** — `prism prompt <worker-session>` to investigate and fix, then `prism merge <number>` again.
+   - **`PR #N was closed without merging...`** — typically nothing; the PR was closed deliberately.
+3. Use `prism merges` to inspect the current queue at any time.
+
+See the prism skill for the full notification table and the `prism merges` command surface.
+
+### Manual fallback
+
+If for any reason the queue is unavailable (e.g. you need to merge a PR that isn't enqueued, or the watcher has misbehaved), the manual flow remains available:
+
+1. Wait for CI to pass. `IN_PROGRESS` means come back later — do not retry in a loop.
 2. `gh pr merge <number> --squash` — if it fails because the branch is behind main, run `gh pr update-branch <number>` and retry. If that still doesn't resolve it, use `prism prompt <session>` to ask the worker to rebase and push.
-3. `git pull` to sync with the merged result.
-4. `prism cleanup --yes --session <name>` to remove the worktree, branch, and tmux session.
+3. `git pull`.
+4. `prism cleanup --yes --session <name>`.
 
 ---
 

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -206,8 +206,8 @@ When a queued PR reaches a terminal outcome, the watcher delivers a bus notifica
 
 | Outcome | Notification text |
 |---|---|
-| Merged (with archive path) | `PR #N merged. Archive: <archive_path>. Run \`git pull\` in @main and \`prism cleanup\` the worker session.` |
-| Merged (no archive path yet) | `PR #N merged. Run \`git pull\` in @main and \`prism cleanup\` the worker session.` |
+| Merged (with archive path) | ``PR #N merged. Archive: <archive_path>. Run `git pull` in @main and `prism cleanup` the worker session.`` |
+| Merged (no archive path yet) | ``PR #N merged. Run `git pull` in @main and `prism cleanup` the worker session.`` |
 | Merge conflicts | `PR #N has merge conflicts — worker rebase needed` |
 | CI failure | `PR #N CI failed — needs worker fix` |
 | Closed without merging | `PR #N was closed without merging — removed from queue` |

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -180,6 +180,57 @@ review to pass. If ANY returns `<verdict>FAIL</verdict>`, fix all blocking
 issues, push, and re-run all five. After 3 full cycles without convergence,
 stop and escalate — do not run a 4th cycle.
 
+## Merge queue (coordinators only)
+
+> **Coordinators only.** Worker agents, container worker agents, bwrap worker agents, and review agents all have `prism merge` and `prism merge *` denied in their bash deny lists. If you are not a coordinator agent, skip this section.
+
+The merge queue is a local serial FIFO queue running in the coordinator's sidecar process. The sidecar polls the head of the queue every 45 seconds; only one PR is in flight at a time. The watcher's lifetime equals the coordinator session's lifetime — there is no persistent daemon.
+
+A queued PR moves through states keyed off GitHub's `mergeStateStatus`: `watching` → `merged` / `failed` / `cancelled` / `abandoned`. See issue #783 for the full state machine.
+
+### Command surface
+
+| Command | Description |
+|---|---|
+| `prism merge <pr>` | Enqueue a PR. Returns within ~2 seconds. Idempotent — safe to call on an already-queued PR. |
+| `prism merges` | Show the queue scoped to the current coordinator session (alias for `prism merges list`). |
+| `prism merges list` | Same as above. |
+| `prism merges list --failed` | Show only failed entries. |
+| `prism merges list --abandoned` | Show entries left behind by a previous coordinator incarnation. |
+| `prism merges list --all` | Include terminal-state history (last 7 days). |
+| `prism merges cancel <pr>` | Remove a `watching` entry from the queue. |
+
+### Notification contract
+
+When a queued PR reaches a terminal outcome, the watcher delivers a bus notification to the coordinator session. The text is:
+
+| Outcome | Notification text |
+|---|---|
+| Merged (with archive path) | `PR #N merged. Archive: <archive_path>. Run \`git pull\` in @main and \`prism cleanup\` the worker session.` |
+| Merged (no archive path yet) | `PR #N merged. Run \`git pull\` in @main and \`prism cleanup\` the worker session.` |
+| Merge conflicts | `PR #N has merge conflicts — worker rebase needed` |
+| CI failure | `PR #N CI failed — needs worker fix` |
+| Closed without merging | `PR #N was closed without merging — removed from queue` |
+| Other merge failure | `PR #N merge failed: <error>` |
+| Coordinator session ended while watching | Row transitions to `abandoned` — surfaces via `prism merges list --abandoned` only; no live notification. |
+
+### Action table
+
+When a merge-queue notification arrives, treat it as high-priority (same as a worker finished-notification):
+
+| Notification | Action |
+|---|---|
+| `merged` | `git pull` in @main, then `prism cleanup --yes --session <worker-session>` |
+| `merge conflicts` | `prism prompt <worker-session>` asking it to rebase onto main and push; re-enqueue with `prism merge <pr>` after the worker finishes |
+| `CI failed` | `prism prompt <worker-session>` asking it to investigate the failed check, fix, and push; re-enqueue with `prism merge <pr>` |
+| `closed without merging` | Usually nothing — the PR was closed deliberately. Investigate if unexpected. |
+| `merge failed: <error>` | Read the error, decide whether to retry (`prism merge <pr>`) or escalate to the user. |
+| `abandoned` (via `--abandoned` listing) | A new coordinator decides whether to re-enqueue with `prism merge <pr>`. |
+
+### Why workers cannot invoke it
+
+Worker agents, container worker agents, bwrap worker agents, and review agents all have `prism merge` and `prism merge *` in their bash deny lists. Only coordinator agents have it allowed. This is by security design: only coordinators arbitrate merge order. Do not attempt to work around the deny list.
+
 ## Example: reviewing a PR (manual spawn)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `## Merge queue (coordinators only)` to the prism skill (`SKILL.md`), placed between `## Running code review` and `## Example: reviewing a PR (manual spawn)`. Covers command surface, verbatim notification strings, action table, and the bash-deny security note.
- Rewrites `## Merge and cleanup` in the coordinator agent definition to present `prism merge` as the primary flow, with the manual `gh pr merge` path demoted to a `### Manual fallback` subsection.

## Example flow

`prism merge 1234` → wait for merge-queue notification → `git pull && prism cleanup --yes --session <worker-session>`

Closes #1019