### PR TITLE
prism: foundation for sandbox-exec isolation mode (enum, platform guard, flag plumbing)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -1,13 +1,15 @@
 package cmd
 
-// prism agent-run — exec the bwrap sandbox for a bwrap-mode agent session.
+// prism agent-run — exec the sandbox for a bwrap or sandbox-exec mode agent session.
 //
 // This command is invoked by the tmux agent window when the resolved isolation
-// mode is "bwrap". It reconstructs the container.Manager from the session's DB
-// row and config, writes the same temp files that Manager.Create() writes for
-// podman sessions (SSH config, gitconfig, opencode.json), and then runs:
+// mode is "bwrap" or "sandbox-exec". It reconstructs the container.Manager
+// from the session's DB row and config, writes the same temp files that
+// Manager.Create() writes for podman sessions (SSH config, gitconfig,
+// opencode.json), and then runs:
 //
-//	bwrap <args...>
+//	bwrap <args...>       (bwrap mode)
+//	sandbox-exec <args...> (sandbox-exec mode — not yet implemented, see #1016)
 //
 // as a child process (not a direct exec). A PTY pair is created so that bwrap
 // and opencode see a real terminal on all three fds (stdin/stdout/stderr).
@@ -31,14 +33,17 @@ package cmd
 // terminal is closed, the kernel sends SIGHUP to agent-run, which forwards
 // it to bwrap and its children.
 //
-// On non-Linux platforms the command fails immediately with a clear error
-// because bubblewrap is Linux-only.
+// On non-Linux platforms the bwrap path fails immediately with a clear error
+// because bubblewrap is Linux-only. The sandbox-exec path requires macOS;
+// the platform guard in spawn.go intercepts sandbox-exec requests on non-Darwin
+// before agent-run is reached.
 //
 // Flags:
 //
 //	--session <name>   prism session name (e.g. "nixos-config@feature")
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -60,18 +65,18 @@ import (
 
 var agentRunCmd = &cobra.Command{
 	Use:   "agent-run",
-	Short: "Exec the bwrap sandbox for a bwrap-mode agent session (internal)",
-	Long: `Exec the bwrap sandbox for a bwrap-mode agent session.
+	Short: "Exec the sandbox for a bwrap or sandbox-exec mode agent session (internal)",
+	Long: `Exec the sandbox for a bwrap or sandbox-exec mode agent session.
 
 This command is an internal implementation detail invoked by the tmux agent
-window when the isolation mode is "bwrap". It is not intended for direct user
-invocation.
+window when the isolation mode is "bwrap" or "sandbox-exec". It is not intended
+for direct user invocation.
 
 It reconstructs the container config from the session's DB row, writes temp
-files (SSH config, gitconfig), builds the bwrap argument list, and runs bwrap
-as a child process. A PTY pair gives bwrap a real terminal so that opencode's
-Bubble Tea TUI can query TIOCGWINSZ correctly. The master side is tee'd to
-both the tmux pane and ~/.local/state/prism/run/<session>/agent-run.log.`,
+files (SSH config, gitconfig), builds the sandbox argument list, and runs the
+sandbox as a child process. A PTY pair gives the sandbox a real terminal so
+that opencode's Bubble Tea TUI can query TIOCGWINSZ correctly. The master side
+is tee'd to both the tmux pane and ~/.local/state/prism/run/<session>/agent-run.log.`,
 	RunE: runAgentRun,
 }
 
@@ -82,11 +87,6 @@ func init() {
 }
 
 func runAgentRun(cmd *cobra.Command, args []string) error {
-	// Fail fast on non-Linux: bubblewrap is Linux-only.
-	if runtime.GOOS != "linux" {
-		return fmt.Errorf("prism agent-run: bwrap isolation requires Linux; current platform is %s", runtime.GOOS)
-	}
-
 	sessionName, _ := cmd.Flags().GetString("session")
 
 	// Open the prism database to look up session state.
@@ -103,10 +103,20 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("agent-run: session %q not found in DB", sessionName)
 	}
 
-	// Verify this is actually a bwrap session.
+	// Dispatch based on the session's isolation mode.
 	isoMode := status.EffectiveIsolationMode()
-	if isoMode != "bwrap" {
-		return fmt.Errorf("agent-run: session %q has isolation mode %q, not bwrap; this command is only for bwrap sessions", sessionName, isoMode)
+	switch config.IsolationMode(isoMode) {
+	case config.IsolationBwrap:
+		// Fail fast on non-Linux: bubblewrap is Linux-only.
+		if runtime.GOOS != "linux" {
+			return fmt.Errorf("prism agent-run: bwrap isolation requires Linux; current platform is %s", runtime.GOOS)
+		}
+	case config.IsolationSandboxExec:
+		// The platform guard in spawn.go ensures this is only reached on Darwin.
+		// The full sandbox-exec implementation is tracked in issue #1016.
+		return errors.New("sandbox-exec mode: not yet implemented (issue #1016)")
+	default:
+		return fmt.Errorf("agent-run: session %q has isolation mode %q; this command is only for bwrap and sandbox-exec sessions", sessionName, isoMode)
 	}
 
 	// Load prism config for git identity and SSH key names.

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -760,7 +760,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 
 	// Validate isolation mode before doing any work.
 	switch statusIsolationMode {
-	case "host", "bwrap", "podman":
+	case "host", "bwrap", "sandbox-exec", "podman":
 		// OK — supported modes.
 	default:
 		fmt.Fprintf(os.Stderr, "[prism] archive: skipping session %q — unsupported isolation mode %q\n",

--- a/modules/programs/prism/prism/cmd/isolation_test.go
+++ b/modules/programs/prism/prism/cmd/isolation_test.go
@@ -31,6 +31,7 @@ func TestResolveIsolationMode_ValidValues(t *testing.T) {
 	}{
 		{"podman", config.IsolationPodman},
 		{"bwrap", config.IsolationBwrap},
+		{"sandbox-exec", config.IsolationSandboxExec},
 		{"host", config.IsolationHost},
 	}
 
@@ -38,6 +39,9 @@ func TestResolveIsolationMode_ValidValues(t *testing.T) {
 		t.Run(tc.flag, func(t *testing.T) {
 			if tc.flag == "bwrap" && runtime.GOOS != "linux" {
 				t.Skip("bwrap only available on Linux")
+			}
+			if tc.flag == "sandbox-exec" && runtime.GOOS != "darwin" {
+				t.Skip("sandbox-exec only available on macOS")
 			}
 			cmd := newSpawnCmdForTest()
 			if err := cmd.Flags().Set("isolation", tc.flag); err != nil {
@@ -70,8 +74,8 @@ func TestResolveIsolationMode_UnknownValue(t *testing.T) {
 	if !strings.Contains(err.Error(), "unknown isolation mode") {
 		t.Errorf("error %q does not contain 'unknown isolation mode'", err.Error())
 	}
-	// Error message must list valid values.
-	for _, m := range []string{"podman", "bwrap", "host"} {
+	// Error message must list all valid values, including sandbox-exec.
+	for _, m := range []string{"podman", "bwrap", "sandbox-exec", "host"} {
 		if !strings.Contains(err.Error(), m) {
 			t.Errorf("error %q does not mention valid mode %q", err.Error(), m)
 		}
@@ -157,6 +161,66 @@ func TestResolveIsolationMode_BwrapOnDarwin(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "requires Linux") {
 		t.Errorf("error %q does not mention 'requires Linux'", err.Error())
+	}
+}
+
+// TestResolveIsolationMode_SandboxExecOnLinux verifies that --isolation
+// sandbox-exec on non-Darwin (e.g. Linux) returns a clear error naming the
+// platform requirement.
+func TestResolveIsolationMode_SandboxExecOnLinux(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("this test validates non-Darwin platform rejection; skipping on macOS")
+	}
+	cmd := newSpawnCmdForTest()
+	if err := cmd.Flags().Set("isolation", "sandbox-exec"); err != nil {
+		t.Fatalf("set --isolation: %v", err)
+	}
+	cfg := config.Config{}
+	_, err := resolveIsolationMode(cmd, cfg)
+	if err == nil {
+		t.Fatal("expected error for sandbox-exec on non-Darwin, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires macOS") {
+		t.Errorf("error %q does not mention 'requires macOS'", err.Error())
+	}
+}
+
+// TestResolveIsolationMode_SandboxExecHostModeAlias verifies that
+// --isolation sandbox-exec combined with --host-mode returns the existing
+// mutual-exclusion error (same behaviour as any other isolation mode + host-mode).
+func TestResolveIsolationMode_SandboxExecHostModeAlias(t *testing.T) {
+	cmd := newSpawnCmdForTest()
+	if err := cmd.Flags().Set("isolation", "sandbox-exec"); err != nil {
+		t.Fatalf("set --isolation: %v", err)
+	}
+	if err := cmd.Flags().Set("host-mode", "true"); err != nil {
+		t.Fatalf("set --host-mode: %v", err)
+	}
+	cfg := config.Config{}
+	_, err := resolveIsolationMode(cmd, cfg)
+	if err == nil {
+		t.Fatal("expected mutual-exclusion error when both --isolation sandbox-exec and --host-mode are set")
+	}
+	if !strings.Contains(err.Error(), "--isolation and --host-mode") {
+		t.Errorf("error %q does not mention both flags", err.Error())
+	}
+}
+
+// TestResolveIsolationMode_FallbackFromConfig_SandboxExec verifies that when
+// no flags are set and config specifies sandbox-exec, the mode is used — but
+// only on Darwin (the platform guard rejects it elsewhere).
+func TestResolveIsolationMode_FallbackFromConfig_SandboxExec(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec from config is only valid on macOS; platform guard rejects it on other platforms")
+	}
+	cmd := newSpawnCmdForTest() // fresh command, no flags set
+	cfg := config.Config{DefaultIsolationMode: config.IsolationSandboxExec}
+	got, err := resolveIsolationMode(cmd, cfg)
+	if err != nil {
+		t.Fatalf("resolveIsolationMode: %v", err)
+	}
+	if got != config.IsolationSandboxExec {
+		t.Errorf("got %q, want %q", got, config.IsolationSandboxExec)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -101,14 +101,15 @@ var prCmd = &cobra.Command{
 			return fmt.Errorf("create worktree: %w", err)
 		}
 
-		// In container/bwrap mode, inject the role-specific opencode.json blob
-		// as the harness config env var so it takes precedence (level 6) over any
-		// project-level opencode.jsonc. This mirrors the pattern in spawn.go.
+		// In container/bwrap/sandbox-exec mode, inject the role-specific
+		// opencode.json blob as the harness config env var so it takes precedence
+		// (level 6) over any project-level opencode.jsonc. This mirrors the pattern
+		// in spawn.go.
 		//
-		// This block fires for both podman and bwrap isolation modes. Host-mode
-		// sessions skip it because they run opencode directly with the host's
-		// real ~/.config/opencode/opencode.json via xdg.configFile.
-		sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
+		// This block fires for podman, bwrap, and sandbox-exec isolation modes.
+		// Host-mode sessions skip it because they run opencode directly with the
+		// host's real ~/.config/opencode/opencode.json via xdg.configFile.
+		sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec
 		var configContent string
 		if sandboxed {
 			pf, pfErr := config.LoadProfiles()
@@ -143,7 +144,9 @@ var prCmd = &cobra.Command{
 		// Podman mode does NOT need this write — the sidecar's Create() path
 		// already writes the file before the container starts. Host mode does
 		// NOT need this write — it uses ~/.config/opencode/opencode.json
-		// directly via xdg.configFile.
+		// directly via xdg.configFile. sandbox-exec mode does NOT yet use this
+		// path — config delivery for sandbox-exec is deferred to #1016 (no
+		// bwrap-equivalent mount mechanism exists yet).
 		//
 		// IMPORTANT: the path key used here must match the one used by Manager
 		// internally. Manager.name = container.NameForSession(tmuxSessionName),

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -319,7 +319,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	//
 	// Host-mode sessions skip this entirely because they run opencode directly
 	// with the host's real ~/.config/opencode/opencode.json via xdg.configFile.
-	sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap
+	sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec
 	if sandboxed {
 		pf, pfErr := loadRestoreProfiles()
 		if pfErr != nil {

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -272,16 +272,17 @@ func runReview(cmd *cobra.Command, args []string) error {
 		SizeBudget:     sizeBudgetFlag,
 	}
 
-	// Load profiles for any sandboxed mode (podman or bwrap) — passed through
-	// to review.RunAsync so each agent receives its own per-agent hardened
-	// opencode.json blob sourced from profiles.json via ContainerConfigForRole.
-	// In podman mode, a missing profiles.json means the per-agent opencode.json
-	// cannot be mounted, causing the container to fall back to the image default
-	// (build agent). In bwrap mode, a missing profiles.json means no per-agent
-	// opencode.json is written to disk, so the bwrap sandbox picks up the host's
-	// ~/.config/opencode/opencode.json (wrong agent identity). Surface this as
-	// an explicit error in both cases rather than silently spawning broken agents.
-	if isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap {
+	// Load profiles for any sandboxed mode (podman, bwrap, or sandbox-exec) —
+	// passed through to review.RunAsync so each agent receives its own per-agent
+	// hardened opencode.json blob sourced from profiles.json via
+	// ContainerConfigForRole. In podman mode, a missing profiles.json means the
+	// per-agent opencode.json cannot be mounted, causing the container to fall
+	// back to the image default (build agent). In bwrap/sandbox-exec mode, a
+	// missing profiles.json means no per-agent opencode.json is written to disk,
+	// so the sandbox picks up the host's ~/.config/opencode/opencode.json (wrong
+	// agent identity). Surface this as an explicit error rather than silently
+	// spawning broken agents.
+	if isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec {
 		pf, pfErr := config.LoadProfiles()
 		if pfErr != nil {
 			return fmt.Errorf("prism review: %s mode requires profiles.json but it could not be loaded: %w\nhint: ensure the system has been rebuilt with the prism NixOS module enabled", isoMode, pfErr)

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -89,7 +89,7 @@ readiness signal. The bwrap sandbox is owned by the tmux pane.`,
 func init() {
 	sidecarCmd.Flags().String("session", "", "Prism session name (e.g. nixos-config@main)")
 	sidecarCmd.Flags().String("opencode-url", "", "Base URL of the opencode HTTP server")
-	sidecarCmd.Flags().String("isolation-mode", "", "Isolation mode: podman, bwrap, or host (default: derived from --container flag)")
+	sidecarCmd.Flags().String("isolation-mode", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: derived from --container flag)")
 	sidecarCmd.Flags().Bool("container", false, "Enable container mode (create/manage podman container) — deprecated, use --isolation-mode=podman")
 	sidecarCmd.Flags().String("agent-role", "", "Agent role: worker or coordinator (used in container mode; inferred from SSE events when empty)")
 	sidecarCmd.Flags().Int("port", 0, "Allocated host port (required in container/bwrap mode)")
@@ -130,12 +130,14 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// Derive the legacy bool for paths that still use it.
 	podmanMode := isolationMode == config.IsolationPodman
 	bwrapMode := isolationMode == config.IsolationBwrap
-	// needsHostAPI is true for podman and bwrap (the agent runs in a sandbox
-	// without direct access to host tmux, so the host-API socket is required).
-	needsHostAPI := podmanMode || bwrapMode
-	// useContainerHarness is true for podman and bwrap (opencode is pre-created
-	// with --prompt at launch in both cases).
-	useContainerHarness := podmanMode || bwrapMode
+	sandboxExecMode := isolationMode == config.IsolationSandboxExec
+	// needsHostAPI is true for podman, bwrap, and sandbox-exec (the agent runs
+	// in a sandbox without direct access to host tmux, so the host-API socket
+	// is required).
+	needsHostAPI := podmanMode || bwrapMode || sandboxExecMode
+	// useContainerHarness is true for podman, bwrap, and sandbox-exec
+	// (opencode is pre-created with --prompt at launch in all three cases).
+	useContainerHarness := podmanMode || bwrapMode || sandboxExecMode
 
 	// Derive repo and worktree from session name and environment.
 	// The session name format is "repo@branch". The worktree is expected
@@ -228,13 +230,14 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Build the host-API socket path for podman and bwrap modes. The agent
-	// runs in a sandbox without direct access to host tmux in both cases, so
-	// the host-API Unix socket is required for proxying prism CLI calls.
+	// Build the host-API socket path for podman, bwrap, and sandbox-exec modes.
+	// The agent runs in a sandbox without direct access to host tmux in all
+	// three cases, so the host-API Unix socket is required for proxying prism
+	// CLI calls.
 	var hostAPISockPath string
 	if needsHostAPI {
-		if port == 0 && bwrapMode {
-			return fmt.Errorf("sidecar: --port is required in bwrap mode")
+		if port == 0 && (bwrapMode || sandboxExecMode) {
+			return fmt.Errorf("sidecar: --port is required in bwrap/sandbox-exec mode")
 		}
 		sockPath, err := prismSession.SidecarHostAPIPath(sessionName)
 		if err != nil {
@@ -243,17 +246,17 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		hostAPISockPath = sockPath
 		// Wire the socket path into the container config so the container
 		// gets the socket mounted and PRISM_HOST_API injected (A-2).
-		// In bwrap mode ctrCfg is nil — the bwrap args are built by
-		// bwrapIsolator.BuildArgs at prism agent-run time, not here.
+		// In bwrap and sandbox-exec modes ctrCfg is nil — the sandbox args
+		// are built by the isolator at prism agent-run time, not here.
 		if ctrCfg != nil {
 			ctrCfg.HostAPISockPath = sockPath
 		}
 	}
 
 	// Build the OnReady callback — only for podman mode (AC-18, AC-19).
-	// In bwrap mode the sidecar does NOT write the readiness signal:
-	// "prism agent-run" in the tmux pane starts immediately without waiting.
-	// In host mode there is no readiness file at all.
+	// In bwrap and sandbox-exec modes the sidecar does NOT write the readiness
+	// signal: "prism agent-run" in the tmux pane starts immediately without
+	// waiting. In host mode there is no readiness file at all.
 	var onReady func()
 	if podmanMode {
 		onReady = func() {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -14,7 +14,7 @@ package cmd
 //	--profile <name>      model profile to use from ~/.config/prism/profiles.json
 //	--model <name>        model identifier override (overrides profile's primary model)
 //	--variant <name>      model variant override (overrides all agents' variant)
-//	--isolation <mode>    isolation mode: podman, bwrap, or host (default: from config.json)
+//	--isolation <mode>    isolation mode: podman, bwrap, sandbox-exec, or host (default: from config.json)
 //	--host-mode           deprecated alias for --isolation host
 //	--harness <name>      agent harness to use (default: "opencode"; only "opencode" is supported)
 
@@ -93,7 +93,7 @@ func init() {
 	spawnCmd.Flags().String("profile", "", "Model profile name from ~/.config/prism/profiles.json (e.g. anthropic, gemini-hybrid)")
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
-	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, or host (default: from ~/.config/prism/config.json)")
+	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().Bool("host-mode", false, "Deprecated alias for --isolation host; bypass container mode and run opencode directly in the tmux pane")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use (currently only 'opencode' is supported)")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
@@ -109,7 +109,8 @@ func init() {
 //
 // Returns an error if both --isolation and --host-mode are set, or if
 // --isolation has an unknown value, or if the resolved mode is "bwrap" on
-// a non-Linux platform.
+// a non-Linux platform, or if the resolved mode is "sandbox-exec" on a
+// non-Darwin platform.
 func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.IsolationMode, error) {
 	isolationFlag, _ := cmd.Flags().GetString("isolation")
 	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
@@ -136,6 +137,9 @@ func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.Isolati
 		if err := checkBwrapPlatform(mode); err != nil {
 			return "", err
 		}
+		if err := checkSandboxExecPlatform(mode); err != nil {
+			return "", err
+		}
 		return mode, nil
 	}
 
@@ -149,6 +153,9 @@ func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.Isolati
 	if err := checkBwrapPlatform(mode); err != nil {
 		return "", err
 	}
+	if err := checkSandboxExecPlatform(mode); err != nil {
+		return "", err
+	}
 	return mode, nil
 }
 
@@ -157,6 +164,15 @@ func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.Isolati
 func checkBwrapPlatform(mode config.IsolationMode) error {
 	if mode == config.IsolationBwrap && runtime.GOOS != "linux" {
 		return fmt.Errorf("isolation mode %q requires Linux; current platform is %s", mode, runtime.GOOS)
+	}
+	return nil
+}
+
+// checkSandboxExecPlatform returns an error if the isolation mode is
+// "sandbox-exec" on a non-Darwin platform (sandbox-exec is macOS-only).
+func checkSandboxExecPlatform(mode config.IsolationMode) error {
+	if mode == config.IsolationSandboxExec && runtime.GOOS != "darwin" {
+		return fmt.Errorf("isolation mode %q requires macOS (Darwin); current platform is %s", mode, runtime.GOOS)
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -258,7 +258,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		var loadErr error
 		pf, loadErr = config.LoadProfiles()
 		if loadErr != nil {
-			if effectiveContainerMode || isolationMode == config.IsolationBwrap || profileFlag != "" {
+			if effectiveContainerMode || isolationMode == config.IsolationBwrap || isolationMode == config.IsolationSandboxExec || profileFlag != "" {
 				return loadErr
 			}
 			fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not load profiles.json (agent env vars will not be injected): %v\n", loadErr)
@@ -288,8 +288,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create worktree: %w", err)
 	}
 
-	// In container/bwrap mode, inject the role-specific opencode.json blob as
-	// the harness config env var so it takes precedence (level 6) over any
+	// In container/bwrap/sandbox-exec mode, inject the role-specific opencode.json
+	// blob as the harness config env var so it takes precedence (level 6) over any
 	// project-level opencode.jsonc. This ensures agent identity is always
 	// determined by Nix config, not by the project file.
 	//
@@ -298,13 +298,13 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// This must run after worktreePath is known so that DefaultAgent can inspect
 	// the directory name (e.g. "main").
 	//
-	// This block fires for both podman and bwrap isolation modes. Host-mode
-	// sessions skip it because they run opencode directly with the host's real
-	// ~/.config/opencode/opencode.json via xdg.configFile.
+	// This block fires for podman, bwrap, and sandbox-exec isolation modes.
+	// Host-mode sessions skip it because they run opencode directly with the
+	// host's real ~/.config/opencode/opencode.json via xdg.configFile.
 	//
 	// DefaultAgent (not DefaultAgentForSession) is intentional: at spawn time the
 	// session has no DB row yet, so this call ASSIGNS the role rather than reading it.
-	sandboxed := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap
+	sandboxed := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap || isolationMode == config.IsolationSandboxExec
 	if sandboxed && pf != nil {
 		effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
 		// Non-worktree paths (effectiveRole == "") use the coordinator config blob

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -1068,16 +1068,16 @@ var switchCmd = &cobra.Command{
 		isoMode := cfg.EffectiveIsolationMode()
 		effectiveContainerMode := isoMode == config.IsolationPodman
 
-		// Load profiles.json for container/bwrap config injection and agent env
-		// var injection (host mode). Always attempt to load; treat missing file as
-		// fatal when sandboxed (podman or bwrap), since those paths require the
-		// role config blob.
+		// Load profiles.json for container/bwrap/sandbox-exec config injection and
+		// agent env var injection (host mode). Always attempt to load; treat missing
+		// file as fatal when sandboxed (podman, bwrap, or sandbox-exec), since those
+		// paths require the role config blob.
 		var pf *config.ProfilesFile
 		{
 			var pfErr error
 			pf, pfErr = config.LoadProfiles()
 			if pfErr != nil {
-				if effectiveContainerMode || isoMode == config.IsolationBwrap {
+				if effectiveContainerMode || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec {
 					return pfErr
 				}
 				fmt.Fprintf(os.Stderr, "[prism switch] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
@@ -1103,9 +1103,9 @@ var switchCmd = &cobra.Command{
 			opts.AgentEnvVars = pf.AgentEnvVars
 		}
 
-		// sandboxed is true for both podman and bwrap isolation modes —
-		// both require container config injection.
-		sandboxed := effectiveContainerMode || isoMode == config.IsolationBwrap
+		// sandboxed is true for podman, bwrap, and sandbox-exec isolation modes —
+		// all require container config injection.
+		sandboxed := effectiveContainerMode || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec
 
 		// --path: open a specific path directly.
 		if pathArg != "" {

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 // IsolationMode represents the isolation mechanism for agent sessions.
-// Valid values are "podman", "bwrap", and "host".
+// Valid values are "podman", "bwrap", "sandbox-exec", and "host".
 type IsolationMode string
 
 const (
@@ -29,15 +29,21 @@ const (
 	// manage the process lifecycle. Linux only.
 	IsolationBwrap IsolationMode = "bwrap"
 
+	// IsolationSandboxExec runs opencode inside an Apple sandbox-exec profile
+	// sandbox, launched and owned by the tmux pane via "prism agent-run". The
+	// sidecar does not manage the process lifecycle. macOS (Darwin) only.
+	IsolationSandboxExec IsolationMode = "sandbox-exec"
+
 	// IsolationHost runs opencode directly in the tmux pane with no isolation.
 	// Equivalent to the legacy --host-mode flag.
 	IsolationHost IsolationMode = "host"
 )
 
 // ValidIsolationModes lists all valid isolation mode strings.
-var ValidIsolationModes = []IsolationMode{IsolationPodman, IsolationBwrap, IsolationHost}
+var ValidIsolationModes = []IsolationMode{IsolationPodman, IsolationBwrap, IsolationSandboxExec, IsolationHost}
 
 // IsValidIsolationMode reports whether s is a valid isolation mode.
+// Valid values are "podman", "bwrap", "sandbox-exec", and "host".
 func IsValidIsolationMode(s string) bool {
 	for _, m := range ValidIsolationModes {
 		if string(m) == s {

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -700,6 +700,8 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// This mirrors the pattern in cmd/spawn.go:334-340 for regular bwrap spawns.
 		// Podman mode does NOT need this write — the sidecar's Create() path
 		// already writes the file before the container starts.
+		// sandbox-exec mode does NOT yet use this path — it has no bwrap-equivalent
+		// mount mechanism. Config delivery for sandbox-exec is deferred to #1016.
 		if opts.IsolationMode == string(config.IsolationBwrap) && agentConfigContent != "" {
 			containerName := container.NameForSession(agentSession)
 			if writeErr := container.WriteOpencodeConfig(containerName, agentConfigContent); writeErr != nil {
@@ -925,6 +927,8 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		// For bwrap sessions, write the opencode.json config file to disk now
 		// so it is present before the agent pane opens. Mirrors the pattern in
 		// cmd/spawn.go:334-340 for regular bwrap spawns.
+		// sandbox-exec mode does NOT yet use this path — config delivery for
+		// sandbox-exec is deferred to #1016.
 		if opts.IsolationMode == string(config.IsolationBwrap) && agentConfigContent != "" {
 			containerName := container.NameForSession(agentSession)
 			if writeErr := container.WriteOpencodeConfig(containerName, agentConfigContent); writeErr != nil {
@@ -1057,13 +1061,14 @@ func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []st
 }
 
 // ResolveAgentConfigContent resolves the per-agent opencode.json config blob
-// for a single agent in sandboxed mode (podman or bwrap). It is factored out
-// of Run so that it can be unit-tested independently of the tmux/DB machinery.
+// for a single agent in sandboxed mode (podman, bwrap, or sandbox-exec). It is
+// factored out of Run so that it can be unit-tested independently of the
+// tmux/DB machinery.
 //
 // Returns ("", nil) in host mode (isolationMode == "host" or ""), because no
 // config injection is needed — opencode is launched directly on the host.
 //
-// In sandboxed mode (isolationMode == "podman" or "bwrap"):
+// In sandboxed mode (isolationMode == "podman", "bwrap", or "sandbox-exec"):
 //   - Returns an error if pf is nil (missing profiles file).
 //   - Returns an error if ContainerConfigForRole returns an error.
 //   - Returns an error if the resolved blob is empty (stale profiles.json).
@@ -1072,7 +1077,7 @@ func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []st
 // Exported so that cmd/review_test.go (and integration tests) can exercise the
 // config-resolution path without needing a live DB or tmux session.
 func ResolveAgentConfigContent(isolationMode string, pf *config.ProfilesFile, agentName string) (string, error) {
-	needsConfig := isolationMode == string(config.IsolationPodman) || isolationMode == string(config.IsolationBwrap)
+	needsConfig := isolationMode == string(config.IsolationPodman) || isolationMode == string(config.IsolationBwrap) || isolationMode == string(config.IsolationSandboxExec)
 	if !needsConfig {
 		return "", nil
 	}

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -78,8 +78,8 @@ type Opts struct {
 	ContainerMode bool
 
 	// IsolationMode is the resolved isolation mode for this session.
-	// Valid values: "podman", "bwrap", "host". When non-empty it overrides
-	// ContainerMode.
+	// Valid values: "podman", "bwrap", "sandbox-exec", "host". When non-empty
+	// it overrides ContainerMode.
 	IsolationMode string
 	// PluginHostPath is the host-side path to the opencode plugin file that
 	// is bind-mounted into the container. Empty string = no plugin. Only used
@@ -249,9 +249,10 @@ func effectiveIsolationMode(opts Opts) string {
 // BuildOpencodeCmd returns the opencode launch command string for the given opts.
 //
 // Isolation mode determines the command:
-//   - "podman": "podman attach --sig-proxy=false <container-name>"
-//   - "bwrap":  "prism agent-run --session <session-name>"
-//   - "host":   direct opencode invocation (legacy behaviour)
+//   - "podman":       "podman attach --sig-proxy=false <container-name>"
+//   - "bwrap":        "prism agent-run --session <session-name>"
+//   - "sandbox-exec": "prism agent-run --session <session-name>"
+//   - "host":         direct opencode invocation (legacy behaviour)
 //
 // For back-compat, ContainerMode=true maps to "podman" when IsolationMode is empty.
 func BuildOpencodeCmd(opts Opts) string {
@@ -275,14 +276,14 @@ func BuildOpencodeCmd(opts Opts) string {
 		// buildReadinessWaitCmd embeds this string in the readiness shell script.
 		return "podman attach --sig-proxy=false " + shellQuote(container.NameForSession(opts.SessionName))
 
-	case "bwrap":
+	case "bwrap", "sandbox-exec":
 		if opts.SessionName == "" {
 			// Shouldn't happen — fall back to direct opencode command.
 			return buildDirectOpencodeCmd(opts)
 		}
-		// The bwrap sandbox is owned by the tmux pane, not the sidecar.
-		// "prism agent-run" reads the resolved bwrap args from the session
-		// state and execs "bwrap <args...> -- opencode ..." directly.
+		// Both bwrap and sandbox-exec sandboxes are owned by the tmux pane,
+		// not the sidecar. "prism agent-run" reads the session's isolation mode
+		// from the DB and dispatches to the appropriate sandbox invocation.
 		return "prism agent-run --session " + shellQuote(opts.SessionName)
 
 	default: // "host" or any unknown value

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -174,8 +174,8 @@ type StartSidecarOpts struct {
 	ContainerMode bool
 	// IsolationMode is the resolved isolation mode for this session. When set,
 	// it is passed to the sidecar via --isolation-mode so the sidecar can
-	// branch on it (e.g. skip container creation for "bwrap" and "host").
-	// Valid values: "podman", "bwrap", "host".
+	// branch on it (e.g. skip container creation for "bwrap", "sandbox-exec",
+	// and "host"). Valid values: "podman", "bwrap", "sandbox-exec", "host".
 	IsolationMode string
 	// AgentRole is "worker" or "coordinator". Passed via --agent-role when in
 	// container mode to select the appropriate credential set.
@@ -271,8 +271,9 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 	}
 
 	// --container enables the full container lifecycle (podman create/stop/rm).
-	// For bwrap mode the sidecar is started but --container is NOT passed —
-	// bwrap's process lifecycle is owned by the tmux pane (prism agent-run).
+	// For bwrap and sandbox-exec modes the sidecar is started but --container
+	// is NOT passed — the sandbox's process lifecycle is owned by the tmux pane
+	// (prism agent-run).
 	if opts.ContainerMode {
 		cmdArgs = append(cmdArgs, "--container")
 		cmdArgs = append(cmdArgs, "--port", strconv.Itoa(opts.Port))
@@ -288,10 +289,10 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 		if opts.ConfigContent != "" {
 			cmdArgs = append(cmdArgs, "--config-content", opts.ConfigContent)
 		}
-	} else if opts.IsolationMode == "bwrap" {
-		// bwrap mode: pass --port and common options but not --container.
-		// The sidecar sets up the host-API socket and harness but does not
-		// create a container.
+	} else if opts.IsolationMode == "bwrap" || opts.IsolationMode == "sandbox-exec" {
+		// bwrap and sandbox-exec modes: pass --port and common options but not
+		// --container. The sidecar sets up the host-API socket and harness but
+		// does not create a container.
 		cmdArgs = append(cmdArgs, "--port", strconv.Itoa(opts.Port))
 		if opts.AgentRole != "" {
 			cmdArgs = append(cmdArgs, "--agent-role", opts.AgentRole)


### PR DESCRIPTION
## Summary

Adds the minimal foundation for the `sandbox-exec` isolation mode — getting the new mode into the type system, validation chain, CLI, and `agent-run` dispatch — without yet implementing the sandbox itself. After this lands, `prism spawn --isolation sandbox-exec` is a valid invocation that exits cleanly with `not yet implemented` on Darwin and a platform-guard error on Linux.

## Changes

- **`internal/config/config.go`**: Add `IsolationSandboxExec = "sandbox-exec"` constant alongside `IsolationBwrap`, append to `ValidIsolationModes`, update `IsValidIsolationMode` doc comment.
- **`cmd/spawn.go`**: Add `checkSandboxExecPlatform()` (symmetric to `checkBwrapPlatform`) — returns error unless `runtime.GOOS == "darwin"`. Wired into `resolveIsolationMode` so a sandbox-exec request on Linux is rejected with a clear message naming the Darwin requirement.
- **`cmd/agent_run.go`**: Restructure from a flat Linux-only guard to a mode-aware switch. Recognises `sandbox-exec` mode and returns `errors.New("sandbox-exec mode: not yet implemented (issue #1016)")`. The platform guard in spawn.go intercepts non-Darwin before reaching here.
- **`cmd/sidecar.go`**: Add `sandboxExecMode` bool, route sandbox-exec the same as bwrap — host-API socket setup, `ContainerHarness`, no `OnReady` readiness signal, no `--container` flag.
- **`cmd/isolation_test.go`**: Add sandbox-exec mirrors of: `ValidValues`, `UnknownValue`, `HostModeAlias`/`BothIsolationAndHostMode`, `FallbackFromConfig`, and a `SandboxExecOnLinux` platform-guard test (mirroring `BwrapOnDarwin`).

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all packages)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Refs #1012
Closes #1015