### PR TITLE
container: extract tempPath, HarnessInvocation, AppendStandardEnv helpers (A2.S1/S2/E1)

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -513,33 +512,14 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--setenv", k, v)
 	}
 
-	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true). These come
-	// from profiles.json agent_env_vars (written by Nix). Emitted in sorted
-	// key order for determinism. bwrap --setenv takes KEY and VALUE as distinct
-	// argv elements so no shell quoting is needed — special characters in
-	// values are passed verbatim.
-	//
-	// KUBECONFIG and AWS_CONFIG_FILE are intentionally suppressed here: both
-	// files are already bind-mounted at their canonical default paths
-	// (~/.kube/config and ~/.aws/config respectively), so the host XDG paths
-	// held in AgentEnvVars do not exist inside the sandbox and would only
-	// override the correctly-mounted locations.
-	sandboxMountedByDefault := map[string]bool{
-		"KUBECONFIG":      true,
-		"AWS_CONFIG_FILE": true,
-	}
-	if len(cfg.AgentEnvVars) > 0 {
-		keys := make([]string, 0, len(cfg.AgentEnvVars))
-		for k := range cfg.AgentEnvVars {
-			if !sandboxMountedByDefault[k] {
-				keys = append(keys, k)
-			}
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			args = append(args, "--setenv", k, cfg.AgentEnvVars[k])
-		}
-	}
+	// Inject profile-level agent env vars (AgentEnvVars, with KUBECONFIG /
+	// AWS_CONFIG_FILE suppressed) and harness-specific runtime env vars
+	// (RuntimeEnv). The bwrap appender uses "--setenv K V" syntax (distinct
+	// argv elements — no shell quoting needed; special characters are verbatim).
+	// See env.go:AppendStandardEnv for the suppression rationale.
+	args = AppendStandardEnv(args, cfg, func(a []string, k, v string) []string {
+		return append(a, "--setenv", k, v)
+	})
 
 	// NIX_CONFIG: tell nix to use the host daemon for store operations.
 	args = append(args, "--setenv", "NIX_CONFIG", "store = daemon")
@@ -594,13 +574,6 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	}
 	args = append(args, "--setenv", "PRISM_SESSION_NAME", cfg.SessionName)
 
-	// Inject harness-specific runtime env vars. For opencode, this includes
-	// the experimental bash-tool timeout (15 min). Populated from
-	// harness.Harness.RuntimeEnv() via the container Config.
-	for k, v := range cfg.RuntimeEnv {
-		args = append(args, "--setenv", k, v)
-	}
-
 	// Host-API env var.
 	if cfg.HostAPITCPPort != 0 {
 		args = append(args,
@@ -644,22 +617,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// theoretical case where AllocatedPort is unset (e.g. a malformed session
 	// row); in normal operation cfg.AllocatedPort is always populated by
 	// agent-run from the DB's harness_port column.
-	opencodePort := cfg.AllocatedPort
-	if opencodePort == 0 {
-		opencodePort = ContainerPort
-	}
-	args = append(args, "--",
-		"opencode",
-		"--port", fmt.Sprintf("%d", opencodePort),
-		"--hostname", "127.0.0.1",
-	)
-
-	if cfg.AgentRole != "" {
-		args = append(args, "--agent", cfg.AgentRole)
-	}
-	if cfg.InitialPrompt != "" {
-		args = append(args, "--prompt", cfg.InitialPrompt)
-	}
+	args = append(args, "--")
+	args = append(args, HarnessInvocation(cfg)...)
 
 	return args
 }

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -360,15 +360,24 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	}
 }
 
-// tempPath returns the host path for a temporary per-session artefact file.
-// All per-session temp files follow the shape:
+// sessionTempPath is the package-level building block for per-session temp
+// file paths. All per-session artefact files follow the shape:
 //
 //	<os.TempDir()>/prism-<stem>-<session_name><suffix>
 //
 // stem identifies the artefact (e.g. "gitdir", "ssh-config"); suffix is ""
 // for most artefacts and ".sb" for the sandbox-exec SBPL profile.
+//
+// It is a free function so that exported helpers like OpencodeConfigFilePath
+// can share the same path logic without requiring a Manager receiver.
+func sessionTempPath(stem, suffix, name string) string {
+	return filepath.Join(os.TempDir(), "prism-"+stem+"-"+name+suffix)
+}
+
+// tempPath returns the host path for a temporary per-session artefact file.
+// It is a thin wrapper over sessionTempPath using the Manager's session name.
 func (m *Manager) tempPath(stem, suffix string) string {
-	return filepath.Join(os.TempDir(), "prism-"+stem+"-"+m.name+suffix)
+	return sessionTempPath(stem, suffix, m.name)
 }
 
 // gitdirFilePath returns the host path for the temporary corrected .git pointer
@@ -424,8 +433,9 @@ func (m *Manager) opencodeConfigFilePath() string {
 // config file for the given session name. The path is deterministic and
 // derived from the session name, so callers outside the Manager (e.g.
 // cmd/spawn.go) can write the file before the Manager is constructed.
+// Delegates to sessionTempPath so all per-session paths share one naming rule.
 func OpencodeConfigFilePath(sessionName string) string {
-	return filepath.Join(os.TempDir(), "prism-opencode-config-"+sessionName)
+	return sessionTempPath("opencode-config", "", sessionName)
 }
 
 // WriteOpencodeConfig writes content to the temp opencode.json file for the

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -32,7 +32,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"time"
 )
@@ -361,11 +360,22 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	}
 }
 
+// tempPath returns the host path for a temporary per-session artefact file.
+// All per-session temp files follow the shape:
+//
+//	<os.TempDir()>/prism-<stem>-<session_name><suffix>
+//
+// stem identifies the artefact (e.g. "gitdir", "ssh-config"); suffix is ""
+// for most artefacts and ".sb" for the sandbox-exec SBPL profile.
+func (m *Manager) tempPath(stem, suffix string) string {
+	return filepath.Join(os.TempDir(), "prism-"+stem+"-"+m.name+suffix)
+}
+
 // gitdirFilePath returns the host path for the temporary corrected .git pointer
 // file written before container start. The file is named after the container
 // so it is stable and can be cleaned up by EnsureRemoved.
 func (m *Manager) gitdirFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-gitdir-"+m.name)
+	return m.tempPath("gitdir", "")
 }
 
 // GitdirFilePath is the exported version of gitdirFilePath for tests.
@@ -377,7 +387,7 @@ func (m *Manager) GitdirFilePath() string { return m.gitdirFilePath() }
 // nix store symlink with wrong ownership (nobody:nogroup, 0444) which SSH
 // rejects. We write a simple config that points to the mounted key.
 func (m *Manager) sshConfigFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-ssh-config-"+m.name)
+	return m.tempPath("ssh-config", "")
 }
 
 // SshConfigFilePath is the exported version of sshConfigFilePath for tests.
@@ -387,7 +397,7 @@ func (m *Manager) SshConfigFilePath() string { return m.sshConfigFilePath() }
 // written before container start. The container needs a minimal gitconfig
 // for commit identity and SSH signing. Mounted read-only at /root/.gitconfig.
 func (m *Manager) gitconfigFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-gitconfig-"+m.name)
+	return m.tempPath("gitconfig", "")
 }
 
 // GitconfigFilePath is the exported version of gitconfigFilePath for tests.
@@ -398,7 +408,7 @@ func (m *Manager) GitconfigFilePath() string { return m.gitconfigFilePath() }
 // read-only at /root/.ssh/allowed_signers and is required for
 // git verify-commit to work with SSH signing.
 func (m *Manager) allowedSignersFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-allowed-signers-"+m.name)
+	return m.tempPath("allowed-signers", "")
 }
 
 // opencodeConfigFilePath returns the host path for the temporary opencode.json
@@ -436,7 +446,7 @@ func WriteOpencodeConfig(sessionName, content string) error {
 // file so it can be bind-mounted at /root/.claude/.credentials.json inside
 // the container where opencode-claude-auth can read it.
 func (m *Manager) claudeCredentialsFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-claude-creds-"+m.name)
+	return m.tempPath("claude-creds", "")
 }
 
 // writeClaudeCredentials extracts Claude Code credentials from the macOS
@@ -633,7 +643,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 // bind-mount it over the original so that nix/libgit2 can resolve the full
 // worktree chain.
 func (m *Manager) worktreeGitdirFilePath() string {
-	return filepath.Join(os.TempDir(), "prism-wt-gitdir-"+m.name)
+	return m.tempPath("wt-gitdir", "")
 }
 
 // WorktreeGitdirFilePath is the exported version of worktreeGitdirFilePath for tests.
@@ -1454,31 +1464,13 @@ func (m *Manager) buildRunArgs() []string {
 		args = append(args, "--env", kv)
 	}
 
-	// Inject profile-level agent env vars (e.g. GIT_EDITOR=true). These come
-	// from profiles.json agent_env_vars (written by Nix). Emitted in sorted
-	// key order for determinism.
-	//
-	// KUBECONFIG and AWS_CONFIG_FILE are intentionally suppressed here: both
-	// files are already bind-mounted at their canonical default paths
-	// (/root/.kube/config and /root/.aws/config respectively), so the host
-	// XDG paths held in AgentEnvVars do not exist inside the container and
-	// would only override the correctly-mounted locations.
-	sandboxMountedByDefault := map[string]bool{
-		"KUBECONFIG":      true,
-		"AWS_CONFIG_FILE": true,
-	}
-	if len(cfg.AgentEnvVars) > 0 {
-		keys := make([]string, 0, len(cfg.AgentEnvVars))
-		for k := range cfg.AgentEnvVars {
-			if !sandboxMountedByDefault[k] {
-				keys = append(keys, k)
-			}
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			args = append(args, "--env", k+"="+cfg.AgentEnvVars[k])
-		}
-	}
+	// Inject profile-level agent env vars (AgentEnvVars, with KUBECONFIG /
+	// AWS_CONFIG_FILE suppressed) and harness-specific runtime env vars
+	// (RuntimeEnv). The podman appender uses "--env K=V" syntax.
+	// See env.go:AppendStandardEnv for the suppression rationale.
+	args = AppendStandardEnv(args, cfg, func(a []string, k, v string) []string {
+		return append(a, "--env", k+"="+v)
+	})
 
 	// opencode.json: mount the generated config file when ConfigContent is set.
 	// The file is written by Create() to a temp path and mounted read-only at
@@ -1510,14 +1502,6 @@ func (m *Manager) buildRunArgs() []string {
 	// connects to the SSE endpoint on the mapped host port exactly as before.
 	// The tmux agent window uses "podman attach" to bridge the PTY (RFC #691,
 	// Phase 1a / Issue #715).
-	// Inject harness-specific runtime env vars into the container. These are
-	// populated from harness.Harness.RuntimeEnv() by the sidecar. For opencode,
-	// this includes the experimental bash-tool timeout (15 min). Precedence:
-	// podman --env overrides any same-named ENV instruction baked into the
-	// image, so the harness values are what the agent runtime sees.
-	for k, v := range cfg.RuntimeEnv {
-		args = append(args, "--env", k+"="+v)
-	}
 
 	args = append(args, Image,
 		"opencode",

--- a/modules/programs/prism/prism/internal/container/env.go
+++ b/modules/programs/prism/prism/internal/container/env.go
@@ -1,0 +1,50 @@
+package container
+
+import "sort"
+
+// EnvAppender appends a single environment variable (key, value) to args in
+// the isolator's native syntax and returns the extended slice. Podman uses
+// "--env", "K=V"; bwrap uses "--setenv", "K", "V".
+type EnvAppender func(args []string, k, v string) []string
+
+// AppendStandardEnv appends the per-session environment variables derived
+// from cfg to args using the provided appender, and returns the extended
+// slice. It handles two sources:
+//
+//  1. cfg.AgentEnvVars — profile-level vars (e.g. GIT_EDITOR=true) emitted
+//     in sorted key order for determinism. KUBECONFIG and AWS_CONFIG_FILE are
+//     suppressed because both files are already bind-mounted at their canonical
+//     default paths inside the sandbox and the host XDG paths held in
+//     AgentEnvVars would only override the correctly-mounted locations.
+//
+//  2. cfg.RuntimeEnv — harness-specific runtime vars (e.g. the bash-tool
+//     timeout) emitted as-is.
+//
+// The caller is responsible for any additional env vars that are
+// mode-specific (e.g. NIX_CONFIG, TERM, COLORTERM, PRISM_* context vars).
+func AppendStandardEnv(args []string, cfg Config, appender EnvAppender) []string {
+	// Suppress keys that are already provided via bind-mounts.
+	sandboxMountedByDefault := map[string]bool{
+		"KUBECONFIG":      true,
+		"AWS_CONFIG_FILE": true,
+	}
+
+	if len(cfg.AgentEnvVars) > 0 {
+		keys := make([]string, 0, len(cfg.AgentEnvVars))
+		for k := range cfg.AgentEnvVars {
+			if !sandboxMountedByDefault[k] {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = appender(args, k, cfg.AgentEnvVars[k])
+		}
+	}
+
+	for k, v := range cfg.RuntimeEnv {
+		args = appender(args, k, v)
+	}
+
+	return args
+}

--- a/modules/programs/prism/prism/internal/container/harness_args.go
+++ b/modules/programs/prism/prism/internal/container/harness_args.go
@@ -1,0 +1,35 @@
+package container
+
+import "fmt"
+
+// HarnessInvocation returns the trailing arg slice that launches opencode
+// with the per-session port, role, and initial prompt. The leading args
+// (sandbox-exec wrapper, bwrap "--" terminator, etc.) are the isolator's
+// responsibility.
+//
+// Port selection follows the AllocatedPort ∥ ContainerPort fallback rule:
+// non-podman isolators share the host network namespace and bind directly
+// to a per-session host port (cfg.AllocatedPort). ContainerPort is retained
+// as a fallback for the theoretical case where AllocatedPort is unset.
+//
+// The hostname is always 127.0.0.1 for non-podman modes (host network
+// namespace is shared; binding 0.0.0.0 would be overly broad). Podman keeps
+// its own inline invocation tail with 0.0.0.0 and ContainerPort.
+func HarnessInvocation(cfg Config) []string {
+	port := cfg.AllocatedPort
+	if port == 0 {
+		port = ContainerPort
+	}
+	args := []string{
+		"opencode",
+		"--port", fmt.Sprintf("%d", port),
+		"--hostname", "127.0.0.1",
+	}
+	if cfg.AgentRole != "" {
+		args = append(args, "--agent", cfg.AgentRole)
+	}
+	if cfg.InitialPrompt != "" {
+		args = append(args, "--prompt", cfg.InitialPrompt)
+	}
+	return args
+}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -152,7 +151,7 @@ func generateProfile(m *Manager) string {
 // file written before sandbox-exec is launched. The path is namespaced by
 // the session name so concurrent sessions never collide.
 func (m *Manager) sandboxExecProfilePath() string {
-	return filepath.Join(os.TempDir(), "prism-sandbox-exec-profile-"+m.name+".sb")
+	return m.tempPath("sandbox-exec-profile", ".sb")
 }
 
 // writeProfile materialises the generated SBPL profile to a temp file and
@@ -195,27 +194,11 @@ func (s *sandboxExecIsolator) BuildArgs(m *Manager) []string {
 
 	profilePath := m.sandboxExecProfilePath()
 
-	args := []string{"sandbox-exec", "-f", profilePath, "opencode"}
-
-	// Match the bwrap port-fallback rule for parity. AllocatedPort is
-	// populated by agent-run from the DB's harness_port column in normal
-	// operation; ContainerPort is the fallback for the theoretical case
-	// where AllocatedPort is unset.
-	opencodePort := cfg.AllocatedPort
-	if opencodePort == 0 {
-		opencodePort = ContainerPort
-	}
-	args = append(args,
-		"--port", fmt.Sprintf("%d", opencodePort),
-		"--hostname", "127.0.0.1",
-	)
-
-	if cfg.AgentRole != "" {
-		args = append(args, "--agent", cfg.AgentRole)
-	}
-	if cfg.InitialPrompt != "" {
-		args = append(args, "--prompt", cfg.InitialPrompt)
-	}
+	// The sandbox-exec wrapper precedes the harness invocation. HarnessInvocation
+	// returns ["opencode", "--port", ..., "--hostname", "127.0.0.1", ...] and
+	// handles the AllocatedPort ∥ ContainerPort fallback rule (matching bwrap).
+	args := []string{"sandbox-exec", "-f", profilePath}
+	args = append(args, HarnessInvocation(cfg)...)
 
 	return args
 }


### PR DESCRIPTION
## Summary

Three small, independent helper extractions in `internal/container/` to eliminate implementation duplication between the podman, bwrap, and sandbox-exec isolators. No behaviour changes.

### A2.S1 — `m.tempPath(stem, suffix)` helper

Seven identical temp-path methods on `Manager` (each of the form `filepath.Join(os.TempDir(), "prism-<stem>-"+m.name)`) are consolidated into a single private helper. All seven methods now delegate to `tempPath`, and the sandbox-exec profile path (`sandboxExecProfilePath`) likewise delegates using the `.sb` suffix.

### A2.S2 — `HarnessInvocation(cfg Config) []string` (new file: `harness_args.go`)

The `["opencode", "--port", ..., "--hostname", "127.0.0.1", ...]` trailing arg slice with `AllocatedPort ∥ ContainerPort` fallback was duplicated between `bwrap.go:608-636` and `sandbox_exec.go:172-194`. Extracted as a package-level function. bwrap appends it after `"--"`; sandbox-exec appends it after the wrapper args.

### A2.E1 — `AppendStandardEnv(args, cfg, appender)` (new file: `env.go`)

The `AgentEnvVars` (sorted-key, KUBECONFIG/AWS_CONFIG_FILE suppressed) + `RuntimeEnv` emission block was duplicated between `container.go:1466-1481/1518-1520` (podman) and `bwrap.go:516-542/573-576` (bwrap). Extracted as a function with an `EnvAppender` callback for the per-mode syntax (`--env K=V` vs `--setenv K V`).

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #1138
Refs #1090