### PR TITLE
prism: distinguish no-start errors from mid-run crashes in review groups

### DIFF
--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -93,6 +93,18 @@ is written to `/tmp` — the full agent reasoning is available via
 5. Non-blocking observations on a failed round MAY also be actioned alongside
    the mandatory fix — the worker decides what to include.
 
+**On ERROR (one or more agents failed to start):**
+
+The review-complete header will say "infrastructure failure" and instruct you
+to re-run. This is **not** a code-quality verdict — the agent never ran, so
+there are no blocking issues to fix. Simply re-run `prism review <pr>`.
+
+If the prompt is mixed — some agents returned FAIL verdicts **and** some
+failed to start — fix the blocking issues from the agents that ran, then
+re-run `prism review <pr>` to cover the agents that never started. Count
+re-run cycles from the first round that had a full set of agent results; do
+not count infrastructure-failure rounds toward your 3-cycle limit.
+
 **On PASS:**
 
 Non-blocking observations MAY be actioned if they represent a genuine

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -165,6 +165,20 @@ prism review <pr-number>
 **Do NOT commit, merge, or announce completion** until the review-complete
 prompt arrives. When it does, handle PASS/FAIL per the worker agent instructions.
 
+### Handling no-start errors in review-complete prompts
+
+When a review-complete prompt says **"One or more review agents failed to start
+(infrastructure failure)"**, treat it as a failed review run — not a
+code-quality FAIL verdict. The agents never ran, so no conclusions about the PR
+quality can be drawn. Re-run `prism review <pr>` to retry the infrastructure
+that failed. Do not treat a no-start error the same as a FAIL verdict from a
+review agent that ran and found issues.
+
+Signs of a no-start error in the per-agent findings:
+- `**Verdict:** ERROR`
+- Output contains `ERROR: agent failed to start (no-start):`
+- The delivery message header mentions "infrastructure failure" and instructs you to re-run
+
 If no review-complete prompt arrives within 30 minutes, check progress with:
 
 ```bash

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -8,6 +8,7 @@ package db
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -2776,10 +2777,11 @@ LIMIT ?`
 // GroupMemberResult holds the terminal state and last assistant message for a
 // single member of a session group. Used by GroupResults to aggregate outcomes.
 type GroupMemberResult struct {
-	SessionName string
-	RootAgent   string // from root_agent_name; empty when not set
-	State       string // terminal state: finished / interrupted / error / deleted
-	LastMessage string // last assistant turn from agent_events; empty when none
+	SessionName  string
+	RootAgent    string // from root_agent_name; empty when not set
+	State        string // terminal state: finished / interrupted / error / deleted
+	LastMessage  string // last assistant turn from agent_events; empty when none
+	StartupError string // reason from startup_error event; empty when not a no-start failure
 }
 
 // terminalStates is the set of agent states that indicate a session has stopped
@@ -2880,6 +2882,30 @@ LIMIT 1`
 			return nil, fmt.Errorf("db: group results: last message for %q: %w", name, err)
 		}
 		r.LastMessage = payload
+
+		// Fetch the startup_error event reason when present. This is written by
+		// writeStartupError in the sidecar when WaitHealthy or CreateSession
+		// fails, allowing the review monitor to distinguish a no-start failure
+		// from a mid-run crash (#1222).
+		const startupErrQ = `
+SELECT payload FROM agent_events
+WHERE session_name = ? AND type = 'startup_error'
+ORDER BY created_at DESC, rowid DESC
+LIMIT 1`
+		var startupErrPayload string
+		seErr := d.conn.QueryRow(startupErrQ, name).Scan(&startupErrPayload)
+		if seErr == nil && startupErrPayload != "" {
+			// Extract the "reason" field from the JSON payload.
+			var p struct {
+				Reason string `json:"reason"`
+			}
+			if jsonErr := json.Unmarshal([]byte(startupErrPayload), &p); jsonErr == nil && p.Reason != "" {
+				r.StartupError = p.Reason
+			} else {
+				r.StartupError = startupErrPayload
+			}
+		}
+
 		results[name] = r
 	}
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -2830,6 +2830,61 @@ func TestGroupResults(t *testing.T) {
 	}
 }
 
+// TestGroupResults_StartupError verifies that GroupResults populates StartupError
+// from the startup_error event written by writeStartupError when a container
+// fails to start (#1222).
+func TestGroupResults_StartupError(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	noStartSession := "nixos-config@feature~review-1-review-code"
+	if err := d.UpsertStatus(noStartSession, "nixos-config", "/wt", "error", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %s: %v", noStartSession, err)
+	}
+	if err := d.QueryRow(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+		groupID, noStartSession,
+	).Scan(new(int)); err != nil {
+		t.Fatalf("set group_id for %s: %v", noStartSession, err)
+	}
+
+	// Write the startup_error event that writeStartupError emits.
+	const startupReason = "opencode: health check timed out after 60s on port 14004"
+	if err := d.WriteEvent(db.Event{
+		ID:          "evt-startup-err-1",
+		SessionName: noStartSession,
+		Repo:        "nixos-config",
+		Worktree:    "/wt",
+		Type:        "startup_error",
+		Payload:     `{"reason":"` + startupReason + `"}`,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteEvent startup_error: %v", err)
+	}
+
+	results, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+	r, ok := results[noStartSession]
+	if !ok {
+		t.Fatalf("GroupResults: missing entry for %q", noStartSession)
+	}
+	if r.State != "error" {
+		t.Errorf("StartupError test: State = %q, want \"error\"", r.State)
+	}
+	if r.StartupError != startupReason {
+		t.Errorf("StartupError = %q, want %q", r.StartupError, startupReason)
+	}
+	if r.LastMessage != "" {
+		t.Errorf("LastMessage = %q, want \"\" (no msg_assistant written)", r.LastMessage)
+	}
+}
+
 // ── Foreign key enforcement tests ─────────────────────────────────────────────
 
 // TestGroupFK_Violation verifies that attempting to set agent_status.group_id to

--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -58,3 +58,10 @@ func BuildAsyncAckForTest(prNumber string, round int, groupID string, sessionNam
 func PollAgentsForTest(ctx context.Context, d *db.DB, agents []Agent, agentSessions []string, timeout time.Duration, spawnTimes []time.Time, onProgress func(string), groupID string) ([]AgentResult, error) {
 	return pollAgents(ctx, d, agents, agentSessions, timeout, spawnTimes, onProgress, groupID)
 }
+
+// BuildDeliveryMessageForTest is an exported wrapper around buildDeliveryMessage
+// for use in external test packages. Allows tests to verify the header text and
+// no-start error signalling without spinning up a real monitor loop (#1222).
+func BuildDeliveryMessageForTest(prNumber string, round int, formattedResults string, allPassed bool, groupData map[string]db.GroupMemberResult, agentSessions []string) string {
+	return buildDeliveryMessage(prNumber, round, formattedResults, allPassed, groupData, agentSessions)
+}

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -222,11 +222,25 @@ func buildMonitorResults(agents []Agent, agentSessions []string, groupData map[s
 
 		switch mr.State {
 		case "interrupted", "error":
-			results[i] = AgentResult{
-				Agent:   ag,
-				Passed:  false,
-				Output:  fmt.Sprintf("ERROR: agent did not complete cleanly (state: %s)", mr.State),
-				IsError: true,
+			// Distinguish a no-start failure from a mid-run crash: when a
+			// startup_error event was written by the sidecar's writeStartupError,
+			// StartupError is non-empty and indicates the container never bound
+			// its port. Label it clearly so the coordinator treats it as an
+			// infrastructure failure rather than a code-quality verdict (#1222).
+			if mr.StartupError != "" {
+				results[i] = AgentResult{
+					Agent:   ag,
+					Passed:  false,
+					Output:  fmt.Sprintf("ERROR: agent failed to start (no-start): %s", mr.StartupError),
+					IsError: true,
+				}
+			} else {
+				results[i] = AgentResult{
+					Agent:   ag,
+					Passed:  false,
+					Output:  fmt.Sprintf("ERROR: agent did not complete cleanly (state: %s)", mr.State),
+					IsError: true,
+				}
 			}
 		case "finished":
 			if mr.LastMessage == "" {
@@ -274,8 +288,25 @@ func buildDeliveryMessage(prNumber string, round int, formattedResults string, a
 
 	sb.WriteString(fmt.Sprintf("## Review complete: PR #%s (round %d)\n\n", prNumber, round))
 
+	// Count no-start failures: agents whose sidecar wrote a startup_error event
+	// (container never bound its port). These are infrastructure failures, not
+	// code-quality signals, and must be treated differently from FAIL verdicts.
+	var noStartSessions []string
+	for _, sess := range agentSessions {
+		if mr, ok := groupData[sess]; ok && mr.StartupError != "" {
+			noStartSessions = append(noStartSessions, sess)
+		}
+	}
+
 	if allPassed {
 		sb.WriteString("**All 5 review agents passed.** You may proceed with announcing completion.\n\n")
+	} else if len(noStartSessions) > 0 {
+		// One or more agents failed to start — the review is incomplete.
+		// This is an infrastructure failure: re-run prism review rather than
+		// treating it as a code-quality FAIL.
+		sb.WriteString("**One or more review agents failed to start (infrastructure failure).** ")
+		sb.WriteString("This is NOT a code-quality verdict — the agents never ran. ")
+		sb.WriteString("Re-run `prism review` to retry; do not treat this as FAIL.\n\n")
 	} else {
 		sb.WriteString("**One or more review agents failed.** Fix the blocking issues and re-run `prism review`.\n\n")
 	}

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -300,13 +300,20 @@ func buildDeliveryMessage(prNumber string, round int, formattedResults string, a
 
 	if allPassed {
 		sb.WriteString("**All 5 review agents passed.** You may proceed with announcing completion.\n\n")
-	} else if len(noStartSessions) > 0 {
-		// One or more agents failed to start — the review is incomplete.
-		// This is an infrastructure failure: re-run prism review rather than
-		// treating it as a code-quality FAIL.
-		sb.WriteString("**One or more review agents failed to start (infrastructure failure).** ")
-		sb.WriteString("This is NOT a code-quality verdict — the agents never ran. ")
+	} else if len(noStartSessions) > 0 && len(noStartSessions) == len(agentSessions) {
+		// Every agent failed to start — pure infrastructure failure with no
+		// code-quality signal at all.
+		sb.WriteString("**All review agents failed to start (infrastructure failure).** ")
+		sb.WriteString("This is NOT a code-quality verdict — no agents ran. ")
 		sb.WriteString("Re-run `prism review` to retry; do not treat this as FAIL.\n\n")
+	} else if len(noStartSessions) > 0 {
+		// Mixed: some agents returned FAIL/PASS verdicts; others failed to start.
+		// Surface both signals so the coordinator knows to both fix code issues
+		// AND re-run for the agents that never ran.
+		sb.WriteString("**One or more review agents failed AND one or more failed to start.** ")
+		sb.WriteString("Fix any blocking issues from the agents that ran, then re-run `prism review` ")
+		sb.WriteString("to cover the agents that failed to start (infrastructure failure). ")
+		sb.WriteString("Do not treat no-start errors as code-quality verdicts.\n\n")
 	} else {
 		sb.WriteString("**One or more review agents failed.** Fix the blocking issues and re-run `prism review`.\n\n")
 	}

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -678,3 +678,76 @@ func setHarnessInfo(t *testing.T, d *db.DB, sessionName string, port int, sessio
 	).Scan(&dummy)
 	return err
 }
+
+// ── no-start error distinction (#1222) ───────────────────────────────────────
+
+// TestBuildMonitorResults_NoStartError verifies that an agent in error state
+// with a StartupError reason produces an output containing "no-start" to
+// distinguish it from a mid-run crash.
+func TestBuildMonitorResults_NoStartError(t *testing.T) {
+	agents := []review.Agent{{Name: "review-code"}}
+	sess := "nixos-config@parent~review-1-review-code"
+	sessions := []string{sess}
+	groupData := map[string]db.GroupMemberResult{
+		sess: {
+			SessionName:  sess,
+			State:        "error",
+			LastMessage:  "",
+			StartupError: "opencode: health check timed out after 60s on port 14004",
+		},
+	}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Passed {
+		t.Errorf("no-start error: Passed=true, want false")
+	}
+	if !r.IsError {
+		t.Errorf("no-start error: IsError=false, want true")
+	}
+	if !findSubstring(r.Output, "no-start") {
+		t.Errorf("no-start error: output should contain 'no-start': %q", r.Output)
+	}
+	if !findSubstring(r.Output, "health check timed out") {
+		t.Errorf("no-start error: output should contain the startup error reason: %q", r.Output)
+	}
+}
+
+// TestBuildMonitorResults_ErrorNoCrashMidRun verifies that an agent in error
+// state WITHOUT a StartupError reason produces a generic "did not complete
+// cleanly" message (mid-run crash, not a no-start failure).
+func TestBuildMonitorResults_ErrorNoCrashMidRun(t *testing.T) {
+	agents := []review.Agent{{Name: "review-code"}}
+	sess := "nixos-config@parent~review-1-review-code"
+	sessions := []string{sess}
+	groupData := map[string]db.GroupMemberResult{
+		sess: {
+			SessionName:  sess,
+			State:        "error",
+			LastMessage:  "",
+			StartupError: "", // no startup_error event — mid-run crash
+		},
+	}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Passed {
+		t.Errorf("mid-run error: Passed=true, want false")
+	}
+	if !r.IsError {
+		t.Errorf("mid-run error: IsError=false, want true")
+	}
+	// Must NOT say no-start — this was a mid-run crash.
+	if findSubstring(r.Output, "no-start") {
+		t.Errorf("mid-run error: output should NOT contain 'no-start': %q", r.Output)
+	}
+	if !findSubstring(r.Output, "did not complete cleanly") {
+		t.Errorf("mid-run error: output should contain 'did not complete cleanly': %q", r.Output)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -751,3 +751,78 @@ func TestBuildMonitorResults_ErrorNoCrashMidRun(t *testing.T) {
 		t.Errorf("mid-run error: output should contain 'did not complete cleanly': %q", r.Output)
 	}
 }
+
+// ── buildDeliveryMessage (#1222) ─────────────────────────────────────────────
+
+// TestBuildDeliveryMessage_AllPassed verifies the all-passed header.
+func TestBuildDeliveryMessage_AllPassed(t *testing.T) {
+	sess := "nixos-config@parent~review-1-review-code"
+	groupData := map[string]db.GroupMemberResult{
+		sess: {SessionName: sess, State: "finished"},
+	}
+	msg := review.BuildDeliveryMessageForTest("42", 1, "results text", true, groupData, []string{sess})
+	if !findSubstring(msg, "All 5 review agents passed") {
+		t.Errorf("all-passed: header missing 'All 5 review agents passed': %q", msg)
+	}
+}
+
+// TestBuildDeliveryMessage_PureFailNoStart verifies that when ALL agents have
+// no-start errors, the header says "infrastructure failure" with no mention of
+// code-quality FAIL.
+func TestBuildDeliveryMessage_PureFailNoStart(t *testing.T) {
+	sess := "nixos-config@parent~review-1-review-code"
+	groupData := map[string]db.GroupMemberResult{
+		sess: {SessionName: sess, State: "error", StartupError: "health check timed out"},
+	}
+	msg := review.BuildDeliveryMessageForTest("42", 1, "results text", false, groupData, []string{sess})
+	if !findSubstring(msg, "infrastructure failure") {
+		t.Errorf("pure no-start: header should mention 'infrastructure failure': %q", msg)
+	}
+	if !findSubstring(msg, "Re-run") {
+		t.Errorf("pure no-start: header should instruct re-run: %q", msg)
+	}
+	// Must NOT say "Fix the blocking issues" (no code ran).
+	if findSubstring(msg, "Fix the blocking issues") {
+		t.Errorf("pure no-start: header should NOT say 'Fix the blocking issues': %q", msg)
+	}
+}
+
+// TestBuildDeliveryMessage_MixedNoStartAndFail verifies that when some agents
+// had FAIL verdicts and some had no-start errors, both signals appear — the
+// coordinator must both fix code issues AND re-run for the failed starts.
+func TestBuildDeliveryMessage_MixedNoStartAndFail(t *testing.T) {
+	sess1 := "nixos-config@parent~review-1-review-code"
+	sess2 := "nixos-config@parent~review-1-review-goal"
+	groupData := map[string]db.GroupMemberResult{
+		sess1: {SessionName: sess1, State: "error", StartupError: "health check timed out"},
+		sess2: {SessionName: sess2, State: "finished", LastMessage: `{"text":"<verdict>FAIL</verdict>"}`},
+	}
+	msg := review.BuildDeliveryMessageForTest("42", 1, "results text", false, groupData, []string{sess1, sess2})
+	if !findSubstring(msg, "infrastructure failure") {
+		t.Errorf("mixed: header should mention 'infrastructure failure': %q", msg)
+	}
+	if !findSubstring(msg, "Re-run") && !findSubstring(msg, "re-run") {
+		t.Errorf("mixed: header should instruct re-run: %q", msg)
+	}
+	// Must also call out blocking issues so coordinator doesn't skip fixing code.
+	if !findSubstring(msg, "blocking issues") {
+		t.Errorf("mixed: header should mention 'blocking issues': %q", msg)
+	}
+}
+
+// TestBuildDeliveryMessage_PureCodeFail verifies that when all failures are
+// code-quality FAILs (no no-start errors), the standard "Fix the blocking
+// issues" header is shown with no infrastructure-failure mention.
+func TestBuildDeliveryMessage_PureCodeFail(t *testing.T) {
+	sess := "nixos-config@parent~review-1-review-code"
+	groupData := map[string]db.GroupMemberResult{
+		sess: {SessionName: sess, State: "finished", LastMessage: `{"text":"<verdict>FAIL</verdict>"}`},
+	}
+	msg := review.BuildDeliveryMessageForTest("42", 1, "results text", false, groupData, []string{sess})
+	if !findSubstring(msg, "Fix the blocking issues") {
+		t.Errorf("pure code fail: header should say 'Fix the blocking issues': %q", msg)
+	}
+	if findSubstring(msg, "infrastructure failure") {
+		t.Errorf("pure code fail: header should NOT mention 'infrastructure failure': %q", msg)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -159,6 +159,10 @@ func (s *Sidecar) writeStartupError(startupErr error) {
 	log.Printf("sidecar: startup failure — writing error state: %v", startupErr)
 	s.upsertState(agent.StateError, nil, nil)
 	s.writeStateChange(agent.StateError)
+	// Write a startup_error event recording the failure reason so the review
+	// monitor can distinguish a no-start failure from a mid-run crash when
+	// formatting the review-complete prompt (#1222).
+	s.writeEvent("startup_error", map[string]string{"reason": startupErr.Error()}, nil)
 	s.mu.Unlock()
 
 	// Gap 2 fix: notify the parent worker when this is a review-agent session.


### PR DESCRIPTION
## Summary

When an opencode container fails to start (WaitHealthy times out), the sidecar already transitioned to `error` state and `GroupCompleted` already treated `error` as terminal. This PR adds the missing pieces to close #1222 fully:

- **Reason persistence**: `writeStartupError` now writes a `startup_error` event with the failure reason so it can be retrieved later
- **DB**: `GroupMemberResult.StartupError` and `GroupResults` fetch this reason per member
- **Monitor**: `buildMonitorResults` emits `"ERROR: agent failed to start (no-start): <reason>"` when a startup_error event was written, vs the generic `"did not complete cleanly"` for mid-run crashes
- **Delivery message**: when no-start errors are present, the header clearly says "infrastructure failure — re-run `prism review`" rather than treating it as a code-quality FAIL
- **SKILL.md**: documents no-start error handling for coordinator agents

## Tests

- `TestGroupResults_StartupError`: verifies `GroupResults` populates `StartupError` from the `startup_error` event
- `TestBuildMonitorResults_NoStartError`: verifies the "no-start" output distinction
- `TestBuildMonitorResults_ErrorNoCrashMidRun`: regression — mid-run crashes still produce the generic message without "no-start"

Closes #1222