### PR TITLE
feat(prism): populate prompt_template_hash and prompt_source for spawn_inputs (C4.PT + C4.SRC)

### DIFF
--- a/modules/programs/prism/prism/cmd/prompt_input.go
+++ b/modules/programs/prism/prism/cmd/prompt_input.go
@@ -40,9 +40,9 @@ func addPromptFlags(cmd *cobra.Command) {
 }
 
 // requirePromptInput is used by commands where a prompt is mandatory (prism
-// prompt). It calls resolvePrompt and then errors if the result is empty.
+// prompt). It calls resolvePromptWithSource and then errors if the result is empty.
 func requirePromptInput(cmd *cobra.Command) (string, error) {
-	text, err := resolvePrompt(cmd)
+	text, _, err := resolvePromptWithSource(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -57,35 +57,50 @@ func requirePromptInput(cmd *cobra.Command) (string, error) {
 	return text, nil
 }
 
-// resolvePrompt reads the prompt text from whichever source was provided:
-//   - --prompt-file <path>  → read file contents
-//   - --prompt -            → read from stdin
-//   - --prompt <text>       → use text directly
+// resolvePrompt reads the prompt text from whichever source was provided.
+// It is a thin wrapper around resolvePromptWithSource for callers that do not
+// need the source discriminator.
+func resolvePrompt(cmd *cobra.Command) (string, error) {
+	text, _, err := resolvePromptWithSource(cmd)
+	return text, err
+}
+
+// resolvePromptWithSource reads the prompt text from whichever source was
+// provided and also returns the prompt_source discriminator for C.4.SRC:
+//
+//   - --prompt-file <path>  → (text, "cli-positional", nil)
+//   - --prompt -            → (text, "cli-stdin", nil)
+//   - --prompt <text>       → (text, "cli-positional", nil)
+//   - no prompt flag        → ("", "", nil)
 //
 // Note: cobra enforces mutual exclusion of --prompt and --prompt-file before
 // RunE is called, so no manual check is needed here.
 // A single trailing newline is stripped from file/stdin input to match the
 // behaviour of most Unix text tools (editors append a final newline that is
 // not part of the intended content).
-func resolvePrompt(cmd *cobra.Command) (string, error) {
+func resolvePromptWithSource(cmd *cobra.Command) (text, source string, err error) {
 	promptFile, _ := cmd.Flags().GetString("prompt-file")
 	promptText, _ := cmd.Flags().GetString("prompt")
 
 	if promptFile != "" {
-		data, err := os.ReadFile(promptFile)
-		if err != nil {
-			return "", fmt.Errorf("read prompt file %q: %w", promptFile, err)
+		data, readErr := os.ReadFile(promptFile)
+		if readErr != nil {
+			return "", "", fmt.Errorf("read prompt file %q: %w", promptFile, readErr)
 		}
-		return strings.TrimSuffix(string(data), "\n"), nil
+		return strings.TrimSuffix(string(data), "\n"), "cli-positional", nil
 	}
 
 	if promptText == "-" {
-		data, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return "", fmt.Errorf("read prompt from stdin: %w", err)
+		data, readErr := io.ReadAll(os.Stdin)
+		if readErr != nil {
+			return "", "", fmt.Errorf("read prompt from stdin: %w", readErr)
 		}
-		return strings.TrimSuffix(string(data), "\n"), nil
+		return strings.TrimSuffix(string(data), "\n"), "cli-stdin", nil
 	}
 
-	return promptText, nil
+	if promptText != "" {
+		return promptText, "cli-positional", nil
+	}
+
+	return "", "", nil
 }

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -134,6 +134,11 @@ func init() {
 	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
+	// --prompt-source is an internal flag used by the host-API /spawn handler
+	// to override the auto-detected prompt source (C.4.SRC, issue #1148).
+	// It is hidden from --help because end users should never pass it directly.
+	spawnCmd.Flags().String("prompt-source", "", "")
+	_ = spawnCmd.Flags().MarkHidden("prompt-source")
 	rootCmd.AddCommand(spawnCmd)
 }
 
@@ -205,9 +210,15 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unknown harness %q: valid harnesses: %s", harnessFlag, strings.Join(harness.Names(), ", "))
 	}
 
-	promptFlag, err := resolvePrompt(cmd)
+	promptText, promptSource, err := resolvePromptWithSource(cmd)
 	if err != nil {
 		return err
+	}
+	// --prompt-source is a hidden internal flag set by the host-API /spawn
+	// handler so that proxy-spawned sessions carry "proxy-spawn" instead of
+	// the auto-detected "cli-positional" (C.4.SRC, issue #1148).
+	if overrideSource, _ := cmd.Flags().GetString("prompt-source"); overrideSource != "" {
+		promptSource = overrideSource
 	}
 
 	attachFlag, _ := cmd.Flags().GetBool("attach")
@@ -461,7 +472,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		Repo:             deriveRepo(worktreePath),
 		Worktree:         worktreePath,
 		AgentRole:        agentRole,
-		Prompt:           promptFlag,
+		Prompt:           promptText,
+		PromptSource:     promptSource,
 		ConfigContent:    configContent,
 		Layout:           session.LayoutFull,
 		IsolationMode:    string(isolationMode),
@@ -536,7 +548,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		branchFlag:         branchFlag,
 		skillsManifestHash: skillsManifestHash,
 		agentPromptHash:    agentPromptHash,
-		promptFlag:         promptFlag,
+		promptText:         promptText,
+		promptSource:       promptSource,
 	})
 
 	if headless {
@@ -584,7 +597,8 @@ type spawnInputsArgs struct {
 	branchFlag         string
 	skillsManifestHash string
 	agentPromptHash    string
-	promptFlag         string
+	promptText         string
+	promptSource       string
 }
 
 // writeSpawnInputs looks up the instance_id for sessionName and inserts a row
@@ -599,7 +613,7 @@ func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
 	si := db.SpawnInputs{
 		InstanceID:   *st.InstanceID,
 		CreatedAt:    time.Now().UnixMilli(),
-		PromptSource: spawnStrPtr("cli-positional"),
+		PromptSource: spawnStrPtr(args.promptSource),
 	}
 
 	if args.profileName != "" {
@@ -640,8 +654,8 @@ func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
 	if args.agentPromptHash != "" {
 		si.AgentPromptHash = &args.agentPromptHash
 	}
-	if args.promptFlag != "" {
-		si.PromptText = &args.promptFlag
+	if args.promptText != "" {
+		si.PromptText = &args.promptText
 	}
 
 	if err := d.InsertSpawnInputs(si); err != nil {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -611,9 +611,11 @@ func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
 	}
 
 	si := db.SpawnInputs{
-		InstanceID:   *st.InstanceID,
-		CreatedAt:    time.Now().UnixMilli(),
-		PromptSource: spawnStrPtr(args.promptSource),
+		InstanceID: *st.InstanceID,
+		CreatedAt:  time.Now().UnixMilli(),
+	}
+	if args.promptSource != "" {
+		si.PromptSource = spawnStrPtr(args.promptSource)
 	}
 
 	if args.profileName != "" {

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1384,7 +1384,6 @@ func migrateV23toV24(conn *sql.DB, version *int) error {
 			}
 		}
 	}
-
 	// Add spawn_outcome table and indexes (idempotent: IF NOT EXISTS).
 	spawnOutcomeSteps := []string{
 		`CREATE TABLE IF NOT EXISTS spawn_outcome (

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -88,14 +88,19 @@ var linkedIssueRe = regexp.MustCompile(`(?i)(?:closes|fixes|refs|references)\s+#
 // via -ldflags '-X github.com/prismatic-koi/prism/internal/review.reviewGoSHA=<sha>'
 // during the Nix build. It is the SHA suffix in spawn_inputs.prompt_template_hash
 // for review fan-out sessions (C.4.PT, issue #1148). An empty value means the
-// binary was not built with the ldflag (e.g. in development); the hash is then
-// recorded as "review-fanout:" with an empty suffix.
+// binary was not built with the ldflag (e.g. in development); prompt_template_hash
+// is then recorded as NULL (consistent with free-form CLI spawns).
 var reviewGoSHA string
 
 // ReviewPromptTemplateHash returns the prompt_template_hash value for review
 // fan-out spawns: "review-fanout:<sha>" where <sha> is the build-time SHA of
-// this file. Used by run.go's spawn loops (C.4.PT, issue #1148).
+// this file. Returns "" when the binary was not built with the ldflag (dev
+// builds), causing the caller to write NULL to the DB.
+// Used by run.go's spawn loops (C.4.PT, issue #1148).
 func ReviewPromptTemplateHash() string {
+	if reviewGoSHA == "" {
+		return ""
+	}
 	return "review-fanout:" + reviewGoSHA
 }
 

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -84,6 +84,21 @@ import (
 // (case-insensitive) in PR body text. Capture group 1 is the issue number.
 var linkedIssueRe = regexp.MustCompile(`(?i)(?:closes|fixes|refs|references)\s+#(\d+)`)
 
+// reviewGoSHA is the build-time SHA of internal/review/review.go, embedded
+// via -ldflags '-X github.com/prismatic-koi/prism/internal/review.reviewGoSHA=<sha>'
+// during the Nix build. It is the SHA suffix in spawn_inputs.prompt_template_hash
+// for review fan-out sessions (C.4.PT, issue #1148). An empty value means the
+// binary was not built with the ldflag (e.g. in development); the hash is then
+// recorded as "review-fanout:" with an empty suffix.
+var reviewGoSHA string
+
+// ReviewPromptTemplateHash returns the prompt_template_hash value for review
+// fan-out spawns: "review-fanout:<sha>" where <sha> is the build-time SHA of
+// this file. Used by run.go's spawn loops (C.4.PT, issue #1148).
+func ReviewPromptTemplateHash() string {
+	return "review-fanout:" + reviewGoSHA
+}
+
 // DiffMaxBytes is the maximum diff size (in bytes) before truncation.
 // Configurable for testing; production code uses this default.
 const DiffMaxBytes = 200 * 1024 // 200 KB

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
@@ -174,19 +175,22 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// WorktreeReadOnly=true ensures review containers cannot modify the
 		// branch under review (satisfies the [security] acceptance criterion).
 		spawnOpts := session.SpawnOpts{
-			SessionName:      agentSession,
-			Repo:             repo,
-			Worktree:         worktree,
-			AgentRole:        ag.Name,
-			Prompt:           prompt,
-			ConfigContent:    agentConfigContent,
-			Layout:           session.LayoutAgentOnly,
-			IsolationMode:    opts.IsolationMode,
-			PluginHostPath:   opts.PluginHostPath,
-			WorktreeReadOnly: true,
-			GroupID:          groupID,
-			RuntimeEnvVars:   opts.RuntimeEnvVars,
-			HarnessName:      opts.Harness,
+			InstanceID:         uuid.New().String(),
+			SessionName:        agentSession,
+			Repo:               repo,
+			Worktree:           worktree,
+			AgentRole:          ag.Name,
+			Prompt:             prompt,
+			PromptSource:       "review-fanout",
+			PromptTemplateHash: ReviewPromptTemplateHash(),
+			ConfigContent:      agentConfigContent,
+			Layout:             session.LayoutAgentOnly,
+			IsolationMode:      opts.IsolationMode,
+			PluginHostPath:     opts.PluginHostPath,
+			WorktreeReadOnly:   true,
+			GroupID:            groupID,
+			RuntimeEnvVars:     opts.RuntimeEnvVars,
+			HarnessName:        opts.Harness,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -411,19 +415,22 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		}
 
 		spawnOpts := session.SpawnOpts{
-			SessionName:      agentSession,
-			Repo:             repo,
-			Worktree:         worktree,
-			AgentRole:        ag.Name,
-			Prompt:           prompt,
-			ConfigContent:    agentConfigContent,
-			Layout:           session.LayoutAgentOnly,
-			IsolationMode:    opts.IsolationMode,
-			PluginHostPath:   opts.PluginHostPath,
-			WorktreeReadOnly: true,
-			GroupID:          groupID,
-			RuntimeEnvVars:   opts.RuntimeEnvVars,
-			HarnessName:      opts.Harness,
+			InstanceID:         uuid.New().String(),
+			SessionName:        agentSession,
+			Repo:               repo,
+			Worktree:           worktree,
+			AgentRole:          ag.Name,
+			Prompt:             prompt,
+			PromptSource:       "review-fanout",
+			PromptTemplateHash: ReviewPromptTemplateHash(),
+			ConfigContent:      agentConfigContent,
+			Layout:             session.LayoutAgentOnly,
+			IsolationMode:      opts.IsolationMode,
+			PluginHostPath:     opts.PluginHostPath,
+			WorktreeReadOnly:   true,
+			GroupID:            groupID,
+			RuntimeEnvVars:     opts.RuntimeEnvVars,
+			HarnessName:        opts.Harness,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -463,10 +463,18 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 
 	// Write spawn_inputs row (C.4.SRC / C.4.PT, issue #1148). Non-fatal:
 	// spawn_inputs is best-effort telemetry; a failure here must never block
-	// session creation. The write requires a non-empty instance_id — skip
-	// silently for LayoutAgentOnly sessions that do not generate one here
-	// (the sidecar generates one downstream for those sessions).
-	if opts.InstanceID != "" {
+	// session creation. The write requires a non-empty instance_id.
+	//
+	// LayoutFull (CLI) spawns: the richer writeSpawnInputs call in cmd/spawn.go
+	// carries all flag-value columns (profile, model, variant, agent, harness,
+	// branch, skills hash, etc.) and will write the row after SpawnSession
+	// returns. Avoid writing here so INSERT OR IGNORE does not silently drop
+	// that richer payload.
+	//
+	// LayoutAgentOnly (review fan-out) spawns: the caller pre-populates
+	// InstanceID; there is no subsequent writeSpawnInputs call, so SpawnSession
+	// owns the only write.
+	if opts.InstanceID != "" && opts.Layout != LayoutFull {
 		// Pre-seed the sessions row so the FK constraint on spawn_inputs is
 		// satisfied. InsertSession uses INSERT OR IGNORE so the call in the
 		// tmux-session-start hook is a safe no-op when the row already exists.

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -61,6 +61,20 @@ type SpawnOpts struct {
 	// (container/bwrap mode).
 	Prompt string
 
+	// PromptSource is the C.4.SRC discriminator written to
+	// spawn_inputs.prompt_source. Values: "cli-positional", "cli-stdin",
+	// "proxy-spawn", "review-fanout", or "" (NULL) when not applicable.
+	// Set by cmd/spawn.go for CLI spawns; set directly by review fan-out.
+	PromptSource string
+
+	// PromptTemplateHash is the C.4.PT identifier written to
+	// spawn_inputs.prompt_template_hash. For review fan-out this is
+	// "review-fanout:<sha>" where <sha> is the build-time SHA of
+	// internal/review/review.go (embedded via -ldflags). For all other
+	// spawn paths this is "" (NULL), because the prompt is a free-form
+	// user-supplied string with no fixed template.
+	PromptTemplateHash string
+
 	// PromptFilePath is set internally by SpawnSession when it has written
 	// the prompt to the per-session run directory (#1064 / #1092). Callers
 	// should leave this empty; SpawnSession populates it from opts.Prompt
@@ -444,6 +458,56 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 				"warning: could not set instance_id for %q: %v\n",
 				opts.SessionName, err)
 			opts.InstanceID = ""
+		}
+	}
+
+	// Write spawn_inputs row (C.4.SRC / C.4.PT, issue #1148). Non-fatal:
+	// spawn_inputs is best-effort telemetry; a failure here must never block
+	// session creation. The write requires a non-empty instance_id — skip
+	// silently for LayoutAgentOnly sessions that do not generate one here
+	// (the sidecar generates one downstream for those sessions).
+	if opts.InstanceID != "" {
+		// Pre-seed the sessions row so the FK constraint on spawn_inputs is
+		// satisfied. InsertSession uses INSERT OR IGNORE so the call in the
+		// tmux-session-start hook is a safe no-op when the row already exists.
+		var agentRolePtr *string
+		if opts.AgentRole != "" {
+			agentRolePtr = &opts.AgentRole
+		}
+		var groupIDPtr *string
+		if opts.GroupID != "" {
+			groupIDPtr = &opts.GroupID
+		}
+		if insertErr := d.InsertSession(db.Session{
+			InstanceID:  opts.InstanceID,
+			SessionName: opts.SessionName,
+			AgentRole:   agentRolePtr,
+			Repo:        opts.Repo,
+			Worktree:    opts.Worktree,
+			GroupID:     groupIDPtr,
+		}); insertErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not pre-seed sessions row for %q: %v\n",
+				opts.SessionName, insertErr)
+		}
+
+		si := db.SpawnInputs{
+			InstanceID: opts.InstanceID,
+			CreatedAt:  time.Now().UnixMilli(),
+		}
+		if opts.Prompt != "" {
+			si.PromptText = &opts.Prompt
+		}
+		if opts.PromptSource != "" {
+			si.PromptSource = &opts.PromptSource
+		}
+		if opts.PromptTemplateHash != "" {
+			si.PromptTemplateHash = &opts.PromptTemplateHash
+		}
+		if insertErr := d.InsertSpawnInputs(si); insertErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not write spawn_inputs for %q: %v\n",
+				opts.SessionName, insertErr)
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -701,6 +701,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		args := []string{"spawn", "--branch", req.Branch}
 		if req.Prompt != "" {
 			args = append(args, "--prompt", req.Prompt)
+			// Pass --prompt-source proxy-spawn so the host-side spawn records
+			// the correct C.4.SRC discriminator (C.4.SRC, issue #1148).
+			args = append(args, "--prompt-source", "proxy-spawn")
 		}
 		if req.Agent != "" {
 			args = append(args, "--agent", req.Agent)

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -699,11 +699,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		args := []string{"spawn", "--branch", req.Branch}
+		// Pass --prompt-source proxy-spawn unconditionally so the host-side spawn
+		// records the correct C.4.SRC discriminator regardless of whether a prompt
+		// is included (C.4.SRC, issue #1148).
+		args = append(args, "--prompt-source", "proxy-spawn")
 		if req.Prompt != "" {
 			args = append(args, "--prompt", req.Prompt)
-			// Pass --prompt-source proxy-spawn so the host-side spawn records
-			// the correct C.4.SRC discriminator (C.4.SRC, issue #1148).
-			args = append(args, "--prompt-source", "proxy-spawn")
 		}
 		if req.Agent != "" {
 			args = append(args, "--agent", req.Agent)

--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -13,11 +13,23 @@ buildGoModule {
 
   vendorHash = "sha256-tU+rnXKz3ALl7pJx7GYTo1hdr3CFMQS4Ih3UYLr4v54=";
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/prismatic-koi/prism/internal/tmux.TmuxBin=${tmux}/bin/tmux"
-  ];
+  # reviewGoSHA is the SHA-256 of internal/review/review.go, computed at
+  # build time via builtins.hashFile so it is content-addressed and changes
+  # whenever the file changes (C.4.PT, issue #1148). The first 12 characters
+  # mirror the git short-SHA convention: short enough to be human-readable,
+  # long enough to be unambiguous in practice.
+  ldflags =
+    let
+      reviewGoHash = builtins.hashFile "sha256" ../modules/programs/prism/prism/internal/review/review.go;
+    in
+    [
+      "-s"
+      "-w"
+      "-X github.com/prismatic-koi/prism/internal/tmux.TmuxBin=${tmux}/bin/tmux"
+      "-X github.com/prismatic-koi/prism/internal/review.reviewGoSHA=${
+        builtins.substring 0 12 reviewGoHash
+      }"
+    ];
 
   # tmux is NOT in nativeCheckInputs.
   #


### PR DESCRIPTION
## Summary

Implements issue #1148 (C4.PT + C4.SRC): captures prompt source and prompt template hash in the \`spawn_inputs\` table for all spawn paths.

### Context

The \`spawn_inputs\` table schema (v24→v25 migration), \`SpawnInputs\` struct, and \`InsertSpawnInputs\` method were already added to \`internal/db/db.go\` by PR #1246. This PR wires \`PromptSource\` and \`PromptTemplateHash\` into all spawn paths.

### Changes

**Prompt source capture (C.4.SRC):**
- \`resolvePromptWithSource\` returns \`(text, source, err)\` — source is \`"cli-positional"\` for \`--prompt\`/\`--prompt-file\`, \`"cli-stdin"\` for \`--prompt -\`, \`""\` (NULL) when no prompt given
- Hidden \`--prompt-source\` flag on \`prism spawn\` allows the sidecar proxy to override
- Sidecar \`/spawn\` handler unconditionally passes \`--prompt-source proxy-spawn\` when forwarding spawns
- Review fan-out sets \`PromptSource = "review-fanout"\` on both \`SpawnOpts\` sites in \`run.go\`

**Prompt template hash (C.4.PT):**
- \`reviewGoSHA\` package variable in \`review.go\` populated at build time via \`-ldflags\`
- \`ReviewPromptTemplateHash()\` returns \`"review-fanout:<sha>"\` for use in fan-out spawns; returns \`""\` (NULL) in dev builds where the ldflag is absent
- Free-form CLI spawns leave \`PromptTemplateHash\` empty (NULL in DB — Option B per design doc)
- \`pkgs/prism.nix\` computes the SHA via \`builtins.hashFile "sha256" review.go\` and embeds via ldflag (first 12 hex chars)

**Spawn_inputs write strategy:**
- \`SpawnSession\` writes \`spawn_inputs\` only for \`LayoutAgentOnly\` (review fan-out) spawns — these paths pre-populate \`InstanceID: uuid.New().String()\` on \`SpawnOpts\` and have no downstream \`writeSpawnInputs\` call
- \`LayoutFull\` (CLI) spawns use \`writeSpawnInputs\` in \`cmd/spawn.go\` exclusively — this carries the full flag-value payload (profile, model, variant, agent, harness, skills hash, agent prompt hash, etc.) in a single \`InsertSpawnInputs\` call

**Wiring:**
- \`SpawnOpts\` gets \`PromptSource\` and \`PromptTemplateHash\` fields
- Pre-seeding sessions row via \`InsertSession\` (INSERT OR IGNORE) before \`InsertSpawnInputs\` satisfies the FK constraint

Closes #1148