### PR TITLE
feat(prism): P2.DARWIN — PI harness on macOS sandbox-exec

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -138,6 +138,7 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		InstanceID:        instanceID,
 		RuntimeEnv:        sandboxRuntimeEnv,
 		AgentEnvVars:      agentEnvVars,
+		Harness:           sandboxHarnessName,
 	}
 
 	// For socket-pipe harnesses (PI), the sidecar stores the TCP port it
@@ -146,6 +147,23 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		if status.HarnessPort != nil {
 			ctrCfg.HarnessPipeTCPPort = *status.HarnessPort
 		}
+	}
+
+	// PI harness: populate PI-specific config fields (system-prompt, extension
+	// dir, provider/model/thinking) from the active profile slot.
+	// On Darwin sandbox-exec there are no bind-mounts, so the "sandbox paths"
+	// are the same as the host paths — sandbox-exec shares the host filesystem.
+	if sandboxHarnessName == "pi" {
+		if piErr := populatePIConfig(&ctrCfg, sessionName, agentRole, cfg); piErr != nil {
+			return fmt.Errorf("agent-run: %w", piErr)
+		}
+		// sandbox-exec shares the host filesystem, so the in-sandbox paths for
+		// the system-prompt file and extension directory are the same as the
+		// host paths. Override the bwrap-oriented sandbox-path defaults so that
+		// PIInvocation passes the correct paths to pi's --append-system-prompt
+		// and --extension flags.
+		ctrCfg.PISystemPromptSandboxPath = ctrCfg.PISystemPromptHostPath
+		ctrCfg.PIExtensionSandboxDir = ctrCfg.PIExtensionHostDir
 	}
 
 	applyInitialPromptEnvVar(&ctrCfg)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -230,14 +229,6 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// tmux session, no DB row).
 	if _, ok := harness.Lookup(harnessFlag); !ok {
 		return fmt.Errorf("unknown harness %q: valid harnesses: %s", harnessFlag, strings.Join(harness.Names(), ", "))
-	}
-
-	// PI harness is only supported on Linux (bwrap path) until P2.DARWIN
-	// (#1213) lands. Reject early with a clear pointer to the tracking issue
-	// so users know what to wait for, rather than failing later with a less
-	// obvious bwrap-not-found / sandbox-exec error.
-	if harnessFlag == "pi" && runtime.GOOS != "linux" {
-		return fmt.Errorf("--harness pi is not yet supported on %s — Darwin support is tracked in #1213", runtime.GOOS)
 	}
 
 	promptText, promptSource, err := resolvePromptWithSource(cmd)

--- a/modules/programs/prism/prism/cmd/spawn_pi_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_pi_test.go
@@ -1,9 +1,9 @@
 package cmd
 
-// spawn_pi_test.go — tests for the PI harness integration (P2.SPAWN, #1212).
+// spawn_pi_test.go — tests for the PI harness spawn path (#1212, #1213).
 //
 // Coverage:
-//   - --harness pi on Darwin returns a clear error pointing at #1213
+//   - --harness pi on Darwin passes harness validation (P2.DARWIN landed)
 //   - --harness pi on Linux passes the harness validation step (the spawn
 //     fails later for an unrelated reason since the test does not prepare a
 //     real bwrap environment, but the failure is NOT a harness validation
@@ -17,18 +17,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TestRunSpawn_HarnessPI_DarwinReturnsClearError verifies the edge-case AC:
-//
-//	`--harness pi` on Darwin fails with a clear "not yet supported, see
-//	 #1213" message until P2.DARWIN lands.
-//
-// On Linux this branch is unreachable; the test skips so that CI on the
-// supported platform continues to exercise the rest of the suite. The string
-// match asserts that the error mentions both the OS and the tracking issue
-// so that an operator on a Mac sees the right pointer immediately.
-func TestRunSpawn_HarnessPI_DarwinReturnsClearError(t *testing.T) {
+// TestRunSpawn_HarnessPI_DarwinPassesValidation verifies that --harness pi on
+// Darwin passes harness validation (P2.DARWIN #1213 landed). The test does not
+// prepare a real sandbox-exec environment so runSpawn fails further down; we
+// assert the failure is NOT a harness-validation error and NOT the old Darwin
+// "not yet supported" guard to prove validation passed and the guard is gone.
+func TestRunSpawn_HarnessPI_DarwinPassesValidation(t *testing.T) {
 	if runtime.GOOS == "linux" {
-		t.Skip("Darwin-specific: --harness pi guard is conditioned on runtime.GOOS != linux")
+		t.Skip("Darwin-specific: verifies Darwin guard has been removed")
 	}
 
 	cmd := &cobra.Command{Use: "spawn"}
@@ -50,15 +46,17 @@ func TestRunSpawn_HarnessPI_DarwinReturnsClearError(t *testing.T) {
 	t.Setenv("PRISM_BARE_ROOT", "")
 
 	err := runSpawn(cmd, nil)
-	if err == nil {
-		t.Fatal("runSpawn with --harness pi on Darwin: expected non-nil error, got nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "not yet supported") {
-		t.Errorf("error %q does not mention 'not yet supported'", msg)
-	}
-	if !strings.Contains(msg, "#1213") {
-		t.Errorf("error %q does not reference the P2.DARWIN tracking issue (#1213)", msg)
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "unknown harness") {
+			t.Errorf("runSpawn with --harness pi on Darwin returned harness validation error: %v", err)
+		}
+		if strings.Contains(msg, "not yet supported") {
+			t.Errorf("runSpawn with --harness pi on Darwin returned the old Darwin guard error — guard should have been removed by P2.DARWIN (#1213): %v", err)
+		}
+		if strings.Contains(msg, "#1213") {
+			t.Errorf("runSpawn with --harness pi on Darwin returned old #1213 pointer — guard should have been removed: %v", err)
+		}
 	}
 }
 
@@ -68,7 +66,7 @@ func TestRunSpawn_HarnessPI_DarwinReturnsClearError(t *testing.T) {
 // the failure is NOT a harness-validation error to prove validation passed.
 func TestRunSpawn_HarnessPI_LinuxPassesValidation(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("Linux-only: PI harness only supported on Linux today")
+		t.Skip("Linux-only: bwrap is only supported on Linux")
 	}
 
 	cmd := &cobra.Command{Use: "spawn"}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -141,6 +141,9 @@ func generateProfile(m *Manager) string {
 
 	// ── 2. Standard system read-only roots ───────────────────────────────
 	// /nix            — Nix store. All Nix-built binaries live here.
+	//   This also covers the PI extension directory (cfg.PIExtensionHostDir),
+	//   which is a Nix store path resolved from piExtensionDir in config.json
+	//   (issue #1213). No separate SBPL rule is needed for the PI extension.
 	// /usr, /bin, /sbin — standard Apple-signed utility directories.
 	// /System, /Library — OS frameworks, dylibs, and shared data.
 	// /Applications/Xcode.app — xcrun (called by /usr/bin/git shim).
@@ -291,6 +294,12 @@ func generateProfile(m *Manager) string {
 			sb.WriteString("  (subpath " + quoteSBPL(m.cfg.BareRoot) + ")\n")
 		}
 		// Host-API socket directory — the sidecar's per-session socket dir.
+		// For PI sessions on Darwin (harness=pi), the per-session run directory
+		// also contains the system-prompt temp file written by WriteSystemPromptFile
+		// (e.g. ~/.local/state/prism/run/<hash>/system-prompt.md). Since the
+		// system-prompt file lives in the same directory as hostapi.sock, this
+		// single (subpath ...) rule covers both — no separate PI SBPL rule is
+		// needed for the system-prompt path (issue #1213, confirmed no new rules).
 		if m.cfg.HostAPISockPath != "" {
 			sockDir := filepath.Dir(m.cfg.HostAPISockPath)
 			sb.WriteString("  (subpath " + quoteSBPL(sockDir) + ")\n")
@@ -608,11 +617,17 @@ func (s *sandboxExecIsolator) BuildArgs(m *Manager) []string {
 
 	profilePath := m.sandboxExecProfilePath()
 
-	// The sandbox-exec wrapper precedes the harness invocation. HarnessInvocation
-	// returns ["opencode", "--port", ..., "--hostname", "127.0.0.1", ...] and
-	// handles the AllocatedPort ∥ ContainerPort fallback rule (matching bwrap).
+	// The sandbox-exec wrapper precedes the harness invocation. For opencode
+	// sessions, HarnessInvocation returns ["opencode", "--port", ..., ...] and
+	// handles the AllocatedPort ∥ ContainerPort fallback. For PI sessions,
+	// PIInvocation returns ["pi", "--provider", ..., "--append-system-prompt",
+	// ..., "--extension", ...] — the PI analogue of HarnessInvocation.
 	args := []string{"sandbox-exec", "-f", profilePath}
-	args = append(args, HarnessInvocation(cfg)...)
+	if cfg.Harness == "pi" {
+		args = append(args, PIInvocation(cfg)...)
+	} else {
+		args = append(args, HarnessInvocation(cfg)...)
+	}
 
 	return args
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_darwin_test.go
@@ -1,0 +1,212 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_pi_darwin_test.go — integration tests for PI harness paths in
+// the SBPL profile (issue #1213, P2.DARWIN).
+//
+// These tests verify that:
+//  1. The per-session run directory (which hosts both hostapi.sock and the PI
+//     system-prompt temp file) is accessible inside the sandbox — the existing
+//     host-API socket dir allow rule covers both (no new SBPL rule needed).
+//  2. The PI extension directory (a Nix store path) is readable inside the
+//     sandbox — the existing /nix subpath allow covers it (no new rule needed).
+//
+// The tests confirm that these paths do NOT need new SBPL rules by verifying
+// the existing rules already grant access (issue #1213: "no new SBPL rules
+// expected"). Each positive test is paired with a negative test that removes
+// the covering rule and asserts failure — proving the positive test is not a
+// no-op.
+//
+// See docs/sandbox-exec-testing.md for the testing convention these tests
+// support (issue #1192).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// newPIProfileManager creates a Manager configured as it would be for a PI
+// session on Darwin: the HostAPISockPath is set so the per-session run dir
+// (which also contains the PI system-prompt file) is included in the SBPL
+// profile's allow rules.
+func newPIProfileManager(t *testing.T, sockPath string) *container.Manager {
+	t.Helper()
+	instanceID := "integ-sbx-pi-" + strings.ReplaceAll(t.Name(), "/", "-")
+	cfg := container.Config{
+		SessionName:     "integ-sandbox-exec-pi-test",
+		InstanceID:      instanceID,
+		Worktree:        t.TempDir(),
+		HostAPISockPath: sockPath,
+	}
+	return container.New(cfg)
+}
+
+// TestSandboxExecPI_SystemPromptFileReadable verifies the positive path for
+// PI's system-prompt file: the per-session run directory is accessible inside
+// the sandbox via the existing host-API socket dir rule. This covers issue
+// #1213 AC: "No new SBPL rules are needed (confirm and document)".
+//
+// The test creates a temp file that stands in for the system-prompt file
+// (co-located with the socket dir), then runs sandbox-exec to read it with
+// the Nix-built bash. Asserts exit 0.
+func TestSandboxExecPI_SystemPromptFileReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	// Create a temp directory to act as the per-session run dir. The PI
+	// system-prompt file and hostapi.sock are co-located here.
+	runDir := t.TempDir()
+	sockPath := filepath.Join(runDir, "hostapi.sock")
+	systemPromptPath := filepath.Join(runDir, "system-prompt.md")
+
+	// Write a stand-in system-prompt file.
+	if err := os.WriteFile(systemPromptPath, []byte("# test system prompt"), 0o600); err != nil {
+		t.Fatalf("write system-prompt stand-in: %v", err)
+	}
+
+	m := newPIProfileManager(t, sockPath)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Verify the socket dir rule is present in the generated profile.
+	sockDirRule := fmt.Sprintf("(subpath %q)", runDir)
+	if !strings.Contains(prepared.content, sockDirRule) {
+		// The profile uses SBPL double-quoted strings (quoteSBPL). Reconstruct
+		// the expected rule using the actual SBPL quoting.
+		quotedDir := `"` + strings.ReplaceAll(strings.ReplaceAll(runDir, `\`, `\\`), `"`, `\"`) + `"`
+		sockDirRuleSBPL := "(subpath " + quotedDir + ")"
+		if !strings.Contains(prepared.content, sockDirRuleSBPL) {
+			t.Fatalf("generated profile does not contain a (subpath ...) rule for the run dir %q.\n"+
+				"The host-API socket dir rule should cover the PI system-prompt path.\nProfile:\n%s",
+				runDir, prepared.content)
+		}
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Run: sandbox-exec -f <profile> bash -c 'cat <system-prompt>'
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "cat "+shQuote(systemPromptPath))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("sandbox-exec reading PI system-prompt file failed.\n"+
+			"Expected the per-session run dir allow to cover %q.\n"+
+			"Output: %s\nError: %v",
+			systemPromptPath, out, runErr)
+	}
+}
+
+// TestSandboxExecPI_SystemPromptFileDeniedWithoutRunDirRule verifies the
+// negative path: when the per-session run dir rule is removed from the SBPL
+// profile, reading the system-prompt file fails. This proves that the
+// positive test is not a no-op — the run dir rule really is the covering rule.
+func TestSandboxExecPI_SystemPromptFileDeniedWithoutRunDirRule(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	runDir := t.TempDir()
+	sockPath := filepath.Join(runDir, "hostapi.sock")
+	systemPromptPath := filepath.Join(runDir, "system-prompt.md")
+
+	if err := os.WriteFile(systemPromptPath, []byte("# test system prompt"), 0o600); err != nil {
+		t.Fatalf("write system-prompt stand-in: %v", err)
+	}
+
+	m := newPIProfileManager(t, sockPath)
+
+	// Build SBPL quoting for runDir. sandbox_exec.go uses quoteSBPL which
+	// double-quotes with backslash escaping. Replicate that here.
+	quotedRunDir := `"` + strings.ReplaceAll(strings.ReplaceAll(runDir, `\`, `\\`), `"`, `\"`) + `"`
+
+	mutatedProfilePath := withMutatedProfile(t, m, func(content string) string {
+		// Remove the (subpath "<runDir>") rule that covers the run dir.
+		return strings.Replace(content, "  (subpath "+quotedRunDir+")\n", "", 1)
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedProfilePath,
+		nixBash, "-c", "cat "+shQuote(systemPromptPath))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("sandbox-exec reading PI system-prompt unexpectedly succeeded with run dir rule removed.\n"+
+			"Output: %s", out)
+	}
+}
+
+// TestSandboxExecPI_NixExtensionDirReadable verifies that a Nix store path
+// (standing in for the PI extension dir) is readable inside the sandbox via
+// the existing (subpath "/nix") rule. This covers issue #1213 AC: "No new
+// SBPL rules are needed" for the extension directory.
+func TestSandboxExecPI_NixExtensionDirReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	// Use the resolved bash path as a stand-in for a file in the Nix store.
+	nixBashDir := filepath.Dir(nixBash)
+
+	m := newProfileManager(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Verify the /nix rule is present.
+	const nixRule = `(subpath "/nix")`
+	if !strings.Contains(prepared.content, nixRule) {
+		t.Fatalf("generated profile is missing %q — the Nix store allow was not emitted.\nProfile:\n%s",
+			nixRule, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Run: sandbox-exec -f <profile> bash -c 'ls <nixBashDir>'
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "ls "+shQuote(nixBashDir))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("sandbox-exec listing Nix store dir failed.\n"+
+			"Expected (subpath \"/nix\") to cover PI extension dir at %q.\n"+
+			"Output: %s\nError: %v",
+			nixBashDir, out, runErr)
+	}
+}
+
+// TestSandboxExecPI_NixExtensionDirDeniedWithoutNixRule verifies the negative
+// path: removing the (subpath "/nix") rule from the profile denies reads from
+// the Nix store. This proves the positive test is not a no-op.
+func TestSandboxExecPI_NixExtensionDirDeniedWithoutNixRule(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	nixBashDir := filepath.Dir(nixBash)
+
+	m := newProfileManager(t)
+
+	mutatedProfilePath := withMutatedProfile(t, m, func(content string) string {
+		// Remove the (subpath "/nix") line from the file-read* allow block.
+		return strings.Replace(content, "  (subpath \"/nix\")\n", "", 1)
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedProfilePath,
+		nixBash, "-c", "ls "+shQuote(nixBashDir))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("sandbox-exec listing Nix store dir unexpectedly succeeded with /nix rule removed.\n"+
+			"Output: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Removes the Darwin guard in `cmd/spawn.go` that rejected `--harness pi` on non-Linux (the guard was the only blocker after P2.SPAWN landed the underlying machinery)
- Wires `populatePIConfig` into the Darwin `agent_run_sandbox_exec_darwin.go` path and sets sandbox-path fields equal to host paths (sandbox-exec shares the host filesystem, no bind-mounts needed)
- Updates `sandbox_exec.go:BuildArgs` to dispatch `PIInvocation` instead of `HarnessInvocation` for `pi` sessions
- Documents in `generateProfile` that no new SBPL rules are needed: the existing per-session run-dir `(subpath ...)` rule covers the PI system-prompt file (co-located with `hostapi.sock`), and the `/nix` rule covers the PI extension dir
- Adds Darwin integration tests per the sandbox-exec testing convention (docs/sandbox-exec-testing.md, #1192): positive + negative pairs for system-prompt file accessibility and PI extension dir accessibility

## SBPL rules assessment

No new SBPL rules required (confirming issue #1213 scope):
- **PI system-prompt file** (`~/.local/state/prism/run/<hash>/system-prompt.md`): covered by the existing host-API socket dir `(subpath ...)` rule — both files live in the same per-session run directory
- **PI extension dir** (Nix store path): covered by the existing `(subpath "/nix")` rule
- **TCP harness pipe** (`host.containers.internal:<port>`): covered by `(allow network*)` — unchanged from P2.SPAWN

## pi-coding-agent on Darwin

`pi-coding-agent` is already in `modules/programs/prism/pi.nix` under `home.packages` for all platforms (no Linux-only guard). The overlay in `overlays/default.nix` provides it via `masterPkgs`. The `pi.nix` module is imported and enabled by default in `modules/programs/prism/default.nix`, so `pi-coding-agent` is in the m4mac PATH after the build.

Closes #1213