### PR TITLE
fix(review): sanitize per-agent spawn errors to prevent argv dump

### DIFF
--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -76,8 +76,8 @@ func SanitizeSpawnErrorForTest(agentName string, err error) string {
 
 // TruncateProgressMsgForTest is an exported wrapper around truncateProgressMsg
 // for use in external test packages.
-func TruncateProgressMsgForTest(msg string) string {
-	return truncateProgressMsg(msg)
+func TruncateProgressMsgForTest(agentName, msg string) string {
+	return truncateProgressMsg(agentName, msg)
 }
 
 // MaxProgressMsgBytesForTest exposes maxProgressMsgBytes for assertions.

--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -70,14 +70,14 @@ func BuildDeliveryMessageForTest(prNumber string, round int, formattedResults st
 // for use in external test packages. Allows tests to verify that the
 // per-agent error message never includes PRISM_INITIAL_PROMPT or oversized
 // argv content (issue #1194).
-func SanitizeSpawnErrorForTest(agentName string, err error) string {
-	return sanitizeSpawnError(agentName, err)
+func SanitizeSpawnErrorForTest(prNumber, agentName string, err error) string {
+	return sanitizeSpawnError(prNumber, agentName, err)
 }
 
 // TruncateProgressMsgForTest is an exported wrapper around truncateProgressMsg
 // for use in external test packages.
-func TruncateProgressMsgForTest(agentName, msg string) string {
-	return truncateProgressMsg(agentName, msg)
+func TruncateProgressMsgForTest(prNumber, agentName, msg string) string {
+	return truncateProgressMsg(prNumber, agentName, msg)
 }
 
 // MaxProgressMsgBytesForTest exposes maxProgressMsgBytes for assertions.

--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -65,3 +65,20 @@ func PollAgentsForTest(ctx context.Context, d *db.DB, agents []Agent, agentSessi
 func BuildDeliveryMessageForTest(prNumber string, round int, formattedResults string, allPassed bool, groupData map[string]db.GroupMemberResult, agentSessions []string) string {
 	return buildDeliveryMessage(prNumber, round, formattedResults, allPassed, groupData, agentSessions)
 }
+
+// SanitizeSpawnErrorForTest is an exported wrapper around sanitizeSpawnError
+// for use in external test packages. Allows tests to verify that the
+// per-agent error message never includes PRISM_INITIAL_PROMPT or oversized
+// argv content (issue #1194).
+func SanitizeSpawnErrorForTest(agentName string, err error) string {
+	return sanitizeSpawnError(agentName, err)
+}
+
+// TruncateProgressMsgForTest is an exported wrapper around truncateProgressMsg
+// for use in external test packages.
+func TruncateProgressMsgForTest(msg string) string {
+	return truncateProgressMsg(msg)
+}
+
+// MaxProgressMsgBytesForTest exposes maxProgressMsgBytes for assertions.
+const MaxProgressMsgBytesForTest = maxProgressMsgBytes

--- a/modules/programs/prism/prism/internal/review/results.go
+++ b/modules/programs/prism/prism/internal/review/results.go
@@ -3,8 +3,9 @@ package review
 // results.go — result formatting and assessment.
 //
 // This file contains the pure post-processing functions that turn raw polling
-// outcomes into human-readable reports. None of the code here has any
-// dependency on DB, tmux, or spawn machinery.
+// outcomes into human-readable reports. It imports session to detect
+// HostLaunchCmdTooLargeError (for spawn-failure sanitization); otherwise
+// it has no dependency on DB, tmux, or runtime spawn machinery.
 
 import (
 	"encoding/json"
@@ -43,23 +44,22 @@ func sanitizeSpawnError(agentName string, err error) string {
 	var hltl *session.HostLaunchCmdTooLargeError
 	if errors.As(err, &hltl) {
 		return fmt.Sprintf(
-			"launch command exceeded HostLaunchCmdSafeBound (%d bytes, limit %d bytes) — diff too large to inline\n"+
+			"agent %s: launch command exceeded HostLaunchCmdSafeBound (%d bytes, limit %d bytes) — diff too large to inline\n"+
 				"hint: try `prism review <pr> --diff-inline-max 0` to skip diff inlining, or reduce the PR diff size.",
-			hltl.CmdSize, hltl.SafeBound,
+			agentName, hltl.CmdSize, hltl.SafeBound,
 		)
 	}
 
 	// Tier 2: any other error — strip env payload, then truncate.
 	raw := err.Error()
 	raw = stripEnvPayload(raw)
-	return truncateProgressMsg(raw)
+	return truncateProgressMsg(agentName, raw)
 }
 
-// stripEnvPayload removes the value of PRISM_INITIAL_PROMPT (and any other
-// -e KEY=VALUE env pairs) from an error string so that launch-argv content
-// does not reach stdout. The stripping is conservative: it looks for
-// "PRISM_INITIAL_PROMPT=" and replaces everything from that point to the
-// next unquoted whitespace boundary with a placeholder.
+// stripEnvPayload removes the value of PRISM_INITIAL_PROMPT from an error
+// string so that launch-argv content does not reach stdout. The stripping is
+// conservative: it looks for "PRISM_INITIAL_PROMPT=" and truncates at that
+// point, appending a redaction note to indicate content was removed.
 func stripEnvPayload(s string) string {
 	const marker = "PRISM_INITIAL_PROMPT="
 	idx := strings.Index(s, marker)
@@ -75,12 +75,15 @@ func stripEnvPayload(s string) string {
 
 // truncateProgressMsg truncates msg to maxProgressMsgBytes. When truncated, a
 // suffix is appended that names a forensic log path where the full message can
-// be read. The returned string is always ≤ maxProgressMsgBytes+len(suffix).
-func truncateProgressMsg(msg string) string {
+// be read. The log path is agent-scoped so concurrent agent failures do not
+// overwrite each other's forensic output. The returned string is always
+// ≤ maxProgressMsgBytes+len(suffix).
+func truncateProgressMsg(agentName, msg string) string {
 	if len(msg) <= maxProgressMsgBytes {
 		return msg
 	}
-	logPath := filepath.Join(os.TempDir(), "prism-review-error.log")
+	safeName := sanitisePRNumber(agentName) // reuse path-safe sanitiser
+	logPath := filepath.Join(os.TempDir(), fmt.Sprintf("prism-review-error-%s.log", safeName))
 	suffix := fmt.Sprintf("\n[...truncated; full error in %s]", logPath)
 	// Write full message to the forensic path (best-effort, non-fatal).
 	_ = os.WriteFile(logPath, []byte(msg), 0o600)

--- a/modules/programs/prism/prism/internal/review/results.go
+++ b/modules/programs/prism/prism/internal/review/results.go
@@ -141,9 +141,9 @@ func AssessPassed(text string) (bool, VerdictKind) {
 
 // failureReason returns the user-facing reason string for a spawn / readiness
 // failure. For *session.ReadinessTimeoutError it produces "not ready within
-// <timeout>" (matching the AC-5 example text exactly); other errors are
-// passed through verbatim.
-func failureReason(err error) string {
+// <timeout>" (matching the AC-5 example text exactly). All other errors are
+// sanitized to prevent exposing PRISM_INITIAL_PROMPT payloads.
+func failureReason(prNumber, agentName string, err error) string {
 	if err == nil {
 		return ""
 	}
@@ -157,7 +157,8 @@ func failureReason(err error) string {
 			return rte.Error()
 		}
 	}
-	return err.Error()
+	// Sanitize spawn-machinery errors to prevent PRISM_INITIAL_PROMPT leakage.
+	return sanitizeSpawnError(prNumber, agentName, err)
 }
 
 // sanitisePRNumber returns a version of prNumber safe for use in a filename by

--- a/modules/programs/prism/prism/internal/review/results.go
+++ b/modules/programs/prism/prism/internal/review/results.go
@@ -35,7 +35,10 @@ const maxProgressMsgBytes = 4 * 1024
 //  2. All other errors — the raw error string is stripped of any
 //     PRISM_INITIAL_PROMPT= content, then hard-capped at maxProgressMsgBytes
 //     via truncateProgressMsg.
-func sanitizeSpawnError(agentName string, err error) string {
+//
+// prNumber is used to scope the forensic log path so concurrent review runs do
+// not overwrite each other's error logs.
+func sanitizeSpawnError(prNumber, agentName string, err error) string {
 	if err == nil {
 		return ""
 	}
@@ -53,7 +56,7 @@ func sanitizeSpawnError(agentName string, err error) string {
 	// Tier 2: any other error — strip env payload, then truncate.
 	raw := err.Error()
 	raw = stripEnvPayload(raw)
-	return truncateProgressMsg(agentName, raw)
+	return truncateProgressMsg(prNumber, agentName, raw)
 }
 
 // stripEnvPayload removes the value of PRISM_INITIAL_PROMPT from an error
@@ -75,15 +78,16 @@ func stripEnvPayload(s string) string {
 
 // truncateProgressMsg truncates msg to maxProgressMsgBytes. When truncated, a
 // suffix is appended that names a forensic log path where the full message can
-// be read. The log path is agent-scoped so concurrent agent failures do not
-// overwrite each other's forensic output. The returned string is always
-// ≤ maxProgressMsgBytes+len(suffix).
-func truncateProgressMsg(agentName, msg string) string {
+// be read. The log path includes both prNumber and agentName so concurrent
+// review runs do not overwrite each other's forensic output. The returned
+// string is always ≤ maxProgressMsgBytes+len(suffix).
+func truncateProgressMsg(prNumber, agentName, msg string) string {
 	if len(msg) <= maxProgressMsgBytes {
 		return msg
 	}
-	safeName := sanitisePRNumber(agentName) // reuse path-safe sanitiser
-	logPath := filepath.Join(os.TempDir(), fmt.Sprintf("prism-review-error-%s.log", safeName))
+	safePR := sanitisePRNumber(prNumber)
+	safeAgent := sanitisePRNumber(agentName)
+	logPath := filepath.Join(os.TempDir(), fmt.Sprintf("prism-review-error-%s-%s.log", safePR, safeAgent))
 	suffix := fmt.Sprintf("\n[...truncated; full error in %s]", logPath)
 	// Write full message to the forensic path (best-effort, non-fatal).
 	_ = os.WriteFile(logPath, []byte(msg), 0o600)

--- a/modules/programs/prism/prism/internal/review/results.go
+++ b/modules/programs/prism/prism/internal/review/results.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/prismatic-koi/prism/internal/session"
 )
@@ -76,22 +77,37 @@ func stripEnvPayload(s string) string {
 	return s[:idx] + "[PRISM_INITIAL_PROMPT redacted]"
 }
 
-// truncateProgressMsg truncates msg to maxProgressMsgBytes. When truncated, a
-// suffix is appended that names a forensic log path where the full message can
-// be read. The log path includes both prNumber and agentName so concurrent
-// review runs do not overwrite each other's forensic output. The returned
-// string is always ≤ maxProgressMsgBytes+len(suffix).
+// truncateProgressMsg truncates msg to maxProgressMsgBytes, respecting UTF-8
+// boundaries. When truncated, a suffix is appended that names a forensic log
+// path where the full message can be read. The log path includes both prNumber
+// and agentName so concurrent review runs do not overwrite each other's
+// forensic output. The returned string is always ≤ maxProgressMsgBytes+len(suffix).
 func truncateProgressMsg(prNumber, agentName, msg string) string {
 	if len(msg) <= maxProgressMsgBytes {
 		return msg
 	}
+
+	// Truncate at a UTF-8 boundary to avoid splitting multi-byte characters.
+	// Walk the string rune-by-rune, stopping when the next rune would exceed
+	// maxProgressMsgBytes.
+	truncated := msg
+	byteCount := 0
+	for i, r := range msg {
+		runeBytes := utf8.RuneLen(r)
+		if byteCount+runeBytes > maxProgressMsgBytes {
+			truncated = msg[:i]
+			break
+		}
+		byteCount += runeBytes
+	}
+
 	safePR := sanitisePRNumber(prNumber)
 	safeAgent := sanitisePRNumber(agentName)
 	logPath := filepath.Join(os.TempDir(), fmt.Sprintf("prism-review-error-%s-%s.log", safePR, safeAgent))
 	suffix := fmt.Sprintf("\n[...truncated; full error in %s]", logPath)
 	// Write full message to the forensic path (best-effort, non-fatal).
 	_ = os.WriteFile(logPath, []byte(msg), 0o600)
-	return msg[:maxProgressMsgBytes] + suffix
+	return truncated + suffix
 }
 
 // VerdictKind describes what kind of verdict marker was found by AssessPassed.

--- a/modules/programs/prism/prism/internal/review/results.go
+++ b/modules/programs/prism/prism/internal/review/results.go
@@ -10,10 +10,82 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/prismatic-koi/prism/internal/session"
 )
+
+// maxProgressMsgBytes is the hard cap on any per-agent error message printed
+// to stdout by prism review. Messages longer than this are truncated and a
+// forensic path is appended. 4 KiB is large enough for any structured error
+// but small enough to be safe for LLM context windows.
+const maxProgressMsgBytes = 4 * 1024
+
+// sanitizeSpawnError returns a short, safe error string for a per-agent spawn
+// failure. It never includes the failed argv or env-injected payload
+// (PRISM_INITIAL_PROMPT) in the returned string.
+//
+// Two tiers:
+//  1. *session.HostLaunchCmdTooLargeError — always produces a ≤1 KB structured
+//     message naming the agent, the failure category, the bound exceeded, and a
+//     hint. This is the "command too long" case described in issue #1194.
+//  2. All other errors — the raw error string is stripped of any
+//     PRISM_INITIAL_PROMPT= content, then hard-capped at maxProgressMsgBytes
+//     via truncateProgressMsg.
+func sanitizeSpawnError(agentName string, err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Tier 1: launch-command-too-large — structured short message.
+	var hltl *session.HostLaunchCmdTooLargeError
+	if errors.As(err, &hltl) {
+		return fmt.Sprintf(
+			"launch command exceeded HostLaunchCmdSafeBound (%d bytes, limit %d bytes) — diff too large to inline\n"+
+				"hint: try `prism review <pr> --diff-inline-max 0` to skip diff inlining, or reduce the PR diff size.",
+			hltl.CmdSize, hltl.SafeBound,
+		)
+	}
+
+	// Tier 2: any other error — strip env payload, then truncate.
+	raw := err.Error()
+	raw = stripEnvPayload(raw)
+	return truncateProgressMsg(raw)
+}
+
+// stripEnvPayload removes the value of PRISM_INITIAL_PROMPT (and any other
+// -e KEY=VALUE env pairs) from an error string so that launch-argv content
+// does not reach stdout. The stripping is conservative: it looks for
+// "PRISM_INITIAL_PROMPT=" and replaces everything from that point to the
+// next unquoted whitespace boundary with a placeholder.
+func stripEnvPayload(s string) string {
+	const marker = "PRISM_INITIAL_PROMPT="
+	idx := strings.Index(s, marker)
+	if idx < 0 {
+		return s
+	}
+	// Replace from the marker to the end-of-token (next whitespace after the
+	// marker that is NOT inside the value) with a redacted placeholder.
+	// Because the value may itself contain whitespace (it is a multi-line
+	// prompt), we simply truncate at the marker and append a note.
+	return s[:idx] + "[PRISM_INITIAL_PROMPT redacted]"
+}
+
+// truncateProgressMsg truncates msg to maxProgressMsgBytes. When truncated, a
+// suffix is appended that names a forensic log path where the full message can
+// be read. The returned string is always ≤ maxProgressMsgBytes+len(suffix).
+func truncateProgressMsg(msg string) string {
+	if len(msg) <= maxProgressMsgBytes {
+		return msg
+	}
+	logPath := filepath.Join(os.TempDir(), "prism-review-error.log")
+	suffix := fmt.Sprintf("\n[...truncated; full error in %s]", logPath)
+	// Write full message to the forensic path (best-effort, non-fatal).
+	_ = os.WriteFile(logPath, []byte(msg), 0o600)
+	return msg[:maxProgressMsgBytes] + suffix
+}
 
 // VerdictKind describes what kind of verdict marker was found by AssessPassed.
 type VerdictKind int

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -3260,6 +3260,7 @@ func TestBuildReviewPrompt_AllFiveAgentsGetSameContextWithLinkedIssues(t *testin
 // TestSanitizeSpawnError_CommandTooLong verifies that a HostLaunchCmdTooLargeError
 // produces a structured message ≤ 1 KB that does not contain PRISM_INITIAL_PROMPT.
 func TestSanitizeSpawnError_CommandTooLong(t *testing.T) {
+	const prNumber = "1194"
 	const agentName = "review-goal"
 	const safeBound = 16 * 1024
 	const cmdSize = safeBound + 300*1024 // ~316 KB — realistic for a 315-line PR
@@ -3270,7 +3271,7 @@ func TestSanitizeSpawnError_CommandTooLong(t *testing.T) {
 		SafeBound:   safeBound,
 	}
 
-	msg := review.SanitizeSpawnErrorForTest(agentName, syntheticErr)
+	msg := review.SanitizeSpawnErrorForTest(prNumber, agentName, syntheticErr)
 
 	// AC: printed message ≤ 1 KiB.
 	if len(msg) > 1024 {
@@ -3302,12 +3303,13 @@ func TestSanitizeSpawnError_CommandTooLong(t *testing.T) {
 // error that embeds PRISM_INITIAL_PROMPT in its string does not pass that payload
 // through to the caller.
 func TestSanitizeSpawnError_OtherError_NoPromptPayload(t *testing.T) {
+	const prNumber = "1194"
 	const agentName = "review-code"
 	// Simulate an error whose string includes PRISM_INITIAL_PROMPT payload.
 	rawPromptValue := strings.Repeat("sensitive context", 1000)
 	err := fmt.Errorf("tmux new-window failed: PRISM_INITIAL_PROMPT=%s: exit status 1: command too long", rawPromptValue)
 
-	msg := review.SanitizeSpawnErrorForTest(agentName, err)
+	msg := review.SanitizeSpawnErrorForTest(prNumber, agentName, err)
 
 	// AC: the raw PRISM_INITIAL_PROMPT value must not appear verbatim.
 	if strings.Contains(msg, "PRISM_INITIAL_PROMPT="+rawPromptValue) {
@@ -3323,9 +3325,10 @@ func TestSanitizeSpawnError_OtherError_NoPromptPayload(t *testing.T) {
 // TestTruncateProgressMsg_Cap verifies that a message longer than 4 KiB is
 // truncated with a suffix naming a forensic path.
 func TestTruncateProgressMsg_Cap(t *testing.T) {
+	const prNumber = "1194"
 	const agentName = "review-code"
 	long := strings.Repeat("x", review.MaxProgressMsgBytesForTest+1)
-	out := review.TruncateProgressMsgForTest(agentName, long)
+	out := review.TruncateProgressMsgForTest(prNumber, agentName, long)
 	if !strings.Contains(out, "[...truncated; full error in ") {
 		t.Errorf("truncateProgressMsg: truncated message does not contain expected suffix\nmessage:\n%s", out)
 	}
@@ -3334,9 +3337,10 @@ func TestTruncateProgressMsg_Cap(t *testing.T) {
 // TestTruncateProgressMsg_ShortPassthrough verifies that a short message is
 // returned unchanged.
 func TestTruncateProgressMsg_ShortPassthrough(t *testing.T) {
+	const prNumber = "1194"
 	const agentName = "review-security"
 	short := "tmux not running"
-	out := review.TruncateProgressMsgForTest(agentName, short)
+	out := review.TruncateProgressMsgForTest(prNumber, agentName, short)
 	if out != short {
 		t.Errorf("truncateProgressMsg: short message modified unexpectedly\ngot: %q\nwant: %q", out, short)
 	}

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -3323,8 +3323,9 @@ func TestSanitizeSpawnError_OtherError_NoPromptPayload(t *testing.T) {
 // TestTruncateProgressMsg_Cap verifies that a message longer than 4 KiB is
 // truncated with a suffix naming a forensic path.
 func TestTruncateProgressMsg_Cap(t *testing.T) {
+	const agentName = "review-code"
 	long := strings.Repeat("x", review.MaxProgressMsgBytesForTest+1)
-	out := review.TruncateProgressMsgForTest(long)
+	out := review.TruncateProgressMsgForTest(agentName, long)
 	if !strings.Contains(out, "[...truncated; full error in ") {
 		t.Errorf("truncateProgressMsg: truncated message does not contain expected suffix\nmessage:\n%s", out)
 	}
@@ -3333,8 +3334,9 @@ func TestTruncateProgressMsg_Cap(t *testing.T) {
 // TestTruncateProgressMsg_ShortPassthrough verifies that a short message is
 // returned unchanged.
 func TestTruncateProgressMsg_ShortPassthrough(t *testing.T) {
+	const agentName = "review-security"
 	short := "tmux not running"
-	out := review.TruncateProgressMsgForTest(short)
+	out := review.TruncateProgressMsgForTest(agentName, short)
 	if out != short {
 		t.Errorf("truncateProgressMsg: short message modified unexpectedly\ngot: %q\nwant: %q", out, short)
 	}

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
 	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 func openTestDB(t *testing.T) *db.DB {
@@ -3251,5 +3252,90 @@ func TestBuildReviewPrompt_AllFiveAgentsGetSameContextWithLinkedIssues(t *testin
 		if prompts[i] != prompts[0] {
 			t.Errorf("prompt[%d] differs from prompt[0]; all agents must receive identical context", i)
 		}
+	}
+}
+
+// ── sanitizeSpawnError / truncateProgressMsg tests (issue #1194) ──────────────
+
+// TestSanitizeSpawnError_CommandTooLong verifies that a HostLaunchCmdTooLargeError
+// produces a structured message ≤ 1 KB that does not contain PRISM_INITIAL_PROMPT.
+func TestSanitizeSpawnError_CommandTooLong(t *testing.T) {
+	const agentName = "review-goal"
+	const safeBound = 16 * 1024
+	const cmdSize = safeBound + 300*1024 // ~316 KB — realistic for a 315-line PR
+
+	syntheticErr := &session.HostLaunchCmdTooLargeError{
+		SessionName: "nixos-config@worker~review-1-review-goal",
+		CmdSize:     cmdSize,
+		SafeBound:   safeBound,
+	}
+
+	msg := review.SanitizeSpawnErrorForTest(agentName, syntheticErr)
+
+	// AC: printed message ≤ 1 KiB.
+	if len(msg) > 1024 {
+		t.Errorf("sanitizeSpawnError: message length = %d, want ≤ 1024 bytes\nmessage:\n%s", len(msg), msg)
+	}
+
+	// AC: does not contain PRISM_INITIAL_PROMPT.
+	if strings.Contains(msg, "PRISM_INITIAL_PROMPT=") {
+		t.Errorf("sanitizeSpawnError: message contains PRISM_INITIAL_PROMPT= — argv payload must not appear in stdout")
+	}
+
+	// AC: contains the failure category.
+	if !strings.Contains(msg, "HostLaunchCmdSafeBound") {
+		t.Errorf("sanitizeSpawnError: message does not mention HostLaunchCmdSafeBound\nmessage:\n%s", msg)
+	}
+
+	// AC: contains the bound exceeded.
+	if !strings.Contains(msg, fmt.Sprintf("%d", safeBound)) {
+		t.Errorf("sanitizeSpawnError: message does not contain safe bound %d\nmessage:\n%s", safeBound, msg)
+	}
+
+	// AC: contains a hint.
+	if !strings.Contains(msg, "hint:") {
+		t.Errorf("sanitizeSpawnError: message does not contain a 'hint:'\nmessage:\n%s", msg)
+	}
+}
+
+// TestSanitizeSpawnError_OtherError_NoPromptPayload verifies that a non-oversized
+// error that embeds PRISM_INITIAL_PROMPT in its string does not pass that payload
+// through to the caller.
+func TestSanitizeSpawnError_OtherError_NoPromptPayload(t *testing.T) {
+	const agentName = "review-code"
+	// Simulate an error whose string includes PRISM_INITIAL_PROMPT payload.
+	rawPromptValue := strings.Repeat("sensitive context", 1000)
+	err := fmt.Errorf("tmux new-window failed: PRISM_INITIAL_PROMPT=%s: exit status 1: command too long", rawPromptValue)
+
+	msg := review.SanitizeSpawnErrorForTest(agentName, err)
+
+	// AC: the raw PRISM_INITIAL_PROMPT value must not appear verbatim.
+	if strings.Contains(msg, "PRISM_INITIAL_PROMPT="+rawPromptValue) {
+		t.Errorf("sanitizeSpawnError: message contains raw PRISM_INITIAL_PROMPT payload")
+	}
+
+	// AC: hard cap (message ≤ maxProgressMsgBytes + len of truncation suffix).
+	if len(msg) > review.MaxProgressMsgBytesForTest+200 {
+		t.Errorf("sanitizeSpawnError: message length = %d, want ≤ %d+200", len(msg), review.MaxProgressMsgBytesForTest)
+	}
+}
+
+// TestTruncateProgressMsg_Cap verifies that a message longer than 4 KiB is
+// truncated with a suffix naming a forensic path.
+func TestTruncateProgressMsg_Cap(t *testing.T) {
+	long := strings.Repeat("x", review.MaxProgressMsgBytesForTest+1)
+	out := review.TruncateProgressMsgForTest(long)
+	if !strings.Contains(out, "[...truncated; full error in ") {
+		t.Errorf("truncateProgressMsg: truncated message does not contain expected suffix\nmessage:\n%s", out)
+	}
+}
+
+// TestTruncateProgressMsg_ShortPassthrough verifies that a short message is
+// returned unchanged.
+func TestTruncateProgressMsg_ShortPassthrough(t *testing.T) {
+	short := "tmux not running"
+	out := review.TruncateProgressMsgForTest(short)
+	if out != short {
+		t.Errorf("truncateProgressMsg: short message modified unexpectedly\ngot: %q\nwant: %q", out, short)
 	}
 }

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -126,7 +126,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		if configErr != nil {
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, configErr)))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, configErr)))
 			}
 			continue
 		}
@@ -140,7 +140,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 				if patchErr != nil {
 					spawnErr[i] = fmt.Errorf("review: apply --model-override for %s: %w", ag.Name, patchErr)
 					if opts.OnProgress != nil {
-						opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
+						opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])))
 					}
 					continue
 				}
@@ -171,14 +171,14 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			if isoErr != nil {
 				spawnErr[i] = fmt.Errorf("review: resolve isolator for agent %s: %w", ag.Name, isoErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])))
 				}
 				continue
 			}
 			if writeErr := iso.WriteHarnessConfigBlob(agentSession, agentConfigContent); writeErr != nil {
 				spawnErr[i] = fmt.Errorf("review: write opencode config for agent %s: %w", ag.Name, writeErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])))
 				}
 				continue
 			}
@@ -212,7 +212,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnSessErr)))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnSessErr)))
 			}
 			// Clean up this agent's resources (sidecar, DB row, tmux session).
 			// SpawnSession may have partially progressed; be defensive so a
@@ -399,7 +399,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		if configErr != nil {
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, configErr)))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, configErr)))
 			}
 			continue
 		}
@@ -410,7 +410,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 				if patchErr != nil {
 					spawnErr[i] = fmt.Errorf("review: apply --model-override for %s: %w", ag.Name, patchErr)
 					if opts.OnProgress != nil {
-						opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
+						opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])))
 					}
 					continue
 				}
@@ -433,14 +433,14 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			if isoErr != nil {
 				spawnErr[i] = fmt.Errorf("review: resolve isolator for agent %s: %w", ag.Name, isoErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])))
 				}
 				continue
 			}
 			if writeErr := iso.WriteHarnessConfigBlob(agentSession, agentConfigContent); writeErr != nil {
 				spawnErr[i] = fmt.Errorf("review: write opencode config for agent %s: %w", ag.Name, writeErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])))
 				}
 				continue
 			}
@@ -467,7 +467,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnSessErr)))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnSessErr)))
 			}
 			session.KillSidecar(agentSession)
 			cleanupAgentSession(d, agentSession)

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -126,7 +126,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		if configErr != nil {
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, configErr)))
 			}
 			continue
 		}
@@ -140,7 +140,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 				if patchErr != nil {
 					spawnErr[i] = fmt.Errorf("review: apply --model-override for %s: %w", ag.Name, patchErr)
 					if opts.OnProgress != nil {
-						opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+						opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
 					}
 					continue
 				}
@@ -171,14 +171,14 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			if isoErr != nil {
 				spawnErr[i] = fmt.Errorf("review: resolve isolator for agent %s: %w", ag.Name, isoErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
 				}
 				continue
 			}
 			if writeErr := iso.WriteHarnessConfigBlob(agentSession, agentConfigContent); writeErr != nil {
 				spawnErr[i] = fmt.Errorf("review: write opencode config for agent %s: %w", ag.Name, writeErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
 				}
 				continue
 			}
@@ -212,7 +212,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnSessErr))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnSessErr)))
 			}
 			// Clean up this agent's resources (sidecar, DB row, tmux session).
 			// SpawnSession may have partially progressed; be defensive so a
@@ -399,7 +399,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		if configErr != nil {
 			spawnErr[i] = configErr
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), configErr))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, configErr)))
 			}
 			continue
 		}
@@ -410,7 +410,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 				if patchErr != nil {
 					spawnErr[i] = fmt.Errorf("review: apply --model-override for %s: %w", ag.Name, patchErr)
 					if opts.OnProgress != nil {
-						opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+						opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
 					}
 					continue
 				}
@@ -433,14 +433,14 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			if isoErr != nil {
 				spawnErr[i] = fmt.Errorf("review: resolve isolator for agent %s: %w", ag.Name, isoErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
 				}
 				continue
 			}
 			if writeErr := iso.WriteHarnessConfigBlob(agentSession, agentConfigContent); writeErr != nil {
 				spawnErr[i] = fmt.Errorf("review: write opencode config for agent %s: %w", ag.Name, writeErr)
 				if opts.OnProgress != nil {
-					opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnErr[i]))
+					opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnErr[i])))
 				}
 				continue
 			}
@@ -467,7 +467,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
-				opts.OnProgress(fmt.Sprintf("%s failed to start: %v", FormatAgentDisplayName(ag.Name), spawnSessErr))
+				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(ag.Name, spawnSessErr)))
 			}
 			session.KillSidecar(agentSession)
 			cleanupAgentSession(d, agentSession)

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -289,7 +289,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			results[i] = AgentResult{
 				Agent:   ag,
 				Passed:  false,
-				Output:  fmt.Sprintf("ERROR: failed to spawn agent: %v", spawnErr[i]),
+				Output:  fmt.Sprintf("ERROR: failed to spawn agent: %s", sanitizeSpawnError(opts.PRNumber, ag.Name, spawnErr[i])),
 				IsError: true,
 			}
 		} else {
@@ -520,7 +520,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		} else {
 			failures = append(failures, failedAgent{
 				name:   agents[i].Name,
-				reason: failureReason(se),
+				reason: failureReason(opts.PRNumber, agents[i].Name, se),
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixes #1194: `prism review` per-agent failure path no longer dumps the full `~350 KB` tmux argv (including `PRISM_INITIAL_PROMPT`) to stdout.
- Detects `HostLaunchCmdTooLargeError` and emits a short structured error (≤1 KB) with agent name, failure category, bound exceeded, and a hint.
- Hard-caps any error printed via `OnProgress` at 4 KiB; longer messages are truncated with `[...truncated; full error in <path>]`.
- Strips `PRISM_INITIAL_PROMPT=` content from all error strings before printing.
- Adds unit tests for both the structured error path and the general truncation path.

Closes #1194