### PR TITLE
prism archive: support sandbox-exec isolation mode (mirror bwrap dispatch)

### DIFF
--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -87,7 +87,7 @@ type Params struct {
 	GroupID string
 	// PrismVersion is the git SHA or version of the prism binary. May be empty.
 	PrismVersion string
-	// IsolationMode is "podman", "bwrap", or "host".
+	// IsolationMode is "podman", "bwrap", "sandbox-exec", or "host".
 	IsolationMode string
 	// AgentRunLogPath is the absolute path to the bwrap harness log file
 	// (~/.local/state/prism/run/<session>/agent-run.log). When non-empty and the
@@ -245,17 +245,18 @@ func resolvePaths(p Params) (archiveRoot, storageRoot string, err error) {
 // resolveStorageRoot returns the host-side opencode storage root for the given
 // isolation mode and session name.
 //
-//   - host / bwrap: $HOME/.local/share/opencode/storage
+//   - host / bwrap / sandbox-exec: $HOME/.local/share/opencode/storage
 //   - podman: $HOME/.local/share/opencode/prism-sessions/<containerName>/storage
 //   - unknown / empty: returns an error
 //
-// bwrap note: bwrap sessions bind-mount the *shared* ~/.local/share/opencode/
-// directory (not a per-session sub-dir); see internal/container/bwrap.go.
-// The per-session isolation used by the podman path (Darwin virtiofs WAL-mode
-// workaround) does not apply to bwrap. The shared root is correct here because
-// copySessionFiles scopes its reads to the specific harness_session_id, so only
-// files belonging to this session are copied even when the storage pool
-// contains concurrent bwrap sessions.
+// bwrap / sandbox-exec note: both modes run on the host filesystem namespace
+// and bind-mount (bwrap) or use (sandbox-exec) the *shared*
+// ~/.local/share/opencode/ directory — not a per-session sub-dir. The
+// per-session isolation used by the podman path (Darwin virtiofs WAL-mode
+// workaround) does not apply to either mode. The shared root is correct here
+// because copySessionFiles scopes its reads to the specific harness_session_id,
+// so only files belonging to this session are copied even when the storage pool
+// contains concurrent sessions.
 func resolveStorageRoot(isolationMode, sessionName string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -263,7 +264,7 @@ func resolveStorageRoot(isolationMode, sessionName string) (string, error) {
 	}
 
 	switch isolationMode {
-	case "host", "bwrap":
+	case "host", "bwrap", "sandbox-exec":
 		return filepath.Join(home, ".local", "share", "opencode", "storage"), nil
 	case "podman":
 		containerName := containerNameForSession(sessionName)

--- a/modules/programs/prism/prism/internal/archive/archive_test.go
+++ b/modules/programs/prism/prism/internal/archive/archive_test.go
@@ -560,10 +560,10 @@ func TestResolveStorageRootPodman(t *testing.T) {
 	}
 }
 
-// TestResolveStorageRootHost verifies the host/bwrap path does not use
-// prism-sessions.
+// TestResolveStorageRootHost verifies the host/bwrap/sandbox-exec path does not
+// use prism-sessions.
 func TestResolveStorageRootHost(t *testing.T) {
-	for _, mode := range []string{"host", "bwrap"} {
+	for _, mode := range []string{"host", "bwrap", "sandbox-exec"} {
 		got, err := resolveStorageRoot(mode, "nixos-config@main")
 		if err != nil {
 			t.Fatalf("resolveStorageRoot %s: %v", mode, err)
@@ -574,6 +574,57 @@ func TestResolveStorageRootHost(t *testing.T) {
 		if !strings.HasSuffix(got, filepath.Join("opencode", "storage")) {
 			t.Errorf("mode=%s storage root = %q, want suffix opencode/storage", mode, got)
 		}
+	}
+}
+
+// TestRunSandboxExec verifies that a session with isolation_mode "sandbox-exec"
+// archives successfully, using the same storage layout as bwrap/host modes.
+func TestRunSandboxExec(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	storageRoot := filepath.Join(tmpDir, "storage")
+
+	projectID := "sbxproj"
+	sessionID := "ses_sbx001"
+	wantFiles := makeStorageTree(t, storageRoot, projectID, sessionID)
+
+	p := baseParams(archiveRoot, storageRoot)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "44444444-5555-6666-7777-888888888888"
+	p.IsolationMode = "sandbox-exec"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() with sandbox-exec error: %v", err)
+	}
+
+	// Verify archive directory exists.
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("archive dir not found: %v", err)
+	}
+
+	// Verify raw/ directory exists.
+	rawDir := filepath.Join(archivePath, "raw")
+	if _, err := os.Stat(rawDir); err != nil {
+		t.Fatalf("raw/ dir not found: %v", err)
+	}
+
+	// Verify each file is present and byte-for-byte identical.
+	for rel, want := range wantFiles {
+		got := readFile(t, filepath.Join(rawDir, rel))
+		if got != want {
+			t.Errorf("raw/%s content = %q, want %q", rel, got, want)
+		}
+	}
+
+	// Verify manifest.json parses and has the correct isolation mode recorded.
+	var m manifest
+	mData := readFile(t, filepath.Join(archivePath, "manifest.json"))
+	if err := json.Unmarshal([]byte(mData), &m); err != nil {
+		t.Fatalf("manifest.json parse error: %v", err)
+	}
+	if m.InstanceID != p.InstanceID {
+		t.Errorf("manifest.instanceId = %q, want %q", m.InstanceID, p.InstanceID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `sandbox-exec` to the `resolveStorageRoot` switch in `internal/archive/archive.go`, mirroring the existing `bwrap` / `host` arm.

Both bwrap and sandbox-exec share the host filesystem namespace and use the shared opencode storage root (`~/.local/share/opencode/storage`), so the archive dispatch logic is identical to bwrap.

## Changes

- `archive.go`: add `"sandbox-exec"` to the `case "host", "bwrap":` arm in `resolveStorageRoot`
- `archive.go`: update `Params.IsolationMode` doc comment to include `sandbox-exec`
- `archive.go`: update `resolveStorageRoot` doc comment to explain the bwrap/sandbox-exec shared rationale
- `archive_test.go`: extend `TestResolveStorageRootHost` to cover `sandbox-exec`
- `archive_test.go`: add `TestRunSandboxExec` — full `Run()` integration test for sandbox-exec mode

## Second archive bug (noted, not fixed)

During cleanup of the #1187 PR worker session, a *separate* archive error appeared after this fix is applied:

```
archive: session file for "ses_22d435225ffep21EGBCgyGxjQm" not found under
  /Users/bensherman/.local/share/opencode/storage/session
```

This is not the same as #1188 — it's the opencode session-storage path lookup failing to find the ses_*.json file. This may be related to the session ending abnormally (status 71) or to an SBPL path-allow gap. Filed as **#1196** for follow-up investigation.

Closes #1188