### PR TITLE
archive: migrate session export from legacy file tree to opencode-stable.db

### DIFF
--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -1,5 +1,5 @@
-// Package archive copies opencode's on-disk session subtree into a prism
-// archive directory at cleanup time.
+// Package archive exports opencode session state from opencode-stable.db into a
+// prism archive directory at cleanup time.
 //
 // # Directory layout
 //
@@ -10,8 +10,14 @@
 //	        session.json
 //	        messages/msg_*.json
 //	        parts/msg_<id>/prt_*.json
-//	        tool-output/tool_*         (only when parts reference sidecar files)
 //	      manifest.json
+//
+// # Storage backend
+//
+// opencode stores all session state in a single SQLite database
+// (~/.local/share/opencode/opencode-stable.db). The archive package queries
+// that database directly — per-file JSON under storage/session/ is the legacy
+// layout and is no longer written by current opencode releases.
 //
 // # Atomicity
 //
@@ -21,18 +27,22 @@
 //
 // # File permissions
 //
-// Archive directories are created with mode 0700; individual files are copied
+// Archive directories are created with mode 0700; individual files are written
 // with mode 0600. These are personal session traces that may contain secrets.
 package archive
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	_ "modernc.org/sqlite" // register sqlite3 driver
 )
 
 // ErrAlreadyExists is returned by Run when the final archive directory already
@@ -95,20 +105,26 @@ type Params struct {
 	// are silently skipped — bwrap sessions that never reached agent-run will not
 	// have this file.
 	AgentRunLogPath string
-	// StorageRoot overrides the host opencode storage root. When empty the
-	// default (~/.local/share/opencode/storage) is used. Tests inject this to
-	// point at a temp dir.
+	// StorageRoot is retained for podman DB path resolution. For podman sessions
+	// the DB lives at <StorageRoot>/../opencode-stable.db (i.e. the parent of the
+	// per-container storage/ directory). For host/bwrap/sandbox-exec it is
+	// unused when DBPath is also empty. Tests may inject this alongside DBPath.
 	StorageRoot string
+	// DBPath overrides the path to opencode-stable.db. When empty the default
+	// path (~/.local/share/opencode/opencode-stable.db) is used for
+	// host/bwrap/sandbox-exec, or the per-container equivalent for podman.
+	// Tests inject this to point at a temp file.
+	DBPath string
 	// ArchiveRoot overrides the archive root (~/.local/share/prism/archive).
 	// When empty the XDG-derived default is used. Tests inject this.
 	ArchiveRoot string
 }
 
-// Run copies the opencode session subtree for p into the archive directory and
+// Run exports the opencode session state for p into the archive directory and
 // returns the absolute path of the archive directory on success.
 //
-// Atomicity: the copy is written to a temp directory under <archiveRoot>/<repo>/
-// and renamed to the final name only when the entire copy succeeds. On any
+// Atomicity: the export is written to a temp directory under <archiveRoot>/<repo>/
+// and renamed to the final name only when the entire export succeeds. On any
 // error the temp directory is removed and Run returns a non-nil error.
 //
 // Idempotency: if the target archive directory already exists when Run is
@@ -118,7 +134,7 @@ type Params struct {
 // Sessions with no HarnessSessionID (opencode failed to start) still produce
 // an archive directory containing manifest.json and an empty raw/ directory.
 func Run(p Params) (archivePath string, err error) {
-	archiveRoot, storageRoot, err := resolvePaths(p)
+	archiveRoot, dbPath, err := resolvePaths(p)
 	if err != nil {
 		return "", err
 	}
@@ -179,10 +195,10 @@ func Run(p Params) (archivePath string, err error) {
 		return "", fmt.Errorf("archive: create raw dir: %w", mkErr)
 	}
 
-	// Copy opencode session files (only when we have a harness_session_id).
+	// Export opencode session data from SQLite (only when we have a harness_session_id).
 	if p.HarnessSessionID != "" {
-		if copyErr := copySessionFiles(p.HarnessSessionID, storageRoot, rawDir); copyErr != nil {
-			return "", copyErr
+		if exportErr := exportSessionFromDB(p.HarnessSessionID, dbPath, rawDir); exportErr != nil {
+			return "", exportErr
 		}
 	}
 
@@ -211,9 +227,9 @@ func Run(p Params) (archivePath string, err error) {
 	return finalDir, nil
 }
 
-// resolvePaths returns (archiveRoot, storageRoot) for the params, applying
-// XDG defaults when the override fields are empty.
-func resolvePaths(p Params) (archiveRoot, storageRoot string, err error) {
+// resolvePaths returns (archiveRoot, dbPath) for the params, applying XDG
+// defaults when the override fields are empty.
+func resolvePaths(p Params) (archiveRoot, dbPath string, err error) {
 	// Archive root: $XDG_DATA_HOME/prism/archive
 	if p.ArchiveRoot != "" {
 		archiveRoot = p.ArchiveRoot
@@ -229,34 +245,54 @@ func resolvePaths(p Params) (archiveRoot, storageRoot string, err error) {
 		archiveRoot = filepath.Join(dataHome, "prism", "archive")
 	}
 
-	// Storage root: $HOME/.local/share/opencode/storage or per-container path.
-	if p.StorageRoot != "" {
-		storageRoot = p.StorageRoot
+	// DB path: explicit override wins, then derive from StorageRoot (for
+	// callers that pre-resolve via ArchivePaths, e.g. podman), then fall back
+	// to the isolation-mode switch.
+	if p.DBPath != "" {
+		dbPath = p.DBPath
+	} else if p.StorageRoot != "" {
+		// StorageRoot is <dataDir>/storage; the DB lives at <dataDir>/opencode-stable.db.
+		dbPath = filepath.Join(filepath.Dir(p.StorageRoot), "opencode-stable.db")
 	} else {
-		storageRoot, err = resolveStorageRoot(p.IsolationMode, p.SessionName)
+		dbPath, err = resolveDBPath(p.IsolationMode, p.SessionName)
 		if err != nil {
 			return "", "", err
 		}
 	}
 
-	return archiveRoot, storageRoot, nil
+	return archiveRoot, dbPath, nil
 }
 
-// resolveStorageRoot returns the host-side opencode storage root for the given
-// isolation mode and session name.
+// resolveDBPath returns the path to opencode-stable.db for the given isolation
+// mode and session name.
 //
-//   - host / bwrap / sandbox-exec: $HOME/.local/share/opencode/storage
-//   - podman: $HOME/.local/share/opencode/prism-sessions/<containerName>/storage
+//   - host / bwrap / sandbox-exec: $HOME/.local/share/opencode/opencode-stable.db
+//   - podman: $HOME/.local/share/opencode/prism-sessions/<containerName>/opencode-stable.db
 //   - unknown / empty: returns an error
 //
-// bwrap / sandbox-exec note: both modes run on the host filesystem namespace
-// and bind-mount (bwrap) or use (sandbox-exec) the *shared*
-// ~/.local/share/opencode/ directory — not a per-session sub-dir. The
-// per-session isolation used by the podman path (Darwin virtiofs WAL-mode
-// workaround) does not apply to either mode. The shared root is correct here
-// because copySessionFiles scopes its reads to the specific harness_session_id,
-// so only files belonging to this session are copied even when the storage pool
-// contains concurrent sessions.
+// bwrap and sandbox-exec both use the host-shared opencode data directory.
+// exportSessionFromDB scopes all queries to the specific harness_session_id, so
+// concurrent sessions in the same DB are not affected.
+func resolveDBPath(isolationMode, sessionName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("archive: resolve home for db path: %w", err)
+	}
+
+	switch isolationMode {
+	case "host", "bwrap", "sandbox-exec":
+		return filepath.Join(home, ".local", "share", "opencode", "opencode-stable.db"), nil
+	case "podman":
+		containerName := containerNameForSession(sessionName)
+		return filepath.Join(home, ".local", "share", "opencode", "prism-sessions", containerName, "opencode-stable.db"), nil
+	default:
+		return "", fmt.Errorf("archive: unsupported isolation mode %q", isolationMode)
+	}
+}
+
+// resolveStorageRoot is retained for back-compat with callers that still
+// reference the storage root path (e.g. tests). It returns the host-side
+// opencode storage root for the given isolation mode.
 func resolveStorageRoot(isolationMode, sessionName string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -285,102 +321,87 @@ func containerNameForSession(sessionName string) string {
 	return "prism-" + safe
 }
 
-// copySessionFiles copies the opencode session subtree rooted at storageRoot
-// into rawDir. The subtree consists of:
+// exportSessionFromDB queries opencode-stable.db for the session identified by
+// harnessSessionID and writes JSON files into rawDir:
 //
-//   - storage/session/<projectID>/ses_<id>.json  → raw/session.json
-//   - storage/message/ses_<id>/*.json             → raw/messages/msg_*.json
-//   - storage/part/msg_<id>/prt_*.json           → raw/parts/msg_<id>/prt_*.json
-//   - storage/tool-output/tool_*                 → raw/tool-output/tool_* (referenced by parts)
-func copySessionFiles(harnessSessionID, storageRoot, rawDir string) error {
-	sessionFile, projectID, err := findSessionFile(harnessSessionID, storageRoot)
+//   - raw/session.json        — the session row
+//   - raw/messages/msg_*.json — one file per message row
+//   - raw/parts/msg_<id>/prt_*.json — one file per part row, grouped by message
+//
+// Graceful no-ops:
+//   - If the DB file does not exist, a single info log is emitted and raw/ is
+//     left empty (not an error).
+//   - If harnessSessionID is not found in the DB, a single info log is emitted
+//     and raw/ is left empty (not an error).
+func exportSessionFromDB(harnessSessionID, dbPath, rawDir string) error {
+	// If the DB doesn't exist at all (fresh install, never run) — graceful no-op.
+	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
+		log.Printf("[prism] archive: opencode DB not found at %s — skipping session export", dbPath)
+		return nil
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_busy_timeout=5000")
 	if err != nil {
-		return err
+		return fmt.Errorf("archive: open opencode DB: %w", err)
+	}
+	defer db.Close()
+
+	// Export session row.
+	sessionData, err := querySessionJSON(db, harnessSessionID)
+	if err != nil {
+		return fmt.Errorf("archive: query session: %w", err)
+	}
+	if sessionData == nil {
+		// Session not in DB — log and leave raw/ empty.
+		log.Printf("[prism] archive: session %q not found in opencode DB — skipping session export", harnessSessionID)
+		return nil
 	}
 
-	// Copy session.json → raw/session.json
-	if copyErr := copyFile(sessionFile, filepath.Join(rawDir, "session.json")); copyErr != nil {
-		return fmt.Errorf("archive: copy session.json: %w", copyErr)
-	}
-	_ = projectID // projectID found but not needed further; session path was already determined
-
-	// Copy messages.
-	msgDir := filepath.Join(storageRoot, "message", harnessSessionID)
-	rawMsgDir := filepath.Join(rawDir, "messages")
-	if err := copyDirFlat(msgDir, rawMsgDir); err != nil {
-		return fmt.Errorf("archive: copy messages: %w", err)
+	// Write raw/session.json.
+	if writeErr := writeJSONFile(filepath.Join(rawDir, "session.json"), sessionData); writeErr != nil {
+		return fmt.Errorf("archive: write session.json: %w", writeErr)
 	}
 
-	// Copy parts — one subdirectory per message ID.
-	partBaseDir := filepath.Join(storageRoot, "part")
-	rawPartDir := filepath.Join(rawDir, "parts")
-
-	// List message IDs from the messages we just copied — these are the
-	// subdirectory names under storage/part/ that belong to this session.
-	// Rather than globbing message IDs from the DB, we enumerate the
-	// part directories that are prefixed by our message files.
-	msgIDs, msgListErr := listDirEntries(msgDir)
-	if msgListErr != nil {
-		// Non-fatal: if there are no messages, there are no parts.
-		msgIDs = nil
+	// Export messages.
+	messages, err := queryMessagesJSON(db, harnessSessionID)
+	if err != nil {
+		return fmt.Errorf("archive: query messages: %w", err)
 	}
 
-	// Build the set of msg_* IDs by stripping the .json suffix from message filenames.
-	type partRef struct {
-		msgID string
-		srcDir string
-	}
-	var partDirs []partRef
-	for _, f := range msgIDs {
-		msgID := strings.TrimSuffix(f, ".json")
-		srcDir := filepath.Join(partBaseDir, msgID)
-		if _, statErr := os.Stat(srcDir); statErr == nil {
-			partDirs = append(partDirs, partRef{msgID: msgID, srcDir: srcDir})
+	if len(messages) > 0 {
+		msgDir := filepath.Join(rawDir, "messages")
+		if mkErr := os.Mkdir(msgDir, archiveDirMode); mkErr != nil {
+			return fmt.Errorf("archive: create messages dir: %w", mkErr)
 		}
-	}
-
-	// Collect tool-output references while copying parts.
-	toolOutputIDs := map[string]bool{}
-
-	for _, pd := range partDirs {
-		destDir := filepath.Join(rawPartDir, pd.msgID)
-		if mkErr := os.MkdirAll(destDir, archiveDirMode); mkErr != nil {
-			return fmt.Errorf("archive: create parts/%s dir: %w", pd.msgID, mkErr)
-		}
-		partFiles, listErr := listDirEntries(pd.srcDir)
-		if listErr != nil {
-			return fmt.Errorf("archive: list parts/%s: %w", pd.msgID, listErr)
-		}
-		for _, pf := range partFiles {
-			src := filepath.Join(pd.srcDir, pf)
-			dst := filepath.Join(destDir, pf)
-			if copyErr := copyFile(src, dst); copyErr != nil {
-				return fmt.Errorf("archive: copy part %s/%s: %w", pd.msgID, pf, copyErr)
-			}
-			// Scan the part file for tool-output references.
-			ids := toolOutputIDsFromPart(src)
-			for _, id := range ids {
-				toolOutputIDs[id] = true
+		for msgID, msgData := range messages {
+			fname := msgID + ".json"
+			if writeErr := writeJSONFile(filepath.Join(msgDir, fname), msgData); writeErr != nil {
+				return fmt.Errorf("archive: write messages/%s: %w", fname, writeErr)
 			}
 		}
 	}
 
-	// Copy tool-output files referenced by parts.
-	if len(toolOutputIDs) > 0 {
-		toolOutputSrcDir := filepath.Join(storageRoot, "tool-output")
-		toolOutputDstDir := filepath.Join(rawDir, "tool-output")
-		if mkErr := os.MkdirAll(toolOutputDstDir, archiveDirMode); mkErr != nil {
-			return fmt.Errorf("archive: create tool-output dir: %w", mkErr)
+	// Export parts — grouped by message_id.
+	partsByMsg, err := queryPartsJSON(db, harnessSessionID)
+	if err != nil {
+		return fmt.Errorf("archive: query parts: %w", err)
+	}
+
+	if len(partsByMsg) > 0 {
+		partsDir := filepath.Join(rawDir, "parts")
+		if mkErr := os.Mkdir(partsDir, archiveDirMode); mkErr != nil {
+			return fmt.Errorf("archive: create parts dir: %w", mkErr)
 		}
-		for toolID := range toolOutputIDs {
-			src := filepath.Join(toolOutputSrcDir, toolID)
-			dst := filepath.Join(toolOutputDstDir, toolID)
-			if _, statErr := os.Stat(src); os.IsNotExist(statErr) {
-				// Tool output file missing — not fatal, just skip.
-				continue
+		for msgID, parts := range partsByMsg {
+			msgPartDir := filepath.Join(partsDir, msgID)
+			if mkErr := os.Mkdir(msgPartDir, archiveDirMode); mkErr != nil {
+				return fmt.Errorf("archive: create parts/%s dir: %w", msgID, mkErr)
 			}
-			if copyErr := copyFile(src, dst); copyErr != nil {
-				return fmt.Errorf("archive: copy tool-output %s: %w", toolID, copyErr)
+			for partID, partData := range parts {
+				fname := partID + ".json"
+				if writeErr := writeJSONFile(filepath.Join(msgPartDir, fname), partData); writeErr != nil {
+					return fmt.Errorf("archive: write parts/%s/%s: %w", msgID, fname, writeErr)
+				}
 			}
 		}
 	}
@@ -388,65 +409,127 @@ func copySessionFiles(harnessSessionID, storageRoot, rawDir string) error {
 	return nil
 }
 
-// findSessionFile scans the storage/session/ subtree to locate the session JSON
-// file for harnessSessionID (a ses_<ULID> value). Returns the absolute path and
-// projectID (directory name under storage/session/).
-func findSessionFile(harnessSessionID, storageRoot string) (path, projectID string, err error) {
-	sessionBaseDir := filepath.Join(storageRoot, "session")
-	projectDirs, listErr := listDirEntries(sessionBaseDir)
-	if listErr != nil {
-		return "", "", fmt.Errorf("archive: list session base dir: %w", listErr)
-	}
+// querySessionJSON fetches the session row for harnessSessionID from the
+// opencode DB and returns it as raw JSON bytes. Returns (nil, nil) when the
+// session is not found.
+func querySessionJSON(db *sql.DB, harnessSessionID string) ([]byte, error) {
+	var dataStr string
+	// The session table stores the full row; we select the columns we need and
+	// marshal them to JSON rather than reading a pre-serialised blob.
+	row := db.QueryRow(`
+		SELECT id, project_id, parent_id, slug, directory, title, version,
+		       share_url, summary_additions, summary_deletions, summary_files,
+		       summary_diffs, revert, permission, time_created, time_updated,
+		       time_compacting, time_archived
+		  FROM session
+		 WHERE id = ?`, harnessSessionID)
 
-	fileName := harnessSessionID + ".json"
-	for _, proj := range projectDirs {
-		candidate := filepath.Join(sessionBaseDir, proj, fileName)
-		if _, statErr := os.Stat(candidate); statErr == nil {
-			return candidate, proj, nil
-		}
+	var (
+		id, projectID, slug, directory, title, version string
+		parentID, shareURL, summaryDiffs, revert, permission *string
+		summaryAdditions, summaryDeletions, summaryFiles    *int64
+		timeCreated, timeUpdated                            int64
+		timeCompacting, timeArchived                        *int64
+	)
+	err := row.Scan(
+		&id, &projectID, &parentID, &slug, &directory, &title, &version,
+		&shareURL, &summaryAdditions, &summaryDeletions, &summaryFiles,
+		&summaryDiffs, &revert, &permission, &timeCreated, &timeUpdated,
+		&timeCompacting, &timeArchived,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
 	}
-	return "", "", fmt.Errorf("archive: session file for %q not found under %s", harnessSessionID, sessionBaseDir)
-}
-
-// copyDirFlat copies all regular files in srcDir into dstDir (created if
-// absent). Subdirectories within srcDir are ignored. If srcDir does not exist,
-// a (possibly empty) dstDir is still created and nil is returned. A real I/O
-// error (e.g. permission denied) reading srcDir is returned to the caller.
-func copyDirFlat(srcDir, dstDir string) error {
-	if mkErr := os.MkdirAll(dstDir, archiveDirMode); mkErr != nil {
-		return fmt.Errorf("create %s: %w", dstDir, mkErr)
-	}
-	entries, err := listDirEntries(srcDir)
 	if err != nil {
-		// listDirEntries returns nil for os.IsNotExist; any remaining error is
-		// a real I/O failure (e.g. EACCES) that we propagate.
-		return fmt.Errorf("read %s: %w", srcDir, err)
-	}
-	for _, name := range entries {
-		src := filepath.Join(srcDir, name)
-		dst := filepath.Join(dstDir, name)
-		if copyErr := copyFile(src, dst); copyErr != nil {
-			return copyErr
-		}
-	}
-	return nil
-}
-
-// listDirEntries returns the names of all directory entries directly under dir.
-// Returns nil (not an error) when dir does not exist.
-func listDirEntries(dir string) ([]string, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
-	names := make([]string, 0, len(entries))
-	for _, e := range entries {
-		names = append(names, e.Name())
+	_ = dataStr // unused; we use individual fields
+
+	out := map[string]any{
+		"id":               id,
+		"projectId":        projectID,
+		"parentId":         parentID,
+		"slug":             slug,
+		"directory":        directory,
+		"title":            title,
+		"version":          version,
+		"shareUrl":         shareURL,
+		"summaryAdditions": summaryAdditions,
+		"summaryDeletions": summaryDeletions,
+		"summaryFiles":     summaryFiles,
+		"summaryDiffs":     summaryDiffs,
+		"revert":           revert,
+		"permission":       permission,
+		"timeCreated":      timeCreated,
+		"timeUpdated":      timeUpdated,
+		"timeCompacting":   timeCompacting,
+		"timeArchived":     timeArchived,
 	}
-	return names, nil
+	return json.Marshal(out)
+}
+
+// queryMessagesJSON returns all messages for the session as a map of
+// messageID → raw JSON bytes. The data column already contains the full
+// message JSON as stored by opencode.
+func queryMessagesJSON(db *sql.DB, sessionID string) (map[string][]byte, error) {
+	rows, err := db.Query(`
+		SELECT id, data FROM message WHERE session_id = ?
+		ORDER BY time_created, id`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string][]byte)
+	for rows.Next() {
+		var id, data string
+		if err := rows.Scan(&id, &data); err != nil {
+			return nil, err
+		}
+		result[id] = []byte(data)
+	}
+	return result, rows.Err()
+}
+
+// queryPartsJSON returns all parts for the session as a nested map of
+// messageID → (partID → raw JSON bytes). The data column already contains
+// the full part JSON as stored by opencode.
+func queryPartsJSON(db *sql.DB, sessionID string) (map[string]map[string][]byte, error) {
+	rows, err := db.Query(`
+		SELECT id, message_id, data FROM part WHERE session_id = ?
+		ORDER BY message_id, time_created, id`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]map[string][]byte)
+	for rows.Next() {
+		var id, messageID, data string
+		if err := rows.Scan(&id, &messageID, &data); err != nil {
+			return nil, err
+		}
+		if result[messageID] == nil {
+			result[messageID] = make(map[string][]byte)
+		}
+		result[messageID][id] = []byte(data)
+	}
+	return result, rows.Err()
+}
+
+// writeJSONFile writes data to path with mode 0600. The destination directory
+// must already exist.
+func writeJSONFile(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, archiveFileMode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return f.Close()
 }
 
 // copyFile copies the file at src to dst with mode 0600.
@@ -471,61 +554,24 @@ func copyFile(src, dst string) error {
 	return out.Close()
 }
 
-// toolOutputIDsFromPart parses the part JSON at path and returns any
-// tool-output file IDs referenced (e.g. "tool_<ulid>"). Returns nil on any
-// parse error (best-effort; caller handles missing tool-output gracefully).
-//
-// The returned IDs are validated to be plain file names (no path separator,
-// no ".." components) to prevent path traversal when used in filepath.Join.
-// Any crafted asset value containing "/" or ".." is silently dropped.
-func toolOutputIDsFromPart(path string) []string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil
-	}
-
-	// We only need the "type" and "asset" (or similar) fields — use a
-	// minimal struct rather than full unmarshalling.
-	var part struct {
-		Type  string `json:"type"`
-		Asset string `json:"asset"` // tool-output references: "tool_<ulid>"
-	}
-	if err := json.Unmarshal(data, &part); err != nil {
-		return nil
-	}
-
-	if part.Type != "tool" || !strings.HasPrefix(part.Asset, "tool_") {
-		return nil
-	}
-
-	// Validate: toolID must be a plain filename with no path separators or
-	// ".." to prevent traversal outside the tool-output directory.
-	toolID := part.Asset
-	if toolID != filepath.Base(toolID) || strings.ContainsRune(toolID, os.PathSeparator) {
-		return nil
-	}
-
-	return []string{toolID}
-}
-
 // manifest is the JSON structure written to manifest.json.
 type manifest struct {
-	ArchiveVersion  int     `json:"archiveVersion"`
-	PiMonoVersion   int     `json:"piMonoVersion"`
-	InstanceID      string  `json:"instanceId"`
-	SessionName     string  `json:"sessionName"`
-	AgentRole       string  `json:"agentRole"`
-	RootAgentName   string  `json:"rootAgentName"`
-	Harness         string  `json:"harness"`
-	HarnessSessionID string `json:"harnessSessionId"`
-	HarnessVersion  string  `json:"harnessVersion"`
-	Repo            string  `json:"repo"`
-	Worktree        string  `json:"worktree"`
-	StartedAt       string  `json:"startedAt"`
-	EndedAt         string  `json:"endedAt"`
-	EndState        string  `json:"endState"`
-	GroupID         *string `json:"groupId"`
-	PrismVersion    string  `json:"prismVersion"`
+	ArchiveVersion   int     `json:"archiveVersion"`
+	PiMonoVersion    int     `json:"piMonoVersion"`
+	InstanceID       string  `json:"instanceId"`
+	SessionName      string  `json:"sessionName"`
+	AgentRole        string  `json:"agentRole"`
+	RootAgentName    string  `json:"rootAgentName"`
+	Harness          string  `json:"harness"`
+	HarnessSessionID string  `json:"harnessSessionId"`
+	HarnessVersion   string  `json:"harnessVersion"`
+	Repo             string  `json:"repo"`
+	Worktree         string  `json:"worktree"`
+	StartedAt        string  `json:"startedAt"`
+	EndedAt          string  `json:"endedAt"`
+	EndState         string  `json:"endState"`
+	GroupID          *string `json:"groupId"`
+	PrismVersion     string  `json:"prismVersion"`
 }
 
 // writeManifest serialises the manifest and writes it to <dir>/manifest.json

--- a/modules/programs/prism/prism/internal/archive/archive_test.go
+++ b/modules/programs/prism/prism/internal/archive/archive_test.go
@@ -1,84 +1,127 @@
 package archive
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-// makeStorageTree creates a minimal opencode storage tree under root for the
-// given session ID and project ID. Returns a map of relative paths → content
+// makeOpenCodeDB creates a minimal opencode-stable.db at dbPath with the given
+// session, messages, and parts. Returns a map of relative raw/ paths → content
 // that the caller can compare against the archive raw/ contents.
-func makeStorageTree(t *testing.T, root, projectID, sessionID string) map[string]string {
+func makeOpenCodeDB(t *testing.T, dbPath, sessionID string) map[string]string {
 	t.Helper()
 
-	// storage/session/<projectID>/ses_<id>.json
-	sessDir := filepath.Join(root, "session", projectID)
-	mustMkdir(t, sessDir)
-	sessContent := `{"id":"` + sessionID + `","projectID":"` + projectID + `"}`
-	mustWriteFile(t, filepath.Join(sessDir, sessionID+".json"), sessContent)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll for DB dir: %v", err)
+	}
 
-	// storage/message/<sessionID>/msg_aaa.json
-	msgDir := filepath.Join(root, "message", sessionID)
-	mustMkdir(t, msgDir)
-	msg1Content := `{"id":"msg_aaa","type":"text"}`
-	mustWriteFile(t, filepath.Join(msgDir, "msg_aaa.json"), msg1Content)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	defer db.Close()
 
-	// storage/part/msg_aaa/prt_001.json (text part — no tool-output ref)
-	partDir := filepath.Join(root, "part", "msg_aaa")
-	mustMkdir(t, partDir)
+	// Create minimal schema matching opencode-stable.db.
+	_, err = db.Exec(`
+		CREATE TABLE project (
+			id TEXT PRIMARY KEY,
+			worktree TEXT NOT NULL,
+			vcs TEXT,
+			name TEXT,
+			icon_url TEXT,
+			icon_color TEXT,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			time_initialized INTEGER,
+			sandboxes TEXT NOT NULL,
+			commands TEXT
+		);
+		CREATE TABLE session (
+			id TEXT PRIMARY KEY,
+			project_id TEXT NOT NULL,
+			parent_id TEXT,
+			slug TEXT NOT NULL,
+			directory TEXT NOT NULL,
+			title TEXT NOT NULL,
+			version TEXT NOT NULL,
+			share_url TEXT,
+			summary_additions INTEGER,
+			summary_deletions INTEGER,
+			summary_files INTEGER,
+			summary_diffs TEXT,
+			revert TEXT,
+			permission TEXT,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			time_compacting INTEGER,
+			time_archived INTEGER
+		);
+		CREATE TABLE message (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			data TEXT NOT NULL
+		);
+		CREATE TABLE part (
+			id TEXT PRIMARY KEY,
+			message_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			data TEXT NOT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	// Insert a project row (required by session FK).
+	projectID := "proj_" + sessionID
+	_, err = db.Exec(`INSERT INTO project (id, worktree, time_created, time_updated, sandboxes)
+		VALUES (?, '/home/test', 1, 1, '[]')`, projectID)
+	if err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+
+	// Insert the session row.
+	_, err = db.Exec(`INSERT INTO session
+		(id, project_id, slug, directory, title, version, time_created, time_updated)
+		VALUES (?, ?, 'test-session', '/home/test', 'Test Session', '1.0', 1000, 1000)`,
+		sessionID, projectID)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	// Insert a message.
+	msg1Content := `{"id":"msg_aaa","type":"user","role":"user"}`
+	_, err = db.Exec(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		VALUES ('msg_aaa', ?, 1000, 1000, ?)`, sessionID, msg1Content)
+	if err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	// Insert a part for that message.
 	part1Content := `{"id":"prt_001","type":"text","text":"hello"}`
-	mustWriteFile(t, filepath.Join(partDir, "prt_001.json"), part1Content)
+	_, err = db.Exec(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		VALUES ('prt_001', 'msg_aaa', ?, 1000, 1000, ?)`, sessionID, part1Content)
+	if err != nil {
+		t.Fatalf("insert part: %v", err)
+	}
 
 	return map[string]string{
-		"session.json":              sessContent,
-		"messages/msg_aaa.json":     msg1Content,
+		"messages/msg_aaa.json":      msg1Content,
 		"parts/msg_aaa/prt_001.json": part1Content,
-	}
-}
-
-// makeStorageTreeWithToolOutput extends makeStorageTree with a tool part that
-// references a tool-output sidecar file. Returns the file map and toolID.
-func makeStorageTreeWithToolOutput(t *testing.T, root, projectID, sessionID string) (map[string]string, string) {
-	t.Helper()
-	files := makeStorageTree(t, root, projectID, sessionID)
-
-	toolID := "tool_abc123"
-	toolContent := "tool output bytes"
-
-	// Add a second part in msg_aaa that references the tool output.
-	partDir := filepath.Join(root, "part", "msg_aaa")
-	part2Content := `{"id":"prt_002","type":"tool","asset":"` + toolID + `"}`
-	mustWriteFile(t, filepath.Join(partDir, "prt_002.json"), part2Content)
-	files["parts/msg_aaa/prt_002.json"] = part2Content
-
-	// Write the tool-output sidecar.
-	toDir := filepath.Join(root, "tool-output")
-	mustMkdir(t, toDir)
-	mustWriteFile(t, filepath.Join(toDir, toolID), toolContent)
-	files["tool-output/"+toolID] = toolContent
-
-	return files, toolID
-}
-
-func mustMkdir(t *testing.T, path string) {
-	t.Helper()
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatalf("MkdirAll %s: %v", path, err)
-	}
-}
-
-func mustWriteFile(t *testing.T, path, content string) {
-	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile %s: %v", path, err)
 	}
 }
 
@@ -91,7 +134,7 @@ func readFile(t *testing.T, path string) string {
 	return string(data)
 }
 
-func baseParams(archiveRoot, storageRoot string) Params {
+func baseParams(archiveRoot, dbPath string) Params {
 	startedAt := time.Date(2026, 4, 25, 14, 30, 22, 0, time.UTC)
 	endedAt := time.Date(2026, 4, 25, 15, 47, 11, 0, time.UTC)
 	return Params{
@@ -110,7 +153,7 @@ func baseParams(archiveRoot, storageRoot string) Params {
 		GroupID:          "",
 		PrismVersion:     "abc123",
 		IsolationMode:    "host",
-		StorageRoot:      storageRoot,
+		DBPath:           dbPath,
 		ArchiveRoot:      archiveRoot,
 	}
 }
@@ -122,13 +165,12 @@ func baseParams(archiveRoot, storageRoot string) Params {
 func TestRunHappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "proj123"
 	sessionID := "ses_test001"
-	wantFiles := makeStorageTree(t, storageRoot, projectID, sessionID)
+	wantFiles := makeOpenCodeDB(t, dbPath, sessionID)
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 
 	archivePath, err := Run(p)
 	if err != nil {
@@ -158,6 +200,16 @@ func TestRunHappyPath(t *testing.T) {
 		if got != want {
 			t.Errorf("raw/%s content = %q, want %q", rel, got, want)
 		}
+	}
+
+	// Verify session.json is present and contains expected fields.
+	sessData := readFile(t, filepath.Join(rawDir, "session.json"))
+	var sessObj map[string]any
+	if err := json.Unmarshal([]byte(sessData), &sessObj); err != nil {
+		t.Fatalf("session.json parse error: %v", err)
+	}
+	if sessObj["id"] != sessionID {
+		t.Errorf("session.json id = %v, want %q", sessObj["id"], sessionID)
 	}
 
 	// Verify manifest.json exists and parses.
@@ -209,49 +261,14 @@ func TestRunHappyPath(t *testing.T) {
 	}
 }
 
-// TestRunWithToolOutput verifies that tool-output sidecar files referenced by
-// parts are copied into raw/tool-output/.
-func TestRunWithToolOutput(t *testing.T) {
-	tmpDir := t.TempDir()
-	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
-
-	projectID := "proj456"
-	sessionID := "ses_test002"
-	wantFiles, toolID := makeStorageTreeWithToolOutput(t, storageRoot, projectID, sessionID)
-
-	p := baseParams(archiveRoot, storageRoot)
-	p.HarnessSessionID = sessionID
-	p.InstanceID = "bbbbbbbb-1234-5678-9abc-def012345678"
-
-	archivePath, err := Run(p)
-	if err != nil {
-		t.Fatalf("Run() error: %v", err)
-	}
-
-	rawDir := filepath.Join(archivePath, "raw")
-	for rel, want := range wantFiles {
-		got := readFile(t, filepath.Join(rawDir, rel))
-		if got != want {
-			t.Errorf("raw/%s content = %q, want %q", rel, got, want)
-		}
-	}
-
-	// Verify the tool-output file is present.
-	toolPath := filepath.Join(rawDir, "tool-output", toolID)
-	if _, err := os.Stat(toolPath); err != nil {
-		t.Errorf("tool-output/%s not found: %v", toolID, err)
-	}
-}
-
 // TestRunNoHarnessSessionID verifies that a session with no harness_session_id
 // still produces an archive dir with manifest.json and an empty raw/.
 func TestRunNoHarnessSessionID(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = "" // opencode failed to start
 	p.InstanceID = "cccccccc-1234-5678-9abc-def012345678"
 	p.EndState = "interrupted"
@@ -290,18 +307,75 @@ func TestRunNoHarnessSessionID(t *testing.T) {
 	}
 }
 
+// TestRunDBAbsent verifies that a missing opencode-stable.db is a graceful no-op
+// (empty raw/, no error).
+func TestRunDBAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	dbPath := filepath.Join(tmpDir, "nonexistent-opencode-stable.db")
+
+	p := baseParams(archiveRoot, dbPath)
+	p.HarnessSessionID = "ses_ghost"
+	p.InstanceID = "bbbbbbbb-1111-2222-3333-444444444444"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error (want success): %v", err)
+	}
+
+	rawDir := filepath.Join(archivePath, "raw")
+	if _, err := os.Stat(rawDir); err != nil {
+		t.Fatalf("raw/ dir not found: %v", err)
+	}
+	entries, err := os.ReadDir(rawDir)
+	if err != nil {
+		t.Fatalf("ReadDir raw/: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("raw/ has %d entries, want 0 (DB absent)", len(entries))
+	}
+}
+
+// TestRunSessionIDAbsentFromDB verifies that a session ID not present in the DB
+// is a graceful no-op (empty raw/, no error).
+func TestRunSessionIDAbsentFromDB(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
+
+	// Create DB with a different session, not the one we'll archive.
+	makeOpenCodeDB(t, dbPath, "ses_other001")
+
+	p := baseParams(archiveRoot, dbPath)
+	p.HarnessSessionID = "ses_nothere"
+	p.InstanceID = "cccccccc-2222-3333-4444-555555555555"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error (want success): %v", err)
+	}
+
+	rawDir := filepath.Join(archivePath, "raw")
+	entries, err := os.ReadDir(rawDir)
+	if err != nil {
+		t.Fatalf("ReadDir raw/: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("raw/ has %d entries, want 0 (session not in DB)", len(entries))
+	}
+}
+
 // TestRunIdempotencyError verifies that calling Run a second time for the same
 // instance returns an error and leaves the existing archive intact.
 func TestRunIdempotencyError(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "proj789"
 	sessionID := "ses_test003"
-	makeStorageTree(t, storageRoot, projectID, sessionID)
+	makeOpenCodeDB(t, dbPath, sessionID)
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = sessionID
 	p.InstanceID = "dddddddd-1234-5678-9abc-def012345678"
 
@@ -332,43 +406,36 @@ func TestRunIdempotencyError(t *testing.T) {
 	}
 }
 
-// TestRunCopyFailureAtomicity verifies that a copy failure leaves no partial
-// archive directory (temp dir is cleaned up).
+// TestRunCopyFailureAtomicity verifies that when temp dir creation fails (due to
+// a bad archive root path), no partial directories are left behind.
 func TestRunCopyFailureAtomicity(t *testing.T) {
 	tmpDir := t.TempDir()
-	archiveRoot := filepath.Join(tmpDir, "archive")
-	// Point storageRoot at a directory that exists but has no session files.
-	storageRoot := filepath.Join(tmpDir, "empty-storage")
-	if err := os.MkdirAll(storageRoot, 0o755); err != nil {
-		t.Fatalf("MkdirAll storageRoot: %v", err)
-	}
-	// Create the session base dir but NO project subdir, so findSessionFile fails.
-	if err := os.MkdirAll(filepath.Join(storageRoot, "session"), 0o755); err != nil {
-		t.Fatalf("MkdirAll session dir: %v", err)
-	}
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	p := baseParams(archiveRoot, storageRoot)
-	p.HarnessSessionID = "ses_missing"
+	// Use a regular file as a directory component in the archive root path so
+	// that MkdirAll fails with ENOTDIR — forcing Run() to return an error
+	// before any temp directory is created.
+	blockingFile := filepath.Join(tmpDir, "blocking-file")
+	if err := os.WriteFile(blockingFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+	badArchiveRoot := filepath.Join(blockingFile, "archive")
+
+	p := baseParams(badArchiveRoot, dbPath)
+	p.HarnessSessionID = "ses_test004"
 	p.InstanceID = "eeeeeeee-1234-5678-9abc-def012345678"
 
 	_, err := Run(p)
 	if err == nil {
-		t.Fatal("Run() succeeded, want error (session file not found)")
+		t.Fatal("Run() with bad archiveRoot succeeded, want error")
 	}
 
-	// No temp dir should remain.
-	repoDir := filepath.Join(archiveRoot, p.Repo)
-	entries, _ := os.ReadDir(repoDir)
+	// No temp dir should remain anywhere under our real tmpDir.
+	entries, _ := os.ReadDir(tmpDir)
 	for _, e := range entries {
 		if strings.HasPrefix(e.Name(), ".tmp-") {
 			t.Errorf("temp dir left behind: %s", e.Name())
 		}
-	}
-
-	// The final directory must not exist either.
-	dirName := p.StartedAt.UTC().Format("20060102T150405Z") + "_" + p.InstanceID
-	if _, statErr := os.Stat(filepath.Join(repoDir, dirName)); statErr == nil {
-		t.Errorf("final archive dir exists after failed Run()")
 	}
 }
 
@@ -376,13 +443,12 @@ func TestRunCopyFailureAtomicity(t *testing.T) {
 func TestFilePermissions(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "permproj"
 	sessionID := "ses_perm001"
-	makeStorageTree(t, storageRoot, projectID, sessionID)
+	makeOpenCodeDB(t, dbPath, sessionID)
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = sessionID
 	p.InstanceID = "ffffffff-1234-5678-9abc-def012345678"
 
@@ -432,13 +498,12 @@ func TestFilePermissions(t *testing.T) {
 func TestRunManifestVersions(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "versionproj"
 	sessionID := "ses_ver001"
-	makeStorageTree(t, storageRoot, projectID, sessionID)
+	makeOpenCodeDB(t, dbPath, sessionID)
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = sessionID
 	p.InstanceID = "11111111-2222-3333-4444-555555555555"
 
@@ -466,13 +531,12 @@ func TestRunManifestVersions(t *testing.T) {
 func TestRunGroupID(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "groupproj"
 	sessionID := "ses_grp001"
-	makeStorageTree(t, storageRoot, projectID, sessionID)
+	makeOpenCodeDB(t, dbPath, sessionID)
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = sessionID
 	p.InstanceID = "22222222-3333-4444-5555-666666666666"
 	p.GroupID = "my-group-id"
@@ -496,22 +560,55 @@ func TestRunGroupID(t *testing.T) {
 	}
 }
 
-// TestRunSessionWithNoMessages verifies that a session with a session.json but
-// no messages produces an archive with raw/session.json and raw/messages/ empty.
+// TestRunSessionWithNoMessages verifies that a session with no messages produces
+// an archive with raw/session.json and no raw/messages/ directory.
 func TestRunSessionWithNoMessages(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "nomsgproj"
+	// Create DB with session but no messages.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
 	sessionID := "ses_nomsg"
-	// Only create the session.json, no message/ dir.
-	sessDir := filepath.Join(storageRoot, "session", projectID)
-	mustMkdir(t, sessDir)
-	sessContent := `{"id":"` + sessionID + `","projectID":"` + projectID + `"}`
-	mustWriteFile(t, filepath.Join(sessDir, sessionID+".json"), sessContent)
+	_, err = db.Exec(`
+		CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL,
+			vcs TEXT, name TEXT, icon_url TEXT, icon_color TEXT,
+			time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+			time_initialized INTEGER, sandboxes TEXT NOT NULL, commands TEXT);
+		CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL,
+			parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL,
+			title TEXT NOT NULL, version TEXT NOT NULL, share_url TEXT,
+			summary_additions INTEGER, summary_deletions INTEGER,
+			summary_files INTEGER, summary_diffs TEXT, revert TEXT,
+			permission TEXT, time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL, time_compacting INTEGER,
+			time_archived INTEGER);
+		CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+		CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL,
+			session_id TEXT NOT NULL, time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+	`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO project (id, worktree, time_created, time_updated, sandboxes)
+		VALUES ('proj_nomsg', '/home/test', 1, 1, '[]')`)
+	if err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO session
+		(id, project_id, slug, directory, title, version, time_created, time_updated)
+		VALUES (?, 'proj_nomsg', 'test', '/home/test', 'Test', '1.0', 1, 1)`, sessionID)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	db.Close()
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = sessionID
 	p.InstanceID = "33333333-4444-5555-6666-777777777777"
 
@@ -525,29 +622,58 @@ func TestRunSessionWithNoMessages(t *testing.T) {
 	if _, err := os.Stat(sessFilePath); err != nil {
 		t.Fatalf("raw/session.json not found: %v", err)
 	}
-	if got := readFile(t, sessFilePath); got != sessContent {
-		t.Errorf("raw/session.json = %q, want %q", got, sessContent)
+	var sessObj map[string]any
+	if err := json.Unmarshal([]byte(readFile(t, sessFilePath)), &sessObj); err != nil {
+		t.Fatalf("parse session.json: %v", err)
+	}
+	if sessObj["id"] != sessionID {
+		t.Errorf("session.json id = %v, want %q", sessObj["id"], sessionID)
 	}
 
-	// messages/ must exist and be empty.
+	// No messages/ dir should be created when there are no messages.
 	msgDir := filepath.Join(archivePath, "raw", "messages")
-	if _, err := os.Stat(msgDir); err != nil {
-		t.Fatalf("raw/messages/ not found: %v", err)
-	}
-	entries, err := os.ReadDir(msgDir)
-	if err != nil {
-		t.Fatalf("ReadDir raw/messages/: %v", err)
-	}
-	if len(entries) != 0 {
-		t.Errorf("raw/messages/ has %d entries, want 0", len(entries))
+	if _, err := os.Stat(msgDir); !os.IsNotExist(err) {
+		t.Errorf("raw/messages/ should not exist for session with no messages, but: %v", err)
 	}
 }
 
-// TestResolveStorageRootPodman verifies the podman path uses the container name.
+// TestResolveDBPathPodman verifies the podman path uses the container name.
+func TestResolveDBPathPodman(t *testing.T) {
+	got, err := resolveDBPath("podman", "nixos-config@feature")
+	if err != nil {
+		t.Fatalf("resolveDBPath podman: %v", err)
+	}
+	if !strings.Contains(got, "prism-sessions") {
+		t.Errorf("podman DB path = %q, want path containing 'prism-sessions'", got)
+	}
+	if !strings.Contains(got, "prism-nixos-config-feature") {
+		t.Errorf("podman DB path = %q, want path containing container name 'prism-nixos-config-feature'", got)
+	}
+	if !strings.HasSuffix(got, "opencode-stable.db") {
+		t.Errorf("podman DB path = %q, want suffix 'opencode-stable.db'", got)
+	}
+}
+
+// TestResolveDBPathHost verifies the host/bwrap/sandbox-exec path does not
+// use prism-sessions.
+func TestResolveDBPathHost(t *testing.T) {
+	for _, mode := range []string{"host", "bwrap", "sandbox-exec"} {
+		got, err := resolveDBPath(mode, "nixos-config@main")
+		if err != nil {
+			t.Fatalf("resolveDBPath %s: %v", mode, err)
+		}
+		if strings.Contains(got, "prism-sessions") {
+			t.Errorf("mode=%s DB path = %q, should not contain 'prism-sessions'", mode, got)
+		}
+		if !strings.HasSuffix(got, "opencode-stable.db") {
+			t.Errorf("mode=%s DB path = %q, want suffix 'opencode-stable.db'", mode, got)
+		}
+	}
+}
+
+// TestResolveStorageRootPodman verifies the podman storage root path uses the container name.
+// resolveStorageRoot is retained for back-compat.
 func TestResolveStorageRootPodman(t *testing.T) {
-	// We don't want to call os.UserHomeDir in a way that makes the test
-	// platform-dependent — just verify the function doesn't return an error
-	// and includes "prism-sessions" in the path.
 	got, err := resolveStorageRoot("podman", "nixos-config@feature")
 	if err != nil {
 		t.Fatalf("resolveStorageRoot podman: %v", err)
@@ -560,8 +686,7 @@ func TestResolveStorageRootPodman(t *testing.T) {
 	}
 }
 
-// TestResolveStorageRootHost verifies the host/bwrap/sandbox-exec path does not
-// use prism-sessions.
+// TestResolveStorageRootHost verifies the host/bwrap/sandbox-exec storage root.
 func TestResolveStorageRootHost(t *testing.T) {
 	for _, mode := range []string{"host", "bwrap", "sandbox-exec"} {
 		got, err := resolveStorageRoot(mode, "nixos-config@main")
@@ -578,17 +703,16 @@ func TestResolveStorageRootHost(t *testing.T) {
 }
 
 // TestRunSandboxExec verifies that a session with isolation_mode "sandbox-exec"
-// archives successfully, using the same storage layout as bwrap/host modes.
+// archives successfully.
 func TestRunSandboxExec(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
-	projectID := "sbxproj"
 	sessionID := "ses_sbx001"
-	wantFiles := makeStorageTree(t, storageRoot, projectID, sessionID)
+	makeOpenCodeDB(t, dbPath, sessionID)
 
-	p := baseParams(archiveRoot, storageRoot)
+	p := baseParams(archiveRoot, dbPath)
 	p.HarnessSessionID = sessionID
 	p.InstanceID = "44444444-5555-6666-7777-888888888888"
 	p.IsolationMode = "sandbox-exec"
@@ -609,15 +733,17 @@ func TestRunSandboxExec(t *testing.T) {
 		t.Fatalf("raw/ dir not found: %v", err)
 	}
 
-	// Verify each file is present and byte-for-byte identical.
-	for rel, want := range wantFiles {
-		got := readFile(t, filepath.Join(rawDir, rel))
-		if got != want {
-			t.Errorf("raw/%s content = %q, want %q", rel, got, want)
-		}
+	// Verify session.json is present and valid.
+	sessData := readFile(t, filepath.Join(rawDir, "session.json"))
+	var sessObj map[string]any
+	if err := json.Unmarshal([]byte(sessData), &sessObj); err != nil {
+		t.Fatalf("session.json parse error: %v", err)
+	}
+	if sessObj["id"] != sessionID {
+		t.Errorf("session.json id = %v, want %q", sessObj["id"], sessionID)
 	}
 
-	// Verify manifest.json parses and has the correct isolation mode recorded.
+	// Verify manifest.json parses correctly.
 	var m manifest
 	mData := readFile(t, filepath.Join(archivePath, "manifest.json"))
 	if err := json.Unmarshal([]byte(mData), &m); err != nil {
@@ -628,12 +754,12 @@ func TestRunSandboxExec(t *testing.T) {
 	}
 }
 
-// TestResolveStorageRootUnknown verifies that an unsupported isolation mode
-// returns an error.
-func TestResolveStorageRootUnknown(t *testing.T) {
-	_, err := resolveStorageRoot("docker", "nixos-config@main")
+// TestResolveDBPathUnknown verifies that an unsupported isolation mode returns
+// an error.
+func TestResolveDBPathUnknown(t *testing.T) {
+	_, err := resolveDBPath("docker", "nixos-config@main")
 	if err == nil {
-		t.Fatal("resolveStorageRoot with unknown mode: expected error, got nil")
+		t.Fatal("resolveDBPath with unknown mode: expected error, got nil")
 	}
 }
 
@@ -642,7 +768,7 @@ func TestResolveStorageRootUnknown(t *testing.T) {
 func TestRunRepoTraversalRejected(t *testing.T) {
 	tmpDir := t.TempDir()
 	archiveRoot := filepath.Join(tmpDir, "archive")
-	storageRoot := filepath.Join(tmpDir, "storage")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
 
 	cases := []string{
 		"../../evil",
@@ -652,49 +778,13 @@ func TestRunRepoTraversalRejected(t *testing.T) {
 	}
 
 	for _, repo := range cases {
-		p := baseParams(archiveRoot, storageRoot)
+		p := baseParams(archiveRoot, dbPath)
 		p.Repo = repo
 		p.InstanceID = "aaaa1111-1111-1111-1111-111111111111"
 
 		_, err := Run(p)
 		if err == nil {
 			t.Errorf("Run() with repo=%q succeeded, want error", repo)
-		}
-	}
-}
-
-// TestToolOutputIDValidation verifies that toolOutputIDsFromPart rejects
-// asset values containing path traversal sequences.
-func TestToolOutputIDValidation(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	cases := []struct {
-		partContent string
-		wantIDs     []string
-	}{
-		// Normal tool part.
-		{`{"type":"tool","asset":"tool_abc123"}`, []string{"tool_abc123"}},
-		// Traversal attempt — must be rejected.
-		{`{"type":"tool","asset":"tool_/../../etc/shadow"}`, nil},
-		{`{"type":"tool","asset":"tool_../secret"}`, nil},
-		// Wrong prefix — ignored.
-		{`{"type":"tool","asset":"output_abc"}`, nil},
-		// Wrong type — ignored.
-		{`{"type":"text","asset":"tool_abc"}`, nil},
-	}
-
-	for i, tc := range cases {
-		partPath := filepath.Join(tmpDir, fmt.Sprintf("prt_%02d.json", i))
-		mustWriteFile(t, partPath, tc.partContent)
-		got := toolOutputIDsFromPart(partPath)
-		if len(got) != len(tc.wantIDs) {
-			t.Errorf("case %d (%s): got %v, want %v", i, tc.partContent, got, tc.wantIDs)
-			continue
-		}
-		for j := range got {
-			if got[j] != tc.wantIDs[j] {
-				t.Errorf("case %d: got[%d] = %q, want %q", i, j, got[j], tc.wantIDs[j])
-			}
 		}
 	}
 }
@@ -715,5 +805,123 @@ func TestContainerNameForSession(t *testing.T) {
 		if got != tc.wantContainer {
 			t.Errorf("containerNameForSession(%q) = %q, want %q", tc.sessionName, got, tc.wantContainer)
 		}
+	}
+}
+
+// TestRunMultipleMessages verifies that multiple messages and their parts are
+// all exported correctly.
+func TestRunMultipleMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+	archiveRoot := filepath.Join(tmpDir, "archive")
+	dbPath := filepath.Join(tmpDir, "opencode-stable.db")
+
+	// Build DB with two messages, each with a part.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	sessionID := "ses_multi01"
+	_, err = db.Exec(`
+		CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL,
+			vcs TEXT, name TEXT, icon_url TEXT, icon_color TEXT,
+			time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+			time_initialized INTEGER, sandboxes TEXT NOT NULL, commands TEXT);
+		CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL,
+			parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL,
+			title TEXT NOT NULL, version TEXT NOT NULL, share_url TEXT,
+			summary_additions INTEGER, summary_deletions INTEGER,
+			summary_files INTEGER, summary_diffs TEXT, revert TEXT,
+			permission TEXT, time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL, time_compacting INTEGER,
+			time_archived INTEGER);
+		CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+		CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL,
+			session_id TEXT NOT NULL, time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+	`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO project VALUES ('proj_multi', '/home/test', NULL, NULL, NULL, NULL, 1, 1, NULL, '[]', NULL)`)
+	if err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO session VALUES (?, 'proj_multi', NULL, 'slug', '/home/test', 'T', '1.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, 1, NULL, NULL)`, sessionID)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	msg1 := `{"id":"msg_111","role":"user"}`
+	msg2 := `{"id":"msg_222","role":"assistant"}`
+	part1 := `{"id":"prt_aaa","type":"text","text":"hello"}`
+	part2 := `{"id":"prt_bbb","type":"text","text":"world"}`
+
+	for _, row := range []struct{ id, data string }{
+		{"msg_111", msg1}, {"msg_222", msg2},
+	} {
+		if _, err := db.Exec(`INSERT INTO message VALUES (?, ?, 1, 1, ?)`, row.id, sessionID, row.data); err != nil {
+			t.Fatalf("insert message: %v", err)
+		}
+	}
+	if _, err := db.Exec(`INSERT INTO part VALUES ('prt_aaa', 'msg_111', ?, 1, 1, ?)`, sessionID, part1); err != nil {
+		t.Fatalf("insert part1: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO part VALUES ('prt_bbb', 'msg_222', ?, 1, 1, ?)`, sessionID, part2); err != nil {
+		t.Fatalf("insert part2: %v", err)
+	}
+	db.Close()
+
+	p := baseParams(archiveRoot, dbPath)
+	p.HarnessSessionID = sessionID
+	p.InstanceID = "55555555-6666-7777-8888-999999999999"
+
+	archivePath, err := Run(p)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	rawDir := filepath.Join(archivePath, "raw")
+
+	// Check both messages exist.
+	if got := readFile(t, filepath.Join(rawDir, "messages", "msg_111.json")); got != msg1 {
+		t.Errorf("messages/msg_111.json = %q, want %q", got, msg1)
+	}
+	if got := readFile(t, filepath.Join(rawDir, "messages", "msg_222.json")); got != msg2 {
+		t.Errorf("messages/msg_222.json = %q, want %q", got, msg2)
+	}
+
+	// Check both parts exist in their respective dirs.
+	if got := readFile(t, filepath.Join(rawDir, "parts", "msg_111", "prt_aaa.json")); got != part1 {
+		t.Errorf("parts/msg_111/prt_aaa.json = %q, want %q", got, part1)
+	}
+	if got := readFile(t, filepath.Join(rawDir, "parts", "msg_222", "prt_bbb.json")); got != part2 {
+		t.Errorf("parts/msg_222/prt_bbb.json = %q, want %q", got, part2)
+	}
+}
+
+// TestResolvePathsStorageRootDerived verifies that when StorageRoot is set (as
+// cleanup.go does for podman sessions via ArchivePaths), the DB path is derived
+// as the parent of storage/ plus opencode-stable.db.
+func TestResolvePathsStorageRootDerived(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Simulate a podman-style storage root: .../prism-sessions/<container>/storage
+	storageRoot := filepath.Join(tmpDir, "prism-sessions", "prism-myrepo-feat", "storage")
+
+	p := Params{
+		Repo:          "myrepo",
+		IsolationMode: "podman",
+		StorageRoot:   storageRoot,
+		ArchiveRoot:   filepath.Join(tmpDir, "archive"),
+		InstanceID:    "aaaaaaaa-0000-0000-0000-000000000000",
+		StartedAt:     time.Now(),
+		EndedAt:       time.Now(),
+	}
+	_, dbPath, err := resolvePaths(p)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+	wantDB := filepath.Join(tmpDir, "prism-sessions", "prism-myrepo-feat", "opencode-stable.db")
+	if dbPath != wantDB {
+		t.Errorf("dbPath = %q, want %q", dbPath, wantDB)
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces `findSessionFile`/`copySessionFiles` (which scanned the legacy `storage/session/<projectID>/ses_<id>.json` path) with `exportSessionFromDB`, which queries `opencode-stable.db` directly via SQLite
- Adds `DBPath` field to `Params` for test injection; `StorageRoot` is retained and used to derive `DBPath` for podman sessions (parent dir of `storage/` + `opencode-stable.db`)
- Graceful no-ops for absent DB (fresh install) and session ID not found in DB — logs a single info line, leaves `raw/` empty, no error
- All tests updated to create in-memory SQLite DBs instead of legacy file trees; two new edge-case tests added (`TestRunDBAbsent`, `TestRunSessionIDAbsentFromDB`)

Closes #1196