### PR TITLE
fix: forward --abtest, --pr, and profile flags through container proxy

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -259,6 +259,11 @@ var prCmd = &cobra.Command{
 			return fmt.Errorf("unknown harness %q: valid harnesses: %s", effectiveHarness, strings.Join(harness.Names(), ", "))
 		}
 
+		modelsByRole, modelOverrideErr := parseModelOverrides(modelOverrideFlag)
+		if modelOverrideErr != nil {
+			return modelOverrideErr
+		}
+
 		prHarness, _ := harness.New(effectiveHarness, "", nil, "", "")
 		opts := session.Opts{
 			Prompt:           promptFlag,
@@ -269,6 +274,7 @@ var prCmd = &cobra.Command{
 			ConfigContent:    configContent,
 			ConfigEnvVarName: prHarness.ConfigEnvVar(),
 			RuntimeEnvVars:   prHarness.RuntimeEnv(),
+			ModelsByRole:     modelsByRole,
 			// ForceFresh=true: prism pr creates a new worktree; if a session
 			// with the same name exists it is a stale zombie and should be
 			// killed, matching the same semantics as prism spawn.

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -7,18 +7,20 @@ package cmd
 //
 // Additional flags mirror prism spawn:
 //
-//	--repo <name>         target repo by folder name under ~/code (or full path)
-//	--prompt <text>       pass an initial prompt to opencode on launch
-//	--prompt-file <path>  read the initial prompt from a file
-//	--agent <name>        opencode agent to use (default: "coordinator" on main, "worker" otherwise)
-//	--attach              switch the current tmux client to the new session
-//	--profile <name>      model profile to use from ~/.config/prism/profiles.json
-//	--model <name>        model identifier override (overrides profile's primary model)
-//	--variant <name>      model variant override (overrides all agents' variant)
-//	--harness <name>      agent harness to use (default: from profile slot or "opencode")
-//	--isolation <mode>    isolation mode: podman, bwrap, sandbox-exec, or host
+//	--repo <name>                   target repo by folder name under ~/code (or full path)
+//	--prompt <text>                 pass an initial prompt to opencode on launch
+//	--prompt-file <path>            read the initial prompt from a file
+//	--agent <name>                  opencode agent to use (default: "coordinator" on main, "worker" otherwise)
+//	--attach                        switch the current tmux client to the new session
+//	--profile <name>                model profile to use from ~/.config/prism/profiles.json
+//	--model <name>                  model identifier override (overrides profile's primary model)
+//	--variant <name>                model variant override (overrides all agents' variant)
+//	--model-override role=model     per-role model override (repeatable)
+//	--harness <name>                agent harness to use (default: from profile slot or "opencode")
+//	--isolation <mode>              isolation mode: podman, bwrap, sandbox-exec, or host
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,6 +51,7 @@ var prCmd = &cobra.Command{
 		harnessFlag, _ := cmd.Flags().GetString("harness")
 		isolationFlag, _ := cmd.Flags().GetString("isolation")
 		ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
+		modelOverrideFlag, _ := cmd.Flags().GetStringArray("model-override")
 
 		promptFlag, err := resolvePrompt(cmd)
 		if err != nil {
@@ -84,6 +87,17 @@ var prCmd = &cobra.Command{
 			}
 			if cmd.Flags().Changed("isolation") {
 				body["isolation"] = isolationFlag
+			}
+			if len(modelOverrideFlag) > 0 {
+				modelsByRole, parseErr := parseModelOverrides(modelOverrideFlag)
+				if parseErr != nil {
+					return parseErr
+				}
+				if len(modelsByRole) > 0 {
+					if encoded, encErr := json.Marshal(modelsByRole); encErr == nil {
+						body["model_variant_overrides"] = string(encoded)
+					}
+				}
 			}
 			if proxyErr := proxyToHostAPI(apiURL, "/spawn", body, &resp); proxyErr != nil {
 				return proxyErr
@@ -273,6 +287,7 @@ func init() {
 	prCmd.Flags().String("profile", "", "Model profile name from ~/.config/prism/profiles.json (e.g. anthropic, gemini-hybrid)")
 	prCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	prCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
+	prCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
 	prCmd.Flags().String("harness", "", "Agent harness to use (default: from profile slot, or opencode)")
 	prCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	rootCmd.AddCommand(prCmd)

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -12,11 +12,17 @@ package cmd
 //	--prompt-file <path>  read the initial prompt from a file
 //	--agent <name>        opencode agent to use (default: "coordinator" on main, "worker" otherwise)
 //	--attach              switch the current tmux client to the new session
+//	--profile <name>      model profile to use from ~/.config/prism/profiles.json
+//	--model <name>        model identifier override (overrides profile's primary model)
+//	--variant <name>      model variant override (overrides all agents' variant)
+//	--harness <name>      agent harness to use (default: from profile slot or "opencode")
+//	--isolation <mode>    isolation mode: podman, bwrap, sandbox-exec, or host
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -37,6 +43,12 @@ var prCmd = &cobra.Command{
 		repoFlag, _ := cmd.Flags().GetString("repo")
 		agentFlag, _ := cmd.Flags().GetString("agent")
 		attachFlag, _ := cmd.Flags().GetBool("attach")
+		profileFlag, _ := cmd.Flags().GetString("profile")
+		modelFlag, _ := cmd.Flags().GetString("model")
+		variantFlag, _ := cmd.Flags().GetString("variant")
+		harnessFlag, _ := cmd.Flags().GetString("harness")
+		isolationFlag, _ := cmd.Flags().GetString("isolation")
+		ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 
 		promptFlag, err := resolvePrompt(cmd)
 		if err != nil {
@@ -55,18 +67,25 @@ var prCmd = &cobra.Command{
 			if branchErr != nil {
 				return branchErr
 			}
-			ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 			repo := filepath.Base(bareRoot)
 			var resp struct {
 				SessionName string `json:"session_name"`
 			}
-			if proxyErr := proxyToHostAPI(apiURL, "/spawn", map[string]any{
+			body := map[string]any{
 				"repo":                   repo,
 				"branch":                 branch,
 				"prompt":                 promptFlag,
 				"agent":                  agentFlag,
 				"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
-			}, &resp); proxyErr != nil {
+				"profile":                profileFlag,
+				"model":                  modelFlag,
+				"variant":                variantFlag,
+				"harness":                harnessFlag,
+			}
+			if cmd.Flags().Changed("isolation") {
+				body["isolation"] = isolationFlag
+			}
+			if proxyErr := proxyToHostAPI(apiURL, "/spawn", body, &resp); proxyErr != nil {
 				return proxyErr
 			}
 			fmt.Printf("session %q created\n", resp.SessionName)
@@ -75,7 +94,9 @@ var prCmd = &cobra.Command{
 
 		cfg := config.Load()
 		isoMode, isoErr := container.Resolve(container.ResolveInput{
-			ConfigDefault: cfg.DefaultIsolationMode,
+			IsolationFlag:        isolationFlag,
+			IsolationFlagChanged: cmd.Flags().Changed("isolation"),
+			ConfigDefault:        cfg.DefaultIsolationMode,
 		})
 		if isoErr != nil {
 			return isoErr
@@ -104,6 +125,26 @@ var prCmd = &cobra.Command{
 			return fmt.Errorf("create worktree: %w", err)
 		}
 
+		// Resolve the active profile (flag → state file → nix default), mirroring
+		// the pattern in spawn.go so that --profile and `prism profile use` work.
+		var pf *config.ProfilesFile
+		{
+			var pfErr error
+			pf, pfErr = config.LoadProfiles()
+			if pfErr != nil {
+				if isoCaps.NeedsConfigBlob || profileFlag != "" {
+					return pfErr
+				}
+				fmt.Fprintf(os.Stderr, "[prism pr] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
+				pf = nil
+			}
+		}
+
+		resolvedProfile, _, profErr := config.ResolveActiveProfile(pf, profileFlag)
+		if profErr != nil {
+			return profErr
+		}
+
 		// In container/bwrap/sandbox-exec mode, inject the role-specific
 		// opencode.json blob as the harness config env var so it takes precedence
 		// (level 6) over any project-level opencode.jsonc. This mirrors the pattern
@@ -113,11 +154,7 @@ var prCmd = &cobra.Command{
 		// Host-mode sessions skip it because they run opencode directly with the
 		// host's real ~/.config/opencode/opencode.json via xdg.configFile.
 		var configContent string
-		if isoCaps.NeedsConfigBlob {
-			pf, pfErr := config.LoadProfiles()
-			if pfErr != nil {
-				return pfErr
-			}
+		if isoCaps.NeedsConfigBlob && pf != nil {
 			effectiveRole := session.DefaultAgent(worktreePath, agentFlag)
 			// Non-worktree paths (effectiveRole == "") use the coordinator config blob
 			// so that build/plan agents are available, but pass no --agent flag.
@@ -134,19 +171,13 @@ var prCmd = &cobra.Command{
 				// the runtime active profile (#1207) so `prism profile use
 				// <name>` flows through to `prism pr` spawns. ApplyProfileToBlob
 				// is a no-op when the resolved profile matches pf.Default.
-				resolvedProfile, _, profErr := config.ResolveActiveProfile(pf, "")
-				if profErr != nil {
-					return profErr
-				}
 				profiled, profileErr := config.ApplyProfileToBlob(roleConfig, resolvedProfile, pf)
 				if profileErr != nil {
 					return profileErr
 				}
 				// Re-apply any --model/--variant overrides on top so they are
-				// not lost. prism pr has no --model/--profile/--variant flags
-				// today, but the call is a no-op when all overrides are empty,
-				// ensuring forward-compatibility if those flags are added later.
-				patched, patchErr := config.ApplyModelOverrides(profiled, "", "", "", pf)
+				// not lost.
+				patched, patchErr := config.ApplyModelOverrides(profiled, resolvedProfile, modelFlag, variantFlag, pf)
 				if patchErr != nil {
 					return patchErr
 				}
@@ -187,7 +218,34 @@ var prCmd = &cobra.Command{
 			}
 		}
 
-		prHarness, _ := harness.New("opencode", "", nil, "", "")
+		// Resolve the effective harness: --harness flag takes precedence; when
+		// absent, derive from the active profile slot (matching spawn.go #1328).
+		// Default to "opencode" when no profile/slot is configured.
+		effectiveHarness := harnessFlag
+		if !cmd.Flags().Changed("harness") && pf != nil && resolvedProfile != "" {
+			plannedRole := agentFlag
+			if plannedRole == "" {
+				if branch == "main" {
+					plannedRole = "coordinator"
+				} else {
+					plannedRole = "worker"
+				}
+			}
+			if slot, ok := config.SlotForRole(pf, resolvedProfile, plannedRole); ok {
+				slotHarness := config.HarnessForSlot(slot)
+				if slotHarness != "" {
+					effectiveHarness = slotHarness
+				}
+			}
+		}
+		if effectiveHarness == "" {
+			effectiveHarness = "opencode"
+		}
+		if _, ok := harness.Lookup(effectiveHarness); !ok {
+			return fmt.Errorf("unknown harness %q: valid harnesses: %s", effectiveHarness, strings.Join(harness.Names(), ", "))
+		}
+
+		prHarness, _ := harness.New(effectiveHarness, "", nil, "", "")
 		opts := session.Opts{
 			Prompt:           promptFlag,
 			Agent:            agentFlag,
@@ -212,5 +270,10 @@ func init() {
 	prCmd.Flags().String("agent", "", `Opencode agent to use (default: "coordinator" on main, "worker" otherwise)`)
 	prCmd.Flags().Bool("attach", false, "Switch the current tmux client to the new session")
 	prCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
+	prCmd.Flags().String("profile", "", "Model profile name from ~/.config/prism/profiles.json (e.g. anthropic, gemini-hybrid)")
+	prCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
+	prCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
+	prCmd.Flags().String("harness", "", "Agent harness to use (default: from profile slot, or opencode)")
+	prCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	rootCmd.AddCommand(prCmd)
 }

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -63,8 +63,10 @@ import (
 // the sidecar log line.
 func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	branchFlag, _ := cmd.Flags().GetString("branch")
+	prFlag, _ := cmd.Flags().GetString("pr")
 	agentFlag, _ := cmd.Flags().GetString("agent")
 	profileFlag, _ := cmd.Flags().GetString("profile")
+	abtestFlag, _ := cmd.Flags().GetStringArray("abtest")
 	modelFlag, _ := cmd.Flags().GetString("model")
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
@@ -91,10 +93,79 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		}
 	}
 
+	// --abtest and --profile are mutually exclusive — enforce client-side for
+	// fast feedback before the round-trip to the host API.
+	if len(abtestFlag) > 0 && cmd.Flags().Changed("profile") {
+		return fmt.Errorf("--abtest and --profile are mutually exclusive")
+	}
+	// Validate --abtest count early: we only allow 0 or 2 values.
+	if len(abtestFlag) == 1 || len(abtestFlag) > 2 {
+		return fmt.Errorf("--abtest requires exactly two profile names (got %d)", len(abtestFlag))
+	}
+
+	// Resolve --pr to a branch client-side when running inside a container.
+	// git is accessible from containers (PRISM_BARE_ROOT is set), so we can
+	// look up the PR branch here and forward it as --branch to the host API.
+	// The --pr flag itself is not forwarded because the host-side handler only
+	// accepts a branch name.
+	if prFlag != "" {
+		if branchFlag != "" {
+			return fmt.Errorf("--pr and --branch are mutually exclusive")
+		}
+		bareRoot, bareErr := resolveBareRoot("")
+		if bareErr != nil {
+			return bareErr
+		}
+		resolvedBranch, branchErr := resolveBranch(bareRoot, "", prFlag)
+		if branchErr != nil {
+			return branchErr
+		}
+		branchFlag = resolvedBranch
+	}
+
 	promptFlag, err := resolvePrompt(cmd)
 	if err != nil {
 		return err
 	}
+
+	// Abtest path: POST with abtest field and parse two session names from response.
+	if len(abtestFlag) == 2 {
+		var resp struct {
+			SessionNames []string `json:"session_names"`
+		}
+		body := map[string]any{
+			"branch":                 branchFlag,
+			"prompt":                 promptFlag,
+			"agent":                  agentFlag,
+			"model":                  modelFlag,
+			"variant":                variantFlag,
+			"harness":                harnessFlag,
+			"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
+			"abtest":                 abtestFlag,
+		}
+		if isolationChanged {
+			body["isolation"] = isolationFlag
+		}
+		if len(modelOverrideFlag) > 0 {
+			modelsByRole, parseErr := parseModelOverrides(modelOverrideFlag)
+			if parseErr != nil {
+				return parseErr
+			}
+			if len(modelsByRole) > 0 {
+				if encoded, encErr := json.Marshal(modelsByRole); encErr == nil {
+					body["model_variant_overrides"] = string(encoded)
+				}
+			}
+		}
+		if err := proxyToHostAPI(apiURL, "/spawn", body, &resp); err != nil {
+			return err
+		}
+		for _, sn := range resp.SessionNames {
+			fmt.Printf("session %q created\n", sn)
+		}
+		return nil
+	}
+
 	var resp struct {
 		SessionName string `json:"session_name"`
 	}

--- a/modules/programs/prism/prism/internal/sidecar/helpers.go
+++ b/modules/programs/prism/prism/internal/sidecar/helpers.go
@@ -219,3 +219,25 @@ func parseSpawnSessionName(output string) string {
 	}
 	return ""
 }
+
+// parseAllSpawnSessionNames collects all session names from the output of
+// `prism spawn --abtest`, which prints two lines of the form:
+//
+//	session "name" created
+//
+// Returns all matched names in order.
+func parseAllSpawnSessionNames(output string) []string {
+	var names []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "session ") || !strings.HasSuffix(line, " created") {
+			continue
+		}
+		inner := strings.TrimPrefix(line, "session ")
+		inner = strings.TrimSuffix(inner, " created")
+		if len(inner) >= 2 && inner[0] == '"' && inner[len(inner)-1] == '"' {
+			names = append(names, inner[1:len(inner)-1])
+		}
+	}
+	return names
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -723,6 +724,39 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if len(req.Abtest) == 2 && req.Profile != "" {
 			writeError(w, http.StatusBadRequest, "--abtest and --profile are mutually exclusive")
 			return
+		}
+		// Validate abtest profile names against the known profile set to prevent
+		// flag injection (e.g. a name like "--isolation host" would inject CLI
+		// flags into the host-side prism spawn invocation).
+		if len(req.Abtest) == 2 {
+			// Structural check: reject names that could be interpreted as flags
+			// or contain path separators.
+			validProfileName := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+			for _, name := range req.Abtest {
+				if !validProfileName.MatchString(name) {
+					writeError(w, http.StatusBadRequest, fmt.Sprintf(
+						"invalid abtest profile name %q: must contain only letters, digits, hyphens, and underscores", name))
+					return
+				}
+			}
+			// Semantic check: validate against the known profile set when
+			// profiles.json is accessible. On load error, the structural check
+			// above is still in effect.
+			if pf, pfErr := config.LoadProfiles(); pfErr == nil {
+				known := config.AvailableProfileNames(pf)
+				knownSet := make(map[string]bool, len(known))
+				for _, n := range known {
+					knownSet[n] = true
+				}
+				for _, name := range req.Abtest {
+					if !knownSet[name] {
+						writeError(w, http.StatusBadRequest, fmt.Sprintf(
+							"unknown abtest profile name %q: must be one of: %s",
+							name, strings.Join(known, ", ")))
+						return
+					}
+				}
+			}
 		}
 		// Validate harness before spawning. Default empty string to "opencode"
 		// for backwards compatibility with clients that don't send the field.

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -665,7 +665,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// Absence of the field (the pre-#1263 behaviour) is treated as an empty map.
 	// See issue #1263 (C2.PROXY proxy-spawn model-override parity).
 	//
+	// Optional field "abtest" accepts a two-element array of profile names that
+	// are forwarded as --abtest flags to the host-side prism spawn. Exactly 0
+	// or 2 values are accepted; 1 or 3+ return HTTP 400. When abtest is set,
+	// "profile" must be absent. The response carries "session_names" (a two-
+	// element array) rather than the singular "session_name". See issue #1330.
+	//
 	// Response: {"session_name":"nixos-config@my-feature"} | {"error":"..."}
+	//           {"session_names":["nixos-config@branch-a","nixos-config@branch-b"]} (abtest)
 	mux.HandleFunc("/spawn", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
 			return
@@ -674,17 +681,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		var req struct {
-			Repo                  string `json:"repo"` // accepted but ignored — ownRepo is always used
-			Branch                string `json:"branch"`
-			Prompt                string `json:"prompt"`
-			Agent                 string `json:"agent"`
-			Profile               string `json:"profile"`
-			Model                 string `json:"model"`
-			Variant               string `json:"variant"`
-			Isolation             string `json:"isolation"`
-			Harness               string `json:"harness"`
-			IgnoreConcurrencyCap  bool   `json:"ignore_concurrency_cap"`
-			ModelVariantOverrides string `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
+			Repo                  string   `json:"repo"` // accepted but ignored — ownRepo is always used
+			Branch                string   `json:"branch"`
+			Prompt                string   `json:"prompt"`
+			Agent                 string   `json:"agent"`
+			Profile               string   `json:"profile"`
+			Model                 string   `json:"model"`
+			Variant               string   `json:"variant"`
+			Isolation             string   `json:"isolation"`
+			Harness               string   `json:"harness"`
+			IgnoreConcurrencyCap  bool     `json:"ignore_concurrency_cap"`
+			ModelVariantOverrides string   `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
+			Abtest                []string `json:"abtest"`                  // two-element array of profile names; see #1330
 		}
 		dec := json.NewDecoder(r.Body)
 		dec.DisallowUnknownFields()
@@ -705,6 +713,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Branch == "" {
 			writeError(w, http.StatusBadRequest, "branch is required")
+			return
+		}
+		// Validate --abtest: must be 0 or 2 values; mutually exclusive with profile.
+		if len(req.Abtest) == 1 || len(req.Abtest) > 2 {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("--abtest requires exactly two profile names (got %d)", len(req.Abtest)))
+			return
+		}
+		if len(req.Abtest) == 2 && req.Profile != "" {
+			writeError(w, http.StatusBadRequest, "--abtest and --profile are mutually exclusive")
 			return
 		}
 		// Validate harness before spawning. Default empty string to "opencode"
@@ -751,7 +768,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.Agent != "" {
 			args = append(args, "--agent", req.Agent)
 		}
-		if req.Profile != "" {
+		// --abtest and --profile are mutually exclusive; validated above.
+		if len(req.Abtest) == 2 {
+			args = append(args, "--abtest", req.Abtest[0], "--abtest", req.Abtest[1])
+		} else if req.Profile != "" {
 			args = append(args, "--profile", req.Profile)
 		}
 		if req.Model != "" {
@@ -781,7 +801,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.Agent != "" {
 			logArgs = append(logArgs, "--agent", req.Agent)
 		}
-		if req.Profile != "" {
+		if len(req.Abtest) == 2 {
+			logArgs = append(logArgs, "--abtest", req.Abtest[0], "--abtest", req.Abtest[1])
+		} else if req.Profile != "" {
 			logArgs = append(logArgs, "--profile", req.Profile)
 		}
 		if req.Model != "" {
@@ -814,9 +836,25 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 
+		outStr := string(out)
+
+		// Abtest path: prism spawn --abtest prints two session lines.
+		// Parse both and return them in "session_names".
+		if len(req.Abtest) == 2 {
+			sessionNames := parseAllSpawnSessionNames(outStr)
+			if len(sessionNames) == 0 {
+				// Fallback: derive from ownRepo@branch-profile (best effort).
+				for _, p := range req.Abtest {
+					sessionNames = append(sessionNames, ownRepo+"@"+req.Branch+"-"+p)
+				}
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"session_names": sessionNames})
+			return
+		}
+
 		// prism spawn headless prints: session "name" created
 		// Parse the session name from the output.
-		sessionName := parseSpawnSessionName(string(out))
+		sessionName := parseSpawnSessionName(outStr)
 		if sessionName == "" {
 			// Fallback: derive from ownRepo@branch (branch already sanitised by spawn).
 			sessionName = ownRepo + "@" + req.Branch


### PR DESCRIPTION
## Summary

Fixes two related gaps where `prism spawn` and `prism pr` silently dropped flags when proxying through the host API from inside a coordinator container.

### Gap 1 — `--abtest` (#1330)
- `proxySpawn` now reads `--abtest` (stringArray), validates 0 or exactly 2 values, enforces mutual exclusivity with `--profile`, and forwards as `"abtest": [...]` in the request body
- Host-API `/spawn` handler gains an `Abtest []string` field; validates 0 or 2 values; builds `--abtest A --abtest B` args for the host-side spawn; parses both session names from abtest output and returns `session_names` array
- New `parseAllSpawnSessionNames` helper in `helpers.go` collects all `session "name" created` lines

### Gap 2 — `prism spawn --pr` and `prism pr` (#1331)
- `proxySpawn` now reads `--pr`, resolves the PR branch client-side via `resolveBranch`, and forwards as `branch` to the host API
- `prism pr` gains `--profile`, `--model`, `--variant`, `--harness`, `--isolation` flags; all are forwarded in the container proxy body
- `prism pr` non-container path now resolves harness from the active profile slot (consistent with spawn.go #1328) instead of hardcoding `"opencode"`

Closes #1330
Closes #1331