### PR TITLE
prism: A.1 Phase 1 — IsolationRegistry skeleton + Capabilities + Resolve

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/prismatic-koi/prism/internal/config"
 )
 
 // bwrapIsolator implements Isolator using bubblewrap (bwrap). It satisfies the
@@ -43,6 +45,30 @@ type bwrapIsolator struct {
 // session name. The returned value satisfies the Isolator interface.
 func newBwrapIsolator(name string) Isolator {
 	return &bwrapIsolator{name: name}
+}
+
+// Name returns config.IsolationBwrap — the registry key for this isolator.
+func (b *bwrapIsolator) Name() config.IsolationMode {
+	return config.IsolationBwrap
+}
+
+// Capabilities returns the bwrap feature flags:
+//   - NeedsConfigBlob: config blob must be written to disk before agent-run.
+//   - NeedsHostAPISocket: the sidecar binds the host-API socket for in-sandbox proxy calls.
+//   - RestartOnExit: the sidecar restart-loop fires to relaunch agent-run on exit.
+//   - NeedsStartupConnectTimeout: bwrap-specific startup-connect timeout in the sidecar.
+func (b *bwrapIsolator) Capabilities() Capabilities {
+	return Capabilities{
+		IsContainer:                false,
+		OwnsContainerLifecycle:     false,
+		NeedsConfigBlob:            true,
+		NeedsHostAPISocket:         true,
+		UsesContainerHarness:       false,
+		RestartOnExit:              true,
+		NeedsStartupConnectTimeout: true,
+		NeedsReadinessWait:         false,
+		EmitsTmuxStatusColumns:     false,
+	}
 }
 
 // BuildRunArgs satisfies the Isolator interface. It returns nil because the
@@ -731,4 +757,10 @@ func (b *bwrapIsolator) HasExited() (bool, int) {
 // for bwrap (stdout/stderr are forwarded live to the sidecar log during Run).
 func (b *bwrapIsolator) DumpLogs() {
 	log.Printf("container: bwrap %q: live output was forwarded to sidecar stderr during Run", b.name)
+}
+
+func init() {
+	MustRegister(config.IsolationBwrap, func(opts ConstructorOpts) Isolator {
+		return newBwrapIsolator(opts.Name)
+	})
 }

--- a/modules/programs/prism/prism/internal/container/host.go
+++ b/modules/programs/prism/prism/internal/container/host.go
@@ -1,0 +1,84 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file defines hostIsolator, a no-op implementation of the Isolator
+// interface for IsolationHost ("host") mode, where opencode runs directly in
+// the tmux pane with no sandbox layer.
+//
+// Option A from A.1 §4.4: hostIsolator is a registered no-op so that every
+// caller goes through registry.For(mode) uniformly — no special-case for host.
+package container
+
+import (
+	"context"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// hostIsolator implements Isolator for the "host" isolation mode. The agent
+// runs directly in the tmux pane with no sandboxing; most lifecycle operations
+// are no-ops. AgentRun returns an error because host mode reaches opencode
+// directly via the tmux pane command, not via prism agent-run.
+type hostIsolator struct {
+	// name is the stable session identifier (used for log messages).
+	name string
+}
+
+// newHostIsolator returns an Isolator that represents the host (no-op) mode
+// for the given session name.
+func newHostIsolator(name string) Isolator {
+	return &hostIsolator{name: name}
+}
+
+// Name returns config.IsolationHost — the registry key for this isolator.
+func (h *hostIsolator) Name() config.IsolationMode {
+	return config.IsolationHost
+}
+
+// Capabilities returns the host feature flags: all flags are false because
+// host mode runs opencode directly with no sandboxing, no container lifecycle,
+// no config-blob injection, and no special sidecar behaviours.
+func (h *hostIsolator) Capabilities() Capabilities {
+	return Capabilities{
+		IsContainer:                false,
+		OwnsContainerLifecycle:     false,
+		NeedsConfigBlob:            false,
+		NeedsHostAPISocket:         false,
+		UsesContainerHarness:       false,
+		RestartOnExit:              false,
+		NeedsStartupConnectTimeout: false,
+		NeedsReadinessWait:         false,
+		EmitsTmuxStatusColumns:     false,
+	}
+}
+
+// BuildRunArgs is a no-op for host mode: opencode is launched directly by the
+// tmux pane command (BuildOpencodeCmd), not via a Run call.
+func (h *hostIsolator) BuildRunArgs() []string {
+	return nil
+}
+
+// Run is a no-op stub for host mode: opencode is launched directly in the
+// tmux pane, so this Isolator's Run path is never reached in the production
+// flow.
+func (h *hostIsolator) Run(_ context.Context, _ []string) error {
+	return nil
+}
+
+// Shutdown is a no-op for host mode: the opencode process is owned by the
+// tmux pane's process tree and terminates when the pane closes.
+func (h *hostIsolator) Shutdown() {}
+
+// HasExited always returns (false, 0) for host mode: the Manager-level
+// Isolator never observes the opencode process in the production flow.
+func (h *hostIsolator) HasExited() (bool, int) {
+	return false, 0
+}
+
+// DumpLogs is a no-op for host mode: opencode writes directly to the tmux
+// pane terminal; there is no separate log capture path.
+func (h *hostIsolator) DumpLogs() {}
+
+func init() {
+	MustRegister(config.IsolationHost, func(opts ConstructorOpts) Isolator {
+		return newHostIsolator(opts.Name)
+	})
+}

--- a/modules/programs/prism/prism/internal/container/isolator.go
+++ b/modules/programs/prism/prism/internal/container/isolator.go
@@ -12,12 +12,73 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/prismatic-koi/prism/internal/config"
 )
+
+// Capabilities is a flat struct of per-mode feature flags consulted by callers
+// that today branch on the literal isolation mode value. A single
+// iso.Capabilities() call is cheaper and more readable than a long parade of
+// yes/no methods on the interface.
+//
+// Each flag is cited with the call sites that would collapse to a capability
+// query after the per-phase migrations in A.1's §7.
+type Capabilities struct {
+	// IsContainer replaces (isoMode == IsolationPodman) tests outside the
+	// package. True only for podmanIsolator.
+	// Cites: cmd/spawn.go:275, cmd/switch.go:1069, cmd/pr.go:77.
+	IsContainer bool
+
+	// OwnsContainerLifecycle means the sidecar creates, stops, and removes
+	// the container. True only for podmanIsolator.
+	// Cites: internal/sidecar/sidecar.go:153-183 (s.cfg.Container == nil branch).
+	OwnsContainerLifecycle bool
+
+	// NeedsConfigBlob means the harness config blob must be supplied via
+	// env-var or on-disk file before the process starts. True for podman,
+	// bwrap, and sandbox-exec; false for host.
+	// Cites: cmd/spawn.go:311-357, cmd/switch.go:1069-1108,
+	//        cmd/restore.go:269-292, cmd/pr.go:77-170,
+	//        internal/review/review.go:1230.
+	NeedsConfigBlob bool
+
+	// NeedsHostAPISocket means the sidecar binds the host-API Unix socket for
+	// this mode. True for bwrap and sandbox-exec; false for podman and host.
+	// Cites: internal/sidecar/sidecar.go:512-547; cmd/sidecar.go:233-249.
+	NeedsHostAPISocket bool
+
+	// UsesContainerHarness means the harness adapter is constructed in
+	// container mode (podman) vs host mode (bwrap, sandbox-exec, host).
+	// Cites: cmd/sidecar.go:288-301.
+	UsesContainerHarness bool
+
+	// RestartOnExit means the sidecar restart-loop goroutine is started for
+	// this mode. True for podman and bwrap; false for sandbox-exec and host.
+	// Cites: cmd/sidecar.go:348.
+	RestartOnExit bool
+
+	// NeedsStartupConnectTimeout means the sidecar's startup-connect timeout
+	// fires for this mode. True for bwrap; false for all others.
+	// Cites: internal/sidecar/sidecar.go:638-680.
+	NeedsStartupConnectTimeout bool
+
+	// NeedsReadinessWait means the agent-pane command should be prefixed by
+	// the readiness-wait shell command. True for podman; false for others.
+	// Cites: internal/session/session.go:539-547.
+	NeedsReadinessWait bool
+
+	// EmitsTmuxStatusColumns means the tmux event hooks should seed
+	// isolation-specific status columns for sessions in this mode. True for
+	// podman; false for bwrap, sandbox-exec, and host.
+	// Cites: cmd/event.go (per §6.22 flat appendix).
+	EmitsTmuxStatusColumns bool
+}
 
 // Isolator is the interface that wraps the isolation-specific operations needed
 // by Manager to create and manage an agent session container.
 //
 // An Isolator is responsible for:
+//   - Reporting its identity (Name, Capabilities).
 //   - Building the argument list for launching the isolated process.
 //   - Executing the launch command.
 //   - Shutting down the isolated process cleanly.
@@ -28,6 +89,16 @@ import (
 // exclusively — no direct exec.CommandContext("podman", ...) calls remain in
 // container.go after this interface is in place.
 type Isolator interface {
+	// Name returns the canonical mode name as persisted in the database and
+	// accepted by --isolation. The value is the IsolationRegistry key.
+	// Cites: internal/config/config.go:18-43 (the IsolationMode constants).
+	Name() config.IsolationMode
+
+	// Capabilities returns the per-mode feature flags consulted by callers
+	// that today branch on the literal mode value. See the Capabilities struct
+	// above for the full set of flags and their citations.
+	Capabilities() Capabilities
+
 	// BuildRunArgs returns the complete argument list for launching the isolated
 	// session process (e.g. all arguments after the "podman" binary for a
 	// podman run invocation). The returned slice must not be modified by the
@@ -65,6 +136,32 @@ type podmanIsolator struct {
 // container with the given stable container name.
 func newPodmanIsolator(name string) Isolator {
 	return &podmanIsolator{name: name}
+}
+
+// Name returns config.IsolationPodman — the registry key for this isolator.
+func (p *podmanIsolator) Name() config.IsolationMode {
+	return config.IsolationPodman
+}
+
+// Capabilities returns the podman feature flags:
+//   - IsContainer + OwnsContainerLifecycle: the sidecar manages a real container.
+//   - NeedsConfigBlob: config blob is injected as an env var into the container.
+//   - UsesContainerHarness: the harness adapter is built in container mode.
+//   - RestartOnExit: the sidecar restart-loop fires to keep the container alive.
+//   - NeedsReadinessWait: the agent pane waits for the container HTTP endpoint.
+//   - EmitsTmuxStatusColumns: podman sessions seed the tmux status columns.
+func (p *podmanIsolator) Capabilities() Capabilities {
+	return Capabilities{
+		IsContainer:            true,
+		OwnsContainerLifecycle: true,
+		NeedsConfigBlob:        true,
+		NeedsHostAPISocket:     false,
+		UsesContainerHarness:   true,
+		RestartOnExit:          true,
+		NeedsStartupConnectTimeout: false,
+		NeedsReadinessWait:     true,
+		EmitsTmuxStatusColumns: true,
+	}
 }
 
 // BuildRunArgs returns the argument list for "podman run …" built by the
@@ -155,4 +252,10 @@ func (p *podmanIsolator) DumpLogs() {
 		return
 	}
 	log.Printf("container: logs for %q:\n%s", p.name, string(out))
+}
+
+func init() {
+	MustRegister(config.IsolationPodman, func(opts ConstructorOpts) Isolator {
+		return newPodmanIsolator(opts.Name)
+	})
 }

--- a/modules/programs/prism/prism/internal/container/registry.go
+++ b/modules/programs/prism/prism/internal/container/registry.go
@@ -1,0 +1,252 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file defines IsolationRegistry — a name→constructor map populated at
+// init() time by each isolator file — and the Resolve helper that centralises
+// the back-compat resolution logic that is currently scattered across multiple
+// call sites.
+//
+// Phase 1 of A.1 §7: the registry exists and is consultable, but no existing
+// caller has been migrated to read from it yet. That migration is the work of
+// A.1 Phases 2–4.
+package container
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// ConstructorOpts carries the per-session parameters passed to an isolator
+// constructor. Name is the stable session identifier (the container name for
+// podman, or the raw session name for the other modes).
+type ConstructorOpts struct {
+	Name string
+}
+
+// Constructor is a factory function that returns an Isolator for a given set
+// of construction options. Each isolator file registers one at init() time.
+type Constructor func(opts ConstructorOpts) Isolator
+
+// Registration holds everything the registry stores for one isolation mode.
+type Registration struct {
+	// Name is the canonical mode name (the registry key).
+	Name config.IsolationMode
+
+	// Constructor is the factory function that creates an Isolator instance.
+	Constructor Constructor
+
+	// Capabilities is a pre-computed snapshot of the mode's feature flags,
+	// used for capability queries that do not need a live Isolator instance.
+	Capabilities Capabilities
+}
+
+// IsolationRegistry maps isolation mode names to their constructors.
+// Isolators register at init() time; the registry is consulted at spawn time
+// and by capability queries. The singleton is package-level; callers use the
+// package-level Register, MustRegister, For, Names, and Resolve functions
+// rather than constructing an IsolationRegistry directly.
+type IsolationRegistry struct {
+	mu            sync.RWMutex
+	registrations map[config.IsolationMode]Registration
+}
+
+// globalRegistry is the package-level singleton populated by init()
+// registrations in each isolator file.
+var globalRegistry = &IsolationRegistry{
+	registrations: make(map[config.IsolationMode]Registration),
+}
+
+// Register adds a constructor for name to the global registry. It returns an
+// error if name is already registered. The Capabilities snapshot is obtained
+// by calling the constructor with a zero-value ConstructorOpts and invoking
+// Capabilities() on the resulting Isolator.
+func Register(name config.IsolationMode, c Constructor) error {
+	globalRegistry.mu.Lock()
+	defer globalRegistry.mu.Unlock()
+
+	if _, exists := globalRegistry.registrations[name]; exists {
+		return fmt.Errorf("container: isolation mode %q is already registered", name)
+	}
+
+	// Compute a capabilities snapshot from a throw-away instance so callers
+	// can query capabilities without constructing a live isolator.
+	probe := c(ConstructorOpts{})
+	globalRegistry.registrations[name] = Registration{
+		Name:         name,
+		Constructor:  c,
+		Capabilities: probe.Capabilities(),
+	}
+	return nil
+}
+
+// MustRegister is like Register but panics on double-registration. It is the
+// intended call site for init() functions — a duplicate registration is always
+// a programming error, not a runtime condition.
+func MustRegister(name config.IsolationMode, c Constructor) {
+	if err := Register(name, c); err != nil {
+		panic(err)
+	}
+}
+
+// For returns a new Isolator for the given mode and construction options. It
+// returns a clear error (not a panic) when mode is not registered.
+func For(mode config.IsolationMode, opts ConstructorOpts) (Isolator, error) {
+	globalRegistry.mu.RLock()
+	reg, ok := globalRegistry.registrations[mode]
+	globalRegistry.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("container: unknown isolation mode %q; registered modes: %s",
+			mode, joinModeNames(globalRegistry))
+	}
+	return reg.Constructor(opts), nil
+}
+
+// Names returns the registered mode names in sorted order. This is the
+// authoritative list of modes the current binary knows how to run.
+func Names() []config.IsolationMode {
+	globalRegistry.mu.RLock()
+	defer globalRegistry.mu.RUnlock()
+
+	names := make([]config.IsolationMode, 0, len(globalRegistry.registrations))
+	for name := range globalRegistry.registrations {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return names[i] < names[j]
+	})
+	return names
+}
+
+// joinModeNames returns a comma-separated string of the registered mode names.
+// The caller must hold at least a read lock on globalRegistry.mu.
+func joinModeNames(r *IsolationRegistry) string {
+	names := make([]string, 0, len(r.registrations))
+	for name := range r.registrations {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += n
+	}
+	return out
+}
+
+// ResolveInput carries all the inputs that the back-compat resolution logic
+// needs. Fields marked "deprecated" correspond to the legacy surfaces that
+// A.4 will remove; they are preserved verbatim here so that Resolve mirrors
+// today's behaviour exactly and A.4 has a single file to edit.
+type ResolveInput struct {
+	// IsolationFlag is the value of the --isolation CLI flag, empty when the
+	// flag was not set (use IsolationFlagChanged to distinguish).
+	IsolationFlag string
+
+	// IsolationFlagChanged is true when --isolation was explicitly set by the
+	// user (cobra's cmd.Flags().Changed("isolation")).
+	IsolationFlagChanged bool
+
+	// HostModeFlag is the value of the deprecated --host-mode CLI flag.
+	// Deprecated: use IsolationFlag with "host" instead.
+	HostModeFlag bool
+
+	// HostModeFlagChanged is true when --host-mode was explicitly set.
+	// Deprecated: A.4 removes this flag.
+	HostModeFlagChanged bool
+
+	// DBIsolationMode is the isolation_mode column value from an
+	// agent_status DB row. Empty string means the column was not recorded
+	// (pre-v10 rows) — fall back to DBHostMode.
+	DBIsolationMode string
+
+	// DBHostMode is the host_mode column value from an agent_status DB row.
+	// Deprecated: A.4 removes this column after backfilling isolation_mode.
+	DBHostMode bool
+
+	// ConfigDefault is the result of cfg.EffectiveIsolationMode() — the
+	// machine-level default from config.json (with ContainerMode back-compat
+	// already applied by the Config method).
+	ConfigDefault config.IsolationMode
+
+	// ContainerMode is the deprecated Opts.ContainerMode / SpawnOpts.ContainerMode
+	// bool. When true and IsolationFlag is empty, it maps to "podman".
+	// Deprecated: A.4 removes this field from all Opts structs.
+	ContainerMode bool
+}
+
+// Resolve picks the effective isolation mode from the various sources of truth,
+// preserving all back-compat paths verbatim so the deprecated surfaces can be
+// removed in one place (A.4) without changing any caller.
+//
+// Resolution order (mirrors today's scattered logic):
+//  1. --isolation flag (explicit override, validated).
+//  2. --host-mode flag (deprecated alias for "host"). Errors if --isolation
+//     is also set.
+//  3. DB isolation_mode column (from a restored session row).
+//  4. DB host_mode column → "host" (back-compat for pre-v10 rows).
+//  5. ContainerMode bool → "podman" (deprecated Opts field).
+//  6. ConfigDefault (cfg.EffectiveIsolationMode() — already applies the
+//     ContainerMode bool from config.json).
+//
+// Cites: cmd/spawn.go:164-198 (resolveIsolationMode);
+//
+//	internal/session/session.go:253-263 (effectiveIsolationMode);
+//	internal/session/spawn.go:604-616 (spawnAgentOnlyLayout fallback);
+//	cmd/restore.go:279-290 (per-row resolver);
+//	internal/db/db.go:86-98 (Status.EffectiveIsolationMode).
+func Resolve(input ResolveInput) (config.IsolationMode, error) {
+	// Reject simultaneous --isolation and --host-mode (mirrors resolveIsolationMode).
+	if input.IsolationFlagChanged && input.HostModeFlagChanged {
+		return "", fmt.Errorf("--isolation and --host-mode cannot be used together; --host-mode is a deprecated alias for --isolation host")
+	}
+
+	// 1. --isolation flag.
+	if input.IsolationFlagChanged && input.IsolationFlag != "" {
+		mode := config.IsolationMode(input.IsolationFlag)
+		if !config.IsValidIsolationMode(input.IsolationFlag) {
+			return "", fmt.Errorf("unknown isolation mode %q; registered modes: %s",
+				input.IsolationFlag, modesString())
+		}
+		return mode, nil
+	}
+
+	// 2. --host-mode (deprecated alias).
+	if input.HostModeFlagChanged && input.HostModeFlag {
+		return config.IsolationHost, nil
+	}
+
+	// 3. DB isolation_mode column (non-empty → use directly).
+	if input.DBIsolationMode != "" {
+		return config.IsolationMode(input.DBIsolationMode), nil
+	}
+
+	// 4. DB host_mode column → "host" (pre-v10 back-compat).
+	if input.DBHostMode {
+		return config.IsolationHost, nil
+	}
+
+	// 5. Deprecated ContainerMode bool → "podman".
+	if input.ContainerMode {
+		return config.IsolationPodman, nil
+	}
+
+	// 6. Machine-level config default.
+	if input.ConfigDefault != "" {
+		return input.ConfigDefault, nil
+	}
+
+	// Final safety net: should not be reached in a correctly configured system.
+	return config.IsolationHost, nil
+}
+
+// modesString returns a comma-separated string of registered mode names for
+// use in error messages. Acquires a read lock on the global registry.
+func modesString() string {
+	globalRegistry.mu.RLock()
+	defer globalRegistry.mu.RUnlock()
+	return joinModeNames(globalRegistry)
+}

--- a/modules/programs/prism/prism/internal/container/registry.go
+++ b/modules/programs/prism/prism/internal/container/registry.go
@@ -98,7 +98,7 @@ func For(mode config.IsolationMode, opts ConstructorOpts) (Isolator, error) {
 
 	if !ok {
 		return nil, fmt.Errorf("container: unknown isolation mode %q; registered modes: %s",
-			mode, joinModeNames(globalRegistry))
+			mode, modesString())
 	}
 	return reg.Constructor(opts), nil
 }
@@ -120,7 +120,7 @@ func Names() []config.IsolationMode {
 }
 
 // joinModeNames returns a comma-separated string of the registered mode names.
-// The caller must hold at least a read lock on globalRegistry.mu.
+// The caller must already hold at least a read lock on r.mu.
 func joinModeNames(r *IsolationRegistry) string {
 	names := make([]string, 0, len(r.registrations))
 	for name := range r.registrations {

--- a/modules/programs/prism/prism/internal/container/registry_test.go
+++ b/modules/programs/prism/prism/internal/container/registry_test.go
@@ -1,0 +1,356 @@
+package container
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// newTestRegistry returns a fresh, empty IsolationRegistry for use in tests
+// that must not share state with the global singleton.
+func newTestRegistry() *IsolationRegistry {
+	return &IsolationRegistry{
+		registrations: make(map[config.IsolationMode]Registration),
+	}
+}
+
+// registerOnto calls the package-level Register logic against a specific
+// registry (not the global one) so tests can run in isolation.
+func registerOnto(r *IsolationRegistry, name config.IsolationMode, c Constructor) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.registrations[name]; exists {
+		return fmt.Errorf("container: isolation mode %q is already registered", name)
+	}
+	probe := c(ConstructorOpts{})
+	r.registrations[name] = Registration{
+		Name:         name,
+		Constructor:  c,
+		Capabilities: probe.Capabilities(),
+	}
+	return nil
+}
+
+// ── IsolationRegistry double-registration ────────────────────────────────────
+
+func TestRegistry_DoubleRegistration_ReturnsError(t *testing.T) {
+	r := newTestRegistry()
+
+	c := func(opts ConstructorOpts) Isolator { return newHostIsolator(opts.Name) }
+
+	if err := registerOnto(r, config.IsolationHost, c); err != nil {
+		t.Fatalf("first registration failed unexpectedly: %v", err)
+	}
+	if err := registerOnto(r, config.IsolationHost, c); err == nil {
+		t.Fatal("second registration should have returned an error, got nil")
+	}
+}
+
+func TestRegistry_MustRegister_PanicsOnDouble(t *testing.T) {
+	// MustRegister wraps Register and panics; test via the global Register
+	// function on an isolated registry to avoid touching the real global.
+	r := newTestRegistry()
+	c := func(opts ConstructorOpts) Isolator { return newHostIsolator(opts.Name) }
+
+	if err := registerOnto(r, config.IsolationHost, c); err != nil {
+		t.Fatalf("first registration failed unexpectedly: %v", err)
+	}
+
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Fatal("MustRegister should have panicked on double-registration")
+		}
+	}()
+
+	// Simulate what MustRegister does: panic on error.
+	if err := registerOnto(r, config.IsolationHost, c); err != nil {
+		panic(err)
+	}
+}
+
+// ── For with an unregistered mode ────────────────────────────────────────────
+
+func TestFor_UnknownMode_ReturnsError(t *testing.T) {
+	_, err := For("nonexistent-mode", ConstructorOpts{Name: "test"})
+	if err == nil {
+		t.Fatal("For with unknown mode should return an error, got nil")
+	}
+}
+
+func TestFor_UnknownMode_DoesNotPanic(t *testing.T) {
+	// Ensure the error path doesn't panic — the AC explicitly says no panics.
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("For with unknown mode panicked: %v", rec)
+		}
+	}()
+	//nolint:errcheck
+	_, _ = For("not-a-mode", ConstructorOpts{Name: "test"})
+}
+
+// ── Names returns all four registered modes ───────────────────────────────────
+
+func TestNames_ReturnsAllFourModes(t *testing.T) {
+	names := Names()
+
+	want := []config.IsolationMode{
+		config.IsolationBwrap,
+		config.IsolationHost,
+		config.IsolationPodman,
+		config.IsolationSandboxExec,
+	}
+
+	// Names() is already sorted; compare after sorting want too.
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+
+	if len(names) != len(want) {
+		t.Fatalf("Names() returned %d modes, want %d; got %v", len(names), len(want), names)
+	}
+	for i, n := range names {
+		if n != want[i] {
+			t.Errorf("Names()[%d] = %q, want %q", i, n, want[i])
+		}
+	}
+}
+
+// ── For returns the right isolator type ──────────────────────────────────────
+
+func TestFor_PodmanMode_ReturnsPodmanIsolator(t *testing.T) {
+	iso, err := For(config.IsolationPodman, ConstructorOpts{Name: "test-session"})
+	if err != nil {
+		t.Fatalf("For(IsolationPodman) returned error: %v", err)
+	}
+	if iso.Name() != config.IsolationPodman {
+		t.Errorf("isolator Name() = %q, want %q", iso.Name(), config.IsolationPodman)
+	}
+	if !iso.Capabilities().IsContainer {
+		t.Error("podmanIsolator.Capabilities().IsContainer should be true")
+	}
+}
+
+func TestFor_HostMode_ReturnsHostIsolator(t *testing.T) {
+	iso, err := For(config.IsolationHost, ConstructorOpts{Name: "test-session"})
+	if err != nil {
+		t.Fatalf("For(IsolationHost) returned error: %v", err)
+	}
+	if iso.Name() != config.IsolationHost {
+		t.Errorf("isolator Name() = %q, want %q", iso.Name(), config.IsolationHost)
+	}
+}
+
+func TestFor_BwrapMode_ReturnsBwrapIsolator(t *testing.T) {
+	iso, err := For(config.IsolationBwrap, ConstructorOpts{Name: "test-session"})
+	if err != nil {
+		t.Fatalf("For(IsolationBwrap) returned error: %v", err)
+	}
+	if iso.Name() != config.IsolationBwrap {
+		t.Errorf("isolator Name() = %q, want %q", iso.Name(), config.IsolationBwrap)
+	}
+}
+
+func TestFor_SandboxExecMode_ReturnsSandboxExecIsolator(t *testing.T) {
+	iso, err := For(config.IsolationSandboxExec, ConstructorOpts{Name: "test-session"})
+	if err != nil {
+		t.Fatalf("For(IsolationSandboxExec) returned error: %v", err)
+	}
+	if iso.Name() != config.IsolationSandboxExec {
+		t.Errorf("isolator Name() = %q, want %q", iso.Name(), config.IsolationSandboxExec)
+	}
+}
+
+// ── Capabilities correctness ──────────────────────────────────────────────────
+
+func TestCapabilities_Podman(t *testing.T) {
+	iso, _ := For(config.IsolationPodman, ConstructorOpts{Name: "test"})
+	caps := iso.Capabilities()
+
+	if !caps.IsContainer {
+		t.Error("podman: IsContainer should be true")
+	}
+	if !caps.OwnsContainerLifecycle {
+		t.Error("podman: OwnsContainerLifecycle should be true")
+	}
+	if !caps.NeedsConfigBlob {
+		t.Error("podman: NeedsConfigBlob should be true")
+	}
+	if caps.NeedsHostAPISocket {
+		t.Error("podman: NeedsHostAPISocket should be false")
+	}
+	if !caps.UsesContainerHarness {
+		t.Error("podman: UsesContainerHarness should be true")
+	}
+	if !caps.RestartOnExit {
+		t.Error("podman: RestartOnExit should be true")
+	}
+	if !caps.NeedsReadinessWait {
+		t.Error("podman: NeedsReadinessWait should be true")
+	}
+}
+
+func TestCapabilities_Bwrap(t *testing.T) {
+	iso, _ := For(config.IsolationBwrap, ConstructorOpts{Name: "test"})
+	caps := iso.Capabilities()
+
+	if caps.IsContainer {
+		t.Error("bwrap: IsContainer should be false")
+	}
+	if !caps.NeedsConfigBlob {
+		t.Error("bwrap: NeedsConfigBlob should be true")
+	}
+	if !caps.NeedsHostAPISocket {
+		t.Error("bwrap: NeedsHostAPISocket should be true")
+	}
+	if !caps.RestartOnExit {
+		t.Error("bwrap: RestartOnExit should be true")
+	}
+	if !caps.NeedsStartupConnectTimeout {
+		t.Error("bwrap: NeedsStartupConnectTimeout should be true")
+	}
+	if caps.NeedsReadinessWait {
+		t.Error("bwrap: NeedsReadinessWait should be false")
+	}
+}
+
+func TestCapabilities_SandboxExec(t *testing.T) {
+	iso, _ := For(config.IsolationSandboxExec, ConstructorOpts{Name: "test"})
+	caps := iso.Capabilities()
+
+	if caps.IsContainer {
+		t.Error("sandbox-exec: IsContainer should be false")
+	}
+	if !caps.NeedsConfigBlob {
+		t.Error("sandbox-exec: NeedsConfigBlob should be true")
+	}
+	if !caps.NeedsHostAPISocket {
+		t.Error("sandbox-exec: NeedsHostAPISocket should be true")
+	}
+	if caps.RestartOnExit {
+		t.Error("sandbox-exec: RestartOnExit should be false")
+	}
+}
+
+func TestCapabilities_Host(t *testing.T) {
+	iso, _ := For(config.IsolationHost, ConstructorOpts{Name: "test"})
+	caps := iso.Capabilities()
+
+	if caps.IsContainer {
+		t.Error("host: IsContainer should be false")
+	}
+	if caps.NeedsConfigBlob {
+		t.Error("host: NeedsConfigBlob should be false")
+	}
+	if caps.NeedsHostAPISocket {
+		t.Error("host: NeedsHostAPISocket should be false")
+	}
+	if caps.RestartOnExit {
+		t.Error("host: RestartOnExit should be false")
+	}
+}
+
+// ── Resolve ───────────────────────────────────────────────────────────────────
+
+func TestResolve_IsolationFlagTakesPrecedence(t *testing.T) {
+	mode, err := Resolve(ResolveInput{
+		IsolationFlag:        "bwrap",
+		IsolationFlagChanged: true,
+		ConfigDefault:        config.IsolationPodman,
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if mode != config.IsolationBwrap {
+		t.Errorf("mode = %q, want %q", mode, config.IsolationBwrap)
+	}
+}
+
+func TestResolve_HostModeFlag_MapsToHost(t *testing.T) {
+	mode, err := Resolve(ResolveInput{
+		HostModeFlag:        true,
+		HostModeFlagChanged: true,
+		ConfigDefault:       config.IsolationPodman,
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if mode != config.IsolationHost {
+		t.Errorf("mode = %q, want %q", mode, config.IsolationHost)
+	}
+}
+
+func TestResolve_BothFlags_ReturnsError(t *testing.T) {
+	_, err := Resolve(ResolveInput{
+		IsolationFlag:        "bwrap",
+		IsolationFlagChanged: true,
+		HostModeFlag:         true,
+		HostModeFlagChanged:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error when both --isolation and --host-mode are set")
+	}
+}
+
+func TestResolve_DBIsolationMode_UsedWhenFlagsAbsent(t *testing.T) {
+	mode, err := Resolve(ResolveInput{
+		DBIsolationMode: "bwrap",
+		ConfigDefault:   config.IsolationPodman,
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if mode != config.IsolationBwrap {
+		t.Errorf("mode = %q, want %q", mode, config.IsolationBwrap)
+	}
+}
+
+func TestResolve_DBHostMode_MapsToHost(t *testing.T) {
+	mode, err := Resolve(ResolveInput{
+		DBHostMode:    true,
+		ConfigDefault: config.IsolationPodman,
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if mode != config.IsolationHost {
+		t.Errorf("mode = %q, want %q", mode, config.IsolationHost)
+	}
+}
+
+func TestResolve_ContainerMode_MapsToPodman(t *testing.T) {
+	mode, err := Resolve(ResolveInput{
+		ContainerMode: true,
+		ConfigDefault: config.IsolationHost,
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if mode != config.IsolationPodman {
+		t.Errorf("mode = %q, want %q", mode, config.IsolationPodman)
+	}
+}
+
+func TestResolve_ConfigDefault_FallsThrough(t *testing.T) {
+	mode, err := Resolve(ResolveInput{
+		ConfigDefault: config.IsolationBwrap,
+	})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if mode != config.IsolationBwrap {
+		t.Errorf("mode = %q, want %q", mode, config.IsolationBwrap)
+	}
+}
+
+func TestResolve_UnknownIsolationFlag_ReturnsError(t *testing.T) {
+	_, err := Resolve(ResolveInput{
+		IsolationFlag:        "firejail",
+		IsolationFlagChanged: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown isolation mode, got nil")
+	}
+}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/prismatic-koi/prism/internal/config"
 )
 
 // sandboxExecIsolator implements Isolator using Apple's sandbox-exec. It
@@ -50,6 +52,30 @@ type sandboxExecIsolator struct {
 // interface.
 func newSandboxExecIsolator(name string) Isolator {
 	return &sandboxExecIsolator{name: name}
+}
+
+// Name returns config.IsolationSandboxExec — the registry key for this isolator.
+func (s *sandboxExecIsolator) Name() config.IsolationMode {
+	return config.IsolationSandboxExec
+}
+
+// Capabilities returns the sandbox-exec feature flags:
+//   - NeedsConfigBlob: config blob is injected as an env var before agent-run.
+//   - NeedsHostAPISocket: the sidecar binds the host-API socket for in-sandbox proxy calls.
+//   - RestartOnExit is false: sandbox-exec replaces the agent-run process via
+//     syscall.Exec, so the sidecar does not observe process exit to restart.
+func (s *sandboxExecIsolator) Capabilities() Capabilities {
+	return Capabilities{
+		IsContainer:                false,
+		OwnsContainerLifecycle:     false,
+		NeedsConfigBlob:            true,
+		NeedsHostAPISocket:         true,
+		UsesContainerHarness:       false,
+		RestartOnExit:              false,
+		NeedsStartupConnectTimeout: false,
+		NeedsReadinessWait:         false,
+		EmitsTmuxStatusColumns:     false,
+	}
 }
 
 // BuildRunArgs satisfies the Isolator interface. It returns nil because the
@@ -223,6 +249,12 @@ func (s *sandboxExecIsolator) HasExited() (bool, int) {
 // production flow).
 func (s *sandboxExecIsolator) DumpLogs() {
 	log.Printf("container: sandbox-exec %q: live output is forwarded via the inherited terminal during syscall.Exec", s.name)
+}
+
+func init() {
+	MustRegister(config.IsolationSandboxExec, func(opts ConstructorOpts) Isolator {
+		return newSandboxExecIsolator(opts.Name)
+	})
 }
 
 // MinimalIsolatedExecEnv filters a hostEnv slice (K=V pairs, as returned by


### PR DESCRIPTION
## Summary

- Adds `IsolationRegistry` in `internal/container/registry.go` — a `init()`-populated name→constructor map with `Register`, `MustRegister`, `For`, `Names`, and `Resolve`.
- Extends the `Isolator` interface with `Name() config.IsolationMode` and `Capabilities() Capabilities` — all five existing methods remain unchanged.
- Adds `Capabilities` struct with the nine flag fields from A.1 §4.3 (`IsContainer`, `OwnsContainerLifecycle`, `NeedsConfigBlob`, `NeedsHostAPISocket`, `UsesContainerHarness`, `RestartOnExit`, `NeedsStartupConnectTimeout`, `NeedsReadinessWait`, `EmitsTmuxStatusColumns`).
- All four isolators (`podmanIsolator`, `bwrapIsolator`, `sandboxExecIsolator`, `hostIsolator`) register at `init()` with correct capabilities and rationale comments.
- New `internal/container/host.go` implements the `hostIsolator` no-op (Option A from A.1 §4.4).
- `Resolve` centralises today's scattered back-compat resolution logic (flag precedence, `--host-mode`, `host_mode` DB column, `ContainerMode` bool, config fallback) without migrating any caller.
- Tests cover: double-registration error/panic, `For` with unknown mode (no panic), `Names` returns all four modes, capabilities per mode, `Resolve` back-compat paths.

**No existing caller changes its call shape.** `go build ./...` and `go test ./...` pass. Nix build passes.

Closes #1120