### PR TITLE
fix: honour --model-override in proxy-spawn path (C2.PROXY)

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -1203,3 +1203,116 @@ func TestProxyReviewAsync_HTTP500BeforeStreamReturnsError(t *testing.T) {
 		t.Errorf("error %q should mention 'review process failed'", callErr.Error())
 	}
 }
+
+// ── proxySpawn model-override forwarding (C2.PROXY, issue #1263) ─────────────
+
+// TestProxySpawn_ModelOverrideForwarded verifies that when --model-override
+// flags are passed, proxySpawn includes model_variant_overrides as a
+// JSON-encoded map[string]string in the request body (AC: functional —
+// proxy-spawn honours --model-override).
+func TestProxySpawn_ModelOverrideForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch                string `json:"branch"`
+		ModelVariantOverrides string `json:"model_variant_overrides"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spawn" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@test-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().StringArray("model-override", nil, "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "test-branch")
+	_ = cmd.Flags().Set("model-override", "review-context=google/gemini-2.5-pro")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.ModelVariantOverrides == "" {
+			t.Fatal("model_variant_overrides not sent in request body")
+		}
+		var overrides map[string]string
+		if err := json.Unmarshal([]byte(req.ModelVariantOverrides), &overrides); err != nil {
+			t.Fatalf("model_variant_overrides is not valid JSON: %v", err)
+		}
+		if overrides["review-context"] != "google/gemini-2.5-pro" {
+			t.Errorf("overrides[review-context] = %q, want %q", overrides["review-context"], "google/gemini-2.5-pro")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// TestProxySpawn_NoModelOverrideOmitsField verifies that when no --model-override
+// flags are passed, model_variant_overrides is absent from the request body
+// (AC: edge-case — absence behaves identically to today).
+func TestProxySpawn_NoModelOverrideOmitsField(t *testing.T) {
+	type spawnReq struct {
+		Branch                string `json:"branch"`
+		ModelVariantOverrides string `json:"model_variant_overrides"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spawn" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		// Decode into raw map to detect presence of the key.
+		var raw map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		// Encode back to typed struct for assertions.
+		b, _ := json.Marshal(raw)
+		var req spawnReq
+		_ = json.Unmarshal(b, &req)
+		// Store whether key was present in raw body.
+		if _, ok := raw["model_variant_overrides"]; ok {
+			req.ModelVariantOverrides = "__present__"
+		}
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@test-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().StringArray("model-override", nil, "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "test-branch")
+	// No --model-override flag set.
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.ModelVariantOverrides == "__present__" {
+			t.Error("model_variant_overrides must not be present in request body when no overrides are set")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -651,6 +651,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// its own repo (derived from its session name) so that a client sending a
 	// mount-path name (e.g. "prism-git") still spawns into the correct repo
 	// (e.g. "nixos-config"). See issue #616.
+	//
+	// Optional field "model_variant_overrides" accepts a JSON-encoded
+	// map[string]string produced by proxySpawn (cmd/spawn.go). Each entry is
+	// forwarded as a --model-override role=model flag to the host-side prism
+	// spawn invocation. A malformed JSON value is rejected with HTTP 400.
+	// Absence of the field (the pre-#1263 behaviour) is treated as an empty map.
+	// See issue #1263 (C2.PROXY proxy-spawn model-override parity).
+	//
 	// Response: {"session_name":"nixos-config@my-feature"} | {"error":"..."}
 	mux.HandleFunc("/spawn", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
@@ -660,22 +668,34 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		var req struct {
-			Repo                 string `json:"repo"` // accepted but ignored — ownRepo is always used
-			Branch               string `json:"branch"`
-			Prompt               string `json:"prompt"`
-			Agent                string `json:"agent"`
-			Profile              string `json:"profile"`
-			Model                string `json:"model"`
-			Variant              string `json:"variant"`
-			Isolation            string `json:"isolation"`
-			Harness              string `json:"harness"`
-			IgnoreConcurrencyCap bool   `json:"ignore_concurrency_cap"`
+			Repo                  string `json:"repo"` // accepted but ignored — ownRepo is always used
+			Branch                string `json:"branch"`
+			Prompt                string `json:"prompt"`
+			Agent                 string `json:"agent"`
+			Profile               string `json:"profile"`
+			Model                 string `json:"model"`
+			Variant               string `json:"variant"`
+			Isolation             string `json:"isolation"`
+			Harness               string `json:"harness"`
+			IgnoreConcurrencyCap  bool   `json:"ignore_concurrency_cap"`
+			ModelVariantOverrides string `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
 		}
 		dec := json.NewDecoder(r.Body)
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
+		}
+
+		// Parse model_variant_overrides when present. An empty string is
+		// treated as no overrides (backwards-compatible). A non-empty string
+		// must decode to map[string]string — a malformed value returns 400.
+		var modelsByRole map[string]string
+		if req.ModelVariantOverrides != "" {
+			if err := json.Unmarshal([]byte(req.ModelVariantOverrides), &modelsByRole); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid model_variant_overrides: must be a JSON-encoded map[string]string: "+err.Error())
+				return
+			}
 		}
 		if req.Branch == "" {
 			writeError(w, http.StatusBadRequest, "branch is required")
@@ -740,6 +760,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.IgnoreConcurrencyCap {
 			args = append(args, "--ignore-concurrency-cap")
 		}
+		// Forward per-role model overrides as repeating --model-override flags.
+		for role, model := range modelsByRole {
+			args = append(args, "--model-override", role+"="+model)
+		}
 		args = append(args, "--harness", req.Harness)
 		args = append(args, "--repo", ownRepo)
 
@@ -765,6 +789,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.IgnoreConcurrencyCap {
 			logArgs = append(logArgs, "--ignore-concurrency-cap")
+		}
+		for role, model := range modelsByRole {
+			logArgs = append(logArgs, "--model-override", role+"="+model)
 		}
 		logArgs = append(logArgs, "--harness", req.Harness)
 		logArgs = append(logArgs, "--repo", ownRepo)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5854,6 +5854,128 @@ exit 1
 	}
 }
 
+// ── /spawn model-override forwarding (C2.PROXY, issue #1263) ─────────────────
+
+// TestHostAPI_Spawn_ModelOverrideForwarded verifies that when the request body
+// contains model_variant_overrides (a JSON-encoded map[string]string as produced
+// by proxySpawn), the handler decodes it and forwards each entry as a
+// --model-override role=model flag to the prism spawn subprocess.
+// This is the regression test for issue #1263: previously the /spawn handler
+// did not decode model_variant_overrides, so --model-override from a coordinator
+// running inside a container was silently dropped.
+func TestHostAPI_Spawn_ModelOverrideForwarded(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@override-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	// model_variant_overrides encodes {"review-context":"google/gemini-2.5-pro"}
+	// as a JSON string, matching what proxySpawn (cmd/spawn.go) sends.
+	body := `{"branch":"override-branch","model_variant_overrides":"{\"review-context\":\"google/gemini-2.5-pro\"}"}`
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	want := "--model-override review-context=google/gemini-2.5-pro"
+	if !strings.Contains(string(capturedArgs), want) {
+		t.Errorf("captured args %q do not contain %q; model_variant_overrides was not forwarded (regression for issue #1263)",
+			string(capturedArgs), want)
+	}
+}
+
+// TestHostAPI_Spawn_ModelOverrideAbsentBehavesAsToday verifies the edge-case
+// AC for issue #1263: a /spawn request with no model_variant_overrides field
+// behaves identically to before the fix — no --model-override flags are added.
+func TestHostAPI_Spawn_ModelOverrideAbsentBehavesAsToday(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@no-override-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@main",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@main",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "coordinator", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"branch":"no-override-branch"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if strings.Contains(string(capturedArgs), "--model-override") {
+		t.Errorf("captured args %q must not contain --model-override when model_variant_overrides is absent",
+			string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Spawn_ModelOverrideMalformedReturns400 verifies the edge-case
+// AC for issue #1263: a /spawn request with a malformed model_variant_overrides
+// value (not valid JSON) returns HTTP 400 rather than silently ignoring it.
+func TestHostAPI_Spawn_ModelOverrideMalformedReturns400(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+
+	// malformed: not valid JSON-encoded map
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"x","model_variant_overrides":"not-json"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for malformed model_variant_overrides; body = %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "model_variant_overrides") {
+		t.Errorf("error %q should mention 'model_variant_overrides'", errResp["error"])
+	}
+}
+
 func TestHostAPI_Cleanup_CoordinatorCrossRepoForbidden(t *testing.T) {
 	d := openTestDB(t)
 	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)


### PR DESCRIPTION
## Summary

Fixes the proxy-spawn path so that `--model-override role=model` is honoured when `prism spawn` is called from inside a container session (where `PRISM_HOST_API` is set).

## Problem

`proxySpawn` in `cmd/spawn.go` sends `model_variant_overrides` in the JSON body, but the `/spawn` host-API handler in `internal/sidecar/host_api.go` did not include the field in its request struct — with `DisallowUnknownFields` active this would return a 400. The field was silently ignored, causing `--model-override` to have no effect from inside containers.

## Changes

- Extended the `/spawn` handler request struct with `ModelVariantOverrides string \`json:"model_variant_overrides"\``
- Added parsing: decodes the JSON-encoded `map[string]string` value, returning HTTP 400 on malformed input
- Forwards each entry as `--model-override role=model` flags to the `prism spawn` subprocess
- Added tests in `cmd/hostapi_test.go` (proxySpawn side) and `internal/sidecar/sidecar_test.go` (handler side) covering: forwarding, absent-field backwards-compat, and malformed value rejection

Closes #1263