### PR TITLE
fix(sidecar): keep host-API socket path under sun_path limit on every platform

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -289,22 +289,13 @@ func TestAgentRunLogFileCreation_LogDirCreated(t *testing.T) {
 
 // agentRunLogPathFromEnv is a thin helper for the test above: it calls the
 // session package to resolve the log path, exercising the same code path as
-// runAgentRun without requiring a real DB or bwrap binary.
+// runAgentRun without requiring a real DB or bwrap binary. Delegating to the
+// real session.AgentRunLogPath ensures this helper stays in sync with the
+// production scheme (e.g. the SessionDirName-based hashed directory from
+// #1050) — re-implementing the path construction here would silently mask
+// regressions in the production path layout.
 func agentRunLogPathFromEnv(sessionName string) (string, error) {
-	// Import the session package's AgentRunLogPath via the same import path
-	// used by agent_run.go — we call it indirectly through the package.
-	// Since we are in package cmd, we can call any unexported helpers here.
-	// The real path resolution uses session.AgentRunLogPath; exercise it via
-	// a direct path construction that mirrors what the session package does.
-	stateHome := os.Getenv("XDG_STATE_HOME")
-	if stateHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		stateHome = home + "/.local/state"
-	}
-	return stateHome + "/prism/run/" + sessionName + "/agent-run.log", nil
+	return prismsession.AgentRunLogPath(sessionName)
 }
 
 // ── integration: tee captures process output in log file ─────────────────────
@@ -320,13 +311,20 @@ func agentRunLogPathFromEnv(sessionName string) (string, error) {
 // process (and its "pane") is gone.
 func TestAgentRunLog_TeeCapture(t *testing.T) {
 	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
 
-	// Create the per-session log directory (mode 0700) and log file (mode 0600).
-	logDir := tmp + "/prism/run/myrepo@feat"
+	// Resolve the per-session log path via the same helper agent-run uses,
+	// so this test exercises the production path layout (hashed per-session
+	// directory after #1050) rather than re-asserting an old layout that no
+	// longer matches production.
+	logPath, err := prismsession.AgentRunLogPath("myrepo@feat")
+	if err != nil {
+		t.Fatalf("AgentRunLogPath: %v", err)
+	}
+	logDir := filepath.Dir(logPath)
 	if err := os.MkdirAll(logDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll log dir: %v", err)
 	}
-	logPath := logDir + "/agent-run.log"
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		t.Fatalf("open log file: %v", err)

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/container"
+	prismsession "github.com/prismatic-koi/prism/internal/session"
 )
 
 // ── applyInitialPromptEnvVar ──────────────────────────────────────────────────
@@ -605,13 +606,14 @@ func TestOpenAgentRunLog_CreatesDirAndFile(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
-	f := openAgentRunLog("myrepo@feature")
+	const sess = "myrepo@feature"
+	f := openAgentRunLog(sess)
 	if f == nil {
 		t.Fatal("openAgentRunLog returned nil")
 	}
 	defer f.Close()
 
-	logPath := filepath.Join(tmp, "prism", "run", "myrepo@feature", "agent-run.log")
+	logPath := filepath.Join(tmp, "prism", "run", prismsession.SessionDirName(sess), "agent-run.log")
 	info, err := os.Stat(logPath)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
@@ -642,7 +644,8 @@ func TestOpenAgentRunLog_AppendMode(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
-	f1 := openAgentRunLog("myrepo@feature")
+	const sess = "myrepo@feature"
+	f1 := openAgentRunLog(sess)
 	if f1 == nil {
 		t.Fatal("openAgentRunLog (1) returned nil")
 	}
@@ -651,7 +654,7 @@ func TestOpenAgentRunLog_AppendMode(t *testing.T) {
 	}
 	f1.Close()
 
-	f2 := openAgentRunLog("myrepo@feature")
+	f2 := openAgentRunLog(sess)
 	if f2 == nil {
 		t.Fatal("openAgentRunLog (2) returned nil")
 	}
@@ -660,7 +663,7 @@ func TestOpenAgentRunLog_AppendMode(t *testing.T) {
 	}
 	f2.Close()
 
-	logPath := filepath.Join(tmp, "prism", "run", "myrepo@feature", "agent-run.log")
+	logPath := filepath.Join(tmp, "prism", "run", prismsession.SessionDirName(sess), "agent-run.log")
 	got, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read: %v", err)

--- a/modules/programs/prism/prism/internal/container/hostapi_path_roundtrip_test.go
+++ b/modules/programs/prism/prism/internal/container/hostapi_path_roundtrip_test.go
@@ -1,0 +1,129 @@
+package container
+
+// AC-6 round-trip test for #1050: confirm that bwrap.BuildArgs and
+// Manager.buildRunArgs both reference the same per-session host-API socket
+// directory derived from a sidecar-style path.
+//
+// This test cannot import internal/session directly (session imports
+// container, which would create a cycle), so it re-derives the expected
+// directory name inline using the same formula that session.SessionDirName
+// uses (12-hex-char SHA-256 prefix). If this drifts from the production
+// formula, the test will fail loudly — which is the desired behaviour: a
+// drift would mean the sidecar binds in dir A but the sandbox mounts dir B,
+// producing the exact silent-failure mode #1050 set out to prevent.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// expectedSessionDirName mirrors session.SessionDirName. Kept as a copy here
+// because the in-package container test cannot import session due to an
+// import cycle (session.go imports internal/container).
+func expectedSessionDirName(sessionName string) string {
+	const hashLen = 12
+	sum := sha256.Sum256([]byte(sessionName))
+	return hex.EncodeToString(sum[:])[:hashLen]
+}
+
+// TestHostAPIPath_RoundTrip_SidecarBwrapPodmanAgree verifies that for the
+// same sidecar-style HostAPISockPath, the bwrap and podman builders both
+// reference the same directory — and that directory is the one a sidecar
+// would produce via session.SidecarHostAPIPath.
+func TestHostAPIPath_RoundTrip_SidecarBwrapPodmanAgree(t *testing.T) {
+	cases := []struct {
+		name    string
+		session string
+	}{
+		{
+			name:    "short coordinator (AC-2)",
+			session: "nixos-config@main",
+		},
+		{
+			name:    "long branch name (AC-2)",
+			session: "nixos-config@fix-something-with-a-fairly-long-branch-name",
+		},
+		{
+			name:    "long branch + review suffix (AC-2)",
+			session: "nixos-config@fix-something-with-a-fairly-long-branch-name~review-1-review-security",
+		},
+		{
+			name:    "worst-case from issue body (AC-1, AC-3)",
+			session: "nixos-config@" + strings.Repeat("x", 80) + "~review-99-review-context",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use a controlled XDG_STATE_HOME so the bwrap fixture
+			// (which writes under the test temp dir) is deterministic.
+			stateHome := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", stateHome)
+
+			// Build the same sidecar-style path the production sidecar
+			// would compute via session.SidecarHostAPIPath.
+			wantDir := filepath.Join(stateHome, "prism", "run", expectedSessionDirName(tc.session))
+			sockPath := filepath.Join(wantDir, "hostapi.sock")
+
+			// 1) Podman: m.buildRunArgs must volume-mount wantDir at /var/run/prism-host.
+			m, _, cleanup := bwrapFixture(t, Config{
+				SessionName:     tc.session,
+				Worktree:        t.TempDir(),
+				AllocatedPort:   14010,
+				HostAPISockPath: sockPath,
+			})
+			defer cleanup()
+
+			podmanArgs := m.buildRunArgs()
+			gotPodmanDir := findVolumeSrcByDst(podmanArgs, "/var/run/prism-host")
+			if gotPodmanDir == "" {
+				t.Fatalf("podman args do not include /var/run/prism-host volume mount: %v", podmanArgs)
+			}
+			if gotPodmanDir != wantDir {
+				t.Errorf("podman volume src = %q, want %q (sidecar-derived)", gotPodmanDir, wantDir)
+			}
+
+			// 2) Bwrap: BuildArgs must --bind wantDir to itself.
+			b := &bwrapIsolator{name: m.name}
+			bwrapArgs := b.BuildArgs(m)
+			gotBwrapDir := findBindSrcByDst(bwrapArgs, wantDir)
+			if gotBwrapDir != wantDir {
+				t.Errorf("bwrap --bind for socket dir: src=%q dst=%q, want SRC==DST==%q",
+					gotBwrapDir, wantDir, wantDir)
+			}
+		})
+	}
+}
+
+// findVolumeSrcByDst scans podman --volume args for "<src>:<dst>[:<opts>]" and
+// returns src for the first arg whose dst matches.
+func findVolumeSrcByDst(args []string, dst string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] != "--volume" {
+			continue
+		}
+		spec := args[i+1]
+		parts := strings.SplitN(spec, ":", 3)
+		if len(parts) >= 2 && parts[1] == dst {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+// findBindSrcByDst scans bwrap --bind args for "<src> <dst>" pairs and returns
+// src for the first pair whose dst matches.
+func findBindSrcByDst(args []string, dst string) string {
+	for i := 0; i < len(args)-2; i++ {
+		if args[i] != "--bind" {
+			continue
+		}
+		if args[i+2] == dst {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -13,6 +13,8 @@ package session
 // (setupFullLayout) treats this as non-fatal and logs a warning.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -21,6 +23,35 @@ import (
 	"strings"
 	"syscall"
 )
+
+// sessionDirHashLen is the number of hex characters used as the per-session
+// run/ subdirectory name. 12 hex chars = 6 bytes = 48 bits of entropy from
+// SHA-256, more than enough to disambiguate the small set of concurrent
+// session names a single user runs (collision probability ≈ N²/2^49).
+//
+// The hashed directory name keeps the host-API socket path under sun_path
+// budgets on every platform: with the default state dir
+// "$HOME/.local/state/prism/run/" + 12 hex + "/hostapi.sock", the path is
+// roughly 58 bytes — comfortably under Darwin's 104-byte limit and Linux's
+// 108-byte limit even when $HOME is unusually long. See issue #1050 for the
+// full path arithmetic and the regression test in this package.
+const sessionDirHashLen = 12
+
+// SessionDirName returns the deterministic per-session directory name used
+// under $XDG_STATE_HOME/prism/run/ for files that must be co-located with the
+// host-API Unix socket (currently hostapi.sock and agent-run.log).
+//
+// The directory name is the first 12 hex characters of SHA-256(sessionName).
+// This keeps the resulting socket path under sun_path budgets on every
+// platform regardless of how long the session name itself is — see #1050.
+//
+// The mapping is pure and deterministic, so cleanup, debugging
+// (`prism logs <session>`), and bwrap/podman bind-mount construction can all
+// re-derive the directory from the session name without any persisted lookup.
+func SessionDirName(sessionName string) string {
+	sum := sha256.Sum256([]byte(sessionName))
+	return hex.EncodeToString(sum[:])[:sessionDirHashLen]
+}
 
 // sidecarStateDir returns the $XDG_STATE_HOME/prism base directory.
 func sidecarStateDir() (string, error) {
@@ -74,13 +105,20 @@ func SidecarPIDPath(sessionName string) (string, error) {
 // when podman evaluates the bind-mount, even though the socket file inside it is
 // created later by the sidecar (after the container becomes healthy).
 //
-// Socket path: $XDG_STATE_HOME/prism/run/<session>/hostapi.sock
+// The directory name is a 12-hex-char SHA-256 prefix of the session name (see
+// SessionDirName) rather than the session name itself. This keeps the resulting
+// socket path under the platform sun_path limits — historically the full session
+// name (e.g. "<repo>@<long-branch>~review-N-review-<role>") could push the path
+// past Linux's 108-byte and Darwin's 104-byte budgets, causing bind(2) to fail
+// with EINVAL. See #1050 for the path arithmetic and regression test.
+//
+// Socket path: $XDG_STATE_HOME/prism/run/<12-hex-of-sha256(session)>/hostapi.sock
 func SidecarHostAPIPath(sessionName string) (string, error) {
 	base, err := sidecarStateDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "run", sessionName, "hostapi.sock"), nil
+	return filepath.Join(base, "run", SessionDirName(sessionName), "hostapi.sock"), nil
 }
 
 // AgentRunLogPath returns the agent-run log file path for the named session.
@@ -90,13 +128,17 @@ func SidecarHostAPIPath(sessionName string) (string, error) {
 // created by the time agent-run opens the file (the sidecar pre-creates it via
 // container.prepareVolumeDirs, and agent-run falls back to creating it if needed).
 //
-// Log path: $XDG_STATE_HOME/prism/run/<session>/agent-run.log
+// The directory name is the same SessionDirName-derived 12-hex prefix used by
+// SidecarHostAPIPath, so the log and the socket always live in the same
+// per-session directory regardless of how long the session name is.
+//
+// Log path: $XDG_STATE_HOME/prism/run/<12-hex-of-sha256(session)>/agent-run.log
 func AgentRunLogPath(sessionName string) (string, error) {
 	base, err := sidecarStateDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "run", sessionName, "agent-run.log"), nil
+	return filepath.Join(base, "run", SessionDirName(sessionName), "agent-run.log"), nil
 }
 
 // KillSidecar reads the PID file for the named session, sends SIGTERM to the

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -295,13 +295,14 @@ func TestAgentRunLogPath_DefaultXDG(t *testing.T) {
 		t.Fatalf("UserHomeDir: %v", err)
 	}
 
-	got, err := AgentRunLogPath("myrepo@feature")
+	const sess = "myrepo@feature"
+	got, err := AgentRunLogPath(sess)
 	if err != nil {
 		t.Fatalf("AgentRunLogPath: %v", err)
 	}
 
-	// Per-session subdirectory format: run/<session>/agent-run.log
-	want := filepath.Join(home, ".local", "state", "prism", "run", "myrepo@feature", "agent-run.log")
+	// Per-session subdirectory format (#1050): run/<12-hex-of-sha256(session)>/agent-run.log
+	want := filepath.Join(home, ".local", "state", "prism", "run", SessionDirName(sess), "agent-run.log")
 	if got != want {
 		t.Errorf("AgentRunLogPath = %q, want %q", got, want)
 	}
@@ -311,13 +312,14 @@ func TestAgentRunLogPath_CustomXDG(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
-	got, err := AgentRunLogPath("myrepo@main")
+	const sess = "myrepo@main"
+	got, err := AgentRunLogPath(sess)
 	if err != nil {
 		t.Fatalf("AgentRunLogPath: %v", err)
 	}
 
-	// Per-session subdirectory format: run/<session>/agent-run.log
-	want := filepath.Join(tmp, "prism", "run", "myrepo@main", "agent-run.log")
+	// Per-session subdirectory format (#1050): run/<12-hex-of-sha256(session)>/agent-run.log
+	want := filepath.Join(tmp, "prism", "run", SessionDirName(sess), "agent-run.log")
 	if got != want {
 		t.Errorf("AgentRunLogPath = %q, want %q", got, want)
 	}
@@ -356,13 +358,15 @@ func TestSidecarHostAPIPath_DefaultXDG(t *testing.T) {
 		t.Fatalf("UserHomeDir: %v", err)
 	}
 
-	got, err := SidecarHostAPIPath("myrepo@feature")
+	const sess = "myrepo@feature"
+	got, err := SidecarHostAPIPath(sess)
 	if err != nil {
 		t.Fatalf("SidecarHostAPIPath: %v", err)
 	}
 
-	// Per-session subdirectory format (security fix #960): run/<session>/hostapi.sock
-	want := filepath.Join(home, ".local", "state", "prism", "run", "myrepo@feature", "hostapi.sock")
+	// Per-session subdirectory format (security fix #960, hashed for #1050):
+	// run/<12-hex-of-sha256(session)>/hostapi.sock
+	want := filepath.Join(home, ".local", "state", "prism", "run", SessionDirName(sess), "hostapi.sock")
 	if got != want {
 		t.Errorf("SidecarHostAPIPath = %q, want %q", got, want)
 	}
@@ -372,14 +376,118 @@ func TestSidecarHostAPIPath_CustomXDG(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
-	got, err := SidecarHostAPIPath("myrepo@main")
+	const sess = "myrepo@main"
+	got, err := SidecarHostAPIPath(sess)
 	if err != nil {
 		t.Fatalf("SidecarHostAPIPath: %v", err)
 	}
 
-	// Per-session subdirectory format (security fix #960): run/<session>/hostapi.sock
-	want := filepath.Join(tmp, "prism", "run", "myrepo@main", "hostapi.sock")
+	// Per-session subdirectory format (security fix #960, hashed for #1050):
+	// run/<12-hex-of-sha256(session)>/hostapi.sock
+	want := filepath.Join(tmp, "prism", "run", SessionDirName(sess), "hostapi.sock")
 	if got != want {
 		t.Errorf("SidecarHostAPIPath = %q, want %q", got, want)
+	}
+}
+
+// ── Path-length invariant tests (#1050) ──────────────────────────────────────
+//
+// The host-API socket path is bound by the kernel's sun_path limit:
+//   - Linux:  108 bytes (sizeof(((struct sockaddr_un *)0)->sun_path))
+//   - Darwin: 104 bytes
+// We assert ≤ 104 bytes on every platform so the same code path works on both.
+//
+// These tests use a deliberately-pessimistic synthetic $HOME that matches the
+// real-world layout under which #1050 was first observed
+// (/home/<user>/.local/state/prism/run/...). Test-time temp dirs are too short
+// to surface the bug, so we substitute the realistic prefix manually.
+
+const sunPathBudget = 104
+
+// realisticHostAPIPath builds the host-API socket path that a production
+// system with the given $HOME would produce, without depending on test-time
+// $XDG_STATE_HOME (which a test harness sets to a short path under /tmp).
+func realisticHostAPIPath(home, sessionName string) string {
+	return filepath.Join(home, ".local", "state", "prism", "run", SessionDirName(sessionName), "hostapi.sock")
+}
+
+// TestSidecarHostAPIPath_LengthInvariant_WorstCaseSession exercises the
+// worst-case session name from the issue (#1050 AC-1) and asserts the
+// resulting path fits the cross-platform budget.
+func TestSidecarHostAPIPath_LengthInvariant_WorstCaseSession(t *testing.T) {
+	const home = "/home/prismatic-koi"
+	worstCase := "nixos-config@" + strings.Repeat("x", 80) + "~review-99-review-context"
+
+	got := realisticHostAPIPath(home, worstCase)
+	if len(got) > sunPathBudget {
+		t.Errorf("worst-case socket path is %d bytes (limit %d): %q",
+			len(got), sunPathBudget, got)
+	}
+}
+
+// TestSidecarHostAPIPath_LengthInvariant_PlausibleShapes asserts the
+// path-length invariant for the three plausible session shapes called out by
+// AC-2: a short coordinator name, a long branch name, and a long branch +
+// review suffix.
+func TestSidecarHostAPIPath_LengthInvariant_PlausibleShapes(t *testing.T) {
+	const home = "/home/prismatic-koi"
+	cases := []struct {
+		name    string
+		session string
+	}{
+		{
+			name:    "short coordinator",
+			session: "nixos-config@main",
+		},
+		{
+			name:    "long branch name",
+			session: "nixos-config@fix-something-with-a-fairly-long-branch-name",
+		},
+		{
+			name:    "long branch + review suffix",
+			session: "nixos-config@fix-something-with-a-fairly-long-branch-name~review-1-review-security",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := realisticHostAPIPath(home, tc.session)
+			if len(got) > sunPathBudget {
+				t.Errorf("session %q produced %d-byte path (limit %d): %q",
+					tc.session, len(got), sunPathBudget, got)
+			}
+		})
+	}
+}
+
+// TestSessionDirName_Deterministic asserts that SessionDirName is a pure
+// function of its input — bwrap.BuildArgs, container.Manager.buildRunArgs,
+// the sidecar bind site and cleanup all derive the directory by calling this
+// function (or SidecarHostAPIPath which calls it), so they must agree
+// regardless of when they are called.
+func TestSessionDirName_Deterministic(t *testing.T) {
+	const session = "nixos-config@fix-mergequeue-merged-field~review-1-review-context"
+	first := SessionDirName(session)
+	second := SessionDirName(session)
+	if first != second {
+		t.Errorf("SessionDirName not deterministic: %q vs %q", first, second)
+	}
+	if got, want := len(first), sessionDirHashLen; got != want {
+		t.Errorf("SessionDirName length = %d, want %d", got, want)
+	}
+}
+
+// TestSessionDirName_StableFormula pins the exact formula (12-hex-char SHA-256
+// prefix) so that any silent drift in the algorithm is caught immediately.
+// internal/container has a parallel test (TestHostAPIPath_RoundTrip_*) that
+// re-derives the dir name with the same formula — if either side changes
+// without the other, both this test and the container-side round-trip test
+// will fail loudly.
+func TestSessionDirName_StableFormula(t *testing.T) {
+	// First 12 hex chars of SHA-256("nixos-config@main") = "896d0e575a71".
+	// Verify with: printf 'nixos-config@main' | sha256sum | cut -c1-12
+	if got, want := SessionDirName("nixos-config@main"), "896d0e575a71"; got != want {
+		t.Errorf("SessionDirName(\"nixos-config@main\") = %q, want %q "+
+			"(formula drift: must remain first 12 hex chars of SHA-256)", got, want)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -5,6 +5,17 @@
 // DB writes, and dashboard sentinel touches — replicating the logic in
 // opencode/plugins/prism-hooks.ts.
 //
+// Host-API socket path budget. The Unix socket the sidecar binds for the
+// host-API server (Config.HostAPISockPath) must fit the kernel's sun_path
+// limit: 108 bytes on Linux, 104 bytes on Darwin. We treat 104 as the budget
+// for both platforms so the same code path works everywhere. The path is
+// constructed by session.SidecarHostAPIPath and uses a 12-hex-char SHA-256
+// prefix of the session name as the per-session directory — see #1050 for the
+// path arithmetic and the regression tests in
+// internal/session/sidecar_test.go (TestSidecarHostAPIPath_LengthInvariant_*).
+// If a future change reverts that to a long-form session name, those tests
+// will fail with a clear message before the bug ships.
+//
 // All runtime-specific logic (session creation, prompt delivery, SSE
 // subscription, event type mapping, message extraction, container command,
 // health check, config mount path) is delegated to the Harness interface.
@@ -524,21 +535,31 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		_ = os.Remove(s.cfg.HostAPISockPath)
 		ln, listenErr := net.Listen("unix", s.cfg.HostAPISockPath)
 		if listenErr != nil {
+			// Failure to bind is FATAL (#1050). Continuing without a socket
+			// produces a partially-functional agent: bwrap exec proceeds with
+			// PRISM_HOST_API set but nothing listening, so anything inside the
+			// container that hits the host-API channel hangs or fails in a
+			// downstream way that prevents opencode from ever binding its TCP
+			// port. The agent then appears as "idle" with no title, the SSE
+			// loop retries forever, and the user has no clear signal that
+			// anything is wrong. Returning the error here surfaces it via the
+			// sidecar log and exits with a non-zero status so the operator
+			// sees the failure immediately.
 			log.Printf("sidecar: host-API server: listen unix: %v", listenErr)
-		} else {
-			srv := &http.Server{Handler: s.hostAPIHandler()}
-			s.mu.Lock()
-			s.hostAPIListener = ln
-			s.hostAPISrv = srv
-			s.mu.Unlock()
-			go func() {
-				if err := srv.Serve(ln); err != nil &&
-					!errors.Is(err, http.ErrServerClosed) &&
-					!errors.Is(err, net.ErrClosed) {
-					log.Printf("sidecar: host-API server (unix): %v", err)
-				}
-			}()
+			return fmt.Errorf("sidecar: host-API socket bind failed for %q: %w", s.cfg.HostAPISockPath, listenErr)
 		}
+		srv := &http.Server{Handler: s.hostAPIHandler()}
+		s.mu.Lock()
+		s.hostAPIListener = ln
+		s.hostAPISrv = srv
+		s.mu.Unlock()
+		go func() {
+			if err := srv.Serve(ln); err != nil &&
+				!errors.Is(err, http.ErrServerClosed) &&
+				!errors.Is(err, net.ErrClosed) {
+				log.Printf("sidecar: host-API server (unix): %v", err)
+			}
+		}()
 
 		// TCP server — Darwin only, when the TCP listener was bound before
 		// container creation. Uses a separate http.Server with the same handler

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_hostapi_bind_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_hostapi_bind_test.go
@@ -1,0 +1,155 @@
+package sidecar
+
+// Tests for the host-API socket bind path (#1050).
+//
+// Two concerns are covered here:
+//
+//   - AC-3: a session whose name would historically have produced a
+//     >104-byte sun_path (e.g. a long worker session composed with
+//     ~review-N-review-<role>) must now bind successfully — i.e. the path
+//     scheme does not return EINVAL for the worst-case name.
+//   - AC-4: if net.Listen("unix", ...) fails for any reason, Run() must
+//     surface the error rather than continuing with a nil listener.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	prismsession "github.com/prismatic-koi/prism/internal/session"
+)
+
+// TestHostAPIBind_WorstCaseSessionName_DoesNotEINVAL is the AC-3 regression
+// test. It exercises the actual net.Listen("unix", ...) call against a path
+// derived from the worst-case session name from the issue body (an 80-char
+// branch + ~review-99-review-context suffix) and asserts that the bind
+// succeeds — i.e. the new short-hash directory scheme produces a bindable
+// path even for pathological inputs. The path-length budget itself is
+// asserted independently in
+// internal/session.TestSidecarHostAPIPath_LengthInvariant_*.
+//
+// The bind is performed under a freshly-created temp directory rooted at /tmp
+// (kept deliberately short so the per-test path itself stays inside the
+// kernel limit on every CI runner). This means the test exercises the
+// SessionDirName-derived suffix shape, which is the part this fix changes —
+// the long input session name no longer pollutes the on-disk path.
+func TestHostAPIBind_WorstCaseSessionName_DoesNotEINVAL(t *testing.T) {
+	// Mirror the worst-case shape called out by AC-1 / AC-3.
+	worstCase := "nixos-config@" + strings.Repeat("x", 80) + "~review-99-review-context"
+
+	// Build the path under a short, controlled XDG_STATE_HOME so the test
+	// does not depend on the runner's TMPDIR length. The point of this
+	// regression test is the SUFFIX of the path (which used to embed the
+	// full session name); the prefix is owned by the deployment.
+	stateHome, err := shortStateHome(t)
+	if err != nil {
+		t.Fatalf("shortStateHome: %v", err)
+	}
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	sockPath, err := prismsession.SidecarHostAPIPath(worstCase)
+	if err != nil {
+		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+
+	if mkErr := os.MkdirAll(filepath.Dir(sockPath), 0o700); mkErr != nil {
+		t.Fatalf("mkdir socket dir: %v", mkErr)
+	}
+
+	ln, listenErr := net.Listen("unix", sockPath)
+	if listenErr != nil {
+		// If we got EINVAL, that is the exact bug #1050 fixed; surface it
+		// loudly so the regression is unmistakable.
+		if errors.Is(listenErr, syscall.EINVAL) {
+			t.Fatalf("net.Listen returned EINVAL — sun_path overflow regression (#1050): %v (path=%q, len=%d)",
+				listenErr, sockPath, len(sockPath))
+		}
+		t.Fatalf("net.Listen unexpected error: %v (path=%q, len=%d)", listenErr, sockPath, len(sockPath))
+	}
+	defer ln.Close()
+}
+
+// shortStateHome creates a short-prefix directory under /tmp (NOT under
+// t.TempDir(), which Go derives from TMPDIR and may itself be long enough to
+// blow the budget on some runners). The test cleans up via t.Cleanup.
+func shortStateHome(t *testing.T) (string, error) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "p1050-")
+	if err != nil {
+		return "", err
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir, nil
+}
+
+// TestSidecarRun_BindFailureReturnsError is the AC-4 regression test. It
+// injects a bind failure by pointing HostAPISockPath at a path that cannot be
+// created (a directory whose parent is a regular file) and asserts that Run()
+// returns within a bounded time with a non-nil error mentioning "bind failed".
+//
+// Before the #1050 fix this would log-and-continue with hostAPIListener nil,
+// leaving the agent partially functional and effectively undetectable.
+func TestSidecarRun_BindFailureReturnsError(t *testing.T) {
+	// Construct an HostAPISockPath whose parent directory cannot be created
+	// because some component along the path is a regular file — that makes
+	// both MkdirAll and the subsequent net.Listen fail without depending on
+	// platform-specific permission behaviour.
+	tmp := t.TempDir()
+	blocker := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("blocker"), 0o644); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	// Path: <tmp>/not-a-dir/sub/hostapi.sock — MkdirAll on the parent will
+	// fail (ENOTDIR) and net.Listen will then fail with the missing dir.
+	sockPath := filepath.Join(blocker, "sub", "hostapi.sock")
+
+	clk := newTestClock()
+	d := openTestDB(t)
+
+	cfg := Config{
+		SessionName:     "test-repo@bind-fail",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-worktree",
+		OpencodeURL:     "http://127.0.0.1:1", // unreachable, but Run() should exit before SSE setup matters
+		HostAPISockPath: sockPath,
+		DB:              d,
+		Clock:           clk,
+		Harness:         opencode.New("http://127.0.0.1:1", nil, "", ""),
+	}
+	s := New(cfg)
+
+	// Run with a bounded timeout. AC-4 says "within a bounded time".
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Run(ctx) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("Run returned nil error despite injected bind failure")
+		}
+		if !strings.Contains(err.Error(), "bind failed") &&
+			!strings.Contains(err.Error(), "host-API socket") {
+			t.Fatalf("Run returned wrong error (want bind-related): %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Run did not exit within bounded time after bind failure")
+	}
+
+	// Defensive: ensure no listener was registered on the sidecar.
+	s.mu.Lock()
+	ln := s.hostAPIListener
+	s.mu.Unlock()
+	if ln != nil {
+		t.Error("hostAPIListener was set despite bind failure")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a sun_path overflow in the sidecar's host-API socket bind site that
caused `bind(2)` to return `EINVAL` for review-agent sessions on workers with
long branch names. The sidecar logged the error and continued without a
socket; the agent then appeared idle forever because nothing was listening on
`PRISM_HOST_API`.

## Root cause

`session.SidecarHostAPIPath` produced
`$XDG_STATE_HOME/prism/run/<full-session-name>/hostapi.sock`. The
`<repo>@<branch>~review-N-review-<role>` composition pushed the path past
Linux's 108-byte `sun_path` limit (and Darwin's 104-byte limit much sooner).
The bind error at `internal/sidecar/sidecar.go:525` was logged via `log.Printf`
and execution continued with `s.hostAPIListener` left nil — `bwrap.go:599-601`
then mounted the empty directory unconditionally and set `PRISM_HOST_API` to
a socket nothing was listening on.

## Path arithmetic

Before — for `~review-1-review-context` on a worker with a moderate branch:

| Component | Bytes |
|---|---|
| `/home/ben/.local/state/prism/run/` | 33 |
| `nixos-config@fix-mergequeue-merged-field~review-1-review-context` | 64 |
| `/hostapi.sock` | 13 |
| **Total** | **110** ❌ |

After — short hash-based directory (`Option A` from #1050):

| Component | Bytes |
|---|---|
| `/home/ben/.local/state/prism/run/` | 33 |
| `<12 hex chars of sha256>` | 12 |
| `/hostapi.sock` | 13 |
| **Total** | **58** ✅ |

Comfortably under both Linux's 108 and Darwin's 104-byte budgets regardless
of session name length. The mapping is a deterministic SHA-256 prefix so
`prism logs`, `prism cleanup`, and bwrap/podman bind-mount construction all
derive the same directory from the session name without a persisted lookup.

## Fail-loud on bind error

Also makes `net.Listen` failure fatal in the sidecar `Run()` loop (#1050
AC-4). The previous log-and-continue behaviour produced partially-functional
agents that gave operators no clear signal of failure; returning the error
surfaces it in the sidecar log and exits with a non-zero status.

## Test coverage

- `internal/session`: path-length invariant tests for the worst-case session
  name and three plausible shapes (AC-1, AC-2), plus determinism and
  stable-formula tests pinning the SHA-256 prefix algorithm so a future
  silent drift (different hash, different prefix length) is caught.
- `internal/sidecar`: bind-failure injection asserts `Run()` returns a
  non-nil error within bounded time (AC-4), and a real `net.Listen` of a
  path derived from the worst-case session name confirms no EINVAL (AC-3).
- `internal/container`: round-trip test confirms `bwrap.BuildArgs` and
  `Manager.buildRunArgs` both reference the same directory the sidecar
  binds, for every shape including the worst case (AC-6).

## Quality gates

- `go build ./...` — green
- `go test ./...` — green (all 19 packages)
- `go vet ./...` — clean
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — green

## Scope

Stayed inside the path-length bug and the bind-failure propagation per the
spawn prompt. Did not widen into spawn-loop visibility, readiness gates, or
per-agent stderr capture — those are #1051's concerns.

Closes #1050
Refs #1046 (test-side sun_path fix that landed alongside discovery)
Refs #960 (per-session-directory security boundary — preserved)