### PR TITLE
feat(flake-update-notifier): show NixOS snowflake icon on notifications

### DIFF
--- a/modules/services/flake-update-notifier.nix
+++ b/modules/services/flake-update-notifier.nix
@@ -22,7 +22,7 @@ let
     MSG="flake.lock is out of date on $(${pkgs.hostname}/bin/hostname). Run: nh os switch"
 
     if command -v ${pkgs.libnotify}/bin/notify-send &>/dev/null; then
-      ${pkgs.libnotify}/bin/notify-send -u normal -t 0 "$TITLE" "$MSG"
+      ${pkgs.libnotify}/bin/notify-send -u normal -t 0 -i nix-snowflake "$TITLE" "$MSG"
     elif command -v osascript &>/dev/null; then
       osascript -e "display notification \"$MSG\" with title \"$TITLE\""
     fi
@@ -48,6 +48,10 @@ in
     lib.mkMerge [
       # ── Linux ──────────────────────────────────────────────────────────────
       (lib.mkIf pkgs.stdenv.isLinux {
+        # Ensure the NixOS snowflake icon theme is present so notify-send can
+        # resolve the `nix-snowflake` icon name at runtime.
+        home-manager.users.${config.nx.username}.home.packages = [ pkgs.nixos-icons ];
+
         # User-level service: fires at graphical session start (login/boot).
         home-manager.users.${config.nx.username}.systemd.user.services.flake-update-notifier = {
           Unit = {

--- a/modules/services/flake-update-notifier.nix
+++ b/modules/services/flake-update-notifier.nix
@@ -48,24 +48,26 @@ in
     lib.mkMerge [
       # ── Linux ──────────────────────────────────────────────────────────────
       (lib.mkIf pkgs.stdenv.isLinux {
-        # Ensure the NixOS snowflake icon theme is present so notify-send can
-        # resolve the `nix-snowflake` icon name at runtime.
-        home-manager.users.${config.nx.username}.home.packages = [ pkgs.nixos-icons ];
+        home-manager.users.${config.nx.username} = {
+          # Ensure the NixOS snowflake icon theme is present so notify-send can
+          # resolve the `nix-snowflake` icon name at runtime.
+          home.packages = [ pkgs.nixos-icons ];
 
-        # User-level service: fires at graphical session start (login/boot).
-        home-manager.users.${config.nx.username}.systemd.user.services.flake-update-notifier = {
-          Unit = {
-            Description = "Check if flake.lock is up to date";
-            After = [ "graphical-session.target" ];
-          };
-          Service = {
-            Type = "oneshot";
-            # Short delay so the notification daemon is ready before we fire.
-            ExecStartPre = "${pkgs.coreutils}/bin/sleep 5";
-            ExecStart = "${check-script}";
-          };
-          Install = {
-            WantedBy = [ "graphical-session.target" ];
+          # User-level service: fires at graphical session start (login/boot).
+          systemd.user.services.flake-update-notifier = {
+            Unit = {
+              Description = "Check if flake.lock is up to date";
+              After = [ "graphical-session.target" ];
+            };
+            Service = {
+              Type = "oneshot";
+              # Short delay so the notification daemon is ready before we fire.
+              ExecStartPre = "${pkgs.coreutils}/bin/sleep 5";
+              ExecStart = "${check-script}";
+            };
+            Install = {
+              WantedBy = [ "graphical-session.target" ];
+            };
           };
         };
 


### PR DESCRIPTION
## Summary

- Pass `-i nix-snowflake` to the `notify-send` call so desktop notifications show the NixOS snowflake icon instead of the generic placeholder.
- Add `pkgs.nixos-icons` to `home.packages` in the Linux section so the icon theme is available at runtime.
- The macOS `osascript` path is unchanged.

Closes #1374