### PR TITLE
fix(prism): proxy merge and merges through host-API in bwrap

### DIFF
--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -59,6 +59,53 @@ func runMerge(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("prism merge: invalid PR number %q — must be a positive integer", prArg)
 	}
 
+	// Inside a bwrap sandbox: proxy the enqueue to the host sidecar (#1043).
+	// The host's prism.db is invisible to direct DB writes from inside the
+	// sandbox, so falling through to the DB path would silently write to a
+	// shadow tmpfs DB that the merge-queue watcher never sees. We must NOT
+	// silently fall back to the direct DB path on socket failure — that is the
+	// exact behaviour this fix replaces. A clear error and non-zero exit is
+	// the correct response (AC-6).
+	//
+	// Coordinator-only enforcement happens on the sidecar side via
+	// requireCoordinator, which returns HTTP 403 for worker sessions. The
+	// preflight is run inside the sandbox (gh works there) before the proxy
+	// call so that invalid PRs do not pin sidecar resources.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		title, preflightErr := preflight(pr)
+		if preflightErr != nil {
+			return fmt.Errorf("prism merge: %w", preflightErr)
+		}
+		var titlePtr *string
+		if title != "" {
+			titlePtr = &title
+		}
+		// The sidecar returns the full PendingMerge struct as JSON. Decode
+		// only the fields we need for the user-facing message; the rest is
+		// ignored. Field names match the Go struct exactly (default JSON
+		// marshalling of internal/db.PendingMerge has no struct tags).
+		var row struct {
+			PR            int    `json:"PR"`
+			QueuePosition int64  `json:"QueuePosition"`
+			Status        string `json:"Status"`
+		}
+		if proxyErr := proxyToHostAPI(apiURL, "/merge", map[string]any{
+			"pr":    pr,
+			"title": titlePtr,
+		}, &row); proxyErr != nil {
+			return fmt.Errorf("prism merge: %w", proxyErr)
+		}
+		fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", row.PR, row.QueuePosition, row.Status)
+		if title != "" {
+			fmt.Printf("  %s\n", title)
+		}
+		fmt.Println("The merge-queue watcher will drive this PR through CI and merge it automatically.")
+		fmt.Println("You will be notified when it merges or fails.")
+		fmt.Println()
+		fmt.Println("Track progress with: prism merges")
+		return nil
+	}
+
 	// Guard: coordinator-only.
 	callerSession := review.LookupParentSession()
 	d, dbErr := openDB()

--- a/modules/programs/prism/prism/cmd/merge_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/merge_proxy_test.go
@@ -1,0 +1,310 @@
+package cmd
+
+// Tests for the PRISM_HOST_API proxy paths in cmd/merge.go and cmd/merges.go
+// added in #1043 to fix the bwrap shadow-DB issue.
+//
+// These tests stand up a real httptest server bound to a Unix socket on disk
+// and point PRISM_HOST_API at it, then exercise runMerge / runMergesList /
+// runMergesCancel and assert that the request reached the host (mirror of
+// the sidecar /merge handler) rather than touching the local DB.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeHostAPIServer is a minimal mirror of the sidecar's /merge, /merges, and
+// /merges/cancel routes. It records the requests it receives so tests can
+// assert that the proxy hit the socket instead of the local DB.
+type fakeHostAPIServer struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+
+	// merges holds pending_merges-shaped rows for /merges responses.
+	merges []map[string]any
+	// cancelOK is the value returned for the /merges/cancel response.
+	cancelOK bool
+	// cancelRow is returned alongside cancelOK.
+	cancelRow map[string]any
+	// failStatus, when non-zero, makes /merge return that status with
+	// {"error": failError}.
+	failStatus int
+	failError  string
+}
+
+type recordedRequest struct {
+	Path string
+	Body string
+	URL  string
+}
+
+func (s *fakeHostAPIServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/merge", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.mu.Lock()
+		s.requests = append(s.requests, recordedRequest{Path: "/merge", Body: string(body), URL: r.URL.String()})
+		fail := s.failStatus
+		failMsg := s.failError
+		s.mu.Unlock()
+		if fail != 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(fail)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": failMsg})
+			return
+		}
+		// Echo back a minimal PendingMerge-shaped response.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"PR":            42,
+			"QueuePosition": 1,
+			"Status":        "watching",
+		})
+	})
+	mux.HandleFunc("/merges", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.requests = append(s.requests, recordedRequest{Path: "/merges", URL: r.URL.String()})
+		merges := s.merges
+		s.mu.Unlock()
+		if merges == nil {
+			merges = []map[string]any{}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(merges)
+	})
+	mux.HandleFunc("/merges/cancel", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.mu.Lock()
+		s.requests = append(s.requests, recordedRequest{Path: "/merges/cancel", Body: string(body)})
+		ok := s.cancelOK
+		row := s.cancelRow
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"cancelled": ok,
+			"row":       row,
+		})
+	})
+	return mux
+}
+
+// startFakeHostAPIServer starts the fake server bound to a unix socket inside
+// t.TempDir() and returns the server, the apiURL string for PRISM_HOST_API,
+// and a teardown function.
+func startFakeHostAPIServer(t *testing.T) (*fakeHostAPIServer, string) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "host.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sockPath, err)
+	}
+	s := &fakeHostAPIServer{}
+	srv := &http.Server{Handler: s.handler()}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return s, "unix://" + sockPath
+}
+
+// stubGhBin replaces `gh` on PATH with a fake script that returns a fixed JSON
+// PR view, so preflight() succeeds in the test. The script writes to stderr
+// the same "enqueueing PR ..." line that real gh would have triggered, but
+// that comes from preflight, not gh.
+func stubGhBin(t *testing.T, pr int, state, title string) {
+	t.Helper()
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	script := fmt.Sprintf(`#!/bin/sh
+# Stub gh — returns a fake PR view.
+exec cat <<EOF
+{"state":"%s","number":%d,"title":"%s"}
+EOF
+`, state, pr, title)
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub gh: %v", err)
+	}
+	// Prepend the dir to PATH for the test so preflight() resolves our stub.
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+}
+
+// ── runMerge proxy tests ──────────────────────────────────────────────────────
+
+// TestRunMerge_ProxiesToHostAPIWhenSet is the headline test: when
+// PRISM_HOST_API is set, runMerge sends the enqueue request to the sidecar
+// socket rather than touching the local DB. This is the fix for #1043.
+func TestRunMerge_ProxiesToHostAPIWhenSet(t *testing.T) {
+	openMergeTestDB(t) // sets PRISM_HOST_API="" — we override below.
+	stubGhBin(t, 42, "OPEN", "test PR")
+
+	server, apiURL := startFakeHostAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	if err := runMerge(mergeCmd, []string{"42"}); err != nil {
+		t.Fatalf("runMerge: %v", err)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	got := server.requests[0]
+	if got.Path != "/merge" {
+		t.Errorf("first request path = %q, want /merge", got.Path)
+	}
+	// Body must include the PR number; title may be the stubbed value.
+	if !strings.Contains(got.Body, `"pr":42`) {
+		t.Errorf("request body %q does not include pr=42", got.Body)
+	}
+}
+
+// TestRunMerge_ProxyDoesNotTouchLocalDB confirms that when PRISM_HOST_API is
+// set, no row is written to the local (sandbox/test) DB. This is the
+// fundamental bug being fixed: shadow-DB writes silently land on the wrong
+// side of the bwrap namespace boundary.
+func TestRunMerge_ProxyDoesNotTouchLocalDB(t *testing.T) {
+	openMergeTestDB(t)
+	stubGhBin(t, 42, "OPEN", "test PR")
+
+	_, apiURL := startFakeHostAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	if err := runMerge(mergeCmd, []string{"42"}); err != nil {
+		t.Fatalf("runMerge: %v", err)
+	}
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB for verify: %v", err)
+	}
+	defer d.Close()
+	row, _ := d.PendingMergeByPR(42)
+	if row != nil {
+		t.Errorf("local DB row exists after proxy call: %+v — proxy must NOT touch the sandbox DB", row)
+	}
+}
+
+// TestRunMerge_ProxyUnreachableSocketReturnsClearError covers AC-6: a bwrap
+// session whose host-API socket is unreachable must NOT silently fall back to
+// the direct DB path. It must return a clear error and exit non-zero.
+func TestRunMerge_ProxyUnreachableSocketReturnsClearError(t *testing.T) {
+	openMergeTestDB(t)
+	stubGhBin(t, 42, "OPEN", "test PR")
+
+	// Point at a non-existent socket path.
+	bogus := filepath.Join(t.TempDir(), "no-such.sock")
+	t.Setenv("PRISM_HOST_API", "unix://"+bogus)
+
+	err := runMerge(mergeCmd, []string{"42"})
+	if err == nil {
+		t.Fatal("runMerge: want error for unreachable socket, got nil")
+	}
+	// The error should mention the socket so the user can diagnose it. Avoid
+	// asserting exact wording — just confirm it's not silently swallowed and
+	// references the host-API or socket layer.
+	msg := err.Error()
+	if !strings.Contains(msg, "host-API") && !strings.Contains(msg, "socket") {
+		t.Errorf("error %q does not mention 'host-API' or 'socket' — fallback to direct DB?", msg)
+	}
+
+	// And the DB must be untouched (no shadow write attempted).
+	d, openErr := openDB()
+	if openErr != nil {
+		t.Fatalf("openDB for verify: %v", openErr)
+	}
+	defer d.Close()
+	row, _ := d.PendingMergeByPR(42)
+	if row != nil {
+		t.Errorf("local DB row exists after unreachable-socket call: %+v — must not fall back to direct DB path", row)
+	}
+}
+
+// ── runMergesList proxy tests ─────────────────────────────────────────────────
+
+func TestRunMergesList_ProxiesToHostAPIWhenSet(t *testing.T) {
+	openMergeTestDB(t)
+	server, apiURL := startFakeHostAPIServer(t)
+	server.mu.Lock()
+	server.merges = []map[string]any{}
+	server.mu.Unlock()
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	if err := runMergesList(mergesListCmd, nil); err != nil {
+		t.Fatalf("runMergesList: %v", err)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if server.requests[0].Path != "/merges" {
+		t.Errorf("first request path = %q, want /merges", server.requests[0].Path)
+	}
+}
+
+func TestRunMergesList_ProxyPassesFilterFlag(t *testing.T) {
+	openMergeTestDB(t)
+	server, apiURL := startFakeHostAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	// Set the --failed flag on the command for this invocation.
+	if err := mergesListCmd.Flags().Set("failed", "true"); err != nil {
+		t.Fatalf("set --failed: %v", err)
+	}
+	t.Cleanup(func() { _ = mergesListCmd.Flags().Set("failed", "false") })
+
+	if err := runMergesList(mergesListCmd, nil); err != nil {
+		t.Fatalf("runMergesList: %v", err)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if !strings.Contains(server.requests[0].URL, "filter=failed") {
+		t.Errorf("request URL %q does not include filter=failed", server.requests[0].URL)
+	}
+}
+
+// ── runMergesCancel proxy tests ───────────────────────────────────────────────
+
+func TestRunMergesCancel_ProxiesToHostAPIWhenSet(t *testing.T) {
+	openMergeTestDB(t)
+	server, apiURL := startFakeHostAPIServer(t)
+	server.mu.Lock()
+	server.cancelOK = true
+	server.mu.Unlock()
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	if err := runMergesCancel(mergesCancelCmd, []string{"55"}); err != nil {
+		t.Fatalf("runMergesCancel: %v", err)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	got := server.requests[0]
+	if got.Path != "/merges/cancel" {
+		t.Errorf("path = %q, want /merges/cancel", got.Path)
+	}
+	if !strings.Contains(got.Body, `"pr":55`) {
+		t.Errorf("body %q does not include pr=55", got.Body)
+	}
+}

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -8,11 +8,17 @@ import (
 
 // openMergeTestDB opens an isolated test DB and registers cleanup.
 // Sets testDBPath so that openDB() in cmd package uses the test DB.
+//
+// It also unsets PRISM_HOST_API for the duration of the test so that
+// runMerge / runMergesList / runMergesCancel exercise the host-side DB path
+// rather than attempting to proxy through a host-API socket that does not
+// exist in the test environment (#1043).
 func openMergeTestDB(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
 	SetTestDBPath(filepath.Join(dir, "merge_test.db"))
 	t.Cleanup(func() { SetTestDBPath("") })
+	t.Setenv("PRISM_HOST_API", "")
 }
 
 // ── runMerge coordinator-only guard ───────────────────────────────────────────

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -87,6 +87,25 @@ func runMergesList(cmd *cobra.Command, _ []string) error {
 		filter = "all"
 	}
 
+	// Inside a bwrap sandbox: proxy the list to the host sidecar (#1043).
+	// The host's prism.db is invisible to direct DB reads from inside the
+	// sandbox, so falling through to the DB path would read from a shadow
+	// tmpfs DB that has none of the host's queued rows. The sidecar reads its
+	// own (host-side) DB using the same instance_id and session_name the
+	// merge-queue watcher uses, so the response matches what `sqlite3
+	// prism.db` shows on the host.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		params := map[string]string{}
+		if filter != "" {
+			params["filter"] = filter
+		}
+		var merges []db.PendingMerge
+		if proxyErr := proxyGetFromHostAPI(apiURL, "/merges", params, &merges); proxyErr != nil {
+			return fmt.Errorf("prism merges list: %w", proxyErr)
+		}
+		return renderMergesList(merges, filter)
+	}
+
 	callerSession := review.LookupParentSession()
 	d, err := openDB()
 	if err != nil {
@@ -113,6 +132,38 @@ func runMergesCancel(cmd *cobra.Command, args []string) error {
 	pr, err := strconv.Atoi(prArg)
 	if err != nil || pr <= 0 {
 		return fmt.Errorf("prism merges cancel: invalid PR number %q", prArg)
+	}
+
+	// Inside a bwrap sandbox: proxy the cancel to the host sidecar (#1043).
+	// See merge.go and runMergesList for the reasoning. The sidecar uses its
+	// own instance_id when calling CancelMerge, which is the same identity
+	// the host watcher and `prism merges` use, so cancellation is visible to
+	// both immediately.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		var resp struct {
+			Cancelled bool             `json:"cancelled"`
+			Row       *db.PendingMerge `json:"row"`
+		}
+		if proxyErr := proxyToHostAPI(apiURL, "/merges/cancel", map[string]any{
+			"pr": pr,
+		}, &resp); proxyErr != nil {
+			return fmt.Errorf("prism merges cancel: %w", proxyErr)
+		}
+		if resp.Cancelled {
+			fmt.Printf("PR #%d removed from merge queue.\n", pr)
+		} else if resp.Row == nil {
+			fmt.Printf("PR #%d is not in the merge queue.\n", pr)
+		} else {
+			// Either the row is owned by a different incarnation, or it is
+			// already in a terminal state. Match the host-path message
+			// shapes so the user sees the same output regardless of mode.
+			if resp.Row.Status == "watching" {
+				fmt.Printf("PR #%d is owned by a different coordinator incarnation — not cancelled.\n", pr)
+			} else {
+				fmt.Printf("PR #%d is already in terminal state %q — no change.\n", pr, resp.Row.Status)
+			}
+		}
+		return nil
 	}
 
 	callerSession := review.LookupParentSession()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2541,13 +2541,16 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 // hostAPIHandler returns an http.Handler that exposes host-side tmux operations
 // to agents running inside the container via a Unix socket. Routes:
 //
-//	POST /spawn        — spawn a new worktree session (coordinator only)
-//	POST /review       — run review agents against a PR (workers and coordinators)
-//	POST /cleanup      — clean up an existing session (coordinator only)
-//	POST /switch       — switch the tmux client to a session
+//	POST /spawn         — spawn a new worktree session (coordinator only)
+//	POST /review        — run review agents against a PR (workers and coordinators)
+//	POST /cleanup       — clean up an existing session (coordinator only)
+//	POST /switch        — switch the tmux client to a session
 //	GET  /list-sessions — list active sessions (role-scoped)
-//	GET  /checkin      — return conversation history for a session (coordinator only)
-//	POST /prompt       — deliver a prompt to a target session (role-scoped)
+//	GET  /checkin       — return conversation history for a session (coordinator only)
+//	POST /prompt        — deliver a prompt to a target session (role-scoped)
+//	POST /merge         — enqueue a PR for the merge queue (coordinator only)
+//	GET  /merges        — list merge queue entries (coordinator only)
+//	POST /merges/cancel — cancel a watching merge queue entry (coordinator only)
 //
 // Role-based permissions are enforced based on s.cfg.AgentRole and
 // s.cfg.SessionName. Workers have restricted access; coordinators have broader
@@ -3438,6 +3441,145 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		writeJSON(w, http.StatusOK, map[string]string{})
+	})
+
+	// POST /merge
+	// Request:  {"pr": <int>, "title": <string|null>}
+	// Response: PendingMerge JSON | {"error":"..."}
+	//
+	// Enqueues a PR into the merge queue using the sidecar's own session_name
+	// and instance_id — the values the merge-queue watcher queries against.
+	// This is the proxy path for `prism merge <pr>` invoked from inside a
+	// bwrap sandbox where dbPath() resolves to a shadow tmpfs (#1043).
+	//
+	// Coordinator-only: the merge queue is owned by coordinator sessions.
+	mux.HandleFunc("/merge", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "merge") {
+			return
+		}
+		var req struct {
+			PR    int     `json:"pr"`
+			Title *string `json:"title"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.PR <= 0 {
+			writeError(w, http.StatusBadRequest, "pr is required and must be a positive integer")
+			return
+		}
+		if s.cfg.InstanceID == "" {
+			writeError(w, http.StatusInternalServerError,
+				"sidecar has no instance_id — cannot enqueue merge without an instance identity")
+			return
+		}
+
+		// Use the sidecar's own session_name and instance_id so that the row
+		// is keyed on exactly the values the merge-queue watcher queries
+		// against. This is the architectural reason for routing through the
+		// sidecar at all (#1043).
+		row, err := s.cfg.DB.EnqueueMerge(req.PR, s.cfg.SessionName, s.cfg.InstanceID, req.Title)
+		if err != nil {
+			log.Printf("sidecar: host-API /merge: EnqueueMerge: %v", err)
+			writeError(w, http.StatusInternalServerError, "enqueue merge: "+err.Error())
+			return
+		}
+		log.Printf("sidecar: host-API /merge: PR #%d enqueued (queue_position=%d, status=%s)",
+			row.PR, row.QueuePosition, row.Status)
+		writeJSON(w, http.StatusOK, row)
+	})
+
+	// GET /merges
+	// Query params: filter=watching|failed|abandoned|all (default: watching)
+	// Response: JSON array of PendingMerge | {"error":"..."}
+	//
+	// Lists merge queue entries scoped to the sidecar's own instance_id and
+	// session_name — the same filters used by the host-side `prism merges`
+	// command. This is the proxy path for `prism merges` invoked from inside
+	// a bwrap sandbox (#1043).
+	mux.HandleFunc("/merges", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "merges") {
+			return
+		}
+		if s.cfg.InstanceID == "" {
+			writeError(w, http.StatusInternalServerError,
+				"sidecar has no instance_id — cannot list merges without an instance identity")
+			return
+		}
+
+		filter := r.URL.Query().Get("filter")
+		merges, err := s.cfg.DB.MergeQueueForInstance(s.cfg.InstanceID, s.cfg.SessionName, filter)
+		if err != nil {
+			log.Printf("sidecar: host-API /merges: MergeQueueForInstance: %v", err)
+			writeError(w, http.StatusInternalServerError, "list merges: "+err.Error())
+			return
+		}
+		// Return empty array rather than null when no rows.
+		if merges == nil {
+			merges = []db.PendingMerge{}
+		}
+		writeJSON(w, http.StatusOK, merges)
+	})
+
+	// POST /merges/cancel
+	// Request:  {"pr": <int>}
+	// Response: {"cancelled": <bool>, "row": <PendingMerge|null>} | {"error":"..."}
+	//
+	// Cancels a watching row owned by the sidecar's instance_id. The response
+	// includes the current row (when present) so the client can render a
+	// helpful message when cancellation is a no-op (already terminal, owned
+	// by a different incarnation, etc.).
+	mux.HandleFunc("/merges/cancel", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "merges cancel") {
+			return
+		}
+		var req struct {
+			PR int `json:"pr"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.PR <= 0 {
+			writeError(w, http.StatusBadRequest, "pr is required and must be a positive integer")
+			return
+		}
+		if s.cfg.InstanceID == "" {
+			writeError(w, http.StatusInternalServerError,
+				"sidecar has no instance_id — cannot cancel merge without an instance identity")
+			return
+		}
+
+		cancelled, err := s.cfg.DB.CancelMerge(req.PR, s.cfg.InstanceID)
+		if err != nil {
+			log.Printf("sidecar: host-API /merges/cancel: CancelMerge: %v", err)
+			writeError(w, http.StatusInternalServerError, "cancel merge: "+err.Error())
+			return
+		}
+		// Always look up the current row so the client can render a helpful
+		// message when cancellation is a no-op. PendingMergeByPR returning nil
+		// means the row does not exist at all.
+		row, lookupErr := s.cfg.DB.PendingMergeByPR(req.PR)
+		if lookupErr != nil {
+			log.Printf("sidecar: host-API /merges/cancel: PendingMergeByPR: %v", lookupErr)
+			// Lookup error is non-fatal — return cancelled status without the row.
+			row = nil
+		}
+		log.Printf("sidecar: host-API /merges/cancel: PR #%d cancelled=%v", req.PR, cancelled)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"cancelled": cancelled,
+			"row":       row,
+		})
 	})
 
 	return mux

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
@@ -1,0 +1,347 @@
+package sidecar
+
+// Tests for the host-API /merge, /merges, and /merges/cancel endpoints
+// added in #1043 to fix the bwrap shadow-DB issue.
+//
+// These tests exercise the hostAPIHandler() method directly without spinning
+// up a real Unix socket server. The shape mirrors the existing /spawn,
+// /cleanup, /prompt tests in sidecar_test.go.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+)
+
+// newSidecarCoordinatorWithInstance builds a coordinator sidecar with a
+// non-empty InstanceID so the merge endpoints have an identity to enqueue
+// rows under. Mirrors newSidecarWithRole but adds the InstanceID field.
+func newSidecarCoordinatorWithInstance(t *testing.T, sessionName, repo, instanceID string, d *db.DB) *Sidecar {
+	t.Helper()
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/tmp/" + sessionName,
+		OpencodeURL: "http://localhost:14000",
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   "coordinator",
+		InstanceID:  instanceID,
+		Harness:     opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	// Seed the DB so isCoordinatorSession() recognises this session as a
+	// coordinator (the merge handlers go through requireCoordinator).
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/tmp/"+sessionName, "active", nil, nil, "coordinator"); err != nil {
+		t.Fatalf("seed coordinator status: %v", err)
+	}
+	return New(cfg)
+}
+
+// ── /merge ────────────────────────────────────────────────────────────────────
+
+// TestHostAPI_Merge_EnqueuesRowWithSidecarIdentity is the headline test for the
+// fix in #1043. It verifies that when /merge is called with just the PR number
+// and title, the resulting pending_merges row uses the sidecar's own
+// session_name and instance_id — the values the watcher queries against — so
+// the watcher will find the row on its next tick (AC #7).
+func TestHostAPI_Merge_EnqueuesRowWithSidecarIdentity(t *testing.T) {
+	d := openTestDB(t)
+	const (
+		sess     = "nixos-config@main"
+		instance = "11111111-2222-3333-4444-555555555555"
+	)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/merge",
+		`{"pr": 1234, "title": "do the mahi"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+
+	var resp db.PendingMerge
+	decodeJSONBody(t, rr, &resp)
+
+	if resp.PR != 1234 {
+		t.Errorf("response PR = %d, want 1234", resp.PR)
+	}
+	if resp.SessionName != sess {
+		t.Errorf("response SessionName = %q, want %q (the sidecar's session_name is what the watcher queries against)", resp.SessionName, sess)
+	}
+	if resp.InstanceID != instance {
+		t.Errorf("response InstanceID = %q, want %q (the sidecar's instance_id is what the watcher queries against)", resp.InstanceID, instance)
+	}
+	if resp.Status != "watching" {
+		t.Errorf("response Status = %q, want %q", resp.Status, "watching")
+	}
+
+	// Confirm the row landed in the host-side DB with the expected identity —
+	// this is the actual fix for the shadow-DB bug.
+	row, err := d.PendingMergeByPR(1234)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row == nil {
+		t.Fatal("PendingMergeByPR(1234) = nil — row was not persisted")
+	}
+	if row.SessionName != sess || row.InstanceID != instance {
+		t.Errorf("DB row identity (session=%q, instance=%q), want (session=%q, instance=%q)",
+			row.SessionName, row.InstanceID, sess, instance)
+	}
+}
+
+// TestHostAPI_Merge_ClientIdentityIsIgnored verifies that the proxy contract
+// is "trust the sidecar, not the client": the request body intentionally has
+// no session_name / instance_id field, so even if a misbehaving client tried
+// to set them, the sidecar would still use its own values. (Asserted
+// indirectly by passing an arbitrary title and verifying that DB identity
+// matches the sidecar config.)
+func TestHostAPI_Merge_ClientIdentityIsIgnored(t *testing.T) {
+	d := openTestDB(t)
+	const (
+		sess     = "nixos-config@main"
+		instance = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+
+	// Body contains stray fields that are not part of the schema; they must
+	// be ignored.
+	rr := doHostAPI(t, sc, http.MethodPost, "/merge",
+		`{"pr": 99, "title": null, "session_name": "evil@spoofed", "instance_id": "spoofed"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	row, err := d.PendingMergeByPR(99)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row == nil || row.SessionName != sess || row.InstanceID != instance {
+		t.Errorf("row identity = (%v, %v), want (%q, %q) — sidecar must ignore client-supplied identity",
+			row.SessionName, row.InstanceID, sess, instance)
+	}
+}
+
+func TestHostAPI_Merge_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/merge", `{"pr": 1, "title": null}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %q, want 403", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHostAPI_Merge_RejectsInvalidPR(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+
+	for _, body := range []string{
+		`{"pr": 0, "title": null}`,
+		`{"pr": -1, "title": null}`,
+		`{"title": "no pr"}`,
+	} {
+		rr := doHostAPI(t, sc, http.MethodPost, "/merge", body)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("body %q: status = %d, want 400", body, rr.Code)
+		}
+	}
+}
+
+func TestHostAPI_Merge_NoInstanceIDIsServerError(t *testing.T) {
+	d := openTestDB(t)
+	// Coordinator sidecar with no InstanceID configured — we should refuse to
+	// enqueue rather than write a row keyed on an empty instance_id (which
+	// would be invisible to a watcher that has a real instance_id).
+	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/merge", `{"pr": 5, "title": null}`)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for missing instance_id", rr.Code)
+	}
+}
+
+func TestHostAPI_Merge_RejectsNonPOST(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/merge", "")
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+// ── /merges ───────────────────────────────────────────────────────────────────
+
+func TestHostAPI_Merges_ListWatching(t *testing.T) {
+	d := openTestDB(t)
+	const (
+		sess     = "nixos-config@main"
+		instance = "deadbeef-1111-2222-3333-444444444444"
+	)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+
+	// Seed a couple of watching rows directly via the DB.
+	t1 := "first"
+	t2 := "second"
+	if _, err := d.EnqueueMerge(101, sess, instance, &t1); err != nil {
+		t.Fatalf("seed EnqueueMerge: %v", err)
+	}
+	if _, err := d.EnqueueMerge(102, sess, instance, &t2); err != nil {
+		t.Fatalf("seed EnqueueMerge: %v", err)
+	}
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+
+	var rows []db.PendingMerge
+	decodeJSONBody(t, rr, &rows)
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2: %+v", len(rows), rows)
+	}
+	prs := map[int]bool{}
+	for _, r := range rows {
+		prs[r.PR] = true
+	}
+	if !prs[101] || !prs[102] {
+		t.Errorf("got PRs = %v, want both 101 and 102", prs)
+	}
+}
+
+func TestHostAPI_Merges_EmptyArrayWhenEmpty(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	// Body must parse as a JSON array (not null), even when empty — clients
+	// rely on this to render "queue is empty" rather than crashing.
+	var raw json.RawMessage
+	decodeJSONBody(t, rr, &raw)
+	if string(raw) != "[]" {
+		t.Errorf("body = %q, want []", string(raw))
+	}
+}
+
+func TestHostAPI_Merges_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges", "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+}
+
+// ── /merges/cancel ────────────────────────────────────────────────────────────
+
+func TestHostAPI_MergesCancel_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	const (
+		sess     = "nixos-config@main"
+		instance = "11111111-1111-1111-1111-111111111111"
+	)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+
+	if _, err := d.EnqueueMerge(77, sess, instance, nil); err != nil {
+		t.Fatalf("seed EnqueueMerge: %v", err)
+	}
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 77}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Cancelled bool             `json:"cancelled"`
+		Row       *db.PendingMerge `json:"row"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if !resp.Cancelled {
+		t.Errorf("response cancelled = false, want true")
+	}
+
+	// DB row should be in 'cancelled' state.
+	row, err := d.PendingMergeByPR(77)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row == nil || row.Status != "cancelled" {
+		t.Errorf("row status after cancel = %v, want cancelled", row)
+	}
+}
+
+func TestHostAPI_MergesCancel_NonExistentReturnsFalse(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 9999}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for no-op cancel", rr.Code)
+	}
+	var resp struct {
+		Cancelled bool             `json:"cancelled"`
+		Row       *db.PendingMerge `json:"row"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Cancelled {
+		t.Error("cancelled = true, want false for non-existent PR")
+	}
+	if resp.Row != nil {
+		t.Errorf("row = %+v, want nil for non-existent PR", resp.Row)
+	}
+}
+
+func TestHostAPI_MergesCancel_DifferentInstanceReturnsRowWatching(t *testing.T) {
+	d := openTestDB(t)
+	const (
+		sess          = "nixos-config@main"
+		ourInstance   = "instance-A"
+		theirInstance = "instance-B"
+	)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", ourInstance, d)
+
+	// Seed a row owned by a DIFFERENT incarnation.
+	if _, err := d.EnqueueMerge(55, sess, theirInstance, nil); err != nil {
+		t.Fatalf("seed EnqueueMerge: %v", err)
+	}
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 55}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var resp struct {
+		Cancelled bool             `json:"cancelled"`
+		Row       *db.PendingMerge `json:"row"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Cancelled {
+		t.Error("cancelled = true, want false (owned by different incarnation)")
+	}
+	if resp.Row == nil {
+		t.Fatal("row = nil, want existing watching row so client can render correct message")
+	}
+	if resp.Row.Status != "watching" {
+		t.Errorf("row.Status = %q, want watching", resp.Row.Status)
+	}
+}
+
+func TestHostAPI_MergesCancel_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 1}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestHostAPI_MergesCancel_RejectsInvalidPR(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 0}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds three new host-API endpoints — `POST /merge`, `GET /merges`, `POST /merges/cancel` — to `internal/sidecar/sidecar.go`, modelled on the existing `/review` proxy pattern
- Adds `PRISM_HOST_API` proxy paths to `cmd/merge.go` and `cmd/merges.go` so the bwrap sandbox routes through the host sidecar instead of writing to a shadow DB
- The sidecar uses its **own** `session_name` and `instance_id` when calling `db.EnqueueMerge`, `db.MergeQueueForInstance`, and `db.CancelMerge` — the values the merge-queue watcher queries against — so the row is visible to the watcher the moment it lands

## Why

\`prism merge\` and \`prism merges\` opened \`prism.db\` directly via \`db.Open(dbPath())\`. Inside a bwrap sandbox \`~/.local/state/prism/\` is not bind-mounted, so \`dbPath()\` resolved to a tmpfs path inside the sandbox namespace. Every \`prism merge\` invocation from a bwrap coordinator session silently wrote to a shadow DB that the host watcher never sees.

## Behaviour

- Inside bwrap (\`PRISM_HOST_API\` set): \`prism merge\` POSTs to the sidecar over the Unix socket. Coordinator-only enforcement happens in the sidecar's \`requireCoordinator\` (HTTP 403 for workers).
- Outside bwrap (no \`PRISM_HOST_API\`): direct DB path is unchanged.
- Unreachable socket: returns a clear error and non-zero exit. **No** silent fallback to the direct DB path — that is the exact behaviour this fix replaces (AC-6).

## Tests

New tests cover both layers:

- \`internal/sidecar/sidecar_merge_test.go\` — exercises the three new handlers directly via \`hostAPIHandler()\`. Asserts that the sidecar's identity (not client-supplied fields) ends up on the row, plus role enforcement, no-instance-id guards, method enforcement, and cancel edge cases.
- \`cmd/merge_proxy_test.go\` — stands up a real Unix socket fake and exercises \`runMerge\` / \`runMergesList\` / \`runMergesCancel\`. Asserts the proxy fires, the local sandbox DB is **not** touched, and an unreachable socket produces a clear error.

\`go build ./...\` and \`go test ./...\` from \`modules/programs/prism/prism/\` both pass. The full \`nix build .#nixosConfigurations.navi.config.system.build.toplevel\` also succeeds.

Closes #1043