### PR TITLE
tmux: include stderr and argv in run() error wrapping

### DIFF
--- a/modules/programs/prism/prism/internal/tmux/tmux.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux.go
@@ -2,6 +2,7 @@
 package tmux
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,11 +26,23 @@ type Session struct {
 	ClientCount int    // number of tmux clients currently attached
 }
 
-// run executes a tmux command and returns trimmed stdout.
+// run executes a tmux command and returns trimmed stdout. On failure, the
+// returned error wraps the original *exec.ExitError (or other exec error) and
+// includes the full tmux argv plus the trimmed contents of tmux's stderr.
+// tmux writes its actual diagnostic ("can't find session", "duplicate session",
+// "index in use", etc.) on stderr, so capturing it is essential — without it
+// every failure surfaces as a context-free "exit status 1".
+//
+// Edge case: if tmux exits non-zero with no stderr output, the error still
+// carries the argv and the wrapped exec error; the trailing ": " is followed
+// by an empty string rather than a nil deref.
 func run(args ...string) (string, error) {
-	out, err := exec.Command(TmuxBin, args...).Output()
+	var stderr bytes.Buffer
+	cmd := exec.Command(TmuxBin, args...)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("tmux %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/modules/programs/prism/prism/internal/tmux/tmux_test.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux_test.go
@@ -12,7 +12,9 @@
 package tmux_test
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -977,5 +979,107 @@ func TestAPI_TwoClientsGlobalStampIsolation(t *testing.T) {
 	}
 	if gotB != "nixos-config@main" {
 		t.Errorf("clientB session = %q, want %q (should be unaffected)", gotB, "nixos-config@main")
+	}
+}
+
+// ─── run() error-format tests ─────────────────────────────────────────────────
+// These verify the diagnostic shape of errors returned when tmux exits
+// non-zero. They install a fake tmux that fails predictably and exercise the
+// public API (which routes through run()).
+//
+// These tests mutate TmuxBin via fakeTmux/spyTmux helpers, so they are
+// intentionally NOT parallel.
+
+// fakeTmux installs a fake tmux binary that writes the given string to stderr
+// and exits with the given code. Returns nothing — TmuxBin is restored via
+// t.Cleanup.
+func fakeTmux(t *testing.T, stderrMsg string, exitCode int) {
+	t.Helper()
+	wrapperPath := t.TempDir() + "/tmux"
+	// printf to stderr, then exit with the requested code.
+	script := "#!/bin/sh\nprintf '%s\\n' " + shellSingleQuote(stderrMsg) + " >&2\nexit " + itoa(exitCode) + "\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+}
+
+// shellSingleQuote single-quotes s for safe inclusion in a /bin/sh script.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// itoa avoids pulling strconv into the test file's import block for one digit.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+// TestRunError_IncludesArgvAndStderr verifies that when tmux exits non-zero,
+// the error returned by a public helper that goes through run() contains both
+// the tmux subcommand name and a substring derived from tmux's stderr.
+//
+// This is the core diagnostic regression test for issue #1054.
+func TestRunError_IncludesArgvAndStderr(t *testing.T) {
+	const stderrMsg = "can't find session: bogus-session"
+	fakeTmux(t, stderrMsg, 1)
+
+	err := tmux.KillSession("bogus-session")
+	if err == nil {
+		t.Fatal("KillSession returned nil error; expected failure from fake tmux")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "kill-session") {
+		t.Errorf("error %q does not contain tmux subcommand name 'kill-session'", msg)
+	}
+	if !strings.Contains(msg, stderrMsg) {
+		t.Errorf("error %q does not contain stderr substring %q", msg, stderrMsg)
+	}
+	// The wrapped exec error must still be unwrappable to *exec.ExitError.
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("error %q does not unwrap to *exec.ExitError", msg)
+	}
+}
+
+// TestRunError_EmptyStderrDegradesGracefully verifies the edge case where tmux
+// exits non-zero but writes nothing to stderr. The error must still carry the
+// argv and the wrapped exec error — no panic, no empty error string.
+func TestRunError_EmptyStderrDegradesGracefully(t *testing.T) {
+	fakeTmux(t, "", 2)
+
+	err := tmux.KillSession("anything")
+	if err == nil {
+		t.Fatal("KillSession returned nil error; expected failure from fake tmux")
+	}
+	msg := err.Error()
+	if msg == "" {
+		t.Fatal("error string is empty; expected argv + wrapped exec error")
+	}
+	if !strings.Contains(msg, "kill-session") {
+		t.Errorf("error %q does not contain 'kill-session' (argv missing)", msg)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("error %q does not unwrap to *exec.ExitError", msg)
 	}
 }

--- a/modules/programs/prism/prism/internal/tmux/tmux_test.go
+++ b/modules/programs/prism/prism/internal/tmux/tmux_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -997,7 +998,7 @@ func fakeTmux(t *testing.T, stderrMsg string, exitCode int) {
 	t.Helper()
 	wrapperPath := t.TempDir() + "/tmux"
 	// printf to stderr, then exit with the requested code.
-	script := "#!/bin/sh\nprintf '%s\\n' " + shellSingleQuote(stderrMsg) + " >&2\nexit " + itoa(exitCode) + "\n"
+	script := "#!/bin/sh\nprintf '%s\\n' " + shellSingleQuote(stderrMsg) + " >&2\nexit " + strconv.Itoa(exitCode) + "\n"
 	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write fake tmux: %v", err)
 	}
@@ -1009,29 +1010,6 @@ func fakeTmux(t *testing.T, stderrMsg string, exitCode int) {
 // shellSingleQuote single-quotes s for safe inclusion in a /bin/sh script.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
-// itoa avoids pulling strconv into the test file's import block for one digit.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var b [20]byte
-	i := len(b)
-	for n > 0 {
-		i--
-		b[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		b[i] = '-'
-	}
-	return string(b[i:])
 }
 
 // TestRunError_IncludesArgvAndStderr verifies that when tmux exits non-zero,


### PR DESCRIPTION
## Summary

`internal/tmux/tmux.go`'s `run()` helper used `exec.Command(...).Output()`, which discards stderr. Every tmux failure surfaced as a context-free `exit status 1` — wasting real time during the PR #1053 review incident, where five `prism review` spawns failed at `tmux.NewWindow` with no diagnostic.

This PR switches `run()` to explicit stderr capture (option 2 from the issue, the author's weak preference) and wraps the returned error with the full tmux argv plus the trimmed stderr contents.

## What changes

- `run()` now sets `cmd.Stderr = &buf` and on failure returns `fmt.Errorf("tmux %s: %w: %s", argv, err, stderr)`.
- Success-path string is unchanged (still trimmed stdout only). No caller parsing changes.
- All public helpers that route through `run()` (`NewSessionDetached`, `NewWindow`, `SelectWindow`, `SendKeys`, `KillSession`, `KillWindow`, etc.) inherit the improved error format automatically.
- Two new tests in `tmux_test.go`:
  - `TestRunError_IncludesArgvAndStderr` — fails a fake tmux with a stderr message, asserts the error contains the subcommand name and the stderr substring, and that `errors.As(err, &*exec.ExitError)` still works.
  - `TestRunError_EmptyStderrDegradesGracefully` — covers the edge case where tmux exits non-zero with no stderr (no panic, argv still present, exec error still unwrappable).

## Verification

- `go build ./...` and `go test ./...` pass from `modules/programs/prism/prism/`.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes.

Closes #1054