### PR TITLE
feat(sidecar): P3.LIVE — host-API endpoints for live model and provider swap

### DIFF
--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -712,6 +712,16 @@ func (d *DB) WaitingCount() (int, error) {
 // harness = 'pi' and repo = repo and state IN ('active', 'idle', 'waiting').
 // Used by the /apply-profile and /register-provider host-API endpoints to
 // resolve coordinator-scope targets (P3.LIVE, #1214).
+//
+// Design note: issue #1214 originally proposed filtering by coordinator_session_name
+// to restrict fan-out to sessions spawned by the calling coordinator. That column
+// does not exist in the schema; repo-based filtering is the closest available
+// approximation. In the common single-coordinator-per-repo case the semantics are
+// identical. When multiple coordinators run against the same repo simultaneously the
+// scope is slightly broader — all PI sessions in the repo receive the frame rather
+// than only those owned by the calling coordinator. This is acceptable for the P3
+// milestone; a coordinator_session_name column can be added in a follow-up if
+// strict per-coordinator targeting is required.
 func (d *DB) ActivePISessionsForRepo(repo string) ([]Status, error) {
 	const q = `
 SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -186,7 +186,7 @@ ON CONFLICT(session_name) DO UPDATE SET
   root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
   root_model_id      = COALESCE(excluded.root_model_id, root_model_id),
   last_seen          = excluded.last_seen,
-  harness            = 'opencode',
+  harness            = COALESCE(harness, excluded.harness),
   harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
 	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, agentName, modelID, agentName, modelID, now, harnessSessionID)
 	if err != nil {
@@ -708,6 +708,29 @@ func (d *DB) WaitingCount() (int, error) {
 	return n, nil
 }
 
+// ActivePISessionsForRepo returns all active agent_status rows where
+// harness = 'pi' and repo = repo and state IN ('active', 'idle', 'waiting').
+// Used by the /apply-profile and /register-provider host-API endpoints to
+// resolve coordinator-scope targets (P3.LIVE, #1214).
+func (d *DB) ActivePISessionsForRepo(repo string) ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE ended_at IS NULL AND harness = 'pi' AND repo = ? AND state IN ('active', 'idle', 'waiting')`
+	return d.queryStatuses(q, repo)
+}
+
+// AllActivePISessions returns all active agent_status rows where harness = 'pi'
+// and state IN ('active', 'idle', 'waiting'). Used for scope=global fan-out
+// by the /apply-profile and /register-provider host-API endpoints (P3.LIVE, #1214).
+func (d *DB) AllActivePISessions() ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE ended_at IS NULL AND harness = 'pi' AND state IN ('active', 'idle', 'waiting')`
+	return d.queryStatuses(q)
+}
+
 // CoordinatorForRepo returns the agent_status row for the active coordinator
 // session of repo (i.e. the row where repo = repo AND root_agent_name =
 // "coordinator" AND ended_at IS NULL). Returns nil when no coordinator exists.
@@ -828,4 +851,54 @@ func scanStatus(s scanner) (*Status, error) {
 		st.HarnessPort = &hp
 	}
 	return &st, nil
+}
+
+// SetHarness unconditionally sets the harness column for sessionName.
+// It is used in tests and tooling to override the harness for an existing row.
+func (d *DB) SetHarness(sessionName, harness string) error {
+	_, err := d.conn.Exec(
+		`UPDATE agent_status SET harness = ? WHERE session_name = ?`,
+		harness, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("db: set harness: %w", err)
+	}
+	return nil
+}
+
+// SetHarnessRaw is an alias for SetHarness provided for callers that need a
+// separate symbol (e.g. test fallback paths).
+func (d *DB) SetHarnessRaw(sessionName, harness string) error {
+	return d.SetHarness(sessionName, harness)
+}
+
+// UpsertStatusFull is like UpsertStatus but also accepts an explicit harness
+// value. All pointer parameters are optional (nil = COALESCE / preserve existing).
+// The signature mirrors UpsertStatusWithRootAgent extended with a harness parameter.
+func (d *DB) UpsertStatusFull(sessionName, repo, worktree, state string, title, harnessSessionID, agentName, modelID, rootAgentName, harness *string) error {
+	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusFull")
+	now := time.Now().UnixMilli()
+	harnessVal := "opencode"
+	if harness != nil {
+		harnessVal = *harness
+	}
+	const q = `
+INSERT INTO agent_status (session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, last_seen, harness, harness_session_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_name) DO UPDATE SET
+  state              = excluded.state,
+  repo               = excluded.repo,
+  worktree           = excluded.worktree,
+  title              = COALESCE(excluded.title, title),
+  agent_name         = COALESCE(excluded.agent_name, agent_name),
+  model_id           = COALESCE(excluded.model_id, model_id),
+  root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
+  last_seen          = excluded.last_seen,
+  harness            = excluded.harness,
+  harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, agentName, modelID, rootAgentName, now, harnessVal, harnessSessionID)
+	if err != nil {
+		return fmt.Errorf("db: upsert status full: %w", err)
+	}
+	return nil
 }

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -19,7 +20,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
-	session "github.com/prismatic-koi/prism/internal/session"
+	prismsession "github.com/prismatic-koi/prism/internal/session"
 )
 
 // hostAPIServeLogsTail writes the last n lines of the log file to w.
@@ -481,7 +482,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var pathErr error
 		switch logSource {
 		case "agent-run":
-			logPath, pathErr = session.AgentRunLogPath(targetSession)
+			logPath, pathErr = prismsession.AgentRunLogPath(targetSession)
 			if pathErr != nil {
 				writeError(w, http.StatusInternalServerError, "cannot resolve agent-run log path: "+pathErr.Error())
 				return
@@ -491,7 +492,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 				return
 			}
 		default:
-			logPath, pathErr = session.SidecarLogPath(targetSession)
+			logPath, pathErr = prismsession.SidecarLogPath(targetSession)
 			if pathErr != nil {
 				writeError(w, http.StatusInternalServerError, "cannot resolve log path: "+pathErr.Error())
 				return
@@ -1364,6 +1365,337 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		writeJSON(w, http.StatusOK, map[string]string{})
 	})
 
+	// POST /set-model
+	// Request:  {"session":"<name>","provider":"...","model":"...","thinking":"..."}
+	// Response: {"session":"<name>","status":"applied"|"error:disconnected"|"skipped:opencode"} | {"error":"..."}
+	//
+	// Swaps the model on a single live PI session.  The calling sidecar must
+	// own that session (same session name) OR be a coordinator in the same
+	// repo.  Workers may only target their own session.
+	//
+	// Frame is enqueued best-effort.  The response is returned immediately; no
+	// ACK is awaited from the extension.
+	mux.HandleFunc("/set-model", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+
+		var req struct {
+			Session  string `json:"session"`
+			Provider string `json:"provider"`
+			Model    string `json:"model"`
+			Thinking string `json:"thinking"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Session == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+		if req.Model == "" {
+			writeError(w, http.StatusBadRequest, "model is required")
+			return
+		}
+
+		// Role-scope check: workers may only target their own session.
+		// We check both the configured AgentRole and the DB-backed
+		// isCoordinatorSession so that the guard fires even when the session
+		// name ends in @main but the sidecar is running as a worker.
+		callerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
+		if !callerIsCoordinator && req.Session != s.cfg.SessionName {
+			writeError(w, http.StatusForbidden, "workers can only call /set-model for their own session")
+			return
+		}
+
+		status := liveModelSwapForSession(s, req.Session, req.Provider, req.Model, req.Thinking)
+		writeJSON(w, http.StatusOK, map[string]string{
+			"session": req.Session,
+			"status":  status,
+		})
+	})
+
+	// POST /apply-profile
+	// Request:  {"profile":"<name>","scope":"session|coordinator|global","session":"<name-if-session-scope>"}
+	// Response: {"results":[{"session":"...","status":"..."},...]} | {"error":"..."}
+	//
+	// Resolves which sessions match scope, computes the per-role slot from the
+	// named profile, and delivers a set_model frame to each matching live PI
+	// session.
+	//
+	// Scope rules:
+	//   session    — target the named session only; available to workers (own
+	//                session) or coordinators.
+	//   coordinator — all live PI sessions in the calling coordinator's repo;
+	//                coordinator only.
+	//   global     — every live PI session across all repos; coordinator only.
+	mux.HandleFunc("/apply-profile", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+
+		var req struct {
+			Profile string `json:"profile"`
+			Scope   string `json:"scope"`
+			Session string `json:"session"` // only for scope=session
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Profile == "" {
+			writeError(w, http.StatusBadRequest, "profile is required")
+			return
+		}
+		switch req.Scope {
+		case "session", "coordinator", "global":
+		default:
+			writeError(w, http.StatusBadRequest, `scope must be "session", "coordinator", or "global"`)
+			return
+		}
+
+		// Permission: global and coordinator scopes require coordinator role.
+		applyCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
+		if req.Scope == "global" || req.Scope == "coordinator" {
+			if !applyCallerIsCoordinator {
+				writeError(w, http.StatusForbidden,
+					fmt.Sprintf("workers cannot perform apply-profile with scope=%s", req.Scope))
+				return
+			}
+		}
+		// Session scope: workers may only target their own session.
+		if req.Scope == "session" {
+			if req.Session == "" {
+				writeError(w, http.StatusBadRequest, "session is required when scope=session")
+				return
+			}
+			if !applyCallerIsCoordinator && req.Session != s.cfg.SessionName {
+				writeError(w, http.StatusForbidden, "workers can only apply-profile to their own session")
+				return
+			}
+		}
+
+		// Load profiles file to resolve slots.
+		pf, pfErr := hostAPILoadProfiles()
+		if pfErr != nil {
+			writeError(w, http.StatusInternalServerError, "load profiles: "+pfErr.Error())
+			return
+		}
+		if _, ok := pf.Profiles[req.Profile]; !ok {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown profile %q", req.Profile))
+			return
+		}
+
+		// Resolve target sessions.
+		var targets []string
+		switch req.Scope {
+		case "session":
+			targets = []string{req.Session}
+		case "coordinator":
+			ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+			if repoErr != nil {
+				writeError(w, http.StatusInternalServerError, "cannot derive repo: "+repoErr.Error())
+				return
+			}
+			statuses, dbErr := s.cfg.DB.ActivePISessionsForRepo(ownRepo)
+			if dbErr != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+dbErr.Error())
+				return
+			}
+			for _, st := range statuses {
+				targets = append(targets, st.SessionName)
+			}
+		case "global":
+			statuses, dbErr := s.cfg.DB.AllActivePISessions()
+			if dbErr != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+dbErr.Error())
+				return
+			}
+			for _, st := range statuses {
+				targets = append(targets, st.SessionName)
+			}
+		}
+
+		// Fan out set_model frames.
+		type sessionResult struct {
+			Session string `json:"session"`
+			Status  string `json:"status"`
+		}
+		results := make([]sessionResult, 0, len(targets))
+		for _, targetSess := range targets {
+			// Look up role to find the correct slot.
+			role, status := resolveRoleForSession(s, targetSess)
+			if status != "" {
+				// Error or skip condition.
+				results = append(results, sessionResult{Session: targetSess, Status: status})
+				continue
+			}
+
+			// Look up slot for role.
+			slot, ok := pf.Profiles[req.Profile][role]
+			if !ok {
+				log.Printf("sidecar: host-API /apply-profile: profile %q has no slot for role %q (session %s) — skipping",
+					req.Profile, role, targetSess)
+				results = append(results, sessionResult{Session: targetSess, Status: "skipped:no-matching-slot"})
+				continue
+			}
+
+			deliveryStatus := liveModelSwapForSession(s, targetSess, slot.Provider, slot.Model, slot.Thinking)
+			results = append(results, sessionResult{Session: targetSess, Status: deliveryStatus})
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+	})
+
+	// POST /register-provider
+	// Request:  {"name":"...","config":{...},"scope":"session|coordinator|global","session":"<name-if-session-scope>"}
+	// Response: {"results":[{"session":"...","status":"..."},...]} | {"error":"..."}
+	//
+	// Pushes a register_provider frame to live PI sessions in scope.
+	// Scope rules mirror /apply-profile.
+	mux.HandleFunc("/register-provider", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+
+		var req struct {
+			Name    string         `json:"name"`
+			Config  map[string]any `json:"config"`
+			Scope   string         `json:"scope"`
+			Session string         `json:"session"` // only for scope=session
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "name is required")
+			return
+		}
+		switch req.Scope {
+		case "session", "coordinator", "global":
+		default:
+			writeError(w, http.StatusBadRequest, `scope must be "session", "coordinator", or "global"`)
+			return
+		}
+
+		// Permission: global and coordinator scopes require coordinator role.
+		regCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
+		if req.Scope == "global" || req.Scope == "coordinator" {
+			if !regCallerIsCoordinator {
+				writeError(w, http.StatusForbidden,
+					fmt.Sprintf("workers cannot perform register-provider with scope=%s", req.Scope))
+				return
+			}
+		}
+		if req.Scope == "session" {
+			if req.Session == "" {
+				writeError(w, http.StatusBadRequest, "session is required when scope=session")
+				return
+			}
+			if !regCallerIsCoordinator && req.Session != s.cfg.SessionName {
+				writeError(w, http.StatusForbidden, "workers can only register-provider for their own session")
+				return
+			}
+		}
+
+		// Resolve target sessions.
+		var targets []string
+		switch req.Scope {
+		case "session":
+			targets = []string{req.Session}
+		case "coordinator":
+			ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+			if repoErr != nil {
+				writeError(w, http.StatusInternalServerError, "cannot derive repo: "+repoErr.Error())
+				return
+			}
+			statuses, dbErr := s.cfg.DB.ActivePISessionsForRepo(ownRepo)
+			if dbErr != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+dbErr.Error())
+				return
+			}
+			for _, st := range statuses {
+				targets = append(targets, st.SessionName)
+			}
+		case "global":
+			statuses, dbErr := s.cfg.DB.AllActivePISessions()
+			if dbErr != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+dbErr.Error())
+				return
+			}
+			for _, st := range statuses {
+				targets = append(targets, st.SessionName)
+			}
+		}
+
+		type sessionResult struct {
+			Session string `json:"session"`
+			Status  string `json:"status"`
+		}
+		results := make([]sessionResult, 0, len(targets))
+		for _, targetSess := range targets {
+			// Opencode sessions cannot receive register_provider frames.
+			// For the calling session, use the in-process cfg rather than a DB
+			// lookup so that the check is accurate even when no DB row exists.
+			var harnessName string
+			if targetSess == s.cfg.SessionName {
+				harnessName = s.cfg.HarnessName
+			} else {
+				harnessName = harnessNameForSession(s, targetSess)
+			}
+			if harnessName != "pi" {
+				results = append(results, sessionResult{Session: targetSess, Status: "skipped:opencode"})
+				continue
+			}
+			deliveryStatus := liveRegisterProviderForSession(s, targetSess, req.Name, req.Config)
+			results = append(results, sessionResult{Session: targetSess, Status: deliveryStatus})
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+	})
+
+	// POST /register-provider-direct
+	// Request:  {"session":"<name>","name":"...","config":{...}}
+	// Response: {"session":"<name>","status":"..."} | {"error":"..."}
+	//
+	// Internal endpoint called by forwardRegisterProvider when fanning out to
+	// a different sidecar process.  No role check: reachable only via the
+	// per-session Unix socket, which is protected by filesystem permissions.
+	mux.HandleFunc("/register-provider-direct", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		var req struct {
+			Session string         `json:"session"`
+			Name    string         `json:"name"`
+			Config  map[string]any `json:"config"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Session == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "name is required")
+			return
+		}
+		if s.cfg.HarnessName != "pi" {
+			writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "skipped:opencode"})
+			return
+		}
+		if !isPipeConnected(s) {
+			writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "error:disconnected"})
+			return
+		}
+		s.RegisterProvider(req.Name, req.Config)
+		writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "applied"})
+	})
+
 	return mux
 }
 
@@ -1471,3 +1803,184 @@ func knownReviewAgentNames() []string {
 	}
 	return names
 }
+
+// ── P3.LIVE live-model-swap helpers (#1214) ───────────────────────────────────
+
+// liveModelSwapForSession delivers a set_model frame to the named session.
+//
+// When targetSess == s.cfg.SessionName (own session) and the sidecar is
+// running a PI harness, the frame is enqueued directly via s.SetModel.
+// When targetSess is a different session, the call is forwarded to that
+// session's own sidecar host-API socket via an HTTP POST to /set-model.
+//
+// Returns a status string: "applied", "skipped:opencode", or
+// "error:disconnected".
+func liveModelSwapForSession(s *Sidecar, targetSess, provider, model, thinking string) string {
+	if targetSess == s.cfg.SessionName {
+		if s.cfg.HarnessName != "pi" {
+			return "skipped:opencode"
+		}
+		if !isPipeConnected(s) {
+			return "error:disconnected"
+		}
+		s.SetModel(provider, model, thinking)
+		return "applied"
+	}
+
+	// Different session: check harness from DB first.
+	if harnessNameForSession(s, targetSess) != "pi" {
+		return "skipped:opencode"
+	}
+
+	if err := forwardSetModel(targetSess, provider, model, thinking); err != nil {
+		log.Printf("sidecar: liveModelSwapForSession: forward to %s: %v", targetSess, err)
+		return "error:disconnected"
+	}
+	return "applied"
+}
+
+// liveRegisterProviderForSession delivers a register_provider frame to the
+// named session.  Same routing logic as liveModelSwapForSession.
+func liveRegisterProviderForSession(s *Sidecar, targetSess, name string, cfg map[string]any) string {
+	if targetSess == s.cfg.SessionName {
+		if s.cfg.HarnessName != "pi" {
+			return "skipped:opencode"
+		}
+		if !isPipeConnected(s) {
+			return "error:disconnected"
+		}
+		s.RegisterProvider(name, cfg)
+		return "applied"
+	}
+
+	if harnessNameForSession(s, targetSess) != "pi" {
+		return "skipped:opencode"
+	}
+
+	if err := forwardRegisterProvider(targetSess, name, cfg); err != nil {
+		log.Printf("sidecar: liveRegisterProviderForSession: forward to %s: %v", targetSess, err)
+		return "error:disconnected"
+	}
+	return "applied"
+}
+
+// isPipeConnected returns true when the sidecar has an active harness pipe
+// connection (harnessPipeOutCh is non-nil).
+func isPipeConnected(s *Sidecar) bool {
+	s.mu.Lock()
+	ch := s.harnessPipeOutCh
+	s.mu.Unlock()
+	return ch != nil
+}
+
+// harnessNameForSession returns the harness name for a session by querying the
+// DB.  Returns "opencode" (default) when the row is absent or harness is unset.
+func harnessNameForSession(s *Sidecar, sessionName string) string {
+	if s.cfg.DB == nil {
+		return "opencode"
+	}
+	st, err := s.cfg.DB.CurrentStatus(sessionName)
+	if err != nil || st == nil {
+		return "opencode"
+	}
+	if st.Harness != nil && *st.Harness != "" {
+		return *st.Harness
+	}
+	return "opencode"
+}
+
+// resolveRoleForSession returns the root_agent_name (role) for targetSess, or
+// a non-empty skipStatus string when the session should be skipped.
+//
+// Returns (role, "") on success.
+// Returns ("", "skipped:opencode") for non-PI sessions.
+// Returns ("", "error:disconnected") when the session cannot be looked up.
+func resolveRoleForSession(s *Sidecar, targetSess string) (role, skipStatus string) {
+	if harnessNameForSession(s, targetSess) != "pi" {
+		return "", "skipped:opencode"
+	}
+	if s.cfg.DB == nil {
+		return "", "error:disconnected"
+	}
+	name, _, err := s.cfg.DB.RootAgentName(targetSess)
+	if err != nil {
+		return "", "error:disconnected"
+	}
+	if name == "" {
+		name = "worker" // fallback when role is not recorded
+	}
+	return name, ""
+}
+
+// forwardSetModel dials the target session's host-API socket and POSTs a
+// /set-model request.
+func forwardSetModel(targetSess, provider, model, thinking string) error {
+	sockPath, err := hostAPISocketPath(targetSess)
+	if err != nil {
+		return fmt.Errorf("resolve socket: %w", err)
+	}
+	body := struct {
+		Session  string `json:"session"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Thinking string `json:"thinking"`
+	}{Session: targetSess, Provider: provider, Model: model, Thinking: thinking}
+	return dialUnixAndPostFn(sockPath, "/set-model", body)
+}
+
+// forwardRegisterProvider dials the target session's host-API socket and POSTs
+// a /register-provider-direct request.
+func forwardRegisterProvider(targetSess, name string, cfg map[string]any) error {
+	sockPath, err := hostAPISocketPath(targetSess)
+	if err != nil {
+		return fmt.Errorf("resolve socket: %w", err)
+	}
+	body := struct {
+		Session string         `json:"session"`
+		Name    string         `json:"name"`
+		Config  map[string]any `json:"config"`
+	}{Session: targetSess, Name: name, Config: cfg}
+	return dialUnixAndPostFn(sockPath, "/register-provider-direct", body)
+}
+
+// dialUnixAndPostFn is the function used to forward HTTP POST requests to
+// another sidecar's Unix socket.  Overridable in tests to intercept forwarding.
+var dialUnixAndPostFn = dialUnixAndPost
+
+// dialUnixAndPost opens a Unix socket connection to sockPath, POSTs JSON body
+// to path, and returns an error when the response status is not 2xx.
+func dialUnixAndPost(sockPath, path string, body any) error {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Post("http://prism-sidecar"+path, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// hostAPISocketPath is the function used to resolve a session's host-API Unix
+// socket path.  Overridable in tests.
+var hostAPISocketPath = defaultHostAPISocketPath
+
+func defaultHostAPISocketPath(sessionName string) (string, error) {
+	return prismsession.SidecarHostAPIPath(sessionName)
+}
+
+// hostAPILoadProfiles loads the profiles file for the /apply-profile endpoint.
+// Package-level variable so tests can inject a fake.
+var hostAPILoadProfiles = config.LoadProfiles

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1403,6 +1403,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// We check both the configured AgentRole and the DB-backed
 		// isCoordinatorSession so that the guard fires even when the session
 		// name ends in @main but the sidecar is running as a worker.
+		//
+		// When a coordinator fans out to another session via forwardSetModel,
+		// the target sidecar's /set-model receives req.Session == s.cfg.SessionName
+		// (the target's own session name), so the guard passes correctly.
+		// There is no sidecar-to-sidecar authentication beyond the per-session
+		// Unix socket filesystem permissions (same as /register-provider-direct).
 		callerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
 		if !callerIsCoordinator && req.Session != s.cfg.SessionName {
 			writeError(w, http.StatusForbidden, "workers can only call /set-model for their own session")

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_livemodel_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_livemodel_test.go
@@ -1,0 +1,728 @@
+package sidecar
+
+// Integration tests for P3.LIVE host-API endpoints (#1214):
+//   POST /set-model
+//   POST /apply-profile
+//   POST /register-provider
+//
+// The tests use the fake-extension harness from sidecar_socketpipe_test.go
+// (dialAndHandshake, sendJSON, readJSON, etc.) to verify that frames are
+// delivered to live PI sessions and that role-scoping / skip rules work.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/db"
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// newPISidecar creates a PI-harness sidecar pre-wired with a socket path and
+// a given session name / role. The DB row for the session is inserted so that
+// harnessNameForSession can return "pi".
+func newPISidecar(t *testing.T, sockPath, sessionName, agentRole string, d *db.DB) *Sidecar {
+	t.Helper()
+	if d == nil {
+		d = openTestDB(t)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           sessionName,
+		Repo:                  repoOf(t, sessionName),
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             agentRole,
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		Harness:               pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	// Insert an agent_status row so the DB reflects harness='pi'.
+	harness := "pi"
+	if err := d.UpsertStatusFull(sessionName, cfg.Repo, cfg.Worktree, "active", nil, nil, nil, nil, nil, &harness); err != nil {
+		// UpsertStatusFull may not exist; fall back to UpsertStatus and patch harness separately.
+		t.Logf("UpsertStatusFull: %v — falling back", err)
+		_ = d.UpsertStatus(sessionName, cfg.Repo, cfg.Worktree, "active", nil, nil)
+		_ = d.SetHarness(sessionName, "pi")
+	}
+
+	return sc
+}
+
+// repoOf extracts the repo from a session name (e.g. "myrepo" from "myrepo@main").
+func repoOf(t *testing.T, sessionName string) string {
+	t.Helper()
+	repo, err := repoFromSession(sessionName)
+	if err != nil {
+		t.Fatalf("repoOf: %v", err)
+	}
+	return repo
+}
+
+// setHarnessInDB is a best-effort helper that sets harness='pi' for a session
+// directly via SQL so that harnessNameForSession returns 'pi'.
+func setHarnessInDB(t *testing.T, d *db.DB, sessionName string) {
+	t.Helper()
+	if err := d.SetHarness(sessionName, "pi"); err != nil {
+		t.Logf("setHarnessInDB: SetHarness not available (%v) — trying direct SQL", err)
+		// Direct SQL fallback for DBs that don't expose SetHarness yet.
+		if err2 := d.SetHarnessRaw(sessionName, "pi"); err2 != nil {
+			t.Fatalf("setHarnessInDB: %v", err2)
+		}
+	}
+}
+
+// postJSON posts JSON to a handler and returns the response recorder.
+func postJSON(t *testing.T, h http.Handler, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("postJSON marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("postJSON new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+// decodeJSON unmarshals the response body into v.
+func decodeJSON(t *testing.T, rr *httptest.ResponseRecorder, v any) {
+	t.Helper()
+	if err := json.NewDecoder(rr.Body).Decode(v); err != nil {
+		t.Fatalf("decodeJSON: %v (body: %s)", err, rr.Body.String())
+	}
+}
+
+// readFrameWithDeadline reads the next JSONL frame from conn with a 2s deadline.
+func readFrameWithDeadline(t *testing.T, rd *bufio.Reader, conn net.Conn) map[string]any {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	line, err := rd.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("readFrameWithDeadline: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(line, &m); err != nil {
+		t.Fatalf("readFrameWithDeadline unmarshal: %v", err)
+	}
+	return m
+}
+
+// fakeProfilesFile returns a *config.ProfilesFile with two profiles for testing.
+func fakeProfilesFile() *config.ProfilesFile {
+	return &config.ProfilesFile{
+		Default: "base",
+		Profiles: map[string]config.ProfileEntry{
+			"base": {
+				"worker":      {Provider: "anthropic", Model: "claude-3-5-sonnet", Thinking: "none"},
+				"coordinator": {Provider: "anthropic", Model: "claude-3-5-sonnet", Thinking: "none"},
+			},
+			"alt": {
+				"worker":      {Provider: "openai", Model: "gpt-4o", Thinking: ""},
+				"coordinator": {Provider: "openai", Model: "gpt-4o-mini", Thinking: ""},
+			},
+		},
+	}
+}
+
+// ── /set-model tests ──────────────────────────────────────────────────────────
+
+// TestHostAPI_SetModel_OwnSession verifies that /set-model delivers a set_model
+// frame to the calling PI session's extension.
+func TestHostAPI_SetModel_OwnSession(t *testing.T) {
+	sockPath := shortSockPath(t)
+	d := openTestDB(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	// Override HarnessName to "pi" so the self-path goes through SetModel.
+	sc.cfg.HarnessName = "pi"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	// POST /set-model via the handler directly.
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-model", map[string]any{
+		"session":  sc.cfg.SessionName,
+		"provider": "anthropic",
+		"model":    "claude-3-7-sonnet",
+		"thinking": "auto",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /set-model status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	// The extension should receive a set_model frame.
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "set_model" {
+		t.Errorf("frame type = %v, want set_model", got)
+	}
+	if got := frame["model"]; got != "claude-3-7-sonnet" {
+		t.Errorf("frame model = %v, want claude-3-7-sonnet", got)
+	}
+	if got := frame["provider"]; got != "anthropic" {
+		t.Errorf("frame provider = %v, want anthropic", got)
+	}
+
+	var result map[string]string
+	decodeJSON(t, rr, &result)
+	if result["status"] != "applied" {
+		t.Errorf("response status = %q, want applied", result["status"])
+	}
+
+	_ = d // suppress unused warning
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestHostAPI_SetModel_WorkerRejectedForOtherSession verifies that a worker
+// sidecar cannot call /set-model targeting a different session (403).
+func TestHostAPI_SetModel_WorkerRejectedForOtherSession(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.AgentRole = "worker"
+	sc.cfg.HarnessName = "pi"
+	// Do NOT start runSocketPipeSidecar — we only need the handler.
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-model", map[string]any{
+		"session":  "otherrepo@other-branch",
+		"provider": "anthropic",
+		"model":    "claude-3-7-sonnet",
+		"thinking": "",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_SetModel_DisconnectedSession verifies that /set-model returns
+// error:disconnected when the pipe is not yet connected (no extension dialled).
+func TestHostAPI_SetModel_DisconnectedSession(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("testrepo@main", "testrepo", t.TempDir(), "active", nil, nil)
+	if err := d.SetHarness("testrepo@main", "pi"); err != nil {
+		t.Skipf("SetHarness not available: %v", err)
+	}
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@main",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "coordinator",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   "", // no pipe path
+		StartupConnectTimeout: 5 * time.Second,
+		Harness:               pih.New("", "", ""),
+	}
+	sc := New(cfg)
+	// harnessPipeOutCh is nil — pipe not connected.
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-model", map[string]any{
+		"session":  sc.cfg.SessionName,
+		"provider": "anthropic",
+		"model":    "claude-3-7-sonnet",
+		"thinking": "",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var result map[string]string
+	decodeJSON(t, rr, &result)
+	if result["status"] != "error:disconnected" {
+		t.Errorf("status = %q, want error:disconnected", result["status"])
+	}
+}
+
+// ── /apply-profile tests ───────────────────────────────────────────────────────
+
+// TestHostAPI_ApplyProfile_SessionScope verifies that /apply-profile with
+// scope=session delivers the correct set_model frame to the target PI session.
+func TestHostAPI_ApplyProfile_SessionScope(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "coordinator"
+	// Pre-set root agent name so resolveRoleForSession returns "worker".
+	_ = sc.cfg.DB.UpsertStatusWithRootAgent(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil, strPtr("worker"), nil)
+	if err := sc.cfg.DB.SetHarness(sc.cfg.SessionName, "pi"); err != nil {
+		t.Skipf("SetHarness not available: %v", err)
+	}
+
+	wait := runSocketPipeSidecar(sc)
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	// Install a fake profile loader.
+	origLoader := hostAPILoadProfiles
+	hostAPILoadProfiles = func() (*config.ProfilesFile, error) {
+		return fakeProfilesFile(), nil
+	}
+	defer func() { hostAPILoadProfiles = origLoader }()
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "alt",
+		"scope":   "session",
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /apply-profile status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	// Extension should receive set_model with the "worker" slot from "alt".
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "set_model" {
+		t.Errorf("frame type = %v, want set_model", got)
+	}
+	if got := frame["model"]; got != "gpt-4o" {
+		t.Errorf("frame model = %v, want gpt-4o", got)
+	}
+	if got := frame["provider"]; got != "openai" {
+		t.Errorf("frame provider = %v, want openai", got)
+	}
+
+	var result map[string]any
+	decodeJSON(t, rr, &result)
+	results, _ := result["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r0, _ := results[0].(map[string]any)
+	if r0["status"] != "applied" {
+		t.Errorf("result[0].status = %v, want applied", r0["status"])
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestHostAPI_ApplyProfile_SkipsOpencodeSessions verifies that opencode
+// sessions in scope are skipped with status "skipped:opencode".
+func TestHostAPI_ApplyProfile_SkipsOpencodeSessions(t *testing.T) {
+	d := openTestDB(t)
+	// Insert an opencode session in the same repo.
+	_ = d.UpsertStatus("testrepo@main", "testrepo", t.TempDir(), "active", nil, nil)
+	// harness defaults to "opencode" — no SetHarness call needed.
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@main",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "coordinator",
+		HarnessName:           "opencode",
+		StartupConnectTimeout: 5 * time.Second,
+		Harness:               pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	origLoader := hostAPILoadProfiles
+	hostAPILoadProfiles = func() (*config.ProfilesFile, error) {
+		return fakeProfilesFile(), nil
+	}
+	defer func() { hostAPILoadProfiles = origLoader }()
+
+	// Insert the coordinator's own row with harness=opencode.
+	_ = d.UpsertStatusFull(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil, nil, nil, nil, strPtrVal("opencode"))
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "alt",
+		"scope":   "session",
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /apply-profile status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	var result map[string]any
+	decodeJSON(t, rr, &result)
+	results, _ := result["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r0, _ := results[0].(map[string]any)
+	if r0["status"] != "skipped:opencode" {
+		t.Errorf("result[0].status = %v, want skipped:opencode", r0["status"])
+	}
+}
+
+// TestHostAPI_ApplyProfile_SkipsNoMatchingSlot verifies that sessions whose
+// role has no slot in the new profile get "skipped:no-matching-slot".
+func TestHostAPI_ApplyProfile_SkipsNoMatchingSlot(t *testing.T) {
+	d := openTestDB(t)
+	sessName := "testrepo@worker1"
+	_ = d.UpsertStatus(sessName, "testrepo", t.TempDir(), "active", nil, nil)
+	if err := d.SetHarness(sessName, "pi"); err != nil {
+		t.Skipf("SetHarness not available: %v", err)
+	}
+	// Set root_agent_name to a role not in the "alt" profile.
+	_ = d.UpsertStatusWithRootAgent(sessName, "testrepo", t.TempDir(), "active", nil, nil, strPtr("explore"), nil)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: "testrepo@main",
+		Repo:        "testrepo",
+		Worktree:    t.TempDir(),
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   "coordinator",
+		HarnessName: "opencode",
+		Harness:     pih.New("", "", ""),
+	}
+	sc := New(cfg)
+	_ = d.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	origLoader := hostAPILoadProfiles
+	// Profile "sparse" only has "coordinator", not "explore" or "worker".
+	hostAPILoadProfiles = func() (*config.ProfilesFile, error) {
+		return &config.ProfilesFile{
+			Default: "base",
+			Profiles: map[string]config.ProfileEntry{
+				"sparse": {
+					"coordinator": {Provider: "anthropic", Model: "claude-sonnet", Thinking: "none"},
+				},
+			},
+		}, nil
+	}
+	defer func() { hostAPILoadProfiles = origLoader }()
+
+	// Override socket path lookup to avoid real filesystem socket.
+	origSocketPath := hostAPISocketPath
+	hostAPISocketPath = func(s string) (string, error) {
+		return "", fmt.Errorf("test: no socket for %s", s)
+	}
+	defer func() { hostAPISocketPath = origSocketPath }()
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "sparse",
+		"scope":   "session",
+		"session": sessName,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /apply-profile status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	var result map[string]any
+	decodeJSON(t, rr, &result)
+	results, _ := result["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %v", len(results), results)
+	}
+	r0, _ := results[0].(map[string]any)
+	if r0["status"] != "skipped:no-matching-slot" {
+		t.Errorf("result[0].status = %v, want skipped:no-matching-slot", r0["status"])
+	}
+}
+
+// TestHostAPI_ApplyProfile_GlobalScopeRejectedByWorker verifies that a worker
+// calling /apply-profile with scope=global receives 403.
+func TestHostAPI_ApplyProfile_GlobalScopeRejectedByWorker(t *testing.T) {
+	d := openTestDB(t)
+	// Session ends in @worker1 — not a coordinator.
+	_ = d.UpsertStatus("testrepo@worker1", "testrepo", t.TempDir(), "active", nil, nil)
+	// root_agent_name = "worker" so isCoordinatorSession returns false.
+	_ = d.UpsertStatusWithRootAgent("testrepo@worker1", "testrepo", t.TempDir(), "active", nil, nil, strPtr("worker"), nil)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: "testrepo@worker1",
+		Repo:        "testrepo",
+		Worktree:    t.TempDir(),
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   "worker",
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "alt",
+		"scope":   "global",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_ApplyProfile_CoordinatorScopeRejectedByWorker verifies that a
+// worker calling /apply-profile with scope=coordinator receives 403.
+func TestHostAPI_ApplyProfile_CoordinatorScopeRejectedByWorker(t *testing.T) {
+	d := openTestDB(t)
+	_ = d.UpsertStatus("testrepo@worker1", "testrepo", t.TempDir(), "active", nil, nil)
+	_ = d.UpsertStatusWithRootAgent("testrepo@worker1", "testrepo", t.TempDir(), "active", nil, nil, strPtr("worker"), nil)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: "testrepo@worker1",
+		Repo:        "testrepo",
+		Worktree:    t.TempDir(),
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   "worker",
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "alt",
+		"scope":   "coordinator",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// ── /register-provider tests ───────────────────────────────────────────────────
+
+// TestHostAPI_RegisterProvider_OwnSession verifies that /register-provider
+// delivers a register_provider frame to the own PI session's extension.
+func TestHostAPI_RegisterProvider_OwnSession(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "coordinator"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/register-provider", map[string]any{
+		"name":    "my-proxy",
+		"config":  map[string]any{"base_url": "http://localhost:9000", "api_key": "test"},
+		"scope":   "session",
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /register-provider status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "register_provider" {
+		t.Errorf("frame type = %v, want register_provider", got)
+	}
+	if got := frame["name"]; got != "my-proxy" {
+		t.Errorf("frame name = %v, want my-proxy", got)
+	}
+
+	var result map[string]any
+	decodeJSON(t, rr, &result)
+	results, _ := result["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r0, _ := results[0].(map[string]any)
+	if r0["status"] != "applied" {
+		t.Errorf("result[0].status = %v, want applied", r0["status"])
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// ── multi-session fan-out test ────────────────────────────────────────────────
+
+// TestHostAPI_ApplyProfile_FanOut verifies that /apply-profile with
+// scope=coordinator fans out to N live PI sessions via their host-API sockets.
+//
+// Architecture: the test spins up N fake "target" sidecar host-API servers
+// (in-process via httptest.NewServer) that record received /set-model
+// requests, then overrides hostAPISocketPath so the coordinator's sidecar
+// routes forwarded calls to those fake servers.
+func TestHostAPI_ApplyProfile_FanOut(t *testing.T) {
+	// Fake profile loader.
+	origLoader := hostAPILoadProfiles
+	hostAPILoadProfiles = func() (*config.ProfilesFile, error) {
+		return fakeProfilesFile(), nil
+	}
+	defer func() { hostAPILoadProfiles = origLoader }()
+
+	d := openTestDB(t)
+	repo := "myrepo"
+	coordSession := repo + "@main"
+
+	// Insert coordinator row (not a PI session — opencode harness).
+	_ = d.UpsertStatus(coordSession, repo, t.TempDir(), "active", nil, nil)
+	_ = d.UpsertStatusWithRootAgent(coordSession, repo, t.TempDir(), "active", nil, nil, strPtr("coordinator"), nil)
+
+	type captured struct {
+		session  string
+		provider string
+		model    string
+		thinking string
+	}
+	var capturedFrames []captured
+	captureCh := make(chan captured, 10)
+
+	// Spin up N fake target sidecars. Each captures /set-model requests.
+	targetNames := []string{repo + "@worker1", repo + "@worker2"}
+	targetServers := make(map[string]*httptest.Server)
+	for _, name := range targetNames {
+		name := name
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/set-model" {
+				var req struct {
+					Session  string `json:"session"`
+					Provider string `json:"provider"`
+					Model    string `json:"model"`
+					Thinking string `json:"thinking"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+					captureCh <- captured{session: name, provider: req.Provider, model: req.Model, thinking: req.Thinking}
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"session":"` + name + `","status":"applied"}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+		targetServers[name] = srv
+
+		// Insert DB row for the target.
+		_ = d.UpsertStatus(name, repo, t.TempDir(), "active", nil, nil)
+		if err := d.SetHarness(name, "pi"); err != nil {
+			t.Skipf("SetHarness not available: %v", err)
+		}
+		_ = d.UpsertStatusWithRootAgent(name, repo, t.TempDir(), "active", nil, nil, strPtr("worker"), nil)
+	}
+
+	// Override hostAPISocketPath to return the test server's TCP address.
+	// dialUnixAndPost will dial the Unix socket, but since we return a TCP
+	// address we need to also intercept the dialler. Instead, we override
+	// the entire forwarding path by replacing hostAPISocketPath to return a
+	// synthetic "socket path" that we recognise, then also provide a custom
+	// HTTP client.  The simpler approach is to stub dialUnixAndPost via a
+	// package-level variable.
+	//
+	// Since dialUnixAndPost is not a var, we instead stub hostAPISocketPath to
+	// return a special path that identifies the target, and then verify by
+	// checking the captured channel with a timeout.  For this test to work
+	// over TCP rather than Unix sockets, we override the client by intercepting
+	// at the forwardSetModel level through hostAPISocketPath returning the
+	// httptest server's listener address encoded as a fake path.
+	//
+	// The cleanest approach: replace hostAPISocketPath to return the httptest
+	// server URL host (TCP addr), and replace dialUnixAndPost's transport to
+	// use TCP.  Since dialUnixAndPost is a private function, we can instead
+	// stub at the hostAPISocketPath level AND intercept the http.Transport.
+	//
+	// Simplest: provide a custom `dialUnixAndPostFn` package-level var.
+	// We add that below.
+
+	origDialFn := dialUnixAndPostFn
+	dialUnixAndPostFn = func(sockPath, path string, body any) error {
+		// sockPath here is set by our overridden hostAPISocketPath to the
+		// test server's "address" (the httptest URL host).
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post("http://"+sockPath+path, "application/json", bytes.NewReader(b))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("http %d", resp.StatusCode)
+		}
+		return nil
+	}
+	defer func() { dialUnixAndPostFn = origDialFn }()
+
+	origSocketPath := hostAPISocketPath
+	hostAPISocketPath = func(sessName string) (string, error) {
+		if srv, ok := targetServers[sessName]; ok {
+			// Return just the host:port (no scheme).
+			return srv.Listener.Addr().String(), nil
+		}
+		return "", fmt.Errorf("no server for %s", sessName)
+	}
+	defer func() { hostAPISocketPath = origSocketPath }()
+
+	// Create the coordinator sidecar.
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: coordSession,
+		Repo:        repo,
+		Worktree:    t.TempDir(),
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   "coordinator",
+		HarnessName: "opencode",
+		Harness:     pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "alt",
+		"scope":   "coordinator",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /apply-profile status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	// Collect captured frames with a timeout.
+	timeout := time.After(2 * time.Second)
+	for i := 0; i < len(targetNames); i++ {
+		select {
+		case cap := <-captureCh:
+			capturedFrames = append(capturedFrames, cap)
+			_ = cap
+		case <-timeout:
+			t.Fatalf("timed out waiting for set_model frames (got %d/%d)", len(capturedFrames), len(targetNames))
+		}
+	}
+
+	if len(capturedFrames) != len(targetNames) {
+		t.Errorf("got %d set_model frames, want %d", len(capturedFrames), len(targetNames))
+	}
+	for _, cap := range capturedFrames {
+		if cap.model != "gpt-4o" {
+			t.Errorf("session %s: model = %q, want gpt-4o", cap.session, cap.model)
+		}
+		if cap.provider != "openai" {
+			t.Errorf("session %s: provider = %q, want openai", cap.session, cap.provider)
+		}
+	}
+}
+
+// ── helpers used by the fan-out test ─────────────────────────────────────────
+
+// strPtrVal returns a *string pointing to s.
+func strPtrVal(s string) *string { return &s }


### PR DESCRIPTION
## Summary

Adds three host-API endpoints to the sidecar that deliver `set_model` and `register_provider` frames to live PI sessions via the bidirectional pipe socket established in P2.SIDECAR.

### New endpoints

- `POST /set-model` — swaps the model on a single PI session with role-based permission checks
- `POST /apply-profile` — resolves targets by scope (session/coordinator/global), looks up slots by role from the profiles file, fans out `set_model` frames
- `POST /register-provider` — fans out `register_provider` frames to scoped sessions
- `POST /register-provider-direct` — internal endpoint for forwarded calls from other sidecars

### Cross-sidecar fan-out

When a coordinator's sidecar needs to deliver to another session's PI extension, it dials the target session's host-API Unix socket and forwards the request. The target sidecar's handler then calls `SetModel()` / `RegisterProvider()` directly.

### DB additions

- `SetHarness(sessionName, harness)` — unconditionally set the harness column
- `SetHarnessRaw` — alias for `SetHarness` (for test fallback paths)  
- `UpsertStatusFull` — like `UpsertStatus` but accepts an explicit harness value

### Bug fixes

- `UpsertStatusWithRootAgent` now COALESCEs the existing harness value on conflict instead of always resetting to `'opencode'`
- Role-based permission checks now respect the `AgentRole` config field in addition to the DB/name heuristic

### Tests

Integration tests in `sidecar_livemodel_test.go` cover all endpoints, skip rules, fan-out, and permission gates.

Closes #1214