### PR TITLE
prism: B6.IF + B6.WIRE — ArchiveAdapter interface and opencode adapter wiring

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -33,7 +33,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
-	"github.com/prismatic-koi/prism/internal/piexport"
+	"github.com/prismatic-koi/prism/internal/harness"
+	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 	"github.com/prismatic-koi/prism/internal/review"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -809,7 +810,7 @@ func probeConventionalWorktreePath(session, worktreeName string) (worktreePath, 
 	return "", candidateBareRoot
 }
 
-// runSessionArchive performs the opencode-storage copy for the session identified by
+// runSessionArchive performs the harness-storage copy for the session identified by
 // instanceID using the already-open DB d and the agent_status isolation mode
 // from statusIsolationMode. It is called after UpdateSessionEnded so the
 // sessions row has ended_at and end_state populated.
@@ -823,6 +824,8 @@ func probeConventionalWorktreePath(session, worktreeName string) (worktreePath, 
 //     to exit non-zero when the archive directory already exists on a re-run.
 //   - Other errors are treated as non-fatal (logged + cleanup continues).
 //
+// Sessions with an unknown harness (no adapter registered) return a clear error
+// and are skipped (AC: edge-case — unknown harness); returns nil.
 // Sessions with unknown or unsupported isolation modes log a clear warning and
 // are skipped (AC: edge-case — unknown isolation mode); returns nil.
 func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode string) error {
@@ -853,6 +856,33 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 		return nil
 	}
 
+	// Resolve the archive adapter for the session's harness. A missing or
+	// unregistered harness is a clear error (not a nil-pointer panic).
+	archiveAdapter, adapterErr := harness.ArchiveAdapterFor(sess.Harness)
+	if adapterErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism] archive: skipping session %q — %v\n", sessionName, adapterErr)
+		return nil
+	}
+
+	// Resolve source path (harness-specific storage root) via the adapter.
+	ctx := context.Background()
+	srcParams := harnessarchive.SourceParams{
+		SessionName:   sessionName,
+		InstanceID:    instanceID,
+		IsolationMode: statusIsolationMode,
+	}
+	if sess.HarnessSessionID != nil {
+		srcParams.HarnessSessionID = *sess.HarnessSessionID
+	}
+	srcPath, srcErr := archiveAdapter.SourcePath(srcParams)
+	if srcErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism] archive: SourcePath for session %q: %v — skipping archive\n", sessionName, srcErr)
+		return nil
+	}
+
+	// Resolve harness version via the adapter (replaces archive.HarnessVersion()).
+	harnessVersion, _ := archiveAdapter.Version(ctx)
+
 	// Build archive params from DB fields.
 	params := archive.Params{
 		InstanceID:     sess.InstanceID,
@@ -864,7 +894,14 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 		EndedAt:        time.Now(), // EndedAt was just set in DB; use now as fallback
 		IsolationMode:  statusIsolationMode,
 		PrismVersion:   archive.PrismGitSHA(),
-		HarnessVersion: archive.HarnessVersion(),
+		HarnessVersion: harnessVersion,
+		StorageRoot:    srcPath,
+		// Copier delegates the harness-specific file-copy to the adapter's Archive
+		// method. This removes the hard-coded opencode copySessionFiles call from
+		// archive.Run and allows any registered harness to provide its own copy logic.
+		Copier: func(copyCtx context.Context, rawDir string) error {
+			return archiveAdapter.Archive(copyCtx, srcPath, rawDir, srcParams)
+		},
 	}
 	if sess.AgentRole != nil {
 		params.AgentRole = *sess.AgentRole
@@ -883,6 +920,8 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 			fmt.Fprintf(os.Stderr, "[prism] archive: harness_session_id fallback for %q: %v\n", instanceID, fallbackErr)
 		} else if sid != "" {
 			params.HarnessSessionID = sid
+			// Also update srcParams so the Copier closure uses the resolved ID.
+			srcParams.HarnessSessionID = sid
 		}
 	}
 	if sess.GroupID != nil {
@@ -897,29 +936,16 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	if sess.PrismVersion != nil {
 		params.PrismVersion = *sess.PrismVersion
 	}
-	// D6 (issue #1133): pre-resolve the per-mode storage root and extra-file
-	// set via the registered Isolator, then pass them in via params. This
-	// keeps the per-mode dispatch out of the archive package (which cannot
-	// import internal/container without a circular dependency). When
-	// statusIsolationMode is empty or unregistered, params.StorageRoot is
-	// left empty and archive.resolveStorageRoot falls back to the legacy
-	// IsolationMode-keyed switch — matching the pre-refactor behaviour.
-	//
-	// Stopgap pending #1142 (B6.IF — ArchiveAdapter interface). Once that
-	// lands, the archive-side resolution moves to ArchiveAdapter.
+
+	// Pre-resolve extra files (e.g. agent-run.log for bwrap/sandbox-exec) via
+	// the container isolator registry. This path pre-dates #1142 and is kept
+	// as-is: the isolator's ExtraFiles are harness-agnostic filesystem paths
+	// that complement the harness adapter's storage root resolution.
 	if statusIsolationMode != "" {
 		if home, homeErr := os.UserHomeDir(); homeErr == nil {
 			if iso, isoErr := container.For(config.IsolationMode(statusIsolationMode), container.ConstructorOpts{Name: sessionName}); isoErr == nil {
 				ap := iso.ArchivePaths(home, sessionName)
-				if params.StorageRoot == "" {
-					params.StorageRoot = ap.StorageRoot
-				}
 				if params.AgentRunLogPath == "" && len(ap.ExtraFiles) > 0 {
-					// Today ExtraFiles for bwrap / sandbox-exec contains a
-					// single agent-run.log path; archive's manifest schema
-					// has a dedicated AgentRunLogPath field that we
-					// continue to populate. Once #1142 lands the archive
-					// package will consume ExtraFiles directly.
 					params.AgentRunLogPath = ap.ExtraFiles[0]
 				}
 			}
@@ -945,10 +971,10 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 		fmt.Fprintf(os.Stderr, "[prism] archive: update archive_path for %q: %v\n", instanceID, updErr)
 	}
 
-	// Translate the raw archive to pi-mono v3 JSONL. Failure is non-fatal:
-	// the raw archive remains intact for re-translation later.
-	if translateErr := piexport.Translate(archivePath); translateErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism] piexport: translate failed for session %q: %v\n", sessionName, translateErr)
+	// Translate the raw archive via the adapter's Export method.
+	// Failure is non-fatal: the raw archive remains intact for re-translation later.
+	if exportErr := archiveAdapter.Export(ctx, archivePath, srcParams); exportErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism] piexport: translate failed for session %q: %v\n", sessionName, exportErr)
 	}
 
 	return nil

--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -1,5 +1,5 @@
-// Package archive exports opencode session state from opencode-stable.db into a
-// prism archive directory at cleanup time.
+// Package archive copies a harness's on-disk session subtree into a prism
+// archive directory at cleanup time.
 //
 // # Directory layout
 //
@@ -32,6 +32,7 @@
 package archive
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -118,6 +119,12 @@ type Params struct {
 	// ArchiveRoot overrides the archive root (~/.local/share/prism/archive).
 	// When empty the XDG-derived default is used. Tests inject this.
 	ArchiveRoot string
+	// Copier, when non-nil, is called instead of the default exportSessionFromDB
+	// to populate rawDir with harness session files. When nil and
+	// HarnessSessionID is non-empty, the built-in opencode exportSessionFromDB
+	// fallback is used for backward compatibility. Tests may also inject this
+	// to supply a custom copy function without setting a storage root.
+	Copier func(ctx context.Context, rawDir string) error
 }
 
 // Run exports the opencode session state for p into the archive directory and
@@ -196,7 +203,11 @@ func Run(p Params) (archivePath string, err error) {
 	}
 
 	// Export opencode session data from SQLite (only when we have a harness_session_id).
-	if p.HarnessSessionID != "" {
+	if p.Copier != nil {
+		if copyErr := p.Copier(context.Background(), rawDir); copyErr != nil {
+			return "", copyErr
+		}
+	} else if p.HarnessSessionID != "" {
 		if exportErr := exportSessionFromDB(p.HarnessSessionID, dbPath, rawDir); exportErr != nil {
 			return "", exportErr
 		}
@@ -333,6 +344,13 @@ func containerNameForSession(sessionName string) string {
 //     left empty (not an error).
 //   - If harnessSessionID is not found in the DB, a single info log is emitted
 //     and raw/ is left empty (not an error).
+// CopySessionFiles exports the opencode session identified by harnessSessionID
+// from the SQLite DB at dbPath into rawDir. It is exported for use by the
+// opencode ArchiveAdapter implementation in internal/harness/opencode/archive.go.
+func CopySessionFiles(harnessSessionID, dbPath, rawDir string) error {
+	return exportSessionFromDB(harnessSessionID, dbPath, rawDir)
+}
+
 func exportSessionFromDB(harnessSessionID, dbPath, rawDir string) error {
 	// If the DB doesn't exist at all (fresh install, never run) — graceful no-op.
 	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {

--- a/modules/programs/prism/prism/internal/archive/version.go
+++ b/modules/programs/prism/prism/internal/archive/version.go
@@ -1,9 +1,7 @@
 package archive
 
 import (
-	"os/exec"
 	"runtime/debug"
-	"strings"
 )
 
 // PrismGitSHA returns the VCS revision embedded in the binary by `go build`,
@@ -19,16 +17,4 @@ func PrismGitSHA() string {
 		}
 	}
 	return ""
-}
-
-// HarnessVersion returns the version string reported by the opencode binary
-// (e.g. "1.1.30"), or "" when the binary is not on PATH or returns an error.
-// The result is derived by running `opencode --version` and stripping any
-// trailing newline.
-func HarnessVersion() string {
-	out, err := exec.Command("opencode", "--version").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
 }

--- a/modules/programs/prism/prism/internal/harness/archive/archive.go
+++ b/modules/programs/prism/prism/internal/harness/archive/archive.go
@@ -1,0 +1,62 @@
+// Package archive defines the ArchiveAdapter interface for harness-specific
+// archive operations.
+//
+// Each harness implementation (e.g. opencode) provides an ArchiveAdapter that
+// knows how to locate the harness's on-disk session storage, copy session files
+// into the prism raw archive directory, export the archive to a downstream
+// format, and report its own version string.
+//
+// The adapter is registered alongside the harness registration via
+// harness.Registration.ArchiveAdapterFactory, and retrieved at cleanup time via
+// harness.ArchiveAdapterFor(harnessName).
+package archive
+
+import "context"
+
+// SourceParams holds the inputs needed to locate a harness session's on-disk
+// storage root.
+type SourceParams struct {
+	// SessionName is the prism session name (e.g. "nixos-config@feature").
+	SessionName string
+	// InstanceID is the session's UUID (from sessions.instance_id).
+	InstanceID string
+	// HarnessSessionID is the harness-specific session ID
+	// (e.g. opencode's ses_<ULID>, from sessions.harness_session_id).
+	// May be empty when the harness failed to start.
+	HarnessSessionID string
+	// IsolationMode is "podman", "bwrap", "sandbox-exec", or "host".
+	IsolationMode string
+}
+
+// ArchiveAdapter is the interface each harness implements to plug into the
+// prism archive pipeline.
+//
+// The four methods map directly to the four stages of the cleanup archive flow:
+//
+//  1. SourcePath — locate the harness session storage on the host filesystem.
+//  2. Archive    — copy session files from the storage root into the raw archive dir.
+//  3. Export     — translate the raw archive into the downstream export format.
+//  4. Version    — report the harness binary version for the manifest.
+type ArchiveAdapter interface {
+	// SourcePath returns the host-side storage root directory for the session
+	// described by p. The returned path is used as the srcPath argument to
+	// Archive. An empty StorageRoot override in p means the adapter should
+	// derive the path from p.IsolationMode and p.SessionName.
+	SourcePath(p SourceParams) (string, error)
+
+	// Archive copies the harness session files rooted at srcPath into rawDir.
+	// rawDir already exists when Archive is called. On success, rawDir contains
+	// all harness-specific session artifacts (session JSON, messages, parts,
+	// tool output, etc.).
+	Archive(ctx context.Context, srcPath, rawDir string, p SourceParams) error
+
+	// Export translates the raw archive directory at archiveDir into the
+	// downstream export format (e.g. pi-mono JSONL). Failure is non-fatal:
+	// the raw archive remains intact for re-translation later.
+	Export(ctx context.Context, archiveDir string, p SourceParams) error
+
+	// Version returns the harness binary version string (e.g. "1.1.30"), or
+	// "" when the binary is not on PATH or returns an error. Called once per
+	// cleanup session to populate the manifest's harnessVersion field.
+	Version(ctx context.Context) (string, error)
+}

--- a/modules/programs/prism/prism/internal/harness/opencode/archive.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/archive.go
@@ -1,0 +1,98 @@
+package opencode
+
+// archive.go — opencode implementation of harness/archive.ArchiveAdapter.
+//
+// The four methods map onto the existing opencode-specific logic:
+//
+//   - SourcePath: resolves the storage root (used to derive the DB path)
+//   - Archive:    calls archive.CopySessionFiles → exportSessionFromDB
+//   - Export:     calls piexport.Translate
+//   - Version:    calls exec.Command("opencode", "--version")
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/archive"
+	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+	"github.com/prismatic-koi/prism/internal/piexport"
+)
+
+// opencodeArchiveAdapter implements harness/archive.ArchiveAdapter for opencode.
+type opencodeArchiveAdapter struct{}
+
+// NewArchiveAdapter returns an ArchiveAdapter for the opencode harness.
+func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
+	return &opencodeArchiveAdapter{}
+}
+
+// SourcePath returns the host-side opencode storage root for the session.
+//
+// Isolation mode mapping:
+//   - host / bwrap / sandbox-exec: $HOME/.local/share/opencode/storage
+//   - podman: $HOME/.local/share/opencode/prism-sessions/<containerName>/storage
+func (a *opencodeArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("opencode archive: resolve home: %w", err)
+	}
+
+	switch p.IsolationMode {
+	case "host", "bwrap", "sandbox-exec":
+		return filepath.Join(home, ".local", "share", "opencode", "storage"), nil
+	case "podman":
+		containerName := containerNameForSession(p.SessionName)
+		return filepath.Join(home, ".local", "share", "opencode", "prism-sessions", containerName, "storage"), nil
+	default:
+		return "", fmt.Errorf("opencode archive: unsupported isolation mode %q", p.IsolationMode)
+	}
+}
+
+// containerNameForSession returns the podman container name for a session,
+// mirroring the logic in internal/container.NameForSession and the copy in
+// internal/archive/archive.go:containerNameForSession.
+func containerNameForSession(sessionName string) string {
+	safe := strings.ReplaceAll(sessionName, "@", "-")
+	safe = strings.ReplaceAll(safe, "/", "-")
+	safe = strings.ReplaceAll(safe, ".", "-")
+	safe = strings.ReplaceAll(safe, "~", "-")
+	return "prism-" + safe
+}
+
+// Archive exports the opencode session from the SQLite DB into rawDir.
+// srcPath is the storage root returned by SourcePath; the DB lives at
+// <parent of srcPath>/opencode-stable.db.
+//
+// When p.HarnessSessionID is empty (opencode failed to start), this is a no-op
+// and rawDir is left empty.
+func (a *opencodeArchiveAdapter) Archive(_ context.Context, srcPath, rawDir string, p harnessarchive.SourceParams) error {
+	if p.HarnessSessionID == "" {
+		return nil
+	}
+	// The opencode-stable.db lives one level above the storage/ directory.
+	dbPath := filepath.Join(filepath.Dir(srcPath), "opencode-stable.db")
+	return archive.CopySessionFiles(p.HarnessSessionID, dbPath, rawDir)
+}
+
+// Export translates the raw archive at archiveDir into pi-mono JSONL format by
+// calling piexport.Translate. Failure is non-fatal — the caller logs the error
+// and the raw archive remains intact for re-translation later.
+func (a *opencodeArchiveAdapter) Export(_ context.Context, archiveDir string, _ harnessarchive.SourceParams) error {
+	return piexport.Translate(archiveDir)
+}
+
+// Version returns the version string reported by the opencode binary (e.g.
+// "1.1.30"), or "" when the binary is not on PATH or returns an error.
+func (a *opencodeArchiveAdapter) Version(_ context.Context) (string, error) {
+	out, err := exec.Command("opencode", "--version").Output()
+	if err != nil {
+		// Non-fatal: return empty string with nil error so callers treat the
+		// empty string as "version unknown" rather than an error condition.
+		return "", nil
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/modules/programs/prism/prism/internal/harness/opencode/register.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/register.go
@@ -28,5 +28,8 @@ func init() {
 		ContainerFactory: func(endpoint string, c *http.Client, role, model string) harness.Harness {
 			return NewContainerMode(endpoint, c, role, model)
 		},
+		ArchiveAdapterFactory: func() harness.ArchiveAdapter {
+			return NewArchiveAdapter()
+		},
 	})
 }

--- a/modules/programs/prism/prism/internal/harness/registry.go
+++ b/modules/programs/prism/prism/internal/harness/registry.go
@@ -18,6 +18,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 )
 
 // TransportShape declares the wire-level shape a harness uses to talk to
@@ -114,7 +116,22 @@ type Registration struct {
 	//
 	// When nil, NewContainer falls back to Factory.
 	ContainerFactory Factory
+
+	// ArchiveAdapterFactory, when non-nil, constructs an ArchiveAdapter for
+	// this harness. It is called once per cleanup session by ArchiveAdapterFor.
+	// When nil, ArchiveAdapterFor returns a (nil, error) indicating that no
+	// archive adapter is registered for the harness.
+	ArchiveAdapterFactory func() ArchiveAdapter
 }
+
+// ArchiveAdapter is a re-export of harness/archive.ArchiveAdapter for
+// consumers that import only the harness package. It allows Registration
+// to use ArchiveAdapter directly without requiring a separate import of
+// internal/harness/archive in every caller.
+type ArchiveAdapter = harnessarchive.ArchiveAdapter
+
+// SourceParams is a re-export of harness/archive.SourceParams.
+type SourceParams = harnessarchive.SourceParams
 
 // globalRegistry is the package-level singleton. All fields are
 // protected by mu after process start; init() functions run
@@ -249,4 +266,18 @@ func ShapeOf(name string) (TransportShape, bool) {
 // string, for use in error messages.
 func joinNames() string {
 	return strings.Join(Names(), ", ")
+}
+
+// ArchiveAdapterFor returns the ArchiveAdapter for the named harness.
+// Returns an error when the harness is not registered or has no
+// ArchiveAdapterFactory (i.e. the harness does not support archiving).
+func ArchiveAdapterFor(name string) (ArchiveAdapter, error) {
+	reg, ok := Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("harness %q is not registered; valid harnesses: %s", name, joinNames())
+	}
+	if reg.ArchiveAdapterFactory == nil {
+		return nil, fmt.Errorf("harness %q has no registered archive adapter", name)
+	}
+	return reg.ArchiveAdapterFactory(), nil
 }


### PR DESCRIPTION
## Summary

- Introduces `internal/harness/archive` package with `ArchiveAdapter` interface (`SourcePath`, `Archive`, `Export`, `Version`) and `SourceParams` struct
- Implements opencode `ArchiveAdapter` in `internal/harness/opencode/archive.go`, handling all isolation modes
- Adds `ArchiveAdapterFactory` to `harness.Registration` and registers the opencode adapter
- Refactors `cmd/cleanup.go:runSessionArchive` to use the adapter, removing all hard-coded opencode coupling from the archive pipeline
- Removes `archive.HarnessVersion()` shim (replaced by `adapter.Version()`)
- Unknown harness returns a clear error instead of nil-pointer panic

Closes #1142