### PR TITLE
fix(merges): show 1-based queue rank in POS column instead of raw timestamp

### DIFF
--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -221,50 +221,68 @@ func resolveCallerIdentity(callerSession string, d *db.DB) (instanceID, sessionN
 // renderMergesList renders a tabular view of merge queue entries.
 func renderMergesList(merges []db.PendingMerge, filter string) error {
 	if len(merges) == 0 {
-		switch filter {
-		case "failed":
-			fmt.Println("no failed merge queue entries")
-		case "abandoned":
-			fmt.Println("no abandoned merge queue entries from previous coordinator sessions")
-		case "all":
-			fmt.Println("no merge queue entries in the last 7 days")
-		default:
-			fmt.Println("merge queue is empty")
-		}
+		fmt.Println(emptyMergesMessage(filter))
 		return nil
 	}
 
 	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
 	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
-	now := time.Now()
 
-	const (
-		wPos     = 5
-		wPR      = 6
-		wTitle   = 40
-		wStatus  = 11
-		wQueued  = 10
-		wChecked = 10
-		wError   = 40
-	)
+	header, rows := formatMergesRows(merges, time.Now())
 
-	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
-		wPos, "POS",
-		wPR, "PR",
-		wTitle, "TITLE",
-		wStatus, "STATUS",
-		wQueued, "QUEUED",
-		wChecked, "CHECKED",
-		"ERROR",
-	)
 	fmt.Println(styleHeader.Render(header))
 	fmt.Println(styleDim.Render(strings.Repeat("─", len(header)+5)))
+	for _, row := range rows {
+		fmt.Println(row)
+	}
+	fmt.Fprintln(os.Stdout)
+	return nil
+}
 
-	for _, m := range merges {
-		posStr := fmt.Sprintf("%d", m.QueuePosition)
-		if len(posStr) > wPos {
-			posStr = posStr[:wPos]
-		}
+// emptyMergesMessage returns the empty-state message for the given filter.
+func emptyMergesMessage(filter string) string {
+	switch filter {
+	case "failed":
+		return "no failed merge queue entries"
+	case "abandoned":
+		return "no abandoned merge queue entries from previous coordinator sessions"
+	case "all":
+		return "no merge queue entries in the last 7 days"
+	default:
+		return "merge queue is empty"
+	}
+}
+
+// mergesColumnWidths defines the column widths for the merges table. Exposed
+// as a package-level block so tests can refer to the same values.
+const (
+	mergesWPos     = 5
+	mergesWPR      = 6
+	mergesWTitle   = 40
+	mergesWStatus  = 11
+	mergesWQueued  = 10
+	mergesWChecked = 10
+	mergesWError   = 40
+)
+
+// formatMergesRows builds the header line and one formatted line per merge
+// queue row. POS is the 1-based rank of the row in the (already FIFO-sorted)
+// input slice — not the raw queue_position timestamp. The header and rows are
+// returned as strings so tests can assert on them without capturing stdout.
+func formatMergesRows(merges []db.PendingMerge, now time.Time) (header string, rows []string) {
+	header = fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
+		mergesWPos, "POS",
+		mergesWPR, "PR",
+		mergesWTitle, "TITLE",
+		mergesWStatus, "STATUS",
+		mergesWQueued, "QUEUED",
+		mergesWChecked, "CHECKED",
+		"ERROR",
+	)
+
+	rows = make([]string, 0, len(merges))
+	for i, m := range merges {
+		posStr := fmt.Sprintf("%d", i+1)
 		prStr := fmt.Sprintf("#%d", m.PR)
 		titleStr := "—"
 		if m.Title != nil && *m.Title != "" {
@@ -279,24 +297,23 @@ func renderMergesList(merges []db.PendingMerge, filter string) error {
 		if m.Error != nil {
 			errStr = *m.Error
 		}
-		if len(errStr) > wError {
-			errStr = errStr[:wError-3] + "..."
+		if len(errStr) > mergesWError {
+			errStr = errStr[:mergesWError-3] + "..."
 		}
 
-		statusStyled := mergeStatusStyle(m.Status).Render(fmt.Sprintf("%-*s", wStatus, truncateStr(m.Status, wStatus)))
+		statusStyled := mergeStatusStyle(m.Status).Render(fmt.Sprintf("%-*s", mergesWStatus, truncateStr(m.Status, mergesWStatus)))
 
-		fmt.Printf("%-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
-			wPos, posStr,
-			wPR, prStr,
-			wTitle, truncateStr(titleStr, wTitle),
+		rows = append(rows, fmt.Sprintf("%-*s  %-*s  %-*s  %s  %-*s  %-*s  %s",
+			mergesWPos, posStr,
+			mergesWPR, prStr,
+			mergesWTitle, truncateStr(titleStr, mergesWTitle),
 			statusStyled,
-			wQueued, queuedStr,
-			wChecked, checkedStr,
+			mergesWQueued, queuedStr,
+			mergesWChecked, checkedStr,
 			errStr,
-		)
+		))
 	}
-	fmt.Fprintln(os.Stdout)
-	return nil
+	return header, rows
 }
 
 // mergeStatusStyle returns a lipgloss style for a merge status value.

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -253,8 +253,7 @@ func emptyMergesMessage(filter string) string {
 	}
 }
 
-// mergesColumnWidths defines the column widths for the merges table. Exposed
-// as a package-level block so tests can refer to the same values.
+// Column widths for the merges table.
 const (
 	mergesWPos     = 5
 	mergesWPR      = 6

--- a/modules/programs/prism/prism/cmd/merges_test.go
+++ b/modules/programs/prism/prism/cmd/merges_test.go
@@ -1,12 +1,20 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
 )
+
+// expectedPosPrefix builds the expected POS-column prefix for a 1-based rank,
+// padded to mergesWPos with %-*s. Using the real constant means the test
+// stays correct if the column width is ever changed.
+func expectedPosPrefix(rank int) string {
+	return fmt.Sprintf("%-*s", mergesWPos, fmt.Sprintf("%d", rank))
+}
 
 // TestFormatMergesRows_PosIsOneBasedRank verifies that the POS column shows
 // the row's 1-based rank in the input slice — not the raw queue_position
@@ -32,10 +40,10 @@ func TestFormatMergesRows_PosIsOneBasedRank(t *testing.T) {
 	}
 
 	// Each row must start with its 1-based rank, padded to mergesWPos columns.
-	wantPrefixes := []string{"1    ", "2    ", "3    "}
 	for i, row := range rows {
-		if !strings.HasPrefix(row, wantPrefixes[i]) {
-			t.Errorf("row %d: expected POS prefix %q, got row %q", i, wantPrefixes[i], row)
+		want := expectedPosPrefix(i + 1)
+		if !strings.HasPrefix(row, want) {
+			t.Errorf("row %d: expected POS prefix %q, got row %q", i, want, row)
 		}
 		// Sanity: the raw timestamp must NOT appear anywhere in the row.
 		if strings.Contains(row, "17771") {
@@ -63,18 +71,19 @@ func TestFormatMergesRows_RankPerFilteredView(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(rows))
 	}
-	if !strings.HasPrefix(rows[0], "1    ") {
-		t.Errorf("filtered row 0: expected POS=1, got %q", rows[0])
+	if want := expectedPosPrefix(1); !strings.HasPrefix(rows[0], want) {
+		t.Errorf("filtered row 0: expected POS prefix %q, got %q", want, rows[0])
 	}
-	if !strings.HasPrefix(rows[1], "2    ") {
-		t.Errorf("filtered row 1: expected POS=2, got %q", rows[1])
+	if want := expectedPosPrefix(2); !strings.HasPrefix(rows[1], want) {
+		t.Errorf("filtered row 1: expected POS prefix %q, got %q", want, rows[1])
 	}
 }
 
 // TestFormatMergesRows_HeaderIncludesPos sanity-checks that the header row
 // still labels the column "POS".
 func TestFormatMergesRows_HeaderIncludesPos(t *testing.T) {
-	header, _ := formatMergesRows(nil, time.Now())
+	now := time.Date(2025, 4, 26, 12, 0, 0, 0, time.UTC)
+	header, _ := formatMergesRows(nil, now)
 	if !strings.HasPrefix(header, "POS") {
 		t.Errorf("expected header to start with POS, got %q", header)
 	}

--- a/modules/programs/prism/prism/cmd/merges_test.go
+++ b/modules/programs/prism/prism/cmd/merges_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestFormatMergesRows_PosIsOneBasedRank verifies that the POS column shows
+// the row's 1-based rank in the input slice — not the raw queue_position
+// timestamp. This is the core fix for the "POS shows truncated Unix-ms
+// timestamp like 17771" bug.
+func TestFormatMergesRows_PosIsOneBasedRank(t *testing.T) {
+	now := time.Date(2025, 4, 26, 12, 0, 0, 0, time.UTC)
+	queuedAt := now.Add(-3 * time.Minute)
+
+	// Three rows whose queue_position values are realistic Unix-ms timestamps.
+	// Pre-fix, the POS column would render the leading 5 digits of each
+	// timestamp ("17771", "17771", "17771"). Post-fix it must render
+	// "1", "2", "3" — the rank in the FIFO-sorted slice.
+	merges := []db.PendingMerge{
+		{PR: 1046, Status: "watching", QueuePosition: 1777154720435, Title: strPtr("first"), QueuedAt: queuedAt},
+		{PR: 1047, Status: "watching", QueuePosition: 1777154720436, Title: strPtr("second"), QueuedAt: queuedAt},
+		{PR: 1048, Status: "watching", QueuePosition: 1777154720437, Title: strPtr("third"), QueuedAt: queuedAt},
+	}
+
+	_, rows := formatMergesRows(merges, now)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+
+	// Each row must start with its 1-based rank, padded to mergesWPos columns.
+	wantPrefixes := []string{"1    ", "2    ", "3    "}
+	for i, row := range rows {
+		if !strings.HasPrefix(row, wantPrefixes[i]) {
+			t.Errorf("row %d: expected POS prefix %q, got row %q", i, wantPrefixes[i], row)
+		}
+		// Sanity: the raw timestamp must NOT appear anywhere in the row.
+		if strings.Contains(row, "17771") {
+			t.Errorf("row %d: raw queue_position timestamp leaked into output: %q", i, row)
+		}
+	}
+}
+
+// TestFormatMergesRows_RankPerFilteredView verifies that the rank reflects
+// display order within a filtered view, not the storage ordering key. AC-2:
+// `prism merges list --failed`, `--abandoned`, `--all` all use the same
+// renderer, so a single test on the renderer covers all of them.
+func TestFormatMergesRows_RankPerFilteredView(t *testing.T) {
+	now := time.Date(2025, 4, 26, 12, 0, 0, 0, time.UTC)
+	queuedAt := now.Add(-1 * time.Hour)
+
+	// Simulate a `--failed` filter result: two failed rows with non-contiguous
+	// queue_position timestamps. Display rank should still be 1, 2.
+	merges := []db.PendingMerge{
+		{PR: 900, Status: "failed", QueuePosition: 1777000000000, Title: strPtr("a"), QueuedAt: queuedAt, Error: strPtr("boom")},
+		{PR: 950, Status: "failed", QueuePosition: 1777200000000, Title: strPtr("b"), QueuedAt: queuedAt, Error: strPtr("kaboom")},
+	}
+
+	_, rows := formatMergesRows(merges, now)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if !strings.HasPrefix(rows[0], "1    ") {
+		t.Errorf("filtered row 0: expected POS=1, got %q", rows[0])
+	}
+	if !strings.HasPrefix(rows[1], "2    ") {
+		t.Errorf("filtered row 1: expected POS=2, got %q", rows[1])
+	}
+}
+
+// TestFormatMergesRows_HeaderIncludesPos sanity-checks that the header row
+// still labels the column "POS".
+func TestFormatMergesRows_HeaderIncludesPos(t *testing.T) {
+	header, _ := formatMergesRows(nil, time.Now())
+	if !strings.HasPrefix(header, "POS") {
+		t.Errorf("expected header to start with POS, got %q", header)
+	}
+}
+
+// TestEmptyMergesMessage covers the empty-state messages for each filter so
+// the refactor (extracting emptyMergesMessage from renderMergesList) is
+// observably equivalent to the previous inline switch.
+func TestEmptyMergesMessage(t *testing.T) {
+	cases := map[string]string{
+		"":          "merge queue is empty",
+		"failed":    "no failed merge queue entries",
+		"abandoned": "no abandoned merge queue entries from previous coordinator sessions",
+		"all":       "no merge queue entries in the last 7 days",
+	}
+	for filter, want := range cases {
+		got := emptyMergesMessage(filter)
+		if got != want {
+			t.Errorf("emptyMergesMessage(%q) = %q, want %q", filter, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix the `POS` column in `prism merges` and `prism merges list` to show the
row's 1-based rank in display order (`1`, `2`, `3` …) instead of the raw
`queue_position` storage value truncated to 5 characters.

## The bug

`prism merges` was rendering output like:

```
POS    PR      TITLE                                     STATUS       QUEUED      CHECKED     ERROR
17771  #1046   fix(prism): use short sun_path for ho...  watching     3m          22s
```

The `17771` is the leading 5 digits of `1777154720435` — the row's
`queue_position` value truncated to fit the column width.

## Root cause

`queue_position` is set at insert time to the current Unix-millisecond
timestamp (see comment in `internal/db/db.go:2867`). It exists purely as a
monotone FIFO ordering key for the SQL layer — it's not intended as a
user-facing rank.

`cmd/merges.go` was formatting that raw timestamp and then truncating it to
the column's 5-char budget, producing the leading-digits gibberish above.

## Fix

Render POS as the 1-based slice index of the row in the (already
`queue_position ASC`-sorted) `merges` slice. The truncation logic is removed —
a 5-char width comfortably supports up to 99,999 entries, well beyond any
realistic per-coordinator queue size.

The same renderer is used for `--failed`, `--abandoned`, and `--all` filters,
so the rank reflects display order within the filtered view, which is the
sensible UX for those listings.

## Refactor for testability

`renderMergesList` was monolithic and wrote directly to stdout. Extracted
two small helpers so the rendering is testable without capturing stdout:

- `formatMergesRows(merges, now) (header, rows)` — pure formatting
- `emptyMergesMessage(filter)` — pure string lookup

`renderMergesList` is now a thin wrapper around them.

## Tests

Added `cmd/merges_test.go` with 4 tests:

- `TestFormatMergesRows_PosIsOneBasedRank` — three rows with realistic
  Unix-ms `queue_position` values render as POS=1,2,3 and the raw timestamp
  digits never appear in any row.
- `TestFormatMergesRows_RankPerFilteredView` — confirms rank reflects
  display order in a `--failed`-style filtered view, not the storage key.
- `TestFormatMergesRows_HeaderIncludesPos` — sanity check that the column
  is still labelled `POS`.
- `TestEmptyMergesMessage` — covers all four empty-state messages so the
  refactor is observably equivalent to the previous inline switch.

## Verification

- `go build ./...` from `modules/programs/prism/prism/` — green
- `go test ./...` from `modules/programs/prism/prism/` — green
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — green

No issue tracked separately — this is a small cosmetic fix described in the
spawn prompt.