### PR TITLE
prism: add [timing] instrumentation to bwrap and sandbox-exec startup paths

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -51,6 +51,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/spf13/cobra"
@@ -87,7 +88,25 @@ func init() {
 }
 
 func runAgentRun(cmd *cobra.Command, args []string) error {
+	// Capture wall-clock entry time so that the bwrap and sandbox-exec
+	// dispatch paths can emit `[timing]` markers symmetric to the podman
+	// path's sidecar-side instrumentation (see internal/sidecar/sidecar.go
+	// "from start" lines). All `[timing]` durations from agent-run are
+	// relative to this point, which is the closest analogue to the podman
+	// `sessionStart` marker (taken when sidecar Run() begins).
+	agentRunStart := time.Now()
+
 	sessionName, _ := cmd.Flags().GetString("session")
+
+	// Open the agent-run log file as early as possible so that pre-exec
+	// `[timing]` markers can be written to it and the failure point is
+	// locatable even when later setup fails (e.g. bwrap exec returns ENOENT).
+	// The log file is also tee-target for bwrap stderr further down; opening
+	// here means there is no second open call.
+	logFile := openAgentRunLog(sessionName)
+	if logFile != nil {
+		defer logFile.Close()
+	}
 
 	// Open the prism database to look up session state.
 	d, err := openDB()
@@ -118,7 +137,7 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		if runtime.GOOS != "darwin" {
 			return fmt.Errorf("prism agent-run: sandbox-exec isolation requires macOS (Darwin); current platform is %s", runtime.GOOS)
 		}
-		return runAgentRunSandboxExec(sessionName, status)
+		return runAgentRunSandboxExec(sessionName, status, agentRunStart, logFile)
 	default:
 		return fmt.Errorf("agent-run: session %q has isolation mode %q; this command is only for bwrap and sandbox-exec sessions", sessionName, isoMode)
 	}
@@ -195,39 +214,28 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	// Construct the Manager. PrepareBwrap will write temp files and build args.
 	m := container.New(ctrCfg)
 
+	// `[timing] pre-exec`: covers everything between agent-run entry and the
+	// start of bwrap-args assembly — DB lookup, config load, profile load,
+	// Manager construction. Symmetric to the podman path's `[timing] pre-Create`
+	// in internal/sidecar/sidecar.go.
+	logTimingTo(logFile, "pre-exec", time.Since(agentRunStart))
+
+	argsBuildStart := time.Now()
 	bwrapArgs, err := m.PrepareBwrap()
 	if err != nil {
 		return fmt.Errorf("agent-run: prepare bwrap args: %w", err)
 	}
+	// `[timing] bwrap-args build`: time spent assembling the bwrap argv plus
+	// writing the per-session SSH config / gitconfig / opencode.json temp files
+	// (PrepareBwrap does both). Analogous to `[timing] buildRunArgs` on the
+	// podman side. Emitted before the binary lookup and exec so that an
+	// exec-stage failure still leaves this marker in the agent-run log.
+	logTimingTo(logFile, "bwrap-args build", time.Since(argsBuildStart))
 
 	// Locate the bwrap binary.
 	bwrapBin, err := findBwrap()
 	if err != nil {
 		return fmt.Errorf("agent-run: %w", err)
-	}
-
-	// Open the per-session agent-run log file. The parent directory is the
-	// per-session run dir (run/<session>/), which also holds hostapi.sock.
-	// We create it here if it does not exist yet (it is normally pre-created
-	// by container.prepareVolumeDirs, but agent-run may run before that on
-	// some paths).
-	logPath, logPathErr := session.AgentRunLogPath(sessionName)
-	var logFile *os.File
-	if logPathErr != nil {
-		fmt.Fprintf(os.Stderr, "[agent-run] warning: cannot resolve agent-run log path: %v — continuing without log file\n", logPathErr)
-	} else {
-		if mkErr := os.MkdirAll(filepath.Dir(logPath), 0o700); mkErr != nil {
-			fmt.Fprintf(os.Stderr, "[agent-run] warning: cannot create log directory %s: %v — continuing without log file\n", filepath.Dir(logPath), mkErr)
-		} else {
-			var openErr error
-			logFile, openErr = os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-			if openErr != nil {
-				fmt.Fprintf(os.Stderr, "[agent-run] warning: cannot open agent-run log %s: %v — continuing without log file\n", logPath, openErr)
-			}
-		}
-	}
-	if logFile != nil {
-		defer logFile.Close()
 	}
 
 	// Build the bwrap command. argv[0] must be the binary path.
@@ -276,6 +284,17 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	// controlling terminal); agent-run then forwards it to the bwrap process
 	// group via forwardSignalsToBwrap.
 	bwrapCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// `[timing] bwrap exec`: total wall time from agent-run entry to the
+	// moment bwrap is started (fork+exec under exec.Cmd.Start). The phase
+	// name follows the AC text — we use exec.Cmd.Start rather than
+	// syscall.Exec because agent-run supervises the child for PTY/signal
+	// handling, but the wall-time semantic is identical: this is the point
+	// at which control passes to the bwrap binary. Sidecar-side markers
+	// (`[timing] opencode listening: <d> from start`) measure from sidecar
+	// spawn, not from this point, so the two timelines are independent —
+	// stitch them via wall-clock from each log to bound "exec → opencode up".
+	logTimingTo(logFile, "bwrap exec", time.Since(agentRunStart))
 
 	if err := bwrapCmd.Start(); err != nil {
 		return fmt.Errorf("agent-run: start bwrap: %w", err)
@@ -489,7 +508,12 @@ func validateSandboxExecArgs(args []string) error {
 //   - syscall.Exec("/usr/bin/sandbox-exec", args, env).
 //
 // PR 4 (#1018) replaces this with a supervised child + lifecycle hardening.
-func runAgentRunSandboxExec(sessionName string, status *db.Status) error {
+//
+// agentRunStart and logFile are passed through from runAgentRun so that the
+// sandbox-exec path can emit `[timing]` markers symmetric to the bwrap path
+// (#1052). All durations are relative to agentRunStart, which is the wall-clock
+// moment agent-run was invoked.
+func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart time.Time, logFile *os.File) error {
 	// Load prism config for git identity and SSH key names. Mirrors the
 	// bwrap path so future PRs in this design can extend the Manager.Config
 	// uniformly (staging HOME, credentials, caches in #1017).
@@ -549,10 +573,20 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status) error {
 
 	m := container.New(ctrCfg)
 
+	// `[timing] pre-exec`: covers DB lookup, config load, profile lookup,
+	// Manager construction. Symmetric to the bwrap path's pre-exec marker
+	// (see runAgentRun).
+	logTimingTo(logFile, "pre-exec", time.Since(agentRunStart))
+
+	argsBuildStart := time.Now()
 	args, err := m.PrepareSandboxExec()
 	if err != nil {
 		return fmt.Errorf("agent-run: prepare sandbox-exec args: %w", err)
 	}
+	// `[timing] sandbox-exec args build`: time spent writing the SBPL profile
+	// and assembling the sandbox-exec argv. Mirrors `[timing] bwrap-args build`
+	// on the bwrap path.
+	logTimingTo(logFile, "sandbox-exec args build", time.Since(argsBuildStart))
 
 	if err := validateSandboxExecArgs(args); err != nil {
 		return err
@@ -566,12 +600,72 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status) error {
 	// and friends land).
 	env := container.MinimalIsolatedExecEnv(os.Environ())
 
+	// `[timing] sandbox-exec exec`: total wall time from agent-run entry to
+	// the moment of syscall.Exec. Mirrors `[timing] bwrap exec` on the bwrap
+	// path. After this line, syscall.Exec replaces the process image — no
+	// further markers can be emitted here, downstream timing arrives via the
+	// sidecar log (`[timing] opencode listening: <d> from start`, etc.).
+	logTimingTo(logFile, "sandbox-exec exec", time.Since(agentRunStart))
+
 	const sandboxExecBinary = "/usr/bin/sandbox-exec"
 	if execErr := syscall.Exec(sandboxExecBinary, args, env); execErr != nil {
 		return fmt.Errorf("agent-run: exec %s: %w", sandboxExecBinary, execErr)
 	}
 	// Unreachable: syscall.Exec only returns on error.
 	return nil
+}
+
+// openAgentRunLog opens the per-session agent-run log file in append mode for
+// the bwrap and sandbox-exec dispatch paths. It encapsulates the resolve →
+// mkdir → open dance previously inlined in runAgentRun, and is reused by both
+// dispatch paths so they share a single log destination for `[timing]` markers
+// and bwrap stderr tee output.
+//
+// Returns nil on any failure (path-resolve, mkdir, open). All failures are
+// reported via stderr warnings — this function never returns an error so that
+// agent-run can continue running an isolated sandbox even when the host log
+// dir is unwritable. Callers must handle a nil return from this function
+// (logTimingTo also tolerates nil).
+//
+// The destination is normally `~/.local/state/prism/run/<session>/agent-run.log`
+// (see internal/session.AgentRunLogPath). The file is opened with O_APPEND so
+// repeated agent-run invocations across a single session preserve history.
+func openAgentRunLog(sessionName string) *os.File {
+	logPath, logPathErr := session.AgentRunLogPath(sessionName)
+	if logPathErr != nil {
+		fmt.Fprintf(os.Stderr, "[agent-run] warning: cannot resolve agent-run log path: %v — continuing without log file\n", logPathErr)
+		return nil
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(logPath), 0o700); mkErr != nil {
+		fmt.Fprintf(os.Stderr, "[agent-run] warning: cannot create log directory %s: %v — continuing without log file\n", filepath.Dir(logPath), mkErr)
+		return nil
+	}
+	logFile, openErr := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if openErr != nil {
+		fmt.Fprintf(os.Stderr, "[agent-run] warning: cannot open agent-run log %s: %v — continuing without log file\n", logPath, openErr)
+		return nil
+	}
+	return logFile
+}
+
+// logTimingTo writes a single `[timing] <phase>: <duration>` line to both the
+// per-session agent-run log file (when non-nil) and stderr. The format matches
+// the podman side's `[timing]` markers (see internal/sidecar/sidecar.go and
+// internal/container/container.go) so the two timelines grep coherently:
+//
+//	grep '\[timing\]' ~/.local/state/prism/run/<session>/agent-run.log
+//	grep '\[timing\]' ~/.local/state/prism/logs/<session>-sidecar.log
+//
+// Durations are rounded to milliseconds for readability — sub-millisecond
+// noise on these phases is rarely actionable. Errors writing to the log file
+// are silently ignored; the stderr write is best-effort too. The intent is
+// instrumentation that never blocks or fails the launch path.
+func logTimingTo(logFile *os.File, phase string, d time.Duration) {
+	line := fmt.Sprintf("[timing] %s: %s\n", phase, d.Round(time.Millisecond))
+	_, _ = fmt.Fprint(os.Stderr, line)
+	if logFile != nil {
+		_, _ = logFile.WriteString(line)
+	}
 }
 
 // findBwrap locates the bwrap binary on PATH or in well-known Nix store paths.

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -527,3 +527,145 @@ func TestValidateSandboxExecArgs_BadShape(t *testing.T) {
 		}
 	}
 }
+
+// ── [timing] markers (#1052) ────────────────────────────────────────────────
+
+// TestLogTimingTo_WritesToLogFile verifies that logTimingTo writes a single
+// `[timing] <phase>: <duration>` line to the supplied log file (with a
+// trailing newline). This is the core invariant for AC #1: the bwrap and
+// sandbox-exec dispatch paths must leave at least pre-exec / args-build
+// markers in the agent-run log even when the launch later fails.
+func TestLogTimingTo_WritesToLogFile(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "agent-run.log")
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	logTimingTo(f, "pre-exec", 1234*time.Millisecond)
+	logTimingTo(f, "bwrap-args build", 50*time.Millisecond)
+	logTimingTo(f, "bwrap exec", 1290*time.Millisecond)
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	want := "[timing] pre-exec: 1.234s\n" +
+		"[timing] bwrap-args build: 50ms\n" +
+		"[timing] bwrap exec: 1.29s\n"
+	if string(got) != want {
+		t.Errorf("log content:\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+// TestLogTimingTo_NilLogFile verifies that logTimingTo is safe to call with
+// a nil log file. The function falls back to stderr-only output. This is
+// important because openAgentRunLog returns nil on any failure (mkdir, open)
+// and we still want the marker visible somewhere rather than panicking.
+func TestLogTimingTo_NilLogFile(t *testing.T) {
+	// Should not panic.
+	logTimingTo(nil, "pre-exec", 5*time.Millisecond)
+}
+
+// TestLogTimingTo_RoundsToMillisecond verifies that sub-millisecond durations
+// are rounded up/down to the nearest millisecond, mirroring the format used
+// by the podman-side `[timing]` markers (`time.Since(...).Round(time.Millisecond)`).
+// This keeps the bwrap and podman log lines visually aligned for grep.
+func TestLogTimingTo_RoundsToMillisecond(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "agent-run.log")
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	// 1500us rounds to 2ms (Go's Duration rounding is half-away-from-zero
+	// for the .Round implementation: 1.5ms → 2ms).
+	logTimingTo(f, "pre-exec", 1500*time.Microsecond)
+	f.Close()
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(got), "[timing] pre-exec: ") {
+		t.Errorf("log missing [timing] prefix: %q", string(got))
+	}
+	if strings.Contains(string(got), "µs") || strings.Contains(string(got), "us") {
+		t.Errorf("log contains sub-ms unit (not rounded): %q", string(got))
+	}
+}
+
+// TestOpenAgentRunLog_CreatesDirAndFile verifies that openAgentRunLog resolves
+// the per-session log path under XDG_STATE_HOME, creates the directory tree
+// with mode 0700, and opens the log file in append+create mode.
+func TestOpenAgentRunLog_CreatesDirAndFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	f := openAgentRunLog("myrepo@feature")
+	if f == nil {
+		t.Fatal("openAgentRunLog returned nil")
+	}
+	defer f.Close()
+
+	logPath := filepath.Join(tmp, "prism", "run", "myrepo@feature", "agent-run.log")
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("file mode = %o, want 0600", info.Mode().Perm())
+	}
+
+	dirInfo, err := os.Stat(filepath.Dir(logPath))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Errorf("dir mode = %o, want 0700", dirInfo.Mode().Perm())
+	}
+
+	// Verify the returned file is writable and append-mode.
+	if _, err := f.WriteString("first line\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestOpenAgentRunLog_AppendMode verifies that repeated calls open the same
+// log file in append mode, so prior content survives across agent-run
+// invocations within a single session. This matters because tmux pane
+// restarts can re-invoke agent-run, and we want the timing history preserved.
+func TestOpenAgentRunLog_AppendMode(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	f1 := openAgentRunLog("myrepo@feature")
+	if f1 == nil {
+		t.Fatal("openAgentRunLog (1) returned nil")
+	}
+	if _, err := f1.WriteString("first\n"); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	f1.Close()
+
+	f2 := openAgentRunLog("myrepo@feature")
+	if f2 == nil {
+		t.Fatal("openAgentRunLog (2) returned nil")
+	}
+	if _, err := f2.WriteString("second\n"); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	f2.Close()
+
+	logPath := filepath.Join(tmp, "prism", "run", "myrepo@feature", "agent-run.log")
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "first\nsecond\n" {
+		t.Errorf("log content = %q, want %q", string(got), "first\nsecond\n")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -658,6 +658,15 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			startupErr := fmt.Errorf("bwrap harness for %s never bound to %s within %v",
 				s.cfg.SessionName, url, startupTimeout)
 			log.Printf("sidecar: startup-connect timeout fired: %v", startupErr)
+			// Emit a `[timing] opencode listening` line recording the timeout
+			// duration so the grep-the-log workflow yields a coherent timeline
+			// even on the failure path (#1052 AC: "When opencode never reaches
+			// the listening state and the sidecar times out, the timing line
+			// emitted records the timeout duration, not silence."). The
+			// "(timed out)" suffix distinguishes failure from a real listening
+			// marker without changing the leading prefix that grep targets.
+			log.Printf("[timing] opencode listening: %s from start (timed out)",
+				time.Since(s.spawnTime).Round(time.Millisecond))
 			s.writeStartupError(startupErr)
 			// writeStartupError notifies the parent worker for review-agent sessions.
 			// For non-review-agent (worker) sessions, also notify the coordinator so
@@ -694,8 +703,36 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 	// Gap 1b: log the first event received from opencode (once per session).
 	if !s.firstEventLogged {
 		s.firstEventLogged = true
-		elapsed := time.Since(s.spawnTime)
-		log.Printf("sidecar: first event received from opencode (%s after spawn)", elapsed.Round(time.Millisecond))
+		elapsed := time.Since(s.spawnTime).Round(time.Millisecond)
+		log.Printf("sidecar: first event received from opencode (%s after spawn)", elapsed)
+
+		// Bwrap path `[timing]` markers (#1052). The podman path emits these
+		// from sidecar.Run() around WaitHealthy / CreateSession; in bwrap
+		// mode opencode is launched by the tmux pane (via prism agent-run)
+		// and the sidecar's only signal of readiness is the first SSE event,
+		// so the markers are emitted here.
+		//
+		//   - opencode listening: equivalent to the podman WaitHealthy ok
+		//     marker — opencode's HTTP endpoint is reachable, since SSE has
+		//     successfully connected and delivered an event.
+		//   - ready: the sidecar is processing events. In bwrap there is no
+		//     CreateSession step (opencode is started with --prompt by
+		//     agent-run, so the session pre-exists), which means listening
+		//     and ready coincide. Both lines are still emitted so the bwrap
+		//     and podman timelines have the same shape for grepping.
+		//   - prompt delivered: when InitialPrompt is non-empty, the prompt
+		//     was supplied to opencode via --prompt at agent-run time. From
+		//     the sidecar's POV "delivered" is observable when opencode
+		//     starts emitting events — the prompt is in flight by then.
+		//     Emitted at the same moment for symmetry with the podman line
+		//     at sidecar.go:489.
+		if s.cfg.Container == nil {
+			log.Printf("[timing] opencode listening: %s from start", elapsed)
+			log.Printf("[timing] ready: %s from start", elapsed)
+			if s.cfg.InitialPrompt != "" {
+				log.Printf("[timing] prompt delivered: %s from start", elapsed)
+			}
+		}
 	}
 
 	switch eventType {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
@@ -8798,5 +8799,206 @@ func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
 	wantText := "Agent test-repo@feature has finished its current task"
 	if msg.Text != wantText {
 		t.Errorf("notification text = %q, want %q", msg.Text, wantText)
+	}
+}
+
+// ── [timing] markers — bwrap path (#1052) ───────────────────────────────────
+
+// TestBwrapTimingMarkers_FirstEvent verifies that on the bwrap path
+// (Container == nil), the sidecar emits both `[timing] opencode listening`
+// and `[timing] ready` lines on the first SSE event. AC #2 and #3 (#1052):
+// the markers must be sourced from "whatever signal the bwrap sidecar uses
+// to detect opencode readiness" — for bwrap that is the first SSE event.
+func TestBwrapTimingMarkers_FirstEvent(t *testing.T) {
+	d := openTestDB(t)
+	cfg := Config{
+		SessionName: "test-repo@feature",
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-bwrap-worktree",
+		OpencodeURL: "http://localhost:19999",
+		DB:          d,
+		Clock:       newTestClock(),
+		Harness:     &harness.FakeHarness{},
+		// Container is nil — bwrap mode.
+	}
+	sc := New(cfg)
+	// Set spawnTime so duration math produces a real value.
+	sc.spawnTime = time.Now().Add(-100 * time.Millisecond)
+
+	getLogs := captureLog(t)
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+	out := getLogs()
+
+	if !strings.Contains(out, "[timing] opencode listening:") {
+		t.Errorf("missing `[timing] opencode listening` line in:\n%s", out)
+	}
+	if !strings.Contains(out, "from start") {
+		t.Errorf("`[timing] opencode listening` line missing `from start` suffix in:\n%s", out)
+	}
+	if !strings.Contains(out, "[timing] ready:") {
+		t.Errorf("missing `[timing] ready` line in:\n%s", out)
+	}
+}
+
+// TestBwrapTimingMarkers_PromptDelivered verifies that when InitialPrompt is
+// non-empty (a prism prompt was supplied at agent-run launch via --prompt),
+// the sidecar emits a `[timing] prompt delivered: <d> from start` marker on
+// the first SSE event. AC #4 (#1052): mirrors the existing podman line at
+// sidecar.go:489 so the bwrap and podman timelines have the same shape.
+func TestBwrapTimingMarkers_PromptDelivered(t *testing.T) {
+	d := openTestDB(t)
+	cfg := Config{
+		SessionName:   "test-repo@feature",
+		Repo:          "test-repo",
+		Worktree:      "/tmp/test-bwrap-worktree",
+		OpencodeURL:   "http://localhost:19999",
+		DB:            d,
+		Clock:         newTestClock(),
+		Harness:       &harness.FakeHarness{},
+		InitialPrompt: "do the thing",
+	}
+	sc := New(cfg)
+	sc.spawnTime = time.Now().Add(-50 * time.Millisecond)
+
+	getLogs := captureLog(t)
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+	out := getLogs()
+
+	if !strings.Contains(out, "[timing] prompt delivered:") {
+		t.Errorf("missing `[timing] prompt delivered` line in:\n%s", out)
+	}
+}
+
+// TestBwrapTimingMarkers_NoPromptDelivered verifies that when InitialPrompt
+// is empty, no `[timing] prompt delivered` marker is emitted. The marker is
+// gated on InitialPrompt != "" because there is no prompt to attribute time
+// to in that case — emitting the line would be misleading.
+func TestBwrapTimingMarkers_NoPromptDelivered(t *testing.T) {
+	d := openTestDB(t)
+	cfg := Config{
+		SessionName: "test-repo@feature",
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-bwrap-worktree",
+		OpencodeURL: "http://localhost:19999",
+		DB:          d,
+		Clock:       newTestClock(),
+		Harness:     &harness.FakeHarness{},
+		// InitialPrompt is empty.
+	}
+	sc := New(cfg)
+	sc.spawnTime = time.Now().Add(-50 * time.Millisecond)
+
+	getLogs := captureLog(t)
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+	out := getLogs()
+
+	if strings.Contains(out, "[timing] prompt delivered:") {
+		t.Errorf("unexpected `[timing] prompt delivered` line when InitialPrompt is empty:\n%s", out)
+	}
+}
+
+// TestBwrapTimingMarkers_OnlyOnFirstEvent verifies that the `[timing]` markers
+// are emitted exactly once per session, on the first SSE event. Subsequent
+// events must NOT emit duplicate markers — this would otherwise pollute the
+// log on every reconnect and make the timeline ambiguous.
+func TestBwrapTimingMarkers_OnlyOnFirstEvent(t *testing.T) {
+	d := openTestDB(t)
+	cfg := Config{
+		SessionName: "test-repo@feature",
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-bwrap-worktree",
+		OpencodeURL: "http://localhost:19999",
+		DB:          d,
+		Clock:       newTestClock(),
+		Harness:     &harness.FakeHarness{},
+	}
+	sc := New(cfg)
+	sc.spawnTime = time.Now().Add(-100 * time.Millisecond)
+
+	getLogs := captureLog(t)
+	// First event: emits markers.
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+	first := getLogs()
+	if !strings.Contains(first, "[timing] opencode listening:") {
+		t.Fatalf("first event missing markers:\n%s", first)
+	}
+
+	// Subsequent events: must NOT re-emit markers. Count occurrences after
+	// the second batch and assert exactly one of each.
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+	sc.HandleEvent(makeSSE("session.idle", map[string]any{}))
+	final := getLogs()
+	if got := strings.Count(final, "[timing] opencode listening:"); got != 1 {
+		t.Errorf("got %d `[timing] opencode listening` lines, want exactly 1:\n%s", got, final)
+	}
+	if got := strings.Count(final, "[timing] ready:"); got != 1 {
+		t.Errorf("got %d `[timing] ready` lines, want exactly 1:\n%s", got, final)
+	}
+}
+
+// TestBwrapTimingMarkers_PodmanModeNotEmittedHere verifies that when Container
+// is non-nil (podman mode), the bwrap-path markers in HandleEvent do NOT fire
+// — the podman path has its own `[timing]` markers in Run() (`pre-Create`,
+// `Create`, `WaitHealthy`, `CreateSession start/done`, `ready`,
+// `prompt delivered`) and emitting them here too would duplicate the lines.
+func TestBwrapTimingMarkers_PodmanModeNotEmittedHere(t *testing.T) {
+	d := openTestDB(t)
+	cfg := Config{
+		SessionName: "test-repo@feature",
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-podman-worktree",
+		OpencodeURL: "http://localhost:19999",
+		DB:          d,
+		Clock:       newTestClock(),
+		Harness:     &harness.FakeHarness{},
+		// Non-nil Container → podman mode. The pointer doesn't have to be
+		// fully populated for HandleEvent's gate — it just needs to be non-nil.
+		Container: &container.Config{},
+	}
+	sc := New(cfg)
+	sc.spawnTime = time.Now().Add(-100 * time.Millisecond)
+
+	getLogs := captureLog(t)
+	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
+	out := getLogs()
+
+	if strings.Contains(out, "[timing] opencode listening:") {
+		t.Errorf("podman mode must not emit bwrap-path `[timing] opencode listening` from HandleEvent:\n%s", out)
+	}
+	if strings.Contains(out, "[timing] ready:") {
+		t.Errorf("podman mode must not emit bwrap-path `[timing] ready` from HandleEvent:\n%s", out)
+	}
+}
+
+// TestStartupConnectTimeout_EmitsTimingMarker verifies AC: "When opencode
+// never reaches the listening state and the sidecar times out, the timing
+// line emitted records the timeout duration, not silence." (#1052)
+//
+// We use the existing blockingHarness fixture and a tight timeout so the
+// timeout goroutine fires deterministically; Run() exits when the SSE context
+// is cancelled by the timeout handler.
+func TestStartupConnectTimeout_EmitsTimingMarker(t *testing.T) {
+	const timeout = 30 * time.Millisecond
+	sc, d := newBwrapSidecarWithTimeout(t, timeout)
+	_ = d.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "idle", nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	getLogs := captureLog(t)
+	done := make(chan error, 1)
+	go func() { done <- sc.Run(ctx) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after startup timeout")
+	}
+	out := getLogs()
+
+	if !strings.Contains(out, "[timing] opencode listening:") {
+		t.Errorf("missing `[timing] opencode listening` line on timeout path:\n%s", out)
+	}
+	if !strings.Contains(out, "(timed out)") {
+		t.Errorf("timeout-path `[timing]` line should include `(timed out)` suffix to distinguish from success:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary

The podman path emits structured `[timing]` markers throughout sidecar startup (`pre-Create`, `EnsureRemoved`, `writeGitconfig`, `buildRunArgs`, `podman run`, `WaitHealthy`, `CreateSession`, `ready`, `prompt delivered`) that land in the sidecar log and are easy to grep for post-hoc analysis. The bwrap and sandbox-exec paths emitted **none of this**, making it impossible to answer "where did the wall time go between spawn and ready" without adding `printf`s to a running session.

This PR adds symmetric `[timing]` markers to both sandboxed paths so the existing grep-the-log workflow works on every isolation mode.

## Markers added

**agent-run side** (`cmd/agent_run.go`) — written to both stderr and the per-session agent-run log (`~/.local/state/prism/run/<session>/agent-run.log`):

```
[timing] pre-exec: <d>              — agent-run entry → start of args build
[timing] bwrap-args build: <d>      — PrepareBwrap (writes temp files + builds argv)
[timing] bwrap exec: <d>            — total to exec.Cmd.Start
[timing] sandbox-exec args build    — equivalent on sandbox-exec path
[timing] sandbox-exec exec          — equivalent on sandbox-exec path
```

The agent-run log file is now opened at the top of `runAgentRun` (rather than mid-function) so the early markers reach the log even when later setup fails — satisfying the AC: "When bwrap fails to exec (missing binary, bad profile, etc.), at least the `pre-exec` and `bwrap-args build` markers have already been written to the agent-run log so the failure point can be located."

A new `logTimingTo` helper writes to both stderr and the log file; `openAgentRunLog` factors out the log-open dance so both dispatch paths share a single destination.

**sidecar side** (`internal/sidecar/sidecar.go`), bwrap path only — written via `log.Printf` to the sidecar log (`~/.local/state/prism/logs/<session>-sidecar.log`):

```
[timing] opencode listening: <d> from start    — at first SSE event
[timing] ready: <d> from start                  — at first SSE event
[timing] prompt delivered: <d> from start       — at first SSE event when InitialPrompt set
[timing] opencode listening: <timeout> from start (timed out)
                                                — on startup-connect timeout (5m default)
```

For bwrap there is no separate `WaitHealthy` / `CreateSession` step (opencode is launched by the tmux pane via `prism agent-run` with `--prompt`), so all three success-path markers fire at the same moment — the first SSE event is the only signal of opencode readiness from the sidecar's POV. They are emitted as distinct lines so the bwrap and podman timelines have the same shape for grepping. Markers fire exactly once per session (gated on `firstEventLogged`).

## Sandbox-exec coverage

Sandbox-exec landed under #1053 just before this PR. Per AC #5, sandbox-exec gets the same instrumentation in this PR — both at agent-run side (via the `runAgentRunSandboxExec` helper, now passed `agentRunStart` and `logFile`) and at the sidecar side (the bwrap-path markers fire for sandbox-exec too because both modes have `Container == nil`).

## Out of scope

No optimisation, log-format changes, or aggregation. This is purely about visibility — once we have the data we can decide what to make faster.

## Tests

- Unit tests for `logTimingTo` (writes to log + nil-tolerance + ms rounding) and `openAgentRunLog` (creates dir 0700, opens file 0600, append mode).
- Sidecar tests for bwrap-path markers: emitted on first SSE event, not duplicated on subsequent events, not emitted in podman mode (which has its own `[timing]` markers in `Run()`), `prompt delivered` gated on `InitialPrompt != ""`, timeout path emits `(timed out)` marker.

## Quality gates

- ` go build ./... ` ✓
- ` go test ./... ` ✓ (all packages green)
- ` nix build .#nixosConfigurations.navi.config.system.build.toplevel ` ✓

Closes #1052