### PR TITLE
feat: add per-path isolation mode overrides

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -26,6 +26,9 @@ in
     programs = {
       prism.profile.default = "anthropic";
       prism.agent.isolation.default = "sandbox-exec";
+      prism.projects.isolationOverrides = {
+        "~/documents/obsidian" = "host";
+      };
       # Disable programs that default to enabled but aren't needed/available on Darwin
       podman.enable = false;
       dragon-drop.enable = false;

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -124,6 +124,27 @@
             (not scanned for subdirectories).
           '';
         };
+
+        isolationOverrides = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = { };
+          example = {
+            "~/documents/obsidian" = "host";
+          };
+          description = ''
+            Per-path isolation mode overrides. Maps path strings (with optional
+            "~/" prefix) to isolation mode strings ("bwrap", "sandbox-exec", or
+            "host"). When a session path matches a key, the associated mode is
+            used instead of the machine default (default_isolation_mode).
+
+            Invalid mode values are silently ignored by prism — the machine
+            default is used instead.
+
+            Written to config.json as project_isolation_overrides. The compiled-in
+            Go default already maps "~/documents/obsidian" → "host" for fresh
+            Darwin installs; set this option explicitly to override or extend it.
+          '';
+        };
       };
 
       profile = {

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -48,6 +48,7 @@ let
     worktree_exclude = config.nx.programs.prism.worktreeExclude;
     project_locations = config.nx.programs.prism.projects.locations;
     project_specific = config.nx.programs.prism.projects.specific;
+    project_isolation_overrides = config.nx.programs.prism.projects.isolationOverrides;
     git_user_name = gitUserName;
     git_user_email = gitUserEmail;
     ssh_access_key_name = config.nx.programs.prism.sshAccessKeyName;

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -295,6 +295,16 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		}
 	}
 
+	// Apply per-path isolation override: if the stored worktree path matches
+	// a configured override, use the override mode regardless of what was
+	// recorded in the DB row. This ensures sessions for paths like
+	// ~/documents/obsidian are always restored with the correct isolation mode
+	// (e.g. "host") even if they were originally recorded with a different mode.
+	if override := cfg.IsolationOverrideForPath(directory); override != "" {
+		fmt.Fprintf(os.Stderr, "[prism restore] using isolation override %q for path %q\n", override, directory)
+		isoMode = override
+	}
+
 	// Look up the isolation capabilities for this mode. All per-mode branching
 	// below reads from isoCaps rather than comparing against raw mode constants.
 	isoCaps := container.CapabilitiesFor(isoMode)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -344,6 +344,15 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// Resolve the effective isolation mode. This validates --isolation
 	// and falls back to config.json.
 	// Done BEFORE any side effects (no worktree, no tmux session, no DB row).
+	//
+	// Note: project_isolation_overrides is intentionally NOT consulted here.
+	// prism spawn creates a new worktree in a git repo and should respect the
+	// explicit --isolation flag and machine default only. The per-path override
+	// is applied by prism switch (opening an existing path) and prism restore
+	// (re-creating a session for a stored path). This matches the edge-case AC
+	// in issue #1404: "prism spawn from inside a session does not consult
+	// project_isolation_overrides — it uses the caller's isolation mode
+	// resolution path unchanged."
 	isolationMode, err := resolveIsolationMode(cmd, cfg)
 	if err != nil {
 		return err

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -25,6 +25,23 @@ import (
 
 // ── session management ────────────────────────────────────────────────────────
 
+// applyPathIsolationOverride checks cfg.ProjectIsolationOverrides for path and,
+// if a valid override is found, updates opts.IsolationMode in place and returns
+// the overridden IsolationMode plus new Capabilities. If no override applies,
+// the original isoMode and isoCaps are returned unchanged.
+//
+// The caller is responsible for passing a non-nil opts pointer. Logging is
+// done to stderr at info level when an override fires.
+func applyPathIsolationOverride(path string, cfg config.Config, opts *session.Opts, isoMode config.IsolationMode, isoCaps container.Capabilities) (config.IsolationMode, container.Capabilities) {
+	override := cfg.IsolationOverrideForPath(path)
+	if override == "" {
+		return isoMode, isoCaps
+	}
+	fmt.Fprintf(os.Stderr, "[prism switch] using isolation override %q for path %q\n", override, path)
+	opts.IsolationMode = string(override)
+	return override, container.CapabilitiesFor(override)
+}
+
 // writeHarnessConfigBlobFor dispatches the per-mode "write opencode.json blob
 // to the deterministic per-session temp path" step through the registered
 // Isolator (D3, issue #1133). cmdName is used in the error wrapper so the
@@ -369,13 +386,15 @@ var switchCmd = &cobra.Command{
 					return fmt.Errorf("no worktrees found in %s", p)
 				}
 				o := opts
-				if isoCaps.NeedsConfigBlob && pf != nil {
+				// Apply per-path isolation override for the first worktree.
+				effIso, effCaps := applyPathIsolationOverride(worktrees[0], cfg, &o, isoMode, isoCaps)
+				if effCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(worktrees[0], pf, &o, "prism switch"); err != nil {
 						return err
 					}
 				}
-				if isoCaps.NeedsConfigBlob {
-					if err := writeHarnessConfigBlobFor(isoMode, session.NameFor(worktrees[0], p), o.ConfigContent, "switch"); err != nil {
+				if effCaps.NeedsConfigBlob {
+					if err := writeHarnessConfigBlobFor(effIso, session.NameFor(worktrees[0], p), o.ConfigContent, "switch"); err != nil {
 						return err
 					}
 				}
@@ -383,26 +402,30 @@ var switchCmd = &cobra.Command{
 			}
 			if bareRoot := git.BareRoot(p); bareRoot != "" {
 				o := opts
-				if isoCaps.NeedsConfigBlob && pf != nil {
+				// Apply per-path isolation override for the worktree path.
+				effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps)
+				if effCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
 					}
 				}
-				if isoCaps.NeedsConfigBlob {
-					if err := writeHarnessConfigBlobFor(isoMode, session.NameFor(p, bareRoot), o.ConfigContent, "switch"); err != nil {
+				if effCaps.NeedsConfigBlob {
+					if err := writeHarnessConfigBlobFor(effIso, session.NameFor(p, bareRoot), o.ConfigContent, "switch"); err != nil {
 						return err
 					}
 				}
 				return ensureAndSwitch(p, bareRoot, o)
 			}
 			o := opts
-			if isoCaps.NeedsConfigBlob && pf != nil {
+			// Apply per-path isolation override for plain directory paths.
+			effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps)
+			if effCaps.NeedsConfigBlob && pf != nil {
 				if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 					return err
 				}
 			}
-			if isoCaps.NeedsConfigBlob {
-				if err := writeHarnessConfigBlobFor(isoMode, session.NameFor(p, ""), o.ConfigContent, "switch"); err != nil {
+			if effCaps.NeedsConfigBlob {
+				if err := writeHarnessConfigBlobFor(effIso, session.NameFor(p, ""), o.ConfigContent, "switch"); err != nil {
 					return err
 				}
 			}
@@ -442,18 +465,21 @@ var switchCmd = &cobra.Command{
 			p := chosen.path
 			switch {
 			case git.IsBareRepo(p):
-				return handleBareRepo(p, pf, opts, isoCaps)
+				return handleBareRepo(p, pf, opts, isoCaps, cfg)
 			case git.IsRegularRepo(p):
-				return handleRegularRepo(p, pf, opts, isoCaps)
+				return handleRegularRepo(p, pf, opts, isoCaps, cfg)
 			default:
 				o := opts
-				if isoCaps.NeedsConfigBlob && pf != nil {
+				// Apply per-path isolation override for plain directory paths
+				// selected from the picker (e.g. ~/documents/obsidian).
+				effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps)
+				if effCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
 					}
 				}
-				if isoCaps.NeedsConfigBlob {
-					if err := writeHarnessConfigBlobFor(isoMode, session.NameFor(p, ""), o.ConfigContent, "switch"); err != nil {
+				if effCaps.NeedsConfigBlob {
+					if err := writeHarnessConfigBlobFor(effIso, session.NameFor(p, ""), o.ConfigContent, "switch"); err != nil {
 						return err
 					}
 				}

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -476,7 +476,7 @@ var switchCmd = &cobra.Command{
 			return ensureAndSwitch("[scratchpad]", "", opts)
 
 		case "[+ clone repo]":
-			return handleCloneRepo(pf, opts, isoCaps)
+			return handleCloneRepo(pf, opts, isoCaps, cfg)
 
 		default:
 			p := chosen.path

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -30,16 +30,33 @@ import (
 // the overridden IsolationMode plus new Capabilities. If no override applies,
 // the original isoMode and isoCaps are returned unchanged.
 //
+// When the override changes the sandbox/host boundary (e.g. sandbox-exec →
+// host), AgentEnvVars are injected from pf when the effective mode is host
+// (NeedsConfigBlob=false). This handles the case where the machine default is
+// a sandboxed mode (AgentEnvVars skipped at opts construction time) but the
+// path override switches to host mode, which requires env var injection.
+//
+// pf may be nil; the AgentEnvVars injection is a no-op when pf is nil.
+//
 // The caller is responsible for passing a non-nil opts pointer. Logging is
 // done to stderr at info level when an override fires.
-func applyPathIsolationOverride(path string, cfg config.Config, opts *session.Opts, isoMode config.IsolationMode, isoCaps container.Capabilities) (config.IsolationMode, container.Capabilities) {
+func applyPathIsolationOverride(path string, cfg config.Config, opts *session.Opts, isoMode config.IsolationMode, isoCaps container.Capabilities, pf *config.ProfilesFile) (config.IsolationMode, container.Capabilities) {
 	override := cfg.IsolationOverrideForPath(path)
 	if override == "" {
 		return isoMode, isoCaps
 	}
 	fmt.Fprintf(os.Stderr, "[prism switch] using isolation override %q for path %q\n", override, path)
 	opts.IsolationMode = string(override)
-	return override, container.CapabilitiesFor(override)
+	effCaps := container.CapabilitiesFor(override)
+	// When the override crosses the sandbox/host boundary (sandboxed → host),
+	// inject AgentEnvVars that would normally be set at opts construction time.
+	// The pre-override isoCaps had NeedsConfigBlob=true (sandboxed), so
+	// AgentEnvVars was not populated; now that effective mode is host
+	// (NeedsConfigBlob=false), we must inject them here.
+	if !effCaps.NeedsConfigBlob && isoCaps.NeedsConfigBlob && pf != nil {
+		opts.AgentEnvVars = pf.AgentEnvVars
+	}
+	return override, effCaps
 }
 
 // writeHarnessConfigBlobFor dispatches the per-mode "write opencode.json blob
@@ -387,7 +404,7 @@ var switchCmd = &cobra.Command{
 				}
 				o := opts
 				// Apply per-path isolation override for the first worktree.
-				effIso, effCaps := applyPathIsolationOverride(worktrees[0], cfg, &o, isoMode, isoCaps)
+				effIso, effCaps := applyPathIsolationOverride(worktrees[0], cfg, &o, isoMode, isoCaps, pf)
 				if effCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(worktrees[0], pf, &o, "prism switch"); err != nil {
 						return err
@@ -403,7 +420,7 @@ var switchCmd = &cobra.Command{
 			if bareRoot := git.BareRoot(p); bareRoot != "" {
 				o := opts
 				// Apply per-path isolation override for the worktree path.
-				effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps)
+				effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps, pf)
 				if effCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err
@@ -418,7 +435,7 @@ var switchCmd = &cobra.Command{
 			}
 			o := opts
 			// Apply per-path isolation override for plain directory paths.
-			effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps)
+			effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps, pf)
 			if effCaps.NeedsConfigBlob && pf != nil {
 				if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 					return err
@@ -472,7 +489,7 @@ var switchCmd = &cobra.Command{
 				o := opts
 				// Apply per-path isolation override for plain directory paths
 				// selected from the picker (e.g. ~/documents/obsidian).
-				effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps)
+				effIso, effCaps := applyPathIsolationOverride(p, cfg, &o, isoMode, isoCaps, pf)
 				if effCaps.NeedsConfigBlob && pf != nil {
 					if err := injectContainerConfig(p, pf, &o, "prism switch"); err != nil {
 						return err

--- a/modules/programs/prism/prism/cmd/switch_project.go
+++ b/modules/programs/prism/prism/cmd/switch_project.go
@@ -460,7 +460,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 
 // ── clone repo ────────────────────────────────────────────────────────────────
 
-func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities) error {
+func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities, cfg config.Config) error {
 	repoURL := promptInput("clone url> ")
 	if repoURL == "" {
 		return nil
@@ -491,13 +491,18 @@ func handleCloneRepo(pf *config.ProfilesFile, opts session.Opts, isoCaps contain
 	if len(worktrees) == 0 {
 		return fmt.Errorf("clone succeeded but no worktrees found in %s", targetDir)
 	}
-	if isoCaps.NeedsConfigBlob && pf != nil {
+	// Apply per-path isolation override for the cloned worktree. In practice
+	// the worktree lives under a project location (e.g. ~/code/<name>/main)
+	// and is unlikely to match an override key, but the check is applied
+	// consistently at every session-creation entry point.
+	effIso, effCaps := applyPathIsolationOverride(worktrees[0], cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
+	if effCaps.NeedsConfigBlob && pf != nil {
 		if err := injectContainerConfig(worktrees[0], pf, &opts, "prism switch"); err != nil {
 			return err
 		}
 	}
-	if isoCaps.NeedsConfigBlob {
-		if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(worktrees[0], targetDir), opts.ConfigContent, "switch"); err != nil {
+	if effCaps.NeedsConfigBlob {
+		if err := writeHarnessConfigBlobFor(effIso, session.NameFor(worktrees[0], targetDir), opts.ConfigContent, "switch"); err != nil {
 			return err
 		}
 	}

--- a/modules/programs/prism/prism/cmd/switch_project.go
+++ b/modules/programs/prism/prism/cmd/switch_project.go
@@ -151,7 +151,7 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 			return fmt.Errorf("create worktree: %w", err)
 		}
 		// Apply per-path isolation override for the new worktree.
-		effIso, effCaps := applyPathIsolationOverride(worktreePath, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		effIso, effCaps := applyPathIsolationOverride(worktreePath, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
 		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
@@ -166,7 +166,7 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 	}
 
 	// Apply per-path isolation override for the chosen worktree.
-	effIso, effCaps := applyPathIsolationOverride(chosen.path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+	effIso, effCaps := applyPathIsolationOverride(chosen.path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
 	if effCaps.NeedsConfigBlob && pf != nil {
 		if err := injectContainerConfig(chosen.path, pf, &opts, "prism switch"); err != nil {
 			return err
@@ -356,7 +356,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 	exclude := switchWorktreeExcludeSet()
 	if exclude[filepath.Base(path)] {
 		// Apply per-path isolation override for excluded-from-conversion paths.
-		effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
 		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
@@ -388,7 +388,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "conversion failed: %v\nopening directly\n", err)
 			// Apply per-path isolation override for the fallback direct-open.
-			effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+			effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
 			if effCaps.NeedsConfigBlob && pf != nil {
 				if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 					return err
@@ -429,7 +429,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		}
 
 		// Apply per-path isolation override for the converted worktree.
-		effIso, effCaps := applyPathIsolationOverride(worktreePath, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		effIso, effCaps := applyPathIsolationOverride(worktreePath, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
 		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
@@ -443,7 +443,7 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		return ensureAndSwitch(worktreePath, path, opts)
 	default:
 		// Apply per-path isolation override for direct-open.
-		effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps, pf)
 		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err

--- a/modules/programs/prism/prism/cmd/switch_project.go
+++ b/modules/programs/prism/prism/cmd/switch_project.go
@@ -97,7 +97,7 @@ func projectEntries() []entry {
 
 // ── worktree second-level picker ──────────────────────────────────────────────
 
-func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities) error {
+func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities, cfg config.Config) error {
 	worktrees := git.Worktrees(projectPath)
 	createNew := entry{display: "[+ create new worktree]", special: "[+ create new worktree]"}
 
@@ -150,26 +150,30 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 		if err != nil {
 			return fmt.Errorf("create worktree: %w", err)
 		}
-		if isoCaps.NeedsConfigBlob && pf != nil {
+		// Apply per-path isolation override for the new worktree.
+		effIso, effCaps := applyPathIsolationOverride(worktreePath, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoCaps.NeedsConfigBlob {
-			if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(worktreePath, projectPath), opts.ConfigContent, "switch"); err != nil {
+		if effCaps.NeedsConfigBlob {
+			if err := writeHarnessConfigBlobFor(effIso, session.NameFor(worktreePath, projectPath), opts.ConfigContent, "switch"); err != nil {
 				return err
 			}
 		}
 		return ensureAndSwitch(worktreePath, projectPath, opts)
 	}
 
-	if isoCaps.NeedsConfigBlob && pf != nil {
+	// Apply per-path isolation override for the chosen worktree.
+	effIso, effCaps := applyPathIsolationOverride(chosen.path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+	if effCaps.NeedsConfigBlob && pf != nil {
 		if err := injectContainerConfig(chosen.path, pf, &opts, "prism switch"); err != nil {
 			return err
 		}
 	}
-	if isoCaps.NeedsConfigBlob {
-		if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(chosen.path, projectPath), opts.ConfigContent, "switch"); err != nil {
+	if effCaps.NeedsConfigBlob {
+		if err := writeHarnessConfigBlobFor(effIso, session.NameFor(chosen.path, projectPath), opts.ConfigContent, "switch"); err != nil {
 			return err
 		}
 	}
@@ -348,16 +352,18 @@ func handleReviewGroupPick(groupKey string) error {
 	return err
 }
 
-func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities) error {
+func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities, cfg config.Config) error {
 	exclude := switchWorktreeExcludeSet()
 	if exclude[filepath.Base(path)] {
-		if isoCaps.NeedsConfigBlob && pf != nil {
+		// Apply per-path isolation override for excluded-from-conversion paths.
+		effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoCaps.NeedsConfigBlob {
-			if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(path, ""), opts.ConfigContent, "switch"); err != nil {
+		if effCaps.NeedsConfigBlob {
+			if err := writeHarnessConfigBlobFor(effIso, session.NameFor(path, ""), opts.ConfigContent, "switch"); err != nil {
 				return err
 			}
 		}
@@ -381,13 +387,15 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "conversion failed: %v\nopening directly\n", err)
-			if isoCaps.NeedsConfigBlob && pf != nil {
+			// Apply per-path isolation override for the fallback direct-open.
+			effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+			if effCaps.NeedsConfigBlob && pf != nil {
 				if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 					return err
 				}
 			}
-			if isoCaps.NeedsConfigBlob {
-				if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(path, ""), opts.ConfigContent, "switch"); err != nil {
+			if effCaps.NeedsConfigBlob {
+				if err := writeHarnessConfigBlobFor(effIso, session.NameFor(path, ""), opts.ConfigContent, "switch"); err != nil {
 					return err
 				}
 			}
@@ -420,25 +428,29 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 			removeContainerIfExists(oldSessionName)
 		}
 
-		if isoCaps.NeedsConfigBlob && pf != nil {
+		// Apply per-path isolation override for the converted worktree.
+		effIso, effCaps := applyPathIsolationOverride(worktreePath, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(worktreePath, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoCaps.NeedsConfigBlob {
-			if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(worktreePath, path), opts.ConfigContent, "switch"); err != nil {
+		if effCaps.NeedsConfigBlob {
+			if err := writeHarnessConfigBlobFor(effIso, session.NameFor(worktreePath, path), opts.ConfigContent, "switch"); err != nil {
 				return err
 			}
 		}
 		return ensureAndSwitch(worktreePath, path, opts)
 	default:
-		if isoCaps.NeedsConfigBlob && pf != nil {
+		// Apply per-path isolation override for direct-open.
+		effIso, effCaps := applyPathIsolationOverride(path, cfg, &opts, config.IsolationMode(opts.IsolationMode), isoCaps)
+		if effCaps.NeedsConfigBlob && pf != nil {
 			if err := injectContainerConfig(path, pf, &opts, "prism switch"); err != nil {
 				return err
 			}
 		}
-		if isoCaps.NeedsConfigBlob {
-			if err := writeHarnessConfigBlobFor(config.IsolationMode(opts.IsolationMode), session.NameFor(path, ""), opts.ConfigContent, "switch"); err != nil {
+		if effCaps.NeedsConfigBlob {
+			if err := writeHarnessConfigBlobFor(effIso, session.NameFor(path, ""), opts.ConfigContent, "switch"); err != nil {
 				return err
 			}
 		}

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -129,6 +130,14 @@ type Config struct {
 	// so that agent-run knows where to find the extension at runtime.
 	// When empty, agent-run falls back to a relative-to-executable heuristic.
 	PIExtensionDir string `json:"pi_extension_dir"`
+
+	// ProjectIsolationOverrides maps path strings (with optional "~/" prefix)
+	// to isolation mode strings. When a session path matches a key (after "~/"
+	// expansion), the associated mode is used instead of DefaultIsolationMode.
+	// Invalid mode values are silently ignored (same treatment as an invalid
+	// DefaultIsolationMode). Keys must exactly match the path after "~/"
+	// expansion; no glob or prefix matching.
+	ProjectIsolationOverrides map[string]string `json:"project_isolation_overrides,omitempty"`
 }
 
 // parsedConfig mirrors Config but uses pointer slices so that a JSON null or
@@ -156,9 +165,10 @@ type parsedConfig struct {
 	SidecarCircuitBreakerThreshold *int      `json:"sidecar_circuit_breaker_threshold"`
 	BwrapConcurrencyCap            *int      `json:"bwrap_concurrency_cap"`
 	SandboxExecConcurrencyCap      *int      `json:"sandbox_exec_concurrency_cap"`
-	WorktreeExclude                *[]string `json:"worktree_exclude"`
-	ProjectLocations               *[]string `json:"project_locations"`
-	ProjectSpecific                *[]string `json:"project_specific"`
+	WorktreeExclude                *[]string          `json:"worktree_exclude"`
+	ProjectLocations               *[]string          `json:"project_locations"`
+	ProjectSpecific                *[]string          `json:"project_specific"`
+	ProjectIsolationOverrides      *map[string]string `json:"project_isolation_overrides"`
 }
 
 // DefaultBwrapConcurrencyCap is the compiled-in default maximum number of
@@ -194,9 +204,12 @@ func defaults() Config {
 		SshSigningKeyName:         "prismatic-koi-ed25519-signingkey",
 		BwrapConcurrencyCap:       DefaultBwrapConcurrencyCap,
 		SandboxExecConcurrencyCap: DefaultSandboxExecConcurrencyCap,
-		WorktreeExclude:           []string{"obsidian"},
-		ProjectLocations:     []string{"~/code"},
-		ProjectSpecific:      []string{"~/documents/obsidian"},
+		WorktreeExclude:  []string{"obsidian"},
+		ProjectLocations: []string{"~/code"},
+		ProjectSpecific:  []string{"~/documents/obsidian"},
+		ProjectIsolationOverrides: map[string]string{
+			"~/documents/obsidian": "host",
+		},
 	}
 }
 
@@ -329,6 +342,12 @@ func load() Config {
 		cfg.ProjectSpecific = *parsed.ProjectSpecific
 	}
 
+	// For map fields: nil pointer means absent (keep default); non-nil
+	// pointer (including pointer to empty map) means replace entirely.
+	if parsed.ProjectIsolationOverrides != nil {
+		cfg.ProjectIsolationOverrides = *parsed.ProjectIsolationOverrides
+	}
+
 	return cfg
 }
 
@@ -367,6 +386,45 @@ func (c Config) CircuitBreakerThreshold() int {
 		return 0
 	}
 	return n
+}
+
+// IsolationOverrideForPath looks up path in ProjectIsolationOverrides and
+// returns the configured IsolationMode if the path matches and the value is
+// valid. Returns "" if the path is not present in the map or the mapped value
+// is not a valid isolation mode (silently ignored).
+//
+// path is expanded: a leading "~/" is replaced with the user home directory
+// before lookup. The keys in ProjectIsolationOverrides are also expanded
+// before comparison, so both "~/documents/obsidian" and an already-expanded
+// absolute path work as keys.
+func (c Config) IsolationOverrideForPath(path string) IsolationMode {
+	if len(c.ProjectIsolationOverrides) == 0 {
+		return ""
+	}
+	expanded := expandHomePath(path)
+	for k, v := range c.ProjectIsolationOverrides {
+		if expandHomePath(k) == expanded {
+			if IsValidIsolationMode(v) {
+				return IsolationMode(v)
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// expandHomePath expands a leading "~/" in p to the user's home directory.
+// If os.UserHomeDir() fails or p does not start with "~/", p is returned
+// unchanged.
+func expandHomePath(p string) string {
+	if !strings.HasPrefix(p, "~/") {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(home, p[2:])
 }
 
 // configFilePath returns the path to look for the config file.

--- a/modules/programs/prism/prism/internal/config/config_test.go
+++ b/modules/programs/prism/prism/internal/config/config_test.go
@@ -277,3 +277,181 @@ func TestMalformedJSON(t *testing.T) {
 		t.Errorf("ProjectLocations: got %v, want default [~/code]", cfg.ProjectLocations)
 	}
 }
+
+// TestProjectIsolationOverridesDefault verifies that defaults() includes the
+// Obsidian vault path mapped to "host" so a fresh Darwin install works without
+// any config.json entry.
+func TestProjectIsolationOverridesDefault(t *testing.T) {
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	if cfg.ProjectIsolationOverrides == nil {
+		t.Fatal("ProjectIsolationOverrides: got nil, want non-nil map from defaults")
+	}
+	got, ok := cfg.ProjectIsolationOverrides["~/documents/obsidian"]
+	if !ok {
+		t.Errorf("ProjectIsolationOverrides: missing key %q", "~/documents/obsidian")
+	} else if got != "host" {
+		t.Errorf("ProjectIsolationOverrides[%q]: got %q, want %q", "~/documents/obsidian", got, "host")
+	}
+}
+
+// TestProjectIsolationOverridesFromFile verifies that a config.json with
+// project_isolation_overrides is loaded and replaces the defaults entirely.
+func TestProjectIsolationOverridesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"project_isolation_overrides": {"~/myproject": "bwrap"}}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	// The file replaces the defaults entirely (map replacement, not merge).
+	if len(cfg.ProjectIsolationOverrides) != 1 {
+		t.Errorf("ProjectIsolationOverrides: got %d entries, want 1", len(cfg.ProjectIsolationOverrides))
+	}
+	got, ok := cfg.ProjectIsolationOverrides["~/myproject"]
+	if !ok {
+		t.Errorf("ProjectIsolationOverrides: missing key %q", "~/myproject")
+	} else if got != "bwrap" {
+		t.Errorf("ProjectIsolationOverrides[%q]: got %q, want %q", "~/myproject", got, "bwrap")
+	}
+	// Defaults must be gone since the file provided a non-nil map.
+	if _, obsidianPresent := cfg.ProjectIsolationOverrides["~/documents/obsidian"]; obsidianPresent {
+		t.Errorf("ProjectIsolationOverrides: default key %q should not be present when file provides the map", "~/documents/obsidian")
+	}
+}
+
+// TestProjectIsolationOverridesAbsentKeepsDefaults verifies that an absent
+// project_isolation_overrides key in config.json leaves the compiled-in
+// defaults intact.
+func TestProjectIsolationOverridesAbsentKeepsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// Config file exists but has no project_isolation_overrides key.
+	raw := `{"color_primary": "#ff0000"}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	got, ok := cfg.ProjectIsolationOverrides["~/documents/obsidian"]
+	if !ok {
+		t.Errorf("ProjectIsolationOverrides: default key %q missing when key absent from config", "~/documents/obsidian")
+	} else if got != "host" {
+		t.Errorf("ProjectIsolationOverrides[%q]: got %q, want %q", "~/documents/obsidian", got, "host")
+	}
+}
+
+// TestProjectIsolationOverridesEmptyMapClearsDefaults verifies that an
+// explicit empty object {} in config.json replaces defaults with an empty map.
+func TestProjectIsolationOverridesEmptyMapClearsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"project_isolation_overrides": {}}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	if len(cfg.ProjectIsolationOverrides) != 0 {
+		t.Errorf("ProjectIsolationOverrides: got %d entries, want 0 (explicit empty should clear defaults)", len(cfg.ProjectIsolationOverrides))
+	}
+}
+
+// TestIsolationOverrideForPathMatch verifies that IsolationOverrideForPath
+// returns the correct mode for a path that matches a configured override.
+func TestIsolationOverrideForPathMatch(t *testing.T) {
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot determine home dir: %v", err)
+	}
+
+	obsidianPath := filepath.Join(home, "documents/obsidian")
+	got := cfg.IsolationOverrideForPath(obsidianPath)
+	if got != config.IsolationHost {
+		t.Errorf("IsolationOverrideForPath(%q): got %q, want %q", obsidianPath, got, config.IsolationHost)
+	}
+}
+
+// TestIsolationOverrideForPathTildeKeyMatch verifies that a "~/" key in
+// ProjectIsolationOverrides matches an already-expanded absolute path.
+func TestIsolationOverrideForPathTildeKeyMatch(t *testing.T) {
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	// The default key "~/documents/obsidian" should match the tilde form too.
+	got := cfg.IsolationOverrideForPath("~/documents/obsidian")
+	if got != config.IsolationHost {
+		t.Errorf("IsolationOverrideForPath(\"~/documents/obsidian\"): got %q, want %q", got, config.IsolationHost)
+	}
+}
+
+// TestIsolationOverrideForPathNoMatch verifies that IsolationOverrideForPath
+// returns "" for a path that does not match any override.
+func TestIsolationOverrideForPathNoMatch(t *testing.T) {
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	got := cfg.IsolationOverrideForPath("/some/other/path")
+	if got != "" {
+		t.Errorf("IsolationOverrideForPath(%q): got %q, want empty string", "/some/other/path", got)
+	}
+}
+
+// TestIsolationOverrideForPathInvalidMode verifies that an override entry with
+// an invalid isolation mode value is silently ignored (returns "").
+func TestIsolationOverrideForPathInvalidMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"project_isolation_overrides": {"~/myproject": "unknown-mode"}}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	got := cfg.IsolationOverrideForPath("~/myproject")
+	if got != "" {
+		t.Errorf("IsolationOverrideForPath(%q): got %q, want empty string (invalid mode ignored)", "~/myproject", got)
+	}
+}
+
+// TestIsolationOverrideForPathEmptyMap verifies that IsolationOverrideForPath
+// returns "" when ProjectIsolationOverrides is empty.
+func TestIsolationOverrideForPathEmptyMap(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"project_isolation_overrides": {}}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	got := cfg.IsolationOverrideForPath("~/documents/obsidian")
+	if got != "" {
+		t.Errorf("IsolationOverrideForPath(%q): got %q, want empty string (empty overrides map)", "~/documents/obsidian", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `project_isolation_overrides` to `config.json` — a map from path strings to isolation mode strings. When a session path matches a key, the override mode is used instead of the machine default.
- The compiled-in default maps `~/documents/obsidian` → `host` so macOS sandbox-exec sessions for the Obsidian vault (TCC-protected) work out of the box without any config.json entry.
- Applies override in `prism switch` (all call sites), `prism restore` (overrides stored DB value), and NOT in `prism spawn` (as specified in the issue).

## Changes

**Go** (`modules/programs/prism/prism/`):
- `internal/config/config.go`: `ProjectIsolationOverrides` field + `IsolationOverrideForPath()` helper + `defaults()` entry + pointer-merge logic
- `cmd/switch.go`: `applyPathIsolationOverride()` helper applied at every `ensureAndSwitch` call site; logs info message when override fires
- `cmd/switch_project.go`: `handleBareRepo`/`handleRegularRepo` accept `cfg` and apply override per worktree path
- `cmd/restore.go`: override applied on top of stored DB `isolation_mode`
- `internal/config/config_test.go`: 9 new tests covering all AC

**Nix** (`modules/programs/prism/`):
- `default.nix`: `nx.programs.prism.projects.isolationOverrides` option (`attrsOf str`, default `{}`)
- `prism-tui.nix`: renders `isolationOverrides` into `config.json` as `project_isolation_overrides`
- `machines/m4mac/configuration.nix`: sets `~/documents/obsidian` → `host`

Closes #1404