### PR TITLE
Remove zsh-history-substring-search plugin

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -103,11 +103,7 @@ in
                 src = pkgs.zsh-vi-mode;
                 file = "share/zsh-vi-mode/zsh-vi-mode.plugin.zsh";
               }
-              {
-                name = "zsh-history-substring-search";
-                src = pkgs.zsh-history-substring-search;
-                file = "share/zsh-history-substring-search/zsh-history-substring-search.zsh";
-              }
+
             ];
 
             # Darwin still uses oh-my-zsh for git plugins
@@ -150,10 +146,12 @@ in
               let
                 # Common init
                 commonInit = ''
-                  # zsh-history-substring-search configuration
-                  bindkey '^[[A' history-substring-search-up # or '\eOA'
-                  bindkey '^[[B' history-substring-search-down # or '\eOB'
-                  HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=1
+                  # History beginning search — matches commands that start with what's typed
+                  autoload -U history-search-end
+                  zle -N history-beginning-search-backward-end history-search-end
+                  zle -N history-beginning-search-forward-end history-search-end
+                  bindkey '^[[A' history-beginning-search-backward-end
+                  bindkey '^[[B' history-beginning-search-forward-end
 
                   # Custom keybindings
                   bindkey -s ^v "nvim\n"


### PR DESCRIPTION
The zsh-history-substring-search plugin is removed in favor of the built-in Zsh history-search-end function. This change reduces dependency overhead while maintaining identical functionality for history navigation keybindings.