### PR TITLE
feat: improve doom-loop similarity key for subcommand-driven CLIs

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.test.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.test.ts
@@ -63,6 +63,93 @@ describe("similarityKey — bash similarity", () => {
     const key = similarityKey("bash", { command: "go test ./..." });
     expect(key).toMatch(/^bash:/);
   });
+
+  // ── Subcommand-driven CLI tests ──────────────────────────────────────────
+
+  test("gh issue view with different issue numbers produces different keys", () => {
+    const keys = [1, 2, 3, 4, 5].map((n) =>
+      similarityKey("bash", { command: `gh issue view ${n}` })
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(5);
+  });
+
+  test("gh pr view with different PR numbers produces different keys", () => {
+    const keys = [10, 11, 12, 13, 14].map((n) =>
+      similarityKey("bash", { command: `gh pr view ${n}` })
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(5);
+  });
+
+  test("git show with different ref:path values produces different keys", () => {
+    const paths = ["foo.go", "bar.go", "baz.go", "qux.go", "quux.go"];
+    const keys = paths.map((p) =>
+      similarityKey("bash", { command: `git show abc123:${p}` })
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(5);
+  });
+
+  test("kubectl get pod with different pod names produces different keys", () => {
+    const pods = ["pod-a", "pod-b", "pod-c", "pod-d", "pod-e"];
+    const keys = pods.map((p) =>
+      similarityKey("bash", { command: `kubectl get pod ${p}` })
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(5);
+  });
+
+  test("five identical gh issue view 1131 calls produce the same key (loop case)", () => {
+    const keys = Array(5).fill(null).map(() =>
+      similarityKey("bash", { command: "gh issue view 1131" })
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(1);
+  });
+
+  test("five identical git show abc123:foo.go calls produce the same key (loop case)", () => {
+    const keys = Array(5).fill(null).map(() =>
+      similarityKey("bash", { command: "git show abc123:foo.go" })
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(1);
+  });
+
+  test("gh alone (no subcommand) falls back gracefully — no error", () => {
+    expect(() => similarityKey("bash", { command: "gh" })).not.toThrow();
+    const key = similarityKey("bash", { command: "gh" });
+    expect(key).toMatch(/^bash:/);
+  });
+
+  test("git alone falls back gracefully — no error", () => {
+    expect(() => similarityKey("bash", { command: "git" })).not.toThrow();
+    const key = similarityKey("bash", { command: "git" });
+    expect(key).toMatch(/^bash:/);
+  });
+
+  test("gh auth (one positional) falls back gracefully — no error", () => {
+    expect(() => similarityKey("bash", { command: "gh auth login" })).not.toThrow();
+    const key = similarityKey("bash", { command: "gh auth login" });
+    expect(key).toMatch(/^bash:gh auth/);
+  });
+
+  test("git status (one positional, no operand) falls back gracefully", () => {
+    const key = similarityKey("bash", { command: "git status" });
+    expect(key).toMatch(/^bash:git status/);
+  });
+
+  test("subcommand CLI key is human-readable (not a hash)", () => {
+    const key = similarityKey("bash", { command: "gh issue view 1255" });
+    expect(key).toBe("bash:gh issue view 1255");
+  });
+
+  test("grep (non-subcommand CLI) behaves as before — same first positional collapses", () => {
+    const a = similarityKey("bash", { command: "grep -r foo ." });
+    const b = similarityKey("bash", { command: "grep -r foo src/" });
+    // Both have same base "grep" and first positional "foo"
+    expect(a).toBe(b);
+  });
 });
 
 describe("similarityKey — edit similarity", () => {

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -10,7 +10,11 @@ import type { Plugin } from "@opencode-ai/plugin";
 // into the next LLM turn via experimental.chat.messages.transform.
 //
 // Similarity rules (per tool):
-//   bash      — compare command + first positional argument only (strips flags).
+//   bash      — for subcommand-driven CLIs (gh, git, kubectl, helm, docker,
+//               podman), include the base command + subcommand + operand in the
+//               key so that "gh issue view 1" and "gh issue view 2" are treated
+//               as different calls. For all other commands, compare the base
+//               command + first positional argument only (strips flags).
 //               "git log -1" and "git log -3" match; "go test ./cmd/..." and
 //               "go build ./..." do not.
 //   edit/write — same file path (first argument), ignoring content.
@@ -60,6 +64,36 @@ export function similarityKey(tool: string, args: any): string | null {
         baseIdx++;
       }
       const base = meaningful[baseIdx] ?? "";
+
+      // Subcommand-driven CLIs: include subcommand + operand in the key so
+      // that calls with different operands are treated as distinct.
+      // e.g. "gh issue view 1" → "bash:gh issue view 1"
+      //      "git show abc:foo.go" → "bash:git show abc:foo.go"
+      const SUBCOMMAND_CLIS = new Set([
+        "gh",
+        "git",
+        "kubectl",
+        "helm",
+        "docker",
+        "podman",
+      ]);
+
+      if (SUBCOMMAND_CLIS.has(base)) {
+        // Collect all non-flag tokens after the base command.
+        const positionals: string[] = [];
+        for (let i = baseIdx + 1; i < meaningful.length; i++) {
+          if (!meaningful[i].startsWith("-")) {
+            positionals.push(meaningful[i]);
+          }
+        }
+        // Include base + up to three positionals (subcommand + sub-subcommand + operand).
+        // e.g. "gh issue view 1" → positionals=["issue","view","1"] → "bash:gh issue view 1"
+        //      "git show abc:foo.go" → positionals=["show","abc:foo.go"] → "bash:git show abc:foo.go"
+        // If fewer positionals exist, fall back gracefully.
+        const parts = [base, ...positionals.slice(0, 3)];
+        return `bash:${parts.join(" ")}`.trimEnd();
+      }
+
       // Find the first positional argument after the base command (skip flags).
       let firstPos = "";
       for (let i = baseIdx + 1; i < meaningful.length; i++) {


### PR DESCRIPTION
## Summary

- Extends `similarityKey` in `prism-hooks.ts` to include up to three positionals (subcommand + sub-subcommand + operand) for `gh`, `git`, `kubectl`, `helm`, `docker`, and `podman`
- Prevents false-positive doom-loop fires when an agent legitimately calls `gh issue view <N>` or `git show <ref>:<path>` with different operands each time
- Genuine loops (five identical calls) still fire correctly
- All 46 unit tests pass; nix build passes

Closes #1255