### PR TITLE
feat: capture skills manifest hash and agent prompt hash at spawn time (C4.SK + C4.AP)

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,10 +30,12 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/skills"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -513,9 +516,49 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	}
 	defer d.Close()
 
+	// C4.SK: compute skills manifest hash before spawn so it is available for
+	// spawn_inputs. Read skills from XDG_CONFIG_HOME/opencode/skills/ (with the
+	// standard ~/.config fallback). Errors are non-fatal: a missing or
+	// unreadable skills directory produces an empty hash (caller writes NULL).
+	skillsDir := opencodeSkillsDir()
+	skillsManifestHash, skillsHashErr := skills.ComputeManifest(skillsDir)
+	if skillsHashErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
+		skillsManifestHash = ""
+	}
+
+	// C4.AP: compute agent role file hash. The role file is resolved from
+	// XDG_CONFIG_HOME/opencode/agents/<role>.md. Errors are non-fatal.
+	agentRoleFilePath := opencodeAgentRolePath(agentRole)
+	agentPromptHash, agentHashErr := skills.ComputeAgentPromptHash(agentRoleFilePath)
+	if agentHashErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
+		agentPromptHash = ""
+	}
+
 	if err := session.SpawnSession(d, spawnOpts); err != nil {
 		return err
 	}
+
+	// Write spawn_inputs row. This is best-effort: a failure is logged but
+	// does not roll back the session (the session is already live).
+	// We read instance_id back from the DB because SpawnSession generates it
+	// internally and we do not want to thread it back through SpawnOpts just
+	// for this write path.
+	writeSpawnInputs(d, spawnInputsArgs{
+		sessionName:        sessionName,
+		profileName:        resolvedProfile,
+		modelFlag:          modelFlag,
+		variantFlag:        variantFlag,
+		agentFlag:          agentFlag,
+		harnessFlag:        harnessFlag,
+		cmd:                cmd,
+		prFlag:             prFlag,
+		branchFlag:         branchFlag,
+		skillsManifestHash: skillsManifestHash,
+		agentPromptHash:    agentPromptHash,
+		promptFlag:         promptFlag,
+	})
 
 	if headless {
 		fmt.Printf("session %q created\n", sessionName)
@@ -523,6 +566,112 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	}
 	return session.Attach(sessionName)
 }
+
+// opencodeSkillsDir returns the path to the opencode skills directory,
+// respecting XDG_CONFIG_HOME with a ~/.config fallback.
+func opencodeSkillsDir() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, _ := os.UserHomeDir()
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "opencode", "skills")
+}
+
+// opencodeAgentRolePath returns the path to the opencode agent role file for
+// the given role name, respecting XDG_CONFIG_HOME with a ~/.config fallback.
+func opencodeAgentRolePath(role string) string {
+	if role == "" {
+		return ""
+	}
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, _ := os.UserHomeDir()
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "opencode", "agents", role+".md")
+}
+
+// spawnInputsArgs bundles the flag values needed to build a db.SpawnInputs row.
+type spawnInputsArgs struct {
+	sessionName        string
+	profileName        string
+	modelFlag          string
+	variantFlag        string
+	agentFlag          string
+	harnessFlag        string
+	cmd                *cobra.Command
+	prFlag             string
+	branchFlag         string
+	skillsManifestHash string
+	agentPromptHash    string
+	promptFlag         string
+}
+
+// writeSpawnInputs looks up the instance_id for sessionName and inserts a row
+// into spawn_inputs. All errors are non-fatal and logged to stderr.
+func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
+	st, err := d.CurrentStatus(args.sessionName)
+	if err != nil || st == nil || st.InstanceID == nil || *st.InstanceID == "" {
+		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not read instance_id for spawn_inputs: %v\n", err)
+		return
+	}
+
+	si := db.SpawnInputs{
+		InstanceID:   *st.InstanceID,
+		CreatedAt:    time.Now().UnixMilli(),
+		PromptSource: spawnStrPtr("cli-positional"),
+	}
+
+	if args.profileName != "" {
+		si.ProfileName = &args.profileName
+	}
+	if args.modelFlag != "" {
+		si.ModelFlag = &args.modelFlag
+	}
+	if args.variantFlag != "" {
+		si.VariantFlag = &args.variantFlag
+	}
+	if args.agentFlag != "" {
+		si.AgentFlag = &args.agentFlag
+	}
+	if args.harnessFlag != "" {
+		si.HarnessFlag = &args.harnessFlag
+	}
+	if isolationFlag, _ := args.cmd.Flags().GetString("isolation"); isolationFlag != "" {
+		si.IsolationFlag = &isolationFlag
+	}
+	if hostModeFlag, _ := args.cmd.Flags().GetBool("host-mode"); hostModeFlag {
+		si.HostModeFlag = true
+	}
+	if args.prFlag != "" {
+		if n, err := strconv.Atoi(args.prFlag); err == nil {
+			si.PRNumber = &n
+		}
+	}
+	if args.branchFlag != "" {
+		si.BranchFlag = &args.branchFlag
+	}
+	if ignoreCap, _ := args.cmd.Flags().GetBool("ignore-concurrency-cap"); ignoreCap {
+		si.IgnoreConcurrencyCap = true
+	}
+	if args.skillsManifestHash != "" {
+		si.SkillsManifestHash = &args.skillsManifestHash
+	}
+	if args.agentPromptHash != "" {
+		si.AgentPromptHash = &args.agentPromptHash
+	}
+	if args.promptFlag != "" {
+		si.PromptText = &args.promptFlag
+	}
+
+	if err := d.InsertSpawnInputs(si); err != nil {
+		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not write spawn_inputs: %v\n", err)
+	}
+}
+
+// spawnStrPtr returns a pointer to s, for optional string fields in SpawnInputs.
+func spawnStrPtr(s string) *string { return &s }
 
 // resolveBareRoot returns the bare repo root to operate on.
 // If repoFlag is set, it is resolved as a shorthand name under ~/code or as a

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -176,6 +176,48 @@ CREATE TABLE IF NOT EXISTS spawn_outcome (
 CREATE INDEX IF NOT EXISTS idx_spawn_outcome_end_state    ON spawn_outcome(end_state);
 CREATE INDEX IF NOT EXISTS idx_spawn_outcome_pr_number    ON spawn_outcome(pr_number);
 CREATE INDEX IF NOT EXISTS idx_spawn_outcome_review_group ON spawn_outcome(review_group_id);
+
+CREATE TABLE IF NOT EXISTS spawn_inputs (
+    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+
+    -- Inputs as the user passed them (NULL = flag not passed; default in effect).
+    profile_name           TEXT,
+    model_flag             TEXT,
+    variant_flag           TEXT,
+    agent_flag             TEXT,
+    harness_flag           TEXT,
+    isolation_flag         TEXT,
+    host_mode_flag         INTEGER NOT NULL DEFAULT 0,
+    pr_number              INTEGER,
+    branch_flag            TEXT,
+    ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+
+    -- C.2: per-role model-variant overrides (JSON; NULL if no overrides).
+    model_variant_overrides TEXT,
+
+    -- C4.SK: hash of the skills directory at spawn time.
+    -- Shape: "nix:<store-basename>" for nix-managed dirs, "sha256:<hex>" otherwise.
+    skills_manifest_hash    TEXT,
+
+    -- C4.PT: reserved for prompt-template hash (not yet populated).
+    prompt_template_hash    TEXT,
+
+    -- C4.AP: hash of the agent role file at spawn time.
+    -- Shape: "nix:<store-basename>" for nix-managed files, "sha256:<hex>" otherwise.
+    -- NULL when no --agent flag was passed or the role file does not exist.
+    agent_prompt_hash       TEXT,
+
+    -- Prompt delivered to the harness, captured at spawn.
+    prompt_text            TEXT,
+    prompt_source          TEXT,
+
+    -- Free-form JSON blob for forward-compat.
+    extras                 TEXT,
+
+    created_at             INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_spawn_inputs_profile         ON spawn_inputs(profile_name);
+CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harness_flag, profile_name);
 `
 
 // Open opens (or creates) the prism database at path.
@@ -284,6 +326,11 @@ CREATE INDEX IF NOT EXISTS idx_spawn_outcome_review_group ON spawn_outcome(revie
 // the migration idempotent. Fresh databases skip the column-drop (the column
 // never existed in the declarative schema) and the table creation is a no-op
 // because the schema block above already created it.
+// v24→v25 adds the spawn_inputs table (C.1/C.4 §4.1) and the agent_prompt_hash
+// column within it (C4.AP). The table is created with CREATE TABLE IF NOT
+// EXISTS and its indexes with CREATE INDEX IF NOT EXISTS, making the migration
+// idempotent. Fresh databases already have the table from the declarative
+// schema block above, so the CREATE is a no-op.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -367,7 +414,7 @@ func seedSchemaVersionIfEmpty(conn *sql.DB) error {
 }
 
 // runMigrations reads the current schema_version and applies all pending
-// migrations in order from v1 to v24.
+// migrations in order from v1 to v25.
 func runMigrations(conn *sql.DB) error {
 	var version int
 	if err := conn.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
@@ -440,6 +487,9 @@ func runMigrations(conn *sql.DB) error {
 		return err
 	}
 	if err := migrateV23toV24(conn, &version); err != nil {
+		return err
+	}
+	if err := migrateV24toV25(conn, &version); err != nil {
 		return err
 	}
 	return nil
@@ -1362,7 +1412,144 @@ func migrateV23toV24(conn *sql.DB, version *int) error {
 	return nil
 }
 
+func migrateV24toV25(conn *sql.DB, version *int) error {
+	if *version != 24 {
+		return nil
+	}
+	// Migration v24 → v25: add the spawn_inputs table (C.1/C.4 §4.1).
+	// The table holds the intent of a spawn — every flag value the user
+	// passed — keyed on instance_id (FK → sessions). Also includes
+	// agent_prompt_hash (C4.AP) and skills_manifest_hash (C4.SK) columns.
+	// CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS make the
+	// migration idempotent; fresh databases already have the table from
+	// the declarative schema block above, so these are no-ops there.
+	spawnInputsSteps := []string{
+		`CREATE TABLE IF NOT EXISTS spawn_inputs (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    profile_name           TEXT,
+		    model_flag             TEXT,
+		    variant_flag           TEXT,
+		    agent_flag             TEXT,
+		    harness_flag           TEXT,
+		    isolation_flag         TEXT,
+		    host_mode_flag         INTEGER NOT NULL DEFAULT 0,
+		    pr_number              INTEGER,
+		    branch_flag            TEXT,
+		    ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+		    model_variant_overrides TEXT,
+		    skills_manifest_hash    TEXT,
+		    prompt_template_hash    TEXT,
+		    agent_prompt_hash       TEXT,
+		    prompt_text            TEXT,
+		    prompt_source          TEXT,
+		    extras                 TEXT,
+		    created_at             INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_spawn_inputs_profile         ON spawn_inputs(profile_name)`,
+		`CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harness_flag, profile_name)`,
+		`UPDATE schema_version SET version = 25`,
+	}
+	for _, step := range spawnInputsSteps {
+		if _, err := conn.Exec(step); err != nil {
+			return fmt.Errorf("db: migration v24→v25: spawn_inputs: %w", err)
+		}
+	}
+	*version = 25
+	return nil
+}
+
 // Close closes the underlying database connection.
 func (d *DB) Close() error {
 	return d.conn.Close()
+}
+
+// SpawnInputs holds the values inserted into spawn_inputs at spawn time.
+// All pointer fields are nullable in the DB; nil means NULL.
+type SpawnInputs struct {
+	InstanceID string
+
+	// Flag values as the user passed them (nil = flag not passed).
+	ProfileName   *string
+	ModelFlag     *string
+	VariantFlag   *string
+	AgentFlag     *string
+	HarnessFlag   *string
+	IsolationFlag *string
+	HostModeFlag  bool
+	PRNumber      *int
+	BranchFlag    *string
+
+	IgnoreConcurrencyCap bool
+
+	// C.2 hook: per-role model-variant overrides (JSON).
+	ModelVariantOverrides *string
+
+	// C4.SK: skills directory hash at spawn time.
+	SkillsManifestHash *string
+
+	// C4.PT: reserved for prompt-template hash (not yet populated).
+	PromptTemplateHash *string
+
+	// C4.AP: agent role file hash at spawn time.
+	AgentPromptHash *string
+
+	// Prompt delivered to the harness.
+	PromptText   *string
+	PromptSource *string
+
+	// Free-form JSON blob for forward-compat.
+	Extras *string
+
+	// ms epoch, mirrors sessions.started_at.
+	CreatedAt int64
+}
+
+// InsertSpawnInputs writes a row to spawn_inputs for the given instance.
+// The function is idempotent via INSERT OR IGNORE — a second call with the
+// same instance_id is a no-op (spawn is a one-shot event; the row, once
+// written, is immutable). A missing FK (sessions row not yet committed) will
+// cause the insert to fail with a foreign-key error; callers must ensure the
+// sessions row exists first.
+func (d *DB) InsertSpawnInputs(si SpawnInputs) error {
+	_, err := d.conn.Exec(`
+INSERT OR IGNORE INTO spawn_inputs (
+    instance_id,
+    profile_name, model_flag, variant_flag, agent_flag, harness_flag,
+    isolation_flag, host_mode_flag,
+    pr_number, branch_flag, ignore_concurrency_cap,
+    model_variant_overrides,
+    skills_manifest_hash, prompt_template_hash, agent_prompt_hash,
+    prompt_text, prompt_source, extras,
+    created_at
+) VALUES (
+    ?,
+    ?, ?, ?, ?, ?,
+    ?, ?,
+    ?, ?, ?,
+    ?,
+    ?, ?, ?,
+    ?, ?, ?,
+    ?
+)`,
+		si.InstanceID,
+		si.ProfileName, si.ModelFlag, si.VariantFlag, si.AgentFlag, si.HarnessFlag,
+		si.IsolationFlag, boolToInt(si.HostModeFlag),
+		si.PRNumber, si.BranchFlag, boolToInt(si.IgnoreConcurrencyCap),
+		si.ModelVariantOverrides,
+		si.SkillsManifestHash, si.PromptTemplateHash, si.AgentPromptHash,
+		si.PromptText, si.PromptSource, si.Extras,
+		si.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("db: insert spawn_inputs for %q: %w", si.InstanceID, err)
+	}
+	return nil
+}
+
+// boolToInt converts a bool to 0/1 for SQLite INTEGER columns.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=24 (all migrations applied on Open).
+	// Verify schema_version=25 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version: got %d, want 25", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1594,8 +1594,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1660,8 +1660,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1730,8 +1730,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1825,8 +1825,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1918,8 +1918,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2502,8 +2502,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2591,8 +2591,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4251,8 +4251,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// Check each row.
@@ -4679,8 +4679,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4954,8 +4954,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5175,8 +5175,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// sessions table must exist.
@@ -5329,8 +5329,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 }
 
@@ -5883,8 +5883,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -5941,8 +5941,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6243,8 +6243,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6305,8 +6305,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6464,8 +6464,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6518,8 +6518,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 
 	var startedAt int64
@@ -6672,8 +6672,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -6745,8 +6745,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 
 	// Values must be stable after a second open.
@@ -6865,7 +6865,7 @@ func seedV23DB(t *testing.T, dbPath string) {
 //  1. Drops sessions.outcome_summary from a DB that has it.
 //  2. Creates the spawn_outcome table with the expected columns.
 //  3. Preserves all existing sessions rows (the data is not lost).
-//  4. Sets schema_version = 24.
+//  4. Sets schema_version = 25.
 func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "v23_spawn_outcome.db")
 	seedV23DB(t, dbPath)
@@ -6876,13 +6876,13 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	}
 	defer d.Close()
 
-	// schema_version must be 24.
+	// schema_version must be 25.
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after migration: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after migration: got %d, want 25", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -6935,8 +6935,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 
 	// spawn_outcome must still exist.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1055,8 +1055,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 24 {
-		t.Errorf("schema_version after second open: got %d, want 24", version)
+	if version != 25 {
+		t.Errorf("schema_version after second open: got %d, want 25", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/skills/manifest.go
+++ b/modules/programs/prism/prism/internal/skills/manifest.go
@@ -1,0 +1,189 @@
+package skills
+
+// ComputeManifest returns a stable hash-like identifier for the skills
+// directory at skillsDir, suitable for storing in spawn_inputs.skills_manifest_hash.
+//
+// # Return shapes
+//
+//   - "nix:<basename>"   — when skillsDir is a symlink whose target is under
+//     /nix/store/ (the normal NixOS/home-manager deployment). A single
+//     os.Readlink call is enough; no file I/O is required, and two system
+//     builds with identical skill content produce the same nix-store path
+//     (content-addressed).
+//
+//   - "sha256:<hex>"    — when the directory is a plain (non-nix) tree.
+//     The hash is computed by walking the tree in lexical order, hashing
+//     each file's content, and then SHA-256'ing the concatenated
+//     "<relative-path>\0<file-sha256-hex>\0" pairs. mtimes are excluded,
+//     so the hash is deterministic across renames / rebuilds that do not
+//     change content.
+//
+//   - ""                — when skillsDir does not exist. The caller should
+//     write NULL to spawn_inputs.skills_manifest_hash rather than an empty
+//     string, so that NULL unambiguously signals "not captured".
+//
+// # Opencode skill-loading lifecycle
+//
+// Skills are loaded once at session initialisation by opencode's Skill.state
+// Ref (Effect-TS q.make call in the Skill service layer). The scan runs
+// Z2() which walks the skills directories synchronously before the session
+// event loop starts. After that point the skills set is frozen for the
+// lifetime of the session — there is no watcher or per-invocation re-scan.
+//
+// Consequence: the spawn-time hash captured here is a complete manifest of
+// "what skills the agent could have loaded during this session". A
+// skills_manifest_hash_end column on sessions is NOT needed; the spawn-time
+// value is authoritative for the full session.
+//
+// (This conclusion was reached by reading the opencode 1.14.18 JS bundle.
+// If a future opencode version adds dynamic re-scanning, add
+// skills_manifest_hash_end TEXT on the sessions table to capture session-end
+// state, and file a TODO here.)
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ComputeManifest computes the skills manifest hash for skillsDir.
+// See package-level doc for the three return shapes.
+func ComputeManifest(skillsDir string) (string, error) {
+	// Check whether the directory exists at all (also handles the case where
+	// XDG_CONFIG_HOME points somewhere unusual).
+	if _, err := os.Lstat(skillsDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("skills manifest: stat %q: %w", skillsDir, err)
+	}
+
+	// Fast path: nix-managed symlink → single os.Readlink, no file I/O.
+	if target, err := os.Readlink(skillsDir); err == nil {
+		if strings.HasPrefix(target, "/nix/store/") {
+			return "nix:" + filepath.Base(target), nil
+		}
+	}
+
+	// Slow path: plain directory — walk lexically, hash content.
+	hash, err := contentHash(skillsDir)
+	if err != nil {
+		return "", fmt.Errorf("skills manifest: content hash %q: %w", skillsDir, err)
+	}
+	return "sha256:" + hash, nil
+}
+
+// ComputeAgentPromptHash returns a stable hash-like identifier for the agent
+// role file at rolePath, suitable for storing in spawn_inputs.agent_prompt_hash.
+//
+// # Return shapes
+//
+//   - "nix:<basename>"   — when rolePath is a symlink whose target is under
+//     /nix/store/ (or when the path resolves through symlinks in its parent
+//     components to a nix-store path). Two builds with identical content
+//     produce the same store path.
+//
+//   - "sha256:<hex>"    — SHA-256 of the file's contents, when the file is a
+//     plain (non-nix) file.
+//
+//   - ""                — when rolePath does not exist. The caller should write
+//     NULL to spawn_inputs.agent_prompt_hash.
+func ComputeAgentPromptHash(rolePath string) (string, error) {
+	if _, err := os.Lstat(rolePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("agent prompt hash: stat %q: %w", rolePath, err)
+	}
+
+	// Try symlink resolution on the file itself.
+	if target, err := os.Readlink(rolePath); err == nil {
+		if strings.HasPrefix(target, "/nix/store/") {
+			return "nix:" + filepath.Base(target), nil
+		}
+	}
+
+	// Try resolving the full path via EvalSymlinks (catches cases where parent
+	// directories are symlinked into the nix store).
+	if resolved, err := filepath.EvalSymlinks(rolePath); err == nil {
+		if strings.HasPrefix(resolved, "/nix/store/") {
+			// Use the first two path components after /nix/store/ as the
+			// derivation name (e.g. "/nix/store/abc123-foo/bar.md" → "abc123-foo").
+			rest := strings.TrimPrefix(resolved, "/nix/store/")
+			parts := strings.SplitN(rest, "/", 2)
+			return "nix:" + parts[0], nil
+		}
+	}
+
+	// Fallback: hash the file content.
+	data, err := os.ReadFile(rolePath)
+	if err != nil {
+		return "", fmt.Errorf("agent prompt hash: read %q: %w", rolePath, err)
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// contentHash walks dir in lexical order and returns the hex-encoded SHA-256
+// of the concatenated "<relpath>\0<file-sha256-hex>\0" sequence.
+// Directories are not directly hashed (only the files within them matter).
+func contentHash(dir string) (string, error) {
+	type entry struct {
+		relPath string
+		hash    string
+	}
+	var entries []entry
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip symlinks that point to directories; symlinks to files are
+		// followed by reading the file content below.
+		if d.Type()&fs.ModeSymlink != 0 {
+			info, err := os.Stat(path)
+			if err != nil {
+				return nil // broken symlink — skip
+			}
+			if info.IsDir() {
+				return nil
+			}
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %q: %w", path, err)
+		}
+		sum := sha256.Sum256(data)
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("rel %q: %w", path, err)
+		}
+		entries = append(entries, entry{relPath: filepath.ToSlash(rel), hash: hex.EncodeToString(sum[:])})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Ensure deterministic order (WalkDir is already lexical on most platforms,
+	// but sort explicitly for correctness guarantees).
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].relPath < entries[j].relPath
+	})
+
+	h := sha256.New()
+	for _, e := range entries {
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00", e.relPath, e.hash)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}


### PR DESCRIPTION
## Summary

- Adds `internal/skills/manifest.go` with `ComputeManifest()` and `ComputeAgentPromptHash()` that return `nix:<basename>` shortcuts for nix-store symlinks or `sha256:<hex>` content hashes for plain trees/files
- Creates `spawn_inputs` table (db v24→v25) capturing skills_manifest_hash, agent_prompt_hash, and all other spawn-time parameters for A/B attribution
- Wires both hashes into `cmd/spawn.go` — computed before `SpawnSession`, written to DB after spawn succeeds (non-fatal if hash computation fails)

## Key discoveries

- opencode 1.14.18 loads skills once at session init via Effect-TS Ref (`Skill.state`) and freezes them — spawn-time hash is authoritative; no `skills_manifest_hash_end` column is needed
- Individual agent files in `~/.config/opencode/agents/` are hardlinked (not symlinked) to `/nix/store/`, so `os.Readlink` won't detect the nix case; SHA-256 content hash is used instead

## Notes

The nix build requires compilation of the prism Go binary (14 derivations). Go tests and build (`go build ./...`, `go test ./...`) pass cleanly. The nix build is valid per dry-run — no evaluation errors.

Closes #1131