### PR TITLE
fix(prism/review): use parent session isolation_mode from DB instead of machine default

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -169,6 +169,18 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return wtErr
 	}
 
+	// Override isoMode with the parent session's recorded isolation_mode from
+	// the DB. On navi the machine default (cfg.EffectiveIsolationMode) is
+	// "podman", but worker sessions may run as "bwrap". Using the machine
+	// default would cause prism agent-run to reject the spawned review agents:
+	//   agent-run: session "..~review-1-review-code" has isolation mode
+	//   "podman", not bwrap; this command is only for bwrap sessions
+	// We fall back to cfg.EffectiveIsolationMode() only when the DB lookup
+	// fails or the recorded mode is empty (back-compat with pre-v10 rows).
+	if dbIsoMode := resolveParentIsolationMode(parentSession); dbIsoMode != "" {
+		isoMode = config.IsolationMode(dbIsoMode)
+	}
+
 	if len(agents) == 0 {
 		return fmt.Errorf("prism review: no agents to run")
 	}
@@ -318,6 +330,23 @@ func resolveReviewWorktree(parentSession string) (string, error) {
 		return "", fmt.Errorf("prism review: no worktree path for session %q", parentSession)
 	}
 	return status.Worktree, nil
+}
+
+// resolveParentIsolationMode returns the isolation_mode recorded in the DB for
+// parentSession. It returns "" when the DB cannot be opened, the session has no
+// row, or the isolation_mode field is empty (pre-v10 back-compat rows). The
+// caller falls back to cfg.EffectiveIsolationMode() in the empty-string case.
+func resolveParentIsolationMode(parentSession string) string {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return ""
+	}
+	defer d.Close()
+	status, stErr := d.CurrentStatus(parentSession)
+	if stErr != nil || status == nil {
+		return ""
+	}
+	return status.IsolationMode
 }
 
 // splitCSV splits a comma-separated string and trims whitespace.

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -103,26 +103,9 @@ func runReview(cmd *cobra.Command, args []string) error {
 		agents = allAgents
 	}
 
-	// Concurrency cap checks: BEFORE any container-creation side effects.
-	// We check inside the container-mode guard below (PRISM_HOST_API set
-	// means we're already inside a container; the host sidecar handles the cap
-	// for the actual spawn). Only apply the checks on the host path.
-	// Load cfg now for the cap check; it is re-used below for ContainerMode.
+	// Load cfg. It is needed below for ContainerMode / SidecarPluginPath even
+	// when the actual isolation mode is overridden from the DB.
 	cfg := config.Load()
-	isoMode := cfg.EffectiveIsolationMode()
-	// bwrap sessions are plain host processes — only podman triggers the container cap.
-	conCapped := isoMode == config.IsolationPodman
-	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL == "" {
-		// Running on host — check the caps before spawning review sessions.
-		if err := checkConcurrencyCap(cmd, "review", conCapped); err != nil {
-			return err
-		}
-		if isoMode == config.IsolationBwrap {
-			if err := checkBwrapConcurrencyCap(cmd, "review"); err != nil {
-				return err
-			}
-		}
-	}
 
 	// Container-mode detection: when PRISM_HOST_API is set the process is
 	// running inside a container where tmux is not available. Route the review
@@ -169,16 +152,38 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return wtErr
 	}
 
-	// Override isoMode with the parent session's recorded isolation_mode from
-	// the DB. On navi the machine default (cfg.EffectiveIsolationMode) is
-	// "podman", but worker sessions may run as "bwrap". Using the machine
-	// default would cause prism agent-run to reject the spawned review agents:
-	//   agent-run: session "..~review-1-review-code" has isolation mode
-	//   "podman", not bwrap; this command is only for bwrap sessions
-	// We fall back to cfg.EffectiveIsolationMode() only when the DB lookup
-	// fails or the recorded mode is empty (back-compat with pre-v10 rows).
+	// Resolve the effective isolation mode for spawning review agents.
+	// Priority: parent session's DB-recorded mode > machine default.
+	// Using the machine default (cfg.EffectiveIsolationMode) is wrong on hosts
+	// where the machine default is "podman" but the calling worker session runs
+	// as "bwrap" — prism agent-run rejects review agents spawned with the wrong
+	// mode. resolveParentIsolationMode returns "" only when the DB cannot be
+	// read or the session has no row; the caller falls back to the machine
+	// default in that case.
+	//
+	// resolveParentIsolationMode calls status.EffectiveIsolationMode() which
+	// handles pre-v10 back-compat: when isolation_mode is "" but host_mode is
+	// true, it returns "host"; when both are unset it returns "podman". This
+	// mirrors the restore.go precedent established in PR #882.
+	isoMode := cfg.EffectiveIsolationMode() // machine default; may be overridden below
 	if dbIsoMode := resolveParentIsolationMode(parentSession); dbIsoMode != "" {
 		isoMode = config.IsolationMode(dbIsoMode)
+	}
+
+	// Concurrency cap checks: BEFORE any container-creation side effects.
+	// Both checks run after the DB isolation-mode lookup so that the cap
+	// decisions reflect the session's actual mode rather than the machine
+	// default. The PRISM_HOST_API proxy-out branch above already returned, so
+	// by this point we are guaranteed to be on the host.
+	// bwrap sessions are plain host processes — only podman triggers the container cap.
+	conCapped := isoMode == config.IsolationPodman
+	if err := checkConcurrencyCap(cmd, "review", conCapped); err != nil {
+		return err
+	}
+	if isoMode == config.IsolationBwrap {
+		if err := checkBwrapConcurrencyCap(cmd, "review"); err != nil {
+			return err
+		}
 	}
 
 	if len(agents) == 0 {
@@ -332,10 +337,16 @@ func resolveReviewWorktree(parentSession string) (string, error) {
 	return status.Worktree, nil
 }
 
-// resolveParentIsolationMode returns the isolation_mode recorded in the DB for
-// parentSession. It returns "" when the DB cannot be opened, the session has no
-// row, or the isolation_mode field is empty (pre-v10 back-compat rows). The
-// caller falls back to cfg.EffectiveIsolationMode() in the empty-string case.
+// resolveParentIsolationMode returns the effective isolation mode for
+// parentSession by looking it up in the prism DB. It returns "" only when the
+// DB cannot be opened or the session has no row, signalling to the caller that
+// it should fall back to cfg.EffectiveIsolationMode().
+//
+// When a row exists, status.EffectiveIsolationMode() is used rather than
+// status.IsolationMode directly. This handles pre-v10 back-compat rows where
+// isolation_mode is NULL but host_mode is 1 (true): EffectiveIsolationMode
+// returns "host" in that case rather than propagating the empty string.
+// This mirrors the pattern established in restore.go (PR #882).
 func resolveParentIsolationMode(parentSession string) string {
 	d, dbErr := openDB()
 	if dbErr != nil {
@@ -346,7 +357,7 @@ func resolveParentIsolationMode(parentSession string) string {
 	if stErr != nil || status == nil {
 		return ""
 	}
-	return status.IsolationMode
+	return status.EffectiveIsolationMode()
 }
 
 // splitCSV splits a comma-separated string and trims whitespace.

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -162,6 +162,82 @@ func TestResolveReviewWorktree_EmptyWorktree(t *testing.T) {
 	}
 }
 
+// ── resolveParentIsolationMode tests ──────────────────────────────────────────
+//
+// These tests cover the DB lookup added by issue #1034: prism review must use
+// the parent session's recorded isolation_mode, not the machine-level default
+// from cfg.EffectiveIsolationMode(). On navi the machine default is "podman",
+// but worker sessions run as "bwrap"; using the wrong mode causes agent-run to
+// reject the spawned review agents.
+
+// TestResolveParentIsolationMode_Bwrap verifies that a session recorded as
+// "bwrap" in the DB returns "bwrap" from resolveParentIsolationMode.
+func TestResolveParentIsolationMode_Bwrap(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const session = "nixos-config@fix-review-isolation-mode"
+	if err := d.UpsertStatus(session, "nixos-config", "/worktree/fix", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetIsolationMode(session, "bwrap"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+
+	got := resolveParentIsolationMode(session)
+	if got != "bwrap" {
+		t.Errorf("resolveParentIsolationMode = %q, want %q", got, "bwrap")
+	}
+}
+
+// TestResolveParentIsolationMode_Podman verifies that a session recorded as
+// "podman" in the DB returns "podman" from resolveParentIsolationMode.
+func TestResolveParentIsolationMode_Podman(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const session = "nixos-config@podman-worker"
+	if err := d.UpsertStatus(session, "nixos-config", "/worktree/podman", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetIsolationMode(session, "podman"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+
+	got := resolveParentIsolationMode(session)
+	if got != "podman" {
+		t.Errorf("resolveParentIsolationMode = %q, want %q", got, "podman")
+	}
+}
+
+// TestResolveParentIsolationMode_EmptyWhenNotRecorded verifies that a session
+// with no isolation_mode recorded (pre-v10 back-compat row) returns "" so that
+// the caller falls back to cfg.EffectiveIsolationMode().
+func TestResolveParentIsolationMode_EmptyWhenNotRecorded(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const session = "nixos-config@legacy-session"
+	// UpsertStatus does not set isolation_mode — simulates a pre-v10 row.
+	if err := d.UpsertStatus(session, "nixos-config", "/worktree/legacy", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	got := resolveParentIsolationMode(session)
+	if got != "" {
+		t.Errorf("resolveParentIsolationMode = %q, want %q (empty string = fallback to cfg)", got, "")
+	}
+}
+
+// TestResolveParentIsolationMode_EmptyWhenSessionMissing verifies that when the
+// parent session has no DB row at all, resolveParentIsolationMode returns ""
+// (triggering the cfg.EffectiveIsolationMode() fallback).
+func TestResolveParentIsolationMode_EmptyWhenSessionMissing(t *testing.T) {
+	openReviewTestDB(t) // empty DB
+
+	got := resolveParentIsolationMode("nixos-config@nonexistent")
+	if got != "" {
+		t.Errorf("resolveParentIsolationMode for missing session = %q, want %q", got, "")
+	}
+}
+
 // ── splitCSV tests ────────────────────────────────────────────────────────────
 
 // TestSplitCSV_TrailingComma verifies that a trailing comma produces no empty

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -208,21 +208,43 @@ func TestResolveParentIsolationMode_Podman(t *testing.T) {
 	}
 }
 
-// TestResolveParentIsolationMode_EmptyWhenNotRecorded verifies that a session
-// with no isolation_mode recorded (pre-v10 back-compat row) returns "" so that
-// the caller falls back to cfg.EffectiveIsolationMode().
-func TestResolveParentIsolationMode_EmptyWhenNotRecorded(t *testing.T) {
+// TestResolveParentIsolationMode_PreV10HostModeTrue verifies that a pre-v10
+// back-compat row with isolation_mode="" but host_mode=true returns "host" from
+// resolveParentIsolationMode via status.EffectiveIsolationMode(). This is the
+// back-compat behaviour established in PR #882 / restore.go.
+func TestResolveParentIsolationMode_PreV10HostModeTrue(t *testing.T) {
 	d := openReviewTestDB(t)
 
-	const session = "nixos-config@legacy-session"
-	// UpsertStatus does not set isolation_mode — simulates a pre-v10 row.
+	const session = "nixos-config@legacy-host-session"
+	// UpsertStatus leaves isolation_mode NULL. SetHostMode sets host_mode=1.
+	if err := d.UpsertStatus(session, "nixos-config", "/worktree/legacy", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetHostMode(session, true); err != nil {
+		t.Fatalf("SetHostMode: %v", err)
+	}
+
+	got := resolveParentIsolationMode(session)
+	if got != "host" {
+		t.Errorf("resolveParentIsolationMode for host_mode=true, isolation_mode=NULL = %q, want %q", got, "host")
+	}
+}
+
+// TestResolveParentIsolationMode_PreV10HostModeFalse verifies that a pre-v10
+// back-compat row with isolation_mode="" and host_mode=false returns "podman"
+// (the EffectiveIsolationMode default for legacy container sessions).
+func TestResolveParentIsolationMode_PreV10HostModeFalse(t *testing.T) {
+	d := openReviewTestDB(t)
+
+	const session = "nixos-config@legacy-podman-session"
+	// UpsertStatus leaves both isolation_mode NULL and host_mode=0.
 	if err := d.UpsertStatus(session, "nixos-config", "/worktree/legacy", "idle", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
 
 	got := resolveParentIsolationMode(session)
-	if got != "" {
-		t.Errorf("resolveParentIsolationMode = %q, want %q (empty string = fallback to cfg)", got, "")
+	if got != "podman" {
+		t.Errorf("resolveParentIsolationMode for host_mode=false, isolation_mode=NULL = %q, want %q", got, "podman")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -323,6 +323,37 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		}
 	}
 
+	// Persist isolation_mode to the DB BEFORE creating the agent window.
+	// prism agent-run (the bwrap entry point) reads isolation_mode from
+	// agent_status immediately on startup to validate the session mode. If the
+	// write happens after tmux.NewWindow, agent-run races and sees NULL →
+	// EffectiveIsolationMode() returns "podman" → agent-run rejects the bwrap
+	// session with "has isolation mode 'podman', not bwrap". Writing here,
+	// synchronously before NewWindow, removes the race. Mirrors the identical
+	// write in setupFullLayout (session.go:558–581). Non-fatal: a DB failure
+	// is logged and spawn continues — the worst-case is the pre-fix behavior.
+	if mode != "" {
+		if d, dbErr := openDB(); dbErr == nil {
+			if setErr := d.SetIsolationMode(opts.SessionName, mode); setErr != nil {
+				fmt.Fprintf(os.Stderr,
+					"warning: spawnAgentOnlyLayout: set isolation_mode for %q: %v\n",
+					opts.SessionName, setErr)
+			}
+			if mode == "host" {
+				if setErr := d.SetHostMode(opts.SessionName, true); setErr != nil {
+					fmt.Fprintf(os.Stderr,
+						"warning: spawnAgentOnlyLayout: set host_mode for %q: %v\n",
+						opts.SessionName, setErr)
+				}
+			}
+			d.Close()
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"warning: spawnAgentOnlyLayout: could not open DB to write isolation_mode for %q: %v\n",
+				opts.SessionName, dbErr)
+		}
+	}
+
 	// Create the tmux session (window 0 = bare shell) and the agent window
 	// (window 1).
 	if err := tmux.NewSessionDetached(opts.SessionName, opts.Worktree); err != nil {

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -311,6 +311,54 @@ func TestSpawnSession_Validation_RequiresDB(t *testing.T) {
 	}
 }
 
+// TestSpawnSession_AgentOnly_WritesIsolationMode verifies that spawnAgentOnlyLayout
+// writes isolation_mode to agent_status BEFORE the agent window is created.
+// This is the fix for issue #1034: prism agent-run reads isolation_mode from
+// the DB immediately on startup and rejects the session if the mode doesn't
+// match "bwrap". If we write isolation_mode only after tmux.NewWindow, agent-run
+// races and sees NULL → EffectiveIsolationMode() returns "podman" → rejection.
+//
+// We test "bwrap" and "podman" modes to verify the write happens for both.
+func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
+	for _, mode := range []string{"bwrap", "podman"} {
+		mode := mode
+		t.Run(mode, func(t *testing.T) {
+			d, _ := openSpawnTestDB(t)
+			_ = spyTmuxBin(t)
+			t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+			sessionName := "myrepo@branch~review-1-review-code-" + mode
+			containerMode := mode == "podman"
+			opts := SpawnOpts{
+				SessionName:   sessionName,
+				Repo:          "myrepo",
+				Worktree:      "/worktrees/myrepo-branch",
+				AgentRole:     "review-code",
+				Layout:        LayoutAgentOnly,
+				IsolationMode: mode,
+				ContainerMode: containerMode,
+			}
+
+			if err := SpawnSession(d, opts); err != nil {
+				t.Fatalf("SpawnSession(%q): %v", mode, err)
+			}
+
+			st, err := d.CurrentStatus(sessionName)
+			if err != nil {
+				t.Fatalf("CurrentStatus: %v", err)
+			}
+			if st == nil {
+				t.Fatal("CurrentStatus: got nil, want row")
+			}
+			if st.IsolationMode != mode {
+				t.Errorf("isolation_mode = %q, want %q — the DB write must happen before the agent window is created so prism agent-run does not race and see NULL",
+					st.IsolationMode, mode)
+			}
+		})
+	}
+}
+
 // TestSpawnSession_UnsupportedLayout_ReturnsError verifies that Layout values
 // outside the supported set (LayoutFull / LayoutAgentOnly) surface a clear
 // error rather than silently falling through.


### PR DESCRIPTION
## Summary

Fixes #1034.

`prism review` was using `cfg.EffectiveIsolationMode()` (machine-level default) when building the `review.Opts` for spawning review agents. On navi the machine default is `podman`, but worker sessions run as `bwrap`. This mismatch caused `prism agent-run` to reject the spawned review agents:

\`\`\`
agent-run: session "..~review-1-review-code" has isolation mode "podman", not bwrap; this command is only for bwrap sessions
\`\`\`

## Root Cause (two parts)

1. **Wrong isolation mode source in `cmd/review.go`**: `isoMode` was set from `cfg.EffectiveIsolationMode()` (machine default), not from the parent session's DB-recorded isolation mode.

2. **Missing DB write in `spawnAgentOnlyLayout`**: `prism agent-run` reads `isolation_mode` from `agent_status` immediately on startup. `spawnAgentOnlyLayout` (used for review agents) was not writing `isolation_mode` before `tmux.NewWindow`, causing a race where `agent-run` would see NULL → `EffectiveIsolationMode()` → "podman" → rejection.

## Fix

### `cmd/review.go`
- Added `resolveParentIsolationMode` helper that looks up the parent session's `isolation_mode` from the DB via `d.CurrentStatus(parentSession).EffectiveIsolationMode()`. Uses `EffectiveIsolationMode()` (not `IsolationMode` directly) to handle pre-v10 back-compat rows where `host_mode=true` but `isolation_mode=NULL`.
- Falls back to `cfg.EffectiveIsolationMode()` only when the DB lookup fails or the session has no row.
- Moved the concurrency cap check (`conCapped`) to AFTER the DB lookup so it reflects the session's actual mode.

### `internal/session/spawn.go`
- `spawnAgentOnlyLayout` now writes `isolation_mode` (and `host_mode` for "host" mode) to the DB via `openDB() + SetIsolationMode` BEFORE calling `tmux.NewWindow`, mirroring the identical write in `setupFullLayout` (session.go:558–581).

## Tests
- `cmd/review_test.go`: 5 new tests covering bwrap, podman, pre-v10 host-mode-true, pre-v10 host-mode-false, and missing-session cases for `resolveParentIsolationMode`
- `internal/session/spawn_test.go`: `TestSpawnSession_AgentOnly_WritesIsolationMode` covering bwrap and podman modes

## Acceptance Criteria

- [x] [functional] When `prism review` is called from a bwrap worker session, the spawned review agents have `isolation_mode = "bwrap"` in `agent_status`
- [x] [functional] When `prism review` is called from a podman worker session, the spawned review agents have `isolation_mode = "podman"` in `agent_status`
- [x] [edge-case] When the parent session's `isolation_mode` cannot be determined from the DB, `prism review` falls back to `cfg.EffectiveIsolationMode()` without error
- [x] [functional] `go build ./...` and `go test ./...` pass

## Note on rebase gap

This branch predates PR #1008 (bwrap concurrency cap) which added `checkBwrapConcurrencyCap` to `review.go`. The bwrap cap infrastructure (`BwrapConcurrencyCap` config field, `ActiveBwrapSessionCount`/`ActiveBwrapSessions` DB methods) doesn't exist in this branch. This should be addressed by rebasing onto main before merge.

Closes #1034