### PR TITLE
C.2: add --model-override per-role model flag to spawn and review

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -59,6 +59,7 @@ func init() {
 	reviewCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	reviewCmd.Flags().Int("diff-inline-max", 0,
 		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
+	reviewCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro); takes precedence over --model for the named role")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -81,6 +82,8 @@ func runReview(cmd *cobra.Command, args []string) error {
 	onlyFlag, _ := cmd.Flags().GetString("only")
 	onlyChanged := cmd.Flags().Changed("only")
 	diffInlineMaxFlag, _ := cmd.Flags().GetInt("diff-inline-max")
+	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
+	modelsByRole := parseModelOverrides(modelOverrideRaw)
 
 	// Validate harness BEFORE any session state is created.
 	if _, ok := harness.Lookup(harnessFlag); !ok {
@@ -268,6 +271,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,
 		RuntimeEnvVars: h.RuntimeEnv(),
+		ModelsByRole:   modelsByRole,
 	}
 
 	// Load profiles for any sandboxed mode (podman, bwrap, or sandbox-exec) —

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -83,7 +83,10 @@ func runReview(cmd *cobra.Command, args []string) error {
 	onlyChanged := cmd.Flags().Changed("only")
 	diffInlineMaxFlag, _ := cmd.Flags().GetInt("diff-inline-max")
 	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
-	modelsByRole := parseModelOverrides(modelOverrideRaw)
+	modelsByRole, err := parseModelOverrides(modelOverrideRaw)
+	if err != nil {
+		return err
+	}
 
 	// Validate harness BEFORE any session state is created.
 	if _, ok := harness.Lookup(harnessFlag); !ok {

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -103,6 +103,7 @@ func init() {
 	sidecarCmd.Flags().String("harness", "opencode", "Agent harness to use (e.g. opencode)")
 	sidecarCmd.Flags().String("harness-binary", "", "Path to the harness binary (required for stdio-pipe harnesses; ignored for http-port harnesses)")
 	sidecarCmd.Flags().String("bwrap-path", "", "Override path to the bwrap binary used to sandbox stdio-pipe harnesses (default: resolved via PATH)")
+	sidecarCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable; C.2)")
 	_ = sidecarCmd.MarkFlagRequired("session")
 	_ = sidecarCmd.MarkFlagRequired("opencode-url")
 	rootCmd.AddCommand(sidecarCmd)
@@ -123,11 +124,28 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	harnessName, _ := cmd.Flags().GetString("harness")
 	harnessBinaryPath, _ := cmd.Flags().GetString("harness-binary")
 	bwrapPath, _ := cmd.Flags().GetString("bwrap-path")
+	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
 	if harnessName == "" {
 		harnessName = "opencode"
 	}
 	if _, ok := harness.Lookup(harnessName); !ok {
 		return fmt.Errorf("sidecar: unknown harness %q: valid harnesses: %s", harnessName, strings.Join(harness.Names(), ", "))
+	}
+
+	// Parse --model-override flags into a role→model map (C.2).
+	// Each entry is expected to be "role=model"; malformed entries are logged
+	// and skipped rather than causing a hard failure at sidecar startup.
+	modelsByRole := make(map[string]string, len(modelOverrideRaw))
+	for _, entry := range modelOverrideRaw {
+		role, model, ok := strings.Cut(entry, "=")
+		if !ok || role == "" || model == "" {
+			fmt.Fprintf(os.Stderr, "[prism sidecar] warning: ignoring malformed --model-override %q (expected role=model)\n", entry)
+			continue
+		}
+		modelsByRole[role] = model
+	}
+	if len(modelsByRole) == 0 {
+		modelsByRole = nil
 	}
 
 	// Resolve the effective isolation mode. When --isolation-mode is set it
@@ -193,8 +211,15 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// Resolve the agent model once via the harness adapter. The adapter is
 	// constructed transiently here for the EffectiveModel call; a fresh
 	// adapter with the resolved model is constructed below for the sidecar.
-	modelProbe, _ := harness.New(harnessName, "", nil, agentRole, "")
-	agentModel := modelProbe.EffectiveModel(agentRole)
+	// When modelsByRole contains an entry for agentRole, that takes precedence
+	// over the profile/opencode.json lookup (C.2 §6.3).
+	var agentModel string
+	if m, ok := modelsByRole[agentRole]; ok && m != "" {
+		agentModel = m
+	} else {
+		modelProbe, _ := harness.New(harnessName, "", nil, agentRole, "")
+		agentModel = modelProbe.EffectiveModel(agentRole)
+	}
 
 	// Load profiles to extract container resource caps and agent env vars.
 	// Non-fatal if missing (e.g. running without the nix module) — resource
@@ -306,8 +331,17 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	//   - CreateSession uses GET /session to retrieve the existing session ID
 	//     (opencode already created a session when the TUI started)
 	//   - DeliverInitialPrompt is a no-op (prompt was sent via --prompt CLI flag)
+	//
+	// When modelsByRole is non-nil (C.2 --model-override), pass the full map
+	// so DeliverInitialPrompt and EffectiveModel use per-role models.
 	var h harness.Harness
-	if useContainerHarness {
+	if len(modelsByRole) > 0 {
+		if useContainerHarness {
+			h, err = harness.NewContainerWithModelOverrides(harnessName, opencodeURL, nil, agentRole, modelsByRole)
+		} else {
+			h, err = harness.NewWithModelOverrides(harnessName, opencodeURL, nil, agentRole, modelsByRole)
+		}
+	} else if useContainerHarness {
 		h, err = harness.NewContainer(harnessName, opencodeURL, nil, agentRole, agentModel)
 	} else {
 		h, err = harness.New(harnessName, opencodeURL, nil, agentRole, agentModel)
@@ -332,6 +366,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		Clock:             sidecar.RealClock(),
 		AgentRole:         agentRole,
 		AgentModel:        agentModel,
+		ModelsByRole:      modelsByRole,
 		HarnessName:       harnessName,
 		HarnessBinaryPath: harnessBinaryPath,
 		BwrapPath:         bwrapPath,

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -5,19 +5,21 @@ package cmd
 //
 // Flags:
 //
-//	--branch <name>       use a specific branch name instead of a timestamp
-//	--pr <number>         check out the branch for a given PR number
-//	--repo <name>         repo shorthand name or absolute path (default: inferred from current pane)
-//	--prompt <text>       pass an initial prompt to opencode on launch
-//	--prompt-file <path>  read the initial prompt from a file
-//	--agent <name>        opencode agent to use (default: "coordinator" on main, "worker" otherwise)
-//	--profile <name>      model profile to use from ~/.config/prism/profiles.json
-//	--model <name>        model identifier override (overrides profile's primary model)
-//	--variant <name>      model variant override (overrides all agents' variant)
-//	--isolation <mode>    isolation mode: podman, bwrap, sandbox-exec, or host (default: from config.json)
-//	--harness <name>      agent harness to use (default: "opencode"; only "opencode" is supported)
+//	--branch <name>              use a specific branch name instead of a timestamp
+//	--pr <number>                check out the branch for a given PR number
+//	--repo <name>                repo shorthand name or absolute path (default: inferred from current pane)
+//	--prompt <text>              pass an initial prompt to opencode on launch
+//	--prompt-file <path>         read the initial prompt from a file
+//	--agent <name>               opencode agent to use (default: "coordinator" on main, "worker" otherwise)
+//	--profile <name>             model profile to use from ~/.config/prism/profiles.json
+//	--model <name>               model identifier override (overrides profile's primary model)
+//	--variant <name>             model variant override (overrides all agents' variant)
+//	--model-override role=model  per-role model override (repeatable); overrides --model for that role
+//	--isolation <mode>           isolation mode: podman, bwrap, sandbox-exec, or host (default: from config.json)
+//	--harness <name>             agent harness to use (default: "opencode"; only "opencode" is supported)
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -65,6 +67,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 	ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 	isolationFlag, _ := cmd.Flags().GetString("isolation")
+	modelOverrideFlag, _ := cmd.Flags().GetStringArray("model-override")
 
 	isolationChanged := cmd.Flags().Changed("isolation")
 
@@ -102,6 +105,14 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"harness":                harnessFlag,
 		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 	}
+	if len(modelOverrideFlag) > 0 {
+		modelsByRole := parseModelOverrides(modelOverrideFlag)
+		if len(modelsByRole) > 0 {
+			if encoded, err := json.Marshal(modelsByRole); err == nil {
+				body["model_variant_overrides"] = string(encoded)
+			}
+		}
+	}
 	// Only forward "isolation" when explicitly set. An empty value would tell
 	// the host-side spawn to fall back to config.json, which is correct only
 	// when the user really did not pass the flag — we must distinguish the
@@ -132,6 +143,7 @@ func init() {
 	spawnCmd.Flags().String("profile", "", "Model profile name from ~/.config/prism/profiles.json (e.g. anthropic, gemini-hybrid)")
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
+	spawnCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro); takes precedence over --model for the named role")
 	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
@@ -204,6 +216,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	modelFlag, _ := cmd.Flags().GetString("model")
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
+	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
+	modelsByRole := parseModelOverrides(modelOverrideRaw)
 
 	// Validate harness BEFORE any session state is created (no worktree, no
 	// tmux session, no DB row).
@@ -482,6 +496,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		ConfigEnvVarName: h.ConfigEnvVar(),
 		RuntimeEnvVars:   h.RuntimeEnv(),
 		HarnessName:      harnessFlag,
+		ModelsByRole:     modelsByRole,
 		// ForceFresh=true: spawn always wants a new instance. If a session
 		// with the same name already exists it is a stale zombie and should
 		// be killed.
@@ -551,6 +566,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		agentPromptHash:    agentPromptHash,
 		promptText:         promptText,
 		promptSource:       promptSource,
+		modelsByRole:       modelsByRole,
 	})
 
 	if headless {
@@ -600,6 +616,7 @@ type spawnInputsArgs struct {
 	agentPromptHash    string
 	promptText         string
 	promptSource       string
+	modelsByRole       map[string]string
 }
 
 // writeSpawnInputs looks up the instance_id for sessionName and inserts a row
@@ -659,6 +676,12 @@ func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
 	}
 	if args.promptText != "" {
 		si.PromptText = &args.promptText
+	}
+	if len(args.modelsByRole) > 0 {
+		if encoded, encErr := json.Marshal(args.modelsByRole); encErr == nil {
+			s := string(encoded)
+			si.ModelVariantOverrides = &s
+		}
 	}
 
 	if err := d.InsertSpawnInputs(si); err != nil {
@@ -767,4 +790,25 @@ func resolveBranch(bareRoot, branchFlag, prFlag string) (string, error) {
 
 	// Default: zettelkasten timestamp.
 	return time.Now().Format("20060102T1504"), nil
+}
+
+// parseModelOverrides converts a slice of "role=model" strings into a map.
+// Malformed entries (no "=" separator, empty role, or empty model) are silently
+// skipped. Returns nil when no valid entries are found.
+func parseModelOverrides(raw []string) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(raw))
+	for _, entry := range raw {
+		role, model, ok := strings.Cut(entry, "=")
+		if !ok || role == "" || model == "" {
+			continue
+		}
+		m[role] = model
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -106,7 +106,10 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 	}
 	if len(modelOverrideFlag) > 0 {
-		modelsByRole := parseModelOverrides(modelOverrideFlag)
+		modelsByRole, parseErr := parseModelOverrides(modelOverrideFlag)
+		if parseErr != nil {
+			return parseErr
+		}
 		if len(modelsByRole) > 0 {
 			if encoded, err := json.Marshal(modelsByRole); err == nil {
 				body["model_variant_overrides"] = string(encoded)
@@ -217,7 +220,10 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
-	modelsByRole := parseModelOverrides(modelOverrideRaw)
+	modelsByRole, err := parseModelOverrides(modelOverrideRaw)
+	if err != nil {
+		return err
+	}
 
 	// Validate harness BEFORE any session state is created (no worktree, no
 	// tmux session, no DB row).
@@ -793,22 +799,19 @@ func resolveBranch(bareRoot, branchFlag, prFlag string) (string, error) {
 }
 
 // parseModelOverrides converts a slice of "role=model" strings into a map.
-// Malformed entries (no "=" separator, empty role, or empty model) are silently
-// skipped. Returns nil when no valid entries are found.
-func parseModelOverrides(raw []string) map[string]string {
+// Returns an error if any entry is malformed (missing "=", empty role, or empty
+// model). Returns nil map when raw is empty.
+func parseModelOverrides(raw []string) (map[string]string, error) {
 	if len(raw) == 0 {
-		return nil
+		return nil, nil
 	}
 	m := make(map[string]string, len(raw))
 	for _, entry := range raw {
 		role, model, ok := strings.Cut(entry, "=")
 		if !ok || role == "" || model == "" {
-			continue
+			return nil, fmt.Errorf("invalid --model-override %q: expected role=model (e.g. review-context=google/gemini-2.5-pro)", entry)
 		}
 		m[role] = model
 	}
-	if len(m) == 0 {
-		return nil
-	}
-	return m
+	return m, nil
 }

--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -106,6 +106,18 @@ type Harness interface {
 	EffectiveModel(role string) string
 }
 
+// ModelOverridesSetter is an optional interface implemented by harness adapters
+// that support per-role model overrides (C.2). Callers that need to apply a
+// full role→model map after construction use harness.NewWithModelOverrides or
+// harness.NewContainerWithModelOverrides, which call SetModelOverrides via this
+// interface.
+type ModelOverridesSetter interface {
+	// SetModelOverrides replaces the adapter's per-role model map with m.
+	// A nil map clears all overrides. The call is not thread-safe; callers
+	// must invoke it before the adapter is shared across goroutines.
+	SetModelOverrides(m map[string]string)
+}
+
 // HarnessEvent is a raw event received from the agent runtime's event stream.
 // It carries the event type and the raw payload bytes so that each harness
 // implementation can decode them in its own way.

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter.go
@@ -47,7 +47,11 @@ type Adapter struct {
 	opencodeURL string
 	httpClient  *http.Client
 	agentRole   string
-	agentModel  string
+	// modelsByRole is the per-role model override map (C.2). When a role key
+	// is present its value takes precedence over the profile/opencode.json
+	// derived model in EffectiveModel and DeliverInitialPrompt. The map may
+	// be nil (no overrides) or may contain only a subset of roles.
+	modelsByRole map[string]string
 	// containerMode, when true, causes DeliverInitialPrompt to be a no-op.
 	// In container mode the initial prompt is delivered via --prompt on the
 	// opencode command line (RFC #691 Phase 1a), so HTTP delivery would be
@@ -64,16 +68,38 @@ type Adapter struct {
 // "http://localhost:4096"). httpClient is used for all HTTP requests; pass nil
 // to use a default short-timeout client. agentRole is the agent role for this
 // session (e.g. "worker" or "coordinator"); agentModel is the model identifier
-// (e.g. "anthropic/claude-sonnet-4-6").
+// (e.g. "anthropic/claude-sonnet-4-6") used as the single-role override for
+// agentRole when non-empty.
+//
+// To supply a full per-role override map (C.2), use NewWithModelOverrides.
 func New(opencodeURL string, httpClient *http.Client, agentRole, agentModel string) *Adapter {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 20 * time.Second}
 	}
-	return &Adapter{
+	a := &Adapter{
 		opencodeURL: opencodeURL,
 		httpClient:  httpClient,
 		agentRole:   agentRole,
-		agentModel:  agentModel,
+	}
+	if agentRole != "" && agentModel != "" {
+		a.modelsByRole = map[string]string{agentRole: agentModel}
+	}
+	return a
+}
+
+// NewWithModelOverrides creates a new Adapter with a full per-role model
+// override map (C.2 §3.3). The map may contain any number of roles; roles
+// absent from the map fall through to the profile/opencode.json lookup in
+// EffectiveModel. Pass nil to disable overrides entirely.
+func NewWithModelOverrides(opencodeURL string, httpClient *http.Client, agentRole string, modelsByRole map[string]string) *Adapter {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &Adapter{
+		opencodeURL:  opencodeURL,
+		httpClient:   httpClient,
+		agentRole:    agentRole,
+		modelsByRole: modelsByRole,
 	}
 }
 
@@ -84,6 +110,14 @@ func New(opencodeURL string, httpClient *http.Client, agentRole, agentModel stri
 // rather than POST /session which would create a second session.
 func NewContainerMode(opencodeURL string, httpClient *http.Client, agentRole, agentModel string) *Adapter {
 	a := New(opencodeURL, httpClient, agentRole, agentModel)
+	a.containerMode = true
+	return a
+}
+
+// NewContainerModeWithModelOverrides creates a container-mode Adapter with a
+// full per-role model override map (C.2).
+func NewContainerModeWithModelOverrides(opencodeURL string, httpClient *http.Client, agentRole string, modelsByRole map[string]string) *Adapter {
+	a := NewWithModelOverrides(opencodeURL, httpClient, agentRole, modelsByRole)
 	a.containerMode = true
 	return a
 }
@@ -397,12 +431,12 @@ func (a *Adapter) DeliverInitialPrompt(ctx context.Context, prompt, role string)
 		"agent": agentRole,
 	}
 
-	if a.agentModel != "" {
-		slashIdx := strings.Index(a.agentModel, "/")
+	if model := a.modelsByRole[agentRole]; model != "" {
+		slashIdx := strings.Index(model, "/")
 		if slashIdx >= 0 {
 			body["model"] = map[string]string{
-				"providerID": a.agentModel[:slashIdx],
-				"modelID":    a.agentModel[slashIdx+1:],
+				"providerID": model[:slashIdx],
+				"modelID":    model[slashIdx+1:],
 			}
 		}
 	}
@@ -632,20 +666,26 @@ func agentsDir() string {
 	return filepath.Join(configHome, "opencode", "agents")
 }
 
+// SetModelOverrides replaces the adapter's per-role model override map.
+// It implements harness.ModelOverridesSetter (C.2). Not thread-safe; call
+// before sharing the adapter across goroutines.
+func (a *Adapter) SetModelOverrides(m map[string]string) {
+	a.modelsByRole = m
+}
+
 // EffectiveModel returns the model identifier configured for the given
 // agent role.
 //
-// As of #1206 the lookup consults prism's role-keyed profile data first
-// (~/.config/prism/profiles.json → active profile → role slot's model). The
-// profile-driven map is the canonical source: it is what was used to render
-// opencode's own config in the first place, so prism's value is always at
-// least as authoritative as opencode's. Falls back to opencode's
-// ~/.config/opencode/opencode.json when the profile data does not resolve a
-// model for the role (no profiles file, unknown profile, or missing slot) so
-// manually-configured opencode sessions still work.
+// Lookup precedence (C.2 §6.3):
+//  1. Per-role override map (modelsByRole) — highest priority.
+//  2. Prism's profile data (~/.config/prism/profiles.json, via effectiveModelFromProfiles).
+//  3. opencode's own ~/.config/opencode/opencode.json (legacy fallback).
 //
 // It satisfies the harness.Harness interface.
 func (a *Adapter) EffectiveModel(role string) string {
+	if model := a.modelsByRole[role]; model != "" {
+		return model
+	}
 	if model := effectiveModelFromProfiles(role); model != "" {
 		return model
 	}

--- a/modules/programs/prism/prism/internal/harness/opencode/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/opencode/adapter_test.go
@@ -469,3 +469,72 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+// ── EffectiveModel per-role override (C.2 §3.2) ───────────────────────────────
+
+// TestEffectiveModel_PerRoleOverrideTakesPrecedence verifies that when a model
+// is set for a role via NewWithModelOverrides, EffectiveModel returns that
+// model ahead of the profile/opencode.json lookup.
+func TestEffectiveModel_PerRoleOverrideTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// opencode.json has a "worker" model — it must NOT be returned when the
+	// per-role override map contains an entry for "worker".
+	config := `{"agent":{"worker":{"model":"anthropic/claude-from-opencode-json"},"coordinator":{"model":"anthropic/claude-coordinator"}}}`
+	if err := os.WriteFile(filepath.Join(configDir, "opencode.json"), []byte(config), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	overrides := map[string]string{
+		"review-context": "google/gemini-2.5-pro",
+		"worker":         "anthropic/claude-override",
+	}
+	a := NewWithModelOverrides("", nil, "worker", overrides)
+
+	// "worker" role: per-role override must win.
+	if got := a.EffectiveModel("worker"); got != "anthropic/claude-override" {
+		t.Errorf("EffectiveModel(worker) = %q, want %q (per-role override)", got, "anthropic/claude-override")
+	}
+	// "review-context" role: per-role override must win.
+	if got := a.EffectiveModel("review-context"); got != "google/gemini-2.5-pro" {
+		t.Errorf("EffectiveModel(review-context) = %q, want %q (per-role override)", got, "google/gemini-2.5-pro")
+	}
+	// "coordinator" role: no override → falls back to opencode.json.
+	if got := a.EffectiveModel("coordinator"); got != "anthropic/claude-coordinator" {
+		t.Errorf("EffectiveModel(coordinator) = %q, want %q (opencode.json fallback)", got, "anthropic/claude-coordinator")
+	}
+}
+
+// TestEffectiveModel_SetModelOverridesApplied verifies SetModelOverrides updates
+// the adapter's per-role map and subsequent EffectiveModel calls reflect it.
+func TestEffectiveModel_SetModelOverridesApplied(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	config := `{"agent":{"worker":{"model":"anthropic/claude-default"}}}`
+	if err := os.WriteFile(filepath.Join(configDir, "opencode.json"), []byte(config), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	a := New("", nil, "worker", "")
+	// Before SetModelOverrides — falls back to opencode.json.
+	if got := a.EffectiveModel("worker"); got != "anthropic/claude-default" {
+		t.Errorf("before SetModelOverrides: EffectiveModel(worker) = %q, want %q", got, "anthropic/claude-default")
+	}
+
+	a.SetModelOverrides(map[string]string{"worker": "google/gemini-overridden"})
+	// After SetModelOverrides — per-role map wins.
+	if got := a.EffectiveModel("worker"); got != "google/gemini-overridden" {
+		t.Errorf("after SetModelOverrides: EffectiveModel(worker) = %q, want %q", got, "google/gemini-overridden")
+	}
+}

--- a/modules/programs/prism/prism/internal/harness/registry.go
+++ b/modules/programs/prism/prism/internal/harness/registry.go
@@ -231,6 +231,25 @@ func New(name, endpoint string, httpClient *http.Client, agentRole, agentModel s
 	return reg.Factory(endpoint, httpClient, agentRole, agentModel), nil
 }
 
+// NewWithModelOverrides constructs a host-mode harness adapter with a
+// full per-role model override map (C.2). It calls the registered Factory with
+// an empty agentModel then applies the map via the ModelOverridesSetter
+// interface if the adapter implements it. Harnesses that do not implement
+// ModelOverridesSetter receive the single-entry agentModel from
+// modelsByRole[agentRole] as a best-effort fallback.
+func NewWithModelOverrides(name, endpoint string, httpClient *http.Client, agentRole string, modelsByRole map[string]string) (Harness, error) {
+	reg, ok := Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("harness %q is not registered; valid harnesses: %s", name, joinNames())
+	}
+	singleModel := modelsByRole[agentRole]
+	h := reg.Factory(endpoint, httpClient, agentRole, singleModel)
+	if setter, ok := h.(ModelOverridesSetter); ok {
+		setter.SetModelOverrides(modelsByRole)
+	}
+	return h, nil
+}
+
 // NewContainer constructs a container-mode harness adapter for the
 // named harness. If the registration has a ContainerFactory it is used;
 // otherwise Factory is used. Returns an error if the name is not
@@ -248,6 +267,25 @@ func NewContainer(name, endpoint string, httpClient *http.Client, agentRole, age
 		f = reg.Factory
 	}
 	return f(endpoint, httpClient, agentRole, agentModel), nil
+}
+
+// NewContainerWithModelOverrides constructs a container-mode harness adapter
+// with a full per-role model override map (C.2).
+func NewContainerWithModelOverrides(name, endpoint string, httpClient *http.Client, agentRole string, modelsByRole map[string]string) (Harness, error) {
+	reg, ok := Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("harness %q is not registered; valid harnesses: %s", name, joinNames())
+	}
+	f := reg.ContainerFactory
+	if f == nil {
+		f = reg.Factory
+	}
+	singleModel := modelsByRole[agentRole]
+	h := f(endpoint, httpClient, agentRole, singleModel)
+	if setter, ok := h.(ModelOverridesSetter); ok {
+		setter.SetModelOverrides(modelsByRole)
+	}
+	return h, nil
 }
 
 // ShapeOf returns the declared TransportShape for the named harness,

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -262,6 +262,14 @@ type Opts struct {
 	// When empty, spawnAgentOnlyLayout resolves the machine default from
 	// cfg.DefaultIsolationMode rather than silently falling back to host.
 	IsolationMode string
+	// ModelsByRole is an optional per-role model override map (C.2,
+	// issue #1122). When a role appears in the map, its model entry overrides
+	// the profile default for that agent's opencode.json config blob.
+	// The map is applied in run.go via config.ApplyModelOverrides after the
+	// per-agent blob is resolved from ProfilesFile.
+	// Nil or empty means no per-role overrides — all agents use the profile
+	// default (equivalent to pre-C.2 behaviour).
+	ModelsByRole map[string]string
 	// ReadinessTimeout is the per-agent deadline for the post-spawn
 	// readiness gate (#1051 Piece A). Zero falls back to
 	// DefaultReviewReadinessTimeout (30s). The gate runs concurrently per

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -130,6 +130,23 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			}
 			continue
 		}
+		// Apply per-role model override (C.2, issue #1122) when a model was
+		// explicitly specified for this agent. This is a no-op for host-mode
+		// sessions (agentConfigContent is empty) — host-mode model selection
+		// happens via the sidecar's --model-override flags instead.
+		if agentConfigContent != "" && len(opts.ModelsByRole) > 0 {
+			if roleModel, ok := opts.ModelsByRole[ag.Name]; ok {
+				patched, patchErr := config.ApplyModelOverrides(agentConfigContent, activeProfile, roleModel, "", opts.ProfilesFile)
+				if patchErr != nil {
+					spawnErr[i] = fmt.Errorf("review: apply --model-override for %s: %w", ag.Name, patchErr)
+					if opts.OnProgress != nil {
+						opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+					}
+					continue
+				}
+				agentConfigContent = patched
+			}
+		}
 
 		// For bwrap sessions, write the opencode.json config file to disk now
 		// so it is present before the agent pane opens. The bwrap harness
@@ -191,6 +208,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			GroupID:            groupID,
 			RuntimeEnvVars:     opts.RuntimeEnvVars,
 			HarnessName:        opts.Harness,
+			ModelsByRole:       opts.ModelsByRole,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -385,6 +403,20 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			}
 			continue
 		}
+		// Apply per-role model override (C.2, issue #1122).
+		if agentConfigContent != "" && len(opts.ModelsByRole) > 0 {
+			if roleModel, ok := opts.ModelsByRole[ag.Name]; ok {
+				patched, patchErr := config.ApplyModelOverrides(agentConfigContent, activeProfile, roleModel, "", opts.ProfilesFile)
+				if patchErr != nil {
+					spawnErr[i] = fmt.Errorf("review: apply --model-override for %s: %w", ag.Name, patchErr)
+					if opts.OnProgress != nil {
+						opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+					}
+					continue
+				}
+				agentConfigContent = patched
+			}
+		}
 
 		// For bwrap and sandbox-exec sessions, write the opencode.json config
 		// file to disk now so it is present before the agent pane opens.
@@ -431,6 +463,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			GroupID:            groupID,
 			RuntimeEnvVars:     opts.RuntimeEnvVars,
 			HarnessName:        opts.Harness,
+			ModelsByRole:       opts.ModelsByRole,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -168,6 +168,10 @@ type Opts struct {
 	// can call harness.ShapeOf to determine its own transport shape. When
 	// empty, the sidecar defaults to "opencode".
 	HarnessName string
+	// ModelsByRole is the per-role model override map (C.2). When non-empty
+	// it is forwarded to the sidecar via repeated --model-override flags.
+	// Nil means no per-role overrides.
+	ModelsByRole map[string]string
 }
 
 // Layout selects the window layout used when creating a new session.
@@ -629,6 +633,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 			ConfigContent:  opts.ConfigContent,
 			InstanceID:     opts.InstanceID,
 			HarnessName:    opts.HarnessName,
+			ModelsByRole:   opts.ModelsByRole,
 		}
 		if err := StartSidecarWithOpts(name, sidecarOpts); err != nil {
 			// Non-fatal: log and continue. The session is created regardless.

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -256,6 +256,10 @@ type StartSidecarOpts struct {
 	// can call harness.ShapeOf to determine its own transport shape. When
 	// empty, the sidecar defaults to "opencode".
 	HarnessName string
+	// ModelsByRole is the per-role model override map (C.2). When non-empty
+	// it is forwarded to the sidecar via repeated --model-override role=model
+	// flags so the harness adapter applies per-role overrides.
+	ModelsByRole map[string]string
 }
 
 // StartSidecar launches a detached `prism sidecar` process for the given
@@ -347,6 +351,9 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 	}
 	if opts.HarnessName != "" {
 		cmdArgs = append(cmdArgs, "--harness", opts.HarnessName)
+	}
+	for role, model := range opts.ModelsByRole {
+		cmdArgs = append(cmdArgs, "--model-override", role+"="+model)
 	}
 
 	cmd := exec.Command(self, cmdArgs...)

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -636,6 +636,8 @@ func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 		Layout:           LayoutFull,
 		ForceFresh:       opts.ForceFresh,
 		Headless:         opts.Headless,
+		HarnessName:      opts.HarnessName,
+		ModelsByRole:     opts.ModelsByRole,
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -163,6 +163,11 @@ type SpawnOpts struct {
 	// can call harness.ShapeOf to determine its own transport shape.
 	HarnessName string
 
+	// ModelsByRole is the per-role model override map (C.2). When non-empty
+	// it is forwarded to the sidecar via repeated --model-override flags so
+	// the harness adapter applies per-role model overrides.
+	ModelsByRole map[string]string
+
 	// ReadinessTimeout, when > 0, causes SpawnSession to gate its return on
 	// the agent reaching a readiness signal in the prism DB (see
 	// WaitForReady). If the gate trips with a timeout, SpawnSession cleans
@@ -734,6 +739,7 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		InstanceID:       opts.InstanceID,
 		WorktreeReadOnly: opts.WorktreeReadOnly,
 		HarnessName:      opts.HarnessName,
+		ModelsByRole:     opts.ModelsByRole,
 	}
 	if err := StartSidecarWithOpts(opts.SessionName, sidecarOpts); err != nil {
 		// Non-fatal: log and continue, matching the LayoutFull behaviour

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -137,6 +137,10 @@ type Config struct {
 	// When non-empty it is seeded into root_model_id in the DB so that
 	// buildPromptBody can include the model in the prompt_async body (#557).
 	AgentModel string
+	// ModelsByRole is the per-role model override map (C.2). When non-nil
+	// it takes precedence over AgentModel for any role present in the map.
+	// The map is passed directly to the harness adapter at construction time.
+	ModelsByRole map[string]string
 	// HarnessName is the registered harness name (e.g. "opencode"). When
 	// non-empty, Run consults harness.ShapeOf(HarnessName) at the top of the
 	// function to determine the transport shape and route to the appropriate


### PR DESCRIPTION
## Summary

- Adds `--model-override role=model` flag (repeatable) to `prism spawn` and `prism review`, allowing per-role model overrides e.g. `prism review 819 --model-override review-context=google/gemini-2.5-pro`
- Threads `ModelsByRole` through `SpawnOpts` → sidecar `--model-override` args, so host-mode sessions pick up the per-role map at runtime
- For sandboxed sessions (podman/bwrap/sandbox-exec), applies `ApplyModelOverrides` per agent in `review/run.go` after the config blob is resolved, so the correct model is baked into the agent's `opencode.json`
- Serialises the map as JSON into `spawn_inputs.model_variant_overrides` for observability
- Adds `TestEffectiveModel_PerRoleOverrideTakesPrecedence` and `TestEffectiveModel_SetModelOverridesApplied` tests

Closes #1122