### PR TITLE
fix: pass InitialPrompt as positional arg to pi, not --prompt flag

### DIFF
--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -65,7 +65,7 @@ const (
 //	--thinking <cfg.PIThinking>           (when non-empty)
 //	--extension <extensionPath>           (always; path is derived from cfg)
 //	--no-session                          (prism manages session state)
-//	--prompt   <cfg.InitialPrompt>        (when non-empty)
+//	<cfg.InitialPrompt>                   (bare positional arg, when non-empty)
 //
 // The system prompt is delivered via PI_CODING_AGENT_DIR (set in the bwrap
 // environment) pointing at the per-session staging directory that contains
@@ -102,7 +102,7 @@ func PIInvocation(cfg Config) []string {
 	args = append(args, "--no-session")
 
 	if cfg.InitialPrompt != "" {
-		args = append(args, "--prompt", cfg.InitialPrompt)
+		args = append(args, cfg.InitialPrompt)
 	}
 
 	return args

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -78,8 +78,13 @@ func TestPIInvocation_InitialPrompt(t *testing.T) {
 	cfg := Config{InitialPrompt: "do the thing"}
 	args := PIInvocation(cfg)
 
-	if !hasPair(args, "--prompt", "do the thing") {
-		t.Errorf("expected --prompt 'do the thing'; got %v", args)
+	// The prompt must appear as a bare positional argument (last element),
+	// not as --prompt <text>.
+	if hasArg(args, "--prompt") {
+		t.Errorf("--prompt flag must not appear; pi takes the message as a positional arg; got %v", args)
+	}
+	if len(args) == 0 || args[len(args)-1] != "do the thing" {
+		t.Errorf("expected 'do the thing' as last positional arg; got %v", args)
 	}
 }
 
@@ -89,6 +94,10 @@ func TestPIInvocation_NoInitialPrompt(t *testing.T) {
 
 	if hasArg(args, "--prompt") {
 		t.Errorf("expected --prompt to be absent; got %v", args)
+	}
+	// When no prompt, the last arg must not be an empty string positional arg.
+	if len(args) > 0 && args[len(args)-1] == "" {
+		t.Errorf("expected no empty positional arg appended; got %v", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Pi does not have a `--prompt` flag — it takes the initial message as a bare positional argument at the end of the command line.
- `PIInvocation` was incorrectly passing `--prompt <text>`; changed to append `cfg.InitialPrompt` as a positional arg.
- Updated godoc comment and tests accordingly: `TestPIInvocation_InitialPrompt` now asserts the prompt appears as the last positional arg (not as `--prompt <value>`).

Closes #1289