### PR TITLE
docs: document bwrap signing key sops rotation safety (investigation for #1412)

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -373,6 +373,39 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	if signingKeyName == "" {
 		signingKeyName = "prismatic-koi-ed25519-signingkey"
 	}
+	// Note on sops rotation and Linux bind-mount inode semantics (issue #1412):
+	//
+	// On NixOS, the signing key is managed by sops-nix. The symlink chain is:
+	//   ~/.ssh/prismatic-koi-ed25519-signingkey
+	//     → /run/secrets/ssh/prismatic-koi-ed25519-signingkey   (stable sops intermediate)
+	//     → /run/secrets.d/<N>/ssh/prismatic-koi-ed25519-signingkey  (concrete sops file)
+	//
+	// sops-nix's pruneGenerations removes old secrets.d/<N>/ directories on
+	// nixos-rebuild switch (keepGenerations = 1 by default). This raised the
+	// question of whether EvalSymlinks here is fragile — mirroring the Darwin
+	// sandbox-exec fix in PR #1411.
+	//
+	// On Linux, bwrap bind-mounts are inode-based, not path-based:
+	//   1. filepath.EvalSymlinks resolves to /run/secrets.d/<N>/ssh/signingkey.
+	//   2. The kernel bind-mount (MS_BIND) increments the inode's reference count.
+	//   3. When pruneGenerations removes secrets.d/<N>/, it unlinks the directory
+	//      entries but cannot free the inodes as long as any reference exists.
+	//   4. The bwrap sandbox's bind mount holds that reference — the file remains
+	//      readable inside the sandbox for the duration of the session.
+	//   5. After the session exits and the bind mount is released, the inode is
+	//      freed (refcount drops to 0). No memory leak.
+	//
+	// For new sessions spawned after a rotation, filepath.EvalSymlinks resolves
+	// to the new /run/secrets.d/<N+1>/ path — so new sessions are always correct.
+	//
+	// This is fundamentally different from the Darwin/sandbox-exec case: SBPL
+	// profile rules are path-based (evaluated at each file access), so a stale
+	// concrete path in the profile causes every access to fail after rotation.
+	// bwrap bind mounts are inode-based, so they survive the rotation cleanly.
+	//
+	// EvalSymlinks is therefore the correct approach here — no fix is needed.
+	// The fix in sandbox_exec_home.go (symlinkIfExists vs symlinkIfResolvable)
+	// does not apply to bwrap for this reason.
 	signingKeyResolved, errPriv := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName))
 	signingKeyPubResolved, errPub := filepath.EvalSymlinks(filepath.Join(sshDir, signingKeyName+".pub"))
 	if errPriv == nil && errPub == nil {


### PR DESCRIPTION
## Summary

Investigated the bwrap/Linux equivalent of the sandbox-exec signing-key rotation bug fixed in #1411. Concluded that the issue is **not a real bug** on Linux due to kernel inode reference semantics. Added documentation comments to `bwrap.go` explaining the investigation findings.

## Investigation findings

### 1. Does sops-nix on NixOS remove old `secrets.d/<N>/` dirs on rotation?

**Yes.** The `pruneGenerations` function in sops-nix (with the default `keepGenerations = 1`) removes old `secrets.d/<N>/` directories after rotation. The symlink chain on NixOS is:

```
~/.ssh/prismatic-koi-ed25519-signingkey
  → /run/secrets/ssh/prismatic-koi-ed25519-signingkey   (stable sops intermediate)
  → /run/secrets.d/<N>/ssh/prismatic-koi-ed25519-signingkey  (concrete sops file)
```

### 2. Is a dangling `--ro-bind` source a hard error in bwrap?

**No — and this is the key difference from Darwin/sandbox-exec.**

On Linux, `--ro-bind SRC DST` creates a kernel bind mount (`mount(2)` with `MS_BIND`). The kernel increments the inode's reference count when creating the bind mount. When sops-nix's `pruneGenerations` removes `secrets.d/<N>/` (via `os.RemoveAll`), it unlinks the directory entries — but cannot free the inodes until all references are dropped. The bwrap sandbox's bind mount holds that reference, so the signing key file remains fully readable inside the sandbox for the entire session lifetime. When the session exits and the bind mount is released, the inode is freed normally.

This is fundamentally different from the Darwin case: SBPL profile rules are path-based (evaluated at each file access), so a stale concrete path in the profile causes every file access to fail after rotation. Linux bind mounts are inode-based, so they survive the rotation cleanly.

### 3. Do long-lived bwrap sessions exist in practice?

**Yes**, agent sessions can span hours and could in principle overlap with a `nixos-rebuild switch`. However, due to the inode retention semantics above, this does not cause any functional breakage.

### 4. Can the `os.Stat` / intermediate-path approach from #1411 be applied to bwrap?

**No.** In sandbox-exec, the staging HOME uses symlinks that are followed dynamically at access time within the sandbox (SBPL profile allows the concrete path). In bwrap, `--ro-bind SRC DST` resolves symlinks in `SRC` at mount creation time (the kernel's `mount(2)` follows symlinks). Passing the intermediate symlink path `~/.ssh/signingkey` to `--ro-bind` produces exactly the same bind as passing the `filepath.EvalSymlinks` result — both end up binding the concrete inode. There is no equivalent mechanism in bwrap to mount a "stable intermediate symlink" that gets re-evaluated after rotation.

## Conclusion

The `filepath.EvalSymlinks` approach in `bwrap.go` is correct for Linux. No code fix is needed. The PR adds documentation comments to `bwrap.go` explaining these findings for future reference.

Closes #1412