### PR TITLE
prism cleanup: probe conventional worktree path when DB lookup returns empty

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -388,11 +388,25 @@ var cleanupCmd = &cobra.Command{
 		// supported in the headless (--yes) path; interactive cleanup needs a
 		// real worktree to display info.
 		if worktreePath == "" {
-			if yesFlag {
-				fmt.Fprintf(os.Stderr, "[prism] warning: could not determine worktree path for session %q — skipping worktree removal\n", session)
+			// Primary lookup failed (tmux gone, DB path missing or not on
+			// disk).  Attempt a filesystem probe at the conventional location
+			// <bare-root>/<branch>/ before giving up.
+			probed, probedBareRoot := probeConventionalWorktreePath(session, worktreeName)
+			if probed != "" {
+				worktreePath = probed
+			} else if yesFlag {
+				if probedBareRoot != "" {
+					// We know where the worktree *should* be but it isn't
+					// there — log an actionable message and continue.
+					fmt.Fprintf(os.Stderr, "[prism] warning: worktree not found at conventional path %s — skipping worktree removal\n",
+						filepath.Join(probedBareRoot, worktreeName))
+				} else {
+					fmt.Fprintf(os.Stderr, "[prism] warning: could not determine worktree path for session %q — skipping worktree removal\n", session)
+				}
 				return headlessCleanup(session, worktreeName, "", "")
+			} else {
+				return fmt.Errorf("could not determine worktree path for session %q (not found in tmux windows or DB)", session)
 			}
-			return fmt.Errorf("could not determine worktree path for session %q (not found in tmux windows or DB)", session)
 		}
 
 		bareRoot := git.BareRoot(worktreePath)
@@ -756,6 +770,43 @@ func worktreePathFromSession(session string) string {
 		}
 	}
 	return ""
+}
+
+// probeConventionalWorktreePath attempts to locate a worktree for the given
+// session at the conventional bare-root layout location: <bare-root>/<branch>/.
+//
+// It derives the bare-root hint from the DB row's worktree_path column (using
+// the parent directory of the stored path, even if that path no longer exists
+// on disk).  This handles the case where the session died before its worktree
+// was visible to the normal worktreePathFromSession lookup (e.g. the stored
+// path points at a now-deleted directory, but the worktree was re-created at
+// the conventional sibling location).
+//
+// Return values:
+//   - (probed, bareRoot) where probed is non-empty when a worktree was found at
+//     the conventional location, and bareRoot is non-empty whenever we could
+//     derive a candidate bare-root from the DB (even when the probe failed).
+//   - ("", "") when there is no DB row or the row contains no worktree path.
+func probeConventionalWorktreePath(session, worktreeName string) (worktreePath, bareRoot string) {
+	d, err := openDB()
+	if err != nil {
+		return "", ""
+	}
+	defer d.Close()
+	status, err := d.CurrentStatus(session)
+	if err != nil || status == nil || status.Worktree == "" {
+		return "", ""
+	}
+	// Derive the bare-root as the parent of the stored worktree path.
+	// E.g. if the DB contains "/code/nixos-config/sandbox-exec-smoke", the
+	// bare root is "/code/nixos-config" and we probe
+	// "/code/nixos-config/<worktreeName>/.git".
+	candidateBareRoot := filepath.Dir(status.Worktree)
+	candidate := filepath.Join(candidateBareRoot, worktreeName)
+	if _, statErr := os.Stat(filepath.Join(candidate, ".git")); statErr == nil {
+		return candidate, candidateBareRoot
+	}
+	return "", candidateBareRoot
 }
 
 // runSessionArchive performs the opencode-storage copy for the session identified by

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -86,6 +86,82 @@ func TestWorktreePathFromSession_DBFallback(t *testing.T) {
 	})
 }
 
+// TestProbeConventionalWorktreePath verifies the filesystem-probe fallback that
+// locates a worktree at <bare-root>/<branch>/ when the primary lookup chain
+// (tmux + DB os.Stat check) returns empty.
+//
+// The test constructs a minimal fake worktree directory (just a ".git" file
+// inside it, enough for the os.Stat probe to succeed), seeds the DB with a
+// *stale* worktree path (pointing at a now-deleted directory) whose parent is
+// the fake bare root, then calls probeConventionalWorktreePath and checks that
+// it returns the conventional candidate path.
+func TestProbeConventionalWorktreePath(t *testing.T) {
+	// Construct: <tmpdir>/bare-root/<branch>/.git
+	bareRoot := t.TempDir()
+	branch := "probe-test-branch"
+	conventionalPath := filepath.Join(bareRoot, branch)
+	if err := os.MkdirAll(conventionalPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Create a .git file (worktrees use a file, not a directory).
+	gitFile := filepath.Join(conventionalPath, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: ../bare/.git/worktrees/"+branch+"\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	// Seed the DB with a stale worktree path: a sibling directory that no
+	// longer exists.  Its parent (bareRoot) is the same, so the probe can
+	// derive the right bare-root.
+	staleWorktreePath := filepath.Join(bareRoot, "old-gone-path")
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	session := "myrepo@" + branch
+	if err := d.UpsertStatus(session, "myrepo", staleWorktreePath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	t.Run("worktree found at conventional path", func(t *testing.T) {
+		gotPath, gotBareRoot := probeConventionalWorktreePath(session, branch)
+		if gotPath != conventionalPath {
+			t.Errorf("worktreePath: got %q, want %q", gotPath, conventionalPath)
+		}
+		if gotBareRoot != bareRoot {
+			t.Errorf("bareRoot: got %q, want %q", gotBareRoot, bareRoot)
+		}
+	})
+
+	t.Run("worktree absent returns empty path but non-empty bareRoot", func(t *testing.T) {
+		// Remove the conventional path so the probe fails.
+		if err := os.RemoveAll(conventionalPath); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+		gotPath, gotBareRoot := probeConventionalWorktreePath(session, branch)
+		if gotPath != "" {
+			t.Errorf("worktreePath: got %q, want empty (worktree removed)", gotPath)
+		}
+		if gotBareRoot != bareRoot {
+			t.Errorf("bareRoot: got %q, want %q", gotBareRoot, bareRoot)
+		}
+	})
+
+	t.Run("no DB row returns empty path and empty bareRoot", func(t *testing.T) {
+		gotPath, gotBareRoot := probeConventionalWorktreePath("myrepo@no-such-session", "no-such-branch")
+		if gotPath != "" {
+			t.Errorf("worktreePath: got %q, want empty (no DB row)", gotPath)
+		}
+		if gotBareRoot != "" {
+			t.Errorf("bareRoot: got %q, want empty (no DB row)", gotBareRoot)
+		}
+	})
+}
+
 // TestHeadlessCleanup_EmptyWorktreePath verifies that when worktreePath is
 // empty, headlessCleanup skips worktree removal, still marks the session as
 // ended in the DB, and returns nil.


### PR DESCRIPTION
## Summary

When a session dies before completing startup, the worktree path stored in the DB may point to a non-existent directory, causing `worktreePathFromSession` to return empty and cleanup to silently skip worktree removal — leaving the worktree on disk.

## Changes

- Add `probeConventionalWorktreePath(session, worktreeName)` which derives the bare-root from the parent of the DB-stored path and probes `<bare-root>/<branch>/.git`
- When the primary lookup returns empty but the filesystem probe succeeds, cleanup proceeds normally with the probed path
- When the probe also fails, emit an actionable warning showing the expected location (if we could derive the bare-root) or the original generic message (if no DB row exists at all)
- Add `TestProbeConventionalWorktreePath` unit test covering: found, absent, and no-DB-row cases

## Acceptance Criteria

- [x] `prism cleanup --yes --session <name>` removes the worktree even when the session died before completing startup, as long as the worktree exists at the conventional `<bare-root>/<branch>/` location
- [x] If the worktree truly doesn't exist (already removed), cleanup logs a warning and continues without error
- [x] Cleanup behaviour for healthy completed sessions (the common case) is unchanged
- [x] If the worktree is at a non-conventional location AND the DB lookup returned empty, cleanup logs a warning with the expected path and skips removal
- [x] `go build ./...` and `go test ./...` pass from `modules/programs/prism/prism/`
- [x] Unit test in `cmd/cleanup_test.go` covers the filesystem-probe fallback

Closes #1189