### PR TITLE
fix: delegate hostIsolator.SidecarFlags to commonHostAPISidecarFlags

### DIFF
--- a/modules/programs/prism/prism/internal/container/dispatch.go
+++ b/modules/programs/prism/prism/internal/container/dispatch.go
@@ -557,11 +557,13 @@ func (h *hostIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
 	return opts.DirectCmd
 }
 
-// SidecarFlags returns nil for host mode: the sidecar is not started for
-// host sessions. (StartSidecarWithOpts is gated by isolation mode upstream;
-// SidecarFlags being nil here is a safety net.)
+// SidecarFlags returns the sidecar argv extensions for host mode. Host
+// sessions use the same host-API socket path as bwrap/sandbox-exec, so the
+// common helper is shared. --agent-role is included when opts.AgentRole is
+// non-empty so that agent_status.agent_name is written for host-isolation
+// sessions (including the pi harness).
 func (h *hostIsolator) SidecarFlags(opts SidecarFlagOpts) []string {
-	return nil
+	return commonHostAPISidecarFlags(opts)
 }
 
 // ArchivePaths returns the host archive layout: storage in the shared root,

--- a/modules/programs/prism/prism/internal/container/dispatch.go
+++ b/modules/programs/prism/prism/internal/container/dispatch.go
@@ -593,10 +593,10 @@ func shellQuotePodman(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// commonHostAPISidecarFlags returns the SidecarFlags shared by bwrap and
-// sandbox-exec. Both modes set up a host-API socket and harness but do not
-// own a container lifecycle, so --container is intentionally omitted. Mirrors
-// the pre-refactor branch in StartSidecarWithOpts
+// commonHostAPISidecarFlags returns the SidecarFlags shared by bwrap,
+// sandbox-exec, and host. All three modes set up a host-API socket and harness
+// but do not own a container lifecycle, so --container is intentionally
+// omitted. Mirrors the pre-refactor branch in StartSidecarWithOpts
 // (internal/session/sidecar.go:336-352).
 func commonHostAPISidecarFlags(opts SidecarFlagOpts) []string {
 	out := []string{"--port", fmt.Sprintf("%d", opts.Port)}

--- a/modules/programs/prism/prism/internal/container/dispatch_test.go
+++ b/modules/programs/prism/prism/internal/container/dispatch_test.go
@@ -1,0 +1,43 @@
+package container
+
+import (
+	"testing"
+)
+
+// ── hostIsolator.SidecarFlags ─────────────────────────────────────────────────
+
+func TestHostIsolator_SidecarFlags_WithAgentRole(t *testing.T) {
+	h := &hostIsolator{}
+	opts := SidecarFlagOpts{
+		Port:      9000,
+		AgentRole: "worker",
+	}
+	flags := h.SidecarFlags(opts)
+
+	// Must include --agent-role worker
+	found := false
+	for i := 0; i+1 < len(flags); i++ {
+		if flags[i] == "--agent-role" && flags[i+1] == "worker" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --agent-role worker in SidecarFlags output, got %v", flags)
+	}
+}
+
+func TestHostIsolator_SidecarFlags_EmptyAgentRole(t *testing.T) {
+	h := &hostIsolator{}
+	opts := SidecarFlagOpts{
+		Port:      9000,
+		AgentRole: "",
+	}
+	flags := h.SidecarFlags(opts)
+
+	for _, f := range flags {
+		if f == "--agent-role" {
+			t.Errorf("expected --agent-role to be absent when AgentRole is empty, got flags: %v", flags)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -350,7 +350,7 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 	//
 	//   - podman:               --container --port --agent-role --plugin-path …
 	//   - bwrap, sandbox-exec:  --port --agent-role --plugin-path …  (no --container)
-	//   - host:                 nil (the sidecar is not started for host)
+	//   - host:                 --port --agent-role --plugin-path …  (same as bwrap/sandbox-exec)
 	//
 	// The pre-refactor branch lived at internal/session/sidecar.go:317-352.
 	if opts.IsolationMode != "" {


### PR DESCRIPTION
## Summary

- `hostIsolator.SidecarFlags()` was returning `nil` unconditionally, so `--agent-role` was never passed to the sidecar for host-isolation-mode sessions (including the pi harness).
- Changed it to delegate to `commonHostAPISidecarFlags(opts)`, consistent with `bwrapIsolator` and `sandboxExecIsolator`.
- Added unit tests asserting `--agent-role` is present when non-empty and absent when empty.

Closes #1311