### PR TITLE
fix: prism spawn harness always forwarded as opencode via proxy

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -128,6 +128,8 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		return err
 	}
 
+	harnessChanged := cmd.Flags().Changed("harness")
+
 	// Abtest path: POST with abtest field and parse two session names from response.
 	if len(abtestFlag) == 2 {
 		var resp struct {
@@ -139,9 +141,13 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 			"agent":                  agentFlag,
 			"model":                  modelFlag,
 			"variant":                variantFlag,
-			"harness":                harnessFlag,
 			"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 			"abtest":                 abtestFlag,
+		}
+		// Only forward "harness" when explicitly set. When absent, the host-side
+		// spawn derives the harness from the profile slot as designed (#1421).
+		if harnessChanged {
+			body["harness"] = harnessFlag
 		}
 		if isolationChanged {
 			body["isolation"] = isolationFlag
@@ -176,7 +182,6 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"profile":                profileFlag,
 		"model":                  modelFlag,
 		"variant":                variantFlag,
-		"harness":                harnessFlag,
 		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 	}
 	if len(modelOverrideFlag) > 0 {
@@ -189,6 +194,11 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 				body["model_variant_overrides"] = string(encoded)
 			}
 		}
+	}
+	// Only forward "harness" when explicitly set. When absent, the host-side
+	// spawn derives the harness from the profile slot as designed (#1421).
+	if harnessChanged {
+		body["harness"] = harnessFlag
 	}
 	// Only forward "isolation" when explicitly set. An empty value would tell
 	// the host-side spawn to fall back to config.json, which is correct only

--- a/modules/programs/prism/prism/cmd/spawn_harness_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_harness_test.go
@@ -5,8 +5,8 @@ package cmd
 // Coverage:
 //   - runSpawn rejects unknown harness values before any state is created
 //   - runSpawn accepts "opencode" (explicitly or as default)
-//   - proxySpawn forwards the harness field to the host-API /spawn endpoint
-//   - Container-mode (PRISM_HOST_API set): harness forwarded correctly
+//   - proxySpawn forwards the harness field only when explicitly set (#1421)
+//   - proxySpawn omits the harness field when --harness is not explicitly passed (#1421)
 
 import (
 	"encoding/json"
@@ -197,21 +197,18 @@ func TestProxySpawn_HarnessForwarded(t *testing.T) {
 	}
 }
 
-// TestProxySpawn_HarnessDefaultForwarded verifies that when --harness is not
-// explicitly set (defaults to "opencode"), the default value is still forwarded
-// to the host-API in the JSON body.
-func TestProxySpawn_HarnessDefaultForwarded(t *testing.T) {
-	type spawnReq struct {
-		Branch  string `json:"branch"`
-		Harness string `json:"harness"`
-	}
-
-	reqCh := make(chan spawnReq, 1)
+// TestProxySpawn_HarnessAbsentWhenNotExplicit verifies that when --harness is
+// not explicitly set (i.e. the user did not pass the flag), the harness field
+// is absent from the JSON body sent to the host-API. This allows the host-side
+// spawn to derive the harness from the profile slot as designed (#1421).
+func TestProxySpawn_HarnessAbsentWhenNotExplicit(t *testing.T) {
+	// Use a raw map to detect field presence vs. zero-value absence.
+	reqCh := make(chan map[string]any, 1)
 
 	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
-		var req spawnReq
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		reqCh <- req
+		var raw map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		reqCh <- raw
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"session_name":"nixos-config@default-harness"}`))
@@ -227,16 +224,16 @@ func TestProxySpawn_HarnessDefaultForwarded(t *testing.T) {
 	addPromptFlags(cmd)
 
 	_ = cmd.Flags().Set("branch", "default-harness")
-	// harness stays at default ("opencode")
+	// harness stays at default ("opencode") but is NOT explicitly changed
 
 	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
 		t.Fatalf("proxySpawn: %v", err)
 	}
 
 	select {
-	case req := <-reqCh:
-		if req.Harness != "opencode" {
-			t.Errorf("harness = %q, want %q (default)", req.Harness, "opencode")
+	case raw := <-reqCh:
+		if _, present := raw["harness"]; present {
+			t.Errorf("harness field present in request body when --harness was not explicitly passed; got %v", raw["harness"])
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for request")

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -792,16 +792,17 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 				}
 			}
 		}
-		// Validate harness before spawning. Default empty string to "opencode"
-		// for backwards compatibility with clients that don't send the field.
-		if req.Harness == "" {
-			req.Harness = "opencode"
-		}
-		if _, ok := harness.Lookup(req.Harness); !ok {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf(
-				"unknown harness %q: valid harnesses: %s",
-				req.Harness, strings.Join(harness.Names(), ", ")))
-			return
+		// Validate harness before spawning. An empty string means the client
+		// did not pass --harness explicitly; the host-side spawn will derive
+		// the harness from the profile slot as designed (#1421). Only validate
+		// when the field is non-empty.
+		if req.Harness != "" {
+			if _, ok := harness.Lookup(req.Harness); !ok {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf(
+					"unknown harness %q: valid harnesses: %s",
+					req.Harness, strings.Join(harness.Names(), ", ")))
+				return
+			}
 		}
 		// Validate isolation server-side as defence-in-depth (the client
 		// already validated, but a non-prism client could send anything).
@@ -858,7 +859,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		for role, model := range modelsByRole {
 			args = append(args, "--model-override", role+"="+model)
 		}
-		args = append(args, "--harness", req.Harness)
+		// Only pass --harness when the client explicitly set it. When absent,
+		// the host-side spawn derives the harness from the profile slot (#1421).
+		if req.Harness != "" {
+			args = append(args, "--harness", req.Harness)
+		}
 		args = append(args, "--repo", ownRepo)
 
 		// Log without the prompt value — it may contain sensitive context.
@@ -889,7 +894,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		for role, model := range modelsByRole {
 			logArgs = append(logArgs, "--model-override", role+"="+model)
 		}
-		logArgs = append(logArgs, "--harness", req.Harness)
+		if req.Harness != "" {
+			logArgs = append(logArgs, "--harness", req.Harness)
+		}
 		logArgs = append(logArgs, "--repo", ownRepo)
 		log.Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
 		cmd := exec.Command(prismBinary(), args...)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -6836,10 +6836,11 @@ echo "session \"${last}@harness-branch\" created"
 	}
 }
 
-// TestHostAPI_Spawn_MissingHarnessDefaultsToOpencode verifies that when the
-// harness field is absent from the request, the server defaults to "opencode"
-// and the spawn proceeds without error.
-func TestHostAPI_Spawn_MissingHarnessDefaultsToOpencode(t *testing.T) {
+// TestHostAPI_Spawn_MissingHarnessNotForwarded verifies that when the harness
+// field is absent from the request, the server does NOT pass --harness to the
+// host-side spawn. This allows the host-side spawn to derive the harness from
+// the profile slot as designed (#1421).
+func TestHostAPI_Spawn_MissingHarnessNotForwarded(t *testing.T) {
 	d := openTestDB(t)
 
 	argsFile := filepath.Join(t.TempDir(), "captured-args")
@@ -6867,20 +6868,21 @@ echo "session \"${last}@no-harness-branch\" created"
 	}
 	sc := New(cfg)
 
-	// No "harness" field in request body — must default to "opencode".
+	// No "harness" field in request body — host-side spawn must not receive --harness.
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
 		`{"branch":"no-harness-branch"}`)
 	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 for missing harness (default opencode); body = %s", rr.Code, rr.Body.String())
+		t.Fatalf("status = %d, want 200 for missing harness; body = %s", rr.Code, rr.Body.String())
 	}
 
 	capturedArgs, err := os.ReadFile(argsFile)
 	if err != nil {
 		t.Fatalf("read captured args: %v", err)
 	}
-	// The spawned prism binary must have received --harness opencode.
-	if !strings.Contains(string(capturedArgs), "--harness opencode") {
-		t.Errorf("captured args %q do not contain '--harness opencode' (harness was not defaulted or forwarded)", string(capturedArgs))
+	// When harness is absent from the proxy request, --harness must NOT be forwarded
+	// so the host-side spawn can derive it from the profile slot (#1421).
+	if strings.Contains(string(capturedArgs), "--harness") {
+		t.Errorf("captured args %q contain '--harness' but harness was not sent in the proxy request body", string(capturedArgs))
 	}
 }
 


### PR DESCRIPTION
## Summary

- `proxySpawn` was unconditionally including `harness` in the JSON body using the cobra flag default `"opencode"`, even when the user never passed `--harness`.
- The host-API `/spawn` handler then always passed `--harness opencode` explicitly to the host-side `prism spawn`, causing `cmd.Flags().Changed("harness")` to be `true` on the host side and bypassing the profile-slot harness resolution.
- This meant spawning from a bwrap coordinator session always produced an opencode agent, ignoring the profile's declared harness (e.g. `pi` for `anthropic-pi`).

## Changes

**`cmd/spawn.go` — `proxySpawn`:** Only include `harness` in the request body when `cmd.Flags().Changed("harness")` is true. Follows the existing pattern used for `isolation`.

**`internal/sidecar/host_api.go` — `/spawn` handler:** Remove the `req.Harness = "opencode"` default. Gate the `--harness` arg append on `req.Harness != ""` so the host-side spawn can derive the harness from the profile slot when the field is absent.

**Tests updated:** Existing tests that asserted the old (broken) behaviour updated to assert the new correct behaviour. New test `TestProxySpawn_HarnessAbsentWhenNotExplicit` added to cover the proxy path.

Closes #1421