### PR TITLE
fix: writeCredentials() now includes type: "oauth" and repairs corrupted auth.json

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
@@ -22,6 +22,7 @@ import { join } from "node:path"
 import {
   readCredentials,
   writeCredentials,
+  repairCredentials,
 } from "./credentials.ts"
 
 let tempDir: string
@@ -132,5 +133,98 @@ describe("writeCredentials", () => {
     writeCredentials({ accessToken: "z", refreshToken: "w", expiresAt: 0 })
     const data = JSON.parse(readFileSync(nested, "utf-8"))
     assert.equal(data.anthropic.access, "z")
+  })
+
+  it("writes type: 'oauth' in the anthropic entry", () => {
+    const expires = Date.now() + 3_600_000
+    writeCredentials({ accessToken: "a", refreshToken: "r", expiresAt: expires })
+
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.equal(data.anthropic.type, "oauth")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readCredentials back-compat: missing type field
+// ---------------------------------------------------------------------------
+
+describe("readCredentials back-compat", () => {
+  it("returns valid credentials when anthropic entry has no type field", () => {
+    const expires = Date.now() + 3_600_000
+    // Simulate a corrupted entry written by older versions of writeCredentials()
+    writeFileSync(
+      authJson,
+      JSON.stringify({
+        anthropic: { access: "acc", refresh: "ref", expires },
+      }),
+      "utf-8",
+    )
+    const creds = readCredentials()
+    assert.ok(creds !== null, "should return credentials even without type field")
+    assert.equal(creds.accessToken, "acc")
+    assert.equal(creds.refreshToken, "ref")
+    assert.equal(creds.expiresAt, expires)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// repairCredentials tests
+// ---------------------------------------------------------------------------
+
+describe("repairCredentials", () => {
+  it("adds type: 'oauth' to an anthropic entry that is missing it", () => {
+    const expires = Date.now() + 3_600_000
+    writeFileSync(
+      authJson,
+      JSON.stringify({
+        anthropic: { access: "acc", refresh: "ref", expires },
+        "github-copilot": { type: "oauth", refresh: "gh-ref" },
+      }),
+      "utf-8",
+    )
+
+    repairCredentials()
+
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.equal(data.anthropic.type, "oauth")
+    // Original fields must be preserved
+    assert.equal(data.anthropic.access, "acc")
+    assert.equal(data.anthropic.refresh, "ref")
+    assert.equal(data.anthropic.expires, expires)
+    // Other top-level keys must be untouched
+    assert.deepEqual(data["github-copilot"], { type: "oauth", refresh: "gh-ref" })
+  })
+
+  it("leaves an anthropic entry that already has type: 'oauth' unchanged", () => {
+    const expires = Date.now() + 3_600_000
+    const original = {
+      anthropic: { type: "oauth", access: "acc", refresh: "ref", expires },
+    }
+    writeFileSync(authJson, JSON.stringify(original), "utf-8")
+
+    repairCredentials()
+
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.equal(data.anthropic.type, "oauth")
+    assert.equal(data.anthropic.access, "acc")
+    assert.equal(data.anthropic.refresh, "ref")
+    assert.equal(data.anthropic.expires, expires)
+  })
+
+  it("is a no-op when auth.json is absent", () => {
+    // File doesn't exist — should not throw
+    assert.doesNotThrow(() => repairCredentials())
+  })
+
+  it("is a no-op when auth.json has no anthropic key", () => {
+    writeFileSync(
+      authJson,
+      JSON.stringify({ "github-copilot": { type: "oauth" } }),
+      "utf-8",
+    )
+    repairCredentials()
+    // File should be unchanged
+    const data = JSON.parse(readFileSync(authJson, "utf-8"))
+    assert.ok(!("anthropic" in data))
   })
 })

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
@@ -137,7 +137,6 @@ export function repairCredentials(): void {
     // Entry exists but lacks type: "oauth" — repair it in place
     log("credentials_repair", { path: authPath })
     provider.type = "oauth"
-    data.anthropic = provider
     writeFileSync(authPath, JSON.stringify(data, null, 2), {
       encoding: "utf-8",
       mode: 0o600,

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
@@ -96,6 +96,7 @@ export function writeCredentials(creds: ClaudeCredentials): void {
   }
 
   existing.anthropic = {
+    type: "oauth",
     access: creds.accessToken,
     refresh: creds.refreshToken,
     expires: creds.expiresAt,
@@ -113,6 +114,44 @@ export function writeCredentials(creds: ClaudeCredentials): void {
     chmodSync(authPath, 0o600)
   }
   log("credentials_write_ok", { path: authPath })
+}
+
+/**
+ * One-time data repair: if auth.json contains an anthropic entry without
+ * type: "oauth", write it back with the field added. This self-heals existing
+ * installations that were corrupted by older versions of writeCredentials().
+ * Safe to call on every startup — a no-op when the entry is already correct
+ * or absent.
+ */
+export function repairCredentials(): void {
+  const authPath = getAuthJsonPath()
+  try {
+    if (!existsSync(authPath)) return
+    const raw = readFileSync(authPath, "utf-8").trim()
+    if (!raw) return
+    const data = JSON.parse(raw) as Record<string, unknown>
+    const provider = data.anthropic as Record<string, unknown> | undefined
+    if (!provider) return
+    if (provider.type === "oauth") return // already correct, nothing to do
+
+    // Entry exists but lacks type: "oauth" — repair it in place
+    log("credentials_repair", { path: authPath })
+    provider.type = "oauth"
+    data.anthropic = provider
+    writeFileSync(authPath, JSON.stringify(data, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    })
+    if (process.platform !== "win32") {
+      chmodSync(authPath, 0o600)
+    }
+    log("credentials_repair_ok", { path: authPath })
+  } catch (err) {
+    log("credentials_repair_error", {
+      path: authPath,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
 }
 
 /**

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -27,7 +27,7 @@ import {
   refreshAnthropicToken,
   isClaudeOAuthAccessToken,
 } from "./auth.ts"
-import { getCachedCredentials } from "./credentials.ts"
+import { getCachedCredentials, repairCredentials } from "./credentials.ts"
 import { transformBody, transformResponseStream } from "./transforms.ts"
 import { streamSimpleAnthropic } from "@mariozechner/pi-ai"
 import { getModelBetas, getExcludedBetas } from "./betas.ts"
@@ -99,6 +99,8 @@ function getUserAgent(): string {
 export default function (pi: ExtensionAPI) {
   initLogger()
   log("extension_init", { version: config.ccVersion })
+
+  repairCredentials()
 
   ensureClaudeCodeSymlink()
   const models = getAnthropicModels()


### PR DESCRIPTION
## Summary

- `writeCredentials()` in `credentials.ts` now includes `type: "oauth"` in the anthropic entry it writes to `auth.json`, matching the schema that pi's `AuthStorage` requires to recognise OAuth credentials.
- New `repairCredentials()` function self-heals existing corrupted installations on startup — if `auth.json` contains an `anthropic` entry without `type: "oauth"`, it is repaired in-place so every subsequent fresh pi process can authenticate without user intervention.
- `index.ts` calls `repairCredentials()` during extension init, after `initLogger()` and before `pi.registerProvider()`.
- `credentials.test.ts` adds 6 new tests covering: `writeCredentials()` emitting `type: "oauth"`, `readCredentials()` back-compat when type is absent, and all four `repairCredentials()` scenarios.

## Root cause

Pi's `AuthStorage` discriminates on `cred?.type === "oauth"` to enter the OAuth refresh branch. Our extension's `writeCredentials()` was not writing this field, so every token refresh call overwrote the entry without it. Every fresh pi process spawned after a refresh would find the entry, see no `type`, fall through to `undefined`, and fail with "No Anthropic auth available."

## Tests

All 15 tests pass (`node --test credentials.test.ts`):
- 5 existing `readCredentials` tests ✔
- 5 existing `writeCredentials` tests ✔ (including new `type: "oauth"` assertion)
- 1 new `readCredentials back-compat` test ✔
- 4 new `repairCredentials` tests ✔

Closes #1427