### PR TITLE
prism review: deliver role prompts via file (fixes #1092)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -470,15 +470,24 @@ func minimalBwrapExecEnv(hostEnv []string) []string {
 //     was set up before #1092 (and for direct callers of agent-run that
 //     have not migrated yet).
 //
-// If both are set, the file path wins — a stale inline value from a
-// re-attached pane should not override the fresh path.
+// Precedence — `PRISM_INITIAL_PROMPT_FILE` wins outright when set:
 //
-// File-read failures are NOT fatal: agent-run logs to stderr and proceeds
-// with an empty prompt rather than refusing to start the agent. The pane
-// is already alive; failing here would leave the operator with a dead
-// review window and no way to recover. The empty-prompt outcome is no
-// worse than the pre-#1042 behaviour where review agents started without
-// a prompt at all.
+//   - If both env vars are set, the file path is used and the inline
+//     value is ignored. A stale inline value from a re-attached pane
+//     must not override the fresh path the spawner just wrote.
+//
+//   - If `PRISM_INITIAL_PROMPT_FILE` is set but the file read fails, the
+//     inline value is NOT consulted as a fallback. The contract is "FILE
+//     takes precedence absolutely" — silently substituting an inline
+//     value would mask a real failure (e.g. the spawner wrote the file
+//     but it was deleted, or perms were tampered with). agent-run logs
+//     the read error to stderr and proceeds with no initial prompt.
+//
+// File-read failures are not fatal to agent-run itself. The pane is
+// already alive; failing here would leave the operator with a dead review
+// window and no way to recover. The empty-prompt outcome is no worse than
+// the pre-#1042 behaviour where review agents started without a prompt at
+// all.
 func applyInitialPromptEnvVar(cfg *container.Config) {
 	if path := os.Getenv("PRISM_INITIAL_PROMPT_FILE"); path != "" {
 		body, err := os.ReadFile(path)

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -455,12 +455,42 @@ func minimalBwrapExecEnv(hostEnv []string) []string {
 	return container.MinimalIsolatedExecEnv(hostEnv)
 }
 
-// applyInitialPromptEnvVar reads PRISM_INITIAL_PROMPT from the process
-// environment and, when non-empty, sets cfg.InitialPrompt. This feeds the
-// existing bwrap.go BuildArgs --prompt append at lines 466-468 without
-// requiring any new persistent state: the env var is set by tmux.NewWindow
-// via the -e flag and exists only for the lifetime of this pane.
+// applyInitialPromptEnvVar populates cfg.InitialPrompt from the agent pane's
+// environment. Two delivery shapes are supported:
+//
+//  1. PRISM_INITIAL_PROMPT_FILE (post-#1092): the env var holds a filesystem
+//     path. agent-run reads the file and uses its contents as the prompt.
+//     This is the shape SpawnSession uses for bwrap/sandbox-exec sessions
+//     so the prompt body never has to fit on tmux's `new-window -e` argv —
+//     the file lives in the per-session run directory next to
+//     agent-startup.log / agent-run.log / hostapi.sock.
+//
+//  2. PRISM_INITIAL_PROMPT (pre-#1092 fallback): the env var carries the
+//     prompt body inline. Honoured for back-compat with any pane env that
+//     was set up before #1092 (and for direct callers of agent-run that
+//     have not migrated yet).
+//
+// If both are set, the file path wins — a stale inline value from a
+// re-attached pane should not override the fresh path.
+//
+// File-read failures are NOT fatal: agent-run logs to stderr and proceeds
+// with an empty prompt rather than refusing to start the agent. The pane
+// is already alive; failing here would leave the operator with a dead
+// review window and no way to recover. The empty-prompt outcome is no
+// worse than the pre-#1042 behaviour where review agents started without
+// a prompt at all.
 func applyInitialPromptEnvVar(cfg *container.Config) {
+	if path := os.Getenv("PRISM_INITIAL_PROMPT_FILE"); path != "" {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"[agent-run] warning: read PRISM_INITIAL_PROMPT_FILE %q: %v — starting agent without an initial prompt\n",
+				path, err)
+			return
+		}
+		cfg.InitialPrompt = string(body)
+		return
+	}
 	if initialPrompt := os.Getenv("PRISM_INITIAL_PROMPT"); initialPrompt != "" {
 		cfg.InitialPrompt = initialPrompt
 	}

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -67,6 +67,74 @@ func TestApplyInitialPromptEnvVar_SpecialChars(t *testing.T) {
 	}
 }
 
+// TestApplyInitialPromptEnvVar_FilePath verifies the post-#1092 file-based
+// delivery path: when PRISM_INITIAL_PROMPT_FILE points to a readable file,
+// applyInitialPromptEnvVar reads the file and assigns its contents to
+// InitialPrompt. This is the regression test for the launch-command size
+// failure on review fan-outs — the role prompt is now delivered via a file
+// instead of inlined into the tmux pane env.
+func TestApplyInitialPromptEnvVar_FilePath(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "initial-prompt.txt")
+	// A 24 KB body to demonstrate that the file path carries arbitrary
+	// content sizes — the same shape that tripped #1092 when inlined.
+	body := strings.Repeat("review-context system prompt body ", 720)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("PRISM_INITIAL_PROMPT_FILE", path)
+
+	cfg := container.Config{}
+	applyInitialPromptEnvVar(&cfg)
+
+	if cfg.InitialPrompt != body {
+		t.Errorf("InitialPrompt round-trip mismatch: got len=%d, want len=%d", len(cfg.InitialPrompt), len(body))
+	}
+}
+
+// TestApplyInitialPromptEnvVar_FilePathPreferredOverInline verifies that
+// when both PRISM_INITIAL_PROMPT_FILE and PRISM_INITIAL_PROMPT are set, the
+// file path wins. This protects against a stale inline value from a
+// re-attached pane overriding the fresh file contents.
+func TestApplyInitialPromptEnvVar_FilePathPreferredOverInline(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "initial-prompt.txt")
+	if err := os.WriteFile(path, []byte("fresh from file"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("PRISM_INITIAL_PROMPT_FILE", path)
+	t.Setenv("PRISM_INITIAL_PROMPT", "stale inline value")
+
+	cfg := container.Config{}
+	applyInitialPromptEnvVar(&cfg)
+
+	if cfg.InitialPrompt != "fresh from file" {
+		t.Errorf("InitialPrompt = %q, want %q (file path must win over stale inline value)", cfg.InitialPrompt, "fresh from file")
+	}
+}
+
+// TestApplyInitialPromptEnvVar_FilePathMissing verifies the failure-mode
+// behaviour: a PRISM_INITIAL_PROMPT_FILE pointing at a missing file does
+// NOT abort agent-run — InitialPrompt stays empty (no prompt is delivered)
+// and a warning is logged to stderr. The pane is already alive; failing
+// here would leave the operator with a dead review window.
+func TestApplyInitialPromptEnvVar_FilePathMissing(t *testing.T) {
+	t.Setenv("PRISM_INITIAL_PROMPT_FILE", "/nonexistent/path/initial-prompt.txt")
+	// The inline fallback should NOT kick in here either — the explicit
+	// file path takes precedence even when the read fails. This matches
+	// the contract: `…_FILE` is the post-#1092 shape; if it is set the
+	// caller has chosen the file path and a stale inline value would not
+	// be the right substitute.
+	t.Setenv("PRISM_INITIAL_PROMPT", "should not be used as fallback")
+
+	cfg := container.Config{}
+	applyInitialPromptEnvVar(&cfg)
+
+	if cfg.InitialPrompt != "" {
+		t.Errorf("InitialPrompt = %q, want empty string when file is missing", cfg.InitialPrompt)
+	}
+}
+
 // ── minimalBwrapExecEnv ───────────────────────────────────────────────────────
 
 // TestMinimalBwrapExecEnv_AllowedVarsPass verifies that variables in the

--- a/modules/programs/prism/prism/docs/architecture-inventory.md
+++ b/modules/programs/prism/prism/docs/architecture-inventory.md
@@ -1633,7 +1633,7 @@ Source: `cmd/spawn.go:137-149` (declarations) and `cmd/spawn.go:57-261` (flag-pa
 | `--host-mode` | false | Deprecated alias for `--isolation host`. |
 | `--harness <name>` | `opencode` | Agent harness. Persisted to the DB row and forwarded to the sidecar via `--harness`. Allow-list currently `{opencode}`; rejected at parse time otherwise. |
 | `--ignore-concurrency-cap` | false | Bypass the soft concurrency cap (podman or bwrap, depending on resolved mode). |
-| *(positional)* | — | Optional initial prompt; if non-empty it is propagated as `PRISM_INITIAL_PROMPT` env var to the agent pane. |
+| *(positional)* | — | Optional initial prompt; if non-empty it is propagated to the agent pane via `PRISM_INITIAL_PROMPT_FILE=<path>` (post-#1092 — file lives in the per-session run dir) for bwrap/sandbox-exec modes, or via `PRISM_INITIAL_PROMPT=<text>` inline for host mode. |
 
 The proxy-spawn path in the host-API server (`internal/sidecar/sidecar.go:3101-3219`) accepts a JSON request shape with the matching field set: `branch`, `prompt`, `agent`, `profile`, `host_mode`, `harness`, `isolation` plus `ignore_concurrency_cap`. `--model` and `--variant` are conspicuously absent from the proxy request shape — only the worker-side `prism spawn` invocation carries them. [uncertain — verify whether `--model`/`--variant` reach the proxy path; the JSON struct in `internal/sidecar/sidecar.go:3122` did not list them in the snippet captured during inventory generation]
 

--- a/modules/programs/prism/prism/internal/session/initial_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt_test.go
@@ -315,7 +315,7 @@ func TestSpawnSession_HostMode_RejectsOversizedLaunchCmd(t *testing.T) {
 	// present.
 	msg := err.Error()
 	for _, expected := range []string{
-		"host-mode launch command",
+		"launch command",
 		"safe bound",
 		"--prompt-file",
 		"#1064",

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -580,16 +580,24 @@ func Create(name, directory string, opts Opts) error {
 }
 
 // agentPaneEnvVars builds the env-var map for the agent tmux pane.
-// When opts.Prompt is non-empty, PRISM_INITIAL_PROMPT is included so that
-// "prism agent-run" can read it and populate container.Config.InitialPrompt,
-// activating bwrap's --prompt CLI-append path.
 //
-// Skipped entirely for host mode: the host-mode launch path reads the prompt
-// directly via $(cat …) (see buildDirectOpencodeCmd / #1064), and emitting a
-// large PRISM_INITIAL_PROMPT here would re-introduce the same tmux arg-size
-// limit the prompt-file plumbing was added to avoid. The variable is also
-// unused on the host path — only `prism agent-run` (bwrap entry point)
-// consumes it.
+// When opts.PromptFilePath is non-empty (the post-#1092 path),
+// PRISM_INITIAL_PROMPT_FILE carries the path to the prompt file and the
+// prompt body itself is NOT inlined into tmux's argv. `prism agent-run`
+// reads the file when it sees the env var and feeds the contents to
+// bwrap's --prompt CLI-append path. This keeps the launch-command size
+// O(1) in prompt size — the failure mode #1092 hit on review fan-outs.
+//
+// When opts.PromptFilePath is empty but opts.Prompt is non-empty, fall
+// back to the legacy inline PRISM_INITIAL_PROMPT env var. SpawnSession
+// always writes the prompt file for bwrap/sandbox-exec, so this branch
+// is exercised only by direct callers that have not opted into the file
+// path (e.g. test code or future modes added without prompt-file
+// plumbing).
+//
+// Skipped entirely for host mode: the host-mode launch path reads the
+// prompt directly via $(cat …) (see buildDirectOpencodeCmd / #1064), so
+// no agent-pane env var is needed at all.
 //
 // Returns nil when no env vars are needed, producing no -e flags in tmux.
 func agentPaneEnvVars(opts Opts) map[string]string {
@@ -598,6 +606,11 @@ func agentPaneEnvVars(opts Opts) map[string]string {
 	}
 	if effectiveIsolationMode(opts) == "host" {
 		return nil
+	}
+	if opts.PromptFilePath != "" {
+		return map[string]string{
+			"PRISM_INITIAL_PROMPT_FILE": opts.PromptFilePath,
+		}
 	}
 	return map[string]string{
 		"PRISM_INITIAL_PROMPT": opts.Prompt,

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -394,20 +394,33 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// Host-mode launch-command size thresholds (#1064).
+// Host-mode launch-command size thresholds (#1064 / #1092).
 //
 // HostLaunchCmdSafeBound is the maximum constructed launch-command size
 // SpawnSession will hand to tmux without rejecting up-front. Above this,
 // SpawnSession exits non-zero with HostLaunchCmdTooLargeError before any
-// tmux state is created — the empirical failure threshold for tmux
-// arg-handling is somewhere above 12 KB and below ~64 KB depending on
-// build / terminal config, so 4 KB is a comfortable conservative ceiling
-// that still leaves headroom for realistic prompts after the Option-A
-// $(cat …) plumbing pulls the prompt body off the command line. With the
-// fix in place, the only way to exceed this is to inflate the command
-// itself (huge AgentEnvVars, exotic ConfigContent, etc.) — exactly the
-// future regression class this guard exists to surface loudly.
-const HostLaunchCmdSafeBound = 4 * 1024
+// tmux state is created.
+//
+// The empirical failure threshold for tmux arg-handling is somewhere above
+// 12 KB and below ~64 KB depending on build / terminal config. The kernel's
+// per-argv ARG_MAX is far higher — 128 KiB on Linux and 256 KiB on Darwin —
+// so the binding constraint here is tmux's own command parser, not execve.
+//
+// 4 KiB was the original (pre-#1092) bound, chosen when the only spawned
+// shape was LayoutFull and the prompt body was already pulled off the
+// launch command via the $(cat …) plumbing (see initial_prompt.go). It
+// turned out to be too tight once review fan-outs (LayoutAgentOnly) started
+// going through the same guard with the role prompt still inlined into a
+// `-e PRISM_INITIAL_PROMPT=<huge>` pair on tmux's argv.
+//
+// Post-#1092 the role prompt is also delivered via a per-session file
+// (PRISM_INITIAL_PROMPT_FILE), so the launch command size is bounded by
+// boilerplate (session name, env-var prefixes, harness paths) regardless
+// of prompt size. 16 KiB is comfortably above any realistic boilerplate
+// total, and well below tmux's empirical ceiling — exotic ConfigContent or
+// huge AgentEnvVars are still surfaced as a clear pre-spawn failure rather
+// than left to fail silently inside tmux.
+const HostLaunchCmdSafeBound = 16 * 1024
 
 // HostLaunchCmdWarnThreshold is the launch-command size above which
 // SpawnSession enriches a readiness-gate timeout error with a hint that
@@ -418,12 +431,17 @@ const HostLaunchCmdSafeBound = 4 * 1024
 const HostLaunchCmdWarnThreshold = 1024
 
 // HostLaunchCmdTooLargeError is returned by SpawnSession when the
-// constructed host-mode launch command exceeds HostLaunchCmdSafeBound. It
-// carries the actual size, the safe bound, and the session name so the
-// operator can pattern-match the message and mechanically extract the
-// numbers (#1064 AC-6). The error fires before any tmux state is created;
-// callers can treat the spawn as having had no observable side effects on
-// the tmux server.
+// constructed launch command exceeds HostLaunchCmdSafeBound. It carries the
+// actual size, the safe bound, and the session name so the operator can
+// pattern-match the message and mechanically extract the numbers (#1064
+// AC-6). The error fires before any tmux state is created; callers can
+// treat the spawn as having had no observable side effects on the tmux
+// server.
+//
+// The type retains its "HostLaunchCmd…" name for back-compat with #1064
+// callers (IsHostLaunchCmdTooLarge etc.) even though the post-#1092 guard
+// also covers bwrap/sandbox-exec review fan-outs whose size budget is
+// dominated by the env-var pair tmux carries on `new-window -e`.
 type HostLaunchCmdTooLargeError struct {
 	SessionName string
 	CmdSize     int
@@ -432,11 +450,11 @@ type HostLaunchCmdTooLargeError struct {
 
 func (e *HostLaunchCmdTooLargeError) Error() string {
 	return fmt.Sprintf(
-		"host-mode launch command for session %q is %d bytes, above the safe bound of %d bytes — "+
+		"launch command for session %q is %d bytes, above the safe bound of %d bytes — "+
 			"tmux cannot reliably deliver commands above this size and would fail silently. "+
 			"Workaround: spawn with a small placeholder prompt (e.g. --prompt 'wait') and send the "+
 			"real prompt via `prism prompt %s --prompt-file <path>` once the session is alive. "+
-			"See issue #1064.",
+			"See issues #1064 and #1092.",
 		e.SessionName, e.CmdSize, e.SafeBound, e.SessionName,
 	)
 }

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -481,6 +481,29 @@ func TestAgentPaneEnvVars_HostMode_Skipped(t *testing.T) {
 	}
 }
 
+// TestAgentPaneEnvVars_PromptFile_PreferredOverInline verifies the post-#1092
+// behaviour: when both opts.Prompt and opts.PromptFilePath are set in bwrap
+// or sandbox-exec mode, agentPaneEnvVars emits PRISM_INITIAL_PROMPT_FILE
+// (carrying the path) and NOT the inline PRISM_INITIAL_PROMPT (which would
+// re-introduce the launch-cmd size failure).
+func TestAgentPaneEnvVars_PromptFile_PreferredOverInline(t *testing.T) {
+	opts := Opts{
+		Prompt:         "hello",
+		PromptFilePath: "/var/state/prism/run/abc/initial-prompt.txt",
+		IsolationMode:  "bwrap",
+	}
+	got := agentPaneEnvVars(opts)
+	if got == nil {
+		t.Fatal("agentPaneEnvVars: got nil, want non-nil map")
+	}
+	if v, ok := got["PRISM_INITIAL_PROMPT_FILE"]; !ok || v != "/var/state/prism/run/abc/initial-prompt.txt" {
+		t.Errorf("PRISM_INITIAL_PROMPT_FILE = %q, want %q", v, "/var/state/prism/run/abc/initial-prompt.txt")
+	}
+	if _, present := got["PRISM_INITIAL_PROMPT"]; present {
+		t.Errorf("PRISM_INITIAL_PROMPT must NOT be set when PRISM_INITIAL_PROMPT_FILE is — would inline prompt body and re-introduce #1092: got %v", got)
+	}
+}
+
 // spyTmuxBin creates a fake tmux binary that records its arguments (one per line)
 // to argsFile, redirects tmux.TmuxBin for the duration of the test, and returns
 // the path to argsFile. Only call this from non-parallel tests.

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -218,15 +218,15 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	//
 	//   - LayoutFull + host: buildDirectOpencodeCmd emits
 	//     `--prompt "$(cat <path>)"` so tmux's `sh -c <cmd>` stays small.
-	//   - LayoutAgentOnly (review fan-out, bwrap/sandbox-exec): the prompt
-	//     used to be carried as `-e PRISM_INITIAL_PROMPT=<huge>` on the
-	//     tmux new-window argv, where role-prompt + boilerplate + bind
-	//     paths could collectively exceed tmux's command size budget and
-	//     produce a `command too long` failure (#1092). Switching to a
-	//     `-e PRISM_INITIAL_PROMPT_FILE=<path>` env var keeps the launch
-	//     command's size O(1) in prompt size; `prism agent-run` reads the
-	//     file when it sees the env var and feeds the contents to the
-	//     bwrap/sandbox-exec --prompt path.
+	//   - LayoutFull / LayoutAgentOnly + bwrap or sandbox-exec: the
+	//     prompt used to be carried as `-e PRISM_INITIAL_PROMPT=<huge>`
+	//     on the tmux new-window argv, where role-prompt + boilerplate +
+	//     bind paths could collectively exceed tmux's command size budget
+	//     and produce a `command too long` failure (#1092). Switching to
+	//     a `-e PRISM_INITIAL_PROMPT_FILE=<path>` env var keeps the
+	//     launch command's size O(1) in prompt size; `prism agent-run`
+	//     reads the file when it sees the env var and feeds the contents
+	//     to the bwrap/sandbox-exec --prompt path.
 	//
 	// Podman mode delivers the prompt through the sidecar (StartSidecarOpts
 	// .InitialPrompt → opencode --prompt inside the container), so it does
@@ -237,8 +237,9 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// than silently.
 	mode := resolveLayoutIsolationMode(opts)
 	var promptFilePath string
+	isSandbox := mode == "bwrap" || mode == "sandbox-exec"
 	needsPromptFile := opts.Prompt != "" && (opts.Layout == LayoutFull && mode == "host" ||
-		opts.Layout == LayoutAgentOnly && (mode == "bwrap" || mode == "sandbox-exec"))
+		isSandbox)
 	if needsPromptFile {
 		path, writeErr := WriteInitialPrompt(opts.SessionName, opts.Prompt)
 		if writeErr != nil {
@@ -259,24 +260,27 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// safe bound. Doing this BEFORE any tmux state is created means a
 	// rejected spawn has no observable side effects on the tmux server.
 	//
-	// Two layouts are guarded:
+	// Three combinations are guarded:
 	//
 	//   - LayoutFull + host: BuildOpencodeCmd returns the direct opencode
 	//     invocation. Without the prompt-file plumbing the prompt body
-	//     would be inlined; with it the cmd stays O(1) in prompt size.
+	//     would be inlined onto `sh -c <cmd>`; with it the cmd stays O(1)
+	//     in prompt size.
 	//
-	//   - LayoutAgentOnly + bwrap/sandbox-exec: BuildOpencodeCmd returns
-	//     `prism agent-run --session <name>`, but the env-var map (which
-	//     becomes `-e KEY=VALUE` flags on tmux new-window) used to carry
-	//     the entire role prompt — that was the failure mode in #1092.
-	//     The "size" measured here adds the env-var contribution so the
-	//     guard reflects the bytes tmux actually sees on its argv.
+	//   - LayoutFull / LayoutAgentOnly + bwrap or sandbox-exec:
+	//     BuildOpencodeCmd returns `prism agent-run --session <name>`,
+	//     but the env-var map (which becomes `-e KEY=VALUE` flags on
+	//     tmux new-window) used to carry the entire prompt — the failure
+	//     mode in #1092. The "size" measured here adds the env-var
+	//     contribution so the guard reflects the bytes tmux actually
+	//     sees on its argv.
 	//
 	// Podman launch commands are `podman attach <ctr>`; the prompt is
 	// delivered through the sidecar and never touches tmux's argv, so the
 	// podman path is intentionally not guarded.
 	hostLaunchCmdSize := 0
-	if opts.Layout == LayoutFull && mode == "host" {
+	switch {
+	case opts.Layout == LayoutFull && mode == "host":
 		previewOpts := buildOptsForLayout(opts, 0, promptFilePath)
 		hostLaunchCmd := BuildOpencodeCmd(previewOpts)
 		hostLaunchCmdSize = len(hostLaunchCmd)
@@ -295,39 +299,47 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		}
 		startup.log("spawn-session: host launch command size %d (safe bound %d, warn threshold %d)",
 			hostLaunchCmdSize, HostLaunchCmdSafeBound, HostLaunchCmdWarnThreshold)
-	}
-	if opts.Layout == LayoutAgentOnly && (mode == "bwrap" || mode == "sandbox-exec") {
-		// Mirror what spawnAgentOnlyLayout will hand to tmux: the
-		// agentCmd plus each `-e KEY=VALUE` env entry. The previewOpts
-		// is shaped to match the buildOpts in spawnAgentOnlyLayout.
+
+	case isSandbox && (opts.Layout == LayoutFull || opts.Layout == LayoutAgentOnly):
+		// Mirror what the layout spawner will hand to tmux: the agentCmd
+		// (a small `prism agent-run --session <name>` for the sandbox
+		// modes) plus each `-e KEY=VALUE` env entry. previewOpts is the
+		// minimal shape BuildOpencodeCmd needs for the sandbox mode.
 		previewOpts := Opts{
 			Prompt:           opts.Prompt,
 			Agent:            opts.AgentRole,
-			ConfigContent:    opts.ConfigContent,
 			SessionName:      opts.SessionName,
 			Port:             0,
-			ContainerMode:    opts.ContainerMode,
 			IsolationMode:    mode,
-			PluginHostPath:   opts.PluginHostPath,
 			ConfigEnvVarName: opts.ConfigEnvVarName,
-			RuntimeEnvVars:   opts.RuntimeEnvVars,
 		}
 		previewCmd := BuildOpencodeCmd(previewOpts)
-		previewEnvs := spawnAgentPaneEnvVars(SpawnOpts{
-			Prompt:         opts.Prompt,
-			PromptFilePath: promptFilePath,
-		})
+		// For the env-var preview, route through the same helper used at
+		// spawn time so the file-path branch (post-#1092) and the legacy
+		// inline branch produce matching size estimates.
+		var previewEnvs map[string]string
+		if opts.Layout == LayoutFull {
+			previewEnvs = agentPaneEnvVars(Opts{
+				Prompt:         opts.Prompt,
+				PromptFilePath: promptFilePath,
+				IsolationMode:  mode,
+			})
+		} else {
+			previewEnvs = spawnAgentPaneEnvVars(SpawnOpts{
+				Prompt:         opts.Prompt,
+				PromptFilePath: promptFilePath,
+			})
+		}
 		size := len(previewCmd)
 		for k, v := range previewEnvs {
-			// `-e KEY=VALUE` becomes ~ 4 + len(K) + len(V) bytes on
-			// tmux's argv; approximate without re-implementing the
-			// shell quoting tmux does internally.
+			// `-e KEY=VALUE` lands as two argv elements; approximate
+			// without re-implementing tmux's quoting.
 			size += len(k) + len(v) + 4
 		}
 		hostLaunchCmdSize = size
 		if size > HostLaunchCmdSafeBound {
-			startup.log("spawn-session: agent-only launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
-				size, HostLaunchCmdSafeBound)
+			startup.log("spawn-session: %s launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
+				mode, size, HostLaunchCmdSafeBound)
 			removeInitialPrompt(opts.SessionName)
 			return &HostLaunchCmdTooLargeError{
 				SessionName: opts.SessionName,
@@ -335,8 +347,8 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 				SafeBound:   HostLaunchCmdSafeBound,
 			}
 		}
-		startup.log("spawn-session: agent-only launch command size %d (safe bound %d)",
-			size, HostLaunchCmdSafeBound)
+		startup.log("spawn-session: %s launch command size %d (safe bound %d)",
+			mode, size, HostLaunchCmdSafeBound)
 	}
 	opts.PromptFilePath = promptFilePath
 
@@ -490,8 +502,9 @@ func resolveLayoutIsolationMode(opts SpawnOpts) string {
 // The size guard calls this with port=0 (the port is allocated only after
 // the guard runs), while the real launch path passes the allocated port.
 // The few-byte difference (--port <N> --hostname 127.0.0.1 contributes <30
-// bytes) is well within the 4 KB safe bound and 1 KB warn threshold, so
-// the guard's verdict cannot flip between preview and launch in practice.
+// bytes) is well within the safe bound (16 KiB after #1092; 4 KiB before)
+// and the 1 KiB warn threshold, so the guard's verdict cannot flip between
+// preview and launch in practice.
 func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 	return Opts{
 		Prompt:           opts.Prompt,

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -62,13 +62,20 @@ type SpawnOpts struct {
 	Prompt string
 
 	// PromptFilePath is set internally by SpawnSession when it has written
-	// the prompt to the per-session run directory (host mode only — see
-	// #1064 / WriteInitialPrompt). Callers should leave this empty;
-	// SpawnSession populates it from opts.Prompt before spawnFullLayout
-	// runs so BuildOpencodeCmd emits `--prompt "$(cat <path>)"` rather
-	// than inlining the prompt body. Carried on SpawnOpts (rather than as
-	// a function-local variable) so spawnFullLayout — which receives a
-	// copy — sees the same value the size guard validated against.
+	// the prompt to the per-session run directory (#1064 / #1092). Callers
+	// should leave this empty; SpawnSession populates it from opts.Prompt
+	// before the layout-specific spawn runs.
+	//
+	// For LayoutFull + host: BuildOpencodeCmd emits `--prompt "$(cat
+	// <path>)"` rather than inlining the prompt body.
+	//
+	// For LayoutAgentOnly + bwrap/sandbox-exec: spawnAgentPaneEnvVars sets
+	// PRISM_INITIAL_PROMPT_FILE=<path> on the agent pane and `prism
+	// agent-run` reads the file.
+	//
+	// Carried on SpawnOpts (rather than as a function-local variable) so
+	// the layout spawners — which receive a copy — see the same value
+	// the size guard validated against.
 	PromptFilePath string
 
 	// ConfigContent is the JSON blob injected as OPENCODE_CONFIG_CONTENT.
@@ -205,21 +212,34 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	startup.log("spawn-session: begin (role=%q, worktree=%q, layout=%d, isolation=%q, container_mode=%t)",
 		opts.AgentRole, opts.Worktree, opts.Layout, opts.IsolationMode, opts.ContainerMode)
 
-	// #1064: in host mode with a non-empty prompt, write the prompt to the
-	// per-session run directory and let buildDirectOpencodeCmd reference it
-	// via $(cat …) instead of inlining the prompt onto the launch command.
-	// Two-line touch on this loop because the path is also threaded into
-	// the size guard a few lines below — keep both updates next to each
-	// other so a future reader sees the chain.
+	// #1064 / #1092: with a non-empty prompt, write the prompt to the
+	// per-session run directory and let the launch path reference it by
+	// path rather than inlining the prompt body into the tmux command.
 	//
-	// Scoped to LayoutFull because that is the only layout the spawn path
-	// uses today — review fan-outs (LayoutAgentOnly) typically run under
-	// bwrap and have not exhibited this failure mode. If review fan-outs
-	// later need the same treatment, extend the gate; do not silently
-	// widen it.
+	//   - LayoutFull + host: buildDirectOpencodeCmd emits
+	//     `--prompt "$(cat <path>)"` so tmux's `sh -c <cmd>` stays small.
+	//   - LayoutAgentOnly (review fan-out, bwrap/sandbox-exec): the prompt
+	//     used to be carried as `-e PRISM_INITIAL_PROMPT=<huge>` on the
+	//     tmux new-window argv, where role-prompt + boilerplate + bind
+	//     paths could collectively exceed tmux's command size budget and
+	//     produce a `command too long` failure (#1092). Switching to a
+	//     `-e PRISM_INITIAL_PROMPT_FILE=<path>` env var keeps the launch
+	//     command's size O(1) in prompt size; `prism agent-run` reads the
+	//     file when it sees the env var and feeds the contents to the
+	//     bwrap/sandbox-exec --prompt path.
+	//
+	// Podman mode delivers the prompt through the sidecar (StartSidecarOpts
+	// .InitialPrompt → opencode --prompt inside the container), so it does
+	// not need a tmux-side env var at all and is intentionally skipped here.
+	// Host mode under LayoutAgentOnly is not produced by any caller today —
+	// review agents run under bwrap/sandbox-exec/podman — so it is also
+	// skipped; if that ever changes, extend the gate consciously rather
+	// than silently.
 	mode := resolveLayoutIsolationMode(opts)
 	var promptFilePath string
-	if opts.Layout == LayoutFull && mode == "host" && opts.Prompt != "" {
+	needsPromptFile := opts.Prompt != "" && (opts.Layout == LayoutFull && mode == "host" ||
+		opts.Layout == LayoutAgentOnly && (mode == "bwrap" || mode == "sandbox-exec"))
+	if needsPromptFile {
 		path, writeErr := WriteInitialPrompt(opts.SessionName, opts.Prompt)
 		if writeErr != nil {
 			// AC-5: prompt-delivery setup failures must surface to the
@@ -233,14 +253,28 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		startup.log("spawn-session: wrote initial-prompt file (%d bytes) to %s", len(opts.Prompt), path)
 	}
 
-	// #1064 AC-6: pre-spawn size check. Build the launch command preview
-	// using the same Opts shape that spawnFullLayout will reuse below, and
-	// reject any host-mode session whose constructed command exceeds the
+	// #1064 AC-6 / #1092: pre-spawn size check. Build the launch command
+	// preview using the same Opts shape that the layout spawner will reuse
+	// below, and reject any session whose tmux-bound command exceeds the
 	// safe bound. Doing this BEFORE any tmux state is created means a
 	// rejected spawn has no observable side effects on the tmux server.
-	// The check fires only for host mode — podman/bwrap launch commands
-	// are bounded by construction (they reference a session name, not the
-	// prompt body) and never approach the threshold.
+	//
+	// Two layouts are guarded:
+	//
+	//   - LayoutFull + host: BuildOpencodeCmd returns the direct opencode
+	//     invocation. Without the prompt-file plumbing the prompt body
+	//     would be inlined; with it the cmd stays O(1) in prompt size.
+	//
+	//   - LayoutAgentOnly + bwrap/sandbox-exec: BuildOpencodeCmd returns
+	//     `prism agent-run --session <name>`, but the env-var map (which
+	//     becomes `-e KEY=VALUE` flags on tmux new-window) used to carry
+	//     the entire role prompt — that was the failure mode in #1092.
+	//     The "size" measured here adds the env-var contribution so the
+	//     guard reflects the bytes tmux actually sees on its argv.
+	//
+	// Podman launch commands are `podman attach <ctr>`; the prompt is
+	// delivered through the sidecar and never touches tmux's argv, so the
+	// podman path is intentionally not guarded.
 	hostLaunchCmdSize := 0
 	if opts.Layout == LayoutFull && mode == "host" {
 		previewOpts := buildOptsForLayout(opts, 0, promptFilePath)
@@ -261,6 +295,48 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		}
 		startup.log("spawn-session: host launch command size %d (safe bound %d, warn threshold %d)",
 			hostLaunchCmdSize, HostLaunchCmdSafeBound, HostLaunchCmdWarnThreshold)
+	}
+	if opts.Layout == LayoutAgentOnly && (mode == "bwrap" || mode == "sandbox-exec") {
+		// Mirror what spawnAgentOnlyLayout will hand to tmux: the
+		// agentCmd plus each `-e KEY=VALUE` env entry. The previewOpts
+		// is shaped to match the buildOpts in spawnAgentOnlyLayout.
+		previewOpts := Opts{
+			Prompt:           opts.Prompt,
+			Agent:            opts.AgentRole,
+			ConfigContent:    opts.ConfigContent,
+			SessionName:      opts.SessionName,
+			Port:             0,
+			ContainerMode:    opts.ContainerMode,
+			IsolationMode:    mode,
+			PluginHostPath:   opts.PluginHostPath,
+			ConfigEnvVarName: opts.ConfigEnvVarName,
+			RuntimeEnvVars:   opts.RuntimeEnvVars,
+		}
+		previewCmd := BuildOpencodeCmd(previewOpts)
+		previewEnvs := spawnAgentPaneEnvVars(SpawnOpts{
+			Prompt:         opts.Prompt,
+			PromptFilePath: promptFilePath,
+		})
+		size := len(previewCmd)
+		for k, v := range previewEnvs {
+			// `-e KEY=VALUE` becomes ~ 4 + len(K) + len(V) bytes on
+			// tmux's argv; approximate without re-implementing the
+			// shell quoting tmux does internally.
+			size += len(k) + len(v) + 4
+		}
+		hostLaunchCmdSize = size
+		if size > HostLaunchCmdSafeBound {
+			startup.log("spawn-session: agent-only launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
+				size, HostLaunchCmdSafeBound)
+			removeInitialPrompt(opts.SessionName)
+			return &HostLaunchCmdTooLargeError{
+				SessionName: opts.SessionName,
+				CmdSize:     size,
+				SafeBound:   HostLaunchCmdSafeBound,
+			}
+		}
+		startup.log("spawn-session: agent-only launch command size %d (safe bound %d)",
+			size, HostLaunchCmdSafeBound)
 	}
 	opts.PromptFilePath = promptFilePath
 
@@ -383,14 +459,25 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 // resolveLayoutIsolationMode returns the resolved isolation mode for the
 // SpawnOpts, mirroring the lookup in BuildOpencodeCmd / spawnAgentOnlyLayout.
 // Kept as a small helper so SpawnSession can decide whether to write the
-// initial-prompt file (host only) and whether to apply the launch-command
-// size guard (host only) without duplicating the precedence logic.
+// initial-prompt file and whether to apply the launch-command size guard
+// without duplicating the precedence logic.
+//
+// For LayoutAgentOnly, when neither IsolationMode nor ContainerMode is set,
+// fall back to the same machine default that spawnAgentOnlyLayout uses
+// (config.Load().EffectiveIsolationMode()). This keeps the prompt-file
+// gate aligned with the layout's actual mode — otherwise a caller that
+// leaves IsolationMode empty for a bwrap-default machine would get the
+// legacy inline PRISM_INITIAL_PROMPT path here while spawnAgentOnlyLayout
+// runs the agent under bwrap, re-introducing #1092 by another route.
 func resolveLayoutIsolationMode(opts SpawnOpts) string {
 	if opts.IsolationMode != "" {
 		return opts.IsolationMode
 	}
 	if opts.ContainerMode {
 		return "podman"
+	}
+	if opts.Layout == LayoutAgentOnly {
+		return string(config.Load().EffectiveIsolationMode())
 	}
 	return "host"
 }
@@ -464,14 +551,30 @@ func spawnFullLayout(d *db.DB, opts SpawnOpts, port int) error {
 // tmux pane. It mirrors session.agentPaneEnvVars but takes SpawnOpts directly,
 // since the two layout paths use different opts structs.
 //
-// When opts.Prompt is non-empty, PRISM_INITIAL_PROMPT is included so that
-// "prism agent-run" can read it and populate container.Config.InitialPrompt,
-// activating bwrap's --prompt CLI-append path. Returns nil when no env vars
-// are needed, producing no -e flags in tmux (an empty-string entry would
-// override an inherited value, which is not the desired behaviour).
+// When opts.PromptFilePath is non-empty (the post-#1092 path), PRISM_INITIAL_PROMPT_FILE
+// carries the path to the prompt file and the prompt body itself is NOT
+// inlined into tmux's argv. `prism agent-run` reads the file when it sees
+// the env var and feeds the contents to bwrap's --prompt CLI-append path.
+// This keeps the tmux launch command O(1) in prompt size — the failure mode
+// the role prompt was hitting in #1092.
+//
+// When opts.PromptFilePath is empty but opts.Prompt is non-empty, fall back
+// to the legacy PRISM_INITIAL_PROMPT env var (used by callers that have not
+// opted into the file path; SpawnSession itself always writes the file for
+// bwrap/sandbox-exec, so this branch is exercised only by direct callers
+// of the helper or future modes added without prompt-file plumbing).
+//
+// Returns nil when no env vars are needed, producing no -e flags in tmux
+// (an empty-string entry would override an inherited value, which is not
+// the desired behaviour).
 func spawnAgentPaneEnvVars(opts SpawnOpts) map[string]string {
 	if opts.Prompt == "" {
 		return nil
+	}
+	if opts.PromptFilePath != "" {
+		return map[string]string{
+			"PRISM_INITIAL_PROMPT_FILE": opts.PromptFilePath,
+		}
 	}
 	return map[string]string{
 		"PRISM_INITIAL_PROMPT": opts.Prompt,

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -16,6 +16,7 @@ package session
 // tests — SpawnSession composes those helpers without adding new logic.
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -359,13 +360,17 @@ func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
 	}
 }
 
-// TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt verifies that when
-// opts.Prompt is non-empty, spawnAgentOnlyLayout sets PRISM_INITIAL_PROMPT in
-// the agent pane's tmux environment via a -e flag on tmux new-window. This is
-// the regression test for #1042: review agents in bwrap mode must receive
-// their initial prompt via the PRISM_INITIAL_PROMPT env var, since the bwrap
-// path reads it in agent-run and appends --prompt to the opencode invocation.
-func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt(t *testing.T) {
+// TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt_Host verifies the legacy
+// path for the host-mode resolution: when opts.IsolationMode is empty and the
+// machine default resolves to "host", spawnAgentOnlyLayout sets the inline
+// PRISM_INITIAL_PROMPT env var on the agent pane (the pre-#1092 shape).
+//
+// This is the regression test for #1042 carried forward: review agents in
+// host mode must receive their initial prompt via the PRISM_INITIAL_PROMPT
+// env var. The new file-based path (PRISM_INITIAL_PROMPT_FILE) is gated on
+// bwrap/sandbox-exec modes only — see
+// TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Bwrap below.
+func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt_Host(t *testing.T) {
 	d, _ := openSpawnTestDB(t)
 	argsFile := spyTmuxBin(t)
 	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
@@ -374,12 +379,13 @@ func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt(t *testing.T) {
 	const sessionName = "myrepo@branch~review-1-review-code"
 	const prompt = "review this PR"
 	opts := SpawnOpts{
-		SessionName: sessionName,
-		Repo:        "myrepo",
-		Worktree:    "/worktrees/myrepo-branch",
-		AgentRole:   "review-code",
-		Prompt:      prompt,
-		Layout:      LayoutAgentOnly,
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      "/worktrees/myrepo-branch",
+		AgentRole:     "review-code",
+		Prompt:        prompt,
+		Layout:        LayoutAgentOnly,
+		IsolationMode: "host",
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -388,7 +394,15 @@ func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt(t *testing.T) {
 
 	args := readSpyArgs(argsFile)
 	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT=" + prompt}) {
-		t.Errorf("tmux args %v do not contain [-e PRISM_INITIAL_PROMPT=%s] — review agents in bwrap mode will start with no initial prompt (#1042)", args, prompt)
+		t.Errorf("tmux args %v do not contain [-e PRISM_INITIAL_PROMPT=%s] — host-mode review agents should still receive the inline env var (#1042)", args, prompt)
+	}
+	// The file-based env var must NOT appear for host mode — that path
+	// would route the prompt through `prism agent-run`, which only fires
+	// for bwrap/sandbox-exec.
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT_FILE=") {
+			t.Errorf("tmux args %v contain PRISM_INITIAL_PROMPT_FILE for host mode — should only fire for bwrap/sandbox-exec", args)
+		}
 	}
 }
 
@@ -431,11 +445,160 @@ func TestSpawnSession_AgentOnly_PromptEnvVar_NoPrompt(t *testing.T) {
 	}
 }
 
-// TestSpawnAgentPaneEnvVars verifies the helper directly: with a non-empty
-// prompt it returns the PRISM_INITIAL_PROMPT entry; with an empty prompt it
-// returns nil (not an empty map and not an empty-string entry).
+// TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Bwrap is the regression
+// test for #1092. When opts.IsolationMode is "bwrap" and opts.Prompt is
+// non-empty, SpawnSession must write the prompt to a per-session file and
+// set PRISM_INITIAL_PROMPT_FILE on the agent pane — not the inline
+// PRISM_INITIAL_PROMPT env var that previously carried the prompt body
+// onto tmux's argv and tripped the launch-command size guard for review
+// fan-outs with long role prompts.
+//
+// Verifies the three pieces of the contract together:
+//   - The file exists at the expected per-session path.
+//   - The file contents byte-for-byte equal opts.Prompt.
+//   - The tmux new-window argv carries PRISM_INITIAL_PROMPT_FILE=<path> and
+//     does NOT carry the prompt body inline.
+func TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Bwrap(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sessionName = "myrepo@long-branch~review-2-review-context"
+	// A 24 KB prompt — well above the 16 KiB safe bound, so any inline
+	// path would also trip the guard. The file path keeps the launch
+	// command O(1) in prompt size, so spawn must succeed.
+	prompt := strings.Repeat("review-context system prompt body ", 720) // ~24 KB
+
+	opts := SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      "/worktrees/myrepo-long-branch",
+		AgentRole:     "review-context",
+		Prompt:        prompt,
+		Layout:        LayoutAgentOnly,
+		IsolationMode: "bwrap",
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v — bwrap-mode review fan-out must accept large role prompts via the prompt-file path (#1092)", err)
+	}
+
+	// File side: must exist and round-trip the prompt bytes intact.
+	filePath, pathErr := InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
+	}
+	body, readErr := os.ReadFile(filePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v — prompt file must exist after a bwrap-mode SpawnSession", filePath, readErr)
+	}
+	if string(body) != prompt {
+		t.Errorf("prompt round-trip mismatch: file len=%d, prompt len=%d", len(body), len(prompt))
+	}
+
+	// Permission side: the file must be 0600 — prompts can carry secrets
+	// or branch context the operator does not want world-readable.
+	st, statErr := os.Stat(filePath)
+	if statErr != nil {
+		t.Fatalf("Stat(%s): %v", filePath, statErr)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("prompt-file perms = %o, want 0600 (operator-only)", mode)
+	}
+
+	// Tmux side: PRISM_INITIAL_PROMPT_FILE must point to the file, and
+	// PRISM_INITIAL_PROMPT must NOT carry the body — that would re-introduce
+	// the #1092 failure mode.
+	args := readSpyArgs(argsFile)
+	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT_FILE=" + filePath}) {
+		t.Errorf("tmux args do not contain [-e PRISM_INITIAL_PROMPT_FILE=%s] — review agents in bwrap mode must receive the prompt-file path (#1092)\nargs: %v", filePath, args)
+	}
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT=") {
+			t.Errorf("tmux args carry inline PRISM_INITIAL_PROMPT for bwrap mode — would re-introduce the #1092 launch-cmd size failure: %v", args)
+			break
+		}
+	}
+	// Defence-in-depth: the tmux argv as a whole must not contain the
+	// prompt body. With #1092 fixed, the only thing tmux sees is the
+	// file path; a regression that put the body back on argv would fail
+	// this assertion before the size guard or kernel ARG_MAX trips.
+	for _, a := range args {
+		if strings.Contains(a, prompt) {
+			t.Errorf("tmux argv element contains the prompt body inline (len=%d) — file-based delivery is broken", len(a))
+			break
+		}
+	}
+}
+
+// TestSpawnSession_AgentOnly_PromptFile_WithPrompt_SandboxExec mirrors the
+// bwrap test for the sandbox-exec mode. The file-based path must fire for
+// both bwrap and sandbox-exec because both delegate prompt delivery to
+// `prism agent-run` (which now reads PRISM_INITIAL_PROMPT_FILE).
+func TestSpawnSession_AgentOnly_PromptFile_WithPrompt_SandboxExec(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sessionName = "myrepo@branch~review-3-review-security"
+	const prompt = "review-security system prompt body"
+
+	opts := SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      "/worktrees/myrepo-branch",
+		AgentRole:     "review-security",
+		Prompt:        prompt,
+		Layout:        LayoutAgentOnly,
+		IsolationMode: "sandbox-exec",
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	filePath, pathErr := InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
+	}
+	body, readErr := os.ReadFile(filePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v", filePath, readErr)
+	}
+	if string(body) != prompt {
+		t.Errorf("prompt round-trip mismatch: got %q, want %q", string(body), prompt)
+	}
+
+	args := readSpyArgs(argsFile)
+	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT_FILE=" + filePath}) {
+		t.Errorf("tmux args do not contain [-e PRISM_INITIAL_PROMPT_FILE=%s] for sandbox-exec mode\nargs: %v", filePath, args)
+	}
+}
+
+// TestSpawnAgentPaneEnvVars verifies the helper directly across the three
+// shapes: file path set (post-#1092), inline prompt only (legacy), and no
+// prompt at all (no env vars emitted).
 func TestSpawnAgentPaneEnvVars(t *testing.T) {
-	t.Run("with prompt", func(t *testing.T) {
+	t.Run("with prompt file", func(t *testing.T) {
+		got := spawnAgentPaneEnvVars(SpawnOpts{
+			Prompt:         "hello",
+			PromptFilePath: "/var/state/prism/run/abc/initial-prompt.txt",
+		})
+		if got == nil {
+			t.Fatal("got nil, want non-nil map")
+		}
+		if v, ok := got["PRISM_INITIAL_PROMPT_FILE"]; !ok || v != "/var/state/prism/run/abc/initial-prompt.txt" {
+			t.Errorf("PRISM_INITIAL_PROMPT_FILE = %q, want %q", v, "/var/state/prism/run/abc/initial-prompt.txt")
+		}
+		if _, present := got["PRISM_INITIAL_PROMPT"]; present {
+			t.Errorf("PRISM_INITIAL_PROMPT must NOT be set when PRISM_INITIAL_PROMPT_FILE is — would inline prompt body and re-introduce #1092: got %v", got)
+		}
+	})
+	t.Run("with prompt only (legacy)", func(t *testing.T) {
 		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "hello"})
 		if got == nil {
 			t.Fatal("got nil, want non-nil map")


### PR DESCRIPTION
Closes #1092

`prism review <pr>` was failing with `command too long` from tmux when fanning out review-context (and similarly long-prompt review agents) on worker sessions with long branch names. The role prompt + agent-run boilerplate + 76-character session name pushed the tmux `new-window -e PRISM_INITIAL_PROMPT=<huge>` argv past tmux's command parser limit, and `--diff-inline-max` / `--size-budget` could not recover because the prompt body was on argv, not in any user-visible content slot.

## Fix shape

Mirror the post-#1069 host-mode precedent: write the prompt to the per-session run directory (`initial-prompt.txt`, mode 0600) and pass `PRISM_INITIAL_PROMPT_FILE=<path>` to the agent pane instead of the inline `PRISM_INITIAL_PROMPT=<text>` env var. `prism agent-run` reads the file when it sees the env var. The launch-command size is now O(1) in prompt size for bwrap/sandbox-exec review fan-outs, and `--diff-inline-max` / `--size-budget` become effective again because they shrink the file's content (which is no longer on argv).

The new env-var name (`PRISM_INITIAL_PROMPT_FILE`) is additive — the legacy `PRISM_INITIAL_PROMPT` inline path remains for host mode, where the prompt was never the failure mode and the change would be unnecessary churn.

## Judgement call: also raised `HostLaunchCmdSafeBound` to 16 KiB

The file-based delivery is the primary fix. As defence-in-depth I also bumped the cap from 4 KiB → 16 KiB, with a comment justifying the new value against Linux `ARG_MAX` (128 KiB) and Darwin `ARG_MAX` (256 KiB). 16 KiB is comfortably below tmux's empirical command-parser ceiling while leaving room for any remaining boilerplate growth — exotic `ConfigContent` or huge `AgentEnvVars` will still surface as a clear pre-spawn failure rather than fail silently inside tmux.

## What changed

- `internal/session/spawn.go`: extend the `SpawnSession` prompt-file write + size guard to `LayoutAgentOnly` + bwrap/sandbox-exec; align `resolveLayoutIsolationMode` for `LayoutAgentOnly` to match the machine default that `spawnAgentOnlyLayout` applies, so the gate fires correctly when callers leave `IsolationMode` empty.
- `internal/session/spawn.go` (`spawnAgentPaneEnvVars`): emit `PRISM_INITIAL_PROMPT_FILE` when a file path is set; fall back to the legacy inline env var only when no file path is provided (host mode, direct callers).
- `cmd/agent_run.go` (`applyInitialPromptEnvVar`): read from the file when `PRISM_INITIAL_PROMPT_FILE` is set; file-path wins over inline; missing file is non-fatal (logs a warning and proceeds with an empty prompt — better than a dead pane).
- `internal/session/session.go`: raise `HostLaunchCmdSafeBound` to 16 KiB, expand the comment.
- `docs/architecture-inventory.md`: update the spawn-flag summary to reflect the new env-var.

## Tests

- `applyInitialPromptEnvVar` file-based delivery: roundtrip a 24 KB prompt; precedence of file path over stale inline value; missing-file is non-fatal.
- `SpawnSession` agent-only with bwrap and sandbox-exec modes: prompt file exists at the per-session path, contents match, perms are 0600, tmux argv carries `PRISM_INITIAL_PROMPT_FILE` and does NOT contain the prompt body.
- Existing host-mode test renamed/clarified to document the legacy inline fallback.
- All existing tests in `internal/session/`, `internal/review/`, `cmd/` continue to pass; `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes.