### PR TITLE
prism: mint instance_id on the fly in merge when session has none

### DIFF
--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -94,13 +94,20 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		}
 	}
 	if instanceID == "" {
+		// Guard: if we have no session identity at all, we cannot mint a
+		// meaningful instance_id — fail with a clear message rather than
+		// creating a garbage DB row keyed on an empty session name.
+		if callerSession == "" {
+			return fmt.Errorf("prism merge: cannot determine calling session — run from inside a prism tmux session or set PRISM_SESSION_NAME")
+		}
+
 		// Determine worktree and repo for the on-the-fly registration.
+		// Prefer the value already stored in agent_status (if the row exists
+		// with a non-empty worktree); fall back to the process's CWD.
 		worktree, _ := os.Getwd()
-		if callerSession != "" {
-			// Re-query: the status row may already exist with a worktree.
-			if existing, _ := d.CurrentStatus(callerSession); existing != nil && existing.Worktree != "" {
-				worktree = existing.Worktree
-			}
+		// Re-query: the status row may already exist with a worktree.
+		if existing, _ := d.CurrentStatus(callerSession); existing != nil && existing.Worktree != "" {
+			worktree = existing.Worktree
 		}
 		repo := deriveRepo(worktree)
 		if repo == "" {
@@ -114,6 +121,14 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		// Ensure the agent_status row exists before writing instance_id.
 		if upsertErr := d.UpsertStatus(callerSession, repo, worktree, "idle", nil, nil); upsertErr != nil {
 			return fmt.Errorf("prism merge: register session %q: %w", callerSession, upsertErr)
+		}
+		// Clear any stale ended_at so the session is visible as active in the
+		// dashboard and in ended_at IS NULL queries. This mirrors the
+		// tmux-session-start handler (event.go:ClearEnded) which does the same
+		// immediately after UpsertStatus, and covers the case where the session
+		// was previously ended but has been re-opened without prism switch.
+		if clearErr := d.ClearEnded(callerSession); clearErr != nil {
+			fmt.Fprintf(os.Stderr, "prism merge: clear ended for %q: %v\n", callerSession, clearErr)
 		}
 		if setErr := d.SetInstanceID(callerSession, minted); setErr != nil {
 			return fmt.Errorf("prism merge: set instance_id for session %q: %w", callerSession, setErr)

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -23,8 +23,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/session"
 )
@@ -77,7 +79,10 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		}
 	}
 
-	// Look up instance_id for the calling session.
+	// Look up instance_id for the calling session. When no instance_id is
+	// registered (e.g. a coordinator session opened outside of prism switch,
+	// which is the common case for @main sessions), mint one on the fly and
+	// write it to the DB so the rest of the merge flow proceeds normally.
 	var instanceID string
 	if callerSession != "" {
 		status, statusErr := d.CurrentStatus(callerSession)
@@ -89,7 +94,43 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		}
 	}
 	if instanceID == "" {
-		return fmt.Errorf("prism merge: cannot determine instance_id for session %q\nhint: ensure the coordinator session is registered in prism.db", callerSession)
+		// Determine worktree and repo for the on-the-fly registration.
+		worktree, _ := os.Getwd()
+		if callerSession != "" {
+			// Re-query: the status row may already exist with a worktree.
+			if existing, _ := d.CurrentStatus(callerSession); existing != nil && existing.Worktree != "" {
+				worktree = existing.Worktree
+			}
+		}
+		repo := deriveRepo(worktree)
+		if repo == "" {
+			// Not inside a bare-repo worktree — derive from the session name.
+			if idx := strings.Index(callerSession, "@"); idx > 0 {
+				repo = callerSession[:idx]
+			}
+		}
+
+		minted := uuid.New().String()
+		// Ensure the agent_status row exists before writing instance_id.
+		if upsertErr := d.UpsertStatus(callerSession, repo, worktree, "idle", nil, nil); upsertErr != nil {
+			return fmt.Errorf("prism merge: register session %q: %w", callerSession, upsertErr)
+		}
+		if setErr := d.SetInstanceID(callerSession, minted); setErr != nil {
+			return fmt.Errorf("prism merge: set instance_id for session %q: %w", callerSession, setErr)
+		}
+		// Insert a sessions row so the incarnation is fully registered
+		// (idempotent: INSERT OR IGNORE).
+		if insErr := d.InsertSession(db.Session{
+			InstanceID:  minted,
+			SessionName: callerSession,
+			Repo:        repo,
+			Worktree:    worktree,
+		}); insErr != nil {
+			// Non-fatal: log and continue. The instance_id is already written
+			// to agent_status, which is sufficient for EnqueueMerge.
+			fmt.Fprintf(os.Stderr, "prism merge: insert session row for %q: %v\n", callerSession, insErr)
+		}
+		instanceID = minted
 	}
 
 	sessionName := callerSession

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -145,12 +145,15 @@ func TestRunMerge_MintsInstanceIDWhenMissing(t *testing.T) {
 	t.Setenv("PRISM_SESSION_NAME", coordSession)
 	t.Setenv("TMUX", "")
 
-	// runMerge should fail at the gh preflight, not at instance_id.
+	// runMerge should fail at the gh preflight, not at the instance_id guard.
 	err = runMerge(mergeCmd, []string{"999"})
 	if err != nil {
 		// Acceptable: gh preflight will fail in CI/test environments.
 		if strings.Contains(err.Error(), "cannot determine instance_id") {
-			t.Fatalf("runMerge still fails with 'cannot determine instance_id' — fix did not take effect: %v", err)
+			t.Fatalf("runMerge still fails with old 'cannot determine instance_id' error — fix did not take effect: %v", err)
+		}
+		if strings.Contains(err.Error(), "cannot determine calling session") {
+			t.Fatalf("runMerge returned 'cannot determine calling session' — should only happen when callerSession is empty, not here: %v", err)
 		}
 		if strings.Contains(err.Error(), "register session") || strings.Contains(err.Error(), "set instance_id") {
 			t.Fatalf("runMerge failed at DB registration step: %v", err)

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -62,12 +62,12 @@ func TestRunMerge_WorkerSessionIsRejected(t *testing.T) {
 	}
 }
 
-// TestRunMerge_MainSessionHeuristicRejected verifies that a @main session
-// name (coordinator heuristic) that calls prism merge IS allowed (not
-// rejected). This tests the inverse: coordinators can enqueue.
-// We can't test a full enqueue without a real GitHub API, so we just verify
-// that the worker-rejection gate is NOT hit for a @main session, i.e. the
-// error (if any) is about missing instance_id, not about being a worker.
+// TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard verifies that a
+// @main session (coordinator heuristic) is allowed past the worker-rejection
+// gate. With the mint-on-the-fly fix, the call no longer fails at the
+// instance_id check — it mints one and proceeds to the gh preflight, which
+// fails in a test environment (no real GitHub API). The only assertion here is
+// that the error is NOT about "coordinator sessions only".
 func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
 	openMergeTestDB(t)
 
@@ -85,8 +85,8 @@ func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
 	t.Setenv("PRISM_SESSION_NAME", coordSession)
 	t.Setenv("TMUX", "")
 
-	// The call will fail — but NOT with "coordinator sessions only".
-	// It should fail at the instance_id check (no instance_id set).
+	// The call will fail at the gh preflight (no real GitHub API in tests),
+	// but NOT with "coordinator sessions only" or "cannot determine instance_id".
 	err = runMerge(mergeCmd, []string{"999"})
 	if err == nil {
 		// Surprising but not impossible in a very unusual test environment.
@@ -95,5 +95,94 @@ func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "coordinator sessions only") {
 		t.Errorf("runMerge error %q mentions 'coordinator sessions only' — coordinator should not be blocked", err.Error())
+	}
+	if strings.Contains(err.Error(), "cannot determine instance_id") {
+		t.Errorf("runMerge error %q mentions 'cannot determine instance_id' — should have been minted on the fly", err.Error())
+	}
+}
+
+// ── mint-on-the-fly instance_id ───────────────────────────────────────────────
+
+// TestRunMerge_MintsInstanceIDWhenMissing verifies that when a coordinator
+// session has no pre-existing instance_id in the DB, runMerge mints one and
+// writes it to both agent_status and the sessions table. The call proceeds
+// past the instance_id check and fails at the gh preflight (expected in a
+// test environment with no real GitHub API), not at the instance_id guard.
+//
+// This is the fix for issue #1031: prism merge failed with
+// "cannot determine instance_id" for @main coordinator sessions opened
+// without going through prism switch.
+func TestRunMerge_MintsInstanceIDWhenMissing(t *testing.T) {
+	openMergeTestDB(t)
+
+	// Seed a coordinator session WITHOUT an instance_id (simulates a
+	// @main session opened outside of prism switch → ensureAndSwitch).
+	const coordSession = "nixos-config@main"
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+		d.Close()
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	// Confirm no instance_id is set.
+	status, err := d.CurrentStatus(coordSession)
+	if err != nil {
+		d.Close()
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		d.Close()
+		t.Fatal("CurrentStatus: got nil, want status row")
+	}
+	if status.InstanceID != nil {
+		d.Close()
+		t.Fatalf("precondition: expected nil instance_id, got %q", *status.InstanceID)
+	}
+	d.Close()
+
+	t.Setenv("PRISM_SESSION_NAME", coordSession)
+	t.Setenv("TMUX", "")
+
+	// runMerge should fail at the gh preflight, not at instance_id.
+	err = runMerge(mergeCmd, []string{"999"})
+	if err != nil {
+		// Acceptable: gh preflight will fail in CI/test environments.
+		if strings.Contains(err.Error(), "cannot determine instance_id") {
+			t.Fatalf("runMerge still fails with 'cannot determine instance_id' — fix did not take effect: %v", err)
+		}
+		if strings.Contains(err.Error(), "register session") || strings.Contains(err.Error(), "set instance_id") {
+			t.Fatalf("runMerge failed at DB registration step: %v", err)
+		}
+		// Any other error (e.g. gh not found, PR 999 not open) is expected.
+		t.Logf("runMerge failed at preflight (expected in test env): %v", err)
+	}
+
+	// Verify the instance_id was minted and persisted to agent_status.
+	d2, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB for verify: %v", err)
+	}
+	defer d2.Close()
+
+	status2, err := d2.CurrentStatus(coordSession)
+	if err != nil {
+		t.Fatalf("CurrentStatus after runMerge: %v", err)
+	}
+	if status2 == nil {
+		t.Fatal("CurrentStatus after runMerge: got nil, want status row")
+	}
+	if status2.InstanceID == nil || *status2.InstanceID == "" {
+		t.Fatal("instance_id was not minted and written to agent_status")
+	}
+
+	// Verify a sessions row was inserted for the minted instance_id.
+	sess, err := d2.SessionByInstanceID(*status2.InstanceID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID: %v", err)
+	}
+	if sess == nil {
+		t.Errorf("no sessions row found for minted instance_id %q", *status2.InstanceID)
 	}
 }


### PR DESCRIPTION
## Summary

- `prism merge` failed for `@main` coordinator sessions with `cannot determine instance_id for session "nixos-config@main"` because those sessions are opened without going through `prism switch` → `ensureAndSwitch`, which is the only existing code path that mints and registers an `instance_id`.
- Fix: when `instance_id` is empty after the DB lookup in `runMerge`, mint a fresh UUID, call `UpsertStatus` + `SetInstanceID` (same as `ensureAndSwitch`), and insert a `sessions` row (idempotent `INSERT OR IGNORE`). The minted ID is then used for `EnqueueMerge` as normal. Strictly additive — no behaviour changes when `instance_id` is already set.
- New test `TestRunMerge_MintsInstanceIDWhenMissing` covers the no-prior-instance_id path, verifying both `agent_status.instance_id` and the `sessions` row are written.

Closes #1031