### PR TITLE
fix: remove review agents from worker and coordinator container blobs

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -583,32 +583,30 @@
           let
             profiledAgents =
               config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider
-                (
-                  {
-                    worker = {
-                      description = "Default worker agent with full tool access";
-                      mode = "primary";
-                      color = config.theme.red;
-                      permission = {
-                        bash = containerWorkerBashCommands;
-                      };
+                ({
+                  worker = {
+                    description = "Default worker agent with full tool access";
+                    mode = "primary";
+                    color = config.theme.red;
+                    permission = {
+                      bash = containerWorkerBashCommands;
                     };
-                    ac = { };
-                    explore = { };
-                    title = { };
-                    summary = { };
-                    compaction = { };
-                    coordinator = {
-                      disable = true;
-                    };
-                    build = {
-                      disable = true;
-                    };
-                    plan = {
-                      disable = true;
-                    };
-                  }
-                );
+                  };
+                  ac = { };
+                  explore = { };
+                  title = { };
+                  summary = { };
+                  compaction = { };
+                  coordinator = {
+                    disable = true;
+                  };
+                  build = {
+                    disable = true;
+                  };
+                  plan = {
+                    disable = true;
+                  };
+                });
             # Strip variant from disabled agents so their primary-role "medium"
             # doesn't poison the model's thinking level for the worker.
             sanitisedAgents = lib.mapAttrs (

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -608,13 +608,6 @@
                       disable = true;
                     };
                   }
-                  // {
-                    review-goal = { };
-                    review-code = { };
-                    review-security = { };
-                    review-qa = { };
-                    review-context = { };
-                  }
                 );
             # Strip variant from disabled agents so their primary-role "medium"
             # doesn't poison the model's thinking level for the worker.
@@ -760,11 +753,6 @@
           title = { };
           summary = { };
           compaction = { };
-          review-goal = { };
-          review-code = { };
-          review-security = { };
-          review-qa = { };
-          review-context = { };
         });
         # lib.mkIf cannot be used here — this is serialised with builtins.toJSON,
         # not processed by the module system. Use optionalAttrs so the key is


### PR DESCRIPTION
## Summary

- Remove incorrect `review-goal`, `review-code`, `review-security`, `review-qa`, `review-context` declarations from `workerContainerOpencodeJson`
- Remove the same five entries from `coordinatorContainerOpencodeJson`

Per the principle documented at `makeReviewAgentBlob`: custom agents only exist because we declare them, so omitting them is the correct way to exclude them from a container's world. The worker and coordinator containers were violating this by explicitly declaring review agents they should never know about.

## Verification

Worker container agent keys: `ac`, `build`, `compaction`, `coordinator`, `explore`, `plan`, `summary`, `title`, `worker` (build/coordinator/plan disabled)
Coordinator container agent keys: `ac`, `build`, `compaction`, `coordinator`, `explore`, `plan`, `summary`, `title`

Darwin build passes: `nix build .#darwinConfigurations.m4mac.config.system.build.toplevel` ✅