### PR TITLE
fix: route pi session prompt delivery via host-API socket

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -33,6 +33,8 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/promptdelivery"
 )
 
 const (
@@ -297,15 +299,33 @@ func (w *Watcher) failAndNotify(head *db.PendingMerge, errMsg string) {
 	w.notify(context.Background(), head.SessionName, head.InstanceID, notifyText)
 }
 
-// notify delivers a notification to the coordinator via the opencode HTTP API.
-// It looks up the coordinator's harness port from agent_status and posts a
-// prompt_async message. Failure is non-fatal (logged).
+// notify delivers a notification to the coordinator via the appropriate
+// delivery path based on the harness type. For pi (TransportSocketPipe)
+// coordinators, it routes through the host-API Unix socket (#1364). For
+// opencode coordinators, it uses the opencode HTTP API (prompt_async).
+// Failure is non-fatal (logged).
 func (w *Watcher) notify(ctx context.Context, targetSession, targetInstanceID, text string) {
 	status, err := w.db.CurrentStatus(targetSession)
 	if err != nil || status == nil {
 		log.Printf("[mergequeue] notify: cannot find coordinator session %q: %v", targetSession, err)
 		return
 	}
+
+	// PI (socket-pipe) coordinators do not have an opencode HTTP server —
+	// route through the coordinator's host-API Unix socket instead (#1364).
+	if status.Harness != nil {
+		if shape, ok := harness.ShapeOf(*status.Harness); ok && shape == harness.TransportSocketPipe {
+			log.Printf("[mergequeue] notify: routing via host-API socket for pi coordinator=%s", targetSession)
+			if deliverErr := promptdelivery.DeliverToSession(targetSession, status, text, buildNotifyBody); deliverErr != nil {
+				log.Printf("[mergequeue] notify: FAILED (pi path) — coordinator=%s reason=%v", targetSession, deliverErr)
+			} else {
+				log.Printf("[mergequeue] notify: delivered to pi coordinator=%s via host-API socket", targetSession)
+			}
+			return
+		}
+	}
+
+	// Opencode path: require harness port and session ID.
 	if status.HarnessPort == nil {
 		log.Printf("[mergequeue] notify: coordinator %q has no harness port", targetSession)
 		return

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
@@ -1,0 +1,176 @@
+// Package promptdelivery provides a harness-aware prompt delivery helper used
+// by all out-of-process callers that need to send a follow-up prompt to a
+// running agent session.
+//
+// # Problem
+//
+// Three delivery paths in prism (review-complete monitor, coordinator notify,
+// merge-queue watcher) originally always POSTed to the opencode HTTP API
+// (http://localhost:<port>/session/<sid>/prompt_async). That path only works
+// for opencode sessions — pi sessions do not have an opencode HTTP server.
+//
+// # Solution
+//
+// DeliverToSession inspects the target session's harness field and routes:
+//
+//   - harness = "pi" (TransportSocketPipe) → POST {"session":…,"prompt":…} to
+//     the session's host-API Unix socket at /prompt. The sidecar's /prompt
+//     handler detects the same-session socket-pipe shape and forwards the text
+//     to the pi process via DeliverPrompt (stdin pipe write).
+//   - harness = "opencode" (or anything else) → POST to the opencode HTTP API
+//     at http://localhost:<port>/session/<sid>/prompt_async (unchanged path).
+//
+// All callers must pass the result of db.CurrentStatus for the target session.
+// The caller is responsible for pre-flight checks (session found, not ended, etc).
+package promptdelivery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// DeliverToSession delivers text to the agent session described by status,
+// routing based on the session's harness field.
+//
+// For pi sessions (TransportSocketPipe), it dials the session's host-API Unix
+// socket and POSTs /prompt. The socket path is derived from sessionName via
+// session.SidecarHostAPIPath.
+//
+// For opencode sessions (or when the harness is unknown / unset), it POSTs
+// to http://localhost:<HarnessPort>/session/<HarnessSessionID>/prompt_async.
+//
+// status must be non-nil. The caller is expected to have already verified that
+// the session is active (EndedAt == nil) before calling this function.
+//
+// buildHTTPBody is called for the opencode path to construct the POST body.
+// For the pi path, only the plain text is sent (the sidecar handles wrapping).
+// When buildHTTPBody is nil, a minimal body with just a "parts" array is used.
+func DeliverToSession(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any) error {
+	// Determine the transport shape from the harness field.
+	if status.Harness != nil && *status.Harness != "" {
+		shape, ok := harness.ShapeOf(*status.Harness)
+		if ok && shape == harness.TransportSocketPipe {
+			return deliverViaSidecarSocket(sessionName, text)
+		}
+	}
+
+	// Default: opencode HTTP path.
+	return deliverViaHTTP(status, text, buildHTTPBody)
+}
+
+// deliverViaSidecarSocket dials the target session's host-API Unix socket and
+// POSTs /prompt with {"session": sessionName, "prompt": text}.
+//
+// The sidecar's /prompt handler checks that req.Session == s.cfg.SessionName
+// and that the harness shape is TransportSocketPipe, then calls s.DeliverPrompt
+// to write the text to the pi process's stdin pipe.
+//
+// Returns an error if the socket does not exist (session ended / socket cleaned
+// up) or the HTTP request fails.
+func deliverViaSidecarSocket(sessionName, text string) error {
+	sockPath, err := session.SidecarHostAPIPath(sessionName)
+	if err != nil {
+		return fmt.Errorf("resolve host-API socket path for %q: %w", sessionName, err)
+	}
+
+	if _, statErr := os.Stat(sockPath); statErr != nil {
+		return fmt.Errorf("host-API socket not found at %s (session may have ended): %w", sockPath, statErr)
+	}
+
+	client := newUnixClient(sockPath)
+
+	body, err := json.Marshal(map[string]string{
+		"session": sessionName,
+		"prompt":  text,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal prompt body: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "http://prism-hostapi/prompt", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("dial host-API socket at %s: %w", sockPath, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("host-API /prompt returned HTTP %d for session %q", resp.StatusCode, sessionName)
+	}
+	return nil
+}
+
+// deliverViaHTTP sends text to the opencode HTTP API at
+// http://localhost:<HarnessPort>/session/<HarnessSessionID>/prompt_async.
+func deliverViaHTTP(status *db.Status, text string, buildBody func(string, *db.Status) map[string]any) error {
+	if status.HarnessPort == nil || status.HarnessSessionID == nil {
+		return fmt.Errorf("session %q has no harness port or session ID — cannot deliver prompt", status.SessionName)
+	}
+
+	var body map[string]any
+	if buildBody != nil {
+		body = buildBody(text, status)
+	} else {
+		body = map[string]any{
+			"parts": []map[string]string{
+				{"type": "text", "text": text},
+			},
+		}
+	}
+
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal prompt body: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/session/%s/prompt_async", *status.HarnessPort, *status.HarnessSessionID)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http status %d from %s", resp.StatusCode, url)
+	}
+	return nil
+}
+
+// newUnixClient returns an *http.Client that dials sockPath over a Unix socket.
+func newUnixClient(sockPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				d := &net.Dialer{Timeout: 5 * time.Second}
+				conn, err := d.DialContext(ctx, "unix", sockPath)
+				if err != nil {
+					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, err)
+				}
+				return conn, nil
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+}

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
@@ -1,0 +1,161 @@
+package promptdelivery_test
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/promptdelivery"
+)
+
+// TestDeliverToSession_OpencodePath verifies that DeliverToSession routes
+// sessions with harness="opencode" through the HTTP prompt_async endpoint,
+// leaving the host-API socket path unused.
+func TestDeliverToSession_OpencodePath(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Extract the port from the test server URL.
+	addr := srv.Listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	harness := "opencode"
+	sid := "session-123"
+	status := &db.Status{
+		SessionName:      "myrepo@feature",
+		Harness:          &harness,
+		HarnessPort:      &port,
+		HarnessSessionID: &sid,
+	}
+
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello opencode", nil)
+	if err != nil {
+		t.Fatalf("DeliverToSession: %v", err)
+	}
+
+	// Verify the body was sent to prompt_async.
+	if !strings.Contains(string(gotBody), "hello opencode") {
+		t.Errorf("expected body to contain 'hello opencode', got %q", gotBody)
+	}
+}
+
+// TestDeliverToSession_OpencodePath_NoPort verifies that DeliverToSession
+// returns an error for opencode sessions that have no harness port.
+func TestDeliverToSession_OpencodePath_NoPort(t *testing.T) {
+	harness := "opencode"
+	status := &db.Status{
+		SessionName: "myrepo@feature",
+		Harness:     &harness,
+		// HarnessPort is nil — cannot deliver.
+	}
+
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil)
+	if err == nil {
+		t.Fatal("expected error for missing harness port, got nil")
+	}
+	if !strings.Contains(err.Error(), "harness port") {
+		t.Errorf("error %q should mention harness port", err.Error())
+	}
+}
+
+// TestDeliverToSession_PiPath_MissingSocket verifies that DeliverToSession
+// returns a clear error when the host-API socket does not exist (session ended
+// or socket cleaned up).
+func TestDeliverToSession_PiPath_MissingSocket(t *testing.T) {
+	piHarness := "pi"
+	status := &db.Status{
+		SessionName: "myrepo@feature",
+		Harness:     &piHarness,
+	}
+
+	// The socket path doesn't exist — we expect a clear error, not a hang.
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil)
+	if err == nil {
+		t.Fatal("expected error for missing socket, got nil")
+	}
+	// Error should mention the socket or session.
+	errStr := err.Error()
+	if !strings.Contains(errStr, "socket") && !strings.Contains(errStr, "session") {
+		t.Errorf("error %q should mention socket or session", errStr)
+	}
+}
+
+// TestDeliverToSession_NilHarness verifies that DeliverToSession falls back to
+// the HTTP path when status.Harness is nil (pre-migration rows).
+func TestDeliverToSession_NilHarness(t *testing.T) {
+	var gotRequest bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequest = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+	sid := "session-456"
+
+	status := &db.Status{
+		SessionName:      "myrepo@feature",
+		Harness:          nil, // pre-migration: no harness recorded
+		HarnessPort:      &port,
+		HarnessSessionID: &sid,
+	}
+
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello nil harness", nil)
+	if err != nil {
+		t.Fatalf("DeliverToSession: %v", err)
+	}
+	if !gotRequest {
+		t.Error("expected HTTP request to be made for nil harness, but none was sent")
+	}
+}
+
+// TestDeliverToSession_CustomBodyBuilder verifies that a custom buildHTTPBody
+// function is called for the opencode HTTP path and its output is used as the
+// POST body.
+func TestDeliverToSession_CustomBodyBuilder(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+	sid := "session-789"
+	harness := "opencode"
+
+	status := &db.Status{
+		SessionName:      "myrepo@feature",
+		Harness:          &harness,
+		HarnessPort:      &port,
+		HarnessSessionID: &sid,
+	}
+
+	customBuilder := func(text string, _ *db.Status) map[string]any {
+		return map[string]any{"custom_text": text, "extra": "field"}
+	}
+
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "custom body test", customBuilder)
+	if err != nil {
+		t.Fatalf("DeliverToSession: %v", err)
+	}
+	if gotBody["custom_text"] != "custom body test" {
+		t.Errorf("custom_text = %v, want 'custom body test'", gotBody["custom_text"])
+	}
+	if gotBody["extra"] != "field" {
+		t.Errorf("extra = %v, want 'field'", gotBody["extra"])
+	}
+}

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -14,10 +14,8 @@ package review
 // called by the monitor-review subcommand.
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +24,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/promptdelivery"
 )
 
 // MonitorOpts configures the group-completion monitor.
@@ -364,10 +363,10 @@ func deliverWithRetry(workerSession, text string, maxRetries int, baseBackoff ti
 	return fmt.Errorf("delivery failed after %d attempts: %w", maxRetries+1, lastErr)
 }
 
-// deliverPrompt sends text to workerSession via the prism prompt HTTP API.
-// It mirrors the logic in cmd/prompt.go's runPrompt but operates directly
-// via the DB + HTTP path (no exec of a subprocess) so the monitor can be
-// embedded without spawning child processes.
+// deliverPrompt sends text to workerSession via the harness-aware delivery
+// helper. For pi sessions (TransportSocketPipe), it routes through the
+// session's host-API Unix socket. For opencode sessions, it uses the
+// opencode HTTP API (prompt_async).
 func deliverPrompt(workerSession, text, dbPath string) error {
 	if dbPath == "" {
 		dbPath = defaultDBPath()
@@ -388,36 +387,8 @@ func deliverPrompt(workerSession, text, dbPath string) error {
 	if status.EndedAt != nil {
 		return fmt.Errorf("session %q has ended — cannot deliver review results", workerSession)
 	}
-	if status.HarnessPort == nil || status.HarnessSessionID == nil {
-		return fmt.Errorf("session %q has no harness port or session ID — cannot deliver prompt", workerSession)
-	}
 
-	// Build prompt body matching cmd/prompt.go's buildPromptBody.
-	body := buildPromptBodyForMonitor(text, status)
-	jsonBytes, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("marshal prompt body: %w", err)
-	}
-
-	url := fmt.Sprintf("http://localhost:%d/session/%s/prompt_async", *status.HarnessPort, *status.HarnessSessionID)
-	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBytes))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("http request to %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("http status %d from %s", resp.StatusCode, url)
-	}
-
-	return nil
+	return promptdelivery.DeliverToSession(workerSession, status, text, buildPromptBodyForMonitor)
 }
 
 // buildPromptBodyForMonitor constructs the HTTP request body for prompt_async.

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -569,12 +569,24 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// is being routed to the sidecar's own pipe-connected harness, so
 		// there is no cross-session boundary to enforce. This is the path
 		// taken by the host-side `prism prompt <pi-session>` CLI when it
-		// dials the per-session host-API socket directly. We still gate on
-		// the harness having a TransportSocketPipe shape so an opencode
-		// session — which uses HTTP-port delivery — does not silently route
-		// through this branch.
+		// dials the per-session host-API socket directly, and by the
+		// promptdelivery.DeliverToSession helper used by the review-complete
+		// monitor, coordinator notify, and merge-queue watcher (#1364).
+		// We still gate on the harness having a TransportSocketPipe shape
+		// so an opencode session — which uses HTTP-port delivery — does not
+		// silently route through this branch.
 		if req.Session == s.cfg.SessionName {
 			if shape, ok := harness.ShapeOf(s.cfg.HarnessName); ok && shape == harness.TransportSocketPipe {
+				// Reject delivery when the pi session is in "waiting" state,
+				// consistent with the `prism prompt` CLI behaviour (#1364).
+				if s.cfg.DB != nil {
+					selfStatus, dbErr := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
+					if dbErr == nil && selfStatus != nil && selfStatus.State == "waiting" {
+						writeError(w, http.StatusConflict,
+							fmt.Sprintf("session %q is in waiting state — prompt not delivered", s.cfg.SessionName))
+						return
+					}
+				}
 				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s)", req.Session)
 				if !s.DeliverPrompt(req.Prompt, "nextTurn") {
 					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/promptdelivery"
 )
 
 // reviewAgentParentSession derives the parent worker session name from a
@@ -62,13 +64,28 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 		log.Printf("sidecar: notifyParentWorker: parent session %q has ended — skipping notification", parentSession)
 		return
 	}
+
+	notifyText := fmt.Sprintf("review agent %s failed to start: %v", s.cfg.SessionName, startupErr)
+
+	// PI (socket-pipe) workers do not have an opencode HTTP server — route
+	// through the parent session's host-API Unix socket instead (#1364).
+	if parentStatus.Harness != nil {
+		if shape, ok := harness.ShapeOf(*parentStatus.Harness); ok && shape == harness.TransportSocketPipe {
+			log.Printf("sidecar: notifyParentWorker: routing via host-API socket for pi parent=%s", parentSession)
+			if err := promptdelivery.DeliverToSession(parentSession, parentStatus, notifyText, buildNotifyPromptBody); err != nil {
+				log.Printf("sidecar: notifyParentWorker: FAILED (pi path) — parent=%s reason=%v", parentSession, err)
+			} else {
+				log.Printf("sidecar: notifyParentWorker: delivered to pi parent=%s via host-API socket", parentSession)
+			}
+			return
+		}
+	}
+
 	if parentStatus.HarnessPort == nil {
 		log.Printf("sidecar: notifyParentWorker: parent session %q has no harness port — cannot deliver notification", parentSession)
 		return
 	}
 	port := *parentStatus.HarnessPort
-
-	notifyText := fmt.Sprintf("review agent %s failed to start: %v", s.cfg.SessionName, startupErr)
 
 	storedSID := ""
 	if parentStatus.HarnessSessionID != nil {
@@ -213,7 +230,27 @@ func (s *Sidecar) notifyCoordinator() {
 		SentAt:       time.Now(),
 	}
 
-	// Require port for HTTP delivery.
+	// PI (socket-pipe) coordinators do not have an opencode HTTP server — route
+	// through the coordinator's host-API Unix socket instead (#1364).
+	if coordStatus.Harness != nil {
+		if shape, ok := harness.ShapeOf(*coordStatus.Harness); ok && shape == harness.TransportSocketPipe {
+			log.Printf("sidecar: notifyCoordinator: routing via host-API socket for pi coordinator=%s", coordinatorName)
+			if err := promptdelivery.DeliverToSession(coordinatorName, coordStatus, notifyText, buildNotifyPromptBody); err != nil {
+				log.Printf("sidecar: notifyCoordinator: FAILED (pi path) — coordinator=%s reason=%v", coordinatorName, err)
+				if writeErr := s.cfg.DB.WriteBusMessageFailed(msg); writeErr != nil {
+					log.Printf("sidecar: notifyCoordinator: write failed audit: %v", writeErr)
+				}
+				return
+			}
+			if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
+				log.Printf("sidecar: notifyCoordinator: write delivered audit: %v", err)
+			}
+			log.Printf("sidecar: notifyCoordinator: delivered to pi coordinator=%s via host-API socket", coordinatorName)
+			return
+		}
+	}
+
+	// Require port for HTTP delivery (opencode path).
 	if coordStatus.HarnessPort == nil {
 		log.Printf("sidecar: notifyCoordinator: coordinator has no harness port — cannot deliver notification")
 		return

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
@@ -1,0 +1,135 @@
+package sidecar
+
+// Tests for PI session prompt delivery via the host-API /prompt endpoint.
+//
+// These tests verify:
+//  1. The /prompt same-session socket-pipe path rejects delivery when the
+//     session is in "waiting" state (AC: edge-case waiting state guard).
+//  2. The /prompt same-session socket-pipe path succeeds when the session is
+//     in an active state.
+//
+// The tests use the hostAPIHandler() directly (no real Unix socket needed).
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+)
+
+// newPiSidecarForHostAPITest creates a Sidecar configured for the pi harness
+// and suitable for hostAPIHandler tests.
+func newPiSidecarForHostAPITest(t *testing.T, sessionName, repo, role string, d *db.DB) *Sidecar {
+	t.Helper()
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/tmp/" + sessionName,
+		DB:          d,
+		Clock:       clk,
+		AgentRole:   role,
+		HarnessName: "pi",
+		Harness:     pih.New("", role, ""),
+	}
+	return New(cfg)
+}
+
+// TestHostAPI_Prompt_PiSession_WaitingStateRejected verifies that the /prompt
+// same-session socket-pipe path returns HTTP 409 Conflict when the pi session
+// is in "waiting" state, consistent with `prism prompt` CLI behaviour (#1364).
+func TestHostAPI_Prompt_PiSession_WaitingStateRejected(t *testing.T) {
+	d := openTestDB(t)
+
+	sessionName := "myrepo@piworker"
+	// Seed the session row with state="waiting".
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "waiting", nil, nil); err != nil {
+		t.Fatalf("seed DB waiting state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+
+	// POST to /prompt targeting this session (same-session).
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"hello pi"}`)
+
+	// Expect 409 Conflict (session in waiting state).
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (waiting state rejection), body=%s", rr.Code, rr.Body.String())
+	}
+
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 409 response")
+	}
+	if errResp["error"] == "" {
+		t.Errorf("error %q should not be empty", errResp["error"])
+	}
+}
+
+// TestHostAPI_Prompt_PiSession_ActiveState_ConnectedPipe verifies that the
+// /prompt same-session socket-pipe path succeeds when the session is active
+// and the harness pipe is connected. Uses an actual pipe channel to simulate
+// the connected state.
+func TestHostAPI_Prompt_PiSession_ActiveState_ConnectedPipe(t *testing.T) {
+	d := openTestDB(t)
+
+	sessionName := "myrepo@piworker"
+	// Seed the session row with state="active".
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed DB active state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+
+	// Inject a fake pipe channel so DeliverPrompt has somewhere to write.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	// POST to /prompt targeting this session (same-session).
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"hello pi active"}`)
+
+	// Expect 200 OK.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the prompt frame was enqueued.
+	select {
+	case frame := <-fakePipeCh:
+		if len(frame) == 0 {
+			t.Error("expected non-empty frame in pipe channel")
+		}
+	default:
+		t.Error("expected a frame in pipe channel after /prompt, but channel was empty")
+	}
+}
+
+// TestHostAPI_Prompt_PiSession_NotConnected verifies that /prompt returns
+// 503 Service Unavailable when the pi harness pipe is not connected (no active
+// extension connection).
+func TestHostAPI_Prompt_PiSession_NotConnected(t *testing.T) {
+	d := openTestDB(t)
+
+	sessionName := "myrepo@piworker"
+	// Seed the session row with state="active".
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed DB active state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+	// harnessPipeOutCh is nil (not connected).
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"hello pi disconnected"}`)
+
+	// Expect 503 Service Unavailable (pipe not connected).
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (pipe not connected), body=%s", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- All three out-of-process prompt delivery paths (review-complete monitor, coordinator notify, merge-queue watcher) were broken for pi sessions — they assumed an opencode HTTP server which pi sessions don't have
- Add `internal/promptdelivery` package with `DeliverToSession` helper that dispatches based on `status.Harness`: pi (TransportSocketPipe) → host-API Unix socket `/prompt` endpoint, opencode → existing `prompt_async` HTTP path (unchanged)
- Add waiting-state guard to the `/prompt` same-session socket-pipe path in host_api.go (rejects with HTTP 409 when pi session is in `waiting` state)
- Wire the helper into the three broken delivery sites: `internal/review/monitor.go`, `internal/sidecar/notify.go`, `internal/mergequeue/watcher.go`

## Testing

- New package `internal/promptdelivery` with tests for opencode path, pi path (missing socket error), nil harness fallback, and custom body builder
- New sidecar tests for `/prompt` waiting state rejection, active state delivery via pipe, and not-connected error

All `go build ./...` and `go test ./...` pass. NixOS build succeeds.

Closes #1364