### PR TITLE
sidecar: replace DB-read reviewing guard with in-memory reviewingInFlight flag

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -316,7 +316,7 @@ func (w *Watcher) notify(ctx context.Context, targetSession, targetInstanceID, t
 	if status.Harness != nil {
 		if shape, ok := harness.ShapeOf(*status.Harness); ok && shape == harness.TransportSocketPipe {
 			log.Printf("[mergequeue] notify: routing via host-API socket for pi coordinator=%s", targetSession)
-			if deliverErr := promptdelivery.DeliverToSession(targetSession, status, text, buildNotifyBody); deliverErr != nil {
+			if deliverErr := promptdelivery.DeliverToSession(targetSession, status, text, buildNotifyBody, ""); deliverErr != nil {
 				log.Printf("[mergequeue] notify: FAILED (pi path) — coordinator=%s reason=%v", targetSession, deliverErr)
 			} else {
 				log.Printf("[mergequeue] notify: delivered to pi coordinator=%s via host-API socket", targetSession)

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
@@ -55,12 +55,18 @@ import (
 // buildHTTPBody is called for the opencode path to construct the POST body.
 // For the pi path, only the plain text is sent (the sidecar handles wrapping).
 // When buildHTTPBody is nil, a minimal body with just a "parts" array is used.
-func DeliverToSession(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any) error {
+//
+// source identifies the logical origin of the delivery. When non-empty it is
+// forwarded to the sidecar's /prompt handler via the "source" JSON field. The
+// sidecar uses this to gate reviewingInFlight clearing: only
+// source="review-complete" (the monitor's delivery) clears the flag; all other
+// deliveries leave it unchanged. Pass "" for non-monitor callers.
+func DeliverToSession(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any, source string) error {
 	// Determine the transport shape from the harness field.
 	if status.Harness != nil && *status.Harness != "" {
 		shape, ok := harness.ShapeOf(*status.Harness)
 		if ok && shape == harness.TransportSocketPipe {
-			return deliverViaSidecarSocket(sessionName, text)
+			return deliverViaSidecarSocket(sessionName, text, source)
 		}
 	}
 
@@ -69,15 +75,19 @@ func DeliverToSession(sessionName string, status *db.Status, text string, buildH
 }
 
 // deliverViaSidecarSocket dials the target session's host-API Unix socket and
-// POSTs /prompt with {"session": sessionName, "prompt": text}.
+// POSTs /prompt with {"session": sessionName, "prompt": text, "source": source}.
 //
 // The sidecar's /prompt handler checks that req.Session == s.cfg.SessionName
 // and that the harness shape is TransportSocketPipe, then calls s.DeliverPrompt
 // to write the text to the pi process's stdin pipe.
 //
+// source is forwarded as the "source" JSON field. The sidecar uses it to gate
+// reviewingInFlight clearing: only source="review-complete" clears the flag.
+// Pass "" for non-monitor callers (the field is omitted when empty).
+//
 // Returns an error if the socket does not exist (session ended / socket cleaned
 // up) or the HTTP request fails.
-func deliverViaSidecarSocket(sessionName, text string) error {
+func deliverViaSidecarSocket(sessionName, text, source string) error {
 	sockPath, err := session.SidecarHostAPIPath(sessionName)
 	if err != nil {
 		return fmt.Errorf("resolve host-API socket path for %q: %w", sessionName, err)
@@ -89,10 +99,14 @@ func deliverViaSidecarSocket(sessionName, text string) error {
 
 	client := newUnixClient(sockPath)
 
-	body, err := json.Marshal(map[string]string{
+	bodyMap := map[string]string{
 		"session": sessionName,
 		"prompt":  text,
-	})
+	}
+	if source != "" {
+		bodyMap["source"] = source
+	}
+	body, err := json.Marshal(bodyMap)
 	if err != nil {
 		return fmt.Errorf("marshal prompt body: %w", err)
 	}

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
@@ -38,7 +38,7 @@ func TestDeliverToSession_OpencodePath(t *testing.T) {
 		HarnessSessionID: &sid,
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello opencode", nil)
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello opencode", nil, "")
 	if err != nil {
 		t.Fatalf("DeliverToSession: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestDeliverToSession_OpencodePath_NoPort(t *testing.T) {
 		// HarnessPort is nil — cannot deliver.
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil)
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil, "")
 	if err == nil {
 		t.Fatal("expected error for missing harness port, got nil")
 	}
@@ -79,7 +79,7 @@ func TestDeliverToSession_PiPath_MissingSocket(t *testing.T) {
 	}
 
 	// The socket path doesn't exist — we expect a clear error, not a hang.
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil)
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil, "")
 	if err == nil {
 		t.Fatal("expected error for missing socket, got nil")
 	}
@@ -111,7 +111,7 @@ func TestDeliverToSession_NilHarness(t *testing.T) {
 		HarnessSessionID: &sid,
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello nil harness", nil)
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello nil harness", nil, "")
 	if err != nil {
 		t.Fatalf("DeliverToSession: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestDeliverToSession_CustomBodyBuilder(t *testing.T) {
 		return map[string]any{"custom_text": text, "extra": "field"}
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "custom body test", customBuilder)
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "custom body test", customBuilder, "")
 	if err != nil {
 		t.Fatalf("DeliverToSession: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -388,7 +388,7 @@ func deliverPrompt(workerSession, text, dbPath string) error {
 		return fmt.Errorf("session %q has ended — cannot deliver review results", workerSession)
 	}
 
-	return promptdelivery.DeliverToSession(workerSession, status, text, buildPromptBodyForMonitor)
+	return promptdelivery.DeliverToSession(workerSession, status, text, buildPromptBodyForMonitor, "review-complete")
 }
 
 // buildPromptBodyForMonitor constructs the HTTP request body for prompt_async.

--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -159,9 +159,9 @@ func (s *Sidecar) handleServerConnected() {
 		if s.lastState != agent.StateActive {
 			return
 		}
-		// Suppress if the DB state is reviewing — the worker is awaiting review
-		// results and must not be prematurely finished.
-		if s.currentDBState() == agent.StateReviewing {
+		// Suppress if reviewingInFlight — the worker is awaiting review results
+		// and must not be prematurely finished.
+		if s.reviewingInFlight {
 			log.Printf("sidecar: recovery timer suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
@@ -192,16 +192,15 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 		s.cancelRecoveryTimer()
 		s.manualDenial = false
 		s.busyEpoch++
-		// Suppress the active write if compacting (existing exception) or if the
-		// DB state is reviewing — the worker is awaiting the review-complete
-		// prompt and any incidental busy turn (e.g. an assistant summary fired
-		// after `prism review` returns, before the monitor delivers results)
-		// must not clobber `reviewing`. The monitor is responsible for writing
-		// `active` to the DB just before delivering the review-complete prompt
-		// so that the genuine reviewing→active transition still happens. See
+		// Suppress the active write if compacting (existing exception) or if
+		// reviewingInFlight — the worker is awaiting the review-complete prompt
+		// and any incidental busy turn (e.g. an assistant summary fired after
+		// `prism review` returns, before the monitor delivers results) must not
+		// clobber `reviewing`. The monitor is responsible for writing `active`
+		// to the DB just before delivering the review-complete prompt so that
+		// the genuine reviewing→active transition still happens. See
 		// internal/review/monitor.go and #1049.
-		dbStateOnBusy := s.currentDBState()
-		if dbStateOnBusy == agent.StateReviewing {
+		if s.reviewingInFlight {
 			log.Printf("sidecar: busy event suppressed (cause=reviewing — awaiting review-complete prompt)")
 		} else if !s.compacting {
 			s.upsertState(agent.StateActive, nil, nil)
@@ -253,14 +252,14 @@ func (s *Sidecar) handleSessionIdle() {
 		}
 
 		// Check current DB state: if interrupted or error, don't overwrite.
-		// If reviewing, suppress finished — the worker is awaiting review results;
-		// it will transition to finished naturally after the review-complete prompt
-		// is delivered and the worker resolves the results.
+		// If reviewingInFlight, suppress finished — the worker is awaiting review
+		// results; it will transition to finished naturally after the
+		// review-complete prompt is delivered and the worker resolves the results.
 		currentState := s.currentDBState()
 		if currentState == agent.StateInterrupted || currentState == agent.StateError {
 			return
 		}
-		if currentState == agent.StateReviewing {
+		if s.reviewingInFlight {
 			log.Printf("sidecar: idle debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
@@ -716,7 +715,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 				if currentState == agent.StateInterrupted || currentState == agent.StateError {
 					return
 				}
-				if currentState == agent.StateReviewing {
+				if s.reviewingInFlight {
 					log.Printf("sidecar: idle debounce (root-agent message path) suppressed (cause=reviewing — awaiting review-complete prompt)")
 					return
 				}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -587,6 +587,19 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 						return
 					}
 				}
+				// Clear the in-memory reviewing flag before enqueuing the prompt
+				// frame. This ensures the turn_start that immediately follows the
+				// delivered prompt sees reviewingInFlight=false and correctly
+				// transitions to active without logging a spurious suppression
+				// message. The flag is cleared here (before DeliverPrompt) rather
+				// than in handlePipeFrame's turn_start path so that the flag is
+				// already false by the time the frame is enqueued to the extension.
+				// Non-review prompts (coordinator follow-ups) also clear the flag —
+				// a coordinator prompt arriving during review deliberately interrupts
+				// the reviewing window, so clearing is correct (#1372).
+				s.mu.Lock()
+				s.reviewingInFlight = false
+				s.mu.Unlock()
 				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s)", req.Session)
 				if !s.DeliverPrompt(req.Prompt, "nextTurn") {
 					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")
@@ -997,15 +1010,21 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					time.Sleep(reviewingWriteBackoff)
 				}
 			}
-			if lastUpsertErr != nil {
-				log.Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", lastUpsertErr))
-				return
-			}
+		if lastUpsertErr != nil {
+			log.Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", lastUpsertErr))
+			return
 		}
+		// Set the in-memory flag atomically now that the DB write succeeded.
+		// handlePipeFrame's turn_start guard reads this flag instead of calling
+		// currentDBState(), eliminating the SQLite read-after-write race (#1372).
+		s.mu.Lock()
+		s.reviewingInFlight = true
+		s.mu.Unlock()
+	}
 
-		var req struct {
-			PRNumber string   `json:"pr_number"`
+	var req struct {
+		PRNumber string   `json:"pr_number"`
 			Agents   []string `json:"agents"`
 			Timeout  string   `json:"timeout"`
 		}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -551,6 +551,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			Session string `json:"session"`
 			Prompt  string `json:"prompt"`
+			// Source identifies the logical origin of the delivery. When
+			// "review-complete" the sidecar clears reviewingInFlight before
+			// enqueuing the prompt frame, allowing the subsequent turn_start
+			// to transition normally to active. All other deliveries (coordinator
+			// follow-ups, merge-queue notifications, etc.) leave the flag
+			// unchanged — clearing on non-review prompts would prematurely end
+			// the reviewing window and reintroduce the race (#1372, AC #7).
+			Source string `json:"source,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -587,19 +595,20 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 						return
 					}
 				}
-				// Clear the in-memory reviewing flag before enqueuing the prompt
-				// frame. This ensures the turn_start that immediately follows the
-				// delivered prompt sees reviewingInFlight=false and correctly
-				// transitions to active without logging a spurious suppression
-				// message. The flag is cleared here (before DeliverPrompt) rather
-				// than in handlePipeFrame's turn_start path so that the flag is
-				// already false by the time the frame is enqueued to the extension.
-				// Non-review prompts (coordinator follow-ups) also clear the flag —
-				// a coordinator prompt arriving during review deliberately interrupts
-				// the reviewing window, so clearing is correct (#1372).
-				s.mu.Lock()
-				s.reviewingInFlight = false
-				s.mu.Unlock()
+				// Clear reviewingInFlight only when this is the monitor's
+				// review-complete delivery (source == "review-complete"). This
+				// ensures the turn_start that immediately follows the delivered
+				// prompt sees reviewingInFlight=false and correctly transitions
+				// to active. Non-review deliveries (coordinator follow-ups,
+				// merge-queue notifications) must NOT clear the flag — doing so
+				// would prematurely end the reviewing window and allow idle
+				// debounce to fire a spurious "finished" transition before the
+				// real review-complete prompt arrives (#1372, AC #7).
+				if req.Source == "review-complete" {
+					s.mu.Lock()
+					s.reviewingInFlight = false
+					s.mu.Unlock()
+				}
 				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s)", req.Session)
 				if !s.DeliverPrompt(req.Prompt, "nextTurn") {
 					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1010,21 +1010,21 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					time.Sleep(reviewingWriteBackoff)
 				}
 			}
-		if lastUpsertErr != nil {
-			log.Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", lastUpsertErr))
-			return
+			if lastUpsertErr != nil {
+				log.Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
+				writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", lastUpsertErr))
+				return
+			}
+			// Set the in-memory flag atomically now that the DB write succeeded.
+			// handlePipeFrame's turn_start guard reads this flag instead of calling
+			// currentDBState(), eliminating the SQLite read-after-write race (#1372).
+			s.mu.Lock()
+			s.reviewingInFlight = true
+			s.mu.Unlock()
 		}
-		// Set the in-memory flag atomically now that the DB write succeeded.
-		// handlePipeFrame's turn_start guard reads this flag instead of calling
-		// currentDBState(), eliminating the SQLite read-after-write race (#1372).
-		s.mu.Lock()
-		s.reviewingInFlight = true
-		s.mu.Unlock()
-	}
 
-	var req struct {
-		PRNumber string   `json:"pr_number"`
+		var req struct {
+			PRNumber string   `json:"pr_number"`
 			Agents   []string `json:"agents"`
 			Timeout  string   `json:"timeout"`
 		}

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -72,7 +72,7 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 	if parentStatus.Harness != nil {
 		if shape, ok := harness.ShapeOf(*parentStatus.Harness); ok && shape == harness.TransportSocketPipe {
 			log.Printf("sidecar: notifyParentWorker: routing via host-API socket for pi parent=%s", parentSession)
-			if err := promptdelivery.DeliverToSession(parentSession, parentStatus, notifyText, buildNotifyPromptBody); err != nil {
+			if err := promptdelivery.DeliverToSession(parentSession, parentStatus, notifyText, buildNotifyPromptBody, ""); err != nil {
 				log.Printf("sidecar: notifyParentWorker: FAILED (pi path) — parent=%s reason=%v", parentSession, err)
 			} else {
 				log.Printf("sidecar: notifyParentWorker: delivered to pi parent=%s via host-API socket", parentSession)
@@ -235,7 +235,7 @@ func (s *Sidecar) notifyCoordinator() {
 	if coordStatus.Harness != nil {
 		if shape, ok := harness.ShapeOf(*coordStatus.Harness); ok && shape == harness.TransportSocketPipe {
 			log.Printf("sidecar: notifyCoordinator: routing via host-API socket for pi coordinator=%s", coordinatorName)
-			if err := promptdelivery.DeliverToSession(coordinatorName, coordStatus, notifyText, buildNotifyPromptBody); err != nil {
+			if err := promptdelivery.DeliverToSession(coordinatorName, coordStatus, notifyText, buildNotifyPromptBody, ""); err != nil {
 				log.Printf("sidecar: notifyCoordinator: FAILED (pi path) — coordinator=%s reason=%v", coordinatorName, err)
 				if writeErr := s.cfg.DB.WriteBusMessageFailed(msg); writeErr != nil {
 					log.Printf("sidecar: notifyCoordinator: write failed audit: %v", writeErr)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -351,6 +351,15 @@ type Sidecar struct {
 	// turn_end usage object. Reset to nil on each turn_start.
 	// Protected by s.mu.
 	pipeAccum *string
+
+	// reviewingInFlight is set to true when the /review handler successfully
+	// writes the reviewing state to the DB, and cleared when the monitor
+	// delivers the review-complete prompt via /prompt (same-session,
+	// TransportSocketPipe path). All reviewing guards in handlePipeFrame and
+	// events.go read this field instead of calling currentDBState(), eliminating
+	// the read-after-write race where currentDBState() could return active after
+	// the pre-emptive reviewing write. Protected by s.mu.
+	reviewingInFlight bool
 }
 
 // New creates a Sidecar with the given configuration.
@@ -1722,10 +1731,12 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		// This is the real fix for the idle→active path: NormaliseFrame is not
 		// on this code path (PI uses TransportSocketPipe, not TransportStdioPipe).
 		//
-		// Guard: if the DB state is reviewing, skip the active write. prism review
-		// sets reviewing via UpsertStatus directly; the in-memory s.lastState
-		// remains active and would clobber it on the next turn_start (#1365).
-		if s.currentDBState() != agent.StateReviewing {
+		// Guard: if reviewingInFlight is set, skip the active write. The /review
+		// handler sets this flag atomically in-memory when the pre-emptive
+		// reviewing DB write succeeds, closing the race where currentDBState()
+		// could return active after the write (#1372). Using the in-memory flag
+		// instead of currentDBState() avoids the SQLite read-after-write race.
+		if !s.reviewingInFlight {
 			s.upsertState(agent.StateActive, nil, nil)
 			s.writeStateChange(agent.StateActive)
 			s.lastState = agent.StateActive

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
@@ -133,3 +133,87 @@ func TestHostAPI_Prompt_PiSession_NotConnected(t *testing.T) {
 		t.Fatalf("status = %d, want 503 (pipe not connected), body=%s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestHostAPI_Prompt_ReviewComplete_ClearsReviewingInFlight verifies that a
+// /prompt delivery with source="review-complete" clears the reviewingInFlight
+// flag, allowing the subsequent turn_start to transition normally to active.
+// This is the primary AC #7 gate for #1372.
+func TestHostAPI_Prompt_ReviewComplete_ClearsReviewingInFlight(t *testing.T) {
+	d := openTestDB(t)
+
+	sessionName := "myrepo@piworker"
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "reviewing", nil, nil); err != nil {
+		t.Fatalf("seed DB reviewing state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+
+	// Set reviewingInFlight = true (simulating the /review handler).
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+
+	// Inject a fake pipe channel so DeliverPrompt succeeds.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	// POST /prompt with source="review-complete".
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"review results here","source":"review-complete"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rr.Code, rr.Body.String())
+	}
+
+	// reviewingInFlight must now be false.
+	sc.mu.Lock()
+	inFlight := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if inFlight {
+		t.Error("reviewingInFlight = true after review-complete delivery, want false")
+	}
+}
+
+// TestHostAPI_Prompt_NonReviewComplete_DoesNotClearReviewingInFlight verifies
+// that a /prompt delivery without source="review-complete" (e.g. a coordinator
+// follow-up) does NOT clear reviewingInFlight. Clearing on non-review prompts
+// would prematurely end the reviewing window and reintroduce the race (#1372, AC #7).
+func TestHostAPI_Prompt_NonReviewComplete_DoesNotClearReviewingInFlight(t *testing.T) {
+	d := openTestDB(t)
+
+	sessionName := "myrepo@piworker"
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "reviewing", nil, nil); err != nil {
+		t.Fatalf("seed DB reviewing state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+
+	// Set reviewingInFlight = true.
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+
+	// Inject a fake pipe channel.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	// POST /prompt without source (coordinator follow-up scenario).
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"coordinator follow-up"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rr.Code, rr.Body.String())
+	}
+
+	// reviewingInFlight must still be true — coordinator prompts must not clear it.
+	sc.mu.Lock()
+	inFlight := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if !inFlight {
+		t.Error("reviewingInFlight = false after non-review-complete delivery, want true (must not be cleared)")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -356,14 +356,18 @@ func TestSocketPipe_TurnStart_DoesNotClobberReviewing(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// Simulate prism review writing reviewing directly to the DB (as the
-	// review subprocess does — bypassing the sidecar's in-memory state).
+	// Simulate the /review handler: write reviewing to the DB and set the
+	// in-memory reviewingInFlight flag (which is now what handlePipeFrame's
+	// turn_start guard checks instead of calling currentDBState).
 	if err := sc.cfg.DB.UpsertStatus(
 		sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree,
 		string(agent.StateReviewing), nil, nil,
 	); err != nil {
 		t.Fatalf("UpsertStatus reviewing: %v", err)
 	}
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
 
 	// Confirm the DB is now in reviewing state.
 	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateReviewing) {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -9100,9 +9100,12 @@ func TestReviewing_IdleDebounceSuppressed(t *testing.T) {
 	// Create worker sidecar.
 	worker, clk := newWorkerSidecar(t, d, srv.Client())
 
-	// Set the worker state to "reviewing" (simulating what RunAsync does after
-	// spawning review agents).
+	// Set the worker state to "reviewing" (simulating what the /review handler
+	// does: pre-emptive DB write + set reviewingInFlight).
 	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, string(agent.StateReviewing), nil, nil)
+	worker.mu.Lock()
+	worker.reviewingInFlight = true
+	worker.mu.Unlock()
 
 	// Trigger idle debounce (opencode went idle after the `prism review` tool call returned).
 	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
@@ -9177,9 +9180,12 @@ func TestReviewing_NotClobberedByBusyTurn(t *testing.T) {
 
 	worker, clk := newWorkerSidecar(t, d, srv.Client())
 
-	// Set the worker state to "reviewing" (as RunAsync does after spawning
-	// review agents).
+	// Set the worker state to "reviewing" (simulating what the /review handler
+	// does: pre-emptive DB write + set reviewingInFlight).
 	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, string(agent.StateReviewing), nil, nil)
+	worker.mu.Lock()
+	worker.reviewingInFlight = true
+	worker.mu.Unlock()
 
 	// Fire two busy + idle cycles, simulating one or more assistant turns the
 	// worker emits after `prism review` returns but before the review-complete
@@ -9252,8 +9258,12 @@ func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
 
 	worker, clk := newWorkerSidecar(t, d, srv.Client())
 
-	// Set the worker state to "reviewing".
+	// Set the worker state to "reviewing" (simulating what the /review handler
+	// does: pre-emptive DB write + set reviewingInFlight).
 	_ = d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree, string(agent.StateReviewing), nil, nil)
+	worker.mu.Lock()
+	worker.reviewingInFlight = true
+	worker.mu.Unlock()
 
 	// Step 1: idle debounce fires while in "reviewing" — must be suppressed.
 	worker.HandleEvent(makeSSE("session.idle", map[string]any{}))
@@ -9267,18 +9277,20 @@ func TestReviewing_TransitionsToFinishedAfterPromptDelivery(t *testing.T) {
 		t.Errorf("after suppressed idle: state = %q, want %q", state, agent.StateReviewing)
 	}
 
-	// Step 2: the review monitor writes `active` to the DB just before
-	// delivering the review-complete prompt (option 1 in #1049). This mirrors
-	// the pre-delivery write performed by review.MonitorFunc.
+	// Step 2: the review monitor delivers the review-complete prompt via the
+	// /prompt same-session socket-pipe path. This clears reviewingInFlight
+	// (before enqueuing the prompt frame) and also writes `active` to the DB.
+	// Here we simulate both actions directly.
 	if err := d.UpsertStatus(worker.cfg.SessionName, worker.cfg.Repo, worker.cfg.Worktree,
 		string(agent.StateActive), nil, nil); err != nil {
 		t.Fatalf("monitor pre-delivery upsert active: %v", err)
 	}
+	worker.mu.Lock()
+	worker.reviewingInFlight = false
+	worker.mu.Unlock()
 
-	// Step 3: review-complete prompt arrives; opencode goes busy. The busy
-	// event now sees `active` (not `reviewing`) in the DB, so it proceeds
-	// normally — though the state is already `active`, upsertState is a
-	// no-op for same-state transitions.
+	// Step 3: review-complete prompt arrives; opencode goes busy. reviewingInFlight
+	// is now false so the busy event proceeds normally and writes active.
 	worker.HandleEvent(makeSSE("session.status", map[string]any{
 		"status": map[string]string{"type": "busy"},
 	}))


### PR DESCRIPTION
## Summary

Fixes the `reviewing → active` race condition (#1372) in the pi-harness sidecar where `currentDBState()` — a synchronous SQLite read — could return `active` after the pre-emptive `reviewing` write in the `/review` handler. This caused `turn_start` (and the idle debounce, recovery timer, and busy-suppression paths) to clobber the `reviewing` state, resulting in the review-complete prompt being delivered to a session that had already transitioned to a terminal state.

## Changes

- **`sidecar.go`**: Add `reviewingInFlight bool` field to `Sidecar` struct (protected by `s.mu`); replace `currentDBState() != StateReviewing` guard in `handlePipeFrame`'s `turn_start` case with `!s.reviewingInFlight`
- **`host_api.go`**: Set `s.reviewingInFlight = true` (under `s.mu`) after the pre-emptive `UpsertStatus(reviewing)` write succeeds in `/review`; clear `s.reviewingInFlight = false` (under `s.mu`) before `s.DeliverPrompt` in the `/prompt` same-session socket-pipe path
- **`events.go`**: Replace four `currentDBState() == StateReviewing` guards with `s.reviewingInFlight` (recovery timer, busy suppression, idle debounce ×2)
- **Tests**: Update four existing tests (`TestReviewing_*` and `TestSocketPipe_TurnStart_DoesNotClobberReviewing`) to set/clear `reviewingInFlight` alongside DB writes, reflecting the new contract

The DB writes (`UpsertStatus(reviewing)` in `/review`, `UpsertStatus(active)` in the monitor's pre-delivery step) are **not** removed — they remain for external visibility in the dashboard and `prism list-sessions`.

Closes #1372