### PR TITLE
db: checkpoint WAL before Close() to prevent t.TempDir cleanup failures

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1675,8 +1675,22 @@ func migrateV27ToV28(conn *sql.DB, version *int) error {
 	return nil
 }
 
-// Close closes the underlying database connection.
+// Close checkpoints the WAL (so -wal and -shm sidecar files are removed when
+// the last connection closes) and then closes the underlying database
+// connection.
+//
+// PASSIVE mode is used: it copies committed WAL frames into the main database
+// file and then lets conn.Close() remove the now-empty sidecar files. TRUNCATE
+// mode is intentionally avoided — it truncates the WAL to zero bytes but leaves
+// a zero-byte -wal file on disk, which prevents t.TempDir() cleanup in tests.
+//
+// If the checkpoint call returns an error (e.g. because the database is in
+// delete-journal mode or has already been closed), the error is logged and
+// Close still calls conn.Close() — a failed checkpoint is non-fatal.
 func (d *DB) Close() error {
+	if _, err := d.conn.Exec("PRAGMA wal_checkpoint(PASSIVE)"); err != nil {
+		fmt.Fprintf(os.Stderr, "[prism] db.Close: wal_checkpoint failed (non-fatal): %v\n", err)
+	}
 	return d.conn.Close()
 }
 


### PR DESCRIPTION
## Summary

- Adds `PRAGMA wal_checkpoint(PASSIVE)` to `(*DB).Close()` before calling `conn.Close()`, ensuring committed WAL frames are flushed into the main database file so SQLite's normal last-connection-close cleanup removes the `-wal` and `-shm` sidecar files.
- Uses PASSIVE mode (not TRUNCATE): TRUNCATE leaves a zero-byte `-wal` file on disk after `conn.Close()`, which still causes `t.TempDir()` RemoveAll to fail. PASSIVE checkpoints the frames and lets `conn.Close()` remove the sidecar files naturally.
- If the checkpoint fails (e.g. the database is in delete-journal mode or already closed), the error is logged and `Close()` still calls `conn.Close()` — a failed checkpoint is non-fatal.

## Root cause

PR #1362 moved `journal_mode=WAL` into the DSN, which means WAL sidecar files (`-wal`, `-shm`) now persist at teardown when WAL frames are not checkpointed before `conn.Close()`. This caused `t.TempDir()` cleanup to fail with "directory not empty" in three sidecar tests.

Closes #1366