### PR TITLE
docs: clarify that coordinators use prism pr, not prism review

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -364,7 +364,8 @@
           If no review-complete prompt arrives within 30 minutes, investigate with `prism checkin <session>~review-<N>-review-goal`.
           After 3 full review cycles without convergence, stop and escalate — do not run a 4th cycle.
           Invoke `@review-goal`, `@review-code`, `@review-security`, `@review-qa`, and `@review-context` as parallel Task calls (all five in a single response) as a fallback when `prism review` is unavailable.
-          **This fallback is for worker and coordinator agents only. Review agents must never follow it — they must never spawn further review sessions of any kind.**
+          **This fallback is for worker and spawned sessions only. Review agents must never follow it — they must never spawn further review sessions of any kind.**
+          **Coordinator agents must not call `prism review` or this fallback directly — use `prism pr <number> --prompt 'review this PR'` instead (see coordinator agent instructions).**
 
         ## Search Scope
 

--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -114,7 +114,25 @@ one represents a PR that may be blocking the next piece of work.
 
 ## Review gate
 
-When a spawned agent opens a PR:
+There are two distinct situations where review comes up. Handle them differently.
+
+### Case 1: User asks you to review a PR
+
+When the user directly asks you to review a PR (e.g. "can you review PR #42?"),
+**do not call `prism review` yourself**. Instead, spawn a session on the PR
+branch and let that session run the review:
+
+```bash
+prism pr <number> --prompt 'review this PR'
+```
+
+Wait for the finish notification from that spawned session before reporting back
+to the user. The spawned session will run `prism review`, handle any blocking
+issues, and summarise the findings. Your role is to relay the outcome.
+
+### Case 2: Worker has self-reviewed and handed off
+
+When a spawned agent opens a PR and announces completion:
 
 1. **Trust the worker review.** The worker runs `prism review <pr>` (async) —
    it spawns 5 review agents as a group and waits for the review-complete

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -146,6 +146,13 @@ prism spawn \
 
 ## Running code review
 
+> **Scope:** `prism review` and the Task-call fallback below are for **worker
+> agents and spawned sessions only**. Coordinator agents must never call
+> `prism review` directly. When a user asks a coordinator to review a PR, the
+> coordinator should use `prism pr <number> --prompt 'review this PR'` to spawn
+> a session on the PR branch — that spawned session then runs `prism review`
+> and reports back.
+
 Code review is done with `prism review <pr>`, which is **async**: it spawns 5
 review agents, registers a group, and returns immediately with an
 acknowledgement. Results are delivered to you via a follow-up `prism prompt`
@@ -165,6 +172,9 @@ prism checkin <session>~review-<N>-review-goal
 ```
 
 ### Fallback: Task-call subagents
+
+> **Scope:** This fallback is for **worker and spawned sessions only** — not for
+> coordinators. Coordinator agents must use `prism pr` as described above.
 
 If `prism review` is unavailable, invoke the five subagents **in parallel** —
 all five as Task tool calls in a single response:

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -371,12 +371,12 @@ func rejectIfCoordinator() error {
 	if session.IsCoordinatorSession(callerSession, d) {
 		return fmt.Errorf(`prism review: this command is for worker sessions only.
 
-Coordinators do not run review directly. To review a PR, delegate to a worker:
+Coordinators do not run review directly. To review a PR, spawn a session on the
+PR branch and let that session run the review:
 
-  prism spawn --pr <number> --prompt 'read the PR and linked issue, run prism review <number>, and report findings'
+  prism pr <number> --prompt 'review this PR'
 
-The worker will run the review agents as children of its own session, which is
-the correct parent for review attribution.
+Wait for the finish notification from that spawned session before reporting back.
 
 See: modules/programs/prism/opencode/agents/coordinator.md`)
 	}

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -413,8 +413,8 @@ func TestRejectIfCoordinator_BlocksCoordinatorSession(t *testing.T) {
 	if !strings.Contains(err.Error(), "worker sessions only") {
 		t.Errorf("rejectIfCoordinator error %q does not mention 'worker sessions only'", err.Error())
 	}
-	if !strings.Contains(err.Error(), "prism spawn") {
-		t.Errorf("rejectIfCoordinator error %q does not mention 'prism spawn'", err.Error())
+	if !strings.Contains(err.Error(), "prism pr") {
+		t.Errorf("rejectIfCoordinator error %q does not mention 'prism pr'", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Distinguishes two review cases in `coordinator.md`: (1) user asks coordinator to review a PR → use `prism pr <number> --prompt 'review this PR'` and wait for the finish notification; (2) worker has self-reviewed and handed off → trust the worker review and do a lightweight sense-check
- Adds scope callouts to `SKILL.md`'s "Running code review" section, clarifying that `prism review` and the Task-call fallback are for workers/spawned sessions only, and directing coordinators to use `prism pr` instead

Closes #1029