### PR TITLE
prism: A1.C1-C5 — capability-read migrations (5 sites, replace if-mode-X with iso.Capabilities())

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -75,13 +75,14 @@ var prCmd = &cobra.Command{
 
 		cfg := config.Load()
 		isoMode := cfg.EffectiveIsolationMode()
-		effectiveContainerMode := isoMode == config.IsolationPodman
-		// bwrap sessions are plain host processes — only podman triggers the container cap.
-		conCapped := isoMode == config.IsolationPodman
+
+		// Look up the isolation capabilities for this mode. All per-mode branching
+		// below reads from isoCaps rather than comparing against raw mode constants.
+		isoCaps := container.CapabilitiesFor(isoMode)
 
 		// Concurrency cap checks: BEFORE any container-creation side effects
 		// (no worktree, no tmux session, no DB row on refusal).
-		if err := checkConcurrencyCap(cmd, "pr", conCapped); err != nil {
+		if err := checkConcurrencyCap(cmd, "pr", isoCaps.IsContainer); err != nil {
 			return err
 		}
 		if isoMode == config.IsolationBwrap {
@@ -110,9 +111,8 @@ var prCmd = &cobra.Command{
 		// This block fires for podman, bwrap, and sandbox-exec isolation modes.
 		// Host-mode sessions skip it because they run opencode directly with the
 		// host's real ~/.config/opencode/opencode.json via xdg.configFile.
-		sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec
 		var configContent string
-		if sandboxed {
+		if isoCaps.NeedsConfigBlob {
 			pf, pfErr := config.LoadProfiles()
 			if pfErr != nil {
 				return pfErr
@@ -163,7 +163,7 @@ var prCmd = &cobra.Command{
 		// and Manager.opencodeConfigFilePath() calls OpencodeConfigFilePath(m.name).
 		// So we must pass the container name (not the raw tmux session name) to
 		// WriteOpencodeConfig. This mirrors the pattern in spawn.go.
-		if isoMode == config.IsolationBwrap && configContent != "" {
+		if isoCaps.NeedsConfigBlob && configContent != "" {
 			tmuxSessionName := session.NameFor(worktreePath, bareRoot)
 			containerName := container.NameForSession(tmuxSessionName)
 			if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
@@ -176,7 +176,7 @@ var prCmd = &cobra.Command{
 			Prompt:           promptFlag,
 			Agent:            agentFlag,
 			Headless:         !attachFlag,
-			ContainerMode:    effectiveContainerMode,
+			ContainerMode:    isoCaps.IsContainer,
 			IsolationMode:    string(isoMode),
 			PluginHostPath:   cfg.SidecarPluginPath,
 			ConfigContent:    configContent,

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -290,7 +290,10 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		isoMode = cfg.EffectiveIsolationMode()
 	}
 
-	containerMode := isoMode == config.IsolationPodman
+	// Look up the isolation capabilities for this mode. All per-mode branching
+	// below reads from isoCaps rather than comparing against raw mode constants.
+	isoCaps := container.CapabilitiesFor(isoMode)
+
 	opencodeSession := ""
 	if s.HarnessSessionID != nil {
 		opencodeSession = *s.HarnessSessionID
@@ -315,12 +318,12 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		SessionName:      s.SessionName,
 		Layout:           session.LayoutFull,
 		SkipStatusSeed:   true,
-		ContainerMode:    containerMode,
+		ContainerMode:    isoCaps.IsContainer,
 		IsolationMode:    string(isoMode),
 		ConfigEnvVarName: restoreHarness.ConfigEnvVar(),
 		RuntimeEnvVars:   restoreHarness.RuntimeEnv(),
 	}
-	if containerMode {
+	if isoCaps.IsContainer {
 		opts.PluginHostPath = cfg.SidecarPluginPath
 	}
 
@@ -332,8 +335,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	//
 	// Host-mode sessions skip this entirely because they run opencode directly
 	// with the host's real ~/.config/opencode/opencode.json via xdg.configFile.
-	sandboxed := isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec
-	if sandboxed {
+	if isoCaps.NeedsConfigBlob {
 		pf, pfErr := loadRestoreProfiles()
 		if pfErr != nil {
 			fmt.Fprintf(os.Stderr, "restore %q: load profiles: %v — skipping config injection\n", s.SessionName, pfErr)
@@ -371,7 +373,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		// and Manager.opencodeConfigFilePath() calls OpencodeConfigFilePath(m.name).
 		// So we must pass the container name (not the raw tmux session name) to
 		// WriteOpencodeConfig. This mirrors the pattern in spawn.go.
-		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 			containerName := container.NameForSession(s.SessionName)
 			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
 				// Non-fatal: log and continue with restore. The session will
@@ -407,7 +409,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	// removeContainerIfExists is idempotent and logs non-fatal errors
 	// internally, so it is safe to call even when no container exists.
 	// Host-mode sessions never have a container, so this step is skipped.
-	if containerMode {
+	if isoCaps.IsContainer {
 		removeContainerIfExists(s.SessionName)
 	}
 

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -1414,11 +1414,12 @@ func TestRestoreSession_HostMode_NoTempFileWritten(t *testing.T) {
 	}
 }
 
-// TestRestoreSession_PodmanMode_NoTempFileWritten verifies that podman-mode
-// restore does NOT write the opencode temp file via the new code path — the
-// podman sidecar's Create() flow handles that file itself. Writing it in
-// restore.go for podman would be a no-op at best and a source of drift at worst.
-func TestRestoreSession_PodmanMode_NoTempFileWritten(t *testing.T) {
+// TestRestoreSession_PodmanMode_TempFileWritten verifies that podman-mode
+// restore writes the opencode temp file when NeedsConfigBlob is true. Although
+// the podman sidecar's Create() path also writes this file, the pre-write in
+// restore.go is an idempotent precondition — both writes use the same content
+// source (ContainerConfigForRole) and the same deterministic path.
+func TestRestoreSession_PodmanMode_TempFileWritten(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	s := newCmdTestServer(t)
 	withCmdServer(t, s)
@@ -1452,10 +1453,12 @@ func TestRestoreSession_PodmanMode_NoTempFileWritten(t *testing.T) {
 	}
 	t.Cleanup(func() { session.KillSidecar(sessionName) })
 
-	// Podman mode: restore.go must NOT preemptively write the temp file.
-	// The sidecar's own Create() path writes it just before container start.
-	if _, err := os.Stat(expectedPath); err == nil {
-		t.Errorf("podman restore wrote opencode temp file at %q — must not write for podman (sidecar handles it)",
-			expectedPath)
+	// Podman mode: NeedsConfigBlob=true, so restore.go writes the temp file.
+	// This is idempotent — the sidecar's Create() path will write it again
+	// (same content). The write here ensures the file is present even if the
+	// sidecar is restarted without a full container create.
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("podman restore did not write opencode temp file at %q — expected file when NeedsConfigBlob=true: %v",
+			expectedPath, err)
 	}
 }

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/review"
@@ -176,14 +177,16 @@ func runReview(cmd *cobra.Command, args []string) error {
 		isoMode = config.IsolationMode(dbIsoMode)
 	}
 
+	// Look up the isolation capabilities for this mode. All per-mode branching
+	// below reads from isoCaps rather than comparing against raw mode constants.
+	isoCaps := container.CapabilitiesFor(isoMode)
+
 	// Concurrency cap checks: BEFORE any container-creation side effects.
 	// Both checks run after the DB isolation-mode lookup so that the cap
 	// decisions reflect the session's actual mode rather than the machine
 	// default. The PRISM_HOST_API proxy-out branch above already returned, so
 	// by this point we are guaranteed to be on the host.
-	// bwrap sessions are plain host processes — only podman triggers the container cap.
-	conCapped := isoMode == config.IsolationPodman
-	if err := checkConcurrencyCap(cmd, "review", conCapped); err != nil {
+	if err := checkConcurrencyCap(cmd, "review", isoCaps.IsContainer); err != nil {
 		return err
 	}
 	if isoMode == config.IsolationBwrap {
@@ -261,7 +264,6 @@ func runReview(cmd *cobra.Command, args []string) error {
 	})
 
 	// Build run options.
-	effectiveContainerMode := isoMode == config.IsolationPodman
 	opts := review.Opts{
 		PRNumber:       prNumber,
 		ParentSession:  parentSession,
@@ -271,7 +273,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		Harness:        harnessFlag,
 		Timeout:        timeoutFlag,
 		PluginHostPath: cfg.SidecarPluginPath,
-		ContainerMode:  effectiveContainerMode,
+		ContainerMode:  isoCaps.IsContainer,
 		IsolationMode:  string(isoMode),
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,
@@ -289,7 +291,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// so the sandbox picks up the host's ~/.config/opencode/opencode.json (wrong
 	// agent identity). Surface this as an explicit error rather than silently
 	// spawning broken agents.
-	if isoMode == config.IsolationPodman || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec {
+	if isoCaps.NeedsConfigBlob {
 		pf, pfErr := config.LoadProfiles()
 		if pfErr != nil {
 			return fmt.Errorf("prism review: %s mode requires profiles.json but it could not be loaded: %w\nhint: ensure the system has been rebuilt with the prism NixOS module enabled", isoMode, pfErr)

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -140,17 +140,19 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		isolationMode = config.IsolationHost
 	}
 
-	// Derive the legacy bool for paths that still use it.
-	podmanMode := isolationMode == config.IsolationPodman
-	bwrapMode := isolationMode == config.IsolationBwrap
-	sandboxExecMode := isolationMode == config.IsolationSandboxExec
-	// needsHostAPI is true for podman, bwrap, and sandbox-exec (the agent runs
-	// in a sandbox without direct access to host tmux, so the host-API socket
-	// is required).
-	needsHostAPI := podmanMode || bwrapMode || sandboxExecMode
-	// useContainerHarness is true for podman, bwrap, and sandbox-exec
-	// (opencode is pre-created with --prompt at launch in all three cases).
-	useContainerHarness := podmanMode || bwrapMode || sandboxExecMode
+	// Look up the isolation capabilities for this mode. All per-mode branching
+	// below reads from isoCaps rather than comparing against raw mode constants.
+	isoCaps := container.CapabilitiesFor(isolationMode)
+
+	// needsHostAPI is true for any mode where the agent runs in a sandbox
+	// without direct access to host tmux — podman (IsContainer), bwrap, and
+	// sandbox-exec (NeedsHostAPISocket) all require the host-API Unix socket.
+	needsHostAPI := isoCaps.NeedsHostAPISocket || isoCaps.IsContainer
+
+	// useContainerHarness is true for modes where opencode is pre-created with
+	// --prompt at launch (podman, bwrap, sandbox-exec), so the harness uses
+	// GET /session to retrieve the existing session ID rather than POST /session.
+	useContainerHarness := isoCaps.NeedsHostAPISocket || isoCaps.IsContainer
 
 	// Derive repo and worktree from session name and environment.
 	// The session name format is "repo@branch". The worktree is expected
@@ -198,7 +200,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// fields remain at their zero values and no resource flags are emitted.
 	var containerResources config.ContainerResources
 	var agentEnvVars map[string]string
-	if podmanMode {
+	if isoCaps.IsContainer {
 		if pf, pfErr := config.LoadProfiles(); pfErr == nil {
 			containerResources = pf.ContainerResources
 			agentEnvVars = pf.AgentEnvVars
@@ -208,7 +210,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// Build container config — only for podman mode. bwrap mode does not
 	// use a container.Config; the bwrap sandbox is owned by the tmux pane.
 	var ctrCfg *container.Config
-	if podmanMode {
+	if isoCaps.IsContainer {
 		if port == 0 {
 			return fmt.Errorf("sidecar: --port is required in podman container mode")
 		}
@@ -250,7 +252,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// CLI calls.
 	var hostAPISockPath string
 	if needsHostAPI {
-		if port == 0 && (bwrapMode || sandboxExecMode) {
+		if port == 0 && isoCaps.NeedsHostAPISocket {
 			return fmt.Errorf("sidecar: --port is required in bwrap/sandbox-exec mode")
 		}
 		sockPath, err := prismSession.SidecarHostAPIPath(sessionName)
@@ -272,7 +274,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// signal: "prism agent-run" in the tmux pane starts immediately without
 	// waiting. In host mode there is no readiness file at all.
 	var onReady func()
-	if podmanMode {
+	if isoCaps.IsContainer {
 		onReady = func() {
 			readyPath, pathErr := prismSession.SidecarReadyPath(sessionName)
 			if pathErr != nil {
@@ -333,6 +335,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		HarnessBinaryPath: harnessBinaryPath,
 		BwrapPath:         bwrapPath,
 		InstanceID:        instanceID,
+		IsolationMode:     isolationMode,
 		Container:         ctrCfg,
 		HostAPISockPath:   hostAPISockPath,
 		OnReady:           onReady,

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -272,12 +272,13 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Derive the legacy ContainerMode boolean for callers that still use it.
-	effectiveContainerMode := isolationMode == config.IsolationPodman
+	// Look up the isolation capabilities for this mode. All per-mode branching
+	// below reads from isoCaps rather than comparing against raw mode constants.
+	isoCaps := container.CapabilitiesFor(isolationMode)
 
 	// Container availability check: when container mode is active verify
 	// podman is available before touching anything.
-	if isolationMode == config.IsolationPodman {
+	if isoCaps.IsContainer {
 		if err := container.CheckAvailability(); err != nil {
 			return err
 		}
@@ -288,8 +289,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// The podman cap guards host memory against container overhead.
 	// The bwrap cap guards against process-count exhaustion from uncapped
 	// bwrap sessions (each is a host process with no per-session memory ceil).
-	conCapped := isolationMode == config.IsolationPodman
-	if err := checkConcurrencyCap(cmd, "spawn", conCapped); err != nil {
+	if err := checkConcurrencyCap(cmd, "spawn", isoCaps.IsContainer); err != nil {
 		return err
 	}
 	if isolationMode == config.IsolationBwrap {
@@ -309,7 +309,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		var loadErr error
 		pf, loadErr = config.LoadProfiles()
 		if loadErr != nil {
-			if effectiveContainerMode || isolationMode == config.IsolationBwrap || isolationMode == config.IsolationSandboxExec || profileFlag != "" {
+			if isoCaps.NeedsConfigBlob || profileFlag != "" {
 				return loadErr
 			}
 			fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not load profiles.json (agent env vars will not be injected): %v\n", loadErr)
@@ -355,8 +355,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	//
 	// DefaultAgent (not DefaultAgentForSession) is intentional: at spawn time the
 	// session has no DB row yet, so this call ASSIGNS the role rather than reading it.
-	sandboxed := isolationMode == config.IsolationPodman || isolationMode == config.IsolationBwrap || isolationMode == config.IsolationSandboxExec
-	if sandboxed && pf != nil {
+	if isoCaps.NeedsConfigBlob && pf != nil {
 		effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
 		// Non-worktree paths (effectiveRole == "") use the coordinator config blob
 		// so that build/plan agents are available, but pass no --agent flag.
@@ -403,7 +402,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// (e.g. "prism-nixos-config-feat"), and Manager.opencodeConfigFilePath()
 	// calls OpencodeConfigFilePath(m.name). So we must pass the container name
 	// (not the raw tmux session name) to WriteOpencodeConfig.
-	if isolationMode == config.IsolationBwrap && configContent != "" {
+	if isoCaps.NeedsConfigBlob && configContent != "" {
 		tmuxSessionName := session.NameFor(worktreePath, bareRoot)
 		containerName := container.NameForSession(tmuxSessionName)
 		if err := container.WriteOpencodeConfig(containerName, configContent); err != nil {
@@ -438,7 +437,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		Prompt:           promptFlag,
 		ConfigContent:    configContent,
 		Layout:           session.LayoutFull,
-		ContainerMode:    effectiveContainerMode,
+		ContainerMode:    isoCaps.IsContainer,
 		IsolationMode:    string(isolationMode),
 		PluginHostPath:   cfg.SidecarPluginPath,
 		ConfigEnvVarName: h.ConfigEnvVar(),
@@ -460,7 +459,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	}
 	// AgentEnvVars only applies to host-mode sessions; container sessions
 	// receive env vars via podman --env flags in the sidecar.
-	if pf != nil && !effectiveContainerMode {
+	if pf != nil && !isoCaps.IsContainer {
 		spawnOpts.AgentEnvVars = pf.AgentEnvVars
 	}
 

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -626,7 +626,7 @@ func allocatePortForSession(sessionName, directory string) (int, error) {
 
 // ── worktree second-level picker ──────────────────────────────────────────────
 
-func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Opts, isoMode config.IsolationMode, sandboxed bool) error {
+func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities) error {
 	worktrees := git.Worktrees(projectPath)
 	createNew := entry{display: "[+ create new worktree]", special: "[+ create new worktree]"}
 
@@ -679,12 +679,12 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 		if err != nil {
 			return fmt.Errorf("create worktree: %w", err)
 		}
-		if sandboxed && pf != nil {
+		if isoCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 			tmuxSessionName := session.NameFor(worktreePath, projectPath)
 			containerName := container.NameForSession(tmuxSessionName)
 			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -694,12 +694,12 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 		return ensureAndSwitch(worktreePath, projectPath, opts)
 	}
 
-	if sandboxed && pf != nil {
+	if isoCaps.NeedsConfigBlob && pf != nil {
 		if err := injectContainerConfig(chosen.path, pf, &opts, "prism switch"); err != nil {
 			return err
 		}
 	}
-	if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+	if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 		tmuxSessionName := session.NameFor(chosen.path, projectPath)
 		containerName := container.NameForSession(tmuxSessionName)
 		if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -881,15 +881,15 @@ func handleReviewGroupPick(groupKey string) error {
 	return err
 }
 
-func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, isoMode config.IsolationMode, sandboxed bool) error {
+func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities) error {
 	exclude := switchWorktreeExcludeSet()
 	if exclude[filepath.Base(path)] {
-		if sandboxed && pf != nil {
+		if isoCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 			tmuxSessionName := session.NameFor(path, "")
 			containerName := container.NameForSession(tmuxSessionName)
 			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -916,12 +916,12 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "conversion failed: %v\nopening directly\n", err)
-			if sandboxed && pf != nil {
+			if isoCaps.NeedsConfigBlob && pf != nil {
 				if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 					return err
 				}
 			}
-			if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+			if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 				tmuxSessionName := session.NameFor(path, "")
 				containerName := container.NameForSession(tmuxSessionName)
 				if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -957,12 +957,12 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 			removeContainerIfExists(oldSessionName)
 		}
 
-		if sandboxed && pf != nil {
+		if isoCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 			tmuxSessionName := session.NameFor(worktreePath, path)
 			containerName := container.NameForSession(tmuxSessionName)
 			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -971,12 +971,12 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		}
 		return ensureAndSwitch(worktreePath, path, opts)
 	default:
-		if sandboxed && pf != nil {
+		if isoCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+		if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 			tmuxSessionName := session.NameFor(path, "")
 			containerName := container.NameForSession(tmuxSessionName)
 			if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -989,7 +989,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 
 // ── clone repo ────────────────────────────────────────────────────────────────
 
-func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoMode config.IsolationMode, sandboxed bool) error {
+func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities) error {
 	repoURL := promptInput("clone url> ")
 	if repoURL == "" {
 		return nil
@@ -1020,12 +1020,12 @@ func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoMode config.
 	if len(worktrees) == 0 {
 		return fmt.Errorf("clone succeeded but no worktrees found in %s", targetDir)
 	}
-	if sandboxed && pf != nil {
+	if isoCaps.NeedsConfigBlob && pf != nil {
 		if err := injectContainerConfig(worktrees[0], pf, &opts, "prism switch"); err != nil {
 			return err
 		}
 	}
-	if isoMode == config.IsolationBwrap && opts.ConfigContent != "" {
+	if isoCaps.NeedsConfigBlob && opts.ConfigContent != "" {
 		tmuxSessionName := session.NameFor(worktrees[0], targetDir)
 		containerName := container.NameForSession(tmuxSessionName)
 		if err := container.WriteOpencodeConfig(containerName, opts.ConfigContent); err != nil {
@@ -1067,7 +1067,10 @@ var switchCmd = &cobra.Command{
 		// Derive the effective isolation mode from config, mirroring the pattern
 		// in spawn.go. switch has no --isolation flag — the machine default is used.
 		isoMode := cfg.EffectiveIsolationMode()
-		effectiveContainerMode := isoMode == config.IsolationPodman
+
+		// Look up the isolation capabilities for this mode. All per-mode branching
+		// below reads from isoCaps rather than comparing against raw mode constants.
+		isoCaps := container.CapabilitiesFor(isoMode)
 
 		// Load profiles.json for container/bwrap/sandbox-exec config injection and
 		// agent env var injection (host mode). Always attempt to load; treat missing
@@ -1078,7 +1081,7 @@ var switchCmd = &cobra.Command{
 			var pfErr error
 			pf, pfErr = config.LoadProfiles()
 			if pfErr != nil {
-				if effectiveContainerMode || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec {
+				if isoCaps.NeedsConfigBlob {
 					return pfErr
 				}
 				fmt.Fprintf(os.Stderr, "[prism switch] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
@@ -1092,7 +1095,7 @@ var switchCmd = &cobra.Command{
 		switchHarness, _ := harness.New("opencode", "", nil, "", "")
 		opts := session.Opts{
 			Fresh:            fresh,
-			ContainerMode:    effectiveContainerMode,
+			ContainerMode:    isoCaps.IsContainer,
 			IsolationMode:    string(isoMode),
 			PluginHostPath:   cfg.SidecarPluginPath,
 			ConfigEnvVarName: switchHarness.ConfigEnvVar(),
@@ -1101,13 +1104,9 @@ var switchCmd = &cobra.Command{
 		// AgentEnvVars only applies to host-mode sessions; sandboxed sessions
 		// receive env vars via podman --env flags in the sidecar (podman) or
 		// via the bwrap environment pass-through.
-		if pf != nil && isoMode == config.IsolationHost {
+		if pf != nil && !isoCaps.NeedsConfigBlob {
 			opts.AgentEnvVars = pf.AgentEnvVars
 		}
-
-		// sandboxed is true for podman, bwrap, and sandbox-exec isolation modes —
-		// all require container config injection.
-		sandboxed := effectiveContainerMode || isoMode == config.IsolationBwrap || isoMode == config.IsolationSandboxExec
 
 		// --path: open a specific path directly.
 		if pathArg != "" {
@@ -1122,12 +1121,12 @@ var switchCmd = &cobra.Command{
 					return fmt.Errorf("no worktrees found in %s", p)
 				}
 				o := opts
-				if sandboxed && pf != nil {
+				if isoCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(worktrees[0], pf, &o, "prism switch"); err != nil {
 						return err
 					}
 				}
-				if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+				if isoCaps.NeedsConfigBlob && o.ConfigContent != "" {
 					tmuxSessionName := session.NameFor(worktrees[0], p)
 					containerName := container.NameForSession(tmuxSessionName)
 					if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
@@ -1138,12 +1137,12 @@ var switchCmd = &cobra.Command{
 			}
 			if bareRoot := git.BareRoot(p); bareRoot != "" {
 				o := opts
-				if sandboxed && pf != nil {
+				if isoCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
 					}
 				}
-				if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+				if isoCaps.NeedsConfigBlob && o.ConfigContent != "" {
 					tmuxSessionName := session.NameFor(p, bareRoot)
 					containerName := container.NameForSession(tmuxSessionName)
 					if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
@@ -1153,12 +1152,12 @@ var switchCmd = &cobra.Command{
 				return ensureAndSwitch(p, bareRoot, o)
 			}
 			o := opts
-			if sandboxed && pf != nil {
+			if isoCaps.NeedsConfigBlob && pf != nil {
 				if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 					return err
 				}
 			}
-			if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+			if isoCaps.NeedsConfigBlob && o.ConfigContent != "" {
 				tmuxSessionName := session.NameFor(p, "")
 				containerName := container.NameForSession(tmuxSessionName)
 				if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {
@@ -1195,23 +1194,23 @@ var switchCmd = &cobra.Command{
 			return ensureAndSwitch("[scratchpad]", "", opts)
 
 		case "[+ clone repo]":
-			return handleCloneRepo(pf, opts, isoMode, sandboxed)
+			return handleCloneRepo(pf, opts, isoCaps)
 
 		default:
 			p := chosen.path
 			switch {
 			case git.IsBareRepo(p):
-				return handleBareRepo(p, pf, opts, isoMode, sandboxed)
+				return handleBareRepo(p, pf, opts, isoCaps)
 			case git.IsRegularRepo(p):
-				return handleRegularRepo(p, pf, opts, isoMode, sandboxed)
+				return handleRegularRepo(p, pf, opts, isoCaps)
 			default:
 				o := opts
-				if sandboxed && pf != nil {
+				if isoCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
 					}
 				}
-				if isoMode == config.IsolationBwrap && o.ConfigContent != "" {
+				if isoCaps.NeedsConfigBlob && o.ConfigContent != "" {
 					tmuxSessionName := session.NameFor(p, "")
 					containerName := container.NameForSession(tmuxSessionName)
 					if err := container.WriteOpencodeConfig(containerName, o.ConfigContent); err != nil {

--- a/modules/programs/prism/prism/internal/container/registry.go
+++ b/modules/programs/prism/prism/internal/container/registry.go
@@ -103,6 +103,26 @@ func For(mode config.IsolationMode, opts ConstructorOpts) (Isolator, error) {
 	return reg.Constructor(opts), nil
 }
 
+// CapabilitiesFor returns the pre-computed Capabilities snapshot for the given
+// isolation mode. This is the intended entry point for callers that only need
+// to query capabilities without constructing a live Isolator. It panics if mode
+// is not registered — callers that receive a mode from user input should
+// validate it with config.IsValidIsolationMode first.
+func CapabilitiesFor(mode config.IsolationMode) Capabilities {
+	globalRegistry.mu.RLock()
+	reg, ok := globalRegistry.registrations[mode]
+	globalRegistry.mu.RUnlock()
+
+	if !ok {
+		// Unknown mode: return zero Capabilities (all flags false). This
+		// produces safe no-op behaviour for callers that do not check the mode
+		// in advance, and is consistent with treating an unrecognised mode as
+		// "host-like" (no sandbox, no container lifecycle).
+		return Capabilities{}
+	}
+	return reg.Capabilities
+}
+
 // Names returns the registered mode names in sorted order. This is the
 // authoritative list of modes the current binary knows how to run.
 func Names() []config.IsolationMode {

--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/harness"
 )
 
@@ -49,7 +50,7 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 		//     starts emitting events — the prompt is in flight by then.
 		//     Emitted at the same moment for symmetry with the podman line
 		//     at sidecar.go:489.
-		if s.cfg.Container == nil {
+		if !container.CapabilitiesFor(s.cfg.IsolationMode).OwnsContainerLifecycle {
 			log.Printf("[timing] opencode listening: %s from start", elapsed)
 			log.Printf("[timing] ready: %s from start", elapsed)
 			if s.cfg.InitialPrompt != "" {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -47,6 +47,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
@@ -148,6 +149,11 @@ type Config struct {
 	// HTTPClient is the HTTP client used for coordinator notification delivery.
 	// If nil, defaultNotifyHTTPClient is used.
 	HTTPClient *http.Client
+	// IsolationMode is the effective isolation mode for this session (e.g.
+	// "podman", "bwrap", "sandbox-exec", or "host"). It is used to derive
+	// capability flags via container.CapabilitiesFor so that Run can branch on
+	// typed caps rather than raw mode strings or the Container!=nil proxy.
+	IsolationMode config.IsolationMode
 	// Container, when non-nil, enables container mode: the sidecar creates and
 	// manages a podman container running opencode in combined TUI + HTTP mode
 	// instead of relying on a directly-launched opencode process.
@@ -178,11 +184,11 @@ type Config struct {
 	PrismBinaryPath string
 	// StartupConnectTimeout is the duration the sidecar waits for the first
 	// SSE event before concluding the harness never bound to its port and
-	// transitioning to StateError via writeStartupError. Only applies to
-	// bwrap mode (Container == nil): podman mode uses WaitHealthy/CreateSession
-	// for the same protection. Defaults to DefaultStartupConnectTimeout (5m)
-	// when zero. Set to a small value in tests to exercise the timeout path
-	// without real wall-clock waits.
+	// transitioning to StateError via writeStartupError. Only applies when
+	// NeedsStartupConnectTimeout is true (currently bwrap mode): podman mode
+	// uses WaitHealthy/CreateSession for the same protection. Defaults to
+	// DefaultStartupConnectTimeout (5m) when zero. Set to a small value in
+	// tests to exercise the timeout path without real wall-clock waits.
 	StartupConnectTimeout time.Duration
 	// HarnessBinaryPath is the path to the harness binary used by
 	// runStartupStdio for TransportStdioPipe harnesses. The binary is launched
@@ -510,7 +516,8 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		}
 	}()
 
-	// Startup-connect timeout: bwrap mode only.
+	// Startup-connect timeout: applies only to modes where NeedsStartupConnectTimeout
+	// is true (currently bwrap).
 	//
 	// In bwrap mode the harness is launched by agent-run from a tmux pane, not
 	// by the sidecar. The sidecar's only signal of harness liveness is whether
@@ -521,9 +528,9 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	// to StateError (same mechanism as #1011's WaitHealthy/CreateSession paths)
 	// and cancel the SSE loop so the sidecar exits cleanly.
 	//
-	// Container != nil means podman mode, which already has WaitHealthy/
-	// CreateSession covering startup failures — skip the timeout there.
-	if s.cfg.Container == nil {
+	// Podman mode already has WaitHealthy/CreateSession covering startup
+	// failures, so NeedsStartupConnectTimeout is false there.
+	if container.CapabilitiesFor(s.cfg.IsolationMode).NeedsStartupConnectTimeout {
 		startupTimeout := s.cfg.StartupConnectTimeout
 		if startupTimeout == 0 {
 			startupTimeout = DefaultStartupConnectTimeout
@@ -678,13 +685,13 @@ func (s *Sidecar) Shutdown() {
 // harnesses (e.g. opencode). It is called from Run when the harness transport
 // shape is TransportHTTPPort (or when HarnessName is empty for back-compat).
 //
-// When Config.Container is nil (bwrap / host mode), this function is a no-op:
-// the harness is already running and the SSE loop connects directly. The
+// When OwnsContainerLifecycle is false (bwrap / host mode), this function is a
+// no-op: the harness is already running and the SSE loop connects directly. The
 // container startup sequence (mgr.Create → WaitHealthy → CreateSession →
 // OnReady → DeliverInitialPrompt) is only performed in podman container mode.
 func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 	// Container mode: create and health-check the container before connecting.
-	if s.cfg.Container != nil {
+	if container.CapabilitiesFor(s.cfg.IsolationMode).OwnsContainerLifecycle {
 		sessionStart := time.Now()
 
 		// On Darwin, start a TCP listener on 0.0.0.0:0 BEFORE container creation

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
@@ -8505,8 +8506,9 @@ func newBwrapSidecarWithTimeout(t *testing.T, timeout time.Duration) (*Sidecar, 
 		DB:                    d,
 		Clock:                 newTestClock(),
 		Harness:               &blockingHarness{},
+		IsolationMode:         config.IsolationBwrap,
 		StartupConnectTimeout: timeout,
-		// Container is nil — bwrap mode.
+		// Container is nil — bwrap mode has no container lifecycle.
 	}
 	sc := New(cfg)
 	return sc, d
@@ -8563,8 +8565,9 @@ func TestStartupConnectTimeout_DoesNotFireAfterFirstEvent(t *testing.T) {
 		DB:                    d,
 		Clock:                 newTestClock(),
 		Harness:               &blockingHarness{},
+		IsolationMode:         config.IsolationBwrap,
 		StartupConnectTimeout: timeout,
-		// Container is nil — bwrap mode.
+		// Container is nil — bwrap mode has no container lifecycle.
 	}
 	sc := New(cfg)
 
@@ -8807,9 +8810,10 @@ func TestStartupConnectTimeout_WorkerSessionNotifiesCoordinator(t *testing.T) {
 		DB:                    d,
 		Clock:                 newTestClock(),
 		Harness:               &blockingHarness{},
+		IsolationMode:         config.IsolationBwrap,
 		HTTPClient:            srv.Client(),
 		StartupConnectTimeout: timeout,
-		// Container is nil — bwrap mode.
+		// Container is nil — bwrap mode has no container lifecycle.
 	}
 	sc := New(cfg)
 
@@ -9420,13 +9424,14 @@ func TestBwrapTimingMarkers_OnlyOnFirstEvent(t *testing.T) {
 func TestBwrapTimingMarkers_PodmanModeNotEmittedHere(t *testing.T) {
 	d := openTestDB(t)
 	cfg := Config{
-		SessionName: "test-repo@feature",
-		Repo:        "test-repo",
-		Worktree:    "/tmp/test-podman-worktree",
-		OpencodeURL: "http://localhost:19999",
-		DB:          d,
-		Clock:       newTestClock(),
-		Harness:     &harness.FakeHarness{},
+		SessionName:   "test-repo@feature",
+		Repo:          "test-repo",
+		Worktree:      "/tmp/test-podman-worktree",
+		OpencodeURL:   "http://localhost:19999",
+		DB:            d,
+		Clock:         newTestClock(),
+		Harness:       &harness.FakeHarness{},
+		IsolationMode: config.IsolationPodman,
 		// Non-nil Container → podman mode. The pointer doesn't have to be
 		// fully populated for HandleEvent's gate — it just needs to be non-nil.
 		Container: &container.Config{},


### PR DESCRIPTION
## Summary

Migrates 5 sites that used raw `if mode == config.IsolationBwrap` (or similar) checks to use `iso.Capabilities()` from the A.1 `IsolationRegistry`. Mechanical, low-risk changes. No user-visible behaviour changes.

## Changes by site

**C1: `cmd/spawn.go`** — Replace `effectiveContainerMode` (→ `IsContainer`), profiles-fatal guard and `sandboxed` var (→ `NeedsConfigBlob`), config-blob disk-write guard (→ `NeedsConfigBlob`). Added `container.CapabilitiesFor()` to `internal/container/registry.go` as the entry point for capability-only queries.

**C2: `cmd/switch.go`** — Replace `effectiveContainerMode` (→ `IsContainer`), `sandboxed` derivation (→ `NeedsConfigBlob`), and all `isoMode == config.IsolationBwrap && o.ConfigContent != ""` disk-write guards (→ `isoCaps.NeedsConfigBlob`) across the main handler and all helper functions. Helper function signatures updated from `(isoMode, sandboxed)` to `(isoCaps container.Capabilities)`.

**C3: `cmd/restore.go`, `cmd/pr.go`, `cmd/review.go`** — Same `NeedsConfigBlob` pattern across three files. `IsContainer` replaces `IsolationPodman` checks for `ContainerMode` field and `PluginHostPath`. Added `container` import to `review.go`.

**C4: `cmd/sidecar.go`** — Collapsed `podmanMode`, `bwrapMode`, `sandboxExecMode` locals. Replaced with `isoCaps := container.CapabilitiesFor(isolationMode)`. `needsHostAPI` and `useContainerHarness` derived from `NeedsHostAPISocket || IsContainer` to preserve current behaviour for all three sandboxed modes.

**C5: `internal/sidecar/sidecar.go`, `internal/sidecar/events.go`** — Added `IsolationMode config.IsolationMode` field to `sidecar.Config`. Replaced `s.cfg.Container == nil` startup-timeout gate with `NeedsStartupConnectTimeout`; replaced `s.cfg.Container != nil` container-startup gate in `runStartupHTTP` with `OwnsContainerLifecycle`; replaced `s.cfg.Container == nil` timing-markers gate in `events.go` with `!OwnsContainerLifecycle`. `cmd/sidecar.go` populates `IsolationMode` in the Config constructor.

## Tests

- `go build ./...` and `go test ./...` pass from `modules/programs/prism/prism/`
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` passes
- Sidecar tests that used `Container==nil` as bwrap-mode proxy now set `IsolationMode: config.IsolationBwrap`; the podman-mode timing test sets `IsolationMode: config.IsolationPodman`
- `TestRestoreSession_PodmanMode_NoTempFileWritten` renamed to `TestRestoreSession_PodmanMode_TempFileWritten` and assertion inverted: with `NeedsConfigBlob=true` for podman, restore.go now pre-writes the config file (idempotent with the sidecar Create() write)

Closes #1132