### PR TITLE
prism: prevent reviewing state from being clobbered by busy events (#1049)

### DIFF
--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
@@ -152,6 +153,36 @@ func MonitorFunc(opts MonitorOpts) error {
 	// overflow-to-file is handled when the total findings exceed the budget.
 	output, allPassed := FormatResults(results, opts.PRNumber, opts.Round, opts.SizeBudget)
 	deliveryText := buildDeliveryMessage(opts.PRNumber, opts.Round, output, allPassed, groupData, opts.AgentSessions)
+
+	// Before delivery, clear the worker's `reviewing` state by writing `active`.
+	// Background: RunAsync writes `reviewing` to the DB so that incidental busy
+	// turns + idle debounces in the worker session do not produce a premature
+	// "has finished" notification while the review is in flight (see #1036 and
+	// #1049). The sidecar's busy-event handler treats `reviewing` as a sticky
+	// state and refuses to write `active` over it. We must therefore flip the
+	// DB state to `active` ourselves *just before* delivering the review-
+	// complete prompt — that way, the busy event triggered by the prompt
+	// arriving is processed against `active`, the subsequent idle debounce
+	// fires normally, and the genuine end-of-review handoff is observed.
+	//
+	// This write only runs while the worker is in `reviewing`; if the state
+	// has already moved on (worker crashed, manual override, etc.) we leave it
+	// alone. Failures here are non-fatal: the prompt is still delivered, and
+	// at worst the suppression remains in effect (no spurious notifications,
+	// just no end-of-review notification — the worker can still observe the
+	// prompt directly).
+	if workerStatus, stErr := d.CurrentStatus(opts.WorkerSession); stErr == nil && workerStatus != nil {
+		if workerStatus.State == string(agent.StateReviewing) {
+			if err := d.UpsertStatus(opts.WorkerSession, workerStatus.Repo, workerStatus.Worktree,
+				string(agent.StateActive), nil, nil); err != nil {
+				fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: could not clear reviewing→active before delivery: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "[prism monitor-review] worker state reviewing→active (pre-delivery)\n")
+			}
+		}
+	} else if stErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: could not look up worker session %q before delivery: %v\n", opts.WorkerSession, stErr)
+	}
 
 	// Deliver to worker via prism prompt with bounded retry.
 	deliverErr := deliverWithRetry(opts.WorkerSession, deliveryText, maxRetries, retryBackoff, dbPath)

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -130,6 +130,94 @@ func TestMonitorFunc_DetectsCompletionAndDelivers(t *testing.T) {
 	}
 }
 
+// TestMonitorFunc_FlipsReviewingToActiveBeforeDelivery verifies the option-1
+// fix for issue #1049: the review monitor must clear the worker's `reviewing`
+// state by writing `active` to the DB *before* delivering the review-complete
+// prompt. This ensures the busy event triggered by the prompt arriving is
+// processed against `active` (not `reviewing`, which the sidecar treats as
+// sticky and refuses to overwrite), so the subsequent idle debounce can fire
+// the genuine end-of-review handoff.
+func TestMonitorFunc_FlipsReviewingToActiveBeforeDelivery(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@monitor-flip-test"
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+	}
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	sessions := []string{parent + "~review-1-review-goal"}
+	for _, sess := range sessions {
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+	}
+	seedAssistantEvent(t, d, sessions[0], "All ACs verified.\n<verdict>PASS</verdict>")
+
+	// Seed the worker session in `reviewing` state — exactly as RunAsync
+	// leaves it after spawning the review-agent group.
+	workerSession := "nixos-config@worker-flip-test"
+	if err := d.UpsertStatus(workerSession, "nixos-config", "/wt", "reviewing", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus worker: %v", err)
+	}
+
+	// Capture the worker's DB state at the moment of delivery (i.e. when the
+	// HTTP server receives the prompt_async POST). If the monitor has correctly
+	// flipped reviewing→active before delivery, this snapshot must read `active`.
+	var stateAtDelivery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status, sErr := d.CurrentStatus(workerSession); sErr == nil && status != nil {
+			stateAtDelivery = status.State
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	port := extractPort(t, srv.URL)
+	if err := setHarnessInfo(t, d, workerSession, port, "test-opencode-session-id"); err != nil {
+		t.Fatalf("SetHarnessInfo: %v", err)
+	}
+
+	opts := review.MonitorOpts{
+		GroupID:              groupID,
+		WorkerSession:        workerSession,
+		PRNumber:             "1049",
+		Round:                1,
+		Agents:               agents,
+		AgentSessions:        sessions,
+		DBPath:               d.Path(),
+		PollInterval:         10 * time.Millisecond,
+		MaxDeliveryRetries:   0,
+		DeliveryRetryBackoff: 1 * time.Millisecond,
+	}
+
+	if err := review.MonitorFunc(opts); err != nil {
+		t.Fatalf("MonitorFunc: %v", err)
+	}
+
+	if stateAtDelivery != "active" {
+		t.Errorf("worker state at moment of delivery = %q, want %q (monitor must flip reviewing→active before delivering)",
+			stateAtDelivery, "active")
+	}
+
+	// Post-delivery: the DB state should still be `active` (or whatever the
+	// worker has moved on to in response to the delivery).
+	finalStatus, err := d.CurrentStatus(workerSession)
+	if err != nil {
+		t.Fatalf("CurrentStatus post-delivery: %v", err)
+	}
+	if finalStatus == nil || finalStatus.State == "reviewing" {
+		t.Errorf("worker state after delivery = %v, want non-reviewing", finalStatus)
+	}
+}
+
 // TestMonitorFunc_DeliveryFailure_WritesFallbackFile verifies that when all
 // delivery retries fail, MonitorFunc writes the fallback file at the expected
 // path.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -934,7 +934,18 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 		s.cancelRecoveryTimer()
 		s.manualDenial = false
 		s.busyEpoch++
-		if !s.compacting {
+		// Suppress the active write if compacting (existing exception) or if the
+		// DB state is reviewing — the worker is awaiting the review-complete
+		// prompt and any incidental busy turn (e.g. an assistant summary fired
+		// after `prism review` returns, before the monitor delivers results)
+		// must not clobber `reviewing`. The monitor is responsible for writing
+		// `active` to the DB just before delivering the review-complete prompt
+		// so that the genuine reviewing→active transition still happens. See
+		// internal/review/monitor.go and #1049.
+		dbStateOnBusy := s.currentDBState()
+		if dbStateOnBusy == agent.StateReviewing {
+			log.Printf("sidecar: busy event suppressed (cause=reviewing — awaiting review-complete prompt)")
+		} else if !s.compacting {
 			s.upsertState(agent.StateActive, nil, nil)
 			s.writeStateChange(agent.StateActive)
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -8731,17 +8731,109 @@ func TestReviewing_IdleDebounceSuppressed(t *testing.T) {
 	}
 }
 
-// TestReviewing_TransitionsToFinishedAfterPromptDelivery verifies the full
-// lifecycle: worker in "reviewing" → review-complete prompt arrives → opencode
-// goes busy (active) → idle debounce fires → finished → coordinator notified.
+// TestReviewing_NotClobberedByBusyTurn verifies that a session.status{busy}
+// event fired while the worker is in "reviewing" does NOT overwrite that state
+// with "active". This is the regression test for issue #1049: prior to the
+// fix, the busy branch of handleSessionStatus wrote `active` unconditionally
+// (only excepting `compacting`), so any incidental assistant turn the worker
+// emitted between `prism review` returning and the review-complete prompt
+// arriving would clobber `reviewing`. The subsequent idle debounce then saw
+// `active` (not `reviewing`), the suppression path was skipped, and the
+// coordinator received a spurious "has finished" notification.
 //
-// This simulates the happy path for issue #1033:
-//  1. Worker is in "reviewing" state (set by RunAsync).
-//  2. Monitor delivers review-complete prompt; opencode goes busy.
-//  3. session.status{busy} fires → sidecar writes "active" to DB.
-//  4. Worker processes results and goes idle.
-//  5. Idle debounce fires → DB state is "active" (not "reviewing") → finished.
-//  6. Coordinator receives the "has finished" notification.
+// The fix adds a `reviewing` exception parallel to the existing `compacting`
+// exception. With it, the state must remain `reviewing` across one or more
+// busy + idle cycles, and no coordinator notification must fire.
+func TestReviewing_NotClobberedByBusyTurn(t *testing.T) {
+	d := openTestDB(t)
+
+	coordSID := "coord-sid-reviewing-clobber"
+	var notifyCount int
+	var notifyMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		notifyMu.Lock()
+		notifyCount++
+		notifyMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	worker, clk := newWorkerSidecar(t, d, srv.Client())
+
+	// Set the worker state to "reviewing" (as RunAsync does after spawning
+	// review agents).
+	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, string(agent.StateReviewing), nil, nil)
+
+	// Fire two busy + idle cycles, simulating one or more assistant turns the
+	// worker emits after `prism review` returns but before the review-complete
+	// prompt arrives.
+	for i := 0; i < 2; i++ {
+		worker.HandleEvent(makeSSE("session.status", map[string]any{
+			"status": map[string]string{"type": "busy"},
+		}))
+		// State must still be "reviewing" — busy must NOT clobber it.
+		if state := getState(t, d, worker.cfg.SessionName); state != string(agent.StateReviewing) {
+			t.Fatalf("cycle %d: after busy: state = %q, want %q (busy must not clobber reviewing)",
+				i, state, agent.StateReviewing)
+		}
+
+		worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
+		timer := clk.LastTimer()
+		if timer == nil {
+			t.Fatalf("cycle %d: expected idle timer from session.idle", i)
+		}
+		timer.Fire()
+
+		// State must still be "reviewing" — the idle debounce suppression
+		// path must trigger because the DB state is still `reviewing`.
+		if state := getState(t, d, worker.cfg.SessionName); state != string(agent.StateReviewing) {
+			t.Errorf("cycle %d: after idle debounce: state = %q, want %q (idle debounce must be suppressed while reviewing)",
+				i, state, agent.StateReviewing)
+		}
+	}
+
+	// Allow async goroutines a moment to settle.
+	time.Sleep(100 * time.Millisecond)
+
+	// No bus messages and no HTTP POST notifications must have been delivered.
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	if totalMsgs != 0 {
+		t.Errorf("worker in reviewing state must NOT send coordinator notification, but got %d bus message(s)", totalMsgs)
+	}
+
+	notifyMu.Lock()
+	nc := notifyCount
+	notifyMu.Unlock()
+	if nc != 0 {
+		t.Errorf("coordinator HTTP POST count = %d, want 0 (busy turns while reviewing must suppress notifications)", nc)
+	}
+}
+
+// TestReviewing_TransitionsToFinishedAfterPromptDelivery verifies the full
+// lifecycle: worker in "reviewing" → review monitor flips state to "active"
+// just before delivering the review-complete prompt → busy event → idle
+// debounce → finished → coordinator notified.
+//
+// Per the option-1 fix for #1049, the reviewing→active flip is driven by the
+// review monitor writing `active` to the DB before delivering the prompt, NOT
+// by an arbitrary busy event (which is suppressed while in `reviewing`). This
+// test mirrors that contract: the test seeds `reviewing`, then simulates the
+// monitor's pre-delivery DB write by upserting `active`, and only then fires
+// the busy + idle events that arise from the prompt being processed.
 func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
 	d := openTestDB(t)
 
@@ -8769,8 +8861,18 @@ func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
 		t.Errorf("after suppressed idle: state = %q, want %q", state, agent.StateReviewing)
 	}
 
-	// Step 2: review-complete prompt arrives; opencode goes busy.
-	// session.status{busy} overwrites "reviewing" with "active".
+	// Step 2: the review monitor writes `active` to the DB just before
+	// delivering the review-complete prompt (option 1 in #1049). This mirrors
+	// the pre-delivery write performed by review.MonitorFunc.
+	if err := d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree,
+		string(agent.StateActive), nil, nil); err != nil {
+		t.Fatalf("monitor pre-delivery upsert active: %v", err)
+	}
+
+	// Step 3: review-complete prompt arrives; opencode goes busy. The busy
+	// event now sees `active` (not `reviewing`) in the DB, so it proceeds
+	// normally — though the state is already `active`, upsertState is a
+	// no-op for same-state transitions.
 	worker.HandleEvent(makeSSE("session.status", map[string]any{
 		"status": map[string]string{"type": "busy"},
 	}))
@@ -8778,7 +8880,7 @@ func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
 		t.Errorf("after busy: state = %q, want %q", state, agent.StateActive)
 	}
 
-	// Step 3: worker processes results and goes idle again.
+	// Step 4: worker processes results and goes idle again.
 	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
 	timer2 := clk.LastTimer()
 	if timer2 == nil {


### PR DESCRIPTION
## Summary

The `reviewing` state introduced by #1036 was silently overwritten by any
`session.status{busy}` event the worker emitted between `prism review` returning
and the first `session.idle`, defeating the premature-finish suppression
mechanism in the universal real-world case (worker writes a brief "standing by"
summary turn after the tool call returns).

This was directly impacting coordinator agents — every review cycle was
producing a spurious "has finished" notification, and the only workaround was
manually checking each one with `prism checkin`.

## Fix (option 1 from the issue)

- **sidecar**: `handleSessionStatus` busy branch now treats `reviewing` as a
  sticky state, parallel to the existing `compacting` exception. While
  `reviewing`, busy no longer writes `active` to the DB.
- **review monitor**: writes `active` to the worker DB row just before
  delivering the review-complete prompt. This is the single legitimate trigger
  for `reviewing → active`, matching the existing pattern where `RunAsync` owns
  the entry transition.

## Regression tests

Per AC-3:

- `TestReviewing_NotClobberedByBusyTurn` (sidecar) — drives multiple busy +
  idle cycles while in `reviewing`, asserts state remains `reviewing` and no
  coordinator notification fires.
- `TestReviewing_TransitionsToFinishedAfterPromptDelivery` (sidecar) — rewritten
  to drive `reviewing → active` via the monitor's pre-delivery DB write, not
  via an arbitrary busy event (which is now suppressed while in `reviewing`).
- `TestMonitorFunc_FlipsReviewingToActiveBeforeDelivery` (review) — asserts
  the monitor flips `reviewing → active` before the `prompt_async` POST hits
  the worker.

## Validation

- `go build ./...` ✓
- `go test ./...` ✓ (all packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✓

## References

- Closes #1049
- Repairs the suppression mechanism introduced by #1036
- Fixes the underlying race condition originally reported in #1033