### PR TITLE
revert: undo tmux extended-keys and allow-passthrough changes from #1386

### DIFF
--- a/modules/programs/prism/neovim/plugins/image.nix
+++ b/modules/programs/prism/neovim/plugins/image.nix
@@ -1,11 +1,5 @@
-{ config, lib, pkgs, ... }:
-# image-nvim uses allow-passthrough to render kitty graphics protocol images.
-# On Darwin, allow-passthrough is disabled globally to prevent opencode's
-# Bubble Tea TUI from pushing kitty keyboard protocol through to kitty (which
-# causes escape keypresses to be swallowed). Disable the plugin on Darwin
-# until per-window passthrough control is implemented.
-# TODO: re-enable when allow-passthrough is scoped per-window (#allow-passthrough-darwin)
-lib.mkIf (!pkgs.stdenv.isDarwin) {
+{ config, pkgs, ... }:
+{
   home-manager.users.${config.nx.username} = {
     programs.neovim.extraLuaPackages = ps: [ ps.magick ];
     programs.neovim.plugins = [

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -116,16 +116,8 @@ in
             # tmux
             ''
               # appearance
-              # extended-keys intentionally omitted. Setting it on globally
-              # causes kitty to encode escape as \x1b[27u (CSI-u), which
-              # opencode's Bubble Tea TUI does not handle — escape keypresses
-              # are silently swallowed in all panes. The PI TUI warns about
-              # this setting being absent, but the warning is cosmetic: PI
-              # works correctly without it. In sandboxed sessions $TMUX is
-              # stripped from the environment so PI's check returns early
-              # without warning. In host-mode PI sessions the warning appears
-              # but can be ignored.
-
+              set -g extended-keys on
+              set -g extended-keys-format csi-u
               set -g status-interval 5
               set -g status-left-length 30
               set -g status-left " [#{session_name}] "
@@ -137,16 +129,7 @@ in
               set -g status-left-style 'bg=${bg1} fg=${secondary}'
               set -g status-right-style 'bg=${bg1} fg=${primary}'
               # for kitty images in image.nvim
-              # Darwin: disable allow-passthrough to prevent opencode's Bubble
-              # Tea TUI from pushing kitty keyboard protocol (\x1b[>31u)
-              # directly to kitty via the passthrough channel. With passthrough
-              # enabled, kitty encodes escape as \x1b[27u (CSI-u) which
-              # opencode doesn't recognise — escape keypresses are silently
-              # swallowed. On NixOS/bwrap this is not needed because bwrap's
-              # intermediate PTY prevents the passthrough from reaching kitty.
-              # TODO: replace with per-window passthrough control so inline
-              # image display can be re-enabled for non-agent windows.
-              ${if isDarwin then "set -gq allow-passthrough off" else "set -gq allow-passthrough on"}
+              set -gq allow-passthrough on
               # sensible debugging behavior
               set -g remain-on-exit on
               # Enable OSC 52 clipboard passthrough so opencode running inside a


### PR DESCRIPTION
## Summary

Reverts the tmux and neovim changes introduced in #1386, which were a workaround for an escape/backspace regression in opencode that has since been fixed by pinning to opencode 1.14.32 (PR #1392).

The changes being reverted:
- Removal of `extended-keys on` / `extended-keys-format csi-u` from `tmux.nix`
- Making `allow-passthrough` conditional (off on Darwin, on elsewhere)
- Adding `lib.mkIf (!pkgs.stdenv.isDarwin)` guard to `neovim/plugins/image.nix`

With opencode 1.14.32 pinned, these workarounds are no longer needed and their removal restores full tmux extended-key support and inline image support across all platforms.

Closes #1393