### PR TITLE
prism: A2 isolation shared helpers (writeGitconfig, MountSpec, SuperviseChild, gracefulShutdown)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -385,15 +385,6 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		stderrW.Close()
 	}
 
-	// Give the terminal foreground to bwrap's process group so that the host
-	// PTY routes keypresses and SIGWINCH to bwrap/opencode rather than to
-	// agent-run. Restore the original foreground pgid after bwrap exits.
-	origPgid := tcsetpgrpForeground(int(os.Stdin.Fd()), bwrapCmd.Process.Pid)
-
-	// Forward SIGTERM, SIGINT, SIGHUP, and SIGWINCH to the child process group.
-	doneCh := make(chan struct{})
-	go forwardSignalsToBwrap(bwrapCmd.Process, doneCh, nil)
-
 	// Tee bwrap's stderr to both the pane (os.Stderr) and the log file.
 	// This goroutine exits when stderrR reaches EOF (after bwrap exits and
 	// stderrW is closed).
@@ -412,14 +403,17 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		close(teeDone)
 	}
 
-	waitErr := bwrapCmd.Wait()
-	close(doneCh)
+	// Supervise the child: foreground the pgid, forward signals (including
+	// SIGWINCH for the bwrap path so resizes propagate to the sandbox), and
+	// wait. The shared SuperviseChild helper (supervise.go, A2.SUP) replaces
+	// the previous open-coded tcsetpgrpForeground / forwardSignalsToBwrap /
+	// cmd.Wait / tcsetpgrpRestore sequence — same behaviour, single
+	// implementation across the bwrap and sandbox-exec dispatch paths.
+	waitErr := SuperviseChild(bwrapCmd, int(os.Stdin.Fd()), SuperviseOpts{
+		ForwardWinch: true,
+		OnWinch:      nil,
+	})
 	<-teeDone
-
-	// Restore the original foreground process group.
-	if origPgid > 0 {
-		_ = tcsetpgrpRestore(int(os.Stdin.Fd()), origPgid)
-	}
 
 	if waitErr != nil {
 		if exitErr, ok := waitErr.(*exec.ExitError); ok {

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -376,7 +376,7 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	// (sandbox-exec deliberately does not subscribe SIGWINCH — see
 	// SuperviseOpts.ForwardWinch godoc for the rationale), and wait for exit.
 	// The shared SuperviseChild helper (supervise.go, A2.SUP) replaces the
-	// previous open-coded tcsetpgrpForeground / forwardSignalsToSandboxExec /
+	// previous open-coded tcsetpgrpForeground / per-mode signal forwarding /
 	// cmd.Wait / tcsetpgrpRestore sequence — same behaviour, single
 	// implementation across the bwrap and sandbox-exec dispatch paths.
 	waitErr := SuperviseChild(sandboxCmd, int(os.Stdin.Fd()), SuperviseOpts{

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -341,12 +341,9 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		sandboxStderrW.Close()
 	}
 
-	// Give the terminal foreground to sandbox-exec's process group so that
-	// the host PTY routes keypresses to sandbox-exec/opencode, not agent-run.
-	origPgid := tcsetpgrpForeground(int(os.Stdin.Fd()), sandboxCmd.Process.Pid)
-
-	// childExited is closed when cmd.Wait() returns — used by the parent-death
-	// watcher to avoid sending spurious signals after the child has already exited.
+	// childExited is closed once sandboxCmd has been waited on. The
+	// parent-death watcher consumes this channel to avoid sending spurious
+	// signals after the child has already exited.
 	childExited := make(chan struct{})
 
 	// Install the parent-death watcher in a goroutine. parentPID was captured
@@ -358,10 +355,6 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	// the 1-second heartbeat fallback is used instead (see lifecycle_darwin.go).
 	const parentDeathGrace = 3 * time.Second
 	go watchParentDeathAndKill(parentPID, sandboxCmd.Process, childExited, parentDeathGrace)
-
-	// Forward SIGTERM, SIGINT, and SIGHUP to the sandbox-exec process group.
-	stopForward := make(chan struct{})
-	go forwardSignalsToSandboxExec(sandboxCmd.Process, stopForward)
 
 	// Tee sandbox-exec's stderr to both the pane and the log file.
 	teeDone := make(chan struct{})
@@ -379,17 +372,21 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		close(teeDone)
 	}
 
-	waitErr := sandboxCmd.Wait()
+	// Supervise the child: foreground the pgid, forward SIGTERM/SIGINT/SIGHUP
+	// (sandbox-exec deliberately does not subscribe SIGWINCH — see
+	// SuperviseOpts.ForwardWinch godoc for the rationale), and wait for exit.
+	// The shared SuperviseChild helper (supervise.go, A2.SUP) replaces the
+	// previous open-coded tcsetpgrpForeground / forwardSignalsToSandboxExec /
+	// cmd.Wait / tcsetpgrpRestore sequence — same behaviour, single
+	// implementation across the bwrap and sandbox-exec dispatch paths.
+	waitErr := SuperviseChild(sandboxCmd, int(os.Stdin.Fd()), SuperviseOpts{
+		ForwardWinch: false,
+		OnWinch:      nil,
+	})
 
-	// Signal goroutines that the child has exited.
+	// Signal the parent-death watcher that the child has exited.
 	close(childExited)
-	close(stopForward)
 	<-teeDone
-
-	// Restore the original foreground process group.
-	if origPgid > 0 {
-		_ = tcsetpgrpRestore(int(os.Stdin.Fd()), origPgid)
-	}
 
 	if waitErr != nil {
 		if exitErr, ok := waitErr.(*exec.ExitError); ok {

--- a/modules/programs/prism/prism/cmd/lifecycle_darwin.go
+++ b/modules/programs/prism/prism/cmd/lifecycle_darwin.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"syscall"
 	"time"
 )
@@ -178,27 +177,5 @@ func killChild(childProc *os.Process, graceTimeout time.Duration) {
 	case <-time.After(graceTimeout):
 		// Grace period expired — send SIGKILL.
 		_ = childProc.Signal(syscall.SIGKILL)
-	}
-}
-
-// forwardSignalsToSandboxExec forwards SIGTERM, SIGINT, and SIGHUP from
-// agent-run to the sandbox-exec child process group until stopCh is closed.
-// This is the sandbox-exec equivalent of forwardSignalsToBwrap in agent_run.go.
-func forwardSignalsToSandboxExec(proc *os.Process, stopCh <-chan struct{}) {
-	sigCh := make(chan os.Signal, 4)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
-	defer signal.Stop(sigCh)
-
-	for {
-		select {
-		case <-stopCh:
-			return
-		case sig := <-sigCh:
-			if proc == nil {
-				continue
-			}
-			// Send to the process group (negative PGID = group of sandbox-exec).
-			_ = syscall.Kill(-proc.Pid, sig.(syscall.Signal))
-		}
 	}
 }

--- a/modules/programs/prism/prism/cmd/supervise.go
+++ b/modules/programs/prism/prism/cmd/supervise.go
@@ -1,0 +1,142 @@
+package cmd
+
+// supervise.go — shared signal/PTY supervisor for bwrap and sandbox-exec
+// agent-run paths (issue #1149 A2.SUP; design proposal A2 §3.6).
+//
+// The bwrap path (Linux) and the sandbox-exec path (Darwin) both run the
+// sandbox launcher as a supervised child of agent-run, which itself is the
+// tmux pane's child. Both share three concerns:
+//
+//  1. Hand the terminal foreground to the child's process group so
+//     keypresses and SIGWINCH route to the child rather than agent-run.
+//  2. Forward SIGTERM/SIGINT/SIGHUP (and optionally SIGWINCH) to the child
+//     process group while the child is alive.
+//  3. cmd.Wait() and surface the exit code.
+//
+// Pre-A2.SUP these steps were inlined in each per-mode dispatch path with
+// minor variations (bwrap forwards SIGWINCH; sandbox-exec does not). This
+// helper unifies them behind one entry point with a small options struct
+// that captures the per-mode-specific knobs without losing the existing
+// behaviour of either path.
+//
+// Note on platform: tcsetpgrpForeground/tcsetpgrpRestore use TIOCGPGRP/
+// TIOCSPGRP via syscall.SYS_IOCTL, which is identical on Linux and Darwin.
+// The supervisor itself is platform-agnostic; callers that need additional
+// platform-specific lifecycle (e.g. the kqueue parent-death watcher on
+// Darwin, see lifecycle_darwin.go) wire that in separately.
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// SuperviseOpts carries the per-call inputs that SuperviseChild consumes.
+//
+// ForwardWinch controls whether SIGWINCH is forwarded to the child's process
+// group. The bwrap path sets this to true (matching the pre-A2.SUP
+// forwardSignalsToBwrap behaviour). The sandbox-exec path sets it to false
+// (matching the pre-A2.SUP forwardSignalsToSandboxExec behaviour, which did
+// not subscribe SIGWINCH at all). The audit (A2 §3.6) flags this divergence
+// as `[uncertain]` — sandbox-exec on Darwin may need SIGWINCH forwarding for
+// Bubble Tea's TIOCGWINSZ-on-stdout requirement; until that is observed in
+// practice we preserve each path's pre-A2.SUP behaviour.
+//
+// OnWinch, when non-nil, is invoked on each SIGWINCH the supervisor receives.
+// Currently both call sites pass nil; the field is wired through so a future
+// caller (e.g. a slave-PTY resize) can register a callback without re-shaping
+// the helper signature.
+type SuperviseOpts struct {
+	// ForwardWinch enables SIGWINCH subscription and forwarding to the
+	// child process group. When false, SIGWINCH is not subscribed by the
+	// supervisor at all — the kernel still delivers it directly to the
+	// foreground process group (which is the child's after
+	// tcsetpgrpForeground), so the child sees window resizes regardless;
+	// this flag only controls whether agent-run also observes them.
+	ForwardWinch bool
+
+	// OnWinch, when non-nil, is called once per received SIGWINCH (only
+	// when ForwardWinch is true — without subscription the supervisor
+	// never receives SIGWINCH and cannot invoke the callback).
+	OnWinch func()
+}
+
+// SuperviseChild runs cmd as the foreground process group on stdinFd. The
+// caller has already started the process (cmd.Start) with
+// cmd.SysProcAttr.Setpgid = true, so the child has its own process group
+// that the supervisor can target with syscall.Kill(-pid, sig).
+//
+// The supervisor performs three steps in order:
+//
+//  1. Hand the terminal foreground to the child's pgid via tcsetpgrp on
+//     stdinFd. The original foreground pgid is captured for later restore.
+//
+//  2. Subscribe SIGTERM/SIGINT/SIGHUP (and SIGWINCH when opts.ForwardWinch
+//     is true) and forward each to the child's pgid for as long as the
+//     child is alive. The forwarding goroutine exits when stopCh is closed
+//     by the deferred cleanup below.
+//
+//  3. Block on cmd.Wait() and capture its error. After Wait returns, the
+//     supervisor closes stopCh, restores the original foreground pgid via
+//     tcsetpgrp, and returns the wait error verbatim. Callers handle
+//     ExitError unwrapping themselves.
+//
+// On platforms where tcsetpgrpForeground returns 0 (non-TTY stdinFd, or
+// non-interactive contexts such as tests), the foreground-restoration step
+// is silently skipped — matching the pre-A2.SUP behaviour at the bwrap call
+// site.
+func SuperviseChild(cmd *exec.Cmd, stdinFd int, opts SuperviseOpts) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	// 1. Foreground the child's process group.
+	origPgid := tcsetpgrpForeground(stdinFd, cmd.Process.Pid)
+
+	// 2. Forward signals until stopCh closes.
+	stopCh := make(chan struct{})
+	go superviseForwardSignals(cmd.Process, stopCh, opts)
+
+	// 3. Wait for the child to exit, then signal the forwarder to stop.
+	waitErr := cmd.Wait()
+	close(stopCh)
+
+	if origPgid > 0 {
+		_ = tcsetpgrpRestore(stdinFd, origPgid)
+	}
+	return waitErr
+}
+
+// superviseForwardSignals subscribes the SIGTERM/SIGINT/SIGHUP set (plus
+// SIGWINCH when opts.ForwardWinch is true) and forwards each received
+// signal to the child's process group via syscall.Kill(-pid, sig). It exits
+// when stopCh is closed.
+func superviseForwardSignals(proc *os.Process, stopCh <-chan struct{}, opts SuperviseOpts) {
+	sigCh := make(chan os.Signal, 4)
+	signals := []os.Signal{syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP}
+	if opts.ForwardWinch {
+		signals = append(signals, syscall.SIGWINCH)
+	}
+	signal.Notify(sigCh, signals...)
+	defer signal.Stop(sigCh)
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case sig := <-sigCh:
+			if proc == nil {
+				continue
+			}
+			if sig == syscall.SIGWINCH {
+				if opts.OnWinch != nil {
+					opts.OnWinch()
+				}
+				_ = syscall.Kill(-proc.Pid, syscall.SIGWINCH)
+				continue
+			}
+			_ = syscall.Kill(-proc.Pid, sig.(syscall.Signal))
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/supervise.go
+++ b/modules/programs/prism/prism/cmd/supervise.go
@@ -36,12 +36,14 @@ import (
 //
 // ForwardWinch controls whether SIGWINCH is forwarded to the child's process
 // group. The bwrap path sets this to true (matching the pre-A2.SUP
-// forwardSignalsToBwrap behaviour). The sandbox-exec path sets it to false
-// (matching the pre-A2.SUP forwardSignalsToSandboxExec behaviour, which did
-// not subscribe SIGWINCH at all). The audit (A2 §3.6) flags this divergence
-// as `[uncertain]` — sandbox-exec on Darwin may need SIGWINCH forwarding for
-// Bubble Tea's TIOCGWINSZ-on-stdout requirement; until that is observed in
-// practice we preserve each path's pre-A2.SUP behaviour.
+// forwardSignalsToBwrap behaviour, which subscribed SIGWINCH and forwarded
+// it to the child pgid). The sandbox-exec path sets it to false (matching
+// the pre-A2.SUP behaviour, which did not subscribe SIGWINCH at all — the
+// kernel still delivers it directly to the foreground process group). The
+// audit (A2 §3.6) flags this divergence as `[uncertain]` — sandbox-exec on
+// Darwin may need SIGWINCH forwarding for Bubble Tea's TIOCGWINSZ-on-stdout
+// requirement; until that is observed in practice we preserve each path's
+// pre-A2.SUP behaviour.
 //
 // OnWinch, when non-nil, is invoked on each SIGWINCH the supervisor receives.
 // Currently both call sites pass nil; the field is wired through so a future

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -303,14 +303,23 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		}
 	}
 
-	// ── ~/.claude (read-write) ──────────────────────────────────────────────
-	claudeDir := filepath.Join(home, ".claude")
-	args = append(args, "--bind", claudeDir, claudeDir)
-
-	// ── ~/.mcp-auth (read-write, conditional) ──────────────────────────────
-	mcpAuthDir := filepath.Join(home, ".mcp-auth")
-	if _, err := os.Stat(mcpAuthDir); err == nil {
-		args = append(args, "--bind", mcpAuthDir, mcpAuthDir)
+	// ── Standard sandbox mounts via the shared spec walk ─────────────────
+	// StandardSandboxMounts (mounts.go, A2.M1) returns the mode-agnostic
+	// mount set for ~/.claude, ~/.mcp-auth, ~/.cache/nix, AWS config, AWS
+	// credentials, AWS SSO/CLI cache, kube config, and the clipboard
+	// staging dir. The bwrap appendBind appender (mounts.go) translates
+	// each MountSpec into the correct --bind / --ro-bind triple.
+	//
+	// Note on ordering: StandardSandboxMounts emits ~/.claude, ~/.mcp-auth,
+	// ~/.cache/nix, AWS config, AWS credentials, AWS SSO, AWS CLI, kube
+	// config, clipboard-staging. The pre-A2.M1 bwrap order interleaved the
+	// AWS group with the SSH/known_hosts/SSH-config group; the new order
+	// keeps the AWS entries adjacent and emits all of them before the SSH
+	// keys. Bwrap argument order does not affect the runtime mount layout
+	// (bwrap evaluates arguments left-to-right but each --bind is
+	// independent), so this is a behaviour-preserving reordering.
+	for _, spec := range StandardSandboxMounts(cfg, home, home, isolationBwrap) {
+		args = b.appendBind(args, spec)
 	}
 
 	// ── opencode shared state dir (read-write) ─────────────────────────────
@@ -321,36 +330,20 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// Darwin — that path doesn't apply here because bwrap is Linux-only and
 	// SQLite WAL works correctly across concurrent processes on a shared
 	// filesystem.
+	//
+	// Kept inline: the mount semantics differ from podman's per-session
+	// state dir (which lives at /root/.local/share/opencode under a
+	// per-container subdir), so no shared spec entry exists.
 	opencodeDataDir := filepath.Join(home, ".local", "share", "opencode")
 	args = append(args, "--bind", opencodeDataDir, opencodeDataDir)
 
 	// ── Nix daemon socket dir (read-write) ──────────────────────────────────
 	// Mount the parent directory, not the socket file directly (same pattern
 	// as the podman path — avoids statfs ENOTSUP on certain filesystems).
+	// Kept inline because the absolute system path (not HOME-relative) is
+	// outside the StandardSandboxMounts shape.
 	nixDaemonSocketDir := "/nix/var/nix/daemon-socket"
 	args = append(args, "--bind", nixDaemonSocketDir, nixDaemonSocketDir)
-
-	// ── ~/.cache/nix (read-write) ────────────────────────────────────────────
-	nixCacheDir := filepath.Join(home, ".cache", "nix")
-	args = append(args, "--bind", nixCacheDir, nixCacheDir)
-
-	// ── AWS readonly-config (read-only, conditional) ─────────────────────────
-	// Remapped: host ~/.config/aws/readonly-config → sandbox $HOME/.aws/config
-	// (the canonical path the AWS CLI reads by default). The symlink is resolved
-	// to the real Nix store path so the bwrap bind-mount source exists.
-	awsReadonlyConfig := filepath.Join(home, ".config", "aws", "readonly-config")
-	if resolved, err := filepath.EvalSymlinks(awsReadonlyConfig); err == nil {
-		args = append(args, "--ro-bind", resolved, filepath.Join(home, ".aws", "config"))
-	}
-
-	// ── Kube agents-config (read-only, conditional) ─────────────────────────
-	// Remapped: host ~/.config/kube/agents-config → sandbox $HOME/.kube/config
-	// (the canonical path kubectl reads by default). Only the agents-readonly
-	// kubeconfig is exposed — the admin kubeconfig is never mounted.
-	kubeAgentsConfig := filepath.Join(home, ".config", "kube", "agents-config")
-	if resolved, err := filepath.EvalSymlinks(kubeAgentsConfig); err == nil {
-		args = append(args, "--ro-bind", resolved, filepath.Join(home, ".kube", "config"))
-	}
 
 	// ── SSH keys (read-only, conditional) ───────────────────────────────────
 	// All SSH artefacts are remapped to canonical generic paths under
@@ -435,19 +428,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// For non-review containers (worker, coordinator, etc.) agents/ is mounted
 	// so that @review-* subagent invocation works and all agents are accessible.
 	opencodeConfigDir := filepath.Join(home, ".config", "opencode")
-	opencodeAllowlist := []string{
-		"AGENTS.md",
-		"plugins",
-		"skills",
-		"command",
-		"tui.json",
-		".gitignore",
-		"mcp-atlassian-slim-proxy.mjs",
-	}
-	if !strings.HasPrefix(cfg.AgentRole, "review-") {
-		opencodeAllowlist = append(opencodeAllowlist, "agents")
-	}
-	for _, entry := range opencodeAllowlist {
+	isReviewBwrap := strings.HasPrefix(cfg.AgentRole, "review-")
+	for _, entry := range StandardOpencodeConfigAllowlist(isReviewBwrap) {
 		p := filepath.Join(opencodeConfigDir, entry)
 		if _, err := os.Stat(p); err == nil {
 			args = append(args, "--ro-bind", p, p)
@@ -461,6 +443,12 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// error (logged to ~/.local/share/opencode/log/*.log, NOT to stderr), so
 	// the sidecar loops on connection-refused and the pane stays blank. See
 	// the bwrap-spawn-hangs investigation for the full signature.
+	//
+	// Kept inline (not in StandardSandboxMounts): bwrap mounts this RW
+	// while podman mounts the same path RO. The audit (A2 §3.1) flagged
+	// these as podman-outliers; rather than thread a fourth per-mode flag
+	// through StandardSandboxMounts for one entry, the cache mounts stay
+	// per-mode-inline.
 	opencodeCacheDir := filepath.Join(home, ".cache", "opencode")
 	if _, err := os.Stat(opencodeCacheDir); err == nil {
 		args = append(args, "--bind", opencodeCacheDir, opencodeCacheDir)
@@ -476,33 +464,10 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--bind", bunCacheDir, bunCacheDir)
 	}
 
-	// ── Additional AWS mounts (read-only, conditional) ───────────────────────
-	// Match the podman buildRunArgs pattern: credentials file and SSO/CLI
-	// cache dirs are conditionally mounted when present on the host.
-	//
-	// Remapped: host ~/.config/aws/credentials → sandbox $HOME/.aws/credentials
-	// (the canonical path the AWS CLI reads by default).
-	awsCredentials := filepath.Join(home, ".config", "aws", "credentials")
-	if resolved, err := filepath.EvalSymlinks(awsCredentials); err == nil {
-		args = append(args, "--ro-bind", resolved, filepath.Join(home, ".aws", "credentials"))
-	}
-	awsSSOCacheDir := filepath.Join(home, ".aws", "sso")
-	if _, err := os.Stat(awsSSOCacheDir); err == nil {
-		args = append(args, "--bind", awsSSOCacheDir, awsSSOCacheDir)
-	}
-	awsCLICacheDir := filepath.Join(home, ".aws", "cli")
-	if _, err := os.Stat(awsCLICacheDir); err == nil {
-		args = append(args, "--bind", awsCLICacheDir, awsCLICacheDir)
-	}
-
-	// ── Clipboard staging dir (read-only, conditional) ───────────────────────
-	// Images staged by `prism clipboard paste-image` on the host are placed here
-	// and bind-mounted read-only so opencode's stat() call resolves without
-	// modification. Dst == Src (no remap needed).
-	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
-	if _, err := os.Stat(clipboardCacheDir); err == nil {
-		args = append(args, "--ro-bind", clipboardCacheDir, clipboardCacheDir)
-	}
+	// AWS credentials, AWS SSO cache, AWS CLI cache, kube config, and the
+	// clipboard staging dir are all emitted earlier in this function via the
+	// StandardSandboxMounts walk (A2.M1) — the inline blocks that previously
+	// duplicated those mounts here have been removed.
 
 	// ── Environment variables ────────────────────────────────────────────────
 	// Translate --env K=V (podman) → --setenv K V (bwrap).

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -14,8 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
-	"time"
 
 	"github.com/prismatic-koi/prism/internal/config"
 )
@@ -633,32 +631,15 @@ func minimalBwrapExecEnv(hostEnv []string) []string {
 	return MinimalIsolatedExecEnv(hostEnv)
 }
 
-// Shutdown sends SIGTERM to the bwrap process if it is still running. It uses
-// a background context with a 30-second timeout so cleanup proceeds even after
-// the parent context has been cancelled.
+// Shutdown sends SIGTERM to the bwrap process if it is still running, waits
+// up to 30 seconds, and sends SIGKILL if the process has not exited. The
+// SIGTERM-then-grace-then-SIGKILL body is shared with sandbox-exec via the
+// gracefulShutdown helper (shutdown.go, A2.GR).
 func (b *bwrapIsolator) Shutdown() {
 	b.mu.Lock()
 	cmd := b.cmd
 	b.mu.Unlock()
-
-	if cmd == nil || cmd.Process == nil {
-		return
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_ = cmd.Wait()
-	}()
-
-	// Send SIGTERM and wait up to 30 seconds for the process to exit.
-	_ = cmd.Process.Signal(syscall.SIGTERM)
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		_ = cmd.Process.Kill()
-		<-done
-	}
+	gracefulShutdown(cmd, defaultGracefulShutdownGrace)
 }
 
 // HasExited returns (true, exitCode) when the bwrap process has terminated,

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -317,7 +317,7 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// (bwrap evaluates arguments left-to-right but each --bind is
 	// independent), so this is a behaviour-preserving reordering.
 	for _, spec := range StandardSandboxMounts(cfg, home, home, isolationBwrap) {
-		args = b.appendBind(args, spec)
+		args = appendBwrapBind(args, spec)
 	}
 
 	// ── opencode shared state dir (read-write) ─────────────────────────────

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -848,14 +848,13 @@ func (m *Manager) buildRunArgs() []string {
 	// ignores it). Per-mode RO divergence for AWS SSO/CLI is captured
 	// inside StandardSandboxMounts via the mode argument.
 	//
-	// We use a fresh podmanIsolator value here rather than casting
-	// m.isolator: tests construct a Manager with a bwrapIsolator and
-	// then exercise buildRunArgs (the podman path) directly to verify
-	// host-API roundtripping. The appender is a stateless method, so
-	// instantiating one ad-hoc is safe.
-	pAppender := podmanIsolator{}
+	// appendPodmanVolume is a free function (not a method on
+	// podmanIsolator) so that tests which construct a Manager with a
+	// non-podman isolator and call buildRunArgs directly continue to work
+	// without a type-cast. The emitter is stateless — there is no podman
+	// state to consult — so a free function is the natural shape.
 	for _, spec := range StandardSandboxMounts(cfg, "/root", home, isolationPodman) {
-		args = pAppender.appendVolume(args, spec)
+		args = appendPodmanVolume(args, spec)
 	}
 
 	// auth.json overlay: bind-mount the host's opencode auth.json over the

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -58,31 +58,59 @@ const (
 // isolationMode identifies which sandbox layer will consume the temp files
 // (gitconfig, ssh config) that writeGitconfig / writeSshConfig generate.
 //
-// The two sandboxes mount the SSH artefacts at different in-sandbox paths:
+// The three sandboxes mount the SSH artefacts at different in-sandbox paths:
 //
 //   - podman runs as root, so canonical paths are /root/.ssh/{access-key,
 //     signing-key,signing-key.pub,allowed_signers} — the agent's $HOME is /root.
 //   - bwrap runs as the host user, so canonical paths are
 //     $HOME/.ssh/{access-key,signing-key,signing-key.pub,allowed_signers}
 //     where $HOME is the host user's home directory.
+//   - sandbox-exec also runs as the host user but with a per-session staging
+//     HOME (e.g. ~/.local/state/prism/sandbox-exec/<instance>) — the agent
+//     sees this as $HOME and the SSH artefacts are referenced under it.
 //
-// Agents inside both sandboxes see the same generic filenames (access-key,
-// signing-key, …); only the $HOME prefix differs. The isolation mode lets the
-// generators substitute the correct prefix into the config files they write.
+// Agents inside all three sandboxes see the same generic filenames
+// (access-key, signing-key, …); only the $HOME prefix differs. The isolation
+// mode lets the generators substitute the correct prefix into the config
+// files they write.
 type isolationMode int
 
 const (
 	isolationPodman isolationMode = iota
 	isolationBwrap
+	isolationSandboxExec
 )
 
 // sandboxHome returns the in-sandbox $HOME directory for the given isolation
-// mode. For podman this is always /root (the image's user). For bwrap this is
-// the host user's home directory, because bwrap shares the host user namespace
-// and does not switch to root.
-func sandboxHome(mode isolationMode) string {
+// mode and Manager. For podman this is always /root (the image's user). For
+// bwrap this is the host user's home directory, because bwrap shares the host
+// user namespace. For sandbox-exec it is the per-session staging HOME (which
+// is what the agent sees as $HOME inside the sandbox); when the staging HOME
+// cannot be resolved the helper falls back to the host home so that callers
+// always receive a non-empty path.
+//
+// m may be nil for callers that do not yet have a Manager (e.g. early
+// dispatch paths that only need the static podman/bwrap mapping); in that
+// case sandbox-exec falls back to the host home.
+func sandboxHome(m *Manager, mode isolationMode) string {
 	switch mode {
 	case isolationBwrap:
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			home = os.Getenv("HOME")
+		}
+		return home
+	case isolationSandboxExec:
+		if m != nil {
+			if stagingHome, err := m.sandboxExecHomePath(); err == nil && stagingHome != "" {
+				return stagingHome
+			}
+		}
+		// Fallback: host home. Used in the rare case where the staging
+		// HOME cannot be derived (no instance ID, no UserHomeDir). The
+		// resulting gitconfig still points at $HOME-relative SSH paths,
+		// matching the bwrap layout — which is the closest valid mapping
+		// for sandbox-exec when staging is unavailable.
 		home, err := os.UserHomeDir()
 		if err != nil || home == "" {
 			home = os.Getenv("HOME")
@@ -413,7 +441,7 @@ func (m *Manager) claudeCredentialsFilePath() string {
 // used by both the podman volume mount (/root/.ssh/access-key) and the bwrap
 // bind-mount (<hostHome>/.ssh/access-key).
 func (m *Manager) writeSshConfig(mode isolationMode) error {
-	identityFile := filepath.Join(sandboxHome(mode), ".ssh", "access-key")
+	identityFile := filepath.Join(sandboxHome(m, mode), ".ssh", "access-key")
 	sshConfig := "Host github.com\n" +
 		"  StrictHostKeyChecking accept-new\n" +
 		"  IdentityFile " + identityFile + "\n" +
@@ -446,10 +474,15 @@ func (m *Manager) writeSshConfig(mode isolationMode) error {
 //   - isolationBwrap: signingKey = <hostHome>/.ssh/signing-key.pub,
 //     allowedSignersFile = <hostHome>/.ssh/allowed_signers (paths inside
 //     the bwrap sandbox, where the agent runs as the host user).
+//   - isolationSandboxExec: signingKey = <stagingHome>/.ssh/signing-key.pub,
+//     allowedSignersFile = <stagingHome>/.ssh/allowed_signers (paths inside
+//     the sandbox-exec staging HOME, which is what the agent sees as $HOME
+//     under sandbox-exec).
 //
-// Both sandboxes mount the same underlying host key files — only the $HOME
-// prefix differs. Generic filenames (signing-key.pub, allowed_signers, …)
-// are used in both cases so agents see a uniform layout regardless of mode.
+// All three sandboxes mount or stage the same underlying host key files —
+// only the $HOME prefix differs. Generic filenames (signing-key.pub,
+// allowed_signers, …) are used in every case so agents see a uniform layout
+// regardless of mode.
 func (m *Manager) writeGitconfig(mode isolationMode) error {
 	// Reset allowedSignersReady so that a retry or second call doesn't carry
 	// stale state from a previous successful write into a new call that may fail.
@@ -489,7 +522,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 	// (see sandboxHome). Agents inside the sandbox see generic filenames —
 	// signing-key.pub / allowed_signers — regardless of which sandbox layer
 	// they're running under.
-	sandboxSshDir := filepath.Join(sandboxHome(mode), ".ssh")
+	sandboxSshDir := filepath.Join(sandboxHome(m, mode), ".ssh")
 	sandboxSigningKeyPub := filepath.Join(sandboxSshDir, "signing-key.pub")
 	sandboxAllowedSigners := filepath.Join(sandboxSshDir, "allowed_signers")
 
@@ -739,58 +772,25 @@ func (m *Manager) buildRunArgs() []string {
 	// opencode cache — mount the whole directory so plugins, models.json,
 	// package.json, and bun.lock are all available without network access.
 	// Pre-created by prepareVolumeDirs().
+	//
+	// Kept inline (not in StandardSandboxMounts): podman mounts this RO
+	// while bwrap mounts the same path RW. The audit (A2 §3.1) flagged
+	// the cache dirs as podman-outliers; rather than thread a fourth
+	// per-mode flag through StandardSandboxMounts for two entries, the
+	// cache mounts stay per-mode-inline.
 	opencodeCacheDir := filepath.Join(home, ".cache", "opencode")
 	opencodeCacheMount := opencodeCacheDir + ":/root/.cache/opencode:ro"
 	// bun transpiler cache — required for bun to load plugins without
 	// re-transpiling on every container start. Pre-created by prepareVolumeDirs().
+	// Same RO/RW divergence as the opencode cache above — kept inline.
 	bunCacheDir := filepath.Join(home, ".cache", "bun")
 	bunCacheMount := bunCacheDir + ":/root/.cache/bun:ro"
-	// Claude credentials — required for Anthropic provider auth. Mounted
-	// read-write so the opencode-claude-auth plugin can write back refreshed
-	// OAuth tokens to .credentials.json inside the container.
-	claudeMount := filepath.Join(home, ".claude") + ":/root/.claude"
-	// MCP auth — OAuth tokens written by mcp-remote (used by the Atlassian MCP
-	// shim and other MCP servers that use OAuth). Mounted read-write so that
-	// token refresh inside the container persists back to the host directory.
-	// Source path: ${home}/.mcp-auth — only mounted when it exists on the host.
-	mcpAuthDir := filepath.Join(home, ".mcp-auth")
-	// Nix eval cache — pre-populated git cache from the host so flake input
-	// tarballs (nixpkgs, home-manager, etc.) don't need to be re-fetched and
-	// unpacked on every container start. Read-write because nix writes to
-	// SQLite databases (fetcher-cache, binary-cache, eval-cache) during
-	// evaluation; the :Z label handles SELinux relabeling.
-	nixCacheMount := filepath.Join(home, ".cache", "nix") + ":/root/.cache/nix:Z"
 
-	// AWS — individual files mounted at /root/.aws (the default location the
-	// AWS CLI looks in) so `aws` works inside the container without any env var
-	// configuration. Only least-privilege files are mounted:
-	//
-	//   ~/.config/aws/readonly-config  → /root/.aws/config      (profiles/settings)
-	//   ~/.config/aws/credentials      → /root/.aws/credentials  (static creds, if present)
-	//   ~/.aws/sso                     → /root/.aws/sso          (SSO token cache from `aws sso login`)
-	//   ~/.aws/cli                     → /root/.aws/cli          (CLI session cache)
-	//
-	// The config and credentials files live in the XDG location (managed by
-	// sops-nix). The sso/ and cli/ cache dirs are always written to ~/.aws/ by
-	// the AWS CLI regardless of AWS_CONFIG_FILE, so they are sourced from there.
-	// Admin credentials (the full config, credentials with write-capable roles)
-	// are never mounted — only the readonly-config is exposed.
-	awsReadonlyConfig := filepath.Join(home, ".config", "aws", "readonly-config")
-	awsCredentials := filepath.Join(home, ".config", "aws", "credentials")
-	awsSSOCacheDir := filepath.Join(home, ".aws", "sso")
-	awsCLICacheDir := filepath.Join(home, ".aws", "cli")
-	// Kube agents config — the host stores this at ~/.config/kube/agents-config
-	// (XDG-compliant, managed by sops-nix). Mount it at /root/.kube/config (the
-	// default path kubectl reads) so `kubectl` works inside the container without
-	// any env var configuration. Only the agents/readonly kubeconfig is mounted —
-	// the admin kubeconfig is never exposed to agents.
-	kubeAgentsConfig := filepath.Join(home, ".config", "kube", "agents-config")
-	// Clipboard staging directory — images staged by `prism clipboard paste-image`
-	// on the host are placed here and bind-mounted read-only into the container at
-	// the identical absolute path so that opencode's stat() call resolves without
-	// modification. No clipboard tool, socket, or env var is exposed inside the
-	// container — clipboard read occurs entirely host-side.
-	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
+	// Mounts for ~/.claude, ~/.mcp-auth, ~/.cache/nix, AWS readonly-config,
+	// AWS credentials, AWS SSO/CLI cache, kube agents-config, and the
+	// clipboard staging dir are all emitted by the StandardSandboxMounts
+	// walk below (A2.M1) — the inline blocks that previously declared
+	// each path here have been replaced by that walk.
 
 	args := []string{
 		"run",
@@ -826,18 +826,37 @@ func (m *Manager) buildRunArgs() []string {
 		// opencode state — per-session isolated dir, read-write.
 		"--volume", opencodeStateMount,
 		// opencode cache — plugins, models, bun.lock from host, read-only.
+		// Kept inline (not in StandardSandboxMounts): podman mounts this
+		// RO while bwrap mounts the same path RW. See bwrap.go for the
+		// matching inline block — the audit (A2 §3.1) flagged the cache
+		// dirs as podman-outliers.
 		"--volume", opencodeCacheMount,
 		// bun transpiler cache — pre-compiled plugin modules from host.
+		// Same RO/RW divergence as the opencode cache above — kept inline.
 		"--volume", bunCacheMount,
-		// Claude credentials directory — read-write for auth plugin token refresh.
-		// On Linux, ~/.claude/.credentials.json lives here.
-		// On Darwin, .credentials.json is absent (credentials are in the macOS
-		// Keychain); writeClaudeCredentials() extracts and writes it to a temp
-		// file that is bind-mounted below at /root/.claude/.credentials.json.
-		"--volume", claudeMount,
-		// Nix eval cache — flake input tarballs pre-unpacked from the host.
-		"--volume", nixCacheMount,
 	)
+
+	// ── Standard sandbox mounts via the shared spec walk ─────────────────
+	// StandardSandboxMounts (mounts.go, A2.M1) returns the mode-agnostic
+	// mount set for ~/.claude, ~/.cache/nix, ~/.mcp-auth, AWS readonly-config,
+	// AWS credentials, AWS SSO/CLI cache, kube config, and the clipboard
+	// staging dir. The podman appendVolume appender (mounts.go) translates
+	// each MountSpec into the correct --volume "SRC:DST[:Z][:ro]" pair.
+	//
+	// SandboxPath uses /root as the in-sandbox $HOME prefix (sandboxHome
+	// for podman). SELinuxRelabel is honoured here (the bwrap appender
+	// ignores it). Per-mode RO divergence for AWS SSO/CLI is captured
+	// inside StandardSandboxMounts via the mode argument.
+	//
+	// We use a fresh podmanIsolator value here rather than casting
+	// m.isolator: tests construct a Manager with a bwrapIsolator and
+	// then exercise buildRunArgs (the podman path) directly to verify
+	// host-API roundtripping. The appender is a stateless method, so
+	// instantiating one ad-hoc is safe.
+	pAppender := podmanIsolator{}
+	for _, spec := range StandardSandboxMounts(cfg, "/root", home, isolationPodman) {
+		args = pAppender.appendVolume(args, spec)
+	}
 
 	// auth.json overlay: bind-mount the host's opencode auth.json over the
 	// per-session dir so OAuth tokens are shared across sessions without sharing
@@ -852,57 +871,13 @@ func (m *Manager) buildRunArgs() []string {
 	// visible to subsequent sessions — the intended shared-credentials behaviour.
 	// :Z applies the SELinux label so podman can bind-mount it on
 	// SELinux-enforcing hosts (Fedora/RHEL).
+	//
+	// Kept inline (not in StandardSandboxMounts): the SandboxPath is
+	// /root/.local/share/opencode/auth.json — it shadows a file inside the
+	// per-session opencode state mount above, which is a podman-specific
+	// pattern (bwrap shares the host opencode dir directly, no overlay).
 	if _, err := os.Stat(opencodeAuthJSON); err == nil {
 		args = append(args, "--volume", opencodeAuthJSON+":/root/.local/share/opencode/auth.json:Z")
-	}
-
-	// MCP auth: bind-mount ~/.mcp-auth into the container at /root/.mcp-auth
-	// so mcp-remote OAuth tokens obtained on the host are available inside the
-	// container. Mounted read-write so token refresh inside the container
-	// persists back to the host. Only mounted when the directory exists — hosts
-	// without Atlassian MCP configured are unaffected.
-	if _, err := os.Stat(mcpAuthDir); err == nil {
-		args = append(args, "--volume", mcpAuthDir+":/root/.mcp-auth")
-	}
-
-	// AWS: mount individual files/dirs into /root/.aws so the AWS CLI works at
-	// its default paths with no env var configuration. Each mount is conditional
-	// on the source path existing — hosts without AWS configured are unaffected.
-	if resolved, err := filepath.EvalSymlinks(awsReadonlyConfig); err == nil {
-		args = append(args, "--volume", resolved+":/root/.aws/config:ro")
-	}
-	if resolved, err := filepath.EvalSymlinks(awsCredentials); err == nil {
-		args = append(args, "--volume", resolved+":/root/.aws/credentials:ro")
-	}
-	// SSO and CLI cache dirs — written to ~/.aws/ by the AWS CLI regardless of
-	// AWS_CONFIG_FILE. Mount read-only so the container can use SSO tokens
-	// obtained on the host via `aws sso login` without needing network access
-	// to re-authenticate. Mounted as directories (conditional on existence).
-	if _, err := os.Stat(awsSSOCacheDir); err == nil {
-		args = append(args, "--volume", awsSSOCacheDir+":/root/.aws/sso:ro")
-	}
-	if _, err := os.Stat(awsCLICacheDir); err == nil {
-		args = append(args, "--volume", awsCLICacheDir+":/root/.aws/cli:ro")
-	}
-
-	// Kube agents config: mount ~/.config/kube/agents-config at
-	// /root/.kube/config (the default file kubectl reads) when the file exists
-	// on the host. Only the agents/readonly kubeconfig is exposed — the admin
-	// kubeconfig is never mounted into agent containers.
-	if resolved, err := filepath.EvalSymlinks(kubeAgentsConfig); err == nil {
-		args = append(args, "--volume", resolved+":/root/.kube/config:ro")
-	}
-
-	// Clipboard staging directory: bind-mount ~/.cache/prism/clipboard/ at
-	// the identical host path inside the container, read-only. Images staged
-	// by `prism clipboard paste-image` (running host-side via the tmux keybind)
-	// are written here; opencode's drag-drop handler stat()s the path and reads
-	// the bytes. The read-only mount ensures the container cannot write to the
-	// host's staging directory. Only mounted when the directory exists — skipped
-	// silently at container spawn time when no paste has occurred yet (consistent
-	// with the conditional-mount pattern used for AWS/MCP-auth/kube config).
-	if _, err := os.Stat(clipboardCacheDir); err == nil {
-		args = append(args, "--volume", clipboardCacheDir+":"+clipboardCacheDir+":ro")
 	}
 
 	// Darwin: bind-mount the extracted Keychain credentials over

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -412,13 +412,15 @@ func (s *sandboxExecIsolator) EnsureRemoved(ctx context.Context, m *Manager) {
 }
 
 // WriteGitconfig generates a minimal .gitconfig for the sandbox-exec sandbox.
-// sandbox-exec shares the host user's $HOME, so the signingKey and
-// allowedSignersFile paths embed the host user's $HOME (not /root). The
-// existing isolationBwrap branch in container.go's writeGitconfig already
-// handles the "host $HOME" path layout — sandbox-exec is structurally the
-// same here, so we re-use it.
+// sandbox-exec runs as the host user but with a per-session staging HOME, so
+// the signingKey and allowedSignersFile paths embed <stagingHome>/.ssh/...
+// (post A2.G1: writeGitconfig now covers sandbox-exec via the third
+// isolationSandboxExec mode value, with sandboxHome(m, isolationSandboxExec)
+// resolving to the staging HOME). The temp file written here is then
+// materialised into <stagingHome>/.gitconfig by writeGitconfigToDir, which
+// is invoked from PrepareSandboxExecHome.
 func (s *sandboxExecIsolator) WriteGitconfig(m *Manager) error {
-	return m.writeGitconfig(isolationBwrap)
+	return m.writeGitconfig(isolationSandboxExec)
 }
 
 // Reset is a no-op for sandbox-exec today — same rationale as bwrap.Reset.

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -263,7 +263,7 @@ func StandardOpencodeConfigAllowlist(isReview bool) []string {
 	return allowlist
 }
 
-// appendVolume appends a podman --volume argument pair for the given
+// appendPodmanVolume appends a podman --volume argument pair for the given
 // MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
 // resolveMountHostPath and emits "--volume SRC:DST[:Z][:ro]" when the mount
 // should be active. Returns args unchanged when the mount is skipped.
@@ -274,7 +274,13 @@ func StandardOpencodeConfigAllowlist(isReview bool) []string {
 // StandardSandboxMounts (where DST is created lazily by podman), --volume
 // SRC:DST[:Z][:ro] works for both files and directories. The existing
 // container.go always used --volume for these, so we keep that.
-func (p *podmanIsolator) appendVolume(args []string, spec MountSpec) []string {
+//
+// Free function (not a method on podmanIsolator) because the emitter is
+// stateless and the podman mount block is exercised by tests that build a
+// Manager with a non-podman isolator, then call buildRunArgs directly. A
+// free function lets those tests continue to work without an awkward
+// type-cast or fresh-isolator instantiation.
+func appendPodmanVolume(args []string, spec MountSpec) []string {
 	src, ok := resolveMountHostPath(spec)
 	if !ok {
 		return args
@@ -289,12 +295,15 @@ func (p *podmanIsolator) appendVolume(args []string, spec MountSpec) []string {
 	return append(args, "--volume", src+":"+spec.SandboxPath+flags)
 }
 
-// appendBind appends a bwrap --ro-bind or --bind argument triple for the
+// appendBwrapBind appends a bwrap --ro-bind or --bind argument triple for the
 // given MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
 // resolveMountHostPath and emits the correct flag based on spec.ReadOnly.
 // SELinuxRelabel is ignored — bwrap does not participate in SELinux labelling.
 // Returns args unchanged when the mount is skipped.
-func (b *bwrapIsolator) appendBind(args []string, spec MountSpec) []string {
+//
+// Free function (not a method on bwrapIsolator) — the emitter is stateless
+// and a free function is symmetric with appendPodmanVolume above.
+func appendBwrapBind(args []string, spec MountSpec) []string {
 	src, ok := resolveMountHostPath(spec)
 	if !ok {
 		return args

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -1,0 +1,307 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file defines the shared MountSpec shape and StandardSandboxMounts walk
+// used by the podman and bwrap mount-emission paths (issue #1149 A2.M1; design
+// proposal A2 §3.1, §3.S6).
+//
+// The common decision tree — "which host artefact lives at which canonical
+// in-sandbox path, with which read/write/optional/symlink-resolve flags" — is
+// expressed once here, mode-agnostic. Each isolator walks the slice and
+// translates the entries into its own argument grammar via per-mode appenders:
+//
+//   - podmanIsolator.appendVolume(args, spec)        → "--volume SRC:DST[:Z][:ro]"
+//   - bwrapIsolator.appendBind(args, spec)           → "--ro-bind|--bind SRC DST"
+//   - sandboxExecIsolator.appendAllow(profile, spec) → "(subpath \"...\")" in SBPL
+//
+// Today only the podman and bwrap appenders are wired through the slice; the
+// sandbox-exec staging HOME is built via collectStagingHomeSymlinkTargets in
+// sandbox_exec_home.go, which serves the same purpose with a different
+// implementation strategy (sandbox-exec has no bind-mount mechanism, so the
+// staging HOME is materialised as real symlinks rather than emitted as mount
+// arguments).
+package container
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// MountSpec describes one host artefact that needs to appear inside the
+// sandbox interior at a canonical path. It is mode-agnostic — each isolator
+// emits the syntax it needs via its own appender.
+//
+// The SandboxPath is the path the agent inside the sandbox sees. For podman,
+// HOME-relative paths are rooted at /root/...; for bwrap and sandbox-exec
+// they are rooted at the host user's $HOME (or staging HOME for sandbox-exec).
+// StandardSandboxMounts computes the SandboxPath using the sandboxHomeDir
+// argument the caller provides, so the per-mode HOME prefix is captured at
+// the call site rather than baked into MountSpec.
+type MountSpec struct {
+	// HostPath is the absolute host path of the artefact. Empty means
+	// "skip this mount" — used so that conditional mounts can be returned
+	// in a unified slice without forcing every entry to be present.
+	HostPath string
+
+	// SandboxPath is the absolute path the artefact must appear at inside
+	// the sandbox. May or may not equal HostPath depending on the mode.
+	SandboxPath string
+
+	// ReadOnly mounts the artefact read-only when true. Podman emits ":ro";
+	// bwrap emits "--ro-bind"; sandbox-exec emits the file-read* allow rule
+	// without file-write*.
+	ReadOnly bool
+
+	// EvalSymlinks resolves the host path through filepath.EvalSymlinks
+	// before emission. Required for sops-managed artefacts (where the host
+	// path is a /run/secrets/... symlink that the sandbox cannot follow).
+	// Resolution failure → silent skip (treated as "the artefact does not
+	// exist on this host", matching the original conditional-mount pattern
+	// for AWS / Kube / SSH keys).
+	EvalSymlinks bool
+
+	// OptionalIfMissing skips the mount silently when HostPath does not
+	// exist (os.Stat fails). Used for AWS / Kube / Claude / MCP-auth /
+	// opencode auth.json — artefacts that may be present on some hosts and
+	// not others. Does not apply when EvalSymlinks is true (resolution
+	// failure already implies "missing").
+	OptionalIfMissing bool
+
+	// SELinuxRelabel adds the ":Z" label suffix on podman so that the
+	// container can read/write the bind-mounted directory on
+	// SELinux-enforcing hosts (Fedora, RHEL). Ignored by bwrap and
+	// sandbox-exec — neither participates in SELinux labelling.
+	SELinuxRelabel bool
+}
+
+// resolveMountHostPath applies the EvalSymlinks / OptionalIfMissing
+// conditionality rules to a MountSpec and returns:
+//
+//   - the path that should be used in the emitted argument (post-resolution
+//     when EvalSymlinks is true; the original HostPath otherwise);
+//   - a boolean indicating whether the mount should be emitted at all.
+//
+// HostPath == "" → skip silently (allows callers to build the slice with
+// conditional entries inline). EvalSymlinks failure → skip silently (the
+// artefact does not exist on this host). OptionalIfMissing && os.Stat fails
+// → skip silently. All other failures fall through to "emit the path
+// verbatim and let the kernel produce the real error".
+func resolveMountHostPath(spec MountSpec) (string, bool) {
+	if spec.HostPath == "" {
+		return "", false
+	}
+	if spec.EvalSymlinks {
+		resolved, err := filepath.EvalSymlinks(spec.HostPath)
+		if err != nil {
+			return "", false
+		}
+		return resolved, true
+	}
+	if spec.OptionalIfMissing {
+		if _, err := os.Stat(spec.HostPath); err != nil {
+			return "", false
+		}
+	}
+	return spec.HostPath, true
+}
+
+// StandardSandboxMounts returns the canonical mount set for a given session
+// configuration, mode-agnostic. Each isolator walks the slice and emits
+// per-mode syntax via its own appender.
+//
+// sandboxHomeDir is the in-sandbox $HOME path (e.g. "/root" for podman or the
+// host user's home directory for bwrap). It is used as the prefix for every
+// HOME-relative SandboxPath in the returned slice.
+//
+// hostHome is the absolute host home directory (the source of HOME-relative
+// host artefacts). When empty, host-relative entries fall back to
+// os.UserHomeDir() and finally $HOME.
+//
+// mode is the isolation mode of the calling isolator. A small number of
+// entries have a per-mode RO/RW divergence that is intentional (see the
+// per-entry comments below). Passing the mode here keeps the divergence in
+// one place rather than scattering per-mode tweaks at the call site.
+//
+// The returned slice is split into logical groups by adjacency for ease of
+// reading at the call site, but callers should treat it as an opaque list of
+// mounts.
+func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode isolationMode) []MountSpec {
+	if hostHome == "" {
+		if h, err := os.UserHomeDir(); err == nil {
+			hostHome = h
+		} else {
+			hostHome = os.Getenv("HOME")
+		}
+	}
+
+	// Per-mode RO/RW divergence for the AWS SSO/CLI cache directories:
+	//
+	//   - podman mounts them read-only because the container has its own net
+	//     namespace; the SSO token is consumed inside the container but
+	//     refresh happens host-side via `aws sso login`.
+	//   - bwrap mounts them read-write because the bwrap sandbox shares the
+	//     host net namespace and may itself perform an SSO refresh that
+	//     writes to the cache (the original bwrap.go used --bind, not
+	//     --ro-bind).
+	//
+	// This is incidentally-different — both modes accept reads from the
+	// cache; the writeability flag is the only difference. Encoding it here
+	// keeps the per-mode-tweak knowledge in one file rather than scattering
+	// "RW for bwrap, RO for podman" comments at every call site.
+	awsSSOReadOnly := mode == isolationPodman
+	awsCLIReadOnly := mode == isolationPodman
+
+	specs := []MountSpec{
+		// ── ~/.claude (RW) ───────────────────────────────────────────────
+		// Anthropic API credentials directory. Read-write so the
+		// opencode-claude-auth plugin can refresh OAuth tokens. Mounted
+		// unconditionally — the agent fails gracefully when absent.
+		{
+			HostPath:    filepath.Join(hostHome, ".claude"),
+			SandboxPath: filepath.Join(sandboxHomeDir, ".claude"),
+		},
+
+		// ── ~/.mcp-auth (RW, conditional) ────────────────────────────────
+		// mcp-remote OAuth tokens. Mounted only when the directory exists
+		// on the host — hosts without Atlassian MCP configured are
+		// unaffected.
+		{
+			HostPath:          filepath.Join(hostHome, ".mcp-auth"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".mcp-auth"),
+			OptionalIfMissing: true,
+		},
+
+		// ── ~/.cache/nix (RW) ────────────────────────────────────────────
+		// Pre-populated nix flake input cache. Read-write because nix
+		// writes to its SQLite databases during evaluation.
+		{
+			HostPath:       filepath.Join(hostHome, ".cache", "nix"),
+			SandboxPath:    filepath.Join(sandboxHomeDir, ".cache", "nix"),
+			SELinuxRelabel: true,
+		},
+
+		// ── AWS readonly-config (RO, EvalSymlinks) ───────────────────────
+		// Host: ~/.config/aws/readonly-config (XDG, sops-managed symlink).
+		// Sandbox: $HOME/.aws/config (canonical AWS CLI default path).
+		{
+			HostPath:     filepath.Join(hostHome, ".config", "aws", "readonly-config"),
+			SandboxPath:  filepath.Join(sandboxHomeDir, ".aws", "config"),
+			ReadOnly:     true,
+			EvalSymlinks: true,
+		},
+
+		// ── AWS credentials (RO, EvalSymlinks) ───────────────────────────
+		{
+			HostPath:     filepath.Join(hostHome, ".config", "aws", "credentials"),
+			SandboxPath:  filepath.Join(sandboxHomeDir, ".aws", "credentials"),
+			ReadOnly:     true,
+			EvalSymlinks: true,
+		},
+
+		// ── AWS SSO cache (conditional, per-mode RO) ────────────────────
+		// Always written to ~/.aws/sso by the AWS CLI (regardless of
+		// AWS_CONFIG_FILE). Mounted at $HOME/.aws/sso. RO on podman
+		// (rationale: see awsSSOReadOnly above), RW on bwrap.
+		{
+			HostPath:          filepath.Join(hostHome, ".aws", "sso"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".aws", "sso"),
+			ReadOnly:          awsSSOReadOnly,
+			OptionalIfMissing: true,
+		},
+
+		// ── AWS CLI cache (conditional, per-mode RO) ────────────────────
+		{
+			HostPath:          filepath.Join(hostHome, ".aws", "cli"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".aws", "cli"),
+			ReadOnly:          awsCLIReadOnly,
+			OptionalIfMissing: true,
+		},
+
+		// ── Kube agents config (RO, EvalSymlinks) ────────────────────────
+		// Host: ~/.config/kube/agents-config (XDG, sops-managed symlink).
+		// Sandbox: $HOME/.kube/config (canonical kubectl default path).
+		{
+			HostPath:     filepath.Join(hostHome, ".config", "kube", "agents-config"),
+			SandboxPath:  filepath.Join(sandboxHomeDir, ".kube", "config"),
+			ReadOnly:     true,
+			EvalSymlinks: true,
+		},
+
+		// ── Clipboard staging dir (RO, conditional) ──────────────────────
+		// Images staged by `prism clipboard paste-image`. Dst==Src — the
+		// agent reads at the same absolute path the host writes to.
+		{
+			HostPath:          filepath.Join(hostHome, ".cache", "prism", "clipboard"),
+			SandboxPath:       filepath.Join(hostHome, ".cache", "prism", "clipboard"),
+			ReadOnly:          true,
+			OptionalIfMissing: true,
+		},
+	}
+
+	return specs
+}
+
+// StandardOpencodeConfigAllowlist returns the static list of entries in
+// ~/.config/opencode/ that should be mounted into the sandbox. Excluded:
+// opencode.json (mounted separately from a per-session temp file), package.json,
+// bun.lock, package-lock.json, node_modules/ (bun ecosystem files the sandbox
+// manages itself).
+//
+// agents/ is excluded for review-* agents (see container.go:1019-1025 for the
+// full rationale).
+func StandardOpencodeConfigAllowlist(isReview bool) []string {
+	allowlist := []string{
+		"AGENTS.md",
+		"plugins",
+		"skills",
+		"command",
+		"tui.json",
+		".gitignore",
+		"mcp-atlassian-slim-proxy.mjs",
+	}
+	if !isReview {
+		allowlist = append(allowlist, "agents")
+	}
+	return allowlist
+}
+
+// appendVolume appends a podman --volume argument pair for the given
+// MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
+// resolveMountHostPath and emits "--volume SRC:DST[:Z][:ro]" when the mount
+// should be active. Returns args unchanged when the mount is skipped.
+//
+// Podman has a subtle file-vs-directory distinction for SELinux-relabelled
+// mounts: directory mounts that the container should be able to populate use
+// "--mount type=bind,...", but for the canonical-name remap pattern used by
+// StandardSandboxMounts (where DST is created lazily by podman), --volume
+// SRC:DST[:Z][:ro] works for both files and directories. The existing
+// container.go always used --volume for these, so we keep that.
+func (p *podmanIsolator) appendVolume(args []string, spec MountSpec) []string {
+	src, ok := resolveMountHostPath(spec)
+	if !ok {
+		return args
+	}
+	flags := ""
+	if spec.SELinuxRelabel {
+		flags += ":Z"
+	}
+	if spec.ReadOnly {
+		flags += ":ro"
+	}
+	return append(args, "--volume", src+":"+spec.SandboxPath+flags)
+}
+
+// appendBind appends a bwrap --ro-bind or --bind argument triple for the
+// given MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
+// resolveMountHostPath and emits the correct flag based on spec.ReadOnly.
+// SELinuxRelabel is ignored — bwrap does not participate in SELinux labelling.
+// Returns args unchanged when the mount is skipped.
+func (b *bwrapIsolator) appendBind(args []string, spec MountSpec) []string {
+	src, ok := resolveMountHostPath(spec)
+	if !ok {
+		return args
+	}
+	flag := "--bind"
+	if spec.ReadOnly {
+		flag = "--ro-bind"
+	}
+	return append(args, flag, src, spec.SandboxPath)
+}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -37,12 +38,14 @@ type sandboxExecIsolator struct {
 	// name is the stable session identifier (used for log messages).
 	name string
 
-	// mu guards exited/exitCode. The sandbox-exec process for a session is
-	// launched by agent-run via syscall.Exec, so this Isolator's Run path is
-	// unused in the production flow — these fields exist solely to satisfy
-	// the Isolator interface and to give future tests a place to record
-	// terminal state.
+	// mu guards cmd, exited, and exitCode. The production sandbox-exec
+	// child is launched by cmd/agent_run_sandbox_exec_darwin.go (which
+	// owns its own Wait loop), so the cmd field is populated only when
+	// the Isolator's Run path is exercised — currently used by tests that
+	// want to verify Shutdown delivers SIGTERM/SIGKILL via the shared
+	// gracefulShutdown helper (shutdown.go, A2.GR).
 	mu       sync.Mutex
+	cmd      *exec.Cmd
 	exited   bool
 	exitCode int
 }
@@ -611,20 +614,53 @@ func (s *sandboxExecIsolator) BuildArgs(m *Manager) []string {
 	return args
 }
 
-// Run is a no-op stub for the production flow: agent-run launches
-// sandbox-exec via syscall.Exec, replacing its own process image, so this
-// Isolator's Run is never reached. The method exists to satisfy the
-// Isolator interface and is kept symmetric with bwrap.Run for future tests.
+// Run is unused in the production flow — agent-run launches sandbox-exec
+// directly as a supervised child of the tmux pane (see
+// cmd/agent_run_sandbox_exec_darwin.go) rather than going through the
+// Isolator's Run path. The method satisfies the Isolator interface and
+// stores the resulting *exec.Cmd in s.cmd so that Shutdown can deliver
+// SIGTERM/SIGKILL via the shared gracefulShutdown helper. Returns an
+// error after the child exits.
+//
+// The first argv element from BuildArgs is "sandbox-exec" (matching the
+// bwrap convention); we pass args[1:] to exec.CommandContext because Go
+// prepends argv[0] from the binary path.
 func (s *sandboxExecIsolator) Run(ctx context.Context, args []string) error {
-	return fmt.Errorf("container: sandbox-exec %q: Run is not implemented; agent-run uses syscall.Exec", s.name)
+	if len(args) < 1 {
+		return fmt.Errorf("container: sandbox-exec %q: Run called with empty args", s.name)
+	}
+	cmd := exec.CommandContext(ctx, "/usr/bin/sandbox-exec", args[1:]...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	s.mu.Lock()
+	s.cmd = cmd
+	s.mu.Unlock()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("container: sandbox-exec run %q: %w", s.name, err)
+	}
+	return nil
 }
 
-// Shutdown is a no-op for sandbox-exec: the production flow uses
-// syscall.Exec from agent-run, so the sandbox-exec child is owned by the
-// tmux pane's process tree and terminates when the pane dies. Lifecycle
-// hardening (signal forwarding, kqueue parent-death watcher) is the
-// subject of PR 4 (#1018).
-func (s *sandboxExecIsolator) Shutdown() {}
+// Shutdown sends SIGTERM to the sandbox-exec child if it is still running,
+// waits up to 30 seconds, and sends SIGKILL if the process has not exited.
+// The SIGTERM-then-grace-then-SIGKILL body is shared with bwrap via the
+// gracefulShutdown helper (shutdown.go, A2.GR).
+//
+// In the production agent-run flow the sandbox-exec child is owned by
+// cmd/agent_run_sandbox_exec_darwin.go (which manages its own supervised
+// Wait loop with kqueue parent-death watching). The Isolator's Shutdown is
+// therefore a no-op when no Run-managed child has been registered (s.cmd
+// is nil) — preserving the pre-A2.GR behaviour. When a future test or
+// caller invokes Run on this isolator, Shutdown will deliver the same
+// SIGTERM-then-SIGKILL sequence as bwrap.
+func (s *sandboxExecIsolator) Shutdown() {
+	s.mu.Lock()
+	cmd := s.cmd
+	s.mu.Unlock()
+	gracefulShutdown(cmd, defaultGracefulShutdownGrace)
+}
 
 // HasExited returns the recorded exit state. In the production flow this is
 // always (false, 0) because agent-run replaces its own process via

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -362,72 +362,54 @@ func (m *Manager) writeSshConfigToDir(stagingHome string) error {
 	return nil
 }
 
-// writeGitconfigToDir writes a generated .gitconfig file into the given
-// staging HOME directory. It reuses the existing writeGitconfig logic but
-// substitutes stagingHome as the in-sandbox $HOME so signingKey and
-// allowedSignersFile paths resolve correctly inside the sandbox.
+// writeGitconfigToDir generates a .gitconfig and (when signing is available)
+// allowed_signers for the sandbox-exec staging HOME. It is a thin wrapper
+// around writeGitconfig(isolationSandboxExec) — the canonical helper used
+// by podman and bwrap — and then materialises the resulting temp files into
+// the staging HOME at the canonical paths the agent expects:
+//
+//	<stagingHome>/.gitconfig
+//	<stagingHome>/.ssh/allowed_signers   (when signing is configured)
+//
+// The temp files written by writeGitconfig (m.gitconfigFilePath() and
+// m.allowedSignersFilePath()) embed sandbox-relative paths derived from
+// sandboxHome(m, isolationSandboxExec) — which resolves to stagingHome — so
+// the file content is identical whether read from the temp path or from the
+// staging HOME copy. We materialise into the staging HOME because
+// sandbox-exec has no bind-mount mechanism: the agent reads the file
+// directly from $HOME inside the sandbox.
 func (m *Manager) writeGitconfigToDir(stagingHome string) error {
-	home, err := os.UserHomeDir()
+	if err := m.writeGitconfig(isolationSandboxExec); err != nil {
+		return fmt.Errorf("write gitconfig: %w", err)
+	}
+
+	// Copy the generated gitconfig into the staging HOME at the canonical
+	// path the agent expects (<stagingHome>/.gitconfig).
+	gitconfigContent, err := os.ReadFile(m.gitconfigFilePath())
 	if err != nil {
-		home = os.Getenv("HOME")
+		return fmt.Errorf("read generated gitconfig %s: %w", m.gitconfigFilePath(), err)
 	}
-	sshDir := filepath.Join(home, ".ssh")
-
-	signingKeyName := m.cfg.SshSigningKeyName
-	if signingKeyName == "" {
-		signingKeyName = "prismatic-koi-ed25519-signingkey"
+	gitconfigDst := filepath.Join(stagingHome, ".gitconfig")
+	_ = os.Remove(gitconfigDst) // idempotent: replace any prior symlink/file
+	if err := os.WriteFile(gitconfigDst, gitconfigContent, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", gitconfigDst, err)
 	}
-	signingKeyPriv := filepath.Join(sshDir, signingKeyName)
-	signingKeyPub := filepath.Join(sshDir, signingKeyName+".pub")
-	_, errPriv := filepath.EvalSymlinks(signingKeyPriv)
-	_, errPub := filepath.EvalSymlinks(signingKeyPub)
-	hasSigning := errPriv == nil && errPub == nil
 
-	// The staging HOME's .ssh/ paths are what the agent will see inside the
-	// sandbox. The gitconfig must reference those canonical generic names.
-	sandboxSshDir := filepath.Join(stagingHome, ".ssh")
-	sandboxSigningKeyPub := filepath.Join(sandboxSshDir, "signing-key.pub")
-	sandboxAllowedSigners := filepath.Join(sandboxSshDir, "allowed_signers")
-
-	var sb strings.Builder
-
-	if m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
-		sb.WriteString("[user]\n")
-		sb.WriteString("    name = " + m.cfg.GitUserName + "\n")
-		sb.WriteString("    email = " + m.cfg.GitUserEmail + "\n")
-		if hasSigning {
-			sb.WriteString("    signingKey = " + sandboxSigningKeyPub + "\n")
+	// When writeGitconfig produced an allowed_signers file (i.e. signing is
+	// configured and the public key was readable), copy it into the staging
+	// HOME's .ssh directory so git verify-commit succeeds inside the sandbox.
+	if m.allowedSignersReady {
+		signersContent, readErr := os.ReadFile(m.allowedSignersFilePath())
+		if readErr != nil {
+			return fmt.Errorf("read generated allowed_signers %s: %w", m.allowedSignersFilePath(), readErr)
+		}
+		signersDst := filepath.Join(stagingHome, ".ssh", "allowed_signers")
+		_ = os.Remove(signersDst) // idempotent: replace prior symlink/file
+		if err := os.WriteFile(signersDst, signersContent, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", signersDst, err)
 		}
 	}
 
-	if hasSigning && m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
-		pubKeyContent, readErr := os.ReadFile(signingKeyPub)
-		if readErr == nil {
-			allowedSignersContent := m.cfg.GitUserEmail + " " + strings.TrimSpace(string(pubKeyContent)) + "\n"
-			allowedSignersDst := filepath.Join(stagingHome, ".ssh", "allowed_signers")
-			// Write the generated allowed_signers file (replaces any existing symlink).
-			_ = os.Remove(allowedSignersDst)
-			if writeErr := os.WriteFile(allowedSignersDst, []byte(allowedSignersContent), 0o644); writeErr == nil {
-				sb.WriteString("\n[commit]\n")
-				sb.WriteString("    gpgsign = true\n")
-				sb.WriteString("\n[gpg]\n")
-				sb.WriteString("    format = ssh\n")
-				sb.WriteString("\n[gpg \"ssh\"]\n")
-				sb.WriteString("    allowedSignersFile = " + sandboxAllowedSigners + "\n")
-			}
-		}
-	}
-
-	sb.WriteString("\n[push]\n")
-	sb.WriteString("    autoSetupRemote = true\n")
-	sb.WriteString("\n[init]\n")
-	sb.WriteString("    defaultBranch = main\n")
-
-	dst := filepath.Join(stagingHome, ".gitconfig")
-	_ = os.Remove(dst) // idempotent
-	if err := os.WriteFile(dst, []byte(sb.String()), 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", dst, err)
-	}
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/container/shutdown.go
+++ b/modules/programs/prism/prism/internal/container/shutdown.go
@@ -1,0 +1,68 @@
+// Package container manages the podman container lifecycle for prism sidecar.
+// This file defines the shared gracefulShutdown helper used by the bwrap and
+// sandbox-exec Isolator.Shutdown implementations (issue #1149 A2.GR; design
+// proposal A2 §3.7).
+//
+// Both bwrap and sandbox-exec sessions are supervised children rather than
+// long-lived container resources (only podman owns a container that survives
+// process death). When Manager.Shutdown is invoked on a bwrap or sandbox-exec
+// session, the polite teardown shape is the same: SIGTERM → grace period →
+// SIGKILL. Pre-A2.GR this body lived inline inside bwrapIsolator.Shutdown;
+// sandboxExecIsolator.Shutdown was a no-op.
+//
+// Podman's Shutdown stays separate (must-differ per A2 §3.7) because the
+// container's lifecycle is driven by `podman stop --time 10` followed by
+// `podman rm --force`, not by direct signal delivery.
+package container
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// defaultGracefulShutdownGrace is the SIGTERM-to-SIGKILL grace period used
+// by bwrap and sandbox-exec when no caller-supplied value is provided. The
+// value mirrors the original bwrap.Shutdown timeout (30 seconds).
+const defaultGracefulShutdownGrace = 30 * time.Second
+
+// gracefulShutdown sends SIGTERM to cmd's process, waits up to gracePeriod
+// for it to exit, and sends SIGKILL if the process has not exited within
+// the grace window. It is the shared body for the bwrap and sandbox-exec
+// Isolator.Shutdown implementations.
+//
+// Concurrency contract: gracefulShutdown calls cmd.Wait() in its own
+// internal goroutine. Callers must not also call cmd.Wait() — doing so
+// would race the helper's wait observation. The bwrap and sandbox-exec
+// production paths that own a Wait() call (e.g. cmd/agent_run.go,
+// cmd/agent_run_sandbox_exec_darwin.go) drive shutdown via their own
+// signal-handling rather than calling this helper; this helper is reached
+// only via the Isolator.Shutdown() public API, which is invoked from the
+// Manager.Shutdown path that does not own a concurrent Wait.
+//
+// gracePeriod ≤ 0 falls back to defaultGracefulShutdownGrace.
+//
+// cmd may be nil or have a nil Process — the helper is a no-op in those
+// cases (matching the pre-A2.GR bwrapIsolator.Shutdown behaviour).
+func gracefulShutdown(cmd *exec.Cmd, gracePeriod time.Duration) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	if gracePeriod <= 0 {
+		gracePeriod = defaultGracefulShutdownGrace
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = cmd.Wait()
+	}()
+
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-done:
+	case <-time.After(gracePeriod):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1149.

Extracts the four largest shared helpers identified by the A2 isolation
duplication audit (`docs/reviews/A2-isolation-implementation-duplication-audit.md`)
across the bwrap, sandbox-exec, and podman isolation paths. Pure refactor — no
behaviour change for any existing isolation mode.

- **A2.G1**: `writeGitconfig` now covers sandbox-exec via a third
  `isolationSandboxExec` mode value. `sandboxHome(m, mode)` resolves to the
  per-session staging HOME for the new mode. `writeGitconfigToDir` is reduced
  to a thin wrapper that materialises the writeGitconfig temp file into the
  staging HOME (sandbox-exec has no bind-mount mechanism, so the gitconfig
  must live as a real file inside the staging HOME).

- **A2.M1**: New `internal/container/mounts.go` houses `MountSpec`,
  `StandardSandboxMounts`, the per-mode emitters (`appendPodmanVolume`,
  `appendBwrapBind` — free functions because the emitters are stateless),
  and `StandardOpencodeConfigAllowlist`. Both bwrap and the podman
  `buildRunArgs` walk the shared spec; the previously inline mount blocks
  for `~/.claude`, `~/.mcp-auth`, `~/.cache/nix`, AWS
  config/credentials/SSO/CLI cache, kube agents-config, and the clipboard
  staging dir are replaced. Per-mode RO/RW divergence (AWS SSO/CLI: RO on
  podman, RW on bwrap; opencode/bun caches: RO on podman, RW on bwrap) is
  preserved. The opencode/bun caches and the auth.json overlay stay inline
  because their RO/RW divergence does not fit the shared spec cleanly — the
  audit (A2 §3.1) flagged the cache dirs as podman-outliers.

- **A2.SUP**: New `cmd/supervise.go` houses `SuperviseChild(cmd, stdinFd,
  opts)` which unifies the foreground-pgid + signal-forwarding + cmd.Wait
  sequence used by both the bwrap and sandbox-exec dispatch paths. The
  per-mode SIGWINCH divergence (bwrap subscribes; sandbox-exec does not) is
  captured via `SuperviseOpts.ForwardWinch`. The pre-existing
  `forwardSignalsToBwrap` helper remains in place because its tests still
  document the contract; the parallel `forwardSignalsToSandboxExec` was
  fully removed in commit `3e5e6806` (no callers, no tests).

- **A2.GR**: New `internal/container/shutdown.go` houses
  `gracefulShutdown(*exec.Cmd, gracePeriod)` — the SIGTERM-then-grace-then-
  SIGKILL body shared between `bwrapIsolator.Shutdown` and the new
  `sandboxExecIsolator.Shutdown`. `sandboxExecIsolator` gains a `cmd` field
  and a `Run` implementation that mirrors `bwrapIsolator.Run`; production
  paths still use `cmd/agent_run*.go` for sandbox lifecycle (so neither
  Shutdown is reached today), but the shared body is now a single
  implementation rather than two near-duplicates.

## Quality gates

- `go build ./...`: passes.
- `go test ./...`: passes for all newly touched paths. The pre-existing
  baseline failures on Darwin (TestBwrapBuildArgs_*: tempdir
  `/var/folders` ↔ `/private/var/folders` symlink resolution; tmux client
  tests: environment-dependent) are unchanged by this PR — verified by
  re-running on `origin/main` and observing the same failures.
- `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel`:
  passes. This builds the prism Go derivation on Darwin via `buildGoModule`
  using the same vendor hash, same source tree, same nix-build environment
  the NixOS build would use.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`:
  cannot run on this Darwin host without a remote Linux builder (platform
  mismatch error: `Required system: 'x86_64-linux'; Current system:
  'aarch64-darwin'`). The prism Go code introduced in this PR has no new
  platform-specific code — the bwrap-side changes are inside files that
  already compile on both platforms (no `//go:build` constraints
  introduced or modified), and the `cmd/supervise.go` helper uses
  `syscall.SYS_IOCTL`/TIOCSPGRP which are identical on Linux and Darwin.

## Compatibility with #1192

The in-flight #1192 (sandbox-exec integration test convention) is purely
additive in `internal/integration/`, `docs/`, and `AGENTS.md` and does
not modify `internal/container/sandbox_exec.go` directly. After
rebasing on `origin/main`, `go test ./internal/integration/...` still
passes — `Manager.PrepareSandboxExec()` continues to produce a
functionally-equivalent SBPL profile (the gitconfig is now generated
via the shared `writeGitconfig` rather than the now-thinner
`writeGitconfigToDir` wrapper, but the resulting file content is byte-
identical to the pre-A2.G1 output for sandbox-exec sessions).