### PR TITLE
prism event: proxy writes to host DB via PRISM_HOST_API sidecar

### DIFF
--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -14,6 +14,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,8 +26,38 @@ import (
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
+
+// proxyEventToHostAPI sends a prism event write to the host sidecar when
+// PRISM_HOST_API is set. kind is the subcommand name (e.g. "doom-loop-detected").
+// session is the session name from --session. args holds the remaining
+// subcommand-specific flags (key → value, omitting the --session pair which is
+// sent in the top-level "session" field).
+//
+// On success (or if PRISM_HOST_API is unset) returns ("", false), which tells
+// the caller to proceed with the direct DB path. When PRISM_HOST_API is set,
+// this always returns a non-nil error or (nil, true) — it never falls back to
+// the local DB (which would re-introduce the shadow-DB bug, AC edge-case).
+func proxyEventToHostAPI(kind, session string, args map[string]string) (bool, error) {
+	apiURL := sandboxenv.HostAPISocket()
+	if apiURL == "" {
+		return false, nil // not in a container — caller proceeds with direct DB path
+	}
+
+	log.Printf("prism event %s: PRISM_HOST_API set — proxying to host sidecar (session=%s)", kind, session)
+
+	body := map[string]any{
+		"kind":    kind,
+		"session": session,
+		"args":    args,
+	}
+	if err := proxyToHostAPI(apiURL, "/event", body, nil); err != nil {
+		return true, fmt.Errorf("prism event %s: host-API proxy: %w", kind, err)
+	}
+	return true, nil
+}
 
 // touchDashboardSentinel creates or updates the modification time of the
 // dashboard sentinel file, which causes the dashboard's watcher goroutine to
@@ -98,6 +129,13 @@ var eventStateChangeCmd = &cobra.Command{
 		session, _ := cmd.Flags().GetString("session")
 		state, _ := cmd.Flags().GetString("state")
 		worktree, _ := cmd.Flags().GetString("worktree")
+
+		if proxied, err := proxyEventToHostAPI("state-change", session, map[string]string{
+			"state":    state,
+			"worktree": worktree,
+		}); proxied {
+			return err
+		}
 
 		// Skip the meta-sessions (scratchpad and prism-dashboard) that must
 		// not appear in agent_status. All other sessions — including
@@ -172,6 +210,13 @@ var eventPaneDiedCmd = &cobra.Command{
 			return nil
 		}
 
+		if proxied, err := proxyEventToHostAPI("pane-died", session, map[string]string{
+			"window":    window,
+			"exit-code": fmt.Sprintf("%d", exitCode),
+		}); proxied {
+			return err
+		}
+
 		d, err := openDB()
 		if err != nil {
 			return fmt.Errorf("event pane-died: %w", err)
@@ -239,6 +284,13 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 		session, _ := cmd.Flags().GetString("session")
 		worktree, _ := cmd.Flags().GetString("worktree")
 		agentRole, _ := cmd.Flags().GetString("agent-role")
+
+		if proxied, err := proxyEventToHostAPI("tmux-session-start", session, map[string]string{
+			"worktree":   worktree,
+			"agent-role": agentRole,
+		}); proxied {
+			return err
+		}
 
 		repo := deriveRepo(worktree)
 		if repo == "" {
@@ -384,6 +436,10 @@ var eventTmuxSessionEndCmd = &cobra.Command{
 			return nil
 		}
 
+		if proxied, err := proxyEventToHostAPI("tmux-session-end", session, map[string]string{}); proxied {
+			return err
+		}
+
 		d, err := openDB()
 		if err != nil {
 			return fmt.Errorf("event tmux-session-end: %w", err)
@@ -465,6 +521,10 @@ var eventCompactionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		session, _ := cmd.Flags().GetString("session")
 
+		if proxied, err := proxyEventToHostAPI("compaction", session, map[string]string{}); proxied {
+			return err
+		}
+
 		d, err := openDB()
 		if err != nil {
 			return fmt.Errorf("event compaction: %w", err)
@@ -516,6 +576,12 @@ var eventErrorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		session, _ := cmd.Flags().GetString("session")
 		message, _ := cmd.Flags().GetString("message")
+
+		if proxied, err := proxyEventToHostAPI("error", session, map[string]string{
+			"message": message,
+		}); proxied {
+			return err
+		}
 
 		d, err := openDB()
 		if err != nil {
@@ -577,6 +643,14 @@ the plugin; this command only writes the event.`,
 		tool, _ := cmd.Flags().GetString("tool")
 		pattern, _ := cmd.Flags().GetString("pattern")
 		count, _ := cmd.Flags().GetInt("count")
+
+		if proxied, err := proxyEventToHostAPI("doom-loop-detected", session, map[string]string{
+			"tool":    tool,
+			"pattern": pattern,
+			"count":   fmt.Sprintf("%d", count),
+		}); proxied {
+			return err
+		}
 
 		d, err := openDB()
 		if err != nil {

--- a/modules/programs/prism/prism/cmd/event_doomloop_test.go
+++ b/modules/programs/prism/prism/cmd/event_doomloop_test.go
@@ -16,6 +16,9 @@ import (
 // `prism event doom-loop-detected` writes a doom_loop_detected event to the DB
 // with the correct payload fields.
 func TestEventDoomLoopDetected_WritesEvent(t *testing.T) {
+	// Unset PRISM_HOST_API so the direct DB path is exercised (#1254 — proxy
+	// tests are in event_proxy_test.go).
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "testrepo@main"
 
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
@@ -83,6 +86,7 @@ func TestEventDoomLoopDetected_WritesEvent(t *testing.T) {
 // event even when the session does not have an agent_status row (repo/worktree
 // default to empty strings in that case).
 func TestEventDoomLoopDetected_UnknownSession(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {
@@ -125,6 +129,7 @@ func TestEventDoomLoopDetected_UnknownSession(t *testing.T) {
 // TestEventDoomLoopDetected_DefaultCount verifies that the default count is 5
 // when not specified.
 func TestEventDoomLoopDetected_DefaultCount(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "testrepo@main"
 
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
@@ -177,6 +182,7 @@ func TestEventDoomLoopDetected_DefaultCount(t *testing.T) {
 // TestEventDoomLoopDetected_PayloadContainsFields verifies the raw JSON payload
 // contains the expected field names.
 func TestEventDoomLoopDetected_PayloadContainsFields(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "testrepo@main"
 
 	dbFile := filepath.Join(t.TempDir(), "prism.db")

--- a/modules/programs/prism/prism/cmd/event_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/event_proxy_test.go
@@ -1,0 +1,321 @@
+package cmd
+
+// Tests for the PRISM_HOST_API proxy paths in cmd/event.go added in #1254 to
+// fix the container shadow-DB issue.
+//
+// These tests stand up a real HTTP server bound to a Unix socket on disk
+// and point PRISM_HOST_API at it, then exercise each event subcommand and
+// assert that the request reached the host (mirror of the sidecar /event
+// handler) rather than touching the local DB.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeEventAPIServer is a minimal mirror of the sidecar's /event route.
+// It records requests and can be configured to return errors.
+type fakeEventAPIServer struct {
+	requests []recordedRequest
+
+	// failStatus, when non-zero, causes /event to return that HTTP status with
+	// {"error": failError}.
+	failStatus int
+	failError  string
+}
+
+func (s *fakeEventAPIServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/event", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.requests = append(s.requests, recordedRequest{Path: "/event", Body: string(body)})
+		if s.failStatus != 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(s.failStatus)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": s.failError})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{})
+	})
+	return mux
+}
+
+// startFakeEventAPIServer starts the fake /event server bound to a Unix socket
+// and returns the server and the apiURL string for PRISM_HOST_API.
+//
+// Uses the same short-path trick as startFakeHostAPIServer to stay within
+// sockaddr_un.sun_path limits on Darwin (104 bytes).
+func startFakeEventAPIServer(t *testing.T) (*fakeEventAPIServer, string) {
+	t.Helper()
+	sockDir, err := os.MkdirTemp("/tmp", "pe")
+	if err != nil {
+		t.Fatalf("mkdir short sock dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "host.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sockPath, err)
+	}
+	s := &fakeEventAPIServer{}
+	srv := &http.Server{Handler: s.handler()}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return s, "unix://" + sockPath
+}
+
+// setEventFlags sets the given flag values on cmd and returns a cleanup func
+// that resets them to their zero values.
+func setDoomLoopFlags(t *testing.T, session, tool, pattern, count string) {
+	t.Helper()
+	_ = eventDoomLoopDetectedCmd.Flags().Set("session", session)
+	_ = eventDoomLoopDetectedCmd.Flags().Set("tool", tool)
+	_ = eventDoomLoopDetectedCmd.Flags().Set("pattern", pattern)
+	_ = eventDoomLoopDetectedCmd.Flags().Set("count", count)
+	t.Cleanup(func() {
+		_ = eventDoomLoopDetectedCmd.Flags().Set("session", "")
+		_ = eventDoomLoopDetectedCmd.Flags().Set("tool", "")
+		_ = eventDoomLoopDetectedCmd.Flags().Set("pattern", "")
+		_ = eventDoomLoopDetectedCmd.Flags().Set("count", "5")
+	})
+}
+
+// ── doom-loop-detected proxy tests ───────────────────────────────────────────
+
+// TestEventDoomLoopDetected_ProxiesToHostAPIWhenSet is the headline test:
+// when PRISM_HOST_API is set, the doom-loop-detected subcommand sends its
+// payload to the sidecar socket rather than touching the local DB.
+func TestEventDoomLoopDetected_ProxiesToHostAPIWhenSet(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	setDoomLoopFlags(t, "myrepo@main", "bash", "gh issue view", "5")
+
+	if err := eventDoomLoopDetectedCmd.RunE(eventDoomLoopDetectedCmd, nil); err != nil {
+		t.Fatalf("doom-loop-detected RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	got := server.requests[0]
+	if got.Path != "/event" {
+		t.Errorf("first request path = %q, want /event", got.Path)
+	}
+	if !strings.Contains(got.Body, `"kind":"doom-loop-detected"`) {
+		t.Errorf("request body %q does not include kind=doom-loop-detected", got.Body)
+	}
+	if !strings.Contains(got.Body, `"session":"myrepo@main"`) {
+		t.Errorf("request body %q does not include session=myrepo@main", got.Body)
+	}
+	if !strings.Contains(got.Body, `"tool":"bash"`) {
+		t.Errorf("request body %q does not include tool=bash", got.Body)
+	}
+}
+
+// TestEventDoomLoopDetected_ProxyDoesNotTouchLocalDB confirms that when
+// PRISM_HOST_API is set, no event row is written to the local (sandbox/test) DB.
+func TestEventDoomLoopDetected_ProxyDoesNotTouchLocalDB(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	_, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	setDoomLoopFlags(t, "myrepo@main", "bash", "gh issue view", "5")
+
+	if err := eventDoomLoopDetectedCmd.RunE(eventDoomLoopDetectedCmd, nil); err != nil {
+		t.Fatalf("doom-loop-detected RunE: %v", err)
+	}
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB for verify: %v", err)
+	}
+	defer d.Close()
+	events, _ := d.QueryEvents("myrepo@main", 100, nil, nil, nil)
+	if len(events) > 0 {
+		t.Errorf("local DB has %d event(s) after proxy call — proxy must NOT touch the sandbox DB", len(events))
+	}
+}
+
+// TestEventDoomLoopDetected_ProxyUnreachableSocketReturnsClearError covers the
+// AC edge-case: when PRISM_HOST_API is set but the socket is unreachable, the
+// command must return a clear error and exit non-zero without falling back to
+// the local DB.
+func TestEventDoomLoopDetected_ProxyUnreachableSocketReturnsClearError(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Point at a non-existent socket path.
+	bogus := filepath.Join(t.TempDir(), "no-such.sock")
+	t.Setenv("PRISM_HOST_API", "unix://"+bogus)
+
+	setDoomLoopFlags(t, "myrepo@main", "bash", "gh issue view", "5")
+
+	err := eventDoomLoopDetectedCmd.RunE(eventDoomLoopDetectedCmd, nil)
+	if err == nil {
+		t.Fatal("want error for unreachable socket, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "host-API") && !strings.Contains(msg, "socket") {
+		t.Errorf("error %q does not mention 'host-API' or 'socket'", msg)
+	}
+
+	// DB must be untouched (no shadow write attempted).
+	d, openErr := openDB()
+	if openErr != nil {
+		t.Fatalf("openDB for verify: %v", openErr)
+	}
+	defer d.Close()
+	events, _ := d.QueryEvents("myrepo@main", 100, nil, nil, nil)
+	if len(events) > 0 {
+		t.Errorf("local DB has %d event(s) after unreachable-socket call — must not fall back to direct DB path", len(events))
+	}
+}
+
+// ── per-kind smoke tests ──────────────────────────────────────────────────────
+
+// TestEventProxy_CompactionProxies verifies the compaction subcommand proxies
+// when PRISM_HOST_API is set.
+func TestEventProxy_CompactionProxies(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	_ = eventCompactionCmd.Flags().Set("session", "myrepo@main")
+	t.Cleanup(func() { _ = eventCompactionCmd.Flags().Set("session", "") })
+
+	if err := eventCompactionCmd.RunE(eventCompactionCmd, nil); err != nil {
+		t.Fatalf("compaction RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if !strings.Contains(server.requests[0].Body, `"kind":"compaction"`) {
+		t.Errorf("body %q does not contain kind=compaction", server.requests[0].Body)
+	}
+}
+
+// TestEventProxy_ErrorSubcmdProxies verifies the error subcommand proxies.
+func TestEventProxy_ErrorSubcmdProxies(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	_ = eventErrorCmd.Flags().Set("session", "myrepo@main")
+	_ = eventErrorCmd.Flags().Set("message", "something went wrong")
+	t.Cleanup(func() {
+		_ = eventErrorCmd.Flags().Set("session", "")
+		_ = eventErrorCmd.Flags().Set("message", "")
+	})
+
+	if err := eventErrorCmd.RunE(eventErrorCmd, nil); err != nil {
+		t.Fatalf("error RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	body := server.requests[0].Body
+	if !strings.Contains(body, `"kind":"error"`) {
+		t.Errorf("body %q does not contain kind=error", body)
+	}
+	if !strings.Contains(body, "something went wrong") {
+		t.Errorf("body %q does not contain the error message", body)
+	}
+}
+
+// TestEventProxy_TmuxSessionEndProxies verifies tmux-session-end proxies after
+// the liveness check passes (session not in tmux).
+func TestEventProxy_TmuxSessionEndProxies(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	// Use a name that definitely does not exist in any local tmux server so
+	// HasSession returns false and the liveness guard passes.
+	const sess = "nonexistent-proxy-test@no-branch"
+	_ = eventTmuxSessionEndCmd.Flags().Set("session", sess)
+	t.Cleanup(func() { _ = eventTmuxSessionEndCmd.Flags().Set("session", "") })
+
+	if err := eventTmuxSessionEndCmd.RunE(eventTmuxSessionEndCmd, nil); err != nil {
+		t.Fatalf("tmux-session-end RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if !strings.Contains(server.requests[0].Body, `"kind":"tmux-session-end"`) {
+		t.Errorf("body %q does not contain kind=tmux-session-end", server.requests[0].Body)
+	}
+}
+
+// TestEventProxy_ServerReturns400ForUnknownKindSurfacesError verifies that
+// when the server returns a 400 (e.g. for an unknown kind), the CLI returns a
+// non-nil error containing the server's message. This covers the AC edge-case
+// where an unknown kind is rejected with a clear error message.
+func TestEventProxy_ServerReturns400ForUnknownKindSurfacesError(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	server.failStatus = http.StatusBadRequest
+	server.failError = `unknown event kind "badkind" — must be one of: compaction, doom-loop-detected, error, pane-died, state-change, tmux-session-end, tmux-session-start`
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	setDoomLoopFlags(t, "myrepo@main", "bash", "pat", "5")
+
+	err := eventDoomLoopDetectedCmd.RunE(eventDoomLoopDetectedCmd, nil)
+	if err == nil {
+		t.Fatal("want error when server returns 400, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown event kind") {
+		t.Errorf("error %q does not mention 'unknown event kind'", err.Error())
+	}
+}
+
+// ── host path unchanged ───────────────────────────────────────────────────────
+
+// TestEventProxy_NoProxyWhenHostAPIUnset verifies that when PRISM_HOST_API is
+// unset, the subcommand uses the direct DB path (host behaviour unchanged).
+func TestEventProxy_NoProxyWhenHostAPIUnset(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	// Seed the DB with a session row so the direct DB path succeeds.
+	dbFile := setupEventTestDB(t, "myrepo@main")
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	_ = eventCompactionCmd.Flags().Set("session", "myrepo@main")
+	t.Cleanup(func() { _ = eventCompactionCmd.Flags().Set("session", "") })
+
+	if err := eventCompactionCmd.RunE(eventCompactionCmd, nil); err != nil {
+		t.Fatalf("compaction RunE (direct DB path): %v", err)
+	}
+
+	// The event should be in the local DB (direct path fired).
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB for verify: %v", err)
+	}
+	defer d.Close()
+	events, _ := d.QueryEvents("myrepo@main", 10, nil, nil, []string{"compaction"})
+	if len(events) == 0 {
+		t.Error("no compaction event in local DB — direct DB path did not write the event")
+	}
+}

--- a/modules/programs/prism/prism/cmd/event_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/event_proxy_test.go
@@ -289,6 +289,83 @@ func TestEventProxy_ServerReturns400ForUnknownKindSurfacesError(t *testing.T) {
 	}
 }
 
+// TestEventProxy_StateChangeProxies verifies the state-change subcommand
+// proxies to the host API when PRISM_HOST_API is set.
+func TestEventProxy_StateChangeProxies(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	_ = eventStateChangeCmd.Flags().Set("session", "myrepo@main")
+	_ = eventStateChangeCmd.Flags().Set("state", "active")
+	_ = eventStateChangeCmd.Flags().Set("worktree", t.TempDir())
+	t.Cleanup(func() {
+		_ = eventStateChangeCmd.Flags().Set("session", "")
+		_ = eventStateChangeCmd.Flags().Set("state", "")
+		_ = eventStateChangeCmd.Flags().Set("worktree", "")
+	})
+
+	if err := eventStateChangeCmd.RunE(eventStateChangeCmd, nil); err != nil {
+		t.Fatalf("state-change RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if !strings.Contains(server.requests[0].Body, `"kind":"state-change"`) {
+		t.Errorf("body %q does not contain kind=state-change", server.requests[0].Body)
+	}
+}
+
+// TestEventProxy_PaneDiedProxies verifies the pane-died subcommand proxies to
+// the host API when PRISM_HOST_API is set.
+func TestEventProxy_PaneDiedProxies(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	_ = eventPaneDiedCmd.Flags().Set("session", "myrepo@main")
+	_ = eventPaneDiedCmd.Flags().Set("window", "agent")
+	t.Cleanup(func() {
+		_ = eventPaneDiedCmd.Flags().Set("session", "")
+		_ = eventPaneDiedCmd.Flags().Set("window", "")
+	})
+
+	if err := eventPaneDiedCmd.RunE(eventPaneDiedCmd, nil); err != nil {
+		t.Fatalf("pane-died RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if !strings.Contains(server.requests[0].Body, `"kind":"pane-died"`) {
+		t.Errorf("body %q does not contain kind=pane-died", server.requests[0].Body)
+	}
+}
+
+// TestEventProxy_TmuxSessionStartProxies verifies the tmux-session-start
+// subcommand proxies to the host API when PRISM_HOST_API is set.
+func TestEventProxy_TmuxSessionStartProxies(t *testing.T) {
+	server, apiURL := startFakeEventAPIServer(t)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	_ = eventTmuxSessionStartCmd.Flags().Set("session", "myrepo@main")
+	_ = eventTmuxSessionStartCmd.Flags().Set("worktree", t.TempDir())
+	t.Cleanup(func() {
+		_ = eventTmuxSessionStartCmd.Flags().Set("session", "")
+		_ = eventTmuxSessionStartCmd.Flags().Set("worktree", "")
+	})
+
+	if err := eventTmuxSessionStartCmd.RunE(eventTmuxSessionStartCmd, nil); err != nil {
+		t.Fatalf("tmux-session-start RunE: %v", err)
+	}
+
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — proxy did not fire")
+	}
+	if !strings.Contains(server.requests[0].Body, `"kind":"tmux-session-start"`) {
+		t.Errorf("body %q does not contain kind=tmux-session-start", server.requests[0].Body)
+	}
+}
+
 // ── host path unchanged ───────────────────────────────────────────────────────
 
 // TestEventProxy_NoProxyWhenHostAPIUnset verifies that when PRISM_HOST_API is

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -23,8 +23,12 @@ import (
 
 // setupEventTestDB seeds a temp DB with a single active session row and
 // returns the DB path. The DB is closed before returning so openDB can reopen it.
+// It also unsets PRISM_HOST_API so that direct-DB-path tests exercise the
+// local DB rather than attempting to proxy (#1254 — proxy tests live in
+// event_proxy_test.go).
 func setupEventTestDB(t *testing.T, session string) string {
 	t.Helper()
+	t.Setenv("PRISM_HOST_API", "")
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
 	if err != nil {
@@ -179,6 +183,7 @@ func TestEventTmuxSessionEnd_EmptySession(t *testing.T) {
 //
 // AC-7: new test for the non-worktree session path.
 func TestEventTmuxSessionStart_NonWorktreeSession(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	// Does not need a live tmux server — no tmux calls in this path.
 	const session = "obsidian"
 
@@ -236,6 +241,7 @@ func TestEventTmuxSessionStart_NonWorktreeSession(t *testing.T) {
 func TestEventTmuxSessionStart_SkipsMetaSessions(t *testing.T) {
 	for _, session := range []string{"scratchpad", "prism-dashboard"} {
 		t.Run(session, func(t *testing.T) {
+			t.Setenv("PRISM_HOST_API", "")
 			worktree := t.TempDir()
 			dbFile := filepath.Join(t.TempDir(), "prism.db")
 			d, err := db.Open(dbFile)
@@ -282,6 +288,7 @@ func TestEventTmuxSessionStart_SkipsMetaSessions(t *testing.T) {
 // for any session whose worktree had no .bare ancestor, leaving the dashboard
 // stuck showing the session as "idle".
 func TestEventStateChange_TracksNonWorktreeSession(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "obsidian"
 
 	// Worktree path with no .bare ancestor — deriveRepo returns "".
@@ -358,6 +365,7 @@ func TestEventStateChange_TracksNonWorktreeSession(t *testing.T) {
 func TestEventStateChange_SkipsMetaSessions(t *testing.T) {
 	for _, session := range []string{"scratchpad", "prism-dashboard"} {
 		t.Run(session, func(t *testing.T) {
+			t.Setenv("PRISM_HOST_API", "")
 			worktree := t.TempDir()
 
 			dbFile := filepath.Join(t.TempDir(), "prism.db")
@@ -413,6 +421,7 @@ func TestEventStateChange_SkipsMetaSessions(t *testing.T) {
 // Regression guard for issue #576 — relaxing the guard must not break the
 // existing worktree flow.
 func TestEventStateChange_WorktreeSession(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "myrepo@main"
 
 	// Build a fake bare repo layout: <tmp>/myrepo/{.bare, worktree}
@@ -495,6 +504,7 @@ func TestEventStateChange_WorktreeSession(t *testing.T) {
 // This is the primary user-visible bug from issue #576 — the row existed but
 // was never updated, so the dashboard showed "idle" forever.
 func TestEventStateChange_UpdatesExistingNonWorktreeRow(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "obsidian"
 	worktree := t.TempDir()
 
@@ -563,6 +573,7 @@ func TestEventStateChange_UpdatesExistingNonWorktreeRow(t *testing.T) {
 // to tmux-session-start, the resulting agent_status row has root_agent_name set
 // to the provided role value immediately (before the sidecar writes it).
 func TestEventTmuxSessionStart_AgentRole(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "myrepo@feature"
 	const agentRole = "worker"
 
@@ -617,6 +628,7 @@ func TestEventTmuxSessionStart_AgentRole(t *testing.T) {
 // from prior value or NULL on fresh insert). Existing callers that don't pass
 // --agent-role continue to behave as before.
 func TestEventTmuxSessionStart_NoAgentRole(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "myrepo@no-role-branch"
 
 	worktree := t.TempDir()
@@ -665,6 +677,7 @@ func TestEventTmuxSessionStart_NoAgentRole(t *testing.T) {
 // subsequent tmux-session-start without --agent-role preserves the existing
 // root_agent_name value (COALESCE in UpsertStatus leaves it unchanged).
 func TestEventTmuxSessionStart_AgentRole_PreservesExisting(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "myrepo@preserve-role-branch"
 
 	worktree := t.TempDir()
@@ -721,6 +734,7 @@ func TestEventTmuxSessionStart_AgentRole_PreservesExisting(t *testing.T) {
 //
 // AC-9: regression protection for PR #475 — ClearEnded must fire for obsidian.
 func TestEventTmuxSessionStart_NonWorktreeSession_ClearsEnded(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
 	const session = "obsidian"
 	worktree := t.TempDir()
 

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -153,6 +153,7 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 //	POST /merge         — enqueue a PR for the merge queue (coordinator only)
 //	GET  /merges        — list merge queue entries (coordinator only)
 //	POST /merges/cancel — cancel a watching merge queue entry (coordinator only)
+//	POST /event         — write a lifecycle event to the host DB (all roles)
 //
 // Role-based permissions are enforced based on s.cfg.AgentRole and
 // s.cfg.SessionName. Workers have restricted access; coordinators have broader
@@ -1231,7 +1232,140 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		})
 	})
 
+	// POST /event
+	// Request:  {"kind":"<kind>","session":"<session>","args":{...kind-specific...}}
+	// Response: {} | {"error":"..."}
+	//
+	// Writes a lifecycle event to the host DB by running `prism event <kind>`
+	// with the supplied args on the host. This is the proxy path for every
+	// `prism event <kind>` subcommand invoked from inside a container where
+	// dbPath() resolves to a per-container shadow DB invisible to the host (#1254).
+	//
+	// Allowed kinds: state-change, pane-died, tmux-session-start, tmux-session-end,
+	// compaction, error, doom-loop-detected.
+	//
+	// Validation:
+	//   - kind must be a known subcommand name (400 for unknown kinds).
+	//   - session must be non-empty and must match a known session in the DB
+	//     (400 for empty; 400 for unknown session).
+	//   - All role levels (worker and coordinator) are permitted — lifecycle
+	//     events are emitted by both.
+	//
+	// Security: accessible only over the Unix socket (consistent with all other
+	// host-API endpoints — no network exposure).
+	mux.HandleFunc("/event", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+
+		var req struct {
+			Kind    string            `json:"kind"`
+			Session string            `json:"session"`
+			Args    map[string]string `json:"args"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+
+		// Validate kind against the known allowlist.
+		if !isKnownEventKind(req.Kind) {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf(
+				"unknown event kind %q — must be one of: %s",
+				req.Kind, knownEventKindsStr()))
+			return
+		}
+
+		// Validate session: must be non-empty.
+		if strings.TrimSpace(req.Session) == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+
+		// Validate session: must match a known session in the host DB.
+		// This prevents silent writes with a NULL/empty session_name (AC edge-case).
+		status, dbErr := s.cfg.DB.CurrentStatus(req.Session)
+		if dbErr != nil {
+			log.Printf("sidecar: host-API /event: CurrentStatus %q: %v", req.Session, dbErr)
+			writeError(w, http.StatusInternalServerError, "db error: "+dbErr.Error())
+			return
+		}
+		if status == nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf(
+				"unknown session %q — event rejected (no agent_status row in host DB)", req.Session))
+			return
+		}
+
+		// Build the prism event <kind> [flags] invocation.
+		// Always include --session from the top-level field; remaining args
+		// come from the Args map as --key value pairs. Empty-value entries
+		// are skipped so that optional flags remain at their defaults on the
+		// host side (e.g. --agent-role "" behaves the same as omitting it).
+		args := []string{"event", req.Kind, "--session", req.Session}
+		for k, v := range req.Args {
+			if v != "" {
+				args = append(args, "--"+k, v)
+			}
+		}
+
+		log.Printf("sidecar: host-API /event: kind=%s session=%s", req.Kind, req.Session)
+		cmd := exec.Command(prismBinary(), args...)
+		// Propagate PRISM_SESSION_NAME so that any internal lookup resolves correctly.
+		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+req.Session)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Printf("sidecar: host-API /event: %v: %s", err, out)
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("event write failed: %v\n%s", err, strings.TrimSpace(string(out))))
+			return
+		}
+
+		log.Printf("sidecar: host-API /event: kind=%s session=%s written to host DB", req.Kind, req.Session)
+		writeJSON(w, http.StatusOK, map[string]string{})
+	})
+
 	return mux
+}
+
+// eventKindAllowlist is the set of valid kind values accepted by the /event
+// host-API endpoint. These match the subcommand names in cmd/event.go.
+var eventKindAllowlist = map[string]bool{
+	"state-change":       true,
+	"pane-died":          true,
+	"tmux-session-start": true,
+	"tmux-session-end":   true,
+	"compaction":         true,
+	"error":              true,
+	"doom-loop-detected": true,
+}
+
+// isKnownEventKind returns true if kind is a recognised event subcommand name.
+func isKnownEventKind(kind string) bool {
+	return eventKindAllowlist[kind]
+}
+
+// knownEventKindsStr returns a sorted comma-separated list of known event kinds
+// for use in error messages.
+func knownEventKindsStr() string {
+	names := make([]string, 0, len(eventKindAllowlist))
+	for name := range eventKindAllowlist {
+		names = append(names, name)
+	}
+	// Simple insertion sort for stable error messages.
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			if names[i] > names[j] {
+				names[i], names[j] = names[j], names[i]
+			}
+		}
+	}
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += ", "
+		}
+		result += n
+	}
+	return result
 }
 
 // worktreePathForSession looks up the worktree path for a session from the DB.

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1246,8 +1246,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	//
 	// Validation:
 	//   - kind must be a known subcommand name (400 for unknown kinds).
-	//   - session must be non-empty and must match a known session in the DB
-	//     (400 for empty; 400 for unknown session).
+	//   - session must be non-empty (400 for empty or whitespace).
+	//     NOTE: we intentionally do NOT require the session to already exist in
+	//     the host DB. tmux-session-start is called for brand-new sessions that
+	//     have no agent_status row yet; a DB-existence check would reject the
+	//     very first event that creates the session record. #1254 originally
+	//     required "matches a known session", but that AC item was relaxed to
+	//     non-empty-only to allow tmux-session-start to work correctly.
 	//   - All role levels (worker and coordinator) are permitted — lifecycle
 	//     events are emitted by both.
 	//

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1282,20 +1282,6 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
-		// Validate session: must match a known session in the host DB.
-		// This prevents silent writes with a NULL/empty session_name (AC edge-case).
-		status, dbErr := s.cfg.DB.CurrentStatus(req.Session)
-		if dbErr != nil {
-			log.Printf("sidecar: host-API /event: CurrentStatus %q: %v", req.Session, dbErr)
-			writeError(w, http.StatusInternalServerError, "db error: "+dbErr.Error())
-			return
-		}
-		if status == nil {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf(
-				"unknown session %q — event rejected (no agent_status row in host DB)", req.Session))
-			return
-		}
-
 		// Build the prism event <kind> [flags] invocation.
 		// Always include --session from the top-level field; remaining args
 		// come from the Args map as --key value pairs. Empty-value entries

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_event_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_event_test.go
@@ -1,0 +1,88 @@
+package sidecar
+
+// Tests for the host-API /event endpoint added to fix the shadow-DB issue for
+// prism event subcommands running inside containers (issue #1254).
+//
+// These tests exercise the hostAPIHandler() method directly without spinning
+// up a real Unix socket server. The shape mirrors sidecar_merge_test.go from
+// #1043.
+//
+// Note: the success path (kind + session both valid, event written to host DB)
+// is covered at the cmd level in cmd/event_proxy_test.go via a fake HTTP
+// server. Sidecar-level tests here focus on the validation rejection paths
+// that the handler enforces before shelling out to prism event.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// ── /event — validation rejections ───────────────────────────────────────────
+
+// TestHostAPI_Event_UnknownKindReturns400 verifies that posting an unknown
+// event kind to /event returns HTTP 400 with a message listing the valid kinds.
+func TestHostAPI_Event_UnknownKindReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/event",
+		`{"kind":"not-a-real-kind","session":"myrepo@main"}`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "unknown event kind") {
+		t.Errorf("body %q: want message containing 'unknown event kind'", body)
+	}
+	// The error should list valid kinds so the caller can diagnose the problem.
+	if !strings.Contains(body, "compaction") {
+		t.Errorf("body %q: want valid-kind list containing 'compaction'", body)
+	}
+}
+
+// TestHostAPI_Event_EmptySessionReturns400 verifies that posting a valid kind
+// but an empty session string to /event returns HTTP 400.
+func TestHostAPI_Event_EmptySessionReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/event",
+		`{"kind":"compaction","session":""}`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "session is required") {
+		t.Errorf("body %q: want message containing 'session is required'", body)
+	}
+}
+
+// TestHostAPI_Event_WhitespaceOnlySessionReturns400 verifies that a session
+// containing only whitespace is also rejected (TrimSpace guard).
+func TestHostAPI_Event_WhitespaceOnlySessionReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/event",
+		`{"kind":"compaction","session":"   "}`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Event_MalformedJSONReturns400 verifies that a malformed request
+// body is rejected with HTTP 400.
+func TestHostAPI_Event_MalformedJSONReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/event", `{not valid json`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- All `prism event` subcommands now check `PRISM_HOST_API` at startup and POST to the host sidecar's `/event` endpoint instead of writing to the local (shadow) DB when running inside a container
- Adds `POST /event` endpoint to `internal/sidecar/host_api.go` with kind allowlist validation and session non-empty validation; shells out to `prism event` on the host to write through the real DB path
- Adds `cmd/event_proxy_test.go` covering proxy fire, no-local-DB-touch, unreachable socket error, per-kind smoke tests, and no-proxy-when-unset
- Fixes test environment contamination by adding `t.Setenv("PRISM_HOST_API", "")` to all direct-DB-path tests in `event_test.go` and `event_doomloop_test.go`

## Approach

Mirrors the established proxy pattern from issue #1043 (`prism merge`): when `PRISM_HOST_API` is set, the command delegates entirely to the sidecar and exits — no fallback to local DB on socket failure (returns a clear error and exits non-zero).

## Deliberate AC deviation

Issue #1254 AC edge-case originally required: *"The `/event` endpoint validates the `session` field is non-empty and **matches a known session**."*

The session-existence check was deliberately removed (commit `ec2efe9e`) because `tmux-session-start` fires for brand-new sessions that have no `agent_status` row yet — a DB-existence check would reject the very first event that creates the session record. The validation was relaxed to non-empty/non-whitespace only. The sidecar comment has been updated to document this trade-off.

Closes #1254