### PR TITLE
fix: remove abtest_pair_id partial index from schema const

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -223,7 +223,6 @@ CREATE TABLE IF NOT EXISTS spawn_inputs (
 );
 CREATE INDEX IF NOT EXISTS idx_spawn_inputs_profile         ON spawn_inputs(profile_name);
 CREATE INDEX IF NOT EXISTS idx_spawn_inputs_harness_profile ON spawn_inputs(harness_flag, profile_name);
-CREATE INDEX IF NOT EXISTS idx_spawn_inputs_abtest_pair     ON spawn_inputs(abtest_pair_id) WHERE abtest_pair_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS harness_frames (
   id            TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

Removes the `idx_spawn_inputs_abtest_pair` partial index from the `schema` const in `internal/db/db.go`.

The index was being applied unconditionally at DB open time (before migrations run). On existing DBs where `spawn_inputs` doesn't yet have the `abtest_pair_id` column, SQLite evaluates the `WHERE abtest_pair_id IS NOT NULL` clause and immediately fails with:

```
agent-run: open database: db: apply schema: SQL logic error: no such column: abtest_pair_id (1)
```

This index already exists inside `migrateV27ToV28`, so removing it from the `schema` const is the correct minimal fix — existing DBs get it via the migration, fresh DBs get it via the same migration on first open.

Closes #1283