### PR TITLE
prism: SBPL profile generator and sandbox-exec launch (minimal read-only)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -43,7 +43,6 @@ package cmd
 //	--session <name>   prism session name (e.g. "nixos-config@feature")
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -58,6 +57,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
 	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -112,9 +112,13 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("prism agent-run: bwrap isolation requires Linux; current platform is %s", runtime.GOOS)
 		}
 	case config.IsolationSandboxExec:
-		// The platform guard in spawn.go ensures this is only reached on Darwin.
-		// The full sandbox-exec implementation is tracked in issue #1016.
-		return errors.New("sandbox-exec mode: not yet implemented (issue #1016)")
+		// Fail fast on non-Darwin: sandbox-exec is macOS-only.
+		// The platform guard in spawn.go also catches this at spawn time;
+		// belt-and-braces guard for direct invocations of agent-run.
+		if runtime.GOOS != "darwin" {
+			return fmt.Errorf("prism agent-run: sandbox-exec isolation requires macOS (Darwin); current platform is %s", runtime.GOOS)
+		}
+		return runAgentRunSandboxExec(sessionName, status)
 	default:
 		return fmt.Errorf("agent-run: session %q has isolation mode %q; this command is only for bwrap and sandbox-exec sessions", sessionName, isoMode)
 	}
@@ -424,34 +428,12 @@ func forwardSignalsToBwrap(proc *os.Process, doneCh <-chan struct{}, onWinch fun
 // Everything else — including PRISM_GITHUB_TOKEN_*, GITHUB_TOKEN,
 // GITHUB_PACKAGES_TOKEN, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, and any
 // other secret a prism coordinator might export — is dropped.
+//
+// The implementation is a thin alias over container.MinimalIsolatedExecEnv
+// (the same logic is reused by the sandbox-exec path, see #1016). Both call
+// sites share a single helper because the filter is identical across modes.
 func minimalBwrapExecEnv(hostEnv []string) []string {
-	allow := map[string]bool{
-		"PATH":      true,
-		"HOME":      true,
-		"USER":      true,
-		"LOGNAME":   true,
-		"TERM":      true,
-		"COLORTERM": true,
-		"LANG":      true,
-		"LC_ALL":    true,
-	}
-	out := make([]string, 0, len(allow))
-	for _, kv := range hostEnv {
-		eq := -1
-		for i := 0; i < len(kv); i++ {
-			if kv[i] == '=' {
-				eq = i
-				break
-			}
-		}
-		if eq <= 0 {
-			continue
-		}
-		if allow[kv[:eq]] {
-			out = append(out, kv)
-		}
-	}
-	return out
+	return container.MinimalIsolatedExecEnv(hostEnv)
 }
 
 // applyInitialPromptEnvVar reads PRISM_INITIAL_PROMPT from the process
@@ -463,6 +445,133 @@ func applyInitialPromptEnvVar(cfg *container.Config) {
 	if initialPrompt := os.Getenv("PRISM_INITIAL_PROMPT"); initialPrompt != "" {
 		cfg.InitialPrompt = initialPrompt
 	}
+}
+
+// validateSandboxExecArgs checks that the args returned by
+// Manager.PrepareSandboxExec have the expected shape and that the profile
+// path on disk is readable. It exists as a separate function so the
+// edge-case AC ("missing/unreadable profile-temp path returns a clear error
+// and does not exec") can be unit-tested without needing a Darwin host or
+// real /usr/bin/sandbox-exec binary.
+//
+// Returned errors are wrapped with the `agent-run:` prefix used by the
+// surrounding command so they appear coherently in the agent-run log.
+func validateSandboxExecArgs(args []string) error {
+	if len(args) < 4 || args[0] != "sandbox-exec" || args[1] != "-f" {
+		return fmt.Errorf("agent-run: sandbox-exec args have unexpected shape (len=%d): %v", len(args), args)
+	}
+	profilePath := args[2]
+	if profilePath == "" {
+		return fmt.Errorf("agent-run: sandbox-exec profile path is empty")
+	}
+	if _, statErr := os.Stat(profilePath); statErr != nil {
+		return fmt.Errorf("agent-run: sandbox-exec profile %s is missing or unreadable: %w", profilePath, statErr)
+	}
+	return nil
+}
+
+// runAgentRunSandboxExec is the sandbox-exec equivalent of the bwrap dispatch
+// path above. It reconstructs the container.Config from the session's DB
+// status, calls Manager.PrepareSandboxExec to materialise the SBPL profile,
+// and then replaces this process with sandbox-exec via syscall.Exec — the
+// same lifecycle pattern bwrap once used (the bwrap path now uses a
+// supervised child for PTY/signal handling; the minimal sandbox-exec path
+// retains the original syscall.Exec model per #1016).
+//
+// Per the AC in #1016, this function:
+//
+//   - calls PrepareSandboxExec() to write the profile and build the args.
+//   - re-stats the profile-temp path before exec'ing; if it is missing or
+//     unreadable, returns a clear error and does NOT exec.
+//   - filters the env via container.MinimalIsolatedExecEnv so the same
+//     allow-list as bwrap (PATH, HOME, USER, LOGNAME, TERM, COLORTERM, LANG,
+//     LC_ALL) is the only thing the sandbox-exec process inherits.
+//   - syscall.Exec("/usr/bin/sandbox-exec", args, env).
+//
+// PR 4 (#1018) replaces this with a supervised child + lifecycle hardening.
+func runAgentRunSandboxExec(sessionName string, status *db.Status) error {
+	// Load prism config for git identity and SSH key names. Mirrors the
+	// bwrap path so future PRs in this design can extend the Manager.Config
+	// uniformly (staging HOME, credentials, caches in #1017).
+	cfg := config.Load()
+
+	worktree := status.Worktree
+	if worktree == "" {
+		return fmt.Errorf("agent-run: session %q has no recorded worktree", sessionName)
+	}
+	bareRoot := git.BareRoot(worktree)
+	var worktreeGitDir string
+	if bareRoot != "" {
+		worktreeGitDir = filepath.Join(bareRoot, ".bare", "worktrees", filepath.Base(worktree))
+	}
+
+	port := 0
+	if status.HarnessPort != nil {
+		port = *status.HarnessPort
+	}
+
+	agentRole := ""
+	if status.RootAgentName != nil {
+		agentRole = *status.RootAgentName
+	}
+	if agentRole == "" {
+		agentRole = session.DefaultAgent(worktree, "")
+	}
+
+	hostAPISockPath := ""
+	if sockPath, sockErr := session.SidecarHostAPIPath(sessionName); sockErr == nil {
+		hostAPISockPath = sockPath
+	}
+
+	var agentEnvVars map[string]string
+	if pf, pfErr := config.LoadProfiles(); pfErr == nil && pf != nil {
+		agentEnvVars = pf.AgentEnvVars
+	}
+
+	agentRunHarness := opencode.New("", nil, "", "")
+	ctrCfg := container.Config{
+		SessionName:       sessionName,
+		Worktree:          worktree,
+		BareRoot:          bareRoot,
+		WorktreeGitDir:    worktreeGitDir,
+		AllocatedPort:     port,
+		AgentRole:         agentRole,
+		GitUserName:       cfg.GitUserName,
+		GitUserEmail:      cfg.GitUserEmail,
+		SshAccessKeyName:  cfg.SshAccessKeyName,
+		SshSigningKeyName: cfg.SshSigningKeyName,
+		HostAPISockPath:   hostAPISockPath,
+		RuntimeEnv:        agentRunHarness.RuntimeEnv(),
+		AgentEnvVars:      agentEnvVars,
+	}
+
+	applyInitialPromptEnvVar(&ctrCfg)
+
+	m := container.New(ctrCfg)
+
+	args, err := m.PrepareSandboxExec()
+	if err != nil {
+		return fmt.Errorf("agent-run: prepare sandbox-exec args: %w", err)
+	}
+
+	if err := validateSandboxExecArgs(args); err != nil {
+		return err
+	}
+
+	// Filter the env passed to sandbox-exec through the same allow-list as
+	// bwrap (PATH, HOME, USER, LOGNAME, TERM, COLORTERM, LANG, LC_ALL). This
+	// is the only line of defence in this PR against host-shell secrets
+	// reaching the sandbox interior — the minimal profile does not yet
+	// rebuild the env via setenv equivalents (#1017 is where staging HOME
+	// and friends land).
+	env := container.MinimalIsolatedExecEnv(os.Environ())
+
+	const sandboxExecBinary = "/usr/bin/sandbox-exec"
+	if execErr := syscall.Exec(sandboxExecBinary, args, env); execErr != nil {
+		return fmt.Errorf("agent-run: exec %s: %w", sandboxExecBinary, execErr)
+	}
+	// Unreachable: syscall.Exec only returns on error.
+	return nil
 }
 
 // findBwrap locates the bwrap binary on PATH or in well-known Nix store paths.

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -447,3 +448,84 @@ func containsAt(s, substr string) bool {
 	}
 	return false
 }
+
+// ── validateSandboxExecArgs ─────────────────────────────────────────────────
+
+// TestValidateSandboxExecArgs_OK verifies that args produced by
+// Manager.PrepareSandboxExec pass validation when the on-disk profile is
+// present.
+func TestValidateSandboxExecArgs_OK(t *testing.T) {
+	m := container.New(container.Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14010,
+	})
+	t.Cleanup(func() {
+		// PrepareSandboxExec writes the profile to a temp file; remove it
+		// after the test so we don't leak across runs.
+		_ = os.Remove(filepath.Join(os.TempDir(), "prism-sandbox-exec-profile-"+m.Name()+".sb"))
+	})
+
+	args, err := m.PrepareSandboxExec()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExec: %v", err)
+	}
+
+	if err := validateSandboxExecArgs(args); err != nil {
+		t.Errorf("validateSandboxExecArgs(%v) = %v, want nil", args, err)
+	}
+}
+
+// TestValidateSandboxExecArgs_MissingProfile verifies the edge-case AC:
+// when the profile-temp file is missing or unreadable, validation returns a
+// clear error containing the path and the underlying stat error.
+func TestValidateSandboxExecArgs_MissingProfile(t *testing.T) {
+	m := container.New(container.Config{
+		SessionName:   "repo@gone",
+		AllocatedPort: 14011,
+	})
+	args, err := m.PrepareSandboxExec()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExec: %v", err)
+	}
+	profilePath := args[2]
+	t.Cleanup(func() { _ = os.Remove(profilePath) })
+
+	// Simulate a missing/unreadable profile-temp file.
+	if err := os.Remove(profilePath); err != nil {
+		t.Fatalf("Remove profile: %v", err)
+	}
+
+	got := validateSandboxExecArgs(args)
+	if got == nil {
+		t.Fatalf("validateSandboxExecArgs with missing profile = nil, want error")
+	}
+	gotMsg := got.Error()
+	if !contains(gotMsg, "missing or unreadable") {
+		t.Errorf("error message %q must mention 'missing or unreadable'", gotMsg)
+	}
+	if !contains(gotMsg, profilePath) {
+		t.Errorf("error message %q must contain the profile path %q", gotMsg, profilePath)
+	}
+}
+
+// TestValidateSandboxExecArgs_BadShape verifies that args without the
+// expected leading ["sandbox-exec", "-f", <path>, ...] shape are rejected.
+func TestValidateSandboxExecArgs_BadShape(t *testing.T) {
+	cases := [][]string{
+		nil,
+		{},
+		{"sandbox-exec"},
+		{"sandbox-exec", "-f"},
+		{"sandbox-exec", "-f", "/tmp/x"},                  // missing harness
+		{"sandbox-exec", "WRONG", "/tmp/x", "opencode"},   // wrong flag
+		{"NOT-SANDBOX", "-f", "/tmp/x", "opencode"},       // wrong argv[0]
+	}
+	for i, args := range cases {
+		err := validateSandboxExecArgs(args)
+		if err == nil {
+			t.Errorf("case %d: validateSandboxExecArgs(%v) = nil, want error", i, args)
+		}
+	}
+}
+
+

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -516,9 +516,9 @@ func TestValidateSandboxExecArgs_BadShape(t *testing.T) {
 		{},
 		{"sandbox-exec"},
 		{"sandbox-exec", "-f"},
-		{"sandbox-exec", "-f", "/tmp/x"},                  // missing harness
-		{"sandbox-exec", "WRONG", "/tmp/x", "opencode"},   // wrong flag
-		{"NOT-SANDBOX", "-f", "/tmp/x", "opencode"},       // wrong argv[0]
+		{"sandbox-exec", "-f", "/tmp/x"}, // missing harness
+		{"sandbox-exec", "WRONG", "/tmp/x", "opencode"}, // wrong flag
+		{"NOT-SANDBOX", "-f", "/tmp/x", "opencode"},     // wrong argv[0]
 	}
 	for i, args := range cases {
 		err := validateSandboxExecArgs(args)
@@ -527,5 +527,3 @@ func TestValidateSandboxExecArgs_BadShape(t *testing.T) {
 		}
 	}
 }
-
-

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -671,36 +671,16 @@ func (b *bwrapIsolator) Run(ctx context.Context, args []string) error {
 // is NOT the sandbox interior env (bwrap starts the sandbox with --clearenv
 // and rebuilds the interior env from explicit --setenv pairs in BuildArgs).
 //
+// This is a thin alias over minimalIsolatedExecEnv (sandbox_exec.go) — the
+// allow-list is identical across bwrap and sandbox-exec, so both call sites
+// share a single helper. The alias is retained so the existing tests and
+// callers in this file continue to read naturally as a bwrap-specific
+// concern.
+//
 // See cmd/agent_run.go for the corresponding filter at the syscall.Exec
 // call site. Both filters use the same allow-list; keep them in sync.
 func minimalBwrapExecEnv(hostEnv []string) []string {
-	allow := map[string]bool{
-		"PATH":      true,
-		"HOME":      true,
-		"USER":      true,
-		"LOGNAME":   true,
-		"TERM":      true,
-		"COLORTERM": true,
-		"LANG":      true,
-		"LC_ALL":    true,
-	}
-	out := make([]string, 0, len(allow))
-	for _, kv := range hostEnv {
-		eq := -1
-		for i := 0; i < len(kv); i++ {
-			if kv[i] == '=' {
-				eq = i
-				break
-			}
-		}
-		if eq <= 0 {
-			continue
-		}
-		if allow[kv[:eq]] {
-			out = append(out, kv)
-		}
-	}
-	return out
+	return MinimalIsolatedExecEnv(hostEnv)
 }
 
 // Shutdown sends SIGTERM to the bwrap process if it is still running. It uses

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -322,6 +322,7 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.opencodeConfigFilePath())
 	_ = os.Remove(m.claudeCredentialsFilePath())
+	_ = os.Remove(m.sandboxExecProfilePath())
 
 	// Check the container's instance label when we have our own InstanceID.
 	// This detects ownership mismatches where a container from a previous
@@ -824,6 +825,7 @@ func (m *Manager) Shutdown() {
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.opencodeConfigFilePath())
 	_ = os.Remove(m.claudeCredentialsFilePath())
+	_ = os.Remove(m.sandboxExecProfilePath())
 
 	log.Printf("container: %q removed", m.name)
 }
@@ -876,6 +878,28 @@ func (m *Manager) PrepareBwrap() ([]string, error) {
 	// Build the bwrap args.
 	b := &bwrapIsolator{name: m.name}
 	return b.BuildArgs(m), nil
+}
+
+// PrepareSandboxExec writes the SBPL profile for this session to a temp file
+// under the per-session state dir and returns the complete sandbox-exec
+// argument list via sandboxExecIsolator.BuildArgs.
+//
+// Call this from "prism agent-run" in the tmux pane for sandbox-exec mode.
+// The returned args slice is suitable for passing directly to
+// syscall.Exec("/usr/bin/sandbox-exec", args, env). The first element of
+// args is "sandbox-exec" itself (which becomes argv[0] under syscall.Exec).
+//
+// This PR (#1016) is the minimal read-only launch — no SSH config,
+// gitconfig, or opencode.json temp files are written here. Staging HOME,
+// credentials, caches, and write paths come in PR 3 (#1017); concurrency
+// cap and lifecycle hardening come in PR 4 (#1018).
+func (m *Manager) PrepareSandboxExec() ([]string, error) {
+	if _, err := writeProfile(m); err != nil {
+		return nil, err
+	}
+
+	s := &sandboxExecIsolator{name: m.name}
+	return s.BuildArgs(m), nil
 }
 
 // prepareVolumeDirs eagerly creates host directories that buildRunArgs() will

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -1,0 +1,277 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file defines sandboxExecIsolator, an Apple sandbox-exec-based
+// implementation of the Isolator interface. It is symmetric to bwrapIsolator
+// in bwrap.go: BuildRunArgs() is a no-op stub, BuildArgs(m *Manager) is the
+// concrete argument builder that has access to the Manager's config and state.
+//
+// This file implements PR 2 of the sandbox-exec design (issue #1012):
+// minimal read-only profile that lets opencode launch and read system paths.
+// Staging HOME, credentials, caches, and write paths are deferred to PR 3
+// (#1017). Concurrency cap and lifecycle hardening are deferred to PR 4
+// (#1018). New top-level allow/deny clauses introduced beyond what is listed
+// in the issue body require a comment pointing back at #1012.
+package container
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// sandboxExecIsolator implements Isolator using Apple's sandbox-exec. It
+// satisfies the interface through Run, Shutdown, HasExited, and DumpLogs.
+// BuildRunArgs() returns nil (a no-op stub) because the real argument
+// construction is performed by BuildArgs(m *Manager), which has access to the
+// Manager's config and state.
+//
+// Symmetric to bwrapIsolator (see bwrap.go). The interface is not widened —
+// BuildArgs is a concrete method that takes the Manager directly, mirroring
+// the bwrap pattern.
+type sandboxExecIsolator struct {
+	// name is the stable session identifier (used for log messages).
+	name string
+
+	// mu guards cmd. The sandbox-exec process for a session is launched by
+	// agent-run via syscall.Exec, so this Isolator's Run path is unused in
+	// the production flow — it exists to satisfy the Isolator interface.
+	mu sync.Mutex
+	// exited and exitCode track terminal state for HasExited(). They are
+	// unused in the production flow (agent-run replaces the current process
+	// via syscall.Exec) but kept for interface parity and future tests.
+	exited   bool
+	exitCode int
+}
+
+// newSandboxExecIsolator returns an Isolator backed by Apple's sandbox-exec
+// for the given session name. The returned value satisfies the Isolator
+// interface.
+func newSandboxExecIsolator(name string) Isolator {
+	return &sandboxExecIsolator{name: name}
+}
+
+// BuildRunArgs satisfies the Isolator interface. It returns nil because the
+// real argument construction requires Manager state and is implemented by the
+// concrete BuildArgs(m *Manager) method below.
+func (s *sandboxExecIsolator) BuildRunArgs() []string {
+	return nil
+}
+
+// generateProfile returns the SBPL profile content for this session.
+//
+// The profile shape is locked in by issue #1012 and is exactly what is
+// listed in the body of issue #1016 for this PR — minimal read-only
+// system roots, the two deny subpaths for sensitive /private/etc subtrees,
+// the process and IPC primitives required by node/opencode, and (allow
+// network*). Staging-HOME, worktree, credential, and cache rules belong to
+// the next PR (#1017) per the locked design.
+//
+// New top-level allow/deny clauses introduced beyond what is sketched in
+// #1012 require a comment in the generator pointing at the issue.
+func generateProfile(m *Manager) string {
+	// Reference m to keep the symmetric BuildArgs(m) signature pattern. The
+	// minimal read-only profile in this PR has no Manager-derived
+	// substitutions; PR 3 (#1017) wires in staging HOME, worktree, and
+	// credential paths that come from m.cfg.
+	_ = m
+
+	var sb strings.Builder
+	sb.WriteString("(version 1)\n")
+	sb.WriteString("(deny default)\n")
+	sb.WriteString("\n")
+
+	// ── Read-only system roots ────────────────────────────────────────────
+	// Mirror the bwrap baseline ro-binds (/nix, /etc, /run/current-system,
+	// /bin, /run/wrappers) for the macOS layout: /nix on macOS is the Nix
+	// store; /usr, /System, /Library, /private/etc, /private/var/db/dyld,
+	// and /private/var/db/timezone are the read-only OS paths that node and
+	// opencode resolve at startup. See #1012 — Design — SBPL profile shape.
+	sb.WriteString("(allow file-read*\n")
+	sb.WriteString("  (subpath \"/nix\")\n")
+	sb.WriteString("  (subpath \"/usr\")\n")
+	sb.WriteString("  (subpath \"/System\")\n")
+	sb.WriteString("  (subpath \"/Library\")\n")
+	sb.WriteString("  (subpath \"/private/etc\")\n")
+	sb.WriteString("  (subpath \"/private/var/db/dyld\")\n")
+	sb.WriteString("  (subpath \"/private/var/db/timezone\"))\n")
+	sb.WriteString("\n")
+
+	// ── Selective shadowing of sensitive subtrees ─────────────────────────
+	// Symmetric to bwrap's --tmpfs shadow of /etc/wireguard and
+	// /etc/wpa_supplicant. Under sandbox-exec, an explicit (deny ...) inside
+	// an otherwise-allow scope wins by precedence rules.
+	sb.WriteString("(deny file-read* file-write*\n")
+	sb.WriteString("  (subpath \"/private/etc/wireguard\")\n")
+	sb.WriteString("  (subpath \"/private/etc/wpa_supplicant\"))\n")
+	sb.WriteString("\n")
+
+	// ── Process and IPC primitives required by node/opencode ──────────────
+	// Locked in #1012. PID/UTS/IPC isolation is a documented gap on macOS;
+	// this is defence in depth, not adversarial workload isolation.
+	sb.WriteString("(allow process-exec* process-fork signal mach-lookup mach-register\n")
+	sb.WriteString("       sysctl-read iokit-open ipc-posix-shm)\n")
+	sb.WriteString("\n")
+
+	// ── Network ───────────────────────────────────────────────────────────
+	// Locked in #1012 — match bwrap. Restriction to specific hosts is a
+	// future concern, applied symmetrically.
+	sb.WriteString("(allow network*)\n")
+
+	return sb.String()
+}
+
+// sandboxExecProfilePath returns the host path for the SBPL profile temp
+// file written before sandbox-exec is launched. The path is namespaced by
+// the session name so concurrent sessions never collide.
+func (m *Manager) sandboxExecProfilePath() string {
+	return filepath.Join(os.TempDir(), "prism-sandbox-exec-profile-"+m.name+".sb")
+}
+
+// writeProfile materialises the generated SBPL profile to a temp file and
+// returns its absolute path. The file is owned by the invoking user and
+// readable only by them (0600) — sandbox-exec reads the file before exec'ing
+// the harness, so the user's own read access is sufficient.
+func writeProfile(m *Manager) (string, error) {
+	path := m.sandboxExecProfilePath()
+	content := generateProfile(m)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return "", fmt.Errorf("container: sandbox-exec: write profile %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// BuildArgs constructs the sandbox-exec argument list:
+//
+//	sandbox-exec -f <profile_path> opencode --port <port> --hostname 127.0.0.1 [--agent X] [--prompt Y]
+//
+// The first element ("sandbox-exec") is argv[0]; the caller invokes
+// syscall.Exec("/usr/bin/sandbox-exec", args, env). After -f and the profile
+// path comes the harness binary (opencode) and its arguments — the inner
+// command sandbox-exec executes inside the SBPL sandbox.
+//
+// The harness invocation mirrors bwrap.go:BuildArgs (see lines 608–636) so
+// that the sandbox interior behaves identically across isolation modes:
+//
+//   - --port: cfg.AllocatedPort, falling back to ContainerPort when 0.
+//   - --hostname 127.0.0.1: same rationale as bwrap (host network namespace
+//     is shared on both modes; binding 0.0.0.0 would be overly broad).
+//   - --agent <role>: appended when cfg.AgentRole is non-empty.
+//   - --prompt <text>: appended when cfg.InitialPrompt is non-empty.
+//
+// The minimal read-only profile in this PR does not yet wire HOME, working
+// directory, or environment overrides through the profile generator —
+// those land in PR 3 (#1017). The harness still inherits the env passed to
+// syscall.Exec, which agent-run filters via minimalIsolatedExecEnv.
+func (s *sandboxExecIsolator) BuildArgs(m *Manager) []string {
+	cfg := m.cfg
+
+	profilePath := m.sandboxExecProfilePath()
+
+	args := []string{"sandbox-exec", "-f", profilePath, "opencode"}
+
+	// Match the bwrap port-fallback rule for parity. AllocatedPort is
+	// populated by agent-run from the DB's harness_port column in normal
+	// operation; ContainerPort is the fallback for the theoretical case
+	// where AllocatedPort is unset.
+	opencodePort := cfg.AllocatedPort
+	if opencodePort == 0 {
+		opencodePort = ContainerPort
+	}
+	args = append(args,
+		"--port", fmt.Sprintf("%d", opencodePort),
+		"--hostname", "127.0.0.1",
+	)
+
+	if cfg.AgentRole != "" {
+		args = append(args, "--agent", cfg.AgentRole)
+	}
+	if cfg.InitialPrompt != "" {
+		args = append(args, "--prompt", cfg.InitialPrompt)
+	}
+
+	return args
+}
+
+// Run is a no-op stub for the production flow: agent-run launches
+// sandbox-exec via syscall.Exec, replacing its own process image, so this
+// Isolator's Run is never reached. The method exists to satisfy the
+// Isolator interface and is kept symmetric with bwrap.Run for future tests.
+func (s *sandboxExecIsolator) Run(ctx context.Context, args []string) error {
+	return fmt.Errorf("container: sandbox-exec %q: Run is not implemented; agent-run uses syscall.Exec", s.name)
+}
+
+// Shutdown is a no-op for sandbox-exec: the production flow uses
+// syscall.Exec from agent-run, so the sandbox-exec child is owned by the
+// tmux pane's process tree and terminates when the pane dies. Lifecycle
+// hardening (signal forwarding, kqueue parent-death watcher) is the
+// subject of PR 4 (#1018).
+func (s *sandboxExecIsolator) Shutdown() {}
+
+// HasExited returns the recorded exit state. In the production flow this is
+// always (false, 0) because agent-run replaces its own process via
+// syscall.Exec — the Manager-level Isolator never observes the child.
+func (s *sandboxExecIsolator) HasExited() (bool, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.exited, s.exitCode
+}
+
+// DumpLogs logs a message indicating that log capture is not implemented
+// for sandbox-exec (stdout/stderr inherit agent-run's terminal in the
+// production flow).
+func (s *sandboxExecIsolator) DumpLogs() {
+	log.Printf("container: sandbox-exec %q: live output is forwarded via the inherited terminal during syscall.Exec", s.name)
+}
+
+// MinimalIsolatedExecEnv filters a hostEnv slice (K=V pairs, as returned by
+// os.Environ()) down to the minimal allow-list that the isolation harness
+// (bwrap on Linux, sandbox-exec on Darwin) needs. It is the same logic as
+// the original minimalBwrapExecEnv — the filter is identical across modes,
+// so a single helper keeps both call sites in sync.
+//
+// The returned env is what the harness *process* sees on the host; it is
+// NOT the sandbox interior env. In bwrap mode the sandbox interior is
+// rebuilt via --setenv pairs in BuildArgs after --clearenv. In sandbox-exec
+// mode the sandbox shares the harness env, so this filter is the only line
+// of defence against host-shell secrets reaching the sandbox interior in
+// this PR.
+//
+// See cmd/agent_run.go for the corresponding filter at the syscall.Exec
+// call site. Both filters use the same allow-list; keep them in sync.
+//
+// Exported because cmd/agent_run.go also filters env at the syscall.Exec
+// boundary using exactly this allow-list.
+func MinimalIsolatedExecEnv(hostEnv []string) []string {
+	allow := map[string]bool{
+		"PATH":      true,
+		"HOME":      true,
+		"USER":      true,
+		"LOGNAME":   true,
+		"TERM":      true,
+		"COLORTERM": true,
+		"LANG":      true,
+		"LC_ALL":    true,
+	}
+	out := make([]string, 0, len(allow))
+	for _, kv := range hostEnv {
+		eq := -1
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				eq = i
+				break
+			}
+		}
+		if eq <= 0 {
+			continue
+		}
+		if allow[kv[:eq]] {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -35,13 +35,12 @@ type sandboxExecIsolator struct {
 	// name is the stable session identifier (used for log messages).
 	name string
 
-	// mu guards cmd. The sandbox-exec process for a session is launched by
-	// agent-run via syscall.Exec, so this Isolator's Run path is unused in
-	// the production flow — it exists to satisfy the Isolator interface.
-	mu sync.Mutex
-	// exited and exitCode track terminal state for HasExited(). They are
-	// unused in the production flow (agent-run replaces the current process
-	// via syscall.Exec) but kept for interface parity and future tests.
+	// mu guards exited/exitCode. The sandbox-exec process for a session is
+	// launched by agent-run via syscall.Exec, so this Isolator's Run path is
+	// unused in the production flow — these fields exist solely to satisfy
+	// the Isolator interface and to give future tests a place to record
+	// terminal state.
+	mu       sync.Mutex
 	exited   bool
 	exitCode int
 }
@@ -273,5 +272,3 @@ func MinimalIsolatedExecEnv(hostEnv []string) []string {
 	}
 	return out
 }
-
-

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -1,0 +1,486 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// newSandboxExecManager creates a Manager and injects a sandboxExecIsolator
+// so tests can drive BuildArgs/PrepareSandboxExec end-to-end without a real
+// macOS host. The test fixture intentionally does not stub HOME or any of the
+// bwrap fixture's fake credential paths because the minimal SBPL profile in
+// this PR does not consume them — staging HOME, credentials, and caches
+// land in #1017.
+func newSandboxExecManager(cfg Config) *Manager {
+	m := New(cfg)
+	m.isolator = newSandboxExecIsolator(m.name)
+	return m
+}
+
+// ── generateProfile content assertions ──────────────────────────────────────
+
+// TestGenerateProfile_VersionAndDenyDefault verifies that the profile begins
+// with the SBPL header that locks deny-by-default semantics: (version 1)
+// followed by (deny default). This is non-negotiable per #1012 — every
+// other clause is interpreted relative to deny-by-default.
+func TestGenerateProfile_VersionAndDenyDefault(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	// (version 1) MUST be the first non-empty content.
+	if !strings.HasPrefix(profile, "(version 1)\n") {
+		t.Errorf("profile must begin with (version 1)\\n; got prefix %q", firstNChars(profile, 64))
+	}
+
+	// (deny default) MUST follow immediately after (version 1).
+	if !strings.HasPrefix(profile, "(version 1)\n(deny default)\n") {
+		t.Errorf("profile must start with (version 1) then (deny default); got prefix %q", firstNChars(profile, 64))
+	}
+}
+
+// TestGenerateProfile_ReadOnlySystemRoots verifies that every read-only
+// system root listed in the AC appears as a (subpath ...) inside an
+// (allow file-read* ...) clause.
+func TestGenerateProfile_ReadOnlySystemRoots(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	// Locate the (allow file-read* ... block (the first one — there is only
+	// one in this PR, but extracting it explicitly insulates the assertion
+	// from accidental clauses appearing later in the file).
+	allowReadBlock := extractClause(t, profile, "(allow file-read*")
+
+	expected := []string{
+		`(subpath "/nix")`,
+		`(subpath "/usr")`,
+		`(subpath "/System")`,
+		`(subpath "/Library")`,
+		`(subpath "/private/etc")`,
+		`(subpath "/private/var/db/dyld")`,
+		`(subpath "/private/var/db/timezone")`,
+	}
+	for _, want := range expected {
+		if !strings.Contains(allowReadBlock, want) {
+			t.Errorf("(allow file-read* ...) block missing %q; block:\n%s", want, allowReadBlock)
+		}
+	}
+}
+
+// TestGenerateProfile_SensitiveSubtreeDenies verifies that the two deny
+// subpaths from the AC appear inside a (deny file-read* file-write* ...)
+// clause. These mirror the bwrap --tmpfs shadows of /etc/wireguard and
+// /etc/wpa_supplicant.
+func TestGenerateProfile_SensitiveSubtreeDenies(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	denyBlock := extractClause(t, profile, "(deny file-read* file-write*")
+	expected := []string{
+		`(subpath "/private/etc/wireguard")`,
+		`(subpath "/private/etc/wpa_supplicant")`,
+	}
+	for _, want := range expected {
+		if !strings.Contains(denyBlock, want) {
+			t.Errorf("(deny file-read* file-write* ...) block missing %q; block:\n%s", want, denyBlock)
+		}
+	}
+}
+
+// TestGenerateProfile_ProcessAndIPCAllows verifies that the profile contains
+// the seven process/IPC primitives required for node and opencode to run.
+// These are listed verbatim in the AC; the test asserts substring presence
+// rather than coupling to the exact whitespace in the generator output.
+func TestGenerateProfile_ProcessAndIPCAllows(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	wantSubstrings := []string{
+		"(allow process-exec*",
+		"process-fork",
+		"signal",
+		"mach-lookup",
+		"mach-register",
+		"sysctl-read",
+		"iokit-open",
+		"ipc-posix-shm",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(profile, want) {
+			t.Errorf("profile missing required substring %q; full profile:\n%s", want, profile)
+		}
+	}
+}
+
+// TestGenerateProfile_NetworkAllow verifies the (allow network*) clause is
+// present. This is locked in #1012 — match bwrap's permissive network
+// policy. Restriction is a future symmetric concern.
+func TestGenerateProfile_NetworkAllow(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	if !strings.Contains(profile, "(allow network*)") {
+		t.Errorf("profile missing (allow network*); full profile:\n%s", profile)
+	}
+}
+
+// TestGenerateProfile_NoOutOfScopeRules guards against accidentally pulling
+// PR 3 (#1017) or PR 4 (#1018) content into this PR. The minimal read-only
+// profile in this PR must NOT contain staging-HOME, worktree, credential, or
+// cache rules.
+func TestGenerateProfile_NoOutOfScopeRules(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName: "repo@main",
+		// Set fields that staging-HOME (#1017) will eventually consume.
+		// generateProfile must NOT emit any clauses derived from them in
+		// this PR.
+		Worktree: "/tmp/fake-worktree",
+		BareRoot: "/tmp/fake-bare",
+	})
+	profile := generateProfile(m)
+
+	for _, forbidden := range []string{
+		"<HOME>",
+		"<STAGING_HOME>",
+		"<WORKTREE>",
+		"<BARE_REPO>",
+		"<RESOLVED_SSH_ACCESS_KEY>",
+		"file-write*",
+		// file-write* should appear ONLY inside the deny clause; the test
+		// for that clause above already gates it. A bare file-write* allow
+		// is out of scope for this PR.
+	} {
+		// "file-write*" is a special case: it appears in the deny clause
+		// "(deny file-read* file-write* ..." which is in scope. So we
+		// instead check that there is NO "(allow file-write*" anywhere.
+		if forbidden == "file-write*" {
+			if strings.Contains(profile, "(allow file-write*") {
+				t.Errorf("profile contains (allow file-write* ...) which is out of scope for #1016; defer to #1017")
+			}
+			continue
+		}
+		if strings.Contains(profile, forbidden) {
+			t.Errorf("profile contains out-of-scope token %q; defer to #1017/#1018", forbidden)
+		}
+	}
+
+	// Worktree path itself must not appear — staging HOME (#1017) is what
+	// will introduce host paths into the profile.
+	if strings.Contains(profile, "/tmp/fake-worktree") || strings.Contains(profile, "/tmp/fake-bare") {
+		t.Errorf("profile contains a host path from cfg; this is staging-HOME territory and belongs to #1017; profile:\n%s", profile)
+	}
+}
+
+// ── PrepareSandboxExec ──────────────────────────────────────────────────────
+
+// TestPrepareSandboxExec_WritesProfileAndReturnsArgs verifies that
+// PrepareSandboxExec materialises the profile to a temp file under the
+// per-session state dir and returns args of the shape
+// ["sandbox-exec", "-f", <profile_path>, <harness>, ...].
+func TestPrepareSandboxExec_WritesProfileAndReturnsArgs(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName:   "repo@feat",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+	})
+
+	args, err := m.PrepareSandboxExec()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExec: %v", err)
+	}
+
+	if len(args) < 4 {
+		t.Fatalf("args too short (%d); want at least 4 elements: %v", len(args), args)
+	}
+	if args[0] != "sandbox-exec" {
+		t.Errorf("args[0] = %q, want %q", args[0], "sandbox-exec")
+	}
+	if args[1] != "-f" {
+		t.Errorf("args[1] = %q, want %q", args[1], "-f")
+	}
+	profilePath := args[2]
+	if profilePath == "" {
+		t.Errorf("args[2] (profile path) is empty: %v", args)
+	}
+
+	// The harness binary follows the profile path. We don't pin the exact
+	// string so future PRs can swap "opencode" for an absolute path without
+	// breaking this assertion, but it must be non-empty.
+	if args[3] == "" {
+		t.Errorf("args[3] (harness binary) is empty: %v", args)
+	}
+
+	// The profile file must exist on disk after PrepareSandboxExec returns.
+	info, statErr := os.Stat(profilePath)
+	if statErr != nil {
+		t.Fatalf("profile path %q not on disk after PrepareSandboxExec: %v", profilePath, statErr)
+	}
+	if info.Size() == 0 {
+		t.Errorf("profile file is empty: %s", profilePath)
+	}
+
+	// The on-disk profile must match generateProfile's output verbatim.
+	gotContent, readErr := os.ReadFile(profilePath)
+	if readErr != nil {
+		t.Fatalf("read profile: %v", readErr)
+	}
+	wantContent := generateProfile(m)
+	if string(gotContent) != wantContent {
+		t.Errorf("on-disk profile content does not match generateProfile output\n--- on disk:\n%s\n--- generateProfile:\n%s",
+			string(gotContent), wantContent)
+	}
+}
+
+// TestPrepareSandboxExec_ProfilePathIsSessionScoped verifies that the
+// profile path is namespaced by the session name so concurrent sessions
+// never collide.
+func TestPrepareSandboxExec_ProfilePathIsSessionScoped(t *testing.T) {
+	mA := newSandboxExecManager(Config{SessionName: "repoA@main"})
+	mB := newSandboxExecManager(Config{SessionName: "repoB@main"})
+
+	if mA.sandboxExecProfilePath() == mB.sandboxExecProfilePath() {
+		t.Errorf("two managers with different session names share a profile path: %s",
+			mA.sandboxExecProfilePath())
+	}
+	if !strings.Contains(mA.sandboxExecProfilePath(), mA.name) {
+		t.Errorf("profile path %q does not contain session-derived name %q",
+			mA.sandboxExecProfilePath(), mA.name)
+	}
+}
+
+// TestSandboxExecBuildArgs_OpencodePortFlag verifies that BuildArgs emits
+// --port <AllocatedPort> --hostname 127.0.0.1 in the harness arguments,
+// mirroring the bwrap path's invocation contract.
+func TestSandboxExecBuildArgs_OpencodePortFlag(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14111,
+	})
+	s := &sandboxExecIsolator{name: m.name}
+	args := s.BuildArgs(m)
+
+	if !sliceContainsPair(args, "--port", "14111") {
+		t.Errorf("expected --port 14111 in args: %v", args)
+	}
+	if !sliceContainsPair(args, "--hostname", "127.0.0.1") {
+		t.Errorf("expected --hostname 127.0.0.1 in args: %v", args)
+	}
+}
+
+// TestSandboxExecBuildArgs_PortFallback verifies that when AllocatedPort is
+// zero, BuildArgs falls back to ContainerPort. This mirrors bwrap.BuildArgs
+// and protects against malformed sessions.
+func TestSandboxExecBuildArgs_PortFallback(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 0,
+	})
+	s := &sandboxExecIsolator{name: m.name}
+	args := s.BuildArgs(m)
+
+	wantPort := containerPortString()
+	if !sliceContainsPair(args, "--port", wantPort) {
+		t.Errorf("expected fallback --port %s in args: %v", wantPort, args)
+	}
+}
+
+// TestSandboxExecBuildArgs_AgentRolePassedThrough verifies that AgentRole
+// is appended as --agent <role> when non-empty, and omitted when empty —
+// matching the bwrap path.
+func TestSandboxExecBuildArgs_AgentRolePassedThrough(t *testing.T) {
+	for _, tc := range []struct {
+		role string
+		want bool
+	}{
+		{"worker", true},
+		{"coordinator", true},
+		{"review-code", true},
+		{"", false},
+	} {
+		t.Run("AgentRole="+tc.role, func(t *testing.T) {
+			m := newSandboxExecManager(Config{
+				SessionName:   "repo@main",
+				AllocatedPort: 14010,
+				AgentRole:     tc.role,
+			})
+			s := &sandboxExecIsolator{name: m.name}
+			args := s.BuildArgs(m)
+
+			has := sliceContainsPair(args, "--agent", tc.role)
+			if tc.want && !has {
+				t.Errorf("expected --agent %q in args (role non-empty): %v", tc.role, args)
+			}
+			if !tc.want && hasFlag(args, "--agent") {
+				t.Errorf("--agent must be absent when role is empty; got: %v", args)
+			}
+		})
+	}
+}
+
+// TestSandboxExecBuildArgs_InitialPromptPassedThrough verifies that
+// InitialPrompt becomes --prompt <text> when non-empty, and is omitted when
+// empty — matching the bwrap path.
+func TestSandboxExecBuildArgs_InitialPromptPassedThrough(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14010,
+		InitialPrompt: "do the thing",
+	})
+	s := &sandboxExecIsolator{name: m.name}
+	args := s.BuildArgs(m)
+	if !sliceContainsPair(args, "--prompt", "do the thing") {
+		t.Errorf("expected --prompt 'do the thing' in args: %v", args)
+	}
+
+	mEmpty := newSandboxExecManager(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14010,
+	})
+	sEmpty := &sandboxExecIsolator{name: mEmpty.name}
+	argsEmpty := sEmpty.BuildArgs(mEmpty)
+	if hasFlag(argsEmpty, "--prompt") {
+		t.Errorf("--prompt must be absent when InitialPrompt is empty; got: %v", argsEmpty)
+	}
+}
+
+// TestSandboxExecBuildArgs_HarnessImmediatelyAfterProfile verifies that the
+// harness binary appears at args[3] — directly after "sandbox-exec -f
+// <profile>". This is the shape the AC requires.
+func TestSandboxExecBuildArgs_HarnessImmediatelyAfterProfile(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName:   "repo@main",
+		AllocatedPort: 14010,
+	})
+	s := &sandboxExecIsolator{name: m.name}
+	args := s.BuildArgs(m)
+	if len(args) < 4 {
+		t.Fatalf("args too short (%d): %v", len(args), args)
+	}
+	if args[0] != "sandbox-exec" || args[1] != "-f" {
+		t.Fatalf("expected leading sandbox-exec -f; got: %v", args)
+	}
+	// args[2] is the profile path; args[3] must be the harness binary.
+	if args[3] != "opencode" {
+		t.Errorf("expected args[3] to be the harness binary 'opencode'; got %q in %v", args[3], args)
+	}
+}
+
+// ── MinimalIsolatedExecEnv ───────────────────────────────────────────────────
+
+// TestMinimalIsolatedExecEnv_AllowsExpectedKeys verifies that the shared
+// helper passes through exactly the eight keys called out in the AC.
+func TestMinimalIsolatedExecEnv_AllowsExpectedKeys(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"HOME=/Users/ben",
+		"USER=ben",
+		"LOGNAME=ben",
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+		"LANG=en_NZ.UTF-8",
+		"LC_ALL=en_NZ.UTF-8",
+		"GITHUB_TOKEN=secret",
+		"ANTHROPIC_API_KEY=sk-secret",
+	}
+	out := MinimalIsolatedExecEnv(in)
+
+	gotSet := map[string]bool{}
+	for _, kv := range out {
+		gotSet[kv] = true
+	}
+	for _, want := range []string{
+		"PATH=/usr/bin", "HOME=/Users/ben", "USER=ben", "LOGNAME=ben",
+		"TERM=xterm-256color", "COLORTERM=truecolor",
+		"LANG=en_NZ.UTF-8", "LC_ALL=en_NZ.UTF-8",
+	} {
+		if !gotSet[want] {
+			t.Errorf("expected %q to be passed through; got %v", want, out)
+		}
+	}
+	for _, kv := range out {
+		k := strings.SplitN(kv, "=", 2)[0]
+		switch k {
+		case "GITHUB_TOKEN", "ANTHROPIC_API_KEY":
+			t.Errorf("forbidden key %q leaked through MinimalIsolatedExecEnv: %q", k, kv)
+		}
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// extractClause finds a top-level (...) form whose opening text matches the
+// given prefix and returns its full text including the trailing closing
+// parenthesis. The implementation is line-and-paren naive — it tracks the
+// nesting depth from the opening prefix and returns when depth returns to 0.
+//
+// This is sufficient for the small, hand-written profile in this PR; if the
+// generator grows nested macros, switch to a real SBPL parser.
+func extractClause(t *testing.T, profile, prefix string) string {
+	t.Helper()
+	idx := strings.Index(profile, prefix)
+	if idx < 0 {
+		t.Fatalf("clause beginning with %q not found in profile:\n%s", prefix, profile)
+	}
+	depth := 0
+	end := -1
+	for i := idx; i < len(profile); i++ {
+		switch profile[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				end = i + 1
+				goto done
+			}
+		}
+	}
+done:
+	if end < 0 {
+		t.Fatalf("clause beginning at index %d (prefix %q) is unterminated", idx, prefix)
+	}
+	return profile[idx:end]
+}
+
+// sliceContainsPair returns true when args contains [..., flag, value, ...].
+func sliceContainsPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// hasFlag returns true when args contains an exact match for flag.
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// firstNChars returns up to n leading characters of s, used in error
+// messages to avoid dumping a multi-line profile when a prefix mismatch is
+// the actual diagnostic value.
+func firstNChars(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// containerPortString returns ContainerPort formatted as a decimal string,
+// for tests that assert on the fallback --port value without repeating the
+// constant.
+func containerPortString() string {
+	return fmt.Sprintf("%d", ContainerPort)
+}


### PR DESCRIPTION
## Summary

Implements PR 2 of the sandbox-exec design (#1012) — the SBPL profile
generator plus the minimal read-only sandbox-exec launch. PR 1 (#1041) wired
up the enum, platform guard, and CLI plumbing; this PR replaces the \"not yet
implemented\" stub with a real \`syscall.Exec\` into \`sandbox-exec\` and a
read-only profile that allows opencode to start.

Staging HOME, credentials, caches, and write paths are deferred to PR 3
(#1017). Concurrency cap and lifecycle hardening are deferred to PR 4
(#1018).

## What is in this PR

- New \`internal/container/sandbox_exec.go\`:
  - \`sandboxExecIsolator\` symmetric to \`bwrapIsolator\` — same shape, no
    new abstraction layer (per the spawn prompt's guidance).
  - \`generateProfile(m *Manager) string\` emits the locked SBPL skeleton
    from #1012: \`(version 1)\`, \`(deny default)\`, the seven
    \`(allow file-read* (subpath ...))\` system roots, the two
    \`(deny file-read* file-write* (subpath ...))\` rules for
    \`/private/etc/wireguard\` and \`/private/etc/wpa_supplicant\`, the
    process/IPC primitives, and \`(allow network*)\`.
  - \`writeProfile(m *Manager) (path, error)\` materialises the profile to
    a per-session temp file (mode 0600).
  - \`BuildArgs(m *Manager)\` returns
    \`[\"sandbox-exec\", \"-f\", <profile>, \"opencode\", \"--port\", <port>, \"--hostname\", \"127.0.0.1\", ...]\`
    matching the AC shape exactly.
- New \`Manager.PrepareSandboxExec()\` symmetric to \`PrepareBwrap()\`.
- \`cmd/agent_run.go\`:
  - Replaces the \"sandbox-exec mode: not yet implemented\" stub with a
    Darwin-only dispatch that builds the args, validates the profile-temp
    path is readable (edge-case AC), and \`syscall.Exec\`s
    \`/usr/bin/sandbox-exec\`.
  - Env passed to \`sandbox-exec\` is filtered through the same allow-list
    as bwrap via the shared helper.
- Shared env helper: extracted \`container.MinimalIsolatedExecEnv\` so
  bwrap and sandbox-exec call sites share a single allow-list (PATH, HOME,
  USER, LOGNAME, TERM, COLORTERM, LANG, LC_ALL). The existing
  \`minimalBwrapExecEnv\` is now a thin alias preserving the bwrap-specific
  reading of the call site.
- Tests:
  - \`internal/container/sandbox_exec_test.go\`: substring-style assertions
    on every clause listed in the AC; \`PrepareSandboxExec\` end-to-end
    test; port/agent/prompt passthrough; out-of-scope guard (no PR 3 or
    PR 4 content).
  - \`cmd/agent_run_test.go\`: \`validateSandboxExecArgs\` covering OK,
    missing-profile (the edge-case AC), and bad-shape paths.

## AC checklist

- [x] [functional] \`internal/container/sandbox_exec.go\` exists and exposes \`generateProfile(m *Manager) string\`.
- [x] [functional] Profile begins with \`(version 1)\` followed by \`(deny default)\`.
- [x] [functional] Profile includes \`(allow file-read*\` with the seven subpaths.
- [x] [functional] Profile includes \`(deny file-read* file-write*\` for \`/private/etc/wireguard\` and \`/private/etc/wpa_supplicant\`.
- [x] [functional] Profile includes process/IPC primitives and \`(allow network*)\`.
- [x] [functional] \`Manager.PrepareSandboxExec()\` writes the profile to a temp file and returns \`[\"sandbox-exec\", \"-f\", <profile>, <harness>, ...]\`.
- [x] [functional] On Darwin with \`--isolation sandbox-exec\`, \`agent-run\` calls \`PrepareSandboxExec()\` and \`syscall.Exec(\"/usr/bin/sandbox-exec\", args, env)\`.
- [x] [functional] Exec env passed to sandbox-exec is filtered through the same allow-list as \`minimalBwrapExecEnv\`.
- [ ] [functional] **Manual end-to-end on real macOS** — verified during PR review per the AC. **Not personally validated from this Linux worktree.**
- [x] [edge-case] Missing/unreadable profile-temp path returns a clear error and does not exec (\`validateSandboxExecArgs\` + the in-line \`os.Stat\` check).
- [x] [functional] Substring tests cover every clause.
- [x] [functional] \`go build ./...\` and \`go test ./...\` pass from \`modules/programs/prism/prism/\`.
- [ ] [functional] \`nix build .#darwinConfigurations.m4mac.config.system.build.toplevel\` — **cannot be run from this Linux worktree** (a \`Brewfile.drv\` build is fixed to \`aarch64-darwin\`). Eval succeeds (\`nix eval ... .drvPath\` returns the derivation path) and the NixOS build (\`nixosConfigurations.navi.config.system.build.toplevel\`) is green. Coordinator: please run the Darwin build on a macOS host as part of merge.

## Notes for review

- Profile shape is exactly what is sketched in #1012's design and listed in #1016's body. New clauses introduced beyond that list would need a comment in the generator pointing at #1012; no such clauses are added in this PR.
- \`(allow network*)\` is locked in #1012 — match bwrap's permissive policy, restriction is a future symmetric concern.
- PID/UTS/IPC isolation gap is documented in #1012; sandbox-exec cannot unshare these namespaces. Defence in depth, not adversarial isolation.
- The bwrap code path is unchanged in behaviour — \`minimalBwrapExecEnv\` is a thin alias over the new shared helper, and tests for it still pass.

Refs #1012
Refs #1016