### PR TITLE
fix: resolve pi-coding-agent binary path and bind-mount in bwrap sandbox

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -724,6 +724,17 @@ func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, c
 	ctrCfg.PIModel = slot.Model
 	ctrCfg.PIThinking = slot.Thinking
 
+	// Resolve the pi-coding-agent binary path. This must be the absolute store
+	// path (or profile path) so that bwrap can bind-mount it into the sandbox.
+	// A missing binary is a hard error: a silent fallback to a bare name would
+	// result in ENOENT inside bwrap and the session exiting in milliseconds
+	// with no useful error message.
+	piBin, lookErr := exec.LookPath("pi-coding-agent")
+	if lookErr != nil {
+		return fmt.Errorf("pi: resolve pi-coding-agent binary: %w — ensure pi-coding-agent is installed and on PATH", lookErr)
+	}
+	ctrCfg.PIBinaryPath = piBin
+
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -318,6 +318,17 @@ type Config struct {
 	// Derived from the profile slot's Thinking field. When empty, the flag is
 	// omitted and PI uses its own default.
 	PIThinking string
+
+	// PIBinaryPath is the absolute host path to the pi-coding-agent binary
+	// (e.g. /nix/store/.../bin/pi-coding-agent or from the Nix profile at
+	// /etc/profiles/per-user/<user>/bin/pi-coding-agent). When non-empty and
+	// Harness == "pi", BuildArgs (bwrap) bind-mounts this path read-only into
+	// the sandbox and PIInvocation uses it as argv[0] so that pi-coding-agent
+	// is accessible inside the bwrap namespace. An empty PIBinaryPath for a
+	// harness=pi session is treated as a configuration error: populatePIConfig
+	// returns a clear error rather than falling back to a bare "pi" name that
+	// would fail with ENOENT inside the sandbox.
+	PIBinaryPath string
 }
 
 // NameForSession returns the stable podman container name for a session.

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -72,7 +72,13 @@ const (
 // APPEND_SYSTEM.md. No --append-system-prompt flag is needed — PI discovers
 // APPEND_SYSTEM.md automatically from its agent config directory.
 func PIInvocation(cfg Config) []string {
-	args := []string{"pi"}
+	// Use the resolved binary path when set; fall back to the bare name for
+	// back-compat in test/host-mode contexts where the binary is on PATH.
+	binary := cfg.PIBinaryPath
+	if binary == "" {
+		binary = "pi-coding-agent"
+	}
+	args := []string{binary}
 
 	if cfg.PIProvider != "" {
 		args = append(args, "--provider", cfg.PIProvider)
@@ -235,6 +241,18 @@ func PIExtensionSandboxPath(sandboxDirOverride string) string {
 // forgot to populate the Config fields) or the extension directory cannot be
 // validated.
 func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
+	// ── PI binary (read-only) ────────────────────────────────────────────────
+	// The pi-coding-agent binary lives in the Nix store and is not reachable
+	// inside the bwrap sandbox purely via PATH (/nix is bind-mounted but the
+	// profile symlink farm may not resolve the specific store path the binary
+	// lives at when the profile is not in scope). Bind-mounting the resolved
+	// absolute path guarantees the binary is accessible at that exact path
+	// inside the sandbox, which is the value PIInvocation uses as argv[0].
+	if cfg.PIBinaryPath == "" {
+		return nil, fmt.Errorf("pi: PIBinaryPath is empty — resolve pi-coding-agent before launching bwrap")
+	}
+	args = append(args, "--ro-bind", cfg.PIBinaryPath, cfg.PIBinaryPath)
+
 	// ── PI agent config directory ────────────────────────────────────────────
 	// The staging directory is always created by StagePIAgentConfigDir before
 	// bwrap launches. Bind-mount it read-only and set PI_CODING_AGENT_DIR to

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestPIInvocation_BasicFlags(t *testing.T) {
 	cfg := Config{
+		PIBinaryPath:          "/nix/store/abc-pi/bin/pi-coding-agent",
 		PIProvider:            "anthropic",
 		PIModel:               "anthropic/claude-opus-4",
 		PIThinking:            "high",
@@ -20,8 +21,8 @@ func TestPIInvocation_BasicFlags(t *testing.T) {
 	}
 	args := PIInvocation(cfg)
 
-	if args[0] != "pi" {
-		t.Errorf("expected args[0] == 'pi', got %q", args[0])
+	if args[0] != "/nix/store/abc-pi/bin/pi-coding-agent" {
+		t.Errorf("expected args[0] == '/nix/store/abc-pi/bin/pi-coding-agent', got %q", args[0])
 	}
 	for _, pair := range [][2]string{
 		{"--provider", "anthropic"},
@@ -95,6 +96,16 @@ func TestPIInvocation_NoInitialPrompt(t *testing.T) {
 func hasPair(args []string, flag, val string) bool {
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTriple returns true when flag, val1, val2 appear consecutively in args.
+func hasTriple(args []string, flag, val1, val2 string) bool {
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val1 && args[i+2] == val2 {
 			return true
 		}
 	}
@@ -249,6 +260,28 @@ func TestValidatePIExtensionDir_MissingExtFile(t *testing.T) {
 
 // ── appendPIBwrapMounts ──────────────────────────────────────────────────────
 
+func TestAppendPIBwrapMounts_EmptyPIBinaryPathReturnsError(t *testing.T) {
+	// An empty PIBinaryPath must return a clear error, not silently fall back
+	// to a bare name that would fail inside the bwrap sandbox with ENOENT.
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:       "", // intentionally empty
+		PIExtensionHostDir: extDir,
+	}
+
+	_, err := appendPIBwrapMounts(nil, cfg)
+	if err == nil {
+		t.Fatal("expected an error for empty PIBinaryPath, got nil")
+	}
+	if !strings.Contains(err.Error(), "PIBinaryPath") {
+		t.Errorf("error should mention PIBinaryPath; got: %v", err)
+	}
+}
+
 func TestAppendPIBwrapMounts_EmitsParentDirUnconditionally(t *testing.T) {
 	// Regression test for the bug where --dir was skipped for /etc-prefixed
 	// parent paths. /etc/prism does not exist on the host, so bwrap would
@@ -259,7 +292,14 @@ func TestAppendPIBwrapMounts_EmitsParentDirUnconditionally(t *testing.T) {
 	}
 	agentConfigDir := t.TempDir()
 
+	// Create a fake pi-coding-agent binary for the test.
+	fakePI := filepath.Join(t.TempDir(), "pi-coding-agent")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
 	cfg := Config{
+		PIBinaryPath:         fakePI,
 		PIAgentConfigHostDir: agentConfigDir,
 		PIExtensionHostDir:   extDir,
 		// Use default sandbox paths so /etc/prism/pi-extensions is the target.
@@ -284,6 +324,11 @@ func TestAppendPIBwrapMounts_EmitsParentDirUnconditionally(t *testing.T) {
 	if !hasPair(args, "--setenv", "PI_CODING_AGENT_DIR") {
 		t.Errorf("expected --setenv PI_CODING_AGENT_DIR in args; got %v", args)
 	}
+
+	// Must ro-bind-mount the PI binary so it is accessible inside the sandbox.
+	if !hasTriple(args, "--ro-bind", fakePI, fakePI) {
+		t.Errorf("expected --ro-bind %q %q for PI binary in args; got %v", fakePI, fakePI, args)
+	}
 }
 
 func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
@@ -294,7 +339,13 @@ func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
 	agentConfigDir := t.TempDir()
 	customSandboxDir := "/run/prism/custom-agent"
 
+	fakePI := filepath.Join(t.TempDir(), "pi-coding-agent")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
 	cfg := Config{
+		PIBinaryPath:            fakePI,
 		PIAgentConfigHostDir:    agentConfigDir,
 		PIAgentConfigSandboxDir: customSandboxDir,
 		PIExtensionHostDir:      extDir,

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -285,19 +285,34 @@ func BuildOpencodeCmd(opts Opts) string {
 	})
 }
 
-// buildDirectOpencodeCmd returns the opencode direct-launch command (pre-container mode).
+// harnessBinary returns the binary name to invoke for the given harness.
+// For "pi" the binary is pi-coding-agent; for "" or "opencode" it is opencode.
+func harnessBinary(harnessName string) string {
+	switch harnessName {
+	case "pi":
+		return "pi-coding-agent"
+	default:
+		return "opencode"
+	}
+}
+
+// buildDirectOpencodeCmd returns the direct-launch command for the session
+// harness (pre-container mode). For harness="" or "opencode" this is an
+// opencode invocation; for harness="pi" it is pi-coding-agent.
 func buildDirectOpencodeCmd(opts Opts) string {
+	binary := harnessBinary(opts.HarnessName)
+	isOpencode := binary == "opencode"
 	agent := opts.Agent
 	var cmd string
-	if agent != "" {
-		cmd = "opencode --agent " + agent
+	if agent != "" && isOpencode {
+		cmd = binary + " --agent " + agent
 	} else {
-		cmd = "opencode"
+		cmd = binary
 	}
-	if opts.Port != 0 {
+	if isOpencode && opts.Port != 0 {
 		cmd += fmt.Sprintf(" --port %d --hostname 127.0.0.1", opts.Port)
 	}
-	if opts.OpencodeSession != "" && !opts.Fresh {
+	if isOpencode && opts.OpencodeSession != "" && !opts.Fresh {
 		cmd += " -s " + opts.OpencodeSession
 	}
 	if opts.Prompt != "" {


### PR DESCRIPTION
## Summary

Fixes two bugs blocking the PI harness smoke test.

**Bug 1 — Silent OpenCode Fallback** (`internal/session/session.go`):
- `buildDirectOpencodeCmd()` hardcoded `"opencode"` regardless of `opts.HarnessName`
- Added `harnessBinary()` helper that returns `"pi-coding-agent"` for `HarnessName == "pi"`, and `"opencode"` for everything else
- Guarded opencode-specific flags (`--port`, `-s`) so they only emit for the opencode binary

**Bug 2 — PI Binary Not in bwrap PATH** (`internal/container/`):
- `PIInvocation` used bare `"pi"` as argv[0] which is not accessible inside the bwrap sandbox
- Added `PIBinaryPath` field to `container.Config`
- `populatePIConfig` resolves `pi-coding-agent` via `exec.LookPath` and sets it; returns a clear error if not found (no silent fallback)
- `PIInvocation` uses `PIBinaryPath` as argv[0]
- `appendPIBwrapMounts` bind-mounts `PIBinaryPath` read-only into the sandbox; returns a clear error if empty

Also updates `pi_invocation_test.go` to reflect the new behaviour and adds a regression test for the empty-PIBinaryPath error case.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass; pre-existing flaky `cmd` LEAK failure is unrelated and reproducible on `main`)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅