### PR TITLE
firefox: adopt XDG config path for HM 26.05

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -27,6 +27,7 @@ in
         # If issues arise, Firefox can be installed via Homebrew while
         # keeping this module enabled for configuration management.
         enable = true;
+        configPath = ".config/mozilla/firefox";
         nativeMessagingHosts = [
           pkgs.tridactyl-native
         ];
@@ -84,7 +85,7 @@ in
       };
       home.persistence."/persist" = {
         directories = [
-          ".mozilla/firefox"
+          ".config/mozilla/firefox"
         ];
       };
     };


### PR DESCRIPTION
## Summary

- Add `configPath = ".config/mozilla/firefox"` to `programs.firefox` to explicitly adopt the new XDG default introduced in Home Manager 26.05
- Update impermanence persistence directory from `.mozilla/firefox` to `.config/mozilla/firefox`

Closes #1325