### PR TITLE
prism: pin merge-queue watcher gh calls with --repo

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -42,31 +42,103 @@ const (
 
 // Watcher runs the merge-queue polling loop for a single coordinator session.
 type Watcher struct {
-	db         *db.DB
-	instanceID string
+	db          *db.DB
+	instanceID  string
 	sessionName string
-	httpClient *http.Client
+	httpClient  *http.Client
+
+	// repo is the GitHub owner/name slug (e.g. "prismatic-koi/nixos-config")
+	// resolved once at construction time from the coordinator session's
+	// worktree. Every gh invocation routes through w.runGH which prepends
+	// "--repo <repo>" so calls succeed regardless of the sidecar's CWD (#1055).
+	// An empty string means resolution failed — Run() logs and exits cleanly
+	// rather than entering a poll loop that can never succeed.
+	repo string
+
+	// runGHFunc is the function used to invoke the gh CLI. It is configurable
+	// so tests can inject a stub that captures argv. When nil, runGH falls back
+	// to execGH (the real os/exec implementation).
+	runGHFunc func(ctx context.Context, args ...string) ([]byte, error)
 }
 
 // New creates a Watcher. instanceID and sessionName identify the coordinator
 // session that owns this watcher. httpClient is used for notification delivery;
 // pass nil to use the default client.
+//
+// New resolves the GitHub owner/name slug once, using the worktree path
+// recorded for sessionName in agent_status. Subsequent gh invocations are
+// pinned to that slug via "--repo", so the watcher works even when the sidecar
+// process CWD is not a git repo (#1055). If resolution fails (no row in
+// agent_status, missing worktree, or `gh repo view` errors), repo is left
+// empty and a warning is logged; Run() will then exit cleanly without polling.
 func New(database *db.DB, instanceID, sessionName string, httpClient *http.Client) *Watcher {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 10 * time.Second}
 	}
-	return &Watcher{
+	w := &Watcher{
 		db:          database,
 		instanceID:  instanceID,
 		sessionName: sessionName,
 		httpClient:  httpClient,
 	}
+	w.repo = resolveRepo(database, sessionName)
+	return w
+}
+
+// resolveRepo looks up the coordinator session's worktree path in agent_status
+// and runs `gh repo view --json nameWithOwner -q .nameWithOwner` from that
+// directory to obtain the GitHub owner/name slug. Returns "" on any failure
+// (no agent_status row, empty worktree, gh error, etc.) and logs a single
+// warning naming the cause.
+func resolveRepo(database *db.DB, sessionName string) string {
+	status, err := database.CurrentStatus(sessionName)
+	if err != nil {
+		log.Printf("[mergequeue] cannot resolve repo for session %q: agent_status lookup failed: %v — watcher will not start", sessionName, err)
+		return ""
+	}
+	if status == nil {
+		log.Printf("[mergequeue] cannot resolve repo for session %q: no agent_status row — watcher will not start", sessionName)
+		return ""
+	}
+	worktree := strings.TrimSpace(status.Worktree)
+	if worktree == "" {
+		log.Printf("[mergequeue] cannot resolve repo for session %q: agent_status.worktree is empty — watcher will not start", sessionName)
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	cmd.Dir = worktree
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("[mergequeue] cannot resolve repo for session %q from worktree %q: gh repo view: %v: %s — watcher will not start",
+			sessionName, worktree, err, strings.TrimSpace(string(out)))
+		return ""
+	}
+	repo := strings.TrimSpace(string(out))
+	if repo == "" {
+		log.Printf("[mergequeue] cannot resolve repo for session %q from worktree %q: gh repo view returned empty output — watcher will not start",
+			sessionName, worktree)
+		return ""
+	}
+	log.Printf("[mergequeue] resolved repo for session %q: %s", sessionName, repo)
+	return repo
 }
 
 // Run starts the polling loop and blocks until ctx is cancelled.
 // It is safe to run in a goroutine.
+//
+// If the watcher has no resolved repo (resolution failed at New() time), Run
+// logs a single warning and returns immediately. The poll loop never starts,
+// so the goroutine exits cleanly and the coordinator session remains usable
+// for non-merge-queue work. (#1055)
 func (w *Watcher) Run(ctx context.Context) {
-	log.Printf("[mergequeue] watcher started (instance=%s)", w.instanceID)
+	if w.repo == "" {
+		log.Printf("[mergequeue] watcher NOT started for session %q (instance=%s): owner/name resolution failed at startup — see prior log line", w.sessionName, w.instanceID)
+		return
+	}
+	log.Printf("[mergequeue] watcher started (instance=%s, repo=%s)", w.instanceID, w.repo)
 	ticker := time.NewTicker(PollInterval)
 	defer ticker.Stop()
 
@@ -104,7 +176,7 @@ func (w *Watcher) tick(ctx context.Context) {
 		log.Printf("[mergequeue] UpdateMergeLastChecked PR #%d: %v", head.PR, err)
 	}
 
-	prInfo, err := fetchPRInfo(ctx, head.PR)
+	prInfo, err := w.fetchPRInfo(ctx, head.PR)
 	if err != nil {
 		log.Printf("[mergequeue] fetchPRInfo PR #%d: %v — leaving watching", head.PR, err)
 		return
@@ -129,7 +201,7 @@ func (w *Watcher) tick(ctx context.Context) {
 
 	case "BEHIND":
 		log.Printf("[mergequeue] PR #%d is BEHIND — calling gh pr update-branch", head.PR)
-		if err := updateBranch(ctx, head.PR); err != nil {
+		if err := w.updateBranch(ctx, head.PR); err != nil {
 			log.Printf("[mergequeue] gh pr update-branch PR #%d: %v — leaving watching", head.PR, err)
 		}
 		// Leave row as watching; next tick will see UNSTABLE→BLOCKED→CLEAN cycle.
@@ -158,7 +230,7 @@ func (w *Watcher) tick(ctx context.Context) {
 // "sha1" message) leaves watching; on other errors transitions to failed.
 func (w *Watcher) tryMerge(ctx context.Context, head *db.PendingMerge) {
 	log.Printf("[mergequeue] PR #%d CLEAN — attempting gh pr merge --squash", head.PR)
-	out, err := runGH(ctx, "pr", "merge", fmt.Sprintf("%d", head.PR), "--squash")
+	out, err := w.runGH(ctx, "pr", "merge", fmt.Sprintf("%d", head.PR), "--squash")
 	if err == nil {
 		log.Printf("[mergequeue] PR #%d merged successfully", head.PR)
 		w.succeedAndNotify(ctx, head)
@@ -353,8 +425,8 @@ type checkEntry struct {
 }
 
 // fetchPRInfo calls `gh pr view <pr> --json` and returns the parsed result.
-func fetchPRInfo(ctx context.Context, pr int) (*prInfo, error) {
-	out, err := runGH(ctx, "pr", "view", fmt.Sprintf("%d", pr),
+func (w *Watcher) fetchPRInfo(ctx context.Context, pr int) (*prInfo, error) {
+	out, err := w.runGH(ctx, "pr", "view", fmt.Sprintf("%d", pr),
 		"--json", prInfoJSONFields)
 	if err != nil {
 		return nil, fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(string(out)))
@@ -395,17 +467,34 @@ func isBranchMovedRace(output string) bool {
 }
 
 // updateBranch calls `gh pr update-branch <pr>` to rebase the PR onto main.
-func updateBranch(ctx context.Context, pr int) error {
-	out, err := runGH(ctx, "pr", "update-branch", fmt.Sprintf("%d", pr))
+func (w *Watcher) updateBranch(ctx context.Context, pr int) error {
+	out, err := w.runGH(ctx, "pr", "update-branch", fmt.Sprintf("%d", pr))
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 
-// runGH runs `gh <args...>` and returns combined output. Uses a 30s timeout
-// per call to avoid hanging the poll loop.
-func runGH(ctx context.Context, args ...string) ([]byte, error) {
+// runGH runs `gh --repo <owner/name> <args...>` and returns combined output.
+// The "--repo" flag is prepended unconditionally so calls succeed regardless
+// of the sidecar process's CWD (#1055). Uses a 30s timeout per call to avoid
+// hanging the poll loop.
+//
+// runGH dispatches to w.runGHFunc when set (used by tests to inject a stub
+// that captures argv), or falls back to execGH for real os/exec invocation.
+func (w *Watcher) runGH(ctx context.Context, args ...string) ([]byte, error) {
+	full := make([]string, 0, len(args)+2)
+	full = append(full, "--repo", w.repo)
+	full = append(full, args...)
+	if w.runGHFunc != nil {
+		return w.runGHFunc(ctx, full...)
+	}
+	return execGH(ctx, full...)
+}
+
+// execGH is the real gh-CLI invocation. Extracted from runGH so tests can
+// substitute Watcher.runGHFunc without losing the production code path.
+func execGH(ctx context.Context, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "gh", args...)

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1198,3 +1198,147 @@ func TestPRInfo_IsMerged(t *testing.T) {
 		})
 	}
 }
+
+// TestWatcher_RunGHPassesRepoFlag verifies the #1055 fix: every gh invocation
+// from the watcher includes "--repo <owner/name>" as the first two argv tokens
+// so calls succeed regardless of the sidecar's CWD. Exercises the real
+// fetchPRInfo / tryMerge / updateBranch methods with an injected runGHFunc
+// that captures argv.
+func TestWatcher_RunGHPassesRepoFlag(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-repo-flag"
+	session := "myrepo@main"
+	const repoSlug = "owner/myrepo"
+
+	// Seed the coordinator so notify() can find the harness port — needed
+	// because the CLEAN→merged path fires a notification.
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-repo-flag")
+
+	// Build a Watcher directly (bypass New so we don't shell out to gh) with
+	// the repo cached and a runGHFunc that records every invocation.
+	var calls [][]string
+	w := &Watcher{
+		db:          d,
+		instanceID:  instanceID,
+		sessionName: session,
+		httpClient:  srv.Client(),
+		repo:        repoSlug,
+		runGHFunc: func(_ context.Context, args ...string) ([]byte, error) {
+			// Copy args defensively so later calls don't alias the slice.
+			snap := make([]string, len(args))
+			copy(snap, args)
+			calls = append(calls, snap)
+			// Tailor the response so each method completes its happy path.
+			if len(args) >= 4 && args[2] == "pr" && args[3] == "view" {
+				return []byte(`{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN","statusCheckRollup":[]}`), nil
+			}
+			// merge / update-branch return empty success.
+			return nil, nil
+		},
+	}
+
+	ctx := context.Background()
+
+	// 1. fetchPRInfo (calls gh pr view).
+	if _, err := w.fetchPRInfo(ctx, 101); err != nil {
+		t.Fatalf("fetchPRInfo: %v", err)
+	}
+	// 2. tryMerge (calls gh pr merge --squash on the CLEAN path).
+	if _, err := d.EnqueueMerge(202, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	head, err := d.MergeQueueHead(session)
+	if err != nil || head == nil {
+		t.Fatalf("MergeQueueHead: %v / nil=%v", err, head == nil)
+	}
+	w.tryMerge(ctx, head)
+	// 3. updateBranch (calls gh pr update-branch).
+	if err := w.updateBranch(ctx, 303); err != nil {
+		t.Fatalf("updateBranch: %v", err)
+	}
+
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 gh invocations (view, merge, update-branch); got %d: %v", len(calls), calls)
+	}
+
+	for i, argv := range calls {
+		if len(argv) < 2 {
+			t.Errorf("call %d argv too short: %v", i, argv)
+			continue
+		}
+		if argv[0] != "--repo" {
+			t.Errorf("call %d argv[0]: got %q, want %q (full argv: %v)", i, argv[0], "--repo", argv)
+		}
+		if argv[1] != repoSlug {
+			t.Errorf("call %d argv[1]: got %q, want %q (full argv: %v)", i, argv[1], repoSlug, argv)
+		}
+	}
+
+	// Spot-check that the trailing subcommand is preserved (defence against a
+	// future refactor that accidentally drops the original args).
+	wantSubs := []string{"view", "merge", "update-branch"}
+	for i, sub := range wantSubs {
+		argv := calls[i]
+		found := false
+		for _, a := range argv {
+			if a == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("call %d argv missing %q subcommand: %v", i, sub, argv)
+		}
+	}
+}
+
+// TestWatcher_RunExitsWhenRepoUnresolved verifies AC #5: when owner/name
+// resolution fails at startup (Watcher.repo == ""), Run() returns immediately
+// without entering the poll loop.
+func TestWatcher_RunExitsWhenRepoUnresolved(t *testing.T) {
+	d := openTestDB(t)
+	w := &Watcher{
+		db:          d,
+		instanceID:  "inst-no-repo",
+		sessionName: "myrepo@main",
+		httpClient:  http.DefaultClient,
+		repo:        "", // resolution failure simulated
+	}
+
+	// A non-cancelled context: if Run enters the poll loop it would block
+	// for PollInterval. We assert it returns within a small budget instead.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// PASS — Run returned without polling.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return when repo was unresolved — would block the goroutine forever")
+	}
+}
+
+// TestNew_NoAgentStatusRow_LeavesRepoEmpty verifies that when CurrentStatus
+// returns no row for the session, New() leaves Watcher.repo == "" rather than
+// shelling out to gh from a possibly-bogus directory. Together with
+// TestWatcher_RunExitsWhenRepoUnresolved this gives end-to-end coverage of the
+// AC #5 startup-failure path.
+func TestNew_NoAgentStatusRow_LeavesRepoEmpty(t *testing.T) {
+	d := openTestDB(t)
+	// No seedCoordinator call → CurrentStatus("ghost-session@main") returns nil.
+	w := New(d, "inst-ghost", "ghost-session@main", nil)
+	if w == nil {
+		t.Fatal("New returned nil")
+	}
+	if w.repo != "" {
+		t.Errorf("Watcher.repo: got %q, want empty (no agent_status row)", w.repo)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the merge-queue watcher so it can drive PRs through to merge from a coordinator whose sidecar CWD is not a git repo (e.g. `/home/ben`). Previously every poll failed with `fatal: not a git repository` because `gh pr view` resolves the target repo from CWD.

## What changed

- Resolve the GitHub `owner/name` slug **once** at `mergequeue.New()` time using the worktree path recorded in `agent_status` for the coordinator session. Cached on the `Watcher` struct as `repo`.
- New `Watcher.runGH` method prepends `--repo <owner/name>` to every `gh` invocation. `fetchPRInfo`, `tryMerge`, and `updateBranch` all now route through it.
- If owner/name resolution fails at startup (no `agent_status` row, empty worktree, or `gh repo view` error), `New` leaves `repo` empty and `Run` logs a single clear warning then returns immediately. The poll loop never starts, so the goroutine exits cleanly and the coordinator session remains usable for non-merge-queue work (AC #5).
- Real `os/exec` invocation extracted to `execGH`; `Watcher.runGHFunc` is an injection point used by the new test.

## Tests

- `TestWatcher_RunGHPassesRepoFlag` exercises the real `fetchPRInfo` / `tryMerge` / `updateBranch` methods with an injected `runGHFunc` that captures argv. Asserts every invocation begins with `--repo owner/myrepo` and preserves the original `view` / `merge` / `update-branch` subcommand.
- `TestWatcher_RunExitsWhenRepoUnresolved` asserts `Run` returns within 2 s when `repo == ""` (i.e. no poll loop entered).
- `TestNew_NoAgentStatusRow_LeavesRepoEmpty` asserts `New` leaves `repo == ""` when `CurrentStatus` returns no row, rather than shelling out to `gh` from a possibly-bogus directory.
- All existing `mergequeue` unit tests still pass.

## Quality gates

- `go build ./...` — pass
- `go test ./...` — pass
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — pass

## Out of scope (per issue)

- Auditing other `gh`-invoking code paths (`internal/quick/pr.go`, `internal/git/git.go`, `internal/review/review.go`, `cmd/merge.go`) for the same bug. File separately if applicable.
- Changing `StartSidecar` to set `cmd.Dir`.

Closes #1055