### PR TITLE
fix: emit session_shutdown from agent_end for review sessions

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -44,6 +44,8 @@ import {
   GIT_PUSH_REMINDER_MESSAGE,
   // turn_end signal resolver
   resolveTurnEndSignal,
+  // agent_end signal resolver
+  resolveAgentEndSignal,
 } from "./prism.ts"
 
 // ---------------------------------------------------------------------------
@@ -1401,5 +1403,67 @@ describe("resolveTurnEndSignal — idle (non-stop reasons that are idle)", () =>
       resolveTurnEndSignal(undefined, false, false, false),
       "none",
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveAgentEndSignal (agent_end state-change resolver)
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentEndSignal — review session + stopReason=stop", () => {
+  it("returns 'finished' for review session with stopReason=stop", () => {
+    // AC: review agent completes cleanly → session_shutdown must be emitted
+    assert.equal(resolveAgentEndSignal(true, "stop"), "finished")
+  })
+})
+
+describe("resolveAgentEndSignal — review session + stopReason=aborted", () => {
+  it("returns 'interrupted' for review session with stopReason=aborted", () => {
+    // AC: user abort → state_change:interrupted, no shutdown
+    assert.equal(resolveAgentEndSignal(true, "aborted"), "interrupted")
+  })
+})
+
+describe("resolveAgentEndSignal — review session + stopReason=error", () => {
+  it("returns 'none' for review session with stopReason=error", () => {
+    // AC: error path is handled separately; agent_end must not emit shutdown
+    assert.equal(resolveAgentEndSignal(true, "error"), "none")
+  })
+})
+
+describe("resolveAgentEndSignal — review session + unknown stopReason", () => {
+  it("returns 'none' for review session with unknown stopReason", () => {
+    assert.equal(resolveAgentEndSignal(true, "toolUse"), "none")
+  })
+
+  it("returns 'none' for review session with undefined stopReason", () => {
+    assert.equal(resolveAgentEndSignal(true, undefined), "none")
+  })
+})
+
+describe("resolveAgentEndSignal — non-review session (always no-op)", () => {
+  it("returns 'none' for non-review session with stopReason=stop", () => {
+    // AC: non-review sessions use the turn_end → isIdle path; agent_end is a no-op
+    assert.equal(resolveAgentEndSignal(false, "stop"), "none")
+  })
+
+  it("returns 'none' for non-review session with stopReason=aborted", () => {
+    assert.equal(resolveAgentEndSignal(false, "aborted"), "none")
+  })
+
+  it("returns 'none' for non-review session with stopReason=error", () => {
+    assert.equal(resolveAgentEndSignal(false, "error"), "none")
+  })
+})
+
+describe("resolveAgentEndSignal — double-emission guard (sessionShutdownEmitted)", () => {
+  it("returns 'finished' for review + stop regardless of guard (guard is caller responsibility)", () => {
+    // The sessionShutdownEmitted guard is checked by the caller (the agent_end hook
+    // in the extension factory), not by this pure helper. Verify the helper itself
+    // consistently returns 'finished' for stop — the caller gates on the flag.
+    assert.equal(resolveAgentEndSignal(true, "stop"), "finished")
+    // A second call still returns 'finished'; the factory will skip emission because
+    // sessionShutdownEmitted is already true in that code path.
+    assert.equal(resolveAgentEndSignal(true, "stop"), "finished")
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -30,6 +30,9 @@
 //                            (stopReason=stop, idle, no pending, not reviewing)
 //                         → turn_end + state_change:interrupted (stopReason=aborted)
 //                         → turn_end + state_change:idle (other idle turns)
+//   agent_end             → state_change:finished + session_shutdown (review sessions, stopReason=stop)
+//                         → state_change:interrupted               (review sessions, stopReason=aborted)
+//                         → no-op                                  (non-review sessions or stopReason=error)
 //   message_update        → msg_assistant       (text_delta only, truncated)
 //   after_provider_response (non-OK)
 //                         → provider_error
@@ -973,6 +976,43 @@ export async function dispatchInboundFrame(
 }
 
 // ---------------------------------------------------------------------------
+// agent_end signal resolver — exported for unit testing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Signal that the agent_end handler should emit for review-agent sessions.
+ *
+ * - "finished"     — emit state_change:finished, session_shutdown, close writer
+ * - "interrupted"  — emit state_change:interrupted (no shutdown)
+ * - "none"         — do not emit any state_change frame
+ *
+ * Only used by review sessions (isReviewSession === true). Non-review sessions
+ * always return "none" here — they rely on the turn_end → isIdle path instead.
+ */
+export type AgentEndSignal = "finished" | "interrupted" | "none"
+
+/**
+ * Determines which state-change signal to emit from the agent_end hook.
+ *
+ * For review sessions:
+ *   - stopReason=stop     → "finished"
+ *   - stopReason=aborted  → "interrupted"
+ *   - anything else       → "none" (error path or unknown)
+ * For non-review sessions: always "none".
+ *
+ * Exported for unit testing.
+ */
+export function resolveAgentEndSignal(
+  isReviewSession: boolean,
+  stopReason: string | undefined,
+): AgentEndSignal {
+  if (!isReviewSession) return "none"
+  if (stopReason === "stop") return "finished"
+  if (stopReason === "aborted") return "interrupted"
+  return "none"
+}
+
+// ---------------------------------------------------------------------------
 // turn_end signal resolver — exported for unit testing.
 // ---------------------------------------------------------------------------
 
@@ -1520,6 +1560,70 @@ export default function prismExtension(pi: ExtensionAPI): void {
         console.error("[prism-extension] turn_end signal resolution failed:", err)
       }
     }
+  })
+
+  // ── agent_end hook ────────────────────────────────────────────────────
+  //
+  // For review-agent sessions (isReviewSession === true), this hook fires
+  // after the model has produced its final response and all tool calls are
+  // complete. At this point we know for certain whether the run ended cleanly
+  // (stopReason=stop), was aborted (stopReason=aborted), or hit an error.
+  //
+  // Background: the turn_end hook fires while isStreaming is still true, so
+  // isIdle() returns false and resolveTurnEndSignal returns "none" — the
+  // session_shutdown frame is never written via that path for review sessions
+  // (which complete in a single run without going idle between turns). The
+  // agent_end hook fires after isStreaming is set to false (the PI agent-core
+  // sets isStreaming=false before emitting agent_end), making it the correct
+  // place to emit session_shutdown for review sessions.
+  //
+  // For non-review sessions the existing turn_end → isIdle path works: between
+  // turns the agent returns to idle, isIdle() returns true, and the normal
+  // resolveTurnEndSignal("finished", ...) path fires correctly when the agent
+  // eventually completes with stopReason=stop.
+  //
+  // The sessionShutdownEmitted guard prevents double-emission if this hook
+  // fires after the session_shutdown PI hook has already closed the writer
+  // (unlikely for review agents but required for correctness).
+  pi.on("agent_end", async (event, ctx) => {
+    lastCtx = ctx
+    if (!isReviewSession) {
+      // Non-review sessions: the turn_end → isIdle path handles shutdown.
+      return
+    }
+    if (!writer || !handshakeComplete) return
+    if (sessionShutdownEmitted) {
+      // session_shutdown PI hook already fired — do not double-emit.
+      return
+    }
+
+    // Extract stopReason from the last message in the event payload.
+    // The agent_end event carries the final messages from the run; the last
+    // one is the terminal assistant message whose stopReason reflects how the
+    // run ended (stop, aborted, error, …).
+    const messages = (event as { messages?: unknown[] }).messages
+    const lastMsg =
+      Array.isArray(messages) && messages.length > 0
+        ? messages[messages.length - 1]
+        : undefined
+    const stopReason =
+      lastMsg !== null && typeof lastMsg === "object"
+        ? (lastMsg as { stopReason?: unknown }).stopReason as string | undefined
+        : undefined
+
+    const signal = resolveAgentEndSignal(isReviewSession, stopReason)
+    if (signal === "finished") {
+      // Clean finish: emit finished + shutdown and close the writer.
+      sessionShutdownEmitted = true
+      writer.write({ type: "state_change", state: "finished" })
+      writer.write({ type: "session_shutdown" })
+      writer.close()
+    } else if (signal === "interrupted") {
+      // User abort: emit interrupted. Do not close with shutdown.
+      writer.write({ type: "state_change", state: "interrupted" })
+    }
+    // signal === "none": stopReason=error or unknown — the existing error path
+    // handles it (or the connection drop + pipeDisconnectTimeout takes over).
   })
 
   pi.on("tool_execution_start", async (event, ctx) => {


### PR DESCRIPTION
## Summary

- PI review agents were staying `active` indefinitely (then flipping to `error` after 30 s) because `session_shutdown` was never sent from the extension.
- Root cause: `turn_end` fires while `isStreaming` is still `true`, so `isIdle()` returns `false` and `resolveTurnEndSignal` returns `"none"` — no shutdown frame is ever written for review sessions (which complete in a single run without going idle between turns).
- Fix: add an `agent_end` hook that for review sessions directly emits `state_change:finished` + `session_shutdown` (clean stop) or `state_change:interrupted` (user abort), bypassing the `isIdle` check. For non-review sessions the hook is a no-op — the existing `turn_end → isIdle` path works correctly there.

## Changes

- **`prism.ts`**: Add `pi.on("agent_end", ...)` handler + export `resolveAgentEndSignal` pure helper
- **`prism.test.ts`**: 9 new unit tests for `resolveAgentEndSignal` covering all AC cases

## Testing

- 146 unit tests pass (`tsx --test prism.test.ts`)  
- Go build + tests pass (`go build ./... && go test ./...`)
- NixOS build succeeds

Closes #1407