### PR TITLE
fix(prism/session): set PRISM_INITIAL_PROMPT in LayoutAgentOnly tmux pane

### DIFF
--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -245,6 +245,24 @@ func spawnFullLayout(d *db.DB, opts SpawnOpts, port int) error {
 	return Create(opts.SessionName, opts.Worktree, createOpts)
 }
 
+// spawnAgentPaneEnvVars builds the env-var map for the LayoutAgentOnly agent
+// tmux pane. It mirrors session.agentPaneEnvVars but takes SpawnOpts directly,
+// since the two layout paths use different opts structs.
+//
+// When opts.Prompt is non-empty, PRISM_INITIAL_PROMPT is included so that
+// "prism agent-run" can read it and populate container.Config.InitialPrompt,
+// activating bwrap's --prompt CLI-append path. Returns nil when no env vars
+// are needed, producing no -e flags in tmux (an empty-string entry would
+// override an inherited value, which is not the desired behaviour).
+func spawnAgentPaneEnvVars(opts SpawnOpts) map[string]string {
+	if opts.Prompt == "" {
+		return nil
+	}
+	return map[string]string{
+		"PRISM_INITIAL_PROMPT": opts.Prompt,
+	}
+}
+
 // spawnAgentOnlyLayout creates a 2-window tmux session for a review-style
 // agent: window 0 is a bare shell, window 1 runs the agent command. The
 // sidecar is started directly (it is owned by the session, not by a tmux
@@ -359,7 +377,7 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	if err := tmux.NewSessionDetached(opts.SessionName, opts.Worktree); err != nil {
 		return fmt.Errorf("spawn session: new tmux session %q: %w", opts.SessionName, err)
 	}
-	if err := tmux.NewWindow(opts.SessionName, 1, "agent", opts.Worktree, agentCmd, nil); err != nil {
+	if err := tmux.NewWindow(opts.SessionName, 1, "agent", opts.Worktree, agentCmd, spawnAgentPaneEnvVars(opts)); err != nil {
 		return fmt.Errorf("spawn session: new agent window for %q: %w", opts.SessionName, err)
 	}
 	_ = tmux.SelectWindow(opts.SessionName, 1)

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -359,6 +359,99 @@ func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
 	}
 }
 
+// TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt verifies that when
+// opts.Prompt is non-empty, spawnAgentOnlyLayout sets PRISM_INITIAL_PROMPT in
+// the agent pane's tmux environment via a -e flag on tmux new-window. This is
+// the regression test for #1042: review agents in bwrap mode must receive
+// their initial prompt via the PRISM_INITIAL_PROMPT env var, since the bwrap
+// path reads it in agent-run and appends --prompt to the opencode invocation.
+func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~review-1-review-code"
+	const prompt = "review this PR"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-code",
+		Prompt:      prompt,
+		Layout:      LayoutAgentOnly,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	args := readSpyArgs(argsFile)
+	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT=" + prompt}) {
+		t.Errorf("tmux args %v do not contain [-e PRISM_INITIAL_PROMPT=%s] — review agents in bwrap mode will start with no initial prompt (#1042)", args, prompt)
+	}
+}
+
+// TestSpawnSession_AgentOnly_PromptEnvVar_NoPrompt verifies that when
+// opts.Prompt is empty, spawnAgentOnlyLayout does NOT set
+// PRISM_INITIAL_PROMPT in the tmux pane environment. An empty-string -e entry
+// would override an inherited value, which is not the desired behaviour.
+func TestSpawnSession_AgentOnly_PromptEnvVar_NoPrompt(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~review-1-review-code-noprompt"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-code",
+		// Prompt intentionally left empty.
+		Layout: LayoutAgentOnly,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	args := readSpyArgs(argsFile)
+	for i, a := range args {
+		if a == "-e" {
+			next := ""
+			if i+1 < len(args) {
+				next = args[i+1]
+			}
+			if strings.HasPrefix(next, "PRISM_INITIAL_PROMPT=") {
+				t.Errorf("tmux args %v contain -e PRISM_INITIAL_PROMPT=… when Prompt was empty; an empty entry would override an inherited value", args)
+				break
+			}
+		}
+	}
+}
+
+// TestSpawnAgentPaneEnvVars verifies the helper directly: with a non-empty
+// prompt it returns the PRISM_INITIAL_PROMPT entry; with an empty prompt it
+// returns nil (not an empty map and not an empty-string entry).
+func TestSpawnAgentPaneEnvVars(t *testing.T) {
+	t.Run("with prompt", func(t *testing.T) {
+		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "hello"})
+		if got == nil {
+			t.Fatal("got nil, want non-nil map")
+		}
+		if v, ok := got["PRISM_INITIAL_PROMPT"]; !ok || v != "hello" {
+			t.Errorf("PRISM_INITIAL_PROMPT = %q, want %q", v, "hello")
+		}
+	})
+	t.Run("empty prompt", func(t *testing.T) {
+		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: ""})
+		if got != nil {
+			t.Errorf("got %v, want nil (an empty entry would override an inherited value)", got)
+		}
+	})
+}
+
 // TestSpawnSession_UnsupportedLayout_ReturnsError verifies that Layout values
 // outside the supported set (LayoutFull / LayoutAgentOnly) surface a clear
 // error rather than silently falling through.


### PR DESCRIPTION
## Summary

Fix #1042: review agents spawned in bwrap isolation mode were starting idle and never receiving their initial prompt.

`spawnAgentOnlyLayout` in `internal/session/spawn.go` was passing `nil` as the tmux pane env vars argument to `tmux.NewWindow`, so `PRISM_INITIAL_PROMPT` was never set in the pane environment. As a result, `prism agent-run`'s `applyInitialPromptEnvVar` became a no-op, `container.Config.InitialPrompt` was empty, `bwrap.go`'s `BuildArgs` did not append `--prompt`, and opencode launched waiting for user input.

The regular worker spawn path (`setupFullLayout`) was already correct — it passes `agentPaneEnvVars(opts)`. This PR adds a `spawnAgentPaneEnvVars` helper that mirrors `agentPaneEnvVars` but takes `SpawnOpts` directly (the two layout paths use different opts structs), and wires it into the `tmux.NewWindow` call.

The empty-prompt branch returns `nil` (not an empty map and not an empty-string entry) so an inherited `PRISM_INITIAL_PROMPT` is never overridden by an empty string.

Podman mode (sidecar's `InitialPrompt` field, `spawn.go:281`) and host mode (prompt baked into the opencode command by `buildDirectOpencodeCmd`) are unaffected.

## Test coverage

Added to `internal/session/spawn_test.go`:

- `TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt` — verifies the tmux new-window call contains `-e PRISM_INITIAL_PROMPT=<prompt>` for `LayoutAgentOnly` when `Prompt` is set.
- `TestSpawnSession_AgentOnly_PromptEnvVar_NoPrompt` — verifies no `-e PRISM_INITIAL_PROMPT=…` flag appears when `Prompt` is empty.
- `TestSpawnAgentPaneEnvVars` — covers the helper directly for both prompt/no-prompt branches.

`go build ./...` and `go test ./...` from `modules/programs/prism/prism/` both pass.

Closes #1042