### PR TITLE
fix: fall back to auth.json when per-session OAuth store is empty

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -114,8 +114,11 @@ export default function (pi: ExtensionAPI) {
       login: loginAnthropic,
       // pi-specific: refreshToken is called by pi when tokens are near expiry
       refreshToken: refreshAnthropicToken,
-      // pi-specific: getApiKey extracts the bearer token from stored credentials
-      getApiKey: (credentials: OAuthCredentials) => credentials.access,
+      // pi-specific: getApiKey extracts the bearer token from stored credentials.
+      // Fall back to auth.json when the per-session credential store is empty
+      // (e.g. new bwrap sessions that have never run /login anthropic).
+      getApiKey: (credentials: OAuthCredentials) =>
+        credentials.access || getCachedCredentials()?.accessToken || null,
     } as unknown as ProviderConfig["oauth"],
 
     // pi-specific: streamSimple wraps the Anthropic messages endpoint with:


### PR DESCRIPTION
## Summary

When pi is launched in a fresh bwrap sandbox (new `prism spawn` or `prism switch` session), the per-session credential store is always empty. `getApiKey` returned `credentials.access` directly, which was null, causing `streamSimple` to throw "No Anthropic auth available" before ever consulting `auth.json`.

The fix: fall back to `getCachedCredentials()` (which reads `~/.pi/agent/auth.json`, already bind-mounted into the sandbox) when `credentials.access` is falsy.

```typescript
getApiKey: (credentials: OAuthCredentials) =>
    credentials.access || getCachedCredentials()?.accessToken || null,
```

- When `credentials.access` is non-empty (persistent sessions like `nixos-config@main`), it is returned directly — no change in behaviour.
- When `credentials.access` is empty (fresh bwrap sessions), `getCachedCredentials()` provides the token from `auth.json`.
- When both are absent/unreadable, returns `null` and pi shows the login prompt rather than crashing.

`getCachedCredentials` was already imported in `index.ts` — no new imports required.

All 11 existing tests pass (`credentials.test.ts` + `auth.test.ts`). NixOS build verified clean.

Closes #1425