### PR TITLE
fix(review): gate Review-X started on agent readiness; capture per-agent startup stderr

### DIFF
--- a/modules/programs/prism/prism/cmd/logs.go
+++ b/modules/programs/prism/prism/cmd/logs.go
@@ -54,6 +54,12 @@ opencode stdout/stderr for the lifetime of the session):
   prism logs nixos-config@feat --agent-run
   prism logs nixos-config@feat --agent-run --follow
 
+Use --startup to read the spawn-time breadcrumb log (covers the window
+between "session created in DB" and "opencode reachable", written by
+session.SpawnSession before tmux send-keys):
+
+  prism logs nixos-config@feat --startup
+
 Works identically from the host or inside a coordinator container — in
 container mode the log is fetched via the host API Unix socket (PRISM_HOST_API).`,
 	Args:         cobra.ExactArgs(1),
@@ -65,6 +71,7 @@ func init() {
 	logsCmd.Flags().Int("tail", 0, "Number of lines to show from the end of the log; 0 prints nothing (omit flag to show all)")
 	logsCmd.Flags().BoolP("follow", "f", false, "Stream new lines as they are written; exits when session ends or Ctrl-C")
 	logsCmd.Flags().Bool("agent-run", false, "Read the agent-run log (bwrap harness stdout/stderr) instead of the sidecar log")
+	logsCmd.Flags().Bool("startup", false, "Read the agent-startup log (spawn-time breadcrumbs written by session.SpawnSession)")
 	rootCmd.AddCommand(logsCmd)
 }
 
@@ -75,9 +82,14 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	follow, _ := cmd.Flags().GetBool("follow")
 	tailSet := cmd.Flags().Changed("tail")
 	agentRun, _ := cmd.Flags().GetBool("agent-run")
+	startup, _ := cmd.Flags().GetBool("startup")
 
 	if tailSet && follow {
 		return fmt.Errorf("--tail and --follow are mutually exclusive")
+	}
+
+	if agentRun && startup {
+		return fmt.Errorf("--agent-run and --startup are mutually exclusive")
 	}
 
 	if tailSet && tailN < 0 {
@@ -85,19 +97,27 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	// Container proxy path: delegate to the host-API sidecar.
-	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+	// (--startup is host-only because the agent-startup log is written by
+	// the host-side SpawnSession; container coordinators have no use for it.)
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" && !startup {
 		return proxyLogsFromHostAPI(apiURL, sessionName, tailN, tailSet, follow, agentRun, os.Stdout)
 	}
 
 	// Host path: resolve the appropriate log file.
 	var logPath string
 	var err error
-	if agentRun {
+	switch {
+	case startup:
+		logPath, err = session.AgentStartupLogPath(sessionName)
+		if err != nil {
+			return fmt.Errorf("resolve agent-startup log path: %w", err)
+		}
+	case agentRun:
 		logPath, err = session.AgentRunLogPath(sessionName)
 		if err != nil {
 			return fmt.Errorf("resolve agent-run log path: %w", err)
 		}
-	} else {
+	default:
 		logPath, err = session.SidecarLogPath(sessionName)
 		if err != nil {
 			return fmt.Errorf("resolve log path: %w", err)
@@ -105,10 +125,22 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, statErr := os.Stat(logPath); os.IsNotExist(statErr) {
-		if agentRun {
+		switch {
+		case startup:
+			return fmt.Errorf("no agent-startup log file found for session %q", sessionName)
+		case agentRun:
 			return fmt.Errorf("no agent-run log file found for session %q", sessionName)
+		default:
+			// For the default sidecar-log path, if a startup log exists, hint
+			// at it — the operator was probably looking at the wrong file
+			// because the agent silently failed to come up before the sidecar
+			// produced any meaningful events (the #1051 failure mode).
+			if session.AgentStartupLogExists(sessionName) {
+				return fmt.Errorf("no sidecar log file found for session %q\nhint: an agent-startup log exists for this session — try `prism logs %s --startup` to see spawn-time breadcrumbs",
+					sessionName, sessionName)
+			}
+			return fmt.Errorf("no log file found for session %q", sessionName)
 		}
-		return fmt.Errorf("no log file found for session %q", sessionName)
 	}
 
 	if follow {
@@ -119,7 +151,76 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		return runLogsTail(logPath, tailN)
 	}
 
-	return runLogsFull(logPath)
+	if err := runLogsFull(logPath); err != nil {
+		return err
+	}
+
+	// AC-4: when the operator is reading the default (sidecar) log and that
+	// log contains nothing beyond SSE-retry noise — the #1051 failure
+	// signature — surface a one-line hint pointing at the agent-startup log
+	// where spawn-time breadcrumbs live. The hint is silenced when the
+	// sidecar log shows real activity (server.connected, first event, etc.)
+	// or when no startup log exists for this session.
+	if !startup && !agentRun && sidecarLogIsStuckOnSSERetries(logPath) && session.AgentStartupLogExists(sessionName) {
+		fmt.Fprintf(os.Stderr,
+			"\nhint: this sidecar log contains only SSE-retry noise — opencode never bound its port.\n"+
+				"      Spawn-time breadcrumbs (port, isolation mode, sidecar PID) are in the agent-startup log:\n"+
+				"        prism logs %s --startup\n"+
+				"      bwrap stderr (if it ran) is in the agent-run log:\n"+
+				"        prism logs %s --agent-run\n",
+			sessionName, sessionName)
+	}
+	return nil
+}
+
+// sidecarLogIsStuckOnSSERetries returns true when the named sidecar log file
+// contains nothing beyond the [prism sidecar] starting line and a series of
+// "sse: …" retry messages — i.e. the sidecar started, opencode never bound
+// its port, and we have no further evidence of progress. Used by runLogs to
+// surface a startup-log hint to operators reading the wrong file.
+//
+// The implementation is deliberately conservative: it returns false on any
+// I/O error, on any line that does not begin with "[prism sidecar]" or "sse:"
+// (or is blank / "clipboard …"), and on logs above 64 KiB (large logs almost
+// always contain real events; the failure mode this targets produces tiny
+// logs of a dozen lines or so). False negatives are fine — the hint is
+// optional. False positives would print a noisy hint on healthy sessions.
+func sidecarLogIsStuckOnSSERetries(logPath string) bool {
+	const maxBytes = 64 * 1024
+	info, statErr := os.Stat(logPath)
+	if statErr != nil || info.Size() == 0 || info.Size() > maxBytes {
+		return false
+	}
+	data, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		return false
+	}
+	hasRealEvent := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// Accept the lines we expect on the failure path:
+		//   "[prism sidecar] starting: …"
+		//   "clipboard clean: …"
+		//   "<timestamp> sse: …"
+		if strings.HasPrefix(trimmed, "[prism sidecar]") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "clipboard ") {
+			continue
+		}
+		// "2026/04/26 10:22:52 sse: …" — match the "sse:" token after
+		// timestamp.
+		if strings.Contains(trimmed, " sse: ") || strings.HasPrefix(trimmed, "sse: ") {
+			continue
+		}
+		// Any other line indicates the sidecar produced real output — bail.
+		hasRealEvent = true
+		break
+	}
+	return !hasRealEvent
 }
 
 // runLogsFull prints the full contents of the log file to stdout.

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -391,6 +391,14 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		// be killed.
 		ForceFresh: true,
 		Headless:   headless,
+		// ReadinessTimeout=DefaultReadinessTimeout (30s) gates SpawnSession's
+		// return on opencode actually binding its port (#1051 AC-14).
+		// Single-worker spawns benefit from the same readiness check that
+		// review fan-outs do: an operator running `prism spawn --branch foo`
+		// sees a clear "failed to start: not ready within 30s" instead of
+		// "session created" followed by a session that idles forever
+		// because opencode never came up.
+		ReadinessTimeout: session.DefaultReadinessTimeout,
 	}
 	// AgentEnvVars only applies to host-mode sessions; container sessions
 	// receive env vars via podman --env flags in the sidecar.

--- a/modules/programs/prism/prism/internal/review/ack_test.go
+++ b/modules/programs/prism/prism/internal/review/ack_test.go
@@ -1,0 +1,142 @@
+package review_test
+
+// Tests for the AsyncResult.Ack format (#1051 AC-5).
+//
+// The Ack is the worker's first piece of evidence about which agents came up
+// successfully and which did not. The headline scan target is the
+// "Spawned: N, Failed: M (...)" line — operators eyeballing prism review
+// output need to see partial-success outcomes immediately, not 20 minutes
+// later when the monitor times out.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// TestBuildAsyncAck_AllReady_NoFailures verifies the Ack format when every
+// agent comes up healthy. The "Failed: 0" line is always emitted (stable
+// format across runs).
+func TestBuildAsyncAck_AllReady_NoFailures(t *testing.T) {
+	sessions := []string{
+		"test@feat~review-1-review-goal",
+		"test@feat~review-1-review-code",
+		"test@feat~review-1-review-security",
+		"test@feat~review-1-review-qa",
+		"test@feat~review-1-review-context",
+	}
+	got := review.BuildAsyncAckForTest("1234", 1, "group-abc", sessions, nil, "test@feat")
+
+	// Headline summary line.
+	if !strings.Contains(got, "Spawned: 5, Failed: 0") {
+		t.Errorf("Ack missing 'Spawned: 5, Failed: 0' headline: %s", got)
+	}
+	// All sessions should appear in the bullet list.
+	for _, s := range sessions {
+		if !strings.Contains(got, s) {
+			t.Errorf("Ack missing session %q: %s", s, got)
+		}
+	}
+	// No failure block.
+	if strings.Contains(got, "agent(s) failed to start") {
+		t.Errorf("Ack contains 'failed to start' block but no failures occurred: %s", got)
+	}
+	// Worker session reference for monitoring.
+	if !strings.Contains(got, "test@feat") {
+		t.Errorf("Ack missing worker session reference: %s", got)
+	}
+}
+
+// TestBuildAsyncAck_PartialSuccess_SurfacesFailures verifies the AC-5
+// example text exactly: "Spawned: 3, Failed: 2 (review-goal: not ready
+// within 30s, review-qa: not ready within 30s)".
+func TestBuildAsyncAck_PartialSuccess_SurfacesFailures(t *testing.T) {
+	sessions := []string{
+		"test@feat~review-1-review-code",
+		"test@feat~review-1-review-security",
+		"test@feat~review-1-review-context",
+	}
+	failures := [][2]string{
+		{"review-goal", "not ready within 30s"},
+		{"review-qa", "not ready within 30s"},
+	}
+	got := review.BuildAsyncAckForTest("1234", 1, "group-abc", sessions, failures, "test@feat")
+
+	// AC-5: the exact headline format.
+	want := "Spawned: 3, Failed: 2 (review-goal: not ready within 30s, review-qa: not ready within 30s)"
+	if !strings.Contains(got, want) {
+		t.Errorf("Ack missing expected headline %q\nfull Ack:\n%s", want, got)
+	}
+
+	// The failure block should mention the per-session startup log.
+	if !strings.Contains(got, "prism logs") || !strings.Contains(got, "--startup") {
+		t.Errorf("Ack failure block must mention `prism logs <session> --startup`: %s", got)
+	}
+
+	// Successful sessions still appear in the bullet list.
+	for _, s := range sessions {
+		if !strings.Contains(got, s) {
+			t.Errorf("Ack missing successful session %q: %s", s, got)
+		}
+	}
+
+	// Failed agents must appear in the failure list.
+	for _, f := range failures {
+		if !strings.Contains(got, f[0]) {
+			t.Errorf("Ack missing failed agent %q: %s", f[0], got)
+		}
+	}
+}
+
+// TestBuildAsyncAck_AllFailed_NoSessions verifies the edge case where every
+// agent failed to come up. The Ack should still render coherently — no
+// stray "monitor progress with" line for an empty session list.
+func TestBuildAsyncAck_AllFailed_NoSessions(t *testing.T) {
+	failures := [][2]string{
+		{"review-goal", "not ready within 30s"},
+		{"review-code", "config error: stale profiles.json"},
+	}
+	got := review.BuildAsyncAckForTest("1234", 1, "group-x", nil, failures, "test@feat")
+
+	if !strings.Contains(got, "Spawned: 0, Failed: 2") {
+		t.Errorf("Ack missing 'Spawned: 0, Failed: 2': %s", got)
+	}
+	// No "prism checkin <…>~review-1-review-goal" line — it would be
+	// pointing at a session that never came up.
+	if strings.Contains(got, "prism checkin") {
+		t.Errorf("Ack has 'prism checkin' suggestion but no live sessions: %s", got)
+	}
+	// Different failure reasons should both appear.
+	if !strings.Contains(got, "review-goal") || !strings.Contains(got, "not ready within 30s") {
+		t.Errorf("Ack missing review-goal failure: %s", got)
+	}
+	if !strings.Contains(got, "review-code") || !strings.Contains(got, "stale profiles.json") {
+		t.Errorf("Ack missing review-code failure with config error reason: %s", got)
+	}
+}
+
+// TestBuildAsyncAck_PreservesOrder verifies that failures appear in the
+// order they are passed in — matching the spawn loop's original agent order
+// rather than alphabetical or insertion-sorted order. This makes the
+// headline string deterministic for grep / scanning.
+func TestBuildAsyncAck_PreservesOrder(t *testing.T) {
+	failures := [][2]string{
+		{"review-context", "not ready within 30s"},
+		{"review-goal", "not ready within 30s"},
+		{"review-qa", "not ready within 30s"},
+	}
+	got := review.BuildAsyncAckForTest("1234", 1, "g", nil, failures, "test@feat")
+
+	// Find the headline; verify ordering of agent names within it.
+	idxContext := strings.Index(got, "review-context")
+	idxGoal := strings.Index(got, "review-goal")
+	idxQa := strings.Index(got, "review-qa")
+	if idxContext < 0 || idxGoal < 0 || idxQa < 0 {
+		t.Fatalf("Ack missing expected agent names: %s", got)
+	}
+	if !(idxContext < idxGoal && idxGoal < idxQa) {
+		t.Errorf("Ack reordered failures (context=%d goal=%d qa=%d): %s",
+			idxContext, idxGoal, idxQa, got)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
@@ -1,0 +1,121 @@
+package review_test
+
+// AC-6 regression: the review monitor must NOT wait the full per-agent
+// timeout for an agent the spawn loop already declared failed (readiness
+// timeout, config error, SpawnSession error, etc.). The mechanism that
+// guarantees this is two-pronged:
+//
+//   1. RunAsync's monitor receives only liveSessions — agents that became
+//      ready — so the failed-to-start agents are not in the monitor's
+//      AgentSessions list at all.
+//   2. The cleanup path for failed agents (cleanupAgentSession) transitions
+//      the agent_status row to state="error", which db.GroupCompleted
+//      treats as terminal. So even if a stale row remains in the group,
+//      GroupCompleted will not block on it.
+//
+// This test validates (2) directly: it sets up a group with one "ready"
+// agent (state=finished) and one "failed-readiness" agent (state=idle on
+// gate trip → cleaned up to state=error), and asserts that GroupCompleted
+// returns true. Without the state=error transition, GroupCompleted would
+// return false and the monitor would spin until its timeout.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+func openMonitorTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// TestMonitor_FailedReadyAgent_DoesNotBlockGroupCompleted verifies AC-6:
+// after the gate cleans up a failed-to-ready agent, the agent's row state
+// is "error" (not "idle"), and db.GroupCompleted returns true once all the
+// alive members have reached their terminal state. Without this, the monitor
+// would block on the half-alive row forever.
+func TestMonitor_FailedReadyAgent_DoesNotBlockGroupCompleted(t *testing.T) {
+	d := openMonitorTestDB(t)
+
+	// Register a group and seed two agents.
+	groupID, err := d.RegisterGroup("test@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	const sessReady = "test@parent~review-1-review-code"
+	const sessFailed = "test@parent~review-1-review-goal"
+
+	// Both agents start at state=idle (the seed state UpsertStatusSeedRootAgentName writes).
+	for _, sess := range []string{sessReady, sessFailed} {
+		if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x"); err != nil {
+			t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+	}
+
+	// Pre-condition: with both at "idle", GroupCompleted must be false.
+	if done, _ := d.GroupCompleted(groupID); done {
+		t.Fatal("pre-condition: GroupCompleted = true with two idle members; want false")
+	}
+
+	// Simulate the gate tripping for sessFailed: the gate calls
+	// gateReviewAgents → cleanupAgentSession, which transitions the row to
+	// "error". Drive the same code path here by running the gate with a
+	// short timeout and no readiness signal for sessFailed.
+	agents := []review.Agent{
+		{Name: "review-goal", OpencodeName: "review-goal"},
+	}
+	sessions := []string{sessFailed}
+	spawnErr := make([]error, 1)
+	spawnTimes := make([]time.Time, 1)
+	review.GateReviewAgentsForTest(d, agents, sessions, spawnErr, spawnTimes,
+		200*time.Millisecond, nil)
+	if spawnErr[0] == nil {
+		t.Fatal("gate did not record an error for the never-ready agent")
+	}
+	if !session.IsReadinessTimeout(spawnErr[0]) {
+		t.Fatalf("gate spawnErr = %v, want *ReadinessTimeoutError", spawnErr[0])
+	}
+
+	// Verify post-cleanup state of the failed agent.
+	stFailed, err := d.CurrentStatus(sessFailed)
+	if err != nil {
+		t.Fatalf("CurrentStatus(%q): %v", sessFailed, err)
+	}
+	if stFailed == nil {
+		t.Fatalf("CurrentStatus(%q): row is gone — cleanup should leave the row but mark it error", sessFailed)
+	}
+	if stFailed.State != "error" {
+		t.Errorf("failed-ready agent state = %q, want %q (AC-6: must be terminal so GroupCompleted treats it as done)", stFailed.State, "error")
+	}
+
+	// Now drive sessReady to a clean terminal state: finished.
+	if err := d.UpsertStatus(sessReady, "test", "/tmp", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(%q, finished): %v", sessReady, err)
+	}
+
+	// AC-6: GroupCompleted must now return true. Without the state=error
+	// transition for sessFailed, this would still return false and the
+	// monitor would block.
+	done, gErr := d.GroupCompleted(groupID)
+	if gErr != nil {
+		t.Fatalf("GroupCompleted: %v", gErr)
+	}
+	if !done {
+		t.Errorf("GroupCompleted = false; expected true now that all members are terminal (review-code=finished, review-goal=error)")
+	}
+}

--- a/modules/programs/prism/prism/internal/review/readiness.go
+++ b/modules/programs/prism/prism/internal/review/readiness.go
@@ -1,0 +1,168 @@
+package review
+
+// Per-agent readiness gate for the review fan-out (#1051 Piece A).
+//
+// The single-worker `prism spawn` path lets session.SpawnSession run its own
+// readiness gate inline, because a single spawn does not benefit from
+// concurrency. The review fan-out is different: five agents are spawned
+// nearly simultaneously, and a 30-second per-agent gate run sequentially
+// would stretch a healthy startup to 30s+ in the worst case.
+//
+// gateReviewAgents runs session.WaitForReady in one goroutine per
+// successfully-spawned agent. The gate completes when every agent has either
+// signalled readiness or timed out. Per-agent outcomes are written back into
+// the caller-provided spawnErr slice (timeouts produce a *session.ReadinessTimeoutError),
+// and the standard cleanup path (KillSidecar + cleanupAgentSession +
+// tmux.KillSession) fires for any agent whose gate trips so a subsequent
+// spawn with the same name does not see stale state.
+//
+// Progress callback contract:
+//
+//   - "<role> started" is emitted when an agent passes its readiness gate.
+//     This replaces the old emission point (immediately after SpawnSession
+//     returns), making the line a truthful "this agent is up and reachable"
+//     signal rather than the optimistic "tmux session was created" signal
+//     it used to be.
+//
+//   - "<role> failed to start: not ready within <timeout>" is emitted when
+//     the readiness gate trips on timeout. Other "failed to start: …" forms
+//     are emitted by the spawn loop itself (config errors, SpawnSession
+//     errors) — the gate only owns the readiness branch.
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// DefaultReviewReadinessTimeout is the per-agent readiness window used by
+// gateReviewAgents when the caller does not pass an explicit value. 30s
+// matches session.DefaultReadinessTimeout — see that constant for the
+// rationale.
+const DefaultReviewReadinessTimeout = 30 * time.Second
+
+// gateReviewAgents runs session.WaitForReady concurrently for every agent
+// whose spawnErr[i] is nil. agentSessions[i] is the session name to gate;
+// spawnTimes[i] is updated on successful gate so the polling phase reports
+// elapsed times relative to the moment the agent became ready (matching the
+// behaviour of the pre-#1051 code, where spawnTimes was set at SpawnSession-
+// return time).
+//
+// Outcomes are written back into spawnErr — timeouts populate a
+// *session.ReadinessTimeoutError, surface via onProgress as "failed to start:
+// not ready within …", and trigger the standard cleanup. The caller still
+// owns the post-gate logic (which agents to poll, whether allFailed → return
+// error, etc.).
+//
+// timeout ≤ 0 falls back to DefaultReviewReadinessTimeout.
+//
+// onProgress may be nil. d must not be nil.
+func gateReviewAgents(
+	d *db.DB,
+	agents []Agent,
+	agentSessions []string,
+	spawnErr []error,
+	spawnTimes []time.Time,
+	timeout time.Duration,
+	onProgress func(string),
+) {
+	if timeout <= 0 {
+		timeout = DefaultReviewReadinessTimeout
+	}
+
+	// Mutex protects concurrent writes to spawnErr / spawnTimes /
+	// onProgress. The slices are indexed by agent and each goroutine writes
+	// only its own slot, but Go's memory model still requires synchronisation
+	// to make those writes visible to the reader after wg.Wait(). The
+	// onProgress callback is also serialised so output lines do not interleave.
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for i := range agents {
+		if spawnErr[i] != nil {
+			// Pre-existing spawn failure (config error, SpawnSession error)
+			// — the spawn loop has already emitted a "failed to start" line
+			// for this agent. Skip the gate.
+			continue
+		}
+
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ag := agents[i]
+			agentSession := agentSessions[i]
+
+			readyErr := session.WaitForReady(d, agentSession, timeout)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if readyErr != nil {
+				spawnErr[i] = fmt.Errorf("readiness gate for %s: %w", ag.Name, readyErr)
+				if onProgress != nil {
+					if session.IsReadinessTimeout(readyErr) {
+						onProgress(fmt.Sprintf("%s failed to start: not ready within %s",
+							FormatAgentDisplayName(ag.Name), formatReadinessTimeout(timeout)))
+					} else {
+						onProgress(fmt.Sprintf("%s failed to start: %v",
+							FormatAgentDisplayName(ag.Name), readyErr))
+					}
+				}
+				// Clean up the half-alive session so a subsequent spawn with
+				// the same name does not see stale state. Mirror the cleanup
+				// the spawn loop already performs for SpawnSession failures.
+				session.KillSidecar(agentSession)
+				cleanupAgentSession(d, agentSession)
+				_ = tmux.KillSession(agentSession)
+				return
+			}
+			// Reset spawnTimes[i] to "ready" time so the polling phase
+			// reports elapsed durations relative to the moment opencode
+			// became reachable (consistent with the pre-#1051 behaviour
+			// where the time was captured immediately after SpawnSession
+			// returned, which was effectively the same moment).
+			spawnTimes[i] = time.Now()
+			if onProgress != nil {
+				onProgress(fmt.Sprintf("%s started", FormatAgentDisplayName(ag.Name)))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// formatReadinessTimeout renders a duration the way the AC text says it
+// should appear in the "failed to start: not ready within X" line.
+// Mirrors session.formatTimeout — duplicated here because that function is
+// unexported in the session package and we don't want to widen its surface
+// just for a string format.
+func formatReadinessTimeout(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Round(time.Second).Seconds()))
+	}
+	m := int(d / time.Minute)
+	s := int((d % time.Minute) / time.Second)
+	if s == 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return fmt.Sprintf("%dm%ds", m, s)
+}
+
+// GateReviewAgentsForTest is the test-only export of gateReviewAgents.
+// External tests use this to exercise the per-agent readiness gate without
+// going through the full Run / RunAsync spawn path. Production code calls
+// gateReviewAgents directly.
+func GateReviewAgentsForTest(
+	d *db.DB,
+	agents []Agent,
+	agentSessions []string,
+	spawnErr []error,
+	spawnTimes []time.Time,
+	timeout time.Duration,
+	onProgress func(string),
+) {
+	gateReviewAgents(d, agents, agentSessions, spawnErr, spawnTimes, timeout, onProgress)
+}

--- a/modules/programs/prism/prism/internal/review/readiness_test.go
+++ b/modules/programs/prism/prism/internal/review/readiness_test.go
@@ -1,0 +1,330 @@
+package review_test
+
+// Tests for the per-agent readiness gate in the review fan-out (#1051 Piece A).
+// These exercise GateReviewAgentsForTest — the test-only export of
+// gateReviewAgents — without spinning up real tmux sessions or sidecars.
+//
+// The gate's contract:
+//
+//   - For each agent whose spawnErr[i] is nil, run session.WaitForReady in a
+//     goroutine.
+//   - On success: emit "<role> started" via OnProgress, set spawnTimes[i] to
+//     "now".
+//   - On timeout: emit "<role> failed to start: not ready within Xs", populate
+//     spawnErr[i] with a *session.ReadinessTimeoutError (wrapped), and clean
+//     up the half-alive session via KillSidecar / cleanupAgentSession /
+//     tmux.KillSession.
+//
+// AC-7 (5-agent fan-out, 2 fail): TestGateReviewAgents_PartialFailure_2of5
+// AC-8 (port-block reproducer):   TestGateReviewAgents_TimeoutSurfacedWithin30s
+// AC-9 (no regressions, healthy): TestGateReviewAgents_AllReady_AllStarted
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+func openGateTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// seedAgentRow writes a minimal agent_status row for the named session — the
+// same shape SpawnSession would write at spawn time. The gate needs the row
+// to exist so CurrentStatus / QueryEvents return cleanly.
+func seedAgentRow(t *testing.T, d *db.DB, sess string) {
+	t.Helper()
+	if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
+	}
+}
+
+// signalReady inserts a state_change event for sess, simulating the sidecar
+// receiving the first SSE event from opencode.
+func signalReady(t *testing.T, d *db.DB, sess string) {
+	t.Helper()
+	if err := d.WriteEvent(db.Event{
+		ID:          sess + "-ready",
+		SessionName: sess,
+		Repo:        "test",
+		Worktree:    "/tmp",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+	}); err != nil {
+		t.Fatalf("WriteEvent(%q): %v", sess, err)
+	}
+}
+
+// progressCollector is a thread-safe collector for OnProgress lines.
+type progressCollector struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (p *progressCollector) callback(line string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lines = append(p.lines, line)
+}
+
+func (p *progressCollector) snapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.lines))
+	copy(out, p.lines)
+	return out
+}
+
+// containsLine reports whether any line in lines contains substr.
+func containsLine(lines []string, substr string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// ── AC-7: fan-out spawn where 2 of 5 agents fail their readiness check ───────
+
+// TestGateReviewAgents_PartialFailure_2of5 simulates the headline #1051
+// scenario: a 5-agent fan-out where 3 agents become ready (state_change
+// event written) and 2 stay silent (timeout). Verifies that:
+//
+//   - The 3 successful agents are reported as "started".
+//   - The 2 failures are reported with "failed to start: not ready within Xs".
+//   - spawnErr[i] is populated for the 2 failures with a
+//     *session.ReadinessTimeoutError (visible through errors.As).
+//   - The 3 successful agents have spawnErr[i] == nil after the gate.
+//
+// AC-7 satisfied: subsequent code can build the partial-success summary
+// from the spawnErr slice.
+func TestGateReviewAgents_PartialFailure_2of5(t *testing.T) {
+	d := openGateTestDB(t)
+
+	agents := review.Agents() // 5 standard review agents
+	const parent = "test@partial-failure"
+	sessions := make([]string, len(agents))
+	for i, ag := range agents {
+		sessions[i] = parent + "~review-1-" + ag.Name
+		seedAgentRow(t, d, sessions[i])
+	}
+
+	// 3 of 5 become ready: review-goal, review-code, review-context.
+	// review-security and review-qa stay silent → timeout.
+	signalReady(t, d, sessions[0]) // review-goal
+	signalReady(t, d, sessions[1]) // review-code
+	signalReady(t, d, sessions[4]) // review-context
+
+	spawnErr := make([]error, len(agents))
+	spawnTimes := make([]time.Time, len(agents))
+	collector := &progressCollector{}
+
+	// Use a short timeout so the test runs quickly. The gate runs the
+	// state_change check as soon as it starts, so the 3 ready agents
+	// resolve in the first poll and the test completes in ~1s.
+	const timeout = 800 * time.Millisecond
+	start := time.Now()
+	review.GateReviewAgentsForTest(d, agents, sessions, spawnErr, spawnTimes, timeout, collector.callback)
+	elapsed := time.Since(start)
+
+	// AC-7: 3 successful agents → spawnErr[i] == nil.
+	for _, i := range []int{0, 1, 4} {
+		if spawnErr[i] != nil {
+			t.Errorf("spawnErr[%d] (%s) = %v, want nil — agent should have become ready", i, agents[i].Name, spawnErr[i])
+		}
+		if spawnTimes[i].IsZero() {
+			t.Errorf("spawnTimes[%d] (%s) is zero — gate should have set it on success", i, agents[i].Name)
+		}
+	}
+
+	// AC-7: 2 failures → spawnErr[i] is *session.ReadinessTimeoutError.
+	for _, i := range []int{2, 3} {
+		if spawnErr[i] == nil {
+			t.Errorf("spawnErr[%d] (%s) = nil, want *ReadinessTimeoutError", i, agents[i].Name)
+			continue
+		}
+		if !session.IsReadinessTimeout(spawnErr[i]) {
+			t.Errorf("spawnErr[%d] (%s) = %v, want *ReadinessTimeoutError", i, agents[i].Name, spawnErr[i])
+		}
+	}
+
+	// AC-7: progress lines.
+	lines := collector.snapshot()
+	if !containsLine(lines, "Review-Goal started") {
+		t.Errorf("missing 'Review-Goal started' in progress lines: %v", lines)
+	}
+	if !containsLine(lines, "Review-Code started") {
+		t.Errorf("missing 'Review-Code started' in progress lines: %v", lines)
+	}
+	if !containsLine(lines, "Review-Context started") {
+		t.Errorf("missing 'Review-Context started' in progress lines: %v", lines)
+	}
+	if !containsLine(lines, "Review-Security failed to start: not ready within") {
+		t.Errorf("missing 'Review-Security failed to start' in progress lines: %v", lines)
+	}
+	if !containsLine(lines, "Review-Qa failed to start: not ready within") {
+		t.Errorf("missing 'Review-Qa failed to start' in progress lines: %v", lines)
+	}
+
+	// AC-8 spirit: total wall time should be bounded by the timeout, not
+	// 5x timeout. The gate runs in parallel.
+	if elapsed > timeout+1*time.Second {
+		t.Errorf("gate took %v, want close to %v (per-agent gates must run concurrently)", elapsed, timeout)
+	}
+}
+
+// ── AC-8: surface the failure within the timeout window ──────────────────────
+
+// TestGateReviewAgents_TimeoutSurfacedWithinWindow is the AC-8 reproducer:
+// when 2 of 5 agents are blocked from emitting a readiness signal (here
+// simulated by simply not writing one), the spawn loop must surface the
+// failure within the configured window — NOT after the 20-minute monitor
+// timeout. This guards against regressions where the gate accidentally
+// runs sequentially or doesn't fire at all.
+//
+// We use a 1-second timeout here; on the production path the timeout is 30s
+// per AC-1 and the same parallelism guarantee holds.
+func TestGateReviewAgents_TimeoutSurfacedWithinWindow(t *testing.T) {
+	d := openGateTestDB(t)
+
+	agents := review.Agents() // 5 standard review agents
+	const parent = "test@ac-8-window"
+	sessions := make([]string, len(agents))
+	for i, ag := range agents {
+		sessions[i] = parent + "~review-1-" + ag.Name
+		seedAgentRow(t, d, sessions[i])
+	}
+
+	// Simulate the headline scenario: 3 succeed, 2 fail (review-goal and
+	// review-qa — same indices as the original #1051 incident).
+	signalReady(t, d, sessions[1]) // review-code
+	signalReady(t, d, sessions[2]) // review-security
+	signalReady(t, d, sessions[4]) // review-context
+
+	spawnErr := make([]error, len(agents))
+	spawnTimes := make([]time.Time, len(agents))
+	collector := &progressCollector{}
+
+	const timeout = 1 * time.Second
+	start := time.Now()
+	review.GateReviewAgentsForTest(d, agents, sessions, spawnErr, spawnTimes, timeout, collector.callback)
+	elapsed := time.Since(start)
+
+	// AC-8: the gate must have completed within roughly the timeout window
+	// — categorically not in 20 minutes (which would mean the gate ran
+	// sequentially or wasn't called at all).
+	if elapsed > timeout+1*time.Second {
+		t.Errorf("gate took %v with %v timeout — failure must be surfaced within the window, not after the monitor timeout", elapsed, timeout)
+	}
+
+	// AC-8: the 2 failed agents must have a timeout error.
+	if !session.IsReadinessTimeout(spawnErr[0]) {
+		t.Errorf("review-goal: spawnErr = %v, want *ReadinessTimeoutError", spawnErr[0])
+	}
+	if !session.IsReadinessTimeout(spawnErr[3]) {
+		t.Errorf("review-qa: spawnErr = %v, want *ReadinessTimeoutError", spawnErr[3])
+	}
+}
+
+// ── AC-9: no regressions when all agents come up healthily ───────────────────
+
+// TestGateReviewAgents_AllReady_AllStarted verifies the happy path: when all
+// 5 agents signal readiness within the gate window, all 5 emit the "started"
+// progress line and none have a populated spawnErr. The wall time should be
+// ~one poll interval (250ms), well under the AC-9 ceiling of "a few seconds".
+func TestGateReviewAgents_AllReady_AllStarted(t *testing.T) {
+	d := openGateTestDB(t)
+
+	agents := review.Agents()
+	const parent = "test@all-healthy"
+	sessions := make([]string, len(agents))
+	for i, ag := range agents {
+		sessions[i] = parent + "~review-1-" + ag.Name
+		seedAgentRow(t, d, sessions[i])
+		signalReady(t, d, sessions[i])
+	}
+
+	spawnErr := make([]error, len(agents))
+	spawnTimes := make([]time.Time, len(agents))
+	collector := &progressCollector{}
+
+	const timeout = 5 * time.Second
+	start := time.Now()
+	review.GateReviewAgentsForTest(d, agents, sessions, spawnErr, spawnTimes, timeout, collector.callback)
+	elapsed := time.Since(start)
+
+	// AC-9: all 5 must report "started" and have no spawnErr.
+	lines := collector.snapshot()
+	for i, ag := range agents {
+		if spawnErr[i] != nil {
+			t.Errorf("spawnErr[%d] (%s) = %v, want nil", i, ag.Name, spawnErr[i])
+		}
+		if spawnTimes[i].IsZero() {
+			t.Errorf("spawnTimes[%d] (%s) is zero, want set", i, ag.Name)
+		}
+		if !containsLine(lines, review.FormatAgentDisplayName(ag.Name)+" started") {
+			t.Errorf("missing %q in progress lines: %v", review.FormatAgentDisplayName(ag.Name)+" started", lines)
+		}
+	}
+
+	// AC-9: "the extra readiness check should add at most ~2 s on a healthy
+	// machine". We're well below that — typically <500ms in the test.
+	if elapsed > 2*time.Second {
+		t.Errorf("gate took %v on healthy path — AC-9 ceiling is ~2s", elapsed)
+	}
+}
+
+// TestGateReviewAgents_SkipsAlreadyFailedAgents verifies that pre-existing
+// spawn failures (config errors, SpawnSession errors) are not re-processed
+// by the gate. The gate must skip agents whose spawnErr[i] is already
+// non-nil, so the spawn loop's earlier "failed to start: <reason>" line is
+// not duplicated by a second readiness-timeout line.
+func TestGateReviewAgents_SkipsAlreadyFailedAgents(t *testing.T) {
+	d := openGateTestDB(t)
+
+	agents := review.Agents()
+	const parent = "test@skip-failed"
+	sessions := make([]string, len(agents))
+	for i, ag := range agents {
+		sessions[i] = parent + "~review-1-" + ag.Name
+		seedAgentRow(t, d, sessions[i])
+	}
+
+	// Mark agent 0 as already failed (e.g. config error from spawn loop).
+	preExistingErr := &session.ReadinessTimeoutError{SessionName: "x", Timeout: time.Second}
+	spawnErr := make([]error, len(agents))
+	spawnErr[0] = preExistingErr // sentinel; actual cause irrelevant here.
+	// All other agents become ready so the gate completes quickly.
+	for i := 1; i < len(agents); i++ {
+		signalReady(t, d, sessions[i])
+	}
+
+	spawnTimes := make([]time.Time, len(agents))
+	collector := &progressCollector{}
+
+	review.GateReviewAgentsForTest(d, agents, sessions, spawnErr, spawnTimes, 1*time.Second, collector.callback)
+
+	// Agent 0's spawnErr must be left untouched.
+	if spawnErr[0] != preExistingErr {
+		t.Errorf("spawnErr[0] = %v, want preExistingErr (gate must not overwrite pre-existing failures)", spawnErr[0])
+	}
+	// No "started" line for agent 0 (it was pre-failed).
+	lines := collector.snapshot()
+	if containsLine(lines, review.FormatAgentDisplayName(agents[0].Name)+" started") {
+		t.Errorf("unexpected 'started' line for pre-failed agent: %v", lines)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -19,12 +19,64 @@
 //
 // The ~ separator in the session name is used by the dashboard for depth-2
 // child detection (review sessions appear indented under their parent branch).
+//
+// Readiness gate (#1051 Piece A):
+//
+// Each per-agent session.SpawnSession call only returns "the tmux session was
+// created and the sidecar process was kicked off" — opencode itself runs
+// inside the bwrap/podman/host process the tmux pane launches, several steps
+// further along, and may take seconds to bind its TCP port (≈8.5s observed
+// in the worst healthy case captured in #1051) or never bind at all if
+// startup fails silently. The spawn loop therefore runs a per-agent
+// readiness gate via gateReviewAgents (see readiness.go) after spawning, in
+// parallel goroutines so one slow agent does not delay the others.
+//
+// Each gate calls session.WaitForReady, which polls the DB for either:
+//   - any state_change event (the sidecar wrote one when the first SSE event
+//     arrived from opencode, which can only happen after opencode bound its
+//     port), or
+//   - agent_status.harness_session_id becoming non-NULL (the sidecar saw
+//     opencode's session.created event).
+//
+// The default per-agent readiness window is 30s
+// (DefaultReviewReadinessTimeout). On timeout, the gate emits
+// "<role> failed to start: not ready within 30s" via OnProgress, populates
+// the spawn-failure slot for that agent, and runs the standard cleanup
+// (KillSidecar + cleanupAgentSession + tmux.KillSession). The other agents
+// are unaffected; the review proceeds with the survivors.
+//
+// Per-agent startup log (#1051 Piece B):
+//
+// Each spawned session has an agent-startup.log file in its run directory:
+//
+//	$XDG_STATE_HOME/prism/run/<session>/agent-startup.log
+//
+// SpawnSession writes timestamped breadcrumbs to this file describing the
+// spawn-time sequence (DB seed, port allocation, tmux session creation,
+// sidecar startup, readiness gate outcome). It is the forensic trail
+// covering the gap between "session created in DB" and "first SSE event
+// arrives at the sidecar" — exactly the window in which the silent failure
+// reported by #1051 occurs. The bwrap-side stderr lands in agent-run.log in
+// the same directory; together they cover the full pre-opencode startup
+// timeline.
+//
+// Async Ack contract (#1051 Piece C):
+//
+// RunAsync's AsyncResult.Ack distinguishes successfully-ready agents from
+// failed-to-spawn / failed-to-ready agents:
+//
+//	Spawned: 3, Failed: 2 (review-goal: not ready within 30s, review-qa: not ready within 30s)
+//
+// so the worker session reading the Ack sees a partial-success outcome
+// immediately instead of discovering it 20 minutes later when the monitor
+// timeout fires.
 package review
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -574,6 +626,11 @@ type Opts struct {
 	// When empty, spawnAgentOnlyLayout will call cfg.EffectiveIsolationMode()
 	// to resolve the machine default rather than silently falling back to host.
 	IsolationMode string
+	// ReadinessTimeout is the per-agent deadline for the post-spawn
+	// readiness gate (#1051 Piece A). Zero falls back to
+	// DefaultReviewReadinessTimeout (30s). The gate runs concurrently per
+	// agent so the worst-case wall time is one timeout, not five.
+	ReadinessTimeout time.Duration
 }
 
 // FormatAgentDisplayName converts an agent name like "review-goal" to a
@@ -749,14 +806,26 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			continue
 		}
 
-		// Emit "started" progress line immediately after successful spawn.
-		if opts.OnProgress != nil {
-			opts.OnProgress(fmt.Sprintf("%s started", FormatAgentDisplayName(ag.Name)))
-		}
+		// Capture the spawn time so the readiness-gate phase below can
+		// reset it once the agent is actually ready, and so the polling
+		// phase has a sensible fallback if the gate is somehow skipped.
+		// The "started" progress line is emitted by the readiness gate,
+		// not here — see #1051 for why "spawned" is not the same as
+		// "ready".
 		spawnTimes[i] = time.Now()
 	}
 
-	// Check if all agents failed to spawn — surface a combined error.
+	// Per-agent readiness gate (#1051 Piece A). Runs in parallel goroutines
+	// so one slow agent does not delay the others. Updates spawnErr[i] for
+	// agents whose gate trips on timeout, and emits "<role> started" /
+	// "<role> failed to start: not ready within <timeout>" via OnProgress.
+	gateReviewAgents(d, agents, agentSessions, spawnErr, spawnTimes,
+		opts.ReadinessTimeout, opts.OnProgress)
+
+	// Check if all agents failed to spawn (or to become ready) — surface
+	// a combined error. With the readiness gate in place, "all failed"
+	// covers both pre-spawn failures (config errors, SpawnSession errors)
+	// and never-came-up failures (readiness timeouts).
 	allFailed := true
 	for _, se := range spawnErr {
 		if se == nil {
@@ -768,8 +837,8 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		return nil, fmt.Errorf("all review agents failed to spawn")
 	}
 
-	// Build the subset of agents that successfully spawned for polling and
-	// SIGINT notification.
+	// Build the subset of agents that successfully spawned AND became ready
+	// for polling and SIGINT notification.
 	var liveAgents []Agent
 	var liveSessions []string
 	var liveSpawnTimes []time.Time
@@ -781,7 +850,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		}
 	}
 
-	// Notify the caller with all successfully-spawned session names for SIGINT handling.
+	// Notify the caller with all successfully-ready session names for SIGINT handling.
 	if onSessionsCreated != nil {
 		onSessionsCreated(liveSessions)
 	}
@@ -966,12 +1035,22 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			continue
 		}
 
-		if opts.OnProgress != nil {
-			opts.OnProgress(fmt.Sprintf("%s started", FormatAgentDisplayName(ag.Name)))
-		}
+		// "started" is now emitted by the readiness gate below, not here.
+		// See #1051 — "spawned" is not the same as "opencode is ready".
 	}
 
-	// Check if all agents failed to spawn.
+	// Per-agent readiness gate (#1051 Piece A). Runs concurrently so one
+	// slow agent does not delay the others. Updates spawnErr[i] for agents
+	// whose gate trips, and emits "<role> started" or
+	// "<role> failed to start: not ready within <timeout>" via OnProgress.
+	// spawnTimes is unused by RunAsync (the monitor process owns timing
+	// from this point on), but the gate signature requires it; allocate a
+	// throwaway slice so the in-loop write does not blow up.
+	gateSpawnTimes := make([]time.Time, len(agents))
+	gateReviewAgents(d, agents, agentSessions, spawnErr, gateSpawnTimes,
+		opts.ReadinessTimeout, opts.OnProgress)
+
+	// Check if all agents failed to spawn or to become ready.
 	allFailed := true
 	for _, se := range spawnErr {
 		if se == nil {
@@ -983,13 +1062,25 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		return nil, fmt.Errorf("all review agents failed to spawn")
 	}
 
-	// Collect successfully-spawned sessions.
+	// Collect successfully-spawned-and-ready sessions, plus the failure
+	// list for the Ack (#1051 Piece C) so the worker sees which agents
+	// did not come up and why.
 	var liveSessions []string
 	var liveAgents []Agent
+	type failedAgent struct {
+		name   string
+		reason string
+	}
+	var failures []failedAgent
 	for i, se := range spawnErr {
 		if se == nil {
 			liveSessions = append(liveSessions, agentSessions[i])
 			liveAgents = append(liveAgents, agents[i])
+		} else {
+			failures = append(failures, failedAgent{
+				name:   agents[i].Name,
+				reason: failureReason(se),
+			})
 		}
 	}
 
@@ -1034,8 +1125,12 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		fmt.Fprintf(os.Stderr, "[prism review] warning: could not look up worker session %q: %v\n", opts.WorkerSession, stErr)
 	}
 
-	// Build acknowledgement message.
-	ack := buildAsyncAck(opts.PRNumber, round, groupID, liveSessions, opts.WorkerSession)
+	// Build acknowledgement message (#1051 Piece C: surface partial-success).
+	failurePairs := make([][2]string, 0, len(failures))
+	for _, f := range failures {
+		failurePairs = append(failurePairs, [2]string{f.name, f.reason})
+	}
+	ack := buildAsyncAck(opts.PRNumber, round, groupID, liveSessions, failurePairs, opts.WorkerSession)
 
 	return &AsyncResult{
 		GroupID:      groupID,
@@ -1045,18 +1140,73 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 	}, nil
 }
 
+// failureReason returns the user-facing reason string for a spawn / readiness
+// failure. For *session.ReadinessTimeoutError it produces "not ready within
+// <timeout>" (matching the AC-5 example text exactly); other errors are
+// passed through verbatim.
+func failureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	if session.IsReadinessTimeout(err) {
+		// session.ReadinessTimeoutError already renders as "not ready
+		// within <timeout>" via its Error() method. Surfacing the inner
+		// message keeps the Ack readable without redundant prefixes from
+		// the gate-side wrapping.
+		var rte *session.ReadinessTimeoutError
+		if errors.As(err, &rte) {
+			return rte.Error()
+		}
+	}
+	return err.Error()
+}
+
 // buildAsyncAck constructs the acknowledgement message returned to the worker
-// immediately after spawning the review agents.
-func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []string, workerSession string) string {
+// immediately after spawning the review agents. failures is a list of
+// (agentName, reason) pairs for agents that did not become ready — see
+// #1051 AC-5: "Coordinators reading the Ack should be able to see
+// `Spawned: 3, Failed: 2 (review-goal: not ready within 30s, …)`."
+func buildAsyncAck(prNumber string, round int, groupID string, sessionNames []string, failures [][2]string, workerSession string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Review in progress — PR #%s, round %d (group: %s)\n\n", prNumber, round, groupID))
-	sb.WriteString(fmt.Sprintf("Spawned %d review agents:\n", len(sessionNames)))
-	for _, name := range sessionNames {
-		sb.WriteString(fmt.Sprintf("  • %s\n", name))
+
+	// Spawned/Failed summary line — the headline scan target for operators
+	// reading the Ack at a glance. Always emit both numbers, even when
+	// Failed is 0, so the format is stable across runs.
+	sb.WriteString(fmt.Sprintf("Spawned: %d", len(sessionNames)))
+	if len(failures) > 0 {
+		// Inline reasons in the same order as the failures slice (which
+		// preserves the original agent order from the spawn loop).
+		var parts []string
+		for _, f := range failures {
+			parts = append(parts, fmt.Sprintf("%s: %s", f[0], f[1]))
+		}
+		sb.WriteString(fmt.Sprintf(", Failed: %d (%s)", len(failures), strings.Join(parts, ", ")))
+	} else {
+		sb.WriteString(", Failed: 0")
+	}
+	sb.WriteString("\n\n")
+
+	if len(sessionNames) > 0 {
+		sb.WriteString(fmt.Sprintf("Spawned %d review agents:\n", len(sessionNames)))
+		for _, name := range sessionNames {
+			sb.WriteString(fmt.Sprintf("  • %s\n", name))
+		}
+	}
+	if len(failures) > 0 {
+		sb.WriteString(fmt.Sprintf("\n%d agent(s) failed to start. Inspect the per-session startup log for details:\n", len(failures)))
+		for _, f := range failures {
+			sb.WriteString(fmt.Sprintf("  • %s — %s\n", f[0], f[1]))
+		}
+		sb.WriteString("\nStartup logs:\n")
+		sb.WriteString("  prism logs <session> --startup            # spawn-time breadcrumbs\n")
+		sb.WriteString("  prism logs <session> --agent-run          # bwrap stderr (if it got that far)\n")
 	}
 	sb.WriteString(fmt.Sprintf("\nResults will be delivered to session %q via prism prompt when all agents complete.\n", workerSession))
 	sb.WriteString("\n**Do NOT commit, merge, or announce completion** until the review-complete prompt arrives.\n")
-	sb.WriteString(fmt.Sprintf("\nYou may monitor progress with:\n  prism checkin %s~review-%d-review-goal\n", workerSession, round))
+	if len(sessionNames) > 0 {
+		sb.WriteString(fmt.Sprintf("\nYou may monitor progress with:\n  prism checkin %s~review-%d-review-goal\n", workerSession, round))
+	}
 	return sb.String()
 }
 
@@ -1403,6 +1553,14 @@ func DiffFilePathForTest(prNumber string, round int) string {
 	return diffFilePath(prNumber, round)
 }
 
+// BuildAsyncAckForTest is an exported wrapper around buildAsyncAck for use
+// in external tests. Mirrors the production signature so AC-5 assertions
+// can verify the partial-success summary text without spinning up a real
+// review run.
+func BuildAsyncAckForTest(prNumber string, round int, groupID string, sessionNames []string, failures [][2]string, workerSession string) string {
+	return buildAsyncAck(prNumber, round, groupID, sessionNames, failures, workerSession)
+}
+
 // PollAgentsForTest is an exported wrapper around pollAgents for use in tests.
 // It accepts pre-seeded DB rows and returns both results and the progress lines
 // emitted via onProgress.
@@ -1600,10 +1758,33 @@ func AssessPassed(text string) (bool, VerdictKind) {
 }
 
 // cleanupAgentSession cleans up the DB state for a completed agent session.
+//
+// In addition to releasing the port and marking the row ended, this transitions
+// the state to "error" when the row is non-terminal. That matters for the
+// review monitor's GroupCompleted check (#1051 AC-6): a half-alive agent
+// stuck at "idle" would otherwise block the group's terminal-state count
+// forever. State="error" is a valid agent state machine transition from any
+// non-terminal state and is treated as terminal by GroupCompleted.
 func cleanupAgentSession(d *db.DB, agentSession string) {
+	st, lookupErr := d.CurrentStatus(agentSession)
+	if lookupErr == nil && st != nil && !isTerminalAgentState(st.State) {
+		_ = d.UpsertStatus(agentSession, st.Repo, st.Worktree, "error", nil, nil)
+	}
 	_ = d.ReleasePort(agentSession)
 	_ = d.SetEnded(agentSession)
 	_ = d.PurgeBusMessages(agentSession)
+}
+
+// isTerminalAgentState mirrors the terminalStates set in internal/db/db.go
+// (finished, interrupted, error, deleted). Duplicated here so the review
+// package does not have to widen the db package's exported surface for a
+// single check.
+func isTerminalAgentState(state string) bool {
+	switch state {
+	case "finished", "interrupted", "error", "deleted":
+		return true
+	}
+	return false
 }
 
 // DefaultFindingsSizeBudget is the default maximum inline size (in bytes) for

--- a/modules/programs/prism/prism/internal/session/readiness.go
+++ b/modules/programs/prism/prism/internal/session/readiness.go
@@ -1,0 +1,170 @@
+package session
+
+// Agent readiness gate (#1051 Piece A).
+//
+// SpawnSession returns success as soon as it has created the tmux session and
+// kicked off the sidecar. That is "spawned", not "ready": opencode itself runs
+// inside the bwrap/podman/host process the tmux pane launches, several steps
+// further along, and may take seconds to bind its TCP port — or never bind at
+// all if startup fails silently.
+//
+// WaitForReady polls the prism DB for an explicit readiness signal: the
+// sidecar writes a `state_change` event to agent_events as soon as it has
+// successfully connected to opencode's SSE stream and processed the first
+// event (see internal/sidecar/sidecar.go HandleEvent → writeStateChange). The
+// presence of any such event for the session means "opencode bound its port,
+// the sidecar connected, and we have a live SSE stream".
+//
+// Equivalent earlier signals fall through too: when opencode emits a
+// session.created event the sidecar calls UpdateHarnessSessionID, which sets
+// agent_status.harness_session_id to a non-NULL value. Either signal is
+// sufficient evidence that opencode is up.
+//
+// The default readiness window is 30 seconds — comfortably longer than the
+// healthy-startup latency observed on real-world hardware (sub-second to ~9s,
+// see #1051 widening comment) but short enough that a never-coming-up agent
+// is surfaced quickly instead of after the 20-minute review monitor timeout.
+//
+// This primitive is shared between single-worker `prism spawn` (via
+// SpawnOpts.ReadinessTimeout) and the parallel review fan-out
+// (internal/review/review.go calls WaitForReady directly, in goroutines, so
+// per-agent gates run concurrently and one slow agent does not delay the
+// others).
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// DefaultReadinessTimeout is the default deadline for WaitForReady. It is
+// exported so callers (and tests) can reference the same constant when they
+// want the documented default.
+//
+// 30 seconds covers the observed slow-but-eventually-successful startup
+// (~8.5s in the worst case captured in #1051) with a comfortable margin
+// while still surfacing never-coming-up agents quickly relative to the
+// 20-minute review-monitor timeout.
+const DefaultReadinessTimeout = 30 * time.Second
+
+// readinessPollInterval is how often WaitForReady samples the DB. 250ms is
+// fast enough that a healthy startup adds tens of ms of overhead at most,
+// and slow enough that the DB read load is negligible across a 5-agent
+// fan-out (≈20 reads/agent over the median healthy startup).
+const readinessPollInterval = 250 * time.Millisecond
+
+// ReadinessTimeoutError indicates that WaitForReady's deadline expired before
+// any readiness signal was observed for the session. Callers should treat this
+// as a "failed to start" outcome, not a transient error: the spawned sidecar
+// is still running and reporting `connection refused` to its own log, but
+// opencode itself never came up. The right response is to clean up the half-
+// alive session (KillSidecar + cleanupAgentSession + tmux KillSession) and
+// surface the failure to the operator.
+type ReadinessTimeoutError struct {
+	SessionName string
+	Timeout     time.Duration
+}
+
+func (e *ReadinessTimeoutError) Error() string {
+	return fmt.Sprintf("not ready within %s", formatTimeout(e.Timeout))
+}
+
+// IsReadinessTimeout reports whether err is (or wraps) a ReadinessTimeoutError.
+// Useful for callers that want to render a different message for readiness
+// failures versus other spawn errors.
+func IsReadinessTimeout(err error) bool {
+	var rte *ReadinessTimeoutError
+	return errors.As(err, &rte)
+}
+
+// formatTimeout renders a duration the same way the AC text says it should
+// appear: "30s", "1m30s", etc. We never round to nanoseconds in user-facing
+// strings.
+func formatTimeout(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Round(time.Second).Seconds()))
+	}
+	m := int(d / time.Minute)
+	s := int((d % time.Minute) / time.Second)
+	if s == 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return fmt.Sprintf("%dm%ds", m, s)
+}
+
+// WaitForReady polls the prism DB for the named session until either:
+//
+//   - The session has at least one event of type "state_change" (the sidecar
+//     successfully connected to opencode's SSE stream and emitted a state
+//     transition — see writeStateChange in internal/sidecar/sidecar.go), OR
+//   - agent_status.harness_session_id is non-NULL (opencode emitted
+//     session.created and the sidecar wrote the session ID), OR
+//   - the timeout elapses.
+//
+// On success returns nil. On timeout returns *ReadinessTimeoutError; check
+// with IsReadinessTimeout. DB-error returns from CurrentStatus / QueryEvents
+// are treated as transient (the sidecar may still be writing) and the loop
+// continues; only the deadline ends the wait.
+//
+// timeout ≤ 0 falls back to DefaultReadinessTimeout.
+//
+// This function does not perform any cleanup on timeout — callers own the
+// "what to do on failed-to-ready" policy. Single-worker spawns might leave
+// the session alive for the operator to debug; review fan-outs typically
+// kill it. Both code paths handle the cleanup explicitly via
+// KillSidecar + cleanupAgentSession + tmux.KillSession.
+func WaitForReady(d *db.DB, sessionName string, timeout time.Duration) error {
+	if d == nil {
+		return fmt.Errorf("wait for ready: db handle is required")
+	}
+	if sessionName == "" {
+		return fmt.Errorf("wait for ready: session name is required")
+	}
+	if timeout <= 0 {
+		timeout = DefaultReadinessTimeout
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		// Primary signal: any state_change event written by the sidecar means
+		// opencode produced at least one SSE event, which can only happen
+		// after opencode bound its port and accepted the sidecar's TCP
+		// connection. This is the cleanest and earliest readiness marker.
+		evts, evtErr := d.QueryEvents(sessionName, 1, nil, nil, []string{"state_change"})
+		if evtErr == nil && len(evts) > 0 {
+			return nil
+		}
+
+		// Secondary signal: harness_session_id set on the agent_status row.
+		// The sidecar writes this on session.created, which arrives shortly
+		// after server.connected. Useful as a belt-and-braces check in case
+		// the state_change query has a transient error or in case future
+		// sidecar refactors order the writes differently.
+		st, stErr := d.CurrentStatus(sessionName)
+		if stErr == nil && st != nil && st.HarnessSessionID != nil && *st.HarnessSessionID != "" {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return &ReadinessTimeoutError{
+				SessionName: sessionName,
+				Timeout:     timeout,
+			}
+		}
+
+		// Sleep for the poll interval, but never overshoot the deadline by
+		// more than one tick. (The deadline check above is the only place we
+		// return ReadinessTimeoutError, so a tight sleep here keeps the
+		// reported wait time honest.)
+		remaining := time.Until(deadline)
+		sleep := readinessPollInterval
+		if remaining < sleep {
+			sleep = remaining
+		}
+		if sleep > 0 {
+			time.Sleep(sleep)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/session/readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/readiness_test.go
@@ -1,0 +1,277 @@
+package session_test
+
+// Tests for the readiness gate (#1051 Piece A). These use a real prism DB
+// and exercise the actual signals SpawnSession's gate consumes:
+//
+//   - "state_change" event written to agent_events (the cleanest readiness
+//     marker — only ever written by the sidecar after the first SSE event
+//     from opencode).
+//   - agent_status.harness_session_id set non-NULL (the secondary signal).
+//
+// We do NOT spin up a real sidecar or tmux session here; the readiness gate
+// is purely a DB poll. Tests inject the readiness signals directly to
+// validate the polling behaviour, the timeout path, and the error type.
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+func openReadinessTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// seedSession creates a minimal agent_status row so CurrentStatus / QueryEvents
+// against it return without error. The state is "idle" — same as what
+// SpawnSession's UpsertStatusSeedRootAgentName writes at spawn time.
+func seedSession(t *testing.T, d *db.DB, sessionName string) {
+	t.Helper()
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker"); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sessionName, err)
+	}
+}
+
+// ── WaitForReady — happy path ─────────────────────────────────────────────────
+
+// TestWaitForReady_StateChangeEventSatisfiesGate verifies that an agent_events
+// row of type "state_change" causes WaitForReady to return nil. This is the
+// primary signal SpawnSession's gate uses, and it's the one the sidecar emits
+// when the first SSE event from opencode arrives.
+func TestWaitForReady_StateChangeEventSatisfiesGate(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@feature"
+	seedSession(t, d, sess)
+
+	// Simulate the sidecar receiving the first SSE event by inserting a
+	// state_change event directly. The payload shape mirrors what
+	// internal/sidecar/sidecar.go writeEvent produces.
+	evt := db.Event{
+		ID:          "evt-1",
+		SessionName: sess,
+		Repo:        "test",
+		Worktree:    "/tmp",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+	}
+	if err := d.WriteEvent(evt); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	if err := session.WaitForReady(d, sess, 2*time.Second); err != nil {
+		t.Errorf("WaitForReady: got %v, want nil (state_change should satisfy the gate)", err)
+	}
+}
+
+// TestWaitForReady_HarnessSessionIDSatisfiesGate verifies that a non-NULL
+// harness_session_id on agent_status causes WaitForReady to return nil. This
+// is the secondary signal — the sidecar writes it on session.created.
+func TestWaitForReady_HarnessSessionIDSatisfiesGate(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@hsid"
+	seedSession(t, d, sess)
+
+	if err := d.UpdateHarnessSessionID(sess, "ses_abc123"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	if err := session.WaitForReady(d, sess, 2*time.Second); err != nil {
+		t.Errorf("WaitForReady: got %v, want nil (harness_session_id should satisfy the gate)", err)
+	}
+}
+
+// TestWaitForReady_ReturnsBeforeDeadline verifies that the gate returns
+// promptly once the signal arrives — not at the end of the timeout window.
+// We insert the state_change after a small delay and assert WaitForReady
+// returned within a generous bound that is still well under the configured
+// timeout.
+func TestWaitForReady_ReturnsBeforeDeadline(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@quick"
+	seedSession(t, d, sess)
+
+	// Insert the readiness signal after 200ms — well before the 5s timeout.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		evt := db.Event{
+			ID:          "evt-quick",
+			SessionName: sess,
+			Repo:        "test",
+			Worktree:    "/tmp",
+			Type:        "state_change",
+			Payload:     `{"state":"active"}`,
+		}
+		_ = d.WriteEvent(evt)
+	}()
+
+	start := time.Now()
+	err := session.WaitForReady(d, sess, 5*time.Second)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("WaitForReady: %v", err)
+	}
+	// Allow a generous bound — the poll interval is 250ms so the worst-case
+	// detection latency is ~450ms after the signal arrives.
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("WaitForReady took %v, expected to return well before the 5s timeout", elapsed)
+	}
+}
+
+// ── WaitForReady — timeout path ───────────────────────────────────────────────
+
+// TestWaitForReady_TimesOutWhenNoSignalArrives verifies the timeout branch:
+// when no state_change event is written and harness_session_id stays NULL,
+// WaitForReady returns *ReadinessTimeoutError after the configured deadline.
+func TestWaitForReady_TimesOutWhenNoSignalArrives(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@stuck"
+	seedSession(t, d, sess)
+
+	const timeout = 500 * time.Millisecond
+	start := time.Now()
+	err := session.WaitForReady(d, sess, timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("WaitForReady: got nil, want *ReadinessTimeoutError")
+	}
+	if !session.IsReadinessTimeout(err) {
+		t.Errorf("WaitForReady error = %v (type %T), want *ReadinessTimeoutError", err, err)
+	}
+	// Sanity-check: elapsed must be at least the configured timeout (no
+	// premature returns), and not absurdly larger (no run-away polling).
+	if elapsed < timeout {
+		t.Errorf("WaitForReady returned in %v, expected at least %v", elapsed, timeout)
+	}
+	if elapsed > timeout+1*time.Second {
+		t.Errorf("WaitForReady returned in %v, expected close to %v", elapsed, timeout)
+	}
+}
+
+// TestReadinessTimeoutError_Message verifies the error message format. The
+// Ack and progress lines depend on this string ("not ready within Xs").
+func TestReadinessTimeoutError_Message(t *testing.T) {
+	cases := []struct {
+		timeout time.Duration
+		want    string
+	}{
+		{30 * time.Second, "not ready within 30s"},
+		{1 * time.Minute, "not ready within 1m"},
+		{90 * time.Second, "not ready within 1m30s"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.want, func(t *testing.T) {
+			e := &session.ReadinessTimeoutError{SessionName: "x", Timeout: c.timeout}
+			if got := e.Error(); got != c.want {
+				t.Errorf("Error() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestIsReadinessTimeout_WrappedError verifies that IsReadinessTimeout sees
+// through error wrapping (errors.As). The review-side gateReviewAgents wraps
+// the error with "readiness gate for X: %w" before storing it in spawnErr.
+func TestIsReadinessTimeout_WrappedError(t *testing.T) {
+	inner := &session.ReadinessTimeoutError{SessionName: "x", Timeout: 30 * time.Second}
+	wrapped := errorWrap("readiness gate for review-goal", inner)
+
+	if !session.IsReadinessTimeout(wrapped) {
+		t.Errorf("IsReadinessTimeout(%v) = false, want true (errors.As must see through wrapping)", wrapped)
+	}
+
+	// Sanity: a non-timeout error should not match.
+	plainErr := errors.New("some other error")
+	if session.IsReadinessTimeout(plainErr) {
+		t.Error("IsReadinessTimeout(plain error) = true, want false")
+	}
+	if session.IsReadinessTimeout(nil) {
+		t.Error("IsReadinessTimeout(nil) = true, want false")
+	}
+}
+
+// errorWrap is a tiny test helper that wraps inner with a prefix while
+// preserving the wrapped-error chain. Cannot use fmt.Errorf("%w: …", inner)
+// directly without importing fmt; the explicit struct keeps this file's
+// import list short.
+type wrappedErr struct {
+	prefix string
+	inner  error
+}
+
+func (w *wrappedErr) Error() string { return w.prefix + ": " + w.inner.Error() }
+func (w *wrappedErr) Unwrap() error { return w.inner }
+
+func errorWrap(prefix string, inner error) error {
+	return &wrappedErr{prefix: prefix, inner: inner}
+}
+
+// ── WaitForReady — argument validation ────────────────────────────────────────
+
+// TestWaitForReady_RequiresDB verifies the nil-DB guard.
+func TestWaitForReady_RequiresDB(t *testing.T) {
+	if err := session.WaitForReady(nil, "x", time.Second); err == nil {
+		t.Error("WaitForReady(nil, …): got nil, want error")
+	}
+}
+
+// TestWaitForReady_RequiresSessionName verifies the empty-name guard.
+func TestWaitForReady_RequiresSessionName(t *testing.T) {
+	d := openReadinessTestDB(t)
+	if err := session.WaitForReady(d, "", time.Second); err == nil {
+		t.Error("WaitForReady(_, \"\"): got nil, want error")
+	}
+}
+
+// TestWaitForReady_ZeroTimeoutFallsBackToDefault verifies that a zero or
+// negative timeout uses DefaultReadinessTimeout. We run with no signal and
+// observe that the wait extends well beyond a brief test window — but we
+// don't actually wait the full default (30s); we cancel with a short
+// goroutine that inserts the signal after 100ms to short-circuit.
+func TestWaitForReady_ZeroTimeoutFallsBackToDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in short mode")
+	}
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@zero-timeout"
+	seedSession(t, d, sess)
+
+	// Inject the signal quickly so the test does not wait 30s.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		evt := db.Event{
+			ID: "z", SessionName: sess, Repo: "t", Worktree: "/t",
+			Type: "state_change", Payload: `{"state":"active"}`,
+		}
+		_ = d.WriteEvent(evt)
+	}()
+
+	start := time.Now()
+	if err := session.WaitForReady(d, sess, 0); err != nil {
+		t.Fatalf("WaitForReady(_, _, 0): %v", err)
+	}
+	elapsed := time.Since(start)
+	// Sanity: the call returned long before the default 30s — proving the
+	// default did not somehow cap it short, and that the signal was honoured.
+	if elapsed > 3*time.Second {
+		t.Errorf("WaitForReady took %v with zero timeout — expected to return on signal, not wait the full default", elapsed)
+	}
+	// Also: the function did NOT return immediately (which would happen if
+	// timeout=0 was treated as "deadline already passed"). It must have
+	// polled for at least the time before the signal arrived.
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("WaitForReady took %v with zero timeout — expected to poll until signal, not return immediately", elapsed)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -25,6 +25,7 @@ package session
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -132,6 +133,24 @@ type SpawnOpts struct {
 	// instance. These are prepended outermost (before AgentEnvVars and
 	// PRISM_SESSION_NAME) in the agent command string.
 	RuntimeEnvVars map[string]string
+
+	// ReadinessTimeout, when > 0, causes SpawnSession to gate its return on
+	// the agent reaching a readiness signal in the prism DB (see
+	// WaitForReady). If the gate trips with a timeout, SpawnSession cleans
+	// up the half-alive session (kill sidecar, release port, end DB row,
+	// kill tmux session) and returns a *ReadinessTimeoutError.
+	//
+	// Zero means SpawnSession returns as soon as tmux/sidecar are kicked
+	// off, leaving the readiness check to the caller. The parallel review
+	// fan-out uses zero here and runs WaitForReady in per-agent goroutines
+	// after the spawn loop completes — that way one slow agent does not
+	// delay the others.
+	//
+	// Single-worker `prism spawn` sets this to DefaultReadinessTimeout so
+	// operators see a clear `failed to start: not ready within 30s` message
+	// instead of a "session created" success line followed by an idle
+	// session that will never make progress (see #1051 widening comment).
+	ReadinessTimeout time.Duration
 }
 
 // SpawnSession creates a single prism session end-to-end: seeds the
@@ -165,14 +184,26 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		return fmt.Errorf("spawn session: Worktree is required")
 	}
 
+	// Open the per-session startup log as the very first step (#1051 Piece B).
+	// Doing this before any other work means the per-session run directory
+	// exists from the moment the spawn begins, so any later failure has a
+	// place to leave breadcrumbs — even when `prism agent-run` never reaches
+	// its own log-open call (the failure mode #1051 reports).
+	startup := openStartupLog(opts.SessionName)
+	defer startup.close()
+	startup.log("spawn-session: begin (role=%q, worktree=%q, layout=%d, isolation=%q, container_mode=%t)",
+		opts.AgentRole, opts.Worktree, opts.Layout, opts.IsolationMode, opts.ContainerMode)
+
 	// Step 1: Seed agent_status with root_agent_name. Idempotent; later
 	// writes by the sidecar and by tmux-session-start COALESCE-preserve the
 	// value written here.
 	if err := d.UpsertStatusSeedRootAgentName(
 		opts.SessionName, opts.Repo, opts.Worktree, "idle", nil, nil, opts.AgentRole,
 	); err != nil {
+		startup.log("spawn-session: seed status FAILED: %v", err)
 		return fmt.Errorf("spawn session: seed status: %w", err)
 	}
+	startup.log("spawn-session: agent_status seeded (state=idle)")
 
 	// Step 2: Write group_id when set (hook for Issue E — single-session
 	// spawns leave GroupID empty and this is a no-op).
@@ -203,20 +234,84 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// allocation fails — a session with no port cannot start opencode.
 	port, err := d.AllocatePort(opts.SessionName)
 	if err != nil {
+		startup.log("spawn-session: allocate port FAILED: %v", err)
 		return fmt.Errorf("spawn session: allocate port: %w", err)
 	}
+	startup.log("spawn-session: allocated port %d", port)
 
 	// Step 4 & 5: Create the tmux session and start the sidecar. Both
 	// layouts share the same responsibilities — only the window shape and
 	// the ownership of the sidecar-start call differ.
+	var layoutErr error
 	switch opts.Layout {
 	case LayoutFull:
-		return spawnFullLayout(d, opts, port)
+		layoutErr = spawnFullLayout(d, opts, port)
 	case LayoutAgentOnly:
-		return spawnAgentOnlyLayout(opts, port)
+		layoutErr = spawnAgentOnlyLayout(opts, port)
 	default:
+		startup.log("spawn-session: unsupported layout %d", opts.Layout)
 		return fmt.Errorf("spawn session: unsupported layout %d", opts.Layout)
 	}
+	if layoutErr != nil {
+		startup.log("spawn-session: layout setup FAILED: %v", layoutErr)
+		return layoutErr
+	}
+	startup.log("spawn-session: tmux session and sidecar kicked off — handing control to agent pane (further bwrap stderr in agent-run.log)")
+
+	// Step 6 (#1051 Piece A): readiness gate. When the caller opted in by
+	// setting opts.ReadinessTimeout > 0, block here until the sidecar
+	// observes the first SSE event from opencode (i.e. opencode actually
+	// bound its port and the sidecar connected). On timeout, clean up the
+	// half-alive session so a second spawn attempt with the same name does
+	// not see stale state, and surface a *ReadinessTimeoutError so callers
+	// can render a "<role> failed to start: not ready within <timeout>"
+	// message instead of the optimistic "session created" line.
+	//
+	// Callers that prefer to run the gate themselves (e.g. the parallel
+	// review fan-out in internal/review/review.go) leave ReadinessTimeout=0
+	// and call WaitForReady directly in goroutines, so per-agent gates run
+	// concurrently and one slow agent does not delay the others.
+	if opts.ReadinessTimeout > 0 {
+		startup.log("spawn-session: waiting for readiness (timeout=%s)", opts.ReadinessTimeout)
+		if readyErr := WaitForReady(d, opts.SessionName, opts.ReadinessTimeout); readyErr != nil {
+			startup.log("spawn-session: readiness gate FAILED: %v", readyErr)
+			// Clean up: the sidecar is still running and reporting
+			// `connection refused` to its own log, but opencode never came
+			// up. KillSidecar releases the sidecar process, the DB cleanup
+			// releases the port and marks the row ended, and tmux.KillSession
+			// releases the pane. All three are best-effort and idempotent.
+			KillSidecar(opts.SessionName)
+			cleanupHalfAliveSession(d, opts.SessionName)
+			_ = tmux.KillSession(opts.SessionName)
+			return readyErr
+		}
+		startup.log("spawn-session: ready")
+	}
+	return nil
+}
+
+// cleanupHalfAliveSession releases the DB resources for a session that was
+// spawned but failed its readiness gate. Mirrors the cleanupAgentSession
+// helper in internal/review/review.go but lives here so the session package
+// can self-contain the readiness-failure cleanup path without an import
+// cycle. All operations are best-effort and tolerant of missing rows.
+//
+// Importantly, this transitions the agent_status state to "error" so that
+// db.GroupCompleted treats the row as terminal — without that, a review
+// monitor watching the group would block indefinitely on the half-alive
+// member's "idle" state (#1051 AC-6).
+func cleanupHalfAliveSession(d *db.DB, sessionName string) {
+	st, lookupErr := d.CurrentStatus(sessionName)
+	if lookupErr == nil && st != nil {
+		// UpsertStatus is idempotent and validates the transition (idle →
+		// error is allowed; error → error is a no-op-shaped repeat). We
+		// preserve repo/worktree from the existing row so we do not blank
+		// them out with empty strings.
+		_ = d.UpsertStatus(sessionName, st.Repo, st.Worktree, "error", nil, nil)
+	}
+	_ = d.ReleasePort(sessionName)
+	_ = d.SetEnded(sessionName)
+	_ = d.PurgeBusMessages(sessionName)
 }
 
 // spawnFullLayout delegates to Create, which handles the 3-window spawn-path

--- a/modules/programs/prism/prism/internal/session/spawn_readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_readiness_test.go
@@ -1,0 +1,196 @@
+package session
+
+// Tests for SpawnSession's integrated readiness gate (#1051 AC-14). The
+// gate fires when SpawnOpts.ReadinessTimeout > 0 and waits for a readiness
+// signal in the DB; on timeout it cleans up the half-alive session and
+// returns *ReadinessTimeoutError.
+//
+// We cannot exercise the full happy path here without a real sidecar
+// (which would write the state_change event the gate looks for), so the
+// test that proves the gate is wired in correctly is the timeout path:
+//
+//   - With ReadinessTimeout > 0 set and no signal arriving, SpawnSession
+//     returns a *ReadinessTimeoutError after the configured deadline AND
+//     cleans up the half-alive DB row.
+//   - With ReadinessTimeout = 0, SpawnSession returns immediately after
+//     tmux/sidecar setup (legacy behaviour, used by the review fan-out
+//     which runs WaitForReady itself in goroutines).
+//
+// The full happy path (with a real sidecar emitting state_change events) is
+// covered indirectly by the existing TestSpawnSession_AgentOnly_*
+// tests — they call SpawnSession with ReadinessTimeout=0 (default), so the
+// gate is bypassed and the existing assertions still hold.
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSpawnSession_ReadinessTimeout_FiresAndCleansUp verifies AC-14:
+// SpawnSession runs the readiness gate when ReadinessTimeout > 0. Since no
+// sidecar is actually writing state_change events in this test, the gate
+// should trip on timeout, return *ReadinessTimeoutError, and clean up the
+// half-alive session (port released, ended_at set) so a second spawn with
+// the same name does not see stale state.
+func TestSpawnSession_ReadinessTimeout_FiresAndCleansUp(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~ready-timeout"
+	opts := SpawnOpts{
+		SessionName:      sessionName,
+		Repo:             "myrepo",
+		Worktree:         "/worktrees/myrepo-branch",
+		AgentRole:        "review-code",
+		Layout:           LayoutAgentOnly,
+		ReadinessTimeout: 300 * time.Millisecond, // short; no signal will arrive
+	}
+
+	start := time.Now()
+	err := SpawnSession(d, opts)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("SpawnSession: got nil error, want *ReadinessTimeoutError (no sidecar to signal readiness)")
+	}
+	if !IsReadinessTimeout(err) {
+		t.Errorf("SpawnSession error = %v (type %T), want *ReadinessTimeoutError", err, err)
+	}
+	// Sanity-check the timing — gate must wait at least the configured
+	// deadline before tripping.
+	if elapsed < 300*time.Millisecond {
+		t.Errorf("SpawnSession returned in %v, expected at least 300ms (the readiness window)", elapsed)
+	}
+
+	// Cleanup verification: the agent_status row should now show ended_at
+	// (cleanupHalfAliveSession calls SetEnded). Either nil status or a
+	// row with EndedAt != nil is acceptable evidence of cleanup.
+	st, _ := d.CurrentStatus(sessionName)
+	if st != nil && st.EndedAt == nil {
+		t.Errorf("agent_status row %q is alive after readiness-timeout cleanup; ended_at should be set", sessionName)
+	}
+}
+
+// TestSpawnSession_ReadinessTimeoutZero_SkipsGate verifies the legacy
+// behaviour: with ReadinessTimeout = 0, SpawnSession does NOT run the gate
+// and returns success as soon as tmux/sidecar setup completes. This is the
+// path the review fan-out uses (it runs WaitForReady itself in goroutines).
+func TestSpawnSession_ReadinessTimeoutZero_SkipsGate(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~ready-skip"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-code",
+		Layout:      LayoutAgentOnly,
+		// ReadinessTimeout omitted (zero) — gate must be skipped.
+	}
+
+	start := time.Now()
+	err := SpawnSession(d, opts)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("SpawnSession with zero ReadinessTimeout: got %v, want nil", err)
+	}
+	// With the gate skipped, the call must return promptly — well under
+	// the DefaultReadinessTimeout (30s).
+	if elapsed > 5*time.Second {
+		t.Errorf("SpawnSession took %v with ReadinessTimeout=0; expected prompt return without polling for readiness", elapsed)
+	}
+}
+
+// TestSpawnSession_WritesStartupLog verifies AC-3: a per-session
+// agent-startup.log is created during spawn, with at least one line
+// containing the spawn-session breadcrumbs.
+func TestSpawnSession_WritesStartupLog(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~startup-log"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-branch",
+		AgentRole:   "review-code",
+		Layout:      LayoutAgentOnly,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	// AC-3: the log file must exist after spawn.
+	if !AgentStartupLogExists(sessionName) {
+		t.Fatal("AgentStartupLogExists returned false after SpawnSession")
+	}
+
+	// And it must contain breadcrumbs: at minimum the begin line and a port
+	// allocation line.
+	path, _ := AgentStartupLogPath(sessionName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	contents := string(data)
+	if !strings.Contains(contents, "spawn-session: begin") {
+		t.Errorf("startup log missing 'spawn-session: begin' breadcrumb:\n%s", contents)
+	}
+	if !strings.Contains(contents, "agent_status seeded") {
+		t.Errorf("startup log missing 'agent_status seeded' breadcrumb:\n%s", contents)
+	}
+	if !strings.Contains(contents, "allocated port") {
+		t.Errorf("startup log missing 'allocated port' breadcrumb:\n%s", contents)
+	}
+	if !strings.Contains(contents, "tmux session and sidecar kicked off") {
+		t.Errorf("startup log missing 'tmux session and sidecar kicked off' breadcrumb:\n%s", contents)
+	}
+}
+
+// TestSpawnSession_ReadinessTimeoutWritesFailureToStartupLog verifies that
+// when the readiness gate trips, the failure is recorded in the startup
+// log so the operator has a forensic trail.
+func TestSpawnSession_ReadinessTimeoutWritesFailureToStartupLog(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~startup-fail"
+	opts := SpawnOpts{
+		SessionName:      sessionName,
+		Repo:             "myrepo",
+		Worktree:         "/worktrees/myrepo-branch",
+		AgentRole:        "review-code",
+		Layout:           LayoutAgentOnly,
+		ReadinessTimeout: 250 * time.Millisecond,
+	}
+
+	if err := SpawnSession(d, opts); err == nil {
+		t.Fatal("SpawnSession: got nil, want timeout error")
+	}
+
+	path, _ := AgentStartupLogPath(sessionName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	contents := string(data)
+	if !strings.Contains(contents, "waiting for readiness") {
+		t.Errorf("startup log missing 'waiting for readiness' breadcrumb:\n%s", contents)
+	}
+	if !strings.Contains(contents, "readiness gate FAILED") {
+		t.Errorf("startup log missing 'readiness gate FAILED' breadcrumb:\n%s", contents)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/startup_log.go
+++ b/modules/programs/prism/prism/internal/session/startup_log.go
@@ -1,0 +1,105 @@
+package session
+
+// Per-agent startup log (#1051 Piece B).
+//
+// SpawnSession writes a small, append-mode log file to the per-session run
+// directory describing the spawn-time sequence: which session, role, port,
+// isolation mode; when the sidecar was started; when the tmux pane was
+// created; and a pointer to where bwrap stderr will land (agent-run.log)
+// after the pane hands control to `prism agent-run`. The intent is forensic:
+// when an agent fails to come up and the operator inspects logs, this file
+// is the breadcrumb trail covering the gap between "session created in DB"
+// and "first SSE event arrives at the sidecar".
+//
+// The file lives in the same directory as agent-run.log:
+//
+//	$XDG_STATE_HOME/prism/run/<session>/agent-startup.log
+//
+// Pre-creating the directory at SpawnSession time means the file path is
+// always valid even if `prism agent-run` never reaches its own log-open call
+// (the failure mode #1051 reports — opencode never binds and the per-session
+// run dir was never created at all).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// AgentStartupLogPath returns the agent-startup.log file path for the named
+// session. It lives next to AgentRunLogPath so the two are co-located on disk
+// and discoverable from a single `ls $XDG_STATE_HOME/prism/run/<session>/`.
+func AgentStartupLogPath(sessionName string) (string, error) {
+	base, err := sidecarStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "run", sessionName, "agent-startup.log"), nil
+}
+
+// startupLogger wraps an *os.File with the conventions used across the
+// agent-startup.log family of writes: timestamps in RFC3339, line-prefixed
+// "[startup] " marker so the file greps coherently against bwrap stderr
+// later, and tolerant best-effort writes (a write error never fails the
+// caller — the spawn must continue even when the log is unwritable).
+type startupLogger struct {
+	f *os.File
+}
+
+// openStartupLog returns a startupLogger writing to AgentStartupLogPath, or
+// nil when the file cannot be created. The directory is mkdir'd 0o700 so the
+// per-session run dir is in place before any later writers (agent-run, the
+// sidecar) attempt to create files inside it. All errors are reported to
+// stderr as warnings — the spawn never fails because the log is unwritable.
+func openStartupLog(sessionName string) *startupLogger {
+	path, err := AgentStartupLogPath(sessionName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: agent-startup log path: %v — continuing without startup log\n", err)
+		return nil
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o700); mkErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: agent-startup log dir %s: %v — continuing without startup log\n", filepath.Dir(path), mkErr)
+		return nil
+	}
+	f, openErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if openErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: agent-startup log %s: %v — continuing without startup log\n", path, openErr)
+		return nil
+	}
+	return &startupLogger{f: f}
+}
+
+// log writes a single timestamped line. Safe to call on a nil receiver — when
+// the startup log could not be opened, all .log() calls are no-ops.
+func (s *startupLogger) log(format string, args ...any) {
+	if s == nil || s.f == nil {
+		return
+	}
+	line := fmt.Sprintf("[%s] [startup] %s\n",
+		time.Now().UTC().Format(time.RFC3339Nano),
+		fmt.Sprintf(format, args...),
+	)
+	_, _ = s.f.WriteString(line)
+}
+
+// close releases the file handle. Safe to call on nil.
+func (s *startupLogger) close() {
+	if s == nil || s.f == nil {
+		return
+	}
+	_ = s.f.Close()
+}
+
+// AgentStartupLogExists reports whether an agent-startup.log file exists for
+// the named session. Used by `prism logs` to surface a pointer when the
+// regular sidecar log is empty or stuck on SSE-retry noise — see
+// cmd/logs.go for the pointer text.
+func AgentStartupLogExists(sessionName string) bool {
+	path, err := AgentStartupLogPath(sessionName)
+	if err != nil {
+		return false
+	}
+	_, statErr := os.Stat(path)
+	return statErr == nil
+}

--- a/modules/programs/prism/prism/internal/session/startup_log_test.go
+++ b/modules/programs/prism/prism/internal/session/startup_log_test.go
@@ -1,0 +1,135 @@
+package session
+
+// Tests for the per-agent startup log helper (#1051 Piece B). These verify
+// the path resolution, the existence helper used by `prism logs`, and the
+// best-effort tolerance to a nil receiver / unwritable directory.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentStartupLogPath_DefaultsToXDGState(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	got, err := AgentStartupLogPath("myrepo@feat")
+	if err != nil {
+		t.Fatalf("AgentStartupLogPath: %v", err)
+	}
+	want := filepath.Join(tmp, "prism", "run", "myrepo@feat", "agent-startup.log")
+	if got != want {
+		t.Errorf("AgentStartupLogPath = %q, want %q", got, want)
+	}
+}
+
+// TestAgentStartupLogPath_LivesNextToAgentRunLog verifies that the startup
+// log and agent-run log share the same parent directory. This co-location
+// matters for forensic discovery: an operator who finds one file should see
+// the other in the same `ls`.
+func TestAgentStartupLogPath_LivesNextToAgentRunLog(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	startupPath, err := AgentStartupLogPath("myrepo@feat")
+	if err != nil {
+		t.Fatalf("AgentStartupLogPath: %v", err)
+	}
+	runPath, err := AgentRunLogPath("myrepo@feat")
+	if err != nil {
+		t.Fatalf("AgentRunLogPath: %v", err)
+	}
+	if filepath.Dir(startupPath) != filepath.Dir(runPath) {
+		t.Errorf("startup log dir %q != agent-run dir %q — files should be co-located",
+			filepath.Dir(startupPath), filepath.Dir(runPath))
+	}
+}
+
+// TestAgentStartupLogExists_FalseWhenMissing verifies the existence helper
+// returns false for sessions that have never been spawned.
+func TestAgentStartupLogExists_FalseWhenMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	if AgentStartupLogExists("myrepo@never-spawned") {
+		t.Error("AgentStartupLogExists returned true for non-existent session")
+	}
+}
+
+// TestOpenStartupLog_CreatesFileAndDirectory verifies the happy path: the
+// directory is created if missing, the file is opened in append mode, and
+// .log() writes a timestamped line.
+func TestOpenStartupLog_CreatesFileAndDirectory(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const sess = "myrepo@open-startup"
+
+	logger := openStartupLog(sess)
+	if logger == nil {
+		t.Fatal("openStartupLog returned nil — expected a usable logger")
+	}
+	logger.log("hello %s", "world")
+	logger.close()
+
+	// The existence helper must now report true.
+	if !AgentStartupLogExists(sess) {
+		t.Error("AgentStartupLogExists returned false after openStartupLog + .log + .close")
+	}
+
+	// Read the file and verify the line was written.
+	path, _ := AgentStartupLogPath(sess)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "hello world") {
+		t.Errorf("startup log missing 'hello world': %q", string(data))
+	}
+	if !strings.Contains(string(data), "[startup]") {
+		t.Errorf("startup log missing '[startup]' prefix: %q", string(data))
+	}
+}
+
+// TestOpenStartupLog_NilReceiverIsNoop verifies that .log() and .close() on
+// a nil *startupLogger do not panic. This matters for the SpawnSession path:
+// when the log cannot be opened (unwritable XDG_STATE_HOME), openStartupLog
+// returns nil and SpawnSession must continue to work without checking.
+func TestStartupLogger_NilReceiverIsNoop(t *testing.T) {
+	var l *startupLogger
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("nil receiver method panicked: %v", r)
+		}
+	}()
+	l.log("anything")
+	l.close()
+}
+
+// TestOpenStartupLog_AppendsAcrossOpens verifies that re-opening the same
+// session's startup log preserves earlier content (O_APPEND). This matters
+// for the rare case where SpawnSession is re-invoked with the same session
+// name (e.g. ForceFresh path) — earlier breadcrumbs remain.
+func TestOpenStartupLog_AppendsAcrossOpens(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const sess = "myrepo@append"
+
+	l1 := openStartupLog(sess)
+	if l1 == nil {
+		t.Fatal("openStartupLog (1) returned nil")
+	}
+	l1.log("first")
+	l1.close()
+
+	l2 := openStartupLog(sess)
+	if l2 == nil {
+		t.Fatal("openStartupLog (2) returned nil")
+	}
+	l2.log("second")
+	l2.close()
+
+	path, _ := AgentStartupLogPath(sess)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "first") || !strings.Contains(string(data), "second") {
+		t.Errorf("expected both 'first' and 'second' in log; got %q", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

Reports of stuck review fan-outs and stuck single-worker spawns traced to the same root cause: `session.SpawnSession` returned success on tmux session creation, but opencode itself runs inside the bwrap pane the tmux session launches and may take seconds to bind its TCP port — or never bind at all. The optimistic `Review-X started` line hid silent failures for up to 20 minutes (the review monitor's per-agent timeout).

This PR adds three pieces of observability and partial-failure handling **without trying to fix any underlying race or container-level cause** (per the issue's explicit scoping).

### Piece A — Readiness gate (AC-1, AC-2, AC-9, AC-14)

- `session.WaitForReady` polls the prism DB for either a `state_change` event (the sidecar wrote one when the first SSE event from opencode arrived) or a non-NULL `harness_session_id`. Default 30 s window.
- `session.SpawnSession` runs the gate inline when `SpawnOpts.ReadinessTimeout > 0`; on timeout it cleans up the half-alive session and returns `*session.ReadinessTimeoutError`.
- `cmd/spawn.go` sets `ReadinessTimeout=DefaultReadinessTimeout` for single-worker spawns (AC-14 — the widening comment scope).
- The review fan-out leaves `ReadinessTimeout=0` and runs `WaitForReady` per-agent in goroutines (`gateReviewAgents`) so one slow agent does not delay the others. Per-agent gates emit `Review-X started` on success or `Review-X failed to start: not ready within 30s` on timeout via `OnProgress`.

### Piece B — Per-agent startup log (AC-3, AC-4)

- `session.AgentStartupLogPath` (`$XDG_STATE_HOME/prism/run/<session>/agent-startup.log`) is opened by `SpawnSession` before the seed-status call, so the per-session run dir always exists from the moment a spawn begins — even when `prism agent-run` never reaches its own log-open call (the failure mode #1051 reports).
- `SpawnSession` writes timestamped breadcrumbs to the file: spawn begin, agent_status seeded, port allocated, tmux+sidecar kicked off, readiness-gate outcome.
- `prism logs --startup` reads the file. `prism logs` (default sidecar log) hints at it both on file-missing and on sidecar logs that contain only SSE-retry noise (the #1051 signature).

### Piece C — Ack contract (AC-5)

- `buildAsyncAck` now emits `Spawned: 3, Failed: 2 (review-goal: not ready within 30s, review-qa: not ready within 30s)` as the headline scan target, plus a per-failure block pointing at `prism logs --startup` / `--agent-run` for forensic follow-up.

### AC-6 (monitor doesn't wait for failed agents)

- `cleanupAgentSession` (review) and `cleanupHalfAliveSession` (session) now transition `agent_status.state` to `error` for half-alive rows so `db.GroupCompleted` treats them as terminal. Without this the monitor would block on the `idle` state forever.

### Tests

- `internal/session/readiness_test.go` — `WaitForReady` happy paths (state_change, harness_session_id), timeout path, error type, argument validation, zero-timeout-defaults.
- `internal/session/spawn_readiness_test.go` — `SpawnSession` integration (gate fires with `ReadinessTimeout > 0`, gate skipped when zero, startup log content on success and timeout).
- `internal/session/startup_log_test.go` — path resolution, existence helper, nil-receiver tolerance, append-across-opens.
- `internal/review/readiness_test.go` — **AC-7** (5-agent fan-out, 2 fail), **AC-8** (failure surfaced within timeout window — not 20 minutes), **AC-9** (no regressions on healthy 5-agent path), pre-failed-agents skipped.
- `internal/review/ack_test.go` — **AC-5** headline format, all-passed, partial-success, all-failed, ordering.
- `internal/review/monitor_failed_ready_test.go` — **AC-6** — failed-ready agent cleaned up to `state=error`, `GroupCompleted` returns true once alive members reach terminal state.

### Documentation (AC-10)

- `internal/review/review.go` package-level comment now describes the readiness gate, per-agent startup log, and Ack contract.

### Quality gates

- `go build ./...` ✓
- `go test ./...` ✓ (all packages green; review tests run in ~4 s, session in ~2 s)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✓

### Original symptom

First observed during `prism review` on PRs #1047 and #1048 (per AC-13).

Closes #1051