### PR TITLE
copy auth.json, settings.json, themes/ into PI agent staging dir

### DIFF
--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -156,7 +157,84 @@ func StagePIAgentConfigDir(slot config.RoleSlot, sessionName string) (hostDir, s
 		}
 	}
 
+	// Copy auth.json, settings.json, and themes/ from ~/.pi/agent/ into the
+	// staging directory. Each copy is best-effort and silent when the source
+	// does not exist — PI can start without auth (e.g. auth not yet set up).
+	if home, err := os.UserHomeDir(); err == nil {
+		piAgentSrc := filepath.Join(home, ".pi", "agent")
+		for _, name := range []string{"auth.json", "settings.json"} {
+			src := filepath.Join(piAgentSrc, name)
+			dst := filepath.Join(stagingDir, name)
+			_ = copyFileIfExists(src, dst)
+		}
+		themeSrc := filepath.Join(piAgentSrc, "themes")
+		themeDst := filepath.Join(stagingDir, "themes")
+		_ = copyDirIfExists(themeSrc, themeDst)
+	}
+
 	return stagingDir, piAgentConfigSandboxDefault, nil
+}
+
+// copyFileIfExists copies a single regular file from src to dst. It is a
+// no-op (returning nil) when src does not exist. The destination file is
+// created with mode 0o600.
+func copyFileIfExists(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// copyDirIfExists recursively copies a directory tree from src to dst. It is a
+// no-op (returning nil) when src does not exist. Files are written with
+// mode 0o600; directories are created with mode 0o700.
+func copyDirIfExists(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+
+	if mkErr := os.MkdirAll(dst, 0o700); mkErr != nil {
+		return mkErr
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyDirIfExists(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFileIfExists(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // ValidatePIExtensionDir checks that the PI extension directory exists and
@@ -293,22 +371,6 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 	args = append(args, "--dir", parent)
 	args = append(args, "--dir", sandboxExtDir)
 	args = append(args, "--ro-bind", cfg.PIExtensionHostDir, sandboxExtDir)
-
-	// ── ~/.pi/agent directory ────────────────────────────────────────────────
-	// PI stores auth credentials, themes, and settings in ~/.pi/agent/ on the
-	// host. Without this mount PI cannot find its auth token inside the sandbox
-	// and fails with a 400 auth error. Mounted read-only at the same host path.
-	// Silently skipped when the directory does not exist — auth may not be set
-	// up yet, and we do not want to break spawning in that case.
-	if home, err := os.UserHomeDir(); err == nil {
-		piAgentDir := filepath.Join(home, ".pi", "agent")
-		if _, statErr := os.Stat(piAgentDir); statErr == nil {
-			// bwrap requires parent dirs to exist in the sandbox namespace.
-			piParent := filepath.Join(home, ".pi")
-			args = append(args, "--dir", piParent)
-			args = append(args, "--ro-bind", piAgentDir, piAgentDir)
-		}
-	}
 
 	return args, nil
 }

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -390,8 +390,10 @@ func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
 	}
 }
 
-func TestAppendPIBwrapMounts_PiAgentDirMounted(t *testing.T) {
-	// When ~/.pi/agent exists, appendPIBwrapMounts must add --ro-bind for it.
+func TestAppendPIBwrapMounts_NoPiAgentBindMount(t *testing.T) {
+	// ~/.pi/agent is no longer bind-mounted — files are copied into the staging
+	// dir by StagePIAgentConfigDir instead. Verify that even when ~/.pi/agent
+	// exists, appendPIBwrapMounts does NOT add a --ro-bind for it.
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
 
@@ -419,48 +421,106 @@ func TestAppendPIBwrapMounts_PiAgentDirMounted(t *testing.T) {
 		t.Fatalf("appendPIBwrapMounts: %v", err)
 	}
 
-	// Must contain --ro-bind <piAgentDir> <piAgentDir>.
-	if !hasTriple(args, "--ro-bind", piAgentDir, piAgentDir) {
-		t.Errorf("expected --ro-bind %q %q in args; got %v", piAgentDir, piAgentDir, args)
-	}
-	// Must also contain --dir for the parent ~/.pi.
-	piParent := filepath.Join(fakeHome, ".pi")
-	if !hasPair(args, "--dir", piParent) {
-		t.Errorf("expected --dir %q in args for ~/.pi parent; got %v", piParent, args)
+	// Must NOT contain any --ro-bind involving ~/.pi/agent.
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == "--ro-bind" && args[i+1] == piAgentDir {
+			t.Errorf("unexpected --ro-bind for ~/.pi/agent in args; got %v", args)
+		}
 	}
 }
 
-func TestAppendPIBwrapMounts_PiAgentDirMissing(t *testing.T) {
-	// When ~/.pi/agent does not exist, no bind-mount is added and no error is returned.
+// ── StagePIAgentConfigDir: host file copies ──────────────────────────────────
+
+func TestStagePIAgentConfigDir_CopiesAuthAndSettings(t *testing.T) {
+	// When ~/.pi/agent/{auth,settings}.json exist, they must be copied into
+	// the staging dir.
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
-	// Deliberately do NOT create ~/.pi/agent.
-
-	extDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
-		t.Fatalf("write ext: %v", err)
-	}
-	fakePI := filepath.Join(t.TempDir(), "pi")
-	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
-		t.Fatalf("write fake pi binary: %v", err)
-	}
-
-	cfg := Config{
-		PIBinaryPath:       fakePI,
-		PIExtensionHostDir: extDir,
-	}
-
-	args, err := appendPIBwrapMounts(nil, cfg)
-	if err != nil {
-		t.Fatalf("expected no error when ~/.pi/agent is absent; got %v", err)
-	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
-	// Must NOT contain a ro-bind for the missing path.
-	for i := 0; i+2 < len(args); i++ {
-		if args[i] == "--ro-bind" && args[i+1] == piAgentDir {
-			t.Errorf("expected no --ro-bind for absent ~/.pi/agent; got %v", args)
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi/agent: %v", err)
+	}
+	authContent := `{"token":"secret"}`
+	settingsContent := `{"theme":"dark"}`
+	if err := os.WriteFile(filepath.Join(piAgentDir, "auth.json"), []byte(authContent), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(piAgentDir, "settings.json"), []byte(settingsContent), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@copy-test")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"auth.json":     authContent,
+		"settings.json": settingsContent,
+	} {
+		got, readErr := os.ReadFile(filepath.Join(hostDir, name))
+		if readErr != nil {
+			t.Errorf("read %s: %v", name, readErr)
+			continue
 		}
+		if string(got) != want {
+			t.Errorf("%s content = %q, want %q", name, string(got), want)
+		}
+	}
+}
+
+func TestStagePIAgentConfigDir_CopiesThemesDir(t *testing.T) {
+	// When ~/.pi/agent/themes/ exists, its contents must be copied recursively
+	// into the staging dir.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	themesDir := filepath.Join(fakeHome, ".pi", "agent", "themes")
+	if err := os.MkdirAll(themesDir, 0o700); err != nil {
+		t.Fatalf("mkdir themes: %v", err)
+	}
+	themeContent := `{"name":"cool"}`
+	if err := os.WriteFile(filepath.Join(themesDir, "cool.json"), []byte(themeContent), 0o600); err != nil {
+		t.Fatalf("write theme file: %v", err)
+	}
+
+	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@themes-test")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir: %v", err)
+	}
+
+	got, readErr := os.ReadFile(filepath.Join(hostDir, "themes", "cool.json"))
+	if readErr != nil {
+		t.Fatalf("read themes/cool.json: %v", readErr)
+	}
+	if string(got) != themeContent {
+		t.Errorf("themes/cool.json content = %q, want %q", string(got), themeContent)
+	}
+}
+
+func TestStagePIAgentConfigDir_MissingHostFiles(t *testing.T) {
+	// When ~/.pi/agent does not exist at all, staging succeeds without error
+	// and the optional files are simply absent from the staging dir.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Deliberately do NOT create ~/.pi/agent.
+
+	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@missing-pi")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir: %v", err)
+	}
+
+	for _, name := range []string{"auth.json", "settings.json"} {
+		if _, statErr := os.Stat(filepath.Join(hostDir, name)); statErr == nil {
+			t.Errorf("%s must not exist when source is absent", name)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(hostDir, "themes")); statErr == nil {
+		t.Errorf("themes/ must not exist when source is absent")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -333,15 +333,6 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".nix-profile"),
 	)
 
-	// ── .pi/agent/ ────────────────────────────────────────────────────────────
-	// PI stores auth credentials, themes, and settings in ~/.pi/agent/ on the
-	// host. Mirrors the bwrap --ro-bind for ~/.pi/agent in pi_invocation.go.
-	// Skipped when the directory does not exist (auth not yet set up).
-	symlinkIfExists(
-		filepath.Join(home, ".pi", "agent"),
-		filepath.Join(stagingHome, ".pi", "agent"),
-	)
-
 	return stagingHome, nil
 }
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -750,10 +750,10 @@ func TestPrepareSandboxExecHome_NixCacheAlwaysIncluded(t *testing.T) {
 	}
 }
 
-// TestPrepareSandboxExecHome_PiAgentDirSymlinked verifies that when ~/.pi/agent
-// exists on the host, PrepareSandboxExecHome creates a symlink at
-// <stagingHome>/.pi/agent pointing to the real directory.
-func TestPrepareSandboxExecHome_PiAgentDirSymlinked(t *testing.T) {
+// TestPrepareSandboxExecHome_PiAgentDirNotSymlinked verifies that
+// PrepareSandboxExecHome no longer creates a ~/.pi/agent symlink — auth files
+// are now copied into the staging dir by StagePIAgentConfigDir instead.
+func TestPrepareSandboxExecHome_PiAgentDirNotSymlinked(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
 	// Create ~/.pi/agent in the fake home.
@@ -772,21 +772,11 @@ func TestPrepareSandboxExecHome_PiAgentDirSymlinked(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// The symlink must exist at <stagingHome>/.pi/agent.
+	// No symlink must be created at <stagingHome>/.pi/agent — the staging dir
+	// approach copies files via StagePIAgentConfigDir instead.
 	symlinkPath := filepath.Join(stagingHome, ".pi", "agent")
-	fi, err := os.Lstat(symlinkPath)
-	if err != nil {
-		t.Fatalf(".pi/agent symlink must exist: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Errorf(".pi/agent must be a symlink, got mode %v", fi.Mode())
-	}
-	target, err := os.Readlink(symlinkPath)
-	if err != nil {
-		t.Fatalf("readlink .pi/agent: %v", err)
-	}
-	if target != piAgentDir {
-		t.Errorf(".pi/agent symlink target = %q, want %q", target, piAgentDir)
+	if _, err := os.Lstat(symlinkPath); err == nil {
+		t.Errorf(".pi/agent must not be symlinked by PrepareSandboxExecHome (files are copied by StagePIAgentConfigDir)")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_agent_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_agent_darwin_test.go
@@ -2,18 +2,22 @@
 
 package integration_test
 
-// sandbox_exec_pi_agent_darwin_test.go — integration tests for the ~/.pi/agent
-// credential directory in the SBPL profile (issue #1305).
+// sandbox_exec_pi_agent_darwin_test.go — integration tests for PI agent
+// credential files in the SBPL profile (issue #1305).
 //
-// PI stores auth credentials in ~/.pi/agent/auth.json. PrepareSandboxExecHome
-// creates a symlink at <stagingHome>/.pi/agent → host ~/.pi/agent, and
-// collectStagingHomeSymlinkTargets resolves the symlink and emits a
-// (subpath "<resolved>") allow rule so PI can read auth.json inside the
-// sandbox.
+// PI stores auth credentials in ~/.pi/agent/auth.json. StagePIAgentConfigDir
+// copies auth.json, settings.json, and themes/ from ~/.pi/agent/ directly into
+// the per-session staging directory. The staging directory is already covered
+// by the stagingHome (subpath ...) allow rule, so no additional SBPL rule is
+// needed for the PI credential files.
 //
-// Each positive test is paired with a negative test that removes the covering
-// SBPL rule and asserts failure — proving the positive test is not a no-op.
-// See docs/sandbox-exec-testing.md for the convention (issue #1192).
+// The positive test verifies that sandbox-exec can read auth.json from the
+// staging directory after StagePIAgentConfigDir copies it there. The negative
+// test removes the stagingHome subpath allow and asserts that the read fails,
+// proving the positive test is not a no-op.
+//
+// Each positive test is paired with a negative test per the convention in
+// docs/sandbox-exec-testing.md (issue #1192).
 
 import (
 	"os"
@@ -22,39 +26,19 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
 )
 
-// hostPIAgentDir creates a fake ~/.pi/agent directory directly under the
-// user's HOME (not under /private/var/folders, which is broadly allowed by
-// the system-paths read rule). Returns the absolute path to the created dir.
-// A cleanup is registered to remove it.
-//
-// We place the dir under HOME deliberately so that the (subpath ...)
-// allow emitted by the profile generator is the specific covering rule —
-// a path under /private/var/folders would remain readable even without it.
-func hostPIAgentDir(t *testing.T) string {
-	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		t.Skipf("cannot determine user home: %v", err)
-	}
-	dir, err := os.MkdirTemp(home, ".prism-1305-pi-agent-*")
-	if err != nil {
-		t.Fatalf("MkdirTemp(home): %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
-}
-
-// TestSandboxExecPI_AgentDirReadable is the positive integration test for the
-// ~/.pi/agent credential directory. It:
+// TestSandboxExecPI_AgentDirReadable is the positive integration test for
+// PI agent credential files. It:
 //
 //  1. Creates a fake ~/.pi/agent directory under HOME with a sentinel auth.json.
-//  2. Symlinks <stagingHome>/.pi/agent → the fake dir.
-//  3. Generates the production SBPL profile and verifies a (subpath ...) allow
-//     is emitted for the resolved ~/.pi/agent path.
-//  4. Runs `cat <stagingHome>/.pi/agent/auth.json` inside sandbox-exec and
-//     asserts exit 0 and the sentinel content in the output.
+//  2. Calls StagePIAgentConfigDir, which copies auth.json into the staging dir.
+//  3. Verifies the production SBPL profile covers the staging dir path.
+//  4. Runs `cat <stagingDir>/auth.json` inside sandbox-exec and asserts exit 0
+//     and the sentinel content in the output.
 func TestSandboxExecPI_AgentDirReadable(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -62,8 +46,7 @@ func TestSandboxExecPI_AgentDirReadable(t *testing.T) {
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	// BareRoot variant: symlink traversal under HOME requires the
-	// BareRoot-ancestor block's file-read-metadata allow on (subpath HOME).
+	// BareRoot variant so the stagingHome subpath rule is present.
 	m := newProfileManagerWithBareRoot(t)
 
 	stagingHome, err := m.PrepareSandboxExecHome()
@@ -73,48 +56,96 @@ func TestSandboxExecPI_AgentDirReadable(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
 	// Plant a fake ~/.pi/agent directory under HOME with a sentinel auth file.
-	piAgentDir := hostPIAgentDir(t)
+	// We use HOME (not /private/var/folders) so the staging dir is the
+	// specific path covered by the (subpath stagingHome) rule rather than
+	// being readable via a broad system-paths allow.
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	piAgentDir, err := os.MkdirTemp(home, ".prism-1305-pi-agent-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(piAgentDir) })
+
 	const sentinel = `{"token":"sentinel-1305"}`
-	authFile := filepath.Join(piAgentDir, "auth.json")
-	if err := os.WriteFile(authFile, []byte(sentinel), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(piAgentDir, "auth.json"), []byte(sentinel), 0o600); err != nil {
 		t.Fatalf("write fake auth.json: %v", err)
 	}
 
-	// Create the staging symlink: <stagingHome>/.pi/agent → piAgentDir.
-	piStagingDir := filepath.Join(stagingHome, ".pi")
-	if err := os.MkdirAll(piStagingDir, 0o700); err != nil {
-		t.Fatalf("mkdir stagingHome/.pi: %v", err)
+	// Override HOME so StagePIAgentConfigDir picks up our fake ~/.pi/agent.
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", home)
+	_ = origHome
+
+	// StagePIAgentConfigDir resolves ~/.pi/agent from HOME. Point it at our
+	// fake dir by temporarily renaming the real one and placing our fake one
+	// at the expected location, or — simpler — we create the fake dir at the
+	// exact path ~/.pi/agent that StagePIAgentConfigDir reads.
+	realPiAgentPath := filepath.Join(home, ".pi", "agent")
+	// Stash the real directory if it exists so we can restore it.
+	stashed := false
+	stashPath := filepath.Join(home, ".pi", "agent.prism-test-stash")
+	if _, statErr := os.Lstat(realPiAgentPath); statErr == nil {
+		if renErr := os.Rename(realPiAgentPath, stashPath); renErr == nil {
+			stashed = true
+			t.Cleanup(func() {
+				_ = os.RemoveAll(realPiAgentPath)
+				_ = os.Rename(stashPath, realPiAgentPath)
+			})
+		}
 	}
-	symlinkPath := filepath.Join(piStagingDir, "agent")
-	_ = os.Remove(symlinkPath)
-	if err := os.Symlink(piAgentDir, symlinkPath); err != nil {
-		t.Fatalf("symlink stagingHome/.pi/agent: %v", err)
+	// Place our fake dir at ~/.pi/agent.
+	if err := os.MkdirAll(filepath.Join(home, ".pi"), 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi: %v", err)
+	}
+	if err := os.Rename(piAgentDir, realPiAgentPath); err != nil {
+		t.Fatalf("rename fake pi agent dir to ~/.pi/agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(realPiAgentPath)
+		if stashed {
+			_ = os.Rename(stashPath, realPiAgentPath)
+		}
+	})
+	// Update piAgentDir to the new location.
+	piAgentDir = realPiAgentPath
+
+	// Call the real StagePIAgentConfigDir so auth.json is copied into the
+	// staging dir. We use a synthetic session name; XDG_STATE_HOME is not
+	// overridden so staging lands under the real state dir.
+	piStagingHostDir, _, stageErr := container.StagePIAgentConfigDir(
+		config.RoleSlot{}, "integration-test-1305@pi-agent-readable")
+	if stageErr != nil {
+		t.Fatalf("StagePIAgentConfigDir: %v", stageErr)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(piStagingHostDir) })
+
+	// auth.json must have been copied into the staging dir.
+	stagedAuthPath := filepath.Join(piStagingHostDir, "auth.json")
+	if _, statErr := os.Stat(stagedAuthPath); statErr != nil {
+		t.Fatalf("auth.json not found in staging dir %q: %v", piStagingHostDir, statErr)
 	}
 
 	prepared, _ := preparePositiveProfile(t, m)
 
-	// The profile must contain a (subpath ...) allow for the resolved
-	// piAgentDir path.
-	resolved, err := filepath.EvalSymlinks(piAgentDir)
-	if err != nil {
-		resolved = piAgentDir
-	}
-	if !strings.Contains(prepared.content, resolved) {
-		t.Fatalf("generated profile does not reference the resolved ~/.pi/agent path %q.\n"+
-			"The symlink-target resolver did not pick up the staging .pi/agent symlink.\nProfile:\n%s",
-			resolved, prepared.content)
+	// The profile must contain a (subpath ...) allow that covers stagingHome
+	// (where auth.json now lives).
+	if !strings.Contains(prepared.content, stagingHome) {
+		t.Fatalf("generated profile does not reference stagingHome %q.\nProfile:\n%s",
+			stagingHome, prepared.content)
 	}
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	// Run: sandbox-exec reads auth.json via the staging HOME symlink chain.
-	authViaStagingPath := filepath.Join(stagingHome, ".pi", "agent", "auth.json")
+	// Run: sandbox-exec reads auth.json from the staging dir.
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(authViaStagingPath))
+		"cat "+shQuote(stagedAuthPath))
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
-		t.Fatalf("read ~/.pi/agent/auth.json via staging HOME failed under production profile.\n"+
+		t.Fatalf("read auth.json from staging dir failed under production profile.\n"+
 			"Exit: %v\nOutput: %s\nProfile: %s",
 			runErr, string(out), testProfilePath)
 	}
@@ -124,10 +155,9 @@ func TestSandboxExecPI_AgentDirReadable(t *testing.T) {
 }
 
 // TestSandboxExecPI_AgentDirDeniedWithoutSubpathAllow is the paired negative
-// test. It removes the (subpath "<resolved>") allow line for the ~/.pi/agent
-// directory from the generated profile, then asserts that reading auth.json
-// via the staging HOME symlink fails. This proves the positive test is not
-// green by accident.
+// test. It removes the (subpath "<stagingHome>") allow line from the generated
+// profile, then asserts that reading auth.json from the staging dir fails.
+// This proves the positive test is not green by accident.
 func TestSandboxExecPI_AgentDirDeniedWithoutSubpathAllow(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -143,43 +173,36 @@ func TestSandboxExecPI_AgentDirDeniedWithoutSubpathAllow(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	piAgentDir := hostPIAgentDir(t)
-	authFile := filepath.Join(piAgentDir, "auth.json")
-	if err := os.WriteFile(authFile, []byte(`{"token":"sentinel-1305-neg"}`), 0o600); err != nil {
-		t.Fatalf("write fake auth.json: %v", err)
+	// Create a minimal auth.json directly in a temp staging dir to test with.
+	piStagingHostDir, _, stageErr := container.StagePIAgentConfigDir(
+		config.RoleSlot{}, "integration-test-1305@pi-agent-denied")
+	if stageErr != nil {
+		t.Fatalf("StagePIAgentConfigDir: %v", stageErr)
 	}
+	t.Cleanup(func() { _ = os.RemoveAll(piStagingHostDir) })
 
-	piStagingDir := filepath.Join(stagingHome, ".pi")
-	if err := os.MkdirAll(piStagingDir, 0o700); err != nil {
-		t.Fatalf("mkdir stagingHome/.pi: %v", err)
-	}
-	symlinkPath := filepath.Join(piStagingDir, "agent")
-	_ = os.Remove(symlinkPath)
-	if err := os.Symlink(piAgentDir, symlinkPath); err != nil {
-		t.Fatalf("symlink stagingHome/.pi/agent: %v", err)
-	}
-
-	resolved, err := filepath.EvalSymlinks(piAgentDir)
-	if err != nil {
-		resolved = piAgentDir
+	// Write a sentinel directly into the staging dir (source ~/.pi/agent may
+	// not exist in CI; we only need the file to be present for the read test).
+	stagedAuthPath := filepath.Join(piStagingHostDir, "auth.json")
+	if err := os.WriteFile(stagedAuthPath, []byte(`{"token":"sentinel-1305-neg"}`), 0o600); err != nil {
+		t.Fatalf("write staged auth.json: %v", err)
 	}
 
 	mutatedPath := withMutatedProfile(t, m, func(p string) string {
-		// Remove the (subpath "<resolved>") line that covers the pi agent dir.
-		toRemove := "  (subpath " + sbplQuoteForTest(resolved) + ")\n"
+		// Remove the (subpath "<stagingHome>") line that covers the staging dir.
+		toRemove := "  (subpath " + sbplQuoteForTest(stagingHome) + ")\n"
 		return strings.ReplaceAll(p, toRemove, "")
 	})
 
-	authViaStagingPath := filepath.Join(stagingHome, ".pi", "agent", "auth.json")
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(authViaStagingPath))
+		"cat "+shQuote(stagedAuthPath))
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
-		t.Errorf("read ~/.pi/agent/auth.json succeeded WITHOUT the (subpath ...) allow for the resolved target.\n"+
+		t.Errorf("read auth.json succeeded WITHOUT the (subpath ...) allow for stagingHome.\n"+
 			"The negative test is not catching the regression — investigate.\n"+
 			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
 	} else {
-		t.Logf("ka pai — pi agent dir read correctly denied without subpath allow (exit: %v)", runErr)
+		t.Logf("ka pai — pi agent auth.json read correctly denied without stagingHome subpath allow (exit: %v)", runErr)
 	}
 }


### PR DESCRIPTION
## Summary

- `StagePIAgentConfigDir` now copies `auth.json`, `settings.json`, and `themes/` from `~/.pi/agent/` into the per-session staging directory. Each copy is best-effort and silent when the source doesn't exist.
- Removes the `~/.pi/agent` bind-mount from `appendPIBwrapMounts` — all needed files now live in the staging dir, which is already bind-mounted read-only into bwrap.
- Removes the `~/.pi/agent` symlink from `PrepareSandboxExecHome` (sandbox-exec path) for the same reason.

Closes #1303