### PR TITLE
fix(prism): use short sun_path for host.sock in merge proxy tests on Darwin

### DIFF
--- a/modules/programs/prism/prism/cmd/merge_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/merge_proxy_test.go
@@ -98,12 +98,25 @@ func (s *fakeHostAPIServer) handler() http.Handler {
 	return mux
 }
 
-// startFakeHostAPIServer starts the fake server bound to a unix socket inside
-// t.TempDir() and returns the server, the apiURL string for PRISM_HOST_API,
-// and a teardown function.
+// startFakeHostAPIServer starts the fake server bound to a unix socket and
+// returns the server and the apiURL string for PRISM_HOST_API.
+//
+// The socket path is placed under a short directory (os.MkdirTemp("/tmp", …))
+// rather than t.TempDir() because Darwin's struct sockaddr_un.sun_path is only
+// 104 bytes (vs 108 on Linux), and on macOS — including the Nix sandbox and
+// GitHub Actions runners — t.TempDir() resolves to a long path like
+// /var/folders/…/T/TestName.../NNN/ or /nix/var/nix/builds/nix-…/TestName.../NNN/
+// that easily exceeds 104 bytes for tests with long names. bind(2) then fails
+// with EINVAL ("invalid argument"). Using /tmp/p<rand>/host.sock keeps the
+// path well under the limit on every platform we target.
 func startFakeHostAPIServer(t *testing.T) (*fakeHostAPIServer, string) {
 	t.Helper()
-	sockPath := filepath.Join(t.TempDir(), "host.sock")
+	sockDir, err := os.MkdirTemp("/tmp", "p")
+	if err != nil {
+		t.Fatalf("mkdir short sock dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "host.sock")
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("listen unix %s: %v", sockPath, err)


### PR DESCRIPTION
## Summary

Hot fix for the `build (macos-15, darwinConfigurations.m4mac, m4mac)` job in `build-and-cache` that started failing on `main` after #1045 merged.

Failing run: https://github.com/prismatic-koi/nixos-config/actions/runs/24941515180/job/73035907658

## The bug

Two of the three new proxy tests in `modules/programs/prism/prism/cmd/merge_proxy_test.go` fail on macOS with:

```
listen unix /nix/var/nix/builds/nix-…/TestRunMergesList_ProxiesToHostAPIWhenSet…/002/host.sock:
  bind: invalid argument
```

This is the Darwin Unix-domain-socket path-length limit: `struct sockaddr_un.sun_path` is **104 bytes** on Darwin (vs 108 on Linux). Inside the Nix sandbox on macOS, `t.TempDir()` resolves under `/nix/var/nix/builds/nix-…/<TestName>…/NNN/`, and the two long-named tests (`TestRunMergesList_ProxiesToHostAPIWhenSet`, `TestRunMergesCancel_ProxiesToHostAPIWhenSet`) blow past the 104-byte limit before `host.sock` is appended. `bind(2)` rejects the path with `EINVAL`.

The third test (`TestRunMerge_ProxiesToHostAPIWhenSet`) has a shorter name and happens to fit, which is why only two failed.

## The fix

In the shared `startFakeHostAPIServer` helper, place the unix socket under a short directory created with `os.MkdirTemp("/tmp", "p")` instead of `t.TempDir()`. Wire `t.Cleanup` to remove the directory. The rest of the fixture is untouched.

Because the fix lives in the shared helper, all three current tests benefit and any future tests using the helper will inherit it too. A comment at the socket-creation site explains the 104-byte Darwin limit so future contributors don't undo the fix.

## Verification

- `go build ./...` from `modules/programs/prism/prism/` — clean
- `go test ./...` from `modules/programs/prism/prism/` — all packages green, including the three targeted proxy tests
- Linux only (this worker doesn't have a Darwin host); CI will exercise the Darwin build path on this PR

Closes the breakage from #1045. References the failing run linked above.