### PR TITLE
fix(mergequeue): filter MergeQueueHead by session_name instead of instance_id

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -2908,18 +2908,25 @@ SELECT pr, session_name, instance_id, queue_position, status, title, error,
 	return m, nil
 }
 
-// MergeQueueHead returns the head of the merge queue for the given instanceID:
-// the watching row with the lowest queue_position. Returns nil when the queue
-// is empty.
-func (d *DB) MergeQueueHead(instanceID string) (*PendingMerge, error) {
+// MergeQueueHead returns the head of the merge queue for the given
+// sessionName: the watching row with the lowest queue_position. Returns nil
+// when the queue is empty.
+//
+// Filtering by session_name rather than instance_id ensures the watcher picks
+// up rows regardless of which instance_id was written at enqueue time (e.g.
+// when prism merge mints a fresh UUID on the fly). Incarnation isolation —
+// preventing stale rows from a previous sidecar from being re-processed — is
+// handled by AbandonWatchingMerges on sidecar shutdown, which sets rows to
+// 'abandoned' before the new sidecar starts.
+func (d *DB) MergeQueueHead(sessionName string) (*PendingMerge, error) {
 	const q = `
 SELECT pr, session_name, instance_id, queue_position, status, title, error,
        queued_at, last_checked_at, merged_at, ended_at
   FROM pending_merges
- WHERE instance_id = ? AND status = 'watching'
+ WHERE session_name = ? AND status = 'watching'
  ORDER BY queue_position ASC
  LIMIT 1`
-	row := d.conn.QueryRow(q, instanceID)
+	row := d.conn.QueryRow(q, sessionName)
 	m, err := scanPendingMerge(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -205,6 +205,7 @@ CREATE TABLE IF NOT EXISTS pending_merges (
   ended_at        INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_pending_merges_status_instance ON pending_merges(instance_id, status, queue_position);
+CREATE INDEX IF NOT EXISTS idx_pending_merges_status_session  ON pending_merges(session_name, status, queue_position);
 `
 
 // Open opens (or creates) the prism database at path.
@@ -273,6 +274,13 @@ CREATE INDEX IF NOT EXISTS idx_pending_merges_status_instance ON pending_merges(
 // block and the migration produce identical sqlite_master output on a fresh
 // database — fresh databases have the table from the schema block and skip the
 // CREATE silently.
+// v19→v20 adds idx_pending_merges_status_session ON
+// pending_merges(session_name, status, queue_position) to cover the
+// MergeQueueHead query, which was changed from filtering by instance_id to
+// filtering by session_name (#1039). The old index
+// idx_pending_merges_status_instance is preserved (it covers
+// AbandonWatchingMerges and CancelMerge). CREATE INDEX IF NOT EXISTS makes
+// this idempotent.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -315,12 +323,12 @@ func Open(path string) (*DB, error) {
 	}
 
 	// Set schema_version=11 if the table is empty. Fresh databases have all
-	// current columns from the schema above (including pending_merges). The
-	// v11→v12 through v18→v19 migrations run immediately below; on a fresh DB
-	// they are all effectively no-ops (indexes already exist, no rows to
-	// backfill, columns already named correctly, sessions and pending_merges
-	// tables already present from the declarative schema block), so starting
-	// at 11 is safe.
+	// current columns from the schema above (including pending_merges and the
+	// new idx_pending_merges_status_session index). The v11→v12 through
+	// v19→v20 migrations run immediately below; on a fresh DB they are all
+	// effectively no-ops (indexes already exist, no rows to backfill, columns
+	// already named correctly, sessions and pending_merges tables already
+	// present from the declarative schema block), so starting at 11 is safe.
 	var count int
 	if err := conn.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		conn.Close()
@@ -937,6 +945,25 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 19
+	}
+	if version == 19 {
+		// Migration v19 → v20: add idx_pending_merges_status_session on
+		// pending_merges(session_name, status, queue_position) to cover the
+		// MergeQueueHead query, which was changed to filter by session_name
+		// instead of instance_id (#1039). The old instance-keyed index is
+		// preserved — it is still used by AbandonWatchingMerges and
+		// CancelMerge. CREATE INDEX IF NOT EXISTS makes this idempotent.
+		steps := []string{
+			`CREATE INDEX IF NOT EXISTS idx_pending_merges_status_session ON pending_merges(session_name, status, queue_position)`,
+			`UPDATE schema_version SET version = 20`,
+		}
+		for _, s := range steps {
+			if _, err := conn.Exec(s); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v19→v20: %w", err)
+			}
+		}
+		version = 20
 	}
 
 	return &DB{conn: conn, path: path}, nil

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=19 (all migrations applied on Open).
+	// Verify schema_version=20 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version: got %d, want 20", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1594,8 +1594,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1660,8 +1660,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1730,8 +1730,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1825,8 +1825,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1918,8 +1918,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2502,8 +2502,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2591,8 +2591,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// isolation_mode column must exist (NULL for pre-migration rows).
@@ -4194,8 +4194,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// Check each row.
@@ -4622,8 +4622,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4897,8 +4897,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5118,8 +5118,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// sessions table must exist.
@@ -5272,8 +5272,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after second open: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after second open: got %d, want 20", version)
 	}
 }
 
@@ -5821,13 +5821,13 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must advance to 19 (v17→v18 backfill + v18→v19 pending_merges).
+	// Schema version must advance to 20 (v17→v18 backfill + v18→v19 pending_merges + v19→v20 index).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after migration: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after migration: got %d, want 20", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -5884,8 +5884,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after second open: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after second open: got %d, want 20", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -1,7 +1,7 @@
 // Package mergequeue implements the local serial merge queue for prism (#783).
 //
 // The Watcher is a goroutine started by the coordinator's sidecar on init.
-// It polls the head of the pending_merges queue for the sidecar's instance_id
+// It polls the head of the pending_merges queue for the sidecar's session_name
 // and drives PRs through the merge lifecycle using the GitHub CLI:
 //
 //   - CLEAN   → gh pr merge --squash
@@ -16,7 +16,8 @@
 // path, and prompts git pull + prism cleanup.
 //
 // Watcher lifetime equals coordinator session lifetime. On sidecar shutdown,
-// all watching rows for this instance_id are transitioned to 'abandoned'.
+// all watching rows for this instance_id are transitioned to 'abandoned' by
+// AbandonWatchingMerges, preventing a future sidecar from inheriting stale rows.
 package mergequeue
 
 import (
@@ -88,7 +89,7 @@ func (w *Watcher) tick(ctx context.Context) {
 		return
 	}
 
-	head, err := w.db.MergeQueueHead(w.instanceID)
+	head, err := w.db.MergeQueueHead(w.sessionName)
 	if err != nil {
 		log.Printf("[mergequeue] db error reading head: %v", err)
 		return

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1015,6 +1015,25 @@ func TestMigration_V18ToV19_CreatesTable(t *testing.T) {
 	}
 }
 
+// TestMigration_V19ToV20_CreatesSessionIndex verifies that the v19→v20
+// migration creates idx_pending_merges_status_session on
+// (session_name, status, queue_position) to cover MergeQueueHead.
+func TestMigration_V19ToV20_CreatesSessionIndex(t *testing.T) {
+	d := openTestDB(t)
+
+	// idx_pending_merges_status_session must exist after v19→v20.
+	var iname string
+	if err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_pending_merges_status_session'").Scan(&iname); err != nil {
+		t.Fatalf("idx_pending_merges_status_session not found after v19→v20 migration: %v", err)
+	}
+
+	// The old instance-keyed index must still exist (used by AbandonWatchingMerges / CancelMerge).
+	var iname2 string
+	if err := d.QueryRow("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_pending_merges_status_instance'").Scan(&iname2); err != nil {
+		t.Fatalf("idx_pending_merges_status_instance missing after v19→v20 — should be preserved: %v", err)
+	}
+}
+
 // TestMigration_V18ToV19_Idempotent verifies opening the same DB twice doesn't error.
 func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	dir := t.TempDir()
@@ -1036,8 +1055,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("schema_version after second open: got %d, want 19", version)
+	if version != 20 {
+		t.Errorf("schema_version after second open: got %d, want 20", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -85,7 +85,7 @@ func TestEnqueueMerge_FIFO(t *testing.T) {
 	}
 
 	// Head must be the first-inserted row (PR 300).
-	head, err := d.MergeQueueHead(instanceID)
+	head, err := d.MergeQueueHead(session)
 	if err != nil {
 		t.Fatalf("MergeQueueHead: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestAbandonWatchingMerges(t *testing.T) {
 	}
 
 	// Head must now be nil.
-	head, err := d.MergeQueueHead(instanceID)
+	head, err := d.MergeQueueHead(session)
 	if err != nil {
 		t.Fatalf("MergeQueueHead after abandon: %v", err)
 	}
@@ -260,25 +260,74 @@ func TestCancelMerge(t *testing.T) {
 	}
 }
 
-// TestMergeQueueHead_ScopedByInstanceID verifies that MergeQueueHead only
-// returns rows for the given instanceID.
-func TestMergeQueueHead_ScopedByInstanceID(t *testing.T) {
+// TestMergeQueueHead_ScopedBySessionName verifies that MergeQueueHead only
+// returns rows for the given session_name, not for a different session even
+// if that session has its own watching rows. This ensures coordinators don't
+// see each other's queue entries.
+func TestMergeQueueHead_ScopedBySessionName(t *testing.T) {
 	d := openTestDB(t)
-	session := "myrepo@main"
+	sessionA := "repo-a@main"
+	sessionB := "repo-b@main"
 
-	// Enqueue a PR under instance A.
-	if _, err := d.EnqueueMerge(10, session, "inst-A", nil); err != nil {
-		t.Fatalf("EnqueueMerge inst-A: %v", err)
+	// Enqueue a PR under session A (any instance_id).
+	if _, err := d.EnqueueMerge(10, sessionA, "inst-A", nil); err != nil {
+		t.Fatalf("EnqueueMerge sessionA: %v", err)
 	}
 
-	// Head for inst-B must be nil.
-	head, err := d.MergeQueueHead("inst-B")
+	// Head for session B must be nil (different coordinator).
+	head, err := d.MergeQueueHead(sessionB)
 	if err != nil {
-		t.Fatalf("MergeQueueHead inst-B: %v", err)
+		t.Fatalf("MergeQueueHead sessionB: %v", err)
 	}
 	if head != nil {
-		t.Errorf("MergeQueueHead inst-B: got PR %d, want nil", head.PR)
+		t.Errorf("MergeQueueHead sessionB: got PR %d, want nil", head.PR)
 	}
+
+	// Head for session A must return PR 10.
+	headA, err := d.MergeQueueHead(sessionA)
+	if err != nil {
+		t.Fatalf("MergeQueueHead sessionA: %v", err)
+	}
+	if headA == nil {
+		t.Fatal("MergeQueueHead sessionA: got nil, want PR 10")
+	}
+	if headA.PR != 10 {
+		t.Errorf("MergeQueueHead sessionA: got PR %d, want 10", headA.PR)
+	}
+}
+
+// TestMergeQueueHead_AcrossInstanceIDs verifies the core fix: MergeQueueHead
+// returns a row even when the enqueued instance_id differs from the watcher's
+// instance_id. This is the scenario triggered when prism merge mints a fresh
+// UUID that doesn't match the sidecar's startup instance_id.
+func TestMergeQueueHead_AcrossInstanceIDs(t *testing.T) {
+	d := openTestDB(t)
+	session := "myrepo@main"
+	mintedInstanceID := "freshly-minted-uuid"
+	watcherInstanceID := "sidecar-startup-uuid"
+
+	// prism merge enqueues with a freshly-minted instance_id.
+	if _, err := d.EnqueueMerge(42, session, mintedInstanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge with minted ID: %v", err)
+	}
+
+	// The watcher queries by session_name, not instance_id — must find the row.
+	head, err := d.MergeQueueHead(session)
+	if err != nil {
+		t.Fatalf("MergeQueueHead: %v", err)
+	}
+	if head == nil {
+		t.Fatal("MergeQueueHead: got nil — watcher cannot see row enqueued with different instance_id")
+	}
+	if head.PR != 42 {
+		t.Errorf("MergeQueueHead.PR: got %d, want 42", head.PR)
+	}
+	// The row still carries the minted instance_id (no mutation needed).
+	if head.InstanceID != mintedInstanceID {
+		t.Errorf("head.InstanceID: got %q, want %q", head.InstanceID, mintedInstanceID)
+	}
+	// The watcher's own instance_id is irrelevant for queue lookup.
+	_ = watcherInstanceID
 }
 
 // TestMergeQueueForInstance_Filters verifies the filter modes.
@@ -419,7 +468,7 @@ type fakeWatcher struct {
 // processHead is a test-friendly version of tick() that uses injected functions
 // instead of the real gh CLI.
 func (fw *fakeWatcher) processHead(ctx context.Context) {
-	head, err := fw.watcher.db.MergeQueueHead(fw.watcher.instanceID)
+	head, err := fw.watcher.db.MergeQueueHead(fw.watcher.sessionName)
 	if err != nil || head == nil {
 		return
 	}
@@ -875,7 +924,7 @@ func TestWatcher_Cancellation(t *testing.T) {
 	}
 
 	// Head must now be nil (no more watching rows).
-	head, err := d.MergeQueueHead(instanceID)
+	head, err := d.MergeQueueHead(session)
 	if err != nil {
 		t.Fatalf("MergeQueueHead after cancel: %v", err)
 	}
@@ -915,7 +964,7 @@ func TestWatcher_NextPRPromotedAfterTerminal(t *testing.T) {
 	fw.processHead(context.Background())
 
 	// Head should now be PR 20.
-	head, err := d.MergeQueueHead(instanceID)
+	head, err := d.MergeQueueHead(session)
 	if err != nil {
 		t.Fatalf("MergeQueueHead after first tick: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `MergeQueueHead` now filters by `session_name` instead of `instance_id`, so the watcher picks up queue rows regardless of which `instance_id` was written at enqueue time
- Updates the watcher to pass `w.sessionName` (instead of `w.instanceID`) to `MergeQueueHead`; `w.instanceID` is preserved for `AbandonWatchingMerges` on shutdown
- Adds `TestMergeQueueHead_AcrossInstanceIDs` directly asserting the fixed behaviour; renames the scoping test to reflect the new filter dimension

## Root cause

When `prism merge` hits the "mint on the fly" branch (`cmd/merge.go` lines 120-148), it generates a fresh UUID and writes it to `agent_status` and `pending_merges`. The sidecar's merge-queue watcher was already started with its own `instance_id`; `MergeQueueHead` filtered on `WHERE instance_id = ?` using that value — a mismatch that left watching rows in limbo forever.

## Fix (Option C from the issue)

`MergeQueueHead(sessionName string)` now queries `WHERE session_name = ? AND status = 'watching'`. A coordinator session always has exactly one watcher, so `session_name` is sufficient to scope the queue. Incarnation isolation (preventing stale rows from a previous sidecar) is already handled by `AbandonWatchingMerges(instanceID)` on sidecar shutdown — the `instance_id` filter in `MergeQueueHead` was redundant for that purpose.

## `cmd/merge.go` assessment

The mint-on-the-fly path is only reached when `agent_status.instance_id` IS NULL (the early-exit at line 92-94 handles the non-NULL case). Writing a freshly-minted UUID in that case is still useful for registering the coordinator's incarnation in the `sessions` table. No change needed.

Closes #1039