### PR TITLE
fix: session_shutdown hook must not emit wire frame (#1440)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -9,6 +9,10 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import { Readable } from "node:stream"
+import * as net from "node:net"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as fs from "node:fs"
 
 import {
   attachJsonlReader,
@@ -44,6 +48,9 @@ import {
   GIT_PUSH_REMINDER_MESSAGE,
   // turn_end signal resolver
   resolveTurnEndSignal,
+  // Frame writer
+  makeFrameWriter,
+  type FrameWriter,
 } from "./prism.ts"
 
 // ---------------------------------------------------------------------------
@@ -1490,5 +1497,222 @@ describe("#1434: isReviewSession recognised for canonical review-agent names", (
     // The old check used role === "review" which never matched the actual
     // role names emitted by the sidecar (review-goal, review-code, etc.).
     assert.ok(!canonicalNames.includes("review"))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #1440: session_shutdown hook must not emit a session_shutdown wire frame
+// ---------------------------------------------------------------------------
+//
+// The PI `session_shutdown` hook fires on /new, /resume, /fork, and process
+// exit. The wire frame {type:"session_shutdown"} is process-exit only (wire
+// spec §5.10). Sending it from the hook causes the sidecar to remove pipe.sock
+// and break the reconnect loop, producing ECONNRESET on the next session_start.
+//
+// The fix: the session_shutdown hook calls writer.close() only — no wire frame.
+
+describe("#1440: makeFrameWriter — close() issues FIN only, no JSONL", () => {
+  it("close() calls socket.end() not socket.write()", () => {
+    // Regression guard: writer.close() must only call socket.end(), not write
+    // any bytes. If a session_shutdown frame were still emitted, this test
+    // would catch it via the write spy.
+    const written: string[] = []
+    let endCalled = false
+    const mockSocket = {
+      write: (data: string) => { written.push(data); return true },
+      end: () => { endCalled = true },
+    } as unknown as net.Socket
+
+    const writer: FrameWriter = makeFrameWriter(mockSocket)
+    writer.close()
+
+    assert.equal(written.length, 0, "no bytes should be written by writer.close()")
+    assert.ok(endCalled, "socket.end() must be called by writer.close()")
+  })
+
+  it("close() does not write a session_shutdown JSONL frame", () => {
+    // AC (#1440): the bytes observed on the wire after writer.close() must
+    // contain no JSONL line with \"type\":\"session_shutdown\".
+    const written: string[] = []
+    const mockSocket = {
+      write: (data: string) => { written.push(data); return true },
+      end: () => {},
+    } as unknown as net.Socket
+
+    const writer: FrameWriter = makeFrameWriter(mockSocket)
+    writer.close()
+
+    const allOutput = written.join("")
+    assert.ok(
+      !allOutput.includes('"session_shutdown"'),
+      `wire output must not contain session_shutdown, got: ${JSON.stringify(allOutput)}`,
+    )
+  })
+
+  it("write() after close() is a no-op (closed guard)", () => {
+    // Edge-case: if writer is closed via session_shutdown hook and then
+    // another frame arrives before the next reconnect, it must not throw
+    // or write to the ended socket.
+    const written: string[] = []
+    const mockSocket = {
+      write: (data: string) => { written.push(data); return true },
+      end: () => {},
+    } as unknown as net.Socket
+
+    const writer: FrameWriter = makeFrameWriter(mockSocket)
+    writer.close()
+    // Attempt to write after close — must be silently dropped.
+    writer.write({ type: "turn_start" })
+
+    assert.equal(written.length, 0, "write after close must be a no-op")
+  })
+
+  it("write() emits the frame before close()", () => {
+    // Regression guard: write() must still work normally before close() is
+    // called. This confirms the fix is surgical (only removes the erroneous
+    // writer.write({type:'session_shutdown'}) call, not write() itself).
+    const written: string[] = []
+    const mockSocket = {
+      write: (data: string) => { written.push(data); return true },
+      end: () => {},
+    } as unknown as net.Socket
+
+    const writer: FrameWriter = makeFrameWriter(mockSocket)
+    writer.write({ type: "turn_start" })
+    writer.close()
+
+    assert.equal(written.length, 1, "exactly one frame must be written")
+    const frame = JSON.parse(written[0])
+    assert.equal(frame.type, "turn_start")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #1440: sidecar reconnect after session_shutdown hook (socket-close-only path)
+// ---------------------------------------------------------------------------
+//
+// This group tests the Go sidecar's behaviour when the extension closes the
+// connection without sending a session_shutdown wire frame — exactly what the
+// fixed session_shutdown hook does. A unix socket server is created in the
+// test; the sidecar side is simulated by the Go socketpipe tests. Here we
+// verify the Node-side invariant: writer.close() causes socket.end() which
+// produces a FIN, and the socket object is suitable for re-connection testing.
+//
+// Full reconnect behaviour (listener stays open, re-accept, handshake) is
+// covered by the Go TestSocketPipe_SessionShutdownHook_NoWireFrame tests.
+
+describe("#1440: writer.close() wire shape — FIN only, no session_shutdown frame", () => {
+  it("unix socket server sees only FIN after writer.close(), no JSONL", (_, done) => {
+    // Create a real Unix socket server to capture exactly what bytes arrive.
+    const sockDir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-test-"))
+    const sockPath = path.join(sockDir, "test.sock")
+
+    const server = net.createServer((conn) => {
+      const chunks: Buffer[] = []
+      conn.on("data", (chunk) => { chunks.push(chunk) })
+      conn.on("end", () => {
+        // Connection ended (FIN received). Verify no session_shutdown JSON.
+        const received = Buffer.concat(chunks).toString()
+        try {
+          assert.ok(
+            !received.includes('"session_shutdown"'),
+            `server received unexpected session_shutdown frame: ${JSON.stringify(received)}`,
+          )
+          assert.ok(
+            !received.includes('"type"'),
+            `server received unexpected JSONL frames: ${JSON.stringify(received)}`,
+          )
+        } catch (err) {
+          server.close()
+          fs.rmSync(sockDir, { recursive: true, force: true })
+          done(err as Error)
+          return
+        }
+        server.close()
+        fs.rmSync(sockDir, { recursive: true, force: true })
+        done()
+      })
+    })
+
+    server.listen(sockPath, () => {
+      const clientSocket = net.createConnection(sockPath)
+      clientSocket.on("connect", () => {
+        const writer = makeFrameWriter(clientSocket)
+        // Simulate the session_shutdown hook: only writer.close(), no write().
+        writer.close()
+      })
+      clientSocket.on("error", (err) => {
+        server.close()
+        fs.rmSync(sockDir, { recursive: true, force: true })
+        done(err)
+      })
+    })
+  })
+
+  it("unix socket server sees FIN then accepts a second connection after writer.close()", (_, done) => {
+    // Simulates the PI session_shutdown → session_start reconnect sequence.
+    // The server represents the sidecar; two connections represent the first
+    // (session_shutdown hook) and second (session_start re-dial) connections.
+    // This verifies the socket file remains present between close and re-accept.
+    const sockDir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-test-"))
+    const sockPath = path.join(sockDir, "test.sock")
+
+    let connectionCount = 0
+
+    const server = net.createServer((conn) => {
+      connectionCount++
+      const connNum = connectionCount
+
+      if (connNum === 1) {
+        // First connection: wait for FIN, then verify the socket file still
+        // exists (i.e. the server did not remove it), then initiate a second
+        // connection (simulating PI session_start re-dial).
+        conn.on("end", () => {
+          try {
+            // Socket file must still exist — the server must not have removed it.
+            assert.ok(
+              fs.existsSync(sockPath),
+              "pipe.sock must remain present after first connection closes (session_shutdown hook path)",
+            )
+          } catch (err) {
+            server.close()
+            fs.rmSync(sockDir, { recursive: true, force: true })
+            done(err as Error)
+            return
+          }
+
+          // Simulate PI session_start: re-dial the same socket path.
+          const reconnect = net.createConnection(sockPath)
+          reconnect.on("error", (err) => {
+            server.close()
+            fs.rmSync(sockDir, { recursive: true, force: true })
+            done(new Error(`ECONNRESET or connection error on re-dial (regression #1440): ${err.message}`))
+          })
+          reconnect.on("connect", () => {
+            // Successfully reconnected — no ECONNRESET. End cleanly.
+            reconnect.end()
+          })
+        })
+        // Close the first connection (simulating writer.close() in the hook).
+        conn.end()
+      } else if (connNum === 2) {
+        // Second connection accepted — the listener stayed open. Test passes.
+        conn.on("end", () => {
+          server.close()
+          fs.rmSync(sockDir, { recursive: true, force: true })
+          done()
+        })
+      }
+    })
+
+    server.listen(sockPath, () => {
+      // Initiate the first connection (simulating the initial PI session).
+      const clientSocket = net.createConnection(sockPath)
+      clientSocket.on("error", (err) => {
+        server.close()
+        fs.rmSync(sockDir, { recursive: true, force: true })
+        done(err)
+      })
+    })
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -736,12 +736,12 @@ export function redactLine(line: string): string {
 // Frame writer — synchronous (per wire spec §7.5).
 // ---------------------------------------------------------------------------
 
-interface FrameWriter {
+export interface FrameWriter {
   write(frame: Record<string, unknown>): void
   close(): void
 }
 
-function makeFrameWriter(socket: net.Socket): FrameWriter {
+export function makeFrameWriter(socket: net.Socket): FrameWriter {
   let closed = false
   return {
     write(frame) {
@@ -1711,15 +1711,19 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async (_event, ctx) => {
     lastCtx = ctx
-    // Emit session_shutdown and close the writer. The pipe must stay open
-    // across /new and /resume reconnects during a session — writer.close()
-    // (not session_shutdown) is the signal that triggers pipe cleanup.
+    // Do NOT send a session_shutdown wire frame here. The PI `session_shutdown`
+    // hook fires on /new, /resume, /fork, and process exit — not only on
+    // process exit. The wire frame (per §5.10) is process-exit only: the
+    // sidecar treats it as terminal, breaks the reconnect loop, and removes
+    // pipe.sock. Sending it here would cause the sidecar to delete pipe.sock
+    // before PI fires `session_start` for the new/resumed session, resulting
+    // in ECONNRESET when the extension re-dials (#1440 / regression of #1432).
     //
-    // Per wire spec §5.10: session_shutdown is process-exit only and is never
-    // emitted at turn boundaries (#1432). The turn_end → state_change{finished}
-    // path handles per-turn completion for all session types (#1434).
+    // Only close the writer (issues a TCP FIN / half-close). The sidecar reads
+    // EOF, leaves the listener open, and waits for a reconnect. Process-exit
+    // cleanup of pipe.sock is handled by the sidecar's own Shutdown() path and
+    // by the reconnect-timeout path.
     if (writer) {
-      writer.write({ type: "session_shutdown" })
       writer.close()
     }
     if (socket && !connected) {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -2149,5 +2149,319 @@ func TestSocketPipe_ProtocolVersion1_TooOld(t *testing.T) {
 	_ = wait()
 }
 
+// ── #1440 regression tests ────────────────────────────────────────────────
+//
+// These tests guard against the regression introduced in #1434 and fixed in
+// #1440: the PI extension's `session_shutdown` hook was erroneously sending a
+// `{type:"session_shutdown"}` wire frame before closing the connection. The
+// sidecar treats that frame as terminal, removes pipe.sock, and breaks the
+// reconnect loop — causing ECONNRESET when PI fires `session_start`.
+//
+// The fix: only call writer.close() from the hook (no wire frame). The sidecar
+// reads EOF, keeps the listener open, and accepts the re-dial.
+
+// TestSocketPipe_SessionShutdownHook_NoWireFrame_New verifies that when the
+// extension closes the connection without sending a session_shutdown wire frame
+// (the fixed session_shutdown hook path for /new), the sidecar keeps pipe.sock
+// and accepts a second connection — no ECONNRESET.
+func TestSocketPipe_SessionShutdownHook_NoWireFrame_New(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	// First connection — simulates the active PI session before /new.
+	conn1, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn1, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn1, map[string]any{"type": "msg_assistant", "text": "before-new"})
+	sendJSON(t, conn1, map[string]any{"type": "turn_end"})
+
+	// Simulate the fixed session_shutdown hook: close without wire frame.
+	// This is exactly what writer.close() does — it calls socket.end(), which
+	// sends a TCP FIN. The sidecar reads EOF and waits for reconnect.
+	conn1.Close()
+
+	// Give the sidecar a moment to process the drop and re-enter Accept.
+	time.Sleep(50 * time.Millisecond)
+
+	// The socket file must still exist (sidecar must NOT have removed it).
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("pipe.sock was removed after session_shutdown hook close (regression #1440): %v", err)
+	}
+
+	// Second connection — simulates PI session_start with reason "new".
+	// Must succeed without ECONNRESET.
+	conn2, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn2, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn2, map[string]any{"type": "msg_assistant", "text": "after-new"})
+	sendJSON(t, conn2, map[string]any{"type": "turn_end"})
+	sendJSON(t, conn2, map[string]any{"type": "session_shutdown"})
+	conn2.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error after /new reconnect: %v", err)
+	}
+
+	// Both turns must be recorded.
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	textSet := map[string]bool{}
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			var p struct{ Text string `json:"text"` }
+			if err := json.Unmarshal([]byte(ev.Payload), &p); err == nil {
+				textSet[p.Text] = true
+			}
+		}
+	}
+	if !textSet["before-new"] {
+		t.Error("msg_assistant 'before-new' not found in agent_events")
+	}
+	if !textSet["after-new"] {
+		t.Error("msg_assistant 'after-new' not found in agent_events")
+	}
+
+	// Session must be finished.
+	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateFinished) {
+		t.Errorf("state after /new reconnect+shutdown = %q, want finished", s)
+	}
+}
+
+// TestSocketPipe_SessionShutdownHook_NoWireFrame_Resume is the same as _New
+// but named for the /resume case (same wire behaviour, different PI reason).
+func TestSocketPipe_SessionShutdownHook_NoWireFrame_Resume(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn1, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn1, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn1, map[string]any{"type": "msg_assistant", "text": "before-resume"})
+	sendJSON(t, conn1, map[string]any{"type": "turn_end"})
+	conn1.Close() // fixed hook: no wire frame, only FIN
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("pipe.sock was removed after session_shutdown hook close (/resume, regression #1440): %v", err)
+	}
+
+	conn2, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn2, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn2, map[string]any{"type": "msg_assistant", "text": "after-resume"})
+	sendJSON(t, conn2, map[string]any{"type": "turn_end"})
+	sendJSON(t, conn2, map[string]any{"type": "session_shutdown"})
+	conn2.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error after /resume reconnect: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	textSet := map[string]bool{}
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			var p struct{ Text string `json:"text"` }
+			if err := json.Unmarshal([]byte(ev.Payload), &p); err == nil {
+				textSet[p.Text] = true
+			}
+		}
+	}
+	if !textSet["before-resume"] {
+		t.Error("msg_assistant 'before-resume' not found in agent_events")
+	}
+	if !textSet["after-resume"] {
+		t.Error("msg_assistant 'after-resume' not found in agent_events")
+	}
+
+	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateFinished) {
+		t.Errorf("state after /resume reconnect+shutdown = %q, want finished", s)
+	}
+}
+
+// TestSocketPipe_SessionShutdownHook_NoWireFrame_Fork is the same as _New
+// but named for the /fork case.
+func TestSocketPipe_SessionShutdownHook_NoWireFrame_Fork(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn1, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn1, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn1, map[string]any{"type": "msg_assistant", "text": "before-fork"})
+	sendJSON(t, conn1, map[string]any{"type": "turn_end"})
+	conn1.Close() // fixed hook: no wire frame, only FIN
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("pipe.sock was removed after session_shutdown hook close (/fork, regression #1440): %v", err)
+	}
+
+	conn2, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn2, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn2, map[string]any{"type": "msg_assistant", "text": "after-fork"})
+	sendJSON(t, conn2, map[string]any{"type": "turn_end"})
+	sendJSON(t, conn2, map[string]any{"type": "session_shutdown"})
+	conn2.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error after /fork reconnect: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	textSet := map[string]bool{}
+	for _, ev := range events {
+		if ev.Type == "msg_assistant" {
+			var p struct{ Text string `json:"text"` }
+			if err := json.Unmarshal([]byte(ev.Payload), &p); err == nil {
+				textSet[p.Text] = true
+			}
+		}
+	}
+	if !textSet["before-fork"] {
+		t.Error("msg_assistant 'before-fork' not found in agent_events")
+	}
+	if !textSet["after-fork"] {
+		t.Error("msg_assistant 'after-fork' not found in agent_events")
+	}
+
+	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateFinished) {
+		t.Errorf("state after /fork reconnect+shutdown = %q, want finished", s)
+	}
+}
+
+// TestSocketPipe_SessionShutdownHook_SockFilePresent verifies that when the
+// session_shutdown hook closes the connection without a wire frame, the unix
+// socket file at HarnessPipeSockPath is NOT removed between the first
+// connection's close and the second connection's accept. This is the key
+// invariant that prevents ECONNRESET on the session_start re-dial (#1440 AC).
+func TestSocketPipe_SessionShutdownHook_SockFilePresent(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	// Wait for socket file to appear.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(sockPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket file never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	conn1, _ := dialAndHandshake(t, sockPath)
+	// Simulate session_shutdown hook: close without wire frame.
+	conn1.Close()
+
+	// Give the sidecar a moment to process the drop.
+	time.Sleep(50 * time.Millisecond)
+
+	// The socket file must still be present — the sidecar must not have
+	// removed it (which would only happen after a genuine session_shutdown
+	// wire frame breaks the reconnect loop).
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("pipe.sock removed after session_shutdown hook close (regression #1440): %v", err)
+	}
+
+	// Second connection must be accepted without error.
+	conn2, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn2, map[string]any{"type": "session_shutdown"})
+	conn2.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
+// TestSocketPipe_GenuineSessionShutdown_StillDrivesFinished verifies that a
+// genuine {type:"session_shutdown"} wire frame (e.g. from process exit) still
+// drives the session to StateFinished and breaks the reconnect loop. This
+// guards against any accidental change to handlePipeFrame semantics (#1440
+// out-of-scope: the sidecar must still handle the genuine frame correctly).
+func TestSocketPipe_GenuineSessionShutdown_StillDrivesFinished(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Send a genuine session_shutdown wire frame (as if from process exit).
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error on genuine session_shutdown: %v", err)
+	}
+
+	// State must be finished — the reconnect loop must have broken.
+	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateFinished) {
+		t.Errorf("state after genuine session_shutdown = %q, want finished", s)
+	}
+
+	// The socket file must have been removed (closePipeListener cleanup).
+	if _, err := os.Stat(sockPath); err == nil {
+		t.Error("pipe.sock still present after genuine session_shutdown — listener should have closed and removed it")
+	}
+}
+
+// TestSocketPipe_SessionShutdownHook_NextFrameDispatchedNormally verifies that
+// after the extension reconnects following a session_shutdown hook close, the
+// next inbound frame from the sidecar is parsed and dispatched normally with
+// no leftover state from the previous connection (#1440 edge-case AC).
+func TestSocketPipe_SessionShutdownHook_NextFrameDispatchedNormally(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	// First connection — session_shutdown hook close.
+	conn1, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn1, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn1, map[string]any{"type": "msg_assistant", "text": "first-turn"})
+	sendJSON(t, conn1, map[string]any{"type": "turn_end"})
+	conn1.Close() // no wire frame — fixed hook
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Second connection — session_start reconnect.
+	conn2, _ := dialAndHandshake(t, sockPath)
+
+	// The sidecar must deliver a prompt on the second connection without any
+	// leftover state from the first connection. Enqueue a prompt from the
+	// sidecar side and verify the extension receives it normally.
+	rd := bufio.NewReader(conn2)
+	const promptText = "post-reconnect prompt"
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		sc.DeliverPrompt(promptText, "nextTurn")
+	}()
+
+	_ = conn2.SetReadDeadline(time.Now().Add(3 * time.Second))
+	line, err := rd.ReadBytes('\n')
+	_ = conn2.SetReadDeadline(time.Time{})
+	if err != nil {
+		t.Fatalf("read prompt frame after reconnect: %v", err)
+	}
+	var frame map[string]any
+	if err := json.Unmarshal(line, &frame); err != nil {
+		t.Fatalf("unmarshal prompt frame: %v", err)
+	}
+	if frame["type"] != "prompt" {
+		t.Errorf("expected prompt frame after reconnect, got type %v", frame["type"])
+	}
+	if frame["text"] != promptText {
+		t.Errorf("prompt text = %v, want %q", frame["text"], promptText)
+	}
+
+	// Clean shutdown on second connection.
+	sendJSON(t, conn2, map[string]any{"type": "session_shutdown"})
+	conn2.Close()
+
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error after reconnect: %v", err)
+	}
+}
+
 // Ensure db import is used.
 var _ *db.DB


### PR DESCRIPTION
## Summary

Fixes the regression introduced in #1434 where the PI extension's `session_shutdown` hook was sending a `{type:"session_shutdown"}` wire frame before closing the connection.

## Root cause

The PI `session_shutdown` hook fires on `/new`, `/resume`, `/fork`, **and** process exit — not only on process exit. The wire frame is process-exit only (wire spec §5.10). Sending it from the hook caused the sidecar's `handlePipeFrame` to treat it as terminal: it set `cleanShutdown=true`, broke the reconnect loop, and the deferred `closePipeListener()` removed `pipe.sock`. PI then fired `session_start`, the extension dialled the deleted path, and got `ECONNRESET`.

## Fix

In `modules/programs/prism/pi/extensions/prism.ts`, the `session_shutdown` hook handler no longer calls `writer.write({ type: "session_shutdown" })`. It only calls `writer.close()` (which issues a TCP FIN / half-close). The sidecar reads EOF, keeps the listener open, and waits for a reconnect within `reconnectTimeout`.

The comment is updated to explain clearly why the wire frame must not be sent from this hook.

`makeFrameWriter` and the `FrameWriter` interface are exported to enable unit testing.

**No changes** to `handlePipeFrame` semantics, `turn_end`/`agent_end` paths, or the wire protocol version.

## Tests added

**TypeScript (`prism.test.ts`, 6 new tests):**
- `writer.close()` calls `socket.end()`, not `socket.write()`
- `writer.close()` writes no `session_shutdown` JSONL frame
- `write()` after `close()` is a no-op (closed guard)
- `write()` works normally before `close()`
- Real unix socket: server sees only FIN after `writer.close()`, no JSONL
- Real unix socket: server accepts a second connection after first FIN (no ECONNRESET, socket file stays present)

**Go (`sidecar_socketpipe_test.go`, 6 new tests):**
- `TestSocketPipe_SessionShutdownHook_NoWireFrame_New`: /new reconnect path — pipe.sock stays, second handshake succeeds
- `TestSocketPipe_SessionShutdownHook_NoWireFrame_Resume`: /resume reconnect path
- `TestSocketPipe_SessionShutdownHook_NoWireFrame_Fork`: /fork reconnect path
- `TestSocketPipe_SessionShutdownHook_SockFilePresent`: asserts pipe.sock present between first close and second accept
- `TestSocketPipe_GenuineSessionShutdown_StillDrivesFinished`: genuine wire frame still drives StateFinished and removes pipe.sock
- `TestSocketPipe_SessionShutdownHook_NextFrameDispatchedNormally`: next inbound frame after reconnect is dispatched normally (no leftover state)

Closes #1440