### PR TITLE
feat: coalesce pi msg_assistant fragments into single row per turn

### DIFF
--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -385,13 +385,32 @@ delta into one `msg_assistant` frame.
 {"type":"msg_assistant","text":"Here is "}
 ```
 
-- `text` (string, required) — the delta text. May be empty (no-op on the
-  sidecar side; recorded as a zero-length event).
+- `text` (string, required) — the delta text. May be empty (treated as a
+  zero-length fragment; contributes nothing to the coalesced text).
 
-The frame maps directly into a `msg_assistant` row in `agent_events`,
-matching `internal/payload/payload.go:MsgAssistant`. The sidecar does **not**
-attempt to coalesce fragments; consumers (the dashboard, `prism checkin`)
-already handle the fragment stream from opencode the same way.
+The sidecar **coalesces** fragments within a turn rather than writing one
+row per fragment. Text from each `msg_assistant` frame is accumulated in
+memory between `turn_start` and `turn_end`. On `turn_end`, a single
+`msg_assistant` event is written to `agent_events` with:
+
+- `text` set to the concatenation of all fragment texts in order.
+- Token and cost fields (`inputTokens`, `outputTokens`, `cacheReadTokens`,
+  `cacheWriteTokens`, `cost`) populated from the `turn_end` frame's `usage`
+  object (zero when absent).
+
+This produces one `msg_assistant` row per turn instead of ~50 fragmented
+rows. The payload schema matches `internal/payload/payload.go:MsgAssistant`.
+
+**Edge cases:**
+
+- If `turn_end` arrives with no preceding `msg_assistant` frames (empty
+  accumulator), a `msg_assistant` row is still written with empty `text`.
+- If `session_shutdown` or a connection drop arrives with a non-empty
+  accumulator, a partial `msg_assistant` row is written with the accumulated
+  text and zero token/cost fields — the partial text is not silently
+  discarded.
+- The accumulator resets on each `turn_start`; multiple turns in a single
+  session each produce their own single `msg_assistant` event.
 
 ### 5.6 `turn_start`
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -55,6 +55,7 @@ import (
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/mergequeue"
+	"github.com/prismatic-koi/prism/internal/payload"
 )
 
 // defaultNotifyHTTPClient is the HTTP client used for coordinator notification
@@ -337,6 +338,13 @@ type Sidecar struct {
 	// on set (before the goroutine starts); after that only the writer goroutine
 	// reads from it; callers enqueue via enqueueHarnessPipeFrame.
 	harnessPipeOutCh chan []byte
+
+	// pipeAccum accumulates msg_assistant text fragments between turn_start and
+	// turn_end for the socket-pipe transport. On turn_end, the accumulated text
+	// is flushed as a single msg_assistant event with token/cost fields from the
+	// turn_end usage object. Reset to nil on each turn_start.
+	// Protected by s.mu.
+	pipeAccum *string
 }
 
 // New creates a Sidecar with the given configuration.
@@ -1441,6 +1449,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			// Unexpected disconnect per P2.WIRE §7.2.
 			log.Printf("sidecar: runStartupSocketPipe: connection dropped: %v", readErr)
 			s.mu.Lock()
+			s.flushPipeAccum()
 			s.upsertState(agent.StateError, nil, nil)
 			s.writeEvent("state_change", map[string]string{"state": string(agent.StateError), "note": "connection dropped"}, nil)
 			s.lastState = agent.StateError
@@ -1476,6 +1485,13 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 //
 // Implements P2.WIRE §5 frame catalogue. Unknown frame types are persisted
 // as raw JSON for forward compatibility (P2.WIRE §8.2).
+//
+// msg_assistant coalescing: rather than writing one agent_events row per
+// streaming fragment, the sidecar accumulates text between turn_start and
+// turn_end, then writes a single msg_assistant row on turn_end (or on
+// session_shutdown / connection drop) with the concatenated text and token/
+// cost fields from the turn_end usage object. This produces one row per
+// assistant turn instead of ~50 fragmented rows.
 func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 	if len(line) == 0 {
 		return false
@@ -1506,13 +1522,66 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		s.writeStateChange(st)
 		s.lastState = st
 
-	case "tool_call", "tool_result", "msg_assistant", "turn_start", "turn_end",
+	case "turn_start":
+		// Reset the accumulator for the new turn, then persist the frame.
+		empty := ""
+		s.pipeAccum = &empty
+		s.writeEvent(frame.Type, json.RawMessage(line), nil)
+
+	case "msg_assistant":
+		// Buffer the text fragment; do not write a row yet.
+		var f struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(line, &f); err == nil {
+			if s.pipeAccum == nil {
+				// Fragments received before turn_start — initialise accumulator.
+				empty := ""
+				s.pipeAccum = &empty
+			}
+			*s.pipeAccum += f.Text
+		}
+
+	case "turn_end":
+		// Flush the accumulator as a single msg_assistant event with token/cost
+		// fields from the usage object, then persist the turn_end frame.
+		var f struct {
+			Usage struct {
+				Input      int     `json:"input"`
+				Output     int     `json:"output"`
+				CacheRead  int     `json:"cache_read"`
+				CacheWrite int     `json:"cache_write"`
+				Cost       float64 `json:"cost"`
+			} `json:"usage"`
+		}
+		_ = json.Unmarshal(line, &f)
+
+		text := ""
+		if s.pipeAccum != nil {
+			text = *s.pipeAccum
+		}
+		s.pipeAccum = nil
+
+		p := payload.MsgAssistant{
+			Text:             text,
+			InputTokens:      f.Usage.Input,
+			OutputTokens:     f.Usage.Output,
+			CacheReadTokens:  f.Usage.CacheRead,
+			CacheWriteTokens: f.Usage.CacheWrite,
+			Cost:             f.Usage.Cost,
+		}
+		s.writeEvent("msg_assistant", p, nil)
+		s.writeEvent(frame.Type, json.RawMessage(line), nil)
+
+	case "tool_call", "tool_result",
 		"provider_error", "auto_retry_start", "auto_retry_end":
 		// Write raw JSON as event payload — the wire schema maps directly to
 		// the existing agent_events payload format (P2.WIRE §8.1).
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
 
 	case "session_shutdown":
+		// Flush any partial accumulator before marking finished.
+		s.flushPipeAccum()
 		// Clean shutdown: mark finished and signal the reader loop.
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
@@ -1524,6 +1593,19 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
 	}
 	return false
+}
+
+// flushPipeAccum writes a msg_assistant event for any text accumulated in
+// pipeAccum and resets the accumulator to nil. Called on session_shutdown and
+// connection drop so that partial turns are not silently discarded.
+// Must be called with s.mu held.
+func (s *Sidecar) flushPipeAccum() {
+	if s.pipeAccum == nil {
+		return
+	}
+	p := payload.MsgAssistant{Text: *s.pipeAccum}
+	s.writeEvent("msg_assistant", p, nil)
+	s.pipeAccum = nil
 }
 
 // sendPipeError writes a protocol-level error frame to the connection and

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -722,5 +722,278 @@ func TestSocketPipe_ShuttingDownSkipsStateActive(t *testing.T) {
 	_ = wait()
 }
 
+// ── coalescing tests ──────────────────────────────────────────────────────────
+
+// TestSocketPipe_MsgAssistantCoalesced verifies that N msg_assistant fragment
+// frames between turn_start and turn_end produce exactly one msg_assistant row
+// in agent_events with the concatenated text (AC: N fragments → 1 row).
+func TestSocketPipe_MsgAssistantCoalesced(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "Hello"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": " world"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "!"})
+	sendJSON(t, conn, map[string]any{
+		"type": "turn_end",
+		"usage": map[string]any{
+			"input":       100,
+			"output":      50,
+			"cache_read":  40,
+			"cache_write": 5,
+			"cost":        0.0015,
+		},
+	})
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+
+	var msgAssistantEvents []db.Event
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			msgAssistantEvents = append(msgAssistantEvents, ev)
+		}
+	}
+
+	if got := len(msgAssistantEvents); got != 1 {
+		t.Fatalf("expected exactly 1 msg_assistant event, got %d", got)
+	}
+
+	var p struct {
+		Text             string  `json:"text"`
+		InputTokens      int     `json:"inputTokens"`
+		OutputTokens     int     `json:"outputTokens"`
+		CacheReadTokens  int     `json:"cacheReadTokens"`
+		CacheWriteTokens int     `json:"cacheWriteTokens"`
+		Cost             float64 `json:"cost"`
+	}
+	if err := json.Unmarshal([]byte(msgAssistantEvents[0].Payload), &p); err != nil {
+		t.Fatalf("unmarshal msg_assistant payload: %v", err)
+	}
+
+	if p.Text != "Hello world!" {
+		t.Errorf("coalesced text = %q, want %q", p.Text, "Hello world!")
+	}
+	if p.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100", p.InputTokens)
+	}
+	if p.OutputTokens != 50 {
+		t.Errorf("OutputTokens = %d, want 50", p.OutputTokens)
+	}
+	if p.CacheReadTokens != 40 {
+		t.Errorf("CacheReadTokens = %d, want 40", p.CacheReadTokens)
+	}
+	if p.CacheWriteTokens != 5 {
+		t.Errorf("CacheWriteTokens = %d, want 5", p.CacheWriteTokens)
+	}
+	if p.Cost != 0.0015 {
+		t.Errorf("Cost = %v, want 0.0015", p.Cost)
+	}
+}
+
+// TestSocketPipe_TurnStartTurnEndPersisted verifies that turn_start and
+// turn_end frames each produce their own row in agent_events.
+func TestSocketPipe_TurnStartTurnEndPersisted(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "hi"})
+	sendJSON(t, conn, map[string]any{"type": "turn_end"})
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	eventTypes := map[string]int{}
+	for _, ev := range events {
+		eventTypes[ev.Type]++
+	}
+
+	if eventTypes["turn_start"] == 0 {
+		t.Error("no turn_start event in agent_events")
+	}
+	if eventTypes["turn_end"] == 0 {
+		t.Error("no turn_end event in agent_events")
+	}
+}
+
+// TestSocketPipe_EmptyAccumulatorAtTurnEnd verifies that a turn_end with no
+// preceding msg_assistant frames still writes a msg_assistant event with empty
+// text (not suppressed).
+func TestSocketPipe_EmptyAccumulatorAtTurnEnd(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	// No msg_assistant frames.
+	sendJSON(t, conn, map[string]any{"type": "turn_end"})
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	found := false
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			found = true
+			var p struct {
+				Text string `json:"text"`
+			}
+			_ = json.Unmarshal([]byte(ev.Payload), &p)
+			if p.Text != "" {
+				t.Errorf("expected empty text for empty-accumulator flush, got %q", p.Text)
+			}
+		}
+	}
+	if !found {
+		t.Error("no msg_assistant event written for empty accumulator at turn_end")
+	}
+}
+
+// TestSocketPipe_AccumulatorResetsOnTurnStart verifies that multiple turns in a
+// single session each produce their own single msg_assistant event and the
+// accumulator resets between turns.
+func TestSocketPipe_AccumulatorResetsOnTurnStart(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// First turn.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "turn1"})
+	sendJSON(t, conn, map[string]any{"type": "turn_end"})
+
+	// Second turn.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "turn2"})
+	sendJSON(t, conn, map[string]any{"type": "turn_end"})
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	textSet := map[string]int{}
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			var p struct {
+				Text string `json:"text"`
+			}
+			if err := json.Unmarshal([]byte(ev.Payload), &p); err == nil {
+				textSet[p.Text]++
+			}
+		}
+	}
+
+	if len(textSet) != 2 {
+		t.Fatalf("expected 2 distinct msg_assistant events (one per turn), got %d: %v", len(textSet), textSet)
+	}
+	if textSet["turn1"] != 1 {
+		t.Errorf("expected exactly 1 msg_assistant with text='turn1', got %d", textSet["turn1"])
+	}
+	if textSet["turn2"] != 1 {
+		t.Errorf("expected exactly 1 msg_assistant with text='turn2', got %d", textSet["turn2"])
+	}
+}
+
+// TestSocketPipe_PartialAccumulatorFlushedOnShutdown verifies that a
+// session_shutdown with a non-empty accumulator writes a partial msg_assistant
+// event — the accumulated text is not silently discarded.
+func TestSocketPipe_PartialAccumulatorFlushedOnShutdown(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "partial"})
+	// No turn_end — simulate abrupt shutdown mid-turn.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	found := false
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			found = true
+			var p struct {
+				Text string `json:"text"`
+			}
+			_ = json.Unmarshal([]byte(ev.Payload), &p)
+			if p.Text != "partial" {
+				t.Errorf("partial flush text = %q, want %q", p.Text, "partial")
+			}
+		}
+	}
+	if !found {
+		t.Error("partial accumulator not flushed on session_shutdown")
+	}
+}
+
+// TestSocketPipe_PartialAccumulatorFlushedOnDrop verifies that a connection
+// drop with a non-empty accumulator writes a partial msg_assistant event.
+func TestSocketPipe_PartialAccumulatorFlushedOnDrop(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "dropped"})
+	// Drop the connection without session_shutdown.
+	conn.Close()
+
+	_ = wait()
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	found := false
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			found = true
+			var p struct {
+				Text string `json:"text"`
+			}
+			_ = json.Unmarshal([]byte(ev.Payload), &p)
+			if p.Text != "dropped" {
+				t.Errorf("partial flush on drop text = %q, want %q", p.Text, "dropped")
+			}
+		}
+	}
+	if !found {
+		t.Error("partial accumulator not flushed on connection drop")
+	}
+}
+
 // Ensure db import is used.
 var _ *db.DB


### PR DESCRIPTION
## Summary

- Buffer `msg_assistant` text fragments between `turn_start` and `turn_end` in the socket-pipe sidecar
- Write a single `msg_assistant` event on `turn_end` with concatenated text and token/cost fields from the `turn_end` usage object
- Handle edge cases: partial flush on `session_shutdown`/connection drop, empty accumulator at `turn_end`, multi-turn reset on `turn_start`
- Update `docs/pi-wire-protocol.md` §5.5 to document coalescing behaviour
- Add 6 new tests covering all AC items

Closes #1309