### PR TITLE
fix(spawn): host-mode large-prompt failure; add launch-cmd size guards (#1064)

### DIFF
--- a/modules/programs/prism/prism/internal/session/initial_prompt.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt.go
@@ -1,0 +1,92 @@
+package session
+
+// Per-session initial-prompt file (#1064 Option A).
+//
+// In host-mode sessions, the initial prompt was historically interpolated
+// directly onto the opencode launch command (`opencode --prompt '<text>'`),
+// which was then handed to `tmux new-window ... sh -c <cmd>`. tmux's command
+// argument handling has practical size limits; prompts above ~12 KB were
+// observed to be silently truncated, leaving opencode unable to start and
+// the operator with no visible signal beyond a session that idles forever
+// (#1064 root cause).
+//
+// To remove the size coupling between the prompt and the tmux command line,
+// host-mode SpawnSession writes the prompt to a small file in the per-session
+// run directory and the constructed launch command reads it with $(cat …)
+// inside the pane shell. The launch command itself stays a few hundred bytes
+// regardless of prompt size, while the prompt content reaches opencode via
+// argv (which comfortably handles 100s of KB on both Linux and Darwin).
+//
+// The file lives next to agent-startup.log (#1051 / #1062) so the per-session
+// run directory has a single authoritative location:
+//
+//	$XDG_STATE_HOME/prism/run/<session>/initial-prompt.txt
+//
+// Cleanup is best-effort and lifecycle-tied:
+//   - Pre-spawn: any stale file from a previous incarnation is removed
+//     before the new file is written, so a recycled session name never
+//     re-uses a previous prompt.
+//   - On readiness-gate timeout: the file is removed alongside the rest of
+//     the half-alive session cleanup.
+//   - On normal shutdown / archive: the surrounding run/<session>/ directory
+//     is reaped by the existing per-session-dir cleanup paths; this file
+//     does not need a separate hook.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// InitialPromptPath returns the initial-prompt.txt file path for the named
+// session. It lives in the per-session run directory next to
+// agent-startup.log (see startup_log.go), keyed on the raw session name so
+// `ls $XDG_STATE_HOME/prism/run/<session>/` shows both files together.
+// (Note: the bwrap agent-run.log uses a hashed-prefix directory under run/
+// instead — see SessionDirName in sidecar.go — so it is NOT in the same
+// dir as this file. Aligning the two layouts is tracked separately.)
+func InitialPromptPath(sessionName string) (string, error) {
+	base, err := sidecarStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "run", sessionName, "initial-prompt.txt"), nil
+}
+
+// WriteInitialPrompt writes the prompt to the per-session initial-prompt.txt
+// file, creating the per-session run directory (mode 0o700) if it does not
+// already exist. Any existing file at the path is overwritten — a fresh spawn
+// must not inherit a stale prompt from a previous incarnation of the same
+// session name.
+//
+// Returns the path that was written so the caller can plumb it through into
+// the constructed launch command. On error the path may be partially written;
+// callers that surface this to the operator should treat the spawn as failed
+// (per #1064 AC-5 — the prompt-delivery path failing must not be swallowed).
+func WriteInitialPrompt(sessionName, prompt string) (string, error) {
+	path, err := InitialPromptPath(sessionName)
+	if err != nil {
+		return "", fmt.Errorf("resolve initial-prompt path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create per-session run dir %s: %w", filepath.Dir(path), err)
+	}
+	// 0o600 keeps the prompt contents readable only by the operator, since
+	// prompts can contain credentials, branch context, or secret URLs.
+	if err := os.WriteFile(path, []byte(prompt), 0o600); err != nil {
+		return "", fmt.Errorf("write initial-prompt file %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// removeInitialPrompt deletes the per-session initial-prompt.txt file.
+// Best-effort: a missing file or unreachable path is not an error. Used by
+// the readiness-gate cleanup path in SpawnSession so a half-alive session's
+// prompt does not linger across spawn retries.
+func removeInitialPrompt(sessionName string) {
+	path, err := InitialPromptPath(sessionName)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(path)
+}

--- a/modules/programs/prism/prism/internal/session/initial_prompt.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt.go
@@ -17,10 +17,16 @@ package session
 // regardless of prompt size, while the prompt content reaches opencode via
 // argv (which comfortably handles 100s of KB on both Linux and Darwin).
 //
-// The file lives next to agent-startup.log (#1051 / #1062) so the per-session
-// run directory has a single authoritative location:
+// The file lives next to agent-startup.log (#1051 / #1062), agent-run.log
+// (#1061), and hostapi.sock under a single SessionDirName-derived directory
+// so the per-session run directory has a single authoritative location:
 //
-//	$XDG_STATE_HOME/prism/run/<session>/initial-prompt.txt
+//	$XDG_STATE_HOME/prism/run/<sessionDirName>/initial-prompt.txt
+//
+// SessionDirName(sessionName) is the 12-hex SHA-256 prefix of the session
+// name (see sidecar.go) — the same scheme #1061 introduced to keep socket
+// paths under the sun_path limit. Using the raw session name here would
+// scatter the forensic trail across two sibling directories — see #1066.
 //
 // Cleanup is best-effort and lifecycle-tied:
 //   - Pre-spawn: any stale file from a previous incarnation is removed
@@ -28,9 +34,9 @@ package session
 //     re-uses a previous prompt.
 //   - On readiness-gate timeout: the file is removed alongside the rest of
 //     the half-alive session cleanup.
-//   - On normal shutdown / archive: the surrounding run/<session>/ directory
-//     is reaped by the existing per-session-dir cleanup paths; this file
-//     does not need a separate hook.
+//   - On normal shutdown / archive: the surrounding run/<sessionDirName>/
+//     directory is reaped by the existing per-session-dir cleanup paths;
+//     this file does not need a separate hook.
 
 import (
 	"fmt"
@@ -39,18 +45,18 @@ import (
 )
 
 // InitialPromptPath returns the initial-prompt.txt file path for the named
-// session. It lives in the per-session run directory next to
-// agent-startup.log (see startup_log.go), keyed on the raw session name so
-// `ls $XDG_STATE_HOME/prism/run/<session>/` shows both files together.
-// (Note: the bwrap agent-run.log uses a hashed-prefix directory under run/
-// instead — see SessionDirName in sidecar.go — so it is NOT in the same
-// dir as this file. Aligning the two layouts is tracked separately.)
+// session. It lives in the per-session run directory keyed on
+// SessionDirName(sessionName), so it is co-located with agent-startup.log
+// (see startup_log.go), agent-run.log, and hostapi.sock — a single
+// `ls $XDG_STATE_HOME/prism/run/<sessionDirName>/` shows the full forensic
+// trail. See #1066 for the alignment rationale and #1061 for the original
+// switch to SessionDirName.
 func InitialPromptPath(sessionName string) (string, error) {
 	base, err := sidecarStateDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "run", sessionName, "initial-prompt.txt"), nil
+	return filepath.Join(base, "run", SessionDirName(sessionName), "initial-prompt.txt"), nil
 }
 
 // WriteInitialPrompt writes the prompt to the per-session initial-prompt.txt

--- a/modules/programs/prism/prism/internal/session/initial_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt_test.go
@@ -30,10 +30,13 @@ import (
 
 // ── prompt-file helpers ─────────────────────────────────────────────────────
 
-// TestInitialPromptPath_LivesUnderRunDir verifies that the prompt-file path
-// lives next to agent-startup.log under the per-session run directory, so a
-// single `ls run/<session>/` shows both forensic artefacts together.
-func TestInitialPromptPath_LivesUnderRunDir(t *testing.T) {
+// TestInitialPromptPath_CoLocatedWithAgentLogs verifies that the prompt-file
+// path lives in the same per-session run directory as agent-startup.log,
+// agent-run.log, and hostapi.sock — see #1066 for the SessionDirName
+// alignment that this test pins. A single
+// `ls run/<sessionDirName>/` should show every forensic artefact for the
+// session.
+func TestInitialPromptPath_CoLocatedWithAgentLogs(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
@@ -42,7 +45,7 @@ func TestInitialPromptPath_LivesUnderRunDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitialPromptPath: %v", err)
 	}
-	want := filepath.Join(tmp, "prism", "run", sessionName, "initial-prompt.txt")
+	want := filepath.Join(tmp, "prism", "run", SessionDirName(sessionName), "initial-prompt.txt")
 	if got != want {
 		t.Errorf("InitialPromptPath = %q, want %q", got, want)
 	}
@@ -54,6 +57,15 @@ func TestInitialPromptPath_LivesUnderRunDir(t *testing.T) {
 	if filepath.Dir(got) != filepath.Dir(startup) {
 		t.Errorf("initial-prompt dir %q != agent-startup dir %q — files should be co-located",
 			filepath.Dir(got), filepath.Dir(startup))
+	}
+
+	runPath, err := AgentRunLogPath(sessionName)
+	if err != nil {
+		t.Fatalf("AgentRunLogPath: %v", err)
+	}
+	if filepath.Dir(got) != filepath.Dir(runPath) {
+		t.Errorf("initial-prompt dir %q != agent-run dir %q — files should be co-located",
+			filepath.Dir(got), filepath.Dir(runPath))
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/initial_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt_test.go
@@ -1,0 +1,415 @@
+package session
+
+// Tests for #1064 — host-mode prompt-file plumbing and launch-command size
+// guard. The headline failure mode: prism spawn --isolation host with a
+// prompt above ~12 KB silently failed because the entire prompt was
+// inlined onto the launch command, which then got truncated by tmux's
+// arg handling.
+//
+// The tests below cover three slices, deliberately small because the same
+// machinery (BuildOpencodeCmd, WriteInitialPrompt, the size guard) is
+// orthogonal to the rest of the spawn pipeline:
+//
+//   1. The constructed launch command stays small regardless of prompt
+//      size — the prompt body is reachable on disk, not on the command
+//      line. (AC-1, AC-3, AC-4, AC-10)
+//   2. The pre-spawn size check rejects pathological host-mode launch
+//      commands before any tmux state is created. (AC-6, AC-11)
+//   3. The readiness-timeout error gets enriched with a prompt-size hint
+//      when the launch command was unusual but not pathological. (AC-7)
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── prompt-file helpers ─────────────────────────────────────────────────────
+
+// TestInitialPromptPath_LivesUnderRunDir verifies that the prompt-file path
+// lives next to agent-startup.log under the per-session run directory, so a
+// single `ls run/<session>/` shows both forensic artefacts together.
+func TestInitialPromptPath_LivesUnderRunDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sessionName = "myrepo@feat"
+	got, err := InitialPromptPath(sessionName)
+	if err != nil {
+		t.Fatalf("InitialPromptPath: %v", err)
+	}
+	want := filepath.Join(tmp, "prism", "run", sessionName, "initial-prompt.txt")
+	if got != want {
+		t.Errorf("InitialPromptPath = %q, want %q", got, want)
+	}
+
+	startup, err := AgentStartupLogPath(sessionName)
+	if err != nil {
+		t.Fatalf("AgentStartupLogPath: %v", err)
+	}
+	if filepath.Dir(got) != filepath.Dir(startup) {
+		t.Errorf("initial-prompt dir %q != agent-startup dir %q — files should be co-located",
+			filepath.Dir(got), filepath.Dir(startup))
+	}
+}
+
+// TestWriteInitialPrompt_RoundtripBytes verifies that a 32 KB prompt with
+// every "interesting" byte class round-trips through the prompt file
+// byte-for-byte. This is the core AC-4 assertion: the file path is the
+// transport, so the content must arrive intact regardless of size.
+func TestWriteInitialPrompt_RoundtripBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	// Build a 32 KB prompt that contains the four byte classes the AC text
+	// names explicitly, plus newlines, plus a 32 KB body of repetitive ASCII
+	// to exercise the size aspect. Hash both sides for an O(1) comparison.
+	prompt := buildLargePrompt(32 * 1024)
+
+	const sessionName = "myrepo@big-prompt"
+	path, err := WriteInitialPrompt(sessionName, prompt)
+	if err != nil {
+		t.Fatalf("WriteInitialPrompt: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != prompt {
+		t.Errorf("prompt roundtrip mismatch: input sha=%s len=%d, output sha=%s len=%d",
+			sha256hex(prompt), len(prompt),
+			sha256hex(string(got)), len(got),
+		)
+	}
+}
+
+// TestWriteInitialPrompt_128KB verifies the same roundtrip at 128 KB so the
+// fix is visibly an architectural removal of the limit, not a slightly
+// larger threshold (AC-3).
+func TestWriteInitialPrompt_128KB(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	prompt := buildLargePrompt(128 * 1024)
+	const sessionName = "myrepo@bigger-prompt"
+	path, err := WriteInitialPrompt(sessionName, prompt)
+	if err != nil {
+		t.Fatalf("WriteInitialPrompt: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(got) != len(prompt) {
+		t.Fatalf("prompt size mismatch: input=%d, output=%d", len(prompt), len(got))
+	}
+	if sha256hex(string(got)) != sha256hex(prompt) {
+		t.Errorf("128 KB prompt roundtrip hash mismatch")
+	}
+}
+
+// TestWriteInitialPrompt_OverwritesStaleFile verifies that a re-spawn of the
+// same session name produces a fresh file rather than leaving stale prompt
+// content from the previous incarnation.
+func TestWriteInitialPrompt_OverwritesStaleFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sessionName = "myrepo@reused-name"
+	if _, err := WriteInitialPrompt(sessionName, "first incarnation"); err != nil {
+		t.Fatalf("first WriteInitialPrompt: %v", err)
+	}
+	path, err := WriteInitialPrompt(sessionName, "second incarnation")
+	if err != nil {
+		t.Fatalf("second WriteInitialPrompt: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "second incarnation" {
+		t.Errorf("stale prompt survived overwrite: got %q, want %q", string(got), "second incarnation")
+	}
+}
+
+// ── BuildOpencodeCmd: host mode + prompt file ──────────────────────────────
+
+// TestBuildOpencodeCmd_HostMode_PromptFile verifies that BuildOpencodeCmd in
+// host mode with PromptFilePath set emits `--prompt "$(cat <quoted path>)"`
+// and does NOT inline the prompt body. This is the core change: the launch
+// command size becomes O(1) in prompt size. (AC-1, AC-10)
+func TestBuildOpencodeCmd_HostMode_PromptFile(t *testing.T) {
+	prompt := buildLargePrompt(32 * 1024)
+	opts := Opts{
+		IsolationMode:  "host",
+		Agent:          "worker",
+		Port:           14000,
+		SessionName:    "myrepo@feat",
+		Prompt:         prompt,
+		PromptFilePath: "/var/state/prism/run/myrepo@feat/initial-prompt.txt",
+	}
+	cmd := BuildOpencodeCmd(opts)
+
+	// The command must reference the file via $(cat …) — operators (and
+	// the size guard) rely on this contract so the launch command size
+	// stays O(1) in prompt size.
+	wantSubstr := `--prompt "$(cat '/var/state/prism/run/myrepo@feat/initial-prompt.txt')"`
+	if !strings.Contains(cmd, wantSubstr) {
+		t.Errorf("host-mode cmd does not contain %q\ngot: %q", wantSubstr, cmd)
+	}
+
+	// The prompt body itself must NOT appear on the command line — that's
+	// the whole point of the file-based plumbing.
+	if strings.Contains(cmd, prompt) {
+		t.Errorf("host-mode cmd contains the prompt body inline; expected to read it via $(cat …). cmd len=%d, prompt len=%d", len(cmd), len(prompt))
+	}
+
+	// The constructed command must be small even though the prompt is 32 KB.
+	// 1 KB is a generous upper bound that comfortably accommodates the
+	// opencode invocation, env-var prefixes, and the cat-substitution.
+	if len(cmd) > 1024 {
+		t.Errorf("host-mode cmd unexpectedly large (%d bytes) — expected O(1) in prompt size", len(cmd))
+	}
+}
+
+// TestBuildOpencodeCmd_HostMode_NoPromptFile verifies the legacy inline path
+// (PromptFilePath empty) still works for small prompts. This covers the
+// no-regression AC-2: small prompts that worked before the fix continue to
+// work without the file plumbing.
+func TestBuildOpencodeCmd_HostMode_NoPromptFile(t *testing.T) {
+	opts := Opts{
+		IsolationMode: "host",
+		Agent:         "worker",
+		Port:          14000,
+		SessionName:   "myrepo@feat",
+		Prompt:        "small prompt",
+	}
+	cmd := BuildOpencodeCmd(opts)
+
+	if strings.Contains(cmd, "$(cat") {
+		t.Errorf("host-mode cmd unexpectedly uses cat-substitution for inline prompt: %q", cmd)
+	}
+	if !strings.Contains(cmd, "'small prompt'") {
+		t.Errorf("host-mode cmd missing inline prompt: %q", cmd)
+	}
+}
+
+// TestBuildOpencodeCmd_HostMode_PromptFile_PathQuoted verifies that a path
+// containing single quotes is shell-quoted so the cat substitution does not
+// terminate early. This is a defence-in-depth check: per-session run dirs
+// derived from session names (e.g. "myrepo@branch") will not contain quotes
+// in normal use, but if a future caller ever passes a path with quotes the
+// surrounding $() must not get confused.
+func TestBuildOpencodeCmd_HostMode_PromptFile_PathQuoted(t *testing.T) {
+	opts := Opts{
+		IsolationMode:  "host",
+		Agent:          "worker",
+		Port:           14000,
+		SessionName:    "myrepo@feat",
+		Prompt:         "x",
+		PromptFilePath: `/tmp/weird's-path/initial-prompt.txt`,
+	}
+	cmd := BuildOpencodeCmd(opts)
+
+	// Single quote must be escaped with the standard '\'' sequence.
+	if !strings.Contains(cmd, `'/tmp/weird'\''s-path/initial-prompt.txt'`) {
+		t.Errorf("expected escaped single-quote in path within cmd, got: %q", cmd)
+	}
+}
+
+// TestBuildOpencodeCmd_HostMode_PromptFile_IgnoredWhenPromptEmpty verifies
+// that PromptFilePath has no effect when Prompt is empty — the cat call
+// only fires when there is actually a prompt to deliver.
+func TestBuildOpencodeCmd_HostMode_PromptFile_IgnoredWhenPromptEmpty(t *testing.T) {
+	opts := Opts{
+		IsolationMode:  "host",
+		Agent:          "worker",
+		Port:           14000,
+		SessionName:    "myrepo@feat",
+		PromptFilePath: "/tmp/initial-prompt.txt",
+	}
+	cmd := BuildOpencodeCmd(opts)
+	if strings.Contains(cmd, "$(cat") {
+		t.Errorf("expected no cat-substitution when Prompt is empty, got: %q", cmd)
+	}
+	if strings.Contains(cmd, "--prompt") {
+		t.Errorf("expected no --prompt flag when Prompt is empty, got: %q", cmd)
+	}
+}
+
+// ── pre-spawn size guard ────────────────────────────────────────────────────
+
+// TestSpawnSession_HostMode_RejectsOversizedLaunchCmd verifies AC-6 / AC-11:
+// a constructed host-mode launch command exceeding HostLaunchCmdSafeBound
+// produces a HostLaunchCmdTooLargeError before any tmux state is created.
+//
+// The test inflates AgentEnvVars with a single huge value to force the
+// constructed cmd above the safe bound — this is the only realistic post-fix
+// path that can still produce an oversized command (the prompt body is no
+// longer on the launch line). It mirrors the future-regression scenario the
+// guard was designed to catch.
+func TestSpawnSession_HostMode_RejectsOversizedLaunchCmd(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+	argsFile := spyTmuxBin(t)
+
+	const sessionName = "myrepo@oversize"
+	bigEnvValue := strings.Repeat("X", HostLaunchCmdSafeBound+1024)
+	opts := SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      tmp,
+		AgentRole:     "worker",
+		Prompt:        "tiny prompt",
+		Layout:        LayoutFull,
+		IsolationMode: "host",
+		AgentEnvVars: map[string]string{
+			"OVERSIZE_VAR": bigEnvValue,
+		},
+	}
+
+	err := SpawnSession(d, opts)
+	if err == nil {
+		t.Fatal("SpawnSession: got nil, want HostLaunchCmdTooLargeError")
+	}
+	if !IsHostLaunchCmdTooLarge(err) {
+		t.Fatalf("SpawnSession err type = %T (%v), want *HostLaunchCmdTooLargeError", err, err)
+	}
+
+	// Error must carry the exact bytes for operator pattern-matching.
+	var hltl *HostLaunchCmdTooLargeError
+	if !errors.As(err, &hltl) {
+		t.Fatalf("errors.As failed for %v", err)
+	}
+	if hltl.SessionName != sessionName {
+		t.Errorf("err.SessionName = %q, want %q", hltl.SessionName, sessionName)
+	}
+	if hltl.SafeBound != HostLaunchCmdSafeBound {
+		t.Errorf("err.SafeBound = %d, want %d", hltl.SafeBound, HostLaunchCmdSafeBound)
+	}
+	if hltl.CmdSize <= HostLaunchCmdSafeBound {
+		t.Errorf("err.CmdSize = %d, want > %d", hltl.CmdSize, HostLaunchCmdSafeBound)
+	}
+
+	// Error message must include the actual size, the safe bound, and a
+	// reference to the workaround. Worded loosely so a future copy edit
+	// does not cascade into a test failure, but the salient nouns must be
+	// present.
+	msg := err.Error()
+	for _, expected := range []string{
+		"host-mode launch command",
+		"safe bound",
+		"--prompt-file",
+		"#1064",
+	} {
+		if !strings.Contains(msg, expected) {
+			t.Errorf("err message missing %q: %s", expected, msg)
+		}
+	}
+
+	// CRITICAL: no tmux state should have been created. Spawn must reject
+	// the request before reaching tmux.NewSessionDetached or NewWindow.
+	args := readSpyArgs(argsFile)
+	for _, a := range args {
+		if a == "new-session" || a == "new-window" {
+			t.Errorf("oversized spawn unexpectedly called tmux %q (full args: %v)", a, args)
+		}
+	}
+}
+
+// TestSpawnSession_HostMode_AcceptsBoundedLaunchCmd verifies the no-regression
+// half of AC-6: a constructed launch command well within the safe bound is
+// not rejected. This is the path most spawns take — small prompts, small
+// env-var prefixes — and must continue to work.
+//
+// We don't actually run a full spawn (that requires a real sidecar/tmux);
+// instead we drive the size guard directly through BuildOpencodeCmd and
+// assert it would not trip. The DB-side path is covered by other spawn
+// tests; the size guard is the new behaviour.
+func TestSpawnSession_HostMode_AcceptsBoundedLaunchCmd(t *testing.T) {
+	opts := Opts{
+		IsolationMode: "host",
+		Agent:         "worker",
+		Port:          14000,
+		SessionName:   "myrepo@feat",
+		Prompt:        "small prompt",
+		// Realistic env-var prefixes — the same shape spawn produces today.
+		AgentEnvVars: map[string]string{
+			"AWS_CONFIG_FILE": "/Users/bensherman/.config/aws/readonly-config",
+			"GIT_EDITOR":      "true",
+		},
+	}
+	cmd := BuildOpencodeCmd(opts)
+	if len(cmd) > HostLaunchCmdSafeBound {
+		t.Errorf("realistic host-mode cmd (%d bytes) unexpectedly exceeds safe bound %d — guard would reject normal spawns. cmd=%q",
+			len(cmd), HostLaunchCmdSafeBound, cmd)
+	}
+}
+
+// ── readiness timeout enrichment ────────────────────────────────────────────
+
+// TestReadinessTimeoutError_WithHint verifies that the Hint field, when set,
+// surfaces in the error message after the standard "not ready within X"
+// prefix — exactly the form the operator sees for AC-7.
+func TestReadinessTimeoutError_WithHint(t *testing.T) {
+	rte := &ReadinessTimeoutError{
+		SessionName: "myrepo@big",
+		Timeout:     30_000_000_000, // 30s in nanoseconds
+		Hint:        "host-mode launch command was 8400 bytes, above the typical safe range of 1024 bytes; a prompt-size issue is a likely cause (see issue #1064)",
+	}
+	got := rte.Error()
+	if !strings.Contains(got, "not ready within 30s") {
+		t.Errorf("error missing standard prefix: %q", got)
+	}
+	if !strings.Contains(got, "#1064") {
+		t.Errorf("error missing issue reference: %q", got)
+	}
+	if !strings.Contains(got, "8400 bytes") {
+		t.Errorf("error missing actual cmd size: %q", got)
+	}
+}
+
+// TestReadinessTimeoutError_WithoutHint verifies that the Hint field is
+// optional — when empty, the error message stays exactly as it was before
+// #1064 (so non-host callers see no behavioural change).
+func TestReadinessTimeoutError_WithoutHint(t *testing.T) {
+	rte := &ReadinessTimeoutError{
+		SessionName: "myrepo@small",
+		Timeout:     30_000_000_000,
+	}
+	got := rte.Error()
+	want := "not ready within 30s"
+	if got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+// buildLargePrompt returns a prompt of approximately size bytes that
+// includes the byte classes named in #1064 AC-4 (single quotes, backticks,
+// dollar signs, double quotes, newlines) so a faithful roundtrip
+// demonstrably preserves all of them.
+func buildLargePrompt(size int) string {
+	header := "Mixed payload: ' \" ` $ \n with a newline, $(cmd), \"quoted\", `back`. "
+	body := strings.Repeat("a", size-len(header))
+	if body == "" {
+		return header[:size]
+	}
+	return header + body
+}
+
+// sha256hex returns the hex SHA-256 of s — used for size-agnostic
+// comparison in roundtrip assertions.
+func sha256hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+

--- a/modules/programs/prism/prism/internal/session/readiness.go
+++ b/modules/programs/prism/prism/internal/session/readiness.go
@@ -65,10 +65,22 @@ const readinessPollInterval = 250 * time.Millisecond
 type ReadinessTimeoutError struct {
 	SessionName string
 	Timeout     time.Duration
+	// Hint, when non-empty, is appended to the error message after the
+	// standard "not ready within <timeout>" prefix. SpawnSession sets this
+	// in #1064's enrichment path (host mode + unusually large launch
+	// command) so the operator sees the prompt-size suspicion alongside
+	// the bare timeout message instead of having to grep through logs to
+	// discover it. Other call sites leave Hint empty and the message stays
+	// unchanged.
+	Hint string
 }
 
 func (e *ReadinessTimeoutError) Error() string {
-	return fmt.Sprintf("not ready within %s", formatTimeout(e.Timeout))
+	base := fmt.Sprintf("not ready within %s", formatTimeout(e.Timeout))
+	if e.Hint == "" {
+		return base
+	}
+	return base + " — " + e.Hint
 }
 
 // IsReadinessTimeout reports whether err is (or wraps) a ReadinessTimeoutError.

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,7 +49,22 @@ func openDB() (*db.DB, error) {
 // Opts carries optional parameters for session creation.
 type Opts struct {
 	// Prompt is passed to opencode via --prompt at startup.
+	//
+	// In host mode, when PromptFilePath is also set, BuildOpencodeCmd
+	// emits `--prompt "$(cat <quoted PromptFilePath>)"` rather than
+	// inlining Prompt onto the launch command. Prompt is still required
+	// (non-empty) to enable the substitution; the field's value is not
+	// embedded in the command in that case. See #1064.
 	Prompt string
+	// PromptFilePath, when non-empty AND IsolationMode is "host" AND Prompt
+	// is non-empty, makes buildDirectOpencodeCmd emit
+	// `--prompt "$(cat <PromptFilePath>)"` so the prompt content does not
+	// travel through the tmux command line. The file at PromptFilePath must
+	// already contain the prompt bytes (caller-owned: see
+	// session.WriteInitialPrompt). Ignored for non-host isolation modes —
+	// those route the prompt through the host-API or sidecar instead.
+	// See #1064 for the failure mode this guards against.
+	PromptFilePath string
 	// Agent is the opencode agent name (e.g. "coordinator", "worker").
 	// When empty, DefaultAgent is called to derive a default from the directory.
 	Agent string
@@ -307,7 +323,21 @@ func buildDirectOpencodeCmd(opts Opts) string {
 		cmd += " -s " + opts.OpencodeSession
 	}
 	if opts.Prompt != "" {
-		cmd += " --prompt " + shellQuote(opts.Prompt)
+		// #1064: when PromptFilePath is supplied, route the prompt through
+		// $(cat …) so the prompt content is loaded inside the pane shell
+		// from disk rather than carried on the tmux command line. Keeps
+		// the launch command small (a few hundred bytes) regardless of
+		// prompt size; the prompt itself reaches opencode via argv after
+		// the shell substitutes the file contents in. The single double-
+		// quotes around the substitution preserve newlines and prevent
+		// word-splitting; the file path is single-quoted so any unusual
+		// characters in the per-session run dir cannot be interpreted as
+		// shell metacharacters.
+		if opts.PromptFilePath != "" {
+			cmd += ` --prompt "$(cat ` + shellQuote(opts.PromptFilePath) + `)"`
+		} else {
+			cmd += " --prompt " + shellQuote(opts.Prompt)
+		}
 	}
 	// Prepend config content env var before the opencode command when set.
 	// The env var name comes from the harness (e.g. "OPENCODE_CONFIG_CONTENT"
@@ -362,6 +392,61 @@ func buildDirectOpencodeCmd(opts Opts) string {
 // shellQuote wraps s in single quotes, escaping any single quotes within.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// Host-mode launch-command size thresholds (#1064).
+//
+// HostLaunchCmdSafeBound is the maximum constructed launch-command size
+// SpawnSession will hand to tmux without rejecting up-front. Above this,
+// SpawnSession exits non-zero with HostLaunchCmdTooLargeError before any
+// tmux state is created — the empirical failure threshold for tmux
+// arg-handling is somewhere above 12 KB and below ~64 KB depending on
+// build / terminal config, so 4 KB is a comfortable conservative ceiling
+// that still leaves headroom for realistic prompts after the Option-A
+// $(cat …) plumbing pulls the prompt body off the command line. With the
+// fix in place, the only way to exceed this is to inflate the command
+// itself (huge AgentEnvVars, exotic ConfigContent, etc.) — exactly the
+// future regression class this guard exists to surface loudly.
+const HostLaunchCmdSafeBound = 4 * 1024
+
+// HostLaunchCmdWarnThreshold is the launch-command size above which
+// SpawnSession enriches a readiness-gate timeout error with a hint that
+// prompt size may be the cause (see #1064 AC-7). Most healthy host-mode
+// launch commands are a few hundred bytes (env-var prefixes plus the
+// opencode invocation); 1 KB is "unusual but not necessarily broken" and
+// big enough to be worth mentioning when a timeout fires.
+const HostLaunchCmdWarnThreshold = 1024
+
+// HostLaunchCmdTooLargeError is returned by SpawnSession when the
+// constructed host-mode launch command exceeds HostLaunchCmdSafeBound. It
+// carries the actual size, the safe bound, and the session name so the
+// operator can pattern-match the message and mechanically extract the
+// numbers (#1064 AC-6). The error fires before any tmux state is created;
+// callers can treat the spawn as having had no observable side effects on
+// the tmux server.
+type HostLaunchCmdTooLargeError struct {
+	SessionName string
+	CmdSize     int
+	SafeBound   int
+}
+
+func (e *HostLaunchCmdTooLargeError) Error() string {
+	return fmt.Sprintf(
+		"host-mode launch command for session %q is %d bytes, above the safe bound of %d bytes — "+
+			"tmux cannot reliably deliver commands above this size and would fail silently. "+
+			"Workaround: spawn with a small placeholder prompt (e.g. --prompt 'wait') and send the "+
+			"real prompt via `prism prompt %s --prompt-file <path>` once the session is alive. "+
+			"See issue #1064.",
+		e.SessionName, e.CmdSize, e.SafeBound, e.SessionName,
+	)
+}
+
+// IsHostLaunchCmdTooLarge reports whether err is (or wraps) a
+// HostLaunchCmdTooLargeError. Used by callers that want to render a
+// targeted message for this specific failure mode.
+func IsHostLaunchCmdTooLarge(err error) bool {
+	var hltl *HostLaunchCmdTooLargeError
+	return errors.As(err, &hltl)
 }
 
 // startupGuardKillOld implements the session instance startup guard. It checks
@@ -480,9 +565,20 @@ func Create(name, directory string, opts Opts) error {
 // When opts.Prompt is non-empty, PRISM_INITIAL_PROMPT is included so that
 // "prism agent-run" can read it and populate container.Config.InitialPrompt,
 // activating bwrap's --prompt CLI-append path.
+//
+// Skipped entirely for host mode: the host-mode launch path reads the prompt
+// directly via $(cat …) (see buildDirectOpencodeCmd / #1064), and emitting a
+// large PRISM_INITIAL_PROMPT here would re-introduce the same tmux arg-size
+// limit the prompt-file plumbing was added to avoid. The variable is also
+// unused on the host path — only `prism agent-run` (bwrap entry point)
+// consumes it.
+//
 // Returns nil when no env vars are needed, producing no -e flags in tmux.
 func agentPaneEnvVars(opts Opts) map[string]string {
 	if opts.Prompt == "" {
+		return nil
+	}
+	if effectiveIsolationMode(opts) == "host" {
 		return nil
 	}
 	return map[string]string{

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -427,15 +427,19 @@ func TestIsolationMode_PodmanWrittenBeforeWindow(t *testing.T) {
 // ── agentPaneEnvVars (initial-prompt env var) ─────────────────────────────────
 
 // TestAgentPaneEnvVars_WithPrompt verifies that agentPaneEnvVars returns a map
-// containing PRISM_INITIAL_PROMPT when opts.Prompt is non-empty.
+// containing PRISM_INITIAL_PROMPT when opts.Prompt is non-empty AND the
+// isolation mode consumes the env var (bwrap / sandbox-exec). Host mode is
+// covered by TestAgentPaneEnvVars_HostMode_Skipped — the env var is omitted
+// there because the host launch path reads the prompt from a file directly
+// (#1064).
 func TestAgentPaneEnvVars_WithPrompt(t *testing.T) {
-	opts := Opts{Prompt: "hello"}
+	opts := Opts{Prompt: "hello", IsolationMode: "bwrap"}
 	got := agentPaneEnvVars(opts)
 	if got == nil {
-		t.Fatal("agentPaneEnvVars(Prompt=hello): got nil, want non-nil map")
+		t.Fatal("agentPaneEnvVars(bwrap, Prompt=hello): got nil, want non-nil map")
 	}
 	if v, ok := got["PRISM_INITIAL_PROMPT"]; !ok || v != "hello" {
-		t.Errorf("agentPaneEnvVars(Prompt=hello): PRISM_INITIAL_PROMPT = %q, want %q", v, "hello")
+		t.Errorf("agentPaneEnvVars(bwrap, Prompt=hello): PRISM_INITIAL_PROMPT = %q, want %q", v, "hello")
 	}
 }
 
@@ -450,16 +454,30 @@ func TestAgentPaneEnvVars_NoPrompt(t *testing.T) {
 }
 
 // TestAgentPaneEnvVars_SpecialChars verifies that a prompt containing newlines,
-// quotes, backticks, and equals signs is stored verbatim.
+// quotes, backticks, and equals signs is stored verbatim. Asserted on bwrap
+// mode (where PRISM_INITIAL_PROMPT is consumed by `prism agent-run`).
 func TestAgentPaneEnvVars_SpecialChars(t *testing.T) {
 	prompt := "line1\nline2 'single' \"double\" `backtick` KEY=value"
-	opts := Opts{Prompt: prompt}
+	opts := Opts{Prompt: prompt, IsolationMode: "bwrap"}
 	got := agentPaneEnvVars(opts)
 	if got == nil {
 		t.Fatal("agentPaneEnvVars: got nil, want non-nil map")
 	}
 	if v := got["PRISM_INITIAL_PROMPT"]; v != prompt {
 		t.Errorf("PRISM_INITIAL_PROMPT = %q, want %q", v, prompt)
+	}
+}
+
+// TestAgentPaneEnvVars_HostMode_Skipped verifies that agentPaneEnvVars returns
+// nil for host mode regardless of prompt content (#1064). The host launch
+// path uses $(cat <prompt-file>) for delivery, so emitting a large
+// PRISM_INITIAL_PROMPT here would re-introduce the same tmux arg-size limit
+// the file-based plumbing was added to avoid.
+func TestAgentPaneEnvVars_HostMode_Skipped(t *testing.T) {
+	opts := Opts{Prompt: "hello", IsolationMode: "host"}
+	got := agentPaneEnvVars(opts)
+	if got != nil {
+		t.Errorf("agentPaneEnvVars(host, Prompt=hello): got %v, want nil — host mode reads prompt from file, not env var", got)
 	}
 }
 
@@ -516,8 +534,10 @@ func containsSeq(haystack, needle []string) bool {
 }
 
 // TestSpawnSession_PromptEnvVar_WithPrompt verifies that when opts.Prompt is
-// set, the tmux new-window call for the agent pane contains
-// -e PRISM_INITIAL_PROMPT=<prompt>.
+// set in a sandboxed isolation mode (bwrap), the tmux new-window call for
+// the agent pane contains -e PRISM_INITIAL_PROMPT=<prompt> — the env var is
+// consumed by `prism agent-run` to populate the bwrap container's
+// initial-prompt path.
 // It calls tmux.NewWindow directly (the same call path used by setupFullLayout)
 // via the spy so no real tmux session is required.
 func TestSpawnSession_PromptEnvVar_WithPrompt(t *testing.T) {
@@ -525,7 +545,7 @@ func TestSpawnSession_PromptEnvVar_WithPrompt(t *testing.T) {
 
 	// Call tmux.NewWindow with the env var map that agentPaneEnvVars would
 	// return for a non-empty prompt. This mirrors setupFullLayout's call site.
-	opts := Opts{Prompt: "hello"}
+	opts := Opts{Prompt: "hello", IsolationMode: "bwrap"}
 	_ = tmux.NewWindow("test-session", 1, "agent", "/tmp", "echo hi", agentPaneEnvVars(opts))
 
 	args := readSpyArgs(argsFile)

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -60,6 +60,16 @@ type SpawnOpts struct {
 	// (container/bwrap mode).
 	Prompt string
 
+	// PromptFilePath is set internally by SpawnSession when it has written
+	// the prompt to the per-session run directory (host mode only — see
+	// #1064 / WriteInitialPrompt). Callers should leave this empty;
+	// SpawnSession populates it from opts.Prompt before spawnFullLayout
+	// runs so BuildOpencodeCmd emits `--prompt "$(cat <path>)"` rather
+	// than inlining the prompt body. Carried on SpawnOpts (rather than as
+	// a function-local variable) so spawnFullLayout — which receives a
+	// copy — sees the same value the size guard validated against.
+	PromptFilePath string
+
 	// ConfigContent is the JSON blob injected as OPENCODE_CONFIG_CONTENT.
 	// Generated upstream from --profile/--model/--variant or from per-role
 	// container profiles. Empty string means no override.
@@ -194,6 +204,65 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	startup.log("spawn-session: begin (role=%q, worktree=%q, layout=%d, isolation=%q, container_mode=%t)",
 		opts.AgentRole, opts.Worktree, opts.Layout, opts.IsolationMode, opts.ContainerMode)
 
+	// #1064: in host mode with a non-empty prompt, write the prompt to the
+	// per-session run directory and let buildDirectOpencodeCmd reference it
+	// via $(cat …) instead of inlining the prompt onto the launch command.
+	// Two-line touch on this loop because the path is also threaded into
+	// the size guard a few lines below — keep both updates next to each
+	// other so a future reader sees the chain.
+	//
+	// Scoped to LayoutFull because that is the only layout the spawn path
+	// uses today — review fan-outs (LayoutAgentOnly) typically run under
+	// bwrap and have not exhibited this failure mode. If review fan-outs
+	// later need the same treatment, extend the gate; do not silently
+	// widen it.
+	mode := resolveLayoutIsolationMode(opts)
+	var promptFilePath string
+	if opts.Layout == LayoutFull && mode == "host" && opts.Prompt != "" {
+		path, writeErr := WriteInitialPrompt(opts.SessionName, opts.Prompt)
+		if writeErr != nil {
+			// AC-5: prompt-delivery setup failures must surface to the
+			// operator instead of being swallowed. Bail out before any
+			// tmux state is created so a re-spawn after fixing the
+			// underlying issue (e.g. disk full) starts from a clean slate.
+			startup.log("spawn-session: write initial-prompt FAILED: %v", writeErr)
+			return fmt.Errorf("spawn session: write initial prompt: %w", writeErr)
+		}
+		promptFilePath = path
+		startup.log("spawn-session: wrote initial-prompt file (%d bytes) to %s", len(opts.Prompt), path)
+	}
+
+	// #1064 AC-6: pre-spawn size check. Build the launch command preview
+	// using the same Opts shape that spawnFullLayout will reuse below, and
+	// reject any host-mode session whose constructed command exceeds the
+	// safe bound. Doing this BEFORE any tmux state is created means a
+	// rejected spawn has no observable side effects on the tmux server.
+	// The check fires only for host mode — podman/bwrap launch commands
+	// are bounded by construction (they reference a session name, not the
+	// prompt body) and never approach the threshold.
+	hostLaunchCmdSize := 0
+	if opts.Layout == LayoutFull && mode == "host" {
+		previewOpts := buildOptsForLayout(opts, 0, promptFilePath)
+		hostLaunchCmd := BuildOpencodeCmd(previewOpts)
+		hostLaunchCmdSize = len(hostLaunchCmd)
+		if hostLaunchCmdSize > HostLaunchCmdSafeBound {
+			startup.log("spawn-session: host launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
+				hostLaunchCmdSize, HostLaunchCmdSafeBound)
+			// Best-effort: remove the prompt file we just wrote so a
+			// subsequent retry doesn't see a stale file under a recycled
+			// session name.
+			removeInitialPrompt(opts.SessionName)
+			return &HostLaunchCmdTooLargeError{
+				SessionName: opts.SessionName,
+				CmdSize:     hostLaunchCmdSize,
+				SafeBound:   HostLaunchCmdSafeBound,
+			}
+		}
+		startup.log("spawn-session: host launch command size %d (safe bound %d, warn threshold %d)",
+			hostLaunchCmdSize, HostLaunchCmdSafeBound, HostLaunchCmdWarnThreshold)
+	}
+	opts.PromptFilePath = promptFilePath
+
 	// Step 1: Seed agent_status with root_agent_name. Idempotent; later
 	// writes by the sidecar and by tmux-session-start COALESCE-preserve the
 	// value written here.
@@ -275,6 +344,20 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		startup.log("spawn-session: waiting for readiness (timeout=%s)", opts.ReadinessTimeout)
 		if readyErr := WaitForReady(d, opts.SessionName, opts.ReadinessTimeout); readyErr != nil {
 			startup.log("spawn-session: readiness gate FAILED: %v", readyErr)
+			// #1064 AC-7: enrich the readiness-gate error when the host-mode
+			// launch command was unusually large. The bare timeout message
+			// ("not ready within 30s") leaves the operator without a hint
+			// for why opencode never came up; for the size-driven failure
+			// mode the cause is structural and predictable, so name it.
+			if mode == "host" && hostLaunchCmdSize > HostLaunchCmdWarnThreshold {
+				if rte, ok := readyErr.(*ReadinessTimeoutError); ok {
+					rte.Hint = fmt.Sprintf(
+						"host-mode launch command was %d bytes, above the typical safe range of %d bytes; "+
+							"a prompt-size issue is a likely cause (see issue #1064)",
+						hostLaunchCmdSize, HostLaunchCmdWarnThreshold,
+					)
+				}
+			}
 			// Clean up: the sidecar is still running and reporting
 			// `connection refused` to its own log, but opencode never came
 			// up. KillSidecar releases the sidecar process, the DB cleanup
@@ -283,11 +366,53 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			KillSidecar(opts.SessionName)
 			cleanupHalfAliveSession(d, opts.SessionName)
 			_ = tmux.KillSession(opts.SessionName)
+			// Drop the per-session prompt file so a retry starts fresh.
+			removeInitialPrompt(opts.SessionName)
 			return readyErr
 		}
 		startup.log("spawn-session: ready")
 	}
 	return nil
+}
+
+// resolveLayoutIsolationMode returns the resolved isolation mode for the
+// SpawnOpts, mirroring the lookup in BuildOpencodeCmd / spawnAgentOnlyLayout.
+// Kept as a small helper so SpawnSession can decide whether to write the
+// initial-prompt file (host only) and whether to apply the launch-command
+// size guard (host only) without duplicating the precedence logic.
+func resolveLayoutIsolationMode(opts SpawnOpts) string {
+	if opts.IsolationMode != "" {
+		return opts.IsolationMode
+	}
+	if opts.ContainerMode {
+		return "podman"
+	}
+	return "host"
+}
+
+// buildOptsForLayout returns the Opts struct that spawnFullLayout (and the
+// pre-spawn size guard in SpawnSession) hands to BuildOpencodeCmd. Centralised
+// here so the size-guard preview and the actual layout invocation cannot
+// drift — both share the same constructed command.
+func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
+	return Opts{
+		Prompt:           opts.Prompt,
+		PromptFilePath:   promptFilePath,
+		Agent:            opts.AgentRole,
+		ConfigContent:    opts.ConfigContent,
+		SessionName:      opts.SessionName,
+		Port:             port,
+		ContainerMode:    opts.ContainerMode,
+		IsolationMode:    opts.IsolationMode,
+		PluginHostPath:   opts.PluginHostPath,
+		InstanceID:       opts.InstanceID,
+		AgentEnvVars:     opts.AgentEnvVars,
+		ConfigEnvVarName: opts.ConfigEnvVarName,
+		RuntimeEnvVars:   opts.RuntimeEnvVars,
+		Layout:           LayoutFull,
+		ForceFresh:       opts.ForceFresh,
+		Headless:         opts.Headless,
+	}
 }
 
 // cleanupHalfAliveSession releases the DB resources for a session that was
@@ -319,24 +444,8 @@ func cleanupHalfAliveSession(d *db.DB, sessionName string) {
 // tmux-session-start hook (which idempotently re-seeds root_agent_name) and
 // starts the sidecar from inside setupFullLayout.
 func spawnFullLayout(d *db.DB, opts SpawnOpts, port int) error {
-	createOpts := Opts{
-		Prompt:           opts.Prompt,
-		Agent:            opts.AgentRole,
-		ConfigContent:    opts.ConfigContent,
-		SessionName:      opts.SessionName,
-		Port:             port,
-		ContainerMode:    opts.ContainerMode,
-		IsolationMode:    opts.IsolationMode,
-		PluginHostPath:   opts.PluginHostPath,
-		InstanceID:       opts.InstanceID,
-		AgentEnvVars:     opts.AgentEnvVars,
-		ConfigEnvVarName: opts.ConfigEnvVarName,
-		RuntimeEnvVars:   opts.RuntimeEnvVars,
-		Layout:           LayoutFull,
-		ForceFresh:       opts.ForceFresh,
-		Headless:         opts.Headless,
-		DB:               d,
-	}
+	createOpts := buildOptsForLayout(opts, port, opts.PromptFilePath)
+	createOpts.DB = d
 	return Create(opts.SessionName, opts.Worktree, createOpts)
 }
 

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -23,6 +23,7 @@ package session
 //     review.go once this primitive lands.
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -350,7 +351,11 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			// for why opencode never came up; for the size-driven failure
 			// mode the cause is structural and predictable, so name it.
 			if mode == "host" && hostLaunchCmdSize > HostLaunchCmdWarnThreshold {
-				if rte, ok := readyErr.(*ReadinessTimeoutError); ok {
+				// errors.As (rather than a bare type assertion) so a future
+				// refactor that wraps the readiness error keeps enrichment
+				// firing — same shape IsReadinessTimeout uses.
+				var rte *ReadinessTimeoutError
+				if errors.As(readyErr, &rte) {
 					rte.Hint = fmt.Sprintf(
 						"host-mode launch command was %d bytes, above the typical safe range of %d bytes; "+
 							"a prompt-size issue is a likely cause (see issue #1064)",
@@ -394,6 +399,12 @@ func resolveLayoutIsolationMode(opts SpawnOpts) string {
 // pre-spawn size guard in SpawnSession) hands to BuildOpencodeCmd. Centralised
 // here so the size-guard preview and the actual layout invocation cannot
 // drift — both share the same constructed command.
+//
+// The size guard calls this with port=0 (the port is allocated only after
+// the guard runs), while the real launch path passes the allocated port.
+// The few-byte difference (--port <N> --hostname 127.0.0.1 contributes <30
+// bytes) is well within the 4 KB safe bound and 1 KB warn threshold, so
+// the guard's verdict cannot flip between preview and launch in practice.
 func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 	return Opts{
 		Prompt:           opts.Prompt,

--- a/modules/programs/prism/prism/internal/session/startup_log.go
+++ b/modules/programs/prism/prism/internal/session/startup_log.go
@@ -35,7 +35,14 @@ import (
 
 // AgentStartupLogPath returns the agent-startup.log file path for the named
 // session. It lives next to AgentRunLogPath so the two are co-located on disk
-// and discoverable from a single `ls $XDG_STATE_HOME/prism/run/<session>/`.
+// and discoverable from a single `ls $XDG_STATE_HOME/prism/run/<dir>/`.
+//
+// The directory name is the SessionDirName-derived 12-hex prefix used by
+// SidecarHostAPIPath and AgentRunLogPath (see sidecar.go), so the path stays
+// under the sun_path limits and the agent-startup.log lives in the same
+// directory as agent-run.log and hostapi.sock. Using the raw session name
+// here would put the file in a sibling directory and break the
+// "single ls discovers the forensic trail" property — see #1066.
 func AgentStartupLogPath(sessionName string) (string, error) {
 	base, err := sidecarStateDir()
 	if err != nil {

--- a/modules/programs/prism/prism/internal/session/startup_log_test.go
+++ b/modules/programs/prism/prism/internal/session/startup_log_test.go
@@ -28,12 +28,18 @@ func TestAgentStartupLogPath_DefaultsToXDGState(t *testing.T) {
 	}
 }
 
-// TestAgentStartupLogPath_LivesNextToAgentRunLog verifies that the startup
-// log and agent-run log share the same parent directory. This co-location
-// matters for forensic discovery: an operator who finds one file should see
-// the other in the same `ls`.
-func TestAgentStartupLogPath_LivesNextToAgentRunLog(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+// TestAgentStartupLogPath_LivesUnderRunDir verifies that the startup log
+// and the agent-run log both live somewhere under $XDG_STATE_HOME/prism/run/.
+// They are not in the same leaf directory — agent-startup.log uses the raw
+// session name (so a `prism logs <name> --startup` lookup is direct), while
+// agent-run.log uses a SessionDirName-hashed prefix so the per-session
+// directory stays under sun_path limits for the host-API socket (#1050).
+// Aligning the two layouts is tracked separately; this test pins the
+// current-and-intended shape so a future refactor must update both call
+// sites coherently.
+func TestAgentStartupLogPath_LivesUnderRunDir(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", xdg)
 	startupPath, err := AgentStartupLogPath("myrepo@feat")
 	if err != nil {
 		t.Fatalf("AgentStartupLogPath: %v", err)
@@ -42,9 +48,12 @@ func TestAgentStartupLogPath_LivesNextToAgentRunLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AgentRunLogPath: %v", err)
 	}
-	if filepath.Dir(startupPath) != filepath.Dir(runPath) {
-		t.Errorf("startup log dir %q != agent-run dir %q — files should be co-located",
-			filepath.Dir(startupPath), filepath.Dir(runPath))
+	wantPrefix := filepath.Join(xdg, "prism", "run") + string(filepath.Separator)
+	if !strings.HasPrefix(startupPath, wantPrefix) {
+		t.Errorf("AgentStartupLogPath = %q, want prefix %q", startupPath, wantPrefix)
+	}
+	if !strings.HasPrefix(runPath, wantPrefix) {
+		t.Errorf("AgentRunLogPath = %q, want prefix %q", runPath, wantPrefix)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/startup_log_test.go
+++ b/modules/programs/prism/prism/internal/session/startup_log_test.go
@@ -15,31 +15,27 @@ func TestAgentStartupLogPath_DefaultsToXDGState(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
-	got, err := AgentStartupLogPath("myrepo@feat")
+	const sessionName = "myrepo@feat"
+	got, err := AgentStartupLogPath(sessionName)
 	if err != nil {
 		t.Fatalf("AgentStartupLogPath: %v", err)
 	}
 	// The per-session subdirectory uses the SessionDirName-derived 12-hex
 	// SHA-256 prefix so the startup log is co-located with hostapi.sock and
 	// agent-run.log (see #1066).
-	want := filepath.Join(tmp, "prism", "run", SessionDirName("myrepo@feat"), "agent-startup.log")
+	want := filepath.Join(tmp, "prism", "run", SessionDirName(sessionName), "agent-startup.log")
 	if got != want {
 		t.Errorf("AgentStartupLogPath = %q, want %q", got, want)
 	}
 }
 
-// TestAgentStartupLogPath_LivesUnderRunDir verifies that the startup log
-// and the agent-run log both live somewhere under $XDG_STATE_HOME/prism/run/.
-// They are not in the same leaf directory — agent-startup.log uses the raw
-// session name (so a `prism logs <name> --startup` lookup is direct), while
-// agent-run.log uses a SessionDirName-hashed prefix so the per-session
-// directory stays under sun_path limits for the host-API socket (#1050).
-// Aligning the two layouts is tracked separately; this test pins the
-// current-and-intended shape so a future refactor must update both call
-// sites coherently.
-func TestAgentStartupLogPath_LivesUnderRunDir(t *testing.T) {
-	xdg := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", xdg)
+// TestAgentStartupLogPath_LivesNextToAgentRunLog verifies that the startup
+// log and agent-run log share the same parent directory. This co-location
+// matters for forensic discovery: an operator who finds one file should see
+// the other in the same `ls`. See #1066 for the alignment fix that brought
+// AgentStartupLogPath onto SessionDirName.
+func TestAgentStartupLogPath_LivesNextToAgentRunLog(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	startupPath, err := AgentStartupLogPath("myrepo@feat")
 	if err != nil {
 		t.Fatalf("AgentStartupLogPath: %v", err)
@@ -48,12 +44,9 @@ func TestAgentStartupLogPath_LivesUnderRunDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AgentRunLogPath: %v", err)
 	}
-	wantPrefix := filepath.Join(xdg, "prism", "run") + string(filepath.Separator)
-	if !strings.HasPrefix(startupPath, wantPrefix) {
-		t.Errorf("AgentStartupLogPath = %q, want prefix %q", startupPath, wantPrefix)
-	}
-	if !strings.HasPrefix(runPath, wantPrefix) {
-		t.Errorf("AgentRunLogPath = %q, want prefix %q", runPath, wantPrefix)
+	if filepath.Dir(startupPath) != filepath.Dir(runPath) {
+		t.Errorf("startup log dir %q != agent-run dir %q — files should be co-located",
+			filepath.Dir(startupPath), filepath.Dir(runPath))
 	}
 }
 


### PR DESCRIPTION
## Summary

`prism spawn --isolation host` (and `--host-mode`) silently failed with prompts above ~12 KB: the launch command inlined the entire prompt body, tmux's arg handling silently truncated it, opencode never bound its port, and the sidecar retried SSE forever with no log surfacing the cause.

This PR removes the prompt body from the host-mode launch command (Option A from the issue), adds a pre-spawn size guard for any future pathological launch command, and enriches the readiness-gate error from #1062 so the operator sees the structural cause in the timeout message.

## What changed

- **Host-mode prompt-file plumbing** (`internal/session/initial_prompt.go`): SpawnSession writes the prompt to `~/.local/state/prism/run/<sessionDirName>/initial-prompt.txt`. `buildDirectOpencodeCmd`, when given `Opts.PromptFilePath`, emits `--prompt "$(cat <quoted-path>)"` instead of inlining the prompt body. The launch command stays a few hundred bytes regardless of prompt size; the prompt reaches opencode via argv after the pane shell substitutes the file contents in.
- **`agentPaneEnvVars` skips PRISM_INITIAL_PROMPT for host mode**: it was unused on the host path (only `prism agent-run` consumes it) and would re-introduce the same tmux-arg size limit via `tmux new-window -e`.
- **Pre-spawn size guard** (AC-6): `HostLaunchCmdSafeBound = 4 KB`. SpawnSession returns `*HostLaunchCmdTooLargeError` before any tmux state is created when the constructed command exceeds the bound. Error names the actual size, the safe bound, and a workaround.
- **Readiness-timeout enrichment** (AC-7): `HostLaunchCmdWarnThreshold = 1 KB`. When the #1062 readiness gate fires for a host-mode session whose launch command was above the warn threshold, the error carries a `Hint` naming prompt size as a likely cause and referencing #1064.
- **Closes #1066 — aligns `AgentStartupLogPath` and the new `InitialPromptPath` with `SessionDirName`** so all three per-session artefacts (agent-startup.log, agent-run.log, initial-prompt.txt, hostapi.sock) live in the same directory and a single `ls run/<sessionDirName>/` shows the full forensic trail. The original co-located assertion in `TestAgentStartupLogPath_LivesNextToAgentRunLog` is now correct.

## Acceptance criteria coverage

- AC-1 (32 KB prompt launches successfully via prompt file): exercised by `TestBuildOpencodeCmd_HostMode_PromptFile` (cmd stays small) and `TestWriteInitialPrompt_RoundtripBytes` (file roundtrip preserves all bytes). End-to-end (real opencode) is not testable in unit-test scope; the stub-style approach described in the spawn prompt is what these tests use.
- AC-2 (small-prompt no-regression): `TestBuildOpencodeCmd_HostMode_NoPromptFile`.
- AC-3 (128 KB roundtrip): `TestWriteInitialPrompt_128KB`.
- AC-4 (exotic byte classes survive): `buildLargePrompt` includes single quotes, double quotes, backticks, dollar signs, newlines, and `$(cmd)`; the roundtrip test SHA-checks the file content.
- AC-5 (prompt-delivery failure surfaces): `WriteInitialPrompt` errors are propagated by SpawnSession as `spawn session: write initial prompt: ...`.
- AC-6 (pre-spawn rejection above safe bound): `TestSpawnSession_HostMode_RejectsOversizedLaunchCmd` asserts the error type, message contents, and that no tmux state is created.
- AC-7 (timeout enrichment above warn threshold): `TestReadinessTimeoutError_WithHint` covers the message shape; the wiring in `SpawnSession` sets the hint when both conditions hold.
- AC-8 (Linux + Darwin symmetry): no platform-specific paths; `$(cat ...)` is POSIX shell.
- AC-9 (existing host-mode tests still pass): `TestBuildOpencodeCmd_HostMode` still passes; `TestAgentPaneEnvVars_*` tests updated to clarify which isolation modes they cover (bwrap mode for the env-var case, new `TestAgentPaneEnvVars_HostMode_Skipped` for host).
- AC-10 (≥32 KB delivered intact): `TestBuildOpencodeCmd_HostMode_PromptFile` + `TestWriteInitialPrompt_RoundtripBytes`.
- AC-11 (pre-spawn check produces stable error/exit code): `TestSpawnSession_HostMode_RejectsOversizedLaunchCmd` asserts the error type and message shape.
- AC-12 (`go build ./... && go test ./...`): pass.
- AC-13 (`nix build`): pass.

## Related

- Closes #1064.
- Closes #1066 (`AgentStartupLogPath` aligned with `SessionDirName`).
- Builds on #1062 (readiness gate that catches the failure within 30s) — the timeout enrichment in this PR extends #1062's `ReadinessTimeoutError` rather than replacing it.
- Builds on #1063 (`--isolation host` plumbing); both `--host-mode` and `--isolation host` exercise the same code path after this PR.
- `internal/session/session.go:BuildOpencodeCmd` + `shellQuote` are the dispatch and quoting functions referenced in the issue body.