### PR TITLE
feat(pi-extension): port behavioural guards from prism-hooks.ts (P5.DOOMLOOP)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -22,6 +22,16 @@ import {
   truncateArgs,
   truncateString,
   type InboundDispatchAPI,
+  // Behavioural guards
+  similarityKey,
+  processDoomLoop,
+  processReviewCycle,
+  reviewCycleEscalationMessage,
+  isGitPush,
+  newDoomLoopState,
+  newReviewCycleState,
+  DOOM_LOOP_THRESHOLD,
+  REVIEW_CYCLE_THRESHOLD,
 } from "./prism.ts"
 
 // ---------------------------------------------------------------------------
@@ -571,5 +581,278 @@ describe("dispatchInboundFrame: forward-compat", () => {
       emit,
     )
     assert.equal(calls.errors[0].code, "malformed_frame")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// similarityKey
+// ---------------------------------------------------------------------------
+
+describe("similarityKey — excluded tools", () => {
+  it("returns null for read", () => {
+    assert.equal(similarityKey("read", { filePath: "/foo.go" }), null)
+  })
+
+  it("returns null for grep", () => {
+    assert.equal(similarityKey("grep", { pattern: "foo" }), null)
+  })
+
+  it("returns null for glob", () => {
+    assert.equal(similarityKey("glob", { pattern: "**/*.ts" }), null)
+  })
+
+  it("returns null for todowrite", () => {
+    assert.equal(similarityKey("todowrite", { todos: [] }), null)
+  })
+})
+
+describe("similarityKey — bash subcommand-driven CLIs", () => {
+  it("gh issue view with different numbers produces different keys", () => {
+    const keys = [1, 2, 3, 4, 5].map((n) =>
+      similarityKey("bash", { command: `gh issue view ${n}` }),
+    )
+    assert.equal(new Set(keys).size, 5)
+  })
+
+  it("git log with different flags produces the same key", () => {
+    const a = similarityKey("bash", { command: "git log -1" })
+    const b = similarityKey("bash", { command: "git log -3" })
+    assert.equal(a, b)
+  })
+
+  it("go test and go build produce different keys", () => {
+    const a = similarityKey("bash", { command: "go test ./..." })
+    const b = similarityKey("bash", { command: "go build ./..." })
+    assert.notEqual(a, b)
+  })
+})
+
+describe("similarityKey — edit/write/webfetch", () => {
+  it("edit same file produces the same key", () => {
+    const a = similarityKey("edit", { filePath: "/foo.go", newString: "a" })
+    const b = similarityKey("edit", { filePath: "/foo.go", newString: "b" })
+    assert.equal(a, b)
+  })
+
+  it("edit different files produces different keys", () => {
+    const a = similarityKey("edit", { filePath: "/foo.go" })
+    const b = similarityKey("edit", { filePath: "/bar.go" })
+    assert.notEqual(a, b)
+  })
+
+  it("webfetch same URL produces the same key", () => {
+    const a = similarityKey("webfetch", { url: "https://example.com" })
+    const b = similarityKey("webfetch", { url: "https://example.com" })
+    assert.equal(a, b)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// processDoomLoop
+// ---------------------------------------------------------------------------
+
+describe("processDoomLoop — basic detection", () => {
+  it("returns null for the first 4 consecutive matching calls", () => {
+    const state = newDoomLoopState()
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD - 1; i++) {
+      const result = processDoomLoop(state, "bash", { command: "go test ./..." })
+      assert.equal(result, null, `expected null on call ${i + 1}`)
+    }
+  })
+
+  it("fires a steering message on the 5th consecutive matching call", () => {
+    const state = newDoomLoopState()
+    let msg: string | null = null
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD; i++) {
+      msg = processDoomLoop(state, "bash", { command: "go test ./..." })
+    }
+    assert.ok(msg !== null)
+    assert.ok(msg.includes("PRISM DOOM-LOOP"))
+    assert.ok(msg.includes("bash"))
+  })
+
+  it("suppresses subsequent calls after firing (one nudge per loop)", () => {
+    const state = newDoomLoopState()
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD; i++) {
+      processDoomLoop(state, "bash", { command: "go test ./..." })
+    }
+    // Further calls after firing should return null.
+    const after = processDoomLoop(state, "bash", { command: "go test ./..." })
+    assert.equal(after, null)
+  })
+
+  it("resets after a different tool call", () => {
+    const state = newDoomLoopState()
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD - 1; i++) {
+      processDoomLoop(state, "bash", { command: "go test ./..." })
+    }
+    // Different tool breaks the run.
+    processDoomLoop(state, "bash", { command: "go build ./..." })
+    // Now 4 more calls should not fire.
+    let msg: string | null = null
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD - 1; i++) {
+      msg = processDoomLoop(state, "bash", { command: "go test ./..." })
+    }
+    assert.equal(msg, null)
+  })
+
+  it("excluded tool (read) breaks the run", () => {
+    const state = newDoomLoopState()
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD - 1; i++) {
+      processDoomLoop(state, "bash", { command: "go test ./..." })
+    }
+    // excluded tool resets state.
+    processDoomLoop(state, "read", { filePath: "/foo.go" })
+    assert.equal(state.currentKey, null)
+    assert.equal(state.consecutiveCount, 0)
+  })
+})
+
+describe("processDoomLoop — per-session isolation", () => {
+  it("two independent states do not cross-contaminate", () => {
+    const stateA = newDoomLoopState()
+    const stateB = newDoomLoopState()
+    // Advance A to 4 calls.
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD - 1; i++) {
+      processDoomLoop(stateA, "bash", { command: "go test ./..." })
+    }
+    // B is untouched.
+    assert.equal(stateB.consecutiveCount, 0)
+    // A fires on the 5th call; B does not.
+    const msgA = processDoomLoop(stateA, "bash", { command: "go test ./..." })
+    const msgB = processDoomLoop(stateB, "bash", { command: "go test ./..." })
+    assert.ok(msgA !== null)
+    assert.equal(msgB, null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// processReviewCycle
+// ---------------------------------------------------------------------------
+
+describe("processReviewCycle — bash prism review", () => {
+  it("counts a prism review bash call", () => {
+    const state = newReviewCycleState()
+    processReviewCycle(state, "bash", { command: "prism review 42" })
+    assert.equal(state.cycles.get("42"), 1)
+    assert.equal(state.detectedPrNumber, "42")
+  })
+
+  it("does not double-count parallel invocations within the same turn", () => {
+    const state = newReviewCycleState()
+    // Simulate two bash calls with prism review in the same turn.
+    processReviewCycle(state, "bash", { command: "prism review 42" })
+    processReviewCycle(state, "bash", { command: "prism review 42" })
+    // pendingCycleCount guard: only counted once.
+    assert.equal(state.cycles.get("42"), 1)
+  })
+
+  it("counts a new cycle after pendingCycleCount is cleared", () => {
+    const state = newReviewCycleState()
+    processReviewCycle(state, "bash", { command: "prism review 42" })
+    state.pendingCycleCount = false // simulates turn_start clearing the flag
+    processReviewCycle(state, "bash", { command: "prism review 42" })
+    assert.equal(state.cycles.get("42"), 2)
+  })
+
+  it("resets cycles when PR number changes", () => {
+    const state = newReviewCycleState()
+    processReviewCycle(state, "bash", { command: "prism review 42" })
+    state.pendingCycleCount = false
+    processReviewCycle(state, "bash", { command: "prism review 43" })
+    assert.equal(state.detectedPrNumber, "43")
+    assert.equal(state.cycles.get("42"), undefined)
+    assert.equal(state.cycles.get("43"), 1)
+    assert.equal(state.frameEmitted, false)
+  })
+
+  it("returns true after REVIEW_CYCLE_THRESHOLD cycles", () => {
+    const state = newReviewCycleState()
+    let exceeded = false
+    for (let i = 0; i < REVIEW_CYCLE_THRESHOLD; i++) {
+      state.pendingCycleCount = false
+      exceeded = processReviewCycle(state, "bash", { command: "prism review 42" })
+    }
+    assert.equal(exceeded, true)
+  })
+})
+
+describe("processReviewCycle — task review subagent", () => {
+  it("counts a review-goal task invocation", () => {
+    const state = newReviewCycleState()
+    processReviewCycle(state, "task", {
+      subagent_type: "review-goal",
+      prompt: "please review PR #99",
+    })
+    assert.equal(state.cycles.get("99"), 1)
+    assert.equal(state.detectedPrNumber, "99")
+  })
+
+  it("ignores non-review task invocations", () => {
+    const state = newReviewCycleState()
+    processReviewCycle(state, "task", {
+      subagent_type: "general",
+      prompt: "do some work",
+    })
+    assert.equal(state.cycles.size, 0)
+  })
+
+  it("returns false for non-review tool calls", () => {
+    const state = newReviewCycleState()
+    const exceeded = processReviewCycle(state, "read", { filePath: "/foo.go" })
+    assert.equal(exceeded, false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reviewCycleEscalationMessage
+// ---------------------------------------------------------------------------
+
+describe("reviewCycleEscalationMessage", () => {
+  it("includes the PR number and cycle count", () => {
+    const state = newReviewCycleState()
+    state.detectedPrNumber = "42"
+    state.cycles.set("42", 3)
+    const msg = reviewCycleEscalationMessage(state)
+    assert.ok(msg.includes("PR #42"))
+    assert.ok(msg.includes("3"))
+    assert.ok(msg.includes("escalate"))
+  })
+
+  it("handles unknown PR number gracefully", () => {
+    const state = newReviewCycleState()
+    state.cycles.set("unknown", 4)
+    const msg = reviewCycleEscalationMessage(state)
+    assert.ok(msg.includes("this PR"))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isGitPush
+// ---------------------------------------------------------------------------
+
+describe("isGitPush", () => {
+  it("matches plain git push", () => {
+    assert.equal(isGitPush("git push"), true)
+  })
+
+  it("matches git push with remote and branch", () => {
+    assert.equal(isGitPush("git push origin main"), true)
+  })
+
+  it("matches git push with -u flag", () => {
+    assert.equal(isGitPush("git push -u origin main"), true)
+  })
+
+  it("matches git -C <path> push", () => {
+    assert.equal(isGitPush("git -C /some/path push"), true)
+  })
+
+  it("does not match git pull", () => {
+    assert.equal(isGitPush("git pull"), false)
+  })
+
+  it("does not match unrelated commands", () => {
+    assert.equal(isGitPush("go test ./..."), false)
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -30,6 +30,9 @@ import {
   isGitPush,
   newDoomLoopState,
   newReviewCycleState,
+  snapshotGuardState,
+  restoreGuardState,
+  GUARD_STATE_ENTRY_TYPE,
   DOOM_LOOP_THRESHOLD,
   REVIEW_CYCLE_THRESHOLD,
 } from "./prism.ts"
@@ -830,6 +833,146 @@ describe("reviewCycleEscalationMessage", () => {
 // ---------------------------------------------------------------------------
 // isGitPush
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// snapshotGuardState / restoreGuardState / GUARD_STATE_ENTRY_TYPE
+// ---------------------------------------------------------------------------
+
+describe("snapshotGuardState", () => {
+  it("serialises doom-loop state", () => {
+    const dl = newDoomLoopState()
+    dl.currentKey = "bash:git push"
+    dl.consecutiveCount = 3
+    dl.fired = false
+    const rc = newReviewCycleState()
+    const snap = snapshotGuardState(dl, rc, false)
+    assert.equal(snap.doomLoop.currentKey, "bash:git push")
+    assert.equal(snap.doomLoop.consecutiveCount, 3)
+    assert.equal(snap.doomLoop.fired, false)
+  })
+
+  it("serialises review-cycle state (Map → plain object)", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    rc.detectedPrNumber = "42"
+    rc.cycles.set("42", 2)
+    rc.frameEmitted = true
+    const snap = snapshotGuardState(dl, rc, true)
+    assert.equal(snap.reviewCycle.detectedPrNumber, "42")
+    assert.equal(snap.reviewCycle.cycles["42"], 2)
+    assert.equal(snap.reviewCycle.frameEmitted, true)
+    assert.equal(snap.pendingGitPushReminder, true)
+  })
+
+  it("produces a JSON-safe value (no Map objects)", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    rc.cycles.set("99", 1)
+    const snap = snapshotGuardState(dl, rc, false)
+    // JSON round-trip must succeed and preserve cycles
+    const json = JSON.stringify(snap)
+    const parsed = JSON.parse(json)
+    assert.equal(parsed.reviewCycle.cycles["99"], 1)
+  })
+})
+
+describe("restoreGuardState", () => {
+  it("restores doom-loop fields", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    const snap = {
+      doomLoop: { currentKey: "bash:nix build", consecutiveCount: 4, fired: true },
+      reviewCycle: { detectedPrNumber: null, cycles: {}, frameEmitted: false },
+      pendingGitPushReminder: false,
+    }
+    restoreGuardState(snap, dl, rc)
+    assert.equal(dl.currentKey, "bash:nix build")
+    assert.equal(dl.consecutiveCount, 4)
+    assert.equal(dl.fired, true)
+  })
+
+  it("restores review-cycle fields including Map entries", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    const snap = {
+      doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
+      reviewCycle: { detectedPrNumber: "77", cycles: { "77": 3 }, frameEmitted: true },
+      pendingGitPushReminder: true,
+    }
+    const result = restoreGuardState(snap, dl, rc)
+    assert.equal(rc.detectedPrNumber, "77")
+    assert.equal(rc.cycles.get("77"), 3)
+    assert.equal(rc.frameEmitted, true)
+    assert.equal(result.pendingGitPushReminder, true)
+  })
+
+  it("clears existing Map entries before restoring", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    rc.cycles.set("old", 99)
+    const snap = {
+      doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
+      reviewCycle: { detectedPrNumber: null, cycles: {}, frameEmitted: false },
+      pendingGitPushReminder: false,
+    }
+    restoreGuardState(snap, dl, rc)
+    assert.equal(rc.cycles.size, 0)
+  })
+
+  it("handles missing/malformed snapshot fields gracefully", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    // Deliberately omit / corrupt fields
+    const snap = {
+      doomLoop: { currentKey: undefined, consecutiveCount: "not-a-number" as unknown as number, fired: undefined },
+      reviewCycle: { detectedPrNumber: undefined, cycles: null as unknown as Record<string, number>, frameEmitted: undefined },
+      pendingGitPushReminder: undefined as unknown as boolean,
+    }
+    restoreGuardState(snap, dl, rc)
+    assert.equal(dl.currentKey, null)
+    assert.equal(dl.consecutiveCount, 0)
+    assert.equal(dl.fired, false)
+    assert.equal(rc.detectedPrNumber, null)
+    assert.equal(rc.cycles.size, 0)
+    assert.equal(rc.frameEmitted, false)
+  })
+})
+
+describe("snapshotGuardState + restoreGuardState round-trip", () => {
+  it("survives a JSON round-trip (simulating session-file persistence)", () => {
+    const dl = newDoomLoopState()
+    dl.currentKey = "bash:git status"
+    dl.consecutiveCount = 2
+    dl.fired = false
+    const rc = newReviewCycleState()
+    rc.detectedPrNumber = "55"
+    rc.cycles.set("55", 2)
+    rc.frameEmitted = false
+
+    const snap = snapshotGuardState(dl, rc, true)
+    // Simulate writing to and reading from the session JSON file.
+    const persisted = JSON.parse(JSON.stringify(snap))
+
+    const dl2 = newDoomLoopState()
+    const rc2 = newReviewCycleState()
+    const { pendingGitPushReminder } = restoreGuardState(persisted, dl2, rc2)
+
+    assert.equal(dl2.currentKey, "bash:git status")
+    assert.equal(dl2.consecutiveCount, 2)
+    assert.equal(dl2.fired, false)
+    assert.equal(rc2.detectedPrNumber, "55")
+    assert.equal(rc2.cycles.get("55"), 2)
+    assert.equal(rc2.frameEmitted, false)
+    assert.equal(pendingGitPushReminder, true)
+  })
+})
+
+describe("GUARD_STATE_ENTRY_TYPE", () => {
+  it("is a non-empty string", () => {
+    assert.equal(typeof GUARD_STATE_ENTRY_TYPE, "string")
+    assert.ok(GUARD_STATE_ENTRY_TYPE.length > 0)
+  })
+})
 
 describe("isGitPush", () => {
   it("matches plain git push", () => {

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -66,6 +66,304 @@ import type {
 /** Wire protocol version this extension speaks. */
 export const PROTOCOL_VERSION = 1
 
+// ---------------------------------------------------------------------------
+// Behavioural guards — ported from opencode's prism-hooks.ts
+// ---------------------------------------------------------------------------
+//
+// Three guards are implemented here:
+//   1. Doom-loop detector: 5 consecutive same-tool calls → steer message.
+//   2. Review-cycle counter: 3 cycles without convergence → escalation message.
+//   3. Git-push reminder: git push without prior review → system prompt reminder.
+//
+// All three guards can be disabled via env vars for debugging.
+// ---------------------------------------------------------------------------
+
+/** Number of consecutive matching tool calls that triggers the doom-loop. */
+export const DOOM_LOOP_THRESHOLD = 5
+
+/** Number of review cycles before the escalation warning fires. */
+export const REVIEW_CYCLE_THRESHOLD = 3
+
+/**
+ * Tools excluded from doom-loop detection. Legitimate exploration revisits
+ * the same paths often; treating them as loops generates false positives.
+ * todowrite is excluded because task-list management is a housekeeping pattern.
+ */
+export const EXCLUDED_TOOLS = new Set(["read", "grep", "glob", "todowrite"])
+
+/**
+ * Compute a normalised similarity key for a tool call.
+ * Returns null for excluded tools (no detection).
+ *
+ * Ported from opencode's prism-hooks.ts — see that file for the full
+ * commentary on similarity rules per tool.
+ */
+export function similarityKey(tool: string, args: unknown): string | null {
+  if (EXCLUDED_TOOLS.has(tool)) {
+    return null
+  }
+
+  switch (tool) {
+    case "bash": {
+      const cmd: string =
+        typeof args === "object" && args !== null
+          ? (args as Record<string, unknown>).command as string ?? ""
+          : String(args ?? "")
+      const tokens = cmd.trim().split(/\s+/)
+      const meaningful = tokens.filter((t) => t.length > 0)
+      let baseIdx = 0
+      while (baseIdx < meaningful.length && meaningful[baseIdx].startsWith("-")) {
+        baseIdx++
+      }
+      const base = meaningful[baseIdx] ?? ""
+
+      const SUBCOMMAND_CLIS = new Set(["gh", "git", "kubectl", "helm", "docker", "podman"])
+      if (SUBCOMMAND_CLIS.has(base)) {
+        const positionals: string[] = []
+        for (let i = baseIdx + 1; i < meaningful.length; i++) {
+          if (!meaningful[i].startsWith("-")) {
+            positionals.push(meaningful[i])
+          }
+        }
+        const parts = [base, ...positionals.slice(0, 3)]
+        return `bash:${parts.join(" ")}`.trimEnd()
+      }
+
+      let firstPos = ""
+      for (let i = baseIdx + 1; i < meaningful.length; i++) {
+        if (!meaningful[i].startsWith("-")) {
+          firstPos = meaningful[i]
+          break
+        }
+      }
+      return `bash:${base} ${firstPos}`.trimEnd()
+    }
+
+    case "edit":
+    case "write": {
+      const filePath: string =
+        typeof args === "object" && args !== null
+          ? ((args as Record<string, unknown>).filePath as string)
+            ?? ((args as Record<string, unknown>).path as string)
+            ?? ""
+          : String(args ?? "")
+      return `${tool}:${filePath}`
+    }
+
+    case "webfetch": {
+      const url: string =
+        typeof args === "object" && args !== null
+          ? (args as Record<string, unknown>).url as string ?? ""
+          : String(args ?? "")
+      return `webfetch:${url}`
+    }
+
+    default: {
+      const raw =
+        typeof args === "object" && args !== null
+          ? JSON.stringify(args)
+          : String(args ?? "")
+      return `${tool}:${raw}`
+    }
+  }
+}
+
+/** Doom-loop detector state (per session). */
+export interface DoomLoopState {
+  /** The similarity key of the current run. */
+  currentKey: string | null
+  /** How many consecutive matching calls we have seen. */
+  consecutiveCount: number
+  /** Whether we have already fired for this run (one nudge per loop). */
+  fired: boolean
+}
+
+/** Review-cycle tracker state (per session). */
+export interface ReviewCycleState {
+  /** Cycle counts keyed by PR number (or "unknown"). */
+  cycles: Map<string, number>
+  /** The PR number most recently detected. */
+  detectedPrNumber: string | null
+  /**
+   * Prevents counting 5 parallel review-agent invocations as 5 cycles.
+   * Set to true when the first review agent fires; cleared on turn_start
+   * so each full round counts as exactly one cycle.
+   */
+  pendingCycleCount: boolean
+  /**
+   * Tracks whether we've already emitted the review_cycle_exceeded wire
+   * frame for the current PR. Prevents flooding the harness_frames table.
+   * Reset when detectedPrNumber changes.
+   */
+  frameEmitted: boolean
+}
+
+/**
+ * Create a fresh doom-loop state object.
+ * Exported for unit testing.
+ */
+export function newDoomLoopState(): DoomLoopState {
+  return { currentKey: null, consecutiveCount: 0, fired: false }
+}
+
+/**
+ * Create a fresh review-cycle state object.
+ * Exported for unit testing.
+ */
+export function newReviewCycleState(): ReviewCycleState {
+  return { cycles: new Map(), detectedPrNumber: null, pendingCycleCount: false, frameEmitted: false }
+}
+
+/**
+ * Process a single tool call against the doom-loop detector.
+ *
+ * Returns the steering message text when the detector fires, or null when
+ * no action is needed. The caller is responsible for injecting the message
+ * into the session.
+ *
+ * Exported for unit testing.
+ */
+export function processDoomLoop(
+  state: DoomLoopState,
+  toolName: string,
+  toolArgs: unknown,
+): string | null {
+  if (EXCLUDED_TOOLS.has(toolName)) {
+    // Break the current run without tracking.
+    state.currentKey = null
+    state.consecutiveCount = 0
+    state.fired = false
+    return null
+  }
+
+  const key = similarityKey(toolName, toolArgs)
+  if (key === null) {
+    return null
+  }
+
+  if (key === state.currentKey) {
+    if (!state.fired) {
+      state.consecutiveCount++
+      if (state.consecutiveCount >= DOOM_LOOP_THRESHOLD) {
+        state.fired = true
+        return (
+          `[PRISM DOOM-LOOP DETECTION] You've called \`${toolName}\` with the same arguments ` +
+          `${state.consecutiveCount} times in a row. ` +
+          `This usually means the current approach isn't working — stop and rethink. ` +
+          `Consider: is there a different tool that would help? Is there a misunderstanding about the task? Should you escalate to the user?`
+        )
+      }
+    }
+    // already fired — suppress
+    return null
+  }
+
+  // Pattern broke — reset and start fresh.
+  state.currentKey = key
+  state.consecutiveCount = 1
+  state.fired = false
+  return null
+}
+
+/**
+ * Process a single tool call against the review-cycle tracker.
+ *
+ * This handles both `bash` calls to `prism review <N>` and `task` calls
+ * to review subagents. Returns true when the review-cycle threshold is
+ * exceeded (caller should inject escalation message).
+ *
+ * Exported for unit testing.
+ */
+export function processReviewCycle(
+  state: ReviewCycleState,
+  toolName: string,
+  toolArgs: unknown,
+): boolean {
+  if (toolName === "bash") {
+    const command: string =
+      typeof toolArgs === "object" && toolArgs !== null
+        ? (toolArgs as Record<string, unknown>).command as string ?? ""
+        : String(toolArgs ?? "")
+
+    const prismReviewMatch = command.match(/\bprism\s+review\s+(\d+)\b/)
+    if (prismReviewMatch) {
+      const newPr = prismReviewMatch[1]
+      if (newPr !== state.detectedPrNumber) {
+        state.detectedPrNumber = newPr
+        state.cycles.clear()
+        state.frameEmitted = false
+      }
+      if (!state.pendingCycleCount) {
+        state.pendingCycleCount = true
+        const prKey = state.detectedPrNumber ?? "unknown"
+        state.cycles.set(prKey, (state.cycles.get(prKey) ?? 0) + 1)
+      }
+    }
+  }
+
+  if (toolName === "task") {
+    const prompt: string =
+      typeof toolArgs === "object" && toolArgs !== null
+        ? (toolArgs as Record<string, unknown>).prompt as string ?? ""
+        : String(toolArgs ?? "")
+    const subagentType: string =
+      typeof toolArgs === "object" && toolArgs !== null
+        ? (toolArgs as Record<string, unknown>).subagent_type as string ?? ""
+        : ""
+
+    const isReviewAgent = /^review(-goal|-code|-security|-qa|-context)?$/.test(subagentType)
+    if (isReviewAgent) {
+      const prMatch =
+        prompt.match(/\bPR\s*#(\d+)\b/i) ??
+        prompt.match(/pull\s+request\s*#(\d+)/i) ??
+        prompt.match(/\bpr[_\s-]?number[:\s]+(\d+)/i) ??
+        prompt.match(/\b#(\d+)\b/)
+      if (prMatch) {
+        const newPr = prMatch[1]
+        if (newPr !== state.detectedPrNumber) {
+          state.detectedPrNumber = newPr
+          state.cycles.clear()
+          state.frameEmitted = false
+        }
+      }
+      if (!state.pendingCycleCount) {
+        state.pendingCycleCount = true
+        const prKey = state.detectedPrNumber ?? "unknown"
+        state.cycles.set(prKey, (state.cycles.get(prKey) ?? 0) + 1)
+      }
+    }
+  }
+
+  const prKey = state.detectedPrNumber ?? "unknown"
+  return (state.cycles.get(prKey) ?? 0) >= REVIEW_CYCLE_THRESHOLD
+}
+
+/**
+ * Build the review-cycle escalation message for the given PR.
+ * Exported for unit testing.
+ */
+export function reviewCycleEscalationMessage(
+  state: ReviewCycleState,
+): string {
+  const prKey = state.detectedPrNumber ?? "unknown"
+  const cycles = state.cycles.get(prKey) ?? 0
+  const prLabel = state.detectedPrNumber ? `PR #${state.detectedPrNumber}` : "this PR"
+  return (
+    `⚠️ REVIEW LOOP LIMIT: You have run ${cycles} review cycles for ${prLabel} without all agents passing. ` +
+    `You MUST stop and escalate to the user now. Do NOT run another review cycle. ` +
+    `Instead, summarise: (1) what was originally requested, (2) what each review cycle found, ` +
+    `and (3) why the fixes are not converging. Hand off to the coordinator.`
+  )
+}
+
+/**
+ * Check whether a bash command string is a git push.
+ * Exported for unit testing.
+ */
+export function isGitPush(command: string): boolean {
+  return /\bgit(\s+-C\s+\S+|\s+--git-dir\S*)*\s+push\b/.test(command)
+}
+
 /** Per-field byte cap for tool args, tool output, and assistant message deltas. */
 export const TRUNCATION_LIMIT_BYTES = 8 * 1024 // 8 KiB
 
@@ -550,6 +848,30 @@ export default function prismExtension(pi: ExtensionAPI): void {
     return
   }
 
+  // ── Behavioural guard state ───────────────────────────────────────────
+  //
+  // Disabled via env vars for debugging:
+  //   PRISM_DOOM_LOOP_DISABLE=1        — disable doom-loop detector
+  //   PRISM_REVIEW_CYCLE_DISABLE=1     — disable review-cycle escalation
+  //   PRISM_GIT_PUSH_REMINDER_DISABLE=1 — disable git-push reminder
+  //
+  // Review agents have legitimate repeated tool patterns so all guards are
+  // suppressed when the session_role from hello_ack is "review".
+  const doomLoopEnabled = !process.env.PRISM_DOOM_LOOP_DISABLE
+  const reviewCycleEnabled = !process.env.PRISM_REVIEW_CYCLE_DISABLE
+  const gitPushReminderEnabled = !process.env.PRISM_GIT_PUSH_REMINDER_DISABLE
+
+  const doomLoopState = newDoomLoopState()
+  const reviewCycleState = newReviewCycleState()
+
+  // Set to true when hello_ack reveals session_role is "review". All guards
+  // are suppressed — review agents legitimately repeat tool patterns.
+  let isReviewSession = false
+
+  // Flag: git push was detected; cleared after the next turn_start so the
+  // reminder fires exactly once.
+  let pendingGitPushReminder = false
+
   // ── Connection state ──────────────────────────────────────────────────
   let socket: net.Socket | null = null
   let writer: FrameWriter | null = null
@@ -655,6 +977,13 @@ export default function prismExtension(pi: ExtensionAPI): void {
           if (socket) socket.end()
           return
         }
+        // Detect review-agent sessions: guards are suppressed so that
+        // review agents (which legitimately repeat tool patterns) are not
+        // falsely nudged.
+        const role = typeof f.session_role === "string" ? f.session_role : ""
+        if (role === "review") {
+          isReviewSession = true
+        }
         handshakeComplete = true
         return
       }
@@ -718,6 +1047,43 @@ export default function prismExtension(pi: ExtensionAPI): void {
     lastCtx = ctx
     if (writer && handshakeComplete) {
       writer.write({ type: "turn_start" })
+    }
+    // Clear per-turn review-cycle deduplication so the next batch of
+    // review agent invocations counts as a fresh cycle.
+    reviewCycleState.pendingCycleCount = false
+
+    if (!isReviewSession) {
+      // Inject review-cycle escalation warning when the threshold is exceeded.
+      // This fires on every turn after the threshold so the agent cannot
+      // simply ignore it and continue.
+      if (reviewCycleEnabled) {
+        const prKey = reviewCycleState.detectedPrNumber ?? "unknown"
+        const cycles = reviewCycleState.cycles.get(prKey) ?? 0
+        if (cycles >= REVIEW_CYCLE_THRESHOLD) {
+          pi.sendUserMessage(reviewCycleEscalationMessage(reviewCycleState), {
+            deliverAs: "steer",
+          })
+          // Emit the wire frame only once per PR (not on every turn).
+          if (!reviewCycleState.frameEmitted && writer && handshakeComplete) {
+            reviewCycleState.frameEmitted = true
+            writer.write({
+              type: "review_cycle_exceeded",
+              session_name: process.env.PRISM_SESSION_NAME ?? "",
+              pr_number: reviewCycleState.detectedPrNumber ?? "",
+              cycle_count: cycles,
+            })
+          }
+        }
+      }
+
+      // Inject git-push reminder if a push was detected on the previous turn.
+      if (gitPushReminderEnabled && pendingGitPushReminder) {
+        pendingGitPushReminder = false
+        pi.sendUserMessage(
+          "You just ran git push. If this was in the context of an open PR, invoke @review-goal-subagent, @review-code-subagent, @review-security-subagent, @review-qa-subagent, and @review-context-subagent as parallel Task calls (all five in a single response) to review the updated changes before the PR is merged. ALL 5 agents must pass before the PR can be merged.",
+          { deliverAs: "steer" },
+        )
+      }
     }
   })
 
@@ -792,6 +1158,41 @@ export default function prismExtension(pi: ExtensionAPI): void {
     }
     if (truncated) frame.truncated = true
     writer.write(frame)
+
+    // ── Behavioural guards ────────────────────────────────────────────────
+    // Guards are suppressed inside review-agent sessions.
+    if (!isReviewSession) {
+      // Doom-loop detection.
+      if (doomLoopEnabled) {
+        const steeringMsg = processDoomLoop(doomLoopState, name, rawArgs)
+        if (steeringMsg !== null) {
+          pi.sendUserMessage(steeringMsg, { deliverAs: "steer" })
+          writer.write({
+            type: "doom_loop_detected",
+            session_name: process.env.PRISM_SESSION_NAME ?? "",
+            tool: name,
+            consecutive_count: doomLoopState.consecutiveCount,
+          })
+        }
+      }
+
+      // Review-cycle tracking + git-push detection.
+      if (name === "bash") {
+        const command: string =
+          typeof rawArgs === "object" && rawArgs !== null
+            ? (rawArgs as Record<string, unknown>).command as string ?? ""
+            : String(rawArgs ?? "")
+
+        // Git-push reminder flag.
+        if (gitPushReminderEnabled && isGitPush(command)) {
+          pendingGitPushReminder = true
+        }
+      }
+
+      if (reviewCycleEnabled) {
+        processReviewCycle(reviewCycleState, name, rawArgs)
+      }
+    }
   })
 
   pi.on("tool_execution_end", async (event, ctx) => {

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -339,9 +339,92 @@ export function processReviewCycle(
 }
 
 /**
- * Build the review-cycle escalation message for the given PR.
+ * Custom entry type used to persist guard state snapshots in the session file.
+ *
+ * Snapshots are written via `pi.appendEntry(GUARD_STATE_ENTRY_TYPE, snapshot)`
+ * after each significant state change. On session resume (`session_switch` with
+ * `reason: "resume"`), the extension scans session entries from newest to oldest,
+ * finds the latest snapshot, and restores state from it.
+ *
+ * This is the "reconstruct from session entries on resume" pattern described in
+ * issue #1219 and referenced in the wire protocol design doc.
+ */
+export const GUARD_STATE_ENTRY_TYPE = "prism-guard-state"
+
+/** Shape persisted in the session file for state reconstruction. */
+export interface GuardStateSnapshot {
+  /** Doom-loop state: the current similarity key and consecutive count. */
+  doomLoop: {
+    currentKey: string | null
+    consecutiveCount: number
+    fired: boolean
+  }
+  /** Review-cycle state: PR number and cycle counts as a plain object (Map not JSON-safe). */
+  reviewCycle: {
+    detectedPrNumber: string | null
+    cycles: Record<string, number>
+    frameEmitted: boolean
+  }
+  /** Whether a git-push reminder is pending injection. */
+  pendingGitPushReminder: boolean
+}
+
+/**
+ * Serialise the current guard state into a snapshot object for persistence.
  * Exported for unit testing.
  */
+export function snapshotGuardState(
+  doomLoop: DoomLoopState,
+  reviewCycle: ReviewCycleState,
+  pendingGitPushReminder: boolean,
+): GuardStateSnapshot {
+  const cycles: Record<string, number> = {}
+  for (const [k, v] of reviewCycle.cycles) {
+    cycles[k] = v
+  }
+  return {
+    doomLoop: {
+      currentKey: doomLoop.currentKey,
+      consecutiveCount: doomLoop.consecutiveCount,
+      fired: doomLoop.fired,
+    },
+    reviewCycle: {
+      detectedPrNumber: reviewCycle.detectedPrNumber,
+      cycles,
+      frameEmitted: reviewCycle.frameEmitted,
+    },
+    pendingGitPushReminder,
+  }
+}
+
+/**
+ * Restore guard state from a snapshot. Mutates the provided state objects in
+ * place. Exported for unit testing.
+ */
+export function restoreGuardState(
+  snapshot: GuardStateSnapshot,
+  doomLoop: DoomLoopState,
+  reviewCycle: ReviewCycleState,
+): { pendingGitPushReminder: boolean } {
+  doomLoop.currentKey = snapshot.doomLoop.currentKey ?? null
+  doomLoop.consecutiveCount = typeof snapshot.doomLoop.consecutiveCount === "number"
+    ? snapshot.doomLoop.consecutiveCount
+    : 0
+  doomLoop.fired = snapshot.doomLoop.fired === true
+
+  reviewCycle.detectedPrNumber = snapshot.reviewCycle.detectedPrNumber ?? null
+  reviewCycle.cycles.clear()
+  if (snapshot.reviewCycle.cycles && typeof snapshot.reviewCycle.cycles === "object") {
+    for (const [k, v] of Object.entries(snapshot.reviewCycle.cycles)) {
+      if (typeof v === "number") {
+        reviewCycle.cycles.set(k, v)
+      }
+    }
+  }
+  reviewCycle.frameEmitted = snapshot.reviewCycle.frameEmitted === true
+
+  return { pendingGitPushReminder: snapshot.pendingGitPushReminder === true }
+}
 export function reviewCycleEscalationMessage(
   state: ReviewCycleState,
 ): string {
@@ -1035,6 +1118,42 @@ export default function prismExtension(pi: ExtensionAPI): void {
     connect()
   })
 
+  // ── State reconstruction on session resume ───────────────────────────
+  //
+  // When PI resumes a session (session_switch with reason="resume"), the
+  // extension scans the session's branch entries for the latest
+  // GUARD_STATE_ENTRY_TYPE snapshot and restores state from it. This
+  // ensures the doom-loop consecutive count, review-cycle counts, and
+  // git-push reminder flag survive a session pause/resume cycle.
+  //
+  // The entry is written whenever significant state changes occur (see
+  // the tool_execution_start hook below). pendingCycleCount is not
+  // persisted (it is cleared on turn_start anyway).
+  pi.on("session_switch", async (event, ctx) => {
+    lastCtx = ctx
+    if ((event as { reason?: unknown }).reason !== "resume") return
+    if (isReviewSession) return // guards are suppressed for review sessions
+
+    const entries = ctx.sessionManager.getBranch()
+    // Walk backward to find the most recent guard state snapshot.
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const entry = entries[i]
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        (entry as { type?: unknown }).type === "custom" &&
+        (entry as { customType?: unknown }).customType === GUARD_STATE_ENTRY_TYPE
+      ) {
+        const snapshot = (entry as { data?: unknown }).data as GuardStateSnapshot | undefined
+        if (snapshot && typeof snapshot === "object") {
+          const restored = restoreGuardState(snapshot, doomLoopState, reviewCycleState)
+          pendingGitPushReminder = restored.pendingGitPushReminder
+        }
+        break
+      }
+    }
+  })
+
   pi.on("before_agent_start", async (_event, ctx) => {
     lastCtx = ctx
     if (writer && handshakeComplete) {
@@ -1192,6 +1311,14 @@ export default function prismExtension(pi: ExtensionAPI): void {
       if (reviewCycleEnabled) {
         processReviewCycle(reviewCycleState, name, rawArgs)
       }
+
+      // Persist guard state after each tool call so session resume can
+      // reconstruct the current doom-loop run and review-cycle counts.
+      // pi.appendEntry is lightweight (appends to the session JSON file);
+      // we do it unconditionally — the reviewer can deduplicate via the
+      // "latest entry wins" pattern in session_switch above.
+      pi.appendEntry(GUARD_STATE_ENTRY_TYPE,
+        snapshotGuardState(doomLoopState, reviewCycleState, pendingGitPushReminder))
     }
   })
 

--- a/modules/programs/prism/prism/cmd/prompt_pi_test.go
+++ b/modules/programs/prism/prism/cmd/prompt_pi_test.go
@@ -39,6 +39,10 @@ func setStatusHarness(t *testing.T, d *db.DB, sessionName, harness string) {
 	}
 }
 
+// maxSunPath is the POSIX limit for sockaddr_un.sun_path (104 on macOS, 108 on Linux).
+// We use 104 as the conservative cross-platform ceiling.
+const maxSunPath = 104
+
 // TestRunPrompt_PISession_RoutesThroughSidecarHostAPI seeds a PI session in
 // the DB and starts a stub Unix-socket HTTP server at the per-session
 // host-api.sock path. It then runs `prism prompt <session>` and asserts that
@@ -46,9 +50,12 @@ func setStatusHarness(t *testing.T, d *db.DB, sessionName, harness string) {
 // (opencode) call was made, and that the audit row was written.
 func TestRunPrompt_PISession_RoutesThroughSidecarHostAPI(t *testing.T) {
 	// Use a short XDG_STATE_HOME so the per-session socket path stays under
-	// the 108-char Unix sun_path limit on Linux.
-	stateHome := filepath.Join(os.TempDir(), "prism-pipe-test-"+randCmdHex(6))
-	if err := os.MkdirAll(stateHome, 0o700); err != nil {
+	// the 104-char Unix sun_path limit on macOS. os.MkdirTemp with a short
+	// two-character prefix keeps the base path short enough on both Linux and
+	// Darwin (unlike filepath.Join(os.TempDir(), ...) which can exceed 104
+	// chars on macOS where TempDir returns a long /private/var/folders/... path).
+	stateHome, err := os.MkdirTemp("", "pp")
+	if err != nil {
 		t.Fatalf("mkdir state home: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
@@ -58,6 +65,9 @@ func TestRunPrompt_PISession_RoutesThroughSidecarHostAPI(t *testing.T) {
 	sockPath, err := session.SidecarHostAPIPath(sessionName)
 	if err != nil {
 		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+	if len(sockPath) > maxSunPath {
+		t.Fatalf("socket path too long (%d > %d): %s", len(sockPath), maxSunPath, sockPath)
 	}
 	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
 		t.Fatalf("mkdir socket dir: %v", err)
@@ -133,8 +143,8 @@ func TestRunPrompt_PISession_RoutesThroughSidecarHostAPI(t *testing.T) {
 // the error message points at the missing socket path so an operator can
 // diagnose the failure.
 func TestRunPrompt_PISession_SocketMissingReturnsClearError(t *testing.T) {
-	stateHome := filepath.Join(os.TempDir(), "prism-pipe-miss-"+randCmdHex(6))
-	if err := os.MkdirAll(stateHome, 0o700); err != nil {
+	stateHome, err := os.MkdirTemp("", "pm")
+	if err != nil {
 		t.Fatalf("mkdir state home: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
@@ -147,11 +157,11 @@ func TestRunPrompt_PISession_SocketMissingReturnsClearError(t *testing.T) {
 	setStatusHarness(t, d, sessionName, "pi")
 
 	rootCmd.SetArgs([]string{"prompt", sessionName, "--prompt", "test"})
-	err := rootCmd.Execute()
-	if err == nil {
+	execErr := rootCmd.Execute()
+	if execErr == nil {
 		t.Fatal("expected error when sidecar socket missing, got nil")
 	}
-	msg := err.Error()
+	msg := execErr.Error()
 	if !strings.Contains(msg, "socket-pipe delivery failed") {
 		t.Errorf("error should mention socket-pipe delivery failure: got %q", msg)
 	}


### PR DESCRIPTION
## Summary

- Ports three behavioural guards from `opencode/plugins/prism-hooks.ts` into the prism PI extension (`pi/extensions/prism.ts`), using PI's richer hook surface for cleaner injection via `pi.sendUserMessage({deliverAs: 'steer'})`.
- **Doom-loop detector**: fires after 5 consecutive same-tool calls, emits `doom_loop_detected` wire frame to the sidecar for `prism logs --harness-events` surfacing.
- **Review-cycle escalation**: injects a steer message on every turn after 3 review cycles; emits `review_cycle_exceeded` wire frame once per PR.
- **Git-push reminder**: detects `git push` in bash tool calls, injects a review reminder steer message on the next turn.
- All guards disabled via env vars; all guards suppressed for sessions with `session_role == "review"` in `hello_ack`.
- Unit tests for all pure helper functions (similarityKey, processDoomLoop, processReviewCycle, isGitPush, etc.).

Closes #1219