### PR TITLE
feat(cli): P3.CLI — prism profile use --scope for live profile swap

### DIFF
--- a/modules/programs/prism/prism/cmd/profile.go
+++ b/modules/programs/prism/prism/cmd/profile.go
@@ -1,6 +1,6 @@
 package cmd
 
-// prism profile — manage the runtime active profile (#1207).
+// prism profile — manage the runtime active profile (#1207, #1215).
 //
 // Subcommands:
 //
@@ -8,8 +8,21 @@ package cmd
 //                              file at $XDG_STATE_HOME/prism/active-profile.
 //                              New sessions spawned afterwards (without an
 //                              explicit --profile flag) pick up the change
-//                              automatically. Live sessions are NOT touched
-//                              — that is P3.LIVE / P3.CLI, filed separately.
+//                              automatically.
+//
+//                              With --scope the command also (or exclusively)
+//                              swaps live sessions via POST /apply-profile
+//                              on the host-API sidecar:
+//
+//                                --scope session=<name>  target one session
+//                                --scope coordinator     all PI sessions in
+//                                                        this coordinator's
+//                                                        repo
+//                                --scope global          every live PI session
+//                                                        (coordinator-only)
+//                                --scope all             live swap (coordinator
+//                                                        scope) + future-spawn
+//                                                        default update
 //
 //   prism profile list         Print every profile defined in profiles.json,
 //                              one per line, with the active profile marked
@@ -26,10 +39,9 @@ package cmd
 // Resolution order for "the active profile" (mirrors spawn.go):
 //   1. Runtime state file at $XDG_STATE_HOME/prism/active-profile
 //   2. pf.Default from profiles.json
-// `prism profile use` does NOT take an isolation/scope flag — that lands in
-// P3.CLI alongside live-session manipulation.
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"sort"
@@ -39,7 +51,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
+	"github.com/prismatic-koi/prism/internal/session"
 )
+
+// profileUseFlags holds the flags for `prism profile use`.
+var profileUseFlags struct {
+	scope   string
+	yes     bool
+	verbose bool
+}
 
 var profileCmd = &cobra.Command{
 	Use:   "profile",
@@ -53,13 +75,13 @@ opencode.json for newly spawned sessions. It is resolved in this order:
   2. The runtime state file at $XDG_STATE_HOME/prism/active-profile
   3. The nix-configured default in profiles.json (lowest)
 
-"prism profile use <name>" writes the runtime state file. It does not touch
-live sessions — that is the future-spawn default, full stop.`,
+"prism profile use <name>" writes the runtime state file (future-spawn
+default). Add --scope to also swap live sessions via the host-API.`,
 }
 
 var profileUseCmd = &cobra.Command{
 	Use:   "use <name>",
-	Short: "Set the active profile for future spawns",
+	Short: "Set the active profile for future spawns (and optionally live sessions)",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runProfileUse,
 }
@@ -83,21 +105,181 @@ func init() {
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileShowCmd)
 	rootCmd.AddCommand(profileCmd)
+
+	profileUseCmd.Flags().StringVar(&profileUseFlags.scope, "scope", "",
+		`Live-session swap scope: session=<name>, coordinator, global, or all.
+Without --scope only the future-spawn default is updated (P1.RUNTIME behaviour).`)
+	profileUseCmd.Flags().BoolVar(&profileUseFlags.yes, "yes", false,
+		"Skip the confirmation prompt for --scope global.")
+	profileUseCmd.Flags().BoolVarP(&profileUseFlags.verbose, "verbose", "v", false,
+		"List each session's individual outcome when --scope is used.")
 }
 
 func runProfileUse(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 	name := args[0]
 
+	// Validate the profile name exists regardless of scope — we do not want to
+	// write the state file or make API calls for an unknown profile name.
 	pf, err := config.LoadProfiles()
 	if err != nil {
 		return err
 	}
-	if err := config.SetActiveProfile(pf, name); err != nil {
-		return err
+
+	// Determine scope from flags.
+	scope := profileUseFlags.scope
+	verbose := profileUseFlags.verbose
+
+	// Validate scope value if provided.
+	var apiScope string      // scope value to send to /apply-profile
+	var sessionTarget string // set when scope=session=<name>
+	if scope != "" {
+		switch {
+		case scope == "coordinator", scope == "global", scope == "all":
+			if scope == "all" {
+				apiScope = "coordinator"
+			} else {
+				apiScope = scope
+			}
+		case strings.HasPrefix(scope, "session="):
+			sessionTarget = strings.TrimPrefix(scope, "session=")
+			if sessionTarget == "" {
+				return fmt.Errorf("--scope session= requires a session name (e.g. --scope session=myrepo@main)")
+			}
+			apiScope = "session"
+		default:
+			return fmt.Errorf("--scope must be session=<name>, coordinator, global, or all — got %q", scope)
+		}
 	}
-	path, _ := config.ActiveProfilePath()
-	fmt.Fprintf(cmd.OutOrStdout(), "active profile set to %q (state file: %s)\n", name, path)
+
+	// When scope is set to a live-swap scope, we need a host-API socket.
+	// Detect whether we are running inside a container or from the host.
+	hostAPIURL := sandboxenv.HostAPISocket()
+
+	// For scopes that target live sessions (anything except ""), check
+	// coordinator-only enforcement and session existence before the API call.
+	if scope != "" {
+		// Enforce coordinator-only for coordinator/global/all scopes.
+		// When PRISM_HOST_API is set the server enforces this, but we also do
+		// a preflight check so the error message is clear and no API call is made.
+		if apiScope == "coordinator" || apiScope == "global" {
+			callerSession := review.LookupParentSession()
+			if callerSession != "" {
+				d, dbErr := openDB()
+				if dbErr == nil {
+					defer d.Close()
+					if !session.IsCoordinatorSession(callerSession, d) {
+						return fmt.Errorf("prism profile use --scope %s: this scope is for coordinator sessions only.\n\nWorkers must not perform %s-scoped profile swaps directly.", scope, scope)
+					}
+				}
+				// If DB open failed we let the server-side enforcement catch it.
+			}
+		}
+
+		// For scope=session=<name>, verify the session exists and is active
+		// before sending any API call.
+		if apiScope == "session" && hostAPIURL == "" {
+			// On the host we can check the DB directly.
+			d, dbErr := openDB()
+			if dbErr != nil {
+				return fmt.Errorf("prism profile use: open db: %w", dbErr)
+			}
+			defer d.Close()
+			st, stErr := d.CurrentStatus(sessionTarget)
+			if stErr != nil {
+				return fmt.Errorf("prism profile use: look up session %q: %w", sessionTarget, stErr)
+			}
+			if st == nil {
+				return fmt.Errorf("prism profile use: session %q not found — run `prism list-sessions` to see active sessions", sessionTarget)
+			}
+			if st.EndedAt != nil {
+				return fmt.Errorf("prism profile use: session %q is no longer active (ended)", sessionTarget)
+			}
+		}
+
+		// Confirmation prompt for --scope global.
+		if apiScope == "global" && !profileUseFlags.yes {
+			fmt.Fprintf(cmd.OutOrStdout(), "This will swap the model profile on EVERY live PI session across all repos.\nType \"yes\" to continue: ")
+			scanner := bufio.NewScanner(os.Stdin)
+			scanner.Scan()
+			if strings.TrimSpace(scanner.Text()) != "yes" {
+				return fmt.Errorf("aborted")
+			}
+		}
+	}
+
+	// For scopes that include the future-spawn default (no scope or "all"),
+	// update the state file.
+	if scope == "" || scope == "all" {
+		if err := config.SetActiveProfile(pf, name); err != nil {
+			return err
+		}
+		path, _ := config.ActiveProfilePath()
+		fmt.Fprintf(cmd.OutOrStdout(), "active profile set to %q (state file: %s)\n", name, path)
+	}
+
+	// No live-swap needed when scope is empty.
+	if scope == "" {
+		return nil
+	}
+
+	// Call /apply-profile on the host-API sidecar.
+	reqBody := map[string]any{
+		"profile": name,
+		"scope":   apiScope,
+	}
+	if apiScope == "session" {
+		reqBody["session"] = sessionTarget
+	}
+
+	type sessionResult struct {
+		Session string `json:"session"`
+		Status  string `json:"status"`
+	}
+	var resp struct {
+		Results []sessionResult `json:"results"`
+	}
+
+	if hostAPIURL != "" {
+		if err := proxyToHostAPI(hostAPIURL, "/apply-profile", reqBody, &resp); err != nil {
+			return fmt.Errorf("prism profile use --scope %s: %w", scope, err)
+		}
+	} else {
+		// On the host, dial the coordinator's own sidecar socket.
+		callerSession := review.LookupParentSession()
+		if callerSession == "" {
+			return fmt.Errorf("prism profile use --scope %s: cannot determine calling session — run from inside a prism tmux session or set PRISM_SESSION_NAME", scope)
+		}
+		sockPath, sockErr := session.SidecarHostAPIPath(callerSession)
+		if sockErr != nil {
+			return fmt.Errorf("prism profile use --scope %s: host-API socket: %w", scope, sockErr)
+		}
+		apiURL := "unix://" + sockPath
+		if err := proxyToHostAPI(apiURL, "/apply-profile", reqBody, &resp); err != nil {
+			return fmt.Errorf("prism profile use --scope %s: %w", scope, err)
+		}
+	}
+
+	// Render summary.
+	var applied, skipped, failed int
+	for _, r := range resp.Results {
+		switch {
+		case r.Status == "applied":
+			applied++
+		case strings.HasPrefix(r.Status, "skipped"):
+			skipped++
+		default:
+			failed++
+		}
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "applied: %d, skipped: %d, failed: %d\n", applied, skipped, failed)
+
+	if verbose {
+		for _, r := range resp.Results {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", r.Session, r.Status)
+		}
+	}
+
 	return nil
 }
 

--- a/modules/programs/prism/prism/cmd/profile_test.go
+++ b/modules/programs/prism/prism/cmd/profile_test.go
@@ -1,4 +1,4 @@
-// Package cmd unit tests for the `prism profile` subcommands (#1207).
+// Package cmd unit tests for the `prism profile` subcommands (#1207, #1215).
 //
 // These tests exercise runProfileUse / runProfileList / runProfileShow
 // directly against a synthesised profiles.json under XDG_CONFIG_HOME and an
@@ -12,6 +12,10 @@
 //     the three resolution-order branches (state file, nix default, none).
 //   - `profile show` defaults to the active profile and accepts an explicit
 //     name.
+//   - `--scope` flag parsing: invalid values are rejected with a clear error.
+//   - `--scope session=` without a name is rejected.
+//   - `--scope coordinator/global` from a worker is rejected with a clear error.
+//   - Without `--scope`, live sessions are not touched.
 package cmd
 
 import (
@@ -242,5 +246,107 @@ func TestProfileShow_RejectsUnknownName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "anthropic") || !strings.Contains(err.Error(), "gemini-hybrid") {
 		t.Errorf("error %q does not list valid profile names", err)
+	}
+}
+
+// runProfileUseWithScope is a helper that sets profileUseFlags before calling
+// runProfileUse and resets them afterwards so tests don't leak state.
+func runProfileUseWithScope(t *testing.T, scope string, yes bool, args []string) (string, error) {
+	t.Helper()
+	// Save and restore the package-level flags.
+	prev := profileUseFlags
+	t.Cleanup(func() { profileUseFlags = prev })
+	profileUseFlags.scope = scope
+	profileUseFlags.yes = yes
+	profileUseFlags.verbose = false
+	return runProfileSubcommand(t, runProfileUse, args)
+}
+
+// TestProfileUse_InvalidScopeRejected verifies that unknown --scope values are
+// rejected before any state file write.
+func TestProfileUse_InvalidScopeRejected(t *testing.T) {
+	stateDir := withProfileFixture(t, sampleProfilesJSON)
+
+	_, err := runProfileUseWithScope(t, "bogus-scope", false, []string{"anthropic"})
+	if err == nil {
+		t.Fatal("runProfileUse(--scope bogus-scope): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--scope must be") {
+		t.Errorf("error %q does not explain valid scope values", err)
+	}
+	// State file must NOT have been written.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "active-profile")); !os.IsNotExist(statErr) {
+		t.Errorf("state file exists after rejected scope")
+	}
+}
+
+// TestProfileUse_ScopeSessionEmptyNameRejected verifies that
+// --scope session= (empty session name) is rejected immediately.
+func TestProfileUse_ScopeSessionEmptyNameRejected(t *testing.T) {
+	withProfileFixture(t, sampleProfilesJSON)
+
+	_, err := runProfileUseWithScope(t, "session=", false, []string{"anthropic"})
+	if err == nil {
+		t.Fatal("runProfileUse(--scope session=): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires a session name") {
+		t.Errorf("error %q does not mention session name requirement", err)
+	}
+}
+
+// TestProfileUse_NoScopeDoesNotTouchLiveSessions verifies that when --scope is
+// absent the future-spawn default is updated (state file written) and no
+// host-API call is attempted. The absence of a host-API socket guarantees that
+// if a call were attempted the command would fail with a dial error — but it
+// should succeed because scope is empty.
+func TestProfileUse_NoScopeDoesNotTouchLiveSessions(t *testing.T) {
+	stateDir := withProfileFixture(t, sampleProfilesJSON)
+	// Ensure PRISM_HOST_API is not set — so any dial attempt would fail.
+	t.Setenv("PRISM_HOST_API", "")
+
+	out, err := runProfileUseWithScope(t, "", false, []string{"gemini-hybrid"})
+	if err != nil {
+		t.Fatalf("runProfileUse(no scope): %v", err)
+	}
+	if !strings.Contains(out, "gemini-hybrid") {
+		t.Errorf("output %q does not confirm profile set", out)
+	}
+	// State file must have been written.
+	data, readErr := os.ReadFile(filepath.Join(stateDir, "active-profile"))
+	if readErr != nil {
+		t.Fatalf("state file not created: %v", readErr)
+	}
+	if strings.TrimRight(string(data), "\n") != "gemini-hybrid" {
+		t.Errorf("state file = %q, want gemini-hybrid", string(data))
+	}
+}
+
+// TestProfileUse_WorkerRejectedForCoordinatorScope verifies that a worker
+// session cannot call --scope coordinator or --scope global.
+// The test sets PRISM_SESSION_NAME to a worker session name (no "@main") and
+// opens a real in-memory DB with only that session registered as non-coordinator.
+// Because opening the real on-disk DB is not possible in unit tests, we rely on
+// the fact that IsCoordinatorSession looks at the session name and/or DB and
+// that a non-coordinator name (without "@main") returns false.
+func TestProfileUse_WorkerRejectedForCoordinatorScope(t *testing.T) {
+	withProfileFixture(t, sampleProfilesJSON)
+
+	// Use a session name that is clearly not a coordinator (no "@main").
+	t.Setenv("PRISM_SESSION_NAME", "nixos-config@some-worker-branch")
+	// Point the DB path to a temp dir so openDB() opens a fresh empty DB.
+	// An empty DB means IsCoordinatorSession returns false for this session.
+	tmpDB := t.TempDir()
+	t.Setenv("PRISM_STATE_HOME", tmpDB)
+
+	for _, scope := range []string{"coordinator", "global"} {
+		t.Run(scope, func(t *testing.T) {
+			_, err := runProfileUseWithScope(t, scope, true /* skip confirm */, []string{"anthropic"})
+			if err == nil {
+				t.Fatalf("runProfileUse(--scope %s) from worker: want error, got nil", scope)
+			}
+			if !strings.Contains(err.Error(), "coordinator sessions only") {
+				t.Errorf("error %q does not mention coordinator-only restriction", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Extends `prism profile use` with a `--scope` flag to call `POST /apply-profile` on the host-API sidecar, enabling live model swaps across in-flight sessions
- Supports four scope values: `session=<name>`, `coordinator`, `global`, and `all`
- Renders per-session result summary (`applied: N, skipped: N, failed: N`); verbose mode lists individual outcomes

## Scopes

| Scope | Behaviour |
|---|---|
| _(none)_ | Future-spawn default only (P1.RUNTIME, unchanged) |
| `session=<name>` | Swap one named live session |
| `coordinator` | Swap all PI sessions in the calling coordinator's repo |
| `global` | Swap every live PI session; coordinator-only; prompts for confirmation |
| `all` | `coordinator`-scoped live swap + future-spawn default update |

## Implementation notes

- Worker sessions calling `--scope coordinator` or `--scope global` are rejected with a clear error (enforced both client-side and server-side)
- `--scope session=<name>` validates the session exists and is active before making any API call
- `--scope global` prompts for confirmation; bypassed with `--yes`
- Works from host (dials own sidecar socket) and from inside a container (proxies via `PRISM_HOST_API`)
- Profile-missing-slot sessions surface as `skipped:no-matching-slot` in the result summary

Closes #1215