### PR TITLE
fix: --model/--variant flags silently ignored for sandboxed sessions

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -128,7 +128,16 @@ var prCmd = &cobra.Command{
 				return roleErr
 			}
 			if roleConfig != "" {
-				configContent = roleConfig
+				// Role config governs agent identity and permissions. Re-apply
+				// any --model/--variant overrides on top so they are not lost.
+				// prism pr has no --model/--profile/--variant flags today, but
+				// the call is a no-op when all overrides are empty, ensuring
+				// forward-compatibility if those flags are added later.
+				patched, patchErr := config.ApplyModelOverrides(roleConfig, "", "", "", pf)
+				if patchErr != nil {
+					return patchErr
+				}
+				configContent = patched
 			} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
 				fmt.Fprintf(os.Stderr, "[prism pr] warning: no container role config for %q in profiles.json — rebuild the system config to generate it\n", effectiveRole)
 			}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -368,9 +368,14 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			return roleErr
 		}
 		if roleConfig != "" {
-			// Role config supersedes profile/model overrides for identity &
-			// permissions; use it as the primary config content.
-			configContent = roleConfig
+			// Role config governs agent identity and permissions (system prompt,
+			// tool allow-list). Re-apply any --model/--variant overrides on top
+			// so that user-supplied flags are not silently discarded.
+			patched, patchErr := config.ApplyModelOverrides(roleConfig, profileFlag, modelFlag, variantFlag, pf)
+			if patchErr != nil {
+				return patchErr
+			}
+			configContent = patched
 		} else if effectiveRole == "worker" || effectiveRole == "coordinator" {
 			// worker and coordinator are container-level roles that must have a
 			// config blob; an empty result means the system config is stale.

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -340,6 +340,124 @@ func allKnownAgents(pf *ProfilesFile) []string {
 	}
 }
 
+// ApplyModelOverrides patches modelOverride and/or variantOverride into an
+// existing role config JSON blob (e.g. ContainerWorkerConfig) and returns the
+// result as a JSON string.
+//
+// Rules (mirror BuildConfigContent semantics):
+//   - modelOverride non-empty → set top-level "model" and every agent's "model".
+//   - variantOverride non-empty → set every agent's "variant".
+//   - profileName non-empty and modelOverride non-empty → only override
+//     primary-role agents' "model" (same as BuildConfigContent when both flags
+//     are set). pf must be non-nil in this case to resolve the primary-role list.
+//   - Both overrides empty → return blob unchanged (no re-marshal).
+//
+// The function preserves all other fields in the blob (agent identity, system
+// prompt, tool allow-list, $schema, etc.).
+//
+// Returns an error if blob is non-empty but not valid JSON.
+func ApplyModelOverrides(blob, profileName, modelOverride, variantOverride string, pf *ProfilesFile) (string, error) {
+	if modelOverride == "" && variantOverride == "" {
+		// Nothing to override — return blob as-is.
+		return blob, nil
+	}
+	if blob == "" {
+		// No base blob — nothing to patch.
+		return blob, nil
+	}
+
+	// Parse the existing blob into a generic map.
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(blob), &cfg); err != nil {
+		return "", fmt.Errorf("profiles: ApplyModelOverrides: parse blob: %w", err)
+	}
+
+	// Ensure the "agent" sub-map exists (it may be absent in minimal blobs).
+	agentObj, _ := cfg["agent"].(map[string]any)
+	if agentObj == nil {
+		agentObj = make(map[string]any)
+	}
+
+	// Determine which agent names should receive the model override.
+	// When profileName is set, only primary-role agents are overridden (matching
+	// BuildConfigContent behaviour). Otherwise all known agents are overridden.
+	var primaryAgents map[string]struct{}
+	if profileName != "" && modelOverride != "" && pf != nil {
+		primaryAgents = make(map[string]struct{})
+		for _, name := range pf.RoleMapping["primary"] {
+			primaryAgents[name] = struct{}{}
+		}
+	}
+
+	// Apply modelOverride to the top-level field.
+	if modelOverride != "" {
+		cfg["model"] = modelOverride
+	}
+
+	// Apply overrides to each existing agent entry, and to every known agent
+	// for variant (which must reach even agents not yet listed in the blob).
+	//
+	// Strategy:
+	//  1. Update existing agent entries in agentObj.
+	//  2. For variantOverride, also ensure every known agent has an entry.
+	//  3. For modelOverride (no-profile path), also ensure every known agent
+	//     has an entry so they don't silently use the system-default model
+	//     when opened in a new blob that lacks them.
+
+	// Collect all agent names we must touch.
+	agentsToTouch := make(map[string]struct{})
+	// Always touch agents already declared in the blob.
+	for name := range agentObj {
+		agentsToTouch[name] = struct{}{}
+	}
+	// When variantOverride is set, ensure every known agent is present.
+	if variantOverride != "" {
+		for _, name := range allKnownAgents(pf) {
+			agentsToTouch[name] = struct{}{}
+		}
+	}
+	// When modelOverride is set without a profile (→ override all agents),
+	// ensure every known agent is present.
+	if modelOverride != "" && profileName == "" {
+		for _, name := range allKnownAgents(pf) {
+			agentsToTouch[name] = struct{}{}
+		}
+	}
+
+	for name := range agentsToTouch {
+		entry, _ := agentObj[name].(map[string]any)
+		if entry == nil {
+			entry = make(map[string]any)
+		}
+		if modelOverride != "" {
+			// Apply model override: to all agents when no profile, or only to
+			// primary-role agents when a profile is set.
+			if primaryAgents == nil {
+				entry["model"] = modelOverride
+			} else if _, isPrimary := primaryAgents[name]; isPrimary {
+				entry["model"] = modelOverride
+			}
+		}
+		if variantOverride != "" {
+			entry["variant"] = variantOverride
+		}
+		// Only write back if the entry has content.
+		if len(entry) > 0 {
+			agentObj[name] = entry
+		}
+	}
+
+	if len(agentObj) > 0 {
+		cfg["agent"] = agentObj
+	}
+
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("profiles: ApplyModelOverrides: marshal: %w", err)
+	}
+	return string(out), nil
+}
+
 // marshalConfigContent builds the JSON blob for OPENCODE_CONFIG_CONTENT.
 func marshalConfigContent(topModel string, agentMap map[string]agentCfg) (string, error) {
 	// Build the top-level map.

--- a/modules/programs/prism/prism/internal/config/profiles_test.go
+++ b/modules/programs/prism/prism/internal/config/profiles_test.go
@@ -481,6 +481,265 @@ func TestContainerConfigForRole_NilProfilesFile(t *testing.T) {
 	}
 }
 
+// ── ApplyModelOverrides tests ─────────────────────────────────────────────────
+
+// workerBlob is a realistic ContainerWorkerConfig blob as produced by Nix.
+// It includes a top-level model, agent entries with model fields, a $schema,
+// and a system prompt field to verify those are preserved unchanged.
+const workerBlob = `{
+  "$schema": "https://opencode.ai/opencode.json",
+  "model": "anthropic/claude-sonnet-4-6",
+  "agent": {
+    "worker": {
+      "model": "anthropic/claude-sonnet-4-6",
+      "system": "You are a worker agent."
+    },
+    "title": {
+      "model": "anthropic/claude-haiku-4-5"
+    }
+  }
+}`
+
+// TestApplyModelOverrides_NoOverrides verifies that an empty modelOverride and
+// variantOverride returns the blob unchanged (no re-marshal side-effects).
+func TestApplyModelOverrides_NoOverrides(t *testing.T) {
+	result, err := config.ApplyModelOverrides(workerBlob, "", "", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != workerBlob {
+		t.Errorf("expected blob unchanged, got %q", result)
+	}
+}
+
+// TestApplyModelOverrides_EmptyBlob verifies that an empty blob is returned
+// as-is even when overrides are set.
+func TestApplyModelOverrides_EmptyBlob(t *testing.T) {
+	result, err := config.ApplyModelOverrides("", "", "anthropic/claude-opus-4-7", "high", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "" {
+		t.Errorf("expected empty result for empty blob, got %q", result)
+	}
+}
+
+// TestApplyModelOverrides_ModelOnly verifies that --model sets the top-level
+// model and all agent models, preserving other fields.
+func TestApplyModelOverrides_ModelOnly(t *testing.T) {
+	result, err := config.ApplyModelOverrides(workerBlob, "", "anthropic/claude-opus-4-7", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	// Top-level model must be overridden.
+	if cfg["model"] != "anthropic/claude-opus-4-7" {
+		t.Errorf("top-level model: got %v, want anthropic/claude-opus-4-7", cfg["model"])
+	}
+
+	// $schema must be preserved.
+	if cfg["$schema"] == nil {
+		t.Error("$schema field was dropped")
+	}
+
+	agents := cfg["agent"].(map[string]any)
+
+	// worker model must be overridden, system prompt preserved.
+	worker := agents["worker"].(map[string]any)
+	if worker["model"] != "anthropic/claude-opus-4-7" {
+		t.Errorf("worker model: got %v, want anthropic/claude-opus-4-7", worker["model"])
+	}
+	if worker["system"] == nil {
+		t.Error("worker system prompt was dropped")
+	}
+
+	// title model must also be overridden.
+	title := agents["title"].(map[string]any)
+	if title["model"] != "anthropic/claude-opus-4-7" {
+		t.Errorf("title model: got %v, want anthropic/claude-opus-4-7", title["model"])
+	}
+}
+
+// TestApplyModelOverrides_VariantOnly verifies that --variant sets the variant
+// on all agents while leaving models unchanged.
+func TestApplyModelOverrides_VariantOnly(t *testing.T) {
+	result, err := config.ApplyModelOverrides(workerBlob, "", "", "high", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	// Top-level model must be unchanged.
+	if cfg["model"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("top-level model changed: got %v", cfg["model"])
+	}
+
+	agents := cfg["agent"].(map[string]any)
+
+	// worker: model unchanged, variant added.
+	worker := agents["worker"].(map[string]any)
+	if worker["model"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("worker model changed: got %v", worker["model"])
+	}
+	if worker["variant"] != "high" {
+		t.Errorf("worker variant: got %v, want high", worker["variant"])
+	}
+
+	// title: model unchanged, variant added.
+	title := agents["title"].(map[string]any)
+	if title["model"] != "anthropic/claude-haiku-4-5" {
+		t.Errorf("title model changed: got %v", title["model"])
+	}
+	if title["variant"] != "high" {
+		t.Errorf("title variant: got %v, want high", title["variant"])
+	}
+}
+
+// TestApplyModelOverrides_ModelAndVariant verifies that both --model and
+// --variant are applied together.
+func TestApplyModelOverrides_ModelAndVariant(t *testing.T) {
+	result, err := config.ApplyModelOverrides(workerBlob, "", "anthropic/claude-opus-4-7", "high", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if cfg["model"] != "anthropic/claude-opus-4-7" {
+		t.Errorf("top-level model: got %v, want anthropic/claude-opus-4-7", cfg["model"])
+	}
+
+	agents := cfg["agent"].(map[string]any)
+	worker := agents["worker"].(map[string]any)
+	if worker["model"] != "anthropic/claude-opus-4-7" {
+		t.Errorf("worker model: got %v, want anthropic/claude-opus-4-7", worker["model"])
+	}
+	if worker["variant"] != "high" {
+		t.Errorf("worker variant: got %v, want high", worker["variant"])
+	}
+}
+
+// TestApplyModelOverrides_WithProfile verifies that when a profile name is
+// supplied alongside a model override, only primary-role agents have their
+// model overridden (matching BuildConfigContent semantics).
+func TestApplyModelOverrides_WithProfile(t *testing.T) {
+	pf := sampleProfilesFile()
+	// "anthropic" profile: primary=["coordinator","plan"], secondary=["worker","review","ac"],
+	// lightweight=["explore","title","summary","compaction"].
+	// The blob has worker (secondary) and title (lightweight) plus we add coordinator.
+	blob := `{
+		"model": "anthropic/claude-sonnet-4-6",
+		"agent": {
+			"coordinator": {"model": "anthropic/claude-opus-4-6"},
+			"worker":      {"model": "anthropic/claude-sonnet-4-6"},
+			"title":       {"model": "anthropic/claude-haiku-4-5"}
+		}
+	}`
+
+	result, err := config.ApplyModelOverrides(blob, "anthropic", "custom/model", "", pf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	// Top-level model must be overridden.
+	if cfg["model"] != "custom/model" {
+		t.Errorf("top-level model: got %v, want custom/model", cfg["model"])
+	}
+
+	agents := cfg["agent"].(map[string]any)
+
+	// coordinator is primary → model overridden.
+	coordinator := agents["coordinator"].(map[string]any)
+	if coordinator["model"] != "custom/model" {
+		t.Errorf("coordinator model: got %v, want custom/model", coordinator["model"])
+	}
+
+	// worker is secondary → model NOT overridden.
+	worker := agents["worker"].(map[string]any)
+	if worker["model"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("worker model: got %v, want anthropic/claude-sonnet-4-6 (unchanged)", worker["model"])
+	}
+
+	// title is lightweight → model NOT overridden.
+	title := agents["title"].(map[string]any)
+	if title["model"] != "anthropic/claude-haiku-4-5" {
+		t.Errorf("title model: got %v, want anthropic/claude-haiku-4-5 (unchanged)", title["model"])
+	}
+}
+
+// TestApplyModelOverrides_PreservesNonModelFields verifies that non-model
+// fields in the blob (system prompt, tool permissions, $schema, etc.) are
+// preserved unchanged after applying overrides.
+func TestApplyModelOverrides_PreservesNonModelFields(t *testing.T) {
+	blob := `{
+		"$schema": "https://opencode.ai/opencode.json",
+		"model": "anthropic/claude-sonnet-4-6",
+		"agent": {
+			"worker": {
+				"model": "anthropic/claude-sonnet-4-6",
+				"system": "You are a worker agent.",
+				"tools": {"bash": {"deny": ["rm -rf"]}}
+			}
+		}
+	}`
+
+	result, err := config.ApplyModelOverrides(blob, "", "anthropic/claude-opus-4-7", "high", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if cfg["$schema"] == nil {
+		t.Error("$schema was dropped")
+	}
+
+	agents := cfg["agent"].(map[string]any)
+	worker := agents["worker"].(map[string]any)
+
+	if worker["system"] == nil {
+		t.Error("system prompt was dropped")
+	}
+	if worker["tools"] == nil {
+		t.Error("tools field was dropped")
+	}
+	if worker["model"] != "anthropic/claude-opus-4-7" {
+		t.Errorf("worker model: got %v, want anthropic/claude-opus-4-7", worker["model"])
+	}
+	if worker["variant"] != "high" {
+		t.Errorf("worker variant: got %v, want high", worker["variant"])
+	}
+}
+
+// TestApplyModelOverrides_InvalidBlob verifies that an invalid JSON blob
+// returns an error.
+func TestApplyModelOverrides_InvalidBlob(t *testing.T) {
+	_, err := config.ApplyModelOverrides("not json {{", "", "some/model", "", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON blob, got nil")
+	}
+}
+
 func TestLoadProfiles_MissingFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/nonexistent/path")
 	_, err := config.LoadProfiles()


### PR DESCRIPTION
## Summary

- `prism spawn --model <x>` on bwrap/podman/sandbox-exec sessions was silently discarded because `ContainerConfigForRole` returned the Nix-baked role config blob which was unconditionally overwriting the `configContent` built from user flags.
- Adds `config.ApplyModelOverrides(blob, profileName, modelOverride, variantOverride, pf)` to `internal/config/profiles.go`: patches model/variant fields into an existing role config blob while preserving all other fields (agent identity, system prompt, tool allow-list, `$schema`, etc.).
- Calls the helper in `spawn.go` (the primary fix site) and `pr.go` (same pattern, no-op today since `prism pr` has no model flags — forward-compat).
- `switch.go` and `restore.go` were audited: neither accepts `--model`/`--profile`/`--variant` flags, so no change needed there.
- 8 new tests cover: no-op when overrides empty, empty blob passthrough, model-only, variant-only, model+variant, profile+model (primary-only override), field preservation, invalid blob error.

Closes #1119