### PR TITLE
feat(prism): add sandbox-exec to isolation enum and set as m4mac default

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -25,6 +25,7 @@ in
   nx = {
     programs = {
       prism.opencode.provider = "anthropic";
+      prism.agent.isolation.default = "sandbox-exec";
       # Disable programs that default to enabled but aren't needed/available on Darwin
       podman.enable = false;
       dragon-drop.enable = false;

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -29,19 +29,22 @@
               "podman"
               "bwrap"
               "host"
+              "sandbox-exec"
             ];
             default = if pkgs.stdenv.hostPlatform.isLinux then "podman" else "host";
             example = "bwrap";
             description = ''
               Default isolation mode for new agent sessions. Valid values:
-              - "podman": run opencode inside a rootless podman container (default on Linux).
-              - "bwrap":  run opencode inside a bubblewrap sandbox (Linux-only).
-              - "host":   run opencode directly in the tmux pane with no isolation (default on Darwin).
+              - "podman":       run opencode inside a rootless podman container (default on Linux).
+              - "bwrap":        run opencode inside a bubblewrap sandbox (Linux-only).
+              - "host":         run opencode directly in the tmux pane with no isolation (default on Darwin).
+              - "sandbox-exec": run opencode inside a macOS sandbox-exec profile (Darwin-only).
 
               This value is written to ~/.config/prism/config.json as default_isolation_mode.
               It can be overridden per-spawn via `prism spawn --isolation <mode>`.
 
               Setting "bwrap" on a Darwin host fails at eval time.
+              Setting "sandbox-exec" on a Linux host fails at eval time.
             '';
           };
         };
@@ -163,6 +166,18 @@
               nx.programs.prism.agent.isolation.default = "bwrap" requires Linux.
               bubblewrap is not available on ${pkgs.stdenv.hostPlatform.system}.
               Use "podman" or "host" instead, or only set "bwrap" on Linux hosts.
+            '';
+          }
+          {
+            assertion =
+              !(
+                config.nx.programs.prism.agent.isolation.default == "sandbox-exec"
+                && !pkgs.stdenv.hostPlatform.isDarwin
+              );
+            message = ''
+              nx.programs.prism.agent.isolation.default = "sandbox-exec" requires Darwin.
+              sandbox-exec is not available on ${pkgs.stdenv.hostPlatform.system}.
+              Use "podman" or "bwrap" instead, or only set "sandbox-exec" on Darwin hosts.
             '';
           }
         ];


### PR DESCRIPTION
## Summary

- Adds `"sandbox-exec"` to the `nx.programs.prism.agent.isolation.default` enum (was missing from the Nix type, causing eval errors despite the Go CLI fully supporting it)
- Adds a Darwin-only assertion: setting `sandbox-exec` on Linux fails at eval time with a clear message
- Updates the option description to document `sandbox-exec` as Darwin-only
- Sets `nx.programs.prism.agent.isolation.default = "sandbox-exec"` on m4mac

## Verification

The generated `~/.config/prism/config.json` on m4mac now contains:
```json
"default_isolation_mode": "sandbox-exec"
```

Darwin build passes. This is an enablement change — no issue to close.