### PR TITLE
fix: persist ~/.config/prism and move profiles.json write outside opencode.enable gate

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -1459,11 +1459,6 @@
           # Skills — mounted as a single directory (like agents/) so
           # impermanence does not create dangling symlinks after GC (#501).
           xdg.configFile."opencode/skills".source = skillsDir;
-          # Model profiles — written to ~/.config/prism/profiles.json.
-          # The Go CLI reads this at runtime when --profile is passed to
-          # prism spawn. It contains all profile definitions and the role-to-agent
-          # mapping, and records which profile is the current default.
-          xdg.configFile."prism/profiles.json".text = config.nx.programs.prism.profiles.json;
           home.persistence."/persist" = {
             directories = [
               ".config/opencode"

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -24,201 +24,187 @@
     };
   };
 
-  config = {
-    nx.programs.prism.profiles =
-      let
-        # ── Role-keyed profile schema (#1206) ──────────────────────────────────
-        #
-        # A profile is a map from session role → per-role configuration record.
-        # Each slot carries:
-        #   - provider:         the routing provider (used by future PI work)
-        #   - model:            the model identifier emitted into opencode.json
-        #   - thinking:         the reasoning level (rendered as opencode "variant")
-        #   - systemPromptPath: optional path to a per-role system prompt (P2.AGENTRUN)
-        #
-        # Helpers below build a profile by stamping the same `slot` value across
-        # every role in a list. This keeps migration concise while leaving room
-        # for per-role divergence (e.g. a different reasoning level for review
-        # agents) without further schema changes.
+  config = lib.mkMerge [
+    {
+      nx.programs.prism.profiles =
+        let
+          # ── Role-keyed profile schema (#1206) ──────────────────────────────────
+          #
+          # A profile is a map from session role → per-role configuration record.
+          # Each slot carries:
+          #   - provider:         the routing provider (used by future PI work)
+          #   - model:            the model identifier emitted into opencode.json
+          #   - thinking:         the reasoning level (rendered as opencode "variant")
+          #   - systemPromptPath: optional path to a per-role system prompt (P2.AGENTRUN)
+          #
+          # Helpers below build a profile by stamping the same `slot` value across
+          # every role in a list. This keeps migration concise while leaving room
+          # for per-role divergence (e.g. a different reasoning level for review
+          # agents) without further schema changes.
 
-        # Role tier classification — preserved for legacy override semantics.
-        # `--model` alongside a `--profile` overrides only the primary-tier
-        # roles (mirrors pre-#1206 behaviour). It is also exported into
-        # profiles.json under role_mapping for the Go-side override logic.
-        roleMapping = {
-          primary = [
-            "coordinator"
-            "plan"
-          ];
-          secondary = [
-            "worker"
-            "review"
-            "review-goal"
-            "review-code"
-            "review-security"
-            "review-qa"
-            "review-context"
-            "ac"
-            "retro"
-          ];
-          lightweight = [
-            "explore"
-            "title"
-            "summary"
-            "compaction"
-          ];
-        };
+          # Role tier classification — preserved for legacy override semantics.
+          # `--model` alongside a `--profile` overrides only the primary-tier
+          # roles (mirrors pre-#1206 behaviour). It is also exported into
+          # profiles.json under role_mapping for the Go-side override logic.
+          roleMapping = {
+            primary = [
+              "coordinator"
+              "plan"
+            ];
+            secondary = [
+              "worker"
+              "review"
+              "review-goal"
+              "review-code"
+              "review-security"
+              "review-qa"
+              "review-context"
+              "ac"
+              "retro"
+            ];
+            lightweight = [
+              "explore"
+              "title"
+              "summary"
+              "compaction"
+            ];
+          };
 
-        # Determine the system prompt file for a given role.
-        # Maps role names to agent files at ~/.config/opencode/agents/<file>.md.
-        roleToSystemPromptFile =
-          role:
-          let
-            roleFileMap = {
-              coordinator = "coordinator";
-              plan = "coordinator";
-              worker = "worker";
-              review = "review-code-subagent";
-              "review-goal" = "review-goal-subagent";
-              "review-code" = "review-code-subagent";
-              "review-security" = "review-security-subagent";
-              "review-qa" = "review-qa-subagent";
-              "review-context" = "review-context-subagent";
-              ac = "ac";
-              retro = "retro";
-              explore = "worker";
-              title = "worker";
-              summary = "worker";
-              compaction = "worker";
-            };
-          in
-          "$HOME/.config/opencode/agents/${roleFileMap.${role}}.md";
-
-        # Stamp a slot value across the given list of role names, adding
-        # role-specific systemPromptPath values for P2.AGENTRUN support.
-        slotsForWithPrompts =
-          roles: baseSlot:
-          lib.genAttrs roles (
+          # Determine the system prompt file for a given role.
+          # Maps role names to agent files at ~/.config/opencode/agents/<file>.md.
+          roleToSystemPromptFile =
             role:
-            baseSlot
-            // {
-              systemPromptPath = roleToSystemPromptFile role;
+            let
+              roleFileMap = {
+                coordinator = "coordinator";
+                plan = "coordinator";
+                worker = "worker";
+                review = "review-code-subagent";
+                "review-goal" = "review-goal-subagent";
+                "review-code" = "review-code-subagent";
+                "review-security" = "review-security-subagent";
+                "review-qa" = "review-qa-subagent";
+                "review-context" = "review-context-subagent";
+                ac = "ac";
+                retro = "retro";
+                explore = "worker";
+                title = "worker";
+                summary = "worker";
+                compaction = "worker";
+              };
+            in
+            "$HOME/.config/opencode/agents/${roleFileMap.${role}}.md";
+
+          # Stamp a slot value across the given list of role names, adding
+          # role-specific systemPromptPath values for P2.AGENTRUN support.
+          slotsForWithPrompts =
+            roles: baseSlot:
+            lib.genAttrs roles (
+              role:
+              baseSlot
+              // {
+                systemPromptPath = roleToSystemPromptFile role;
+              }
+            );
+
+          # Build a profile by combining tiered slot values. Each tier is a
+          # `{primary, secondary, lightweight}` triple of slot values — the
+          # canonical migration shape from the pre-#1206 schema. Tiers map onto
+          # roleMapping so existing per-agent model assignments are preserved
+          # bit-identically.
+          profileFromTiers =
+            tiers:
+            (slotsForWithPrompts roleMapping.primary tiers.primary)
+            // (slotsForWithPrompts roleMapping.secondary tiers.secondary)
+            // (slotsForWithPrompts roleMapping.lightweight tiers.lightweight);
+
+          # Convenience: build a slot. `thinking` defaults to "off" (the PI harness
+          # zero value). `provider` defaults to "" — populated explicitly by the
+          # migrated profiles below.
+          # `systemPromptPath` is null until P2.AGENTRUN populates per-role prompts.
+          # `harness` defaults to "" (omitted from JSON via omitempty) which the Go
+          # side treats as "opencode". Set explicitly to e.g. "pi" for PI sessions.
+          slot =
+            {
+              provider ? "",
+              model,
+              thinking ? "off",
+              systemPromptPath ? null,
+              harness ? "",
+            }:
+            {
+              inherit provider model thinking;
+              systemPromptPath = if systemPromptPath == null then "" else toString systemPromptPath;
             }
-          );
+            // (if harness == "" then { } else { inherit harness; });
 
-        # Build a profile by combining tiered slot values. Each tier is a
-        # `{primary, secondary, lightweight}` triple of slot values — the
-        # canonical migration shape from the pre-#1206 schema. Tiers map onto
-        # roleMapping so existing per-agent model assignments are preserved
-        # bit-identically.
-        profileFromTiers =
-          tiers:
-          (slotsForWithPrompts roleMapping.primary tiers.primary)
-          // (slotsForWithPrompts roleMapping.secondary tiers.secondary)
-          // (slotsForWithPrompts roleMapping.lightweight tiers.lightweight);
-
-        # Convenience: build a slot. `thinking` defaults to "off" (the PI harness
-        # zero value). `provider` defaults to "" — populated explicitly by the
-        # migrated profiles below.
-        # `systemPromptPath` is null until P2.AGENTRUN populates per-role prompts.
-        # `harness` defaults to "" (omitted from JSON via omitempty) which the Go
-        # side treats as "opencode". Set explicitly to e.g. "pi" for PI sessions.
-        slot =
-          {
-            provider ? "",
-            model,
-            thinking ? "off",
-            systemPromptPath ? null,
-            harness ? "",
-          }:
-          {
-            inherit provider model thinking;
-            systemPromptPath = if systemPromptPath == null then "" else toString systemPromptPath;
-          }
-          // (if harness == "" then { } else { inherit harness; });
-
-        # ── Migrated profiles ──────────────────────────────────────────────────
-        # Each existing profile is expanded into per-role slots via
-        # profileFromTiers. The output is bit-identical (modulo whitespace /
-        # key ordering) for opencode sessions because applyProfile (below)
-        # consumes role-keyed slots directly and produces the same
-        # {model, variant} merge per agent as the pre-#1206 implementation.
-        profiles = {
-          anthropic = profileFromTiers {
-            primary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-sonnet-4-6";
+          # ── Migrated profiles ──────────────────────────────────────────────────
+          # Each existing profile is expanded into per-role slots via
+          # profileFromTiers. The output is bit-identical (modulo whitespace /
+          # key ordering) for opencode sessions because applyProfile (below)
+          # consumes role-keyed slots directly and produces the same
+          # {model, variant} merge per agent as the pre-#1206 implementation.
+          profiles = {
+            anthropic = profileFromTiers {
+              primary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-sonnet-4-6";
+              };
+              secondary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-sonnet-4-6";
+              };
+              lightweight = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-haiku-4-5";
+              };
             };
-            secondary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-sonnet-4-6";
+            anthropic-pi = profileFromTiers {
+              primary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-sonnet-4-6";
+                harness = "pi";
+              };
+              secondary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-sonnet-4-6";
+                harness = "pi";
+              };
+              lightweight = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-haiku-4-5";
+                harness = "pi";
+              };
             };
-            lightweight = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-haiku-4-5";
+            anthropic-opus = profileFromTiers {
+              primary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-7";
+              };
+              secondary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-7";
+              };
+              lightweight = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-haiku-4-5";
+              };
             };
-          };
-          anthropic-pi = profileFromTiers {
-            primary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-sonnet-4-6";
-              harness = "pi";
+            gemini-hybrid = profileFromTiers {
+              primary = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-sonnet-4-6";
+              };
+              secondary = slot {
+                provider = "google";
+                model = "google/gemini-3.1-pro-preview-customtools";
+              };
+              lightweight = slot {
+                provider = "anthropic";
+                model = "anthropic/claude-haiku-4-5";
+              };
             };
-            secondary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-sonnet-4-6";
-              harness = "pi";
-            };
-            lightweight = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-haiku-4-5";
-              harness = "pi";
-            };
-          };
-          anthropic-opus = profileFromTiers {
-            primary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-opus-4-7";
-            };
-            secondary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-opus-4-7";
-            };
-            lightweight = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-haiku-4-5";
-            };
-          };
-          gemini-hybrid = profileFromTiers {
-            primary = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-sonnet-4-6";
-            };
-            secondary = slot {
-              provider = "google";
-              model = "google/gemini-3.1-pro-preview-customtools";
-            };
-            lightweight = slot {
-              provider = "anthropic";
-              model = "anthropic/claude-haiku-4-5";
-            };
-          };
-          github-copilot = profileFromTiers {
-            primary = slot {
-              provider = "github-copilot";
-              model = "github-copilot/claude-sonnet-4.6";
-            };
-            secondary = slot {
-              provider = "github-copilot";
-              model = "github-copilot/claude-sonnet-4.6";
-            };
-            lightweight = slot {
-              provider = "github-copilot";
-              model = "github-copilot/claude-haiku-4.5";
-            };
-          };
-          github-copilot-pi-worker =
-            (profileFromTiers {
+            github-copilot = profileFromTiers {
               primary = slot {
                 provider = "github-copilot";
                 model = "github-copilot/claude-sonnet-4.6";
@@ -231,152 +217,188 @@
                 provider = "github-copilot";
                 model = "github-copilot/claude-haiku-4.5";
               };
-            })
-            // {
-              worker =
-                slot {
+            };
+            github-copilot-pi-worker =
+              (profileFromTiers {
+                primary = slot {
                   provider = "github-copilot";
                   model = "github-copilot/claude-sonnet-4.6";
-                  harness = "pi";
-                }
-                // {
-                  systemPromptPath = roleToSystemPromptFile "worker";
                 };
-            };
-          google = profileFromTiers {
-            primary = slot {
-              provider = "google";
-              model = "google/gemini-3-flash-preview";
-            };
-            secondary = slot {
-              provider = "google";
-              model = "google/gemini-3.1-flash-lite-preview";
-            };
-            lightweight = slot {
-              provider = "google";
-              model = "google/gemini-3.1-flash-lite-preview";
-            };
-          };
-        };
-
-        quickProfiles = {
-          pr = {
-            model = "google/gemini-3.1-flash-lite-preview";
-            providerOrder = [
-              "google"
-              "google-vertex"
-            ];
-          };
-        };
-
-        # Translate a profile thinking value to the opencode variant string.
-        # The canonical zero value in profiles is "off" (the PI harness
-        # convention), but opencode expects "none" as its zero value.
-        thinkingToVariant = thinking: if thinking == "off" then "none" else thinking;
-      in
-      {
-        data = {
-          inherit roleMapping profiles quickProfiles;
-        };
-
-        json =
-          let
-            homeDir = config.home-manager.users.${config.nx.username}.home.homeDirectory;
-            # Resolve a possible $HOME reference inside a string. Used so that
-            # systemPromptPath values pass through with $HOME expanded.
-            expandHome =
-              s:
-              lib.strings.replaceStrings
-                [
-                  "$HOME"
-                  "\${HOME}"
-                ]
-                [
-                  homeDir
-                  homeDir
-                ]
-                s;
-          in
-          builtins.toJSON {
-            default = config.nx.programs.prism.opencode.provider;
-            role_mapping = config.nx.programs.prism.profiles.data.roleMapping;
-            # Profiles are role-keyed. Each slot is emitted with its full record
-            # (provider, model, thinking, systemPromptPath). systemPromptPath is
-            # always present (empty string when unset) to keep the JSON shape
-            # uniform — Go reads it via the `omitempty` tag so empty values
-            # round-trip cleanly.
-            profiles = lib.mapAttrs (
-              _name: profileEntry:
-              lib.mapAttrs (
-                _role: roleSlot:
-                {
-                  provider = roleSlot.provider or "";
-                  model = roleSlot.model;
-                  thinking = roleSlot.thinking or "off";
-                  systemPromptPath = expandHome (roleSlot.systemPromptPath or "");
-                }
-                // (if (roleSlot.harness or "") == "" then { } else { harness = roleSlot.harness; })
-              ) profileEntry
-            ) config.nx.programs.prism.profiles.data.profiles;
-            # Container role configs — full opencode.json blobs injected as
-            # OPENCODE_CONFIG_CONTENT (precedence level 6) so no project-level
-            # opencode.jsonc can override agent identity or permissions.
-            container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
-            container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
-            # Per-agent review configs — each blob declares only its own agent.
-            # The old container_review_config (PR-A) is retired; PR-B replaces it
-            # with five agent-specific blobs.
-            container_review_goal_config = config.nx.programs.prism.opencode.containerReviewGoalConfigJson;
-            container_review_code_config = config.nx.programs.prism.opencode.containerReviewCodeConfigJson;
-            container_review_security_config =
-              config.nx.programs.prism.opencode.containerReviewSecurityConfigJson;
-            container_review_qa_config = config.nx.programs.prism.opencode.containerReviewQaConfigJson;
-            container_review_context_config =
-              config.nx.programs.prism.opencode.containerReviewContextConfigJson;
-            # Agent environment variables to inject into host-mode opencode processes.
-            # Both $HOME and ${HOME} are expanded at Nix eval time so the JSON
-            # always contains absolute paths regardless of which form is used.
-            agent_env_vars = lib.mapAttrs (
-              _name: value: expandHome value
-            ) config.nx.programs.prism.agent.envVars;
-            # Quick command profiles — lightweight model configs for prism quick subcommands.
-            quick_profiles = config.nx.programs.prism.profiles.data.quickProfiles;
-            # Per-container resource caps. These are read by the prism sidecar
-            # and passed to container.Config so that podman run receives
-            # --memory, --memory-swap, and --pids-limit for every agent container.
-            # Values flow: nix option → _internal.agentResources → here → profiles.json
-            # → prism sidecar → container.Config → buildRunArgs → podman run.
-            container_resources = config.nx.programs.prism._internal.agentResources;
-          };
-
-        # applyProfile patches `model` and `variant` onto each baseAgent that
-        # the active profile defines a slot for. Agents not present in the
-        # profile (e.g. `build`) are returned unchanged so they inherit the
-        # top-level opencode model.
-        #
-        # The mapping is direct under the role-keyed schema: `agentName` is the
-        # slot key. `slot.thinking` is translated to opencode's `variant` via
-        # thinkingToVariant ("off" → "none") to preserve bit-identical output
-        # with the pre-#1206 schema.
-        applyProfile =
-          profileName: baseAgents:
-          let
-            currentProfile = profiles.${profileName} or { };
-          in
-          lib.mapAttrs (
-            name: cfg:
-            let
-              slotCfg = currentProfile.${name} or null;
-            in
-            if slotCfg == null then
-              cfg
-            else
-              cfg
+                secondary = slot {
+                  provider = "github-copilot";
+                  model = "github-copilot/claude-sonnet-4.6";
+                };
+                lightweight = slot {
+                  provider = "github-copilot";
+                  model = "github-copilot/claude-haiku-4.5";
+                };
+              })
               // {
-                model = slotCfg.model;
-                variant = thinkingToVariant slotCfg.thinking;
-              }
-          ) baseAgents;
+                worker =
+                  slot {
+                    provider = "github-copilot";
+                    model = "github-copilot/claude-sonnet-4.6";
+                    harness = "pi";
+                  }
+                  // {
+                    systemPromptPath = roleToSystemPromptFile "worker";
+                  };
+              };
+            google = profileFromTiers {
+              primary = slot {
+                provider = "google";
+                model = "google/gemini-3-flash-preview";
+              };
+              secondary = slot {
+                provider = "google";
+                model = "google/gemini-3.1-flash-lite-preview";
+              };
+              lightweight = slot {
+                provider = "google";
+                model = "google/gemini-3.1-flash-lite-preview";
+              };
+            };
+          };
+
+          quickProfiles = {
+            pr = {
+              model = "google/gemini-3.1-flash-lite-preview";
+              providerOrder = [
+                "google"
+                "google-vertex"
+              ];
+            };
+          };
+
+          # Translate a profile thinking value to the opencode variant string.
+          # The canonical zero value in profiles is "off" (the PI harness
+          # convention), but opencode expects "none" as its zero value.
+          thinkingToVariant = thinking: if thinking == "off" then "none" else thinking;
+        in
+        {
+          data = {
+            inherit roleMapping profiles quickProfiles;
+          };
+
+          json =
+            let
+              homeDir = config.home-manager.users.${config.nx.username}.home.homeDirectory;
+              # Resolve a possible $HOME reference inside a string. Used so that
+              # systemPromptPath values pass through with $HOME expanded.
+              expandHome =
+                s:
+                lib.strings.replaceStrings
+                  [
+                    "$HOME"
+                    "\${HOME}"
+                  ]
+                  [
+                    homeDir
+                    homeDir
+                  ]
+                  s;
+            in
+            builtins.toJSON {
+              default = config.nx.programs.prism.opencode.provider;
+              role_mapping = config.nx.programs.prism.profiles.data.roleMapping;
+              # Profiles are role-keyed. Each slot is emitted with its full record
+              # (provider, model, thinking, systemPromptPath). systemPromptPath is
+              # always present (empty string when unset) to keep the JSON shape
+              # uniform — Go reads it via the `omitempty` tag so empty values
+              # round-trip cleanly.
+              profiles = lib.mapAttrs (
+                _name: profileEntry:
+                lib.mapAttrs (
+                  _role: roleSlot:
+                  {
+                    provider = roleSlot.provider or "";
+                    model = roleSlot.model;
+                    thinking = roleSlot.thinking or "off";
+                    systemPromptPath = expandHome (roleSlot.systemPromptPath or "");
+                  }
+                  // (if (roleSlot.harness or "") == "" then { } else { harness = roleSlot.harness; })
+                ) profileEntry
+              ) config.nx.programs.prism.profiles.data.profiles;
+              # Container role configs — full opencode.json blobs injected as
+              # OPENCODE_CONFIG_CONTENT (precedence level 6) so no project-level
+              # opencode.jsonc can override agent identity or permissions.
+              container_worker_config = config.nx.programs.prism.opencode.containerWorkerConfigJson;
+              container_coordinator_config = config.nx.programs.prism.opencode.containerCoordinatorConfigJson;
+              # Per-agent review configs — each blob declares only its own agent.
+              # The old container_review_config (PR-A) is retired; PR-B replaces it
+              # with five agent-specific blobs.
+              container_review_goal_config = config.nx.programs.prism.opencode.containerReviewGoalConfigJson;
+              container_review_code_config = config.nx.programs.prism.opencode.containerReviewCodeConfigJson;
+              container_review_security_config =
+                config.nx.programs.prism.opencode.containerReviewSecurityConfigJson;
+              container_review_qa_config = config.nx.programs.prism.opencode.containerReviewQaConfigJson;
+              container_review_context_config =
+                config.nx.programs.prism.opencode.containerReviewContextConfigJson;
+              # Agent environment variables to inject into host-mode opencode processes.
+              # Both $HOME and ${HOME} are expanded at Nix eval time so the JSON
+              # always contains absolute paths regardless of which form is used.
+              agent_env_vars = lib.mapAttrs (
+                _name: value: expandHome value
+              ) config.nx.programs.prism.agent.envVars;
+              # Quick command profiles — lightweight model configs for prism quick subcommands.
+              quick_profiles = config.nx.programs.prism.profiles.data.quickProfiles;
+              # Per-container resource caps. These are read by the prism sidecar
+              # and passed to container.Config so that podman run receives
+              # --memory, --memory-swap, and --pids-limit for every agent container.
+              # Values flow: nix option → _internal.agentResources → here → profiles.json
+              # → prism sidecar → container.Config → buildRunArgs → podman run.
+              container_resources = config.nx.programs.prism._internal.agentResources;
+            };
+
+          # applyProfile patches `model` and `variant` onto each baseAgent that
+          # the active profile defines a slot for. Agents not present in the
+          # profile (e.g. `build`) are returned unchanged so they inherit the
+          # top-level opencode model.
+          #
+          # The mapping is direct under the role-keyed schema: `agentName` is the
+          # slot key. `slot.thinking` is translated to opencode's `variant` via
+          # thinkingToVariant ("off" → "none") to preserve bit-identical output
+          # with the pre-#1206 schema.
+          applyProfile =
+            profileName: baseAgents:
+            let
+              currentProfile = profiles.${profileName} or { };
+            in
+            lib.mapAttrs (
+              name: cfg:
+              let
+                slotCfg = currentProfile.${name} or null;
+              in
+              if slotCfg == null then
+                cfg
+              else
+                cfg
+                // {
+                  model = slotCfg.model;
+                  variant = thinkingToVariant slotCfg.thinking;
+                }
+            ) baseAgents;
+        };
+    }
+
+    # Write profiles.json to ~/.config/prism/ and persist that directory on
+    # impermanence systems. This block is gated on prism.enable (not
+    # opencode.enable) so the file is present regardless of whether the
+    # opencode submodule is active — the prism CLI reads profiles.json
+    # unconditionally at runtime.
+    (lib.mkIf config.nx.programs.prism.enable {
+      home-manager.users.${config.nx.username} = {
+        # Model profiles — written to ~/.config/prism/profiles.json.
+        # The Go CLI reads this at runtime when --profile is passed to
+        # prism spawn. It contains all profile definitions and the role-to-agent
+        # mapping, and records which profile is the current default.
+        xdg.configFile."prism/profiles.json".text = config.nx.programs.prism.profiles.json;
+        home.persistence."/persist" = {
+          directories = [
+            ".config/prism"
+          ];
+        };
       };
-  };
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

After setting `nx.programs.prism.opencode.provider = "anthropic-pi"` and running `nixos-rebuild switch`, `~/.config/prism/profiles.json` was never created on disk because:

1. `xdg.configFile."prism/profiles.json"` was defined inside `lib.mkIf config.nx.programs.prism.opencode.enable` in `opencode.nix` — not active when opencode is disabled
2. `.config/prism` was not listed in `home.persistence."/persist"` — on btrfs-wipe impermanence systems the directory is wiped on every boot

## Changes

- **`profiles.nix`**: Wrap `config` in `lib.mkMerge`. Add a second block gated on `prism.enable` (not `opencode.enable`) that:
  - Writes `xdg.configFile."prism/profiles.json"` — the file is now present regardless of whether the opencode submodule is active
  - Adds `.config/prism` to `home.persistence."/persist"` — directory is recreated by impermanence on every boot

- **`opencode.nix`**: Remove the now-redundant `xdg.configFile."prism/profiles.json"` line (moved to profiles.nix). The `.config/opencode`, `.local/share/opencode`, and `.local/state/opencode` persistence entries are unchanged.

## Verification

Go harness resolution logic in `cmd/spawn.go:450–482` was reviewed and is correct — once `profiles.json` is present and `pf != nil`, `ResolveActiveProfile` reads `pf.Default`, `RequireSlot` validates the slot, and `HarnessForSlot` returns the `harness` field from the slot (e.g. `"pi"` for the `anthropic-pi` profile). No Go code changes needed.

NixOS build passes: `nix build .#nixosConfigurations.navi.config.system.build.toplevel` succeeded with `hm_prismprofiles.json.drv` and `unit-home-ben-.config-prism.mount.drv` both built.

Closes #1388