### PR TITLE
sidecar: lift instance_id mint/load and merge-queue watcher above transport switch (#1437)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -484,10 +484,62 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		}()
 	}
 
-	// B.3 Stage 1: transport-shape gate. Consult the harness registry to
+	// B.3 Stage 1: Mint or load instance_id. This is transport-agnostic and
+	// must run for ALL transport shapes (HTTP-port, socket-pipe, stdio-pipe).
+	// When --instance-id was passed at spawn time, s.cfg.InstanceID is already
+	// set (fast path). Otherwise, query the DB: if the row has a non-NULL
+	// instance_id, load it; if not, mint a fresh UUID and write it.
+	// This runs before the merge-queue watcher so the watcher always has an
+	// identity to key on.
+	if s.cfg.InstanceID == "" && s.cfg.DB != nil {
+		status, _ := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
+		if status != nil && status.InstanceID != nil && *status.InstanceID != "" {
+			s.cfg.InstanceID = *status.InstanceID
+			log.Printf("sidecar: instance_id loaded from DB (%s)", s.cfg.InstanceID)
+		} else {
+			minted := uuid.New().String()
+			// Defensively ensure the row exists before writing instance_id.
+			_ = s.cfg.DB.UpsertStatus(s.cfg.SessionName, s.cfg.Repo, s.cfg.Worktree, "idle", nil, nil)
+			if err := s.cfg.DB.SetInstanceID(s.cfg.SessionName, minted); err != nil {
+				log.Printf("sidecar: warning: could not write minted instance_id: %v", err)
+			} else {
+				s.cfg.InstanceID = minted
+				log.Printf("sidecar: instance_id minted (%s)", s.cfg.InstanceID)
+			}
+		}
+	}
+
+	// B.3 Stage 2: Start the merge-queue watcher for coordinator sessions.
+	// This is transport-agnostic and must run for ALL transport shapes so that
+	// PI coordinator sessions receive merge-queue notifications exactly like
+	// opencode coordinator sessions.
+	//
+	// The watcher polls the pending_merges head on a 45s ticker and drives PRs
+	// through the merge lifecycle. It is started only when:
+	//   - AgentRole is "coordinator" (explicit), OR
+	//   - SessionName ends with "@main" (legacy heuristic).
+	// The watcher context is stored so Shutdown() can cancel it before the
+	// abandon-watching-rows SQL runs (preventing a race where the watcher fires
+	// a terminal transition after AbandonWatchingMerges clears the rows).
+	if s.cfg.AgentRole == "coordinator" || isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
+		if s.cfg.InstanceID != "" {
+			watcherCtx, watcherCancel := context.WithCancel(ctx)
+			s.mu.Lock()
+			s.mergeWatcherCancel = watcherCancel
+			s.mu.Unlock()
+			watcher := mergequeue.New(s.cfg.DB, s.cfg.InstanceID, s.cfg.SessionName, s.cfg.HTTPClient)
+			go watcher.Run(watcherCtx)
+			log.Printf("sidecar: merge-queue watcher started (instance=%s)", s.cfg.InstanceID)
+		} else {
+			log.Printf("sidecar: merge-queue watcher NOT started — no instance_id")
+		}
+	}
+
+	// B.3 Stage 3: transport-shape gate. Consult the harness registry to
 	// determine the wire-level shape and dispatch to the appropriate startup
-	// helper. The back half of Run (merge-queue watcher, SSE loop, shutdown)
-	// is shape-agnostic and is unchanged.
+	// helper. Socket-pipe and stdio-pipe helpers run the duplex loop and return
+	// when the session ends — the remaining blocks below (TCP server, SSE loop)
+	// are HTTP-port-specific and are only reached for TransportHTTPPort.
 	//
 	// When HarnessName is empty (back-compat: callers that pre-date this field)
 	// the registry lookup is skipped and we fall through to runStartupHTTP,
@@ -539,52 +591,6 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			}
 		}()
 		log.Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
-	}
-
-	// Mint or load instance_id. The sidecar is the single owner of session
-	// identity. When --instance-id was passed at spawn time, s.cfg.InstanceID
-	// is already set (fast path). Otherwise, query the DB: if the row has a
-	// non-NULL instance_id, load it; if not, mint a fresh UUID and write it.
-	// This runs before the merge-queue watcher so the watcher always has an
-	// identity to key on.
-	if s.cfg.InstanceID == "" && s.cfg.DB != nil {
-		status, _ := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
-		if status != nil && status.InstanceID != nil && *status.InstanceID != "" {
-			s.cfg.InstanceID = *status.InstanceID
-			log.Printf("sidecar: instance_id loaded from DB (%s)", s.cfg.InstanceID)
-		} else {
-			minted := uuid.New().String()
-			// Defensively ensure the row exists before writing instance_id.
-			_ = s.cfg.DB.UpsertStatus(s.cfg.SessionName, s.cfg.Repo, s.cfg.Worktree, "idle", nil, nil)
-			if err := s.cfg.DB.SetInstanceID(s.cfg.SessionName, minted); err != nil {
-				log.Printf("sidecar: warning: could not write minted instance_id: %v", err)
-			} else {
-				s.cfg.InstanceID = minted
-				log.Printf("sidecar: instance_id minted (%s)", s.cfg.InstanceID)
-			}
-		}
-	}
-
-	// Start the merge-queue watcher for coordinator sessions. The watcher polls
-	// the pending_merges head on a 45s ticker and drives PRs through the merge
-	// lifecycle. It is started only when:
-	//   - AgentRole is "coordinator" (explicit), OR
-	//   - SessionName ends with "@main" (legacy heuristic).
-	// The watcher context is stored so Shutdown() can cancel it before the
-	// abandon-watching-rows SQL runs (preventing a race where the watcher fires
-	// a terminal transition after AbandonWatchingMerges clears the rows).
-	if s.cfg.AgentRole == "coordinator" || isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
-		if s.cfg.InstanceID != "" {
-			watcherCtx, watcherCancel := context.WithCancel(ctx)
-			s.mu.Lock()
-			s.mergeWatcherCancel = watcherCancel
-			s.mu.Unlock()
-			watcher := mergequeue.New(s.cfg.DB, s.cfg.InstanceID, s.cfg.SessionName, s.cfg.HTTPClient)
-			go watcher.Run(watcherCtx)
-			log.Printf("sidecar: merge-queue watcher started (instance=%s)", s.cfg.InstanceID)
-		} else {
-			log.Printf("sidecar: merge-queue watcher NOT started — no instance_id")
-		}
 	}
 
 	// Wrap ctx with a cancel so the startup-timeout goroutine (bwrap mode only)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_init_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_init_test.go
@@ -1,0 +1,179 @@
+package sidecar
+
+// Tests for the socket-pipe startup init path (issue #1437).
+//
+// These tests exercise Sidecar.Run with a TransportSocketPipe harness and
+// assert that the transport-agnostic init blocks (instance_id mint/load and
+// merge-queue watcher start) run correctly for PI sessions, not just for
+// HTTP-port (opencode) sessions.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+)
+
+// newSocketPipeCoordinatorSidecar creates a Sidecar configured for socket-pipe
+// testing with AgentRole=coordinator and a @main session name. This matches
+// a PI coordinator session.
+func newSocketPipeCoordinatorSidecar(t *testing.T, sockPath string) *Sidecar {
+	t.Helper()
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@main",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "coordinator",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		Harness:               pih.New("", "coordinator", ""),
+	}
+	return New(cfg)
+}
+
+// newSocketPipeWorkerSidecar creates a Sidecar configured for socket-pipe
+// testing with AgentRole=worker. This matches a PI worker session.
+func newSocketPipeWorkerSidecar(t *testing.T, sockPath string) *Sidecar {
+	t.Helper()
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@worker-branch",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "worker",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		Harness:               pih.New("", "worker", ""),
+	}
+	return New(cfg)
+}
+
+// runSidecarRun starts sc.Run(ctx) in a goroutine and returns a function that
+// waits for it to finish and returns its error.
+func runSidecarRun(ctx context.Context, sc *Sidecar) func() error {
+	errc := make(chan error, 1)
+	go func() {
+		errc <- sc.Run(ctx)
+	}()
+	return func() error {
+		return <-errc
+	}
+}
+
+// TestSocketPipeInit_CoordinatorInstanceIDAndWatcher verifies that after
+// Sidecar.Run starts for a PI coordinator session (TransportSocketPipe):
+//   - s.cfg.InstanceID is non-empty (instance_id was minted or loaded)
+//   - s.mergeWatcherCancel is set (merge-queue watcher was started)
+//
+// This is the primary regression test for issue #1437: before the fix, both
+// of these assertions would fail because runStartupSocketPipe returned before
+// the post-switch init block ran.
+func TestSocketPipeInit_CoordinatorInstanceIDAndWatcher(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeCoordinatorSidecar(t, sockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wait := runSidecarRun(ctx, sc)
+
+	// Wait for the socket file to appear — proves Run() has entered
+	// runStartupSocketPipe (i.e. the transport-shape switch was reached and
+	// the transport-agnostic init blocks before it have completed).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(sockPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket file never appeared — sidecar may not have dispatched to runStartupSocketPipe")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Assert instance_id is populated.
+	sc.mu.Lock()
+	instanceID := sc.cfg.InstanceID
+	watcherCancel := sc.mergeWatcherCancel
+	sc.mu.Unlock()
+
+	if instanceID == "" {
+		t.Error("s.cfg.InstanceID is empty after socket-pipe startup — instance_id mint/load did not run (#1437)")
+	}
+
+	if watcherCancel == nil {
+		t.Error("s.mergeWatcherCancel is nil after socket-pipe coordinator startup — merge-queue watcher did not start (#1437)")
+	}
+
+	// Clean shutdown.
+	conn, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("Run() returned error: %v", err)
+	}
+}
+
+// TestSocketPipeInit_WorkerInstanceIDNoWatcher verifies that after
+// Sidecar.Run starts for a PI worker session (TransportSocketPipe):
+//   - s.cfg.InstanceID is non-empty (instance_id was minted or loaded)
+//   - s.mergeWatcherCancel is NOT set (merge-queue watcher is coordinator-only)
+//
+// PI worker sessions must get an instance_id (for identity) but must NOT
+// start the merge-queue watcher (which is coordinator-only behaviour).
+func TestSocketPipeInit_WorkerInstanceIDNoWatcher(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeWorkerSidecar(t, sockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wait := runSidecarRun(ctx, sc)
+
+	// Wait for the socket file to appear.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(sockPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket file never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Assert instance_id is populated.
+	sc.mu.Lock()
+	instanceID := sc.cfg.InstanceID
+	watcherCancel := sc.mergeWatcherCancel
+	sc.mu.Unlock()
+
+	if instanceID == "" {
+		t.Error("s.cfg.InstanceID is empty after socket-pipe worker startup — instance_id mint/load did not run")
+	}
+
+	if watcherCancel != nil {
+		t.Error("s.mergeWatcherCancel is set for a worker session — merge-queue watcher must not start for workers")
+	}
+
+	// Clean shutdown.
+	conn, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("Run() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

PI/stdio-pipe sessions (TransportSocketPipe, TransportStdioPipe) never reached the post-switch init blocks in `Sidecar.Run` because `runStartupSocketPipe` and `runStartupStdio` block in their duplex loop and return instead of falling through. This meant PI coordinator sessions had no `instance_id` and no merge-queue watcher, breaking `prism merge` and merge-queue notifications.

## Fix (Option A — lift blocks above switch)

Move the instance_id mint/load block and the merge-queue watcher start block to run **before** the transport-shape switch. Both blocks are transport-agnostic and must execute for every session type. The Darwin host-API TCP server block stays where it is (HTTP-port only, depends on `runStartupHTTP` having bound the listener).

The watcher-start gate is unchanged: coordinator sessions get a watcher, worker sessions get an instance_id but no watcher.

## Tests Added

New file `internal/sidecar/sidecar_socketpipe_init_test.go`:
- `TestSocketPipeInit_CoordinatorInstanceIDAndWatcher`: exercises `Run()` with `TransportSocketPipe`, asserts `InstanceID` is populated and `mergeWatcherCancel` is set for a coordinator session.
- `TestSocketPipeInit_WorkerInstanceIDNoWatcher`: same setup, asserts `InstanceID` is populated but `mergeWatcherCancel` is nil for a worker session.

## Quality Gates

- `go build ./...` ✅
- `go test ./internal/sidecar/...` ✅ (42s, all pass)
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` ✅

Closes #1437