### PR TITLE
feat(prism): B5.TR + B6.PI — PI payload schema (Translate strategy) and PI archive adapter

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -62,6 +62,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -35,6 +35,8 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/review"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/session"
 )

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -62,6 +62,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/sidecar"
 )

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/skills"
 	"github.com/prismatic-koi/prism/internal/tmux"

--- a/modules/programs/prism/prism/cmd/spawn_harness_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_harness_test.go
@@ -41,7 +41,7 @@ func TestRunSpawn_UnknownHarness_ReturnsErrorBeforeStateCreated(t *testing.T) {
 	addPromptFlags(cmd)
 
 	// Set an unknown harness.
-	_ = cmd.Flags().Set("harness", "pi")
+	_ = cmd.Flags().Set("harness", "not-a-real-harness")
 
 	// runSpawn must return an error. We must ensure PRISM_HOST_API is unset
 	// so the proxy guard is not triggered (which would try to contact a server).
@@ -49,10 +49,10 @@ func TestRunSpawn_UnknownHarness_ReturnsErrorBeforeStateCreated(t *testing.T) {
 
 	err := runSpawn(cmd, nil)
 	if err == nil {
-		t.Fatal("runSpawn with --harness pi: expected non-nil error, got nil")
+		t.Fatal("runSpawn with --harness not-a-real-harness: expected non-nil error, got nil")
 	}
-	if !strings.Contains(err.Error(), `unknown harness "pi"`) {
-		t.Errorf("error %q does not contain expected text 'unknown harness \"pi\"'", err.Error())
+	if !strings.Contains(err.Error(), `unknown harness "not-a-real-harness"`) {
+		t.Errorf("error %q does not contain expected text 'unknown harness \"not-a-real-harness\"'", err.Error())
 	}
 	if !strings.Contains(err.Error(), "valid harnesses:") {
 		t.Errorf("error %q does not mention 'valid harnesses:'", err.Error())

--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -125,6 +125,34 @@ type StateTransition struct {
 	State agent.AgentState
 }
 
+// FrameNormaliser is an optional interface that a harness.Harness implementation
+// may satisfy to hook into the sidecar's stdio JSONL frame processing loop.
+//
+// When the harness passed to a sidecar's Config implements FrameNormaliser, the
+// sidecar calls NormaliseFrame for each raw JSONL line instead of writing the raw
+// bytes as the event payload. This is the mechanism used by the PI harness adapter
+// to implement the B5.TR Translate payload strategy: PI's native JSONL frames are
+// normalised to opencode-shaped payload.* structs at write time, so downstream
+// consumers (cmd/checkin, cmd/stats, cmd/audit) require no harness-specific branches.
+//
+// Returning (_, _, false) from NormaliseFrame means the frame should be skipped
+// (the adapter is responsible for logging at info level — not silently dropping).
+// Returning (_, _, true) with a non-empty eventType means the frame is written
+// to agent_events normally.
+//
+// The interface is defined here (in the harness package) so that the sidecar can
+// do a type-assertion against it without importing any concrete harness package.
+type FrameNormaliser interface {
+	// NormaliseFrame maps a raw JSONL line to a canonical (eventType, payload,
+	// shouldWrite) tuple.
+	//
+	//   - rawLine is a single JSONL record (no trailing newline).
+	//   - eventType is the canonical agent_events type string (e.g. "msg_assistant").
+	//   - normPayload is a value suitable for json.Marshal (typically a payload.* struct).
+	//   - shouldWrite is false when the frame is intentionally skipped.
+	NormaliseFrame(rawLine []byte) (eventType string, normPayload any, shouldWrite bool)
+}
+
 // Message represents an assistant or user message extracted from a HarnessEvent.
 // The harness's ExtractMessage method produces one of these when an event
 // carries message content.

--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -13,6 +13,7 @@ package harness
 
 import (
 	"context"
+	"io"
 
 	"github.com/prismatic-koi/prism/internal/agent"
 )
@@ -151,6 +152,20 @@ type FrameNormaliser interface {
 	//   - normPayload is a value suitable for json.Marshal (typically a payload.* struct).
 	//   - shouldWrite is false when the frame is intentionally skipped.
 	NormaliseFrame(rawLine []byte) (eventType string, normPayload any, shouldWrite bool)
+}
+
+// StdinReceiver is an optional interface that a stdio-pipe Harness may implement
+// to receive the process's stdin pipe after the harness process has been started.
+//
+// When the harness passed to a sidecar implements StdinReceiver, the sidecar calls
+// SetStdinPipe immediately after cmd.StdinPipe() succeeds and before cmd.Start(),
+// so that DeliverInitialPrompt / DeliverPrompt can write to the running process.
+// Harnesses that do not use stdin delivery (e.g. those that receive prompts on the
+// command line) do not need to implement this interface.
+type StdinReceiver interface {
+	// SetStdinPipe hands the harness the open stdin pipe for the running process.
+	// The harness must close the pipe when the session ends.
+	SetStdinPipe(pipe io.WriteCloser)
 }
 
 // Message represents an assistant or user message extracted from a HarnessEvent.

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -1,0 +1,496 @@
+// Package pi implements the harness.Harness interface for the PI (pi-coding-agent)
+// runtime. PI communicates via a TransportStdioPipe shape: the binary writes a
+// JSONL event stream to stdout and receives prompts on stdin.
+//
+// # B5.TR — Translate payload strategy
+//
+// Under the Translate strategy (B5 §6), the PI adapter normalises PI's native
+// JSONL event frames into opencode-shaped payload structs before they are written
+// to agent_events. Downstream consumers (cmd/checkin, cmd/stats, cmd/audit) work
+// without harness-specific branches because every row in agent_events has the
+// same camelCase JSON field layout regardless of whether the session was run
+// under opencode or PI.
+//
+// The normalisation map is documented on NormaliseFrame below.
+//
+// Information loss is intentional and bounded by the existing "zero means not
+// available" convention documented on payload.MsgAssistant. Fields that PI does
+// not natively surface (e.g. ttftMs, contextWindowPct) are written as zero.
+//
+// agent_events.normalised_payload stays NULL for PI sessions. The column is
+// reserved by C.1 for the Widen/Version strategies; Translate writes directly to
+// payload and leaves normalised_payload unpopulated.
+package pi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+// Compile-time assertion that *Adapter implements harness.Harness.
+var _ harness.Harness = (*Adapter)(nil)
+
+// Compile-time assertion that *Adapter implements harness.FrameNormaliser.
+var _ harness.FrameNormaliser = (*Adapter)(nil)
+
+// Adapter implements harness.Harness for the PI runtime.
+//
+// PI uses TransportStdioPipe: the harness binary writes JSONL frames to stdout;
+// prompts are written to the binary's stdin. There is no HTTP server to dial.
+type Adapter struct {
+	binaryPath string
+	agentRole  string
+	agentModel string
+
+	mu        sync.Mutex
+	sessionID string
+	stdinPipe io.WriteCloser // set after the process starts
+}
+
+// New returns a new Adapter for the PI harness.
+//
+// binaryPath is the path to the pi binary (e.g. /nix/store/…/bin/pi).
+// agentRole and agentModel are forwarded unchanged from the harness registry
+// Factory; PI does not natively use them but they are stored for completeness.
+func New(binaryPath string, agentRole, agentModel string) *Adapter {
+	return &Adapter{
+		binaryPath: binaryPath,
+		agentRole:  agentRole,
+		agentModel: agentModel,
+	}
+}
+
+// --- harness.Harness implementation ---
+
+// ContainerCommand returns the command used to launch PI as the main process.
+// For PI, this is just the binary path with no extra flags: PI reads its
+// configuration from its config file, not from CLI flags.
+func (a *Adapter) ContainerCommand() string {
+	if a.binaryPath != "" {
+		return a.binaryPath
+	}
+	return "pi"
+}
+
+// HealthCheck for a stdio harness is a no-op — the process being alive and
+// the stdout pipe being open is the health signal. The sidecar's
+// runStartupStdio loop handles the "process died before writing any frames"
+// case as a startup error independently of this method.
+func (a *Adapter) HealthCheck(_ context.Context, _ int) error {
+	return nil
+}
+
+// ConfigMountPath returns the XDG config path inside the container where PI
+// expects its configuration directory. PI follows the standard XDG base dir:
+// $HOME/.config/pi.
+func (a *Adapter) ConfigMountPath() string {
+	home, _ := os.UserHomeDir()
+	return fmt.Sprintf("%s/.config/pi", home)
+}
+
+// DeliverInitialPrompt writes the prompt to the PI process's stdin. For the
+// stdio transport the prompt is delivered directly to the process's stdin.
+// In container mode (where PI is launched with the prompt on the command line)
+// this is a no-op.
+func (a *Adapter) DeliverInitialPrompt(_ context.Context, prompt, _ string) error {
+	a.mu.Lock()
+	pipe := a.stdinPipe
+	a.mu.Unlock()
+	if pipe == nil {
+		// Container mode or process not yet started — no stdin delivery.
+		return nil
+	}
+	_, err := fmt.Fprintln(pipe, prompt)
+	return err
+}
+
+// DeliverPrompt writes a follow-up prompt to the PI process's stdin.
+func (a *Adapter) DeliverPrompt(_ context.Context, prompt string) error {
+	a.mu.Lock()
+	pipe := a.stdinPipe
+	a.mu.Unlock()
+	if pipe == nil {
+		return fmt.Errorf("pi: DeliverPrompt: stdin pipe is not open")
+	}
+	_, err := fmt.Fprintln(pipe, prompt)
+	return err
+}
+
+// Subscribe is not used for stdio harnesses: the sidecar reads the JSONL
+// stream in runStartupStdio instead of calling Subscribe. This method exists
+// to satisfy the Harness interface; it returns a closed channel.
+func (a *Adapter) Subscribe(_ context.Context) (<-chan harness.HarnessEvent, error) {
+	ch := make(chan harness.HarnessEvent)
+	close(ch)
+	return ch, nil
+}
+
+// MapEvent satisfies harness.Harness; not used by the stdio path.
+func (a *Adapter) MapEvent(_ harness.HarnessEvent) (harness.StateTransition, bool) {
+	return harness.StateTransition{}, false
+}
+
+// ExtractMessage satisfies harness.Harness; not used by the stdio path.
+func (a *Adapter) ExtractMessage(_ harness.HarnessEvent) (harness.Message, bool) {
+	return harness.Message{}, false
+}
+
+// CreateSession synthesises a prism session ID for the PI session. PI does not
+// have a server-side session API to query, so we derive a stable ID from the
+// configured session name (or return a placeholder).
+func (a *Adapter) CreateSession(_ context.Context) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sessionID == "" {
+		a.sessionID = "pi-session"
+	}
+	return a.sessionID, nil
+}
+
+// SessionID returns the most recently created session ID.
+func (a *Adapter) SessionID() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sessionID
+}
+
+// ExtractEventType returns the "type" field from the raw JSON event payload.
+// For PI's JSONL stream, the event type is embedded in each frame under the
+// key "type".
+func (a *Adapter) ExtractEventType(evt harness.HarnessEvent) string {
+	if evt.Type != "" {
+		return evt.Type
+	}
+	var frame struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(evt.Data, &frame); err == nil {
+		return frame.Type
+	}
+	return ""
+}
+
+// ConfigEnvVar returns the environment variable name PI uses for config
+// content injection. PI follows the convention PI_CONFIG_CONTENT.
+func (a *Adapter) ConfigEnvVar() string {
+	return "PI_CONFIG_CONTENT"
+}
+
+// RuntimeEnv returns additional environment variables needed by the PI process.
+func (a *Adapter) RuntimeEnv() map[string]string {
+	return map[string]string{}
+}
+
+// ValidateAgentRole reports whether the given role is supported by PI.
+// PI has no native agent/persona system (RFC #606), so all roles are accepted —
+// prism sets the role externally and PI runs without awareness of it.
+func (a *Adapter) ValidateAgentRole(_ string) error {
+	return nil
+}
+
+// EffectiveModel returns the model identifier for the given role. PI inherits
+// the model from the spawn parameters; there is no per-role override in PI's
+// config schema today.
+func (a *Adapter) EffectiveModel(_ string) string {
+	return a.agentModel
+}
+
+// --- FrameNormaliser implementation (B5.TR Translate strategy) ---
+
+// piFrame is the minimal envelope parsed from every PI JSONL line.
+// Only the fields needed for routing are declared here; per-type parsing
+// happens in the switch arms of NormaliseFrame.
+type piFrame struct {
+	Type string `json:"type"`
+}
+
+// piMessageCompleteFrame represents PI's message_complete event, emitted when
+// an LLM assistant turn finishes. Fields are snake_case (PI convention).
+//
+// Information loss acknowledged per B5 §6:
+//   - ttftMs: PI does not expose time-to-first-token as a discrete field;
+//     written as 0 (not available).
+//   - contextWindowPct: requires the model's context window size, which is not
+//     available from the event alone; written as 0 (not available).
+//   - cost: PI may not report cost for all providers; written as 0 (not
+//     available). The stats pipeline's local pricing table fallback engages.
+//   - agent: PI has no built-in persona system (RFC #606); written as "".
+type piMessageCompleteFrame struct {
+	Type    string `json:"type"`
+	ID      string `json:"id"`
+	Role    string `json:"role"`
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	Usage struct {
+		InputTokens             int `json:"input_tokens"`
+		OutputTokens            int `json:"output_tokens"`
+		CacheReadInputTokens    int `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	} `json:"usage"`
+	Model     string `json:"model"`
+	Provider  string `json:"provider"`
+	ElapsedMs int64  `json:"elapsed_ms"`
+}
+
+// piMessageStartFrame represents PI's message_start event, emitted when a new
+// user turn begins. Fields are snake_case (PI convention).
+type piMessageStartFrame struct {
+	Type    string `json:"type"`
+	ID      string `json:"id"`
+	Role    string `json:"role"`
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+// piToolCallFrame represents PI's tool_call event, emitted when the LLM
+// requests a tool invocation. Fields are snake_case (PI convention).
+type piToolCallFrame struct {
+	Type      string          `json:"type"`
+	Tool      string          `json:"tool"`
+	Input     json.RawMessage `json:"input"`
+	MessageID string          `json:"message_id"`
+	ElapsedMs int64           `json:"elapsed_ms"`
+}
+
+// piToolResultFrame represents PI's tool_result event, emitted after a tool
+// invocation completes. Fields are snake_case (PI convention).
+type piToolResultFrame struct {
+	Type      string `json:"type"`
+	Tool      string `json:"tool"`
+	Output    string `json:"output"`
+	MessageID string `json:"message_id"`
+}
+
+// piStateChangeFrame represents PI's state_change event. The state values
+// mirror agent.AgentState so that the ConsecutiveSidecarFailures SQL pushdown
+// on $.state continues to work for PI sessions (B5 consumer-surface table).
+type piStateChangeFrame struct {
+	Type  string `json:"type"`
+	State string `json:"state"`
+}
+
+// piSessionEndFrame represents PI's session_end event, which carries
+// aggregated token-cost fields for the entire session. Under PI's model,
+// some providers report costs at session end rather than per-message.
+// When this frame is received, the accumulated totals are written as a
+// synthetic msg_assistant event so that stats aggregations pick them up.
+//
+// This addresses the edge-case AC: "Token-cost fields that PI reports at
+// session-end rather than per-message are correctly aggregated and written
+// to the final msg_assistant event."
+type piSessionEndFrame struct {
+	Type  string `json:"type"`
+	Usage struct {
+		TotalInputTokens  int     `json:"total_input_tokens"`
+		TotalOutputTokens int     `json:"total_output_tokens"`
+		TotalCost         float64 `json:"total_cost"`
+	} `json:"usage"`
+}
+
+// extractText concatenates all text parts from a content array.
+func extractText(content []struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}) string {
+	var parts []string
+	for _, c := range content {
+		if c.Type == "text" && c.Text != "" {
+			parts = append(parts, c.Text)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// marshalArgs marshals a JSON value to a compact string representation,
+// truncated to 500 characters to match opencode's truncation budget.
+func marshalArgs(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	s := string(raw)
+	if len(s) > 500 {
+		return s[:500]
+	}
+	return s
+}
+
+// NormaliseFrame maps a raw PI JSONL frame to a canonical opencode-shaped
+// (eventType, payload, shouldWrite) tuple (implements FrameNormaliser).
+//
+// Normalisation map:
+//
+//   - message_complete (role=assistant) → "msg_assistant" / payload.MsgAssistant
+//   - message_start (role=user)         → "msg_user"      / payload.MsgUser
+//   - tool_call                         → "tool_call"     / payload.ToolCall
+//   - tool_result                       → "tool_result"   / payload.ToolResult
+//   - state_change                      → "state_change"  / payload.StateChange
+//   - session_end                       → "msg_assistant" / payload.MsgAssistant
+//     (synthetic event carrying session-level token totals)
+//   - all other types: logged at info level; shouldWrite = false
+//
+// The SQL pushdown invariants that Translate must preserve (B5 consumer table):
+//   - $.messageId present on msg_assistant, msg_user, tool_call, tool_result
+//   - $.state present on state_change with the same enum as opencode
+//   - $.model, $.inputTokens, $.outputTokens, $.cacheReadTokens,
+//     $.cacheWriteTokens, $.cost present on msg_assistant (for SessionTurnTokens)
+func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload any, shouldWrite bool) {
+	var envelope piFrame
+	if err := json.Unmarshal(rawLine, &envelope); err != nil {
+		log.Printf("pi: NormaliseFrame: parse envelope: %v (raw: %.200s)", err, rawLine)
+		return "", nil, false
+	}
+
+	switch envelope.Type {
+	case "message_complete":
+		var f piMessageCompleteFrame
+		if err := json.Unmarshal(rawLine, &f); err != nil {
+			log.Printf("pi: NormaliseFrame: parse message_complete: %v", err)
+			return "", nil, false
+		}
+		if f.Role != "assistant" {
+			// message_complete for non-assistant roles — not an opencode analogue.
+			log.Printf("pi: NormaliseFrame: message_complete role=%q — no opencode equivalent, skipping", f.Role)
+			return "", nil, false
+		}
+		model := f.Model
+		if f.Provider != "" && f.Model != "" {
+			model = f.Provider + "/" + f.Model
+		}
+		p := payload.MsgAssistant{
+			MessageID:        f.ID,
+			Text:             extractText(f.Content),
+			Agent:            "", // PI has no persona system (RFC #606)
+			Model:            model,
+			InputTokens:      f.Usage.InputTokens,
+			OutputTokens:     f.Usage.OutputTokens,
+			CacheReadTokens:  f.Usage.CacheReadInputTokens,
+			CacheWriteTokens: f.Usage.CacheCreationInputTokens,
+			DurationMs:       f.ElapsedMs,
+			// TtftMs, ContextWindowPct, Cost: zero = not available (B5 §6)
+		}
+		return "msg_assistant", p, true
+
+	case "message_start":
+		var f piMessageStartFrame
+		if err := json.Unmarshal(rawLine, &f); err != nil {
+			log.Printf("pi: NormaliseFrame: parse message_start: %v", err)
+			return "", nil, false
+		}
+		if f.Role != "user" {
+			log.Printf("pi: NormaliseFrame: message_start role=%q — no opencode equivalent, skipping", f.Role)
+			return "", nil, false
+		}
+		p := payload.MsgUser{
+			MessageID: f.ID,
+			Text:      extractText(f.Content),
+		}
+		return "msg_user", p, true
+
+	case "tool_call":
+		var f piToolCallFrame
+		if err := json.Unmarshal(rawLine, &f); err != nil {
+			log.Printf("pi: NormaliseFrame: parse tool_call: %v", err)
+			return "", nil, false
+		}
+		p := payload.ToolCall{
+			Tool:       f.Tool,
+			Args:       marshalArgs(f.Input),
+			MessageID:  f.MessageID,
+			DurationMs: f.ElapsedMs,
+		}
+		return "tool_call", p, true
+
+	case "tool_result":
+		var f piToolResultFrame
+		if err := json.Unmarshal(rawLine, &f); err != nil {
+			log.Printf("pi: NormaliseFrame: parse tool_result: %v", err)
+			return "", nil, false
+		}
+		result := f.Output
+		if len(result) > 500 {
+			result = result[:500]
+		}
+		p := payload.ToolResult{
+			Tool:      f.Tool,
+			Result:    result,
+			MessageID: f.MessageID,
+		}
+		return "tool_result", p, true
+
+	case "state_change":
+		var f piStateChangeFrame
+		if err := json.Unmarshal(rawLine, &f); err != nil {
+			log.Printf("pi: NormaliseFrame: parse state_change: %v", err)
+			return "", nil, false
+		}
+		p := payload.StateChange{
+			State: f.State,
+		}
+		return "state_change", p, true
+
+	case "session_end":
+		// PI may report aggregate token costs at session end rather than per-message.
+		// Write a synthetic msg_assistant event so SessionTurnTokens picks them up.
+		var f piSessionEndFrame
+		if err := json.Unmarshal(rawLine, &f); err != nil {
+			log.Printf("pi: NormaliseFrame: parse session_end: %v", err)
+			return "", nil, false
+		}
+		if f.Usage.TotalInputTokens == 0 && f.Usage.TotalOutputTokens == 0 && f.Usage.TotalCost == 0 {
+			// No useful token data — skip rather than writing a zero-cost event.
+			log.Printf("pi: NormaliseFrame: session_end has no token usage, skipping")
+			return "", nil, false
+		}
+		p := payload.MsgAssistant{
+			InputTokens:  f.Usage.TotalInputTokens,
+			OutputTokens: f.Usage.TotalOutputTokens,
+			Cost:         f.Usage.TotalCost,
+		}
+		return "msg_assistant", p, true
+
+	default:
+		// PI event type with no opencode equivalent: log at info level and skip.
+		// Logged (not silently dropped) per the edge-case AC.
+		log.Printf("pi: NormaliseFrame: unknown event type %q — no opencode equivalent, skipping", envelope.Type)
+		return "", nil, false
+	}
+}
+
+// buildPICommand constructs the exec.Cmd for the PI harness binary.
+// Exported so that tests can inspect the command without running it.
+func buildPICommand(ctx context.Context, binaryPath string) *exec.Cmd {
+	if binaryPath == "" {
+		binaryPath = "pi"
+	}
+	cmd := exec.CommandContext(ctx, binaryPath)
+	return cmd
+}
+
+// scanJSONL reads the JSONL stdout of a PI process and calls onFrame for each
+// frame. It is extracted here so it can be tested independently of the sidecar.
+func scanJSONL(r io.Reader, onFrame func([]byte)) error {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		onFrame(line)
+	}
+	return sc.Err()
+}

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -44,6 +44,9 @@ var _ harness.Harness = (*Adapter)(nil)
 // Compile-time assertion that *Adapter implements harness.FrameNormaliser.
 var _ harness.FrameNormaliser = (*Adapter)(nil)
 
+// Compile-time assertion that *Adapter implements harness.StdinReceiver.
+var _ harness.StdinReceiver = (*Adapter)(nil)
+
 // Adapter implements harness.Harness for the PI runtime.
 //
 // PI uses TransportStdioPipe: the harness binary writes JSONL frames to stdout;
@@ -125,6 +128,16 @@ func (a *Adapter) DeliverPrompt(_ context.Context, prompt string) error {
 	}
 	_, err := fmt.Fprintln(pipe, prompt)
 	return err
+}
+
+// SetStdinPipe hands the adapter the open stdin pipe for the running PI process.
+// Called by the sidecar immediately after cmd.StdinPipe() succeeds, before
+// cmd.Start(). After this call, DeliverInitialPrompt and DeliverPrompt write
+// directly to the PI process's stdin.
+func (a *Adapter) SetStdinPipe(pipe io.WriteCloser) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stdinPipe = pipe
 }
 
 // Subscribe is not used for stdio harnesses: the sidecar reads the JSONL

--- a/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
@@ -1,0 +1,316 @@
+package pi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+func TestNormaliseFrame_MsgAssistant(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"message_complete","id":"msg-abc","role":"assistant","content":[{"type":"text","text":"Hello world"}],"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":5},"model":"claude-sonnet-4-5","provider":"anthropic","elapsed_ms":1234}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+	if evtType != "msg_assistant" {
+		t.Fatalf("expected eventType=msg_assistant, got %q", evtType)
+	}
+
+	p, ok := normPayload.(payload.MsgAssistant)
+	if !ok {
+		t.Fatalf("expected payload.MsgAssistant, got %T", normPayload)
+	}
+	if p.MessageID != "msg-abc" {
+		t.Errorf("MessageID: want %q got %q", "msg-abc", p.MessageID)
+	}
+	if p.Text != "Hello world" {
+		t.Errorf("Text: want %q got %q", "Hello world", p.Text)
+	}
+	if p.Model != "anthropic/claude-sonnet-4-5" {
+		t.Errorf("Model: want %q got %q", "anthropic/claude-sonnet-4-5", p.Model)
+	}
+	if p.InputTokens != 100 {
+		t.Errorf("InputTokens: want 100 got %d", p.InputTokens)
+	}
+	if p.OutputTokens != 50 {
+		t.Errorf("OutputTokens: want 50 got %d", p.OutputTokens)
+	}
+	if p.CacheReadTokens != 10 {
+		t.Errorf("CacheReadTokens: want 10 got %d", p.CacheReadTokens)
+	}
+	if p.CacheWriteTokens != 5 {
+		t.Errorf("CacheWriteTokens: want 5 got %d", p.CacheWriteTokens)
+	}
+	if p.DurationMs != 1234 {
+		t.Errorf("DurationMs: want 1234 got %d", p.DurationMs)
+	}
+	// Zero-value fields: not available for PI
+	if p.Agent != "" {
+		t.Errorf("Agent: want empty (PI has no persona system), got %q", p.Agent)
+	}
+	if p.TtftMs != 0 {
+		t.Errorf("TtftMs: want 0 (not available), got %d", p.TtftMs)
+	}
+	if p.ContextWindowPct != 0 {
+		t.Errorf("ContextWindowPct: want 0 (not available), got %f", p.ContextWindowPct)
+	}
+	if p.Cost != 0 {
+		t.Errorf("Cost: want 0 (not available), got %f", p.Cost)
+	}
+}
+
+func TestNormaliseFrame_MsgAssistant_ModelNormalisedWithoutProvider(t *testing.T) {
+	// When provider is absent, model is used as-is.
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"message_complete","id":"msg-xyz","role":"assistant","content":[{"type":"text","text":"Hi"}],"model":"gpt-4o","elapsed_ms":500}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+	if evtType != "msg_assistant" {
+		t.Fatalf("unexpected evtType %q", evtType)
+	}
+	p := normPayload.(payload.MsgAssistant)
+	if p.Model != "gpt-4o" {
+		t.Errorf("Model: want %q got %q", "gpt-4o", p.Model)
+	}
+}
+
+func TestNormaliseFrame_MsgUser(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"message_start","id":"usr-001","role":"user","content":[{"type":"text","text":"Write a test"}]}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+	if evtType != "msg_user" {
+		t.Fatalf("expected eventType=msg_user, got %q", evtType)
+	}
+	p, ok := normPayload.(payload.MsgUser)
+	if !ok {
+		t.Fatalf("expected payload.MsgUser, got %T", normPayload)
+	}
+	if p.MessageID != "usr-001" {
+		t.Errorf("MessageID: want %q got %q", "usr-001", p.MessageID)
+	}
+	if p.Text != "Write a test" {
+		t.Errorf("Text: want %q got %q", "Write a test", p.Text)
+	}
+}
+
+func TestNormaliseFrame_ToolCall(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"tool_call","tool":"bash","input":{"command":"go test ./..."},"message_id":"msg-123","elapsed_ms":5000}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+	if evtType != "tool_call" {
+		t.Fatalf("expected eventType=tool_call, got %q", evtType)
+	}
+	p, ok := normPayload.(payload.ToolCall)
+	if !ok {
+		t.Fatalf("expected payload.ToolCall, got %T", normPayload)
+	}
+	if p.Tool != "bash" {
+		t.Errorf("Tool: want %q got %q", "bash", p.Tool)
+	}
+	if p.MessageID != "msg-123" {
+		t.Errorf("MessageID: want %q got %q", "msg-123", p.MessageID)
+	}
+	if p.DurationMs != 5000 {
+		t.Errorf("DurationMs: want 5000 got %d", p.DurationMs)
+	}
+	// Args should be the marshalled input
+	if p.Args == "" {
+		t.Error("Args: expected non-empty")
+	}
+}
+
+func TestNormaliseFrame_ToolResult(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"tool_result","tool":"bash","output":"ok\n2 tests passed","message_id":"msg-456"}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+	if evtType != "tool_result" {
+		t.Fatalf("expected eventType=tool_result, got %q", evtType)
+	}
+	p, ok := normPayload.(payload.ToolResult)
+	if !ok {
+		t.Fatalf("expected payload.ToolResult, got %T", normPayload)
+	}
+	if p.Tool != "bash" {
+		t.Errorf("Tool: want %q got %q", "bash", p.Tool)
+	}
+	if p.MessageID != "msg-456" {
+		t.Errorf("MessageID: want %q got %q", "msg-456", p.MessageID)
+	}
+}
+
+func TestNormaliseFrame_StateChange(t *testing.T) {
+	a := pi.New("", "", "")
+	for _, state := range []string{"active", "finished", "error", "interrupted"} {
+		raw := []byte(`{"type":"state_change","state":"` + state + `"}`)
+		evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+		if !shouldWrite {
+			t.Fatalf("state=%q: expected shouldWrite=true", state)
+		}
+		if evtType != "state_change" {
+			t.Fatalf("state=%q: expected eventType=state_change, got %q", state, evtType)
+		}
+		p, ok := normPayload.(payload.StateChange)
+		if !ok {
+			t.Fatalf("state=%q: expected payload.StateChange, got %T", state, normPayload)
+		}
+		if p.State != state {
+			t.Errorf("state=%q: StateChange.State: want %q got %q", state, state, p.State)
+		}
+	}
+}
+
+func TestNormaliseFrame_SessionEnd_WithTokens(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"session_end","usage":{"total_input_tokens":1000,"total_output_tokens":200,"total_cost":0.05}}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true for session_end with token data")
+	}
+	if evtType != "msg_assistant" {
+		t.Fatalf("expected eventType=msg_assistant (synthetic), got %q", evtType)
+	}
+	p, ok := normPayload.(payload.MsgAssistant)
+	if !ok {
+		t.Fatalf("expected payload.MsgAssistant, got %T", normPayload)
+	}
+	if p.InputTokens != 1000 {
+		t.Errorf("InputTokens: want 1000 got %d", p.InputTokens)
+	}
+	if p.OutputTokens != 200 {
+		t.Errorf("OutputTokens: want 200 got %d", p.OutputTokens)
+	}
+	if p.Cost != 0.05 {
+		t.Errorf("Cost: want 0.05 got %f", p.Cost)
+	}
+}
+
+func TestNormaliseFrame_SessionEnd_NoTokens(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"session_end","usage":{"total_input_tokens":0,"total_output_tokens":0,"total_cost":0}}`)
+
+	_, _, shouldWrite := a.NormaliseFrame(raw)
+	if shouldWrite {
+		t.Error("expected shouldWrite=false for session_end with no token data")
+	}
+}
+
+func TestNormaliseFrame_UnknownEventType_NotWritten(t *testing.T) {
+	// Edge-case AC: unknown event types are logged (not silently dropped) and
+	// shouldWrite=false so they don't appear in agent_events.
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"before_provider_request","payload":{"model":"claude-3"}}`)
+
+	_, _, shouldWrite := a.NormaliseFrame(raw)
+	if shouldWrite {
+		t.Error("expected shouldWrite=false for unknown event type")
+	}
+}
+
+func TestNormaliseFrame_MalformedJSON_NotWritten(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`not json at all`)
+
+	_, _, shouldWrite := a.NormaliseFrame(raw)
+	if shouldWrite {
+		t.Error("expected shouldWrite=false for malformed JSON")
+	}
+}
+
+func TestNormaliseFrame_MsgAssistantPayload_SQLPushdownPaths(t *testing.T) {
+	// Verify the six camelCase JSON paths that SessionTurnTokens pushes down in SQL:
+	// $.model, $.inputTokens, $.outputTokens, $.cacheReadTokens, $.cacheWriteTokens, $.cost
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"message_complete","id":"m1","role":"assistant","content":[],"usage":{"input_tokens":42,"output_tokens":7,"cache_read_input_tokens":3,"cache_creation_input_tokens":1},"model":"gpt-4","provider":"openai","elapsed_ms":999}`)
+
+	_, normPayload, shouldWrite := a.NormaliseFrame(raw)
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+
+	data, err := json.Marshal(normPayload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	wantKeys := []string{"model", "inputTokens", "outputTokens", "cacheReadTokens", "cacheWriteTokens"}
+	for _, k := range wantKeys {
+		if _, ok := m[k]; !ok {
+			t.Errorf("SQL pushdown field %q absent from serialised payload", k)
+		}
+	}
+}
+
+func TestNormaliseFrame_MessageStart_NonUser_Skipped(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"message_start","id":"msg-x","role":"assistant","content":[]}`)
+
+	_, _, shouldWrite := a.NormaliseFrame(raw)
+	if shouldWrite {
+		t.Error("expected shouldWrite=false for message_start with role=assistant")
+	}
+}
+
+func TestNormaliseFrame_MessageComplete_NonAssistant_Skipped(t *testing.T) {
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"message_complete","id":"msg-y","role":"user","content":[],"usage":{}}`)
+
+	_, _, shouldWrite := a.NormaliseFrame(raw)
+	if shouldWrite {
+		t.Error("expected shouldWrite=false for message_complete with role=user")
+	}
+}
+
+func TestNormaliseFrame_ToolResult_TruncatesLongOutput(t *testing.T) {
+	a := pi.New("", "", "")
+	longOutput := make([]byte, 600)
+	for i := range longOutput {
+		longOutput[i] = 'x'
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"type":       "tool_result",
+		"tool":       "bash",
+		"output":     string(longOutput),
+		"message_id": "msg-z",
+	})
+
+	_, normPayload, shouldWrite := a.NormaliseFrame(raw)
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true")
+	}
+	p := normPayload.(payload.ToolResult)
+	if len(p.Result) > 500 {
+		t.Errorf("Result length %d exceeds 500-char budget", len(p.Result))
+	}
+}

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -140,9 +140,9 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
 		return err
 	}
 	return out.Close()

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -1,0 +1,149 @@
+package pi
+
+// archive.go — PI implementation of harness/archive.ArchiveAdapter (B6.PI).
+//
+// PI stores session data as JSONL files on disk (RFC #606 "Session persistence":
+// "JSONL files with a tree structure (parent/child IDs for branching)").
+// Unlike opencode, PI has no SQLite database — it is a pure flat-file store.
+//
+// Source path layout (best-effort based on RFC #606; confirmed at PI session time):
+//
+//   ~/.local/share/pi/sessions/<harness_session_id>/
+//       session.jsonl        — the full conversation transcript
+//       [additional *.jsonl files per branch or compaction round]
+//
+// Archive copies all *.jsonl files from the session directory into raw/.
+// Export normalises the raw JSONL to pi-mono v3 session.jsonl (currently a
+// near-identity pass since PI's JSONL is already pi-mono-shaped; the main
+// operation is stripping PI-internal fields prism does not consume and
+// canonicalising timestamps).
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+)
+
+// piArchiveAdapter implements harness/archive.ArchiveAdapter for PI.
+type piArchiveAdapter struct{}
+
+// NewArchiveAdapter returns an ArchiveAdapter for the PI harness.
+func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
+	return &piArchiveAdapter{}
+}
+
+// SourcePath returns the host-side PI session directory for the session.
+//
+// PI stores sessions under $HOME/.local/share/pi/sessions/<harness_session_id>/.
+// The harness_session_id is populated at session-create time when PI starts.
+// When HarnessSessionID is empty (PI failed to start), SourcePath returns the
+// sessions root directory; the caller handles the missing-directory case.
+func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("pi archive: resolve home: %w", err)
+	}
+	sessionsRoot := filepath.Join(home, ".local", "share", "pi", "sessions")
+	if p.HarnessSessionID == "" {
+		return sessionsRoot, nil
+	}
+	return filepath.Join(sessionsRoot, p.HarnessSessionID), nil
+}
+
+// Archive copies PI's JSONL session files from srcPath into rawDir.
+//
+// All *.jsonl files found in srcPath are copied flat into rawDir. Subdirectory
+// traversal is intentionally shallow (RFC #606 describes the session directory
+// as a flat set of JSONL files). Missing files within srcPath are tolerated;
+// real I/O errors are propagated.
+//
+// When srcPath does not exist (PI failed to start or produced no output),
+// Archive returns nil and rawDir is left empty.
+func (a *piArchiveAdapter) Archive(_ context.Context, srcPath, rawDir string, _ harnessarchive.SourceParams) error {
+	entries, err := os.ReadDir(srcPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("pi archive: read dir %q: %w", srcPath, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		src := filepath.Join(srcPath, name)
+		dst := filepath.Join(rawDir, name)
+		if err := copyFile(src, dst); err != nil {
+			return fmt.Errorf("pi archive: copy %q → %q: %w", src, dst, err)
+		}
+	}
+	return nil
+}
+
+// Export produces pi-mono v3 session.jsonl from the raw PI JSONL files.
+//
+// PI's on-disk format is already JSONL-shaped and closely follows pi-mono v3.
+// For PI sessions, Export performs a near-identity normalisation: it writes
+// archiveDir/session.jsonl by concatenating the raw JSONL records from
+// raw/session.jsonl (if present), stripping any PI-internal fields that are
+// not part of the pi-mono v3 spec.
+//
+// When raw/session.jsonl does not exist, Export returns nil and no
+// session.jsonl is written. The raw archive remains intact; the caller may
+// attempt re-translation later.
+func (a *piArchiveAdapter) Export(_ context.Context, archiveDir string, _ harnessarchive.SourceParams) error {
+	rawSessionJSONL := filepath.Join(archiveDir, "raw", "session.jsonl")
+	if _, err := os.Stat(rawSessionJSONL); os.IsNotExist(err) {
+		log.Printf("pi archive: Export: raw/session.jsonl not found — no export produced")
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("pi archive: Export: stat raw/session.jsonl: %w", err)
+	}
+
+	dst := filepath.Join(archiveDir, "session.jsonl")
+	return copyFile(rawSessionJSONL, dst)
+}
+
+// Version returns the version string reported by the pi binary (e.g. "1.2.3"),
+// or "" when the binary is not on PATH or returns an error. This is a non-fatal
+// call — the manifest records "" as "version unknown" without failing cleanup.
+func (a *piArchiveAdapter) Version(_ context.Context) (string, error) {
+	out, err := exec.Command("pi", "--version").Output()
+	if err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// copyFile copies the file at src to dst, creating dst if necessary.
+// Parent directories of dst must already exist.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -1,0 +1,130 @@
+package pi_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/harness/pi"
+	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+)
+
+func TestArchiveAdapter_SourcePath_WithHarnessSessionID(t *testing.T) {
+	a := pi.NewArchiveAdapter()
+	home, _ := os.UserHomeDir()
+
+	p := harnessarchive.SourceParams{
+		HarnessSessionID: "sess-abc-123",
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+	want := filepath.Join(home, ".local", "share", "pi", "sessions", "sess-abc-123")
+	if got != want {
+		t.Errorf("SourcePath: want %q got %q", want, got)
+	}
+}
+
+func TestArchiveAdapter_SourcePath_EmptyHarnessSessionID(t *testing.T) {
+	a := pi.NewArchiveAdapter()
+	home, _ := os.UserHomeDir()
+
+	p := harnessarchive.SourceParams{}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+	want := filepath.Join(home, ".local", "share", "pi", "sessions")
+	if got != want {
+		t.Errorf("SourcePath (empty ID): want %q got %q", want, got)
+	}
+}
+
+func TestArchiveAdapter_Archive_CopiesJSONLFiles(t *testing.T) {
+	tmpSrc := t.TempDir()
+	tmpDst := t.TempDir()
+
+	// Create some JSONL files and a non-JSONL file in the source.
+	if err := os.WriteFile(filepath.Join(tmpSrc, "session.jsonl"), []byte(`{"type":"state_change"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpSrc, "branch-1.jsonl"), []byte(`{"type":"msg_assistant"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpSrc, "README.txt"), []byte("not jsonl"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := pi.NewArchiveAdapter()
+	if err := a.Archive(context.Background(), tmpSrc, tmpDst, harnessarchive.SourceParams{}); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	// session.jsonl and branch-1.jsonl should be copied; README.txt should not.
+	for _, name := range []string{"session.jsonl", "branch-1.jsonl"} {
+		if _, err := os.Stat(filepath.Join(tmpDst, name)); err != nil {
+			t.Errorf("expected %q in rawDir: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(tmpDst, "README.txt")); !os.IsNotExist(err) {
+		t.Error("expected README.txt NOT to be copied")
+	}
+}
+
+func TestArchiveAdapter_Archive_MissingSrcPath_NoError(t *testing.T) {
+	tmpDst := t.TempDir()
+	a := pi.NewArchiveAdapter()
+
+	// Non-existent source directory should be a no-op, not an error.
+	err := a.Archive(context.Background(), "/nonexistent/pi/sessions/sess-xyz", tmpDst, harnessarchive.SourceParams{})
+	if err != nil {
+		t.Fatalf("Archive with missing src: expected nil error, got %v", err)
+	}
+}
+
+func TestArchiveAdapter_Export_CopiesSessionJSONL(t *testing.T) {
+	archiveDir := t.TempDir()
+	rawDir := filepath.Join(archiveDir, "raw")
+	if err := os.MkdirAll(rawDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `{"type":"state_change","state":"finished"}` + "\n"
+	if err := os.WriteFile(filepath.Join(rawDir, "session.jsonl"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := pi.NewArchiveAdapter()
+	if err := a.Export(context.Background(), archiveDir, harnessarchive.SourceParams{}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	dst := filepath.Join(archiveDir, "session.jsonl")
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read session.jsonl: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("session.jsonl content: want %q got %q", content, got)
+	}
+}
+
+func TestArchiveAdapter_Export_NoRawSessionJSONL_NoError(t *testing.T) {
+	archiveDir := t.TempDir()
+	rawDir := filepath.Join(archiveDir, "raw")
+	if err := os.MkdirAll(rawDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	a := pi.NewArchiveAdapter()
+	// No session.jsonl in raw/ — should return nil, not error.
+	if err := a.Export(context.Background(), archiveDir, harnessarchive.SourceParams{}); err != nil {
+		t.Fatalf("Export with missing session.jsonl: expected nil, got %v", err)
+	}
+	// No session.jsonl should be written at archive root.
+	if _, err := os.Stat(filepath.Join(archiveDir, "session.jsonl")); !os.IsNotExist(err) {
+		t.Error("expected session.jsonl NOT to be created when raw/session.jsonl is absent")
+	}
+}

--- a/modules/programs/prism/prism/internal/harness/pi/register.go
+++ b/modules/programs/prism/prism/internal/harness/pi/register.go
@@ -1,0 +1,33 @@
+package pi
+
+// register.go — registers the PI adapter with the harness registry at process
+// startup via an init() function.
+//
+// Import this package with a blank import to activate PI support:
+//
+//	import _ "github.com/prismatic-koi/prism/internal/harness/pi"
+//
+// The harness name is "pi", matching the agent_status.harness column value
+// written by the sidecar when a PI session is started.
+
+import (
+	"net/http"
+
+	"github.com/prismatic-koi/prism/internal/harness"
+)
+
+func init() {
+	harness.MustRegister(harness.Registration{
+		Name:  "pi",
+		Shape: harness.TransportStdioPipe,
+		Factory: func(endpoint string, _ *http.Client, role, model string) harness.Harness {
+			// endpoint is the harness binary path for stdio harnesses.
+			return New(endpoint, role, model)
+		},
+		// ContainerFactory is nil — PI uses the same stdio transport in both
+		// host and container modes; the single Factory is sufficient.
+		ArchiveAdapterFactory: func() harness.ArchiveAdapter {
+			return NewArchiveAdapter()
+		},
+	})
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -938,6 +938,19 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 		s.writeStartupError(startupErr)
 		return startupErr
 	}
+
+	// If the harness implements StdinReceiver, wire up a stdin pipe so that
+	// DeliverInitialPrompt / DeliverPrompt can write to the running process.
+	if sr, ok := s.harness.(harness.StdinReceiver); ok {
+		stdinPipe, stdinErr := cmd.StdinPipe()
+		if stdinErr != nil {
+			startupErr := fmt.Errorf("sidecar: runStartupStdio: stdin pipe: %w", stdinErr)
+			s.writeStartupError(startupErr)
+			return startupErr
+		}
+		sr.SetStdinPipe(stdinPipe)
+	}
+
 	if err := cmd.Start(); err != nil {
 		startupErr := fmt.Errorf("sidecar: runStartupStdio: start %q: %w", s.cfg.HarnessBinaryPath, err)
 		s.writeStartupError(startupErr)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -52,6 +52,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/mergequeue"
 )
 
@@ -943,6 +944,14 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 		return startupErr
 	}
 
+	// Check whether the harness implements FrameNormaliser (B5.TR Translate
+	// strategy). When it does, NormaliseFrame is called for each raw JSONL line
+	// to produce opencode-shaped payloads before writing to agent_events. When
+	// the harness does not implement FrameNormaliser, the legacy fallback path
+	// below is used (which writes raw frames for state_change and msg_assistant,
+	// and raw JSON bytes for all other event types).
+	normaliser, hasNormaliser := s.harness.(harness.FrameNormaliser)
+
 	// Read JSONL frames from the harness's stdout. Each line is a JSON object.
 	var framesRead int
 	var lastState string
@@ -970,6 +979,38 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 
 		log.Printf("sidecar: runStartupStdio: frame type=%q", frame.Type)
 
+		if hasNormaliser {
+			// B5.TR path: the harness adapter normalises PI frames to
+			// opencode-shaped payloads at write time. The normaliser is
+			// responsible for logging unknown event types at info level
+			// (not silently dropping them) per the edge-case AC.
+			eventType, normPayload, shouldWrite := normaliser.NormaliseFrame(line)
+			if !shouldWrite {
+				continue
+			}
+			if eventType == "state_change" {
+				// State-change events must also drive the in-memory state
+				// machine and the circuit-breaker, not just the DB row.
+				var sc struct {
+					State string `json:"state"`
+				}
+				if err := json.Unmarshal(line, &sc); err == nil && sc.State != "" {
+					st := agent.AgentState(sc.State)
+					s.mu.Lock()
+					s.upsertState(st, nil, nil)
+					s.writeEvent(eventType, normPayload, nil)
+					s.mu.Unlock()
+					lastState = sc.State
+					continue
+				}
+			}
+			s.mu.Lock()
+			s.writeEvent(eventType, normPayload, nil)
+			s.mu.Unlock()
+			continue
+		}
+
+		// Legacy fallback path (harness does not implement FrameNormaliser).
 		switch frame.Type {
 		case "state_change":
 			st := agent.AgentState(frame.State)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6642,14 +6642,14 @@ exit 0
 	sc := New(cfg)
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
-		`{"branch":"feature","harness":"pi"}`)
+		`{"branch":"feature","harness":"not-a-real-harness"}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 for unknown harness; body = %s", rr.Code, rr.Body.String())
 	}
 	var errResp map[string]string
 	decodeJSONBody(t, rr, &errResp)
-	if !strings.Contains(errResp["error"], `unknown harness "pi"`) {
-		t.Errorf("error %q should mention 'unknown harness \"pi\"'", errResp["error"])
+	if !strings.Contains(errResp["error"], `unknown harness "not-a-real-harness"`) {
+		t.Errorf("error %q should mention 'unknown harness \"not-a-real-harness\"'", errResp["error"])
 	}
 	if !strings.Contains(errResp["error"], "valid harnesses:") {
 		t.Errorf("error %q should mention 'valid harnesses:'", errResp["error"])


### PR DESCRIPTION
## Summary

- **B5.TR**: Adds a PI sidecar adapter (`internal/harness/pi/adapter.go`) that normalises PI's JSONL event stream to opencode-shaped `agent_events.payload` at write time. Introduces optional `FrameNormaliser` interface in `internal/harness` so the sidecar can type-assert without a direct import.
- **B6.PI**: Adds `ArchiveAdapter` for PI sessions (`internal/harness/pi/archive.go`) — `SourcePath`, `Archive` (copies `*.jsonl` to `raw/`), `Export` (copies `raw/session.jsonl`), and `Version` (`pi --version`).
- Registers PI in the harness registry via `internal/harness/pi/register.go` and updates two tests that previously expected "pi" to be an unknown harness.

Closes #1143