### PR TITLE
fix: disable extended-keys and allow-passthrough on Darwin to unblock escape/backspace in opencode

### DIFF
--- a/modules/programs/prism/neovim/plugins/image.nix
+++ b/modules/programs/prism/neovim/plugins/image.nix
@@ -1,5 +1,11 @@
-{ config, pkgs, ... }:
-{
+{ config, lib, pkgs, ... }:
+# image-nvim uses allow-passthrough to render kitty graphics protocol images.
+# On Darwin, allow-passthrough is disabled globally to prevent opencode's
+# Bubble Tea TUI from pushing kitty keyboard protocol through to kitty (which
+# causes escape keypresses to be swallowed). Disable the plugin on Darwin
+# until per-window passthrough control is implemented.
+# TODO: re-enable when allow-passthrough is scoped per-window (#allow-passthrough-darwin)
+lib.mkIf (!pkgs.stdenv.isDarwin) {
   home-manager.users.${config.nx.username} = {
     programs.neovim.extraLuaPackages = ps: [ ps.magick ];
     programs.neovim.plugins = [

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -116,8 +116,16 @@ in
             # tmux
             ''
               # appearance
-              set -g extended-keys on
-              set -g extended-keys-format csi-u
+              # extended-keys intentionally omitted. Setting it on globally
+              # causes kitty to encode escape as \x1b[27u (CSI-u), which
+              # opencode's Bubble Tea TUI does not handle — escape keypresses
+              # are silently swallowed in all panes. The PI TUI warns about
+              # this setting being absent, but the warning is cosmetic: PI
+              # works correctly without it. In sandboxed sessions $TMUX is
+              # stripped from the environment so PI's check returns early
+              # without warning. In host-mode PI sessions the warning appears
+              # but can be ignored.
+
               set -g status-interval 5
               set -g status-left-length 30
               set -g status-left " [#{session_name}] "
@@ -129,7 +137,16 @@ in
               set -g status-left-style 'bg=${bg1} fg=${secondary}'
               set -g status-right-style 'bg=${bg1} fg=${primary}'
               # for kitty images in image.nvim
-              set -gq allow-passthrough on
+              # Darwin: disable allow-passthrough to prevent opencode's Bubble
+              # Tea TUI from pushing kitty keyboard protocol (\x1b[>31u)
+              # directly to kitty via the passthrough channel. With passthrough
+              # enabled, kitty encodes escape as \x1b[27u (CSI-u) which
+              # opencode doesn't recognise — escape keypresses are silently
+              # swallowed. On NixOS/bwrap this is not needed because bwrap's
+              # intermediate PTY prevents the passthrough from reaching kitty.
+              # TODO: replace with per-window passthrough control so inline
+              # image display can be re-enabled for non-agent windows.
+              ${if isDarwin then "set -gq allow-passthrough off" else "set -gq allow-passthrough on"}
               # sensible debugging behavior
               set -g remain-on-exit on
               # Enable OSC 52 clipboard passthrough so opencode running inside a


### PR DESCRIPTION
## Summary
- Removes `extended-keys on` / `extended-keys-format csi-u` from tmux config globally — these cause kitty to encode escape as `\x1b[27u` (CSI-u) which opencode's Bubble Tea TUI does not handle, silently swallowing escape keypresses.
- Makes `allow-passthrough` conditional: `off` on Darwin, `on` on NixOS/Linux. On Darwin, opencode's BubbleTea TUI pushes kitty keyboard protocol (`\x1b[>31u`) through the passthrough channel directly to kitty; with passthrough enabled kitty then encodes escape as CSI-u. On NixOS/bwrap, bwrap's intermediate PTY blocks the passthrough from reaching kitty so the setting can stay on.
- Disables `image-nvim` on Darwin (`lib.mkIf (!pkgs.stdenv.isDarwin)`) since it depends on `allow-passthrough` for the kitty graphics protocol.
## Notes
- The PI TUI warns about `extended-keys` being absent but works correctly without it. In sandboxed sessions `$TMUX` is stripped so the check returns early without warning.
- A TODO is left for re-enabling inline images and restoring per-window passthrough once that is scoped per-window (`#allow-passthrough-darwin`).