### PR TITLE
fix: preserve harness column in UpsertStatusSeedRootAgentName ON CONFLICT

### DIFF
--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -7243,3 +7243,37 @@ func TestUpsertStatusWithRootAgent_FreshRowDefaultsOpencode(t *testing.T) {
 		t.Errorf("harness = %q for fresh row; want %q", got, "opencode")
 	}
 }
+
+// TestUpsertStatusSeedRootAgentName_PreservesHarness verifies that calling
+// UpsertStatusSeedRootAgentName with an empty harnessName on a row that already
+// has harness='pi' does NOT overwrite it with the 'opencode' default (issue #1297).
+func TestUpsertStatusSeedRootAgentName_PreservesHarness(t *testing.T) {
+	d := openTestDB(t)
+
+	const session = "repo@pi-branch"
+
+	// Seed the row with harness='pi' (as SpawnSession does).
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Simulate the tmux-session-start event hook calling with empty harnessName.
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", ""); err != nil {
+		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	st, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("no row found")
+	}
+	if st.Harness == nil || *st.Harness != "pi" {
+		got := "<nil>"
+		if st.Harness != nil {
+			got = *st.Harness
+		}
+		t.Errorf("harness = %q after empty-harness upsert; want %q", got, "pi")
+	}
+}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -157,7 +157,7 @@ ON CONFLICT(session_name) DO UPDATE SET
   title              = COALESCE(excluded.title, title),
   root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
   last_seen          = excluded.last_seen,
-  harness            = excluded.harness,
+  harness            = COALESCE(harness, excluded.harness),
   harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
 	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, effectiveHarness, harnessSessionID)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Change `UpsertStatusSeedRootAgentName`'s ON CONFLICT clause to use `COALESCE(harness, excluded.harness)` so a subsequent call with empty `harnessName` (defaulting to `'opencode'`) does not clobber a harness value already written by `SpawnSession` (e.g. `'pi'`).
- Adds `TestUpsertStatusSeedRootAgentName_PreservesHarness` to verify the new semantics.

Closes #1297