### PR TITLE
fix(prism-hooks): use Bun.spawn for doom loop event write — pluginInput has no $ property

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -284,12 +284,22 @@ export const PrismHooks: Plugin = async (pluginInput) => {
               // Log the event to the prism DB asynchronously (fire-and-forget).
               // We do not await this so the tool execution path is not blocked.
               if (sessionName) {
-                const $ = (pluginInput as any).$;
-                if ($) {
-                  void $`prism event doom-loop-detected --session ${sessionName} --tool ${input.tool} --pattern ${key} --count ${String(doomLoop.consecutiveCount)}`.quiet().catch(() => {
-                    // Ignore errors — event logging is best-effort.
-                  });
-                }
+                Bun.spawn(
+                  [
+                    "prism",
+                    "event",
+                    "doom-loop-detected",
+                    "--session",
+                    sessionName,
+                    "--tool",
+                    input.tool,
+                    "--pattern",
+                    key,
+                    "--count",
+                    String(doomLoop.consecutiveCount),
+                  ],
+                  { stderr: "ignore", stdout: "ignore" },
+                );
               }
             }
           }


### PR DESCRIPTION
## Summary

`pluginInput` in the opencode plugin context has no `$` shell-tag property, so the doom loop event write was gated behind a condition that was always false. `prism stats --doomloops` always showed empty results as a consequence.

Replaces the dead `(pluginInput as any).$` pattern with a direct `Bun.spawn` call, which is the correct way to invoke a subprocess from an opencode plugin. The call remains fire-and-forget with stderr/stdout suppressed — the steering prompt injection is unaffected.

## Changes

- `modules/programs/prism/opencode/plugins/prism-hooks.ts`: replace broken `pluginInput.$` shell-tag pattern with `Bun.spawn(["prism", "event", "doom-loop-detected", ...])` at lines 284–303

Closes #1114