### PR TITLE
fix review instructions for pi harness: use prism review, not Task subagents

### DIFF
--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -55,6 +55,8 @@ When your work is complete and quality gates pass:
 
 ## Running a review
 
+Before running `prism review`, load the `prism` skill via the skill tool. The skill contains the full async review workflow and async expectations — loading it first ensures you handle the review-complete prompt correctly.
+
 `prism review <pr>` is **async**. It spawns 5 review agents in a group and
 returns immediately with a "review in progress" acknowledgement. Results are
 delivered to you via a follow-up `prism prompt` when all agents complete.
@@ -120,6 +122,8 @@ Avoid cosmetic bikeshedding that invites another full review round for no
 substantive gain. When in doubt, ship the PR as-is — review rounds aren't free.
 
 ### Fallback: Task-call subagents
+
+**This fallback is only applicable when the `task` tool is present in your active toolset (i.e. you are running under the opencode harness). If you are running under the pi harness, the `task` tool is not available — `prism review` is the only supported review path. Pi harness agents must NOT attempt to invoke Task subagents.**
 
 If `prism review` is unavailable or the environment does not support it, invoke
 the five review subagents **in parallel** (in a single response with 5 Task tool

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -40,6 +40,8 @@ import {
   extractBranch,
   // Connection guard
   shouldAttemptConnect,
+  // Git-push reminder
+  GIT_PUSH_REMINDER_MESSAGE,
 } from "./prism.ts"
 
 // ---------------------------------------------------------------------------
@@ -1002,6 +1004,41 @@ describe("isGitPush", () => {
 
   it("does not match unrelated commands", () => {
     assert.equal(isGitPush("go test ./..."), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GIT_PUSH_REMINDER_MESSAGE
+// ---------------------------------------------------------------------------
+
+describe("GIT_PUSH_REMINDER_MESSAGE", () => {
+  it("instructs the agent to load the prism skill", () => {
+    assert.ok(
+      GIT_PUSH_REMINDER_MESSAGE.includes("prism` skill") ||
+        GIT_PUSH_REMINDER_MESSAGE.includes("prism skill"),
+      "message should mention loading the prism skill",
+    )
+  })
+
+  it("instructs the agent to run prism review", () => {
+    assert.ok(
+      GIT_PUSH_REMINDER_MESSAGE.includes("prism review"),
+      "message should contain 'prism review'",
+    )
+  })
+
+  it("does not mention Task subagents", () => {
+    assert.ok(
+      !GIT_PUSH_REMINDER_MESSAGE.includes("subagent"),
+      "message must not mention Task subagents",
+    )
+  })
+
+  it("does not mention parallel Task calls", () => {
+    assert.ok(
+      !GIT_PUSH_REMINDER_MESSAGE.includes("Task call"),
+      "message must not mention parallel Task calls",
+    )
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -456,6 +456,13 @@ export const TRUNCATION_SENTINEL = "…[truncated]"
 /** Harness identifier sent in the `hello` frame. */
 export const HARNESS_NAME = "pi"
 
+/**
+ * The message injected as a steer after the agent runs `git push`.
+ * Exported so unit tests can assert against the canonical text.
+ */
+export const GIT_PUSH_REMINDER_MESSAGE =
+  "You just ran git push. If this was in the context of an open PR, first load the `prism` skill via the skill tool so you have the full async review workflow context, then run `prism review <pr-number>` to kick off the parallel review. Wait for the review-complete prompt before merging."
+
 // ---------------------------------------------------------------------------
 // Status bar helper — exported for unit testing.
 // ---------------------------------------------------------------------------
@@ -1314,7 +1321,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
       if (gitPushReminderEnabled && pendingGitPushReminder) {
         pendingGitPushReminder = false
         pi.sendUserMessage(
-          "You just ran git push. If this was in the context of an open PR, invoke @review-goal-subagent, @review-code-subagent, @review-security-subagent, @review-qa-subagent, and @review-context-subagent as parallel Task calls (all five in a single response) to review the updated changes before the PR is merged. ALL 5 agents must pass before the PR can be merged.",
+          GIT_PUSH_REMINDER_MESSAGE,
           { deliverAs: "steer" },
         )
       }


### PR DESCRIPTION
## Summary

- Replace the git-push reminder message in `prism.ts` with one that instructs agents to load the `prism` skill then run `prism review <pr-number>`, with no mention of Task subagents
- Export `GIT_PUSH_REMINDER_MESSAGE` as a named constant and add unit tests asserting the new content
- Add a skill-load note before the `prism review` instructions in `worker.md`
- Scope the Task-call fallback section in `worker.md` to opencode harness only (where the `task` tool is present); pi harness agents must use `prism review` exclusively

Closes #1340