### PR TITLE
fix(pi): set PI_OFFLINE=1 in RuntimeEnv to suppress telemetry in bwrap sessions

### DIFF
--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -201,8 +201,12 @@ func (a *Adapter) ConfigEnvVar() string {
 }
 
 // RuntimeEnv returns additional environment variables needed by the PI process.
+// PI_OFFLINE=1 suppresses telemetry and update-check network calls, matching
+// the behaviour of the host shell alias that always sets this variable.
 func (a *Adapter) RuntimeEnv() map[string]string {
-	return map[string]string{}
+	return map[string]string{
+		"PI_OFFLINE": "1",
+	}
 }
 
 // ValidateAgentRole reports whether the given role is supported by PI.

--- a/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
@@ -8,6 +8,36 @@ import (
 	"github.com/prismatic-koi/prism/internal/payload"
 )
 
+// ── RuntimeEnv ────────────────────────────────────────────────────────────────
+
+func TestRuntimeEnv_ContainsPIOffline(t *testing.T) {
+	a := pi.New("", "", "")
+	env := a.RuntimeEnv()
+	if env == nil {
+		t.Fatal("RuntimeEnv() returned nil")
+	}
+	val, ok := env["PI_OFFLINE"]
+	if !ok {
+		t.Error("RuntimeEnv() missing PI_OFFLINE")
+	}
+	if val != "1" {
+		t.Errorf("PI_OFFLINE = %q, want %q", val, "1")
+	}
+}
+
+func TestRuntimeEnv_ReturnsNewMapEachCall(t *testing.T) {
+	a := pi.New("", "", "")
+	env1 := a.RuntimeEnv()
+	env2 := a.RuntimeEnv()
+	// Mutating the returned map should not affect subsequent calls.
+	env1["NEW_KEY"] = "value"
+	if _, ok := env2["NEW_KEY"]; ok {
+		t.Error("RuntimeEnv() returned the same map instance — mutations leak across calls")
+	}
+}
+
+// ── NormaliseFrame ────────────────────────────────────────────────────────────
+
 func TestNormaliseFrame_MsgAssistant(t *testing.T) {
 	a := pi.New("", "", "")
 	raw := []byte(`{"type":"message_complete","id":"msg-abc","role":"assistant","content":[{"type":"text","text":"Hello world"}],"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":5},"model":"claude-sonnet-4-5","provider":"anthropic","elapsed_ms":1234}`)


### PR DESCRIPTION
## Summary

- `(*Adapter).RuntimeEnv()` was returning an empty map, so `PI_OFFLINE=1` was never injected into sandboxed bwrap PI sessions.
- Changed `RuntimeEnv()` to return `{"PI_OFFLINE": "1"}`, matching the host shell alias behaviour that always sets this variable to suppress telemetry/update-check network calls.
- Added two unit tests: one asserting the key is present with the correct value, and one asserting successive calls return distinct map instances (no shared state).

Closes #1417