### PR TITLE
fix: preserve harness='pi' through UpsertStatus and fix pi binary name

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -724,14 +724,14 @@ func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, c
 	ctrCfg.PIModel = slot.Model
 	ctrCfg.PIThinking = slot.Thinking
 
-	// Resolve the pi-coding-agent binary path. This must be the absolute store
+	// Resolve the pi binary path. This must be the absolute store
 	// path (or profile path) so that bwrap can bind-mount it into the sandbox.
 	// A missing binary is a hard error: a silent fallback to a bare name would
 	// result in ENOENT inside bwrap and the session exiting in milliseconds
 	// with no useful error message.
-	piBin, lookErr := exec.LookPath("pi-coding-agent")
+	piBin, lookErr := exec.LookPath("pi")
 	if lookErr != nil {
-		return fmt.Errorf("pi: resolve pi-coding-agent binary: %w — ensure pi-coding-agent is installed and on PATH", lookErr)
+		return fmt.Errorf("pi: resolve pi binary: %w — ensure pi is installed and on PATH", lookErr)
 	}
 	ctrCfg.PIBinaryPath = piBin
 

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -319,11 +319,11 @@ type Config struct {
 	// omitted and PI uses its own default.
 	PIThinking string
 
-	// PIBinaryPath is the absolute host path to the pi-coding-agent binary
-	// (e.g. /nix/store/.../bin/pi-coding-agent or from the Nix profile at
-	// /etc/profiles/per-user/<user>/bin/pi-coding-agent). When non-empty and
+	// PIBinaryPath is the absolute host path to the pi binary
+	// (e.g. /nix/store/.../bin/pi or from the Nix profile at
+	// /etc/profiles/per-user/<user>/bin/pi). When non-empty and
 	// Harness == "pi", BuildArgs (bwrap) bind-mounts this path read-only into
-	// the sandbox and PIInvocation uses it as argv[0] so that pi-coding-agent
+	// the sandbox and PIInvocation uses it as argv[0] so that pi
 	// is accessible inside the bwrap namespace. An empty PIBinaryPath for a
 	// harness=pi session is treated as a configuration error: populatePIConfig
 	// returns a clear error rather than falling back to a bare "pi" name that

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -242,14 +242,14 @@ func PIExtensionSandboxPath(sandboxDirOverride string) string {
 // validated.
 func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 	// ── PI binary (read-only) ────────────────────────────────────────────────
-	// The pi-coding-agent binary lives in the Nix store and is not reachable
+	// The pi binary lives in the Nix store and is not reachable
 	// inside the bwrap sandbox purely via PATH (/nix is bind-mounted but the
 	// profile symlink farm may not resolve the specific store path the binary
 	// lives at when the profile is not in scope). Bind-mounting the resolved
 	// absolute path guarantees the binary is accessible at that exact path
 	// inside the sandbox, which is the value PIInvocation uses as argv[0].
 	if cfg.PIBinaryPath == "" {
-		return nil, fmt.Errorf("pi: PIBinaryPath is empty — resolve pi-coding-agent before launching bwrap")
+		return nil, fmt.Errorf("pi: PIBinaryPath is empty — resolve pi before launching bwrap")
 	}
 	args = append(args, "--ro-bind", cfg.PIBinaryPath, cfg.PIBinaryPath)
 

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -76,7 +76,7 @@ func PIInvocation(cfg Config) []string {
 	// back-compat in test/host-mode contexts where the binary is on PATH.
 	binary := cfg.PIBinaryPath
 	if binary == "" {
-		binary = "pi-coding-agent"
+		binary = "pi"
 	}
 	args := []string{binary}
 

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPIInvocation_BasicFlags(t *testing.T) {
 	cfg := Config{
-		PIBinaryPath:          "/nix/store/abc-pi/bin/pi-coding-agent",
+		PIBinaryPath:          "/nix/store/abc-pi/bin/pi",
 		PIProvider:            "anthropic",
 		PIModel:               "anthropic/claude-opus-4",
 		PIThinking:            "high",
@@ -21,8 +21,8 @@ func TestPIInvocation_BasicFlags(t *testing.T) {
 	}
 	args := PIInvocation(cfg)
 
-	if args[0] != "/nix/store/abc-pi/bin/pi-coding-agent" {
-		t.Errorf("expected args[0] == '/nix/store/abc-pi/bin/pi-coding-agent', got %q", args[0])
+	if args[0] != "/nix/store/abc-pi/bin/pi" {
+		t.Errorf("expected args[0] == '/nix/store/abc-pi/bin/pi', got %q", args[0])
 	}
 	for _, pair := range [][2]string{
 		{"--provider", "anthropic"},
@@ -292,8 +292,8 @@ func TestAppendPIBwrapMounts_EmitsParentDirUnconditionally(t *testing.T) {
 	}
 	agentConfigDir := t.TempDir()
 
-	// Create a fake pi-coding-agent binary for the test.
-	fakePI := filepath.Join(t.TempDir(), "pi-coding-agent")
+	// Create a fake pi binary for the test.
+	fakePI := filepath.Join(t.TempDir(), "pi")
 	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
 		t.Fatalf("write fake pi binary: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
 	agentConfigDir := t.TempDir()
 	customSandboxDir := "/run/prism/custom-agent"
 
-	fakePI := filepath.Join(t.TempDir(), "pi-coding-agent")
+	fakePI := filepath.Join(t.TempDir(), "pi")
 	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
 		t.Fatalf("write fake pi binary: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -7180,3 +7180,66 @@ func TestAbtestPairsForSessions(t *testing.T) {
 		t.Errorf("non-abtest session repo@main should not appear in pairs map")
 	}
 }
+
+// TestUpsertStatus_PreservesHarness verifies that UpsertStatus does not
+// overwrite an existing harness value when called on a row that already has
+// harness='pi' (issue #1290, Bug 1).
+func TestUpsertStatus_PreservesHarness(t *testing.T) {
+	d := openTestDB(t)
+
+	// Seed a row with harness='pi' via UpsertStatusSeedRootAgentName (the
+	// same path used by SpawnSession).
+	const session = "repo@pi-worker"
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Simulate the sidecar's initial UpsertStatus("idle") call.
+	if err := d.UpsertStatus(session, "repo", "/wt", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// The harness column must still be 'pi'.
+	st, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("no row found after upsert")
+	}
+	if st.Harness == nil || *st.Harness != "pi" {
+		got := "<nil>"
+		if st.Harness != nil {
+			got = *st.Harness
+		}
+		t.Errorf("harness = %q after UpsertStatus; want %q", got, "pi")
+	}
+}
+
+// TestUpsertStatusWithRootAgent_FreshRowDefaultsOpencode verifies that a fresh
+// insert via UpsertStatusWithRootAgent writes harness='opencode' when no row
+// exists (issue #1290, Bug 1 — INSERT path).
+func TestUpsertStatusWithRootAgent_FreshRowDefaultsOpencode(t *testing.T) {
+	d := openTestDB(t)
+
+	const session = "repo@fresh-opencode"
+	agentName := "coordinator"
+	if err := d.UpsertStatusWithRootAgent(session, "repo", "/wt", "idle", nil, nil, &agentName, nil); err != nil {
+		t.Fatalf("UpsertStatusWithRootAgent: %v", err)
+	}
+
+	st, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("no row found after upsert")
+	}
+	if st.Harness == nil || *st.Harness != "opencode" {
+		got := "<nil>"
+		if st.Harness != nil {
+			got = *st.Harness
+		}
+		t.Errorf("harness = %q for fresh row; want %q", got, "opencode")
+	}
+}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -89,7 +89,7 @@ ON CONFLICT(session_name) DO UPDATE SET
   agent_name         = COALESCE(excluded.agent_name, agent_name),
   model_id           = COALESCE(excluded.model_id, model_id),
   last_seen          = excluded.last_seen,
-  harness            = 'opencode',
+  harness            = COALESCE(harness, excluded.harness),
   harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
 	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, agentName, modelID, now, harnessSessionID)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -293,11 +293,11 @@ func BuildOpencodeCmd(opts Opts) string {
 }
 
 // harnessBinary returns the binary name to invoke for the given harness.
-// For "pi" the binary is pi-coding-agent; for "" or "opencode" it is opencode.
+// For "pi" the binary is pi; for "" or "opencode" it is opencode.
 func harnessBinary(harnessName string) string {
 	switch harnessName {
 	case "pi":
-		return "pi-coding-agent"
+		return "pi"
 	default:
 		return "opencode"
 	}
@@ -305,7 +305,7 @@ func harnessBinary(harnessName string) string {
 
 // buildDirectOpencodeCmd returns the direct-launch command for the session
 // harness (pre-container mode). For harness="" or "opencode" this is an
-// opencode invocation; for harness="pi" it is pi-coding-agent.
+// opencode invocation; for harness="pi" it is pi.
 func buildDirectOpencodeCmd(opts Opts) string {
 	binary := harnessBinary(opts.HarnessName)
 	isOpencode := binary == "opencode"

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -683,3 +683,22 @@ func TestDefaultAgentForSession_NoRow(t *testing.T) {
 		t.Errorf("DefaultAgentForSession (no row) = %q, want %q", got, want)
 	}
 }
+
+// TestHarnessBinary asserts that harnessBinary returns the correct binary name
+// for each harness value (issue #1290).
+func TestHarnessBinary(t *testing.T) {
+	tests := []struct {
+		harness string
+		want    string
+	}{
+		{"pi", "pi"},
+		{"opencode", "opencode"},
+		{"", "opencode"},
+	}
+	for _, tc := range tests {
+		got := harnessBinary(tc.harness)
+		if got != tc.want {
+			t.Errorf("harnessBinary(%q) = %q, want %q", tc.harness, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug 1 (DB):** `UpsertStatusWithAgent` hardcoded `harness = 'opencode'` in its `ON CONFLICT DO UPDATE` clause, causing the sidecar's initial `UpsertStatus("idle")` to overwrite the `harness='pi'` seeded by `SpawnSession`. Fixed by changing the UPDATE to `COALESCE(harness, excluded.harness)` so the existing value is preserved.

- **Bug 2 (binary name):** `harnessBinary("pi")` returned `"pi-coding-agent"`; the correct binary name is `"pi"`. Fixed in `session.go`, `pi_invocation.go`, and `agent_run.go`.

- Tests added for both bugs covering the preserve-harness conflict update path, the fresh-insert default, and harnessBinary outputs.

Closes #1290