### PR TITLE
container: bind-mount ~/.pi/agent into bwrap sandbox for pi harness sessions

### DIFF
--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -294,5 +294,21 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 	args = append(args, "--dir", sandboxExtDir)
 	args = append(args, "--ro-bind", cfg.PIExtensionHostDir, sandboxExtDir)
 
+	// ── ~/.pi/agent directory ────────────────────────────────────────────────
+	// PI stores auth credentials, themes, and settings in ~/.pi/agent/ on the
+	// host. Without this mount PI cannot find its auth token inside the sandbox
+	// and fails with a 400 auth error. Mounted read-only at the same host path.
+	// Silently skipped when the directory does not exist — auth may not be set
+	// up yet, and we do not want to break spawning in that case.
+	if home, err := os.UserHomeDir(); err == nil {
+		piAgentDir := filepath.Join(home, ".pi", "agent")
+		if _, statErr := os.Stat(piAgentDir); statErr == nil {
+			// bwrap requires parent dirs to exist in the sandbox namespace.
+			piParent := filepath.Join(home, ".pi")
+			args = append(args, "--dir", piParent)
+			args = append(args, "--ro-bind", piAgentDir, piAgentDir)
+		}
+	}
+
 	return args, nil
 }

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -390,6 +390,80 @@ func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
 	}
 }
 
+func TestAppendPIBwrapMounts_PiAgentDirMounted(t *testing.T) {
+	// When ~/.pi/agent exists, appendPIBwrapMounts must add --ro-bind for it.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi/agent: %v", err)
+	}
+
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+	fakePI := filepath.Join(t.TempDir(), "pi")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:       fakePI,
+		PIExtensionHostDir: extDir,
+	}
+
+	args, err := appendPIBwrapMounts(nil, cfg)
+	if err != nil {
+		t.Fatalf("appendPIBwrapMounts: %v", err)
+	}
+
+	// Must contain --ro-bind <piAgentDir> <piAgentDir>.
+	if !hasTriple(args, "--ro-bind", piAgentDir, piAgentDir) {
+		t.Errorf("expected --ro-bind %q %q in args; got %v", piAgentDir, piAgentDir, args)
+	}
+	// Must also contain --dir for the parent ~/.pi.
+	piParent := filepath.Join(fakeHome, ".pi")
+	if !hasPair(args, "--dir", piParent) {
+		t.Errorf("expected --dir %q in args for ~/.pi parent; got %v", piParent, args)
+	}
+}
+
+func TestAppendPIBwrapMounts_PiAgentDirMissing(t *testing.T) {
+	// When ~/.pi/agent does not exist, no bind-mount is added and no error is returned.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	// Deliberately do NOT create ~/.pi/agent.
+
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+	fakePI := filepath.Join(t.TempDir(), "pi")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:       fakePI,
+		PIExtensionHostDir: extDir,
+	}
+
+	args, err := appendPIBwrapMounts(nil, cfg)
+	if err != nil {
+		t.Fatalf("expected no error when ~/.pi/agent is absent; got %v", err)
+	}
+
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	// Must NOT contain a ro-bind for the missing path.
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == "--ro-bind" && args[i+1] == piAgentDir {
+			t.Errorf("expected no --ro-bind for absent ~/.pi/agent; got %v", args)
+		}
+	}
+}
+
 // ── piHarnessPipePath ────────────────────────────────────────────────────────
 
 func TestPIHarnessPipePath_UsesXDGStateHome(t *testing.T) {

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -103,6 +103,7 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".kube"),
 		filepath.Join(stagingHome, ".config", "opencode"),
 		filepath.Join(stagingHome, ".cache"),
+		filepath.Join(stagingHome, ".pi"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o700); err != nil {
@@ -330,6 +331,15 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	symlinkIfExists(
 		filepath.Join(home, ".nix-profile"),
 		filepath.Join(stagingHome, ".nix-profile"),
+	)
+
+	// ── .pi/agent/ ────────────────────────────────────────────────────────────
+	// PI stores auth credentials, themes, and settings in ~/.pi/agent/ on the
+	// host. Mirrors the bwrap --ro-bind for ~/.pi/agent in pi_invocation.go.
+	// Skipped when the directory does not exist (auth not yet set up).
+	symlinkIfExists(
+		filepath.Join(home, ".pi", "agent"),
+		filepath.Join(stagingHome, ".pi", "agent"),
 	)
 
 	return stagingHome, nil
@@ -619,7 +629,7 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 	// Scan the top-level staging HOME and all immediate subdirectories that
 	// the staging HOME builder creates (one level deep).
 	scanDir("")
-	subDirs := []string{".ssh", ".aws", ".kube", ".config/opencode", ".cache"}
+	subDirs := []string{".ssh", ".aws", ".kube", ".config/opencode", ".cache", ".pi"}
 	for _, sub := range subDirs {
 		scanDir(sub)
 	}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -750,6 +750,71 @@ func TestPrepareSandboxExecHome_NixCacheAlwaysIncluded(t *testing.T) {
 	}
 }
 
+// TestPrepareSandboxExecHome_PiAgentDirSymlinked verifies that when ~/.pi/agent
+// exists on the host, PrepareSandboxExecHome creates a symlink at
+// <stagingHome>/.pi/agent pointing to the real directory.
+func TestPrepareSandboxExecHome_PiAgentDirSymlinked(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Create ~/.pi/agent in the fake home.
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("create ~/.pi/agent: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-agent-test",
+		InstanceID:  "pi-agent-symlink-test",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// The symlink must exist at <stagingHome>/.pi/agent.
+	symlinkPath := filepath.Join(stagingHome, ".pi", "agent")
+	fi, err := os.Lstat(symlinkPath)
+	if err != nil {
+		t.Fatalf(".pi/agent symlink must exist: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf(".pi/agent must be a symlink, got mode %v", fi.Mode())
+	}
+	target, err := os.Readlink(symlinkPath)
+	if err != nil {
+		t.Fatalf("readlink .pi/agent: %v", err)
+	}
+	if target != piAgentDir {
+		t.Errorf(".pi/agent symlink target = %q, want %q", target, piAgentDir)
+	}
+}
+
+// TestPrepareSandboxExecHome_PiAgentDirMissingSkipped verifies that when
+// ~/.pi/agent does not exist, PrepareSandboxExecHome succeeds without creating
+// a dangling symlink.
+func TestPrepareSandboxExecHome_PiAgentDirMissingSkipped(t *testing.T) {
+	fakeHome := newFakeHome(t)
+	// Ensure ~/.pi/agent does NOT exist.
+	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-agent-missing",
+		InstanceID:  "pi-agent-missing-test",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// No symlink must exist for .pi/agent when source is absent.
+	symlinkPath := filepath.Join(stagingHome, ".pi", "agent")
+	if _, err := os.Lstat(symlinkPath); err == nil {
+		t.Errorf(".pi/agent must not exist when ~/.pi/agent is absent")
+	}
+}
+
 // TestPrepareSandboxExecHome_IdempotentReCreation verifies that calling
 // PrepareSandboxExecHome a second time on an existing staging dir succeeds
 // without error and does not corrupt symlinks.

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_agent_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_agent_darwin_test.go
@@ -1,0 +1,185 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_pi_agent_darwin_test.go — integration tests for the ~/.pi/agent
+// credential directory in the SBPL profile (issue #1305).
+//
+// PI stores auth credentials in ~/.pi/agent/auth.json. PrepareSandboxExecHome
+// creates a symlink at <stagingHome>/.pi/agent → host ~/.pi/agent, and
+// collectStagingHomeSymlinkTargets resolves the symlink and emits a
+// (subpath "<resolved>") allow rule so PI can read auth.json inside the
+// sandbox.
+//
+// Each positive test is paired with a negative test that removes the covering
+// SBPL rule and asserts failure — proving the positive test is not a no-op.
+// See docs/sandbox-exec-testing.md for the convention (issue #1192).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// hostPIAgentDir creates a fake ~/.pi/agent directory directly under the
+// user's HOME (not under /private/var/folders, which is broadly allowed by
+// the system-paths read rule). Returns the absolute path to the created dir.
+// A cleanup is registered to remove it.
+//
+// We place the dir under HOME deliberately so that the (subpath ...)
+// allow emitted by the profile generator is the specific covering rule —
+// a path under /private/var/folders would remain readable even without it.
+func hostPIAgentDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	dir, err := os.MkdirTemp(home, ".prism-1305-pi-agent-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// TestSandboxExecPI_AgentDirReadable is the positive integration test for the
+// ~/.pi/agent credential directory. It:
+//
+//  1. Creates a fake ~/.pi/agent directory under HOME with a sentinel auth.json.
+//  2. Symlinks <stagingHome>/.pi/agent → the fake dir.
+//  3. Generates the production SBPL profile and verifies a (subpath ...) allow
+//     is emitted for the resolved ~/.pi/agent path.
+//  4. Runs `cat <stagingHome>/.pi/agent/auth.json` inside sandbox-exec and
+//     asserts exit 0 and the sentinel content in the output.
+func TestSandboxExecPI_AgentDirReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	// BareRoot variant: symlink traversal under HOME requires the
+	// BareRoot-ancestor block's file-read-metadata allow on (subpath HOME).
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Plant a fake ~/.pi/agent directory under HOME with a sentinel auth file.
+	piAgentDir := hostPIAgentDir(t)
+	const sentinel = `{"token":"sentinel-1305"}`
+	authFile := filepath.Join(piAgentDir, "auth.json")
+	if err := os.WriteFile(authFile, []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("write fake auth.json: %v", err)
+	}
+
+	// Create the staging symlink: <stagingHome>/.pi/agent → piAgentDir.
+	piStagingDir := filepath.Join(stagingHome, ".pi")
+	if err := os.MkdirAll(piStagingDir, 0o700); err != nil {
+		t.Fatalf("mkdir stagingHome/.pi: %v", err)
+	}
+	symlinkPath := filepath.Join(piStagingDir, "agent")
+	_ = os.Remove(symlinkPath)
+	if err := os.Symlink(piAgentDir, symlinkPath); err != nil {
+		t.Fatalf("symlink stagingHome/.pi/agent: %v", err)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The profile must contain a (subpath ...) allow for the resolved
+	// piAgentDir path.
+	resolved, err := filepath.EvalSymlinks(piAgentDir)
+	if err != nil {
+		resolved = piAgentDir
+	}
+	if !strings.Contains(prepared.content, resolved) {
+		t.Fatalf("generated profile does not reference the resolved ~/.pi/agent path %q.\n"+
+			"The symlink-target resolver did not pick up the staging .pi/agent symlink.\nProfile:\n%s",
+			resolved, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Run: sandbox-exec reads auth.json via the staging HOME symlink chain.
+	authViaStagingPath := filepath.Join(stagingHome, ".pi", "agent", "auth.json")
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(authViaStagingPath))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("read ~/.pi/agent/auth.json via staging HOME failed under production profile.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), "sentinel-1305") {
+		t.Errorf("read succeeded but output does not contain the sentinel marker.\nOutput: %s", string(out))
+	}
+}
+
+// TestSandboxExecPI_AgentDirDeniedWithoutSubpathAllow is the paired negative
+// test. It removes the (subpath "<resolved>") allow line for the ~/.pi/agent
+// directory from the generated profile, then asserts that reading auth.json
+// via the staging HOME symlink fails. This proves the positive test is not
+// green by accident.
+func TestSandboxExecPI_AgentDirDeniedWithoutSubpathAllow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	piAgentDir := hostPIAgentDir(t)
+	authFile := filepath.Join(piAgentDir, "auth.json")
+	if err := os.WriteFile(authFile, []byte(`{"token":"sentinel-1305-neg"}`), 0o600); err != nil {
+		t.Fatalf("write fake auth.json: %v", err)
+	}
+
+	piStagingDir := filepath.Join(stagingHome, ".pi")
+	if err := os.MkdirAll(piStagingDir, 0o700); err != nil {
+		t.Fatalf("mkdir stagingHome/.pi: %v", err)
+	}
+	symlinkPath := filepath.Join(piStagingDir, "agent")
+	_ = os.Remove(symlinkPath)
+	if err := os.Symlink(piAgentDir, symlinkPath); err != nil {
+		t.Fatalf("symlink stagingHome/.pi/agent: %v", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(piAgentDir)
+	if err != nil {
+		resolved = piAgentDir
+	}
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		// Remove the (subpath "<resolved>") line that covers the pi agent dir.
+		toRemove := "  (subpath " + sbplQuoteForTest(resolved) + ")\n"
+		return strings.ReplaceAll(p, toRemove, "")
+	})
+
+	authViaStagingPath := filepath.Join(stagingHome, ".pi", "agent", "auth.json")
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(authViaStagingPath))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read ~/.pi/agent/auth.json succeeded WITHOUT the (subpath ...) allow for the resolved target.\n"+
+			"The negative test is not catching the regression — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — pi agent dir read correctly denied without subpath allow (exit: %v)", runErr)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--ro-bind ~/.pi/agent ~/.pi/agent` to `appendPIBwrapMounts` when the directory exists on the host
- Creates the `~/.pi` parent with `--dir` first so bwrap can resolve the mount point
- Silently skips the mount when `~/.pi/agent` does not exist (auth not yet set up)
- Adds two new tests: `TestAppendPIBwrapMounts_PiAgentDirMounted` and `TestAppendPIBwrapMounts_PiAgentDirMissing`

Without this mount, PI inside the sandbox gets a 400 auth error trying to contact the GitHub Copilot API because it cannot find its credentials in `~/.pi/agent/auth.json`.

Closes #1305