### PR TITLE
mergequeue: detect review-required BLOCKED state and notify coordinator

### DIFF
--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -173,6 +173,7 @@ Once the sense-check passes, enqueue the PR in the merge queue and continue with
    - **`PR #N merged...`** — `git pull` in @main, then `prism cleanup --yes --session <worker-session>`.
    - **`PR #N has merge conflicts...`** — `prism prompt <worker-session>` to rebase and push, then `prism merge <number>` again.
    - **`PR #N CI failed...`** — `prism prompt <worker-session>` to investigate and fix, then `prism merge <number>` again.
+   - **`PR #N is blocked — human reviewer approval required...`** — request a human review on the PR (e.g. `gh pr review --request <user>`); once approved, `prism merge <number>` again.
    - **`PR #N was closed without merging...`** — typically nothing; the PR was closed deliberately.
 3. Use `prism merges` to inspect the current queue at any time.
 

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -235,6 +235,7 @@ When a queued PR reaches a terminal outcome, the watcher delivers a bus notifica
 | Merge conflicts | `PR #N has merge conflicts — worker rebase needed` |
 | CI failure | `PR #N CI failed — needs worker fix` |
 | Closed without merging | `PR #N was closed without merging — removed from queue` |
+| Review required | `PR #N is blocked — human reviewer approval required before merge` |
 | Other merge failure | `PR #N merge failed: <error>` |
 | Coordinator session ended while watching | Row transitions to `abandoned` — surfaces via `prism merges list --abandoned` only; no live notification. |
 
@@ -248,6 +249,7 @@ When a merge-queue notification arrives, treat it as high-priority (same as a wo
 | `merge conflicts` | `prism prompt <worker-session>` asking it to rebase onto main and push; re-enqueue with `prism merge <pr>` after the worker finishes |
 | `CI failed` | `prism prompt <worker-session>` asking it to investigate the failed check, fix, and push; re-enqueue with `prism merge <pr>` |
 | `closed without merging` | Usually nothing — the PR was closed deliberately. Investigate if unexpected. |
+| `blocked — human reviewer approval required` | Request a human review on the PR (e.g. via `gh pr review --request <user>`). Once approved, re-enqueue with `prism merge <pr>`. |
 | `merge failed: <error>` | Read the error, decide whether to retry (`prism merge <pr>`) or escalate to the user. |
 | `abandoned` (via `--abandoned` listing) | A new coordinator decides whether to re-enqueue with `prism merge <pr>`. |
 

--- a/modules/programs/prism/prism/docs/architecture-inventory.md
+++ b/modules/programs/prism/prism/docs/architecture-inventory.md
@@ -262,7 +262,7 @@ counted with `wc -l` over `*.go` and `*_test.go` files at the directory level
   queue for the sidecar's session_name and drives PRs through the merge
   lifecycle using the GitHub CLI: CLEAN → gh pr merge --squash; BEHIND → gh
   pr update-branch; DIRTY → fail with 'merge conflicts'; BLOCKED → fail on CI
-  failure, keep watching otherwise; Others → keep watching (transient). On
+  failure or review required, keep watching otherwise; Others → keep watching (transient). On
   each terminal outcome (merged, failed, closed) a bus notification is
   delivered to the enqueuing coordinator session via the opencode HTTP API.
   The notification text names the PR, includes the worker session's archive
@@ -1979,7 +1979,7 @@ For each top-level prism subcommand, the function chain and side-effects.
 
 **Function chain (cancel):** `cmd/merges.go:mergesCancelCmd → runMergesCancel → (proxy to host-API when in bwrap) → db.CancelMerge`.
 
-**Function chain (the watcher inside coordinator sidecar):** `internal/sidecar/sidecar.go:Run → mergequeue.New(db, instanceID, sessionName, httpClient).Run(ctx) → poll loop → db.MergeQueueHead → exec.CommandContext(ctx, "gh", "pr", "view", …) → branch on mergeable_state: CLEAN→gh pr merge --squash, BEHIND→gh pr update-branch, DIRTY→fail, BLOCKED→fail-on-CI or keep watching → on terminal: db.TerminateMerge + bus notification via opencode HTTP API`.
+**Function chain (the watcher inside coordinator sidecar):** `internal/sidecar/sidecar.go:Run → mergequeue.New(db, instanceID, sessionName, httpClient).Run(ctx) → poll loop → db.MergeQueueHead → exec.CommandContext(ctx, "gh", "pr", "view", …) → branch on mergeable_state: CLEAN→gh pr merge --squash, BEHIND→gh pr update-branch, DIRTY→fail, BLOCKED→fail-on-CI-or-review-required or keep watching → on terminal: db.TerminateMerge + bus notification via opencode HTTP API`.
 
 **Side-effects:**
 

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -7,7 +7,7 @@
 //   - CLEAN   → gh pr merge --squash
 //   - BEHIND  → gh pr update-branch
 //   - DIRTY   → fail with "merge conflicts"
-//   - BLOCKED → fail on CI failure, keep watching otherwise
+//   - BLOCKED → fail on CI failure or review required, keep watching otherwise
 //   - Others  → keep watching (transient)
 //
 // On each terminal outcome (merged, failed, closed) a bus notification is
@@ -212,11 +212,13 @@ func (w *Watcher) tick(ctx context.Context) {
 		w.failAndNotify(head, "merge conflicts")
 
 	case "BLOCKED":
-		// Disambiguate: CI failure vs. still running / required review.
+		// Disambiguate: CI failure, review required, or still running.
 		if hasCIFailure(prInfo.StatusCheckRollup) {
 			w.failAndNotify(head, "CI failed")
+		} else if prInfo.ReviewDecision == "REVIEW_REQUIRED" {
+			w.failAndNotify(head, "human reviewer approval required before merge")
 		} else {
-			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure — staying watching", head.PR)
+			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure or review requirement — staying watching", head.PR)
 		}
 
 	case "UNSTABLE", "UNKNOWN", "HAS_HOOKS", "DRAFT":
@@ -292,6 +294,8 @@ func (w *Watcher) failAndNotify(head *db.PendingMerge, errMsg string) {
 		notifyText = fmt.Sprintf("PR #%d CI failed — needs worker fix", head.PR)
 	case "PR was closed without merging":
 		notifyText = fmt.Sprintf("PR #%d was closed without merging — removed from queue", head.PR)
+	case "human reviewer approval required before merge":
+		notifyText = fmt.Sprintf("PR #%d is blocked — human reviewer approval required before merge", head.PR)
 	default:
 		notifyText = fmt.Sprintf("PR #%d merge failed: %s", head.PR, errMsg)
 	}
@@ -422,7 +426,7 @@ func buildNotifyBody(text string, status *db.Status) map[string]any {
 // the field list never regresses to use the (invalid) "merged" field again —
 // `gh pr view` rejects unknown JSON fields with a non-zero exit, so an invalid
 // field name silently breaks the entire merge-queue watcher (see #1014 fallout).
-const prInfoJSONFields = "state,mergedAt,mergeStateStatus,statusCheckRollup"
+const prInfoJSONFields = "state,mergedAt,mergeStateStatus,statusCheckRollup,reviewDecision"
 
 // prInfo holds the fields we care about from `gh pr view --json`.
 type prInfo struct {
@@ -430,6 +434,9 @@ type prInfo struct {
 	MergedAt          *string      `json:"mergedAt"`
 	MergeStateStatus  string       `json:"mergeStateStatus"`
 	StatusCheckRollup []checkEntry `json:"statusCheckRollup"`
+	// ReviewDecision is the PR's review decision from GitHub: "REVIEW_REQUIRED",
+	// "APPROVED", "CHANGES_REQUESTED", or "" (empty when no review policy exists).
+	ReviewDecision string `json:"reviewDecision"`
 }
 
 // isMerged reports whether the PR has been merged. `gh pr view` emits

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -511,6 +511,8 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 	case "BLOCKED":
 		if hasCIFailure(prInfoVal.StatusCheckRollup) {
 			fw.watcher.failAndNotify(head, "CI failed")
+		} else if prInfoVal.ReviewDecision == "REVIEW_REQUIRED" {
+			fw.watcher.failAndNotify(head, "human reviewer approval required before merge")
 		}
 
 	case "UNSTABLE", "UNKNOWN", "HAS_HOOKS", "DRAFT":
@@ -767,6 +769,179 @@ func TestWatcher_BLOCKEDWithoutCIFailureStaysWatching(t *testing.T) {
 	}
 	if row.Status != "watching" {
 		t.Errorf("status: got %q, want watching (no CI failure)", row.Status)
+	}
+}
+
+// TestWatcher_BLOCKEDWithReviewRequired transitions to failed with the review
+// notification message when reviewDecision is "REVIEW_REQUIRED" and CI is passing.
+func TestWatcher_BLOCKEDWithReviewRequired(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-review"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-review")
+
+	if _, err := d.EnqueueMerge(555, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "SUCCESS"}},
+				ReviewDecision:    "REVIEW_REQUIRED",
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	// Row must have transitioned to failed.
+	row, err := d.PendingMergeByPR(555)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+	if row.Error == nil || *row.Error != "human reviewer approval required before merge" {
+		t.Errorf("error: got %v, want 'human reviewer approval required before merge'", row.Error)
+	}
+
+	// Notification must have been sent and contain the expected text.
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(srv.lastBody, &body); err != nil {
+		t.Fatalf("unmarshal notification body: %v", err)
+	}
+	parts, _ := body["parts"].([]interface{})
+	if len(parts) == 0 {
+		t.Fatal("notification body has no parts")
+	}
+	part, _ := parts[0].(map[string]interface{})
+	text, _ := part["text"].(string)
+	if !strings.Contains(text, "PR #555") {
+		t.Errorf("notification text %q does not contain 'PR #555'", text)
+	}
+	if !strings.Contains(text, "human reviewer approval required before merge") {
+		t.Errorf("notification text %q does not contain review-required message", text)
+	}
+}
+
+// TestWatcher_BLOCKEDCIFailureNotMisdiagnosedAsReviewRequired verifies that
+// a BLOCKED PR with a CI failure and REVIEW_REQUIRED reviewDecision is
+// diagnosed as CI failure (CI check takes precedence) — or more precisely,
+// that CI failure is checked first and is not suppressed by reviewDecision.
+func TestWatcher_BLOCKEDCIFailureNotMisdiagnosedAsReviewRequired(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-cifirst"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-cifirst")
+
+	if _, err := d.EnqueueMerge(444, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "FAILURE"}},
+				ReviewDecision:    "REVIEW_REQUIRED",
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	// Row must be failed with "CI failed" (CI check takes precedence).
+	row, err := d.PendingMergeByPR(444)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+	if row.Error == nil || *row.Error != "CI failed" {
+		t.Errorf("error: got %v, want 'CI failed'", row.Error)
+	}
+}
+
+// TestWatcher_BLOCKEDReviewRequiredIsReEnqueueable verifies the edge-case AC:
+// after a terminal "review required" failure, the coordinator can re-enqueue
+// the same PR with prism merge and the new row starts as watching.
+func TestWatcher_BLOCKEDReviewRequiredIsReEnqueueable(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-reenqueue"
+	session := "myrepo@main"
+
+	// First enqueue and fail with review-required.
+	if _, err := d.EnqueueMerge(666, session, instanceID, nil); err != nil {
+		t.Fatalf("first EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(666, "failed", "human reviewer approval required before merge"); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+
+	// Re-enqueue — simulates coordinator running `prism merge <pr>` after approval.
+	m, err := d.EnqueueMerge(666, session, instanceID, nil)
+	if err != nil {
+		t.Fatalf("second EnqueueMerge: %v", err)
+	}
+	if m.Status != "watching" {
+		t.Errorf("re-enqueued status: got %q, want watching", m.Status)
+	}
+	if m.Error != nil {
+		t.Errorf("re-enqueued error: got %v, want nil", m.Error)
+	}
+}
+
+// TestWatcher_BLOCKEDNoReviewDecisionNoCI stays watching (CI still running case).
+func TestWatcher_BLOCKEDNoReviewDecisionNoCIStaysWatching(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-nostatus"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(777, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			// No CI failure, no review requirement — e.g. CI still running.
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "PENDING"}},
+				ReviewDecision:    "",
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(777)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching", row.Status)
 	}
 }
 
@@ -1146,13 +1321,20 @@ func TestPRInfoJSONFields_NoMergedField(t *testing.T) {
 		}
 	}
 	hasMergedAt := false
+	hasReviewDecision := false
 	for _, f := range fields {
 		if f == "mergedAt" {
 			hasMergedAt = true
 		}
+		if f == "reviewDecision" {
+			hasReviewDecision = true
+		}
 	}
 	if !hasMergedAt {
 		t.Errorf("prInfoJSONFields must include 'mergedAt' to detect merged state. Got: %q", prInfoJSONFields)
+	}
+	if !hasReviewDecision {
+		t.Errorf("prInfoJSONFields must include 'reviewDecision' to detect review-required blocks (#1357). Got: %q", prInfoJSONFields)
 	}
 }
 
@@ -1232,7 +1414,7 @@ func TestWatcher_RunGHPassesRepoFlag(t *testing.T) {
 			calls = append(calls, snap)
 			// Tailor the response so each method completes its happy path.
 			if len(args) >= 4 && args[2] == "pr" && args[3] == "view" {
-				return []byte(`{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN","statusCheckRollup":[]}`), nil
+				return []byte(`{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN","statusCheckRollup":[],"reviewDecision":""}`), nil
 			}
 			// merge / update-branch return empty success.
 			return nil, nil


### PR DESCRIPTION
## Summary

When `prism merge <pr>` enqueues a PR into a repo that requires human reviewer approval, the watcher was polling forever because `BLOCKED` with no CI failure had no terminal path. This PR adds the missing disambiguation.

### Changes

- **`prInfoJSONFields`** — adds `reviewDecision` to the GraphQL fields fetched via `gh pr view --json`
- **`prInfo` struct** — adds `ReviewDecision string` field
- **`BLOCKED` case** — after the existing CI-failure check, adds a second check: if `reviewDecision == "REVIEW_REQUIRED"`, calls `failAndNotify` with `"human reviewer approval required before merge"`
- **`failAndNotify`** — adds a notification message case that formats the coordinator notification as `PR #N is blocked — human reviewer approval required before merge`
- **Tests** — four new tests covering: the happy path (BLOCKED+REVIEW_REQUIRED → fail+notify), CI-takes-precedence over reviewDecision, re-enqueueability after terminal failure, and the stay-watching fallthrough when neither CI nor review-required

The CI failure check continues to take precedence. Other BLOCKED causes (CI still running, other branch protections) remain in the watching fallthrough.

Closes #1357