### PR TITLE
fix: signing-key.pub symlink in sandbox-exec staging home becomes stale after sops rotation

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -163,11 +163,34 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	if signingKeyName == "" {
 		signingKeyName = "prismatic-koi-ed25519-signingkey"
 	}
-	symlinkIfResolvable(
+	// Use symlinkIfExists (not symlinkIfResolvable) for signing keys so that
+	// the staging HOME symlink points at the stable intermediate sops symlink
+	// (~/.ssh/prismatic-koi-ed25519-signingkey{,.pub}) rather than the
+	// fully-resolved sops temp path (e.g. /private/var/folders/.../secrets.d/271/).
+	//
+	// sops secrets rotate: on darwin-rebuild switch the secrets.d/<N> directory
+	// increments. If the staging HOME symlink points at the fully-resolved
+	// concrete path, it becomes dangling after rotation and git push fails with
+	// "Couldn't load public key … No such file or directory" (issue #1410).
+	//
+	// With symlinkIfExists the chain is:
+	//   <stagingHome>/.ssh/signing-key{,.pub}
+	//     → ~/.ssh/prismatic-koi-ed25519-signingkey{,.pub}   (stable sops symlink)
+	//     → /private/var/folders/.../secrets.d/<current>/... (sops resolves this)
+	//
+	// The SBPL profile already grants (allow file-read* (subpath "/private/var/folders"))
+	// so the sandbox can follow the chain to whatever secrets.d/<N> is current,
+	// even after a rotation that occurred after session spawn.
+	//
+	// Note: symlinkIfResolvable is still used for the access key below because
+	// collectStagingHomeSymlinkTargets resolves the access key symlink to emit
+	// a (literal ...) SBPL rule for it — the access key does not go through
+	// sops and its path does not rotate.
+	symlinkIfExists(
 		filepath.Join(sshDir, signingKeyName),
 		filepath.Join(stagingHome, ".ssh", "signing-key"),
 	)
-	symlinkIfResolvable(
+	symlinkIfExists(
 		filepath.Join(sshDir, signingKeyName+".pub"),
 		filepath.Join(stagingHome, ".ssh", "signing-key.pub"),
 	)

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -182,7 +182,7 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// so the sandbox can follow the chain to whatever secrets.d/<N> is current,
 	// even after a rotation that occurred after session spawn.
 	//
-	// Note: symlinkIfResolvable is still used for the access key below because
+	// Note: symlinkIfResolvable is still used for the access key above because
 	// collectStagingHomeSymlinkTargets resolves the access key symlink to emit
 	// a (literal ...) SBPL rule for it — the access key does not go through
 	// sops and its path does not rotate.

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -889,6 +889,213 @@ func TestPrepareSandboxExecHome_NixCacheAlwaysIncluded(t *testing.T) {
 	}
 }
 
+// TestPrepareSandboxExecHome_SigningKeyUsesIntermediatePath verifies that the
+// signing-key and signing-key.pub symlinks in the staging HOME point at the
+// intermediate ~/.ssh/<name> path (i.e. the stable sops symlink), not the
+// fully-resolved concrete path underneath it. This is the fix for issue #1410:
+// using the intermediate symlink means the staging HOME stays valid across sops
+// rotations (when secrets.d/<N>/ increments), whereas using the resolved path
+// would produce a dangling symlink after the rotation.
+//
+// The access-key symlink is NOT checked here — it still uses symlinkIfResolvable
+// and is expected to point at the resolved real path.
+func TestPrepareSandboxExecHome_SigningKeyUsesIntermediatePath(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// In newFakeHome, the signing key files are plain files directly under
+	// ~/.ssh/. For this test, we simulate the sops-managed layout:
+	// ~/.ssh/prismatic-koi-ed25519-signingkey.pub → a "concrete" sops path,
+	// and later rotate that concrete path.
+	//
+	// We replace the plain files with symlinks that point at a "current" dir,
+	// mimicking secrets.d/271/.
+	sshDir := filepath.Join(fakeHome, ".ssh")
+	sopsDir1 := filepath.Join(fakeHome, "sops-dir-1")
+	if err := os.MkdirAll(sopsDir1, 0o700); err != nil {
+		t.Fatalf("create sops-dir-1: %v", err)
+	}
+	keyPrivPath1 := filepath.Join(sopsDir1, "signing-key")
+	keyPubPath1 := filepath.Join(sopsDir1, "signing-key.pub")
+	if err := os.WriteFile(keyPrivPath1, []byte("priv-v1"), 0o600); err != nil {
+		t.Fatalf("write sops priv key v1: %v", err)
+	}
+	if err := os.WriteFile(keyPubPath1, []byte("pub-v1"), 0o600); err != nil {
+		t.Fatalf("write sops pub key v1: %v", err)
+	}
+
+	// Replace the plain files with symlinks to the "sops v1" concrete paths.
+	intermediatePriv := filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey")
+	intermediatePub := filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub")
+	_ = os.Remove(intermediatePriv)
+	_ = os.Remove(intermediatePub)
+	if err := os.Symlink(keyPrivPath1, intermediatePriv); err != nil {
+		t.Fatalf("symlink intermediate priv: %v", err)
+	}
+	if err := os.Symlink(keyPubPath1, intermediatePub); err != nil {
+		t.Fatalf("symlink intermediate pub: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@signing-key-test",
+		InstanceID:  "signing-key-intermediate-test",
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Verify signing-key.pub symlink points at the INTERMEDIATE path, not the
+	// fully-resolved sops-dir-1/signing-key.pub path.
+	pubLink := filepath.Join(stagingHome, ".ssh", "signing-key.pub")
+	pubTarget, err := os.Readlink(pubLink)
+	if err != nil {
+		t.Fatalf("signing-key.pub is not a symlink: %v", err)
+	}
+	if pubTarget != intermediatePub {
+		t.Errorf("signing-key.pub symlink points at %q, want intermediate path %q\n"+
+			"(the symlink must point at the stable sops intermediate, not the resolved concrete path,\n"+
+			"so it stays valid after a sops rotation)",
+			pubTarget, intermediatePub)
+	}
+
+	// Same for signing-key (private).
+	privLink := filepath.Join(stagingHome, ".ssh", "signing-key")
+	privTarget, err := os.Readlink(privLink)
+	if err != nil {
+		t.Fatalf("signing-key is not a symlink: %v", err)
+	}
+	if privTarget != intermediatePriv {
+		t.Errorf("signing-key symlink points at %q, want intermediate path %q",
+			privTarget, intermediatePriv)
+	}
+
+	// Now simulate a sops rotation: update the intermediate symlinks to point
+	// at a new secrets.d/v2 directory, leaving sops-dir-1 in place but unreachable.
+	sopsDir2 := filepath.Join(fakeHome, "sops-dir-2")
+	if err := os.MkdirAll(sopsDir2, 0o700); err != nil {
+		t.Fatalf("create sops-dir-2: %v", err)
+	}
+	keyPrivPath2 := filepath.Join(sopsDir2, "signing-key")
+	keyPubPath2 := filepath.Join(sopsDir2, "signing-key.pub")
+	if err := os.WriteFile(keyPrivPath2, []byte("priv-v2"), 0o600); err != nil {
+		t.Fatalf("write sops priv key v2: %v", err)
+	}
+	if err := os.WriteFile(keyPubPath2, []byte("pub-v2"), 0o600); err != nil {
+		t.Fatalf("write sops pub key v2: %v", err)
+	}
+	// Rotate: update intermediate symlinks to point at v2.
+	_ = os.Remove(intermediatePriv)
+	_ = os.Remove(intermediatePub)
+	if err := os.Symlink(keyPrivPath2, intermediatePriv); err != nil {
+		t.Fatalf("rotate intermediate priv to v2: %v", err)
+	}
+	if err := os.Symlink(keyPubPath2, intermediatePub); err != nil {
+		t.Fatalf("rotate intermediate pub to v2: %v", err)
+	}
+
+	// After rotation, the staging HOME signing-key.pub still points at
+	// intermediatePub, which now resolves to sops-dir-2. Verify the chain
+	// resolves (os.Stat follows symlinks) and the content is from v2.
+	content, err := os.ReadFile(pubLink)
+	if err != nil {
+		t.Fatalf("cannot read signing-key.pub through staging HOME after rotation: %v\n"+
+			"(this would cause 'Couldn't load public key' in git push — the fix for #1410)", err)
+	}
+	if string(content) != "pub-v2" {
+		t.Errorf("signing-key.pub after rotation: got %q, want %q", string(content), "pub-v2")
+	}
+}
+
+// TestPrepareSandboxExecHome_SigningKeyAbsentNoDanglingSymlink verifies that
+// when the signing key intermediate symlink does not exist (genuinely absent,
+// not just stale), no dangling symlink is created in the staging HOME.
+// This covers AC: "if signing keys are genuinely absent, git push still works
+// — it pushes without signing rather than crashing."
+func TestPrepareSandboxExecHome_SigningKeyAbsentNoDanglingSymlink(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Remove the signing key files from the fake home (simulate absent keys).
+	sshDir := filepath.Join(fakeHome, ".ssh")
+	_ = os.Remove(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey"))
+	_ = os.Remove(filepath.Join(sshDir, "prismatic-koi-ed25519-signingkey.pub"))
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@absent-signing-key",
+		InstanceID:  "signing-key-absent-test",
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Signing key symlinks must NOT exist in staging HOME when source is absent.
+	for _, name := range []string{"signing-key", "signing-key.pub"} {
+		p := filepath.Join(stagingHome, ".ssh", name)
+		if _, err := os.Lstat(p); err == nil {
+			t.Errorf("%s must not exist when source is absent (no dangling symlinks)", name)
+		}
+	}
+}
+
+// TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath verifies that the
+// access-key symlink in the staging HOME still points at the fully-resolved
+// real path (not an intermediate symlink). This is unchanged from the original
+// behaviour — access-key uses symlinkIfResolvable so that the SBPL profile
+// collectStagingHomeSymlinkTargets can emit a (literal ...) rule for it.
+func TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Make the access key file a symlink to a "resolved" path, to ensure
+	// symlinkIfResolvable resolves it fully before creating the staging link.
+	sshDir := filepath.Join(fakeHome, ".ssh")
+	resolvedDir := filepath.Join(fakeHome, "resolved-keys")
+	if err := os.MkdirAll(resolvedDir, 0o700); err != nil {
+		t.Fatalf("create resolved-keys dir: %v", err)
+	}
+	resolvedKey := filepath.Join(resolvedDir, "access-key-real")
+	if err := os.WriteFile(resolvedKey, []byte("access-key-content"), 0o600); err != nil {
+		t.Fatalf("write resolved access key: %v", err)
+	}
+	// Replace the plain access key file with a symlink.
+	_ = os.Remove(filepath.Join(sshDir, "prismatic-koi-ed25519"))
+	if err := os.Symlink(resolvedKey, filepath.Join(sshDir, "prismatic-koi-ed25519")); err != nil {
+		t.Fatalf("symlink access key: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@access-key-test",
+		InstanceID:  "access-key-resolved-test",
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// The access-key symlink should point at the fully-resolved path
+	// (symlinkIfResolvable resolves through the intermediate).
+	accessLink := filepath.Join(stagingHome, ".ssh", "access-key")
+	accessTarget, err := os.Readlink(accessLink)
+	if err != nil {
+		t.Fatalf("access-key is not a symlink: %v", err)
+	}
+	// resolvedKey might itself resolve further on macOS (e.g. /tmp → /private/tmp).
+	expectedTarget, _ := filepath.EvalSymlinks(resolvedKey)
+	if expectedTarget == "" {
+		expectedTarget = resolvedKey
+	}
+	if accessTarget != expectedTarget {
+		t.Errorf("access-key target = %q, want resolved path %q\n"+
+			"(access-key must use symlinkIfResolvable to expose the real path for the SBPL profile)",
+			accessTarget, expectedTarget)
+	}
+}
+
 // TestPrepareSandboxExecHome_PiAgentDirNotSymlinked verifies that
 // PrepareSandboxExecHome no longer creates a ~/.pi/agent symlink — auth files
 // are now copied into the staging dir by StagePIAgentConfigDir instead.

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_signing_key_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_signing_key_darwin_test.go
@@ -1,0 +1,322 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_signing_key_darwin_test.go — integration coverage for the
+// signing-key sops rotation fix (issue #1410).
+//
+// The staging HOME's signing-key.pub symlink now uses symlinkIfExists (not
+// symlinkIfResolvable), so it points at the stable sops intermediate symlink
+// (~/.ssh/prismatic-koi-ed25519-signingkey.pub) rather than the fully-resolved
+// sops temp path. After a sops secrets.d/<N>/ rotation, the staging HOME
+// symlink remains valid because it anchors to the intermediate, not the
+// concrete path.
+//
+// These tests verify that the sandbox can follow the two-hop chain
+//
+//   <stagingHome>/.ssh/signing-key.pub
+//     → <sshIntermediate>                 (simulates the stable sops symlink)
+//     → <concreteFile>                    (simulates secrets.d/<N>/signing-key.pub)
+//
+// and read the final content through sandbox-exec. The concrete file is
+// placed under $HOME (via hostCredentialDir) — not under /private/var/folders/
+// — so that the relevant SBPL rule is the per-symlink (literal ...) emitted by
+// collectStagingHomeSymlinkTargets, not the broad (subpath "/private/var/folders")
+// rule. This makes the negative test meaningful: stripping that (literal ...)
+// line causes the read to fail.
+//
+// Two-hop chain design notes
+// ──────────────────────────
+// The chain traverses two directories outside the staging HOME:
+//
+//   1. The SSH intermediate dir (simulating ~/.ssh/). On Darwin, sandbox-exec
+//      requires file-read-metadata permission to follow symlinks inside a
+//      directory. The production profile grants (subpath HOME) for
+//      file-test-existence and file-read-metadata via the BareRoot ancestor
+//      block, which lets the kernel traverse symlinks in $HOME/.ssh/.
+//      We therefore use newProfileManagerWithBareRoot() to activate this block.
+//
+//   2. The concrete file lives under $HOME (via hostCredentialDir) so the
+//      per-symlink (literal <concrete>) allow rule emitted by
+//      collectStagingHomeSymlinkTargets is the authoritative grant — not the
+//      broader /private/var/folders allow. This makes the negative test
+//      sensitive to removal of that specific literal.
+//
+// Shared helpers: requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
+// preparePositiveProfile, writeAugmentedPositiveProfile, withMutatedProfile,
+// hostCredentialDir, sbplQuoteForTest — all in sandbox_exec_helpers_darwin_test.go.
+//
+// See docs/sandbox-exec-testing.md for the convention these tests support (#1192).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// setupSigningKeyTwoHopChain creates a two-hop symlink chain that simulates
+// the sops-managed signing key layout. It returns:
+//
+//   - sshIntermediateDir: directory that contains the intermediate symlink
+//     (simulates ~/.ssh/)
+//   - concreteFile: the actual key content file (simulates secrets.d/<N>/key.pub)
+//   - intermediateSymlink: path of the intermediate symlink
+//     (<sshIntermediateDir>/prismatic-koi-ed25519-signingkey.pub)
+//
+// Layout:
+//
+//	sshIntermediateDir/prismatic-koi-ed25519-signingkey.pub
+//	  → concreteFile
+//	    (contains sentinel content)
+//
+// The concrete file is placed under $HOME (via hostCredentialDir) so the
+// per-symlink (literal ...) SBPL rule emitted by collectStagingHomeSymlinkTargets
+// is the authoritative read grant — not the broad /private/var/folders allow.
+//
+// The caller is responsible for creating staging HOME symlinks that point
+// at the intermediate symlink (simulating symlinkIfExists behavior).
+func setupSigningKeyTwoHopChain(t *testing.T, sentinel string) (sshIntermediateDir, concreteFile, intermediateSymlink string) {
+	t.Helper()
+
+	// Concrete file under $HOME (not /private/var/folders) so the
+	// per-symlink literal rule is load-bearing for the negative test.
+	concreteDir := hostCredentialDir(t)
+	concreteFile = filepath.Join(concreteDir, "signing-key.pub")
+	if err := os.WriteFile(concreteFile, []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("write concrete signing key file: %v", err)
+	}
+
+	// sshIntermediateDir simulates ~/.ssh/. It must be under HOME so the
+	// BareRoot ancestor block (subpath HOME) provides file-read-metadata,
+	// letting the kernel follow the symlink stored here.
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	sshIntermediateDir, err = os.MkdirTemp(home, ".prism-1410-ssh-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp for sshIntermediateDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sshIntermediateDir) })
+
+	// The intermediate symlink: simulates ~/.ssh/prismatic-koi-ed25519-signingkey.pub
+	intermediateSymlink = filepath.Join(sshIntermediateDir, "prismatic-koi-ed25519-signingkey.pub")
+	if err := os.Symlink(concreteFile, intermediateSymlink); err != nil {
+		t.Fatalf("create intermediate symlink: %v", err)
+	}
+
+	return sshIntermediateDir, concreteFile, intermediateSymlink
+}
+
+// TestSandboxExecSigningKey_TwoHopChainReadable is the positive integration
+// test for the sops-rotation fix (issue #1410).
+//
+// It sets up the two-hop chain:
+//
+//	<stagingHome>/.ssh/signing-key.pub
+//	  → <sshIntermediateDir>/prismatic-koi-ed25519-signingkey.pub  (intermediate)
+//	  → <concreteFile>                                              (final key content)
+//
+// Generates the production SBPL profile, then reads the signing key file
+// via the staging HOME path inside sandbox-exec. Asserts exit 0 and that
+// the sentinel content is visible — confirming the sandbox can follow the
+// full two-hop chain.
+//
+// Uses newProfileManagerWithBareRoot so the BareRoot ancestor block fires
+// and grants file-read-metadata on (subpath HOME), enabling the kernel to
+// traverse the intermediate symlink inside sshIntermediateDir.
+func TestSandboxExecSigningKey_TwoHopChainReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	const sentinel = "ssh-ed25519 AAAA1410 signing-key-sentinel"
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	_, concreteFile, intermediateSymlink := setupSigningKeyTwoHopChain(t, sentinel)
+
+	// Install the staging HOME signing-key.pub symlink → intermediate
+	// (simulating the symlinkIfExists behavior from the #1410 fix).
+	signingKeyLink := filepath.Join(stagingHome, ".ssh", "signing-key.pub")
+	_ = os.Remove(signingKeyLink) // replace whatever PrepareSandboxExecHome placed
+	if err := os.Symlink(intermediateSymlink, signingKeyLink); err != nil {
+		t.Fatalf("create staging signing-key.pub → intermediate: %v", err)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The profile must reference the concrete file (resolved by
+	// collectStagingHomeSymlinkTargets via filepath.EvalSymlinks).
+	resolved, _ := filepath.EvalSymlinks(concreteFile)
+	if resolved == "" {
+		resolved = concreteFile
+	}
+	if !strings.Contains(prepared.content, resolved) {
+		t.Fatalf("generated profile does not reference the resolved concrete signing key path %q.\n"+
+			"collectStagingHomeSymlinkTargets did not pick up the staging signing-key.pub symlink chain.\nProfile:\n%s",
+			resolved, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Read the signing key file from inside the sandbox via the staging HOME
+	// path. The kernel must traverse: signingKeyLink → intermediate → concreteFile.
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", fmt.Sprintf("HOME=%s", stagingHome), nixBash, "-c",
+		"cat "+shQuote(signingKeyLink))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("read signing key via two-hop staging-HOME chain failed under production profile.\n"+
+			"This means the sandbox cannot follow the sops-style symlink chain required by #1410.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), sentinel) {
+		t.Errorf("signing key read succeeded but output does not contain the sentinel.\nOutput: %s", string(out))
+	}
+}
+
+// TestSandboxExecSigningKey_TwoHopChainDeniedWithoutConcreteAllow is the
+// paired negative test. It removes the (literal <concreteFile>) allow line
+// from the profile and asserts that reading the signing key via the staging
+// HOME symlink chain fails.
+//
+// This proves TestSandboxExecSigningKey_TwoHopChainReadable is not green by
+// accident: the read works specifically because of the (literal <concreteFile>)
+// allow emitted by collectStagingHomeSymlinkTargets, not because of a
+// broader rule.
+//
+// The concrete file is under $HOME (not /private/var/folders) so the broad
+// (subpath "/private/var/folders") rule does NOT cover it — only the
+// per-symlink literal allow does. Stripping that literal makes the read
+// fail, confirming the two-hop chain is load-bearing.
+func TestSandboxExecSigningKey_TwoHopChainDeniedWithoutConcreteAllow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	const sentinel = "ssh-ed25519 AAAA1410-neg signing-key-sentinel-neg"
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	_, concreteFile, intermediateSymlink := setupSigningKeyTwoHopChain(t, sentinel)
+
+	signingKeyLink := filepath.Join(stagingHome, ".ssh", "signing-key.pub")
+	_ = os.Remove(signingKeyLink)
+	if err := os.Symlink(intermediateSymlink, signingKeyLink); err != nil {
+		t.Fatalf("create staging signing-key.pub → intermediate: %v", err)
+	}
+
+	// Resolve the concrete path to its canonical form (the same form
+	// generateProfile emits via filepath.EvalSymlinks).
+	resolved, err := filepath.EvalSymlinks(concreteFile)
+	if err != nil {
+		resolved = concreteFile
+	}
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		// Remove the (literal "<resolved>") line from the allow block.
+		// Match only the indented form to avoid accidentally hitting
+		// unrelated occurrences.
+		toRemove := "  (literal " + sbplQuoteForTest(resolved) + ")\n"
+		return strings.ReplaceAll(p, toRemove, "")
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", fmt.Sprintf("HOME=%s", stagingHome), nixBash, "-c",
+		"cat "+shQuote(signingKeyLink))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("signing key read via staging-HOME chain succeeded WITHOUT the (literal ...) allow for the concrete file.\n"+
+			"The negative test is not catching the regression — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — signing key read correctly denied without concrete-file allow (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecSigningKey_DanglingSymlinkFails verifies that a dangling
+// staging HOME symlink (pointing directly at a concrete sops path that has
+// since been rotated away) causes cat to fail — demonstrating why the
+// #1410 fix (pointing at the intermediate instead) is necessary.
+//
+// This is not a profile mutation test; it tests symlink staleness rather
+// than an SBPL rule. It documents the failure mode that the fix prevents
+// and confirms the test suite can detect it.
+func TestSandboxExecSigningKey_DanglingSymlinkFails(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Create a temp "concrete v1" file, point staging home directly at it
+	// (simulating the old symlinkIfResolvable behaviour).
+	home, homeErr := os.UserHomeDir()
+	if homeErr != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", homeErr)
+	}
+	v1Dir, err := os.MkdirTemp(home, ".prism-1410-v1-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp for v1Dir: %v", err)
+	}
+	v1File := filepath.Join(v1Dir, "signing-key.pub")
+	if err := os.WriteFile(v1File, []byte("ssh-ed25519 AAAA1410 v1"), 0o600); err != nil {
+		t.Fatalf("write v1 concrete key: %v", err)
+	}
+
+	// Point staging HOME directly at the concrete v1 path (old behaviour).
+	signingKeyLink := filepath.Join(stagingHome, ".ssh", "signing-key.pub")
+	_ = os.Remove(signingKeyLink)
+	if err := os.Symlink(v1File, signingKeyLink); err != nil {
+		t.Fatalf("create staging signing-key.pub → v1 concrete: %v", err)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Simulate sops rotation: delete v1 dir (key now gone at the concrete path).
+	_ = os.RemoveAll(v1Dir)
+
+	// With a dangling staging HOME symlink, cat must fail.
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", fmt.Sprintf("HOME=%s", stagingHome), nixBash, "-c",
+		"cat "+shQuote(signingKeyLink))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("reading a dangling staging HOME signing-key.pub symlink succeeded — expected failure.\n"+
+			"This means the negative baseline for #1410 is not working correctly.\n"+
+			"Output: %s\nProfile: %s", string(out), testProfilePath)
+	} else {
+		t.Logf("ka pai — dangling symlink correctly causes failure (exit: %v): this is the failure the #1410 fix prevents", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_signing_key_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_signing_key_darwin_test.go
@@ -42,9 +42,12 @@ package integration_test
 //      broader /private/var/folders allow. This makes the negative test
 //      sensitive to removal of that specific literal.
 //
-// Shared helpers: requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
-// preparePositiveProfile, writeAugmentedPositiveProfile, withMutatedProfile,
-// hostCredentialDir, sbplQuoteForTest — all in sandbox_exec_helpers_darwin_test.go.
+// Shared helpers:
+//   - requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
+//     preparePositiveProfile, writeAugmentedPositiveProfile, withMutatedProfile
+//     → sandbox_exec_helpers_darwin_test.go
+//   - hostCredentialDir, sbplQuoteForTest
+//     → sandbox_exec_staging_home_darwin_test.go
 //
 // See docs/sandbox-exec-testing.md for the convention these tests support (#1192).
 


### PR DESCRIPTION
## Summary

- Fixes a bug where `darwin-rebuild switch` rotates the sops `secrets.d/` directory, making the `signing-key.pub` symlink in the sandbox-exec staging HOME dangling — causing git push to fail with \"Couldn't load public key … No such file or directory\".
- Changes `symlinkIfResolvable` → `symlinkIfExists` for signing key symlinks in `PrepareSandboxExecHome`, so the staging HOME symlink points at the stable intermediate sops symlink (`~/.ssh/prismatic-koi-ed25519-signingkey{,.pub}`) rather than the fully-resolved concrete sops temp path.
- The SBPL profile already has `(allow file-read* (subpath \"/private/var/folders\"))` which covers reading through the sops temp dir regardless of which `secrets.d/<N>` rotation number is current.

## How it works

Before this fix, the chain was:
```
<stagingHome>/.ssh/signing-key.pub → /private/var/folders/.../secrets.d/271/... (stale after rotation!)
```

After this fix:
```
<stagingHome>/.ssh/signing-key.pub
  → ~/.ssh/prismatic-koi-ed25519-signingkey.pub   (stable sops intermediate)
  → /private/var/folders/.../secrets.d/<current>/ (sops keeps this current)
```

The access key symlink is unchanged — it still uses `symlinkIfResolvable` so `collectStagingHomeSymlinkTargets` can emit a precise `(literal ...)` SBPL rule for it. The access key is a plain Nix store path that doesn't rotate.

## Tests added

### Unit tests (sandbox_exec_test.go)
- `TestPrepareSandboxExecHome_SigningKeyUsesIntermediatePath`: verifies the staging HOME symlink points at the intermediate path and remains readable after a simulated sops rotation (symlink retarget to a new dir).
- `TestPrepareSandboxExecHome_SigningKeyAbsentNoDanglingSymlink`: verifies no dangling symlink when keys are genuinely absent; git push degrades gracefully (no signing config emitted).
- `TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath`: verifies access-key still uses the fully-resolved path (unchanged behaviour).

### Integration tests (internal/integration/, per docs/sandbox-exec-testing.md convention)
- `TestSandboxExecSigningKey_TwoHopChainReadable` (positive): runs sandbox-exec with a Nix-built binary to read the signing key via the two-hop symlink chain, asserts exit 0.
- `TestSandboxExecSigningKey_TwoHopChainDeniedWithoutConcreteAllow` (negative): removes the `(literal <concrete>)` allow rule, asserts the read fails — proving the positive test is not green by accident.
- `TestSandboxExecSigningKey_DanglingSymlinkFails`: documents the pre-fix failure mode where a stale staging symlink (old symlinkIfResolvable behavior) causes read failure after simulated rotation.

## Out of scope

The bwrap.go (Linux) equivalent of this issue is tracked in #1412 and is out of scope for this PR (which is Darwin/sandbox-exec specific per issue #1410).

Closes #1410