### PR TITLE
prism: A1.S1 — internal/sandboxenv package (IsInsideSandbox, HostAPISocket helpers)

### DIFF
--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -71,7 +72,7 @@ func runMerge(cmd *cobra.Command, args []string) error {
 	// requireCoordinator, which returns HTTP 403 for worker sessions. The
 	// preflight is run inside the sandbox (gh works there) before the proxy
 	// call so that invalid PRs do not pin sidecar resources.
-	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+	if apiURL := sandboxenv.HostAPISocket(); apiURL != "" {
 		title, preflightErr := preflight(pr)
 		if preflightErr != nil {
 			return fmt.Errorf("prism merge: %w", preflightErr)

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
 )
 
 var mergesCmd = &cobra.Command{
@@ -94,7 +95,7 @@ func runMergesList(cmd *cobra.Command, _ []string) error {
 	// own (host-side) DB using the same instance_id and session_name the
 	// merge-queue watcher uses, so the response matches what `sqlite3
 	// prism.db` shows on the host.
-	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+	if apiURL := sandboxenv.HostAPISocket(); apiURL != "" {
 		params := map[string]string{}
 		if filter != "" {
 			params["filter"] = filter
@@ -139,7 +140,7 @@ func runMergesCancel(cmd *cobra.Command, args []string) error {
 	// own instance_id when calling CancelMerge, which is the same identity
 	// the host watcher and `prism merges` use, so cancellation is visible to
 	// both immediately.
-	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+	if apiURL := sandboxenv.HostAPISocket(); apiURL != "" {
 		var resp struct {
 			Cancelled bool             `json:"cancelled"`
 			Row       *db.PendingMerge `json:"row"`

--- a/modules/programs/prism/prism/internal/sandboxenv/sandboxenv.go
+++ b/modules/programs/prism/prism/internal/sandboxenv/sandboxenv.go
@@ -1,0 +1,42 @@
+// Package sandboxenv provides helpers for detecting whether the current
+// process is running inside a prism sandbox and for accessing sandbox
+// configuration injected via environment variables.
+//
+// # Sandbox sentinel
+//
+// IsInsideSandbox uses PRISM_HOST_API != "" as its sentinel. This matches the
+// condition every existing inline check (cmd/merge.go, cmd/merges.go, etc.)
+// already uses to decide "am I inside a sandbox and need to proxy?":
+//
+//   - PRISM_HOST_API is set exclusively by the prism sidecar when launching a
+//     sandboxed session (bwrap, sandbox-exec, or podman container).
+//   - PRISM_SPAWN_PATH is also set in sandboxed sessions but serves as a
+//     working-directory hint, not a sandbox sentinel — using it would be a
+//     semantic stretch.
+//
+// Future callers that need to know "am I sandboxed?" should use
+// IsInsideSandbox() rather than repeating the inline os.Getenv check.
+package sandboxenv
+
+import "os"
+
+// IsInsideSandbox reports whether the current process is running inside a
+// prism sandbox (bwrap, sandbox-exec, or podman container).
+//
+// It uses PRISM_HOST_API != "" as the sentinel: the sidecar sets this variable
+// exclusively when launching a sandboxed session, so its presence is a reliable
+// indicator that the process is inside a sandbox.
+func IsInsideSandbox() bool {
+	return os.Getenv("PRISM_HOST_API") != ""
+}
+
+// HostAPISocket returns the host-API URL injected into the sandbox via the
+// PRISM_HOST_API environment variable. Returns "" if not set.
+//
+// NOTE: despite the name, this returns a URL string (e.g.
+// "unix:///path/to/sock" or "http://host:port"), not a bare socket path.
+// Callers pass it to proxyToHostAPI / hostapi helpers that parse the URL.
+// The value is returned verbatim — no parsing or transformation is applied.
+func HostAPISocket() string {
+	return os.Getenv("PRISM_HOST_API")
+}

--- a/modules/programs/prism/prism/internal/sandboxenv/sandboxenv_test.go
+++ b/modules/programs/prism/prism/internal/sandboxenv/sandboxenv_test.go
@@ -1,0 +1,78 @@
+package sandboxenv_test
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
+)
+
+func TestIsInsideSandbox(t *testing.T) {
+	t.Run("returns true when PRISM_HOST_API is set to a non-empty value", func(t *testing.T) {
+		t.Setenv("PRISM_HOST_API", "unix:///tmp/prism.sock")
+		if !sandboxenv.IsInsideSandbox() {
+			t.Error("IsInsideSandbox() = false, want true when PRISM_HOST_API is set")
+		}
+	})
+
+	t.Run("returns true when PRISM_HOST_API is set to an http URL", func(t *testing.T) {
+		t.Setenv("PRISM_HOST_API", "http://localhost:9999")
+		if !sandboxenv.IsInsideSandbox() {
+			t.Error("IsInsideSandbox() = false, want true when PRISM_HOST_API is set")
+		}
+	})
+
+	t.Run("returns false when PRISM_HOST_API is empty string", func(t *testing.T) {
+		t.Setenv("PRISM_HOST_API", "")
+		if sandboxenv.IsInsideSandbox() {
+			t.Error("IsInsideSandbox() = true, want false when PRISM_HOST_API is empty")
+		}
+	})
+
+	t.Run("returns false when PRISM_HOST_API is unset", func(t *testing.T) {
+		t.Setenv("PRISM_HOST_API", "")
+		if sandboxenv.IsInsideSandbox() {
+			t.Error("IsInsideSandbox() = true, want false when PRISM_HOST_API is unset")
+		}
+	})
+}
+
+func TestHostAPISocket(t *testing.T) {
+	t.Run("returns exact value of PRISM_HOST_API when set to unix socket URL", func(t *testing.T) {
+		const want = "unix:///tmp/prism.sock"
+		t.Setenv("PRISM_HOST_API", want)
+		if got := sandboxenv.HostAPISocket(); got != want {
+			t.Errorf("HostAPISocket() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns exact value of PRISM_HOST_API when set to http URL", func(t *testing.T) {
+		const want = "http://localhost:9999"
+		t.Setenv("PRISM_HOST_API", want)
+		if got := sandboxenv.HostAPISocket(); got != want {
+			t.Errorf("HostAPISocket() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns empty string when PRISM_HOST_API is empty", func(t *testing.T) {
+		t.Setenv("PRISM_HOST_API", "")
+		if got := sandboxenv.HostAPISocket(); got != "" {
+			t.Errorf("HostAPISocket() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("returns empty string when PRISM_HOST_API is unset", func(t *testing.T) {
+		t.Setenv("PRISM_HOST_API", "")
+		if got := sandboxenv.HostAPISocket(); got != "" {
+			t.Errorf("HostAPISocket() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("does not transform or parse the URL value", func(t *testing.T) {
+		// Verify no stripping of unix:// prefix or other transformation occurs.
+		const want = "unix:///var/run/prism/host-api.sock"
+		t.Setenv("PRISM_HOST_API", want)
+		if got := sandboxenv.HostAPISocket(); got != want {
+			t.Errorf("HostAPISocket() = %q, want %q (no transformation)", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `internal/sandboxenv/` package with two exported helpers: `IsInsideSandbox() bool` and `HostAPISocket() string`.
- `IsInsideSandbox()` uses `PRISM_HOST_API != ""` as the sandbox sentinel — matching the condition all existing inline proxy checks already use.
- Migrates the three call sites in `cmd/merge.go:74` and `cmd/merges.go:97,142` from inline `os.Getenv("PRISM_HOST_API")` to `sandboxenv.HostAPISocket()`.

## Changes

- `internal/sandboxenv/sandboxenv.go` — new package with `IsInsideSandbox` and `HostAPISocket`, including package-level doc explaining the sentinel choice.
- `internal/sandboxenv/sandboxenv_test.go` — unit tests covering set/unset/empty-string conditions for both helpers.
- `cmd/merge.go` — migrated line 74 proxy sentinel.
- `cmd/merges.go` — migrated lines 97 and 142 proxy sentinels.

Call sites outside scope (`cmd/checkin.go`, `cmd/checkin_list.go`, `cmd/sidecar.go`) retain their inline `os.Getenv` calls per the issue scope.

Closes #1156
Refs #1090