### PR TITLE
pi harness: emit state_change:active on turn_start; guard idle emission during review

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -852,7 +852,7 @@ describe("snapshotGuardState", () => {
     dl.consecutiveCount = 3
     dl.fired = false
     const rc = newReviewCycleState()
-    const snap = snapshotGuardState(dl, rc, false)
+    const snap = snapshotGuardState(dl, rc, false, false)
     assert.equal(snap.doomLoop.currentKey, "bash:git push")
     assert.equal(snap.doomLoop.consecutiveCount, 3)
     assert.equal(snap.doomLoop.fired, false)
@@ -864,18 +864,26 @@ describe("snapshotGuardState", () => {
     rc.detectedPrNumber = "42"
     rc.cycles.set("42", 2)
     rc.frameEmitted = true
-    const snap = snapshotGuardState(dl, rc, true)
+    const snap = snapshotGuardState(dl, rc, true, false)
     assert.equal(snap.reviewCycle.detectedPrNumber, "42")
     assert.equal(snap.reviewCycle.cycles["42"], 2)
     assert.equal(snap.reviewCycle.frameEmitted, true)
     assert.equal(snap.pendingGitPushReminder, true)
+    assert.equal(snap.pendingReviewCall, false)
+  })
+
+  it("serialises pendingReviewCall", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    const snap = snapshotGuardState(dl, rc, false, true)
+    assert.equal(snap.pendingReviewCall, true)
   })
 
   it("produces a JSON-safe value (no Map objects)", () => {
     const dl = newDoomLoopState()
     const rc = newReviewCycleState()
     rc.cycles.set("99", 1)
-    const snap = snapshotGuardState(dl, rc, false)
+    const snap = snapshotGuardState(dl, rc, false, false)
     // JSON round-trip must succeed and preserve cycles
     const json = JSON.stringify(snap)
     const parsed = JSON.parse(json)
@@ -891,6 +899,7 @@ describe("restoreGuardState", () => {
       doomLoop: { currentKey: "bash:nix build", consecutiveCount: 4, fired: true },
       reviewCycle: { detectedPrNumber: null, cycles: {}, frameEmitted: false },
       pendingGitPushReminder: false,
+      pendingReviewCall: false,
     }
     restoreGuardState(snap, dl, rc)
     assert.equal(dl.currentKey, "bash:nix build")
@@ -905,12 +914,27 @@ describe("restoreGuardState", () => {
       doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
       reviewCycle: { detectedPrNumber: "77", cycles: { "77": 3 }, frameEmitted: true },
       pendingGitPushReminder: true,
+      pendingReviewCall: false,
     }
     const result = restoreGuardState(snap, dl, rc)
     assert.equal(rc.detectedPrNumber, "77")
     assert.equal(rc.cycles.get("77"), 3)
     assert.equal(rc.frameEmitted, true)
     assert.equal(result.pendingGitPushReminder, true)
+    assert.equal(result.pendingReviewCall, false)
+  })
+
+  it("restores pendingReviewCall=true from snapshot", () => {
+    const dl = newDoomLoopState()
+    const rc = newReviewCycleState()
+    const snap = {
+      doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
+      reviewCycle: { detectedPrNumber: "10", cycles: {}, frameEmitted: false },
+      pendingGitPushReminder: false,
+      pendingReviewCall: true,
+    }
+    const result = restoreGuardState(snap, dl, rc)
+    assert.equal(result.pendingReviewCall, true)
   })
 
   it("clears existing Map entries before restoring", () => {
@@ -921,6 +945,7 @@ describe("restoreGuardState", () => {
       doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
       reviewCycle: { detectedPrNumber: null, cycles: {}, frameEmitted: false },
       pendingGitPushReminder: false,
+      pendingReviewCall: false,
     }
     restoreGuardState(snap, dl, rc)
     assert.equal(rc.cycles.size, 0)
@@ -934,14 +959,16 @@ describe("restoreGuardState", () => {
       doomLoop: { currentKey: undefined, consecutiveCount: "not-a-number" as unknown as number, fired: undefined },
       reviewCycle: { detectedPrNumber: undefined, cycles: null as unknown as Record<string, number>, frameEmitted: undefined },
       pendingGitPushReminder: undefined as unknown as boolean,
+      pendingReviewCall: undefined as unknown as boolean,
     }
-    restoreGuardState(snap, dl, rc)
+    const result = restoreGuardState(snap, dl, rc)
     assert.equal(dl.currentKey, null)
     assert.equal(dl.consecutiveCount, 0)
     assert.equal(dl.fired, false)
     assert.equal(rc.detectedPrNumber, null)
     assert.equal(rc.cycles.size, 0)
     assert.equal(rc.frameEmitted, false)
+    assert.equal(result.pendingReviewCall, false)
   })
 })
 
@@ -956,13 +983,13 @@ describe("snapshotGuardState + restoreGuardState round-trip", () => {
     rc.cycles.set("55", 2)
     rc.frameEmitted = false
 
-    const snap = snapshotGuardState(dl, rc, true)
+    const snap = snapshotGuardState(dl, rc, true, true)
     // Simulate writing to and reading from the session JSON file.
     const persisted = JSON.parse(JSON.stringify(snap))
 
     const dl2 = newDoomLoopState()
     const rc2 = newReviewCycleState()
-    const { pendingGitPushReminder } = restoreGuardState(persisted, dl2, rc2)
+    const { pendingGitPushReminder, pendingReviewCall } = restoreGuardState(persisted, dl2, rc2)
 
     assert.equal(dl2.currentKey, "bash:git status")
     assert.equal(dl2.consecutiveCount, 2)
@@ -971,6 +998,7 @@ describe("snapshotGuardState + restoreGuardState round-trip", () => {
     assert.equal(rc2.cycles.get("55"), 2)
     assert.equal(rc2.frameEmitted, false)
     assert.equal(pendingGitPushReminder, true)
+    assert.equal(pendingReviewCall, true)
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -367,6 +367,13 @@ export interface GuardStateSnapshot {
   }
   /** Whether a git-push reminder is pending injection. */
   pendingGitPushReminder: boolean
+  /**
+   * Whether a `prism review` call is in-flight (set on detection, cleared on
+   * prompt delivery). Must be persisted so that a session pause/resume during
+   * the review-wait window does not reset the guard and allow turn_end to
+   * emit state_change:idle and clobber the reviewing state.
+   */
+  pendingReviewCall: boolean
 }
 
 /**
@@ -377,6 +384,7 @@ export function snapshotGuardState(
   doomLoop: DoomLoopState,
   reviewCycle: ReviewCycleState,
   pendingGitPushReminder: boolean,
+  pendingReviewCall: boolean,
 ): GuardStateSnapshot {
   const cycles: Record<string, number> = {}
   for (const [k, v] of reviewCycle.cycles) {
@@ -394,6 +402,7 @@ export function snapshotGuardState(
       frameEmitted: reviewCycle.frameEmitted,
     },
     pendingGitPushReminder,
+    pendingReviewCall,
   }
 }
 
@@ -405,7 +414,7 @@ export function restoreGuardState(
   snapshot: GuardStateSnapshot,
   doomLoop: DoomLoopState,
   reviewCycle: ReviewCycleState,
-): { pendingGitPushReminder: boolean } {
+): { pendingGitPushReminder: boolean; pendingReviewCall: boolean } {
   doomLoop.currentKey = snapshot.doomLoop.currentKey ?? null
   doomLoop.consecutiveCount = typeof snapshot.doomLoop.consecutiveCount === "number"
     ? snapshot.doomLoop.consecutiveCount
@@ -423,7 +432,10 @@ export function restoreGuardState(
   }
   reviewCycle.frameEmitted = snapshot.reviewCycle.frameEmitted === true
 
-  return { pendingGitPushReminder: snapshot.pendingGitPushReminder === true }
+  return {
+    pendingGitPushReminder: snapshot.pendingGitPushReminder === true,
+    pendingReviewCall: snapshot.pendingReviewCall === true,
+  }
 }
 export function reviewCycleEscalationMessage(
   state: ReviewCycleState,
@@ -1268,6 +1280,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
         if (snapshot && typeof snapshot === "object") {
           const restored = restoreGuardState(snapshot, doomLoopState, reviewCycleState)
           pendingGitPushReminder = restored.pendingGitPushReminder
+          pendingReviewCall = restored.pendingReviewCall
         }
         break
       }
@@ -1465,7 +1478,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
       // we do it unconditionally — the reviewer can deduplicate via the
       // "latest entry wins" pattern in session_switch above.
       pi.appendEntry(GUARD_STATE_ENTRY_TYPE,
-        snapshotGuardState(doomLoopState, reviewCycleState, pendingGitPushReminder))
+        snapshotGuardState(doomLoopState, reviewCycleState, pendingGitPushReminder, pendingReviewCall))
     }
   })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1032,6 +1032,13 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // reminder fires exactly once.
   let pendingGitPushReminder = false
 
+  // Flag: `prism review` was called during this session. When true, the
+  // turn_end idle emission is suppressed so that the `reviewing` state is
+  // not clobbered while waiting for the review-complete prompt. Cleared
+  // when a `prompt` inbound frame arrives (review-complete delivery) so
+  // that subsequent turns can go idle normally.
+  let pendingReviewCall = false
+
   // ── Connection state ──────────────────────────────────────────────────
   let socket: net.Socket | null = null
   let writer: FrameWriter | null = null
@@ -1206,6 +1213,13 @@ export default function prismExtension(pi: ExtensionAPI): void {
         },
       }
 
+      // A prompt frame signals that the sidecar is delivering a message
+      // (e.g. review-complete). Clear the reviewing-state guard so subsequent
+      // turns can emit state_change:idle normally.
+      if (f.type === "prompt") {
+        pendingReviewCall = false
+      }
+
       void dispatchInboundFrame(f, apiAdapter, sendError)
     })
   }
@@ -1363,8 +1377,12 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
       // Idle detection: if PI reports idle and no pending messages, emit
       // state_change:idle. Sidecar applies its own debounce window.
+      // Guard: if `prism review` was called this session and the
+      // review-complete prompt has not yet arrived, suppress the idle
+      // emission so the `reviewing` state is not clobbered.
       try {
         if (
+          !pendingReviewCall &&
           typeof ctx.isIdle === "function" &&
           ctx.isIdle() &&
           (typeof ctx.hasPendingMessages !== "function" ||
@@ -1427,6 +1445,13 @@ export default function prismExtension(pi: ExtensionAPI): void {
         // Git-push reminder flag.
         if (gitPushReminderEnabled && isGitPush(command)) {
           pendingGitPushReminder = true
+        }
+
+        // Reviewing-state guard: set flag when `prism review` is called so
+        // that the turn_end idle emission is suppressed until the
+        // review-complete prompt arrives.
+        if (/\bprism\s+review\b/.test(command)) {
+          pendingReviewCall = true
         }
       }
 

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -1,6 +1,6 @@
 // Package pi implements the harness.Harness interface for the PI (pi-coding-agent)
-// runtime. PI communicates via a TransportStdioPipe shape: the binary writes a
-// JSONL event stream to stdout and receives prompts on stdin.
+// runtime. PI communicates via a TransportSocketPipe shape: the extension
+// connects to a Unix socket bound by the sidecar and exchanges JSONL frames.
 //
 // # B5.TR — Translate payload strategy
 //
@@ -345,6 +345,13 @@ func marshalArgs(raw json.RawMessage) string {
 // NormaliseFrame maps a raw PI JSONL frame to a canonical opencode-shaped
 // (eventType, payload, shouldWrite) tuple (implements FrameNormaliser).
 //
+// Note: PI is registered as TransportSocketPipe. NormaliseFrame is only called
+// from the TransportStdioPipe path (runStartupStdio). It is retained here to
+// satisfy the FrameNormaliser interface and to normalise any PI frames that may
+// be replayed or parsed outside the socket-pipe path (e.g. tests, piexport).
+// The idle→active state transition on turn_start is handled by handlePipeFrame
+// in sidecar.go, which is the actual runtime code path for PI sessions.
+//
 // Normalisation map:
 //
 //   - message_complete (role=assistant) → "msg_assistant" / payload.MsgAssistant
@@ -352,7 +359,6 @@ func marshalArgs(raw json.RawMessage) string {
 //   - tool_call                         → "tool_call"     / payload.ToolCall
 //   - tool_result                       → "tool_result"   / payload.ToolResult
 //   - state_change                      → "state_change"  / payload.StateChange
-//   - turn_start                        → "state_change"  / payload.StateChange{State:"active"}
 //   - session_end                       → "msg_assistant" / payload.MsgAssistant
 //     (synthetic event carrying session-level token totals)
 //   - all other types: logged at info level; shouldWrite = false
@@ -445,15 +451,6 @@ func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload 
 			MessageID: f.MessageID,
 		}
 		return "tool_result", p, true
-
-	case "turn_start":
-		// Emit state_change:active so the session transitions from idle→active
-		// when a new turn begins. The sidecar's upsertState deduplicates — if
-		// the session is already active the write is a no-op.
-		p := payload.StateChange{
-			State: "active",
-		}
-		return "state_change", p, true
 
 	case "state_change":
 		var f piStateChangeFrame

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -352,6 +352,7 @@ func marshalArgs(raw json.RawMessage) string {
 //   - tool_call                         → "tool_call"     / payload.ToolCall
 //   - tool_result                       → "tool_result"   / payload.ToolResult
 //   - state_change                      → "state_change"  / payload.StateChange
+//   - turn_start                        → "state_change"  / payload.StateChange{State:"active"}
 //   - session_end                       → "msg_assistant" / payload.MsgAssistant
 //     (synthetic event carrying session-level token totals)
 //   - all other types: logged at info level; shouldWrite = false
@@ -444,6 +445,15 @@ func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload 
 			MessageID: f.MessageID,
 		}
 		return "tool_result", p, true
+
+	case "turn_start":
+		// Emit state_change:active so the session transitions from idle→active
+		// when a new turn begins. The sidecar's upsertState deduplicates — if
+		// the session is already active the write is a no-op.
+		p := payload.StateChange{
+			State: "active",
+		}
+		return "state_change", p, true
 
 	case "state_change":
 		var f piStateChangeFrame

--- a/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
@@ -292,27 +292,19 @@ func TestNormaliseFrame_MessageComplete_NonAssistant_Skipped(t *testing.T) {
 	}
 }
 
-func TestNormaliseFrame_TurnStart_EmitsStateChangeActive(t *testing.T) {
-	// turn_start must emit state_change:active so the session transitions
-	// from idle→active when a new turn begins. The sidecar's upsertState
-	// deduplicates — if already active the write is a no-op.
+func TestNormaliseFrame_TurnStart_NotWritten(t *testing.T) {
+	// turn_start is handled by handlePipeFrame (the TransportSocketPipe path),
+	// not by NormaliseFrame (TransportStdioPipe path). NormaliseFrame treats
+	// it as an unknown type — logged and shouldWrite=false. The socket-pipe
+	// integration tests in sidecar_socketpipe_test.go cover the real runtime
+	// behaviour.
 	a := pi.New("", "", "")
 	raw := []byte(`{"type":"turn_start"}`)
 
-	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+	_, _, shouldWrite := a.NormaliseFrame(raw)
 
-	if !shouldWrite {
-		t.Fatal("expected shouldWrite=true for turn_start")
-	}
-	if evtType != "state_change" {
-		t.Fatalf("expected eventType=state_change, got %q", evtType)
-	}
-	p, ok := normPayload.(payload.StateChange)
-	if !ok {
-		t.Fatalf("expected payload.StateChange, got %T", normPayload)
-	}
-	if p.State != "active" {
-		t.Errorf("StateChange.State: want %q got %q", "active", p.State)
+	if shouldWrite {
+		t.Error("expected shouldWrite=false for turn_start (handled by handlePipeFrame, not NormaliseFrame)")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
@@ -292,6 +292,30 @@ func TestNormaliseFrame_MessageComplete_NonAssistant_Skipped(t *testing.T) {
 	}
 }
 
+func TestNormaliseFrame_TurnStart_EmitsStateChangeActive(t *testing.T) {
+	// turn_start must emit state_change:active so the session transitions
+	// from idle→active when a new turn begins. The sidecar's upsertState
+	// deduplicates — if already active the write is a no-op.
+	a := pi.New("", "", "")
+	raw := []byte(`{"type":"turn_start"}`)
+
+	evtType, normPayload, shouldWrite := a.NormaliseFrame(raw)
+
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true for turn_start")
+	}
+	if evtType != "state_change" {
+		t.Fatalf("expected eventType=state_change, got %q", evtType)
+	}
+	p, ok := normPayload.(payload.StateChange)
+	if !ok {
+		t.Fatalf("expected payload.StateChange, got %T", normPayload)
+	}
+	if p.State != "active" {
+		t.Errorf("StateChange.State: want %q got %q", "active", p.State)
+	}
+}
+
 func TestNormaliseFrame_ToolResult_TruncatesLongOutput(t *testing.T) {
 	a := pi.New("", "", "")
 	longOutput := make([]byte, 600)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1717,6 +1717,13 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		s.lastState = st
 
 	case "turn_start":
+		// Transition the session to active on every new turn. The sidecar's
+		// upsertState deduplicates — if already active the write is a no-op.
+		// This is the real fix for the idle→active path: NormaliseFrame is not
+		// on this code path (PI uses TransportSocketPipe, not TransportStdioPipe).
+		s.upsertState(agent.StateActive, nil, nil)
+		s.writeStateChange(agent.StateActive)
+		s.lastState = agent.StateActive
 		// Reset the accumulator for the new turn, then persist the frame.
 		empty := ""
 		s.pipeAccum = &empty

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -236,6 +236,99 @@ func TestSocketPipe_StateChange(t *testing.T) {
 	}
 }
 
+// TestSocketPipe_TurnStartEmitsStateActive verifies that a turn_start frame
+// causes the sidecar to transition the session to active state in the DB.
+// This is the real fix for #1350: PI uses TransportSocketPipe, so the fix must
+// live in handlePipeFrame — NormaliseFrame is not on this code path.
+func TestSocketPipe_TurnStartEmitsStateActive(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive to idle first via state_change, then send turn_start.
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "active"})
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "idle"})
+
+	// Wait for idle to be committed.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+		if s == string(agent.StateIdle) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("state never reached idle, got %q", s)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Now send turn_start — must transition back to active.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+		if s == string(agent.StateActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("state never reached active after turn_start, got %q", s)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
+// TestSocketPipe_TurnStartActiveWhenAlreadyActive verifies that a turn_start
+// frame when the session is already active is a no-op (no invalid transition
+// error — the upsertState deduplication handles it).
+func TestSocketPipe_TurnStartActiveWhenAlreadyActive(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// First turn_start — transitions from initial state to active.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+
+	// Wait for active.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+		if s == string(agent.StateActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("state never reached active after first turn_start, got %q", s)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Second consecutive turn_start — already active, must be a no-op.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	time.Sleep(50 * time.Millisecond)
+
+	// State must still be active (not error or anything else).
+	s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if s != string(agent.StateActive) {
+		t.Errorf("state after consecutive turn_start = %q, want active", s)
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
 // TestSocketPipe_EventFrames verifies that tool_call, tool_result, and
 // msg_assistant frames are persisted to agent_events.
 func TestSocketPipe_EventFrames(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Change 1 (`adapter.go`):** Add `turn_start` case to `NormaliseFrame` that emits `state_change:active`. This maps the pi extension's `turn_start` frame to an active state transition, enabling the `idle → active → reviewing` path that `prism review` requires. The sidecar's `upsertState` deduplicates — if the session is already `active`, the write is a no-op.

- **Change 2 (`prism.ts`):** Add `pendingReviewCall` boolean flag. Set it when a `prism review` bash command is detected in `tool_execution_start`; clear it when a `prompt` inbound frame arrives (review-complete delivery). Suppress `state_change:idle` emission in `turn_end` while the flag is set, preventing the `reviewing` state from being clobbered before the review-complete prompt is delivered back to the worker session.

- Added a unit test `TestNormaliseFrame_TurnStart_EmitsStateChangeActive` for the new adapter behaviour.

Closes #1350