### PR TITLE
fix: three pi harness fixes and profiles system prompt injection

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -747,6 +747,11 @@ func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, c
 	if lookErr != nil {
 		return fmt.Errorf("pi: resolve pi binary: %w — ensure pi is installed and on PATH", lookErr)
 	}
+	// Resolve symlinks so bwrap gets the real nix store path, not a profile
+	// symlink that does not exist inside the sandbox namespace.
+	if resolved, evalErr := filepath.EvalSymlinks(piBin); evalErr == nil {
+		piBin = resolved
+	}
 	ctrCfg.PIBinaryPath = piBin
 
 	return nil

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -146,6 +146,7 @@ type parsedConfig struct {
 	GitUserEmail                   string    `json:"git_user_email"`
 	SshAccessKeyName               string    `json:"ssh_access_key_name"`
 	SshSigningKeyName              string    `json:"ssh_signing_key_name"`
+	PIExtensionDir                 string    `json:"pi_extension_dir"`
 	RestoreStaggerDelayMs          *int      `json:"restore_stagger_delay_ms"`
 	SidecarCircuitBreakerThreshold *int      `json:"sidecar_circuit_breaker_threshold"`
 	BwrapConcurrencyCap            *int      `json:"bwrap_concurrency_cap"`
@@ -287,6 +288,9 @@ func load() Config {
 	}
 	if parsed.SshSigningKeyName != "" {
 		cfg.SshSigningKeyName = parsed.SshSigningKeyName
+	}
+	if parsed.PIExtensionDir != "" {
+		cfg.PIExtensionDir = parsed.PIExtensionDir
 	}
 
 	// For integer pointer fields: nil means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -592,6 +592,17 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// These must be appended before the "--" terminator so bwrap processes
 	// them as namespace arguments rather than as parts of the inner command.
 	if cfg.Harness == "pi" {
+		// Use ~/.config/prism/pi-extensions as the sandbox path for the
+		// extension directory. /etc is ro-bind-mounted from the host so
+		// bwrap cannot create /etc/prism inside the sandbox; .config/prism
+		// follows the same pattern as other prism config mounts.
+		if cfg.PIExtensionSandboxDir == "" {
+			cfg.PIExtensionSandboxDir = filepath.Join(home, ".config", "prism", "pi-extensions")
+		}
+		// Same for the pi-agent config dir.
+		if cfg.PIAgentConfigSandboxDir == "" {
+			cfg.PIAgentConfigSandboxDir = filepath.Join(home, ".config", "prism", "pi-agent")
+		}
 		var piErr error
 		args, piErr = appendPIBwrapMounts(args, cfg)
 		if piErr != nil {

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -69,8 +69,37 @@
           ];
         };
 
-        # Stamp a slot value across the given list of role names.
-        slotsFor = roles: slot: lib.genAttrs roles (_: slot);
+
+        # Determine the system prompt file for a given role.
+        # Maps role names to agent files at ~/.config/opencode/agents/<file>.md.
+        roleToSystemPromptFile = role:
+          let
+            roleFileMap = {
+              coordinator = "coordinator";
+              plan = "coordinator";
+              worker = "worker";
+              review = "review-code-subagent";
+              "review-goal" = "review-goal-subagent";
+              "review-code" = "review-code-subagent";
+              "review-security" = "review-security-subagent";
+              "review-qa" = "review-qa-subagent";
+              "review-context" = "review-context-subagent";
+              ac = "ac";
+              retro = "retro";
+              explore = "worker";
+              title = "worker";
+              summary = "worker";
+              compaction = "worker";
+            };
+          in
+          "$HOME/.config/opencode/agents/${roleFileMap.${role}}.md";
+
+        # Stamp a slot value across the given list of role names, adding
+        # role-specific systemPromptPath values for P2.AGENTRUN support.
+        slotsForWithPrompts = roles: baseSlot:
+          lib.genAttrs roles (role: baseSlot // {
+            systemPromptPath = roleToSystemPromptFile role;
+          });
 
         # Build a profile by combining tiered slot values. Each tier is a
         # `{primary, secondary, lightweight}` triple of slot values — the
@@ -79,9 +108,9 @@
         # bit-identically.
         profileFromTiers =
           tiers:
-          (slotsFor roleMapping.primary tiers.primary)
-          // (slotsFor roleMapping.secondary tiers.secondary)
-          // (slotsFor roleMapping.lightweight tiers.lightweight);
+          (slotsForWithPrompts roleMapping.primary tiers.primary)
+          // (slotsForWithPrompts roleMapping.secondary tiers.secondary)
+          // (slotsForWithPrompts roleMapping.lightweight tiers.lightweight);
 
         # Convenience: build a slot. `thinking` defaults to "none" to preserve
         # current opencode behaviour (renders as variant: "none"). `provider`


### PR DESCRIPTION
## Summary

Bug fixes discovered during debugging of \`prism spawn --harness pi\`:

- **\`cmd/agent_run.go\`** — resolve pi binary symlink via \`filepath.EvalSymlinks\` so bwrap gets the real Nix store path; profile symlinks don't exist inside the sandbox namespace
- **\`internal/config/config.go\`** — add \`PIExtensionDir\` to \`parsedConfig\` struct and merge block so \`pi_extension_dir\` from \`config.json\` is actually read (was silently dropped before)
- **\`internal/container/bwrap.go\`** — default \`PIExtensionSandboxDir\` and \`PIAgentConfigSandboxDir\` to \`~/.config/prism/pi-extensions\` and \`~/.config/prism/pi-agent\`; \`/etc\` is ro-bind-mounted from the host so bwrap cannot create paths under it inside the sandbox
- **\`modules/programs/prism/profiles.nix\`** — replace \`slotsFor\` with \`slotsForWithPrompts\` which injects a role-specific \`systemPromptPath\` into each slot, mapping roles to their opencode agent files for P2.AGENTRUN support