### PR TITLE
feat: sidecar self-mints instance_id at startup

### DIFF
--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -23,10 +23,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/sandboxenv"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -127,79 +125,23 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		}
 	}
 
-	// Look up instance_id for the calling session. When no instance_id is
-	// registered (e.g. a coordinator session opened outside of prism switch,
-	// which is the common case for @main sessions), mint one on the fly and
-	// write it to the DB so the rest of the merge flow proceeds normally.
-	var instanceID string
-	if callerSession != "" {
-		status, statusErr := d.CurrentStatus(callerSession)
-		if statusErr != nil {
-			return fmt.Errorf("prism merge: look up session %q: %w", callerSession, statusErr)
-		}
-		if status != nil && status.InstanceID != nil {
-			instanceID = *status.InstanceID
-		}
+	// Look up instance_id for the calling session. The sidecar mints
+	// instance_id at startup, so it should always be present in the DB row.
+	// If it is missing, the sidecar startup did not run correctly — return a
+	// clear error rather than attempting on-the-fly recovery.
+	if callerSession == "" {
+		return fmt.Errorf("prism merge: cannot determine calling session — run from inside a prism tmux session or set PRISM_SESSION_NAME")
 	}
-	if instanceID == "" {
-		// Guard: if we have no session identity at all, we cannot mint a
-		// meaningful instance_id — fail with a clear message rather than
-		// creating a garbage DB row keyed on an empty session name.
-		if callerSession == "" {
-			return fmt.Errorf("prism merge: cannot determine calling session — run from inside a prism tmux session or set PRISM_SESSION_NAME")
-		}
-
-		// Determine worktree and repo for the on-the-fly registration.
-		// Prefer the value already stored in agent_status (if the row exists
-		// with a non-empty worktree); fall back to the process's CWD.
-		worktree, _ := os.Getwd()
-		// Re-query: the status row may already exist with a worktree.
-		if existing, _ := d.CurrentStatus(callerSession); existing != nil && existing.Worktree != "" {
-			worktree = existing.Worktree
-		}
-		repo := deriveRepo(worktree)
-		if repo == "" {
-			// Not inside a bare-repo worktree — derive from the session name.
-			if idx := strings.Index(callerSession, "@"); idx > 0 {
-				repo = callerSession[:idx]
-			}
-		}
-
-		minted := uuid.New().String()
-		// Ensure the agent_status row exists before writing instance_id.
-		if upsertErr := d.UpsertStatus(callerSession, repo, worktree, "idle", nil, nil); upsertErr != nil {
-			return fmt.Errorf("prism merge: register session %q: %w", callerSession, upsertErr)
-		}
-		// Clear any stale ended_at so the session is visible as active in the
-		// dashboard and in ended_at IS NULL queries. This mirrors the
-		// tmux-session-start handler (event.go:ClearEnded) which does the same
-		// immediately after UpsertStatus, and covers the case where the session
-		// was previously ended but has been re-opened without prism switch.
-		if clearErr := d.ClearEnded(callerSession); clearErr != nil {
-			fmt.Fprintf(os.Stderr, "prism merge: clear ended for %q: %v\n", callerSession, clearErr)
-		}
-		if setErr := d.SetInstanceID(callerSession, minted); setErr != nil {
-			return fmt.Errorf("prism merge: set instance_id for session %q: %w", callerSession, setErr)
-		}
-		// Insert a sessions row so the incarnation is fully registered
-		// (idempotent: INSERT OR IGNORE).
-		if insErr := d.InsertSession(db.Session{
-			InstanceID:  minted,
-			SessionName: callerSession,
-			Repo:        repo,
-			Worktree:    worktree,
-		}); insErr != nil {
-			// Non-fatal: log and continue. The instance_id is already written
-			// to agent_status, which is sufficient for EnqueueMerge.
-			fmt.Fprintf(os.Stderr, "prism merge: insert session row for %q: %v\n", callerSession, insErr)
-		}
-		instanceID = minted
+	status, statusErr := d.CurrentStatus(callerSession)
+	if statusErr != nil {
+		return fmt.Errorf("prism merge: look up session %q: %w", callerSession, statusErr)
 	}
+	if status == nil || status.InstanceID == nil || *status.InstanceID == "" {
+		return fmt.Errorf("prism merge: session %q has no instance_id — the sidecar did not start correctly", callerSession)
+	}
+	instanceID := *status.InstanceID
 
 	sessionName := callerSession
-	if sessionName == "" {
-		sessionName = "unknown"
-	}
 
 	// Pre-flight: verify the PR exists and is open, and fetch its title.
 	// Timeout is kept tight (5s) so the overall command returns well within

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -109,20 +109,16 @@ func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
 
 // ── mint-on-the-fly instance_id ───────────────────────────────────────────────
 
-// TestRunMerge_MintsInstanceIDWhenMissing verifies that when a coordinator
-// session has no pre-existing instance_id in the DB, runMerge mints one and
-// writes it to both agent_status and the sessions table. The call proceeds
-// past the instance_id check and fails at the gh preflight (expected in a
-// test environment with no real GitHub API), not at the instance_id guard.
-//
-// This is the fix for issue #1031: prism merge failed with
-// "cannot determine instance_id" for @main coordinator sessions opened
-// without going through prism switch.
-func TestRunMerge_MintsInstanceIDWhenMissing(t *testing.T) {
+// TestRunMerge_FailsWhenInstanceIDMissing verifies that when a coordinator
+// session has no instance_id in the DB, runMerge returns a clear error
+// indicating the sidecar did not start correctly. The sidecar is now the
+// sole owner of instance_id minting (issue #1252); on-the-fly recovery in
+// runMerge has been removed.
+func TestRunMerge_FailsWhenInstanceIDMissing(t *testing.T) {
 	openMergeTestDB(t)
 
 	// Seed a coordinator session WITHOUT an instance_id (simulates a
-	// @main session opened outside of prism switch → ensureAndSwitch).
+	// @main session whose sidecar did not run correctly).
 	const coordSession = "nixos-config@main"
 	d, err := openDB()
 	if err != nil {
@@ -132,66 +128,18 @@ func TestRunMerge_MintsInstanceIDWhenMissing(t *testing.T) {
 		d.Close()
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
-	// Confirm no instance_id is set.
-	status, err := d.CurrentStatus(coordSession)
-	if err != nil {
-		d.Close()
-		t.Fatalf("CurrentStatus: %v", err)
-	}
-	if status == nil {
-		d.Close()
-		t.Fatal("CurrentStatus: got nil, want status row")
-	}
-	if status.InstanceID != nil {
-		d.Close()
-		t.Fatalf("precondition: expected nil instance_id, got %q", *status.InstanceID)
-	}
 	d.Close()
 
 	t.Setenv("PRISM_SESSION_NAME", coordSession)
 	t.Setenv("TMUX", "")
 
-	// runMerge should fail at the gh preflight, not at the instance_id guard.
+	// runMerge should fail with a clear error about missing instance_id,
+	// not attempt on-the-fly minting.
 	err = runMerge(mergeCmd, []string{"999"})
-	if err != nil {
-		// Acceptable: gh preflight will fail in CI/test environments.
-		if strings.Contains(err.Error(), "cannot determine instance_id") {
-			t.Fatalf("runMerge still fails with old 'cannot determine instance_id' error — fix did not take effect: %v", err)
-		}
-		if strings.Contains(err.Error(), "cannot determine calling session") {
-			t.Fatalf("runMerge returned 'cannot determine calling session' — should only happen when callerSession is empty, not here: %v", err)
-		}
-		if strings.Contains(err.Error(), "register session") || strings.Contains(err.Error(), "set instance_id") {
-			t.Fatalf("runMerge failed at DB registration step: %v", err)
-		}
-		// Any other error (e.g. gh not found, PR 999 not open) is expected.
-		t.Logf("runMerge failed at preflight (expected in test env): %v", err)
+	if err == nil {
+		t.Fatal("expected runMerge to return an error when instance_id is missing, got nil")
 	}
-
-	// Verify the instance_id was minted and persisted to agent_status.
-	d2, err := openDB()
-	if err != nil {
-		t.Fatalf("openDB for verify: %v", err)
-	}
-	defer d2.Close()
-
-	status2, err := d2.CurrentStatus(coordSession)
-	if err != nil {
-		t.Fatalf("CurrentStatus after runMerge: %v", err)
-	}
-	if status2 == nil {
-		t.Fatal("CurrentStatus after runMerge: got nil, want status row")
-	}
-	if status2.InstanceID == nil || *status2.InstanceID == "" {
-		t.Fatal("instance_id was not minted and written to agent_status")
-	}
-
-	// Verify a sessions row was inserted for the minted instance_id.
-	sess, err := d2.SessionByInstanceID(*status2.InstanceID)
-	if err != nil {
-		t.Fatalf("SessionByInstanceID: %v", err)
-	}
-	if sess == nil {
-		t.Errorf("no sessions row found for minted instance_id %q", *status2.InstanceID)
+	if !strings.Contains(err.Error(), "no instance_id") && !strings.Contains(err.Error(), "sidecar did not start") {
+		t.Fatalf("expected error about missing instance_id / sidecar not starting, got: %v", err)
 	}
 }

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -533,8 +533,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 
 	// Write spawn_inputs row. This is best-effort: a failure is logged but
 	// does not roll back the session (the session is already live).
-	// We read instance_id back from the DB because SpawnSession generates it
-	// internally and we do not want to thread it back through SpawnOpts just
+	// We read instance_id back from the DB because the sidecar mints it
+	// at startup and we do not want to thread it back through SpawnOpts just
 	// for this write path.
 	writeSpawnInputs(d, spawnInputsArgs{
 		sessionName:        sessionName,

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
@@ -170,34 +169,6 @@ func ensureAndSwitch(path string, projectRoot string, opts session.Opts) error {
 		// ForceFresh=true so session.Create kills unconditionally without a
 		// second DB query that would see the freshly-written UpsertStatus row.
 		opts.ForceFresh = true
-	}
-
-	// Pre-generate a UUID instance_id and write it to agent_status before
-	// starting the sidecar. The sidecar is launched inside session.Create
-	// (before tmux-session-start fires), so the instance_id must be in the DB
-	// before the sidecar reads it. We also pass it via opts.InstanceID so
-	// StartSidecarWithOpts can forward it as --instance-id to the sidecar
-	// process without needing a DB read.
-	//
-	// This block is reached only for new sessions or stale zombies (the live
-	// early-exit above handles the attach-to-live case).
-	if d != nil && opts.Layout == session.LayoutFull {
-		instanceID := uuid.New().String()
-		// Ensure the agent_status row exists before writing instance_id.
-		// allocatePortForSession already upserts it, but call UpsertStatus
-		// here defensively in case port allocation is skipped.
-		repo := deriveRepo(directory)
-		if repo == "" {
-			if idx := strings.Index(sessionName, "@"); idx > 0 {
-				repo = sessionName[:idx]
-			}
-		}
-		_ = d.UpsertStatus(sessionName, repo, directory, "idle", nil, nil)
-		if err := d.SetInstanceID(sessionName, instanceID); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not set instance_id for %q: %v\n", sessionName, err)
-		} else {
-			opts.InstanceID = instanceID
-		}
 	}
 
 	// Allocate a port for full-layout sessions. The agent_status row must

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -28,8 +28,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -441,23 +439,6 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	if opts.GroupID != "" {
 		if err := d.SetGroupID(opts.SessionName, opts.GroupID); err != nil {
 			return fmt.Errorf("spawn session: set group_id: %w", err)
-		}
-	}
-
-	// Generate an instance_id if the caller did not pre-populate one. The
-	// sidecar needs it via --instance-id to tag container labels and bus
-	// messages; writing it to the DB here keeps the DB row in sync before
-	// the tmux-session-start hook fires.
-	if opts.InstanceID == "" && opts.Layout == LayoutFull {
-		opts.InstanceID = uuid.New().String()
-		if err := d.SetInstanceID(opts.SessionName, opts.InstanceID); err != nil {
-			// Non-fatal: instance isolation degrades gracefully. Log and
-			// continue — the sidecar will read back an empty instance_id
-			// from the DB (which is the pre-instance-id behaviour).
-			fmt.Fprintf(os.Stderr,
-				"warning: could not set instance_id for %q: %v\n",
-				opts.SessionName, err)
-			opts.InstanceID = ""
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1122,8 +1122,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		if s.cfg.InstanceID == "" {
+			log.Printf("sidecar: host-API /merge: no instance_id — sidecar startup did not run correctly")
 			writeError(w, http.StatusInternalServerError,
-				"sidecar has no instance_id — cannot enqueue merge without an instance identity")
+				"sidecar has no instance_id — sidecar startup did not run")
 			return
 		}
 
@@ -1158,8 +1159,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		if s.cfg.InstanceID == "" {
+			log.Printf("sidecar: host-API /merges: no instance_id — sidecar startup did not run correctly")
 			writeError(w, http.StatusInternalServerError,
-				"sidecar has no instance_id — cannot list merges without an instance identity")
+				"sidecar has no instance_id — sidecar startup did not run")
 			return
 		}
 
@@ -1204,8 +1206,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		if s.cfg.InstanceID == "" {
+			log.Printf("sidecar: host-API /merges/cancel: no instance_id — sidecar startup did not run correctly")
 			writeError(w, http.StatusInternalServerError,
-				"sidecar has no instance_id — cannot cancel merge without an instance identity")
+				"sidecar has no instance_id — sidecar startup did not run")
 			return
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -46,6 +46,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
@@ -462,6 +463,30 @@ func (s *Sidecar) Run(ctx context.Context) error {
 				}
 			}()
 			log.Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
+		}
+	}
+
+	// Mint or load instance_id. The sidecar is the single owner of session
+	// identity. When --instance-id was passed at spawn time, s.cfg.InstanceID
+	// is already set (fast path). Otherwise, query the DB: if the row has a
+	// non-NULL instance_id, load it; if not, mint a fresh UUID and write it.
+	// This runs before the merge-queue watcher so the watcher always has an
+	// identity to key on.
+	if s.cfg.InstanceID == "" && s.cfg.DB != nil {
+		status, _ := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
+		if status != nil && status.InstanceID != nil && *status.InstanceID != "" {
+			s.cfg.InstanceID = *status.InstanceID
+			log.Printf("sidecar: instance_id loaded from DB (%s)", s.cfg.InstanceID)
+		} else {
+			minted := uuid.New().String()
+			// Defensively ensure the row exists before writing instance_id.
+			_ = s.cfg.DB.UpsertStatus(s.cfg.SessionName, "", "", "idle", nil, nil)
+			if err := s.cfg.DB.SetInstanceID(s.cfg.SessionName, minted); err != nil {
+				log.Printf("sidecar: warning: could not write minted instance_id: %v", err)
+			} else {
+				s.cfg.InstanceID = minted
+				log.Printf("sidecar: instance_id minted (%s)", s.cfg.InstanceID)
+			}
 		}
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -480,7 +480,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		} else {
 			minted := uuid.New().String()
 			// Defensively ensure the row exists before writing instance_id.
-			_ = s.cfg.DB.UpsertStatus(s.cfg.SessionName, "", "", "idle", nil, nil)
+			_ = s.cfg.DB.UpsertStatus(s.cfg.SessionName, s.cfg.Repo, s.cfg.Worktree, "idle", nil, nil)
 			if err := s.cfg.DB.SetInstanceID(s.cfg.SessionName, minted); err != nil {
 				log.Printf("sidecar: warning: could not write minted instance_id: %v", err)
 			} else {


### PR DESCRIPTION
## Summary

- The sidecar is now the single owner of `instance_id`. On startup, it mints a fresh UUID (or loads the existing one from the DB) before the merge-queue watcher starts — fixing the live bug where `prism merge` failed on live-attached `@main` sessions that never acquired an `instance_id`.
- Removed caller-side minting from `cmd/switch.go` and `internal/session/spawn.go`.
- Removed on-the-fly recovery in `cmd/merge.go`; missing `instance_id` is now a real error (sidecar startup bug), not a recoverable state.
- Tightened host-API guards to log a warning mentioning "sidecar startup did not run".

Closes #1252