### PR TITLE
fix: remove at-spawn Keychain extraction from sandbox-exec (#1413)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -17,14 +17,11 @@ package cmd
 // non-Darwin via a runtime.GOOS check, so the stub is unreachable in practice.
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -187,33 +184,6 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 
 	if err := validateSandboxExecArgs(args); err != nil {
 		return err
-	}
-
-	// Write Claude Code credentials into the staging HOME.
-	//
-	// In bwrap/podman mode, writeClaudeCredentials() writes a temp file that
-	// is bind-mounted at /root/.claude/.credentials.json inside the container.
-	// sandbox-exec has no bind-mount mechanism, so we write the credentials
-	// directly to $STAGING_HOME/.claude/.credentials.json instead. The staging
-	// HOME's .claude/ is a symlink to the real ~/.claude/, so the write lands
-	// at the host path — which is in the SBPL profile's RW allow set for the
-	// .claude symlink target. On macOS, credentials live in the Keychain and
-	// ~/.claude/.credentials.json is absent or empty; opencode-claude-auth
-	// reads it at startup and fails silently if it is missing.
-	if stagingHomeCreds, credErr := m.SandboxExecHomePath(); credErr == nil && stagingHomeCreds != "" {
-		credsDst := filepath.Join(stagingHomeCreds, ".claude", ".credentials.json")
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		out, keychainErr := exec.CommandContext(ctx, "security", "find-generic-password",
-			"-l", "Claude Code-credentials", "-w").Output()
-		if keychainErr == nil {
-			creds := strings.TrimSpace(string(out))
-			if creds != "" {
-				if writeErr := os.WriteFile(credsDst, []byte(creds), 0o600); writeErr != nil {
-					log.Printf("agent-run: sandbox-exec: write claude credentials: %v", writeErr)
-				}
-			}
-		}
 	}
 
 	// Build the env for sandbox-exec. The slice is K=V pairs (os/exec uses the

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -221,9 +221,6 @@ func (s *sandboxExecIsolator) Prepare(ctx context.Context, m *Manager) ([]string
 	}
 	_ = stagingHome // consumed by generateProfile via m.sandboxExecHomePath()
 
-	// On Darwin, extract Claude Code credentials from the Keychain.
-	m.writeClaudeCredentials()
-
 	if _, err := writeProfile(m); err != nil {
 		return nil, err
 	}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -12,10 +12,10 @@ package container
 // Design decisions locked by the coordinator in issue #1017:
 //
 //  1. .claude/ is a symlink to host ~/.claude (matches bwrap's RW treatment at
-//     bwrap.go:306-308). On Darwin this means writeClaudeCredentials() extracts
-//     to its existing temp path, and the file is reachable inside the sandbox
-//     at $HOME/.claude/.credentials.json via the symlink. On Darwin, writes to
-//     .credentials.json flow through the symlink to the host's ~/.claude/.credentials.json.
+//     bwrap.go:306-308). On Darwin, opencode-claude-auth calls the Keychain API
+//     (Mach IPC) directly from inside the sandbox — no pre-seeded credentials
+//     file is needed. Writes to .credentials.json (e.g. token refreshes) flow
+//     through the symlink to the host's ~/.claude/.credentials.json.
 //     This is the accepted trade-off (simplest, matches bwrap's RW treatment).
 //
 //  2. .config/opencode/agents/ is role-conditional: included as a symlink for
@@ -237,16 +237,15 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	)
 
 	// ── .claude/ — symlink to host ~/.claude (RW write-through) ──────────────
-	// On Darwin, opencode-claude-auth writes .credentials.json inside
-	// ~/.claude/. Since this is a symlink to host ~/.claude, writes inside
-	// the sandbox flow through to the host's ~/.claude/.credentials.json.
-	// This is the accepted trade-off: simplest, matches bwrap's RW bind of
-	// ~/.claude at bwrap.go:306-308. On Linux, ~/.claude/.credentials.json
-	// already lives there; no Keychain extraction is needed.
-	// Darwin-specific: writeClaudeCredentials() below extracts from Keychain
-	// to a temp path (m.claudeCredentialsFilePath()), which is reachable at
-	// $HOME/.claude/.credentials.json via this symlink (because the temp path
-	// equals the host's ~/.claude/.credentials.json location via write-through).
+	// On Darwin, opencode-claude-auth calls the Keychain API (Mach IPC)
+	// directly from inside the sandbox — no pre-seeded credentials file is
+	// needed at spawn time. Token refreshes performed by opencode-claude-auth
+	// during a session write .credentials.json inside ~/.claude/, and since
+	// this is a symlink to host ~/.claude, those writes flow through to the
+	// host path and are immediately reflected in subsequent sessions.
+	// On Linux, ~/.claude/.credentials.json already lives on disk; the bwrap
+	// path bind-mounts ~/.claude/ with RW access (bwrap.go:306-308), matching
+	// the same write-through semantics via a different mechanism.
 	symlinkIfExists(
 		filepath.Join(home, ".claude"),
 		filepath.Join(stagingHome, ".claude"),

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
@@ -499,6 +499,55 @@ func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 	}
 }
 
+// TestSandboxExecIntegration_KeychainAPIAccessible verifies that the macOS
+// Keychain Services API (Mach IPC) is accessible from inside the sandbox-exec
+// profile. The test invokes /usr/bin/security find-generic-password for the
+// "Claude Code-credentials" service inside the sandbox and asserts that the
+// command does not fail with a sandbox deny.
+//
+// The Keychain API operates over Mach IPC (securityd/secd), not direct file
+// access. The SBPL profile grants mach-lookup and network*, so the API is
+// reachable from inside the sandbox even when direct file reads of
+// ~/Library/Keychains/ are denied (see TestSandboxExecIntegration_KeychainDenied).
+//
+// A missing Keychain entry (exit 44 from security, meaning "item not found")
+// is treated as a successful API call — the test skips gracefully when the
+// "Claude Code-credentials" entry is absent so that CI hosts without a Claude
+// login still pass. This is the regression guard ensuring that
+// opencode-claude-auth can call the Keychain API directly from inside the
+// sandbox (issue #1413).
+func TestSandboxExecIntegration_KeychainAPIAccessible(t *testing.T) {
+	if !sandboxExecAvailable() {
+		t.Skip("sandbox-exec not available")
+	}
+	if _, err := os.Stat("/usr/bin/security"); err != nil {
+		t.Skip("/usr/bin/security not present")
+	}
+
+	m, stagingHome := newIntegrationManager(t)
+	profilePath := writeProfileForIntegration(t, m)
+
+	out, code := runUnderSandbox(t, profilePath, baseEnv(stagingHome),
+		"/usr/bin/security", "find-generic-password", "-l", "Claude Code-credentials", "-w")
+
+	// exit 0: credentials found — Keychain API accessible and entry present.
+	// exit 44: "item not found" — Keychain API accessible but entry absent.
+	// Any other exit (e.g. sandbox deny producing "Operation not permitted") is a failure.
+	const securityItemNotFound = 44
+	switch code {
+	case 0:
+		// Credentials retrieved successfully — Keychain API is accessible.
+	case securityItemNotFound:
+		// Entry absent from host Keychain. API is still accessible — skip so
+		// the test does not require a Claude login to pass.
+		t.Skipf("Claude Code-credentials entry absent from host Keychain — Keychain API is accessible inside sandbox (security exit 44); skipping")
+	default:
+		// Unexpected exit. A sandbox deny would produce "Operation not permitted"
+		// in stderr. Treat any other code as a failure.
+		t.Errorf("Keychain API call inside sandbox: expected exit 0 or 44 (item not found), got %d\noutput: %s\n(A sandbox deny produces 'Operation not permitted')", code, out)
+	}
+}
+
 // TestSandboxExecIntegration_DocumentsDenied verifies that a file under
 // ~/Documents is NOT readable from inside the sandbox (N5 in F.1 §3.2).
 func TestSandboxExecIntegration_DocumentsDenied(t *testing.T) {


### PR DESCRIPTION
## Summary

On Darwin, sandbox-exec sessions were extracting Claude OAuth credentials from the Keychain at spawn time via `security find-generic-password` and writing them to `$STAGING_HOME/.claude/.credentials.json`. This caused auth expiry because the snapshot went stale when `opencode-claude-auth` refreshed the token during a long session.

The Keychain Services API (Mach IPC via securityd/secd) is accessible from inside the sandbox-exec profile, so `opencode-claude-auth` can call the Keychain API directly during the session without any pre-seeded file.

## Changes

- **`internal/container/lifecycle_dispatch.go`**: Remove `m.writeClaudeCredentials()` call from `sandboxExecIsolator.Prepare()` — the temp file it wrote was never bind-mounted for sandbox-exec (only bwrap uses that path)
- **`cmd/agent_run_sandbox_exec_darwin.go`**: Remove the `security find-generic-password` block that wrote credentials to `$STAGING_HOME/.claude/.credentials.json` at spawn time
- **`internal/container/sandbox_exec_home.go`**: Update stale comments around the `.claude/` symlink setup to describe the new direct-Keychain model
- **`internal/container/sandbox_exec_integration_test.go`**: Add `TestSandboxExecIntegration_KeychainAPIAccessible` — a regression guard that verifies the Keychain API is accessible inside the sandbox profile; skips gracefully when the `Claude Code-credentials` Keychain entry is absent

The bwrap/podman credential extraction path (`writeClaudeCredentials`, `claudeCredentialsReady`, the bind-mount in `buildRunArgs`) is **unchanged** — those containers genuinely cannot access the Keychain.

Closes #1413