### PR TITLE
Configure swapfile and earlyoom for navi

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -224,6 +224,21 @@
     ];
   };
 
+  # Swapfile on /persist for OOM protection (survives reboots, btrfs-aware)
+  swapDevices = [
+    {
+      device = "/persist/swapfile";
+      size = 16384; # 16 GiB
+    }
+  ];
+
+  # Kill memory hogs early before the system freezes under OOM pressure
+  services.earlyoom = {
+    enable = true;
+    freeMemThreshold = 5;
+    freeSwapThreshold = 10;
+  };
+
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/machines/navi/disko.nix
+++ b/machines/navi/disko.nix
@@ -21,7 +21,7 @@
             };
           };
           swap = {
-            size = "4G";
+            size = "16G";
             content = {
               type = "swap";
               resumeDevice = true;


### PR DESCRIPTION
Added a 16GiB swapfile on /persist to provide persistent OOM protection for the system. Enabled the earlyoom service to proactively manage memory pressure and prevent system freezes. Additionally, updated the disko configuration to increase the dedicated swap partition size to 16GiB.