### PR TITLE
fix(prism/session): use SessionDirName for AgentStartupLogPath (#1066)

### DIFF
--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -49,7 +49,7 @@
 //
 // Each spawned session has an agent-startup.log file in its run directory:
 //
-//	$XDG_STATE_HOME/prism/run/<session>/agent-startup.log
+//	$XDG_STATE_HOME/prism/run/<12-hex-of-sha256(session)>/agent-startup.log
 //
 // SpawnSession writes timestamped breadcrumbs to this file describing the
 // spawn-time sequence (DB seed, port allocation, tmux session creation,

--- a/modules/programs/prism/prism/internal/session/startup_log.go
+++ b/modules/programs/prism/prism/internal/session/startup_log.go
@@ -13,7 +13,13 @@ package session
 //
 // The file lives in the same directory as agent-run.log:
 //
-//	$XDG_STATE_HOME/prism/run/<session>/agent-startup.log
+//	$XDG_STATE_HOME/prism/run/<12-hex-of-sha256(session)>/agent-startup.log
+//
+// The per-session subdirectory uses the same SessionDirName-derived 12-hex
+// SHA-256 prefix as the host-API socket and agent-run.log so all three files
+// are co-located on disk and discoverable from a single `ls`. See
+// internal/session/sidecar.go:SessionDirName for the formula and #1050 for
+// the sun_path budget that motivated the hashing.
 //
 // Pre-creating the directory at SpawnSession time means the file path is
 // always valid even if `prism agent-run` never reaches its own log-open call
@@ -35,7 +41,7 @@ func AgentStartupLogPath(sessionName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "run", sessionName, "agent-startup.log"), nil
+	return filepath.Join(base, "run", SessionDirName(sessionName), "agent-startup.log"), nil
 }
 
 // startupLogger wraps an *os.File with the conventions used across the

--- a/modules/programs/prism/prism/internal/session/startup_log_test.go
+++ b/modules/programs/prism/prism/internal/session/startup_log_test.go
@@ -19,7 +19,10 @@ func TestAgentStartupLogPath_DefaultsToXDGState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AgentStartupLogPath: %v", err)
 	}
-	want := filepath.Join(tmp, "prism", "run", "myrepo@feat", "agent-startup.log")
+	// The per-session subdirectory uses the SessionDirName-derived 12-hex
+	// SHA-256 prefix so the startup log is co-located with hostapi.sock and
+	// agent-run.log (see #1066).
+	want := filepath.Join(tmp, "prism", "run", SessionDirName("myrepo@feat"), "agent-startup.log")
 	if got != want {
 		t.Errorf("AgentStartupLogPath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Fixes a merge-race between #1061 and #1062. PR #1061 introduced the
`SessionDirName(sessionName)` helper (12-hex SHA-256 prefix) and switched
`SidecarHostAPIPath` and `AgentRunLogPath` to use it. PR #1062, authored
in parallel, added `AgentStartupLogPath` using the legacy raw-`sessionName`
shape — so the startup log ended up in a different directory from the
host-API socket and agent-run log.

`TestAgentStartupLogPath_LivesNextToAgentRunLog` (added in #1062 to encode
the co-location intent) caught the divergence on `main` and broke the
Darwin `build-and-cache` workflow.

The fix is one line: `AgentStartupLogPath` now calls
`SessionDirName(sessionName)` for the per-session subdirectory, matching
its two siblings.

## Other resolvers using the legacy shape

Per the side-check in the issue: I grepped the prism Go source for any
other production resolver that builds `filepath.Join(base, "run", sessionName, ...)`.
**There are no other such resolvers.** The only matches in production code
are:

- `SidecarReadyPath` and `SidecarPIDPath` — these use `sessionName+"-sidecar.ready"`
  and `sessionName+"-sidecar.pid"` as flat filenames directly under `run/`,
  not as a per-session subdirectory. They are intentionally a different
  shape and the issue's "Out of scope" note covers them.
- `SidecarHostAPIPath` and `AgentRunLogPath` — already correct (using
  `SessionDirName` since #1061).

So `AgentStartupLogPath` was the sole offender.

## Tests

- `TestAgentStartupLogPath_LivesNextToAgentRunLog` — now passes (was the
  failing test on `main`). Test body unchanged, per the AC.
- `TestAgentStartupLogPath_DefaultsToXDGState` — had hard-coded the old
  `"prism", "run", "myrepo@feat", ...` shape. Updated to compute the
  expected path via `SessionDirName("myrepo@feat")` so it asserts the
  correct directory naming.
- All other startup-log tests (`TestOpenStartupLog_*`,
  `TestStartupLogger_NilReceiverIsNoop`, `TestSpawnSession_WritesStartupLog`)
  use `AgentStartupLogPath` directly rather than hard-coding the path, so
  they auto-update without changes.
- Full `go test ./...` from `modules/programs/prism/prism/` passes on
  Linux.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`
  succeeds. The Darwin equivalent will be confirmed by the post-merge
  `build-and-cache` workflow (the failing test is platform-agnostic Go
  code).

## Doc updates

- `internal/session/startup_log.go` package comment now reflects the
  hashed directory and points at `SessionDirName` and #1050.
- `internal/review/review.go` package comment updated similarly.

## Related

- #1061 — introduced `SessionDirName` and used it for `SidecarHostAPIPath`
  and `AgentRunLogPath`.
- #1062 — introduced `AgentStartupLogPath` using the legacy shape.

Closes #1066