### PR TITLE
fix: skip early-return in allocatePortForSession for ended DB rows

### DIFF
--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -235,7 +235,7 @@ func allocatePortForSession(sessionName, directory, harnessName string) (int, er
 	if err != nil {
 		return 0, fmt.Errorf("current status: %w", err)
 	}
-	if existing != nil && existing.HarnessPort != nil {
+	if existing != nil && existing.HarnessPort != nil && existing.EndedAt == nil {
 		return *existing.HarnessPort, nil
 	}
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -7244,6 +7244,44 @@ func TestUpsertStatusWithRootAgent_FreshRowDefaultsOpencode(t *testing.T) {
 	}
 }
 
+// TestUpsertStatusSeedRootAgentName_OverridesStaleHarness verifies that calling
+// UpsertStatusSeedRootAgentName with an explicit non-empty harnessName overwrites
+// an existing harness value on the DB row. This is the ended-row case from
+// issue #1400: after prism reset, the ended row has harness='opencode'; the
+// next prism switch (with active profile declaring harness='pi') must write
+// 'pi' into the row when it falls through to UpsertStatusSeedRootAgentName.
+func TestUpsertStatusSeedRootAgentName_OverridesStaleHarness(t *testing.T) {
+	d := openTestDB(t)
+
+	const session = "repo@override-branch"
+
+	// Seed the row with harness='opencode' (simulating a pre-reset ended row).
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "opencode"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Simulate allocatePortForSession falling through to UpsertStatusSeedRootAgentName
+	// with the new harness ('pi') from the active profile.
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+		t.Fatalf("override upsert: %v", err)
+	}
+
+	st, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("no row found")
+	}
+	if st.Harness == nil || *st.Harness != "pi" {
+		got := "<nil>"
+		if st.Harness != nil {
+			got = *st.Harness
+		}
+		t.Errorf("harness = %q after explicit-pi upsert; want %q", got, "pi")
+	}
+}
+
 // TestUpsertStatusSeedRootAgentName_PreservesHarness verifies that calling
 // UpsertStatusSeedRootAgentName with an empty harnessName on a row that already
 // has harness='pi' does NOT overwrite it with the 'opencode' default (issue #1297).

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -140,12 +140,21 @@ func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state st
 	if rootAgentName != "" {
 		rootAgentNamePtr = &rootAgentName
 	}
-	// Resolve the harness name to write. Default to "opencode" when empty so
-	// existing callers that do not pass a harness name continue to write the
-	// same value they wrote before.
-	effectiveHarness := harnessName
-	if effectiveHarness == "" {
-		effectiveHarness = "opencode"
+	// Resolve the harness name to write for a fresh INSERT. Default to
+	// "opencode" when empty so new rows always have a non-NULL harness column.
+	// The UPDATE path is handled separately below.
+	insertHarness := harnessName
+	if insertHarness == "" {
+		insertHarness = "opencode"
+	}
+	// For the ON CONFLICT UPDATE path, pass harnessName as a pointer so that
+	// the SQL can distinguish "empty (no override)" from "explicit value".
+	// When harnessNamePtr is NULL, CASE preserves the existing DB value; when
+	// non-NULL, it overwrites — allowing an explicit harness (e.g. "pi") to
+	// replace a stale value (e.g. "opencode") left in an ended DB row.
+	var harnessNamePtr *string
+	if harnessName != "" {
+		harnessNamePtr = &harnessName
 	}
 	const q = `
 INSERT INTO agent_status (session_name, repo, worktree, state, title, root_agent_name, last_seen, harness, harness_session_id)
@@ -157,9 +166,9 @@ ON CONFLICT(session_name) DO UPDATE SET
   title              = COALESCE(excluded.title, title),
   root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
   last_seen          = excluded.last_seen,
-  harness            = COALESCE(harness, excluded.harness),
+  harness            = CASE WHEN ? IS NOT NULL THEN ? ELSE harness END,
   harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
-	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, effectiveHarness, harnessSessionID)
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, insertHarness, harnessSessionID, harnessNamePtr, harnessNamePtr)
 	if err != nil {
 		return fmt.Errorf("db: upsert status seed root agent name: %w", err)
 	}


### PR DESCRIPTION
## Summary

After `prism reset` or `prism cleanup`, the ended `agent_status` row still has `harness_port` set from the previous session. The early-return guard in `allocatePortForSession` was firing on this ended row, skipping the `UpsertStatusSeedRootAgentName` call and leaving the stale harness name (e.g. `opencode`) in the DB. The next `prism switch` call then launched with the wrong harness instead of the one declared in the active profile's worker slot (e.g. `pi`).

## Fix

Added `existing.EndedAt == nil` to the early-return condition in `allocatePortForSession`:

```go
// Before:
if existing != nil && existing.HarnessPort != nil {
    return *existing.HarnessPort, nil
}

// After:
if existing != nil && existing.HarnessPort != nil && existing.EndedAt == nil {
    return *existing.HarnessPort, nil
}
```

Ended rows now fall through to `UpsertStatusSeedRootAgentName`, which writes the correct harness name and allocates a fresh port. Live sessions (non-ended, `ended_at IS NULL`) continue to reuse their existing port via the early-return.

The `CurrentStatus` function in `internal/db/status.go` is intentionally left without an `ended_at IS NULL` filter — other callers depend on getting ended rows from it.

Closes #1400