### PR TITLE
fix: anthropic-oauth extension no longer intercepts github-copilot requests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777518431,
-        "narHash": "sha256-SwgiG2T5pbyo33Vz7/vUCAhEMgwCK8Pa2nDSx5a6/WE=",
+        "lastModified": 1777733408,
+        "narHash": "sha256-lyKV2GtkMPS1Mp8bKJ8sBr7LPCzL4GnVnQQYa4e7UsQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e54a938cdd4c8e414b2518edc3d82308027c670",
+        "rev": "9ce9f7f128c5834bb71a4f5c62232187371379b6",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1777526009,
-        "narHash": "sha256-HpDDrmLvq+In5Pn/AMrihcU+Oy9qFXpH4nk0GmUYkeY=",
+        "lastModified": 1777758553,
+        "narHash": "sha256-HoAS8bKwefKZFjmiMTpp1F+7/phwJAjI8vWbPGx6lFw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5715298dbadcfac44c53b4d67f6ae0cfff05e69d",
+        "rev": "84a302f87ce6c7d88d37972e84bb22ce50cc769e",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1777077449,
-        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -72,6 +72,9 @@
         treeFilterMode = "default";
         quietStartup = true;
         enableInstallTelemetry = false;
+        warnings = {
+          anthropicExtraUsage = false;
+        };
 
         # Vendored extension: replaces the previous npm:pi-anthropic-oauth@0.1.9
         # package. The extension is stored in the nix store as plain TypeScript

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -29,6 +29,7 @@ import {
 } from "./auth.ts"
 import { getCachedCredentials } from "./credentials.ts"
 import { transformBody, transformResponseStream } from "./transforms.ts"
+import { streamSimpleAnthropic } from "@mariozechner/pi-ai"
 import { getModelBetas, getExcludedBetas } from "./betas.ts"
 import { config } from "./model-config.ts"
 import {
@@ -125,6 +126,14 @@ export default function (pi: ExtensionAPI) {
     //   - Automatic token refresh on 401
     //   - Manual SSE parsing (zero npm deps — no @anthropic-ai/sdk)
     streamSimple: (model, context, options) => {
+      // Only intercept requests for the anthropic provider (Claude OAuth subscriptions).
+      // For all other providers (github-copilot, openrouter, etc.) that also use the
+      // anthropic-messages API type, delegate to pi's built-in handler which has
+      // provider-specific logic (e.g. Copilot dynamic headers).
+      if (model.provider !== "anthropic") {
+        return streamSimpleAnthropic(model, context, options)
+      }
+
       const { createAssistantMessageEventStream, calculateCost } =
         require("@mariozechner/pi-ai") as typeof import("@mariozechner/pi-ai")
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -120,14 +120,24 @@ rec {
           jsonschema = "${placeholder "out"}/share/opencode/schema.json";
         };
       });
-      pi-coding-agent = masterPkgs.pi-coding-agent.overrideAttrs (old: {
-        postPatch = (old.postPatch or "") + ''
-          substituteInPlace packages/coding-agent/src/modes/interactive/interactive-mode.ts \
-            --replace-fail \
-              'this.showWarning(ANTHROPIC_SUBSCRIPTION_AUTH_WARNING);' \
-              '/* anthropic subscription warning suppressed */'
-        '';
-      });
+      pi-coding-agent =
+        let
+          newSrc = prev.fetchFromGitHub {
+            owner = "badlogic";
+            repo = "pi-mono";
+            tag = "v0.72.1";
+            hash = "sha256-SqUxghc60P3HfmaFJGB/m23mvzw0cD7cDEUrNFOqo0Y=";
+          };
+        in
+        prev.pi-coding-agent.overrideAttrs (old: {
+          version = "0.72.1";
+          src = newSrc;
+          npmDeps = prev.fetchNpmDeps {
+            inherit (old) npmWorkspace;
+            src = newSrc;
+            hash = "sha256-KUC1xQK6oJXtg962YeLOnO76uTdR10/VNa9iiCdT3VM=";
+          };
+        });
 
       # direnv: disable the test phase on Darwin to work around a hang in
       # `direnv-test.zsh` introduced when libarchive was bumped 3.8.4 -> 3.8.6


### PR DESCRIPTION
## Summary

- The `anthropic-oauth` extension's `streamSimple` handler was registered against the `anthropic-messages` API type globally. Pi dispatches `streamSimple` by API type, not provider name, so it was intercepting **all** `anthropic-messages` requests — including github-copilot ones.
- When called for a github-copilot request, the custom handler rebuilt the request body from scratch without Copilot-specific headers, causing a 400 from GitHub's endpoint.
- Fix adds a `model.provider !== "anthropic"` guard at the top of `streamSimple`, delegating non-anthropic requests to pi's built-in `streamSimpleAnthropic` which already handles github-copilot correctly (dynamic headers, correct auth, etc.).
- Also bumps `pi-coding-agent` overlay to v0.72.1 and updates `flake.lock`.

Closes #1305