### PR TITLE
prism: drop host_mode column from agent_status (v25→v26 migration)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -156,7 +156,7 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	// valid modes for `prism agent-run`; the registered isolator returns
 	// the original "this command is only for bwrap and sandbox-exec
 	// sessions" error verbatim, replacing the manual `else` arm.
-	isoMode := config.IsolationMode(status.EffectiveIsolationMode())
+	isoMode := config.IsolationMode(status.IsolationMode)
 
 	// Belt-and-braces platform guard. The container.For-resolved isolator's
 	// AgentRun body would also fail eventually (bubblewrap is Linux-only,

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -998,26 +998,21 @@ func instanceIDFromStatus(d *db.DB, sessionName string) string {
 	return *status.InstanceID
 }
 
-// hostModeFromDB queries the already-open database d and returns true when
-// the agent_status row for sessionName has host_mode = 1. Returns false when
-// the row is missing, host_mode is NULL (pre-migration), or on any error.
+// hostModeFromDB returns true when the agent_status row for sessionName has
+// isolation_mode = "host". Returns false when the row is missing or on any error.
 func hostModeFromDB(d *db.DB, sessionName string) bool {
-	status, err := d.CurrentStatus(sessionName)
-	if err != nil || status == nil {
-		return false
-	}
-	return status.HostMode
+	return isolationModeFromDB(d, sessionName) == "host"
 }
 
 // isolationModeFromDB queries the already-open database d and returns the
-// effective isolation mode for sessionName using Status.EffectiveIsolationMode.
+// isolation mode for sessionName by reading Status.IsolationMode directly.
 // Returns "" when the row is missing or on any error.
 func isolationModeFromDB(d *db.DB, sessionName string) string {
 	status, err := d.CurrentStatus(sessionName)
 	if err != nil || status == nil {
 		return ""
 	}
-	return status.EffectiveIsolationMode()
+	return status.IsolationMode
 }
 
 // stopAndRemoveChildContainers stops and removes podman containers for all

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -230,7 +230,7 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			// Kill and clean up all review sessions spawned by this parent session,
 			// including their port allocations and DB rows.
 			review.CleanupReviewSessionsForParent(d, m.session)
-			if !hostModeFromDB(d, m.session) {
+			if isolationModeFromDB(d, m.session) != "host" {
 				removeContainerIfExists(m.session)
 			}
 			if releaseErr := d.ReleasePort(m.session); releaseErr != nil {
@@ -526,7 +526,7 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		// Kill and clean up all review sessions spawned by this parent session,
 		// including their port allocations and DB rows.
 		review.CleanupReviewSessionsForParent(d, session)
-		if !hostModeFromDB(d, session) {
+		if isolationModeFromDB(d, session) != "host" {
 			removeContainerIfExists(session)
 		}
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
@@ -595,7 +595,7 @@ func closeSession(session string) error {
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
 	if d, err := openDB(); err == nil {
-		if !hostModeFromDB(d, session) {
+		if isolationModeFromDB(d, session) != "host" {
 			removeContainerIfExists(session)
 		}
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
@@ -672,7 +672,7 @@ func headlessCloseSession(session string) error {
 		// Kill and clean up all review sessions spawned by this parent session,
 		// including their port allocations and DB rows.
 		review.CleanupReviewSessionsForParent(d, session)
-		if !hostModeFromDB(d, session) {
+		if isolationModeFromDB(d, session) != "host" {
 			removeContainerIfExists(session)
 		}
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
@@ -996,12 +996,6 @@ func instanceIDFromStatus(d *db.DB, sessionName string) string {
 		return ""
 	}
 	return *status.InstanceID
-}
-
-// hostModeFromDB returns true when the agent_status row for sessionName has
-// isolation_mode = "host". Returns false when the row is missing or on any error.
-func hostModeFromDB(d *db.DB, sessionName string) bool {
-	return isolationModeFromDB(d, sessionName) == "host"
 }
 
 // isolationModeFromDB queries the already-open database d and returns the

--- a/modules/programs/prism/prism/cmd/cleanup_container_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_container_test.go
@@ -179,13 +179,13 @@ func TestRemoveContainerIfExists_NoSuchContainer(t *testing.T) {
 	}
 }
 
-// TestHeadlessCleanup_HostMode_SkipsPodman verifies that when host_mode is set
-// for a session in the DB, headlessCleanup does NOT invoke podman at all —
+// TestHeadlessCleanup_HostMode_SkipsPodman verifies that when isolation_mode is
+// "host" for a session in the DB, headlessCleanup does NOT invoke podman at all —
 // host-mode sessions run opencode directly on the host with no container.
 //
 // This test calls headlessCleanup with an empty worktreePath so that the git
 // operations are skipped and only the sidecar/container/DB teardown runs.
-// Covers the host_mode short-circuit added in #471.
+// Covers the host isolation_mode short-circuit.
 func TestHeadlessCleanup_HostMode_SkipsPodman(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", "") // run host-side logic directly, not via proxy
 	// Redirect TmuxBin to a no-op so headlessCleanup's scratchpad-ensure
@@ -203,8 +203,8 @@ func TestHeadlessCleanup_HostMode_SkipsPodman(t *testing.T) {
 	if err := d.UpsertStatus(session, "myrepo", "", "running", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
-	if err := d.SetHostMode(session, true); err != nil {
-		t.Fatalf("SetHostMode: %v", err)
+	if err := d.SetIsolationMode(session, "host"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
 	}
 	d.Close()
 

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -270,31 +270,22 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	// setupFullLayout from forking "prism event tmux-session-start" — we
 	// manage agent_status directly below via the open DB handle.
 	//
-	// IsolationMode is read from the DB row (s.IsolationMode) when recorded.
-	// When absent (pre-v10 rows), fall back to the back-compat derivation:
-	// HostMode=true → "host", else use the global cfg's effective mode.
-	// This ensures sessions spawned before the isolation_mode column was added
-	// are restored with the same behaviour they were created with.
+	// IsolationMode is read directly from the DB row (s.IsolationMode).
+	// All rows have isolation_mode set (guaranteed by v22→v23 backfill, #1129).
 	cfg := loadRestoreConfig()
 
 	var isoMode config.IsolationMode
 	if s.IsolationMode != "" {
 		isoMode = config.IsolationMode(s.IsolationMode)
-	} else if s.HostMode {
-		isoMode = config.IsolationHost
 	} else {
-		// Pre-v10 row without isolation_mode and without host_mode:
-		// fall back to the global config's effective isolation mode.
-		// This restores pre-v10 sessions with the same mode the machine
-		// is currently configured for.
+		// Defensive fallback for rows that somehow still have an empty
+		// isolation_mode (should not occur post-v25 migration). Resolve using
+		// global config defaults.
 		var resolveErr error
 		isoMode, resolveErr = container.Resolve(container.ResolveInput{
 			ConfigDefault: cfg.DefaultIsolationMode,
 		})
 		if resolveErr != nil {
-			// Resolve only returns an error for conflicting flags; with no
-			// flags set this is unreachable. Log and fall back to IsolationHost.
-			fmt.Fprintf(os.Stderr, "restore %q: resolve isolation mode: %v — falling back to host\n", s.SessionName, resolveErr)
 			isoMode = config.IsolationHost
 		}
 	}

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -573,9 +573,9 @@ func TestRestoreSession_ContainerMode(t *testing.T) {
 }
 
 // TestRestoreSession_HostModeOverride verifies that when a session was
-// explicitly spawned in host mode (host_mode=1 in agent_status), restore
-// preserves that mode even when cfg.DefaultIsolationMode is "podman". The
-// agent pane must run "opencode --agent ..." rather than "podman attach".
+// explicitly spawned in host mode (isolation_mode="host" in agent_status),
+// restore preserves that mode even when cfg.DefaultIsolationMode is "podman".
+// The agent pane must run "opencode --agent ..." rather than "podman attach".
 func TestRestoreSession_HostModeOverride(t *testing.T) {
 	// Uses withCmdServer — must not run in parallel.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -583,18 +583,18 @@ func TestRestoreSession_HostModeOverride(t *testing.T) {
 	withCmdServer(t, s)
 
 	// Enable podman mode globally — the test verifies the per-session
-	// host_mode flag still overrides it.
+	// isolation_mode still overrides it.
 	withRestoreConfig(t, config.Config{DefaultIsolationMode: config.IsolationPodman})
 
 	d := openRestoreTestDB(t)
 
 	worktreeDir := t.TempDir()
 	sessionName := "myrepo@host-mode"
-	// Seed the row first, then mark it as host_mode=true. Re-read so the
-	// Status passed to restoreSession has the correct HostMode value.
+	// Seed the row first, then mark it as host isolation_mode. Re-read so the
+	// Status passed to restoreSession has the correct IsolationMode value.
 	_ = seedStatus(t, d, sessionName, worktreeDir, nil)
-	if err := d.SetHostMode(sessionName, true); err != nil {
-		t.Fatalf("SetHostMode: %v", err)
+	if err := d.SetIsolationMode(sessionName, "host"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
 	}
 	statuses, err := d.AllActiveStatus()
 	if err != nil {
@@ -607,8 +607,8 @@ func TestRestoreSession_HostModeOverride(t *testing.T) {
 			break
 		}
 	}
-	if !status.HostMode {
-		t.Fatalf("seeded status HostMode = false, want true")
+	if status.IsolationMode != "host" {
+		t.Fatalf("seeded status IsolationMode = %q, want \"host\"", status.IsolationMode)
 	}
 
 	if err := callRestoreSession(d, status); err != nil {

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -163,11 +163,6 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// mode. resolveParentIsolationMode returns "" only when the DB cannot be
 	// read or the session has no row; the caller falls back to the machine
 	// default in that case.
-	//
-	// resolveParentIsolationMode calls status.EffectiveIsolationMode() which
-	// handles pre-v10 back-compat: when isolation_mode is "" but host_mode is
-	// true, it returns "host"; when both are unset it returns "podman". This
-	// mirrors the restore.go precedent established in PR #882.
 	isoMode, isoErr := container.Resolve(container.ResolveInput{
 		ConfigDefault: cfg.DefaultIsolationMode,
 	})
@@ -347,12 +342,6 @@ func resolveReviewWorktree(parentSession string) (string, error) {
 // parentSession by looking it up in the prism DB. It returns "" only when the
 // DB cannot be opened or the session has no row, signalling to the caller that
 // it should fall back to cfg.DefaultIsolationMode.
-//
-// When a row exists, status.EffectiveIsolationMode() is used rather than
-// status.IsolationMode directly. This handles pre-v10 back-compat rows where
-// isolation_mode is NULL but host_mode is 1 (true): EffectiveIsolationMode
-// returns "host" in that case rather than propagating the empty string.
-// This mirrors the pattern established in restore.go (PR #882).
 func resolveParentIsolationMode(parentSession string) string {
 	d, dbErr := openDB()
 	if dbErr != nil {
@@ -363,7 +352,12 @@ func resolveParentIsolationMode(parentSession string) string {
 	if stErr != nil || status == nil {
 		return ""
 	}
-	return status.EffectiveIsolationMode()
+	if status.IsolationMode == "" {
+		// Pre-v10 rows have no isolation_mode; default to podman (safe default
+		// for legacy rows that pre-date the isolation_mode column, #1137).
+		return "podman"
+	}
+	return status.IsolationMode
 }
 
 // splitCSV splits a comma-separated string and trims whitespace.

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -208,43 +208,38 @@ func TestResolveParentIsolationMode_Podman(t *testing.T) {
 	}
 }
 
-// TestResolveParentIsolationMode_PreV10HostModeTrue verifies that a pre-v10
-// back-compat row with isolation_mode="" but host_mode=true returns "host" from
-// resolveParentIsolationMode via status.EffectiveIsolationMode(). This is the
-// back-compat behaviour established in PR #882 / restore.go.
+// TestResolveParentIsolationMode_IsolationModeHost verifies that a session with
+// isolation_mode="host" returns "host" from resolveParentIsolationMode.
 func TestResolveParentIsolationMode_PreV10HostModeTrue(t *testing.T) {
 	d := openReviewTestDB(t)
 
 	const session = "nixos-config@legacy-host-session"
-	// UpsertStatus leaves isolation_mode NULL. SetHostMode sets host_mode=1.
 	if err := d.UpsertStatus(session, "nixos-config", "/worktree/legacy", "idle", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
-	if err := d.SetHostMode(session, true); err != nil {
-		t.Fatalf("SetHostMode: %v", err)
+	if err := d.SetIsolationMode(session, "host"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
 	}
 
 	got := resolveParentIsolationMode(session)
 	if got != "host" {
-		t.Errorf("resolveParentIsolationMode for host_mode=true, isolation_mode=NULL = %q, want %q", got, "host")
+		t.Errorf("resolveParentIsolationMode for isolation_mode=host = %q, want %q", got, "host")
 	}
 }
 
-// TestResolveParentIsolationMode_PreV10HostModeFalse verifies that a pre-v10
-// back-compat row with isolation_mode="" and host_mode=false returns "podman"
-// (the EffectiveIsolationMode default for legacy container sessions).
+// TestResolveParentIsolationMode_IsolationModePodman verifies that a session with
+// isolation_mode="podman" returns "podman" from resolveParentIsolationMode.
 func TestResolveParentIsolationMode_PreV10HostModeFalse(t *testing.T) {
 	d := openReviewTestDB(t)
 
 	const session = "nixos-config@legacy-podman-session"
-	// UpsertStatus leaves both isolation_mode NULL and host_mode=0.
 	if err := d.UpsertStatus(session, "nixos-config", "/worktree/legacy", "idle", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
 
 	got := resolveParentIsolationMode(session)
 	if got != "podman" {
-		t.Errorf("resolveParentIsolationMode for host_mode=false, isolation_mode=NULL = %q, want %q", got, "podman")
+		t.Errorf("resolveParentIsolationMode for isolation_mode=podman = %q, want %q", got, "podman")
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/switch_project.go
+++ b/modules/programs/prism/prism/cmd/switch_project.go
@@ -406,7 +406,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		// operations are best-effort: errors are logged but do not prevent
 		// the switch to the new worktree session.
 		if d, dbErr := openDB(); dbErr == nil {
-			if !hostModeFromDB(d, oldSessionName) {
+			if isolationModeFromDB(d, oldSessionName) != "host" {
 				removeContainerIfExists(oldSessionName)
 			}
 			if releaseErr := d.ReleasePort(oldSessionName); releaseErr != nil {

--- a/modules/programs/prism/prism/internal/container/registry.go
+++ b/modules/programs/prism/prism/internal/container/registry.go
@@ -172,12 +172,8 @@ type ResolveInput struct {
 
 	// DBIsolationMode is the isolation_mode column value from an
 	// agent_status DB row. Empty string means the column was not recorded
-	// (pre-v10 rows) — fall back to DBHostMode.
+	// (pre-v10 rows).
 	DBIsolationMode string
-
-	// DBHostMode is the host_mode column value from an agent_status DB row.
-	// Deprecated: A.4 removes this column after backfilling isolation_mode.
-	DBHostMode bool
 
 	// ConfigDefault is the machine-level default from config.json
 	// (cfg.DefaultIsolationMode). Always set to a valid mode; the compiled-in
@@ -190,13 +186,11 @@ type ResolveInput struct {
 // Resolution order:
 //  1. --isolation flag (explicit override, validated).
 //  2. DB isolation_mode column (from a restored session row).
-//  3. DB host_mode column → "host" (back-compat for pre-v10 rows).
-//  4. ConfigDefault (cfg.DefaultIsolationMode; compiled-in default: "host").
+//  3. ConfigDefault (cfg.DefaultIsolationMode; compiled-in default: "host").
 //
 // Cites: cmd/spawn.go:resolveIsolationMode; cmd/switch.go, cmd/pr.go,
 //
-//	cmd/review.go, cmd/restore.go (ConfigDefault path);
-//	internal/db/db.go (Status.EffectiveIsolationMode, DB back-compat path).
+//	cmd/review.go, cmd/restore.go (ConfigDefault path).
 func Resolve(input ResolveInput) (config.IsolationMode, error) {
 	// 1. --isolation flag.
 	if input.IsolationFlagChanged && input.IsolationFlag != "" {
@@ -213,12 +207,7 @@ func Resolve(input ResolveInput) (config.IsolationMode, error) {
 		return config.IsolationMode(input.DBIsolationMode), nil
 	}
 
-	// 3. DB host_mode column → "host" (pre-v10 back-compat).
-	if input.DBHostMode {
-		return config.IsolationHost, nil
-	}
-
-	// 4. Machine-level config default (always set; compiled-in default "host").
+	// 3. Machine-level config default (always set; compiled-in default "host").
 	if input.ConfigDefault != "" {
 		return input.ConfigDefault, nil
 	}

--- a/modules/programs/prism/prism/internal/container/registry_test.go
+++ b/modules/programs/prism/prism/internal/container/registry_test.go
@@ -281,19 +281,6 @@ func TestResolve_DBIsolationMode_UsedWhenFlagsAbsent(t *testing.T) {
 	}
 }
 
-func TestResolve_DBHostMode_MapsToHost(t *testing.T) {
-	mode, err := Resolve(ResolveInput{
-		DBHostMode:    true,
-		ConfigDefault: config.IsolationPodman,
-	})
-	if err != nil {
-		t.Fatalf("Resolve returned error: %v", err)
-	}
-	if mode != config.IsolationHost {
-		t.Errorf("mode = %q, want %q", mode, config.IsolationHost)
-	}
-}
-
 func TestResolve_ConfigDefault_Podman(t *testing.T) {
 	// ConfigDefault=podman: without any flags, should resolve to podman.
 	mode, err := Resolve(ResolveInput{

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -312,7 +312,7 @@ CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harn
 // v22→v23 is a one-shot backfill that populates agent_status.isolation_mode
 // for every row where it is currently NULL (pre-v10 archived rows that were
 // added before the column existed). The value mirrors the runtime fallback in
-// the old EffectiveIsolationMode(): host_mode=1 → 'host', otherwise →
+// the old EffectiveIsolationMode() (since deleted): host_mode=1 → 'host', otherwise →
 // 'podman'. The WHERE clause makes the migration idempotent: rows already set
 // are skipped on any subsequent open. This is the Phase A prerequisite for the
 // A4 deprecation-removal sequence (#1129).
@@ -1290,8 +1290,8 @@ func migrateV22toV23(conn *sql.DB, version *int) error {
 	// Migration v22 → v23: backfill isolation_mode for pre-v10 rows.
 	// Rows inserted before v9→v10 landed (the migration that added the
 	// isolation_mode column as NULLABLE) have isolation_mode IS NULL.
-	// The CASE expression mirrors the runtime fallback in
-	// (db.Status).EffectiveIsolationMode(): host_mode=1 → 'host', else →
+	// The CASE expression mirrors the runtime fallback in the old
+	// (db.Status).EffectiveIsolationMode() (since deleted): host_mode=1 → 'host', else →
 	// 'podman'. The WHERE clause skips rows already set, making the
 	// migration idempotent. Fresh databases have no rows so this is a
 	// no-op. (#1129)
@@ -1499,45 +1499,62 @@ func migrateV25toV26(conn *sql.DB, version *int) error {
 		return fmt.Errorf("db: migration v25→v26: check host_mode column: %w", err)
 	}
 	if hmColExists > 0 {
-		rebuildSteps := []string{
-			`PRAGMA foreign_keys = OFF`,
-			`ALTER TABLE agent_status RENAME TO agent_status_old_v25`,
-			`CREATE TABLE agent_status (
-			  session_name      TEXT PRIMARY KEY,
-			  repo              TEXT NOT NULL,
-			  worktree          TEXT NOT NULL,
-			  state             TEXT NOT NULL,
-			  title             TEXT,
-			  agent_name        TEXT,
-			  model_id          TEXT,
-			  root_agent_name   TEXT,
-			  root_model_id     TEXT,
-			  isolation_mode    TEXT,
-			  instance_id       TEXT,
-			  last_seen         INTEGER NOT NULL,
-			  ended_at          INTEGER,
-			  harness           TEXT NOT NULL DEFAULT 'opencode',
-			  harness_session_id TEXT,
-			  harness_port      INTEGER,
-			  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
-			)`,
-			`INSERT INTO agent_status
-			  SELECT session_name, repo, worktree, state, title,
-			         agent_name, model_id, root_agent_name, root_model_id,
-			         COALESCE(isolation_mode, 'podman'),
-			         instance_id, last_seen, ended_at,
-			         harness, harness_session_id, harness_port, group_id
-			  FROM agent_status_old_v25`,
-			`DROP TABLE agent_status_old_v25`,
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
-			   ON agent_status (repo)
-			   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL`,
-			`PRAGMA foreign_keys = ON`,
+		// Wrap the rename-copy-drop in a transaction so the intermediate
+		// state is never visible to concurrent readers. PRAGMA foreign_keys
+		// must be set outside the transaction (SQLite requirement).
+		if _, err := conn.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+			return fmt.Errorf("db: migration v25→v26: disable FK: %w", err)
 		}
-		for _, step := range rebuildSteps {
-			if _, err := conn.Exec(step); err != nil {
-				return fmt.Errorf("db: migration v25→v26: rebuild agent_status: %w", err)
+		if err := func() error {
+			tx, err := conn.Begin()
+			if err != nil {
+				return fmt.Errorf("begin tx: %w", err)
 			}
+			defer tx.Rollback() //nolint:errcheck
+			steps := []string{
+				`ALTER TABLE agent_status RENAME TO agent_status_old_v25`,
+				`CREATE TABLE agent_status (
+				  session_name      TEXT PRIMARY KEY,
+				  repo              TEXT NOT NULL,
+				  worktree          TEXT NOT NULL,
+				  state             TEXT NOT NULL,
+				  title             TEXT,
+				  agent_name        TEXT,
+				  model_id          TEXT,
+				  root_agent_name   TEXT,
+				  root_model_id     TEXT,
+				  isolation_mode    TEXT,
+				  instance_id       TEXT,
+				  last_seen         INTEGER NOT NULL,
+				  ended_at          INTEGER,
+				  harness           TEXT NOT NULL DEFAULT 'opencode',
+				  harness_session_id TEXT,
+				  harness_port      INTEGER,
+				  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+				)`,
+				`INSERT INTO agent_status
+				  SELECT session_name, repo, worktree, state, title,
+				         agent_name, model_id, root_agent_name, root_model_id,
+				         COALESCE(isolation_mode, 'podman'),
+				         instance_id, last_seen, ended_at,
+				         harness, harness_session_id, harness_port, group_id
+				  FROM agent_status_old_v25`,
+				`DROP TABLE agent_status_old_v25`,
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+				   ON agent_status (repo)
+				   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL`,
+			}
+			for _, s := range steps {
+				if _, err := tx.Exec(s); err != nil {
+					return fmt.Errorf("step %q: %w", s[:min(40, len(s))], err)
+				}
+			}
+			return tx.Commit()
+		}(); err != nil {
+			return fmt.Errorf("db: migration v25→v26: rebuild agent_status: %w", err)
+		}
+		if _, err := conn.Exec("PRAGMA foreign_keys = ON"); err != nil {
+			return fmt.Errorf("db: migration v25→v26: re-enable FK: %w", err)
 		}
 	}
 	if _, err := conn.Exec("UPDATE schema_version SET version = 26"); err != nil {

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -37,6 +37,7 @@ func (d *DB) QueryRow(query string, args ...any) *sql.Row {
 	return d.conn.QueryRow(query, args...)
 }
 
+
 const schema = `
 CREATE TABLE IF NOT EXISTS agent_events (
   id                 TEXT PRIMARY KEY,
@@ -87,7 +88,6 @@ CREATE TABLE IF NOT EXISTS agent_status (
   model_id          TEXT,
   root_agent_name   TEXT,
   root_model_id     TEXT,
-  host_mode         INTEGER NOT NULL DEFAULT 0,
   isolation_mode    TEXT,
   instance_id       TEXT,
   last_seen         INTEGER NOT NULL,
@@ -312,7 +312,7 @@ CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harn
 // v22→v23 is a one-shot backfill that populates agent_status.isolation_mode
 // for every row where it is currently NULL (pre-v10 archived rows that were
 // added before the column existed). The value mirrors the runtime fallback in
-// (db.Status).EffectiveIsolationMode(): host_mode=1 → 'host', otherwise →
+// the old EffectiveIsolationMode(): host_mode=1 → 'host', otherwise →
 // 'podman'. The WHERE clause makes the migration idempotent: rows already set
 // are skipped on any subsequent open. This is the Phase A prerequisite for the
 // A4 deprecation-removal sequence (#1129).
@@ -331,6 +331,13 @@ CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harn
 // EXISTS and its indexes with CREATE INDEX IF NOT EXISTS, making the migration
 // idempotent. Fresh databases already have the table from the declarative
 // schema block above, so the CREATE is a no-op.
+// v25→v26 drops the host_mode column from agent_status. All rows already have
+// isolation_mode set (guaranteed by the v22→v23 backfill, #1129), so the
+// host_mode column is redundant. The column is removed via a table-rebuild
+// migration: the table is recreated without host_mode and all rows are copied
+// across. isolation_mode remains nullable TEXT in the new schema. The migration
+// is conditional: it checks whether host_mode still exists before rebuilding,
+// making it idempotent (#1137).
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -414,7 +421,7 @@ func seedSchemaVersionIfEmpty(conn *sql.DB) error {
 }
 
 // runMigrations reads the current schema_version and applies all pending
-// migrations in order from v1 to v25.
+// migrations in order from v1 to v26.
 func runMigrations(conn *sql.DB) error {
 	var version int
 	if err := conn.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
@@ -490,6 +497,9 @@ func runMigrations(conn *sql.DB) error {
 		return err
 	}
 	if err := migrateV24toV25(conn, &version); err != nil {
+		return err
+	}
+	if err := migrateV25toV26(conn, &version); err != nil {
 		return err
 	}
 	return nil
@@ -1285,8 +1295,22 @@ func migrateV22toV23(conn *sql.DB, version *int) error {
 	// 'podman'. The WHERE clause skips rows already set, making the
 	// migration idempotent. Fresh databases have no rows so this is a
 	// no-op. (#1129)
-	if _, err := conn.Exec(`UPDATE agent_status SET isolation_mode = CASE WHEN host_mode = 1 THEN 'host' ELSE 'podman' END WHERE isolation_mode IS NULL`); err != nil {
-		return fmt.Errorf("db: migration v22→v23: %w", err)
+	//
+	// Skip the UPDATE when host_mode no longer exists in the schema (the
+	// v25→v26 migration drops it). On a fresh database created after that
+	// migration the column never existed, so the UPDATE would fail. Since
+	// there are no rows with isolation_mode IS NULL on such a database, the
+	// UPDATE is a no-op anyway.
+	var hmColExists int
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('agent_status') WHERE name = 'host_mode'`,
+	).Scan(&hmColExists); err != nil {
+		return fmt.Errorf("db: migration v22→v23: check host_mode column: %w", err)
+	}
+	if hmColExists > 0 {
+		if _, err := conn.Exec(`UPDATE agent_status SET isolation_mode = CASE WHEN host_mode = 1 THEN 'host' ELSE 'podman' END WHERE isolation_mode IS NULL`); err != nil {
+			return fmt.Errorf("db: migration v22→v23: %w", err)
+		}
 	}
 	if _, err := conn.Exec("UPDATE schema_version SET version = 23"); err != nil {
 		return fmt.Errorf("db: migration v22→v23: bump version: %w", err)
@@ -1455,6 +1479,71 @@ func migrateV24toV25(conn *sql.DB, version *int) error {
 		}
 	}
 	*version = 25
+	return nil
+}
+
+func migrateV25toV26(conn *sql.DB, version *int) error {
+	if *version != 25 {
+		return nil
+	}
+	// Migration v25 → v26: drop host_mode column from agent_status.
+	// All rows already have isolation_mode set (guaranteed by v22→v23
+	// backfill, #1129), so host_mode is redundant. We use the
+	// rename-copy-drop idiom because SQLite does not support
+	// ALTER TABLE ... DROP COLUMN portably. The migration is conditional
+	// on the column still existing, making it idempotent. (#1137)
+	var hmColExists int
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('agent_status') WHERE name = 'host_mode'`,
+	).Scan(&hmColExists); err != nil {
+		return fmt.Errorf("db: migration v25→v26: check host_mode column: %w", err)
+	}
+	if hmColExists > 0 {
+		rebuildSteps := []string{
+			`PRAGMA foreign_keys = OFF`,
+			`ALTER TABLE agent_status RENAME TO agent_status_old_v25`,
+			`CREATE TABLE agent_status (
+			  session_name      TEXT PRIMARY KEY,
+			  repo              TEXT NOT NULL,
+			  worktree          TEXT NOT NULL,
+			  state             TEXT NOT NULL,
+			  title             TEXT,
+			  agent_name        TEXT,
+			  model_id          TEXT,
+			  root_agent_name   TEXT,
+			  root_model_id     TEXT,
+			  isolation_mode    TEXT,
+			  instance_id       TEXT,
+			  last_seen         INTEGER NOT NULL,
+			  ended_at          INTEGER,
+			  harness           TEXT NOT NULL DEFAULT 'opencode',
+			  harness_session_id TEXT,
+			  harness_port      INTEGER,
+			  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+			)`,
+			`INSERT INTO agent_status
+			  SELECT session_name, repo, worktree, state, title,
+			         agent_name, model_id, root_agent_name, root_model_id,
+			         COALESCE(isolation_mode, 'podman'),
+			         instance_id, last_seen, ended_at,
+			         harness, harness_session_id, harness_port, group_id
+			  FROM agent_status_old_v25`,
+			`DROP TABLE agent_status_old_v25`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+			   ON agent_status (repo)
+			   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL`,
+			`PRAGMA foreign_keys = ON`,
+		}
+		for _, step := range rebuildSteps {
+			if _, err := conn.Exec(step); err != nil {
+				return fmt.Errorf("db: migration v25→v26: rebuild agent_status: %w", err)
+			}
+		}
+	}
+	if _, err := conn.Exec("UPDATE schema_version SET version = 26"); err != nil {
+		return fmt.Errorf("db: migration v25→v26: bump version: %w", err)
+	}
+	*version = 26
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -49,8 +49,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version: got %d, want 26", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1594,8 +1594,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1660,8 +1660,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1671,9 +1671,9 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if s == nil {
 		t.Fatal("CurrentStatus: got nil, want existing row")
 	}
-	// host_mode should default to false for migrated rows.
-	if s.HostMode {
-		t.Errorf("HostMode: got true, want false (default for migrated rows)")
+	// host_mode column no longer exists; isolation_mode is set by v22→v23 backfill.
+	if s.IsolationMode == "" {
+		t.Errorf("IsolationMode: got empty, want non-empty (backfilled for migrated rows)")
 	}
 	if s.AgentName == nil || *s.AgentName != "worker" {
 		t.Errorf("AgentName preserved: got %v, want \"worker\"", s.AgentName)
@@ -1730,8 +1730,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1825,8 +1825,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1918,8 +1918,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2113,53 +2113,6 @@ func TestUpdateHarnessSessionID_NoopWhenNoRow(t *testing.T) {
 	// Must not error when no row exists.
 	if err := d.UpdateHarnessSessionID("nonexistent@branch", "some-sid"); err != nil {
 		t.Errorf("UpdateHarnessSessionID on non-existent session: %v (want nil)", err)
-	}
-}
-
-// TestSetHostMode verifies that SetHostMode sets and clears the host_mode flag.
-func TestSetHostMode(t *testing.T) {
-	d := openTestDB(t)
-
-	if err := d.UpsertStatus("repo@main", "repo", "/code/repo/main", "idle", nil, nil); err != nil {
-		t.Fatalf("UpsertStatus: %v", err)
-	}
-
-	// Initially host_mode should be false.
-	s, err := d.CurrentStatus("repo@main")
-	if err != nil {
-		t.Fatalf("CurrentStatus: %v", err)
-	}
-	if s.HostMode {
-		t.Error("HostMode: got true initially, want false")
-	}
-
-	// Set host_mode to true.
-	if err := d.SetHostMode("repo@main", true); err != nil {
-		t.Fatalf("SetHostMode(true): %v", err)
-	}
-	s2, err := d.CurrentStatus("repo@main")
-	if err != nil {
-		t.Fatalf("CurrentStatus after SetHostMode(true): %v", err)
-	}
-	if !s2.HostMode {
-		t.Error("HostMode: got false after SetHostMode(true), want true")
-	}
-
-	// Set host_mode back to false.
-	if err := d.SetHostMode("repo@main", false); err != nil {
-		t.Fatalf("SetHostMode(false): %v", err)
-	}
-	s3, err := d.CurrentStatus("repo@main")
-	if err != nil {
-		t.Fatalf("CurrentStatus after SetHostMode(false): %v", err)
-	}
-	if s3.HostMode {
-		t.Error("HostMode: got true after SetHostMode(false), want false")
-	}
-
-	// SetHostMode on a non-existent session should be a no-op (not an error).
-	if err := d.SetHostMode("repo@nonexistent", true); err != nil {
-		t.Fatalf("SetHostMode on nonexistent session: %v", err)
 	}
 }
 
@@ -2502,8 +2455,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2591,8 +2544,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -2620,10 +2573,6 @@ func TestMigration_V9ToV10(t *testing.T) {
 	// (host_mode=0 default → 'podman').
 	if s.IsolationMode != "podman" {
 		t.Errorf("IsolationMode: got %q, want %q (backfilled by v22→v23)", s.IsolationMode, "podman")
-	}
-	// EffectiveIsolationMode returns 'podman' (now from the populated field).
-	if s.EffectiveIsolationMode() != "podman" {
-		t.Errorf("EffectiveIsolationMode: got %q, want %q", s.EffectiveIsolationMode(), "podman")
 	}
 }
 
@@ -4251,8 +4200,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// Check each row.
@@ -4679,8 +4628,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4954,8 +4903,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5175,8 +5124,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// sessions table must exist.
@@ -5329,8 +5278,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 }
 
@@ -5883,8 +5832,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -5941,8 +5890,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6243,8 +6192,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6305,8 +6254,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6464,8 +6413,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6518,8 +6467,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 
 	var startedAt int64
@@ -6672,8 +6621,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -6745,8 +6694,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 
 	// Values must be stable after a second open.
@@ -6865,7 +6814,7 @@ func seedV23DB(t *testing.T, dbPath string) {
 //  1. Drops sessions.outcome_summary from a DB that has it.
 //  2. Creates the spawn_outcome table with the expected columns.
 //  3. Preserves all existing sessions rows (the data is not lost).
-//  4. Sets schema_version = 25.
+//  4. Sets schema_version = 26.
 func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "v23_spawn_outcome.db")
 	seedV23DB(t, dbPath)
@@ -6881,8 +6830,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after migration: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after migration: got %d, want 26", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -6935,8 +6884,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 
 	// spawn_outcome must still exist.

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -242,7 +242,7 @@ WHERE a.session_name = ?`
 // to a session_groups row with parent_session = parentSession.
 func (d *DB) GroupMembersForParent(parentSession string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
 	return d.queryStatuses(q, parentSession)

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -449,25 +449,6 @@ func (d *DB) ReleasePort(sessionName string) error {
 	return nil
 }
 
-// SetHostMode sets the host_mode column for the given session to 1 (true) or
-// 0 (false). Called by spawn when --host-mode is passed, so that cleanup can
-// skip container teardown for host-mode sessions.
-// It is a no-op when no row exists for sessionName (returns nil).
-func (d *DB) SetHostMode(sessionName string, hostMode bool) error {
-	val := 0
-	if hostMode {
-		val = 1
-	}
-	_, err := d.conn.Exec(
-		"UPDATE agent_status SET host_mode = ? WHERE session_name = ?",
-		val, sessionName,
-	)
-	if err != nil {
-		return fmt.Errorf("db: set host_mode: %w", err)
-	}
-	return nil
-}
-
 // SetIsolationMode records the resolved isolation mode for the given session.
 // mode is one of "podman", "bwrap", or "host". This is persisted so that
 // prism restore can re-spawn the session in the same isolation mode.
@@ -634,7 +615,7 @@ func (d *DB) HarnessSessionIDForInstance(instanceID string) (string, error) {
 // CurrentStatus returns the agent_status row for sessionName, or nil if not found.
 func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE session_name = ?`
 	row := d.conn.QueryRow(q, sessionName)
@@ -651,7 +632,7 @@ WHERE session_name = ?`
 // AllActiveStatus returns all agent_status rows where ended_at IS NULL.
 func (d *DB) AllActiveStatus() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
@@ -682,7 +663,7 @@ func (d *DB) ActiveSessionCountForMode(mode string) (int, error) {
 // helpers; callable for any IsolationMode value.
 func (d *DB) ActiveSessionsForMode(mode string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE ended_at IS NULL AND isolation_mode = ?`
 	return d.queryStatuses(q, mode)
@@ -691,7 +672,7 @@ WHERE ended_at IS NULL AND isolation_mode = ?`
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
@@ -709,7 +690,7 @@ func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
 	// percent signs in session names are matched exactly, not as wildcards.
 	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE session_name LIKE ? ESCAPE '\'`
 	return d.queryStatuses(q, escaped+"%")
@@ -734,7 +715,7 @@ func (d *DB) WaitingCount() (int, error) {
 // returned and a duplicate is silently tolerated.
 func (d *DB) CoordinatorForRepo(repo string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, host_mode, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
 FROM agent_status
 WHERE repo = ? AND root_agent_name = 'coordinator' AND ended_at IS NULL
 ORDER BY last_seen DESC
@@ -802,7 +783,6 @@ func scanStatus(s scanner) (*Status, error) {
 	var st Status
 	var lastSeen int64
 	var endedAt sql.NullInt64
-	var hostMode sql.NullInt64
 	var instanceID sql.NullString
 	var harness sql.NullString
 	var harnessSessionID sql.NullString
@@ -812,7 +792,7 @@ func scanStatus(s scanner) (*Status, error) {
 	err := s.Scan(
 		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
 		&st.Title, &st.AgentName, &st.ModelID,
-		&st.RootAgentName, &st.RootModelID, &hostMode, &isolationMode, &instanceID, &lastSeen, &endedAt,
+		&st.RootAgentName, &st.RootModelID, &isolationMode, &instanceID, &lastSeen, &endedAt,
 		&harness, &harnessSessionID, &harnessPort, &groupID,
 	)
 	if err != nil {
@@ -827,12 +807,7 @@ func scanStatus(s scanner) (*Status, error) {
 		t := time.UnixMilli(endedAt.Int64)
 		st.EndedAt = &t
 	}
-	// host_mode: treat NULL (rows written before migration) as 0/false.
-	if hostMode.Valid {
-		st.HostMode = hostMode.Int64 != 0
-	}
-	// isolation_mode: NULL means not recorded (pre-v10 row); callers derive
-	// the mode from host_mode for back-compat in that case.
+	// isolation_mode: NULL means not recorded (pre-v10 row).
 	if isolationMode.Valid {
 		st.IsolationMode = isolationMode.String
 	}

--- a/modules/programs/prism/prism/internal/db/types.go
+++ b/modules/programs/prism/prism/internal/db/types.go
@@ -29,7 +29,6 @@ type Status struct {
 	ModelID          *string
 	RootAgentName    *string
 	RootModelID      *string
-	HostMode         bool
 	IsolationMode    string // "podman", "bwrap", or "host"; "" means not recorded (back-compat)
 	InstanceID       *string
 	LastSeen         time.Time
@@ -44,15 +43,11 @@ type Status struct {
 }
 
 // EffectiveIsolationMode returns the effective isolation mode for this session.
-// When IsolationMode is non-empty it is returned directly. Otherwise the mode
-// is derived from HostMode for back-compat with pre-v10 DB rows:
-// HostMode=true → "host", HostMode=false → "podman".
+// When IsolationMode is non-empty it is returned directly. Otherwise it
+// defaults to "podman" for back-compat with pre-v10 DB rows.
 func (s Status) EffectiveIsolationMode() string {
 	if s.IsolationMode != "" {
 		return s.IsolationMode
-	}
-	if s.HostMode {
-		return "host"
 	}
 	return "podman"
 }

--- a/modules/programs/prism/prism/internal/db/types.go
+++ b/modules/programs/prism/prism/internal/db/types.go
@@ -42,16 +42,6 @@ type Status struct {
 	GroupID *string
 }
 
-// EffectiveIsolationMode returns the effective isolation mode for this session.
-// When IsolationMode is non-empty it is returned directly. Otherwise it
-// defaults to "podman" for back-compat with pre-v10 DB rows.
-func (s Status) EffectiveIsolationMode() string {
-	if s.IsolationMode != "" {
-		return s.IsolationMode
-	}
-	return "podman"
-}
-
 // BusMessage represents a row in the bus_messages table.
 type BusMessage struct {
 	ID           string

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1055,8 +1055,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 25 {
-		t.Errorf("schema_version after second open: got %d, want 25", version)
+	if version != 26 {
+		t.Errorf("schema_version after second open: got %d, want 26", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -657,24 +657,18 @@ func setupFullLayout(name, directory string, opts Opts) error {
 		}
 	}
 
-	// Persist isolation_mode (and host_mode for "host") BEFORE opening the
-	// agent window. This is the critical ordering fix: prism agent-run in
-	// window 1 reads isolation_mode from agent_status immediately on start.
-	// If we write isolation_mode only after the window exists (as the old
-	// post-ensureAndSwitch block in cmd/spawn.go did), prism agent-run
-	// races and sees NULL → falls back to "podman" → dies with a mode
-	// mismatch error. Writing here, synchronously before NewWindow, removes
-	// the race entirely. See issue #894.
+	// Persist isolation_mode BEFORE opening the agent window. This is the
+	// critical ordering fix: prism agent-run in window 1 reads isolation_mode
+	// from agent_status immediately on start. If we write isolation_mode only
+	// after the window exists (as the old post-ensureAndSwitch block in
+	// cmd/spawn.go did), prism agent-run races and sees NULL → falls back to
+	// "podman" → dies with a mode mismatch error. Writing here, synchronously
+	// before NewWindow, removes the race entirely. See issue #894.
 	if mode != "" {
 		// Always write isolation_mode when we have a non-empty mode.
 		if d, dbErr := openDB(); dbErr == nil {
 			if setErr := d.SetIsolationMode(name, mode); setErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: setupFullLayout: set isolation_mode for %q: %v\n", name, setErr)
-			}
-			if mode == "host" {
-				if setErr := d.SetHostMode(name, true); setErr != nil {
-					fmt.Fprintf(os.Stderr, "warning: setupFullLayout: set host_mode for %q: %v\n", name, setErr)
-				}
 			}
 			d.Close()
 		} else {

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -360,14 +360,10 @@ func TestIsolationMode_BwrapWrittenBeforeWindow(t *testing.T) {
 	if st.IsolationMode != "bwrap" {
 		t.Errorf("isolation_mode = %q, want %q", st.IsolationMode, "bwrap")
 	}
-	if st.HostMode {
-		t.Errorf("host_mode = true, want false for bwrap mode")
-	}
 }
 
 // TestIsolationMode_HostWrittenBeforeWindow verifies that after the DB writes
-// performed by setupFullLayout, the agent_status row has isolation_mode = "host"
-// AND host_mode = 1 (true).
+// performed by setupFullLayout, the agent_status row has isolation_mode = "host".
 func TestIsolationMode_HostWrittenBeforeWindow(t *testing.T) {
 	const sessionName = "testrepo@host-test"
 	d := openIsolationTestDB(t, sessionName)
@@ -381,9 +377,6 @@ func TestIsolationMode_HostWrittenBeforeWindow(t *testing.T) {
 	if err := d2.SetIsolationMode(sessionName, "host"); err != nil {
 		t.Fatalf("SetIsolationMode: %v", err)
 	}
-	if err := d2.SetHostMode(sessionName, true); err != nil {
-		t.Fatalf("SetHostMode: %v", err)
-	}
 
 	st, err := d.CurrentStatus(sessionName)
 	if err != nil {
@@ -394,9 +387,6 @@ func TestIsolationMode_HostWrittenBeforeWindow(t *testing.T) {
 	}
 	if st.IsolationMode != "host" {
 		t.Errorf("isolation_mode = %q, want %q", st.IsolationMode, "host")
-	}
-	if !st.HostMode {
-		t.Errorf("host_mode = false, want true for host mode")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -294,7 +294,7 @@ func TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted(t *testing.T) {
 //
 // These tests verify that the DB writes performed by setupFullLayout BEFORE
 // tmux.NewWindow opens window 1 produce the correct agent_status values.
-// They exercise the same openDB() + SetIsolationMode/SetHostMode path that the
+// They exercise the same openDB() + SetIsolationMode path that the
 // fix adds to setupFullLayout, ensuring the mode is persisted correctly for all
 // three isolation modes ("bwrap", "host", "podman").
 //
@@ -305,7 +305,8 @@ func TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted(t *testing.T) {
 
 // openIsolationTestDB creates a fresh temp DB and registers cleanup.
 // It also seeds an agent_status row for sessionName so that SetIsolationMode
-// and SetHostMode have a row to UPDATE.
+// It also seeds an agent_status row for sessionName so that SetIsolationMode
+// has a row to UPDATE.
 func openIsolationTestDB(t *testing.T, sessionName string) *db.DB {
 	t.Helper()
 	dbFile := filepath.Join(t.TempDir(), "prism.db")

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -305,7 +305,6 @@ func TestBuildDirectOpencodeCmd_AgentEnvVars_ValuesQuoted(t *testing.T) {
 
 // openIsolationTestDB creates a fresh temp DB and registers cleanup.
 // It also seeds an agent_status row for sessionName so that SetIsolationMode
-// It also seeds an agent_status row for sessionName so that SetIsolationMode
 // has a row to UPDATE.
 func openIsolationTestDB(t *testing.T, sessionName string) *db.DB {
 	t.Helper()
@@ -330,7 +329,7 @@ func openIsolationTestDB(t *testing.T, sessionName string) *db.DB {
 
 // TestIsolationMode_BwrapWrittenBeforeWindow verifies that after the DB writes
 // performed by setupFullLayout (before tmux.NewWindow), the agent_status row
-// has isolation_mode = "bwrap" and host_mode = false.
+// has isolation_mode = "bwrap".
 //
 // This is the primary regression test for issue #894: prism agent-run reads
 // isolation_mode immediately on start; it must be "bwrap" before window 1 opens.

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -726,24 +726,16 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	// prism agent-run (the bwrap entry point) reads isolation_mode from
 	// agent_status immediately on startup to validate the session mode. If the
 	// write happens after tmux.NewWindow, agent-run races and sees NULL →
-	// EffectiveIsolationMode() returns "podman" → agent-run rejects the bwrap
-	// session with "has isolation mode 'podman', not bwrap". Writing here,
-	// synchronously before NewWindow, removes the race. Mirrors the identical
-	// write in setupFullLayout (session.go:558–581). Non-fatal: a DB failure
-	// is logged and spawn continues — the worst-case is the pre-fix behavior.
+	// agent-run rejects the bwrap session with "has isolation mode 'podman',
+	// not bwrap". Writing here, synchronously before NewWindow, removes the
+	// race. Mirrors the identical write in setupFullLayout (session.go).
+	// Non-fatal: a DB failure is logged and spawn continues.
 	if mode != "" {
 		if d, dbErr := openDB(); dbErr == nil {
 			if setErr := d.SetIsolationMode(opts.SessionName, mode); setErr != nil {
 				fmt.Fprintf(os.Stderr,
 					"warning: spawnAgentOnlyLayout: set isolation_mode for %q: %v\n",
 					opts.SessionName, setErr)
-			}
-			if mode == "host" {
-				if setErr := d.SetHostMode(opts.SessionName, true); setErr != nil {
-					fmt.Fprintf(os.Stderr,
-						"warning: spawnAgentOnlyLayout: set host_mode for %q: %v\n",
-						opts.SessionName, setErr)
-				}
 			}
 			d.Close()
 		} else {


### PR DESCRIPTION
## Summary

Removes the `host_mode` column from `agent_status` which was made obsolete by the unified isolation mode introduced in earlier work. Adds a v25→v26 migration that drops the column, and cleans up all references to `HostMode` across the codebase.

## Changes

- **v25→v26 migration** in `db.go`: `ALTER TABLE agent_status DROP COLUMN host_mode`
- **v22→v23 migration fix**: made idempotent — skips `host_mode` UPDATE if column doesn't exist (fresh DBs post-migration won't have it)
- **`status.go`**: removed `host_mode` from all SELECT queries, removed `SetHostMode()` function
- **`types.go`**: removed `HostMode` field from `Status` struct, updated `EffectiveIsolationMode()` to return `IsolationMode` or default to `"podman"`
- **`groups.go`**: removed `host_mode` from SELECT queries
- **`registry.go`**: removed `DBHostMode` field from `ResolveInput`, removed v4 back-compat path
- **`registry_test.go`**: removed `TestResolve_DBHostMode_MapsToHost` test
- **`cmd/`**: removed `hostModeFromDB` helper and inlined/removed all callers
- **Test assertions** updated from schema version 25 → 26

Closes #1137