### PR TITLE
fix(review): inject per-agent opencode.json in bwrap mode

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -272,16 +272,19 @@ func runReview(cmd *cobra.Command, args []string) error {
 		SizeBudget:     sizeBudgetFlag,
 	}
 
-	// Load profiles for container mode — passed through to review.RunAsync so
-	// each agent's sidecar receives its own per-agent hardened config blob.
-	// In container mode a missing or malformed profiles.json means the
-	// per-agent opencode.json cannot be mounted, which causes the container
-	// to fall back to the image default (build agent). Surface this as an
-	// explicit error rather than silently spawning broken review containers.
-	if effectiveContainerMode {
+	// Load profiles for any sandboxed mode (podman or bwrap) — passed through
+	// to review.RunAsync so each agent receives its own per-agent hardened
+	// opencode.json blob sourced from profiles.json via ContainerConfigForRole.
+	// In podman mode, a missing profiles.json means the per-agent opencode.json
+	// cannot be mounted, causing the container to fall back to the image default
+	// (build agent). In bwrap mode, a missing profiles.json means no per-agent
+	// opencode.json is written to disk, so the bwrap sandbox picks up the host's
+	// ~/.config/opencode/opencode.json (wrong agent identity). Surface this as
+	// an explicit error in both cases rather than silently spawning broken agents.
+	if isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap {
 		pf, pfErr := config.LoadProfiles()
 		if pfErr != nil {
-			return fmt.Errorf("prism review: container mode requires profiles.json but it could not be loaded: %w\nhint: ensure the system has been rebuilt with the prism NixOS module enabled", pfErr)
+			return fmt.Errorf("prism review: %s mode requires profiles.json but it could not be loaded: %w\nhint: ensure the system has been rebuilt with the prism NixOS module enabled", isoMode, pfErr)
 		}
 		opts.ProfilesFile = pf
 	}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -678,16 +679,35 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// Resolve the per-agent config blob. Each agent gets its own hardened
 		// opencode.json that declares only that one review agent.
 		//
-		// In container mode a missing or empty blob means the container falls
-		// back to the image default (build agent). ResolveAgentConfigContent
-		// surfaces this as an explicit error to prevent silent build-agent spawns.
-		agentConfigContent, configErr := ResolveAgentConfigContent(opts.ContainerMode, opts.ProfilesFile, ag.Name)
+		// In sandboxed mode (podman or bwrap) a missing or empty blob means the
+		// sandbox falls back to the host config (wrong agent identity).
+		// ResolveAgentConfigContent surfaces this as an explicit error to
+		// prevent silent wrong-agent spawns.
+		agentConfigContent, configErr := ResolveAgentConfigContent(opts.IsolationMode, opts.ProfilesFile, ag.Name)
 		if configErr != nil {
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
 				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
 			}
 			continue
+		}
+
+		// For bwrap sessions, write the opencode.json config file to disk now
+		// so it is present before the agent pane opens. The bwrap harness
+		// checks for file existence (os.Stat) rather than reading ConfigContent
+		// from the session state, so it must be written here at spawn time.
+		// This mirrors the pattern in cmd/spawn.go:334-340 for regular bwrap spawns.
+		// Podman mode does NOT need this write — the sidecar's Create() path
+		// already writes the file before the container starts.
+		if opts.IsolationMode == string(config.IsolationBwrap) && agentConfigContent != "" {
+			containerName := container.NameForSession(agentSession)
+			if writeErr := container.WriteOpencodeConfig(containerName, agentConfigContent); writeErr != nil {
+				spawnErr[i] = fmt.Errorf("review: write opencode config for bwrap agent %s: %w", ag.Name, writeErr)
+				if opts.OnProgress != nil {
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+				}
+				continue
+			}
 		}
 
 		// Spawn the per-agent session via the shared primitive. SpawnSession
@@ -892,13 +912,27 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		}
 		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree)
 
-		agentConfigContent, configErr := ResolveAgentConfigContent(opts.ContainerMode, opts.ProfilesFile, ag.Name)
+		agentConfigContent, configErr := ResolveAgentConfigContent(opts.IsolationMode, opts.ProfilesFile, ag.Name)
 		if configErr != nil {
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
 				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
 			}
 			continue
+		}
+
+		// For bwrap sessions, write the opencode.json config file to disk now
+		// so it is present before the agent pane opens. Mirrors the pattern in
+		// cmd/spawn.go:334-340 for regular bwrap spawns.
+		if opts.IsolationMode == string(config.IsolationBwrap) && agentConfigContent != "" {
+			containerName := container.NameForSession(agentSession)
+			if writeErr := container.WriteOpencodeConfig(containerName, agentConfigContent); writeErr != nil {
+				spawnErr[i] = fmt.Errorf("review: write opencode config for bwrap agent %s: %w", ag.Name, writeErr)
+				if opts.OnProgress != nil {
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+				}
+				continue
+			}
 		}
 
 		spawnOpts := session.SpawnOpts{
@@ -1001,13 +1035,13 @@ func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []st
 }
 
 // ResolveAgentConfigContent resolves the per-agent opencode.json config blob
-// for a single agent in container mode. It is factored out of Run so that it
-// can be unit-tested independently of the tmux/DB machinery.
+// for a single agent in sandboxed mode (podman or bwrap). It is factored out
+// of Run so that it can be unit-tested independently of the tmux/DB machinery.
 //
-// Returns ("", nil) in host mode (containerMode=false), because no config
-// injection is needed — opencode is launched directly on the host.
+// Returns ("", nil) in host mode (isolationMode == "host" or ""), because no
+// config injection is needed — opencode is launched directly on the host.
 //
-// In container mode (containerMode=true):
+// In sandboxed mode (isolationMode == "podman" or "bwrap"):
 //   - Returns an error if pf is nil (missing profiles file).
 //   - Returns an error if ContainerConfigForRole returns an error.
 //   - Returns an error if the resolved blob is empty (stale profiles.json).
@@ -1015,12 +1049,13 @@ func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []st
 //
 // Exported so that cmd/review_test.go (and integration tests) can exercise the
 // config-resolution path without needing a live DB or tmux session.
-func ResolveAgentConfigContent(containerMode bool, pf *config.ProfilesFile, agentName string) (string, error) {
-	if !containerMode {
+func ResolveAgentConfigContent(isolationMode string, pf *config.ProfilesFile, agentName string) (string, error) {
+	needsConfig := isolationMode == string(config.IsolationPodman) || isolationMode == string(config.IsolationBwrap)
+	if !needsConfig {
 		return "", nil
 	}
 	if pf == nil {
-		return "", fmt.Errorf("review: container mode requires a profiles file to resolve per-agent config for %q; got nil ProfilesFile", agentName)
+		return "", fmt.Errorf("review: %s mode requires a profiles file to resolve per-agent config for %q; got nil ProfilesFile", isolationMode, agentName)
 	}
 	blob, cfgErr := config.ContainerConfigForRole(pf, agentName)
 	if cfgErr != nil {

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1182,47 +1182,71 @@ func sampleReviewProfilesFile() *config.ProfilesFile {
 	}
 }
 
-// TestResolveAgentConfigContent_HostMode verifies that host mode (containerMode=false)
-// always returns ("", nil) regardless of ProfilesFile or agent name.
+// TestResolveAgentConfigContent_HostMode verifies that host mode (isolationMode="host"
+// or "") always returns ("", nil) regardless of ProfilesFile or agent name.
 // This is the regression guard for the host-mode path (#735 domain).
 func TestResolveAgentConfigContent_HostMode(t *testing.T) {
 	pf := sampleReviewProfilesFile()
-	for _, agentName := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context", "review", "worker"} {
-		blob, err := review.ResolveAgentConfigContent(false, pf, agentName)
-		if err != nil {
-			t.Errorf("host mode, agent %q: unexpected error: %v", agentName, err)
-		}
-		if blob != "" {
-			t.Errorf("host mode, agent %q: expected empty blob, got %q", agentName, blob)
+	for _, isolationMode := range []string{"host", ""} {
+		for _, agentName := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context", "review", "worker"} {
+			blob, err := review.ResolveAgentConfigContent(isolationMode, pf, agentName)
+			if err != nil {
+				t.Errorf("host mode %q, agent %q: unexpected error: %v", isolationMode, agentName, err)
+			}
+			if blob != "" {
+				t.Errorf("host mode %q, agent %q: expected empty blob, got %q", isolationMode, agentName, blob)
+			}
 		}
 	}
 	// nil ProfilesFile in host mode must also be safe.
-	blob, err := review.ResolveAgentConfigContent(false, nil, "review-goal")
+	blob, err := review.ResolveAgentConfigContent("host", nil, "review-goal")
 	if err != nil {
 		t.Errorf("host mode, nil pf: unexpected error: %v", err)
 	}
 	if blob != "" {
 		t.Errorf("host mode, nil pf: expected empty blob, got %q", blob)
 	}
+	blob, err = review.ResolveAgentConfigContent("", nil, "review-goal")
+	if err != nil {
+		t.Errorf("empty isolation mode, nil pf: unexpected error: %v", err)
+	}
+	if blob != "" {
+		t.Errorf("empty isolation mode, nil pf: expected empty blob, got %q", blob)
+	}
 }
 
 // TestResolveAgentConfigContent_ContainerMode_NilProfilesFile verifies that
-// container mode with a nil ProfilesFile returns an explicit error.
+// podman mode with a nil ProfilesFile returns an explicit error.
 // This is the primary regression test for issue #784 (silent build-agent spawn).
 func TestResolveAgentConfigContent_ContainerMode_NilProfilesFile(t *testing.T) {
 	for _, agentName := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
-		_, err := review.ResolveAgentConfigContent(true, nil, agentName)
+		_, err := review.ResolveAgentConfigContent("podman", nil, agentName)
 		if err == nil {
-			t.Errorf("container mode, nil pf, agent %q: expected error, got nil", agentName)
+			t.Errorf("podman mode, nil pf, agent %q: expected error, got nil", agentName)
 		}
 		if !findSubstring(err.Error(), "nil ProfilesFile") {
-			t.Errorf("container mode, nil pf, agent %q: error should mention 'nil ProfilesFile', got: %v", agentName, err)
+			t.Errorf("podman mode, nil pf, agent %q: error should mention 'nil ProfilesFile', got: %v", agentName, err)
+		}
+	}
+}
+
+// TestResolveAgentConfigContent_BwrapMode_NilProfilesFile verifies that
+// bwrap mode with a nil ProfilesFile returns an explicit error, matching
+// the podman-mode error path (AC: edge-case from issue #1037).
+func TestResolveAgentConfigContent_BwrapMode_NilProfilesFile(t *testing.T) {
+	for _, agentName := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
+		_, err := review.ResolveAgentConfigContent("bwrap", nil, agentName)
+		if err == nil {
+			t.Errorf("bwrap mode, nil pf, agent %q: expected error, got nil", agentName)
+		}
+		if !findSubstring(err.Error(), "nil ProfilesFile") {
+			t.Errorf("bwrap mode, nil pf, agent %q: error should mention 'nil ProfilesFile', got: %v", agentName, err)
 		}
 	}
 }
 
 // TestResolveAgentConfigContent_ContainerMode_EmptyBlob verifies that
-// container mode with a ProfilesFile that has empty review config blobs returns
+// podman mode with a ProfilesFile that has empty review config blobs returns
 // an explicit error instead of silently falling back to the build agent.
 // This is the root cause of issue #784.
 func TestResolveAgentConfigContent_ContainerMode_EmptyBlob(t *testing.T) {
@@ -1239,19 +1263,43 @@ func TestResolveAgentConfigContent_ContainerMode_EmptyBlob(t *testing.T) {
 		ContainerReviewContextConfig:  "",
 	}
 	for _, agentName := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
-		_, err := review.ResolveAgentConfigContent(true, stale, agentName)
+		_, err := review.ResolveAgentConfigContent("podman", stale, agentName)
 		if err == nil {
-			t.Errorf("container mode, empty blob, agent %q: expected error, got nil (would have silently spawned as build agent)", agentName)
+			t.Errorf("podman mode, empty blob, agent %q: expected error, got nil (would have silently spawned as build agent)", agentName)
 		}
 		if !findSubstring(err.Error(), "stale") {
-			t.Errorf("container mode, empty blob, agent %q: error should mention 'stale', got: %v", agentName, err)
+			t.Errorf("podman mode, empty blob, agent %q: error should mention 'stale', got: %v", agentName, err)
+		}
+	}
+}
+
+// TestResolveAgentConfigContent_BwrapMode_EmptyBlob verifies that bwrap mode
+// with a ProfilesFile that has empty review config blobs returns an explicit
+// error (AC: edge-case from issue #1037 — mirrors the podman error path).
+func TestResolveAgentConfigContent_BwrapMode_EmptyBlob(t *testing.T) {
+	stale := &config.ProfilesFile{
+		ContainerWorkerConfig:      `{"model":"worker"}`,
+		ContainerCoordinatorConfig: `{"model":"coordinator"}`,
+		ContainerReviewGoalConfig:     "",
+		ContainerReviewCodeConfig:     "",
+		ContainerReviewSecurityConfig: "",
+		ContainerReviewQaConfig:       "",
+		ContainerReviewContextConfig:  "",
+	}
+	for _, agentName := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
+		_, err := review.ResolveAgentConfigContent("bwrap", stale, agentName)
+		if err == nil {
+			t.Errorf("bwrap mode, empty blob, agent %q: expected error, got nil (would have fallen back to host config)", agentName)
+		}
+		if !findSubstring(err.Error(), "stale") {
+			t.Errorf("bwrap mode, empty blob, agent %q: error should mention 'stale', got: %v", agentName, err)
 		}
 	}
 }
 
 // TestResolveAgentConfigContent_ContainerMode_Success verifies that all five
-// per-agent review config blobs are resolved correctly when the ProfilesFile
-// is fully populated.
+// per-agent review config blobs are resolved correctly in podman mode when the
+// ProfilesFile is fully populated.
 func TestResolveAgentConfigContent_ContainerMode_Success(t *testing.T) {
 	pf := sampleReviewProfilesFile()
 	want := map[string]string{
@@ -1262,19 +1310,45 @@ func TestResolveAgentConfigContent_ContainerMode_Success(t *testing.T) {
 		"review-context":  pf.ContainerReviewContextConfig,
 	}
 	for agentName, wantBlob := range want {
-		blob, err := review.ResolveAgentConfigContent(true, pf, agentName)
+		blob, err := review.ResolveAgentConfigContent("podman", pf, agentName)
 		if err != nil {
-			t.Errorf("container mode, agent %q: unexpected error: %v", agentName, err)
+			t.Errorf("podman mode, agent %q: unexpected error: %v", agentName, err)
 			continue
 		}
 		if blob != wantBlob {
-			t.Errorf("container mode, agent %q: got blob %q, want %q", agentName, blob, wantBlob)
+			t.Errorf("podman mode, agent %q: got blob %q, want %q", agentName, blob, wantBlob)
+		}
+	}
+}
+
+// TestResolveAgentConfigContent_BwrapMode_Success verifies that all five
+// per-agent review config blobs are resolved correctly in bwrap mode when the
+// ProfilesFile is fully populated. This is the primary AC for issue #1037:
+// the per-agent opencode.json blob is sourced from profiles.json via
+// ContainerConfigForRole for bwrap mode, consistent with podman mode.
+func TestResolveAgentConfigContent_BwrapMode_Success(t *testing.T) {
+	pf := sampleReviewProfilesFile()
+	want := map[string]string{
+		"review-goal":     pf.ContainerReviewGoalConfig,
+		"review-code":     pf.ContainerReviewCodeConfig,
+		"review-security": pf.ContainerReviewSecurityConfig,
+		"review-qa":       pf.ContainerReviewQaConfig,
+		"review-context":  pf.ContainerReviewContextConfig,
+	}
+	for agentName, wantBlob := range want {
+		blob, err := review.ResolveAgentConfigContent("bwrap", pf, agentName)
+		if err != nil {
+			t.Errorf("bwrap mode, agent %q: unexpected error: %v", agentName, err)
+			continue
+		}
+		if blob != wantBlob {
+			t.Errorf("bwrap mode, agent %q: got blob %q, want %q", agentName, blob, wantBlob)
 		}
 	}
 }
 
 // TestResolveAgentConfigContent_ContainerMode_WorkerAndCoordinator verifies
-// that worker and coordinator roles in container mode return empty blob (they
+// that worker and coordinator roles in podman mode return empty blob (they
 // are not review agents and their blobs are not expected by this function —
 // they are handled by the spawn path, not the review path).
 // The function returns an empty-blob error for them, which prevents accidental
@@ -1284,9 +1358,19 @@ func TestResolveAgentConfigContent_ContainerMode_WorkerRole(t *testing.T) {
 	// Worker and coordinator are not review agents — ContainerConfigForRole
 	// returns their blobs, but they are not set in sampleReviewProfilesFile.
 	// Empty blob should produce an error.
-	_, err := review.ResolveAgentConfigContent(true, pf, "worker")
+	_, err := review.ResolveAgentConfigContent("podman", pf, "worker")
 	if err == nil {
-		t.Error("container mode, agent 'worker': expected error for empty blob, got nil")
+		t.Error("podman mode, agent 'worker': expected error for empty blob, got nil")
+	}
+}
+
+// TestResolveAgentConfigContent_BwrapMode_WorkerRole verifies that worker role
+// in bwrap mode also returns an empty-blob error (mirrors podman behaviour).
+func TestResolveAgentConfigContent_BwrapMode_WorkerRole(t *testing.T) {
+	pf := sampleReviewProfilesFile()
+	_, err := review.ResolveAgentConfigContent("bwrap", pf, "worker")
+	if err == nil {
+		t.Error("bwrap mode, agent 'worker': expected error for empty blob, got nil")
 	}
 }
 
@@ -1564,7 +1648,7 @@ func TestRun_ProgressCallback_SpawnFailure(t *testing.T) {
 		{Name: "review-goal", OpencodeName: "review-goal"},
 	}
 
-	// container mode with nil ProfilesFile triggers ResolveAgentConfigContent
+	// podman mode with nil ProfilesFile triggers ResolveAgentConfigContent
 	// to return a "nil ProfilesFile" error before any tmux session is created.
 	opts := review.Opts{
 		PRNumber:      "999",
@@ -1574,6 +1658,7 @@ func TestRun_ProgressCallback_SpawnFailure(t *testing.T) {
 		Timeout:       30 * time.Second,
 		DBPath:        dbPath,
 		ContainerMode: true,
+		IsolationMode: "podman",
 		ProfilesFile:  nil,
 	}
 
@@ -2669,6 +2754,7 @@ func TestRunAsync_ReturnsImmediately(t *testing.T) {
 		Timeout:       30 * time.Second,
 		DBPath:        dbPath,
 		ContainerMode: true,
+		IsolationMode: "podman",
 		ProfilesFile:  nil, // triggers immediate config-resolution failure → fast return
 	}
 
@@ -2718,6 +2804,7 @@ func TestRunAsync_AllSpawnFailReturnsError(t *testing.T) {
 		Timeout:       30 * time.Second,
 		DBPath:        dbPath,
 		ContainerMode: true,
+		IsolationMode: "podman",
 		ProfilesFile:  nil, // → all agents fail to spawn
 	}
 


### PR DESCRIPTION
## Summary

- `ResolveAgentConfigContent` previously short-circuited for all non-podman isolation modes, so bwrap review agents always got an empty config blob and inherited the host's `~/.config/opencode/opencode.json` (wrong agent identity).
- `cmd/review.go` only loaded `profiles.json` for podman mode, so `opts.ProfilesFile` was nil for bwrap, making blob resolution impossible.
- Even when a blob was resolved, it was never written to disk for bwrap agents — the bwrap harness reads from the temp file path via `os.Stat`, not from session state.

## Changes

- **`ResolveAgentConfigContent`**: changed signature from `containerMode bool` to `isolationMode string`. Both `"podman"` and `"bwrap"` now resolve a config blob from `profiles.json` via `ContainerConfigForRole`. Host mode (`""` or `"host"`) still returns `("", nil)`. Error paths (nil pf, empty blob) are identical for both sandboxed modes.
- **`cmd/review.go`**: load `ProfilesFile` when `isoMode == IsolationPodman || isoMode == IsolationBwrap`. Missing `profiles.json` returns a descriptive error for both modes.
- **`Run` / `RunAsync` spawn loops**: after resolving a non-empty `ConfigContent` for a bwrap agent, write it to disk via `container.WriteOpencodeConfig(containerName, agentConfigContent)` before `session.SpawnSession`. Mirrors `cmd/spawn.go:334–340`.
- **Tests**: added bwrap cases for `ResolveAgentConfigContent` (nil pf, empty blob, success, worker role); updated existing tests to pass `IsolationMode: "podman"` where they previously relied on `ContainerMode: true` triggering config resolution.

## Quality gates

- `go build ./...` ✓
- `go test ./...` ✓ (all packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✓

Closes #1037