### PR TITLE
feat(prism): P5.LOGS — prism logs --harness-events raw JSONL frame ar…

### DIFF
--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -410,6 +410,12 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 			// Non-fatal — log but don't fail the command.
 			fmt.Fprintf(os.Stderr, "prism event tmux-session-start: prune: %v\n", err)
 		}
+		// harness_frames retention is shorter (7d) — the raw JSONL archive is
+		// voluminous on a busy PI session and only useful for near-term wire-
+		// protocol debugging. agent_events stays at 90d above.
+		if err := d.PruneHarnessFrames(7 * 24 * time.Hour); err != nil {
+			fmt.Fprintf(os.Stderr, "prism event tmux-session-start: prune harness_frames: %v\n", err)
+		}
 
 		return nil
 	},

--- a/modules/programs/prism/prism/cmd/logs.go
+++ b/modules/programs/prism/prism/cmd/logs.go
@@ -60,6 +60,15 @@ session.SpawnSession before tmux send-keys):
 
   prism logs nixos-config@feat --startup
 
+Use --harness-events to print the raw PI JSONL frames recorded for a
+socket-pipe session (P5.LOGS / #1218). One JSON object per line in
+chronological order; pipe to jq for pretty-printing:
+
+  prism logs nixos-config@feat --harness-events
+  prism logs nixos-config@feat --harness-events --follow
+  prism logs nixos-config@feat --harness-events --direction in
+  prism logs nixos-config@feat --harness-events --types tool_call,tool_result
+
 Works identically from the host or inside a coordinator container — in
 container mode the log is fetched via the host API Unix socket (PRISM_HOST_API).`,
 	Args:         cobra.ExactArgs(1),
@@ -72,6 +81,9 @@ func init() {
 	logsCmd.Flags().BoolP("follow", "f", false, "Stream new lines as they are written; exits when session ends or Ctrl-C")
 	logsCmd.Flags().Bool("agent-run", false, "Read the agent-run log (bwrap harness stdout/stderr) instead of the sidecar log")
 	logsCmd.Flags().Bool("startup", false, "Read the agent-startup log (spawn-time breadcrumbs written by session.SpawnSession)")
+	logsCmd.Flags().Bool("harness-events", false, "Print raw PI JSONL frames recorded for this session (P5.LOGS / #1218)")
+	logsCmd.Flags().String("direction", "", "With --harness-events: filter frames by direction (in|out)")
+	logsCmd.Flags().String("types", "", "With --harness-events: comma-separated list of frame types to include")
 	rootCmd.AddCommand(logsCmd)
 }
 
@@ -83,6 +95,26 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	tailSet := cmd.Flags().Changed("tail")
 	agentRun, _ := cmd.Flags().GetBool("agent-run")
 	startup, _ := cmd.Flags().GetBool("startup")
+	harnessEvents, _ := cmd.Flags().GetBool("harness-events")
+	direction, _ := cmd.Flags().GetString("direction")
+	typesCSV, _ := cmd.Flags().GetString("types")
+
+	// --harness-events is its own pipeline (DB-backed, not a log file). It
+	// supersedes --agent-run / --startup / --tail and only honours --follow,
+	// --direction, and --types.
+	if harnessEvents {
+		if agentRun || startup {
+			return fmt.Errorf("--harness-events cannot be combined with --agent-run or --startup")
+		}
+		if tailSet {
+			return fmt.Errorf("--harness-events does not support --tail (use --follow to stream new frames)")
+		}
+		return runHarnessEvents(sessionName, direction, typesCSV, follow, os.Stdout)
+	}
+
+	if direction != "" || typesCSV != "" {
+		return fmt.Errorf("--direction and --types require --harness-events")
+	}
 
 	if tailSet && follow {
 		return fmt.Errorf("--tail and --follow are mutually exclusive")

--- a/modules/programs/prism/prism/cmd/logs_harness.go
+++ b/modules/programs/prism/prism/cmd/logs_harness.go
@@ -1,0 +1,175 @@
+package cmd
+
+// prism logs --harness-events <session> — raw PI JSONL frame archive viewer
+// (P5.LOGS / #1218).
+//
+// The PI sidecar persists every inbound and outbound JSONL frame on a
+// socket-pipe session into the harness_frames DB table (see
+// internal/sidecar/frame_archive.go). This subcommand replays those frames
+// in chronological order — one JSON object per line — and is the primary
+// debugging surface for diagnosing PI wire-protocol issues without grepping
+// the sidecar log.
+//
+// Usage:
+//
+//   prism logs --harness-events <session>
+//   prism logs --harness-events <session> --follow
+//   prism logs --harness-events <session> --direction in|out
+//   prism logs --harness-events <session> --types tool_call,tool_result
+//
+// Output is intentionally raw (no formatting, no annotation) so it is safe
+// to pipe into jq, grep, etc.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// runHarnessEvents implements the `prism logs --harness-events` subcommand.
+//
+// On a non-PI session (no harness_frames rows recorded) it prints a clear
+// hint to stderr and returns a non-zero error so the caller's shell sees an
+// exit code distinguishable from "session has zero frames yet" — this matches
+// the edge-case AC.
+func runHarnessEvents(sessionName, direction, typesCSV string, follow bool, w io.Writer) error {
+	if direction != "" && direction != directionIn && direction != directionOut {
+		return fmt.Errorf("--direction must be %q or %q (got %q)", directionIn, directionOut, direction)
+	}
+
+	types := parseTypesCSV(typesCSV)
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("open DB: %w", err)
+	}
+	defer d.Close()
+
+	// AC edge-case: a session with zero archived frames is treated as
+	// non-PI and we exit non-zero with a clear hint. The CountHarnessFrames
+	// short-circuit is necessary because an empty filter (e.g. an unknown
+	// --direction) would otherwise yield zero rows and look identical to
+	// the non-PI case.
+	count, err := d.CountHarnessFrames(sessionName)
+	if err != nil {
+		return fmt.Errorf("count harness frames: %w", err)
+	}
+	if count == 0 {
+		fmt.Fprintf(os.Stderr,
+			"no harness frames recorded for session %q; this is a PI-harness-only feature\n",
+			sessionName)
+		return errNoHarnessFrames
+	}
+
+	frames, err := d.QueryHarnessFrames(sessionName, direction, types, "")
+	if err != nil {
+		return fmt.Errorf("query harness frames: %w", err)
+	}
+
+	// Print the existing frames (one JSONL object per line).
+	var lastID string
+	for _, f := range frames {
+		if _, err := fmt.Fprintln(w, f.Payload); err != nil {
+			return fmt.Errorf("write harness frame: %w", err)
+		}
+		lastID = f.ID
+	}
+
+	if !follow {
+		return nil
+	}
+
+	// --follow: poll every 500ms for new frames after lastID. Exits cleanly
+	// on Ctrl-C. We intentionally do not exit on session termination here:
+	// frames are persisted and the operator can still tail interesting
+	// post-mortem traffic (e.g. the trailing session_shutdown / error frame
+	// that arrived after they hit follow).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			next, err := d.QueryHarnessFrames(sessionName, direction, types, lastID)
+			if err != nil {
+				// A "cursor frame not found" error means the cursor row
+				// was pruned out from under us (very unlikely on a 7d
+				// retention window during interactive use, but possible).
+				// Fall back to a blanket query to keep the stream alive.
+				if strings.Contains(err.Error(), "cursor frame") {
+					lastID = ""
+					continue
+				}
+				return fmt.Errorf("follow harness frames: %w", err)
+			}
+			for _, f := range next {
+				if _, err := fmt.Fprintln(w, f.Payload); err != nil {
+					return fmt.Errorf("write harness frame: %w", err)
+				}
+				lastID = f.ID
+			}
+		}
+	}
+}
+
+// parseTypesCSV splits a comma-separated list, trims whitespace from each
+// element, and drops empty entries. Returns nil when the input has no usable
+// entries so the DB query treats it as "no type filter".
+func parseTypesCSV(csv string) []string {
+	if csv == "" {
+		return nil
+	}
+	raw := strings.Split(csv, ",")
+	out := raw[:0]
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// errNoHarnessFrames is returned by runHarnessEvents when the requested
+// session has zero harness_frames rows. The CLI surface treats this as a
+// non-zero exit code while keeping the user-facing message on stderr.
+//
+// Defined as a package-level sentinel so test code can assert on it via
+// errors.Is.
+var errNoHarnessFrames = noHarnessFramesError{}
+
+type noHarnessFramesError struct{}
+
+func (noHarnessFramesError) Error() string {
+	return "no harness frames recorded for this session"
+}
+
+// directionIn / directionOut mirror the constants in internal/db so the
+// CLI doesn't need to import the db package's literals into help text.
+const (
+	directionIn  = "in"
+	directionOut = "out"
+)

--- a/modules/programs/prism/prism/cmd/logs_harness_test.go
+++ b/modules/programs/prism/prism/cmd/logs_harness_test.go
@@ -1,0 +1,258 @@
+package cmd
+
+// Tests for `prism logs --harness-events` (P5.LOGS / #1218).
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func setUpHarnessFramesDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+	return d
+}
+
+func writeFrameForCLI(t *testing.T, d *db.DB, sessionName, direction, typ, payload string, ts time.Time) {
+	t.Helper()
+	if err := d.WriteHarnessFrame(db.HarnessFrame{
+		ID:          uuid.New().String(),
+		SessionName: sessionName,
+		Direction:   direction,
+		Type:        typ,
+		Payload:     payload,
+		CreatedAt:   ts,
+	}); err != nil {
+		t.Fatalf("WriteHarnessFrame: %v", err)
+	}
+}
+
+// TestRunHarnessEvents_NonPISession exercises the "no harness frames recorded"
+// edge case (AC: non-PI session prints a clear hint and exits non-zero).
+func TestRunHarnessEvents_NonPISession(t *testing.T) {
+	setUpHarnessFramesDB(t)
+
+	var buf bytes.Buffer
+	err := runHarnessEvents("opencode-session@main", "", "", false, &buf)
+	if err == nil {
+		t.Fatal("expected error for non-PI session, got nil")
+	}
+	if !errors.Is(err, errNoHarnessFrames) {
+		t.Errorf("err = %v; want errNoHarnessFrames sentinel", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("stdout should be empty on no-frames path, got: %q", buf.String())
+	}
+}
+
+// TestRunHarnessEvents_PrintsAllFramesChronologically covers the basic
+// "print all frames in chronological order, one JSON object per line" AC.
+func TestRunHarnessEvents_PrintsAllFramesChronologically(t *testing.T) {
+	d := setUpHarnessFramesDB(t)
+
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrameForCLI(t, d, "s@main", "in", "hello", `{"type":"hello","i":1}`, t0)
+	writeFrameForCLI(t, d, "s@main", "out", "hello_ack", `{"type":"hello_ack","i":2}`, t0.Add(1*time.Millisecond))
+	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"type":"tool_call","i":3}`, t0.Add(2*time.Millisecond))
+
+	var buf bytes.Buffer
+	if err := runHarnessEvents("s@main", "", "", false, &buf); err != nil {
+		t.Fatalf("runHarnessEvents: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3:\n%s", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], `"i":1`) ||
+		!strings.Contains(lines[1], `"i":2`) ||
+		!strings.Contains(lines[2], `"i":3`) {
+		t.Errorf("lines not in chronological order:\n%s", buf.String())
+	}
+}
+
+// TestRunHarnessEvents_DirectionFilter covers the --direction in/out AC.
+func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
+	d := setUpHarnessFramesDB(t)
+
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrameForCLI(t, d, "s@main", "in", "hello", `{"d":"in1"}`, t0)
+	writeFrameForCLI(t, d, "s@main", "out", "hello_ack", `{"d":"out1"}`, t0.Add(1*time.Millisecond))
+	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"d":"in2"}`, t0.Add(2*time.Millisecond))
+
+	var inBuf bytes.Buffer
+	if err := runHarnessEvents("s@main", "in", "", false, &inBuf); err != nil {
+		t.Fatalf("runHarnessEvents in: %v", err)
+	}
+	if !strings.Contains(inBuf.String(), "in1") || !strings.Contains(inBuf.String(), "in2") {
+		t.Errorf("inbound output missing in1/in2:\n%s", inBuf.String())
+	}
+	if strings.Contains(inBuf.String(), "out1") {
+		t.Errorf("inbound output unexpectedly contains out1:\n%s", inBuf.String())
+	}
+
+	var outBuf bytes.Buffer
+	if err := runHarnessEvents("s@main", "out", "", false, &outBuf); err != nil {
+		t.Fatalf("runHarnessEvents out: %v", err)
+	}
+	if !strings.Contains(outBuf.String(), "out1") {
+		t.Errorf("outbound output missing out1:\n%s", outBuf.String())
+	}
+	if strings.Contains(outBuf.String(), "in1") || strings.Contains(outBuf.String(), "in2") {
+		t.Errorf("outbound output should not contain inbound frames:\n%s", outBuf.String())
+	}
+}
+
+func TestRunHarnessEvents_DirectionInvalid(t *testing.T) {
+	setUpHarnessFramesDB(t)
+	var buf bytes.Buffer
+	err := runHarnessEvents("s@main", "sideways", "", false, &buf)
+	if err == nil {
+		t.Fatal("expected error for invalid direction")
+	}
+	if !strings.Contains(err.Error(), "--direction") {
+		t.Errorf("err = %v; want a --direction message", err)
+	}
+}
+
+// TestRunHarnessEvents_TypesFilter covers the --types AC.
+func TestRunHarnessEvents_TypesFilter(t *testing.T) {
+	d := setUpHarnessFramesDB(t)
+
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrameForCLI(t, d, "s@main", "in", "hello", `{"t":"hello"}`, t0)
+	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"t":"tool_call"}`, t0.Add(1*time.Millisecond))
+	writeFrameForCLI(t, d, "s@main", "in", "tool_result", `{"t":"tool_result"}`, t0.Add(2*time.Millisecond))
+	writeFrameForCLI(t, d, "s@main", "in", "msg_assistant", `{"t":"msg_assistant"}`, t0.Add(3*time.Millisecond))
+
+	var buf bytes.Buffer
+	if err := runHarnessEvents("s@main", "", "tool_call,tool_result", false, &buf); err != nil {
+		t.Fatalf("runHarnessEvents: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"tool_call"`) || !strings.Contains(out, `"tool_result"`) {
+		t.Errorf("output missing tool_call/tool_result:\n%s", out)
+	}
+	if strings.Contains(out, `"hello"`) || strings.Contains(out, `"msg_assistant"`) {
+		t.Errorf("output unexpectedly contains filtered-out types:\n%s", out)
+	}
+}
+
+// syncBuf is a goroutine-safe bytes.Buffer used by the --follow test.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncBuf) waitForContains(needle string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if strings.Contains(s.String(), needle) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %q; got:\n%s", needle, s.String())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestRunHarnessEvents_FollowStreamsNewFrames covers the --follow AC: frames
+// added to the DB after the call begins are streamed live.
+func TestRunHarnessEvents_FollowStreamsNewFrames(t *testing.T) {
+	d := setUpHarnessFramesDB(t)
+
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrameForCLI(t, d, "s@main", "in", "hello", `{"f":1}`, t0)
+
+	sb := &syncBuf{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runHarnessEvents("s@main", "", "", true, sb)
+	}()
+
+	// Wait for the initial frame to appear.
+	if err := sb.waitForContains(`"f":1`, 2*time.Second); err != nil {
+		t.Fatalf("initial frame did not appear: %v", err)
+	}
+
+	// Inject a new frame; --follow polls every 500ms so allow up to ~1.5s
+	// plus generous slack.
+	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"f":2}`, time.Now())
+	if err := sb.waitForContains(`"f":2`, 3*time.Second); err != nil {
+		t.Fatalf("follow did not pick up new frame: %v", err)
+	}
+
+	// Cancel the follow loop by sending SIGINT to ourselves.
+	if p, perr := os.FindProcess(os.Getpid()); perr == nil {
+		_ = p.Signal(syscall.SIGINT)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runHarnessEvents (follow) returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runHarnessEvents (follow) did not exit after SIGINT")
+	}
+}
+
+func TestParseTypesCSV(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{",", nil},
+		{"  ", nil},
+		{"a", []string{"a"}},
+		{"a,b", []string{"a", "b"}},
+		{" tool_call , tool_result ", []string{"tool_call", "tool_result"}},
+		{"a,,b", []string{"a", "b"}},
+	}
+	for _, c := range cases {
+		got := parseTypesCSV(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("parseTypesCSV(%q) = %v; want %v", c.in, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("parseTypesCSV(%q)[%d] = %q; want %q", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -105,6 +105,10 @@ func Restore(dryRun bool) error {
 		fmt.Fprintf(os.Stderr, "prism restore: prune: %v\n", err)
 		// Non-fatal — continue with restore.
 	}
+	// Shorter retention for the raw harness wire archive (P5.LOGS / #1218).
+	if err := d.PruneHarnessFrames(7 * 24 * time.Hour); err != nil {
+		fmt.Fprintf(os.Stderr, "prism restore: prune harness_frames: %v\n", err)
+	}
 
 	// Remove any stale dashboard socket left behind by a crashed dashboard.
 	// Non-fatal: a stale socket only affects real-time push delivery.

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -218,6 +218,18 @@ CREATE TABLE IF NOT EXISTS spawn_inputs (
 );
 CREATE INDEX IF NOT EXISTS idx_spawn_inputs_profile         ON spawn_inputs(profile_name);
 CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harness_flag, profile_name);
+
+CREATE TABLE IF NOT EXISTS harness_frames (
+  id            TEXT PRIMARY KEY,
+  session_name  TEXT NOT NULL,
+  instance_id   TEXT,
+  direction     TEXT NOT NULL,
+  type          TEXT,
+  payload       TEXT NOT NULL,
+  created_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_harness_frames_session ON harness_frames(session_name, created_at);
+CREATE INDEX IF NOT EXISTS idx_harness_frames_session_dir ON harness_frames(session_name, direction, created_at);
 `
 
 // Open opens (or creates) the prism database at path.
@@ -338,6 +350,12 @@ CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harn
 // across. isolation_mode remains nullable TEXT in the new schema. The migration
 // is conditional: it checks whether host_mode still exists before rebuilding,
 // making it idempotent (#1137).
+// v26→v27 adds the harness_frames table for the raw PI JSONL frame archive
+// (P5.LOGS / #1218). The table stores every inbound and outbound frame on a
+// socket-pipe session keyed by session_name + created_at, with a denormalised
+// type column for fast --types filtering. CREATE TABLE IF NOT EXISTS and
+// CREATE INDEX IF NOT EXISTS make the migration idempotent; fresh databases
+// already have the table from the declarative schema block above.
 //
 // PRAGMA foreign_keys = ON: SQLite foreign-key enforcement is off by default.
 // It is set explicitly here — the single constructor through which all prism
@@ -421,7 +439,7 @@ func seedSchemaVersionIfEmpty(conn *sql.DB) error {
 }
 
 // runMigrations reads the current schema_version and applies all pending
-// migrations in order from v1 to v26.
+// migrations in order from v1 to v27.
 func runMigrations(conn *sql.DB) error {
 	var version int
 	if err := conn.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
@@ -500,6 +518,9 @@ func runMigrations(conn *sql.DB) error {
 		return err
 	}
 	if err := migrateV25toV26(conn, &version); err != nil {
+		return err
+	}
+	if err := migrateV26toV27(conn, &version); err != nil {
 		return err
 	}
 	return nil
@@ -1560,6 +1581,55 @@ func migrateV25toV26(conn *sql.DB, version *int) error {
 		return fmt.Errorf("db: migration v25→v26: bump version: %w", err)
 	}
 	*version = 26
+	return nil
+}
+
+func migrateV26toV27(conn *sql.DB, version *int) error {
+	if *version != 26 {
+		return nil
+	}
+	// Migration v26 → v27: introduce the harness_frames table for the PI
+	// raw JSONL frame archive (P5.LOGS / #1218). The table stores every
+	// inbound (extension→sidecar) and outbound (sidecar→extension) frame
+	// for socket-pipe sessions, keyed by session_name and created_at, so
+	// `prism logs --harness-events <session>` can replay the wire-protocol
+	// stream for debugging without grepping the sidecar log.
+	//
+	// Direction is one of 'in' (extension→sidecar) or 'out' (sidecar→
+	// extension). type is the JSON "type" field of the frame, denormalised
+	// so --types filtering can be a simple WHERE clause without parsing
+	// payload JSON. Payload is the raw JSONL bytes (excluding the trailing
+	// newline) so consumers can pipe the output of `prism logs --harness-events`
+	// directly into a JSONL parser.
+	//
+	// CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS make this
+	// migration idempotent. Fresh databases already have the table from the
+	// declarative schema block, so the CREATE statements are no-ops there.
+	//
+	// Rollback: DROP TABLE harness_frames. The table holds no data referenced
+	// by other tables (the optional instance_id column has no FK to keep frame
+	// writes cheap and to allow legacy frames whose instance_id is NULL), so a
+	// drop is non-destructive to the rest of the schema.
+	steps := []string{
+		`CREATE TABLE IF NOT EXISTS harness_frames (
+		  id            TEXT PRIMARY KEY,
+		  session_name  TEXT NOT NULL,
+		  instance_id   TEXT,
+		  direction     TEXT NOT NULL,
+		  type          TEXT,
+		  payload       TEXT NOT NULL,
+		  created_at    INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_harness_frames_session ON harness_frames(session_name, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_harness_frames_session_dir ON harness_frames(session_name, direction, created_at)`,
+		`UPDATE schema_version SET version = 27`,
+	}
+	for _, s := range steps {
+		if _, err := conn.Exec(s); err != nil {
+			return fmt.Errorf("db: migration v26→v27: %w", err)
+		}
+	}
+	*version = 27
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -49,8 +49,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version: got %d, want 27", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1594,8 +1594,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1660,8 +1660,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1730,8 +1730,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1825,8 +1825,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1918,8 +1918,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2455,8 +2455,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2544,8 +2544,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4200,8 +4200,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// Check each row.
@@ -4628,8 +4628,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -4903,8 +4903,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5124,8 +5124,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// sessions table must exist.
@@ -5278,8 +5278,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 }
 
@@ -5832,8 +5832,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -5890,8 +5890,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6192,8 +6192,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6254,8 +6254,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6413,8 +6413,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6467,8 +6467,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 
 	var startedAt int64
@@ -6621,8 +6621,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -6694,8 +6694,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 
 	// Values must be stable after a second open.
@@ -6830,8 +6830,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after migration: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after migration: got %d, want 27", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -6884,8 +6884,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 
 	// spawn_outcome must still exist.

--- a/modules/programs/prism/prism/internal/db/harness_frames.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames.go
@@ -1,0 +1,155 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// HarnessFrameDirectionIn marks frames received from the extension.
+const HarnessFrameDirectionIn = "in"
+
+// HarnessFrameDirectionOut marks frames sent from the sidecar to the extension.
+const HarnessFrameDirectionOut = "out"
+
+// HarnessFrame represents a row in the harness_frames table.
+//
+// Direction is one of "in" (extension → sidecar) or "out" (sidecar → extension).
+// Payload is the raw JSONL bytes of the frame (excluding the trailing newline)
+// so callers can write it back out verbatim with one append.
+type HarnessFrame struct {
+	ID          string
+	SessionName string
+	// InstanceID links the frame to the spawning sessions row. Nullable so
+	// frames captured before instance_id is minted (or for legacy rows) are
+	// still recorded; no FK is enforced for the same reason.
+	InstanceID *string
+	Direction  string
+	// Type is the value of the JSON "type" field at the top level of the
+	// frame, denormalised so --types filtering does not need JSON_EXTRACT.
+	// Empty when the frame omits the field or fails JSON parsing.
+	Type      string
+	Payload   string
+	CreatedAt time.Time
+}
+
+// WriteHarnessFrame inserts a single row into harness_frames.
+//
+// The function is intentionally narrow: callers (sidecar.frame_archive) handle
+// derivation of the type field from the raw JSONL bytes, ID generation, and
+// timestamping. This keeps the SQL layer dumb and easy to test.
+func (d *DB) WriteHarnessFrame(f HarnessFrame) error {
+	if f.CreatedAt.IsZero() {
+		f.CreatedAt = time.Now()
+	}
+	const q = `
+INSERT INTO harness_frames (id, session_name, instance_id, direction, type, payload, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)`
+	if _, err := d.conn.Exec(q,
+		f.ID, f.SessionName, f.InstanceID, f.Direction, f.Type, f.Payload, f.CreatedAt.UnixMilli(),
+	); err != nil {
+		return fmt.Errorf("db: write harness frame: %w", err)
+	}
+	return nil
+}
+
+// QueryHarnessFrames returns harness frames for sessionName ordered by
+// created_at ASC (chronological).
+//
+// direction filters to one of "in" or "out"; pass "" for both.
+// types filters to the comma-separated set of frame types; pass nil for all.
+// afterID is a cursor used by --follow: when non-empty, only frames whose
+// rowid is strictly greater than the rowid of the named frame are returned.
+// (We use rowid rather than created_at so two frames recorded in the same
+// millisecond are returned in insertion order.)
+func (d *DB) QueryHarnessFrames(sessionName, direction string, types []string, afterID string) ([]HarnessFrame, error) {
+	args := []any{sessionName}
+	conditions := []string{"session_name = ?"}
+
+	if direction != "" {
+		conditions = append(conditions, "direction = ?")
+		args = append(args, direction)
+	}
+
+	if len(types) > 0 {
+		placeholders := make([]string, len(types))
+		for i, t := range types {
+			placeholders[i] = "?"
+			args = append(args, t)
+		}
+		conditions = append(conditions, "type IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	if afterID != "" {
+		var afterRowID int64
+		err := d.conn.QueryRow(
+			"SELECT rowid FROM harness_frames WHERE id = ?", afterID,
+		).Scan(&afterRowID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("QueryHarnessFrames: cursor frame %q not found", afterID)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("db: resolve harness-frame cursor: %w", err)
+		}
+		conditions = append(conditions, "rowid > ?")
+		args = append(args, afterRowID)
+	}
+
+	q := `SELECT id, session_name, instance_id, direction, type, payload, created_at
+	      FROM harness_frames
+	      WHERE ` + strings.Join(conditions, " AND ") +
+		` ORDER BY created_at ASC, rowid ASC`
+
+	rows, err := d.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: query harness frames: %w", err)
+	}
+	defer rows.Close()
+
+	var frames []HarnessFrame
+	for rows.Next() {
+		var f HarnessFrame
+		var createdAtMs int64
+		if err := rows.Scan(&f.ID, &f.SessionName, &f.InstanceID, &f.Direction, &f.Type, &f.Payload, &createdAtMs); err != nil {
+			return nil, fmt.Errorf("db: scan harness frame: %w", err)
+		}
+		f.CreatedAt = time.UnixMilli(createdAtMs)
+		frames = append(frames, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate harness frames: %w", err)
+	}
+	return frames, nil
+}
+
+// CountHarnessFrames returns the total number of harness frames for the
+// session. Used by `prism logs --harness-events` to distinguish "no frames
+// recorded — this is a non-PI session" from "PI session that just hasn't
+// produced any frames yet" (the latter is a legitimate empty result).
+func (d *DB) CountHarnessFrames(sessionName string) (int, error) {
+	var n int
+	if err := d.conn.QueryRow(
+		"SELECT COUNT(*) FROM harness_frames WHERE session_name = ?", sessionName,
+	).Scan(&n); err != nil {
+		return 0, fmt.Errorf("db: count harness frames: %w", err)
+	}
+	return n, nil
+}
+
+// PruneHarnessFrames deletes frames older than olderThan.
+//
+// IMPORTANT: this only touches the harness_frames table. agent_events and
+// sessions are unaffected — the goal is to retire raw wire-protocol bytes
+// (which are voluminous on a busy session) while preserving the structured
+// agent_events derived from them. See P5.LOGS retention AC.
+func (d *DB) PruneHarnessFrames(olderThan time.Duration) error {
+	threshold := time.Now().Add(-olderThan).UnixMilli()
+	if _, err := d.conn.Exec(
+		"DELETE FROM harness_frames WHERE created_at < ?", threshold,
+	); err != nil {
+		return fmt.Errorf("db: prune harness frames: %w", err)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -1,0 +1,317 @@
+package db_test
+
+// Tests for the harness_frames table (P5.LOGS / #1218).
+//
+// Coverage:
+//   - WriteHarnessFrame round-trips through QueryHarnessFrames.
+//   - Filtering by direction and types behaves as documented.
+//   - The follow cursor (afterID) returns only later rows.
+//   - PruneHarnessFrames drops rows older than the threshold but does NOT
+//     touch agent_events written for the same session — this is the AC
+//     guarantee that retention does not lose structured derivative data.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func writeFrame(t *testing.T, d *db.DB, sessionName, direction, typ, payload string, ts time.Time) string {
+	t.Helper()
+	id := uuid.New().String()
+	if err := d.WriteHarnessFrame(db.HarnessFrame{
+		ID:          id,
+		SessionName: sessionName,
+		Direction:   direction,
+		Type:        typ,
+		Payload:     payload,
+		CreatedAt:   ts,
+	}); err != nil {
+		t.Fatalf("WriteHarnessFrame: %v", err)
+	}
+	return id
+}
+
+func TestHarnessFrame_RoundTrip(t *testing.T) {
+	d := openTestDB(t)
+
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrame(t, d, "repo@main", "in", "tool_call", `{"type":"tool_call","name":"bash"}`, t0)
+	writeFrame(t, d, "repo@main", "out", "prompt", `{"type":"prompt","text":"hi"}`, t0.Add(1*time.Millisecond))
+	writeFrame(t, d, "other@main", "in", "tool_call", `{"type":"tool_call","name":"read"}`, t0.Add(2*time.Millisecond))
+
+	frames, err := d.QueryHarnessFrames("repo@main", "", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames: %v", err)
+	}
+	if len(frames) != 2 {
+		t.Fatalf("got %d frames, want 2", len(frames))
+	}
+	// Check chronological order.
+	if !frames[0].CreatedAt.Before(frames[1].CreatedAt) {
+		t.Errorf("frames not in chronological order: %v before %v?", frames[0].CreatedAt, frames[1].CreatedAt)
+	}
+	if frames[0].Type != "tool_call" || frames[1].Type != "prompt" {
+		t.Errorf("frame types = %q,%q; want tool_call,prompt", frames[0].Type, frames[1].Type)
+	}
+	if !strings.Contains(frames[0].Payload, `"name":"bash"`) {
+		t.Errorf("payload[0] = %q; want bash", frames[0].Payload)
+	}
+}
+
+func TestHarnessFrame_DirectionFilter(t *testing.T) {
+	d := openTestDB(t)
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrame(t, d, "s@main", "in", "tool_call", `{"type":"tool_call"}`, t0)
+	writeFrame(t, d, "s@main", "out", "prompt", `{"type":"prompt"}`, t0.Add(1*time.Millisecond))
+	writeFrame(t, d, "s@main", "in", "tool_result", `{"type":"tool_result"}`, t0.Add(2*time.Millisecond))
+
+	in, err := d.QueryHarnessFrames("s@main", "in", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames in: %v", err)
+	}
+	if len(in) != 2 {
+		t.Errorf("inbound count = %d, want 2", len(in))
+	}
+	for _, f := range in {
+		if f.Direction != "in" {
+			t.Errorf("got direction %q, want in", f.Direction)
+		}
+	}
+
+	out, err := d.QueryHarnessFrames("s@main", "out", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames out: %v", err)
+	}
+	if len(out) != 1 || out[0].Direction != "out" {
+		t.Errorf("outbound = %v, want one out frame", out)
+	}
+}
+
+func TestHarnessFrame_TypeFilter(t *testing.T) {
+	d := openTestDB(t)
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrame(t, d, "s@main", "in", "tool_call", `{"type":"tool_call"}`, t0)
+	writeFrame(t, d, "s@main", "in", "tool_result", `{"type":"tool_result"}`, t0.Add(1*time.Millisecond))
+	writeFrame(t, d, "s@main", "in", "msg_assistant", `{"type":"msg_assistant"}`, t0.Add(2*time.Millisecond))
+
+	got, err := d.QueryHarnessFrames("s@main", "", []string{"tool_call", "tool_result"}, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("count = %d, want 2", len(got))
+	}
+	seen := map[string]bool{}
+	for _, f := range got {
+		seen[f.Type] = true
+	}
+	if !seen["tool_call"] || !seen["tool_result"] {
+		t.Errorf("expected tool_call and tool_result; saw %v", seen)
+	}
+	if seen["msg_assistant"] {
+		t.Errorf("msg_assistant should have been filtered out")
+	}
+}
+
+func TestHarnessFrame_FollowCursor(t *testing.T) {
+	d := openTestDB(t)
+	t0 := time.UnixMilli(1_700_000_000_000)
+	id1 := writeFrame(t, d, "s@main", "in", "tool_call", `{"i":1}`, t0)
+	writeFrame(t, d, "s@main", "in", "tool_call", `{"i":2}`, t0.Add(1*time.Millisecond))
+	writeFrame(t, d, "s@main", "in", "tool_call", `{"i":3}`, t0.Add(2*time.Millisecond))
+
+	got, err := d.QueryHarnessFrames("s@main", "", nil, id1)
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames after cursor: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("after-cursor count = %d, want 2", len(got))
+	}
+	// The cursor frame itself must be excluded.
+	for _, f := range got {
+		if f.ID == id1 {
+			t.Errorf("cursor frame %q should not appear in result set", id1)
+		}
+	}
+}
+
+func TestHarnessFrame_FollowCursor_UnknownID(t *testing.T) {
+	d := openTestDB(t)
+	_, err := d.QueryHarnessFrames("s@main", "", nil, "no-such-frame")
+	if err == nil {
+		t.Fatal("expected error for unknown cursor; got nil")
+	}
+	if !strings.Contains(err.Error(), "cursor frame") {
+		t.Errorf("error = %q; want substring 'cursor frame'", err.Error())
+	}
+}
+
+func TestHarnessFrame_CountIsolatedPerSession(t *testing.T) {
+	d := openTestDB(t)
+	t0 := time.UnixMilli(1_700_000_000_000)
+	writeFrame(t, d, "a@main", "in", "tool_call", `{}`, t0)
+	writeFrame(t, d, "a@main", "in", "tool_call", `{}`, t0.Add(1*time.Millisecond))
+	writeFrame(t, d, "b@main", "in", "tool_call", `{}`, t0.Add(2*time.Millisecond))
+
+	if n, err := d.CountHarnessFrames("a@main"); err != nil || n != 2 {
+		t.Errorf("count(a) = (%d, %v); want (2, nil)", n, err)
+	}
+	if n, err := d.CountHarnessFrames("b@main"); err != nil || n != 1 {
+		t.Errorf("count(b) = (%d, %v); want (1, nil)", n, err)
+	}
+	if n, err := d.CountHarnessFrames("nobody@main"); err != nil || n != 0 {
+		t.Errorf("count(nobody) = (%d, %v); want (0, nil)", n, err)
+	}
+}
+
+// TestPruneHarnessFrames_DoesNotTouchAgentEvents is the AC for "Retention
+// cutoff drops frames older than the configured window without dropping the
+// corresponding agent_events rows".
+func TestPruneHarnessFrames_DoesNotTouchAgentEvents(t *testing.T) {
+	d := openTestDB(t)
+
+	// Mint an old frame and an old agent_event for the same session at the
+	// same timestamp.
+	old := time.Now().Add(-30 * 24 * time.Hour) // 30 days ago
+	writeFrame(t, d, "s@main", "in", "tool_call", `{"type":"tool_call"}`, old)
+	if err := d.WriteEvent(db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "s@main",
+		Repo:        "repo",
+		Worktree:    "/tmp/wt",
+		Type:        "tool_call",
+		Payload:     `{"type":"tool_call"}`,
+		CreatedAt:   old,
+	}); err != nil {
+		t.Fatalf("WriteEvent (old): %v", err)
+	}
+
+	// Add a recent frame and event so we can verify they're preserved.
+	now := time.Now()
+	writeFrame(t, d, "s@main", "in", "tool_call", `{"type":"tool_call","fresh":true}`, now)
+	if err := d.WriteEvent(db.Event{
+		ID:          uuid.New().String(),
+		SessionName: "s@main",
+		Repo:        "repo",
+		Worktree:    "/tmp/wt",
+		Type:        "tool_call",
+		Payload:     `{"type":"tool_call","fresh":true}`,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatalf("WriteEvent (fresh): %v", err)
+	}
+
+	// Prune frames older than 7d.
+	if err := d.PruneHarnessFrames(7 * 24 * time.Hour); err != nil {
+		t.Fatalf("PruneHarnessFrames: %v", err)
+	}
+
+	// The old frame should be gone, the fresh one preserved.
+	frames, err := d.QueryHarnessFrames("s@main", "", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count after prune = %d, want 1 (fresh only)", len(frames))
+	}
+	if !strings.Contains(frames[0].Payload, `"fresh":true`) {
+		t.Errorf("surviving frame payload = %q; expected fresh frame", frames[0].Payload)
+	}
+
+	// agent_events for the same session must be untouched — both rows still
+	// present.
+	events, err := d.QueryEvents("s@main", 0, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Errorf("agent_events count after PruneHarnessFrames = %d; want 2 (prune must not touch agent_events)", len(events))
+	}
+}
+
+func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
+	d := openTestDB(t)
+
+	// On a fresh DB the harness_frames table should exist (created via the
+	// declarative schema block) and accept rows.
+	id := uuid.New().String()
+	if err := d.WriteHarnessFrame(db.HarnessFrame{
+		ID:          id,
+		SessionName: "smoke@main",
+		Direction:   "in",
+		Type:        "hello",
+		Payload:     `{"type":"hello"}`,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteHarnessFrame on fresh DB: %v", err)
+	}
+	frames, err := d.QueryHarnessFrames("smoke@main", "", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames: %v", err)
+	}
+	if len(frames) != 1 || frames[0].ID != id {
+		t.Errorf("round trip failed: got %+v", frames)
+	}
+
+	// schema_version must be at v27 on a fresh DB after the v26→v27
+	// migration has run (the harness_frames migration's bump step).
+	var ver int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if ver != 27 {
+		t.Errorf("schema_version after fresh open = %d, want 27", ver)
+	}
+
+	// The expected indexes must exist (look them up by name).
+	for _, idx := range []string{
+		"idx_harness_frames_session",
+		"idx_harness_frames_session_dir",
+	} {
+		var got string
+		if err := d.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='index' AND name=?", idx,
+		).Scan(&got); err != nil {
+			t.Errorf("index %q not found: %v", idx, err)
+		}
+	}
+}
+
+// TestHarnessFrame_MigrationIdempotent verifies that opening a DB at v27
+// twice does not fail or duplicate the table.
+func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
+	d := openTestDB(t)
+	// First open already ran migrations via openTestDB; a second open of the
+	// same path must be a no-op.
+	d.Close()
+	d2, err := db.Open(d.Path())
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	var ver int
+	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if ver != 27 {
+		t.Errorf("schema_version after second open = %d, want 27", ver)
+	}
+
+	// The table must still accept rows.
+	if err := d2.WriteHarnessFrame(db.HarnessFrame{
+		ID:          uuid.New().String(),
+		SessionName: "idem@main",
+		Direction:   "in",
+		Type:        "hello",
+		Payload:     `{"type":"hello"}`,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteHarnessFrame after idempotent open: %v", err)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/maintenance.go
+++ b/modules/programs/prism/prism/internal/db/maintenance.go
@@ -8,6 +8,11 @@ import (
 // Prune deletes agent_events older than olderThan, and delivered or failed
 // bus_messages older than olderThan. It does NOT delete agent_status rows or
 // undelivered/unfailed bus_messages.
+//
+// harness_frames is pruned separately via PruneHarnessFrames so callers can
+// pick a different (typically shorter) retention window for the raw wire
+// archive — the JSONL frames are voluminous on a busy session, while
+// agent_events stays at the historical 90-day default.
 func (d *DB) Prune(olderThan time.Duration) error {
 	threshold := time.Now().Add(-olderThan).UnixMilli()
 

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1055,8 +1055,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 26 {
-		t.Errorf("schema_version after second open: got %d, want 26", version)
+	if version != 27 {
+		t.Errorf("schema_version after second open: got %d, want 27", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/frame_archive.go
+++ b/modules/programs/prism/prism/internal/sidecar/frame_archive.go
@@ -1,0 +1,93 @@
+package sidecar
+
+// frame_archive.go — persistence helpers for the raw PI JSONL frame archive
+// (P5.LOGS / #1218).
+//
+// The PI extension and sidecar exchange JSONL frames over a Unix-or-TCP socket
+// (see runStartupSocketPipe in sidecar.go). Structured agent_events rows are
+// derived from inbound frames at handlePipeFrame time, but the raw bytes
+// themselves are not persisted there. This file adds a thin write helper that
+// is called from runStartupSocketPipe at every read/write, so the operator can
+// later replay the stream with `prism logs --harness-events <session>`.
+//
+// Design intent: the helpers MUST be cheap and tolerant of malformed input.
+// A failure to archive a frame is non-fatal — we log and move on. The hot
+// path (the duplex frame loop) cannot afford to block on slow DB writes.
+//
+// Why a separate file? P2.SPAWN (#1212) is touching the same sidecar.go
+// concurrently. Keeping the persistence helpers in their own file (and the
+// call sites in sidecar.go to one-liner invocations) makes the rebase across
+// the two PRs mechanical.
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// archiveInboundFrame persists a frame received from the PI extension.
+// The provided bytes are the raw JSONL payload WITHOUT the trailing newline.
+//
+// Errors are logged and swallowed: the frame archive is a debugging aid and
+// must never block or fail the live wire-protocol path.
+func (s *Sidecar) archiveInboundFrame(frame []byte) {
+	s.archiveFrame(db.HarnessFrameDirectionIn, frame)
+}
+
+// archiveOutboundFrame persists a frame the sidecar is sending to the PI
+// extension. The provided bytes are the raw JSONL payload WITH the trailing
+// newline (matching what is written to the wire); the newline is stripped
+// before storage so consumers can append their own.
+//
+// Errors are logged and swallowed (same rationale as archiveInboundFrame).
+func (s *Sidecar) archiveOutboundFrame(frame []byte) {
+	// Strip a single trailing '\n' if present so the archive stores the same
+	// shape as inbound frames (one JSON object, no terminator). Callers
+	// already terminate outbound frames before calling Write; we don't want
+	// the trailing newline to show up in the persisted payload.
+	if n := len(frame); n > 0 && frame[n-1] == '\n' {
+		frame = frame[:n-1]
+	}
+	s.archiveFrame(db.HarnessFrameDirectionOut, frame)
+}
+
+// archiveFrame is the shared core: extract the frame type, build a HarnessFrame,
+// and write it. Called from archiveInboundFrame / archiveOutboundFrame above.
+func (s *Sidecar) archiveFrame(direction string, payload []byte) {
+	if s == nil || s.cfg.DB == nil || len(payload) == 0 {
+		return
+	}
+
+	// Best-effort extraction of the frame type. A frame that fails to parse
+	// here (or whose type is empty) is still persisted — we keep the raw
+	// payload so the operator can see the corrupt bytes.
+	var typeOnly struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(payload, &typeOnly) // best-effort, errors ignored
+
+	var instanceIDPtr *string
+	if s.cfg.InstanceID != "" {
+		// Take a copy so callers mutating cfg.InstanceID later cannot
+		// retroactively change persisted frames.
+		iid := s.cfg.InstanceID
+		instanceIDPtr = &iid
+	}
+
+	f := db.HarnessFrame{
+		ID:          uuid.New().String(),
+		SessionName: s.cfg.SessionName,
+		InstanceID:  instanceIDPtr,
+		Direction:   direction,
+		Type:        typeOnly.Type,
+		Payload:     string(payload),
+		CreatedAt:   s.cfg.Clock.Now(),
+	}
+	if err := s.cfg.DB.WriteHarnessFrame(f); err != nil {
+		// Non-fatal: log once per failure. The wire-protocol path keeps
+		// running.
+		log.Printf("sidecar: archive harness frame (%s): %v", direction, err)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/frame_archive_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/frame_archive_test.go
@@ -1,0 +1,172 @@
+package sidecar
+
+// Integration tests for the harness frame archive (P5.LOGS / #1218).
+//
+// These tests piggyback on the socket-pipe test harness defined in
+// sidecar_socketpipe_test.go: a fake PI extension dials the sidecar, performs
+// the hello/hello_ack handshake, exchanges some frames, and shuts down. The
+// assertions here are about the harness_frames table — every byte that
+// crossed the socket should be persisted with the right direction and type.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// waitForHarnessFrameCount blocks (with a deadline) until the harness_frames
+// row count for sessionName reaches at least want, or fails the test.
+func waitForHarnessFrameCount(t *testing.T, d *db.DB, sessionName string, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		n, err := d.CountHarnessFrames(sessionName)
+		if err != nil {
+			t.Fatalf("CountHarnessFrames: %v", err)
+		}
+		if n >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("harness_frames count = %d after %s, want >= %d", n, timeout, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestSocketPipe_ArchivesHandshakeFrames verifies that the hello and
+// hello_ack frames are persisted via the frame archive.
+func TestSocketPipe_ArchivesHandshakeFrames(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// After the handshake at least 2 frames (hello in, hello_ack out) must
+	// be in the archive. Wait briefly because writes happen on a background
+	// goroutine for the outbound path.
+	waitForHarnessFrameCount(t, sc.cfg.DB, sc.cfg.SessionName, 2, 2*time.Second)
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	frames, err := sc.cfg.DB.QueryHarnessFrames(sc.cfg.SessionName, "", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames: %v", err)
+	}
+	// We expect at minimum: in/hello, out/hello_ack, in/session_shutdown.
+	// Some test environments may write more frames (e.g. an internal
+	// state_change) — assert that the canonical set is present rather than
+	// hard-coding the total count.
+	type key struct{ dir, typ string }
+	seen := map[key]bool{}
+	for _, f := range frames {
+		seen[key{f.Direction, f.Type}] = true
+	}
+	want := []key{
+		{"in", "hello"},
+		{"out", "hello_ack"},
+		{"in", "session_shutdown"},
+	}
+	for _, k := range want {
+		if !seen[k] {
+			t.Errorf("expected archived frame %+v; saw %+v", k, seen)
+		}
+	}
+}
+
+// TestSocketPipe_ArchivesEventFrames verifies that tool_call/tool_result/
+// msg_assistant frames sent by the fake extension show up in harness_frames
+// in chronological order with the correct direction.
+func TestSocketPipe_ArchivesEventFrames(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "tool_call", "tool_id": "bash", "input": "ls"})
+	sendJSON(t, conn, map[string]any{"type": "tool_result", "tool_id": "bash", "output": "ok"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "content": "done"})
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	in, err := sc.cfg.DB.QueryHarnessFrames(sc.cfg.SessionName, "in", nil, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames in: %v", err)
+	}
+	wantTypes := []string{"hello", "tool_call", "tool_result", "msg_assistant", "session_shutdown"}
+	gotTypes := []string{}
+	for _, f := range in {
+		gotTypes = append(gotTypes, f.Type)
+	}
+	if strings.Join(gotTypes, ",") != strings.Join(wantTypes, ",") {
+		t.Errorf("inbound types = %v; want %v", gotTypes, wantTypes)
+	}
+
+	// Each payload must be the raw JSONL bytes (no trailing newline,
+	// parseable as JSON). Spot-check tool_call.
+	for _, f := range in {
+		if f.Type == "tool_call" {
+			if !strings.Contains(f.Payload, `"tool_id":"bash"`) {
+				t.Errorf("tool_call payload = %q; expected tool_id field", f.Payload)
+			}
+			if strings.HasSuffix(f.Payload, "\n") {
+				t.Errorf("payload should not have trailing newline: %q", f.Payload)
+			}
+		}
+	}
+}
+
+// TestSocketPipe_ArchivesOutboundDeliverPrompt verifies that frames sent via
+// DeliverPrompt are archived with direction=out.
+func TestSocketPipe_ArchivesOutboundDeliverPrompt(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Trigger an outbound prompt frame.
+	if !sc.DeliverPrompt("hello world", "nextTurn") {
+		t.Fatal("DeliverPrompt returned false; expected true")
+	}
+
+	// Read it on the fake extension side so we know it's been written.
+	got := readJSON(t, conn)
+	if got["type"] != "prompt" {
+		t.Errorf("read type = %v, want prompt", got["type"])
+	}
+
+	// The archive write happens in the writer goroutine before conn.Write,
+	// so by now the row must exist. Allow a tiny grace window for the DB
+	// commit to land.
+	waitForHarnessFrameCount(t, sc.cfg.DB, sc.cfg.SessionName, 3, 2*time.Second)
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	out, err := sc.cfg.DB.QueryHarnessFrames(sc.cfg.SessionName, "out", []string{"prompt"}, "")
+	if err != nil {
+		t.Fatalf("QueryHarnessFrames: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("outbound prompt frames = %d, want 1", len(out))
+	}
+	if !strings.Contains(out[0].Payload, `"text":"hello world"`) {
+		t.Errorf("prompt payload = %q; expected text field", out[0].Payload)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1294,6 +1294,13 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 		s.writeStartupError(err2)
 		return err2
 	}
+	// Archive the raw hello bytes (P5.LOGS / #1218) so `prism logs --harness-events`
+	// can replay the full handshake. archiveInboundFrame strips the trailing newline.
+	if n := len(helloLine); n > 0 && helloLine[n-1] == '\n' {
+		s.archiveInboundFrame(helloLine[:n-1])
+	} else {
+		s.archiveInboundFrame(helloLine)
+	}
 
 	var helloFrame struct {
 		Type            string `json:"type"`
@@ -1341,6 +1348,9 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 	}
 	ackBytes, _ := json.Marshal(ackFrame)
 	ackBytes = append(ackBytes, '\n')
+	// Archive hello_ack (P5.LOGS / #1218) before sending so we record what we
+	// tried to send even if the write fails.
+	s.archiveOutboundFrame(ackBytes)
 	if _, err := conn.Write(ackBytes); err != nil {
 		startupErr := fmt.Errorf("sidecar: runStartupSocketPipe: write hello_ack: %w", err)
 		s.writeStartupError(startupErr)
@@ -1366,6 +1376,10 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 	go func() {
 		defer close(writerDone)
 		for frame := range outCh {
+			// Archive the outbound frame BEFORE Write so a failed write
+			// (connection closed) still leaves an audit trail of what we
+			// tried to send. archiveOutboundFrame strips the trailing '\n'.
+			s.archiveOutboundFrame(frame)
 			if _, err := conn.Write(frame); err != nil {
 				log.Printf("sidecar: runStartupSocketPipe: write outbound frame: %v", err)
 				return
@@ -1383,8 +1397,13 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			if len(line) > 1 && line[len(line)-2] == '\r' {
 				line = append(line[:len(line)-2], '\n')
 			}
-			cleanShutdown := s.handlePipeFrame(line[:len(line)-1]) // strip trailing \n
-			_ = maxLineBytes                                         // silence unused-var lint if buf not used
+			frameBytes := line[:len(line)-1] // strip trailing \n
+			// Archive the raw inbound frame (P5.LOGS / #1218) BEFORE
+			// handlePipeFrame so a frame that triggers a clean shutdown
+			// (session_shutdown) is still recorded.
+			s.archiveInboundFrame(frameBytes)
+			cleanShutdown := s.handlePipeFrame(frameBytes)
+			_ = maxLineBytes // silence unused-var lint if buf not used
 			if cleanShutdown {
 				break
 			}
@@ -1492,6 +1511,9 @@ func (s *Sidecar) sendPipeError(conn net.Conn, code, message string) {
 	}
 	b, _ := json.Marshal(errFrame)
 	b = append(b, '\n')
+	// Archive the outbound error (P5.LOGS / #1218) so handshake failures show
+	// up in `prism logs --harness-events`.
+	s.archiveOutboundFrame(b)
 	_, _ = conn.Write(b)
 	_ = conn.Close()
 }


### PR DESCRIPTION
…chive (#1218)

Persist every inbound (extension→sidecar) and outbound (sidecar→extension) JSONL frame on PI socket-pipe sessions to a new harness_frames table, and expose them via prism logs --harness-events <session> with --follow / --direction / --types filters.

Closes #1218