### PR TITLE
prism: anchor host-API /review subprocess CWD to session worktree

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -3124,6 +3124,32 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		defer cancel()
 		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 
+		// Anchor the subprocess CWD to the calling session's worktree so that
+		// `prism review` can run `gh` and `git` commands against the correct
+		// repository. Without this, the subprocess inherits the sidecar's CWD
+		// (typically the tmux session-start directory), which may not be a git
+		// repository — producing the "not a git repository" warning and causing
+		// prism review to fall back to degraded per-agent git discovery.
+		//
+		// Lookup order:
+		//   1. DB: agent_status.worktree for this session.
+		//   2. Existence check: verify the directory is reachable on disk
+		//      (defence in depth — the path is from the trusted DB but the
+		//      worktree may have been cleaned up since the row was written).
+		//   3. Fallback: log and proceed with default CWD when the lookup
+		//      fails or the directory no longer exists, so that the existing
+		//      degraded-context path keeps working rather than hard-failing.
+		if status, dbErr := s.cfg.DB.CurrentStatus(s.cfg.SessionName); dbErr != nil {
+			log.Printf("sidecar: host-API /review: worktree lookup failed (DB error): %v — using default CWD", dbErr)
+		} else if status == nil || status.Worktree == "" {
+			log.Printf("sidecar: host-API /review: worktree not set for session %q — using default CWD", s.cfg.SessionName)
+		} else if _, statErr := os.Stat(status.Worktree); statErr != nil {
+			log.Printf("sidecar: host-API /review: worktree %q is not accessible: %v — using default CWD", status.Worktree, statErr)
+		} else {
+			cmd.Dir = status.Worktree
+			log.Printf("sidecar: host-API /review: subprocess CWD set to worktree %q", status.Worktree)
+		}
+
 		// Build the subprocess environment:
 		// PRISM_SESSION_NAME: so review.LookupParentSession() resolves the
 		// parent session correctly. The sidecar daemon is not inside tmux,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7131,6 +7131,118 @@ exit 1
 	}
 }
 
+// TestHostAPI_Review_CWDSetToWorktree verifies that the /review handler sets
+// cmd.Dir to the calling session's worktree path (from agent_status.worktree).
+// This anchors `prism review` to the correct git repository so that gh and git
+// commands succeed and PR metadata is injected into review-agent prompts
+// (rather than falling back to degraded per-agent discovery). See issue #1021.
+func TestHostAPI_Review_CWDSetToWorktree(t *testing.T) {
+	d := openTestDB(t)
+
+	// Create a real temp directory to use as the worktree.
+	// The handler validates that the directory exists (os.Stat), so we need a
+	// real path — not a placeholder string.
+	worktreeDir := t.TempDir()
+
+	// Seed the session with the temp dir as its worktree path.
+	if err := d.UpsertStatus("myrepo@feature", "myrepo", worktreeDir, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	cwdFile := filepath.Join(t.TempDir(), "captured-cwd")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub writes its own CWD to cwdFile so the test can inspect it.
+	stubScript := `#!/bin/sh
+pwd > ` + cwdFile + `
+echo "✓ review               passed"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "myrepo@feature",
+		Repo:            "myrepo",
+		Worktree:        worktreeDir,
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "worker",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "worker", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"1021"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedCWD, err := os.ReadFile(cwdFile)
+	if err != nil {
+		t.Fatalf("read captured CWD: %v", err)
+	}
+	got := strings.TrimSpace(string(capturedCWD))
+	if got != worktreeDir {
+		t.Errorf("subprocess CWD = %q, want %q (must be set to session worktree)", got, worktreeDir)
+	}
+}
+
+// TestHostAPI_Review_CWDFallbackWhenWorktreeMissing verifies that when the
+// calling session has a worktree path in the DB that no longer exists on disk,
+// the /review handler logs a warning and proceeds with the default CWD rather
+// than returning an error. The fallback path must still produce a valid
+// response (sentinel present), and must NOT set cmd.Dir to the missing path
+// (which would cause exec.Command to fail with "no such file or directory").
+// See issue #1021 (edge-case AC).
+func TestHostAPI_Review_CWDFallbackWhenWorktreeMissing(t *testing.T) {
+	d := openTestDB(t)
+
+	// Use a path that is guaranteed not to exist.
+	missingWorktree := filepath.Join(t.TempDir(), "nonexistent-worktree-dir")
+
+	// Seed the session with the non-existent worktree.
+	if err := d.UpsertStatus("myrepo@feature", "myrepo", missingWorktree, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Stub just exits 0. If cmd.Dir were set to the missing path, cmd.Start()
+	// would fail and the handler would return 500 before streaming begins —
+	// that would cause rr.Code == 500, which this test checks against.
+	stubScript := "#!/bin/sh\necho '✓ review               passed'\nexit 0\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "myrepo@feature",
+		Repo:            "myrepo",
+		Worktree:        missingWorktree,
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "worker",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "worker", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review", `{"pr_number":"1021"}`)
+	// Handler must succeed (fallback CWD) — NOT return 500.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fallback when worktree missing); body = %s",
+			rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, ReviewSentinelPassed) {
+		t.Errorf("body %q should contain ReviewSentinelPassed %q (fallback path must still complete)", body, ReviewSentinelPassed)
+	}
+}
+
 // ── buildNotifyPromptBody tests (issue #848) ────────────────────────────────
 
 // TestBuildNotifyPromptBody_OmitsAgentField verifies that the outgoing


### PR DESCRIPTION
## Summary

- When a worker session calls `prism review <pr>` via the host-API, the spawned `prism review` subprocess inherited the sidecar's CWD instead of the worker's worktree, causing `gh` and `git` to fail with "not a git repository" and falling back to degraded per-agent git discovery.
- Fix: in the `/review` handler, look up `agent_status.worktree` for the calling session and set `cmd.Dir` before invoking the subprocess. Includes an existence check (defence in depth) and a logged fallback when the lookup fails or the directory no longer exists.
- Unit tests added for both the happy path (CWD set to worktree) and the fallback path (missing worktree directory proceeds without error).

Closes #1021