### PR TITLE
fix(bwrap/pi): remove --no-session and fix sessions dir mount path

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -622,21 +622,17 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	}
 
 	// ── PI session persistence dir (read-write, conditional, pi only) ────────
-	// PI stores session state as JSONL files at ~/.local/share/pi/sessions/
-	// <harness_session_id>/. This directory must be bind-mounted read-write so
-	// that PI can write session files inside the sandbox and the host-side
-	// archiver (internal/harness/pi/archive.go) can read them after the session
-	// exits. Currently PIInvocation always passes --no-session which suppresses
-	// PI's native session persistence, so no active writes occur — but the
-	// mount must be present for when --no-session is removed or made conditional.
-	// Without it, PI would get ENOENT writing sessions inside the sandbox and
-	// the host-side archiver would never see those files.
+	// PI stores OAuth session state at ~/.pi/agent/sessions/. This directory
+	// must be bind-mounted read-write so that PI can load existing OAuth tokens
+	// inside the sandbox and write back refreshed tokens. Without the mount,
+	// PI's anthropic-oauth extension receives null from getApiKey and the
+	// session fails with "No Anthropic auth available."
 	//
 	// Conditional: only emitted when the directory exists on the host. When
 	// absent (e.g. a fresh install before any PI session has run), the mount is
 	// silently omitted and the session starts normally.
 	if cfg.Harness == "pi" {
-		piSessionsDir := filepath.Join(home, ".local", "share", "pi", "sessions")
+		piSessionsDir := filepath.Join(home, ".pi", "agent", "sessions")
 		if _, err := os.Stat(piSessionsDir); err == nil {
 			args = append(args, "--bind", piSessionsDir, piSessionsDir)
 		}

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -2661,14 +2661,14 @@ func bwrapPIFixture(t *testing.T) (m *Manager, fakeHome string, cleanup func()) 
 }
 
 // TestBwrapBuildArgs_PISessionsDirBoundWhenExists verifies that when
-// ~/.local/share/pi/sessions exists on the host and cfg.Harness == "pi",
+// ~/.pi/agent/sessions exists on the host and cfg.Harness == "pi",
 // BuildArgs emits --bind SRC SRC for the directory (read-write).
 func TestBwrapBuildArgs_PISessionsDirBoundWhenExists(t *testing.T) {
 	m, fakeHome, cleanup := bwrapPIFixture(t)
 	defer cleanup()
 
 	// Create the PI sessions directory under the fake HOME.
-	piSessionsDir := filepath.Join(fakeHome, ".local", "share", "pi", "sessions")
+	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
 	if err := os.MkdirAll(piSessionsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll pi sessions dir: %v", err)
 	}
@@ -2682,13 +2682,13 @@ func TestBwrapBuildArgs_PISessionsDirBoundWhenExists(t *testing.T) {
 }
 
 // TestBwrapBuildArgs_PISessionsDirOmittedWhenAbsent verifies that when
-// ~/.local/share/pi/sessions does not exist on the host, BuildArgs does NOT
+// ~/.pi/agent/sessions does not exist on the host, BuildArgs does NOT
 // emit --bind for it — the session must start without error.
 func TestBwrapBuildArgs_PISessionsDirOmittedWhenAbsent(t *testing.T) {
 	m, fakeHome, cleanup := bwrapPIFixture(t)
 	defer cleanup()
 
-	piSessionsDir := filepath.Join(fakeHome, ".local", "share", "pi", "sessions")
+	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
 	// Do NOT create piSessionsDir — it should be absent from args.
 
 	b := &bwrapIsolator{name: m.name}
@@ -2713,7 +2713,7 @@ func TestBwrapBuildArgs_PISessionsDirNotBoundForNonPI(t *testing.T) {
 
 	// Create the PI sessions directory so the stat() would succeed if the
 	// code were wrong.
-	piSessionsDir := filepath.Join(fakeHome, ".local", "share", "pi", "sessions")
+	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
 	if err := os.MkdirAll(piSessionsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll pi sessions dir: %v", err)
 	}
@@ -2733,7 +2733,7 @@ func TestBwrapBuildArgs_PISessionsDirBindBeforeTerminator(t *testing.T) {
 	m, fakeHome, cleanup := bwrapPIFixture(t)
 	defer cleanup()
 
-	piSessionsDir := filepath.Join(fakeHome, ".local", "share", "pi", "sessions")
+	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
 	if err := os.MkdirAll(piSessionsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll pi sessions dir: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -65,7 +65,6 @@ const (
 //	--model    <cfg.PIModel>              (when non-empty)
 //	--thinking <cfg.PIThinking>           (when non-empty)
 //	--extension <extensionPath>           (always; path is derived from cfg)
-//	--no-session                          (prism manages session state)
 //	<cfg.InitialPrompt>                   (bare positional arg, when non-empty)
 //
 // The system prompt is delivered via PI_CODING_AGENT_DIR (set in the bwrap
@@ -98,9 +97,6 @@ func PIInvocation(cfg Config) []string {
 	}
 	extensionSandboxPath := filepath.Join(extensionSandboxDir, piExtensionFilename)
 	args = append(args, "--extension", extensionSandboxPath)
-
-	// PI manages its own session continuity; prism owns session state.
-	args = append(args, "--no-session")
 
 	if cfg.InitialPrompt != "" {
 		args = append(args, cfg.InitialPrompt)

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -35,8 +35,10 @@ func TestPIInvocation_BasicFlags(t *testing.T) {
 			t.Errorf("expected %q %q in args; got %v", flag, val, args)
 		}
 	}
-	if !hasArg(args, "--no-session") {
-		t.Error("expected --no-session in args")
+	// --no-session must NOT appear — PI must use its native OAuth session
+	// persistence so that spawned sessions can authenticate with Anthropic.
+	if hasArg(args, "--no-session") {
+		t.Errorf("--no-session must not appear in PIInvocation args; got %v", args)
 	}
 	// --append-system-prompt must NOT appear — system prompt is delivered via
 	// PI_CODING_AGENT_DIR / APPEND_SYSTEM.md, not via a CLI flag.

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -6,11 +6,16 @@ package pi
 // "JSONL files with a tree structure (parent/child IDs for branching)").
 // Unlike opencode, PI has no SQLite database — it is a pure flat-file store.
 //
-// Source path layout (best-effort based on RFC #606; confirmed at PI session time):
+// Source path layout (confirmed via PI_CODING_AGENT_SESSION_DIR env var and
+// PI's --help which shows "~/.pi/agent/sessions/" as the export example path):
 //
-//   ~/.local/share/pi/sessions/<harness_session_id>/
+//   ~/.pi/agent/sessions/<harness_session_id>/
 //       session.jsonl        — the full conversation transcript
 //       [additional *.jsonl files per branch or compaction round]
+//
+// The PI_CODING_AGENT_DIR defaults to ~/.pi/agent and session storage is a
+// subdirectory of it. The XDG path ~/.local/share/pi/sessions/ does NOT
+// exist — it was incorrectly assumed in issue #1419.
 //
 // Archive copies all *.jsonl files from the session directory into raw/.
 // Export normalises the raw JSONL to pi-mono v3 session.jsonl (currently a
@@ -41,7 +46,9 @@ func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
 
 // SourcePath returns the host-side PI session directory for the session.
 //
-// PI stores sessions under $HOME/.local/share/pi/sessions/<harness_session_id>/.
+// PI stores sessions under $HOME/.pi/agent/sessions/<harness_session_id>/.
+// This matches PI_CODING_AGENT_DIR (defaults to ~/.pi/agent) with the sessions/
+// subdirectory appended, and is confirmed by PI's own --help example path.
 // The harness_session_id is populated at session-create time when PI starts.
 // When HarnessSessionID is empty (PI failed to start), SourcePath returns the
 // sessions root directory; the caller handles the missing-directory case.
@@ -50,7 +57,7 @@ func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, er
 	if err != nil {
 		return "", fmt.Errorf("pi archive: resolve home: %w", err)
 	}
-	sessionsRoot := filepath.Join(home, ".local", "share", "pi", "sessions")
+	sessionsRoot := filepath.Join(home, ".pi", "agent", "sessions")
 	if p.HarnessSessionID == "" {
 		return sessionsRoot, nil
 	}

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -21,7 +21,7 @@ func TestArchiveAdapter_SourcePath_WithHarnessSessionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SourcePath: %v", err)
 	}
-	want := filepath.Join(home, ".local", "share", "pi", "sessions", "sess-abc-123")
+	want := filepath.Join(home, ".pi", "agent", "sessions", "sess-abc-123")
 	if got != want {
 		t.Errorf("SourcePath: want %q got %q", want, got)
 	}
@@ -36,7 +36,7 @@ func TestArchiveAdapter_SourcePath_EmptyHarnessSessionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SourcePath: %v", err)
 	}
-	want := filepath.Join(home, ".local", "share", "pi", "sessions")
+	want := filepath.Join(home, ".pi", "agent", "sessions")
 	if got != want {
 		t.Errorf("SourcePath (empty ID): want %q got %q", want, got)
 	}


### PR DESCRIPTION
## Summary

Two bugs caused spawned pi sessions to fail with "No Anthropic auth available. Run /login anthropic.":

1. **`PIInvocation` unconditionally appended `--no-session`** — this suppressed pi's native OAuth session persistence. Without it, pi's anthropic-oauth extension receives null from `getApiKey` and the session cannot authenticate.

2. **Wrong sessions dir mounted** — PR #1420 added a bind mount for `~/.local/share/pi/sessions/` but pi actually stores its OAuth session state at `~/.pi/agent/sessions/`. The old path doesn't exist on the host so the mount was silently skipped.

## Changes

- `internal/container/pi_invocation.go`: Remove `--no-session` from `PIInvocation` so pi can load and refresh OAuth tokens from its native session store.
- `internal/container/bwrap.go`: Fix the sessions dir mount path from `~/.local/share/pi/sessions` to `~/.pi/agent/sessions` (read-write, conditional on directory existence).
- `internal/container/pi_invocation_test.go`: Update test to assert `--no-session` is absent (was: present).
- `internal/container/bwrap_test.go`: Update all four sessions-dir mount tests to use the correct `~/.pi/agent/sessions` path.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #1423