### PR TITLE
prism: B.2 harness registry + TransportShape enum

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -60,7 +60,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -186,8 +187,21 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		agentEnvVars = pf.AgentEnvVars
 	}
 
+	// Resolve the harness name from the DB status. Fall back to "opencode"
+	// for pre-registry rows that have a NULL harness column.
+	harnessName := "opencode"
+	if status.Harness != nil && *status.Harness != "" {
+		harnessName = *status.Harness
+	}
+
 	// Populate harness-specific runtime env vars for the bwrap sandbox.
-	agentRunHarness := opencode.New("", nil, "", "")
+	// harnessName comes from the DB; if it is not registered, fall back to
+	// a zero-env map rather than failing the entire agent-run.
+	agentRunHarness, _ := harness.New(harnessName, "", nil, "", "")
+	var runtimeEnv map[string]string
+	if agentRunHarness != nil {
+		runtimeEnv = agentRunHarness.RuntimeEnv()
+	}
 	ctrCfg := container.Config{
 		SessionName:       sessionName,
 		Worktree:          worktree,
@@ -200,7 +214,7 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 		SshAccessKeyName:  cfg.SshAccessKeyName,
 		SshSigningKeyName: cfg.SshSigningKeyName,
 		HostAPISockPath:   hostAPISockPath,
-		RuntimeEnv:        agentRunHarness.RuntimeEnv(),
+		RuntimeEnv:        runtimeEnv,
 		AgentEnvVars:      agentEnvVars,
 	}
 
@@ -591,7 +605,18 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		agentEnvVars = pf.AgentEnvVars
 	}
 
-	agentRunHarness := opencode.New("", nil, "", "")
+	// Resolve the harness name from the DB status. Fall back to "opencode"
+	// for pre-registry rows that have a NULL harness column.
+	sandboxHarnessName := "opencode"
+	if status.Harness != nil && *status.Harness != "" {
+		sandboxHarnessName = *status.Harness
+	}
+
+	sandboxHarness, _ := harness.New(sandboxHarnessName, "", nil, "", "")
+	var sandboxRuntimeEnv map[string]string
+	if sandboxHarness != nil {
+		sandboxRuntimeEnv = sandboxHarness.RuntimeEnv()
+	}
 	ctrCfg := container.Config{
 		SessionName:       sessionName,
 		Worktree:          worktree,
@@ -604,7 +629,7 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		SshAccessKeyName:  cfg.SshAccessKeyName,
 		SshSigningKeyName: cfg.SshSigningKeyName,
 		HostAPISockPath:   hostAPISockPath,
-		RuntimeEnv:        agentRunHarness.RuntimeEnv(),
+		RuntimeEnv:        sandboxRuntimeEnv,
 		AgentEnvVars:      agentEnvVars,
 	}
 

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -23,7 +23,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -170,7 +171,7 @@ var prCmd = &cobra.Command{
 			}
 		}
 
-		prHarness := opencode.New("", nil, "", "")
+		prHarness, _ := harness.New("opencode", "", nil, "", "")
 		opts := session.Opts{
 			Prompt:           promptFlag,
 			Agent:            agentFlag,

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -33,7 +33,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/dashboard"
 	"github.com/prismatic-koi/prism/internal/db"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -294,7 +295,19 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	if s.HarnessSessionID != nil {
 		opencodeSession = *s.HarnessSessionID
 	}
-	restoreHarness := opencode.New("", nil, "", "")
+	// Resolve the harness name from the DB row. Fall back to "opencode" for
+	// pre-registry rows where the harness column is NULL.
+	restoreHarnessName := "opencode"
+	if s.Harness != nil && *s.Harness != "" {
+		restoreHarnessName = *s.Harness
+	}
+	// If the persisted harness is not registered (e.g. a future harness that
+	// was later uninstalled), fall back to the opencode adapter so that
+	// restore does not hard-fail on every row.
+	restoreHarness, restoreHarnessErr := harness.New(restoreHarnessName, "", nil, "", "")
+	if restoreHarnessErr != nil {
+		restoreHarness, _ = harness.New("opencode", "", nil, "", "")
+	}
 	opts := session.Opts{
 		Headless:         true,
 		OpencodeSession:  opencodeSession,

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -82,6 +82,11 @@ func runReview(cmd *cobra.Command, args []string) error {
 	diffInlineMaxFlag, _ := cmd.Flags().GetInt("diff-inline-max")
 	sizeBudgetFlag, _ := cmd.Flags().GetInt("size-budget")
 
+	// Validate harness BEFORE any session state is created.
+	if _, ok := harness.Lookup(harnessFlag); !ok {
+		return fmt.Errorf("unknown harness %q: valid harnesses: %s", harnessFlag, strings.Join(harness.Names(), ", "))
+	}
+
 	// Resolve the full agent list and apply --only filtering up-front.
 	// This is done before the container-mode branch so that validation
 	// (empty CSV, unknown names) is consistent across both paths and no
@@ -205,8 +210,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// harness-specific check (for opencode: agent .md files in the agents
 	// directory). This keeps opencode-specific filesystem paths out of
 	// cmd/ and review/ packages.
-	// harnessFlag was already used to resolve allAgents above; it is a valid
-	// harness name if we reached this point. The error is unreachable.
+	// harnessFlag was validated via harness.Lookup above; the error is unreachable.
 	h, _ := harness.New(harnessFlag, "", nil, "", "")
 	if err := review.CheckAgentAvailability(agents, h.ValidateAgentRole); err != nil {
 		return fmt.Errorf("prism review: %w", err)

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -27,7 +27,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/session"
 )
@@ -204,7 +205,9 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// harness-specific check (for opencode: agent .md files in the agents
 	// directory). This keeps opencode-specific filesystem paths out of
 	// cmd/ and review/ packages.
-	h := opencode.New("", nil, "", "")
+	// harnessFlag was already used to resolve allAgents above; it is a valid
+	// harness name if we reached this point. The error is unreachable.
+	h, _ := harness.New(harnessFlag, "", nil, "", "")
 	if err := review.CheckAgentAvailability(agents, h.ValidateAgentRole); err != nil {
 		return fmt.Errorf("prism review: %w", err)
 	}

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -60,7 +60,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/sidecar"
 )
@@ -98,6 +99,7 @@ func init() {
 	sidecarCmd.Flags().String("config-content", "", "JSON blob for container opencode.json; written to temp file and mounted (container mode only)")
 	sidecarCmd.Flags().String("instance-id", "", "UUID instance identifier for this session incarnation (for container labels and bus message scoping)")
 	sidecarCmd.Flags().Bool("worktree-readonly", false, "Mount the worktree read-only inside the container (used for review agents)")
+	sidecarCmd.Flags().String("harness", "opencode", "Agent harness to use (e.g. opencode)")
 	_ = sidecarCmd.MarkFlagRequired("session")
 	_ = sidecarCmd.MarkFlagRequired("opencode-url")
 	rootCmd.AddCommand(sidecarCmd)
@@ -115,6 +117,13 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	configContent, _ := cmd.Flags().GetString("config-content")
 	instanceID, _ := cmd.Flags().GetString("instance-id")
 	worktreeReadOnly, _ := cmd.Flags().GetBool("worktree-readonly")
+	harnessName, _ := cmd.Flags().GetString("harness")
+	if harnessName == "" {
+		harnessName = "opencode"
+	}
+	if _, ok := harness.Lookup(harnessName); !ok {
+		return fmt.Errorf("sidecar: unknown harness %q: valid harnesses: %s", harnessName, strings.Join(harness.Names(), ", "))
+	}
 
 	// Resolve the effective isolation mode. When --isolation-mode is set it
 	// takes precedence. Otherwise fall back to --container for back-compat.
@@ -177,7 +186,8 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// Resolve the agent model once via the harness adapter. The adapter is
 	// constructed transiently here for the EffectiveModel call; a fresh
 	// adapter with the resolved model is constructed below for the sidecar.
-	agentModel := opencode.New("", nil, agentRole, "").EffectiveModel(agentRole)
+	modelProbe, _ := harness.New(harnessName, "", nil, agentRole, "")
+	agentModel := modelProbe.EffectiveModel(agentRole)
 
 	// Load profiles to extract container resource caps and agent env vars.
 	// Non-fatal if missing (e.g. running without the nix module) — resource
@@ -279,21 +289,24 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Construct the opencode harness adapter and inject it via Config.Harness.
-	// The adapter encapsulates all opencode-specific behaviour: session
+	// Construct the harness adapter and inject it via Config.Harness.
+	// The adapter encapsulates all runtime-specific behaviour: session
 	// creation, prompt delivery, SSE subscription, event type extraction, and
 	// event mapping. The sidecar calls through the harness.Harness interface
-	// and has no direct dependency on the opencode package (#710).
+	// and has no direct dependency on the adapter package (#710).
 	//
-	// In podman and bwrap mode, use NewContainerMode so that:
+	// In podman and bwrap mode, use NewContainer so that:
 	//   - CreateSession uses GET /session to retrieve the existing session ID
 	//     (opencode already created a session when the TUI started)
 	//   - DeliverInitialPrompt is a no-op (prompt was sent via --prompt CLI flag)
-	var h *opencode.Adapter
+	var h harness.Harness
 	if useContainerHarness {
-		h = opencode.NewContainerMode(opencodeURL, nil, agentRole, agentModel)
+		h, err = harness.NewContainer(harnessName, opencodeURL, nil, agentRole, agentModel)
 	} else {
-		h = opencode.New(opencodeURL, nil, agentRole, agentModel)
+		h, err = harness.New(harnessName, opencodeURL, nil, agentRole, agentModel)
+	}
+	if err != nil {
+		return fmt.Errorf("sidecar: construct harness adapter: %w", err)
 	}
 
 	// Inject harness-specific runtime env vars into the container config.

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -31,7 +31,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -145,7 +146,7 @@ func init() {
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
 	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().Bool("host-mode", false, "Deprecated alias for --isolation host; bypass container mode and run opencode directly in the tmux pane")
-	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use (currently only 'opencode' is supported)")
+	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	rootCmd.AddCommand(spawnCmd)
 }
@@ -247,9 +248,9 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 
 	// Validate harness BEFORE any session state is created (no worktree, no
-	// tmux session, no DB row). Only "opencode" is supported in this version.
-	if harnessFlag != "opencode" {
-		return fmt.Errorf("unknown harness %q: only 'opencode' is supported in this version of prism", harnessFlag)
+	// tmux session, no DB row).
+	if _, ok := harness.Lookup(harnessFlag); !ok {
+		return fmt.Errorf("unknown harness %q: valid harnesses: %s", harnessFlag, strings.Join(harness.Names(), ", "))
 	}
 
 	promptFlag, err := resolvePrompt(cmd)
@@ -427,7 +428,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// These are populated from the harness adapter and threaded through
 	// SpawnOpts → Opts → buildDirectOpencodeCmd so that no
 	// opencode-specific string literals appear in the session package.
-	h := opencode.New("", nil, "", "")
+	// harnessFlag was already validated above, so the error is unreachable.
+	h, _ := harness.New(harnessFlag, "", nil, "", "")
 	spawnOpts := session.SpawnOpts{
 		SessionName:      sessionName,
 		Repo:             deriveRepo(worktreePath),

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -443,6 +443,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		PluginHostPath:   cfg.SidecarPluginPath,
 		ConfigEnvVarName: h.ConfigEnvVar(),
 		RuntimeEnvVars:   h.RuntimeEnv(),
+		HarnessName:      harnessFlag,
 		// ForceFresh=true: spawn always wants a new instance. If a session
 		// with the same name already exists it is a stale zombie and should
 		// be killed.

--- a/modules/programs/prism/prism/cmd/spawn_harness_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_harness_test.go
@@ -55,8 +55,8 @@ func TestRunSpawn_UnknownHarness_ReturnsErrorBeforeStateCreated(t *testing.T) {
 	if !strings.Contains(err.Error(), `unknown harness "pi"`) {
 		t.Errorf("error %q does not contain expected text 'unknown harness \"pi\"'", err.Error())
 	}
-	if !strings.Contains(err.Error(), "only 'opencode' is supported") {
-		t.Errorf("error %q does not mention 'only 'opencode' is supported'", err.Error())
+	if !strings.Contains(err.Error(), "valid harnesses:") {
+		t.Errorf("error %q does not mention 'valid harnesses:'", err.Error())
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -21,7 +21,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/dashboard"
 	"github.com/prismatic-koi/prism/internal/git"
-	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -1087,7 +1088,8 @@ var switchCmd = &cobra.Command{
 
 		// Populate harness-specific env var names from the adapter so that
 		// no opencode-specific string literals appear in session.go.
-		switchHarness := opencode.New("", nil, "", "")
+		// "opencode" is the only registered harness; fall back gracefully.
+		switchHarness, _ := harness.New("opencode", "", nil, "", "")
 		opts := session.Opts{
 			Fresh:            fresh,
 			ContainerMode:    effectiveContainerMode,

--- a/modules/programs/prism/prism/internal/harness/opencode/register.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/register.go
@@ -1,0 +1,32 @@
+package opencode
+
+// register.go — registers the opencode adapter with the harness registry at
+// process startup via an init() function.
+//
+// Callers that today import this package directly for opencode.New /
+// opencode.NewContainerMode should switch to a blank import:
+//
+//	import _ "github.com/prismatic-koi/prism/internal/harness/opencode"
+//
+// The harness.New / harness.NewContainer functions then construct the
+// correct adapter via the registry without any direct dependency on this
+// package. B.2 proposal §5.15.
+
+import (
+	"net/http"
+
+	"github.com/prismatic-koi/prism/internal/harness"
+)
+
+func init() {
+	harness.MustRegister(harness.Registration{
+		Name:  "opencode",
+		Shape: harness.TransportHTTPPort,
+		Factory: func(endpoint string, c *http.Client, role, model string) harness.Harness {
+			return New(endpoint, c, role, model)
+		},
+		ContainerFactory: func(endpoint string, c *http.Client, role, model string) harness.Harness {
+			return NewContainerMode(endpoint, c, role, model)
+		},
+	})
+}

--- a/modules/programs/prism/prism/internal/harness/registry.go
+++ b/modules/programs/prism/prism/internal/harness/registry.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -120,7 +121,7 @@ type Registration struct {
 // sequentially so no lock is needed during registration itself, but
 // callers after init may run concurrently.
 var (
-	mu           sync.RWMutex
+	mu            sync.RWMutex
 	registrations = map[string]Registration{}
 )
 
@@ -247,13 +248,5 @@ func ShapeOf(name string) (TransportShape, bool) {
 // joinNames returns the sorted registered names as a comma-separated
 // string, for use in error messages.
 func joinNames() string {
-	names := Names()
-	result := ""
-	for i, n := range names {
-		if i > 0 {
-			result += ", "
-		}
-		result += n
-	}
-	return result
+	return strings.Join(Names(), ", ")
 }

--- a/modules/programs/prism/prism/internal/harness/registry.go
+++ b/modules/programs/prism/prism/internal/harness/registry.go
@@ -1,0 +1,259 @@
+package harness
+
+// registry.go — global harness registry, TransportShape enum, and
+// the Factory / Registration types that adapters use to register.
+//
+// Design mirrors database/sql.Register: adapter packages call
+// harness.MustRegister from their init() functions, and consumers call
+// harness.New / harness.NewContainer / harness.Lookup / harness.Names
+// without importing the adapter package directly (only a blank import is
+// needed to trigger registration).
+//
+// B.2 proposal: modules/programs/prism/prism/docs/reviews/
+// B2-harness-registry-and-transport-shape.md §3–§4.
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+)
+
+// TransportShape declares the wire-level shape a harness uses to talk to
+// its agent runtime. It is a registration-time property of each harness
+// adapter: code that does not need to know the harness name (container
+// manager, sidecar lifecycle, agent-pane command builder) consults the
+// shape instead.
+//
+// The enum is closed: registration with an unknown TransportShape value
+// fails at init time. Adding a new value is a deliberate change that
+// requires updating every consumer that switches on the value.
+type TransportShape string
+
+const (
+	// TransportHTTPPort declares that the harness runs a long-lived
+	// HTTP server inside its container (or process) and the sidecar
+	// dials it on a TCP port. Health checks are HTTP probes against
+	// a known endpoint. Event delivery is server-sent events (SSE) or
+	// long-polling. Prompts are POSTed; the response status code is the
+	// delivery acknowledgement. Examples: opencode (today),
+	// Claude Code (planned).
+	TransportHTTPPort TransportShape = "http-port"
+
+	// TransportStdioPipe declares that the harness runs as a child
+	// process whose stdin/stdout the sidecar (or sidecar-equivalent)
+	// owns. Wire format is JSON Lines (or another framed stream).
+	// Health is the process being alive and the pipe being open.
+	// Prompts are written to stdin fire-and-forget — the OS write
+	// succeeds or fails, but there is no transport-level
+	// acknowledgement that the harness has processed the prompt.
+	// Examples: PI (planned, RFC #606), Codex (likely future).
+	TransportStdioPipe TransportShape = "stdio-pipe"
+
+	// TransportFallbackScreenScrape declares that the harness has no
+	// structured wire protocol and the sidecar must observe the
+	// agent's behaviour by reading its TTY output (typically via a
+	// capture pipe attached to the container's PTY). Prompt delivery
+	// is by writing to the harness's controlling TTY rather than to
+	// any structured channel. Health is "the process is alive".
+	// This is the safety-net shape for harnesses that ship before
+	// their structured protocol is stable, and for any future harness
+	// whose vendor declines to expose a structured API.
+	TransportFallbackScreenScrape TransportShape = "fallback-screen-scrape"
+)
+
+// knownShapes is the closed set of valid TransportShape values. Registration
+// with an unknown value is rejected so that typos and future enum extensions
+// are caught at init time rather than silently at runtime.
+var knownShapes = map[TransportShape]bool{
+	TransportHTTPPort:             true,
+	TransportStdioPipe:            true,
+	TransportFallbackScreenScrape: true,
+}
+
+// Factory constructs a harness.Harness adapter for a single sidecar
+// session. The arguments are the cross-harness inputs the registry
+// promises to provide to every adapter:
+//
+//   - endpoint: the transport-specific endpoint hint. For
+//     TransportHTTPPort this is the URL the sidecar dials (e.g.
+//     "http://localhost:4096"). For TransportStdioPipe this is the
+//     path to the harness binary (or a launch spec — TBD by B.3).
+//     For TransportFallbackScreenScrape this is the path to the TTY
+//     capture pipe. The factory treats it as opaque per its shape.
+//   - httpClient: optional. Non-nil when the caller wants to inject
+//     a test client; nil means the adapter uses its default. Ignored
+//     by stdio and screen-scrape adapters.
+//   - agentRole: "worker" | "coordinator" | "" (review subagents
+//     pass empty here; their role is set later via env vars).
+//   - agentModel: model identifier (e.g. "anthropic/claude-sonnet-4-6").
+//     Empty means "let the adapter resolve from its config".
+//
+// Factory is intentionally narrow: it returns a Harness, not a
+// concrete adapter type.
+type Factory func(endpoint string, httpClient *http.Client, agentRole, agentModel string) Harness
+
+// Registration is the data an adapter package supplies at registration
+// time. The Name is the user-visible identifier (matches the --harness
+// flag value and the agent_status.harness column). Shape is the
+// declared transport shape; consumers may switch on it without
+// knowing the name.
+type Registration struct {
+	Name  string
+	Shape TransportShape
+	// Factory constructs a host-mode harness adapter.
+	Factory Factory
+
+	// ContainerFactory, when non-nil, is the factory used in container
+	// mode. It exists because the opencode adapter today exposes
+	// opencode.New / opencode.NewContainerMode as two separate
+	// constructors that differ in CreateSession and DeliverInitialPrompt
+	// semantics. Other harnesses (stdio especially) probably need a
+	// single Factory; ContainerFactory is opt-in.
+	//
+	// When nil, NewContainer falls back to Factory.
+	ContainerFactory Factory
+}
+
+// globalRegistry is the package-level singleton. All fields are
+// protected by mu after process start; init() functions run
+// sequentially so no lock is needed during registration itself, but
+// callers after init may run concurrently.
+var (
+	mu           sync.RWMutex
+	registrations = map[string]Registration{}
+)
+
+// Register adds a Registration to the global registry. It returns an
+// error for: empty Name, empty/unknown Shape, nil Factory, or
+// duplicate Name. MustRegister panics on the same conditions and is
+// the form intended for init().
+//
+//	// in internal/harness/opencode/register.go
+//	func init() {
+//	    harness.MustRegister(harness.Registration{
+//	        Name:             "opencode",
+//	        Shape:            harness.TransportHTTPPort,
+//	        Factory:          ...,
+//	        ContainerFactory: ...,
+//	    })
+//	}
+func Register(reg Registration) error {
+	if reg.Name == "" {
+		return fmt.Errorf("harness.Register: Name must not be empty")
+	}
+	if reg.Shape == "" {
+		return fmt.Errorf("harness.Register: Shape must not be empty for harness %q", reg.Name)
+	}
+	if !knownShapes[reg.Shape] {
+		return fmt.Errorf("harness.Register: unknown TransportShape %q for harness %q; valid values: http-port, stdio-pipe, fallback-screen-scrape", reg.Shape, reg.Name)
+	}
+	if reg.Factory == nil {
+		return fmt.Errorf("harness.Register: Factory must not be nil for harness %q", reg.Name)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, exists := registrations[reg.Name]; exists {
+		return fmt.Errorf("harness.Register: harness %q is already registered", reg.Name)
+	}
+	registrations[reg.Name] = reg
+	return nil
+}
+
+// MustRegister calls Register and panics if it returns an error.
+// Intended for use in adapter package init() functions.
+func MustRegister(reg Registration) {
+	if err := Register(reg); err != nil {
+		panic(err)
+	}
+}
+
+// Lookup returns the Registration for a given harness name, or
+// (Registration{}, false) if no harness with that name is registered.
+// Callers that want a usable harness use New / NewContainer instead;
+// Lookup is for the spawn allow-list and for tests.
+func Lookup(name string) (Registration, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	reg, ok := registrations[name]
+	return reg, ok
+}
+
+// Names returns the registered harness names in deterministic order
+// (sorted ascending). Used by:
+//   - the --harness flag's validation error message ("valid: opencode, pi"),
+//   - the host-API /spawn handler's allow-list,
+//   - dashboard / stats display.
+func Names() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	names := make([]string, 0, len(registrations))
+	for name := range registrations {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// New constructs a host-mode harness adapter for the named harness.
+// Returns an error if the name is not registered. The endpoint /
+// httpClient / agentRole / agentModel arguments are forwarded to the
+// registered Factory verbatim.
+//
+// Replaces the hard-coded opencode.New(...) calls at cmd/sidecar.go:296
+// and the construction-only-for-side-effects opencode.New("", nil, "", "")
+// calls in cmd/spawn.go, cmd/agent_run.go, cmd/restore.go, cmd/switch.go,
+// cmd/pr.go, cmd/review.go.
+func New(name, endpoint string, httpClient *http.Client, agentRole, agentModel string) (Harness, error) {
+	reg, ok := Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("harness %q is not registered; valid harnesses: %s", name, joinNames())
+	}
+	return reg.Factory(endpoint, httpClient, agentRole, agentModel), nil
+}
+
+// NewContainer constructs a container-mode harness adapter for the
+// named harness. If the registration has a ContainerFactory it is used;
+// otherwise Factory is used. Returns an error if the name is not
+// registered.
+//
+// Replaces the hard-coded opencode.NewContainerMode(...) call at
+// cmd/sidecar.go:294.
+func NewContainer(name, endpoint string, httpClient *http.Client, agentRole, agentModel string) (Harness, error) {
+	reg, ok := Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("harness %q is not registered; valid harnesses: %s", name, joinNames())
+	}
+	f := reg.ContainerFactory
+	if f == nil {
+		f = reg.Factory
+	}
+	return f(endpoint, httpClient, agentRole, agentModel), nil
+}
+
+// ShapeOf returns the declared TransportShape for the named harness,
+// or ("", false) if not registered. Convenience over Lookup for sites
+// that only need the shape (e.g. session.StartSidecarWithOpts deciding
+// whether to allocate a port).
+func ShapeOf(name string) (TransportShape, bool) {
+	reg, ok := Lookup(name)
+	if !ok {
+		return "", false
+	}
+	return reg.Shape, true
+}
+
+// joinNames returns the sorted registered names as a comma-separated
+// string, for use in error messages.
+func joinNames() string {
+	names := Names()
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += ", "
+		}
+		result += n
+	}
+	return result
+}

--- a/modules/programs/prism/prism/internal/harness/registry_test.go
+++ b/modules/programs/prism/prism/internal/harness/registry_test.go
@@ -1,0 +1,217 @@
+package harness_test
+
+// registry_test.go — unit tests for the harness registry.
+//
+// Covers the acceptance-criteria edge cases:
+//   - harness.Lookup("unknown") returns (Registration{}, false)
+//   - harness.Names() returns ["opencode"] once the opencode init() has run
+//   - MustRegister panics on duplicate registration
+//   - Register rejects empty Name / Shape / nil Factory
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/harness"
+	// Blank import to trigger the opencode init() registration.
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+)
+
+// noopFactory is a minimal Factory that returns nil (sufficient for
+// registration tests that don't exercise the constructed harness).
+func noopFactory(endpoint string, _ *http.Client, _, _ string) harness.Harness {
+	return &harness.FakeHarness{}
+}
+
+func TestLookup_Unknown(t *testing.T) {
+	reg, ok := harness.Lookup("unknown-harness-that-does-not-exist")
+	if ok {
+		t.Errorf("Lookup(unknown): expected ok=false, got ok=true; reg=%+v", reg)
+	}
+	if !reflect.DeepEqual(reg, harness.Registration{}) {
+		t.Errorf("Lookup(unknown): expected zero Registration, got %+v", reg)
+	}
+}
+
+func TestLookup_Opencode(t *testing.T) {
+	reg, ok := harness.Lookup("opencode")
+	if !ok {
+		t.Fatalf("Lookup(opencode): expected ok=true, got ok=false")
+	}
+	if reg.Name != "opencode" {
+		t.Errorf("Lookup(opencode): Name = %q, want %q", reg.Name, "opencode")
+	}
+	if reg.Shape != harness.TransportHTTPPort {
+		t.Errorf("Lookup(opencode): Shape = %q, want %q", reg.Shape, harness.TransportHTTPPort)
+	}
+	if reg.Factory == nil {
+		t.Error("Lookup(opencode): Factory is nil")
+	}
+	if reg.ContainerFactory == nil {
+		t.Error("Lookup(opencode): ContainerFactory is nil")
+	}
+}
+
+func TestNames_ContainsOpencode(t *testing.T) {
+	names := harness.Names()
+	found := false
+	for _, n := range names {
+		if n == "opencode" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Names() = %v, want it to contain %q", names, "opencode")
+	}
+}
+
+func TestNames_Sorted(t *testing.T) {
+	names := harness.Names()
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("Names() = %v is not sorted ascending: %q < %q", names, names[i], names[i-1])
+		}
+	}
+}
+
+func TestShapeOf_Opencode(t *testing.T) {
+	shape, ok := harness.ShapeOf("opencode")
+	if !ok {
+		t.Fatalf("ShapeOf(opencode): expected ok=true, got ok=false")
+	}
+	if shape != harness.TransportHTTPPort {
+		t.Errorf("ShapeOf(opencode) = %q, want %q", shape, harness.TransportHTTPPort)
+	}
+}
+
+func TestShapeOf_Unknown(t *testing.T) {
+	shape, ok := harness.ShapeOf("no-such-harness")
+	if ok {
+		t.Errorf("ShapeOf(unknown): expected ok=false, got ok=true; shape=%q", shape)
+	}
+	if shape != "" {
+		t.Errorf("ShapeOf(unknown): expected empty shape, got %q", shape)
+	}
+}
+
+func TestNew_KnownHarness(t *testing.T) {
+	h, err := harness.New("opencode", "", nil, "", "")
+	if err != nil {
+		t.Fatalf("New(opencode): unexpected error: %v", err)
+	}
+	if h == nil {
+		t.Fatal("New(opencode): returned nil Harness")
+	}
+}
+
+func TestNew_UnknownHarness(t *testing.T) {
+	h, err := harness.New("no-such-harness", "", nil, "", "")
+	if err == nil {
+		t.Fatalf("New(unknown): expected error, got nil; h=%v", h)
+	}
+	if !strings.Contains(err.Error(), "no-such-harness") {
+		t.Errorf("New(unknown): error %q does not mention the harness name", err.Error())
+	}
+}
+
+func TestNewContainer_KnownHarness(t *testing.T) {
+	h, err := harness.NewContainer("opencode", "", nil, "", "")
+	if err != nil {
+		t.Fatalf("NewContainer(opencode): unexpected error: %v", err)
+	}
+	if h == nil {
+		t.Fatal("NewContainer(opencode): returned nil Harness")
+	}
+}
+
+func TestRegister_RejectsDuplicateName(t *testing.T) {
+	// Register a temporary harness with a unique name, then try to register
+	// the same name again.  We can't use "opencode" (already registered by
+	// init()), so we create a uniquely-named one.
+	const name = "test-duplicate-harness"
+
+	err := harness.Register(harness.Registration{
+		Name:    name,
+		Shape:   harness.TransportStdioPipe,
+		Factory: noopFactory,
+	})
+	if err != nil {
+		t.Fatalf("first Register(%q): unexpected error: %v", name, err)
+	}
+
+	err = harness.Register(harness.Registration{
+		Name:    name,
+		Shape:   harness.TransportStdioPipe,
+		Factory: noopFactory,
+	})
+	if err == nil {
+		t.Fatalf("second Register(%q): expected duplicate error, got nil", name)
+	}
+	if !strings.Contains(err.Error(), "already registered") {
+		t.Errorf("duplicate error = %q, want it to contain 'already registered'", err.Error())
+	}
+}
+
+func TestRegister_RejectsEmptyName(t *testing.T) {
+	err := harness.Register(harness.Registration{
+		Name:    "",
+		Shape:   harness.TransportHTTPPort,
+		Factory: noopFactory,
+	})
+	if err == nil {
+		t.Fatal("Register(empty Name): expected error, got nil")
+	}
+}
+
+func TestRegister_RejectsEmptyShape(t *testing.T) {
+	err := harness.Register(harness.Registration{
+		Name:    "test-empty-shape",
+		Shape:   "",
+		Factory: noopFactory,
+	})
+	if err == nil {
+		t.Fatal("Register(empty Shape): expected error, got nil")
+	}
+}
+
+func TestRegister_RejectsUnknownShape(t *testing.T) {
+	err := harness.Register(harness.Registration{
+		Name:    "test-unknown-shape",
+		Shape:   harness.TransportShape("grpc-stream"),
+		Factory: noopFactory,
+	})
+	if err == nil {
+		t.Fatal("Register(unknown Shape): expected error, got nil")
+	}
+}
+
+func TestRegister_RejectsNilFactory(t *testing.T) {
+	err := harness.Register(harness.Registration{
+		Name:    "test-nil-factory",
+		Shape:   harness.TransportHTTPPort,
+		Factory: nil,
+	})
+	if err == nil {
+		t.Fatal("Register(nil Factory): expected error, got nil")
+	}
+}
+
+func TestTransportShape_Constants(t *testing.T) {
+	// Smoke-test that the three constants exist and have the correct string values.
+	tests := []struct {
+		shape harness.TransportShape
+		want  string
+	}{
+		{harness.TransportHTTPPort, "http-port"},
+		{harness.TransportStdioPipe, "stdio-pipe"},
+		{harness.TransportFallbackScreenScrape, "fallback-screen-scrape"},
+	}
+	for _, tt := range tests {
+		if string(tt.shape) != tt.want {
+			t.Errorf("TransportShape constant: got %q, want %q", tt.shape, tt.want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -160,6 +160,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			WorktreeReadOnly: true,
 			GroupID:          groupID,
 			RuntimeEnvVars:   opts.RuntimeEnvVars,
+			HarnessName:      opts.Harness,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -378,6 +379,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			WorktreeReadOnly: true,
 			GroupID:          groupID,
 			RuntimeEnvVars:   opts.RuntimeEnvVars,
+			HarnessName:      opts.Harness,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -171,6 +171,11 @@ type Opts struct {
 	// These are prepended outermost (before AgentEnvVars and
 	// PRISM_SESSION_NAME).
 	RuntimeEnvVars map[string]string
+	// HarnessName is the registered harness name (e.g. "opencode"). When
+	// non-empty it is forwarded to the sidecar via --harness so the sidecar
+	// can call harness.ShapeOf to determine its own transport shape. When
+	// empty, the sidecar defaults to "opencode".
+	HarnessName string
 }
 
 // Layout selects the window layout used when creating a new session.
@@ -655,6 +660,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 			InitialPrompt:  opts.Prompt,
 			ConfigContent:  opts.ConfigContent,
 			InstanceID:     opts.InstanceID,
+			HarnessName:    opts.HarnessName,
 		}
 		if err := StartSidecarWithOpts(name, sidecarOpts); err != nil {
 			// Non-fatal: log and continue. The session is created regardless.

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -251,6 +251,11 @@ type StartSidecarOpts struct {
 	// container. Set for review agent containers so they cannot modify the
 	// branch under review. Passed via --worktree-readonly to the sidecar.
 	WorktreeReadOnly bool
+	// HarnessName is the registered harness name (e.g. "opencode"). When
+	// non-empty it is forwarded to the sidecar via --harness so the sidecar
+	// can call harness.ShapeOf to determine its own transport shape. When
+	// empty, the sidecar defaults to "opencode".
+	HarnessName string
 }
 
 // StartSidecar launches a detached `prism sidecar` process for the given
@@ -354,6 +359,9 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 	}
 	if opts.WorktreeReadOnly {
 		cmdArgs = append(cmdArgs, "--worktree-readonly")
+	}
+	if opts.HarnessName != "" {
+		cmdArgs = append(cmdArgs, "--harness", opts.HarnessName)
 	}
 
 	cmd := exec.Command(self, cmdArgs...)

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -152,6 +152,11 @@ type SpawnOpts struct {
 	// PRISM_SESSION_NAME) in the agent command string.
 	RuntimeEnvVars map[string]string
 
+	// HarnessName is the registered harness name (e.g. "opencode"). When
+	// non-empty it is forwarded to the sidecar via --harness so the sidecar
+	// can call harness.ShapeOf to determine its own transport shape.
+	HarnessName string
+
 	// ReadinessTimeout, when > 0, causes SpawnSession to gate its return on
 	// the agent reaching a readiness signal in the prism DB (see
 	// WaitForReady). If the gate trips with a timeout, SpawnSession cleans
@@ -631,6 +636,7 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		ConfigContent:    opts.ConfigContent,
 		InstanceID:       opts.InstanceID,
 		WorktreeReadOnly: opts.WorktreeReadOnly,
+		HarnessName:      opts.HarnessName,
 	}
 	if err := StartSidecarWithOpts(opts.SessionName, sidecarOpts); err != nil {
 		// Non-fatal: log and continue, matching the LayoutFull behaviour

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -57,6 +57,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/mergequeue"
 	session "github.com/prismatic-koi/prism/internal/session"
 )
@@ -3137,8 +3138,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.Harness == "" {
 			req.Harness = "opencode"
 		}
-		if req.Harness != "opencode" {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown harness %q: only 'opencode' is supported in this version of prism", req.Harness))
+		if _, ok := harness.Lookup(req.Harness); !ok {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf(
+				"unknown harness %q: valid harnesses: %s",
+				req.Harness, strings.Join(harness.Names(), ", ")))
 			return
 		}
 		// Reject conflicting isolation flags at the API boundary so the error

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6715,8 +6715,8 @@ exit 0
 	if !strings.Contains(errResp["error"], `unknown harness "pi"`) {
 		t.Errorf("error %q should mention 'unknown harness \"pi\"'", errResp["error"])
 	}
-	if !strings.Contains(errResp["error"], "only 'opencode' is supported") {
-		t.Errorf("error %q should mention 'only 'opencode' is supported'", errResp["error"])
+	if !strings.Contains(errResp["error"], "valid harnesses:") {
+		t.Errorf("error %q should mention 'valid harnesses:'", errResp["error"])
 	}
 	// The stub must NOT have been called (no state was created).
 	if _, err := os.Stat(argsFile); err == nil {


### PR DESCRIPTION
## Summary

Implements the B.2 harness registry as specified in [`B2-harness-registry-and-transport-shape.md`](modules/programs/prism/prism/docs/reviews/B2-harness-registry-and-transport-shape.md) §3–§4.

### New code

- **`internal/harness/registry.go`**: `TransportShape` enum (`http-port`, `stdio-pipe`, `fallback-screen-scrape`), `Factory`/`Registration` types, and `Register`/`MustRegister`/`Lookup`/`Names`/`New`/`NewContainer`/`ShapeOf` API. Singleton pattern mirrors `database/sql.Register`.
- **`internal/harness/opencode/register.go`**: `init()` that calls `harness.MustRegister` with `Name="opencode"`, `Shape=TransportHTTPPort`, `Factory=opencode.New`, `ContainerFactory=opencode.NewContainerMode`.
- **`internal/harness/registry_test.go`**: edge-case tests covering `Lookup("unknown")→false`, `Names()→["opencode"]`, duplicate registration panic, invalid shape rejection, and nil factory rejection.

### Migrated call sites (all 10)

- `cmd/sidecar.go` — `--harness` flag added; `opencode.New`/`NewContainerMode` replaced with `harness.New`/`NewContainer` via registry
- `cmd/spawn.go` — hard-coded allow-list replaced with `harness.Lookup`; `opencode.New` replaced with `harness.New`
- `cmd/review.go` — `opencode.New` replaced with `harness.New`
- `cmd/agent_run.go` — both bwrap and sandbox-exec paths; harness name from `status.Harness` with opencode fallback
- `cmd/restore.go` — harness name from DB row with opencode fallback
- `cmd/switch.go` — `opencode.New` replaced with `harness.New`
- `cmd/pr.go` — `opencode.New` replaced with `harness.New`
- `internal/sidecar/sidecar.go` — hard-coded `if req.Harness != "opencode"` replaced with `harness.Lookup`

### Propagation

`session.Opts` and `SpawnOpts` gain a `HarnessName` field; propagated through `setupFullLayout` and `spawnAgentOnlyLayout` into `StartSidecarWithOpts`, and then `--harness` on the sidecar argv.

### Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (all 16 affected files pass; fixed two tests that checked the old hard-coded error message)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #1128
Refs #1090