### PR TITLE
fix(pi-extension): don't emit session_shutdown on turn completion

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -1271,17 +1271,27 @@ describe("shouldAttemptConnect", () => {
 // resolveTurnEndSignal (turn_end state-change resolver)
 // ---------------------------------------------------------------------------
 
-describe("resolveTurnEndSignal — finished", () => {
-  it("returns 'finished' when stopReason=stop, idle, no pending, not reviewing", () => {
+describe("resolveTurnEndSignal — clean stop (idle, no pending, not reviewing)", () => {
+  it("returns 'idle' (not 'finished') when stopReason=stop, idle, no pending, not reviewing", () => {
+    // AC: clean turn end now emits state_change{idle}; sidecar idle debounce
+    // converts that to StateFinished + notifyCoordinator() without closing the pipe.
+    // This prevents /new and /resume from hitting ECONNRESET (fix for #1432).
     assert.equal(
+      resolveTurnEndSignal("stop", true, false, false),
+      "idle",
+    )
+  })
+
+  it("never returns 'finished'", () => {
+    // 'finished' has been removed from TurnEndSignal; turn_end never emits it.
+    assert.notEqual(
       resolveTurnEndSignal("stop", true, false, false),
       "finished",
     )
   })
 
   it("returns 'none' when stopReason=stop but hasPendingMessages=true", () => {
-    // AC: stop + pending messages → agent has more work queued, NOT finished.
-    // hasPendingMessages also suppresses idle emission (same as old behaviour).
+    // AC: stop + pending messages → agent has more work queued; no idle emitted.
     assert.equal(
       resolveTurnEndSignal("stop", true, true, false),
       "none",
@@ -1289,7 +1299,7 @@ describe("resolveTurnEndSignal — finished", () => {
   })
 
   it("returns 'none' when stopReason=stop but isIdle=false", () => {
-    // Session is still streaming — not idle, cannot be finished
+    // Session is still streaming — not idle; no state change emitted.
     assert.equal(
       resolveTurnEndSignal("stop", false, false, false),
       "none",
@@ -1297,7 +1307,7 @@ describe("resolveTurnEndSignal — finished", () => {
   })
 
   it("returns 'none' when stopReason=stop and pendingReviewCall=true", () => {
-    // AC: in reviewing state — do not emit finished; agent awaits review-complete
+    // AC: in reviewing state — do not emit idle; agent awaits review-complete.
     assert.equal(
       resolveTurnEndSignal("stop", true, false, true),
       "none",
@@ -1330,12 +1340,13 @@ describe("resolveTurnEndSignal — interrupted", () => {
 })
 
 describe("resolveTurnEndSignal — toolUse", () => {
-  it("does NOT return 'finished' when stopReason=toolUse", () => {
-    // AC: turn ended to execute tools, agent is not done — no finished emitted.
-    // In practice isIdle=false when toolUse fires, but even if idle, not finished.
-    assert.notEqual(
+  it("returns 'idle' when stopReason=toolUse and idle (unusual but possible)", () => {
+    // toolUse + idle is unusual in practice (tool execution follows toolUse stops)
+    // but the function doesn't discriminate on stopReason for the idle path.
+    // 'finished' is never returned by resolveTurnEndSignal.
+    assert.equal(
       resolveTurnEndSignal("toolUse", true, false, false),
-      "finished",
+      "idle",
     )
   })
 
@@ -1356,11 +1367,12 @@ describe("resolveTurnEndSignal — toolUse", () => {
 })
 
 describe("resolveTurnEndSignal — length", () => {
-  it("does NOT return 'finished' when stopReason=length", () => {
-    // AC: context limit hit, agent may continue — no finished emitted.
-    assert.notEqual(
+  it("returns 'idle' when stopReason=length and idle (context limit, may continue)", () => {
+    // length + idle — context limit was hit but no further work is pending.
+    // 'finished' is never returned by resolveTurnEndSignal.
+    assert.equal(
       resolveTurnEndSignal("length", true, false, false),
-      "finished",
+      "idle",
     )
   })
 
@@ -1402,6 +1414,14 @@ describe("resolveTurnEndSignal — idle (non-stop reasons that are idle)", () =>
     assert.equal(
       resolveTurnEndSignal(undefined, false, false, false),
       "none",
+    )
+  })
+
+  it("returns 'idle' for stopReason=toolUse when idle and no pending", () => {
+    // toolUse + idle is unusual in practice but must still produce idle.
+    assert.equal(
+      resolveTurnEndSignal("toolUse", true, false, false),
+      "idle",
     )
   })
 })
@@ -1456,14 +1476,90 @@ describe("resolveAgentEndSignal — non-review session (always no-op)", () => {
   })
 })
 
-describe("resolveAgentEndSignal — double-emission guard (sessionShutdownEmitted)", () => {
-  it("returns 'finished' for review + stop regardless of guard (guard is caller responsibility)", () => {
-    // The sessionShutdownEmitted guard is checked by the caller (the agent_end hook
-    // in the extension factory), not by this pure helper. Verify the helper itself
-    // consistently returns 'finished' for stop — the caller gates on the flag.
+describe("resolveAgentEndSignal — idempotency (sessionShutdownEmitted guard removed)", () => {
+  it("returns 'finished' for review + stop on every call (guard was caller responsibility, now removed)", () => {
+    // The sessionShutdownEmitted flag has been removed from the extension factory
+    // (fix for #1432). The helper itself is pure and returns 'finished' on every
+    // call for review + stop; the agent_end hook in the factory calls it at most
+    // once per session so double-emission is not possible.
     assert.equal(resolveAgentEndSignal(true, "stop"), "finished")
-    // A second call still returns 'finished'; the factory will skip emission because
-    // sessionShutdownEmitted is already true in that code path.
     assert.equal(resolveAgentEndSignal(true, "stop"), "finished")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix #1432: turn_end never emits session_shutdown for non-review sessions
+// ---------------------------------------------------------------------------
+//
+// These tests verify the signal-level contract that the turn_end handler
+// (via resolveTurnEndSignal) never produces a path that would close the pipe.
+// The sidecar's idle debounce (added in #1429) handles the coordinator
+// notification after receiving state_change{idle}.
+
+describe("#1432: turn_end does not close pipe on clean task completion", () => {
+  it("stopReason=stop, idle, no pending, non-review → 'idle' (not 'finished', no pipe close)", () => {
+    // AC: resolveTurnEndSignal returns 'idle' so the turn_end handler only
+    // emits state_change{idle}. It never emits session_shutdown or closes the
+    // writer, keeping the pipe open for /new and /resume reconnects.
+    assert.equal(resolveTurnEndSignal("stop", true, false, false), "idle")
+  })
+
+  it("turn_end result is never 'finished' for any input combination", () => {
+    // 'finished' has been removed from TurnEndSignal; exhaustive spot-check.
+    const inputs: Array<[string | undefined, boolean, boolean, boolean]> = [
+      ["stop", true, false, false],
+      ["stop", true, false, true],
+      ["stop", false, false, false],
+      ["stop", true, true, false],
+      ["toolUse", true, false, false],
+      ["length", true, false, false],
+      ["error", true, false, false],
+      [undefined, true, false, false],
+      ["aborted", true, false, false],
+    ]
+    for (const [stopReason, isIdle, hasPending, pendingReview] of inputs) {
+      assert.notEqual(
+        resolveTurnEndSignal(stopReason, isIdle, hasPending, pendingReview),
+        "finished",
+        `expected not 'finished' for (${stopReason}, ${isIdle}, ${hasPending}, ${pendingReview})`,
+      )
+    }
+  })
+
+  it("stopReason=aborted → 'interrupted' (pipe stays open for reconnect)", () => {
+    // AC: interrupted session does not emit session_shutdown; pipe stays open.
+    assert.equal(resolveTurnEndSignal("aborted", true, false, false), "interrupted")
+    assert.equal(resolveTurnEndSignal("aborted", false, false, false), "interrupted")
+  })
+
+  it("hasPendingMessages=true suppresses idle emission (agent continues)", () => {
+    // AC: pending messages → agent has more work; no state change emitted.
+    assert.equal(resolveTurnEndSignal("stop", true, true, false), "none")
+    assert.equal(resolveTurnEndSignal(undefined, true, true, false), "none")
+  })
+
+  it("pendingReviewCall=true suppresses idle emission (agent awaits review)", () => {
+    // AC: review in flight → do not transition to idle.
+    assert.equal(resolveTurnEndSignal("stop", true, false, true), "none")
+  })
+})
+
+describe("#1432: review session agent_end still emits full shutdown sequence", () => {
+  it("resolveAgentEndSignal returns 'finished' for review + stop", () => {
+    // AC: review-session agent_end must still emit state_change{finished}
+    // + session_shutdown + writer.close().
+    assert.equal(resolveAgentEndSignal(true, "stop"), "finished")
+  })
+
+  it("resolveAgentEndSignal returns 'interrupted' for review + aborted", () => {
+    // AC: abort → interrupted, no session_shutdown.
+    assert.equal(resolveAgentEndSignal(true, "aborted"), "interrupted")
+  })
+
+  it("non-review agent_end is always a no-op (turn_end handles shutdown)", () => {
+    // AC: non-review sessions must not emit session_shutdown from agent_end.
+    assert.equal(resolveAgentEndSignal(false, "stop"), "none")
+    assert.equal(resolveAgentEndSignal(false, "aborted"), "none")
+    assert.equal(resolveAgentEndSignal(false, "error"), "none")
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -26,7 +26,7 @@
 //   tool_execution_start  → tool_call           (truncated args)
 //   tool_execution_end    → tool_result         (truncated output)
 //   turn_start            → turn_start
-//   turn_end              → turn_end + state_change:finished + session_shutdown
+//   turn_end              → turn_end + state_change:idle
 //                            (stopReason=stop, idle, no pending, not reviewing)
 //                         → turn_end + state_change:interrupted (stopReason=aborted)
 //                         → turn_end + state_change:idle (other idle turns)
@@ -38,7 +38,8 @@
 //                         → provider_error
 //   auto_retry_start      → auto_retry_start
 //   auto_retry_end        → auto_retry_end
-//   session_shutdown      → state_change:finished + session_shutdown
+//   session_shutdown      → writer.close() only (non-review sessions)
+//                        → no-op (review sessions; agent_end already emitted shutdown)
 //
 // Inbound frames → PI runtime
 // ---------------------------
@@ -1030,12 +1031,17 @@ export type StopReason = "stop" | "toolUse" | "length" | "error" | "aborted"
 /**
  * Signal that the turn_end handler should emit.
  *
- * - "finished"     — emit state_change:finished, session_shutdown, close writer
  * - "interrupted"  — emit state_change:interrupted
- * - "idle"         — emit state_change:idle (existing behaviour)
+ * - "idle"         — emit state_change:idle
  * - "none"         — do not emit any state_change frame
+ *
+ * Note: the former "finished" variant has been removed. A clean turn
+ * completion (stopReason=stop, idle, no pending, not reviewing) now emits
+ * "idle" — the sidecar's idle debounce (added in #1429) converts
+ * state_change{idle} into StateFinished + notifyCoordinator() after 2s,
+ * without closing the pipe and breaking /new or /resume.
  */
-export type TurnEndSignal = "finished" | "interrupted" | "idle" | "none"
+export type TurnEndSignal = "interrupted" | "idle" | "none"
 
 /**
  * Determines which state-change signal to emit at the end of a turn.
@@ -1043,13 +1049,14 @@ export type TurnEndSignal = "finished" | "interrupted" | "idle" | "none"
  * Priority order:
  *  1. If stopReason is "aborted" → "interrupted" (always, regardless of idle)
  *  2. If stopReason is "stop" AND isIdle AND !hasPendingMessages AND
- *     !pendingReviewCall → "finished"
+ *     !pendingReviewCall → "idle"
  *  3. If stopReason is "stop" (or any non-aborted, non-error reason) AND
  *     isIdle AND !hasPendingMessages AND !pendingReviewCall → "idle"
  *  4. Otherwise → "none"
  *
- * The "finished" path is only taken on a clean "stop" to avoid false-positives
- * from tool-use mid-turn or context-limit truncation.
+ * A clean "stop" turn and other idle turns both produce "idle". The sidecar's
+ * idle debounce (added in #1429) converts state_change{idle} to StateFinished
+ * + notifyCoordinator() without permanently closing the pipe.
  */
 export function resolveTurnEndSignal(
   stopReason: StopReason | string | undefined,
@@ -1059,14 +1066,6 @@ export function resolveTurnEndSignal(
 ): TurnEndSignal {
   if (stopReason === "aborted") {
     return "interrupted"
-  }
-  if (
-    stopReason === "stop" &&
-    isIdle &&
-    !hasPendingMessages &&
-    !pendingReviewCall
-  ) {
-    return "finished"
   }
   if (
     stopReason !== "error" &&
@@ -1184,10 +1183,6 @@ export default function prismExtension(pi: ExtensionAPI): void {
   let writer: FrameWriter | null = null
   let handshakeComplete = false
   let connected = false
-  // Flag: session_shutdown has already been emitted from the turn_end handler
-  // (clean-finish path). When true, the session_shutdown hook must not emit
-  // a second finished+shutdown sequence or attempt to write to a closed writer.
-  let sessionShutdownEmitted = false
   // Track the latest active turn's abort handle. ctx.abort() requires an
   // ExtensionContext, so we capture one whenever a turn-active hook fires.
   let lastCtx: ExtensionContext | null = null
@@ -1525,9 +1520,9 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
       // Determine which state-change signal to emit based on stopReason and
       // session context. resolveTurnEndSignal handles all cases:
-      //   "finished"    → clean finish; emit finished + shutdown and close
       //   "interrupted" → user abort; emit interrupted
-      //   "idle"        → normal idle; emit idle (existing behaviour)
+      //   "idle"        → clean finish or normal idle; emit idle
+      //                   (sidecar idle debounce converts to finished after 2s)
       //   "none"        → do nothing
       try {
         const stopReason =
@@ -1546,12 +1541,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
           hasPending,
           pendingReviewCall,
         )
-        if (signal === "finished") {
-          sessionShutdownEmitted = true
-          writer.write({ type: "state_change", state: "finished" })
-          writer.write({ type: "session_shutdown" })
-          writer.close()
-        } else if (signal === "interrupted") {
+        if (signal === "interrupted") {
           writer.write({ type: "state_change", state: "interrupted" })
         } else if (signal === "idle") {
           writer.write({ type: "state_change", state: "idle" })
@@ -1577,14 +1567,11 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // sets isStreaming=false before emitting agent_end), making it the correct
   // place to emit session_shutdown for review sessions.
   //
-  // For non-review sessions the existing turn_end → isIdle path works: between
-  // turns the agent returns to idle, isIdle() returns true, and the normal
-  // resolveTurnEndSignal("finished", ...) path fires correctly when the agent
-  // eventually completes with stopReason=stop.
+  // For non-review sessions, the turn_end → isIdle path works: between turns
+  // the agent returns to idle, isIdle() returns true, and resolveTurnEndSignal
+  // returns "idle". The sidecar's idle debounce converts state_change{idle} to
+  // StateFinished + notifyCoordinator() after 2s without closing the pipe.
   //
-  // The sessionShutdownEmitted guard prevents double-emission if this hook
-  // fires after the session_shutdown PI hook has already closed the writer
-  // (unlikely for review agents but required for correctness).
   pi.on("agent_end", async (event, ctx) => {
     lastCtx = ctx
     if (!isReviewSession) {
@@ -1592,10 +1579,6 @@ export default function prismExtension(pi: ExtensionAPI): void {
       return
     }
     if (!writer || !handshakeComplete) return
-    if (sessionShutdownEmitted) {
-      // session_shutdown PI hook already fired — do not double-emit.
-      return
-    }
 
     // Extract stopReason from the last message in the event payload.
     // The agent_end event carries the final messages from the run; the last
@@ -1614,7 +1597,6 @@ export default function prismExtension(pi: ExtensionAPI): void {
     const signal = resolveAgentEndSignal(isReviewSession, stopReason)
     if (signal === "finished") {
       // Clean finish: emit finished + shutdown and close the writer.
-      sessionShutdownEmitted = true
       writer.write({ type: "state_change", state: "finished" })
       writer.write({ type: "session_shutdown" })
       writer.close()
@@ -1809,15 +1791,16 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async (_event, ctx) => {
     lastCtx = ctx
-    if (writer && handshakeComplete) {
-      // If the turn_end handler already emitted finished+shutdown (clean-finish
-      // path), do not double-emit. The writer is already closed in that case.
-      if (!sessionShutdownEmitted) {
-        writer.write({ type: "state_change", state: "finished" })
-        writer.write({ type: "session_shutdown" })
-        writer.close()
-      }
-    } else if (writer) {
+    // For non-review sessions: only close the writer. The pipe must stay open
+    // across /new and /resume reconnects — emitting session_shutdown here would
+    // cause the sidecar to permanently close pipe.sock, breaking any subsequent
+    // session_start reconnect attempt.
+    //
+    // For review sessions: agent_end has already emitted state_change{finished}
+    // + session_shutdown + writer.close(), so there is nothing left to do here.
+    //
+    // In both cases, closing the writer is the only action needed.
+    if (writer) {
       writer.close()
     }
     if (socket && !connected) {


### PR DESCRIPTION
Fixes #1432: After a PI session completes a task, using `/new` or `/resume` produced `ECONNRESET` because the extension was emitting `session_shutdown` on every clean turn end, causing the sidecar to permanently remove `pipe.sock`.

## Root cause

`resolveTurnEndSignal` returned `"finished"` for `stopReason=stop, isIdle=true, hasPendingMessages=false, pendingReviewCall=false`. The `turn_end` handler then emitted `state_change{finished}` + `session_shutdown` + `writer.close()`, which caused the sidecar to close its accept loop and delete the socket. Any subsequent `/new` or `/resume` reconnect attempt found no socket.

## Fix

Now that #1429 landed, the sidecar idle debounce converts `state_change{idle}` to `StateFinished` + `notifyCoordinator()` after 2s without closing the pipe. So `session_shutdown` is no longer needed from `turn_end`.

Changes to `prism.ts`:
1. `resolveTurnEndSignal`: `stop`+idle+no-pending+non-reviewing now returns `"idle"` (was `"finished"`).
2. `TurnEndSignal` type: removed the `"finished"` variant.
3. `turn_end` handler: removed the dead `signal === "finished"` branch.
4. Removed the `sessionShutdownEmitted` flag (only guarded the old `turn_end` path; `agent_end` is now the sole emitter).
5. `session_shutdown` PI hook: non-review sessions only close the writer (no frames); for review sessions `agent_end` already ran and closed the writer so `writer.close()` is a no-op.

Review sessions unaffected: `agent_end` still emits `state_change{finished}` + `session_shutdown` + `writer.close()` for `stopReason=stop`.

**Note on `sessionShutdownEmitted` AC:** The flag has been removed per fix plan step 4. Double-emission cannot occur because `agent_end` closes the writer before the `session_shutdown` PI hook fires; `writer.close()` on an already-closed writer is safe.

## Tests

- Updated `resolveTurnEndSignal` tests: `stop`+idle+non-reviewing now asserts `"idle"`.
- Updated `toolUse`/`length` tests to reflect new `"idle"` return for idle inputs.
- Added 10 new tests in two `#1432` describe blocks.
- All 156 tests pass.

Closes #1432