### PR TITLE
fix(mergequeue): use mergedAt instead of invalid merged field in watcher poll

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -111,14 +111,14 @@ func (w *Watcher) tick(ctx context.Context) {
 	}
 
 	// PR closed without merging.
-	if prInfo.State == "CLOSED" && !prInfo.Merged {
+	if prInfo.State == "CLOSED" && !prInfo.isMerged() {
 		msg := "PR was closed without merging"
 		w.failAndNotify(head, msg)
 		return
 	}
 
 	// PR already merged (shouldn't happen, but handle it gracefully).
-	if prInfo.State == "MERGED" || prInfo.Merged {
+	if prInfo.State == "MERGED" || prInfo.isMerged() {
 		w.succeedAndNotify(ctx, head)
 		return
 	}
@@ -325,12 +325,26 @@ func buildNotifyBody(text string, status *db.Status) map[string]any {
 	return body
 }
 
+// prInfoJSONFields is the comma-separated list of fields requested from
+// `gh pr view --json`. Exposed as a package-level constant so tests can assert
+// the field list never regresses to use the (invalid) "merged" field again —
+// `gh pr view` rejects unknown JSON fields with a non-zero exit, so an invalid
+// field name silently breaks the entire merge-queue watcher (see #1014 fallout).
+const prInfoJSONFields = "state,mergedAt,mergeStateStatus,statusCheckRollup"
+
 // prInfo holds the fields we care about from `gh pr view --json`.
 type prInfo struct {
-	State             string          `json:"state"`
-	Merged            bool            `json:"merged"`
-	MergeStateStatus  string          `json:"mergeStateStatus"`
-	StatusCheckRollup []checkEntry    `json:"statusCheckRollup"`
+	State             string       `json:"state"`
+	MergedAt          *string      `json:"mergedAt"`
+	MergeStateStatus  string       `json:"mergeStateStatus"`
+	StatusCheckRollup []checkEntry `json:"statusCheckRollup"`
+}
+
+// isMerged reports whether the PR has been merged. `gh pr view` emits
+// mergedAt as a non-null ISO-8601 timestamp string when the PR is merged, and
+// null otherwise (which unmarshals to a nil pointer).
+func (p *prInfo) isMerged() bool {
+	return p.MergedAt != nil && *p.MergedAt != ""
 }
 
 type checkEntry struct {
@@ -341,7 +355,7 @@ type checkEntry struct {
 // fetchPRInfo calls `gh pr view <pr> --json` and returns the parsed result.
 func fetchPRInfo(ctx context.Context, pr int) (*prInfo, error) {
 	out, err := runGH(ctx, "pr", "view", fmt.Sprintf("%d", pr),
-		"--json", "state,merged,mergeStateStatus,statusCheckRollup")
+		"--json", prInfoJSONFields)
 	if err != nil {
 		return nil, fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(string(out)))
 	}

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -479,11 +479,11 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 		return
 	}
 
-	if prInfoVal.State == "CLOSED" && !prInfoVal.Merged {
+	if prInfoVal.State == "CLOSED" && !prInfoVal.isMerged() {
 		fw.watcher.failAndNotify(head, "PR was closed without merging")
 		return
 	}
-	if prInfoVal.State == "MERGED" || prInfoVal.Merged {
+	if prInfoVal.State == "MERGED" || prInfoVal.isMerged() {
 		fw.watcher.succeedAndNotify(ctx, head)
 		return
 	}
@@ -888,7 +888,7 @@ func TestWatcher_ClosedExternallyTransitionsToFailed(t *testing.T) {
 
 	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
 		func(_ context.Context, pr int) (*prInfo, error) {
-			return &prInfo{State: "CLOSED", Merged: false}, nil
+			return &prInfo{State: "CLOSED", MergedAt: nil}, nil
 		},
 		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
 		func(_ context.Context, pr int) error { return nil },
@@ -1131,4 +1131,70 @@ func TestWatcher_NotificationBodyContainsPR(t *testing.T) {
 	}
 
 	_ = os.Getenv // avoid unused import
+}
+
+// TestPRInfoJSONFields_NoMergedField guards against regressing to the
+// (invalid) "merged" field. `gh pr view` rejects unknown JSON fields with a
+// non-zero exit, which silently broke the entire merge-queue watcher between
+// #1014 and the fix for this regression. The canonical merge-detection field
+// is `mergedAt` (a nullable timestamp string).
+func TestPRInfoJSONFields_NoMergedField(t *testing.T) {
+	fields := strings.Split(prInfoJSONFields, ",")
+	for _, f := range fields {
+		if f == "merged" {
+			t.Errorf("prInfoJSONFields contains invalid 'merged' field; gh pr view will reject it. Got: %q", prInfoJSONFields)
+		}
+	}
+	hasMergedAt := false
+	for _, f := range fields {
+		if f == "mergedAt" {
+			hasMergedAt = true
+		}
+	}
+	if !hasMergedAt {
+		t.Errorf("prInfoJSONFields must include 'mergedAt' to detect merged state. Got: %q", prInfoJSONFields)
+	}
+}
+
+// TestPRInfo_IsMerged verifies the merged-detection logic against the three
+// states the watcher cares about: a non-empty mergedAt timestamp (merged), a
+// nil mergedAt pointer (not merged), and an empty-string mergedAt (also not
+// merged — a defensive case in case `gh` ever emits "" instead of null).
+func TestPRInfo_IsMerged(t *testing.T) {
+	mergedTime := "2026-04-26T10:09:40Z"
+	emptyStr := ""
+
+	cases := []struct {
+		name     string
+		info     prInfo
+		wantMerged bool
+	}{
+		{
+			name:       "MergedAt set to ISO timestamp",
+			info:       prInfo{State: "MERGED", MergedAt: &mergedTime},
+			wantMerged: true,
+		},
+		{
+			name:       "MergedAt is nil pointer (PR open or closed without merge)",
+			info:       prInfo{State: "OPEN", MergedAt: nil},
+			wantMerged: false,
+		},
+		{
+			name:       "MergedAt points to empty string (defensive)",
+			info:       prInfo{State: "OPEN", MergedAt: &emptyStr},
+			wantMerged: false,
+		},
+		{
+			name:       "CLOSED + nil MergedAt = closed without merging",
+			info:       prInfo{State: "CLOSED", MergedAt: nil},
+			wantMerged: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.info.isMerged(); got != tc.wantMerged {
+				t.Errorf("isMerged() = %v, want %v", got, tc.wantMerged)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The local merge-queue watcher introduced in #1014 has been broken on every poll since it shipped, and as a result the queue has never actually merged a PR. `fetchPRInfo` requests `merged` from `gh pr view --json`, but `gh` has no such field — its merge-related fields are `mergedAt`, `mergedBy`, `mergeCommit`, `mergeStateStatus`, `mergeable`. `gh` rejects unknown JSON fields with a non-zero exit, so every 45-second poll has been failing with:

```
[mergequeue] fetchPRInfo PR #N: gh pr view: exit status 1: Unknown JSON field: "merged"
```

…leaving the head row stuck in `watching` forever. The whole feature has been broken end-to-end since #1014 — the queue has never actually merged a PR since launch.

## Fix

- Replace `Merged bool` (`json:"merged"`) with `MergedAt *string` (`json:"mergedAt"`) — the canonical, nullable timestamp field.
- Add an `isMerged()` helper so the two consumer sites in `tick()` stay readable.
- Extract the `--json` field list as `prInfoJSONFields` (package-level constant) so the regression has a guard test.
- Update the test fakeWatcher and the `Merged: false` fixture in `TestWatcher_ClosedExternallyTransitionsToFailed`.
- Add `TestPRInfoJSONFields_NoMergedField` to assert the field list never reintroduces `merged` and always includes `mergedAt`.
- Add `TestPRInfo_IsMerged` covering merged / nil / empty-string / closed-without-merge cases.

## Verification

- `go build ./...` and `go test ./...` from `modules/programs/prism/prism/` are green.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeds.
- Manual: `gh pr view <pr> --json mergedAt` confirms the field name; the same JSON arg list now succeeds where the old one exited 1.

## Notes for the merger

The merge queue is itself broken until this lands, so this PR must be merged manually (`gh pr merge <n> --squash`) rather than via `prism merge`.