### PR TITLE
Migrate password manager and patch direnv build on Darwin

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -145,8 +145,6 @@ in
       "vfkit"
     ];
     casks = [
-      "1password"
-      "1password-cli"
       "bitwarden"
       "firefox"
       "karabiner-elements"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -129,6 +129,21 @@ rec {
         '';
       });
 
+      # direnv: disable the test phase on Darwin to work around a hang in
+      # `direnv-test.zsh` introduced when libarchive was bumped 3.8.4 -> 3.8.6
+      # on staging-25.11 (nixpkgs commit 32e655f). Direnv's source is
+      # unchanged but transitive input changes force rebuilds, and the test
+      # harness wedges on aarch64-darwin.
+      # See: https://github.com/NixOS/nixpkgs/issues/507531
+      # Remove this override once upstream lands a fix.
+      direnv =
+        if final.stdenv.isDarwin then
+          prev.direnv.overrideAttrs (_: {
+            doCheck = false;
+          })
+        else
+          prev.direnv;
+
       # packages not yet in nixpkgs; use local definitions
       # playwright-cli depends on chromium which is Linux-only
       playwright-cli =


### PR DESCRIPTION
This change removes 1Password from brew (installed using nix anyway) on mac configuration. Additionally, it disables the test phase for direnv on Darwin to resolve an intermittent build hang caused by recent libarchive updates.