### PR TITLE
fix: suppress empty msg_assistant rows for tool-only turns

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1628,15 +1628,20 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		}
 		s.pipeAccum = nil
 
-		p := payload.MsgAssistant{
-			Text:             text,
-			InputTokens:      f.Usage.Input,
-			OutputTokens:     f.Usage.Output,
-			CacheReadTokens:  f.Usage.CacheRead,
-			CacheWriteTokens: f.Usage.CacheWrite,
-			Cost:             f.Usage.Cost,
+		// Only write a msg_assistant row when there is actual text content.
+		// Tool-only turns emit turn_start/turn_end with zero msg_assistant
+		// fragments, which would produce a spurious "(no text)" row in checkin.
+		if text != "" {
+			p := payload.MsgAssistant{
+				Text:             text,
+				InputTokens:      f.Usage.Input,
+				OutputTokens:     f.Usage.Output,
+				CacheReadTokens:  f.Usage.CacheRead,
+				CacheWriteTokens: f.Usage.CacheWrite,
+				Cost:             f.Usage.Cost,
+			}
+			s.writeEvent("msg_assistant", p, nil)
 		}
-		s.writeEvent("msg_assistant", p, nil)
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
 
 	case "tool_call", "tool_result",

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -834,8 +834,9 @@ func TestSocketPipe_TurnStartTurnEndPersisted(t *testing.T) {
 }
 
 // TestSocketPipe_EmptyAccumulatorAtTurnEnd verifies that a turn_end with no
-// preceding msg_assistant frames still writes a msg_assistant event with empty
-// text (not suppressed).
+// preceding msg_assistant frames does NOT write a msg_assistant event. Tool-only
+// turns (turn_start → tool_call → tool_result → turn_end, no text fragments)
+// must not produce a spurious "(no text)" row in prism checkin (#1319).
 func TestSocketPipe_EmptyAccumulatorAtTurnEnd(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc := newSocketPipeSidecar(t, sockPath)
@@ -844,7 +845,7 @@ func TestSocketPipe_EmptyAccumulatorAtTurnEnd(t *testing.T) {
 	conn, _ := dialAndHandshake(t, sockPath)
 
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
-	// No msg_assistant frames.
+	// No msg_assistant frames — tool-only turn.
 	sendJSON(t, conn, map[string]any{"type": "turn_end"})
 
 	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
@@ -854,21 +855,10 @@ func TestSocketPipe_EmptyAccumulatorAtTurnEnd(t *testing.T) {
 	}
 
 	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
-	found := false
 	for _, ev := range events {
 		if ev.Type == "msg_assistant" {
-			found = true
-			var p struct {
-				Text string `json:"text"`
-			}
-			_ = json.Unmarshal([]byte(ev.Payload), &p)
-			if p.Text != "" {
-				t.Errorf("expected empty text for empty-accumulator flush, got %q", p.Text)
-			}
+			t.Errorf("unexpected msg_assistant event written for empty-accumulator turn_end: %s", ev.Payload)
 		}
-	}
-	if !found {
-		t.Error("no msg_assistant event written for empty accumulator at turn_end")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Tool-only PI turns (turn_start → tool_call(s) → tool_result(s) → turn_end, no text fragments) were producing spurious empty `msg_assistant` rows visible as `(no text)` in `prism checkin`
- Added a `text != ""` guard in the socket-pipe `turn_end` handler to skip the `writeEvent` call when no text was accumulated
- Updated `TestSocketPipe_EmptyAccumulatorAtTurnEnd` to assert the correct behaviour (no row written) instead of the old buggy behaviour

Closes #1319