### PR TITLE
fix: mount pi agent staging dir read-write so pi can create lock files

### DIFF
--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -346,7 +346,7 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 		parent := filepath.Dir(agentConfigSandboxDir)
 		args = append(args, "--dir", parent)
 		args = append(args, "--dir", agentConfigSandboxDir)
-		args = append(args, "--ro-bind", agentConfigHostDir, agentConfigSandboxDir)
+		args = append(args, "--bind", agentConfigHostDir, agentConfigSandboxDir)
 		args = append(args, "--setenv", "PI_CODING_AGENT_DIR", agentConfigSandboxDir)
 	}
 

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -380,13 +380,13 @@ func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
 	// The agent config dir must be ro-bind-mounted.
 	found = false
 	for i := 0; i+2 < len(args); i++ {
-		if args[i] == "--ro-bind" && args[i+1] == agentConfigDir && args[i+2] == customSandboxDir {
+		if args[i] == "--bind" && args[i+1] == agentConfigDir && args[i+2] == customSandboxDir {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected --ro-bind %q %q in args; got %v", agentConfigDir, customSandboxDir, args)
+		t.Errorf("expected --bind %q %q in args; got %v", agentConfigDir, customSandboxDir, args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Changes `--ro-bind` to `--bind` for the PI agent config staging directory in `appendPIBwrapMounts`
- PI tries to create `settings.json.lock` in `PI_CODING_AGENT_DIR` on startup; the read-only mount caused `EROFS: read-only file system` errors, preventing settings and theming from loading
- Updates the corresponding test assertion from `--ro-bind` to `--bind`