### PR TITLE
fix(prism): populate sessions.harness_session_id for archive copy

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -801,6 +801,16 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	}
 	if sess.HarnessSessionID != nil {
 		params.HarnessSessionID = *sess.HarnessSessionID
+	} else {
+		// sessions.harness_session_id is NULL — this can happen for sessions
+		// started before UpdateHarnessSessionID was fixed to write to both
+		// tables. Fall back to agent_status, which is where the sidecar
+		// historically wrote the value.
+		if sid, fallbackErr := d.HarnessSessionIDForInstance(instanceID); fallbackErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism] archive: harness_session_id fallback for %q: %v\n", instanceID, fallbackErr)
+		} else if sid != "" {
+			params.HarnessSessionID = sid
+		}
 	}
 	if sess.GroupID != nil {
 		params.GroupID = *sess.GroupID

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -281,6 +281,22 @@ CREATE INDEX IF NOT EXISTS idx_pending_merges_status_session  ON pending_merges(
 // idx_pending_merges_status_instance is preserved (it covers
 // AbandonWatchingMerges and CancelMerge). CREATE INDEX IF NOT EXISTS makes
 // this idempotent.
+// v20→v21 is a one-shot backfill that sets sessions.harness_session_id from
+// agent_status.harness_session_id for rows where sessions.harness_session_id
+// IS NULL. This fixes sessions created before UpdateHarnessSessionID was
+// changed to write to both tables (#1126). The join is on instance_id, which
+// is present in both tables. Rows with no matching agent_status row, or where
+// agent_status.harness_session_id is also NULL, are left unchanged — their
+// raw/ directories will remain empty (the harness never ran for them).
+// The migration is idempotent: a second run matches no rows (all NULL sessions
+// rows either got backfilled or have no agent_status counterpart).
+// v21→v22 extends the v17→v18 started_at backfill to also cover rows where
+// started_at = 0 (literal Unix epoch zero). The earlier migration only fixed
+// rows with started_at < 0 (Go zero-time as -62135596800000 ms); a separate
+// code path could insert started_at = 0 directly, producing
+// "00010101T000000Z_" archive directory names (#1127). Recovery strategy is
+// the same: set started_at = MIN(agent_events.created_at) for the matching
+// instance_id. Idempotent: rows with started_at > 0 are skipped.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -325,7 +341,7 @@ func Open(path string) (*DB, error) {
 	// Set schema_version=11 if the table is empty. Fresh databases have all
 	// current columns from the schema above (including pending_merges and the
 	// new idx_pending_merges_status_session index). The v11→v12 through
-	// v19→v20 migrations run immediately below; on a fresh DB they are all
+	// v21→v22 migrations run immediately below; on a fresh DB they are all
 	// effectively no-ops (indexes already exist, no rows to backfill, columns
 	// already named correctly, sessions and pending_merges tables already
 	// present from the declarative schema block), so starting at 11 is safe.
@@ -964,6 +980,103 @@ func Open(path string) (*DB, error) {
 			}
 		}
 		version = 20
+	}
+	if version == 20 {
+		// Migration v20 → v21: backfill sessions.harness_session_id from
+		// agent_status for rows where sessions.harness_session_id IS NULL.
+		// UpdateHarnessSessionID historically only wrote to agent_status; this
+		// one-shot backfill ensures that sessions created before the fix for
+		// #1126 also have harness_session_id set in the sessions table, so that
+		// cleanup.runSessionArchive can archive them on the next run.
+		//
+		// The join is on instance_id (present in both tables). Rows where
+		// agent_status.harness_session_id is also NULL, or where there is no
+		// matching agent_status row, are left unchanged.
+		//
+		// Idempotency: sessions rows already having a non-NULL harness_session_id
+		// are excluded by the WHERE clause, so a second run is a no-op.
+		if _, err := conn.Exec(`
+			UPDATE sessions
+			   SET harness_session_id = (
+			         SELECT harness_session_id
+			           FROM agent_status
+			          WHERE agent_status.instance_id = sessions.instance_id
+			            AND agent_status.harness_session_id IS NOT NULL
+			       )
+			 WHERE harness_session_id IS NULL
+			   AND EXISTS (
+			         SELECT 1 FROM agent_status
+			          WHERE agent_status.instance_id = sessions.instance_id
+			            AND agent_status.harness_session_id IS NOT NULL
+			       )`); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v20→v21: backfill harness_session_id: %w", err)
+		}
+		if _, err := conn.Exec("UPDATE schema_version SET version = 21"); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v20→v21: bump version: %w", err)
+		}
+		version = 21
+	}
+	if version == 21 {
+		// Migration v21 → v22: extend the v17→v18 started_at backfill to also
+		// cover rows where started_at = 0 (literal Unix epoch). The v17→v18
+		// migration fixed rows where started_at < 0 (Go zero-time marshalled as
+		// -62135596800000 ms), but a separate code path could store started_at = 0
+		// directly, producing "00010101T000000Z_" directory names in the archive
+		// (#1127). The same recovery strategy is used: set started_at to
+		// MIN(agent_events.created_at) for the matching instance_id. Rows with no
+		// matching events are left with started_at = 0 and will display as
+		// "00010101T000000Z_<instanceID>" in archive listings (the same
+		// formatDurationLong fallback applies).
+		//
+		// Idempotency: rows with started_at = 0 are either fixed or have no
+		// usable events; a second run is a no-op.
+		brokenRows2, err := conn.Query(`SELECT instance_id FROM sessions WHERE started_at = 0`)
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v21→v22: query zero sessions: %w", err)
+		}
+		var zeroIDs []string
+		for brokenRows2.Next() {
+			var iid string
+			if err := brokenRows2.Scan(&iid); err != nil {
+				brokenRows2.Close()
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v21→v22: scan zero session: %w", err)
+			}
+			zeroIDs = append(zeroIDs, iid)
+		}
+		brokenRows2.Close()
+		if err := brokenRows2.Err(); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v21→v22: iterate zero sessions: %w", err)
+		}
+
+		for _, iid := range zeroIDs {
+			var minTs *int64
+			if err := conn.QueryRow(`
+				SELECT MIN(created_at) FROM agent_events WHERE instance_id = ?`, iid,
+			).Scan(&minTs); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v21→v22: min timestamp for %q: %w", iid, err)
+			}
+			if minTs == nil || *minTs <= 0 {
+				continue
+			}
+			if _, err := conn.Exec(`
+				UPDATE sessions SET started_at = ? WHERE instance_id = ?`, *minTs, iid,
+			); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("db: migration v21→v22: update started_at for %q: %w", iid, err)
+			}
+		}
+
+		if _, err := conn.Exec("UPDATE schema_version SET version = 22"); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("db: migration v21→v22: bump version: %w", err)
+		}
+		version = 22
 	}
 
 	return &DB{conn: conn, path: path}, nil
@@ -2053,16 +2166,65 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
 // keep the stored SID current when the user creates a new harness session
 // mid-conversation (e.g. via /continue or TUI restart).
 //
+// It writes to both agent_status and sessions (matching by instance_id) so
+// that cleanup.runSessionArchive can read harness_session_id directly from the
+// sessions row without a fallback query. The sessions update is best-effort:
+// if no row exists for the current instance_id it is silently skipped.
+//
 // It is a no-op when no row exists for sessionName (returns nil).
 func (d *DB) UpdateHarnessSessionID(sessionName, sid string) error {
-	_, err := d.conn.Exec(
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("db: update harness_session_id: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.Exec(
 		"UPDATE agent_status SET harness_session_id = ? WHERE session_name = ?",
 		sid, sessionName,
-	)
-	if err != nil {
-		return fmt.Errorf("db: update harness_session_id: %w", err)
+	); err != nil {
+		return fmt.Errorf("db: update harness_session_id (agent_status): %w", err)
+	}
+
+	// Also update sessions.harness_session_id for the current incarnation so
+	// that cleanup reads the correct value without a fallback query.
+	if _, err := tx.Exec(`
+		UPDATE sessions
+		   SET harness_session_id = ?
+		 WHERE instance_id = (
+		         SELECT instance_id FROM agent_status WHERE session_name = ?
+		       )`, sid, sessionName,
+	); err != nil {
+		return fmt.Errorf("db: update harness_session_id (sessions): %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("db: update harness_session_id: commit: %w", err)
 	}
 	return nil
+}
+
+// HarnessSessionIDForInstance returns the harness_session_id stored in
+// agent_status for the given instance_id, or "" when not found or NULL.
+// Used by cleanup as a fallback when sessions.harness_session_id is NULL
+// (e.g. for sessions started before UpdateHarnessSessionID was fixed to
+// also write to sessions).
+func (d *DB) HarnessSessionIDForInstance(instanceID string) (string, error) {
+	var sid sql.NullString
+	err := d.conn.QueryRow(
+		"SELECT harness_session_id FROM agent_status WHERE instance_id = ?",
+		instanceID,
+	).Scan(&sid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("db: harness_session_id for instance: %w", err)
+	}
+	if !sid.Valid {
+		return "", nil
+	}
+	return sid.String, nil
 }
 
 // QueryDoomLoopEvents returns doom_loop_detected events from agent_events,

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=20 (all migrations applied on Open).
+	// Verify schema_version=22 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version: got %d, want 22", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1594,8 +1594,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1660,8 +1660,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1730,8 +1730,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1825,8 +1825,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1918,8 +1918,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2502,8 +2502,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2591,8 +2591,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// isolation_mode column must exist (NULL for pre-migration rows).
@@ -4194,8 +4194,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// Check each row.
@@ -4622,8 +4622,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4897,8 +4897,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5118,8 +5118,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// sessions table must exist.
@@ -5272,8 +5272,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after second open: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after second open: got %d, want 22", version)
 	}
 }
 
@@ -5821,13 +5821,13 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	}
 	defer d.Close()
 
-	// Schema version must advance to 20 (v17→v18 backfill + v18→v19 pending_merges + v19→v20 index).
+	// Schema version must advance to 22 (v17→v18 backfill + v18→v19 pending_merges + v19→v20 index + v20→v21 harness_session_id backfill + v21→v22 zero started_at backfill).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after migration: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -5884,8 +5884,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after second open: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after second open: got %d, want 22", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -5895,5 +5895,581 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	}
 	if startedAt != 1600000000000 {
 		t.Errorf("started_at after idempotent run: got %d, want 1600000000000", startedAt)
+	}
+}
+
+// ── UpdateHarnessSessionID dual-write (#1126) ─────────────────────────────────
+
+// TestUpdateHarnessSessionID_AlsoWritesSessions verifies that
+// UpdateHarnessSessionID writes the new SID to both agent_status and the
+// sessions row for the current incarnation (instance_id match).
+func TestUpdateHarnessSessionID_AlsoWritesSessions(t *testing.T) {
+	d := openTestDB(t)
+
+	sid := "ses_dual_write"
+
+	// Set up agent_status with an instance_id.
+	iid := uuid.New().String()
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID("repo@main", iid); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+
+	// Insert a sessions row for this instance.
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: "repo@main",
+		Repo:        "repo",
+		Worktree:    "/wt",
+		Harness:     "opencode",
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	// Pre-condition: sessions.harness_session_id is NULL.
+	sess, err := d.SessionByInstanceID(iid)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID before update: %v", err)
+	}
+	if sess.HarnessSessionID != nil {
+		t.Fatalf("pre-condition: sessions.harness_session_id = %v, want nil", sess.HarnessSessionID)
+	}
+
+	// Call UpdateHarnessSessionID — must write to both tables.
+	if err := d.UpdateHarnessSessionID("repo@main", sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	// Verify agent_status.harness_session_id was updated.
+	status, err := d.CurrentStatus("repo@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status.HarnessSessionID == nil || *status.HarnessSessionID != sid {
+		t.Errorf("agent_status.harness_session_id: got %v, want %q", status.HarnessSessionID, sid)
+	}
+
+	// Verify sessions.harness_session_id was updated.
+	sess2, err := d.SessionByInstanceID(iid)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID after update: %v", err)
+	}
+	if sess2.HarnessSessionID == nil || *sess2.HarnessSessionID != sid {
+		t.Errorf("sessions.harness_session_id: got %v, want %q", sess2.HarnessSessionID, sid)
+	}
+}
+
+// TestUpdateHarnessSessionID_NoSessionsRow verifies that
+// UpdateHarnessSessionID succeeds (no error) when agent_status has no
+// matching instance_id in sessions (e.g. InsertSession was not yet called).
+func TestUpdateHarnessSessionID_NoSessionsRow(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	// No InsertSession call — sessions table has no row for this session.
+	if err := d.UpdateHarnessSessionID("repo@main", "ses_no_sessions_row"); err != nil {
+		t.Errorf("UpdateHarnessSessionID without sessions row: %v (want nil)", err)
+	}
+}
+
+// ── HarnessSessionIDForInstance (#1126) ──────────────────────────────────────
+
+// TestHarnessSessionIDForInstance_Found verifies that HarnessSessionIDForInstance
+// returns the harness_session_id from agent_status for a known instance_id.
+func TestHarnessSessionIDForInstance_Found(t *testing.T) {
+	d := openTestDB(t)
+
+	iid := uuid.New().String()
+	sid := "ses_fallback_test"
+
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID("repo@main", iid); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID("repo@main", sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	got, err := d.HarnessSessionIDForInstance(iid)
+	if err != nil {
+		t.Fatalf("HarnessSessionIDForInstance: %v", err)
+	}
+	if got != sid {
+		t.Errorf("HarnessSessionIDForInstance: got %q, want %q", got, sid)
+	}
+}
+
+// TestHarnessSessionIDForInstance_NotFound verifies that
+// HarnessSessionIDForInstance returns "" with no error when the instance_id
+// does not exist in agent_status.
+func TestHarnessSessionIDForInstance_NotFound(t *testing.T) {
+	d := openTestDB(t)
+
+	got, err := d.HarnessSessionIDForInstance("nonexistent-iid")
+	if err != nil {
+		t.Errorf("HarnessSessionIDForInstance for missing iid: %v (want nil)", err)
+	}
+	if got != "" {
+		t.Errorf("HarnessSessionIDForInstance for missing iid: got %q, want empty", got)
+	}
+}
+
+// TestHarnessSessionIDForInstance_NullSID verifies that
+// HarnessSessionIDForInstance returns "" when the agent_status row exists but
+// harness_session_id is NULL.
+func TestHarnessSessionIDForInstance_NullSID(t *testing.T) {
+	d := openTestDB(t)
+
+	iid := uuid.New().String()
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID("repo@main", iid); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	// Do NOT call UpdateHarnessSessionID — harness_session_id stays NULL.
+
+	got, err := d.HarnessSessionIDForInstance(iid)
+	if err != nil {
+		t.Errorf("HarnessSessionIDForInstance with NULL sid: %v (want nil)", err)
+	}
+	if got != "" {
+		t.Errorf("HarnessSessionIDForInstance with NULL sid: got %q, want empty", got)
+	}
+}
+
+// ── Migration v20→v21 (backfill harness_session_id in sessions, #1126) ───────
+
+// seedV20DB creates a raw SQLite database seeded at schema_version=20.
+// It contains:
+//   - 'iid-with-sid':  sessions row with NULL harness_session_id + agent_status row
+//     with harness_session_id = 'ses_from_agent_status' → must be backfilled
+//   - 'iid-no-agent':  sessions row with NULL harness_session_id, no agent_status
+//     row → must remain NULL
+//   - 'iid-already-set': sessions row with harness_session_id already set →
+//     must not be overwritten
+func seedV20DB(t *testing.T, dbPath string) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open v20 db: %v", err)
+	}
+	defer rawConn.Close()
+
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, harness_session_id TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL,
+		  instance_id TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, created_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
+
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY,
+		  repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL,
+		  state TEXT NOT NULL,
+		  title TEXT,
+		  agent_name TEXT,
+		  model_id TEXT,
+		  root_agent_name TEXT,
+		  root_model_id TEXT,
+		  host_mode INTEGER NOT NULL DEFAULT 0,
+		  isolation_mode TEXT,
+		  instance_id TEXT,
+		  last_seen INTEGER NOT NULL,
+		  ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT,
+		  harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+
+		CREATE TABLE IF NOT EXISTS sessions (
+		  instance_id        TEXT PRIMARY KEY,
+		  session_name       TEXT NOT NULL,
+		  agent_role         TEXT,
+		  root_agent_name    TEXT,
+		  repo               TEXT NOT NULL,
+		  worktree           TEXT NOT NULL,
+		  harness            TEXT NOT NULL,
+		  harness_session_id TEXT,
+		  group_id           TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  started_at         INTEGER NOT NULL,
+		  ended_at           INTEGER,
+		  end_state          TEXT,
+		  archive_path       TEXT,
+		  prism_version      TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_sessions_repo_started ON sessions(repo, started_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_sessions_name         ON sessions(session_name, started_at DESC);
+
+		CREATE TABLE IF NOT EXISTS pending_merges (
+		  pr              INTEGER PRIMARY KEY,
+		  session_name    TEXT NOT NULL,
+		  instance_id     TEXT NOT NULL,
+		  queue_position  INTEGER NOT NULL,
+		  status          TEXT NOT NULL,
+		  title           TEXT,
+		  error           TEXT,
+		  queued_at       INTEGER NOT NULL,
+		  last_checked_at INTEGER,
+		  merged_at       INTEGER,
+		  ended_at        INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS idx_pending_merges_status_instance ON pending_merges(instance_id, status, queue_position);
+		CREATE INDEX IF NOT EXISTS idx_pending_merges_status_session  ON pending_merges(session_name, status, queue_position);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (20);
+
+		-- sessions row needing backfill: harness_session_id is NULL.
+		INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at)
+		  VALUES ('iid-with-sid', 'repo@main', 'repo', '/wt', 'opencode', 1700000000000);
+
+		-- Corresponding agent_status row with a non-NULL harness_session_id.
+		INSERT INTO agent_status (session_name, repo, worktree, state, instance_id, last_seen, harness_session_id)
+		  VALUES ('repo@main', 'repo', '/wt', 'finished', 'iid-with-sid', 1700000000000, 'ses_from_agent_status');
+
+		-- sessions row with NULL harness_session_id and no agent_status counterpart.
+		INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at)
+		  VALUES ('iid-no-agent', 'repo@other', 'repo', '/wt', 'opencode', 1700000000001);
+
+		-- sessions row already has a harness_session_id — must not be overwritten.
+		INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, harness_session_id, started_at)
+		  VALUES ('iid-already-set', 'repo@branch', 'repo', '/wt', 'opencode', 'ses_pre_existing', 1700000000002);
+	`)
+	if err != nil {
+		t.Fatalf("seed v20 db: %v", err)
+	}
+}
+
+// TestMigration_V20ToV21_BackfillsHarnessSessionID verifies that the v20→v21
+// migration copies harness_session_id from agent_status to sessions for rows
+// where sessions.harness_session_id IS NULL.
+func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v20_harness_backfill.db")
+	seedV20DB(t, dbPath)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v20 db: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
+	}
+
+	// iid-with-sid: harness_session_id must have been backfilled.
+	sess1, err := d.SessionByInstanceID("iid-with-sid")
+	if err != nil {
+		t.Fatalf("SessionByInstanceID(iid-with-sid): %v", err)
+	}
+	if sess1 == nil || sess1.HarnessSessionID == nil || *sess1.HarnessSessionID != "ses_from_agent_status" {
+		var got any
+		if sess1 != nil {
+			got = sess1.HarnessSessionID
+		}
+		t.Errorf("iid-with-sid harness_session_id: got %v, want \"ses_from_agent_status\"", got)
+	}
+
+	// iid-no-agent: harness_session_id must remain NULL (no agent_status row).
+	sess2, err := d.SessionByInstanceID("iid-no-agent")
+	if err != nil {
+		t.Fatalf("SessionByInstanceID(iid-no-agent): %v", err)
+	}
+	if sess2 != nil && sess2.HarnessSessionID != nil {
+		t.Errorf("iid-no-agent harness_session_id: got %v, want nil", sess2.HarnessSessionID)
+	}
+
+	// iid-already-set: pre-existing harness_session_id must not be overwritten.
+	sess3, err := d.SessionByInstanceID("iid-already-set")
+	if err != nil {
+		t.Fatalf("SessionByInstanceID(iid-already-set): %v", err)
+	}
+	if sess3 == nil || sess3.HarnessSessionID == nil || *sess3.HarnessSessionID != "ses_pre_existing" {
+		var got any
+		if sess3 != nil {
+			got = sess3.HarnessSessionID
+		}
+		t.Errorf("iid-already-set harness_session_id: got %v, want \"ses_pre_existing\" (must not overwrite)", got)
+	}
+}
+
+// TestMigration_V20ToV21_Idempotent verifies that opening a DB already at v21
+// (or higher) is a no-op for the backfill.
+func TestMigration_V20ToV21_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v20_harness_idem.db")
+	seedV20DB(t, dbPath)
+
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first db.Open: %v", err)
+	}
+	d1.Close()
+
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	var version int
+	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version on second open: %v", err)
+	}
+	if version != 22 {
+		t.Errorf("schema_version after second open: got %d, want 22", version)
+	}
+
+	// iid-with-sid must still have the backfilled value.
+	sess, err := d2.SessionByInstanceID("iid-with-sid")
+	if err != nil {
+		t.Fatalf("SessionByInstanceID on second open: %v", err)
+	}
+	if sess == nil || sess.HarnessSessionID == nil || *sess.HarnessSessionID != "ses_from_agent_status" {
+		t.Errorf("iid-with-sid harness_session_id on second open: got %v, want \"ses_from_agent_status\"",
+			func() any {
+				if sess != nil {
+					return sess.HarnessSessionID
+				}
+				return nil
+			}())
+	}
+}
+
+// ── Migration v21→v22 (backfill started_at=0, #1127) ─────────────────────────
+
+// seedV21DB creates a raw SQLite database seeded at schema_version=21.
+// It contains:
+//   - 'iid-zero-has-events':  started_at=0 with matching agent_events → must be fixed
+//   - 'iid-zero-no-events':   started_at=0 with no agent_events → left unchanged
+//   - 'iid-valid-started':    started_at=1700000000000 → must not be touched
+func seedV21DB(t *testing.T, dbPath string) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open v21 db: %v", err)
+	}
+	defer rawConn.Close()
+
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, harness_session_id TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL,
+		  instance_id TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, created_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
+
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY,
+		  repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL,
+		  state TEXT NOT NULL,
+		  title TEXT,
+		  agent_name TEXT,
+		  model_id TEXT,
+		  root_agent_name TEXT,
+		  root_model_id TEXT,
+		  host_mode INTEGER NOT NULL DEFAULT 0,
+		  isolation_mode TEXT,
+		  instance_id TEXT,
+		  last_seen INTEGER NOT NULL,
+		  ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'opencode',
+		  harness_session_id TEXT,
+		  harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+
+		CREATE TABLE IF NOT EXISTS sessions (
+		  instance_id        TEXT PRIMARY KEY,
+		  session_name       TEXT NOT NULL,
+		  agent_role         TEXT,
+		  root_agent_name    TEXT,
+		  repo               TEXT NOT NULL,
+		  worktree           TEXT NOT NULL,
+		  harness            TEXT NOT NULL,
+		  harness_session_id TEXT,
+		  group_id           TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  started_at         INTEGER NOT NULL,
+		  ended_at           INTEGER,
+		  end_state          TEXT,
+		  archive_path       TEXT,
+		  prism_version      TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_sessions_repo_started ON sessions(repo, started_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_sessions_name         ON sessions(session_name, started_at DESC);
+
+		CREATE TABLE IF NOT EXISTS pending_merges (
+		  pr              INTEGER PRIMARY KEY,
+		  session_name    TEXT NOT NULL,
+		  instance_id     TEXT NOT NULL,
+		  queue_position  INTEGER NOT NULL,
+		  status          TEXT NOT NULL,
+		  title           TEXT,
+		  error           TEXT,
+		  queued_at       INTEGER NOT NULL,
+		  last_checked_at INTEGER,
+		  merged_at       INTEGER,
+		  ended_at        INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS idx_pending_merges_status_instance ON pending_merges(instance_id, status, queue_position);
+		CREATE INDEX IF NOT EXISTS idx_pending_merges_status_session  ON pending_merges(session_name, status, queue_position);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (21);
+
+		-- started_at = 0 with events → migration must fix it.
+		INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at)
+		  VALUES ('iid-zero-has-events', 'repo@main', 'repo', '/wt', 'opencode', 0);
+		INSERT INTO agent_events (id, session_name, repo, worktree, type, payload, created_at, instance_id)
+		  VALUES ('ze-evt-1', 'repo@main', 'repo', '/wt', 'state_change', '{}', 1650000000000, 'iid-zero-has-events');
+		INSERT INTO agent_events (id, session_name, repo, worktree, type, payload, created_at, instance_id)
+		  VALUES ('ze-evt-2', 'repo@main', 'repo', '/wt', 'state_change', '{}', 1650000099999, 'iid-zero-has-events');
+
+		-- started_at = 0 with no events → migration must leave it unchanged.
+		INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at)
+		  VALUES ('iid-zero-no-events', 'repo@other', 'repo', '/wt', 'opencode', 0);
+
+		-- started_at already valid → must not be touched.
+		INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at)
+		  VALUES ('iid-valid-started', 'repo@good', 'repo', '/wt', 'opencode', 1700000000000);
+	`)
+	if err != nil {
+		t.Fatalf("seed v21 db: %v", err)
+	}
+}
+
+// TestMigration_V21ToV22_BackfillsZeroStartedAt verifies that the v21→v22
+// migration fixes sessions rows with started_at=0 using the minimum
+// agent_events.created_at for the matching instance_id.
+func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v21_zero_started_at.db")
+	seedV21DB(t, dbPath)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open on v21 db: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 22 {
+		t.Errorf("schema_version after migration: got %d, want 22", version)
+	}
+
+	// iid-zero-has-events: started_at must be updated to the minimum event ts.
+	var startedAtZeroHasEvents int64
+	if err := d.QueryRow("SELECT started_at FROM sessions WHERE instance_id = 'iid-zero-has-events'").Scan(&startedAtZeroHasEvents); err != nil {
+		t.Fatalf("query iid-zero-has-events: %v", err)
+	}
+	if startedAtZeroHasEvents != 1650000000000 {
+		t.Errorf("iid-zero-has-events started_at: got %d, want 1650000000000", startedAtZeroHasEvents)
+	}
+
+	// iid-zero-no-events: started_at must remain 0 (no events to recover from).
+	var startedAtZeroNoEvents int64
+	if err := d.QueryRow("SELECT started_at FROM sessions WHERE instance_id = 'iid-zero-no-events'").Scan(&startedAtZeroNoEvents); err != nil {
+		t.Fatalf("query iid-zero-no-events: %v", err)
+	}
+	if startedAtZeroNoEvents != 0 {
+		t.Errorf("iid-zero-no-events started_at: got %d, want 0 (unchanged)", startedAtZeroNoEvents)
+	}
+
+	// iid-valid-started: must not be touched.
+	var startedAtValid int64
+	if err := d.QueryRow("SELECT started_at FROM sessions WHERE instance_id = 'iid-valid-started'").Scan(&startedAtValid); err != nil {
+		t.Fatalf("query iid-valid-started: %v", err)
+	}
+	if startedAtValid != 1700000000000 {
+		t.Errorf("iid-valid-started started_at: got %d, want 1700000000000 (untouched)", startedAtValid)
+	}
+}
+
+// TestMigration_V21ToV22_Idempotent verifies that opening a DB already at v22
+// is a no-op for the zero started_at backfill.
+func TestMigration_V21ToV22_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v21_zero_idem.db")
+	seedV21DB(t, dbPath)
+
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first db.Open: %v", err)
+	}
+	d1.Close()
+
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	var version int
+	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version on second open: %v", err)
+	}
+	if version != 22 {
+		t.Errorf("schema_version after second open: got %d, want 22", version)
+	}
+
+	var startedAt int64
+	if err := d2.QueryRow("SELECT started_at FROM sessions WHERE instance_id = 'iid-zero-has-events'").Scan(&startedAt); err != nil {
+		t.Fatalf("query started_at on second open: %v", err)
+	}
+	if startedAt != 1650000000000 {
+		t.Errorf("started_at after idempotent run: got %d, want 1650000000000", startedAt)
 	}
 }

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1055,8 +1055,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("schema_version after second open: got %d, want 20", version)
+	if version != 22 {
+		t.Errorf("schema_version after second open: got %d, want 22", version)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `UpdateHarnessSessionID` now writes to both `agent_status` and `sessions` (matched by `instance_id`), so `cleanup.runSessionArchive` can read `harness_session_id` directly from the sessions row and populate `raw/`.
- For sessions created before this fix (where `sessions.harness_session_id` is NULL), cleanup falls back to querying `agent_status.harness_session_id` via the new `HarnessSessionIDForInstance` DB function.
- Migration v20→v21 backfills `sessions.harness_session_id` from `agent_status` for all existing rows where the sessions column is NULL, enabling past sessions to be re-archived immediately after upgrade.
- Migration v21→v22 extends the v17→v18 `started_at` backfill to also cover rows where `started_at=0` (literal Unix epoch), which produced `00010101T000000Z_` archive directory names.

## Root cause

`cmd/cleanup.go` reads `sess.HarnessSessionID` from the `sessions` table row to populate `archive.Params.HarnessSessionID`. That field was always NULL because:
1. `InsertSession` is called at `tmux-session-start` before the harness has started — so `harness_session_id` is NULL at insert time.
2. `sidecar.handleSessionCreated` calls `db.UpdateHarnessSessionID` which wrote to `agent_status` only, never to `sessions`.
3. Nothing ever backfilled `sessions.harness_session_id` after the initial insert.

## Changes

- `internal/db/db.go`: `UpdateHarnessSessionID` now uses a transaction to write to both `agent_status` and `sessions`. New `HarnessSessionIDForInstance` function for the cleanup fallback.
- `cmd/cleanup.go`: When `sess.HarnessSessionID` is nil, falls back to `HarnessSessionIDForInstance` before giving up.
- `internal/db/db.go`: Migration v20→v21 backfills `sessions.harness_session_id` from `agent_status`. Migration v21→v22 backfills `started_at=0` rows (extending v17→v18 which only covered negative values).
- `internal/db/db_test.go`, `internal/mergequeue/watcher_test.go`: Updated schema version assertions to 22; added tests for dual-write, fallback function, and both new migrations.

## Issue #1127 companion fix

The `started_at=0` migration is included as it is small and self-contained (same backfill pattern as v17→v18, just widening the filter to `= 0`).

Closes #1126
Closes #1127