### PR TITLE
fix: set PI_AUTH_JSON in bwrap sandbox to staging dir auth.json

### DIFF
--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -348,6 +348,12 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 		args = append(args, "--dir", agentConfigSandboxDir)
 		args = append(args, "--bind", agentConfigHostDir, agentConfigSandboxDir)
 		args = append(args, "--setenv", "PI_CODING_AGENT_DIR", agentConfigSandboxDir)
+		// PI reads credentials from PI_AUTH_JSON. The staging dir bind-mount
+		// (above) places auth.json inside the sandbox at this path. Without
+		// this env var, pi falls back to ~/.pi/agent/auth.json which is never
+		// mounted into the bwrap sandbox.
+		args = append(args, "--setenv", "PI_AUTH_JSON",
+			filepath.Join(agentConfigSandboxDir, "auth.json"))
 	}
 
 	// ── Extension directory ──────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -404,6 +404,79 @@ func TestAppendPIBwrapMounts_SetsAgentConfigDirEnv(t *testing.T) {
 	}
 }
 
+func TestAppendPIBwrapMounts_SetsPIAuthJSON(t *testing.T) {
+	// When PIAgentConfigHostDir is set, appendPIBwrapMounts must emit
+	// --setenv PI_AUTH_JSON <PIAgentConfigSandboxDir>/auth.json so that PI
+	// can find its credentials inside the bwrap sandbox.
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+	agentConfigDir := t.TempDir()
+	customSandboxDir := "/run/prism/pi-agent"
+
+	fakePI := filepath.Join(t.TempDir(), "pi")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:            fakePI,
+		PIAgentConfigHostDir:    agentConfigDir,
+		PIAgentConfigSandboxDir: customSandboxDir,
+		PIExtensionHostDir:      extDir,
+	}
+
+	args, err := appendPIBwrapMounts(nil, cfg)
+	if err != nil {
+		t.Fatalf("appendPIBwrapMounts: %v", err)
+	}
+
+	// PI_AUTH_JSON must be set to <PIAgentConfigSandboxDir>/auth.json.
+	expectedAuthJSON := filepath.Join(customSandboxDir, "auth.json")
+	found := false
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == "--setenv" && args[i+1] == "PI_AUTH_JSON" && args[i+2] == expectedAuthJSON {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --setenv PI_AUTH_JSON %q in args; got %v", expectedAuthJSON, args)
+	}
+}
+
+func TestAppendPIBwrapMounts_NoPIAuthJSONWhenNoAgentConfigDir(t *testing.T) {
+	// When PIAgentConfigHostDir is empty (no agent config dir configured),
+	// PI_AUTH_JSON must not be set — the setenv is conditional on the bind-mount.
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+	fakePI := filepath.Join(t.TempDir(), "pi")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:         fakePI,
+		PIAgentConfigHostDir: "", // intentionally empty
+		PIExtensionHostDir:   extDir,
+	}
+
+	args, err := appendPIBwrapMounts(nil, cfg)
+	if err != nil {
+		t.Fatalf("appendPIBwrapMounts: %v", err)
+	}
+
+	// PI_AUTH_JSON must NOT be set when no agent config dir is provided.
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--setenv" && args[i+1] == "PI_AUTH_JSON" {
+			t.Errorf("PI_AUTH_JSON must not be set when PIAgentConfigHostDir is empty; got %v", args)
+		}
+	}
+}
+
 func TestAppendPIBwrapMounts_NoPiAgentBindMount(t *testing.T) {
 	// ~/.pi/agent is no longer bind-mounted — files are copied into the staging
 	// dir by StagePIAgentConfigDir instead. Verify that even when ~/.pi/agent


### PR DESCRIPTION
## Summary

Without this fix, bwrap pi sessions fall back to `~/.pi/agent/auth.json` which is never mounted into the bwrap sandbox namespace, causing Anthropic auth errors on startup.

`StagePIAgentConfigDir` already copies `auth.json` into the per-session staging directory, which is bind-mounted into the sandbox at `PIAgentConfigSandboxDir`. This fix sets `PI_AUTH_JSON` to point at `auth.json` within that mounted directory, so pi's credential lookup resolves correctly inside the sandbox — without needing to expose `~/.pi` broadly.

The change is confined to `appendPIBwrapMounts` and does not affect host-mode or sandbox-exec pi sessions.

Closes #1398