### PR TITLE
feat: show isolation mode in PI footer (host) when not sandboxed

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -1137,46 +1137,82 @@ describe("GIT_PUSH_REMINDER_MESSAGE", () => {
 // formatPrismStatus
 // ---------------------------------------------------------------------------
 
-describe("formatPrismStatus — coordinator", () => {
-  it("shows role and branch", () => {
-    const text = formatPrismStatus("coordinator", "main", null, 0)
+describe("formatPrismStatus — coordinator (sandbox-exec, no suffix)", () => {
+  it("shows role and branch without isolation suffix", () => {
+    const text = formatPrismStatus("coordinator", "main", "sandbox-exec", null, 0)
     assert.equal(text, "[coordinator] main")
   })
 })
 
+describe("formatPrismStatus — coordinator (bwrap, no suffix)", () => {
+  it("shows role and branch without isolation suffix", () => {
+    const text = formatPrismStatus("coordinator", "main", "bwrap", null, 0)
+    assert.equal(text, "[coordinator] main")
+  })
+})
+
+describe("formatPrismStatus — coordinator (host, suffix shown)", () => {
+  it("appends (host) suffix when isolation mode is 'host'", () => {
+    const text = formatPrismStatus("coordinator", "obsidian", "host", null, 0)
+    assert.equal(text, "[coordinator] obsidian (host)")
+  })
+})
+
+describe("formatPrismStatus — coordinator (empty string, treated as host)", () => {
+  it("appends (host) suffix when isolation mode is absent/empty", () => {
+    const text = formatPrismStatus("coordinator", "main", "", null, 0)
+    assert.equal(text, "[coordinator] main (host)")
+  })
+})
+
 describe("formatPrismStatus — worker", () => {
-  it("shows role and branch", () => {
-    const text = formatPrismStatus("worker", "fix-login-redirect", null, 0)
+  it("shows role and branch (sandbox-exec, no suffix)", () => {
+    const text = formatPrismStatus("worker", "fix-login-redirect", "sandbox-exec", null, 0)
     assert.equal(text, "[worker] fix-login-redirect")
   })
 
-  it("does not include PR info even if cycles > 0", () => {
-    const text = formatPrismStatus("worker", "some-branch", "42", 2)
+  it("shows (host) suffix in host mode", () => {
+    const text = formatPrismStatus("worker", "fix-login-redirect", "host", null, 0)
+    assert.equal(text, "[worker] fix-login-redirect (host)")
+  })
+
+  it("does not include PR info even if cycles > 0 (sandbox-exec)", () => {
+    const text = formatPrismStatus("worker", "some-branch", "sandbox-exec", "42", 2)
     assert.equal(text, "[worker] some-branch")
   })
 })
 
 describe("formatPrismStatus — review", () => {
-  it("includes PR number and cycle count", () => {
-    const text = formatPrismStatus("review", "fix-login-redirect", "42", 2)
+  it("includes PR number and cycle count (sandbox-exec, no suffix)", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", "sandbox-exec", "42", 2)
     assert.equal(text, "[review] fix-login-redirect · PR#42 · 2 cycles")
   })
 
-  it("uses singular 'cycle' when count is 1", () => {
-    const text = formatPrismStatus("review", "fix-login-redirect", "42", 1)
+  it("includes PR number and cycle count with (host) suffix in host mode", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", "host", "42", 2)
+    assert.equal(text, "[review] fix-login-redirect (host) · PR#42 · 2 cycles")
+  })
+
+  it("uses singular 'cycle' when count is 1 (sandbox-exec)", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", "sandbox-exec", "42", 1)
     assert.equal(text, "[review] fix-login-redirect · PR#42 · 1 cycle")
   })
 
-  it("omits PR info when pr_number is null", () => {
-    const text = formatPrismStatus("review", "fix-login-redirect", null, 0)
+  it("omits PR info when pr_number is null (sandbox-exec)", () => {
+    const text = formatPrismStatus("review", "fix-login-redirect", "sandbox-exec", null, 0)
     assert.equal(text, "[review] fix-login-redirect")
   })
 })
 
 describe("formatPrismStatus — unknown role", () => {
-  it("shows [unknown] when role is empty", () => {
-    const text = formatPrismStatus("", "main", null, 0)
+  it("shows [unknown] when role is empty (sandbox-exec, no suffix)", () => {
+    const text = formatPrismStatus("", "main", "sandbox-exec", null, 0)
     assert.equal(text, "[unknown] main")
+  })
+
+  it("shows [unknown] with (host) suffix in host mode", () => {
+    const text = formatPrismStatus("", "main", "host", null, 0)
+    assert.equal(text, "[unknown] main (host)")
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -494,25 +494,37 @@ export const GIT_PUSH_REMINDER_MESSAGE =
  *   [coordinator] main
  *   [worker] fix-login-redirect
  *   [review] PR#42 · 2 cycles
+ *   [coordinator] obsidian (host)
  *
- * @param role         - session role from hello_ack (e.g. "coordinator", "worker", "review")
- * @param branch       - branch label extracted from session_name (part after "@", or full name)
- * @param prNumber     - detected PR number (null when unknown)
- * @param cycles       - current review cycle count
+ * The isolation mode suffix is appended only when the session is running in
+ * "host" isolation mode (or when isolation_mode is absent/unknown, treated
+ * the same as "host"). Sandboxed modes ("sandbox-exec", "bwrap") produce no
+ * suffix — they are the normal/expected case.
+ *
+ * @param role          - session role from hello_ack (e.g. "coordinator", "worker", "review")
+ * @param branch        - branch label extracted from session_name (part after "@", or full name)
+ * @param isolationMode - isolation mode from hello_ack ("sandbox-exec", "bwrap", "host", or "" for absent)
+ * @param prNumber      - detected PR number (null when unknown)
+ * @param cycles        - current review cycle count
  */
 export function formatPrismStatus(
   role: string,
   branch: string,
+  isolationMode: string,
   prNumber: string | null,
   cycles: number,
 ): string {
   const roleLabel = role.length > 0 ? role : "unknown"
   const prefix = `[${roleLabel}] ${branch}`
+  // Append isolation mode suffix when host mode (or absent/unknown).
+  // Sandboxed modes ("sandbox-exec", "bwrap") are the default — no suffix.
+  const isHostMode = isolationMode !== "sandbox-exec" && isolationMode !== "bwrap"
+  const isolationSuffix = isHostMode ? " (host)" : ""
   if (roleLabel === "review" && prNumber !== null) {
     const cycleLabel = cycles === 1 ? "1 cycle" : `${cycles} cycles`
-    return `${prefix} · PR#${prNumber} · ${cycleLabel}`
+    return `${prefix}${isolationSuffix} · PR#${prNumber} · ${cycleLabel}`
   }
-  return prefix
+  return `${prefix}${isolationSuffix}`
 }
 
 /**
@@ -1114,6 +1126,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // Session identity captured from hello_ack. Used for status bar display.
   let sessionRole = ""
   let sessionBranch = extractBranch(process.env.PRISM_SESSION_NAME ?? "")
+  let sessionIsolationMode = ""
 
   // Flag: git push was detected; cleared after the next turn_start so the
   // reminder fires exactly once.
@@ -1250,13 +1263,16 @@ export default function prismExtension(pi: ExtensionAPI): void {
         if (typeof f.session_name === "string" && f.session_name.length > 0) {
           sessionBranch = extractBranch(f.session_name)
         }
+        // Capture isolation_mode from hello_ack. Absent field is treated as
+        // empty string, which formatPrismStatus maps to the (host) suffix.
+        sessionIsolationMode = typeof f.isolation_mode === "string" ? f.isolation_mode : ""
         handshakeComplete = true
 
         // Set the status bar immediately after handshake.
         const prCycles = sessionRole === "review"
           ? (reviewCycleState.cycles.get(reviewCycleState.detectedPrNumber ?? "unknown") ?? 0)
           : 0
-        const statusText = formatPrismStatus(sessionRole, sessionBranch, reviewCycleState.detectedPrNumber, prCycles)
+        const statusText = formatPrismStatus(sessionRole, sessionBranch, sessionIsolationMode, reviewCycleState.detectedPrNumber, prCycles)
         lastCtx?.ui?.setStatus("prism", statusText)
         if (writer) {
           writer.write({
@@ -1386,7 +1402,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
     // Refresh status bar on each turn_start so review-cycle count is live.
     if (handshakeComplete) {
       const prCycles = reviewCycleState.cycles.get(reviewCycleState.detectedPrNumber ?? "unknown") ?? 0
-      const statusText = formatPrismStatus(sessionRole, sessionBranch, reviewCycleState.detectedPrNumber, prCycles)
+      const statusText = formatPrismStatus(sessionRole, sessionBranch, sessionIsolationMode, reviewCycleState.detectedPrNumber, prCycles)
       lastCtx?.ui?.setStatus("prism", statusText)
       if (writer) {
         writer.write({

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -233,7 +233,7 @@ event frame. Sending any other frame first is a protocol violation
 In response, the sidecar sends:
 
 ```json
-{"type":"hello_ack","protocol_version":1,"session_name":"prism@feature","session_role":"worker","instance_id":"01HZ..."}
+{"type":"hello_ack","protocol_version":1,"session_name":"prism@feature","session_role":"worker","isolation_mode":"sandbox-exec","instance_id":"01HZ..."}
 ```
 
 - `type` (string, required) — literal `"hello_ack"`.
@@ -248,6 +248,12 @@ In response, the sidecar sends:
   derived from the sidecar's `Config.AgentRole`. The extension may
   branch on this to adjust behaviour (e.g. coordinators do not auto-start
   the merge-queue watcher from inside PI; that lives in the sidecar).
+- `isolation_mode` (string, optional) — the effective isolation mode for
+  this session: `"sandbox-exec"`, `"bwrap"`, or `"host"`. Absent (or
+  empty string) when the sidecar is older and does not populate this
+  field; the extension treats absent/empty as `"host"`. Used by the
+  extension to show a `(host)` suffix in the status bar when the session
+  is running without a sandbox (see §5.11).
 - `instance_id` (string, required) — the UUID for this session
   incarnation, matching the value the sidecar uses for `to_instance_id`
   on bus messages (`internal/sidecar/sidecar.go:Config.InstanceID`).
@@ -555,7 +561,16 @@ human-readable summary at the same points. The status text format is:
 [coordinator] main
 [worker] fix-login-redirect
 [review] fix-login-redirect · PR#42 · 2 cycles
+[coordinator] obsidian (host)
+[coordinator] obsidian (host) · PR#42 · 2 cycles
 ```
+
+When `isolation_mode` from `hello_ack` is `"sandbox-exec"` or `"bwrap"`,
+no isolation suffix is appended (sandboxed sessions are the normal case).
+When `isolation_mode` is `"host"` or absent/empty (treated as host), the
+suffix ` (host)` is appended after the branch label and before any PR/cycle
+info. This surfaces unsandboxed sessions visually so users can tell them
+apart from sandboxed ones at a glance.
 
 ## 6. Frame catalogue — sidecar → extension
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1595,11 +1595,13 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			ProtocolVersion int    `json:"protocol_version"`
 			SessionName     string `json:"session_name"`
 			SessionRole     string `json:"session_role"`
+			IsolationMode   string `json:"isolation_mode"`
 		}{
 			Type:            "hello_ack",
 			ProtocolVersion: piWireProtocolVersion,
 			SessionName:     s.cfg.SessionName,
 			SessionRole:     s.cfg.AgentRole,
+			IsolationMode:   string(s.cfg.IsolationMode),
 		}
 		ackBytes, _ := json.Marshal(ackFrame)
 		ackBytes = append(ackBytes, '\n')


### PR DESCRIPTION
## Summary

- Adds `isolation_mode` to the `hello_ack` frame in the sidecar, sourced from `s.cfg.IsolationMode`
- Updates `formatPrismStatus` in the PI extension to accept an `isolationMode` parameter and append `(host)` when the mode is `"host"` or `""` (absent/unknown)
- Sandboxed modes (`sandbox-exec`, `bwrap`) show no suffix — normal case, no noise
- Wires `sessionIsolationMode` into both status-bar refresh call sites (post-handshake and `turn_start`)
- Updates all `formatPrismStatus` tests to the new 5-parameter signature and adds four isolation mode test cases

Closes #1405