### PR TITLE
fix: persist harness name in DB at spawn time and inject PRISM_HARNESS_PIPE for host-mode PI sessions

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -979,7 +979,7 @@ func TestIsCoordinatorFromDB(t *testing.T) {
 	}
 
 	// Post-migration coordinator on the conventional @main branch.
-	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator @main: %v", err)
 	}
 
@@ -987,12 +987,12 @@ func TestIsCoordinatorFromDB(t *testing.T) {
 	// root_agent_name = "coordinator" must be the deciding factor, not the
 	// branch name. This is the primary motivation for the DB-backed migration.
 	// Use a different repo name to avoid the unique-active-coordinator-per-repo constraint.
-	if err := d.UpsertStatusSeedRootAgentName("custom-repo@custom-branch", "custom-repo", "/code/custom", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("custom-repo@custom-branch", "custom-repo", "/code/custom", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator on custom branch: %v", err)
 	}
 
 	// Post-migration worker on @main-named branch (should not be detected as coordinator).
-	if err := d.UpsertStatusSeedRootAgentName("otherwork@main", "otherwork", "/code/other/main", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("otherwork@main", "otherwork", "/code/other/main", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker @main: %v", err)
 	}
 

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -317,7 +317,7 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 		// plain UpsertStatus path which leaves root_agent_name as-is (NULL on
 		// insert, preserved on update).
 		if agentRole != "" {
-			if err := d.UpsertStatusSeedRootAgentName(session, repo, worktree, string(agent.StateIdle), nil, nil, agentRole); err != nil {
+			if err := d.UpsertStatusSeedRootAgentName(session, repo, worktree, string(agent.StateIdle), nil, nil, agentRole, ""); err != nil {
 				return fmt.Errorf("event tmux-session-start: upsert status: %w", err)
 			}
 		} else {

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -688,7 +688,7 @@ func TestEventTmuxSessionStart_AgentRole_PreservesExisting(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	// Pre-seed a row with root_agent_name already set.
-	if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", worktree, "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", worktree, "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	d.Close()

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -36,7 +36,7 @@ func TestRunMerge_WorkerSessionIsRejected(t *testing.T) {
 		t.Fatalf("openDB: %v", err)
 	}
 	defer d.Close()
-	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature", "idle", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature", "idle", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	d.Close()
@@ -82,7 +82,7 @@ func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openDB: %v", err)
 	}
-	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		d.Close()
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestRunMerge_FailsWhenInstanceIDMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openDB: %v", err)
 	}
-	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		d.Close()
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -471,7 +471,7 @@ func TestRejectIfCoordinator_BlocksCoordinatorSession(t *testing.T) {
 	d := openReviewTestDB(t)
 
 	const coordSession = "nixos-config@main"
-	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -498,7 +498,7 @@ func TestRejectIfCoordinator_AllowsWorkerSession(t *testing.T) {
 	d := openReviewTestDB(t)
 
 	const workerSession = "nixos-config@feature-branch"
-	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -537,6 +537,17 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		// because opencode never came up.
 		ReadinessTimeout: session.DefaultReadinessTimeout,
 	}
+	// For socket-pipe harnesses (e.g. "pi") in host isolation mode, pre-compute
+	// the Unix socket path so agentPaneEnvVars can inject PRISM_HARNESS_PIPE
+	// into the tmux pane. bwrap and sandbox-exec set PRISM_HARNESS_PIPE via
+	// their own paths (bwrap.go --setenv); only inject here for host mode.
+	if hShape, hShapeOK := harness.ShapeOf(harnessFlag); hShapeOK && hShape == harness.TransportSocketPipe && string(isolationMode) == "host" {
+		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
+			spawnOpts.HarnessPipeSockPath = pipePath
+		} else {
+			fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
+		}
+	}
 	// AgentEnvVars only applies to host-mode sessions; container sessions
 	// receive env vars via podman --env flags in the sidecar.
 	if pf != nil && !isoCaps.IsContainer {
@@ -1158,6 +1169,13 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {
 		spawnOpts.AgentEnvVars = a.pf.AgentEnvVars
+	}
+	if hShape, hShapeOK := harness.ShapeOf(a.harnessFlag); hShapeOK && hShape == harness.TransportSocketPipe && string(a.isolationMode) == "host" {
+		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
+			spawnOpts.HarnessPipeSockPath = pipePath
+		} else {
+			fmt.Fprintf(os.Stderr, "[prism spawn --abtest] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
+		}
 	}
 
 	if err := session.SpawnSession(a.d, spawnOpts); err != nil {

--- a/modules/programs/prism/prism/internal/container/concurrency_test.go
+++ b/modules/programs/prism/prism/internal/container/concurrency_test.go
@@ -28,7 +28,7 @@ func seedSession(t *testing.T, d *db.DB, sessionName, role string) {
 	t.Helper()
 	// Use UpsertStatusSeedRootAgentName to set the root_agent_name so roleFor
 	// can return the correct label.
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "repo", "/workspace", "idle", nil, nil, role); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "repo", "/workspace", "idle", nil, nil, role, ""); err != nil {
 		t.Fatalf("seedSession(%q): %v", sessionName, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -3560,7 +3560,7 @@ func TestConsecutiveSidecarFailures_TieBreaker(t *testing.T) {
 func TestUpsertStatusSeedRootAgentName_Insert(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -3589,7 +3589,7 @@ func TestUpsertStatusSeedRootAgentName_Insert(t *testing.T) {
 func TestUpsertStatusSeedRootAgentName_EmptyRole(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName (empty role): %v", err)
 	}
 
@@ -3614,12 +3614,12 @@ func TestUpsertStatusSeedRootAgentName_Idempotent(t *testing.T) {
 	d := openTestDB(t)
 
 	// First call: seed with "review-code".
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code", ""); err != nil {
 		t.Fatalf("first UpsertStatusSeedRootAgentName: %v", err)
 	}
 
 	// Second call: write the same role — must be a no-op for root_agent_name.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "review-code"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "review-code", ""); err != nil {
 		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -3646,12 +3646,12 @@ func TestUpsertStatusSeedRootAgentName_PreservesExisting(t *testing.T) {
 	d := openTestDB(t)
 
 	// Seed with a known role.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
 	// Update with empty role — existing root_agent_name must survive.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "", ""); err != nil {
 		t.Fatalf("update with empty role: %v", err)
 	}
 
@@ -3675,7 +3675,7 @@ func TestUpsertStatusSeedRootAgentName_SidecarWriteIdempotent(t *testing.T) {
 	d := openTestDB(t)
 
 	// Spawn-time seed: root_agent_name = "review-code", agent_name = nil.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -3716,11 +3716,11 @@ func TestCoordinatorForRepo(t *testing.T) {
 	defer d.Close()
 
 	// Seed a coordinator row with root_agent_name = "coordinator".
-	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/myrepo/main", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/myrepo/main", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	// Seed a worker row.
-	if err := d.UpsertStatusSeedRootAgentName("myrepo@feature", "myrepo", "/code/myrepo/feature", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@feature", "myrepo", "/code/myrepo/feature", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 
@@ -3804,7 +3804,7 @@ func TestRootAgentName(t *testing.T) {
 	}
 
 	// Post-migration row: root_agent_name is populated — returns (name, true, nil).
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	nameCoord, rowExistsCoord, err := d.RootAgentName("repo@main")
@@ -3825,7 +3825,7 @@ func TestIsGroupMember(t *testing.T) {
 	defer d.Close()
 
 	// Seed a session and a group.
-	if err := d.UpsertStatusSeedRootAgentName("repo@worker", "repo", "/code/worker", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@worker", "repo", "/code/worker", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 	groupID, err := d.RegisterGroup("repo@worker")
@@ -3834,7 +3834,7 @@ func TestIsGroupMember(t *testing.T) {
 	}
 
 	// Seed a review agent session and assign it to the group.
-	if err := d.UpsertStatusSeedRootAgentName("repo@worker~review-1-review-goal", "repo", "/code/worker", "active", nil, nil, "review-goal"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@worker~review-1-review-goal", "repo", "/code/worker", "active", nil, nil, "review-goal", ""); err != nil {
 		t.Fatalf("seed review agent: %v", err)
 	}
 	if err := d.SetGroupID("repo@worker~review-1-review-goal", groupID); err != nil {
@@ -4011,10 +4011,10 @@ func TestUpsertStatusWithAgent_WorktreeUpdatedOnConflict(t *testing.T) {
 func TestUpsertStatusSeedRootAgentName_WorktreeUpdatedOnConflict(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/old/worktree", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/old/worktree", "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("first UpsertStatusSeedRootAgentName: %v", err)
 	}
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/new/worktree", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/new/worktree", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -129,7 +129,7 @@ func (d *DB) UpdateRootModelID(sessionName, modelID string) error {
 // so that the DB row has a non-NULL root_agent_name from the first moment.
 // The sidecar will later write the same value idempotently via
 // UpsertStatusWithRootAgent (COALESCE preserves the already-set value).
-func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state string, title *string, harnessSessionID *string, rootAgentName string) error {
+func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state string, title *string, harnessSessionID *string, rootAgentName string, harnessName string) error {
 	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusSeedRootAgentName")
 	now := time.Now().UnixMilli()
 	// When rootAgentName is empty, fall back to leaving root_agent_name as-is
@@ -140,9 +140,16 @@ func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state st
 	if rootAgentName != "" {
 		rootAgentNamePtr = &rootAgentName
 	}
+	// Resolve the harness name to write. Default to "opencode" when empty so
+	// existing callers that do not pass a harness name continue to write the
+	// same value they wrote before.
+	effectiveHarness := harnessName
+	if effectiveHarness == "" {
+		effectiveHarness = "opencode"
+	}
 	const q = `
 INSERT INTO agent_status (session_name, repo, worktree, state, title, root_agent_name, last_seen, harness, harness_session_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, 'opencode', ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(session_name) DO UPDATE SET
   state              = excluded.state,
   repo               = excluded.repo,
@@ -150,9 +157,9 @@ ON CONFLICT(session_name) DO UPDATE SET
   title              = COALESCE(excluded.title, title),
   root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
   last_seen          = excluded.last_seen,
-  harness            = 'opencode',
+  harness            = excluded.harness,
   harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
-	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, harnessSessionID)
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, effectiveHarness, harnessSessionID)
 	if err != nil {
 		return fmt.Errorf("db: upsert status seed root agent name: %w", err)
 	}

--- a/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
@@ -59,7 +59,7 @@ func TestMonitor_FailedReadyAgent_DoesNotBlockGroupCompleted(t *testing.T) {
 
 	// Both agents start at state=idle (the seed state UpsertStatusSeedRootAgentName writes).
 	for _, sess := range []string{sessReady, sessFailed} {
-		if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x"); err != nil {
+		if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x", ""); err != nil {
 			t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
 		}
 		if err := d.SetGroupID(sess, groupID); err != nil {

--- a/modules/programs/prism/prism/internal/review/readiness_test.go
+++ b/modules/programs/prism/prism/internal/review/readiness_test.go
@@ -47,7 +47,7 @@ func openGateTestDB(t *testing.T) *db.DB {
 // to exist so CurrentStatus / QueryEvents return cleanly.
 func seedAgentRow(t *testing.T, d *db.DB, sess string) {
 	t.Helper()
-	if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1740,7 +1740,7 @@ func TestRun_SeedsRootAgentNameAtSpawnTime(t *testing.T) {
 	for _, ag := range agents {
 		agentSession := roundPrefix + ag.Name
 		// This mirrors what review.Run does synchronously at spawn time.
-		if err := d.UpsertStatusSeedRootAgentName(agentSession, "nixos-config", worktree, "idle", nil, nil, ag.Name); err != nil {
+		if err := d.UpsertStatusSeedRootAgentName(agentSession, "nixos-config", worktree, "idle", nil, nil, ag.Name, ""); err != nil {
 			t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", ag.Name, err)
 		}
 	}

--- a/modules/programs/prism/prism/internal/session/meta_test.go
+++ b/modules/programs/prism/prism/internal/session/meta_test.go
@@ -58,7 +58,7 @@ func openTestDB(t *testing.T) *db.DB {
 func TestIsCoordinatorSession_DBBackedCoordinator(t *testing.T) {
 	d := openTestDB(t)
 	const sess = "nixos-config@main"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if !IsCoordinatorSession(sess, d) {
@@ -74,7 +74,7 @@ func TestIsCoordinatorSession_DBBackedWorker(t *testing.T) {
 	d := openTestDB(t)
 	// A worker session on a non-@main branch — DB value must cause false.
 	const sess = "nixos-config@feature-worker"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-worker", "idle", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-worker", "idle", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if IsCoordinatorSession(sess, d) {
@@ -87,7 +87,7 @@ func TestIsCoordinatorSession_DBBackedWorker(t *testing.T) {
 func TestIsCoordinatorSession_DBBackedWorkerBranch(t *testing.T) {
 	d := openTestDB(t)
 	const sess = "nixos-config@feature-branch"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if IsCoordinatorSession(sess, d) {
@@ -156,7 +156,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainHeuristicWins(t *testing.T)
 
 	sess := "nixos-config@main"
 	// Seed the session with a stale root_agent_name of "worker".
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/main", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/main", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
@@ -172,7 +172,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_NonMain(t *testing.T) {
 	d := openTestDB(t)
 
 	sess := "nixos-config@feature"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/feature", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/session/readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/readiness_test.go
@@ -38,7 +38,7 @@ func openReadinessTestDB(t *testing.T) *db.DB {
 // SpawnSession's UpsertStatusSeedRootAgentName writes at spawn time.
 func seedSession(t *testing.T, d *db.DB, sessionName string) {
 	t.Helper()
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sessionName, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -168,6 +168,13 @@ type Opts struct {
 	// can call harness.ShapeOf to determine its own transport shape. When
 	// empty, the sidecar defaults to "opencode".
 	HarnessName string
+	// HarnessPipeSockPath is the Unix socket path for the PI harness pipe
+	// (TransportSocketPipe). When non-empty and isolation mode is "host",
+	// agentPaneEnvVars injects PRISM_HARNESS_PIPE=unix://<path> into the
+	// agent tmux pane so the PI extension can connect to the sidecar socket.
+	// Ignored for bwrap/sandbox-exec (those modes set PRISM_HARNESS_PIPE via
+	// their own paths) and for podman (container mode uses ctrCfg).
+	HarnessPipeSockPath string
 	// ModelsByRole is the per-role model override map (C.2). When non-empty
 	// it is forwarded to the sidecar via repeated --model-override flags.
 	// Nil means no per-role overrides.
@@ -594,10 +601,21 @@ func Create(name, directory string, opts Opts) error {
 //
 // Returns nil when no env vars are needed, producing no -e flags in tmux.
 func agentPaneEnvVars(opts Opts) map[string]string {
-	if opts.Prompt == "" {
+	if effectiveIsolationMode(opts) == "host" {
+		// In host mode the prompt is delivered via $(cat …) in the launch
+		// command (buildDirectOpencodeCmd / #1064), so no PRISM_INITIAL_PROMPT
+		// env var is needed. However, for socket-pipe harnesses (e.g. "pi")
+		// we must inject PRISM_HARNESS_PIPE so the PI extension can find the
+		// sidecar Unix socket. bwrap and sandbox-exec set this via their own
+		// paths; only inject here for host mode.
+		if opts.HarnessPipeSockPath != "" {
+			return map[string]string{
+				"PRISM_HARNESS_PIPE": "unix://" + opts.HarnessPipeSockPath,
+			}
+		}
 		return nil
 	}
-	if effectiveIsolationMode(opts) == "host" {
+	if opts.Prompt == "" {
 		return nil
 	}
 	if opts.PromptFilePath != "" {

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -599,7 +599,7 @@ func TestDefaultAgentForSession_DBHappyPath(t *testing.T) {
 	}
 	defer d.Close()
 
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -620,7 +620,7 @@ func TestDefaultAgentForSession_ExplicitOverridesDB(t *testing.T) {
 	}
 	defer d.Close()
 
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -163,6 +163,15 @@ type SpawnOpts struct {
 	// can call harness.ShapeOf to determine its own transport shape.
 	HarnessName string
 
+	// HarnessPipeSockPath is the Unix socket path for the PI harness pipe
+	// (TransportSocketPipe). When non-empty and isolation mode is "host",
+	// agentPaneEnvVars injects PRISM_HARNESS_PIPE=unix://<path> into the
+	// agent tmux pane. Pre-computed by the caller (cmd/spawn.go) from
+	// SidecarHarnessPipePath so that the spawner and sidecar agree on the
+	// path deterministically without a round-trip through the sidecar process.
+	// Empty for non-socket-pipe harnesses (e.g. "opencode").
+	HarnessPipeSockPath string
+
 	// ModelsByRole is the per-role model override map (C.2). When non-empty
 	// it is forwarded to the sidecar via repeated --model-override flags so
 	// the harness adapter applies per-role model overrides.
@@ -431,8 +440,15 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// Step 1: Seed agent_status with root_agent_name. Idempotent; later
 	// writes by the sidecar and by tmux-session-start COALESCE-preserve the
 	// value written here.
+	// Resolve effective harness for DB seeding — default to "opencode" when
+	// empty so sessions without an explicit --harness flag continue to write
+	// the same value they wrote before this fix.
+	effectiveHarness := opts.HarnessName
+	if effectiveHarness == "" {
+		effectiveHarness = "opencode"
+	}
 	if err := d.UpsertStatusSeedRootAgentName(
-		opts.SessionName, opts.Repo, opts.Worktree, "idle", nil, nil, opts.AgentRole,
+		opts.SessionName, opts.Repo, opts.Worktree, "idle", nil, nil, opts.AgentRole, effectiveHarness,
 	); err != nil {
 		startup.log("spawn-session: seed status FAILED: %v", err)
 		return fmt.Errorf("spawn session: seed status: %w", err)
@@ -636,8 +652,9 @@ func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 		Layout:           LayoutFull,
 		ForceFresh:       opts.ForceFresh,
 		Headless:         opts.Headless,
-		HarnessName:      opts.HarnessName,
-		ModelsByRole:     opts.ModelsByRole,
+		HarnessName:         opts.HarnessName,
+		HarnessPipeSockPath: opts.HarnessPipeSockPath,
+		ModelsByRole:        opts.ModelsByRole,
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
@@ -35,7 +35,7 @@ func newSidecarCoordinatorWithInstance(t *testing.T, sessionName, repo, instance
 	}
 	// Seed the DB so isCoordinatorSession() recognises this session as a
 	// coordinator (the merge handlers go through requireCoordinator).
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/tmp/"+sessionName, "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/tmp/"+sessionName, "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator status: %v", err)
 	}
 	return New(cfg)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2671,7 +2671,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	defer d.Close()
 
 	// Happy path: post-migration coordinator row on the conventional @main branch.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	if !isCoordinatorSession("repo@main", d) {
@@ -2681,7 +2681,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	// Core value of the change: coordinator on a non-@main branch name.
 	// The DB read must identify it correctly regardless of branch name.
 	// Use a different repo name to avoid the unique-coordinator-per-repo constraint.
-	if err := d.UpsertStatusSeedRootAgentName("other-repo@custom-branch", "other-repo", "/code/custom", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("other-repo@custom-branch", "other-repo", "/code/custom", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator on custom branch: %v", err)
 	}
 	if !isCoordinatorSession("other-repo@custom-branch", d) {
@@ -2689,7 +2689,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	}
 
 	// Post-migration worker row: DB says false.
-	if err := d.UpsertStatusSeedRootAgentName("repo@feature", "repo", "/code/feature", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@feature", "repo", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 	if isCoordinatorSession("repo@feature", d) {
@@ -2741,7 +2741,7 @@ func TestNotifyCoordinator_SelfNotificationSkipped_StaleRootAgentName(t *testing
 	coordinator := New(cfg)
 
 	// Seed with stale root_agent_name="worker" — simulates the bug scenario.
-	if err := d.UpsertStatusSeedRootAgentName(coordinator.cfg.SessionName, coordinator.cfg.Repo, coordinator.cfg.Worktree, "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordinator.cfg.SessionName, coordinator.cfg.Repo, coordinator.cfg.Worktree, "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
@@ -2777,7 +2777,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
 	defer d.Close()
 
 	sess := "myrepo@main"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "myrepo", "/code/main", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "myrepo", "/code/main", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
@@ -2787,7 +2787,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
 
 	// Worker on a non-@main branch must still return false.
 	workerSess := "myrepo@feature"
-	if err := d.UpsertStatusSeedRootAgentName(workerSess, "myrepo", "/code/feature", "active", nil, nil, "worker"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(workerSess, "myrepo", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 	if isCoordinatorSession(workerSess, d) {
@@ -5246,7 +5246,7 @@ func TestHostAPI_Cleanup_WorkerForbidden(t *testing.T) {
 func TestHostAPI_SessionNameNoAt_NoCheckinPanic(t *testing.T) {
 	d := openTestDB(t)
 	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
-	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed DB: %v", err)
 	}
 	// Session name without "@" — edge case for repoFromSession.
@@ -5511,7 +5511,7 @@ func TestHostAPI_Spawn_EmptyBranchReturns400(t *testing.T) {
 func TestHostAPI_Spawn_SidecarNoAtSign_Returns500(t *testing.T) {
 	d := openTestDB(t)
 	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
-	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed DB: %v", err)
 	}
 	// Session name without "@" — repoFromSession will fail.


### PR DESCRIPTION
## Summary

Two bugs prevented PI harness sessions from working correctly in host isolation mode:

**Bug 1: Wrong harness written to DB at spawn time**
`UpsertStatusSeedRootAgentName` hardcoded `harness='opencode'` in its SQL. When `prism agent-run` ran inside bwrap and read `status.Harness`, it always got `'opencode'` — so it launched `opencode` inside the sandbox instead of `pi-coding-agent`.

Fix: add `harnessName string` parameter to `UpsertStatusSeedRootAgentName`, default to `"opencode"` when empty for backward compat, and thread `opts.HarnessName` through `SpawnSession`. All test call sites pass `""`.

**Bug 2: `PRISM_HARNESS_PIPE` not injected for host-mode panes**
In bwrap mode, `PRISM_HARNESS_PIPE` is set via `--setenv` inside the bwrap invocation. In host mode, nothing set it — so `pi-coding-agent` launched in the tmux pane without knowing where to connect to the sidecar socket.

Fix: add `HarnessPipeSockPath` field to `session.Opts` and `SpawnOpts`, compute it in `cmd/spawn.go` for socket-pipe harnesses in host isolation mode, thread through `buildOptsForLayout`, and inject `PRISM_HARNESS_PIPE=unix://<path>` in `agentPaneEnvVars` when mode is `"host"` and the path is set.

## Changes

- `internal/db/status.go`: `UpsertStatusSeedRootAgentName` accepts `harnessName string`
- `internal/session/spawn.go`: thread `HarnessName`→DB and add `HarnessPipeSockPath` to `SpawnOpts`
- `internal/session/session.go`: add `HarnessPipeSockPath` to `Opts`, update `agentPaneEnvVars`
- `cmd/spawn.go`: compute `HarnessPipeSockPath` for host-mode socket-pipe harnesses (both normal and `--abtest` paths)
- `cmd/event.go` + all test files: update `UpsertStatusSeedRootAgentName` call sites

## Acceptance Criteria
- [x] `prism spawn --harness pi` (host isolation) launches `pi-coding-agent` with `PRISM_HARNESS_PIPE` set
- [x] `prism spawn` without `--harness pi` is unaffected
- [x] bwrap and sandbox-exec modes unaffected — they set `PRISM_HARNESS_PIPE` via their own paths
- [x] `go build ./...` and `go test ./...` pass
- [x] `nix build` passes

Closes #1289