### PR TITLE
fix: add pname to custom buildVimPlugin calls

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776904464,
-        "narHash": "sha256-sBUCj7/4d3Hoevpu3oQp8ccJNA1EDeVmFi1F8O6VJro=",
+        "lastModified": 1777258755,
+        "narHash": "sha256-EC07KwADRE2LdIk7vEDyAaD3I0ZUq24T9jQF9L0iEPk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "667b3c47325441e6a444faaf405bba76ec70338a",
+        "rev": "7f8bbc93d63401e41368d6ddc46a4f631610fa90",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1776920365,
-        "narHash": "sha256-+tOsjH7+7Gg08KXlmvb+l+TDjDzGKsGf93pjiby50bo=",
+        "lastModified": 1777263820,
+        "narHash": "sha256-7XU9Abnlh3ftrovcnvSpoNP6O2TGcZT+QF0IUA8a06o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "760cd162a3b8e1a655c39750e045811437156b77",
+        "rev": "1a3f1fd87c66aeb505be862c335982f47a5e6d24",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777258755,
-        "narHash": "sha256-EC07KwADRE2LdIk7vEDyAaD3I0ZUq24T9jQF9L0iEPk=",
+        "lastModified": 1776904464,
+        "narHash": "sha256-sBUCj7/4d3Hoevpu3oQp8ccJNA1EDeVmFi1F8O6VJro=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f8bbc93d63401e41368d6ddc46a4f631610fa90",
+        "rev": "667b3c47325441e6a444faaf405bba76ec70338a",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1777263820,
-        "narHash": "sha256-7XU9Abnlh3ftrovcnvSpoNP6O2TGcZT+QF0IUA8a06o=",
+        "lastModified": 1776920365,
+        "narHash": "sha256-+tOsjH7+7Gg08KXlmvb+l+TDjDzGKsGf93pjiby50bo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1a3f1fd87c66aeb505be862c335982f47a5e6d24",
+        "rev": "760cd162a3b8e1a655c39750e045811437156b77",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1777077449,
-        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/modules/programs/prism/neovim/plugins/markdown-preview.nix
+++ b/modules/programs/prism/neovim/plugins/markdown-preview.nix
@@ -5,7 +5,8 @@
 }:
 let
   live-server-nvim = pkgs.vimUtils.buildVimPlugin {
-    name = "live-server-nvim";
+    pname = "live-server-nvim";
+    version = "unstable";
     src = pkgs.fetchFromGitHub {
       owner = "selimacerbas";
       repo = "live-server.nvim";
@@ -14,7 +15,8 @@ let
     };
   };
   markdown-preview-nvim = pkgs.vimUtils.buildVimPlugin {
-    name = "markdown-preview-nvim";
+    pname = "markdown-preview-nvim";
+    version = "unstable";
     nvimSkipModules = [ "markdown_preview" ];
     src = pkgs.fetchFromGitHub {
       owner = "selimacerbas";

--- a/modules/programs/prism/neovim/plugins/theme-everforest.nix
+++ b/modules/programs/prism/neovim/plugins/theme-everforest.nix
@@ -6,7 +6,8 @@
 }:
 let
   everforest-nvim = pkgs.vimUtils.buildVimPlugin {
-    name = "everforest-nvim";
+    pname = "everforest-nvim";
+    version = "unstable";
     src = pkgs.fetchFromGitHub {
       owner = "neanias";
       repo = "everforest-nvim";

--- a/modules/programs/prism/neovim/plugins/theme-github-light.nix
+++ b/modules/programs/prism/neovim/plugins/theme-github-light.nix
@@ -6,7 +6,8 @@
 }:
 let
   github-nvim-theme = pkgs.vimUtils.buildVimPlugin {
-    name = "github-nvim-theme";
+    pname = "github-nvim-theme";
+    version = "unstable";
     src = pkgs.fetchFromGitHub {
       owner = "projekt0n";
       repo = "github-nvim-theme";

--- a/modules/programs/prism/neovim/plugins/theme-nightcity-kabuki.nix
+++ b/modules/programs/prism/neovim/plugins/theme-nightcity-kabuki.nix
@@ -6,7 +6,8 @@
 }:
 let
   nightcity-theme = pkgs.vimUtils.buildVimPlugin {
-    name = "nightcity-theme";
+    pname = "nightcity-theme";
+    version = "unstable";
     src = pkgs.fetchFromGitHub {
       owner = "cryptomilk";
       repo = "nightcity.nvim";


### PR DESCRIPTION
## Problem

The `update-flakes` action failed after updating nixpkgs to `0726a0ecb6d4e08f6adced58726b95db924cef57`.

nixpkgs commit `0726a0ec` changed `vim-utils.nix` to detect duplicate nvim-treesitter versions using:

```nix
allAndOptPluginNames = map (plugin: plugin.pname) (allPlugins ++ opt);
```

Previously it compared derivations directly (`builtins.elem vimPlugins.nvim-treesitter ...`), but now it maps `.pname` over all plugins.

## Root Cause

Five custom plugins in this repo were built with `buildVimPlugin { name = "..."; ... }` instead of `buildVimPlugin { pname = "..."; version = "..."; ... }`. This meant those derivations had no `pname` attribute, causing eval to fail with:

```
error: attribute 'pname' missing
Did you mean name?
```

Affected plugins:
- `everforest-nvim` (theme-everforest.nix)
- `live-server-nvim` (markdown-preview.nix)
- `markdown-preview-nvim` (markdown-preview.nix)
- `nightcity-theme` (theme-nightcity-kabuki.nix)
- `github-nvim-theme` (theme-github-light.nix)

## Fix

Changed all five `buildVimPlugin` calls to use `pname = "..."` + `version = "unstable"` instead of `name = "..."`. The `buildVimPlugin` function signature already handles `name` derivation from `pname` + `version` automatically.