### PR TITLE
feat: prism status bar — show role, branch, and review cycles in PI footer

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -35,6 +35,9 @@ import {
   GUARD_STATE_ENTRY_TYPE,
   DOOM_LOOP_THRESHOLD,
   REVIEW_CYCLE_THRESHOLD,
+  // Status bar
+  formatPrismStatus,
+  extractBranch,
 } from "./prism.ts"
 
 // ---------------------------------------------------------------------------
@@ -997,5 +1000,74 @@ describe("isGitPush", () => {
 
   it("does not match unrelated commands", () => {
     assert.equal(isGitPush("go test ./..."), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatPrismStatus
+// ---------------------------------------------------------------------------
+
+describe("formatPrismStatus — coordinator", () => {
+  it("shows role and branch", () => {
+    const text = formatPrismStatus("coordinator", "main", null, 0)
+    assert.equal(text, "[coordinator] main")
+  })
+})
+
+describe("formatPrismStatus — worker", () => {
+  it("shows role and branch", () => {
+    const text = formatPrismStatus("worker", "fix-login-redirect", null, 0)
+    assert.equal(text, "[worker] fix-login-redirect")
+  })
+
+  it("does not include PR info even if cycles > 0", () => {
+    const text = formatPrismStatus("worker", "some-branch", "42", 2)
+    assert.equal(text, "[worker] some-branch")
+  })
+})
+
+describe("formatPrismStatus — review", () => {
+  it("includes PR number and cycle count", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", "42", 2)
+    assert.equal(text, "[review] fix-login-redirect · PR#42 · 2 cycles")
+  })
+
+  it("uses singular 'cycle' when count is 1", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", "42", 1)
+    assert.equal(text, "[review] fix-login-redirect · PR#42 · 1 cycle")
+  })
+
+  it("omits PR info when pr_number is null", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", null, 0)
+    assert.equal(text, "[review] fix-login-redirect")
+  })
+})
+
+describe("formatPrismStatus — unknown role", () => {
+  it("shows [unknown] when role is empty", () => {
+    const text = formatPrismStatus("", "main", null, 0)
+    assert.equal(text, "[unknown] main")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractBranch
+// ---------------------------------------------------------------------------
+
+describe("extractBranch", () => {
+  it("extracts the part after @ in session_name", () => {
+    assert.equal(extractBranch("nixos-config@fix-login"), "fix-login")
+  })
+
+  it("returns full string when no @ is present", () => {
+    assert.equal(extractBranch("main"), "main")
+  })
+
+  it("handles multiple @ signs — uses last segment after first @", () => {
+    assert.equal(extractBranch("nixos-config@fix@extra"), "fix@extra")
+  })
+
+  it("returns empty string for empty input", () => {
+    assert.equal(extractBranch(""), "")
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -457,6 +457,51 @@ export const TRUNCATION_SENTINEL = "…[truncated]"
 export const HARNESS_NAME = "pi"
 
 // ---------------------------------------------------------------------------
+// Status bar helper — exported for unit testing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the prism status bar text for PI's footer.
+ *
+ * Format:
+ *   [coordinator] main
+ *   [worker] fix-login-redirect
+ *   [review] PR#42 · 2 cycles
+ *
+ * @param role         - session role from hello_ack (e.g. "coordinator", "worker", "review")
+ * @param branch       - branch label extracted from session_name (part after "@", or full name)
+ * @param prNumber     - detected PR number (null when unknown)
+ * @param cycles       - current review cycle count
+ */
+export function formatPrismStatus(
+  role: string,
+  branch: string,
+  prNumber: string | null,
+  cycles: number,
+): string {
+  const roleLabel = role.length > 0 ? role : "unknown"
+  const prefix = `[${roleLabel}] ${branch}`
+  if (roleLabel === "review" && prNumber !== null) {
+    const cycleLabel = cycles === 1 ? "1 cycle" : `${cycles} cycles`
+    return `${prefix} · PR#${prNumber} · ${cycleLabel}`
+  }
+  return prefix
+}
+
+/**
+ * Extract the branch label from a session_name.
+ * If session_name contains "@", return the part after it.
+ * Otherwise return the full session_name.
+ */
+export function extractBranch(sessionName: string): string {
+  const atIdx = sessionName.indexOf("@")
+  if (atIdx !== -1) {
+    return sessionName.slice(atIdx + 1)
+  }
+  return sessionName
+}
+
+// ---------------------------------------------------------------------------
 // Truncation helpers — exported for unit testing.
 // ---------------------------------------------------------------------------
 
@@ -951,6 +996,10 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // are suppressed — review agents legitimately repeat tool patterns.
   let isReviewSession = false
 
+  // Session identity captured from hello_ack. Used for status bar display.
+  let sessionRole = ""
+  let sessionBranch = extractBranch(process.env.PRISM_SESSION_NAME ?? "")
+
   // Flag: git push was detected; cleared after the next turn_start so the
   // reminder fires exactly once.
   let pendingGitPushReminder = false
@@ -1067,7 +1116,28 @@ export default function prismExtension(pi: ExtensionAPI): void {
         if (role === "review") {
           isReviewSession = true
         }
+        sessionRole = role
+        // Override branch from hello_ack session_name if provided.
+        if (typeof f.session_name === "string" && f.session_name.length > 0) {
+          sessionBranch = extractBranch(f.session_name)
+        }
         handshakeComplete = true
+
+        // Set the status bar immediately after handshake.
+        const prCycles = sessionRole === "review"
+          ? (reviewCycleState.cycles.get(reviewCycleState.detectedPrNumber ?? "unknown") ?? 0)
+          : 0
+        const statusText = formatPrismStatus(sessionRole, sessionBranch, reviewCycleState.detectedPrNumber, prCycles)
+        lastCtx?.ui?.setStatus("prism", statusText)
+        if (writer) {
+          writer.write({
+            type: "session_status",
+            role: sessionRole,
+            branch: sessionBranch,
+            review_cycles: prCycles,
+            pr_number: reviewCycleState.detectedPrNumber ?? "",
+          })
+        }
         return
       }
 
@@ -1170,6 +1240,22 @@ export default function prismExtension(pi: ExtensionAPI): void {
     // Clear per-turn review-cycle deduplication so the next batch of
     // review agent invocations counts as a fresh cycle.
     reviewCycleState.pendingCycleCount = false
+
+    // Refresh status bar on each turn_start so review-cycle count is live.
+    if (handshakeComplete) {
+      const prCycles = reviewCycleState.cycles.get(reviewCycleState.detectedPrNumber ?? "unknown") ?? 0
+      const statusText = formatPrismStatus(sessionRole, sessionBranch, reviewCycleState.detectedPrNumber, prCycles)
+      lastCtx?.ui?.setStatus("prism", statusText)
+      if (writer) {
+        writer.write({
+          type: "session_status",
+          role: sessionRole,
+          branch: sessionBranch,
+          review_cycles: prCycles,
+          pr_number: reviewCycleState.detectedPrNumber ?? "",
+        })
+      }
+    }
 
     if (!isReviewSession) {
       // Inject review-cycle escalation warning when the threshold is exceeded.

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -495,6 +495,44 @@ Sidecar response:
 This is the **clean** termination path. Connection drops without a
 preceding `session_shutdown` are handled per §7.2.
 
+### 5.11 `session_status`
+
+Status snapshot emitted by the extension to inform the sidecar of the
+current session identity and review-cycle progress. This frame is sent
+immediately after the `hello_ack` handshake completes and again at the
+start of each turn (`turn_start`), so the sidecar always has an up-to-date
+picture of the session state.
+
+```json
+{"type":"session_status","role":"worker","branch":"fix-login-redirect","review_cycles":0,"pr_number":""}
+{"type":"session_status","role":"review","branch":"fix-login-redirect","review_cycles":2,"pr_number":"42"}
+```
+
+Fields:
+
+- `role` (string, required) — session role as received in `hello_ack`
+  (`"coordinator"`, `"worker"`, `"review"`, or `""` when unknown).
+- `branch` (string, required) — branch label extracted from the
+  `session_name`: the part after `@` when the name contains `@`, otherwise
+  the full `session_name`.
+- `review_cycles` (integer, required) — current review-cycle count for the
+  detected PR. Zero when no PR has been detected yet.
+- `pr_number` (string, required) — the PR number most recently detected by
+  the review-cycle tracker, or `""` when unknown.
+
+Sidecar behaviour: store as a harness frame per §8.2 forward-compat rules
+(unknown frames are stored as-is). No active dispatch is required; the
+sidecar may use this frame for monitoring and session metadata.
+
+The extension also calls `ctx.ui.setStatus("prism", text)` with a
+human-readable summary at the same points. The status text format is:
+
+```
+[coordinator] main
+[worker] fix-login-redirect
+[review] fix-login-redirect · PR#42 · 2 cycles
+```
+
 ## 6. Frame catalogue — sidecar → extension
 
 Frames sent by the sidecar to the extension. These represent **prism


### PR DESCRIPTION
## Summary

- Adds `formatPrismStatus(role, branch, prNumber, cycles)` pure exported helper that formats the PI status bar text
- Adds `extractBranch(sessionName)` helper (splits on `@`, uses full name if no `@`)
- Calls `ctx.ui.setStatus("prism", text)` after `hello_ack` and on each `turn_start`
- Emits a `session_status` wire frame on each status update with `role`, `branch`, `review_cycles`, and `pr_number` fields
- Documents the new `session_status` outbound frame in `pi-wire-protocol.md` §5.11
- All 97 unit tests pass including new tests for `formatPrismStatus` and `extractBranch`

Closes #1310