### PR TITLE
Disable qutebrowser on m4mac

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -41,6 +41,7 @@ in
       homeAutomation.enable = true;
       aws.enable = true;
       gitlab-cli.enable = true;
+      qutebrowser.enable = false; # broken, due to https://github.com/NixOS/nixpkgs/issues/514179
     };
     desktop = {
       theme = "onedark";


### PR DESCRIPTION
Disabled qutebrowser in the m4mac configuration due to an upstream breakage tracked in nixpkgs. This prevents build failures while waiting for an upstream resolution.