### PR TITLE
Update Prism sandbox permissions and MCP proxy paths

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -296,6 +296,9 @@
         "gh issue close *" = "allow";
         "gh issue edit *" = "allow";
         "gh issue comment *" = "allow";
+        "gh issue list" = "allow";
+        "gh issue list *" = "allow";
+        "gh issue view *" = "allow";
         # nix build validation (read-only result)
         "nix build *" = "allow";
         # system switch — requires sudo, will be caught by permission prompt
@@ -627,7 +630,7 @@
           atlasian = {
             type = "local";
             enabled = true;
-            command = [ "./mcp-atlassian-slim-proxy.mjs" ];
+            command = [ "${hmUser.xdg.configHome}/opencode/mcp-atlassian-slim-proxy.mjs" ];
             environment = {
               ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
             };
@@ -770,7 +773,7 @@
           atlasian = {
             type = "local";
             enabled = true;
-            command = [ "./mcp-atlassian-slim-proxy.mjs" ];
+            command = [ "${hmUser.xdg.configHome}/opencode/mcp-atlassian-slim-proxy.mjs" ];
             environment = {
               ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
             };
@@ -1075,7 +1078,7 @@
             atlasian = {
               type = "local";
               enabled = true;
-              command = [ "./mcp-atlassian-slim-proxy.mjs" ];
+              command = [ "${hmUser.xdg.configHome}/opencode/mcp-atlassian-slim-proxy.mjs" ];
               environment = {
                 ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
               };

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -172,6 +172,7 @@ func generateProfile(m *Manager) string {
 	sb.WriteString("  (subpath \"/usr\")\n")
 	sb.WriteString("  (subpath \"/bin\")\n")
 	sb.WriteString("  (subpath \"/sbin\")\n")
+	sb.WriteString("  (subpath \"/opt/homebrew\")\n")
 	sb.WriteString("  (subpath \"/System\")\n")
 	sb.WriteString("  (subpath \"/Library\")\n")
 	sb.WriteString("  (subpath \"/Applications/Xcode.app\")\n")

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -234,6 +234,15 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".mcp-auth"),
 	)
 
+	// ── .npm/ ─────────────────────────────────────────────────────────────────
+	// npx caches downloaded packages (e.g. mcp-remote) under ~/.npm/_npx/.
+	// Without this symlink, npx cannot find its cache and attempts to re-download
+	// packages, which fails due to network restrictions in the sandbox.
+	symlinkIfExists(
+		filepath.Join(home, ".npm"),
+		filepath.Join(stagingHome, ".npm"),
+	)
+
 	// ── .config/opencode/ ─────────────────────────────────────────────────────
 	// Mirror bwrap.go:438-455 allowlist. opencode.json is a generated regular
 	// file (written below), not a symlink.
@@ -540,6 +549,7 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 		// images staged there; mirrors bwrap.go's --ro-bind treatment.
 		".claude":                       true, // write-through for .credentials.json
 		".mcp-auth":                     true, // MCP auth token writes
+		".npm":                          true, // npx package cache (mcp-remote et al.)
 		".config/opencode/node_modules": true, // bun may update lockfile entries during plugin load
 	}
 


### PR DESCRIPTION
This change updates the Atlassian MCP proxy command to use absolute paths based on the XDG config home. It adds Homebrew to the sandbox execution profile and ensures the .npm directory is available to allow npx caching. Finally, it expands the GitHub CLI permission set to include issue listing and viewing.