### PR TITLE
prism: A1.L1-L6 — lifecycle migrations

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -204,7 +204,7 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 	logFile := opts.LogFile
 	status := loadAgentRunStatus(sessionName)
 	if status == nil {
-		return fmt.Errorf("agent-run: session %q not found in cached status", sessionName)
+		return errAgentRunNoStatus(sessionName)
 	}
 
 	// Load prism config for git identity and SSH key names.

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -43,6 +43,7 @@ package cmd
 //	--session <name>   prism session name (e.g. "nixos-config@feature")
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -63,6 +64,15 @@ import (
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
 )
+
+// errAgentRunNoStatus is the error a registered AgentRun handler returns
+// when the dispatcher has not stashed a DB status in the per-session cache.
+// In practice this should not happen — runAgentRun stashes the status
+// before calling iso.AgentRun — but the handler surfaces a clear error
+// rather than panicking on a nil pointer.
+func errAgentRunNoStatus(sessionName string) error {
+	return fmt.Errorf("agent-run: session %q: status cache is empty (programming error)", sessionName)
+}
 
 var agentRunCmd = &cobra.Command{
 	Use:   "agent-run",
@@ -85,6 +95,23 @@ func init() {
 	agentRunCmd.Flags().String("session", "", "Prism session name (e.g. nixos-config@main)")
 	_ = agentRunCmd.MarkFlagRequired("session")
 	rootCmd.AddCommand(agentRunCmd)
+
+	// Register the per-mode AgentRun handlers with the container package
+	// (issue #1140 A1.L6). The dispatch in cmd/agent_run.go's runAgentRun
+	// resolves the persisted isolation mode from the DB, looks up the
+	// registered isolator via container.For(mode, ...), and calls
+	// iso.AgentRun(ctx, opts) — which routes back here via the registered
+	// handlers below.
+	//
+	// Keeping the handler bodies in the cmd package (rather than moving
+	// them into internal/container) is a deliberate scope decision: moving
+	// them would create a circular dependency with internal/session,
+	// internal/git, internal/harness, and internal/db, none of which the
+	// container package imports today. Registration at init() time keeps
+	// the dispatch shape (`iso.AgentRun(ctx, opts)`) without re-plumbing
+	// the dependency graph.
+	container.RegisterAgentRunHandler(config.IsolationBwrap, runAgentRunBwrapHandler)
+	container.RegisterAgentRunHandler(config.IsolationSandboxExec, runAgentRunSandboxExecHandler)
 }
 
 func runAgentRun(cmd *cobra.Command, args []string) error {
@@ -123,23 +150,61 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// Dispatch based on the session's isolation mode.
-	isoMode := status.EffectiveIsolationMode()
-	switch config.IsolationMode(isoMode) {
+	//
+	// Post A1.L6 (issue #1140): the per-mode switch collapses to a single
+	// container.For(mode).AgentRun(ctx, opts) call. host and podman are not
+	// valid modes for `prism agent-run`; the registered isolator returns
+	// the original "this command is only for bwrap and sandbox-exec
+	// sessions" error verbatim, replacing the manual `else` arm.
+	isoMode := config.IsolationMode(status.EffectiveIsolationMode())
+
+	// Belt-and-braces platform guard. The container.For-resolved isolator's
+	// AgentRun body would also fail eventually (bubblewrap is Linux-only,
+	// sandbox-exec is macOS-only) but the platform check here surfaces a
+	// clearer error before the binary lookup. Mirrors the pre-refactor
+	// switch's runtime.GOOS gates.
+	switch isoMode {
 	case config.IsolationBwrap:
-		// Fail fast on non-Linux: bubblewrap is Linux-only.
 		if runtime.GOOS != "linux" {
 			return fmt.Errorf("prism agent-run: bwrap isolation requires Linux; current platform is %s", runtime.GOOS)
 		}
 	case config.IsolationSandboxExec:
-		// Fail fast on non-Darwin: sandbox-exec is macOS-only.
-		// The platform guard in spawn.go also catches this at spawn time;
-		// belt-and-braces guard for direct invocations of agent-run.
 		if runtime.GOOS != "darwin" {
 			return fmt.Errorf("prism agent-run: sandbox-exec isolation requires macOS (Darwin); current platform is %s", runtime.GOOS)
 		}
-		return runAgentRunSandboxExec(sessionName, status, agentRunStart, logFile)
-	default:
-		return fmt.Errorf("agent-run: session %q has isolation mode %q; this command is only for bwrap and sandbox-exec sessions", sessionName, isoMode)
+	}
+
+	iso, err := container.For(isoMode, container.ConstructorOpts{Name: sessionName})
+	if err != nil {
+		return fmt.Errorf("agent-run: %w", err)
+	}
+
+	// The handler stashes the looked-up status on the package-level cache
+	// so the registered handlers (which only get AgentRunOpts) can read it
+	// without re-querying the DB. The cache is per-session-name and is
+	// cleared by the handler when it is done.
+	storeAgentRunStatus(sessionName, status)
+	defer clearAgentRunStatus(sessionName)
+
+	return iso.AgentRun(cmd.Context(), container.AgentRunOpts{
+		SessionName: sessionName,
+		StartTime:   agentRunStart,
+		LogFile:     logFile,
+	})
+}
+
+// runAgentRunBwrapHandler is the registered AgentRun handler for the bwrap
+// isolation mode (issue #1140 A1.L6). It is the body that previously lived
+// in the bwrap arm of runAgentRun's switch statement. The handler reads the
+// pre-looked-up DB status from the package-level cache populated by
+// runAgentRun.
+func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) error {
+	sessionName := opts.SessionName
+	agentRunStart := opts.StartTime
+	logFile := opts.LogFile
+	status := loadAgentRunStatus(sessionName)
+	if status == nil {
+		return fmt.Errorf("agent-run: session %q not found in cached status", sessionName)
 	}
 
 	// Load prism config for git identity and SSH key names.

--- a/modules/programs/prism/prism/cmd/agent_run_handlers.go
+++ b/modules/programs/prism/prism/cmd/agent_run_handlers.go
@@ -1,0 +1,70 @@
+package cmd
+
+// Per-session DB status cache for the AgentRun dispatch path (issue #1140
+// A1.L6). The runAgentRun command opens the prism DB once at the top of the
+// dispatch, looks up the session status, and stashes it here so the
+// registered AgentRun handlers (runAgentRunBwrapHandler,
+// runAgentRunSandboxExecHandler) can read it without re-querying the DB.
+//
+// The cache is populated by runAgentRun before iso.AgentRun is invoked and
+// cleared by the same function on return (deferred). It must therefore not
+// be shared across invocations of `prism agent-run` — a single agent-run
+// process services exactly one session.
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var (
+	agentRunStatusMu sync.Mutex
+	// agentRunStatusCache is keyed by session name. In practice the map
+	// contains at most one entry at a time (runAgentRun is single-shot per
+	// process); the map shape lets us key cleanly without a global pointer
+	// race.
+	agentRunStatusCache = map[string]*db.Status{}
+)
+
+// storeAgentRunStatus stashes the looked-up DB status for sessionName so the
+// registered AgentRun handler can read it via loadAgentRunStatus. Called
+// once by runAgentRun before iso.AgentRun.
+func storeAgentRunStatus(sessionName string, status *db.Status) {
+	agentRunStatusMu.Lock()
+	defer agentRunStatusMu.Unlock()
+	agentRunStatusCache[sessionName] = status
+}
+
+// loadAgentRunStatus returns the cached DB status for sessionName, or nil
+// when no entry has been stored. The handler treats nil as "DB lookup
+// failed" and surfaces a clear error.
+func loadAgentRunStatus(sessionName string) *db.Status {
+	agentRunStatusMu.Lock()
+	defer agentRunStatusMu.Unlock()
+	return agentRunStatusCache[sessionName]
+}
+
+// clearAgentRunStatus removes the cached entry for sessionName. Called via
+// defer from runAgentRun so the cache is cleared even when the handler
+// returns an error.
+func clearAgentRunStatus(sessionName string) {
+	agentRunStatusMu.Lock()
+	defer agentRunStatusMu.Unlock()
+	delete(agentRunStatusCache, sessionName)
+}
+
+// runAgentRunSandboxExecHandler is the registered AgentRun handler for the
+// sandbox-exec isolation mode (issue #1140 A1.L6). It forwards to
+// runAgentRunSandboxExec, which is implemented per-platform
+// (agent_run_sandbox_exec_darwin.go on Darwin, _other.go elsewhere) and
+// owns the kqueue parent-death watcher and the supervised-child lifecycle.
+func runAgentRunSandboxExecHandler(ctx context.Context, opts container.AgentRunOpts) error {
+	sessionName := opts.SessionName
+	status := loadAgentRunStatus(sessionName)
+	if status == nil {
+		return errAgentRunNoStatus(sessionName)
+	}
+	return runAgentRunSandboxExec(sessionName, status, opts.StartTime, opts.LogFile)
+}

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -992,26 +991,33 @@ func stopAndRemoveChildContainers(d *db.DB, parentSession string) {
 	for _, childSession := range childNames {
 		name := container.NameForSession(childSession)
 
-		// Stop (5-second grace). Independent context so a slow stop doesn't
-		// starve the rm --force that follows.
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
-		stopCmd := exec.CommandContext(stopCtx, "podman", "stop", "--time", "5", name)
-		if out, err := stopCmd.CombinedOutput(); err != nil {
-			if !container.IsNoSuchContainerError(string(out)) {
-				fmt.Fprintf(os.Stderr, "[prism] warning: stop review container %q (child of %q): %v — continuing\n", name, parentSession, err)
+		// Resolve the child session's persisted isolation mode. Most review
+		// children are podman today, but bwrap/sandbox-exec children are
+		// supported under #1197 — dispatching via the registry handles all
+		// modes uniformly. Fall back to podman when the DB row is missing or
+		// the column is empty (matches pre-refactor behaviour).
+		isoMode := config.IsolationPodman
+		if d != nil {
+			if modeStr := isolationModeFromDB(d, childSession); modeStr != "" {
+				isoMode = config.IsolationMode(modeStr)
 			}
 		}
-		stopCancel()
 
-		// Force-remove. Independent context ensures this always runs.
-		rmCtx, rmCancel := context.WithTimeout(context.Background(), 15*time.Second)
-		rmCmd := exec.CommandContext(rmCtx, "podman", "rm", "--force", name)
-		if out, err := rmCmd.CombinedOutput(); err != nil {
-			if !container.IsNoSuchContainerError(string(out)) {
-				fmt.Fprintf(os.Stderr, "[prism] warning: rm review container %q (child of %q): %v — continuing\n", name, parentSession, err)
+		iso, isoErr := container.For(isoMode, container.ConstructorOpts{Name: name})
+		if isoErr != nil {
+			// Unknown mode — fall back to podman.
+			if iso, isoErr = container.For(config.IsolationPodman, container.ConstructorOpts{Name: name}); isoErr != nil {
+				fmt.Fprintf(os.Stderr, "[prism] warning: stopAndRemoveChildContainers: unknown mode %q for %q: %v\n", isoMode, childSession, isoErr)
+				continue
 			}
 		}
-		rmCancel()
+
+		// 30-second budget collapses the previous 15s stop + 15s rm split.
+		// The podman isolator internally issues stop (10s grace) followed
+		// by rm --force.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		iso.EnsureRemoved(ctx, nil)
+		cancel()
 	}
 }
 
@@ -1021,42 +1027,49 @@ func stopAndRemoveChildContainers(d *db.DB, parentSession string) {
 // Called after KillSidecar to handle the case where the sidecar is already dead.
 // For host-mode (non-container) sessions, the podman calls return "no such
 // container" which is silently ignored.
-// Each podman command gets its own independent context so that a slow or
-// hung stop does not consume the budget for the rm --force fallback.
+//
+// Post A1.L1 (issue #1140): the per-mode stop/rm + temp-file cleanup logic
+// moved into the registered Isolator's EnsureRemoved method. This function
+// resolves the session's persisted isolation mode (with podman as the
+// fallback for pre-migration rows) and dispatches via
+// registry.For(mode).EnsureRemoved. Both contexts (20s for stop, 15s for rm)
+// are kept by collapsing into a single 35s budget consumed by the isolator.
 func removeContainerIfExists(sessionName string) {
 	name := container.NameForSession(sessionName)
 
-	// Stop the container (10s grace period). Own context so that a slow stop
-	// cannot starve the rm --force that follows.
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer stopCancel()
-	stopCmd := exec.CommandContext(stopCtx, "podman", "stop", "--time", "10", name)
-	if out, err := stopCmd.CombinedOutput(); err != nil {
-		if !container.IsNoSuchContainerError(string(out)) {
-			fmt.Fprintf(os.Stderr, "[prism] stop container %q: %v\n", name, err)
+	// Resolve the session's persisted isolation mode. When the DB row is
+	// missing or has an empty isolation_mode, fall back to podman: that is
+	// the pre-refactor behaviour (the open-coded podman stop/rm always ran
+	// regardless of mode, and the "no such container" path was silently
+	// ignored).
+	isoMode := config.IsolationPodman
+	if d, dbErr := openDB(); dbErr == nil {
+		modeStr := isolationModeFromDB(d, sessionName)
+		d.Close()
+		if modeStr != "" {
+			isoMode = config.IsolationMode(modeStr)
 		}
 	}
 
-	// Force-remove the container. Independent context ensures this always runs
-	// even when podman stop timed out.
-	rmCtx, rmCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer rmCancel()
-	rmCmd := exec.CommandContext(rmCtx, "podman", "rm", "--force", name)
-	if out, err := rmCmd.CombinedOutput(); err != nil {
-		if !container.IsNoSuchContainerError(string(out)) {
-			fmt.Fprintf(os.Stderr, "[prism] rm container %q: %v\n", name, err)
+	// Per-mode dispatch: podman runs stop/rm + temp-file cleanup; bwrap and
+	// sandbox-exec do temp-file cleanup only; host is a no-op.
+	iso, isoErr := container.For(isoMode, container.ConstructorOpts{Name: name})
+	if isoErr != nil {
+		// Unknown mode — fall back to the podman path so the legacy
+		// behaviour (always try podman stop/rm) is preserved.
+		if iso, isoErr = container.For(config.IsolationPodman, container.ConstructorOpts{Name: name}); isoErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism] removeContainerIfExists: unknown isolation mode %q for %q: %v\n", isoMode, sessionName, isoErr)
+			return
 		}
 	}
 
-	// Clean up temp files created by container.Manager.Create. This list must
-	// stay in sync with container.Manager.EnsureRemoved / Shutdown so that
-	// a direct cleanup path (sidecar already dead) leaves no stale files
-	// behind that a subsequent Create would otherwise overwrite.
-	_ = os.Remove(filepath.Join(os.TempDir(), "prism-gitdir-"+name))
-	_ = os.Remove(filepath.Join(os.TempDir(), "prism-wt-gitdir-"+name))
-	_ = os.Remove(filepath.Join(os.TempDir(), "prism-ssh-config-"+name))
-	_ = os.Remove(filepath.Join(os.TempDir(), "prism-gitconfig-"+name))
-	_ = os.Remove(filepath.Join(os.TempDir(), "prism-allowed-signers-"+name))
+	// Single 35s budget for the per-mode EnsureRemoved (was: 20s stop + 15s
+	// rm in two independent contexts). The isolator's EnsureRemoved owns the
+	// internal split; for podman it issues the same stop+rm sequence with
+	// the same 10s grace.
+	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+	defer cancel()
+	iso.EnsureRemoved(ctx, nil)
 
 	// Clean up the host-API Unix socket, the agent-run log, and their
 	// per-session directory. The sidecar's own shutdown path would normally

--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -20,15 +20,18 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/container"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -86,10 +89,15 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		fmt.Println("  tmux server killed.")
 	}
 
-	// ── Step 2: Remove prism- podman containers ───────────────────────────────
+	// ── Step 2: Reset every registered isolator ──────────────────────────────
+	// Post A1.L3 (issue #1140): the per-mode reset logic moved into each
+	// Isolator's Reset method. `prism reset` iterates over the registered
+	// modes and dispatches to each. Today only podman has a non-stub Reset
+	// body (the prism-* container sweep); bwrap, sandbox-exec, and host
+	// return nil — orphan-agent-run reaping is a future implementation.
 	fmt.Println("Removing prism- podman containers...")
-	if err := resetRemovePodmanContainers(); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism reset] podman cleanup: %v (continuing)\n", err)
+	if err := resetIsolators(); err != nil {
+		fmt.Fprintf(os.Stderr, "[prism reset] isolator cleanup: %v (continuing)\n", err)
 	}
 
 	// ── Step 3: Mark all agent_status rows as ended ───────────────────────────
@@ -123,66 +131,38 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	return launchCmd.Run()
 }
 
-// resetRemovePodmanContainers lists all podman containers whose names start
-// with "prism-" and removes them. If podman is not available or returns no
-// containers, the function is a no-op.
-func resetRemovePodmanContainers() error {
-	podmanBin, err := exec.LookPath("podman")
-	if err != nil {
-		// podman not installed — nothing to do.
-		fmt.Println("  podman not found — skipping container cleanup.")
-		return nil
-	}
+// resetIsolators iterates over every registered isolation mode and calls
+// Reset on each one. Returns the first non-nil error encountered (other
+// modes still get a chance to run). Today only podmanIsolator.Reset has a
+// non-stub body — the prism-* container sweep (was: resetRemovePodmanContainers).
+//
+// Failures are logged at the call site (Step 2 in runReset); this function
+// returns the error verbatim so the caller can decide whether to continue.
+func resetIsolators() error {
+	// Use a generous per-mode timeout so a slow `podman ps` does not starve
+	// the rm step. The podman implementation issues two podman calls
+	// (`ps -a` then `rm -f <ids...>`); 60 s covers both with margin.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
-	// Fetch "name\tid" for every container (including stopped ones).
-	//
-	// We avoid --filter name=prism- because podman's name filter is a
-	// substring match, not a prefix match — it would incorrectly include
-	// containers like "not-prism-foo". Instead we do the prefix check
-	// client-side after fetching all names.
-	//
-	// We avoid --format {{.Names}} alone because podman emits comma-separated
-	// values for containers with multiple aliases (e.g. "prism-foo,prism-foo-alias"),
-	// which breaks `podman rm -f` when passed as a single argument. Using
-	// {{.ID}} gives a stable, unique identifier; we only use {{.Names}} here
-	// to decide which containers to target.
-	out, err := exec.Command(podmanBin, "ps", "-a", "--format", "{{.Names}}\t{{.ID}}").Output()
-	if err != nil {
-		// If podman fails (e.g. no running machine), treat as no containers.
-		fmt.Printf("  podman ps failed: %v — skipping container cleanup.\n", err)
-		return nil
-	}
-
-	var prismContainers []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	var firstErr error
+	for _, mode := range container.Names() {
+		iso, err := container.For(mode, container.ConstructorOpts{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[prism reset] %s: %v\n", mode, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		// parts[0] may be "name" or "name1,name2,..."; check the first name only.
-		firstName := strings.SplitN(parts[0], ",", 2)[0]
-		if strings.HasPrefix(firstName, "prism-") {
-			prismContainers = append(prismContainers, strings.TrimSpace(parts[1]))
+		if err := iso.Reset(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "[prism reset] %s: %v\n", mode, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
-
-	if len(prismContainers) == 0 {
-		fmt.Println("  no prism- containers found.")
-		return nil
-	}
-
-	fmt.Printf("  removing %d container(s)\n", len(prismContainers))
-	args := append([]string{"rm", "-f"}, prismContainers...)
-	rmOut, err := exec.Command(podmanBin, args...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("podman rm -f: %w\n%s", err, strings.TrimSpace(string(rmOut)))
-	}
-	fmt.Println("  containers removed.")
-	return nil
+	return firstErr
 }
 
 // resetMarkDBEnded opens the prism DB and calls MarkAllEnded to update all

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -33,6 +33,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/prismatic-koi/prism/internal/config"
 )
 
 const (
@@ -574,58 +576,19 @@ func (m *Manager) WorktreeGitdirFilePath() string { return m.worktreeGitdirFileP
 // Call this from "prism agent-run" in the tmux pane for bwrap mode. The
 // returned args slice is suitable for passing directly to exec.Exec("bwrap").
 //
-// Note: this method also calls prepareVolumeDirs() to ensure bind-mount
-// sources exist. bwrap (unlike podman) does not emit an exit-125 error for
-// missing sources — it simply fails to bind. Eagerly creating the directories
-// avoids confusing "No such file or directory" errors at bwrap startup.
+// Post A1.L4 (issue #1140): the body of this method moved into
+// bwrapIsolator.Prepare; this method is now a thin dispatcher that resolves
+// the bwrap isolator from the registry and forwards to its Prepare method.
 func (m *Manager) PrepareBwrap() ([]string, error) {
-	// Write a minimal SSH config for bwrap. The bwrap SSH key mount remaps
-	// the host signing/access keys to canonical generic paths under
-	// $HOME/.ssh/ inside the sandbox (see bwrap.go), so the IdentityFile path
-	// is $HOME/.ssh/access-key — same generic name as the podman path, just
-	// rooted at the host user's $HOME instead of /root.
-	if err := m.writeSshConfig(isolationBwrap); err != nil {
+	iso, err := For(config.IsolationBwrap, ConstructorOpts{Name: m.name})
+	if err != nil {
 		return nil, fmt.Errorf("container: bwrap: %w", err)
 	}
-
-	// Write the gitconfig. Mirrors the Create() path, but with bwrap-mode
-	// paths (signingKey and allowedSignersFile rooted at <hostHome>/.ssh/
-	// rather than /root/.ssh/).
-	if err := m.writeGitconfig(isolationBwrap); err != nil {
-		return nil, fmt.Errorf("container: bwrap: write gitconfig: %w", err)
-	}
-
-	// Write the opencode config file, if provided.
-	if m.cfg.ConfigContent != "" {
-		if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o644); err != nil {
-			return nil, fmt.Errorf("container: bwrap: write opencode config: %w", err)
-		}
-	}
-
-	// Pre-create directories that BuildArgs will reference as bind-mount
-	// sources. bwrap silently fails rather than printing a clear error, so
-	// we create eagerly here.
-	if err := m.prepareVolumeDirs(false); err != nil {
-		log.Printf("container: bwrap: prepareVolumeDirs partial failure: %v", err)
-	}
-
-	// Build the bwrap args.
-	b := &bwrapIsolator{name: m.name}
-	return b.BuildArgs(m), nil
+	return iso.Prepare(context.Background(), m)
 }
 
 // PrepareSandboxExec prepares the per-session staging HOME, writes the SBPL
 // profile, and returns the complete sandbox-exec argument list.
-//
-// Steps:
-//  1. PrepareSandboxExecHome() — create the staging HOME directory tree and
-//     populate it with symlinks to the host credential, config, and cache
-//     paths. On Darwin this also calls writeClaudeCredentials() so that the
-//     Keychain-extracted credentials file is reachable at
-//     $HOME/.claude/.credentials.json via the .claude symlink.
-//  2. writeProfile() — generate the SBPL profile with staging HOME,
-//     worktree, credential, and AWS deny rules, and write it to a temp file.
-//  3. Build and return the sandbox-exec argument list.
 //
 // The returned args slice is suitable for passing directly to
 // syscall.Exec("/usr/bin/sandbox-exec", args, env). The first element of
@@ -634,35 +597,15 @@ func (m *Manager) PrepareBwrap() ([]string, error) {
 // The env passed to syscall.Exec should set HOME=<staging_home> so that
 // opencode and its tools find credentials and config at their canonical paths
 // inside the staging HOME. agent_run.go constructs that env after this call.
+//
+// Post A1.L4 (issue #1140): the body of this method moved into
+// sandboxExecIsolator.Prepare; this method is now a thin dispatcher.
 func (m *Manager) PrepareSandboxExec() ([]string, error) {
-	// Populate the staging HOME with symlinks. This must happen before
-	// generateProfile() so the profile generator can call
-	// collectStagingHomeSymlinkTargets to emit (allow file-read* (literal ...))
-	// rules for every resolved symlink target.
-	//
-	// Non-fatal: if the staging HOME cannot be created (e.g. the home dir is
-	// read-only, as in the nix sandbox build environment), log a warning and
-	// continue with a degraded profile. The sandbox will still launch but will
-	// lack the staged credentials and caches.
-	stagingHome, err := m.PrepareSandboxExecHome()
+	iso, err := For(config.IsolationSandboxExec, ConstructorOpts{Name: m.name})
 	if err != nil {
-		log.Printf("container: sandbox-exec: prepare staging home: %v — launching with degraded profile", err)
+		return nil, fmt.Errorf("container: sandbox-exec: %w", err)
 	}
-	_ = stagingHome // consumed by generateProfile via m.sandboxExecHomePath()
-
-	// On Darwin, extract Claude Code credentials from the macOS Keychain and
-	// write them to a temp file. The temp file path (m.claudeCredentialsFilePath())
-	// is reachable inside the sandbox at $HOME/.claude/.credentials.json via the
-	// .claude symlink in the staging HOME (which points at host ~/.claude).
-	// The writeClaudeCredentials helper sets m.claudeCredentialsReady on success.
-	m.writeClaudeCredentials()
-
-	if _, err := writeProfile(m); err != nil {
-		return nil, err
-	}
-
-	s := &sandboxExecIsolator{name: m.name}
-	return s.BuildArgs(m), nil
+	return iso.Prepare(context.Background(), m)
 }
 
 // prepareVolumeDirs eagerly creates host directories that buildRunArgs() will

--- a/modules/programs/prism/prism/internal/container/isolator.go
+++ b/modules/programs/prism/prism/internal/container/isolator.go
@@ -197,6 +197,78 @@ type Isolator interface {
 	// interface.
 	// Cites: A1 §3 (LogPaths future shape).
 	LogPaths() LogPaths
+
+	// ----- A1.L1-L6 lifecycle methods ----------------------------------------
+	//
+	// Implementations live in lifecycle_dispatch.go. Each method's body is
+	// mechanically equivalent to the per-mode branch it replaces — see the
+	// per-method comments in lifecycle_dispatch.go for the call-site citations.
+
+	// EnsureRemoved tears down any per-session state owned by this isolator
+	// (containers, sandbox processes, temp files, staging directories).
+	// It must use the supplied context for deadlines but proceed on
+	// best-effort — errors for "already gone" are silently swallowed by the
+	// implementation. m carries the Manager state (temp file paths,
+	// InstanceID) consulted by the implementation; it may be nil for
+	// callers that do not own a Manager (cmd/cleanup.go's
+	// removeContainerIfExists path), in which case implementations fall
+	// back to the per-session temp-path helpers in container.go.
+	// Cites: internal/container/lifecycle.go:24 (Manager.EnsureRemoved);
+	//        cmd/cleanup.go:1026 (removeContainerIfExists).
+	EnsureRemoved(ctx context.Context, m *Manager)
+
+	// WriteGitconfig generates a minimal .gitconfig for this isolator's
+	// sandbox layout and writes it to the per-session temp path. The
+	// in-sandbox $HOME differs per mode — podman runs as root (/root),
+	// bwrap/sandbox-exec run as the host user — so each isolator picks
+	// the correct $HOME prefix when emitting the signingKey and
+	// allowedSignersFile paths. Returns nil on success or a wrapped error.
+	// host: no-op (the agent reads the host gitconfig directly).
+	// Cites: internal/container/container.go:451 (writeGitconfig with mode);
+	//        internal/container/lifecycle.go:121 (Create caller);
+	//        internal/container/container.go:594 (PrepareBwrap caller).
+	WriteGitconfig(m *Manager) error
+
+	// Reset performs the heavier "wipe everything matching this mode"
+	// cleanup invoked by `prism reset`. For podman this is the existing
+	// `podman ps` / `podman rm -f prism-*` sweep. For bwrap, sandbox-exec,
+	// and host the implementation is a no-op stub today; orphan-agent-run
+	// reaping is a future implementation. `prism reset` iterates over the
+	// registered isolators and calls Reset on each.
+	// Cites: cmd/reset.go:126 (resetRemovePodmanContainers).
+	Reset(ctx context.Context) error
+
+	// Prepare materialises any per-session temp files (SSH config,
+	// gitconfig, harness config, sandbox staging HOME, SBPL profile) that
+	// the sandbox needs at start time and returns the complete argument
+	// list for the sandbox launcher. Bwrap returns the bwrap argv;
+	// sandbox-exec returns the sandbox-exec argv. Podman/host return nil
+	// args and a non-nil error — they do not use this dispatch path
+	// (podman uses Create; host runs opencode directly in the tmux pane).
+	// Cites: internal/container/container.go:581 (Manager.PrepareBwrap);
+	//        internal/container/container.go:637 (Manager.PrepareSandboxExec).
+	Prepare(ctx context.Context, m *Manager) ([]string, error)
+
+	// Create starts a new isolated session: writes any pre-launch temp
+	// files, builds the launcher arg list, and runs it under the supplied
+	// context. Today only podman implements a non-stub body — bwrap and
+	// sandbox-exec use Prepare + cmd/agent-run, and host runs opencode
+	// directly in the tmux pane. Non-podman implementations return nil
+	// (host) or an error noting that Create is not the right entry point
+	// for that mode (bwrap, sandbox-exec).
+	// Cites: internal/container/lifecycle.go:79 (Manager.Create body).
+	Create(ctx context.Context, m *Manager) error
+
+	// AgentRun executes the agent (opencode) inside this isolation mode.
+	// Bwrap and sandbox-exec own a real implementation: they reconstruct
+	// the container.Config from the supplied AgentRunOpts, materialise
+	// temp files, and exec/spawn the sandbox launcher with PTY and signal
+	// forwarding. Host and podman return errors because `prism agent-run`
+	// is not the entry point for those modes (host runs opencode directly
+	// in the tmux pane; podman is driven by the sidecar via podman attach).
+	// Cites: cmd/agent_run.go:90 (runAgentRun dispatch);
+	//        cmd/agent_run.go:128-143 (per-mode switch).
+	AgentRun(ctx context.Context, opts AgentRunOpts) error
 }
 
 // podmanIsolator implements Isolator using rootless podman.

--- a/modules/programs/prism/prism/internal/container/lifecycle.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle.go
@@ -6,9 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -21,8 +18,19 @@ import (
 // and does not match the current InstanceID, a warning is logged indicating
 // that the container belongs to a different session instance. Removal still
 // proceeds regardless — the new session needs the container name.
+//
+// Post A1.L1 (issue #1140): the per-mode logic moved into the registered
+// Isolator's EnsureRemoved method. Manager.EnsureRemoved is a thin
+// dispatcher that also unlinks the per-session temp files unconditionally
+// (the legacy "defensive cleanup" behaviour, mode-agnostic) so that a stale
+// session's mode-mismatched temp files do not survive the cleanup pass.
 func (m *Manager) EnsureRemoved(ctx context.Context) {
-	// Clean up temp files created by Create.
+	// Mode-agnostic temp-file cleanup: always remove every per-session
+	// artefact regardless of which isolator the Manager was constructed
+	// for. This preserves the pre-refactor "defensive cleanup" behaviour
+	// where Manager.EnsureRemoved unlinked all temp files, including those
+	// belonging to other modes (so a session that switched modes between
+	// runs leaves no orphan files on disk).
 	_ = os.Remove(m.gitdirFilePath())
 	_ = os.Remove(m.worktreeGitdirFilePath())
 	_ = os.Remove(m.sshConfigFilePath())
@@ -31,141 +39,24 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.opencodeConfigFilePath())
 	_ = os.Remove(m.claudeCredentialsFilePath())
 	_ = os.Remove(m.sandboxExecProfilePath())
-	// Remove the per-session sandbox-exec staging HOME directory tree.
 	if stagingHome, err := m.sandboxExecHomePath(); err == nil {
 		_ = os.RemoveAll(stagingHome)
 	}
 
-	// Check the container's instance label when we have our own InstanceID.
-	// This detects ownership mismatches where a container from a previous
-	// session incarnation is being cleaned up by a new one.
-	if m.cfg.InstanceID != "" {
-		inspectCtx, inspectCancel := context.WithTimeout(ctx, 5*time.Second)
-		out, inspectErr := exec.CommandContext(inspectCtx, "podman", "inspect",
-			"--format", `{{index .Config.Labels "prism.instance-id"}}`,
-			m.name,
-		).Output()
-		inspectCancel()
-		if inspectErr == nil {
-			containerInstanceID := strings.TrimSpace(string(out))
-			if containerInstanceID != "" && containerInstanceID != m.cfg.InstanceID {
-				log.Printf("container: warning: container %q has instance-id %q but current session has %q — removing anyway",
-					m.name, containerInstanceID, m.cfg.InstanceID)
-			}
-		}
-	}
-
-	// Stop the container (ignore errors — may not be running).
-	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", m.name)
-	if out, err := stopCmd.CombinedOutput(); err != nil {
-		// Only log if it looks like a real error (not "no such container").
-		if !IsNoSuchContainerError(string(out)) {
-			log.Printf("container: stop existing %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
-		}
-	}
-
-	// Remove the container (ignore errors — may not exist).
-	rmCmd := exec.CommandContext(ctx, "podman", "rm", "--force", m.name)
-	if out, err := rmCmd.CombinedOutput(); err != nil {
-		if !IsNoSuchContainerError(string(out)) {
-			log.Printf("container: rm existing %q: %v — %s", m.name, err, strings.TrimSpace(string(out)))
-		}
-	}
+	// Per-mode lifecycle cleanup (podman stop/rm for the podman isolator;
+	// no-op for the others) lives on the registered Isolator. See
+	// lifecycle_dispatch.go (issue #1140 A1.L1).
+	m.isolator.EnsureRemoved(ctx, m)
 }
 
 // Create creates and starts the podman container for this session.
 // It first calls EnsureRemoved to handle any stale container with the same name.
 // Returns an error if podman create or start fails.
+//
+// Post A1.L5 (issue #1140): the per-mode session-start logic moved into the
+// registered Isolator's Create method. Manager.Create is a thin dispatcher.
 func (m *Manager) Create(ctx context.Context) error {
-	createStart := time.Now()
-
-	// Remove any stale container first (AC-15).
-	m.EnsureRemoved(ctx)
-	log.Printf("[timing] EnsureRemoved: %s", time.Since(createStart).Round(time.Millisecond))
-
-	// Write corrected git pointer files for the container.
-	if m.cfg.BareRoot != "" && m.cfg.WorktreeGitDir != "" {
-		branch := filepath.Base(m.cfg.WorktreeGitDir)
-
-		// Forward pointer: /workspace/.git → /prism-git/worktrees/<branch> (#492).
-		// The host's .git file contains an absolute host path that doesn't exist
-		// inside the container.
-		gitdirContent := "gitdir: /prism-git/worktrees/" + branch + "\n"
-		if err := os.WriteFile(m.gitdirFilePath(), []byte(gitdirContent), 0o644); err != nil {
-			return fmt.Errorf("container: write gitdir file: %w", err)
-		}
-
-		// Back-pointer: worktrees/<branch>/gitdir → /workspace/.git
-		// This file is the reverse pointer from git metadata back to the
-		// worktree checkout. On the host it contains the host worktree path
-		// (e.g. /home/user/code/repo/branch/.git) which doesn't exist in the
-		// container. nix/libgit2 follows this pointer when resolving the
-		// working tree, so it must point to the container-internal path.
-		wtGitdirContent := "/workspace/.git\n"
-		if err := os.WriteFile(m.worktreeGitdirFilePath(), []byte(wtGitdirContent), 0o644); err != nil {
-			return fmt.Errorf("container: write worktree gitdir file: %w", err)
-		}
-	}
-
-	// Write a minimal SSH config for the container. The host's ~/.ssh/config
-	// is a nix store symlink with wrong ownership that SSH rejects.
-	if err := m.writeSshConfig(isolationPodman); err != nil {
-		return err
-	}
-
-	// Write a minimal .gitconfig for the container. The host's git config lives
-	// in ~/.config/git/config (managed by home-manager) and is not mounted into
-	// containers. We generate a minimal config with identity, signing, and
-	// convenience settings.
-	t0 := time.Now()
-	if err := m.writeGitconfig(isolationPodman); err != nil {
-		return fmt.Errorf("container: write gitconfig: %w", err)
-	}
-	log.Printf("[timing] writeGitconfig: %s", time.Since(t0).Round(time.Millisecond))
-
-	// Write the opencode config file for the container. This replaces the
-	// previous OPENCODE_CONFIG_CONTENT env var approach so that relative plugin
-	// paths (e.g. "./plugins/my-plugin") resolve correctly from the config
-	// file's location at /root/.config/opencode/opencode.json.
-	if m.cfg.ConfigContent != "" {
-		if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o644); err != nil {
-			return fmt.Errorf("container: write opencode config: %w", err)
-		}
-	}
-
-	// On Darwin, extract Claude Code credentials from the macOS Keychain and
-	// write them to a temp file so the container can find them. On Linux,
-	// ~/.claude/.credentials.json is already inside the claudeMount directory.
-	m.writeClaudeCredentials()
-
-	// Pre-create directories that buildRunArgs() will reference as volume mount
-	// sources. podman validates all bind-mount source paths before starting the
-	// container and exits 125 if any are absent, so we create them eagerly here.
-	// Failures are logged and non-fatal — podman will surface the real error if
-	// the directory is still absent after this attempt.
-	if err := m.prepareVolumeDirs(true); err != nil {
-		// prepareVolumeDirs logs individual failures; a non-nil error means
-		// multiple dirs failed and is logged here for observability only.
-		log.Printf("container: prepareVolumeDirs partial failure: %v", err)
-	}
-
-	// Build the podman run arguments.
-	t0 = time.Now()
-	args := m.buildRunArgs()
-	log.Printf("[timing] buildRunArgs: %s", time.Since(t0).Round(time.Millisecond))
-
-	log.Printf("container: creating %q: podman %s", m.name, strings.Join(redactArgs(args), " "))
-
-	podmanStart := time.Now()
-	if err := m.isolator.Run(ctx, args); err != nil {
-		return err
-	}
-	log.Printf("[timing] podman run: %s (total to here: %s)",
-		time.Since(podmanStart).Round(time.Millisecond),
-		time.Since(createStart).Round(time.Millisecond))
-	log.Printf("[timing] Create total: %s", time.Since(createStart).Round(time.Millisecond))
-
-	return nil
+	return m.isolator.Create(ctx, m)
 }
 
 // WaitHealthy polls the container's HTTP endpoint until it responds with a

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -1,0 +1,526 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file extends the Isolator interface with the lifecycle dispatch methods
+// migrated from the per-mode branches in container.go, lifecycle.go, cmd/cleanup.go,
+// cmd/reset.go, and cmd/agent_run.go (issue #1140, A1.L1-L6).
+//
+// Methods added by this file:
+//
+//   - EnsureRemoved()   — L1: replaces Manager.EnsureRemoved + cleanup.go's open-coded podman stop/rm.
+//   - WriteGitconfig()  — L2: replaces (*Manager).writeGitconfig(mode) per-mode switch.
+//   - Reset()           — L3: replaces resetRemovePodmanContainers in cmd/reset.go.
+//   - Prepare()         — L4: replaces Manager.PrepareBwrap / Manager.PrepareSandboxExec.
+//   - Create()          — L5: replaces Manager.Create body.
+//   - AgentRun()        — L6: replaces cmd/agent_run.go's per-mode dispatch switch.
+//
+// The methods are declared on the interface in isolator.go and implemented per
+// isolator (podman, bwrap, sandbox-exec, host) below.
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// AgentRunOpts carries the per-call inputs that a registered AgentRun handler
+// needs without coupling the container package to internal/db, internal/session,
+// internal/git, or internal/harness. The cmd-level dispatch in
+// cmd/agent_run.go fills this in and passes it to iso.AgentRun. The handlers
+// themselves live in the cmd package and are registered with the container
+// package at init() time via RegisterAgentRunHandler.
+//
+// Keeping the handlers in cmd/ is a deliberate scope decision: moving the
+// bodies into internal/container would create a circular dependency with
+// internal/session (which imports internal/container today). The dispatch
+// shape — `iso.AgentRun(ctx, opts)` — is the deliverable; the body location
+// is an implementation detail.
+type AgentRunOpts struct {
+	// SessionName is the prism session name (e.g. "nixos-config@feature").
+	SessionName string
+
+	// StartTime is the wall-clock entry time captured by the cmd
+	// dispatcher. Handlers use it to emit `[timing]` markers symmetric to
+	// the podman path's sidecar-side instrumentation. Zero means "not
+	// captured" — handlers fall back to time.Now() in that case.
+	StartTime time.Time
+
+	// LogFile is the per-session agent-run log file (already opened in
+	// append mode by the cmd dispatcher). May be nil when the log file
+	// cannot be opened — handlers tolerate nil.
+	LogFile *os.File
+}
+
+// AgentRunHandler is the function signature that cmd/agent_run.go registers
+// with the container package at init() time, one entry per per-mode dispatch
+// path. The handler is responsible for the body that previously lived in the
+// per-mode branch of runAgentRun.
+type AgentRunHandler func(ctx context.Context, opts AgentRunOpts) error
+
+var (
+	agentRunHandlersMu sync.Mutex
+	agentRunHandlers   = map[config.IsolationMode]AgentRunHandler{}
+)
+
+// RegisterAgentRunHandler registers fn as the AgentRun body for mode. The
+// cmd package calls this at init() time for the bwrap and sandbox-exec
+// modes — the only two modes for which `prism agent-run` is the entry
+// point. Re-registering panics: the registration is intended to be a
+// once-per-process action.
+func RegisterAgentRunHandler(mode config.IsolationMode, fn AgentRunHandler) {
+	agentRunHandlersMu.Lock()
+	defer agentRunHandlersMu.Unlock()
+	if _, exists := agentRunHandlers[mode]; exists {
+		panic(fmt.Sprintf("container: AgentRun handler for %q already registered", mode))
+	}
+	agentRunHandlers[mode] = fn
+}
+
+// lookupAgentRunHandler returns the registered handler for mode (or nil if
+// none is registered). Used by per-isolator AgentRun bodies below.
+func lookupAgentRunHandler(mode config.IsolationMode) AgentRunHandler {
+	agentRunHandlersMu.Lock()
+	defer agentRunHandlersMu.Unlock()
+	return agentRunHandlers[mode]
+}
+
+// ----------------------------------------------------------------------------
+// podmanIsolator
+// ----------------------------------------------------------------------------
+
+// EnsureRemoved tears down the podman container with this isolator's name and
+// cleans up the legacy set of per-session temp files (gitdir, wt-gitdir,
+// ssh-config, gitconfig, allowed-signers). Mirrors the pre-refactor body of
+// cmd/cleanup.go's removeContainerIfExists — same podman stop/rm sequence,
+// same temp-file unlink list. Errors for "no such container" are silently
+// swallowed, exactly as before.
+//
+// The opencode-config, Claude credentials, and sandbox-exec staging files
+// are NOT removed here. They are owned by the Manager-level lifecycle
+// (Manager.EnsureRemoved) which retains the comprehensive cleanup list to
+// preserve the pre-refactor "Create resets every per-session artefact"
+// behaviour. The cleanup.go shortcut path historically did not touch
+// opencode-config either; tests like TestRestoreSession_PodmanMode_TempFileWritten
+// assert that the opencode-config written by restore.go survives a subsequent
+// removeContainerIfExists call.
+//
+// m may be nil for callers that do not own a Manager (cmd/cleanup.go's
+// removeContainerIfExists). When m is nil the implementation falls back to
+// the per-session temp paths derived from the isolator's name (which is the
+// container name for podman — see NameForSession).
+func (p *podmanIsolator) EnsureRemoved(ctx context.Context, m *Manager) {
+	// Clean up the legacy set of per-session temp files (gitdir, wt-gitdir,
+	// ssh-config, gitconfig, allowed-signers). The opencode-config and
+	// sandbox-exec specific files are deliberately excluded here.
+	cleanupLegacyTempFiles(p.name)
+
+	// Check the container's instance label when we have our own InstanceID.
+	// This detects ownership mismatches where a container from a previous
+	// session incarnation is being cleaned up by a new one.
+	if m != nil && m.cfg.InstanceID != "" {
+		inspectCtx, inspectCancel := context.WithTimeout(ctx, 5*time.Second)
+		out, inspectErr := exec.CommandContext(inspectCtx, "podman", "inspect",
+			"--format", `{{index .Config.Labels "prism.instance-id"}}`,
+			p.name,
+		).Output()
+		inspectCancel()
+		if inspectErr == nil {
+			containerInstanceID := strings.TrimSpace(string(out))
+			if containerInstanceID != "" && containerInstanceID != m.cfg.InstanceID {
+				log.Printf("container: warning: container %q has instance-id %q but current session has %q — removing anyway",
+					p.name, containerInstanceID, m.cfg.InstanceID)
+			}
+		}
+	}
+
+	// Stop the container (ignore errors — may not be running).
+	stopCmd := exec.CommandContext(ctx, "podman", "stop", "--time", "10", p.name)
+	if out, err := stopCmd.CombinedOutput(); err != nil {
+		// Only log if it looks like a real error (not "no such container").
+		if !IsNoSuchContainerError(string(out)) {
+			log.Printf("container: stop existing %q: %v — %s", p.name, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	// Remove the container (ignore errors — may not exist).
+	rmCmd := exec.CommandContext(ctx, "podman", "rm", "--force", p.name)
+	if out, err := rmCmd.CombinedOutput(); err != nil {
+		if !IsNoSuchContainerError(string(out)) {
+			log.Printf("container: rm existing %q: %v — %s", p.name, err, strings.TrimSpace(string(out)))
+		}
+	}
+}
+
+// WriteGitconfig generates a minimal .gitconfig for the podman container and
+// writes it to the per-session temp path. The container runs as root, so the
+// signingKey and allowedSignersFile paths use /root/.ssh/* — see the
+// container.go writeGitconfig body (lines 425-550) for the full rationale.
+func (p *podmanIsolator) WriteGitconfig(m *Manager) error {
+	return m.writeGitconfig(isolationPodman)
+}
+
+// Reset performs the heavier "wipe everything matching prism-*" cleanup
+// invoked by `prism reset`. Lists every container with the "prism-" name
+// prefix and removes them with `podman rm -f`. If podman is not available
+// the function is a no-op.
+//
+// Mirrors the pre-refactor resetRemovePodmanContainers (cmd/reset.go:129)
+// — same prefix scan, same single `podman rm -f <ids...>` invocation.
+func (p *podmanIsolator) Reset(ctx context.Context) error {
+	podmanBin, err := exec.LookPath("podman")
+	if err != nil {
+		// podman not installed — nothing to do.
+		fmt.Println("  podman not found — skipping container cleanup.")
+		return nil
+	}
+
+	// Fetch "name\tid" for every container (including stopped ones).
+	out, err := exec.CommandContext(ctx, podmanBin, "ps", "-a", "--format", "{{.Names}}\t{{.ID}}").Output()
+	if err != nil {
+		// If podman fails (e.g. no running machine), treat as no containers.
+		fmt.Printf("  podman ps failed: %v — skipping container cleanup.\n", err)
+		return nil
+	}
+
+	var prismContainers []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		// parts[0] may be "name" or "name1,name2,..."; check the first name only.
+		firstName := strings.SplitN(parts[0], ",", 2)[0]
+		if strings.HasPrefix(firstName, "prism-") {
+			prismContainers = append(prismContainers, strings.TrimSpace(parts[1]))
+		}
+	}
+
+	if len(prismContainers) == 0 {
+		fmt.Println("  no prism- containers found.")
+		return nil
+	}
+
+	fmt.Printf("  removing %d container(s)\n", len(prismContainers))
+	args := append([]string{"rm", "-f"}, prismContainers...)
+	rmOut, err := exec.CommandContext(ctx, podmanBin, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("podman rm -f: %w\n%s", err, strings.TrimSpace(string(rmOut)))
+	}
+	fmt.Println("  containers removed.")
+	return nil
+}
+
+// Prepare is not the entry point for podman — Manager.Create handles podman
+// session start. Returns an error so callers that route through the registry
+// surface the misuse loudly rather than silently doing nothing.
+func (p *podmanIsolator) Prepare(ctx context.Context, m *Manager) ([]string, error) {
+	return nil, fmt.Errorf("container: podman does not use Prepare; use Create")
+}
+
+// Create is the body of the podman session-start path. Mirrors the
+// pre-refactor Manager.Create (internal/container/lifecycle.go:79):
+// EnsureRemoved → write gitdir/wt-gitdir → write SSH config → write
+// gitconfig → write opencode config → write Claude credentials → pre-create
+// volume dirs → buildRunArgs → isolator.Run.
+func (p *podmanIsolator) Create(ctx context.Context, m *Manager) error {
+	createStart := time.Now()
+
+	// Remove any stale container first (AC-15). Use the Manager-level
+	// EnsureRemoved so the comprehensive (mode-agnostic) temp-file unlink
+	// runs — this matches the pre-refactor behaviour where Create cleared
+	// every per-session temp file before writing fresh ones.
+	m.EnsureRemoved(ctx)
+	log.Printf("[timing] EnsureRemoved: %s", time.Since(createStart).Round(time.Millisecond))
+
+	// Write corrected git pointer files for the container.
+	if m.cfg.BareRoot != "" && m.cfg.WorktreeGitDir != "" {
+		branch := filepath.Base(m.cfg.WorktreeGitDir)
+
+		// Forward pointer: /workspace/.git → /prism-git/worktrees/<branch> (#492).
+		gitdirContent := "gitdir: /prism-git/worktrees/" + branch + "\n"
+		if err := os.WriteFile(m.gitdirFilePath(), []byte(gitdirContent), 0o644); err != nil {
+			return fmt.Errorf("container: write gitdir file: %w", err)
+		}
+
+		// Back-pointer: worktrees/<branch>/gitdir → /workspace/.git
+		wtGitdirContent := "/workspace/.git\n"
+		if err := os.WriteFile(m.worktreeGitdirFilePath(), []byte(wtGitdirContent), 0o644); err != nil {
+			return fmt.Errorf("container: write worktree gitdir file: %w", err)
+		}
+	}
+
+	// Write a minimal SSH config for the container.
+	if err := m.writeSshConfig(isolationPodman); err != nil {
+		return err
+	}
+
+	// Write a minimal .gitconfig for the container.
+	t0 := time.Now()
+	if err := p.WriteGitconfig(m); err != nil {
+		return fmt.Errorf("container: write gitconfig: %w", err)
+	}
+	log.Printf("[timing] writeGitconfig: %s", time.Since(t0).Round(time.Millisecond))
+
+	// Write the opencode config file for the container.
+	if m.cfg.ConfigContent != "" {
+		if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o644); err != nil {
+			return fmt.Errorf("container: write opencode config: %w", err)
+		}
+	}
+
+	// On Darwin, extract Claude Code credentials from the macOS Keychain.
+	m.writeClaudeCredentials()
+
+	// Pre-create directories that buildRunArgs() will reference as volume mount sources.
+	if err := m.prepareVolumeDirs(true); err != nil {
+		log.Printf("container: prepareVolumeDirs partial failure: %v", err)
+	}
+
+	// Build the podman run arguments.
+	t0 = time.Now()
+	args := m.buildRunArgs()
+	log.Printf("[timing] buildRunArgs: %s", time.Since(t0).Round(time.Millisecond))
+
+	log.Printf("container: creating %q: podman %s", p.name, strings.Join(redactArgs(args), " "))
+
+	podmanStart := time.Now()
+	if err := m.isolator.Run(ctx, args); err != nil {
+		return err
+	}
+	log.Printf("[timing] podman run: %s (total to here: %s)",
+		time.Since(podmanStart).Round(time.Millisecond),
+		time.Since(createStart).Round(time.Millisecond))
+	log.Printf("[timing] Create total: %s", time.Since(createStart).Round(time.Millisecond))
+
+	return nil
+}
+
+// AgentRun is not the entry point for podman: the podman path uses the
+// sidecar's restart loop and `podman attach`, not `prism agent-run`. Returns
+// an error so callers surface the misuse loudly. This replaces the manual
+// `else` arm in cmd/agent_run.go's per-mode switch (issue #1140 AC).
+func (p *podmanIsolator) AgentRun(ctx context.Context, opts AgentRunOpts) error {
+	return fmt.Errorf("agent-run: session %q has isolation mode %q; this command is only for bwrap and sandbox-exec sessions",
+		opts.SessionName, config.IsolationPodman)
+}
+
+// ----------------------------------------------------------------------------
+// bwrapIsolator
+// ----------------------------------------------------------------------------
+
+// EnsureRemoved cleans up the per-session temp files written by PrepareBwrap.
+// Bwrap sessions do not own a container lifecycle — there is nothing to stop
+// or rm — so this method is a temp-file unlink only. Mirrors the per-session
+// list in cmd/cleanup.go:1055-1059 (the legacy 5-file cleanup; the
+// opencode-config file is intentionally excluded — see podmanIsolator.EnsureRemoved
+// for the rationale).
+func (b *bwrapIsolator) EnsureRemoved(ctx context.Context, m *Manager) {
+	cleanupLegacyTempFiles(b.name)
+}
+
+// WriteGitconfig generates a minimal .gitconfig for the bwrap sandbox. bwrap
+// runs as the host user, so the signingKey and allowedSignersFile paths
+// embed the host user's $HOME (not /root). See container.go writeGitconfig
+// for the full rationale.
+func (b *bwrapIsolator) WriteGitconfig(m *Manager) error {
+	return m.writeGitconfig(isolationBwrap)
+}
+
+// Reset is a no-op for bwrap today. Orphan-agent-run reaping (the bwrap
+// equivalent of "wipe every prism-* container") is a future implementation
+// — A1 §7 names the shape, the cleanup work lands later.
+func (b *bwrapIsolator) Reset(ctx context.Context) error {
+	return nil
+}
+
+// Prepare writes the per-session temp files (SSH config, gitconfig,
+// opencode.json config) that bwrap needs at start time and returns the
+// complete bwrap argument list. Mirrors the pre-refactor body of
+// Manager.PrepareBwrap (internal/container/container.go:581).
+//
+// Like the previous implementation, this also pre-creates bind-mount source
+// directories so bwrap (which silently fails on missing sources) can find
+// them.
+func (b *bwrapIsolator) Prepare(ctx context.Context, m *Manager) ([]string, error) {
+	// Write a minimal SSH config for bwrap.
+	if err := m.writeSshConfig(isolationBwrap); err != nil {
+		return nil, fmt.Errorf("container: bwrap: %w", err)
+	}
+
+	// Write the gitconfig.
+	if err := b.WriteGitconfig(m); err != nil {
+		return nil, fmt.Errorf("container: bwrap: write gitconfig: %w", err)
+	}
+
+	// Write the opencode config file, if provided.
+	if m.cfg.ConfigContent != "" {
+		if err := os.WriteFile(m.opencodeConfigFilePath(), []byte(m.cfg.ConfigContent), 0o644); err != nil {
+			return nil, fmt.Errorf("container: bwrap: write opencode config: %w", err)
+		}
+	}
+
+	// Pre-create directories referenced as bind-mount sources.
+	if err := m.prepareVolumeDirs(false); err != nil {
+		log.Printf("container: bwrap: prepareVolumeDirs partial failure: %v", err)
+	}
+
+	// Build the bwrap args.
+	return b.BuildArgs(m), nil
+}
+
+// Create is not the entry point for bwrap — the bwrap path uses Prepare +
+// `prism agent-run`. Returns an error so callers that route through the
+// registry surface the misuse loudly.
+func (b *bwrapIsolator) Create(ctx context.Context, m *Manager) error {
+	return fmt.Errorf("container: bwrap does not use Create; use Prepare + prism agent-run")
+}
+
+// AgentRun dispatches to the registered bwrap handler in cmd/agent_run.go.
+// Returns an error if no handler is registered (programming error: cmd/
+// must call RegisterAgentRunHandler at init() time).
+func (b *bwrapIsolator) AgentRun(ctx context.Context, opts AgentRunOpts) error {
+	fn := lookupAgentRunHandler(config.IsolationBwrap)
+	if fn == nil {
+		return errors.New("container: no AgentRun handler registered for bwrap")
+	}
+	return fn(ctx, opts)
+}
+
+// ----------------------------------------------------------------------------
+// sandboxExecIsolator
+// ----------------------------------------------------------------------------
+
+// EnsureRemoved cleans up the legacy per-session temp files. The
+// sandbox-exec specific files (SBPL profile, staging HOME, Claude
+// credentials, opencode config) are owned by the Manager-level lifecycle
+// (Manager.EnsureRemoved); EnsureRemoved here mirrors the legacy cleanup.go
+// behaviour which only touched the 5-file legacy set.
+func (s *sandboxExecIsolator) EnsureRemoved(ctx context.Context, m *Manager) {
+	cleanupLegacyTempFiles(s.name)
+}
+
+// WriteGitconfig generates a minimal .gitconfig for the sandbox-exec sandbox.
+// sandbox-exec shares the host user's $HOME, so the signingKey and
+// allowedSignersFile paths embed the host user's $HOME (not /root). The
+// existing isolationBwrap branch in container.go's writeGitconfig already
+// handles the "host $HOME" path layout — sandbox-exec is structurally the
+// same here, so we re-use it.
+func (s *sandboxExecIsolator) WriteGitconfig(m *Manager) error {
+	return m.writeGitconfig(isolationBwrap)
+}
+
+// Reset is a no-op for sandbox-exec today — same rationale as bwrap.Reset.
+func (s *sandboxExecIsolator) Reset(ctx context.Context) error {
+	return nil
+}
+
+// Prepare prepares the per-session staging HOME, writes the SBPL profile,
+// and returns the complete sandbox-exec argument list. Mirrors the
+// pre-refactor body of Manager.PrepareSandboxExec
+// (internal/container/container.go:637).
+func (s *sandboxExecIsolator) Prepare(ctx context.Context, m *Manager) ([]string, error) {
+	// Populate the staging HOME with symlinks. Non-fatal if the staging HOME
+	// cannot be created (e.g. read-only home, as in the nix sandbox build
+	// environment): log and continue with a degraded profile.
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		log.Printf("container: sandbox-exec: prepare staging home: %v — launching with degraded profile", err)
+	}
+	_ = stagingHome // consumed by generateProfile via m.sandboxExecHomePath()
+
+	// On Darwin, extract Claude Code credentials from the Keychain.
+	m.writeClaudeCredentials()
+
+	if _, err := writeProfile(m); err != nil {
+		return nil, err
+	}
+
+	return s.BuildArgs(m), nil
+}
+
+// Create is not the entry point for sandbox-exec — the sandbox-exec path
+// uses Prepare + `prism agent-run`. Returns an error so callers that route
+// through the registry surface the misuse loudly.
+func (s *sandboxExecIsolator) Create(ctx context.Context, m *Manager) error {
+	return fmt.Errorf("container: sandbox-exec does not use Create; use Prepare + prism agent-run")
+}
+
+// AgentRun dispatches to the registered sandbox-exec handler in
+// cmd/agent_run.go. Returns an error if no handler is registered.
+func (s *sandboxExecIsolator) AgentRun(ctx context.Context, opts AgentRunOpts) error {
+	fn := lookupAgentRunHandler(config.IsolationSandboxExec)
+	if fn == nil {
+		return errors.New("container: no AgentRun handler registered for sandbox-exec")
+	}
+	return fn(ctx, opts)
+}
+
+// ----------------------------------------------------------------------------
+// hostIsolator
+// ----------------------------------------------------------------------------
+
+// EnsureRemoved is a no-op for host mode: there is no sandbox layer, no
+// container, and no per-session temp files (the agent reads the host's
+// own ~/.config/opencode/ directly).
+func (h *hostIsolator) EnsureRemoved(ctx context.Context, m *Manager) {}
+
+// WriteGitconfig is a no-op for host mode: the agent reads the host's own
+// ~/.gitconfig directly, so there is nothing to materialise.
+func (h *hostIsolator) WriteGitconfig(m *Manager) error { return nil }
+
+// Reset is a no-op for host mode: there is no sandbox state to wipe.
+func (h *hostIsolator) Reset(ctx context.Context) error { return nil }
+
+// Prepare is not the entry point for host mode — host runs opencode
+// directly in the tmux pane via the BuildOpencodeCmd (DirectCmd) path.
+// Returns an error so callers route correctly.
+func (h *hostIsolator) Prepare(ctx context.Context, m *Manager) ([]string, error) {
+	return nil, fmt.Errorf("container: host does not use Prepare; opencode launches directly in the tmux pane")
+}
+
+// Create is a no-op for host mode: opencode is launched directly by the
+// tmux pane command, not via a Create call.
+func (h *hostIsolator) Create(ctx context.Context, m *Manager) error { return nil }
+
+// AgentRun is not the entry point for host mode. Returns an error so the
+// dispatch in cmd/agent_run.go surfaces the misuse loudly. This replaces
+// the manual `else` arm in the per-mode switch (issue #1140 AC).
+func (h *hostIsolator) AgentRun(ctx context.Context, opts AgentRunOpts) error {
+	return fmt.Errorf("agent-run: session %q has isolation mode %q; this command is only for bwrap and sandbox-exec sessions",
+		opts.SessionName, config.IsolationHost)
+}
+
+// ----------------------------------------------------------------------------
+// shared helpers
+// ----------------------------------------------------------------------------
+
+// cleanupLegacyTempFiles removes the legacy set of per-session temp files
+// previously inlined in cmd/cleanup.go's removeContainerIfExists (the
+// 5-file list: gitdir, wt-gitdir, ssh-config, gitconfig, allowed-signers).
+// The removals are best-effort — missing files are silently ignored.
+//
+// The opencode-config, Claude credentials, and sandbox-exec staging files
+// are deliberately NOT cleaned here: those are owned by the Manager-level
+// lifecycle (Manager.EnsureRemoved retains the full cleanup list). Tests
+// that exercise the cleanup.go shortcut path
+// (TestRestoreSession_PodmanMode_TempFileWritten) rely on the
+// opencode-config file surviving this cleanup.
+func cleanupLegacyTempFiles(name string) {
+	_ = os.Remove(sessionTempPath("gitdir", "", name))
+	_ = os.Remove(sessionTempPath("wt-gitdir", "", name))
+	_ = os.Remove(sessionTempPath("ssh-config", "", name))
+	_ = os.Remove(sessionTempPath("gitconfig", "", name))
+	_ = os.Remove(sessionTempPath("allowed-signers", "", name))
+}


### PR DESCRIPTION
## Summary

Migrate the six lifecycle call sites that manage isolation-mode-specific resource creation, teardown, and agent launching. Each per-mode branch becomes a method body on the appropriate `Isolator`, mirroring the [A1.D1-D7 dispatch shape](https://github.com/prismatic-koi/nixos-config/pull/1223) (#1133) but for **lifecycle** rather than **dispatch**.

This is the last blocker for #1209 (P2.SIDECAR — pipe socket support for the new PI harness).

### New Isolator methods

| | What it replaces | Where the body lives now |
|---|---|---|
| `EnsureRemoved()` | `Manager.EnsureRemoved` + `cleanup.go`'s open-coded `podman stop/rm` | `podmanIsolator.EnsureRemoved` (real body); bwrap/sandbox-exec/host are temp-file-only / no-op |
| `WriteGitconfig()` | `(*Manager).writeGitconfig(mode)` per-mode switch | each isolator picks its own `$HOME` prefix |
| `Reset()` | `resetRemovePodmanContainers` in `cmd/reset.go` | `podmanIsolator.Reset` (real body); others are stubs |
| `Prepare()` | `Manager.PrepareBwrap` / `Manager.PrepareSandboxExec` | `bwrapIsolator.Prepare` / `sandboxExecIsolator.Prepare` |
| `Create()` | `Manager.Create` (podman-only body) | `podmanIsolator.Create` |
| `AgentRun()` | `cmd/agent_run.go`'s per-mode dispatch switch | host/podman return errors; bwrap/sandbox-exec route through a registration table populated by `cmd` at `init()` time |

### Caller migrations

- **`cmd/cleanup.go`**: `removeContainerIfExists` and `stopAndRemoveChildContainers` resolve the persisted isolation mode from the DB and dispatch via `registry.For(mode).EnsureRemoved`.
- **`cmd/reset.go`**: iterates `container.Names()` and calls `Reset` on each registered isolator.
- **`cmd/agent_run.go`**: per-mode `switch` collapses to `iso.AgentRun(ctx, opts)`. Host and podman return the original "this command is only for bwrap and sandbox-exec sessions" error verbatim, replacing the manual `else` arm (#1140 edge-case AC).
- **`Manager.Create`** / **`Manager.EnsureRemoved`** / **`Manager.PrepareBwrap`** / **`Manager.PrepareSandboxExec`**: thin dispatchers that forward to the registered isolator.

### Why AgentRun handlers stay in `cmd/`

Moving the bwrap and sandbox-exec `AgentRun` bodies into `internal/container/` would create a circular dependency with `internal/session` (which imports `internal/container` today), plus `internal/git`, `internal/harness`, and `internal/db`. The dispatch shape — `iso.AgentRun(ctx, opts)` — is the deliverable; the body location is an implementation detail. The cmd package registers handlers with the container package at `init()` time and the `Isolator.AgentRun` method routes through the registration table.

### Edge case handled

`Manager.EnsureRemoved` retains the comprehensive temp-file cleanup list (opencode-config, claude-creds, sandbox-exec profile, staging HOME) so the pre-refactor "Create resets every per-session artefact" semantics are preserved. The `cleanup.go` shortcut path historically only cleaned the legacy 5-file set (gitdir, wt-gitdir, ssh-config, gitconfig, allowed-signers); the per-isolator `EnsureRemoved` methods mirror that narrower list. This keeps `TestRestoreSession_PodmanMode_TempFileWritten` passing (it asserts the opencode-config survives a `removeContainerIfExists` call between `writeHarnessConfigBlobFor` and the sidecar's `Create`).

### Validation

- `go build ./...` ✓
- `go test ./...` ✓ (all suites)
- `GOOS=darwin go build ./...` ✓
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✓

Closes #1140