### PR TITLE
fix: inject PRISM_HARNESS_PIPE into bwrap sandbox for PI harness

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -259,6 +259,19 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		harnessName = *status.Harness
 	}
 
+	// Look up the harness pipe socket path for socket-pipe harnesses (e.g. "pi").
+	// This must be set on ctrCfg so that bwrap.go's BuildArgs emits
+	// --setenv PRISM_HARNESS_PIPE unix://<path>. Without it the PI binary starts
+	// inside the sandbox without knowing where the sidecar pipe socket is.
+	harnessPipeSockPath := ""
+	if shape, ok := harness.ShapeOf(harnessName); ok && shape == harness.TransportSocketPipe {
+		pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName)
+		if pipeErr != nil {
+			return fmt.Errorf("agent-run: resolve harness pipe path for %q: %w", harnessName, pipeErr)
+		}
+		harnessPipeSockPath = pipePath
+	}
+
 	// Populate harness-specific runtime env vars for the bwrap sandbox.
 	// harnessName comes from the DB; if it is not registered, fall back to
 	// a zero-env map rather than failing the entire agent-run.
@@ -278,8 +291,9 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		GitUserEmail:      cfg.GitUserEmail,
 		SshAccessKeyName:  cfg.SshAccessKeyName,
 		SshSigningKeyName: cfg.SshSigningKeyName,
-		HostAPISockPath:   hostAPISockPath,
-		RuntimeEnv:        runtimeEnv,
+		HostAPISockPath:     hostAPISockPath,
+		HarnessPipeSockPath: harnessPipeSockPath,
+		RuntimeEnv:          runtimeEnv,
 		AgentEnvVars:      agentEnvVars,
 		Harness:           harnessName,
 	}


### PR DESCRIPTION
## Summary

- **Bug 1 (#1292):** `runAgentRunBwrapHandler` was not setting `HarnessPipeSockPath` on `ctrCfg`, so `bwrap.go`'s `BuildArgs` never emitted `--setenv PRISM_HARNESS_PIPE`. The PI binary started inside the sandbox without knowing where the sidecar pipe socket is. Fix: resolve `harnessName` before the socket lookups, call `session.SidecarHarnessPipePath` for any socket-pipe harness (via `harness.ShapeOf`), and populate `ctrCfg.HarnessPipeSockPath`. Errors are surfaced rather than silently dropped.

- **Bug 2 (#1293):** `piBwrapErr` from `appendPIBwrapMounts` was already checked and returned in `lifecycle_dispatch.go` (`bwrapIsolator.Prepare`) — no code change needed.

Closes #1292
Closes #1293