### PR TITLE
refactor: decouple profiles.json generation from opencode and rename provider option

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -24,7 +24,7 @@ in
   # Module configuration using nx namespace (matching NixOS pattern)
   nx = {
     programs = {
-      prism.opencode.provider = "anthropic";
+      prism.profile.default = "anthropic";
       prism.agent.isolation.default = "sandbox-exec";
       # Disable programs that default to enabled but aren't needed/available on Darwin
       podman.enable = false;

--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -27,7 +27,7 @@
     };
     programs = {
       prism = {
-        opencode.provider = "anthropic";
+        profile.default = "anthropic";
         agent.isolation.default = "bwrap";
         bwrapConcurrencyCap = 50;
       };

--- a/machines/tui/configuration.nix
+++ b/machines/tui/configuration.nix
@@ -26,7 +26,7 @@
       wallpaper.variant = "enso";
     };
     programs = {
-      prism.opencode.provider = "anthropic";
+      prism.profile.default = "anthropic";
       chromium.enable = true;
       calibre.enable = true;
       cura.enable = true;

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -126,6 +126,20 @@
         };
       };
 
+      profile = {
+        default = lib.mkOption {
+          type = lib.types.enum (builtins.attrNames config.nx.programs.prism.profiles.data.profiles);
+          default = "anthropic";
+          description = ''
+            The system-wide default profile written as `default` in profiles.json.
+            This controls which profile is active when prism spawns a new session
+            and affects all harnesses (opencode, pi, etc.), not just opencode.
+            Changing this selects a different set of model assignments for all
+            session roles (coordinator, worker, explore, etc.).
+          '';
+        };
+      };
+
       # Internal computed values for submodules to use
       _internal = lib.mkOption {
         type = lib.types.attrs;
@@ -136,6 +150,22 @@
   };
 
   imports = [
+    (lib.mkRenamedOptionModule
+      [
+        "nx"
+        "programs"
+        "prism"
+        "opencode"
+        "provider"
+      ]
+      [
+        "nx"
+        "programs"
+        "prism"
+        "profile"
+        "default"
+      ]
+    )
     ./container-tokens.nix
     ./neovim
     ./opencode.nix

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -9,17 +9,7 @@
     nx.programs.prism.opencode.enable = lib.mkEnableOption "enables opencode" // {
       default = true;
     };
-    nx.programs.prism.opencode.provider = lib.mkOption {
-      type = lib.types.enum (builtins.attrNames config.nx.programs.prism.profiles.data.profiles);
-      default = "anthropic";
-      description = ''
-        The model profile to use for baked-in opencode agent config.
-        This selects the default profile recorded in profiles.json and drives
-        the model strings written into opencode.json. All provider auth plugins
-        are always present so any provider can be used mid-session regardless
-        of which profile is active.
-      '';
-    };
+
     # Serialised opencode.json blobs for container roles.
     # Set by opencode.nix and consumed by profiles.nix to embed them into
     # profiles.json under container_worker_config / container_coordinator_config.
@@ -410,7 +400,7 @@
         - Never use Te Reo as decoration or performance – only where it fits naturally.
       '';
       currentProfile =
-        config.nx.programs.prism.profiles.data.profiles.${config.nx.programs.prism.opencode.provider};
+        config.nx.programs.prism.profiles.data.profiles.${config.nx.programs.prism.profile.default};
       # Resolve a model from the role-keyed profile by picking the first role in
       # each legacy tier (#1206). Profiles defined via profileFromTiers stamp the
       # same slot value across every role in a tier, so any role from the tier
@@ -582,7 +572,7 @@
         agent =
           let
             profiledAgents =
-              config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider
+              config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.profile.default
                 ({
                   worker = {
                     description = "Default worker agent with full tool access";
@@ -655,7 +645,7 @@
         default_agent = "coordinator";
         enabled_providers = containerEnabledProviders;
         model = models.primary;
-        agent = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider ({
+        agent = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.profile.default ({
           coordinator = {
             description = "Repo coordinator — orchestrates agents, reviews PRs, merges work";
             mode = "primary";
@@ -1045,7 +1035,7 @@
               };
             };
           };
-          profiledAgents = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider baseAgentMap;
+          profiledAgents = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.profile.default baseAgentMap;
           # Strip variant from disabled agents
           sanitisedAgents = lib.mapAttrs (
             _name: cfg: if cfg ? disable && cfg.disable then builtins.removeAttrs cfg [ "variant" ] else cfg
@@ -1145,7 +1135,7 @@
             settings = {
               autoupdate = false;
               model = models.primary;
-              agent = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.opencode.provider (
+              agent = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.profile.default (
                 {
                   worker = {
                     description = "Default worker agent with full tool access";

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -299,7 +299,7 @@
                   s;
             in
             builtins.toJSON {
-              default = config.nx.programs.prism.opencode.provider;
+              default = config.nx.programs.prism.profile.default;
               role_mapping = config.nx.programs.prism.profiles.data.roleMapping;
               # Profiles are role-keyed. Each slot is emitted with its full record
               # (provider, model, thinking, systemPromptPath). systemPromptPath is


### PR DESCRIPTION
## Summary

- Renames `nx.programs.prism.opencode.provider` → `nx.programs.prism.profile.default` under a harness-agnostic namespace, since this option controls the system-wide default profile for **all** harnesses (opencode, pi, etc.), not just opencode
- Adds `lib.mkRenamedOptionModule` so any machine config still using the old name gets a clear Nix evaluation error pointing to the new option path rather than silently misconfiguring
- Updates all three machine configs (navi, tui, m4mac) to use the new option name
- Updates all internal references in `opencode.nix` and `profiles.nix`

Note: `profiles.json` generation was already moved out of the `opencode.enable` guard by PR #1390 (already merged). This PR completes the rename half of #1389.

Closes #1389