### PR TITLE
prism sidecar: re-assert root agent on notification delivery to prevent coordinator flip

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -403,16 +403,28 @@ func deliverNotificationViaHTTP(port int, opencodeSID string, text string, statu
 // so the session continues using its root model. Falls back to model_id for
 // sessions created before the root fields migration.
 //
-// The receiving session's active-turn agent context is deliberately NOT
-// overridden: the notification is processed by whichever agent the session is
-// configured to run. Setting an "agent" field here would let an incoming
-// notification switch a subagent's context to the notifier's agent — a real
-// bug that caused subagent context-switch incidents. See issue #848.
+// The "agent" field is included when root_agent_name is non-nil and non-empty.
+// This re-asserts the correct agent on notification delivery, preventing
+// opencode from defaulting to its last-active (wrong) agent in host mode.
+//
+// Background: issue #848 showed that setting "agent" let an incoming
+// notification switch a subagent's context to the notifier's agent. That
+// concern does not apply here: the status passed in is the *receiving*
+// session's own status, not the sender's. Re-asserting root_agent_name on
+// delivery is safe and correct — it keeps the coordinator pinned to the right
+// agent persona regardless of what opencode last processed.
 func buildNotifyPromptBody(text string, status *db.Status) map[string]any {
 	body := map[string]any{
 		"parts": []map[string]string{
 			{"type": "text", "text": text},
 		},
+	}
+
+	// Re-assert the receiving session's root agent so opencode does not default
+	// to its internally-tracked last-active agent (which may differ in host
+	// mode). Only set when root_agent_name is known and non-empty.
+	if status.RootAgentName != nil && *status.RootAgentName != "" {
+		body["agent"] = *status.RootAgentName
 	}
 
 	modelID := status.RootModelID

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7440,67 +7440,69 @@ func TestHostAPI_Review_CWDFallbackWhenWorktreeMissing(t *testing.T) {
 	}
 }
 
-// ── buildNotifyPromptBody tests (issue #848) ────────────────────────────────
+// ── buildNotifyPromptBody tests (issues #848, #1203) ────────────────────────
 
-// TestBuildNotifyPromptBody_OmitsAgentField verifies that the outgoing
-// notification body never carries an "agent" field. Setting this field lets an
-// incoming notification switch the receiving session's active-turn agent
-// context (e.g. a subagent gets promoted to the coordinator's agent). See
-// issue #848 — the "agent" override was a host-mode-era workaround that is no
-// longer needed and causes a real context-switch bug.
-func TestBuildNotifyPromptBody_OmitsAgentField(t *testing.T) {
-	rootAgent := "coordinator"
+// TestBuildNotifyPromptBody_AgentField verifies that the outgoing notification
+// body includes the "agent" field when the receiving session has a non-nil,
+// non-empty RootAgentName, and omits it otherwise.
+//
+// Background: issue #848 flagged setting "agent" as dangerous because it could
+// switch a subagent's context. The status passed to buildNotifyPromptBody is
+// the *receiving* session's own status; re-asserting root_agent_name is safe
+// and necessary to prevent opencode from defaulting to its last-active (wrong)
+// agent in host mode — see issue #1203.
+func TestBuildNotifyPromptBody_AgentField(t *testing.T) {
+	coordinatorAgent := "coordinator"
+	workerAgent := "worker"
 	agentName := "explore"
 	rootModel := "anthropic/claude-opus-4"
 	modelID := "anthropic/claude-sonnet-4"
 
-	cases := []struct {
-		name   string
-		status *db.Status
-	}{
-		{
-			name: "root fields present",
-			status: &db.Status{
-				RootAgentName: &rootAgent,
-				RootModelID:   &rootModel,
-				AgentName:     &agentName,
-				ModelID:       &modelID,
-			},
-		},
-		{
-			name: "only legacy fields present",
-			status: &db.Status{
-				AgentName: &agentName,
-				ModelID:   &modelID,
-			},
-		},
-		{
-			name: "only root fields present",
-			status: &db.Status{
-				RootAgentName: &rootAgent,
-				RootModelID:   &rootModel,
-			},
-		},
-		{
-			name:   "no fields present",
-			status: &db.Status{},
-		},
-		{
-			name: "agent known but no model",
-			status: &db.Status{
-				RootAgentName: &rootAgent,
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			body := buildNotifyPromptBody("hello", tc.status)
-			if _, ok := body["agent"]; ok {
-				t.Errorf("body must not contain \"agent\" field (got %v); setting it switches the receiving session's agent context — see issue #848", body["agent"])
-			}
+	t.Run("includes agent when RootAgentName is coordinator", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{
+			RootAgentName: &coordinatorAgent,
+			RootModelID:   &rootModel,
+			AgentName:     &agentName,
+			ModelID:       &modelID,
 		})
-	}
+		agent, ok := body["agent"]
+		if !ok {
+			t.Fatal("body must contain \"agent\" field when RootAgentName is set")
+		}
+		if agent != "coordinator" {
+			t.Errorf("body[\"agent\"] = %q, want \"coordinator\"", agent)
+		}
+	})
+
+	t.Run("includes agent when RootAgentName is worker", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{
+			RootAgentName: &workerAgent,
+		})
+		agent, ok := body["agent"]
+		if !ok {
+			t.Fatal("body must contain \"agent\" field when RootAgentName is set")
+		}
+		if agent != "worker" {
+			t.Errorf("body[\"agent\"] = %q, want \"worker\"", agent)
+		}
+	})
+
+	t.Run("omits agent when RootAgentName is nil", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{
+			AgentName: &agentName,
+			ModelID:   &modelID,
+		})
+		if _, ok := body["agent"]; ok {
+			t.Errorf("body must not contain \"agent\" field when RootAgentName is nil (got %v)", body["agent"])
+		}
+	})
+
+	t.Run("omits agent when no fields present", func(t *testing.T) {
+		body := buildNotifyPromptBody("hello", &db.Status{})
+		if _, ok := body["agent"]; ok {
+			t.Errorf("body must not contain \"agent\" field when status is empty (got %v)", body["agent"])
+		}
+	})
 }
 
 // ── error-state debounce tests (issue #923) ─────────────────────────────────


### PR DESCRIPTION
## Summary

When a worker finishes and the sidecar delivers a finish notification to a host-mode coordinator, opencode was defaulting to its last-active agent (e.g. `build`) because the incoming `prompt_async` had no `"agent"` field. This caused the coordinator's TUI to flip to the wrong agent and idle-suppression to fire, blocking subsequent state transitions.

## Root cause

`buildNotifyPromptBody` deliberately omitted `"agent"` per issue #848 — setting it could switch a subagent's context. However, in host mode, a coordinator session can drift to a non-coordinator agent between turns, and a notification without `"agent"` then arrives under the wrong persona.

## Fix

`buildNotifyPromptBody` now includes `"agent": *status.RootAgentName` when `RootAgentName` is non-nil and non-empty. The status passed in is the *receiving* session's own status (not the sender's), so this re-asserts the correct agent persona — the issue #848 concern doesn't apply.

## Tests

Replaced `TestBuildNotifyPromptBody_OmitsAgentField` (written before the host-mode coordinator flip was understood) with `TestBuildNotifyPromptBody_AgentField`, which:
- Asserts `"agent"` IS included when `RootAgentName` is set (coordinator and worker cases)
- Asserts `"agent"` is omitted when `RootAgentName` is nil or not set

Closes #1203