### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777518431,
-        "narHash": "sha256-SwgiG2T5pbyo33Vz7/vUCAhEMgwCK8Pa2nDSx5a6/WE=",
+        "lastModified": 1777679572,
+        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e54a938cdd4c8e414b2518edc3d82308027c670",
+        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1777526009,
-        "narHash": "sha256-HpDDrmLvq+In5Pn/AMrihcU+Oy9qFXpH4nk0GmUYkeY=",
+        "lastModified": 1777697216,
+        "narHash": "sha256-E7Rtw6cjk4x0aWpvAQKgHm0u9yNyoESAiqjnErKGvgk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5715298dbadcfac44c53b4d67f6ae0cfff05e69d",
+        "rev": "7911ee5c8ba4ad014ef2ded216773cb650f499c5",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1777077449,
-        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/25244641727

## Closure diff: navi

```
55-nixos-aslr-entropy.conf: ∅ → ε
chromium: 147.0.7727.116 → 147.0.7727.137
chromium-unwrapped: 147.0.7727.116 → 147.0.7727.137, 36.0 KiB
claude-code: 2.1.121 → 2.1.123, 456.0 KiB
crun: 1.27 → 1.27.1, -85.3 KiB
curl-impersonate: 1.5.2 → 1.5.5
electron: 40.9.2 → 41.3.0
electron-unwrapped: 40.9.2 → 41.3.0, 8.5 MiB
firefox: 150.0 → 150.0.1, 12.9 KiB
firefox-unwrapped: 150.0 → 150.0.1, -193.2 KiB
fluxcd: 2.8.5 → 2.8.6, 19.8 KiB
gh: 2.91.0 → 2.92.0, 28.7 KiB
htop: 3.5.0 → 3.5.1
initrd-linux: 7.0.1 → 7.0.3, -18.9 KiB
libblake3: 1.8.4 → 1.8.5
linux: 7.0.1 → 7.0.3
nano: 8.7.1 → 9.0, 93.6 KiB
nixos-manual: 114.6 KiB
nixos-system-navi: 26.05.20260427.1c3fe55 → 26.05.20260430.15f4ee4
ntfs3g: 2022.10.3 → 2026.2.25, 12.7 KiB
opencode: 47.1 KiB
openrazer: 3.12.2-7.0.1 → 3.12.2-7.0.3
podman: 5.8.1 → 5.8.2, 46.2 KiB
python3.13-pyqt6-webengine: 6.10.0 → 6.11.0
python3.14-pyqt6-webengine: 6.10.0 → 6.11.0
rust-analyzer: 2026-04-13 → 2026-04-27
rust-analyzer-unwrapped: 2026-04-13 → 2026-04-27, 72.7 KiB
signal-desktop: 8.6.1 → 8.8.0, -10.7 MiB
source: 482.8 KiB
strace: 6.19 → 7.0, 1.1 MiB
thin-provisioning-tools: 1.3.1 → 1.3.2
vimplugin-leap.nvim: 0-unstable-2026-04-20 → 0-unstable-2026-04-26
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-16 → 1.17.0-unstable-2026-04-25
xwayland: 24.1.10 → 24.1.11
```

## Closure diff: tui

```
55-nixos-aslr-entropy.conf: ∅ → ε
chromium: 147.0.7727.116 → 147.0.7727.137
chromium-unwrapped: 147.0.7727.116 → 147.0.7727.137, 36.0 KiB
claude-code: 2.1.121 → 2.1.123, 456.0 KiB
crun: 1.27 → 1.27.1, -85.3 KiB
curl-impersonate: 1.5.2 → 1.5.5
electron: 40.9.2 → 41.3.0
electron-unwrapped: 40.9.2 → 41.3.0, 8.5 MiB
firefox: 150.0 → 150.0.1, 12.9 KiB
firefox-unwrapped: 150.0 → 150.0.1, -193.2 KiB
fluxcd: 2.8.5 → 2.8.6, 19.8 KiB
gh: 2.91.0 → 2.92.0, 28.7 KiB
htop: 3.5.0 → 3.5.1
initrd-linux: 7.0.1 → 7.0.3, -61.0 KiB
libblake3: 1.8.4 → 1.8.5
linux: 7.0.1 → 7.0.3
nano: 8.7.1 → 9.0, 93.6 KiB
nixos-manual: 114.6 KiB
nixos-system-tui: 26.05.20260427.1c3fe55 → 26.05.20260430.15f4ee4
ntfs3g: 2022.10.3 → 2026.2.25, 12.7 KiB
opencode: 47.1 KiB
openrazer: 3.12.2-7.0.1 → 3.12.2-7.0.3
podman: 5.8.1 → 5.8.2, 46.2 KiB
python3.13-pyqt6-webengine: 6.10.0 → 6.11.0
python3.14-pyqt6-webengine: 6.10.0 → 6.11.0
rust-analyzer: 2026-04-13 → 2026-04-27
rust-analyzer-unwrapped: 2026-04-13 → 2026-04-27, 72.7 KiB
signal-desktop: 8.6.1 → 8.8.0, -10.7 MiB
source: 482.8 KiB
strace: 6.19 → 7.0, 1.1 MiB
thin-provisioning-tools: 1.3.1 → 1.3.2
vimplugin-leap.nvim: 0-unstable-2026-04-20 → 0-unstable-2026-04-26
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-16 → 1.17.0-unstable-2026-04-25
xwayland: 24.1.10 → 24.1.11
```