### PR TITLE
prism review: integration test for >100 KiB review-agent prompt-file delivery

### DIFF
--- a/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
+++ b/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
@@ -232,6 +232,103 @@ func TestSpawnReviewAgent_LargePrompt_UsesPromptFile(t *testing.T) {
 	t.Logf("initial-prompt file verified: %d bytes at %s", len(body), promptFilePath)
 }
 
+// TestSpawnReviewAgent_LargePrompt_HostMode is the AC integration test for the
+// LayoutAgentOnly+host cell that was missing from the needsPromptFile gate
+// before issue #1195. Darwin coordinators run review fan-outs with
+// IsolationMode="host" and Layout=LayoutAgentOnly. Before the fix, this
+// combination inlined the full prompt in the tmux argv, hitting
+// HostLaunchCmdSafeBound on any non-trivial PR.
+//
+// This test must NOT call t.Parallel(): it rewrites the global tmux.TmuxBin.
+func TestSpawnReviewAgent_LargePrompt_HostMode(t *testing.T) {
+	d, _ := openSpawnIntegTestDB(t)
+	argsFile := spawnSpyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	// Synthesise the same >100 KiB review prompt as the bwrap test, this time
+	// with IsolationMode="host" to exercise the previously-missing cell.
+	largeDiff := strings.Repeat("+// host-mode regression test for #1195\n", 3000) // ~120 KB
+
+	prCtx := &review.PRContext{
+		PRNumber:    "1195",
+		Title:       "review-agent-prompt-file host-mode test",
+		Body:        "Closes #1195\n\nHost-mode coordinator review fan-out.",
+		HeadRefName: "review-agent-prompt-file",
+		HeadRefOid:  "abc1234",
+		BaseRefName: "main",
+		BaseRefOid:  "def5678",
+		Diff:        largeDiff,
+		DiffLines:   3000,
+		DiffBytes:   len(largeDiff),
+	}
+
+	prompt := review.BuildReviewPromptForTest("1195", prCtx)
+	if len(prompt) < 100*1024 {
+		t.Fatalf("test setup: host-mode prompt is only %d bytes, need ≥ 100 KiB", len(prompt))
+	}
+	t.Logf("host-mode synthesised review prompt: %d bytes (%.1f KiB)", len(prompt), float64(len(prompt))/1024)
+
+	const sessionName = "nixos-config@review-agent-prompt-file~review-1-review-goal-host"
+	opts := session.SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "nixos-config",
+		Worktree:      "/worktrees/nixos-config/review-agent-prompt-file",
+		AgentRole:     "review-goal",
+		Prompt:        prompt,
+		Layout:        session.LayoutAgentOnly,
+		IsolationMode: "host", // the previously-broken cell
+	}
+
+	// (a) Spawn must succeed. Before the #1195 fix, this call would trip
+	// HostLaunchCmdSafeBound because PRISM_INITIAL_PROMPT=<120KB> would be
+	// inlined into the tmux new-window env var — a regression of #1092.
+	if err := session.SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession (host mode, LayoutAgentOnly) with >100 KiB prompt: %v — regression of #1195: host-mode review fan-out must not exceed HostLaunchCmdSafeBound", err)
+	}
+
+	// (b) Inspect the tmux argv.
+	args := spawnReadSpyArgs(argsFile)
+
+	promptFilePath, pathErr := session.InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
+	}
+
+	// PRISM_INITIAL_PROMPT_FILE must appear — the host-mode LayoutAgentOnly
+	// cell now goes through the same file-based path as bwrap/sandbox-exec.
+	found := false
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && args[i+1] == "PRISM_INITIAL_PROMPT_FILE="+promptFilePath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("tmux argv (host mode) does not contain [-e PRISM_INITIAL_PROMPT_FILE=%s] — the LayoutAgentOnly+host cell must now use file-based delivery (#1195)\nargs: %v",
+			promptFilePath, args)
+	}
+
+	// PRISM_INITIAL_PROMPT inline must NOT appear — that's the pre-fix path.
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT=") {
+			t.Errorf("tmux argv (host mode) contains inline PRISM_INITIAL_PROMPT — the LayoutAgentOnly+host cell was not fixed properly (#1195): %s", args[i+1])
+			break
+		}
+	}
+
+	// (c) File content must match.
+	body, readErr := os.ReadFile(promptFilePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v (host mode)", promptFilePath, readErr)
+	}
+	if string(body) != prompt {
+		t.Errorf("host-mode initial-prompt file: %d bytes, want %d", len(body), len(prompt))
+	}
+	t.Logf("host-mode initial-prompt file verified: %d bytes at %s", len(body), promptFilePath)
+}
+
 // TestSpawnReviewAgent_LargePrompt_SandboxExec mirrors the bwrap test for
 // sandbox-exec mode. Both modes delegate prompt delivery to `prism agent-run`
 // (which reads PRISM_INITIAL_PROMPT_FILE), so the file-based path must fire

--- a/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
+++ b/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
@@ -1,0 +1,321 @@
+package review_test
+
+// spawn_prompt_file_test.go — integration test for the review-agent prompt-file
+// delivery path (issue #1195 / regression of #1092).
+//
+// These tests synthesise a >100 KiB review context (the prompt that Run/RunAsync
+// builds for each review agent) and verify that session.SpawnSession:
+//
+//  (a) succeeds — the launch command is within HostLaunchCmdSafeBound (16 KiB)
+//  (b) the constructed tmux new-window argv does NOT contain the prompt body
+//      inline (no -e PRISM_INITIAL_PROMPT=<huge>) — the file-based path is used
+//  (c) the agent receives the full prompt content via the initial-prompt file
+//
+// Test structure:
+//   - A fake tmux binary (shell script) that records its argv to a file is
+//     installed for the duration of each test via tmux.TmuxBin.
+//   - PRISM_TEST_SUBPROCESS=1 makes the StartSidecar call use the test binary
+//     as a stub sidecar (exits after 50ms — see TestMain in the session package
+//     which owns the PRISM_TEST_SUBPROCESS handling).
+//   - XDG_STATE_HOME is redirected to a temp dir so no real state files are
+//     written to the user's home directory.
+//
+// AC: [functional] An integration test under internal/integration/ or
+// internal/review/ synthesises a >100 KiB review context, invokes the spawn
+// path, and asserts (a) the spawn succeeds, (b) the constructed launch command
+// is < 16 KiB, (c) the agent receives the full prompt content via the file.
+// — issue #1195
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// spawnSpyTmuxBin installs a fake tmux binary for the test, recording each
+// argv element on a separate line to argsFile. Returns the path to argsFile.
+// Restores the original TmuxBin in t.Cleanup. Call only from non-parallel tests.
+func spawnSpyTmuxBin(t *testing.T) string {
+	t.Helper()
+	argsFile := filepath.Join(t.TempDir(), "tmux-args")
+	wrapperPath := filepath.Join(t.TempDir(), "tmux")
+	script := "#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> " + argsFile + "; done\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write spy tmux: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+	return argsFile
+}
+
+// spawnReadSpyArgs reads the space-separated argv elements recorded by the spy.
+func spawnReadSpyArgs(argsFile string) []string {
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		return nil
+	}
+	var args []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+	return args
+}
+
+// openSpawnIntegTestDB opens a fresh temp SQLite DB and registers cleanup.
+func openSpawnIntegTestDB(t *testing.T) (*db.DB, string) {
+	t.Helper()
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	session.SetTestDBPath(dbFile)
+	t.Cleanup(func() {
+		d.Close()
+		session.SetTestDBPath("")
+	})
+	return d, dbFile
+}
+
+// TestSpawnReviewAgent_LargePrompt_UsesPromptFile is the regression test for
+// issue #1195. It verifies that session.SpawnSession (the shared primitive used
+// by review.Run and review.RunAsync) routes a >100 KiB review prompt through
+// the initial-prompt-file mechanism rather than inlining it in the tmux argv.
+//
+// The test synthesises a PRContext whose diff section alone exceeds 100 KiB,
+// then builds the review prompt via the exported BuildReviewPromptForTest shim.
+// It then calls SpawnSession in bwrap mode (the mode that triggered the original
+// failure in #1092 and the reported regression in #1195) and verifies:
+//
+//   (a) The spawn succeeds — HostLaunchCmdSafeBound (16 KiB) is NOT exceeded.
+//   (b) The tmux argv does NOT contain the prompt body inline.
+//       PRISM_INITIAL_PROMPT_FILE is present; PRISM_INITIAL_PROMPT is absent.
+//   (c) The initial-prompt file on disk contains the full prompt content.
+//
+// This test must NOT call t.Parallel(): it rewrites the global tmux.TmuxBin.
+func TestSpawnReviewAgent_LargePrompt_UsesPromptFile(t *testing.T) {
+	d, _ := openSpawnIntegTestDB(t)
+	argsFile := spawnSpyTmuxBin(t)
+
+	// Stub the sidecar so StartSidecarWithOpts does not try to exec a real
+	// prism binary. The session package's TestMain handles PRISM_TEST_SUBPROCESS.
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+
+	// Route all XDG state writes to a temp dir.
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	// Build a >100 KiB review context. The diff section of a typical PR
+	// review prompt is the largest contributor; replicate a realistic diff
+	// body of ~120 KB.
+	largeDiff := strings.Repeat("+// review-agent-prompt-file-test regression-#1195\n", 3000) // ~120 KB
+	if len(largeDiff) < 100*1024 {
+		t.Fatalf("test setup: largeDiff is only %d bytes, need ≥ 100 KiB", len(largeDiff))
+	}
+
+	prCtx := &review.PRContext{
+		PRNumber:      "1195",
+		Title:         "prism review: review-agent spawn inlines PRISM_INITIAL_PROMPT",
+		Body:          "Closes #1195\n\nSee issue for root cause and proposed fix.",
+		HeadRefName:   "review-agent-prompt-file",
+		HeadRefOid:    "abc1234",
+		BaseRefName:   "main",
+		BaseRefOid:    "def5678",
+		Additions:     3000,
+		Deletions:     0,
+		ChangedFiles:  4,
+		RecentCommits: "abc1234 prism: fix review agent prompt delivery\ndef5678 main\n",
+		BranchCommits: "abc1234 prism: fix review agent prompt delivery\n",
+		Diff:          largeDiff,
+		DiffLines:     3000,
+		DiffBytes:     len(largeDiff),
+		LinkedIssues: map[string]string{
+			"1195": "title: prism review: launch-cmd size cap\nstate: OPEN\n",
+		},
+		WorktreePath: "/worktrees/nixos-config/review-agent-prompt-file",
+	}
+
+	prompt := review.BuildReviewPromptForTest("1195", prCtx)
+	if len(prompt) < 100*1024 {
+		t.Fatalf("test setup: prompt is only %d bytes, need ≥ 100 KiB for a meaningful regression test", len(prompt))
+	}
+	t.Logf("synthesised review prompt: %d bytes (%.1f KiB)", len(prompt), float64(len(prompt))/1024)
+
+	const sessionName = "nixos-config@review-agent-prompt-file~review-1-review-context"
+	opts := session.SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "nixos-config",
+		Worktree:      "/worktrees/nixos-config/review-agent-prompt-file",
+		AgentRole:     "review-context",
+		Prompt:        prompt,
+		Layout:        session.LayoutAgentOnly,
+		IsolationMode: "bwrap",
+	}
+
+	// (a) Spawn must succeed. Before the #1092 / #1195 fix, this call would
+	// fail with HostLaunchCmdTooLargeError because the full prompt was inlined
+	// into the tmux new-window argv as -e PRISM_INITIAL_PROMPT=<120KB>.
+	if err := session.SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession with >100 KiB prompt: %v — bwrap review-agent spawn must not exceed HostLaunchCmdSafeBound (regression of #1092, #1195)", err)
+	}
+
+	// (b) Inspect the tmux argv recorded by the spy.
+	args := spawnReadSpyArgs(argsFile)
+	joined := strings.Join(args, " ")
+
+	// PRISM_INITIAL_PROMPT_FILE must be present (file-based delivery).
+	promptFilePath, pathErr := session.InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
+	}
+	found := false
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && args[i+1] == "PRISM_INITIAL_PROMPT_FILE="+promptFilePath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("tmux argv does not contain [-e PRISM_INITIAL_PROMPT_FILE=%s] — bwrap review-agent must use file-based prompt delivery, not inline env var (#1195)\nfull argv: %v",
+			promptFilePath, args)
+	}
+
+	// PRISM_INITIAL_PROMPT must NOT appear (the pre-fix inline path).
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT=") {
+			t.Errorf("tmux argv contains inline PRISM_INITIAL_PROMPT — would re-introduce #1092 / #1195 launch-cmd size failure:\n  arg: %s", args[i+1])
+			break
+		}
+	}
+
+	// Defence-in-depth: the prompt body must not appear anywhere in the tmux argv.
+	// Even a partial match (first 200 chars of the diff) would indicate regression.
+	bodySnippet := largeDiff[:200]
+	if strings.Contains(joined, bodySnippet) {
+		t.Errorf("tmux argv contains prompt body inline (snippet: %.50q…) — file-based delivery is broken (#1195)", bodySnippet)
+	}
+
+	// Launch-command size bound: the entire tmux new-window argv approximation
+	// must stay well below HostLaunchCmdSafeBound (16 KiB). The argv from the
+	// spy is larger than what tmux sees (shell quoting is not stripped), but
+	// the agent-only command ("prism agent-run --session <name>") + the file
+	// path env var together are a few hundred bytes at most.
+	argsByteCount := 0
+	for _, a := range args {
+		argsByteCount += len(a) + 4 // approximate '-e KEY=VALUE' overhead
+	}
+	const safebound = 16 * 1024
+	if argsByteCount > safebound {
+		t.Errorf("tmux argv total size %d bytes exceeds HostLaunchCmdSafeBound (%d) — prompt-file delivery is not keeping launch command O(1) in prompt size (#1195)",
+			argsByteCount, safebound)
+	}
+	t.Logf("tmux argv total size: %d bytes (safe bound: %d)", argsByteCount, safebound)
+
+	// (c) The initial-prompt file must exist and contain the full prompt.
+	body, readErr := os.ReadFile(promptFilePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v — initial-prompt file must exist after SpawnSession with bwrap mode", promptFilePath, readErr)
+	}
+	if string(body) != prompt {
+		t.Errorf("initial-prompt file content mismatch: file has %d bytes, prompt has %d bytes — the full review context must be preserved verbatim",
+			len(body), len(prompt))
+	}
+	t.Logf("initial-prompt file verified: %d bytes at %s", len(body), promptFilePath)
+}
+
+// TestSpawnReviewAgent_LargePrompt_SandboxExec mirrors the bwrap test for
+// sandbox-exec mode. Both modes delegate prompt delivery to `prism agent-run`
+// (which reads PRISM_INITIAL_PROMPT_FILE), so the file-based path must fire
+// for both. Covers the Darwin-native isolation mode that macOS workers use.
+//
+// This test must NOT call t.Parallel(): it rewrites the global tmux.TmuxBin.
+func TestSpawnReviewAgent_LargePrompt_SandboxExec(t *testing.T) {
+	d, _ := openSpawnIntegTestDB(t)
+	argsFile := spawnSpyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	// Synthesise a >100 KiB diff section — same size as the bwrap test so
+	// both modes are exercised against the same threshold.
+	largeDiff := strings.Repeat("+// sandbox-exec regression test for #1195\n", 3000) // ~120 KB
+
+	prCtx := &review.PRContext{
+		PRNumber:    "1195",
+		Title:       "review-agent-prompt-file sandbox-exec test",
+		Body:        "Closes #1195",
+		HeadRefName: "review-agent-prompt-file",
+		HeadRefOid:  "abc1234",
+		BaseRefName: "main",
+		BaseRefOid:  "def5678",
+		Diff:        largeDiff,
+		DiffLines:   3000,
+		DiffBytes:   len(largeDiff),
+	}
+
+	prompt := review.BuildReviewPromptForTest("1195", prCtx)
+	if len(prompt) < 100*1024 {
+		t.Fatalf("test setup: sandbox-exec prompt is only %d bytes, need ≥ 100 KiB", len(prompt))
+	}
+
+	const sessionName = "nixos-config@review-agent-prompt-file~review-1-review-qa"
+	opts := session.SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "nixos-config",
+		Worktree:      "/worktrees/nixos-config/review-agent-prompt-file",
+		AgentRole:     "review-qa",
+		Prompt:        prompt,
+		Layout:        session.LayoutAgentOnly,
+		IsolationMode: "sandbox-exec",
+	}
+
+	if err := session.SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession (sandbox-exec) with >100 KiB prompt: %v — sandbox-exec review-agent spawn must not exceed HostLaunchCmdSafeBound (#1195)", err)
+	}
+
+	args := spawnReadSpyArgs(argsFile)
+
+	promptFilePath, pathErr := session.InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
+	}
+
+	// PRISM_INITIAL_PROMPT_FILE must appear.
+	found := false
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && args[i+1] == "PRISM_INITIAL_PROMPT_FILE="+promptFilePath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("tmux argv (sandbox-exec) does not contain [-e PRISM_INITIAL_PROMPT_FILE=%s] — file-based delivery must work for sandbox-exec too (#1195)\nargs: %v",
+			promptFilePath, args)
+	}
+
+	// Inline env var must NOT appear.
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT=") {
+			t.Errorf("tmux argv (sandbox-exec) contains inline PRISM_INITIAL_PROMPT — would re-introduce #1195: %s", args[i+1])
+			break
+		}
+	}
+
+	// File must contain the full prompt.
+	body, readErr := os.ReadFile(promptFilePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v (sandbox-exec)", promptFilePath, readErr)
+	}
+	if string(body) != prompt {
+		t.Errorf("sandbox-exec initial-prompt file: %d bytes, want %d", len(body), len(prompt))
+	}
+}

--- a/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
+++ b/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
@@ -290,6 +290,7 @@ func TestSpawnReviewAgent_LargePrompt_HostMode(t *testing.T) {
 
 	// (b) Inspect the tmux argv.
 	args := spawnReadSpyArgs(argsFile)
+	joined := strings.Join(args, " ")
 
 	promptFilePath, pathErr := session.InitialPromptPath(sessionName)
 	if pathErr != nil {
@@ -316,6 +317,15 @@ func TestSpawnReviewAgent_LargePrompt_HostMode(t *testing.T) {
 			t.Errorf("tmux argv (host mode) contains inline PRISM_INITIAL_PROMPT — the LayoutAgentOnly+host cell was not fixed properly (#1195): %s", args[i+1])
 			break
 		}
+	}
+
+	// The agentCmd (the `sh -c <cmd>` argument) must use $(cat <path>) rather
+	// than inlining the prompt body. Verify the body snippet doesn't appear
+	// anywhere in the tmux argv — if it does, buildDirectOpencodeCmd inlined
+	// the prompt despite the PromptFilePath being set (#1195 review-code AC).
+	bodySnippet := largeDiff[:200]
+	if strings.Contains(joined, bodySnippet) {
+		t.Errorf("tmux argv (host mode) contains prompt body inline (snippet: %.50q…) — spawnAgentOnlyLayout must pass PromptFilePath to BuildOpencodeCmd (#1195)", bodySnippet)
 	}
 
 	// (c) File content must match.

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -572,19 +572,19 @@ func Create(name, directory string, opts Opts) error {
 
 // agentPaneEnvVars builds the env-var map for the agent tmux pane.
 //
-// When opts.PromptFilePath is non-empty (the post-#1092 path),
+// When opts.PromptFilePath is non-empty (the post-#1092/#1195 path),
 // PRISM_INITIAL_PROMPT_FILE carries the path to the prompt file and the
 // prompt body itself is NOT inlined into tmux's argv. `prism agent-run`
 // reads the file when it sees the env var and feeds the contents to
-// bwrap's --prompt CLI-append path. This keeps the launch-command size
-// O(1) in prompt size — the failure mode #1092 hit on review fan-outs.
+// the agent's --prompt path. This keeps the launch-command size O(1) in
+// prompt size.
 //
-// When opts.PromptFilePath is empty but opts.Prompt is non-empty, fall
-// back to the legacy inline PRISM_INITIAL_PROMPT env var. SpawnSession
-// always writes the prompt file for bwrap/sandbox-exec, so this branch
-// is exercised only by direct callers that have not opted into the file
-// path (e.g. test code or future modes added without prompt-file
-// plumbing).
+// SpawnSession always writes the prompt file when there is a non-empty
+// prompt, regardless of isolation mode or layout, so the legacy
+// PRISM_INITIAL_PROMPT inline branch below is exercised only by direct
+// callers that have not opted into the file path (e.g. test code).
+// Every production callsite goes through SpawnSession and receives a
+// file path.
 //
 // Skipped entirely for host mode: the host-mode launch path reads the
 // prompt directly via $(cat …) (see buildDirectOpencodeCmd / #1064), so

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -237,8 +237,22 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	mode := resolveLayoutIsolationMode(opts)
 	var promptFilePath string
 	isSandbox := mode == "bwrap" || mode == "sandbox-exec"
-	needsPromptFile := opts.Prompt != "" && (opts.Layout == LayoutFull && mode == "host" ||
-		isSandbox)
+	// needsPromptFile is true for every mode/layout combination that carries a
+	// non-empty prompt. Before #1195, the gate was:
+	//
+	//   (LayoutFull && host) || isSandbox
+	//
+	// which silently excluded LayoutAgentOnly+host — the Darwin coordinator's
+	// review fan-out path. That left `spawnAgentPaneEnvVars` to fall back to
+	// the legacy PRISM_INITIAL_PROMPT=<blob> env var, re-introducing the
+	// HostLaunchCmdSafeBound failure that #1092 fixed for other modes.
+	//
+	// Post-#1195: the invariant is universal — **every** mode/layout
+	// combination with a non-empty prompt uses the file path. LayoutBare and
+	// LayoutScratchpad never carry prompts (those layouts are for shells and
+	// dashboards, not agent panes), so the `opts.Prompt != ""` guard already
+	// excludes them without needing an explicit carve-out.
+	needsPromptFile := opts.Prompt != "" && (mode == "host" || isSandbox)
 	if needsPromptFile {
 		path, writeErr := WriteInitialPrompt(opts.SessionName, opts.Prompt)
 		if writeErr != nil {
@@ -253,18 +267,24 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		startup.log("spawn-session: wrote initial-prompt file (%d bytes) to %s", len(opts.Prompt), path)
 	}
 
-	// #1064 AC-6 / #1092: pre-spawn size check. Build the launch command
-	// preview using the same Opts shape that the layout spawner will reuse
-	// below, and reject any session whose tmux-bound command exceeds the
-	// safe bound. Doing this BEFORE any tmux state is created means a
+	// #1064 AC-6 / #1092 / #1195: pre-spawn size check. Build the launch
+	// command preview using the same Opts shape that the layout spawner will
+	// reuse below, and reject any session whose tmux-bound command exceeds
+	// the safe bound. Doing this BEFORE any tmux state is created means a
 	// rejected spawn has no observable side effects on the tmux server.
 	//
-	// Three combinations are guarded:
+	// Four combinations are guarded:
 	//
 	//   - LayoutFull + host: BuildOpencodeCmd returns the direct opencode
 	//     invocation. Without the prompt-file plumbing the prompt body
 	//     would be inlined onto `sh -c <cmd>`; with it the cmd stays O(1)
 	//     in prompt size.
+	//
+	//   - LayoutAgentOnly + host (#1195): review agents on Darwin coordinators
+	//     run in host mode. Pre-#1195 this cell was missing from the gate and
+	//     from the needsPromptFile logic above, causing PRISM_INITIAL_PROMPT
+	//     inline delivery with its HostLaunchCmdSafeBound failure mode. Now
+	//     covered by the unified gate below.
 	//
 	//   - LayoutFull / LayoutAgentOnly + bwrap or sandbox-exec:
 	//     BuildOpencodeCmd returns `prism agent-run --session <name>`,
@@ -279,7 +299,7 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// podman path is intentionally not guarded.
 	hostLaunchCmdSize := 0
 	switch {
-	case opts.Layout == LayoutFull && mode == "host":
+	case mode == "host" && opts.Layout == LayoutFull:
 		previewOpts := buildOptsForLayout(opts, 0, promptFilePath)
 		hostLaunchCmd := BuildOpencodeCmd(previewOpts)
 		hostLaunchCmdSize = len(hostLaunchCmd)
@@ -298,6 +318,48 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		}
 		startup.log("spawn-session: host launch command size %d (safe bound %d, warn threshold %d)",
 			hostLaunchCmdSize, HostLaunchCmdSafeBound, HostLaunchCmdWarnThreshold)
+
+	case mode == "host" && opts.Layout == LayoutAgentOnly:
+		// LayoutAgentOnly + host: Darwin coordinator review fan-out (#1195).
+		// The agent command is `prism agent-run --session <name>` in bwrap
+		// and sandbox-exec, but for host mode it is a direct opencode
+		// invocation — same as LayoutFull + host but without the sidecar-
+		// managed 3-window layout. The env-var map carries PRISM_INITIAL_PROMPT_FILE
+		// (post-#1195 path); measure the full contribution so any exotic
+		// ConfigContent or large session name is caught here.
+		previewEnvs := spawnAgentPaneEnvVars(SpawnOpts{
+			Prompt:         opts.Prompt,
+			PromptFilePath: promptFilePath,
+		})
+		size := 0
+		for k, v := range previewEnvs {
+			size += len(k) + len(v) + 4
+		}
+		// The host-mode LayoutAgentOnly command is built inside
+		// spawnAgentOnlyLayout; approximate via buildDirectOpencodeCmd.
+		previewOpts := Opts{
+			Prompt:           opts.Prompt,
+			PromptFilePath:   promptFilePath,
+			Agent:            opts.AgentRole,
+			SessionName:      opts.SessionName,
+			Port:             0,
+			IsolationMode:    mode,
+			ConfigEnvVarName: opts.ConfigEnvVarName,
+		}
+		size += len(BuildOpencodeCmd(previewOpts))
+		hostLaunchCmdSize = size
+		if size > HostLaunchCmdSafeBound {
+			startup.log("spawn-session: host/LayoutAgentOnly launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
+				size, HostLaunchCmdSafeBound)
+			removeInitialPrompt(opts.SessionName)
+			return &HostLaunchCmdTooLargeError{
+				SessionName: opts.SessionName,
+				CmdSize:     size,
+				SafeBound:   HostLaunchCmdSafeBound,
+			}
+		}
+		startup.log("spawn-session: host/LayoutAgentOnly launch command size %d (safe bound %d)",
+			size, HostLaunchCmdSafeBound)
 
 	case isSandbox && (opts.Layout == LayoutFull || opts.Layout == LayoutAgentOnly):
 		// Mirror what the layout spawner will hand to tmux: the agentCmd
@@ -559,18 +621,17 @@ func spawnFullLayout(d *db.DB, opts SpawnOpts, port int) error {
 // tmux pane. It mirrors session.agentPaneEnvVars but takes SpawnOpts directly,
 // since the two layout paths use different opts structs.
 //
-// When opts.PromptFilePath is non-empty (the post-#1092 path), PRISM_INITIAL_PROMPT_FILE
-// carries the path to the prompt file and the prompt body itself is NOT
-// inlined into tmux's argv. `prism agent-run` reads the file when it sees
-// the env var and feeds the contents to bwrap's --prompt CLI-append path.
-// This keeps the tmux launch command O(1) in prompt size — the failure mode
-// the role prompt was hitting in #1092.
+// When opts.PromptFilePath is non-empty (the post-#1092/#1195 path),
+// PRISM_INITIAL_PROMPT_FILE carries the path to the prompt file and the prompt
+// body itself is NOT inlined into tmux's argv. `prism agent-run` reads the
+// file when it sees the env var and feeds the contents to the agent's --prompt
+// path. This keeps the tmux launch command O(1) in prompt size.
 //
-// When opts.PromptFilePath is empty but opts.Prompt is non-empty, fall back
-// to the legacy PRISM_INITIAL_PROMPT env var (used by callers that have not
-// opted into the file path; SpawnSession itself always writes the file for
-// bwrap/sandbox-exec, so this branch is exercised only by direct callers
-// of the helper or future modes added without prompt-file plumbing).
+// SpawnSession always writes the prompt file when there is a non-empty prompt,
+// regardless of isolation mode or layout, so the legacy PRISM_INITIAL_PROMPT
+// inline branch below is exercised only by direct callers of this helper (e.g.
+// test code) that pass Prompt without going through SpawnSession. Every
+// production callsite goes through SpawnSession and receives a file path.
 //
 // Returns nil when no env vars are needed, producing no -e flags in tmux
 // (an empty-string entry would override an inherited value, which is not

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -230,10 +230,8 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// Podman mode delivers the prompt through the sidecar (StartSidecarOpts
 	// .InitialPrompt → opencode --prompt inside the container), so it does
 	// not need a tmux-side env var at all and is intentionally skipped here.
-	// Host mode under LayoutAgentOnly is not produced by any caller today —
-	// review agents run under bwrap/sandbox-exec/podman — so it is also
-	// skipped; if that ever changes, extend the gate consciously rather
-	// than silently.
+	// All other modes (host and sandbox) write the prompt file regardless of
+	// layout — see the needsPromptFile gate below (#1195).
 	mode := resolveLayoutIsolationMode(opts)
 	var promptFilePath string
 	isSandbox := mode == "bwrap" || mode == "sandbox-exec"
@@ -699,6 +697,7 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	// container.
 	buildOpts := Opts{
 		Prompt:           opts.Prompt,
+		PromptFilePath:   opts.PromptFilePath, // set by SpawnSession (#1195: keeps agentCmd O(1) in prompt size for host mode)
 		Agent:            opts.AgentRole,
 		ConfigContent:    opts.ConfigContent,
 		SessionName:      opts.SessionName,

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
 )
@@ -358,21 +359,23 @@ func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
 	}
 }
 
-// TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt_Host verifies the legacy
-// path for the host-mode resolution: when opts.IsolationMode is empty and the
-// machine default resolves to "host", spawnAgentOnlyLayout sets the inline
-// PRISM_INITIAL_PROMPT env var on the agent pane (the pre-#1092 shape).
+// TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Host verifies the
+// LayoutAgentOnly+host cell that was missing from the needsPromptFile gate
+// before issue #1195. Darwin coordinators running review fan-outs use
+// IsolationMode="host" with Layout=LayoutAgentOnly. Before the fix, this
+// combination fell through to the legacy PRISM_INITIAL_PROMPT inline path,
+// exceeding HostLaunchCmdSafeBound on non-trivial PRs.
 //
-// This is the regression test for #1042 carried forward: review agents in
-// host mode must receive their initial prompt via the PRISM_INITIAL_PROMPT
-// env var. The new file-based path (PRISM_INITIAL_PROMPT_FILE) is gated on
-// bwrap/sandbox-exec modes only — see
-// TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Bwrap below.
-func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt_Host(t *testing.T) {
+// Post-#1195: host mode also uses PRISM_INITIAL_PROMPT_FILE regardless of
+// layout. The legacy PRISM_INITIAL_PROMPT env var is no longer set by
+// SpawnSession for any mode — it remains as a fallback only for direct
+// callers of spawnAgentPaneEnvVars / agentPaneEnvVars that bypass SpawnSession.
+func TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Host(t *testing.T) {
 	d, _ := openSpawnTestDB(t)
 	argsFile := spyTmuxBin(t)
 	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
 
 	const sessionName = "myrepo@branch~review-1-review-code"
 	const prompt = "review this PR"
@@ -390,17 +393,31 @@ func TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt_Host(t *testing.T) {
 		t.Fatalf("SpawnSession: %v", err)
 	}
 
-	args := readSpyArgs(argsFile)
-	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT=" + prompt}) {
-		t.Errorf("tmux args %v do not contain [-e PRISM_INITIAL_PROMPT=%s] — host-mode review agents should still receive the inline env var (#1042)", args, prompt)
+	// Post-#1195: PRISM_INITIAL_PROMPT_FILE must appear (file-based delivery).
+	filePath, pathErr := InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
 	}
-	// The file-based env var must NOT appear for host mode — that path
-	// would route the prompt through `prism agent-run`, which only fires
-	// for bwrap/sandbox-exec.
+	args := readSpyArgs(argsFile)
+	if !containsSeq(args, []string{"-e", "PRISM_INITIAL_PROMPT_FILE=" + filePath}) {
+		t.Errorf("tmux args %v do not contain [-e PRISM_INITIAL_PROMPT_FILE=%s] — host-mode LayoutAgentOnly must now use file-based delivery (#1195)", args, filePath)
+	}
+
+	// The legacy inline env var must NOT appear — that was the pre-#1195 broken path.
 	for i, a := range args {
-		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT_FILE=") {
-			t.Errorf("tmux args %v contain PRISM_INITIAL_PROMPT_FILE for host mode — should only fire for bwrap/sandbox-exec", args)
+		if a == "-e" && i+1 < len(args) && strings.HasPrefix(args[i+1], "PRISM_INITIAL_PROMPT=") {
+			t.Errorf("tmux args contain inline PRISM_INITIAL_PROMPT for host mode — would re-introduce #1195 launch-cmd size failure: %v", args)
+			break
 		}
+	}
+
+	// The prompt file must exist and contain the prompt verbatim.
+	body, readErr := os.ReadFile(filePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v — prompt file must exist after host-mode SpawnSession (#1195)", filePath, readErr)
+	}
+	if string(body) != prompt {
+		t.Errorf("prompt round-trip mismatch: file=%q, want=%q", string(body), prompt)
 	}
 }
 
@@ -633,5 +650,173 @@ func TestSpawnSession_UnsupportedLayout_ReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "layout") {
 		t.Errorf("error %q does not mention layout", err.Error())
+	}
+}
+
+// TestSpawnSession_NeedsPromptFile_AllModesAndLayouts is a table-driven
+// regression test for issue #1195. It verifies that SpawnSession writes the
+// initial-prompt file for every (mode, layout) combination that carries a
+// non-empty prompt — including the LayoutAgentOnly+host cell that was missing
+// from the gate before #1195 and caused Darwin host-mode review fan-outs to
+// inline large prompts in the tmux argv.
+//
+// The test checks the observable outcome (file written to InitialPromptPath)
+// rather than the internal needsPromptFile variable, making it robust to
+// future refactors that rename or restructure the gate.
+func TestSpawnSession_NeedsPromptFile_AllModesAndLayouts(t *testing.T) {
+	cases := []struct {
+		name          string
+		layout        Layout
+		isolationMode string
+	}{
+		// LayoutFull cases
+		{"LayoutFull+host", LayoutFull, "host"},
+		{"LayoutFull+bwrap", LayoutFull, "bwrap"},
+		{"LayoutFull+sandbox-exec", LayoutFull, "sandbox-exec"},
+
+		// LayoutAgentOnly cases (the #1195 regression was LayoutAgentOnly+host)
+		{"LayoutAgentOnly+host", LayoutAgentOnly, "host"},
+		{"LayoutAgentOnly+bwrap", LayoutAgentOnly, "bwrap"},
+		{"LayoutAgentOnly+sandbox-exec", LayoutAgentOnly, "sandbox-exec"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// These tests cannot run in parallel: they rewrite TmuxBin and
+			// XDG_STATE_HOME (package-level globals).
+			d, _ := openSpawnTestDB(t)
+			_ = spyTmuxBin(t)
+			t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+			tmp := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", tmp)
+
+			const prompt = "review this PR — this is the initial prompt"
+			sessionName := "myrepo@branch~review-1-review-code-" + strings.ReplaceAll(tc.name, "+", "-")
+
+			opts := SpawnOpts{
+				SessionName:   sessionName,
+				Repo:          "myrepo",
+				Worktree:      "/worktrees/myrepo",
+				AgentRole:     "review-code",
+				Prompt:        prompt,
+				Layout:        tc.layout,
+				IsolationMode: tc.isolationMode,
+			}
+
+			if err := SpawnSession(d, opts); err != nil {
+				t.Fatalf("SpawnSession(%s): %v", tc.name, err)
+			}
+
+			// The prompt file must exist and contain the prompt verbatim.
+			filePath, pathErr := InitialPromptPath(sessionName)
+			if pathErr != nil {
+				t.Fatalf("InitialPromptPath: %v", pathErr)
+			}
+			body, readErr := os.ReadFile(filePath)
+			if readErr != nil {
+				t.Fatalf("ReadFile(%s): %v — SpawnSession(%s) must write the prompt file for every mode/layout combination when Prompt is non-empty (#1195)", filePath, readErr, tc.name)
+			}
+			if string(body) != prompt {
+				t.Errorf("SpawnSession(%s): prompt round-trip mismatch: file len=%d, prompt len=%d", tc.name, len(body), len(prompt))
+			}
+		})
+	}
+}
+
+// TestSpawnSession_AgentOnly_PromptFile_WriteFails_ReturnsError is the AC5
+// edge-case test for issue #1195. When WriteInitialPrompt fails (e.g. because
+// the run directory is not writable), SpawnSession must return a clear error
+// naming the failed write target and must NOT create any tmux session.
+//
+// We force the failure by making XDG_STATE_HOME point to a read-only
+// directory after sidecarStateDir() would resolve the path, so the
+// MkdirAll inside WriteInitialPrompt fails.
+func TestSpawnSession_AgentOnly_PromptFile_WriteFails_ReturnsError(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	argsFile := spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+
+	// Create a read-only root so any attempt to mkdir or write under it fails.
+	roDir := t.TempDir()
+	if err := os.Chmod(roDir, 0o555); err != nil {
+		t.Skipf("could not chmod dir to read-only: %v (skipping on this platform)", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o755) }) // restore so t.Cleanup can remove it
+	t.Setenv("XDG_STATE_HOME", roDir)
+
+	const sessionName = "myrepo@branch~review-1-review-code-write-fail"
+	opts := SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      "/worktrees/myrepo",
+		AgentRole:     "review-code",
+		Prompt:        "review this PR",
+		Layout:        LayoutAgentOnly,
+		IsolationMode: "bwrap",
+	}
+
+	err := SpawnSession(d, opts)
+	if err == nil {
+		t.Fatal("SpawnSession with read-only XDG_STATE_HOME: got nil error, want write-failure error (AC5 edge-case)")
+	}
+
+	// Error must mention the write operation so the operator can diagnose it.
+	if !strings.Contains(err.Error(), "write initial prompt") &&
+		!strings.Contains(err.Error(), "initial-prompt") &&
+		!strings.Contains(err.Error(), "spawn session") {
+		t.Errorf("error %q does not identify the write-failure cause — expected 'write initial prompt' or similar (#1195 AC5)", err.Error())
+	}
+
+	// No tmux session must have been created (fail before tmux state).
+	args := readSpyArgs(argsFile)
+	for _, a := range args {
+		if a == "new-session" {
+			t.Errorf("tmux new-session was invoked despite write failure — AC5 requires the spawn to fail before any tmux state is created; args: %v", args)
+			break
+		}
+	}
+}
+
+// TestSpawnSession_AgentOnly_PromptFile_CleanedUpOnReadinessTimeout verifies
+// AC6 (edge-case): the initial-prompt file is cleaned up when SpawnSession's
+// readiness gate trips on timeout. This ensures a second spawn attempt with the
+// same session name starts fresh rather than inheriting a stale prompt file.
+//
+// We rely on the existing readiness-gate-timeout path that fires when
+// ReadinessTimeout > 0 and no sidecar writes state_change events (the PRISM_TEST_SUBPROCESS
+// stub sidecar exits immediately, so no readiness signal ever arrives).
+func TestSpawnSession_AgentOnly_PromptFile_CleanedUpOnReadinessTimeout(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sessionName = "myrepo@branch~review-1-review-code-cleanup"
+	opts := SpawnOpts{
+		SessionName:      sessionName,
+		Repo:             "myrepo",
+		Worktree:         "/worktrees/myrepo",
+		AgentRole:        "review-code",
+		Prompt:           "review this PR",
+		Layout:           LayoutAgentOnly,
+		IsolationMode:    "bwrap",
+		ReadinessTimeout: 300 * time.Millisecond, // short; stub sidecar never signals readiness
+	}
+
+	// The spawn will fail (readiness gate trips after 300ms).
+	if err := SpawnSession(d, opts); err == nil {
+		t.Fatal("SpawnSession with short ReadinessTimeout: got nil, want *ReadinessTimeoutError")
+	}
+
+	// AC6: the initial-prompt file must be removed after the readiness-gate
+	// timeout cleanup path runs removeInitialPrompt.
+	filePath, pathErr := InitialPromptPath(sessionName)
+	if pathErr != nil {
+		t.Fatalf("InitialPromptPath: %v", pathErr)
+	}
+	if _, err := os.Stat(filePath); err == nil {
+		t.Errorf("initial-prompt file %s still exists after readiness-gate timeout cleanup — AC6 requires it to be removed so a re-spawn with the same session name starts fresh (#1195)", filePath)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the regression reported in #1195: `prism review` fails with `command too long` from tmux when a Darwin host-mode coordinator reviews any PR with a non-trivial diff.

**Root cause:** The `needsPromptFile` gate in `SpawnSession` had a missing cell:

| Layout | host | bwrap | sandbox-exec |
|---|---|---|---|
| `LayoutFull` | ✅ file | ✅ file | ✅ file |
| `LayoutAgentOnly` | ❌ **inline** (pre-fix) | ✅ file | ✅ file |

Darwin coordinators use `LayoutAgentOnly + host` for review fan-outs. The fix makes the invariant universal: every mode/layout combination with a non-empty prompt uses the file path.

## What this changes

**Production fix:**
- `spawn.go`: unified `needsPromptFile` gate — `opts.Prompt != "" && (mode == "host" || isSandbox)` — covering `LayoutAgentOnly+host` for the first time
- `spawn.go`: pre-spawn size check extended to include `LayoutAgentOnly+host` cell
- `spawn.go`, `session.go`: comments updated to reflect universal file-path invariant

**Tests:**
- `spawn_test.go`: updated `TestSpawnSession_AgentOnly_PromptEnvVar_WithPrompt_Host` to assert new correct behavior (file-based, not inline)
- `spawn_test.go`: `TestSpawnSession_NeedsPromptFile_AllModesAndLayouts` — table-driven test for all 6 mode×layout combinations
- `spawn_test.go`: `TestSpawnSession_AgentOnly_PromptFile_WriteFails_ReturnsError` — AC5 edge-case (write failure → error before tmux state)
- `spawn_test.go`: `TestSpawnSession_AgentOnly_PromptFile_CleanedUpOnReadinessTimeout` — AC6 edge-case (file cleaned up on timeout)
- `review/spawn_prompt_file_test.go`: integration tests synthesising >100 KiB review context for bwrap, sandbox-exec, and **host** modes

## Verification

```
go build ./...   # passes
go test ./internal/session/... # passes
go test ./internal/review/... -run TestSpawnReviewAgent -v
# TestSpawnReviewAgent_LargePrompt_UsesPromptFile: 150 KiB, bwrap — PASS
# TestSpawnReviewAgent_LargePrompt_HostMode: 118 KiB, host — PASS
# TestSpawnReviewAgent_LargePrompt_SandboxExec: sandbox-exec — PASS
```

Closes #1195