### PR TITLE
fix: use "off" as zero thinking value in profiles to silence PI warning

### DIFF
--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -23,11 +23,11 @@
 //	  },
 //	  "profiles": {
 //	    "anthropic": {
-//	      "coordinator": {"provider":"anthropic","model":"anthropic/claude-sonnet-4-6","thinking":"none","systemPromptPath":""},
-//	      "plan":        {"provider":"anthropic","model":"anthropic/claude-sonnet-4-6","thinking":"none","systemPromptPath":""},
-//	      "worker":      {"provider":"anthropic","model":"anthropic/claude-sonnet-4-6","thinking":"none","systemPromptPath":""},
+//	      "coordinator": {"provider":"anthropic","model":"anthropic/claude-sonnet-4-6","thinking":"off","systemPromptPath":""},
+//	      "plan":        {"provider":"anthropic","model":"anthropic/claude-sonnet-4-6","thinking":"off","systemPromptPath":""},
+//	      "worker":      {"provider":"anthropic","model":"anthropic/claude-sonnet-4-6","thinking":"off","systemPromptPath":""},
 //	      ...
-//	      "explore":     {"provider":"anthropic","model":"anthropic/claude-haiku-4-5","thinking":"none","systemPromptPath":""}
+//	      "explore":     {"provider":"anthropic","model":"anthropic/claude-haiku-4-5","thinking":"off","systemPromptPath":""}
 //	    },
 //	    "anthropic-opus": {...},
 //	    "gemini-hybrid":  {...}
@@ -353,9 +353,16 @@ type agentCfg struct {
 // concept but kept the wire format identical so that opencode sessions
 // produce bit-identical output across the migration.
 //
+// The canonical zero value in profiles is "off" (the PI harness convention),
+// but opencode expects "none" as its zero value. This function translates
+// "off" → "none" so both consumers receive what they expect.
+//
 // An empty thinking value is rendered as an empty variant (which
 // marshalConfigContent then omits from the output entirely).
 func variantFromThinking(thinking string) string {
+	if thinking == "off" {
+		return "none"
+	}
 	return thinking
 }
 

--- a/modules/programs/prism/prism/internal/config/profiles_test.go
+++ b/modules/programs/prism/prism/internal/config/profiles_test.go
@@ -1293,3 +1293,66 @@ func TestApplyProfileToBlob_RejectsMalformedBlob(t *testing.T) {
 		t.Fatal("ApplyProfileToBlob(garbage): want parse error")
 	}
 }
+
+// ── thinking → variant translation (#1299) ────────────────────────────────────
+
+// TestBuildConfigContent_OffThinkingTranslatesToNoneVariant verifies that a
+// profile slot with thinking="off" produces variant="none" in the opencode
+// config content (the PI zero value must be translated to the opencode zero
+// value).
+func TestBuildConfigContent_OffThinkingTranslatesToNoneVariant(t *testing.T) {
+	pf := sampleProfilesFile()
+	// Add an "off-thinking" profile whose coordinator slot uses thinking="off".
+	pf.Profiles["off-test"] = config.ProfileEntry{
+		"coordinator": {Provider: "anthropic", Model: "anthropic/claude-opus-4-6", Thinking: "off"},
+		"worker":      {Provider: "anthropic", Model: "anthropic/claude-sonnet-4-6", Thinking: "off"},
+	}
+	pf.RoleMapping = map[string][]string{
+		"primary":     {"coordinator"},
+		"secondary":   {"worker"},
+		"lightweight": {},
+	}
+	out, err := config.BuildConfigContent(pf, "off-test", "", "")
+	if err != nil {
+		t.Fatalf("BuildConfigContent: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	agents, _ := cfg["agent"].(map[string]any)
+	for _, role := range []string{"coordinator", "worker"} {
+		entry, ok := agents[role].(map[string]any)
+		if !ok {
+			continue
+		}
+		// thinking="off" must produce variant="none" for opencode, not "off".
+		if v, hasVariant := entry["variant"]; hasVariant && v != "none" {
+			t.Errorf("agent.%s variant: got %v, want none (translated from off)", role, v)
+		}
+		// Must not pass "off" through to opencode.
+		if v, hasVariant := entry["variant"]; hasVariant && v == "off" {
+			t.Errorf("agent.%s variant: got 'off' — should have been translated to 'none'", role)
+		}
+	}
+}
+
+// TestBuildConfigContent_NonZeroThinkingPassesThrough verifies that a
+// non-zero thinking level (e.g. "medium") is passed through unchanged to
+// opencode's variant field.
+func TestBuildConfigContent_NonZeroThinkingPassesThrough(t *testing.T) {
+	pf := sampleProfilesFile()
+	out, err := config.BuildConfigContent(pf, "gemini-hybrid", "", "")
+	if err != nil {
+		t.Fatalf("BuildConfigContent: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	agents := cfg["agent"].(map[string]any)
+	worker := agents["worker"].(map[string]any)
+	if worker["variant"] != "medium" {
+		t.Errorf("worker variant: got %v, want medium (non-zero thinking passed through unchanged)", worker["variant"])
+	}
+}

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -59,6 +59,20 @@ func TestPIInvocation_NoOptionalFlags(t *testing.T) {
 	}
 }
 
+// TestPIInvocation_OffThinkingPassedThrough verifies that thinking="off"
+// (the zero value in profiles after #1299) is passed as --thinking off to
+// PI — not translated or dropped.
+func TestPIInvocation_OffThinkingPassedThrough(t *testing.T) {
+	cfg := Config{
+		PIThinking:            "off",
+		PIExtensionSandboxDir: "/etc/prism/pi-extensions",
+	}
+	args := PIInvocation(cfg)
+	if !hasPair(args, "--thinking", "off") {
+		t.Errorf("expected --thinking off in PI invocation args; got %v", args)
+	}
+}
+
 func TestPIInvocation_DefaultSandboxPaths(t *testing.T) {
 	// When sandbox path overrides are empty the defaults must be used.
 	cfg := Config{}

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -69,10 +69,10 @@
           ];
         };
 
-
         # Determine the system prompt file for a given role.
         # Maps role names to agent files at ~/.config/opencode/agents/<file>.md.
-        roleToSystemPromptFile = role:
+        roleToSystemPromptFile =
+          role:
           let
             roleFileMap = {
               coordinator = "coordinator";
@@ -96,10 +96,15 @@
 
         # Stamp a slot value across the given list of role names, adding
         # role-specific systemPromptPath values for P2.AGENTRUN support.
-        slotsForWithPrompts = roles: baseSlot:
-          lib.genAttrs roles (role: baseSlot // {
-            systemPromptPath = roleToSystemPromptFile role;
-          });
+        slotsForWithPrompts =
+          roles: baseSlot:
+          lib.genAttrs roles (
+            role:
+            baseSlot
+            // {
+              systemPromptPath = roleToSystemPromptFile role;
+            }
+          );
 
         # Build a profile by combining tiered slot values. Each tier is a
         # `{primary, secondary, lightweight}` triple of slot values — the
@@ -112,15 +117,15 @@
           // (slotsForWithPrompts roleMapping.secondary tiers.secondary)
           // (slotsForWithPrompts roleMapping.lightweight tiers.lightweight);
 
-        # Convenience: build a slot. `thinking` defaults to "none" to preserve
-        # current opencode behaviour (renders as variant: "none"). `provider`
-        # defaults to "" — populated explicitly by the migrated profiles below.
+        # Convenience: build a slot. `thinking` defaults to "off" (the PI harness
+        # zero value). `provider` defaults to "" — populated explicitly by the
+        # migrated profiles below.
         # `systemPromptPath` is null until P2.AGENTRUN populates per-role prompts.
         slot =
           {
             provider ? "",
             model,
-            thinking ? "none",
+            thinking ? "off",
             systemPromptPath ? null,
           }:
           {
@@ -253,7 +258,7 @@
               lib.mapAttrs (_role: roleSlot: {
                 provider = roleSlot.provider or "";
                 model = roleSlot.model;
-                thinking = roleSlot.thinking or "none";
+                thinking = roleSlot.thinking or "off";
                 systemPromptPath = expandHome (roleSlot.systemPromptPath or "");
               }) profileEntry
             ) config.nx.programs.prism.profiles.data.profiles;
@@ -288,14 +293,20 @@
             container_resources = config.nx.programs.prism._internal.agentResources;
           };
 
+        # Translate a profile thinking value to the opencode variant string.
+        # The canonical zero value in profiles is "off" (the PI harness
+        # convention), but opencode expects "none" as its zero value.
+        thinkingToVariant = thinking: if thinking == "off" then "none" else thinking;
+
         # applyProfile patches `model` and `variant` onto each baseAgent that
         # the active profile defines a slot for. Agents not present in the
         # profile (e.g. `build`) are returned unchanged so they inherit the
         # top-level opencode model.
         #
         # The mapping is direct under the role-keyed schema: `agentName` is the
-        # slot key. `slot.thinking` is rendered as opencode's `variant` to
-        # preserve bit-identical output with the pre-#1206 schema.
+        # slot key. `slot.thinking` is translated to opencode's `variant` via
+        # thinkingToVariant ("off" → "none") to preserve bit-identical output
+        # with the pre-#1206 schema.
         applyProfile =
           profileName: baseAgents:
           let
@@ -312,7 +323,7 @@
               cfg
               // {
                 model = slotCfg.model;
-                variant = slotCfg.thinking;
+                variant = thinkingToVariant slotCfg.thinking;
               }
           ) baseAgents;
       };

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -221,6 +221,11 @@
             ];
           };
         };
+
+        # Translate a profile thinking value to the opencode variant string.
+        # The canonical zero value in profiles is "off" (the PI harness
+        # convention), but opencode expects "none" as its zero value.
+        thinkingToVariant = thinking: if thinking == "off" then "none" else thinking;
       in
       {
         data = {
@@ -292,11 +297,6 @@
             # → prism sidecar → container.Config → buildRunArgs → podman run.
             container_resources = config.nx.programs.prism._internal.agentResources;
           };
-
-        # Translate a profile thinking value to the opencode variant string.
-        # The canonical zero value in profiles is "off" (the PI harness
-        # convention), but opencode expects "none" as its zero value.
-        thinkingToVariant = thinking: if thinking == "off" then "none" else thinking;
 
         # applyProfile patches `model` and `variant` onto each baseAgent that
         # the active profile defines a slot for. Agents not present in the


### PR DESCRIPTION
## Summary

- Changes the canonical zero thinking value in all profile definitions from `"none"` to `"off"` (the PI harness convention)
- Adds `variantFromThinking("off") → "none"` translation in `profiles.go` so opencode continues to receive `"none"`
- Adds `thinkingToVariant` in `profiles.nix` with the same `"off"` → `"none"` translation for Nix-generated opencode config blobs
- Non-zero thinking levels (e.g. `"medium"`) pass through unchanged to both PI and opencode

Fixes the `Warning: Invalid thinking level "none". Valid values: off, minimal, low, medium, high, xhigh` emitted by PI on every startup.

Closes #1299