### PR TITLE
prism: add reviewing state to prevent premature coordinator finish notification

### DIFF
--- a/modules/programs/prism/prism/internal/agent/agent.go
+++ b/modules/programs/prism/prism/internal/agent/agent.go
@@ -19,4 +19,12 @@ const (
 	StateIdle        AgentState = "idle"
 	StateInterrupted AgentState = "interrupted"
 	StateDeleted     AgentState = "deleted"
+	// StateReviewing is a non-terminal state entered by a worker session
+	// immediately after calling `prism review`. The worker stays in this state
+	// until the review-complete prompt is received and resolved:
+	//   - PASS verdict → transitions to finished (coordinator notified).
+	//   - FAIL verdict → transitions back to active (worker fixes issues).
+	// The coordinator must not receive a "has finished" notification while the
+	// worker is in the reviewing state.
+	StateReviewing AgentState = "reviewing"
 )

--- a/modules/programs/prism/prism/internal/agent/machine.go
+++ b/modules/programs/prism/prism/internal/agent/machine.go
@@ -14,6 +14,14 @@ import "fmt"
 //   - idle → error: container startup failure (WaitHealthy timeout or CreateSession
 //     failure) before the session became active. The sidecar writes error directly
 //     to avoid relying on the pane-died tmux hook for state cleanup.
+//   - active → reviewing: entered by a worker immediately after calling
+//     `prism review`. The worker remains here until the review-complete prompt
+//     arrives. The coordinator does NOT receive a "has finished" notification
+//     while the worker is in this state.
+//   - reviewing → finished: PASS verdict received; coordinator is notified now.
+//   - reviewing → active: FAIL verdict received; worker returns to active to
+//     fix blocking issues and re-run the review.
+//   - reviewing → interrupted: pane-died or SIGTERM while awaiting review results.
 //   - finished → interrupted: explicitly allowed for the pane-died hook when the
 //     pane exits with a non-zero code — a crash overrides a cleanly-written
 //     "finished" (see UpsertStatusInterruptedOverrideFinished).
@@ -41,6 +49,7 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 		StateInterrupted: true,
 		StateError:       true,
 		StateCompacting:  true,
+		StateReviewing:   true, // prism review called — awaiting review results
 		StateDeleted:     true,
 	},
 	StateWaiting: {
@@ -59,6 +68,15 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 		StateActive:      true,
 		StateInterrupted: true,
 		StateFinished:    true,
+		StateDeleted:     true,
+	},
+	// reviewing→finished: PASS verdict received; coordinator notified now.
+	// reviewing→active: FAIL verdict received; worker resumes to fix issues.
+	// reviewing→interrupted: pane-died or SIGTERM while awaiting results.
+	StateReviewing: {
+		StateFinished:    true,
+		StateActive:      true,
+		StateInterrupted: true,
 		StateDeleted:     true,
 	},
 	// finished→interrupted: non-zero pane exit overrides a clean finish.

--- a/modules/programs/prism/prism/internal/agent/machine_test.go
+++ b/modules/programs/prism/prism/internal/agent/machine_test.go
@@ -41,6 +41,13 @@ func TestTransition_ValidPairs(t *testing.T) {
 		{StateInterrupted, StateActive, "session resumed after interruption"},
 		{StateInterrupted, StateIdle, "tmux-session-start resets interrupted session on recreate"},
 
+		// Reviewing state (issue #1033)
+		{StateActive, StateReviewing, "prism review called — entering reviewing state"},
+		{StateReviewing, StateFinished, "PASS verdict received — coordinator notified"},
+		{StateReviewing, StateActive, "FAIL verdict received — worker resumes to fix issues"},
+		{StateReviewing, StateInterrupted, "pane-died or SIGTERM while awaiting review results"},
+		{StateReviewing, StateDeleted, "session.deleted while reviewing"},
+
 		// Deleted from any state
 		{StateActive, StateDeleted, "session.deleted while active"},
 		{StateWaiting, StateDeleted, "session.deleted while waiting"},
@@ -105,7 +112,7 @@ func TestTransition_DeletedIsTerminal(t *testing.T) {
 	// a state were somehow not a key in ValidTransitions.
 	allStates := []AgentState{
 		StateActive, StateWaiting, StateFinished, StateCompacting,
-		StateError, StateIdle, StateInterrupted, StateDeleted,
+		StateError, StateIdle, StateInterrupted, StateDeleted, StateReviewing,
 	}
 	for _, to := range allStates {
 		if to == StateDeleted {
@@ -134,7 +141,7 @@ func TestTransition_UnknownFromState(t *testing.T) {
 func TestValidTransitionsCompleteness(t *testing.T) {
 	allStates := []AgentState{
 		StateActive, StateWaiting, StateFinished, StateCompacting,
-		StateError, StateIdle, StateInterrupted, StateDeleted,
+		StateError, StateIdle, StateInterrupted, StateDeleted, StateReviewing,
 	}
 	for _, s := range allStates {
 		if _, ok := ValidTransitions[s]; !ok {

--- a/modules/programs/prism/prism/internal/dashboard/style.go
+++ b/modules/programs/prism/prism/internal/dashboard/style.go
@@ -57,6 +57,8 @@ func stateStyle(state string) lipgloss.Style {
 		color = ColorBlue
 	case agent.StateError:
 		color = ColorRed
+	case agent.StateReviewing:
+		color = ColorBlue
 	}
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(color))
 }
@@ -70,6 +72,7 @@ func stateLabel(state string) string {
 		agent.StateInterrupted: "interrupted",
 		agent.StateCompacting:  "compacting",
 		agent.StateError:       "error",
+		agent.StateReviewing:   "reviewing",
 		"":                     "idle",
 	}
 	if l, ok := labels[agent.AgentState(state)]; ok {

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -972,6 +973,27 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			"Review results will NOT be delivered automatically.\n"+
 			"Check agent progress with: prism checkin %s~review-%d-<agent>\n",
 			startErr, opts.ParentSession, round)
+	}
+
+	// Transition the worker session to "reviewing" so that:
+	//   1. The coordinator does not receive a premature "has finished" notification.
+	//   2. The dashboard and `prism list-sessions` display the worker as awaiting
+	//      review results rather than finished or idle.
+	// This write uses the still-open DB handle (d). The sidecar's upsertState
+	// path is intentionally bypassed here: the sidecar is running in the worker
+	// session and will respect the reviewing state when it checks currentDBState()
+	// before firing the coordinator notification.
+	//
+	// Non-fatal: if the update fails (e.g. session row not found) the monitor
+	// will still deliver results and the worker will still receive them — only
+	// the interim display state is affected.
+	if workerStatus, stErr := d.CurrentStatus(opts.WorkerSession); stErr == nil && workerStatus != nil {
+		if err := d.UpsertStatus(opts.WorkerSession, workerStatus.Repo, workerStatus.Worktree,
+			string(agent.StateReviewing), nil, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "[prism review] warning: could not set worker state to reviewing: %v\n", err)
+		}
+	} else if stErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism review] warning: could not look up worker session %q: %v\n", opts.WorkerSession, stErr)
 	}
 
 	// Build acknowledgement message.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -864,6 +864,12 @@ func (s *Sidecar) handleServerConnected() {
 		if s.lastState != agent.StateActive {
 			return
 		}
+		// Suppress if the DB state is reviewing — the worker is awaiting review
+		// results and must not be prematurely finished.
+		if s.currentDBState() == agent.StateReviewing {
+			log.Printf("sidecar: recovery timer suppressed (cause=reviewing — awaiting review-complete prompt)")
+			return
+		}
 		log.Printf("sidecar: recovery timer fired, writing finished (session.idle likely missed on reconnect)")
 		log.Printf("sidecar: transition -> finished (cause=recovery_timer)")
 		s.upsertState(agent.StateFinished, nil, nil)
@@ -941,8 +947,15 @@ func (s *Sidecar) handleSessionIdle() {
 		}
 
 		// Check current DB state: if interrupted or error, don't overwrite.
+		// If reviewing, suppress finished — the worker is awaiting review results;
+		// it will transition to finished naturally after the review-complete prompt
+		// is delivered and the worker resolves the results.
 		currentState := s.currentDBState()
 		if currentState == agent.StateInterrupted || currentState == agent.StateError {
+			return
+		}
+		if currentState == agent.StateReviewing {
+			log.Printf("sidecar: idle debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
 
@@ -1395,6 +1408,10 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 
 				currentState := s.currentDBState()
 				if currentState == agent.StateInterrupted || currentState == agent.StateError {
+					return
+				}
+				if currentState == agent.StateReviewing {
+					log.Printf("sidecar: idle debounce (root-agent message path) suppressed (cause=reviewing — awaiting review-complete prompt)")
 					return
 				}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -8655,3 +8655,148 @@ func TestStartupConnectTimeout_WorkerSessionNotifiesCoordinator(t *testing.T) {
 		t.Errorf("coordinator POST calls = %d, want >= 1", *promptCalls)
 	}
 }
+
+// TestReviewing_IdleDebounceSuppressed verifies that the idle debounce does NOT
+// transition a worker session to "finished" when the DB state is "reviewing".
+// This is the primary regression test for issue #1033: the worker called
+// `prism review` (which set the DB state to "reviewing"), went idle waiting for
+// the review-complete prompt, and must not emit a premature "has finished"
+// notification to the coordinator.
+func TestReviewing_IdleDebounceSuppressed(t *testing.T) {
+	d := openTestDB(t)
+
+	// Seed a live coordinator with an HTTP server so that if a notification
+	// fires unexpectedly we can detect it via bus_messages.
+	coordSID := "coord-sid-reviewing-test"
+	var notifyCount int
+	var notifyMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		// POST /session/<sid>/prompt_async — count unexpected delivery attempts.
+		notifyMu.Lock()
+		notifyCount++
+		notifyMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	// Create worker sidecar.
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+
+	// Set the worker state to "reviewing" (simulating what RunAsync does after
+	// spawning review agents).
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, string(agent.StateReviewing), nil, nil)
+
+	// Trigger idle debounce (opencode went idle after the `prism review` tool call returned).
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer")
+	}
+	timer.Fire()
+
+	// DB state must still be "reviewing" — the idle debounce must be suppressed.
+	if state := getState(t, d, worker.cfg.SessionName); state != string(agent.StateReviewing) {
+		t.Errorf("worker state = %q, want %q (idle debounce must be suppressed while reviewing)", state, agent.StateReviewing)
+	}
+
+	// Give a brief window for any async goroutines to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	// No bus messages must have been written to the coordinator.
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	if totalMsgs != 0 {
+		t.Errorf("worker in reviewing state must NOT send coordinator notification, but got %d bus message(s)", totalMsgs)
+	}
+
+	notifyMu.Lock()
+	nc := notifyCount
+	notifyMu.Unlock()
+	if nc != 0 {
+		t.Errorf("coordinator HTTP POST count = %d, want 0 (reviewing state must suppress notification)", nc)
+	}
+}
+
+// TestReviewing_TransitionsToFinishedAfterPromptDelivery verifies the full
+// lifecycle: worker in "reviewing" → review-complete prompt arrives → opencode
+// goes busy (active) → idle debounce fires → finished → coordinator notified.
+//
+// This simulates the happy path for issue #1033:
+//  1. Worker is in "reviewing" state (set by RunAsync).
+//  2. Monitor delivers review-complete prompt; opencode goes busy.
+//  3. session.status{busy} fires → sidecar writes "active" to DB.
+//  4. Worker processes results and goes idle.
+//  5. Idle debounce fires → DB state is "active" (not "reviewing") → finished.
+//  6. Coordinator receives the "has finished" notification.
+func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
+	d := openTestDB(t)
+
+	coordSID := "coord-sid-reviewing-pass"
+	srv, _ := makeSessionListServer(t, []string{coordSID}, http.StatusOK)
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+
+	// Set the worker state to "reviewing".
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, string(agent.StateReviewing), nil, nil)
+
+	// Step 1: idle debounce fires while in "reviewing" — must be suppressed.
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer := clk.LastTimer()
+	if timer == nil {
+		t.Fatal("expected idle timer from session.idle")
+	}
+	timer.Fire()
+
+	if state := getState(t, d, worker.cfg.SessionName); state != string(agent.StateReviewing) {
+		t.Errorf("after suppressed idle: state = %q, want %q", state, agent.StateReviewing)
+	}
+
+	// Step 2: review-complete prompt arrives; opencode goes busy.
+	// session.status{busy} overwrites "reviewing" with "active".
+	worker.HandleEvent(makeSSE("session.status", map[string]any{
+		"status": map[string]string{"type": "busy"},
+	}))
+	if state := getState(t, d, worker.cfg.SessionName); state != string(agent.StateActive) {
+		t.Errorf("after busy: state = %q, want %q", state, agent.StateActive)
+	}
+
+	// Step 3: worker processes results and goes idle again.
+	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	timer2 := clk.LastTimer()
+	if timer2 == nil {
+		t.Fatal("expected idle timer after second session.idle")
+	}
+	timer2.Fire()
+
+	// Now the DB state must be "finished".
+	if state := getState(t, d, worker.cfg.SessionName); state != string(agent.StateFinished) {
+		t.Errorf("after idle debounce: state = %q, want %q", state, agent.StateFinished)
+	}
+
+	// Coordinator must receive the "has finished" notification.
+	msg := waitForBusMessageDelivered(t, d, "test-repo@main")
+	if msg == nil {
+		t.Fatal("expected coordinator notification after reviewing→active→finished, got none")
+	}
+	wantText := "Agent test-repo@feature has finished its current task"
+	if msg.Text != wantText {
+		t.Errorf("notification text = %q, want %q", msg.Text, wantText)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the race condition described in #1033: a worker calls `prism review` (which is async — returns immediately after spawning 5 review agents), then the worker's opencode session goes idle. The idle debounce fires and transitions the session to `finished`, sending a premature "has finished" notification to the coordinator before the review-complete prompt has arrived.

## Changes

- **`agent/agent.go`**: Add `StateReviewing = "reviewing"` constant, with doc comment explaining the lifecycle.
- **`agent/machine.go`**: Add valid transitions — `active→reviewing` (prism review called), `reviewing→finished` (PASS verdict processed), `reviewing→active` (FAIL verdict; worker resumes), `reviewing→interrupted` (pane died while waiting).
- **`agent/machine_test.go`**: Tests for all new `reviewing` transitions and updated completeness/deleted-terminal checks.
- **`review/review.go`** (`RunAsync`): After spawning agents and starting the monitor, write `reviewing` to the worker session's DB state using the already-open DB handle.
- **`sidecar/sidecar.go`**: Three idle-debounce paths (standard, recovery timer, root-agent message) now check `currentDBState() == StateReviewing` and suppress the `finished` write + coordinator notification. When the monitor later delivers the review-complete prompt via HTTP, opencode goes busy → `session.status{busy}` fires → sidecar writes `active` (overwriting `reviewing`). The worker processes results and finishes normally from there.
- **`dashboard/style.go`**: `reviewing` displays in blue (same as `compacting`) and has its own label, so operators can identify sessions awaiting review results.
- **`sidecar/sidecar_test.go`**: Two new tests — `TestReviewing_IdleDebounceSuppressed` (idle debounce suppressed while reviewing, no coordinator notification) and `TestReviewing_TransitionsToFinishedAfterPromptDelivery` (full lifecycle: reviewing → active via busy event → finished → coordinator notified).

## How it works

1. Worker calls `prism review <pr>` → `RunAsync` spawns agents, starts monitor, sets worker DB state to `reviewing`.
2. Worker's opencode is idle (tool call returned) → `session.idle` fires → idle debounce timer starts → debounce fires → checks `currentDBState()` → sees `reviewing` → **suppressed**.
3. Monitor delivers review-complete prompt via HTTP POST to worker's opencode.
4. opencode goes busy → `session.status{busy}` → sidecar writes `active` to DB (overwriting `reviewing`).
5. Worker processes results, goes idle → idle debounce fires → `currentDBState()` is `active` → proceeds → writes `finished` → `notifyCoordinator()` fires. ✓

Closes #1033