### PR TITLE
feat(prism): P2.SPAWN — wire prism spawn --harness pi end-to-end on Linux bwrap

### DIFF
--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -21,6 +21,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -126,6 +129,24 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 		SentAt:       time.Now(),
 	}
 
+	// Socket-pipe transports (e.g. PI) do not have an opencode HTTP port —
+	// route the prompt through the sidecar's per-session host-API socket
+	// instead. The sidecar's /prompt handler detects same-session targets
+	// with a TransportSocketPipe shape and forwards to harness.DeliverPrompt
+	// via the active pipe connection (P2.SIDECAR).
+	if status.Harness != nil {
+		if shape, ok := harness.ShapeOf(*status.Harness); ok && shape == harness.TransportSocketPipe {
+			if err := deliverViaSidecarHostAPI(sessionName, promptText); err != nil {
+				return fmt.Errorf("socket-pipe delivery failed: %w", err)
+			}
+			if err := database.WriteBusMessageDelivered(msg); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not write audit bus message: %v\n", err)
+			}
+			fmt.Printf("prompt delivered to %s via socket-pipe\n", sessionName)
+			return nil
+		}
+	}
+
 	// Require port and session ID for HTTP delivery.
 	if status.HarnessPort == nil || status.HarnessSessionID == nil {
 		return fmt.Errorf("session %q has no harness port or session ID — cannot deliver prompt", sessionName)
@@ -142,6 +163,48 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "warning: could not write audit bus message: %v\n", err)
 	}
 	fmt.Printf("prompt delivered to %s via HTTP\n", sessionName)
+	return nil
+}
+
+// deliverViaSidecarHostAPI dials the per-session host-API Unix socket and
+// POSTs /prompt to deliver a prompt to a socket-pipe (e.g. PI) session. The
+// socket-pipe path bypasses the HTTP harness API used for opencode and
+// instead routes through the sidecar's pipe-frame queue.
+//
+// The function dials the socket directly rather than going through the
+// PRISM_HOST_API proxy mechanism: PRISM_HOST_API is only set inside
+// containerised agent processes; the host-side prism CLI must look up the
+// per-session socket itself via session.SidecarHostAPIPath.
+func deliverViaSidecarHostAPI(sessionName, promptText string) error {
+	sockPath, err := session.SidecarHostAPIPath(sessionName)
+	if err != nil {
+		return fmt.Errorf("resolve sidecar host-api socket: %w", err)
+	}
+	if _, statErr := os.Stat(sockPath); statErr != nil {
+		return fmt.Errorf("sidecar host-api socket missing at %s: %w", sockPath, statErr)
+	}
+	client := newHostAPIClient(sockPath)
+
+	body, err := json.Marshal(map[string]string{
+		"session": sessionName,
+		"prompt":  promptText,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal prompt: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://prism-hostapi/prompt", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("dial sidecar host-api: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("sidecar host-api returned HTTP %d", resp.StatusCode)
+	}
 	return nil
 }
 

--- a/modules/programs/prism/prism/cmd/prompt_pi_test.go
+++ b/modules/programs/prism/prism/cmd/prompt_pi_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+// prompt_pi_test.go — tests for the PI socket-pipe routing in `prism prompt`
+// (P2.SPAWN, #1212).
+//
+// The host-side `prism prompt <pi-session>` CLI cannot use the opencode HTTP
+// API path (PI sessions have no harness_port). Instead it must dial the
+// per-session sidecar host-API Unix socket and route via /prompt, which the
+// sidecar then forwards to the harness pipe via DeliverPrompt.
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// setStatusHarness updates the harness column for an existing agent_status
+// row. The DB package's UpsertStatus* helpers hard-code harness='opencode',
+// so tests covering non-opencode harnesses use this raw UPDATE via the
+// public QueryRow accessor (UPDATE … RETURNING is required because QueryRow
+// needs at least one row to scan).
+func setStatusHarness(t *testing.T, d *db.DB, sessionName, harness string) {
+	t.Helper()
+	var dummy int
+	err := d.QueryRow(
+		"UPDATE agent_status SET harness = ? WHERE session_name = ? RETURNING 1",
+		harness, sessionName,
+	).Scan(&dummy)
+	if err != nil {
+		t.Fatalf("set harness: %v", err)
+	}
+}
+
+// TestRunPrompt_PISession_RoutesThroughSidecarHostAPI seeds a PI session in
+// the DB and starts a stub Unix-socket HTTP server at the per-session
+// host-api.sock path. It then runs `prism prompt <session>` and asserts that
+// the request reached the stub server with the correct body, that no HTTP
+// (opencode) call was made, and that the audit row was written.
+func TestRunPrompt_PISession_RoutesThroughSidecarHostAPI(t *testing.T) {
+	// Use a short XDG_STATE_HOME so the per-session socket path stays under
+	// the 108-char Unix sun_path limit on Linux.
+	stateHome := filepath.Join(os.TempDir(), "prism-pipe-test-"+randCmdHex(6))
+	if err := os.MkdirAll(stateHome, 0o700); err != nil {
+		t.Fatalf("mkdir state home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	sessionName := "repo@pi"
+	sockPath, err := session.SidecarHostAPIPath(sessionName)
+	if err != nil {
+		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+
+	type req struct {
+		Session string `json:"session"`
+		Prompt  string `json:"prompt"`
+	}
+	reqCh := make(chan req, 1)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/prompt" {
+			http.Error(w, `{"error":"unexpected path"}`, http.StatusBadRequest)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var got req
+		_ = json.Unmarshal(body, &got)
+		reqCh <- got
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	d := openPromptTestDB(t)
+	seedSession(t, d, sessionName, "active", nil, nil, strPtr("worker"), nil)
+	// Override the harness column so the prompt path takes the socket-pipe branch.
+	setStatusHarness(t, d, sessionName, "pi")
+
+	rootCmd.SetArgs([]string{"prompt", sessionName, "--prompt", "do the mahi"})
+	output := captureStdout(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "socket-pipe") {
+		t.Errorf("output should mention socket-pipe delivery: got %q", output)
+	}
+
+	select {
+	case got := <-reqCh:
+		if got.Session != sessionName {
+			t.Errorf("request session: got %q, want %q", got.Session, sessionName)
+		}
+		if got.Prompt != "do the mahi" {
+			t.Errorf("request prompt: got %q, want %q", got.Prompt, "do the mahi")
+		}
+	default:
+		t.Fatal("did not receive a /prompt request on the per-session socket")
+	}
+
+	// Verify the audit row was written.
+	var count int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ? AND delivered_at IS NOT NULL", sessionName).Scan(&count); err != nil {
+		t.Fatalf("count audit row: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("audit row count: got %d, want 1", count)
+	}
+}
+
+// TestRunPrompt_PISession_SocketMissingReturnsClearError verifies that when
+// the per-session host-API socket does not exist (e.g. sidecar not running),
+// the error message points at the missing socket path so an operator can
+// diagnose the failure.
+func TestRunPrompt_PISession_SocketMissingReturnsClearError(t *testing.T) {
+	stateHome := filepath.Join(os.TempDir(), "prism-pipe-miss-"+randCmdHex(6))
+	if err := os.MkdirAll(stateHome, 0o700); err != nil {
+		t.Fatalf("mkdir state home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	sessionName := "repo@pi-no-sock"
+
+	d := openPromptTestDB(t)
+	seedSession(t, d, sessionName, "active", nil, nil, strPtr("worker"), nil)
+	setStatusHarness(t, d, sessionName, "pi")
+
+	rootCmd.SetArgs([]string{"prompt", sessionName, "--prompt", "test"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when sidecar socket missing, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "socket-pipe delivery failed") {
+		t.Errorf("error should mention socket-pipe delivery failure: got %q", msg)
+	}
+}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -229,6 +230,14 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// tmux session, no DB row).
 	if _, ok := harness.Lookup(harnessFlag); !ok {
 		return fmt.Errorf("unknown harness %q: valid harnesses: %s", harnessFlag, strings.Join(harness.Names(), ", "))
+	}
+
+	// PI harness is only supported on Linux (bwrap path) until P2.DARWIN
+	// (#1213) lands. Reject early with a clear pointer to the tracking issue
+	// so users know what to wait for, rather than failing later with a less
+	// obvious bwrap-not-found / sandbox-exec error.
+	if harnessFlag == "pi" && runtime.GOOS != "linux" {
+		return fmt.Errorf("--harness pi is not yet supported on %s — Darwin support is tracked in #1213", runtime.GOOS)
 	}
 
 	promptText, promptSource, err := resolvePromptWithSource(cmd)

--- a/modules/programs/prism/prism/cmd/spawn_pi_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_pi_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+// spawn_pi_test.go — tests for the PI harness integration (P2.SPAWN, #1212).
+//
+// Coverage:
+//   - --harness pi on Darwin returns a clear error pointing at #1213
+//   - --harness pi on Linux passes the harness validation step (the spawn
+//     fails later for an unrelated reason since the test does not prepare a
+//     real bwrap environment, but the failure is NOT a harness validation
+//     error).
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRunSpawn_HarnessPI_DarwinReturnsClearError verifies the edge-case AC:
+//
+//	`--harness pi` on Darwin fails with a clear "not yet supported, see
+//	 #1213" message until P2.DARWIN lands.
+//
+// On Linux this branch is unreachable; the test skips so that CI on the
+// supported platform continues to exercise the rest of the suite. The string
+// match asserts that the error mentions both the OS and the tracking issue
+// so that an operator on a Mac sees the right pointer immediately.
+func TestRunSpawn_HarnessPI_DarwinReturnsClearError(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Darwin-specific: --harness pi guard is conditioned on runtime.GOOS != linux")
+	}
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	cmd.Flags().StringArray("model-override", nil, "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("harness", "pi")
+
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_BARE_ROOT", "")
+
+	err := runSpawn(cmd, nil)
+	if err == nil {
+		t.Fatal("runSpawn with --harness pi on Darwin: expected non-nil error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not yet supported") {
+		t.Errorf("error %q does not mention 'not yet supported'", msg)
+	}
+	if !strings.Contains(msg, "#1213") {
+		t.Errorf("error %q does not reference the P2.DARWIN tracking issue (#1213)", msg)
+	}
+}
+
+// TestRunSpawn_HarnessPI_LinuxPassesValidation verifies the positive path:
+// the PI harness is registered and validation passes. The test does not
+// prepare a real bwrap environment so runSpawn fails further down; we assert
+// the failure is NOT a harness-validation error to prove validation passed.
+func TestRunSpawn_HarnessPI_LinuxPassesValidation(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only: PI harness only supported on Linux today")
+	}
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "opencode", "")
+	cmd.Flags().StringArray("model-override", nil, "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("harness", "pi")
+
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_BARE_ROOT", "")
+	withNoopTmux(t)
+
+	err := runSpawn(cmd, nil)
+	// We expect a non-nil error (no git repo), but it must not be a harness
+	// validation or Darwin-guard error.
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "unknown harness") {
+			t.Errorf("runSpawn with --harness pi returned harness validation error: %v", err)
+		}
+		if strings.Contains(msg, "not yet supported") {
+			t.Errorf("runSpawn with --harness pi on Linux hit Darwin guard: %v", err)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -563,6 +563,26 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
+		// Same-session targeting bypasses cross-session auth: the request
+		// is being routed to the sidecar's own pipe-connected harness, so
+		// there is no cross-session boundary to enforce. This is the path
+		// taken by the host-side `prism prompt <pi-session>` CLI when it
+		// dials the per-session host-API socket directly. We still gate on
+		// the harness having a TransportSocketPipe shape so an opencode
+		// session — which uses HTTP-port delivery — does not silently route
+		// through this branch.
+		if req.Session == s.cfg.SessionName {
+			if shape, ok := harness.ShapeOf(s.cfg.HarnessName); ok && shape == harness.TransportSocketPipe {
+				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s)", req.Session)
+				if !s.DeliverPrompt(req.Prompt, "nextTurn") {
+					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]string{})
+				return
+			}
+		}
+
 		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
@@ -612,21 +632,6 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			if req.Session != ownCoordinator {
 				writeError(w, http.StatusForbidden,
 					fmt.Sprintf("workers can only prompt their own coordinator (%s), got %q", ownCoordinator, req.Session))
-				return
-			}
-		}
-
-		// For socket-pipe (PI) sessions targeting this sidecar directly,
-		// deliver via the harness pipe rather than shelling out to prism prompt
-		// (which would fail: PI sessions have no opencode HTTP port).
-		if req.Session == s.cfg.SessionName {
-			if shape, ok := harness.ShapeOf(s.cfg.HarnessName); ok && shape == harness.TransportSocketPipe {
-				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s)", req.Session)
-				if !s.DeliverPrompt(req.Prompt, "nextTurn") {
-					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")
-					return
-				}
-				writeJSON(w, http.StatusOK, map[string]string{})
 				return
 			}
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -723,12 +723,34 @@ func (s *Sidecar) Shutdown() {
 	}
 
 	// Close the harness pipe listener and connection (socket-pipe transport).
+	// Best-effort graceful shutdown: send an abort frame so the PI extension
+	// can flush state to disk, write a final session_end event, and exit
+	// cleanly. The frame is only delivered when the connection is still live;
+	// in the typical cleanup path the tmux pane (and therefore PI) has
+	// already been killed before the sidecar receives SIGTERM, so this write
+	// is a no-op there. Either way the connection is then closed below.
 	s.mu.Lock()
 	pipeLn := s.harnessPipeListener
 	pipeConn := s.harnessPipeConn
+	pipeOutCh := s.harnessPipeOutCh
 	s.harnessPipeListener = nil
 	s.harnessPipeConn = nil
 	s.mu.Unlock()
+	if pipeOutCh != nil {
+		abortFrame := []byte(`{"type":"abort"}` + "\n")
+		select {
+		case pipeOutCh <- abortFrame:
+			// Give the writer goroutine a brief moment to flush the frame
+			// onto the wire before the connection is torn down. Bounded so
+			// shutdown never blocks longer than a couple of seconds even if
+			// the extension is unresponsive.
+			time.Sleep(100 * time.Millisecond)
+		default:
+			// Outbound queue full or no longer accepting — fall through to
+			// the connection close. handlePipeFrame's connection-dropped
+			// handler will mark the session error if PI exits unexpectedly.
+		}
+	}
 	if pipeConn != nil {
 		_ = pipeConn.Close()
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -590,5 +590,56 @@ func TestSocketPipe_SidecarDispatchesSocketPipe(t *testing.T) {
 	_ = runErr
 }
 
+// TestSocketPipe_HostAPIPromptSelfWorkerBypassesAuth verifies that a worker
+// PI session can be self-prompted via the host-API /prompt endpoint, bypassing
+// the worker→own-coordinator-only auth check that the HTTP-port path enforces.
+//
+// The bypass is necessary because the host-side `prism prompt <pi-session>`
+// CLI dials the per-session host-API socket directly — the request targets
+// the sidecar's own session, so there is no cross-session security boundary
+// to enforce. Without the bypass, a worker PI session could not be prompted
+// from the host CLI at all (P2.SPAWN edge-case AC, #1212).
+func TestSocketPipe_HostAPIPromptSelfWorkerBypassesAuth(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	defer conn.Close()
+
+	// Drive the host-API /prompt as if the host CLI dialled hostapi.sock and
+	// targeted the sidecar's own session. The sidecar role is "worker" — under
+	// the cross-session rules, a worker may only prompt its own coordinator;
+	// the bypass is what permits a same-session target.
+	rr := doHostAPI(t, sc, "POST", "/prompt",
+		`{"session":"testrepo@main","prompt":"hello pi"}`)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200 (bypass should permit same-session worker self-prompt); body=%s",
+			rr.Code, rr.Body.String())
+	}
+
+	// The sidecar must have enqueued a prompt frame to the extension.
+	rd := bufio.NewReader(conn)
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	line, err := rd.ReadBytes('\n')
+	_ = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		t.Fatalf("read prompt frame: %v", err)
+	}
+	var frame map[string]any
+	if err := json.Unmarshal(line, &frame); err != nil {
+		t.Fatalf("unmarshal prompt frame: %v", err)
+	}
+	if frame["type"] != "prompt" || frame["text"] != "hello pi" {
+		t.Errorf("prompt frame = %v, want type=prompt text=hello pi", frame)
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
 // Ensure db import is used.
 var _ *db.DB


### PR DESCRIPTION
## Summary

Stitches together P2.SIDECAR (#1209), P2.EXTENSION (#1210), and P2.AGENTRUN (#1211) so that \`prism spawn --harness pi --prompt \"...\"\` produces a working PI session in tmux on Linux bwrap, with parity to opencode for spawn / prompt / checkin / cleanup / list-sessions.

## What changed

- **spawn**: reject \`--harness pi\` on non-Linux with a clear pointer to P2.DARWIN (#1213) **before** any session state is created.
- **prompt**: route the host-side \`prism prompt <pi-session>\` CLI through the per-session sidecar host-API Unix socket, since PI sessions have no opencode HTTP port. The sidecar's \`/prompt\` handler then forwards the prompt via the harness pipe to the PI extension.
- **sidecar /prompt**: short-circuit the cross-session auth check when the request targets the sidecar's own session and the harness has a \`TransportSocketPipe\` shape — there is no cross-session boundary to enforce for self-targeting, and without the bypass a worker PI session could not be self-prompted from the host CLI at all.
- **sidecar Shutdown**: best-effort \`abort\` frame to the PI extension on socket-pipe shutdown so the extension can flush state cleanly when the connection is still live.

## Tests

- \`TestRunSpawn_HarnessPI_DarwinReturnsClearError\` (skipped on Linux) — Darwin guard returns clear \`not yet supported, see #1213\`.
- \`TestRunSpawn_HarnessPI_LinuxPassesValidation\` — Linux validation passes (rest fails for an unrelated reason in the unit test sandbox).
- \`TestRunPrompt_PISession_RoutesThroughSidecarHostAPI\` — host-side PI prompts dial the per-session host-API socket; body is correct; audit row written.
- \`TestRunPrompt_PISession_SocketMissingReturnsClearError\` — clear error when sidecar isn't running.
- \`TestSocketPipe_HostAPIPromptSelfWorkerBypassesAuth\` — same-session worker PI prompts bypass the worker→own-coordinator auth check and reach the harness pipe.

## Acceptance criteria

All functional and edge-case ACs from #1212 are addressed by either pre-existing wiring (sidecar dispatch, agent-run PI invocation, tmux pane visibility) or by the changes above. Existing opencode tests continue to pass; the same-session bypass is gated on \`TransportSocketPipe\` so opencode sessions still go through the HTTP path.

\`go build ./...\` and \`go test ./...\` pass (the pre-existing \`scratchpad\` leak guard FAIL in \`./cmd\` reproduces on \`main\` and is unrelated to this change). \`nix build .#nixosConfigurations.navi.config.system.build.toplevel\` passes.

Closes #1212