### PR TITLE
bwrap: shadow /etc/ssh to prevent OpenSSH nobody-owned drop-in failing git push

### DIFF
--- a/modules/programs/prism/prism/docs/sandbox-exec-testing.md
+++ b/modules/programs/prism/prism/docs/sandbox-exec-testing.md
@@ -150,7 +150,7 @@ integration test coverage exists for:
   time (e.g. `~/.config/aws/readonly-config`, the SSH access key) accessed
   via the in-sandbox `$HOME` path.
 - **Explicit denies** — `~/.aws`, `/private/etc/wireguard`,
-  `/private/etc/wpa_supplicant` are blocked.
+  `/private/etc/wpa_supplicant`, `/private/etc/ssh` are blocked.
 - **Network egress** — `(allow network*)` permits outbound TCP.
 
 Each positive case has a paired negative case that mutates the profile to

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -255,6 +255,7 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	for _, sensitiveEtcDir := range []string{
 		"/etc/wireguard",
 		"/etc/wpa_supplicant",
+		"/etc/ssh", // systemd drop-ins are nobody-owned; OpenSSH rejects them
 	} {
 		if _, err := os.Stat(sensitiveEtcDir); err == nil {
 			args = append(args, "--tmpfs", sensitiveEtcDir)

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -245,6 +245,13 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// /etc/wpa_supplicant/ — wpa_supplicant configs may contain Wi-Fi
 	// credentials and network identifiers. Agents have no need for these.
 	//
+	// /etc/ssh/ — contains SSH host private keys (ssh_host_*_key) and
+	// system-wide ssh_config. On NixOS the system ssh_config includes a
+	// nobody-owned systemd drop-in via Include; OpenSSH enforces strict
+	// ownership and rejects it, causing git push over SSH to fail. Shadowing
+	// the entire subtree is safe: the generated ~/.ssh/config already
+	// provides all the SSH configuration an agent needs.
+	//
 	// The --tmpfs mounts are conditional on the directory existing on the
 	// host: bwrap requires the mount-point to already exist inside the
 	// namespace (the /etc ro-bind makes the host tree visible, so the check

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -2193,10 +2193,10 @@ func TestBwrapBuildArgs_SystemRootsBeforeWorktree(t *testing.T) {
 // ── Security: sensitive /etc subtree shadowing ───────────────────────────────
 
 // TestBwrapBuildArgs_SensitiveEtcSubtreesShadowed verifies that when
-// /etc/wireguard and /etc/wpa_supplicant exist on the host, BuildArgs emits
-// --tmpfs for each AFTER the /etc ro-bind-mount. The ordering is critical:
-// bwrap applies mounts left-to-right, so the tmpfs must come after the ro-bind
-// to shadow the subtree rather than being overwritten by it.
+// /etc/wireguard, /etc/wpa_supplicant, and /etc/ssh exist on the host,
+// BuildArgs emits --tmpfs for each AFTER the /etc ro-bind-mount. The ordering
+// is critical: bwrap applies mounts left-to-right, so the tmpfs must come
+// after the ro-bind to shadow the subtree rather than being overwritten by it.
 func TestBwrapBuildArgs_SensitiveEtcSubtreesShadowed(t *testing.T) {
 	// Create fake /etc/wireguard and /etc/wpa_supplicant directories in a temp
 	// location, then temporarily point the os.Stat checks at them by creating
@@ -2210,6 +2210,7 @@ func TestBwrapBuildArgs_SensitiveEtcSubtreesShadowed(t *testing.T) {
 	sensitives := []tempDir{
 		{path: "/etc/wireguard"},
 		{path: "/etc/wpa_supplicant"},
+		{path: "/etc/ssh"},
 	}
 	for i := range sensitives {
 		if _, err := os.Stat(sensitives[i].path); os.IsNotExist(err) {
@@ -2272,16 +2273,16 @@ func TestBwrapBuildArgs_SensitiveEtcSubtreesShadowed(t *testing.T) {
 }
 
 // TestBwrapBuildArgs_SensitiveEtcSubtreesAbsentWhenMissing verifies that when
-// /etc/wireguard and /etc/wpa_supplicant do not exist on the host, BuildArgs
-// does NOT emit --tmpfs for them. On a machine without wgnord enabled and
-// without the directories pre-created, the mounts must be omitted to avoid
+// /etc/wireguard, /etc/wpa_supplicant, and /etc/ssh do not exist on the host,
+// BuildArgs does NOT emit --tmpfs for them. On a machine without wgnord enabled
+// and without the directories pre-created, the mounts must be omitted to avoid
 // failing with EROFS when bwrap tries to create the mount-point inside the
 // read-only /etc namespace.
 func TestBwrapBuildArgs_SensitiveEtcSubtreesAbsentWhenMissing(t *testing.T) {
 	// This test only runs meaningfully when the directories are absent.
-	// If they both exist (e.g. this is the navi machine with impermanence),
+	// If they all exist (e.g. this is the navi machine with impermanence),
 	// there's nothing to verify here — skip gracefully.
-	for _, p := range []string{"/etc/wireguard", "/etc/wpa_supplicant"} {
+	for _, p := range []string{"/etc/wireguard", "/etc/wpa_supplicant", "/etc/ssh"} {
 		if _, err := os.Stat(p); err == nil {
 			t.Skipf("%s exists on this host — cannot test the absent-path branch", p)
 		}
@@ -2297,7 +2298,7 @@ func TestBwrapBuildArgs_SensitiveEtcSubtreesAbsentWhenMissing(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	for _, p := range []string{"/etc/wireguard", "/etc/wpa_supplicant"} {
+	for _, p := range []string{"/etc/wireguard", "/etc/wpa_supplicant", "/etc/ssh"} {
 		for i := 0; i+1 < len(args); i++ {
 			if args[i] == "--tmpfs" && args[i+1] == p {
 				t.Errorf("--tmpfs %s should NOT appear in args when the directory does not exist on the host, but it does: %v", p, args)

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -99,7 +99,7 @@ func (s *sandboxExecIsolator) BuildRunArgs() []string {
 //     file-read-metadata alongside file-read* (required by dyld/AMFI)
 //   - /bin, /sbin, and /var/... symlink-alias forms (v3 additions)
 //   - /tmp read-write for xcrun and transient files
-//   - Deny of sensitive /private/etc subtrees (wireguard, wpa_supplicant),
+//   - Deny of sensitive /private/etc subtrees (wireguard, wpa_supplicant, ssh),
 //     both /etc/... and /private/etc/... forms (symlink non-transparency)
 //   - Host ~/.aws deny (only staged entries accessible)
 //   - Staging HOME / worktree / bare repo / host-API socket dir (RW)
@@ -256,8 +256,10 @@ func generateProfile(m *Manager) string {
 	sb.WriteString("(deny file-read* file-write*\n")
 	sb.WriteString("  (subpath \"/etc/wireguard\")\n")
 	sb.WriteString("  (subpath \"/etc/wpa_supplicant\")\n")
+	sb.WriteString("  (subpath \"/etc/ssh\")\n")
 	sb.WriteString("  (subpath \"/private/etc/wireguard\")\n")
-	sb.WriteString("  (subpath \"/private/etc/wpa_supplicant\"))\n")
+	sb.WriteString("  (subpath \"/private/etc/wpa_supplicant\")\n")
+	sb.WriteString("  (subpath \"/private/etc/ssh\"))\n")
 	sb.WriteString("\n")
 
 	// ── 5. Host ~/.aws deny — keep host credentials invisible ─────────────

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -113,8 +113,10 @@ func TestGenerateProfile_SensitiveSubtreeDenies(t *testing.T) {
 	expected := []string{
 		`(subpath "/etc/wireguard")`,
 		`(subpath "/etc/wpa_supplicant")`,
+		`(subpath "/etc/ssh")`,
 		`(subpath "/private/etc/wireguard")`,
 		`(subpath "/private/etc/wpa_supplicant")`,
+		`(subpath "/private/etc/ssh")`,
 	}
 	for _, want := range expected {
 		if !strings.Contains(denyBlock, want) {

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_denies_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_denies_darwin_test.go
@@ -8,10 +8,12 @@ package integration_test
 //   - (deny file-read* file-write* (subpath "<HOME>/.aws"))
 //   - (deny file-read* file-write* (subpath "/etc/wireguard"))
 //   - (deny file-read* file-write* (subpath "/etc/wpa_supplicant"))
+//   - (deny file-read* file-write* (subpath "/etc/ssh"))
 //   - (deny file-read* file-write* (subpath "/private/etc/wireguard"))
 //   - (deny file-read* file-write* (subpath "/private/etc/wpa_supplicant"))
+//   - (deny file-read* file-write* (subpath "/private/etc/ssh"))
 //
-// Approach: the wireguard/wpa_supplicant directories typically do not
+// Approach: the wireguard/wpa_supplicant/ssh directories typically do not
 // exist on developer macOS workstations, so a literal stat on those paths
 // is dominated by ENOENT rather than EPERM and does not distinguish "denied
 // by sandbox" from "absent on disk". The ~/.aws deny is defensive — it
@@ -78,8 +80,10 @@ func TestSandboxExecProfile_Denies_Present(t *testing.T) {
 	expected := []string{
 		"  (subpath \"/etc/wireguard\")",
 		"  (subpath \"/etc/wpa_supplicant\")",
+		"  (subpath \"/etc/ssh\")",
 		"  (subpath \"/private/etc/wireguard\")",
-		"  (subpath \"/private/etc/wpa_supplicant\"))",
+		"  (subpath \"/private/etc/wpa_supplicant\")",
+		"  (subpath \"/private/etc/ssh\"))",
 		"  (subpath \"" + home + "/.aws\"))",
 	}
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_denies_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_denies_darwin_test.go
@@ -25,21 +25,29 @@ package integration_test
 //
 // We therefore split the coverage into:
 //
-//   1. Profile-content assertions
-//      (`TestSandboxExecProfile_Denies_Present`) that the five expected
-//      deny rules are emitted. These guard against the rules being
-//      silently dropped from the generator — the regression mode the
-//      backfilling convention exists to catch.
+//  1. Profile-content assertions
+//     (`TestSandboxExecProfile_Denies_Present`) that the seven expected
+//     deny rules are emitted. These guard against the rules being
+//     silently dropped from the generator — the regression mode the
+//     backfilling convention exists to catch.
 //
-//   2. A deny-mechanism integration test pair
-//      (`TestSandboxExecProfile_DenyOverridesAllow_BlocksReads` /
-//      `TestSandboxExecProfile_DenyOverridesAllow_NegationAllowsReads`)
-//      that proves the deny precedence works end-to-end against
-//      sandbox-exec. The positive test mutates the generated profile to
-//      add an allow + deny pair on a controlled host path and asserts the
-//      deny wins. The negative test removes only the deny and asserts the
-//      same read now succeeds — proving the deny rule itself is what
-//      blocked the read in the positive case.
+//  2. A deny-mechanism integration test pair
+//     (`TestSandboxExecProfile_DenyOverridesAllow_BlocksReads` /
+//     `TestSandboxExecProfile_DenyOverridesAllow_NegationAllowsReads`)
+//     that proves the deny precedence works end-to-end against
+//     sandbox-exec. The positive test mutates the generated profile to
+//     add an allow + deny pair on a controlled host path and asserts the
+//     deny wins. The negative test removes only the deny and asserts the
+//     same read now succeeds — proving the deny rule itself is what
+//     blocked the read in the positive case.
+//
+//  3. A production /etc/ssh deny test pair
+//     (`TestSandboxExecProfile_EtcSSHDenied_BlocksReads` /
+//     `TestSandboxExecProfile_EtcSSHDenied_NegationAllowsReads`)
+//     that tests the production deny rules directly against a real file
+//     on the host (/private/etc/ssh/ssh_config). Unlike wireguard/
+//     wpa_supplicant (which may not exist on developer machines), /etc/ssh
+//     is present on macOS, so the deny vs. ENOENT ambiguity is resolved.
 //
 // This is more precise than testing ~/.aws or wireguard directly: it
 // isolates the deny mechanism (allow + deny → deny wins) from the
@@ -257,5 +265,92 @@ func TestSandboxExecProfile_DenyOverridesAllow_NegationAllowsReads(t *testing.T)
 	if !strings.Contains(string(out), sentinelData) {
 		t.Errorf("read of %s exited 0 but output does not contain the sentinel marker.\nOutput: %s",
 			sentinel, string(out))
+	}
+}
+
+// TestSandboxExecProfile_EtcSSHDenied_BlocksReads is the positive half of the
+// /etc/ssh deny coverage (issue #1260). /private/etc/ssh exists on macOS and
+// is covered by the broad (allow file-read* (subpath "/private/etc")) rule in
+// section 2 of the profile. The deny rule for /private/etc/ssh must override
+// it so that reads of files under /private/etc/ssh (e.g. ssh_config, host
+// keys) are blocked inside the sandbox.
+//
+// If /private/etc/ssh or /private/etc/ssh/ssh_config does not exist on the
+// host, this test is skipped — the read-block would be indistinguishable from
+// ENOENT.
+func TestSandboxExecProfile_EtcSSHDenied_BlocksReads(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	target := "/private/etc/ssh/ssh_config"
+	if _, err := os.Stat(target); err != nil {
+		t.Skipf("%s does not exist on this host — cannot distinguish sandbox deny from ENOENT: %v", target, err)
+	}
+
+	// Use BareRoot so the profile's ancestor block grants traversal to /
+	// (needed for /private/etc/ssh path resolution).
+	m := newProfileManagerWithBareRoot(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	augmented := augmentProfileForTest(prepared.content)
+	testProfilePath := prepared.path + ".integ-ssh-pos"
+	if err := os.WriteFile(testProfilePath, []byte(augmented), 0o600); err != nil {
+		t.Fatalf("write test profile: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(testProfilePath) })
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read of %s succeeded (exit 0) even with the (deny file-read* (subpath \"/private/etc/ssh\")) rule in the profile.\n"+
+			"The /etc/ssh deny is not load-bearing — sandboxed agents can read SSH host keys.\n"+
+			"Output: %s\nProfile: %s", target, string(out), testProfilePath)
+	} else {
+		t.Logf("ka pai — /private/etc/ssh read correctly blocked (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecProfile_EtcSSHDenied_NegationAllowsReads is the paired
+// negative test. It removes the /etc/ssh and /private/etc/ssh deny rules and
+// asserts that the same read succeeds — proving the deny rules are what block
+// the read in the positive test, not the default-deny posture.
+func TestSandboxExecProfile_EtcSSHDenied_NegationAllowsReads(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	target := "/private/etc/ssh/ssh_config"
+	if _, err := os.Stat(target); err != nil {
+		t.Skipf("%s does not exist on this host — cannot distinguish sandbox deny from ENOENT: %v", target, err)
+	}
+
+	m := newProfileManagerWithBareRoot(t)
+	profilePath := withMutatedProfile(t, m, func(p string) string {
+		// Remove the /etc/ssh subpath line from the deny block.
+		p = strings.ReplaceAll(p, "  (subpath \"/etc/ssh\")\n", "")
+		// The /private/etc/ssh line is the last in the block (has closing "))").
+		// Promote /private/etc/wpa_supplicant to be the last entry instead.
+		p = strings.ReplaceAll(p, "  (subpath \"/private/etc/wpa_supplicant\")\n  (subpath \"/private/etc/ssh\"))\n",
+			"  (subpath \"/private/etc/wpa_supplicant\"))\n")
+		return p
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("read of %s failed even with the /etc/ssh deny rules removed.\n"+
+			"The profile's (allow file-read* (subpath \"/private/etc\")) should permit this read.\n"+
+			"If it doesn't, the negative test is not isolating the right rules.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	} else {
+		t.Logf("ka pai — read succeeded without deny rules (expected)")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `/etc/ssh` to the sensitive-etc-dir shadow block in `BuildArgs` (`internal/container/bwrap.go`)
- A `--tmpfs` is mounted over `/etc/ssh` inside the bwrap sandbox, hiding the host's `ssh_config` (which includes a nobody-owned systemd drop-in that OpenSSH rejects)
- Follows the identical pattern already used for `/etc/wireguard` and `/etc/wpa_supplicant`

Closes #1260