### PR TITLE
sandbox-exec: carve out ~/.aws/sso and ~/.aws/cli from broad deny rule

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -265,14 +265,30 @@ func generateProfile(m *Manager) string {
 	sb.WriteString("  (subpath \"/private/etc/ssh\"))\n")
 	sb.WriteString("\n")
 
-	// ── 5. Host ~/.aws deny — keep host credentials invisible ─────────────
+	// ── 5. Host ~/.aws deny with sso/ and cli/ carve-outs ────────────────
 	// The staging HOME contains symlinks to the staged .aws credential
 	// entries (per issue #1017). The host raw ~/.aws subtree must remain
 	// read-denied so that path traversal cannot bypass the staging map.
+	//
+	// Exception: ~/.aws/sso and ~/.aws/cli must remain accessible so that
+	// AWS SSO auth and tools that read SSO tokens (e.g. kubectl) work inside
+	// the sandbox. The staging HOME creates symlinks for these two subdirs
+	// pointing at the host paths, and collectStagingHomeSymlinkTargets emits
+	// per-symlink allow rules for them. The more-specific allow rules below
+	// override the broad deny for exactly these two subdirs (SBPL evaluates
+	// more-specific rules as overrides of broader ones). See issue #1380.
 	if home != "" {
 		awsPath := filepath.Join(home, ".aws")
 		sb.WriteString("(deny file-read* file-write*\n")
 		sb.WriteString("  (subpath " + quoteSBPL(awsPath) + "))\n")
+		sb.WriteString("\n")
+		// Carve-outs: allow sso/ and cli/ subtrees within ~/.aws. These
+		// more-specific allow rules override the broad deny above.
+		awsSSOPath := filepath.Join(home, ".aws", "sso")
+		awsCLIPath := filepath.Join(home, ".aws", "cli")
+		sb.WriteString("(allow file-read*\n")
+		sb.WriteString("  (subpath " + quoteSBPL(awsSSOPath) + ")\n")
+		sb.WriteString("  (subpath " + quoteSBPL(awsCLIPath) + "))\n")
 		sb.WriteString("\n")
 	}
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -524,12 +524,34 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 	// Symlink targets that fall under these prefixes are excluded from the
 	// allow-literal/subpath block to avoid the literal-over-subpath precedence
 	// issue in Apple's SBPL.
+	//
+	// allowedUnderDenied lists specific sub-paths that are carved out of the
+	// denied region. generateProfile emits explicit (allow file-read* (subpath
+	// ...)) rules for these after the broad deny, so it is safe for the
+	// per-symlink allow block to reference their targets.
+	// Concretely: ~/.aws/sso and ~/.aws/cli are carved out so that the staging
+	// HOME symlinks for those dirs produce per-symlink allow rules.
 	var deniedPrefixes []string
+	var allowedUnderDenied []string
 	if home != "" {
 		deniedPrefixes = append(deniedPrefixes, filepath.Join(home, ".aws")+"/")
+		// Carve sso/ and cli/ out of the denied region — generateProfile emits
+		// explicit (allow file-read* (subpath ~/.aws/sso)) and
+		// (allow file-read* (subpath ~/.aws/cli)) after the broad deny.
+		allowedUnderDenied = append(allowedUnderDenied,
+			filepath.Join(home, ".aws", "sso")+"/",
+			filepath.Join(home, ".aws", "cli")+"/",
+		)
 	}
 
 	isDenied := func(path string) bool {
+		// Check whether the path falls under any allowed carve-out first.
+		// If yes, it is not considered denied even if a broader deny prefix matches.
+		for _, allowed := range allowedUnderDenied {
+			if strings.HasPrefix(path+"/", allowed) || path == strings.TrimSuffix(allowed, "/") {
+				return false
+			}
+		}
 		for _, prefix := range deniedPrefixes {
 			if strings.HasPrefix(path+"/", prefix) || path == strings.TrimSuffix(prefix, "/") {
 				return true

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -268,6 +268,145 @@ func TestGenerateProfile_AWSHomePathDenied(t *testing.T) {
 	}
 }
 
+// TestGenerateProfile_AWSSSOAndCLICarveouts verifies that the profile contains
+// explicit (allow file-read* (subpath ".../.aws/sso")) and
+// (allow file-read* (subpath ".../.aws/cli")) rules after the broad ~/.aws deny.
+// These more-specific allow rules let AWS SSO tokens and kubectl credential
+// files be read through the staging HOME symlinks (issue #1380).
+func TestGenerateProfile_AWSSSOAndCLICarveouts(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "aws-carveout-test",
+		Worktree:    t.TempDir(),
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.RemoveAll(filepath.Join(fakeHome, ".local", "state", "prism"))
+	})
+
+	profile := generateProfile(m)
+
+	awsSSOPath := filepath.Join(fakeHome, ".aws", "sso")
+	awsCLIPath := filepath.Join(fakeHome, ".aws", "cli")
+
+	// Both carve-out paths must appear in the profile.
+	if !strings.Contains(profile, awsSSOPath) {
+		t.Errorf("profile missing ~/.aws/sso carve-out path %q; full profile:\n%s", awsSSOPath, profile)
+	}
+	if !strings.Contains(profile, awsCLIPath) {
+		t.Errorf("profile missing ~/.aws/cli carve-out path %q; full profile:\n%s", awsCLIPath, profile)
+	}
+
+	// Each carve-out path must be inside an (allow ...) clause that follows
+	// the broad (deny ...) clause for ~/.aws. Verify ordering: find the deny
+	// clause, then find each allow carve-out after it.
+	awsDenyPath := filepath.Join(fakeHome, ".aws")
+	denyIdx := strings.Index(profile, awsDenyPath)
+	if denyIdx < 0 {
+		t.Fatalf("profile missing ~/.aws deny path %q; full profile:\n%s", awsDenyPath, profile)
+	}
+
+	ssoIdx := strings.Index(profile, awsSSOPath)
+	if ssoIdx < 0 {
+		t.Fatalf("profile missing ~/.aws/sso path; already checked above — this should not happen")
+	}
+	if ssoIdx <= denyIdx {
+		t.Errorf("~/.aws/sso carve-out (at index %d) must appear AFTER the ~/.aws deny (at index %d); full profile:\n%s", ssoIdx, denyIdx, profile)
+	}
+	// Verify sso path is inside an (allow ...) block.
+	ssoAllowStart := strings.LastIndex(profile[:ssoIdx], "(allow")
+	ssoDenyStart := strings.LastIndex(profile[:ssoIdx], "(deny")
+	if ssoAllowStart < 0 || ssoDenyStart > ssoAllowStart {
+		t.Errorf("~/.aws/sso path is not inside an (allow ...) block; full profile:\n%s", profile)
+	}
+
+	cliIdx := strings.Index(profile, awsCLIPath)
+	if cliIdx < 0 {
+		t.Fatalf("profile missing ~/.aws/cli path; already checked above — this should not happen")
+	}
+	if cliIdx <= denyIdx {
+		t.Errorf("~/.aws/cli carve-out (at index %d) must appear AFTER the ~/.aws deny (at index %d); full profile:\n%s", cliIdx, denyIdx, profile)
+	}
+	// Verify cli path is inside an (allow ...) block.
+	cliAllowStart := strings.LastIndex(profile[:cliIdx], "(allow")
+	cliDenyStart := strings.LastIndex(profile[:cliIdx], "(deny")
+	if cliAllowStart < 0 || cliDenyStart > cliAllowStart {
+		t.Errorf("~/.aws/cli path is not inside an (allow ...) block; full profile:\n%s", profile)
+	}
+}
+
+// TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded verifies that when
+// ~/.aws/sso and ~/.aws/cli symlinks exist in the staging HOME, their resolved
+// targets are included in the collected set (not excluded by the deniedPrefixes
+// logic). This exercises the carve-out in isDenied (issue #1380).
+func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Create ~/.aws/sso and ~/.aws/cli directories in the fake home so the
+	// symlinkIfExists helper in PrepareSandboxExecHome creates symlinks for them.
+	for _, dir := range []string{
+		filepath.Join(fakeHome, ".aws", "sso"),
+		filepath.Join(fakeHome, ".aws", "cli"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "aws-sso-not-excluded-test",
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
+	if err != nil {
+		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
+	}
+
+	// The resolved targets for ~/.aws/sso and ~/.aws/cli must be present.
+	// Use filepath.EvalSymlinks to resolve the expected paths: on macOS
+	// the fakeHome is under /tmp/ which resolves to /private/tmp/ via the
+	// /var → /private/var symlink, so we must compare against canonical forms.
+	awsSSOPathRaw := filepath.Join(fakeHome, ".aws", "sso")
+	awsCLIPathRaw := filepath.Join(fakeHome, ".aws", "cli")
+	awsSSOPath, _ := filepath.EvalSymlinks(awsSSOPathRaw)
+	if awsSSOPath == "" {
+		awsSSOPath = awsSSOPathRaw
+	}
+	awsCLIPath, _ := filepath.EvalSymlinks(awsCLIPathRaw)
+	if awsCLIPath == "" {
+		awsCLIPath = awsCLIPathRaw
+	}
+	foundSSO, foundCLI := false, false
+	for _, target := range targets {
+		if target.ResolvedPath == awsSSOPath {
+			foundSSO = true
+		}
+		if target.ResolvedPath == awsCLIPath {
+			foundCLI = true
+		}
+	}
+	if !foundSSO {
+		t.Errorf("~/.aws/sso resolved path %q not found in collectStagingHomeSymlinkTargets output; got: %v", awsSSOPath, targets)
+	}
+	if !foundCLI {
+		t.Errorf("~/.aws/cli resolved path %q not found in collectStagingHomeSymlinkTargets output; got: %v", awsCLIPath, targets)
+	}
+}
+
 // ── PrepareSandboxExec ──────────────────────────────────────────────────────
 
 // TestPrepareSandboxExec_WritesProfileAndReturnsArgs verifies that

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
@@ -1,0 +1,332 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_aws_sso_darwin_test.go — integration coverage for the
+// ~/.aws/sso and ~/.aws/cli carve-outs in the SBPL profile (issue #1380).
+//
+// The SBPL profile contains a broad (deny file-read* file-write* (subpath
+// ~/.aws)) to prevent host credential leakage. However, the staging HOME
+// creates symlinks for ~/.aws/sso and ~/.aws/cli pointing at the host paths
+// so that AWS SSO auth and kubectl (which reads SSO tokens) work inside the
+// sandbox.
+//
+// generateProfile emits explicit (allow file-read* (subpath ~/.aws/sso)) and
+// (allow file-read* (subpath ~/.aws/cli)) rules after the broad deny. In SBPL,
+// more-specific rules override broader ones, so these carve-outs let the
+// sandbox traverse into those two subdirs while the rest of ~/.aws remains
+// denied.
+//
+// This file tests:
+//
+//  1. Positive case: when ~/.aws/sso exists on the host, a sentinel file
+//     inside it is readable from inside the sandbox via the staging HOME
+//     symlink chain.
+//
+//  2. Negative case: removing the (subpath ~/.aws/sso) carve-out from the
+//     profile causes the same read to fail — proving the positive is not
+//     green by accident and that the carve-out is load-bearing.
+//
+//  3. A symmetric positive/negative pair for ~/.aws/cli.
+//
+// Shared helpers (requireSandboxExec, requireNixBash, newProfileManager,
+// newProfileManagerWithBareRoot, augmentProfileForTest, withMutatedProfile,
+// sbplQuoteForTest, shQuote) live in sandbox_exec_helpers_darwin_test.go.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// awsSSOSentinelContent is the content written to the sentinel file inside
+// ~/.aws/sso during the positive tests. Using a unique marker ensures the
+// output check is not fooled by empty output or by another file's content.
+const awsSSOSentinelContent = "prism-1380-aws-sso-sentinel"
+
+// awsCLISentinelContent is the analogous sentinel for the ~/.aws/cli tests.
+const awsCLISentinelContent = "prism-1380-aws-cli-sentinel"
+
+// realUserHome returns the user's real (non-staging) home directory. It uses
+// the REAL_HOME env var when set (the prism harness exports this so agents
+// running inside a sandbox-exec session can find the host HOME), falling
+// back to os.UserHomeDir(). Inside a prism sandbox-exec session, UserHomeDir()
+// returns the staging HOME, which makes writes to ~/.aws/sso fail (the
+// carve-out grants only read access); REAL_HOME bypasses that.
+func realUserHome(t *testing.T) string {
+	t.Helper()
+	if rh := os.Getenv("REAL_HOME"); rh != "" {
+		return rh
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	return home
+}
+
+// prepareSSOSentinel creates ~/.aws/sso under the user's real HOME (NOT under
+// t.TempDir, which resolves to /private/var/folders and is broadly allowed)
+// and plants a sentinel file inside it.
+//
+// The helper uses the real user HOME (see realUserHome) so that the sentinel
+// is inside the host ~/.aws/sso — the directory that the carve-out rules
+// govern — rather than the staging HOME's symlinked view.
+//
+// If the directory cannot be created or written to (e.g. the test is running
+// inside a sandbox that denies write access to ~/.aws/sso), the test is
+// skipped rather than failed.
+//
+// Returns (ssoDir, sentinelPath). The caller owns cleanup via t.Cleanup.
+func prepareSSOSentinel(t *testing.T) (ssoDir, sentinelPath string) {
+	t.Helper()
+	home := realUserHome(t)
+	awsDir := filepath.Join(home, ".aws")
+	if mkErr := os.MkdirAll(awsDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.aws for test: %v", mkErr)
+	}
+	ssoDir = filepath.Join(awsDir, "sso")
+	if mkErr := os.MkdirAll(ssoDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.aws/sso for test: %v", mkErr)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(ssoDir) })
+
+	sentinelPath = filepath.Join(ssoDir, ".prism-1380-test-sentinel")
+	if wErr := os.WriteFile(sentinelPath, []byte(awsSSOSentinelContent), 0o600); wErr != nil {
+		t.Skipf("cannot plant ~/.aws/sso sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+	return ssoDir, sentinelPath
+}
+
+// prepareCLISentinel is the analogous helper for ~/.aws/cli.
+func prepareCLISentinel(t *testing.T) (cliDir, sentinelPath string) {
+	t.Helper()
+	home := realUserHome(t)
+	awsDir := filepath.Join(home, ".aws")
+	if mkErr := os.MkdirAll(awsDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.aws for test: %v", mkErr)
+	}
+	cliDir = filepath.Join(awsDir, "cli")
+	if mkErr := os.MkdirAll(cliDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.aws/cli for test: %v", mkErr)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(cliDir) })
+
+	sentinelPath = filepath.Join(cliDir, ".prism-1380-test-sentinel")
+	if wErr := os.WriteFile(sentinelPath, []byte(awsCLISentinelContent), 0o600); wErr != nil {
+		t.Skipf("cannot plant ~/.aws/cli sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+	return cliDir, sentinelPath
+}
+
+// TestSandboxExecProfile_AWSSSOReadable is the positive integration test for
+// the ~/.aws/sso carve-out (issue #1380). It:
+//
+//  1. Creates ~/.aws/sso and plants a sentinel file inside it.
+//  2. Calls PrepareSandboxExecHome so the staging HOME contains
+//     <stagingHome>/.aws/sso → ~/.aws/sso.
+//  3. Generates the production profile (which emits the carve-out rule).
+//  4. Reads the sentinel via the staging HOME symlink chain from inside
+//     the sandbox and asserts exit 0 and correct content.
+func TestSandboxExecProfile_AWSSSOReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, sentinelPath := prepareSSOSentinel(t)
+
+	// BareRoot manager: the carve-out path resolution under HOME requires the
+	// BareRoot-ancestor block's file-read-metadata allow on (subpath HOME).
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Verify the staging HOME has the sso symlink before generating the profile.
+	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
+	if _, lstatErr := os.Lstat(ssoLink); lstatErr != nil {
+		t.Fatalf("staging HOME must have a .aws/sso symlink after PrepareSandboxExecHome: %v", lstatErr)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The carve-out rule must appear in the generated profile.
+	// Use the real user home (not the staging home) because generateProfile
+	// derives the carve-out path from os.UserHomeDir() called at profile
+	// generation time, which resolves to the real host HOME (not the staging
+	// HOME that the sandbox sets as $HOME).
+	realHome := realUserHome(t)
+	awsSSOPath := filepath.Join(realHome, ".aws", "sso")
+	if !strings.Contains(prepared.content, awsSSOPath) {
+		t.Fatalf("generated profile does not contain the ~/.aws/sso carve-out path %q.\n"+
+			"The carve-out rule was not emitted by generateProfile.\nProfile:\n%s",
+			awsSSOPath, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Read the sentinel via <stagingHome>/.aws/sso/<sentinel> inside the sandbox.
+	sentinelInSandbox := filepath.Join(ssoLink, filepath.Base(sentinelPath))
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(sentinelInSandbox))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("read ~/.aws/sso sentinel failed under production profile with carve-out.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), awsSSOSentinelContent) {
+		t.Errorf("read exited 0 but output does not contain sentinel marker.\nOutput: %s", string(out))
+	}
+}
+
+// TestSandboxExecProfile_AWSSSODeniedWithoutCarveout is the paired negative
+// test. It removes the (subpath ~/.aws/sso) carve-out line from the profile
+// and asserts the same read fails — proving the carve-out is load-bearing.
+func TestSandboxExecProfile_AWSSSODeniedWithoutCarveout(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, sentinelPath := prepareSSOSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
+
+	home, _ := os.UserHomeDir()
+	awsSSOPath := filepath.Join(home, ".aws", "sso")
+
+	// Remove the (subpath ~/.aws/sso) carve-out line from the profile.
+	// The line is emitted as `  (subpath "<awsSSOPath>")\n` inside the
+	// (allow file-read* ...) block that immediately follows the broad deny.
+	carveoutLine := "  (subpath " + sbplQuoteForTest(awsSSOPath) + ")\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, carveoutLine, "")
+	})
+
+	sentinelInSandbox := filepath.Join(ssoLink, filepath.Base(sentinelPath))
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(sentinelInSandbox))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read ~/.aws/sso sentinel succeeded WITHOUT the (subpath %q) carve-out rule.\n"+
+			"The carve-out is not the load-bearing rule — investigate.\n"+
+			"Output: %s\nMutated profile: %s", awsSSOPath, string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — ~/.aws/sso read correctly denied without carve-out (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecProfile_AWSCLIReadable is the positive integration test for
+// the ~/.aws/cli carve-out (issue #1380), symmetric to AWSSSOReadable.
+func TestSandboxExecProfile_AWSCLIReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, sentinelPath := prepareCLISentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	cliLink := filepath.Join(stagingHome, ".aws", "cli")
+	if _, lstatErr := os.Lstat(cliLink); lstatErr != nil {
+		t.Fatalf("staging HOME must have a .aws/cli symlink after PrepareSandboxExecHome: %v", lstatErr)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	home, _ := os.UserHomeDir()
+	awsCLIPath := filepath.Join(home, ".aws", "cli")
+	if !strings.Contains(prepared.content, awsCLIPath) {
+		t.Fatalf("generated profile does not contain the ~/.aws/cli carve-out path %q.\n"+
+			"The carve-out rule was not emitted by generateProfile.\nProfile:\n%s",
+			awsCLIPath, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	sentinelInSandbox := filepath.Join(cliLink, filepath.Base(sentinelPath))
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(sentinelInSandbox))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("read ~/.aws/cli sentinel failed under production profile with carve-out.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), awsCLISentinelContent) {
+		t.Errorf("read exited 0 but output does not contain sentinel marker.\nOutput: %s", string(out))
+	}
+}
+
+// TestSandboxExecProfile_AWSCLIDeniedWithoutCarveout is the paired negative
+// test for AWSCLIReadable. It removes the (subpath ~/.aws/cli) carve-out and
+// asserts the read fails.
+func TestSandboxExecProfile_AWSCLIDeniedWithoutCarveout(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, sentinelPath := prepareCLISentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	cliLink := filepath.Join(stagingHome, ".aws", "cli")
+
+	home, _ := os.UserHomeDir()
+	awsCLIPath := filepath.Join(home, ".aws", "cli")
+
+	carveoutLine := "  (subpath " + sbplQuoteForTest(awsCLIPath) + ")\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, carveoutLine, "")
+	})
+
+	sentinelInSandbox := filepath.Join(cliLink, filepath.Base(sentinelPath))
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(sentinelInSandbox))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read ~/.aws/cli sentinel succeeded WITHOUT the (subpath %q) carve-out rule.\n"+
+			"The carve-out is not the load-bearing rule — investigate.\n"+
+			"Output: %s\nMutated profile: %s", awsCLIPath, string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — ~/.aws/cli read correctly denied without carve-out (exit: %v)", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
@@ -89,14 +89,28 @@ func prepareSSOSentinel(t *testing.T) (ssoDir, sentinelPath string) {
 		t.Skipf("cannot create ~/.aws for test: %v", mkErr)
 	}
 	ssoDir = filepath.Join(awsDir, "sso")
+	// Check whether the directory already exists BEFORE creating it. If it
+	// already existed (e.g. the user has real SSO tokens there), register a
+	// cleanup that removes only the sentinel file — not the whole directory.
+	// Only remove the directory itself if this test created it.
+	ssoDirExisted := false
+	if _, statErr := os.Stat(ssoDir); statErr == nil {
+		ssoDirExisted = true
+	}
 	if mkErr := os.MkdirAll(ssoDir, 0o700); mkErr != nil {
 		t.Skipf("cannot create ~/.aws/sso for test: %v", mkErr)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(ssoDir) })
 
 	sentinelPath = filepath.Join(ssoDir, ".prism-1380-test-sentinel")
 	if wErr := os.WriteFile(sentinelPath, []byte(awsSSOSentinelContent), 0o600); wErr != nil {
 		t.Skipf("cannot plant ~/.aws/sso sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+	if ssoDirExisted {
+		// Directory already existed — only clean up the sentinel file we created.
+		t.Cleanup(func() { _ = os.Remove(sentinelPath) })
+	} else {
+		// We created the directory — remove it entirely on cleanup.
+		t.Cleanup(func() { _ = os.RemoveAll(ssoDir) })
 	}
 	return ssoDir, sentinelPath
 }
@@ -110,14 +124,28 @@ func prepareCLISentinel(t *testing.T) (cliDir, sentinelPath string) {
 		t.Skipf("cannot create ~/.aws for test: %v", mkErr)
 	}
 	cliDir = filepath.Join(awsDir, "cli")
+	// Check whether the directory already exists BEFORE creating it. If it
+	// already existed (e.g. the user has real CLI config there), register a
+	// cleanup that removes only the sentinel file — not the whole directory.
+	// Only remove the directory itself if this test created it.
+	cliDirExisted := false
+	if _, statErr := os.Stat(cliDir); statErr == nil {
+		cliDirExisted = true
+	}
 	if mkErr := os.MkdirAll(cliDir, 0o700); mkErr != nil {
 		t.Skipf("cannot create ~/.aws/cli for test: %v", mkErr)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(cliDir) })
 
 	sentinelPath = filepath.Join(cliDir, ".prism-1380-test-sentinel")
 	if wErr := os.WriteFile(sentinelPath, []byte(awsCLISentinelContent), 0o600); wErr != nil {
 		t.Skipf("cannot plant ~/.aws/cli sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+	if cliDirExisted {
+		// Directory already existed — only clean up the sentinel file we created.
+		t.Cleanup(func() { _ = os.Remove(sentinelPath) })
+	} else {
+		// We created the directory — remove it entirely on cleanup.
+		t.Cleanup(func() { _ = os.RemoveAll(cliDir) })
 	}
 	return cliDir, sentinelPath
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `~/.aws/sso` and `~/.aws/cli` were inaccessible inside sandbox-exec sessions, breaking AWS SSO authentication and kubectl SSO token reads.

**Root cause:** The broad `(deny file-read* file-write* (subpath ~/.aws))` SBPL rule correctly blocks direct host credential access, but `collectStagingHomeSymlinkTargets` also excluded `~/.aws/sso` and `~/.aws/cli` symlink targets from the per-symlink allow block. Since both the staging path and the real target were denied, traversal through the staging HOME symlinks was blocked.

**Fix (two coordinated changes):**

1. **`sandbox_exec.go` — `generateProfile`**: After the broad `~/.aws` deny, emit explicit `(allow file-read* (subpath ~/.aws/sso))` and `(allow file-read* (subpath ~/.aws/cli))` carve-out rules. In SBPL, more-specific rules override broader ones.

2. **`sandbox_exec_home.go` — `collectStagingHomeSymlinkTargets`**: Introduce an `allowedUnderDenied` set that exempts `~/.aws/sso/` and `~/.aws/cli/` from the `deniedPrefixes` exclusion, so the per-symlink allow block includes their resolved targets.

**Tests added:**
- `TestGenerateProfile_AWSSSOAndCLICarveouts` — unit test verifying carve-out rules are emitted correctly
- `TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded` — unit test verifying sso/cli targets are included in collected set
- `sandbox_exec_aws_sso_darwin_test.go` — integration test pairs (positive + negative) for both `~/.aws/sso` and `~/.aws/cli`

Closes #1380