### PR TITLE
feat(prism): P4.RETRO — prism checkin --compare and prism stats --abtest

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -27,6 +27,7 @@ package cmd
 //	checkin_legacy.go  — runCheckinSessionLegacy (screen-scrape fallback)
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -41,8 +42,12 @@ var checkinCmd = &cobra.Command{
 prism DB. Falls back to tmux screen-scrape for sessions that have no DB rows.
 
 With no argument, lists available sessions for the current repo (use --all
-for all repos).`,
-	Args: cobra.MaximumNArgs(1),
+for all repos).
+
+Use --compare <session-a> <session-b> to show a side-by-side narrative view
+of two paired A/B test sessions (they must share an abtest_pair_id). Add
+--diff to emit a text diff suitable for piping into a viewer.`,
+	Args: cobra.MaximumNArgs(2),
 	RunE: runCheckin,
 }
 
@@ -53,10 +58,23 @@ func init() {
 	checkinCmd.Flags().String("types", "", "Orthogonal event-type filter (e.g. --types audit, --types state_change). When set, routes to the raw-event path instead of the rich default view.")
 	checkinCmd.Flags().BoolP("verbose", "v", false, "Show full tool args/results without truncation (forensic mode)")
 	checkinCmd.Flags().Bool("all", false, "List all sessions across all repos (no-arg mode only)")
+	checkinCmd.Flags().Bool("compare", false, "Side-by-side comparison of two A/B test sessions (requires two session args)")
+	checkinCmd.Flags().Bool("diff", false, "Emit a text diff (use with --compare)")
 	rootCmd.AddCommand(checkinCmd)
 }
 
 func runCheckin(cmd *cobra.Command, args []string) error {
+	compare, _ := cmd.Flags().GetBool("compare")
+	diffMode, _ := cmd.Flags().GetBool("diff")
+
+	// --compare requires exactly two session arguments.
+	if compare || diffMode {
+		if len(args) != 2 {
+			return fmt.Errorf("checkin --compare requires exactly two session arguments: prism checkin --compare <session-a> <session-b>")
+		}
+		return runCheckinCompare(args[0], args[1], diffMode)
+	}
+
 	if len(args) == 0 {
 		showAll, _ := cmd.Flags().GetBool("all")
 		return runCheckinNoArg(showAll)

--- a/modules/programs/prism/prism/cmd/checkin_compare.go
+++ b/modules/programs/prism/prism/cmd/checkin_compare.go
@@ -1,0 +1,398 @@
+package cmd
+
+// checkin_compare.go — side-by-side narrative comparison of two A/B test sessions.
+//
+// Usage:
+//
+//	prism checkin --compare <session-a> <session-b>
+//	prism checkin --compare --diff <session-a> <session-b>
+//
+// The two sessions must share a common abtest_pair_id in spawn_inputs.
+// Passing two unrelated sessions (no shared pair_id) produces a clear error.
+//
+// --diff emits a unified text diff of the two narrative views suitable for
+// piping into a viewer.
+//
+// One sibling missing (cleaned up): the surviving session is shown in full
+// with a clear "sibling missing" indicator rather than erroring.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/archive"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+// runCheckinCompare implements prism checkin --compare [--diff] <sessionA> <sessionB>.
+func runCheckinCompare(sessionA, sessionB string, diffMode bool) error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("checkin --compare: %w", err)
+	}
+	defer d.Close()
+
+	// Resolve pair IDs for both sessions.
+	pairIDA, err := abtestPairIDForSession(d, sessionA)
+	if err != nil {
+		return err
+	}
+	pairIDB, err := abtestPairIDForSession(d, sessionB)
+	if err != nil {
+		return err
+	}
+
+	// Both sessions must share a pair ID.
+	if pairIDA == "" || pairIDB == "" || pairIDA != pairIDB {
+		return fmt.Errorf(
+			"checkin --compare: sessions %q and %q do not share an abtest_pair_id\n"+
+				"  Use 'prism checkin <session>' to view a single session.",
+			sessionA, sessionB,
+		)
+	}
+
+	pairID := pairIDA
+
+	// Load structured data for the pair.
+	pair, err := archive.LoadAbtestPair(d, pairID)
+	if err != nil {
+		return fmt.Errorf("checkin --compare: %w", err)
+	}
+
+	if diffMode {
+		return renderCheckinCompareDiff(d, pair, sessionA, sessionB)
+	}
+	return renderCheckinCompareSideBySide(d, pair, sessionA, sessionB)
+}
+
+// abtestPairIDForSession looks up the abtest_pair_id for a session by name,
+// querying spawn_inputs via the sessions table. Returns "" when the session
+// has no abtest_pair_id.
+func abtestPairIDForSession(d *db.DB, sessionName string) (string, error) {
+	// Look up the most recent sessions row for this name.
+	sess, err := d.MostRecentSessionForName(sessionName)
+	if err != nil {
+		return "", fmt.Errorf("checkin --compare: lookup session %q: %w", sessionName, err)
+	}
+	if sess == nil {
+		// Try all historical sessions — the session may be ended.
+		sessions, err := d.SessionsByName(sessionName)
+		if err != nil {
+			return "", fmt.Errorf("checkin --compare: lookup session %q: %w", sessionName, err)
+		}
+		if len(sessions) == 0 {
+			return "", fmt.Errorf("checkin --compare: session %q not found", sessionName)
+		}
+		sess = &sessions[0]
+	}
+	si, err := d.SpawnInputsByInstanceID(sess.InstanceID)
+	if err != nil {
+		return "", fmt.Errorf("checkin --compare: spawn_inputs for %q: %w", sessionName, err)
+	}
+	if si == nil || si.AbtestPairID == nil {
+		return "", nil
+	}
+	return *si.AbtestPairID, nil
+}
+
+// extractAssistantText parses a msg_assistant payload and returns the text field.
+func extractAssistantText(rawPayload string) string {
+	var ap payload.MsgAssistant
+	if err := json.Unmarshal([]byte(rawPayload), &ap); err == nil {
+		return ap.Text
+	}
+	return ""
+}
+
+// buildNarrativeLines returns the checkin narrative for a session as a slice
+// of lines (without ANSI codes) suitable for text comparison.
+func buildNarrativeLines(d *db.DB, sessionName string) []string {
+	assistantEvents, err := d.QueryEvents(sessionName, 100, nil, nil, []string{"msg_assistant"})
+	if err != nil || len(assistantEvents) == 0 {
+		return []string{fmt.Sprintf("[no events for session %s]", sessionName)}
+	}
+
+	var lines []string
+	lines = append(lines, fmt.Sprintf("=== %s ===", sessionName))
+
+	status, _ := d.CurrentStatus(sessionName)
+	state := "unknown"
+	if status != nil {
+		state = status.State
+	}
+	lines = append(lines, fmt.Sprintf("state: %s", state))
+	lines = append(lines, "")
+
+	for i, ae := range assistantEvents {
+		ts := ae.CreatedAt.Local().Format("15:04:05")
+		lines = append(lines, fmt.Sprintf("[%s] assistant turn %d", ts, i+1))
+		text := extractAssistantText(ae.Payload)
+		if text == "" {
+			text = "(no text)"
+		}
+		// Wrap long lines for better diff output.
+		for _, l := range strings.Split(text, "\n") {
+			lines = append(lines, l)
+		}
+		lines = append(lines, "")
+	}
+	lines = append(lines, "── end of event log ──")
+	return lines
+}
+
+// renderCheckinCompareSideBySide prints a side-by-side view of the two sessions.
+func renderCheckinCompareSideBySide(d *db.DB, pair *archive.AbtestPair, sessionA, sessionB string) error {
+	fmt.Printf("abtest compare: pair %s\n\n", pair.PairID)
+
+	// Show sibling-missing warnings.
+	if pair.MissingA {
+		fmt.Printf("⚠  session A: sibling missing (cleaned up)\n\n")
+	}
+	if pair.MissingB {
+		fmt.Printf("⚠  session B: sibling missing (cleaned up)\n\n")
+	}
+
+	// Header line showing the two sessions.
+	labelA := sessionA
+	labelB := sessionB
+	if pair.SessionA != nil {
+		labelA = pair.SessionA.SessionName
+	}
+	if pair.SessionB != nil {
+		labelB = pair.SessionB.SessionName
+	}
+
+	// Print session A's narrative.
+	fmt.Printf("──────────────────────────────────────────────────────────────────\n")
+	fmt.Printf("SESSION A: %s\n", labelA)
+	fmt.Printf("──────────────────────────────────────────────────────────────────\n")
+	if pair.MissingA {
+		fmt.Println("[sibling missing — session was cleaned up before comparison]")
+	} else {
+		linesA := buildNarrativeLines(d, labelA)
+		for _, l := range linesA {
+			fmt.Println(l)
+		}
+	}
+
+	fmt.Println()
+
+	// Print session B's narrative.
+	fmt.Printf("──────────────────────────────────────────────────────────────────\n")
+	fmt.Printf("SESSION B: %s\n", labelB)
+	fmt.Printf("──────────────────────────────────────────────────────────────────\n")
+	if pair.MissingB {
+		fmt.Println("[sibling missing — session was cleaned up before comparison]")
+	} else {
+		linesB := buildNarrativeLines(d, labelB)
+		for _, l := range linesB {
+			fmt.Println(l)
+		}
+	}
+
+	// Summary metrics footer.
+	fmt.Printf("\n──────────────────────────────────────────────────────────────────\n")
+	fmt.Println("SUMMARY METRICS")
+	fmt.Printf("──────────────────────────────────────────────────────────────────\n")
+	printAbtestSessionMetrics("A", labelA, pair.OutcomeA)
+	printAbtestSessionMetrics("B", labelB, pair.OutcomeB)
+
+	return nil
+}
+
+// renderCheckinCompareDiff emits a unified diff of the two session narratives.
+func renderCheckinCompareDiff(d *db.DB, pair *archive.AbtestPair, sessionA, sessionB string) error {
+	labelA := sessionA
+	labelB := sessionB
+	if pair.SessionA != nil {
+		labelA = pair.SessionA.SessionName
+	}
+	if pair.SessionB != nil {
+		labelB = pair.SessionB.SessionName
+	}
+
+	var linesA, linesB []string
+	if pair.MissingA {
+		linesA = []string{"[sibling missing — session was cleaned up before comparison]"}
+	} else {
+		linesA = buildNarrativeLines(d, labelA)
+	}
+	if pair.MissingB {
+		linesB = []string{"[sibling missing — session was cleaned up before comparison]"}
+	} else {
+		linesB = buildNarrativeLines(d, labelB)
+	}
+
+	// Emit a simple unified diff.
+	fmt.Printf("--- a/%s\n", labelA)
+	fmt.Printf("+++ b/%s\n", labelB)
+	fmt.Println(unifiedDiff(linesA, linesB, 3))
+	return nil
+}
+
+// printAbtestSessionMetrics prints a summary line for one session.
+func printAbtestSessionMetrics(slot, sessionName string, outcome *db.SpawnOutcome) {
+	if outcome == nil {
+		fmt.Printf("  %s  %-50s  (no metrics)\n", slot, sessionName)
+		return
+	}
+	endState := "—"
+	if outcome.EndState != nil {
+		endState = *outcome.EndState
+	}
+	durStr := "—"
+	if outcome.DurationMs != nil {
+		dur := *outcome.DurationMs
+		mins := dur / 60000
+		secs := (dur % 60000) / 1000
+		if mins > 0 {
+			durStr = fmt.Sprintf("%dm%ds", mins, secs)
+		} else {
+			durStr = fmt.Sprintf("%ds", secs)
+		}
+	}
+	tokIn := outcome.TokensInputTotal
+	tokOut := outcome.TokensOutputTotal
+	turns := outcome.MsgAssistantCount
+
+	fmt.Printf("  %s  %-40s  state=%-12s  turns=%-4d  in=%-8d  out=%-8d  dur=%s\n",
+		slot, sessionName, endState, turns, tokIn, tokOut, durStr)
+}
+
+// diffEdit is a single edit operation in a diff: keep (' '), remove ('-'), or add ('+').
+type diffEdit struct {
+	op   rune
+	line string
+}
+
+// unifiedDiff produces a simple unified-diff string from two slices of lines.
+// context is the number of unchanged context lines to show around changes.
+func unifiedDiff(a, b []string, context int) string {
+	edits := myersDiff(a, b)
+
+	var sb strings.Builder
+	type hunk struct {
+		aStart, aLen int
+		bStart, bLen int
+		lines        []diffEdit
+	}
+
+	// Group edits into hunks with context lines.
+	var hunks []hunk
+	var current *hunk
+	aIdx, bIdx := 0, 0
+	pendingCtx := 0
+
+	for i, e := range edits {
+		switch e.op {
+		case ' ':
+			if current != nil {
+				if pendingCtx < context {
+					current.lines = append(current.lines, e)
+					current.aLen++
+					current.bLen++
+					pendingCtx++
+				} else {
+					// Check if there are more changes nearby.
+					hasMoreChanges := false
+					for j := i + 1; j < len(edits) && j < i+context+1; j++ {
+						if edits[j].op != ' ' {
+							hasMoreChanges = true
+							break
+						}
+					}
+					if !hasMoreChanges {
+						hunks = append(hunks, *current)
+						current = nil
+						pendingCtx = 0
+					} else {
+						current.lines = append(current.lines, e)
+						current.aLen++
+						current.bLen++
+					}
+				}
+			}
+			aIdx++
+			bIdx++
+		case '-':
+			if current == nil {
+				current = &hunk{aStart: aIdx + 1, bStart: bIdx + 1}
+			}
+			current.lines = append(current.lines, e)
+			current.aLen++
+			pendingCtx = 0
+			aIdx++
+		case '+':
+			if current == nil {
+				current = &hunk{aStart: aIdx + 1, bStart: bIdx + 1}
+			}
+			current.lines = append(current.lines, e)
+			current.bLen++
+			pendingCtx = 0
+			bIdx++
+		}
+	}
+	if current != nil {
+		hunks = append(hunks, *current)
+	}
+
+	for _, h := range hunks {
+		fmt.Fprintf(&sb, "@@ -%d,%d +%d,%d @@\n", h.aStart, h.aLen, h.bStart, h.bLen)
+		for _, e := range h.lines {
+			fmt.Fprintf(&sb, "%c%s\n", e.op, e.line)
+		}
+	}
+	if sb.Len() == 0 {
+		return "(no differences)"
+	}
+	return sb.String()
+}
+
+// myersDiff returns an edit script (sequence of keep/add/remove operations)
+// that transforms slice a into slice b using a simple LCS-based approach.
+func myersDiff(a, b []string) []diffEdit {
+	// Build DP table for LCS.
+	m, n := len(a), len(b)
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := m - 1; i >= 0; i-- {
+		for j := n - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else {
+				if dp[i+1][j] > dp[i][j+1] {
+					dp[i][j] = dp[i+1][j]
+				} else {
+					dp[i][j] = dp[i][j+1]
+				}
+			}
+		}
+	}
+	// Traceback.
+	var edits []diffEdit
+	i, j := 0, 0
+	for i < m && j < n {
+		if a[i] == b[j] {
+			edits = append(edits, diffEdit{' ', a[i]})
+			i++
+			j++
+		} else if dp[i+1][j] >= dp[i][j+1] {
+			edits = append(edits, diffEdit{'-', a[i]})
+			i++
+		} else {
+			edits = append(edits, diffEdit{'+', b[j]})
+			j++
+		}
+	}
+	for ; i < m; i++ {
+		edits = append(edits, diffEdit{'-', a[i]})
+	}
+	for ; j < n; j++ {
+		edits = append(edits, diffEdit{'+', b[j]})
+	}
+	return edits
+}

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -102,6 +102,7 @@ func init() {
 	statsCmd.Flags().String("since", "", "Filter rows to those started on or after this date (ISO 8601 or YYYY-MM-DD)")
 	statsCmd.Flags().Bool("instance", false, "Treat the argument as a full instance_id (UUID) even if it might match a session name")
 	statsCmd.Flags().String("group-by", "", "Render a breakdown table grouped by this axis: harness, profile, variant, model")
+	statsCmd.Flags().Bool("abtest", false, "List all A/B test pairs with summary metrics")
 	rootCmd.AddCommand(statsCmd)
 }
 
@@ -137,10 +138,16 @@ func runStats(cmd *cobra.Command, args []string) error {
 	doomloops, _ := cmd.Flags().GetBool("doomloops")
 	denials, _ := cmd.Flags().GetBool("denials")
 	asks, _ := cmd.Flags().GetBool("asks")
+	abtest, _ := cmd.Flags().GetBool("abtest")
 	repoFilter, _ := cmd.Flags().GetString("repo")
 	sinceStr, _ := cmd.Flags().GetString("since")
 	forceInstance, _ := cmd.Flags().GetBool("instance")
 	groupBy, _ := cmd.Flags().GetString("group-by")
+
+	// --abtest: list all A/B test pairs with summary metrics.
+	if abtest {
+		return runStatsAbtestFlag()
+	}
 
 	// Validate --group-by early so we fail fast on bad input.
 	if groupBy != "" {

--- a/modules/programs/prism/prism/cmd/stats_abtest.go
+++ b/modules/programs/prism/prism/cmd/stats_abtest.go
@@ -1,0 +1,154 @@
+package cmd
+
+// stats_abtest.go — prism stats --abtest listing of all abtest pairs.
+//
+// Shows one row per abtest pair with summary metrics:
+//   - Profile A vs Profile B (from spawn_inputs)
+//   - Token usage per session
+//   - Wall time per session
+//   - Turn count per session
+//   - Outcome (both finished, one errored, one still running, etc.)
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// runStatsAbtestFlag implements prism stats --abtest (the --abtest top-level flag,
+// distinct from `prism stats abtest <group_id>` which is runStatsAbtest in stats_compare.go).
+func runStatsAbtestFlag() error {
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("stats --abtest: %w", err)
+	}
+	defer d.Close()
+
+	pairs, err := d.AbtestPairsAll()
+	if err != nil {
+		return fmt.Errorf("stats --abtest: %w", err)
+	}
+
+	if len(pairs) == 0 {
+		fmt.Println("no abtest pairs recorded")
+		fmt.Println("  Use 'prism spawn --abtest <profileA> <profileB> --prompt \"...\"' to create a pair.")
+		return nil
+	}
+
+	renderAbtestPairsTable(pairs)
+	return nil
+}
+
+// renderAbtestPairsTable renders the abtest pairs table to stdout.
+func renderAbtestPairsTable(pairs []db.AbtestPairRow) {
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	styleBold := lipgloss.NewStyle().Bold(true)
+
+	fmt.Println(styleBold.Render("A/B Test Pairs"))
+	fmt.Println()
+
+	const (
+		wPairID   = 12
+		wSession  = 36
+		wProfile  = 16
+		wTurns    = 6
+		wTokIn    = 9
+		wTokOut   = 9
+		wDur      = 9
+		wState    = 12
+	)
+
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s  %-*s",
+		wPairID, "PAIR",
+		wSession, "SESSION",
+		wProfile, "PROFILE",
+		wTurns, "TURNS",
+		wTokIn, "TOK-IN",
+		wTokOut, "TOK-OUT",
+		wDur, "DURATION",
+		wState, "STATE",
+	)
+	fmt.Println(styleHeader.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header))))
+
+	for _, p := range pairs {
+		pairShort := p.PairID
+		if len(pairShort) > wPairID {
+			pairShort = pairShort[:wPairID]
+		}
+
+		// Print two rows per pair (A then B).
+		printAbtestPairRow(pairShort, p.SessionNameA, p.ProfileA, p.TurnsA, p.TokensInputA, p.TokensOutputA, p.DurationMsA, p.EndStateA, wPairID, wSession, wProfile, wTurns, wTokIn, wTokOut, wDur, wState)
+		if p.SessionNameB != "" {
+			printAbtestPairRow("↳", p.SessionNameB, p.ProfileB, p.TurnsB, p.TokensInputB, p.TokensOutputB, p.DurationMsB, p.EndStateB, wPairID, wSession, wProfile, wTurns, wTokIn, wTokOut, wDur, wState)
+		} else {
+			fmt.Printf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s  %-*s\n",
+				wPairID, "↳",
+				wSession, "(sibling missing)",
+				wProfile, "—",
+				wTurns, "—",
+				wTokIn, "—",
+				wTokOut, "—",
+				wDur, "—",
+				wState, "—",
+			)
+		}
+		fmt.Println()
+	}
+}
+
+func printAbtestPairRow(label, sessionName, profile string, turns *int, tokIn, tokOut, durMs *int64, endState *string, wPairID, wSession, wProfile, wTurns, wTokIn, wTokOut, wDur, wState int) {
+	sessName := sessionName
+	if len(sessName) > wSession {
+		sessName = sessName[:wSession-3] + "..."
+	}
+
+	prof := profile
+	if prof == "" {
+		prof = "(none)"
+	}
+	if len(prof) > wProfile {
+		prof = prof[:wProfile-3] + "..."
+	}
+
+	turnsStr := "—"
+	if turns != nil {
+		turnsStr = fmt.Sprintf("%d", *turns)
+	}
+
+	tokInStr := "—"
+	if tokIn != nil && *tokIn > 0 {
+		tokInStr = formatTokenCount(int(*tokIn))
+	}
+	tokOutStr := "—"
+	if tokOut != nil && *tokOut > 0 {
+		tokOutStr = formatTokenCount(int(*tokOut))
+	}
+
+	durStr := "—"
+	if durMs != nil && *durMs > 0 {
+		d := time.Duration(*durMs) * time.Millisecond
+		durStr = formatDurationLong(d)
+	}
+
+	stateStr := "—"
+	if endState != nil && *endState != "" {
+		stateStr = *endState
+	}
+
+	fmt.Printf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s  %-*s\n",
+		wPairID, label,
+		wSession, sessName,
+		wProfile, prof,
+		wTurns, turnsStr,
+		wTokIn, tokInStr,
+		wTokOut, tokOutStr,
+		wDur, durStr,
+		wState, stateStr,
+	)
+}

--- a/modules/programs/prism/prism/internal/archive/abtest.go
+++ b/modules/programs/prism/prism/internal/archive/abtest.go
@@ -1,0 +1,84 @@
+package archive
+
+// abtest.go — programmatic A/B test pair loading for downstream tooling.
+//
+// LoadAbtestPair returns structured data for both sibling sessions of an A/B
+// test pair identified by its shared abtest_pair_id. This is the primary API
+// for downstream tooling (retro agent, dashboard) that needs to compare the
+// two sessions without needing to know about the underlying DB schema.
+//
+// The caller is responsible for opening and closing the DB. This function is
+// intentionally stateless — it does not perform any I/O beyond the DB query.
+
+import (
+	"fmt"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// AbtestPair holds the structured data for both sibling sessions of an
+// abtest pair. Either SessionA or SessionB may reflect a missing sibling
+// (MissingA / MissingB flags set) when one session was cleaned up before
+// the pair data could be read.
+type AbtestPair struct {
+	PairID string
+
+	// Sessions are ordered by started_at ASC: A is the earlier-spawned session.
+	SessionA *db.Session
+	SessionB *db.Session
+
+	// SpawnInputs for each sibling (nil when spawn_inputs row is missing).
+	InputsA *db.SpawnInputs
+	InputsB *db.SpawnInputs
+
+	// SpawnOutcome for each sibling (nil when outcome not yet computed or missing).
+	OutcomeA *db.SpawnOutcome
+	OutcomeB *db.SpawnOutcome
+
+	// MissingA / MissingB are set when the corresponding sibling session row
+	// could not be found (cleaned up or never created). When set, the
+	// corresponding Session / Inputs / Outcome fields are nil.
+	MissingA bool
+	MissingB bool
+}
+
+// LoadAbtestPair returns an AbtestPair for the given pairID from the DB.
+//
+// The pair is looked up by querying spawn_inputs for sessions with
+// abtest_pair_id = pairID, joined to sessions, spawn_inputs, and spawn_outcome.
+// Sessions are ordered by started_at ASC: index 0 is SessionA, index 1 is
+// SessionB.
+//
+// When only one sibling is found (the other was cleaned up), the surviving
+// sibling is returned in SessionA and MissingB is set to true.
+//
+// When pairID is not found at all, a non-nil error is returned.
+func LoadAbtestPair(d *db.DB, pairID string) (*AbtestPair, error) {
+	sessions, err := d.SessionsByAbtestPairID(pairID)
+	if err != nil {
+		return nil, fmt.Errorf("archive: LoadAbtestPair %q: %w", pairID, err)
+	}
+	if len(sessions) == 0 {
+		return nil, fmt.Errorf("archive: LoadAbtestPair %q: pair not found", pairID)
+	}
+
+	pair := &AbtestPair{PairID: pairID}
+
+	// Populate SessionA.
+	sA := sessions[0]
+	pair.SessionA = &sA
+	pair.InputsA, _ = d.SpawnInputsByInstanceID(sA.InstanceID)
+	pair.OutcomeA, _ = d.SpawnOutcomeByInstanceID(sA.InstanceID)
+
+	// Populate SessionB if present.
+	if len(sessions) >= 2 {
+		sB := sessions[1]
+		pair.SessionB = &sB
+		pair.InputsB, _ = d.SpawnInputsByInstanceID(sB.InstanceID)
+		pair.OutcomeB, _ = d.SpawnOutcomeByInstanceID(sB.InstanceID)
+	} else {
+		pair.MissingB = true
+	}
+
+	return pair, nil
+}

--- a/modules/programs/prism/prism/internal/archive/abtest_test.go
+++ b/modules/programs/prism/prism/internal/archive/abtest_test.go
@@ -1,0 +1,135 @@
+package archive_test
+
+// abtest_test.go — tests for LoadAbtestPair.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/archive"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// openTestDBForArchive opens an in-memory DB for archive tests.
+// It mirrors the pattern used in the db package test helpers.
+func openTestDBForArchive(t *testing.T) *db.DB {
+	t.Helper()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func strPtrArchive(s string) *string { return &s }
+
+func insertMinimalSession(t *testing.T, d *db.DB, sessionName, iid, pairID, profile string, startedAt time.Time) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, "repo", "/wt/"+sessionName, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	sess := db.Session{
+		InstanceID:  iid,
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		Harness:     "opencode",
+		StartedAt:   startedAt,
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	si := db.SpawnInputs{
+		InstanceID:   iid,
+		AbtestPairID: strPtrArchive(pairID),
+		CreatedAt:    startedAt.UnixMilli(),
+	}
+	if profile != "" {
+		si.ProfileName = strPtrArchive(profile)
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+	}
+}
+
+// TestLoadAbtestPair_BothPresent verifies that LoadAbtestPair returns both
+// siblings when both are present in the DB.
+func TestLoadAbtestPair_BothPresent(t *testing.T) {
+	d := openTestDBForArchive(t)
+
+	const pairID = "load-abtest-pair-both-present"
+	now := time.Now()
+	iidA := uuid.New().String()
+	iidB := uuid.New().String()
+
+	insertMinimalSession(t, d, "repo@branch-A", iidA, pairID, "profileA", now.Add(-2*time.Second))
+	insertMinimalSession(t, d, "repo@branch-B", iidB, pairID, "profileB", now.Add(-1*time.Second))
+
+	pair, err := archive.LoadAbtestPair(d, pairID)
+	if err != nil {
+		t.Fatalf("LoadAbtestPair: %v", err)
+	}
+	if pair.PairID != pairID {
+		t.Errorf("PairID = %q, want %q", pair.PairID, pairID)
+	}
+	if pair.MissingA {
+		t.Error("MissingA should be false when session A is present")
+	}
+	if pair.MissingB {
+		t.Error("MissingB should be false when session B is present")
+	}
+	if pair.SessionA == nil {
+		t.Fatal("SessionA is nil")
+	}
+	if pair.SessionB == nil {
+		t.Fatal("SessionB is nil")
+	}
+	if pair.SessionA.SessionName != "repo@branch-A" {
+		t.Errorf("SessionA.SessionName = %q, want repo@branch-A", pair.SessionA.SessionName)
+	}
+	if pair.SessionB.SessionName != "repo@branch-B" {
+		t.Errorf("SessionB.SessionName = %q, want repo@branch-B", pair.SessionB.SessionName)
+	}
+	if pair.InputsA == nil || pair.InputsA.AbtestPairID == nil || *pair.InputsA.AbtestPairID != pairID {
+		t.Errorf("InputsA.AbtestPairID = %v, want %q", pair.InputsA, pairID)
+	}
+}
+
+// TestLoadAbtestPair_OneSibling verifies that LoadAbtestPair handles the case
+// where only one sibling exists (the other was cleaned up). MissingB is set.
+func TestLoadAbtestPair_OneSibling(t *testing.T) {
+	d := openTestDBForArchive(t)
+
+	const pairID = "load-abtest-pair-one-sibling"
+	iidA := uuid.New().String()
+
+	insertMinimalSession(t, d, "repo@branch-A-only", iidA, pairID, "", time.Now())
+	// Note: no session B inserted.
+
+	pair, err := archive.LoadAbtestPair(d, pairID)
+	if err != nil {
+		t.Fatalf("LoadAbtestPair: %v", err)
+	}
+	if pair.SessionA == nil {
+		t.Fatal("SessionA is nil")
+	}
+	if !pair.MissingB {
+		t.Error("MissingB should be true when session B is absent")
+	}
+	if pair.SessionB != nil {
+		t.Errorf("SessionB should be nil when B is missing, got %+v", pair.SessionB)
+	}
+}
+
+// TestLoadAbtestPair_NotFound verifies that LoadAbtestPair returns an error
+// when the pairID does not exist.
+func TestLoadAbtestPair_NotFound(t *testing.T) {
+	d := openTestDBForArchive(t)
+
+	_, err := archive.LoadAbtestPair(d, "no-such-pair-id")
+	if err == nil {
+		t.Error("expected error for non-existent pair, got nil")
+	}
+}

--- a/modules/programs/prism/prism/internal/db/abtest_test.go
+++ b/modules/programs/prism/prism/internal/db/abtest_test.go
@@ -1,0 +1,187 @@
+package db_test
+
+// abtest_test.go — tests for SessionsByAbtestPairID, AbtestPairsAll,
+// and SpawnInputsByInstanceID.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// insertAbtestSessionForTest inserts the minimal set of rows needed by the
+// abtest query surface:
+//   - agent_status (for AbtestPairsForSessions compatibility)
+//   - sessions
+//   - spawn_inputs (with optional abtest_pair_id and profile_name)
+func insertAbtestSessionForTest(t *testing.T, d *db.DB, sessionName, iid, pairIDVal, profile string, startedAt time.Time) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, "repo", "/wt/"+sessionName, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	sess := db.Session{
+		InstanceID:  iid,
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		Harness:     "opencode",
+		StartedAt:   startedAt,
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	si := db.SpawnInputs{
+		InstanceID: iid,
+		CreatedAt:  startedAt.UnixMilli(),
+	}
+	if pairIDVal != "" {
+		si.AbtestPairID = strPtr(pairIDVal)
+	}
+	if profile != "" {
+		si.ProfileName = strPtr(profile)
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+	}
+}
+
+// TestSessionsByAbtestPairID verifies that SessionsByAbtestPairID returns only
+// the sessions sharing the given abtest_pair_id, in started_at ASC order.
+func TestSessionsByAbtestPairID(t *testing.T) {
+	d := openTestDB(t)
+
+	const pairID = "test-pair-1111-2222-3333-444444444444"
+	const otherPairID = "other-pair-5555-6666-7777-888888888888"
+
+	now := time.Now()
+	iidA := uuid.New().String()
+	iidB := uuid.New().String()
+	iidOther := uuid.New().String()
+
+	insertAbtestSessionForTest(t, d, "repo@branch-A", iidA, pairID, "", now.Add(-2*time.Second))
+	insertAbtestSessionForTest(t, d, "repo@branch-B", iidB, pairID, "", now.Add(-1*time.Second))
+	insertAbtestSessionForTest(t, d, "repo@branch-other", iidOther, otherPairID, "", now)
+
+	sessions, err := d.SessionsByAbtestPairID(pairID)
+	if err != nil {
+		t.Fatalf("SessionsByAbtestPairID: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+	if sessions[0].SessionName != "repo@branch-A" {
+		t.Errorf("sessions[0] = %q, want repo@branch-A", sessions[0].SessionName)
+	}
+	if sessions[1].SessionName != "repo@branch-B" {
+		t.Errorf("sessions[1] = %q, want repo@branch-B", sessions[1].SessionName)
+	}
+
+	// Non-existent pair — should return empty slice, not error.
+	none, err := d.SessionsByAbtestPairID("no-such-pair")
+	if err != nil {
+		t.Fatalf("SessionsByAbtestPairID(none): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("got %d sessions for non-existent pair, want 0", len(none))
+	}
+}
+
+// TestAbtestPairsAll verifies the aggregated pair listing with metrics.
+func TestAbtestPairsAll(t *testing.T) {
+	d := openTestDB(t)
+
+	const pairID = "pairs-all-test-aaaa-bbbb-cccc-dddddddddddd"
+	now := time.Now()
+	iidA := uuid.New().String()
+	iidB := uuid.New().String()
+
+	insertAbtestSessionForTest(t, d, "r@a-profileA", iidA, pairID, "profileA", now.Add(-2*time.Second))
+	insertAbtestSessionForTest(t, d, "r@a-profileB", iidB, pairID, "profileB", now.Add(-1*time.Second))
+
+	pairs, err := d.AbtestPairsAll()
+	if err != nil {
+		t.Fatalf("AbtestPairsAll: %v", err)
+	}
+
+	var found *db.AbtestPairRow
+	for i := range pairs {
+		if pairs[i].PairID == pairID {
+			found = &pairs[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("pair %q not found in AbtestPairsAll results", pairID)
+	}
+	if found.SessionNameA != "r@a-profileA" {
+		t.Errorf("SessionNameA = %q, want r@a-profileA", found.SessionNameA)
+	}
+	if found.SessionNameB != "r@a-profileB" {
+		t.Errorf("SessionNameB = %q, want r@a-profileB", found.SessionNameB)
+	}
+	if found.ProfileA != "profileA" {
+		t.Errorf("ProfileA = %q, want profileA", found.ProfileA)
+	}
+	if found.ProfileB != "profileB" {
+		t.Errorf("ProfileB = %q, want profileB", found.ProfileB)
+	}
+}
+
+// TestSpawnInputsByInstanceID verifies that SpawnInputsByInstanceID returns the
+// correct row and nil for unknown instance IDs.
+func TestSpawnInputsByInstanceID(t *testing.T) {
+	d := openTestDB(t)
+
+	iid := uuid.New().String()
+	const pairID = "spawn-inputs-test-pair-id"
+	const profile = "test-profile"
+
+	if err := d.UpsertStatus("r@si-test", "r", "/wt/si-test", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	sess := db.Session{
+		InstanceID:  iid,
+		SessionName: "r@si-test",
+		Repo:        "r",
+		Worktree:    "/wt/si-test",
+		Harness:     "opencode",
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	si := db.SpawnInputs{
+		InstanceID:   iid,
+		AbtestPairID: strPtr(pairID),
+		ProfileName:  strPtr(profile),
+		CreatedAt:    time.Now().UnixMilli(),
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(iid)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want non-nil SpawnInputs")
+	}
+	if got.AbtestPairID == nil || *got.AbtestPairID != pairID {
+		t.Errorf("AbtestPairID = %v, want %q", got.AbtestPairID, pairID)
+	}
+	if got.ProfileName == nil || *got.ProfileName != profile {
+		t.Errorf("ProfileName = %v, want %q", got.ProfileName, profile)
+	}
+
+	// Missing.
+	missing, err := d.SpawnInputsByInstanceID("non-existent-iid")
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID(missing): %v", err)
+	}
+	if missing != nil {
+		t.Errorf("expected nil for non-existent instance_id, got %+v", missing)
+	}
+}
+

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -8,6 +8,7 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1773,6 +1774,98 @@ INSERT OR IGNORE INTO spawn_inputs (
 		return fmt.Errorf("db: insert spawn_inputs for %q: %w", si.InstanceID, err)
 	}
 	return nil
+}
+
+// SpawnInputsByInstanceID returns the spawn_inputs row for the given
+// instance_id, or nil when not found.
+func (d *DB) SpawnInputsByInstanceID(instanceID string) (*SpawnInputs, error) {
+	const q = `
+SELECT
+    instance_id,
+    profile_name, model_flag, variant_flag, agent_flag, harness_flag,
+    isolation_flag, host_mode_flag,
+    pr_number, branch_flag, ignore_concurrency_cap,
+    model_variant_overrides,
+    skills_manifest_hash, prompt_template_hash, agent_prompt_hash,
+    prompt_text, prompt_source, abtest_pair_id, extras,
+    created_at
+FROM spawn_inputs
+WHERE instance_id = ?`
+	row := d.conn.QueryRow(q, instanceID)
+	var si SpawnInputs
+	var profileName, modelFlag, variantFlag, agentFlag, harnessFlag, isolationFlag sql.NullString
+	var prNumber sql.NullInt64
+	var branchFlag, modelVariantOverrides, skillsManifestHash, promptTemplateHash, agentPromptHash sql.NullString
+	var promptText, promptSource, abtestPairID, extras sql.NullString
+	var hostModeFlag, ignoreConcurrencyCap int
+	err := row.Scan(
+		&si.InstanceID,
+		&profileName, &modelFlag, &variantFlag, &agentFlag, &harnessFlag,
+		&isolationFlag, &hostModeFlag,
+		&prNumber, &branchFlag, &ignoreConcurrencyCap,
+		&modelVariantOverrides,
+		&skillsManifestHash, &promptTemplateHash, &agentPromptHash,
+		&promptText, &promptSource, &abtestPairID, &extras,
+		&si.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: spawn_inputs by instance_id %q: %w", instanceID, err)
+	}
+	if profileName.Valid {
+		si.ProfileName = &profileName.String
+	}
+	if modelFlag.Valid {
+		si.ModelFlag = &modelFlag.String
+	}
+	if variantFlag.Valid {
+		si.VariantFlag = &variantFlag.String
+	}
+	if agentFlag.Valid {
+		si.AgentFlag = &agentFlag.String
+	}
+	if harnessFlag.Valid {
+		si.HarnessFlag = &harnessFlag.String
+	}
+	if isolationFlag.Valid {
+		si.IsolationFlag = &isolationFlag.String
+	}
+	si.HostModeFlag = hostModeFlag != 0
+	if prNumber.Valid {
+		n := int(prNumber.Int64)
+		si.PRNumber = &n
+	}
+	if branchFlag.Valid {
+		si.BranchFlag = &branchFlag.String
+	}
+	si.IgnoreConcurrencyCap = ignoreConcurrencyCap != 0
+	if modelVariantOverrides.Valid {
+		si.ModelVariantOverrides = &modelVariantOverrides.String
+	}
+	if skillsManifestHash.Valid {
+		si.SkillsManifestHash = &skillsManifestHash.String
+	}
+	if promptTemplateHash.Valid {
+		si.PromptTemplateHash = &promptTemplateHash.String
+	}
+	if agentPromptHash.Valid {
+		si.AgentPromptHash = &agentPromptHash.String
+	}
+	if promptText.Valid {
+		si.PromptText = &promptText.String
+	}
+	if promptSource.Valid {
+		si.PromptSource = &promptSource.String
+	}
+	if abtestPairID.Valid {
+		si.AbtestPairID = &abtestPairID.String
+	}
+	if extras.Valid {
+		si.Extras = &extras.String
+	}
+	return &si, nil
 }
 
 // boolToInt converts a bool to 0/1 for SQLite INTEGER columns.

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -913,6 +913,195 @@ ON CONFLICT(session_name) DO UPDATE SET
 	return nil
 }
 
+// SessionsByAbtestPairID returns all sessions rows (active and ended) whose
+// spawn_inputs.abtest_pair_id equals pairID. The result is ordered by
+// started_at ASC so the caller can treat index 0 as "session A" and index 1
+// as "session B" deterministically.
+//
+// A pair that is fully cleaned up (both sessions ended) is still returned —
+// callers use the results to render historical comparison views.
+//
+// The query joins sessions → spawn_inputs on instance_id. Sessions that have
+// no spawn_inputs row (pre-migration or non-abtest) are excluded.
+func (d *DB) SessionsByAbtestPairID(pairID string) ([]Session, error) {
+	// We cannot use sessionsSelectCols directly because a JOIN with
+	// spawn_inputs would make 'instance_id' ambiguous in SQLite.
+	// Explicitly qualify all columns with the sessions table alias.
+	const q = `
+SELECT s.instance_id, s.session_name, s.agent_role, s.root_agent_name,
+       s.repo, s.worktree, s.harness, s.harness_session_id, s.group_id,
+       s.started_at, s.ended_at, s.end_state, s.archive_path, s.prism_version
+  FROM sessions s
+INNER JOIN spawn_inputs si ON si.instance_id = s.instance_id
+WHERE si.abtest_pair_id = ?
+ORDER BY s.started_at ASC`
+	return d.querySessions(q, pairID)
+}
+
+// AbtestPairRow holds summary data for a single abtest pair, aggregated from
+// spawn_inputs and spawn_outcome.
+type AbtestPairRow struct {
+	PairID string // shared abtest_pair_id UUID
+
+	// Session A (first spawned, lower started_at)
+	SessionNameA string
+	InstanceIDA  string
+	ProfileA     string // spawn_inputs.profile_name; "" when not set
+	StartedAtA   int64  // ms epoch
+	EndedAtA     *int64 // nil when still running
+
+	// Session B (second spawned)
+	SessionNameB string
+	InstanceIDB  string
+	ProfileB     string
+	StartedAtB   int64
+	EndedAtB     *int64
+
+	// Metrics from spawn_outcome (nil when outcome not yet computed)
+	TurnsA        *int   // msg_assistant_count
+	TurnsB        *int
+	TokensInputA  *int64
+	TokensInputB  *int64
+	TokensOutputA *int64
+	TokensOutputB *int64
+	DurationMsA   *int64
+	DurationMsB   *int64
+	EndStateA     *string
+	EndStateB     *string
+}
+
+// AbtestPairsAll returns one AbtestPairRow per distinct abtest_pair_id.
+// Pairs are ordered by the started_at of their first session (oldest first).
+// Sessions that lack spawn_inputs or spawn_outcome rows are included but with
+// nil metric fields.
+func (d *DB) AbtestPairsAll() ([]AbtestPairRow, error) {
+	// Fetch all (instance_id, session_name, started_at, ended_at, abtest_pair_id, profile_name)
+	// tuples ordered by pair_id, started_at. We then group by pair_id in Go.
+	const q = `
+SELECT
+    si.abtest_pair_id,
+    s.instance_id,
+    s.session_name,
+    s.started_at,
+    s.ended_at,
+    COALESCE(si.profile_name, ''),
+    COALESCE(so.msg_assistant_count, 0),
+    COALESCE(so.tokens_input_total, 0),
+    COALESCE(so.tokens_output_total, 0),
+    so.duration_ms,
+    so.end_state
+FROM spawn_inputs si
+INNER JOIN sessions s ON s.instance_id = si.instance_id
+LEFT  JOIN spawn_outcome so ON so.instance_id = si.instance_id
+WHERE si.abtest_pair_id IS NOT NULL
+ORDER BY si.abtest_pair_id ASC, s.started_at ASC`
+
+	rows, err := d.conn.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("db: abtest_pairs_all: %w", err)
+	}
+	defer rows.Close()
+
+	// Accumulate into a map pair_id → AbtestPairRow (filling A slot first,
+	// then B). Order of insertion is preserved via pairOrder slice.
+	type abtestRawRow struct {
+		pairID      string
+		instanceID  string
+		sessionName string
+		startedAt   int64
+		endedAt     sql.NullInt64
+		profile     string
+		turns       int
+		tokensIn    int64
+		tokensOut   int64
+		durationMs  sql.NullInt64
+		endState    sql.NullString
+	}
+
+	var rawRows []abtestRawRow
+	for rows.Next() {
+		var r abtestRawRow
+		if scanErr := rows.Scan(
+			&r.pairID, &r.instanceID, &r.sessionName, &r.startedAt, &r.endedAt,
+			&r.profile, &r.turns, &r.tokensIn, &r.tokensOut, &r.durationMs, &r.endState,
+		); scanErr != nil {
+			return nil, fmt.Errorf("db: abtest_pairs_all: scan: %w", scanErr)
+		}
+		rawRows = append(rawRows, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: abtest_pairs_all: iterate: %w", err)
+	}
+
+	// Group into pairs by pairID.
+	pairMap := make(map[string]*AbtestPairRow)
+	var pairOrder []string
+	for _, r := range rawRows {
+		pr, exists := pairMap[r.pairID]
+		if !exists {
+			pr = &AbtestPairRow{PairID: r.pairID}
+			pairMap[r.pairID] = pr
+			pairOrder = append(pairOrder, r.pairID)
+		}
+		// Fill A first, then B.
+		if pr.InstanceIDA == "" {
+			// Slot A
+			pr.InstanceIDA = r.instanceID
+			pr.SessionNameA = r.sessionName
+			pr.ProfileA = r.profile
+			pr.StartedAtA = r.startedAt
+			if r.endedAt.Valid {
+				v := r.endedAt.Int64
+				pr.EndedAtA = &v
+			}
+			turns := r.turns
+			pr.TurnsA = &turns
+			tokIn := r.tokensIn
+			pr.TokensInputA = &tokIn
+			tokOut := r.tokensOut
+			pr.TokensOutputA = &tokOut
+			if r.durationMs.Valid {
+				v := r.durationMs.Int64
+				pr.DurationMsA = &v
+			}
+			if r.endState.Valid {
+				v := r.endState.String
+				pr.EndStateA = &v
+			}
+		} else {
+			// Slot B
+			pr.InstanceIDB = r.instanceID
+			pr.SessionNameB = r.sessionName
+			pr.ProfileB = r.profile
+			pr.StartedAtB = r.startedAt
+			if r.endedAt.Valid {
+				v := r.endedAt.Int64
+				pr.EndedAtB = &v
+			}
+			turns := r.turns
+			pr.TurnsB = &turns
+			tokIn := r.tokensIn
+			pr.TokensInputB = &tokIn
+			tokOut := r.tokensOut
+			pr.TokensOutputB = &tokOut
+			if r.durationMs.Valid {
+				v := r.durationMs.Int64
+				pr.DurationMsB = &v
+			}
+			if r.endState.Valid {
+				v := r.endState.String
+				pr.EndStateB = &v
+			}
+		}
+	}
+
+	result := make([]AbtestPairRow, 0, len(pairOrder))
+	for _, pid := range pairOrder {
+		result = append(result, *pairMap[pid])
+	}
+	return result, nil
+}
+
 // AbtestPairsForSessions returns a map of session_name → abtest_pair_id for
 // sessions that have a non-NULL abtest_pair_id in spawn_inputs. Only sessions
 // whose instance_id appears in spawn_inputs with a non-NULL abtest_pair_id are


### PR DESCRIPTION
## Summary

- Adds `prism checkin --compare <session-a> <session-b>` for side-by-side narrative comparison of two A/B test sessions (must share `abtest_pair_id`); `--diff` emits a unified text diff
- Adds `prism stats --abtest` to list all A/B test pairs with per-session summary metrics (profile, turns, token usage, wall time, end state)
- Adds `archive.LoadAbtestPair(pairID)` programmatic API returning `AbtestPair` with both siblings, their `SpawnInputs`, and `SpawnOutcome`
- Adds `db.SessionsByAbtestPairID`, `db.AbtestPairsAll`, and `db.SpawnInputsByInstanceID` query methods
- Edge cases handled: one sibling missing → renders surviving session with "sibling missing" indicator; sessions with no shared `abtest_pair_id` → clear error directing user to `prism checkin <session>`

## Quality Gates

- `go build ./...` ✅
- `go test ./... -p=1` ✅
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #1217