### PR TITLE
prism: forward --isolation through host-API proxy

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -371,6 +371,197 @@ func TestProxySpawn_IgnoreConcurrencyCapForwarded(t *testing.T) {
 	}
 }
 
+// TestProxySpawn_IsolationForwarded verifies that --isolation <mode> is
+// forwarded over the host-API as the "isolation" JSON field, for each of the
+// four valid values. Regression test for issue #1059: previously the proxy
+// dropped --isolation entirely, so coordinators inside containers spawning
+// `--isolation host` (or any other value) silently fell back to the configured
+// default. The fix requires that the value reach the host-API request body
+// unchanged.
+func TestProxySpawn_IsolationForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch    string `json:"branch"`
+		Isolation string `json:"isolation"`
+	}
+
+	cases := []string{"podman", "bwrap", "sandbox-exec", "host"}
+	for _, mode := range cases {
+		t.Run(mode, func(t *testing.T) {
+			reqCh := make(chan spawnReq, 1)
+			srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/spawn" {
+					http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+					return
+				}
+				var req spawnReq
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				reqCh <- req
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"session_name":"nixos-config@iso-branch"}`))
+			})
+
+			t.Setenv("PRISM_HOST_API", srv.apiURL())
+			t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+			cmd := &cobra.Command{Use: "spawn"}
+			cmd.Flags().String("branch", "", "")
+			cmd.Flags().String("agent", "", "")
+			cmd.Flags().String("profile", "", "")
+			cmd.Flags().String("model", "", "")
+			cmd.Flags().String("variant", "", "")
+			cmd.Flags().Bool("host-mode", false, "")
+			cmd.Flags().String("isolation", "", "")
+			cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+			cmd.Flags().String("harness", "opencode", "")
+			addPromptFlags(cmd)
+			_ = cmd.Flags().Set("branch", "iso-branch")
+			_ = cmd.Flags().Set("isolation", mode)
+
+			if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+				t.Fatalf("proxySpawn: %v", err)
+			}
+
+			select {
+			case req := <-reqCh:
+				if req.Isolation != mode {
+					t.Errorf("isolation = %q, want %q (issue #1059: --isolation must be forwarded)", req.Isolation, mode)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for request")
+			}
+		})
+	}
+}
+
+// TestProxySpawn_IsolationOmittedWhenUnset verifies that when --isolation is
+// not passed on the command line, the JSON body does NOT include an
+// "isolation" key (so the host-side spawn falls back to its config.json
+// default rather than receiving an empty-string override). The contract is
+// that absence is meaningful — proxySpawn must distinguish "user did not pass
+// the flag" from "user passed --isolation= (empty string)".
+func TestProxySpawn_IsolationOmittedWhenUnset(t *testing.T) {
+	rawCh := make(chan map[string]any, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		rawCh <- raw
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@no-iso-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "no-iso-branch")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case raw := <-rawCh:
+		if _, present := raw["isolation"]; present {
+			t.Errorf("isolation key present in body when --isolation not passed; body = %v", raw)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// TestProxySpawn_IsolationUnknownValueRejectedClientSide verifies that
+// --isolation banana fails fast at the proxy boundary with the same error
+// shape as the direct (host-shell) path, rather than being silently forwarded
+// to the host-API server. The client-side validation prevents the bad value
+// from being sent at all.
+func TestProxySpawn_IsolationUnknownValueRejectedClientSide(t *testing.T) {
+	// Server should never be hit — the client must fail before sending.
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not receive a request; got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "bad-iso-branch")
+	_ = cmd.Flags().Set("isolation", "banana")
+
+	err := proxySpawn(srv.apiURL(), cmd)
+	if err == nil {
+		t.Fatal("expected error for --isolation banana, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown isolation mode") {
+		t.Errorf("error %q does not mention 'unknown isolation mode'", err.Error())
+	}
+	// Error message must list all valid values so the user sees the accepted set.
+	for _, m := range []string{"podman", "bwrap", "sandbox-exec", "host"} {
+		if !strings.Contains(err.Error(), m) {
+			t.Errorf("error %q does not mention valid mode %q", err.Error(), m)
+		}
+	}
+}
+
+// TestProxySpawn_IsolationAndHostModeRejected verifies that passing both
+// --isolation and --host-mode at the same time fails fast at the proxy
+// boundary with the same mutual-exclusion message as the direct path.
+func TestProxySpawn_IsolationAndHostModeRejected(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not receive a request when both flags are set; got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("host-mode", false, "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "both-flags-branch")
+	_ = cmd.Flags().Set("isolation", "host")
+	_ = cmd.Flags().Set("host-mode", "true")
+
+	err := proxySpawn(srv.apiURL(), cmd)
+	if err == nil {
+		t.Fatal("expected error when both --isolation and --host-mode are set, got nil")
+	}
+	if !strings.Contains(err.Error(), "--isolation and --host-mode") {
+		t.Errorf("error %q does not mention both flags", err.Error())
+	}
+}
+
 // ── cleanup proxy tests (AC-2, AC-11) ─────────────────────────────────────────
 
 // TestHeadlessCleanup_Proxy verifies AC-11 for cleanup: when PRISM_HOST_API is

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -44,6 +44,15 @@ import (
 // derives the repo from its own session name, so a client running inside a
 // container where PRISM_BARE_ROOT is a mount-path name (e.g. "/prism-git")
 // does not need to supply the correct repo name. See issue #616.
+//
+// The "isolation" field forwards the --isolation flag value when explicitly
+// set. Validation of unknown values happens client-side here so the error
+// surfaces immediately at the proxy boundary with the same error message
+// shape as the direct (host-shell) path; see issue #1059. Without this, a
+// coordinator running inside a container could silently drop --isolation host
+// (or any other valid value) because the proxy never read the flag — the
+// sidecar fell back to its default mode and the user only noticed by reading
+// the sidecar log line.
 func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	branchFlag, _ := cmd.Flags().GetString("branch")
 	agentFlag, _ := cmd.Flags().GetString("agent")
@@ -53,6 +62,39 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	hostModeFlag, _ := cmd.Flags().GetBool("host-mode")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 	ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
+	isolationFlag, _ := cmd.Flags().GetString("isolation")
+
+	// Detect explicit-set state for the mutually-exclusive isolation flags so
+	// the proxy mirrors the validation behaviour of the direct (host-shell)
+	// path in resolveIsolationMode.
+	isolationChanged := cmd.Flags().Changed("isolation")
+	hostModeChanged := cmd.Flags().Changed("host-mode")
+
+	// Reject simultaneous use of --isolation and --host-mode at the proxy
+	// boundary so the user gets the same error as the direct path. Without
+	// this, the host-API server would still see both fields populated and
+	// would have to re-run the same check.
+	if isolationChanged && hostModeChanged {
+		return fmt.Errorf("--isolation and --host-mode cannot be used together; --host-mode is a deprecated alias for --isolation host")
+	}
+
+	// Validate --isolation client-side so unknown values fail fast with the
+	// same error message as the direct path. The platform guards in
+	// resolveIsolationMode (bwrap on non-Linux, sandbox-exec on non-Darwin)
+	// are intentionally NOT applied here: the proxy is running inside a
+	// container, but the spawned session lands on the host, so the host's
+	// platform — not the proxy's — is what matters. The host-side prism spawn
+	// re-runs resolveIsolationMode and will reject an incompatible mode there.
+	if isolationChanged {
+		if !config.IsValidIsolationMode(isolationFlag) {
+			valid := make([]string, len(config.ValidIsolationModes))
+			for i, m := range config.ValidIsolationModes {
+				valid[i] = string(m)
+			}
+			return fmt.Errorf("unknown isolation mode %q; valid values: %s", isolationFlag, strings.Join(valid, ", "))
+		}
+	}
+
 	promptFlag, err := resolvePrompt(cmd)
 	if err != nil {
 		return err
@@ -60,7 +102,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	var resp struct {
 		SessionName string `json:"session_name"`
 	}
-	if err := proxyToHostAPI(apiURL, "/spawn", map[string]any{
+	body := map[string]any{
 		"branch":                 branchFlag,
 		"prompt":                 promptFlag,
 		"agent":                  agentFlag,
@@ -70,7 +112,15 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"host_mode":              hostModeFlag,
 		"harness":                harnessFlag,
 		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
-	}, &resp); err != nil {
+	}
+	// Only forward "isolation" when explicitly set. An empty value would tell
+	// the host-side spawn to fall back to config.json, which is correct only
+	// when the user really did not pass the flag — we must distinguish the
+	// "absent" and "empty" cases here.
+	if isolationChanged {
+		body["isolation"] = isolationFlag
+	}
+	if err := proxyToHostAPI(apiURL, "/spawn", body, &resp); err != nil {
 		return err
 	}
 	fmt.Printf("session %q created\n", resp.SessionName)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -42,6 +42,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
@@ -3087,6 +3088,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Model                string `json:"model"`
 			Variant              string `json:"variant"`
 			HostMode             bool   `json:"host_mode"`
+			Isolation            string `json:"isolation"`
 			Harness              string `json:"harness"`
 			IgnoreConcurrencyCap bool   `json:"ignore_concurrency_cap"`
 		}
@@ -3105,6 +3107,24 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Harness != "opencode" {
 			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown harness %q: only 'opencode' is supported in this version of prism", req.Harness))
+			return
+		}
+		// Reject conflicting isolation flags at the API boundary so the error
+		// surfaces from the proxy (the spawned subprocess would also reject it,
+		// but doing it here avoids the round-trip and keeps the error close to
+		// the source). Mirrors the resolveIsolationMode rule in cmd/spawn.go.
+		if req.Isolation != "" && req.HostMode {
+			writeError(w, http.StatusBadRequest, "--isolation and --host-mode cannot be used together; --host-mode is a deprecated alias for --isolation host")
+			return
+		}
+		// Validate isolation server-side as defence-in-depth (the client
+		// already validated, but a non-prism client could send anything).
+		if req.Isolation != "" && !config.IsValidIsolationMode(req.Isolation) {
+			valid := make([]string, len(config.ValidIsolationModes))
+			for i, m := range config.ValidIsolationModes {
+				valid[i] = string(m)
+			}
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown isolation mode %q; valid values: %s", req.Isolation, strings.Join(valid, ", ")))
 			return
 		}
 
@@ -3138,6 +3158,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.HostMode {
 			args = append(args, "--host-mode")
 		}
+		if req.Isolation != "" {
+			args = append(args, "--isolation", req.Isolation)
+		}
 		if req.IgnoreConcurrencyCap {
 			args = append(args, "--ignore-concurrency-cap")
 		}
@@ -3163,6 +3186,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.HostMode {
 			logArgs = append(logArgs, "--host-mode")
+		}
+		if req.Isolation != "" {
+			logArgs = append(logArgs, "--isolation", req.Isolation)
 		}
 		if req.IgnoreConcurrencyCap {
 			logArgs = append(logArgs, "--ignore-concurrency-cap")

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5672,6 +5672,200 @@ echo "session \"${last}@cap-branch\" created"
 	}
 }
 
+// TestHostAPI_Spawn_IsolationForwarded verifies that when a /spawn request
+// carries {"isolation":"<mode>"} for each of the four valid modes, the sidecar
+// includes "--isolation <mode>" in the args passed to the prism binary.
+// This is the regression test for issue #1059: previously the /spawn handler
+// did not read the isolation field at all, so a coordinator inside a container
+// running `prism spawn --isolation host` saw the value silently dropped and
+// the spawned session landed in the configured default mode (typically bwrap).
+func TestHostAPI_Spawn_IsolationForwarded(t *testing.T) {
+	for _, mode := range []string{"podman", "bwrap", "sandbox-exec", "host"} {
+		t.Run(mode, func(t *testing.T) {
+			d := openTestDB(t)
+
+			argsFile := filepath.Join(t.TempDir(), "captured-args")
+			stubPath := filepath.Join(t.TempDir(), "prism-stub")
+			stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@iso-branch\" created"
+`
+			if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+				t.Fatalf("write stub: %v", err)
+			}
+			clk := newTestClock()
+			cfg := Config{
+				SessionName:     "nixos-config@main",
+				Repo:            "nixos-config",
+				Worktree:        "/tmp/nixos-config@main",
+				OpencodeURL:     "http://localhost:14000",
+				DB:              d,
+				Clock:           clk,
+				AgentRole:       "coordinator",
+				PrismBinaryPath: stubPath,
+				Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+			}
+			sc := New(cfg)
+
+			body := `{"branch":"iso-branch","isolation":"` + mode + `"}`
+			rr := doHostAPI(t, sc, http.MethodPost, "/spawn", body)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+			}
+
+			capturedArgs, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("read captured args: %v", err)
+			}
+			want := "--isolation " + mode
+			if !strings.Contains(string(capturedArgs), want) {
+				t.Errorf("captured args %q do not contain %q; isolation:%q was not forwarded (regression for issue #1059)",
+					string(capturedArgs), want, mode)
+			}
+		})
+	}
+}
+
+// TestHostAPI_Spawn_IsolationOmittedWhenAbsent verifies that when the /spawn
+// request body does NOT include an isolation field, no --isolation flag is
+// appended to the spawned subprocess args. Absence must mean "fall back to
+// config.json default", not "force an empty-string value".
+func TestHostAPI_Spawn_IsolationOmittedWhenAbsent(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@no-iso-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"no-iso-branch"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if strings.Contains(string(capturedArgs), "--isolation") {
+		t.Errorf("captured args %q contain --isolation; absence in body must omit the flag, not pass empty",
+			string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Spawn_IsolationUnknownValueRejected verifies that an unknown
+// isolation mode is rejected at the API boundary with HTTP 400 and a clear
+// error listing the accepted values, rather than being silently forwarded to
+// a subprocess that would also reject it (the API rejection is faster and
+// keeps the error close to the source).
+func TestHostAPI_Spawn_IsolationUnknownValueRejected(t *testing.T) {
+	d := openTestDB(t)
+
+	// Stub should never be invoked — the API must reject before exec.
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "stub should not be invoked" >&2
+exit 99
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"bad-iso-branch","isolation":"banana"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	errMsg := errResp["error"]
+	if !strings.Contains(errMsg, "unknown isolation mode") {
+		t.Errorf("error %q does not mention 'unknown isolation mode'", errMsg)
+	}
+	for _, m := range []string{"podman", "bwrap", "sandbox-exec", "host"} {
+		if !strings.Contains(errMsg, m) {
+			t.Errorf("error %q does not list valid mode %q", errMsg, m)
+		}
+	}
+}
+
+// TestHostAPI_Spawn_IsolationAndHostModeRejected verifies that a /spawn
+// request that sets both isolation and host_mode is rejected at the API
+// boundary, mirroring the resolveIsolationMode mutual-exclusion rule.
+func TestHostAPI_Spawn_IsolationAndHostModeRejected(t *testing.T) {
+	d := openTestDB(t)
+
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "stub should not be invoked" >&2
+exit 99
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"both-branch","isolation":"host","host_mode":true}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	errMsg := errResp["error"]
+	if !strings.Contains(errMsg, "--isolation and --host-mode") {
+		t.Errorf("error %q does not mention both flags", errMsg)
+	}
+}
+
 // TestHostAPI_Spawn_SubprocessOutputIncludedInError verifies that when the
 // host-side prism spawn subprocess exits non-zero, the error response includes
 // the subprocess stdout/stderr output (not just "exit status 1").


### PR DESCRIPTION
Closes #1059.

## Root cause

`prism spawn --isolation host` was silently ignored when `prism spawn` ran
inside a coordinator container. Two coordinated holes leaked the value:

1. `cmd/spawn.go` — `proxySpawn` (lines 47–78 pre-fix) read `branch`,
   `agent`, `profile`, `model`, `variant`, `host-mode`, `harness`, and
   `ignore-concurrency-cap`, but **never** read `--isolation`. The value
   never made it into the JSON body sent to the host-API socket.
2. `internal/sidecar/sidecar.go` — the `/spawn` handler's request struct
   (around line 3081 pre-fix) had a `host_mode` field but no `isolation`
   field, and the args/logArgs construction (around line 3138 pre-fix) only
   appended `--host-mode` when `host_mode:true` was set; there was nothing
   to append `--isolation`.

The deprecated `--host-mode` flag worked because it had a corresponding
JSON field (`host_mode`) plumbed through both the proxy and the handler;
`--isolation` was the new flag added later without that plumbing.

The function `resolveIsolationMode` in `cmd/spawn.go` (lines 114–160) is
correct — it was simply never reached on the proxy path because the value
was dropped before the host-side `prism spawn` was even invoked. So the
coordinator's diagnostic option (a) was right: validation succeeds, the
function returns `IsolationHost` cleanly, but the value is dropped at the
proxy boundary on the way to the sidecar that the spawned session
ultimately reads from.

## Fix

- `proxySpawn` now reads `--isolation`, validates it client-side against
  `config.IsValidIsolationMode` (so `--isolation banana` fails fast at the
  proxy with the same error shape as the direct host-shell path), rejects
  the simultaneous-flag case, and forwards the value as the `isolation`
  JSON field. The field is omitted when the flag is not explicitly set, so
  config.json fall-through still works.
- The `/spawn` host-API handler now accepts an `isolation` field,
  validates it server-side as defence-in-depth (a non-prism client could
  send anything), rejects `isolation` + `host_mode` simultaneously, and
  appends `--isolation <mode>` to the args passed to the spawned `prism
  spawn` subprocess (and to `logArgs` for visibility).

## Tests

Covering the full path from CLI flag through to the spawned subprocess
args:

- `TestProxySpawn_IsolationForwarded` — parameterised over
  podman/bwrap/sandbox-exec/host; asserts the value reaches the host-API
  request body.
- `TestProxySpawn_IsolationOmittedWhenUnset` — absence in the CLI must
  omit the field, not send an empty-string override.
- `TestProxySpawn_IsolationUnknownValueRejectedClientSide` — `--isolation
  banana` fails fast with `unknown isolation mode` and the four valid
  values listed.
- `TestProxySpawn_IsolationAndHostModeRejected` — mutual-exclusion at the
  proxy boundary.
- `TestHostAPI_Spawn_IsolationForwarded` — mirror on the server side;
  asserts `--isolation <mode>` is appended to the spawned subprocess args
  for each of the four valid values.
- `TestHostAPI_Spawn_IsolationOmittedWhenAbsent`,
  `TestHostAPI_Spawn_IsolationUnknownValueRejected`,
  `TestHostAPI_Spawn_IsolationAndHostModeRejected` — defence-in-depth at
  the API boundary.

The existing `TestResolveIsolationMode_*` tests in `cmd/isolation_test.go`
already cover the direct (host-shell) path; together with the new tests
above the full matrix is now exercised end-to-end.

## Verification notes

- Linux: `go build ./...`, `go test ./...` from `modules/programs/prism/prism/`
  green.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`
  green.
- **Darwin verification still required at merge time**: the `sandbox-exec`
  cases in `TestProxySpawn_IsolationForwarded` and
  `TestHostAPI_Spawn_IsolationForwarded` exercise the JSON
  forwarding path on Linux (the body check is OS-agnostic), but a real
  macOS host is needed to confirm an end-to-end `prism spawn --isolation
  sandbox-exec` produces a session whose sidecar log reads
  `isolation=sandbox-exec`. AC #3 acknowledged this.

## Out of scope

Per the issue's Out-of-scope section: did not remove `--host-mode`, did
not change platform defaults, did not audit other commands for the same
shape (e.g. `prism pr`). If those have analogous holes they should be
filed separately.