### PR TITLE
fix: read/write credentials under anthropic key in auth.json

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
@@ -1,0 +1,136 @@
+// Unit tests for credentials.ts — nested auth.json shape.
+// Run with: node --test credentials.test.ts  (Node 20+, zero new deps)
+//
+// credentials.ts respects PI_AUTH_JSON env var so we point it at a temp file
+// in each test, avoiding any dependency on the real home directory.
+
+import { describe, it, beforeEach, afterEach } from "node:test"
+import assert from "node:assert/strict"
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Import under test after env is set. Since the module caches nothing about
+// the path at import time (it calls getAuthJsonPath() at call time), a single
+// import suffices; individual tests just update PI_AUTH_JSON before calling.
+import {
+  readCredentials,
+  writeCredentials,
+} from "./credentials.ts"
+
+let tempDir: string
+let authJson: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "pi-creds-test-"))
+  authJson = join(tempDir, "auth.json")
+  process.env.PI_AUTH_JSON = authJson
+})
+
+afterEach(() => {
+  delete process.env.PI_AUTH_JSON
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+function writeAuthJson(data: unknown): void {
+  writeFileSync(authJson, JSON.stringify(data, null, 2), "utf-8")
+}
+
+// ---------------------------------------------------------------------------
+// readCredentials tests
+// ---------------------------------------------------------------------------
+
+describe("readCredentials", () => {
+  it("returns null when auth.json is absent", () => {
+    assert.equal(readCredentials(), null)
+  })
+
+  it("returns null when auth.json is malformed JSON", () => {
+    writeFileSync(authJson, "not-json", "utf-8")
+    assert.equal(readCredentials(), null)
+  })
+
+  it("returns null when auth.json has no 'anthropic' key", () => {
+    writeAuthJson({ "github-copilot": { token: "abc" } })
+    assert.equal(readCredentials(), null)
+  })
+
+  it("returns null when anthropic block is missing required fields", () => {
+    writeAuthJson({ anthropic: { access: "tok" } }) // missing refresh, expires
+    assert.equal(readCredentials(), null)
+  })
+
+  it("returns valid ClaudeCredentials from nested anthropic key", () => {
+    const expires = Date.now() + 3_600_000
+    writeAuthJson({
+      anthropic: {
+        access: "acc-token",
+        refresh: "ref-token",
+        expires,
+      },
+      "github-copilot": { token: "gh-token" },
+    })
+    const creds = readCredentials()
+    assert.ok(creds !== null, "should return credentials")
+    assert.equal(creds.accessToken, "acc-token")
+    assert.equal(creds.refreshToken, "ref-token")
+    assert.equal(creds.expiresAt, expires)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// writeCredentials tests
+// ---------------------------------------------------------------------------
+
+describe("writeCredentials", () => {
+  it("writes credentials under the anthropic key", () => {
+    const expires = Date.now() + 3_600_000
+    writeCredentials({ accessToken: "a", refreshToken: "r", expiresAt: expires })
+
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.ok(data.anthropic, "anthropic key should exist")
+    assert.equal(data.anthropic.access, "a")
+    assert.equal(data.anthropic.refresh, "r")
+    assert.equal(data.anthropic.expires, expires)
+  })
+
+  it("creates the anthropic key when auth.json previously had none", () => {
+    writeAuthJson({ "github-copilot": { token: "gh" } })
+    writeCredentials({ accessToken: "x", refreshToken: "y", expiresAt: 123 })
+
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.equal(data.anthropic.access, "x")
+    // Existing keys must be preserved
+    assert.deepEqual(data["github-copilot"], { token: "gh" })
+  })
+
+  it("preserves other top-level keys when updating anthropic", () => {
+    const expires = Date.now() + 1000
+    writeAuthJson({
+      anthropic: { access: "old-a", refresh: "old-r", expires: 0 },
+      "github-copilot": { token: "gh" },
+      someOtherKey: 42,
+    })
+    writeCredentials({ accessToken: "new-a", refreshToken: "new-r", expiresAt: expires })
+
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.equal(data.anthropic.access, "new-a")
+    assert.deepEqual(data["github-copilot"], { token: "gh" })
+    assert.equal(data.someOtherKey, 42)
+  })
+
+  it("creates parent directories if auth.json dir does not exist", () => {
+    // Point to a nested path that doesn't exist yet
+    const nested = join(tempDir, "deep", "nested", "auth.json")
+    process.env.PI_AUTH_JSON = nested
+    writeCredentials({ accessToken: "z", refreshToken: "w", expiresAt: 0 })
+    const data = JSON.parse(readFileSync(nested, "utf-8"))
+    assert.equal(data.anthropic.access, "z")
+  })
+})

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
@@ -34,7 +34,7 @@ export const OAUTH_TOKEN_URL = "https://claude.ai/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 function getAuthJsonPath(): string {
-  return join(homedir(), ".pi", "agent", "auth.json")
+  return process.env.PI_AUTH_JSON ?? join(homedir(), ".pi", "agent", "auth.json")
 }
 
 /**
@@ -48,23 +48,27 @@ export function readCredentials(): ClaudeCredentials | null {
     const raw = readFileSync(authPath, "utf-8").trim()
     if (!raw) return null
     const data = JSON.parse(raw) as {
-      access?: string
-      refresh?: string
-      expires?: number
+      anthropic?: {
+        access?: string
+        refresh?: string
+        expires?: number
+      }
     }
+    const provider = data.anthropic
     if (
-      typeof data.access !== "string" ||
-      typeof data.refresh !== "string" ||
-      typeof data.expires !== "number"
+      !provider ||
+      typeof provider.access !== "string" ||
+      typeof provider.refresh !== "string" ||
+      typeof provider.expires !== "number"
     ) {
       log("credentials_read_malformed", { path: authPath })
       return null
     }
     log("credentials_read_ok", { path: authPath })
     return {
-      accessToken: data.access,
-      refreshToken: data.refresh,
-      expiresAt: data.expires,
+      accessToken: provider.access,
+      refreshToken: provider.refresh,
+      expiresAt: provider.expires,
     }
   } catch (err) {
     log("credentials_read_error", {
@@ -91,9 +95,11 @@ export function writeCredentials(creds: ClaudeCredentials): void {
     // Start fresh if malformed
   }
 
-  existing.access = creds.accessToken
-  existing.refresh = creds.refreshToken
-  existing.expires = creds.expiresAt
+  existing.anthropic = {
+    access: creds.accessToken,
+    refresh: creds.refreshToken,
+    expires: creds.expiresAt,
+  }
 
   const dir = dirname(authPath)
   if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary

- `readCredentials()` was returning `null` because it looked for top-level `access`/`refresh`/`expires` fields, but pi's `auth.json` nests credentials under an `anthropic` key
- Updated `readCredentials()` to read from `data.anthropic.{access,refresh,expires}`
- Updated `writeCredentials()` to write back under the `anthropic` key, preserving all other top-level keys (e.g. `github-copilot`)
- Added `PI_AUTH_JSON` env var override to allow test isolation
- Added `credentials.test.ts` with 9 tests covering all AC scenarios

Closes #1305