### PR TITLE
anthropic-oauth: remove dead ensureClaudeCodeSymlink helper

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/LICENSE-leohenon
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/LICENSE-leohenon
@@ -25,8 +25,7 @@ SOFTWARE.
 Origin: https://github.com/leohenon/pi-anthropic-oauth
 
 Files in this vendored extension that primarily originate from this upstream:
-  - index.ts   (pi.registerProvider wrapper structure, ensureClaudeCodeSymlink,
-                getAnthropicModels, model list fallback)
+  - index.ts   (pi.registerProvider wrapper structure, getAnthropicModels, model list fallback)
   - auth.ts    (OAuth PKCE flow, local callback server, loginAnthropic,
                 refreshAnthropicToken, CLIENT_ID, TOKEN_URL, AUTHORIZE_URL)
   - stream.ts  (pi message conversion patterns from convert.ts + prompt.ts;

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -11,9 +11,6 @@
 //
 // See UPSTREAM.md for the port procedure.
 
-import { existsSync, symlinkSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import {
   AuthStorage,
   ModelRegistry,
@@ -50,18 +47,6 @@ const DEFAULT_OPUS_4_7: NonNullable<ProviderConfig["models"]>[number] = {
   contextWindow: 1000000,
   maxTokens: 128000,
   compat: undefined,
-}
-
-// pi-specific: create a ~/.Claude Code → ~/.pi symlink so that pi's jiti
-// resolver can find modules in the expected Claude Code credential path.
-function ensureClaudeCodeSymlink() {
-  const target = join(homedir(), ".pi")
-  const link = join(homedir(), ".Claude Code")
-  if (existsSync(target) && !existsSync(link)) {
-    try {
-      symlinkSync(target, link)
-    } catch {}
-  }
 }
 
 function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
@@ -102,7 +87,6 @@ export default function (pi: ExtensionAPI) {
 
   repairCredentials()
 
-  ensureClaudeCodeSymlink()
   const models = getAnthropicModels()
 
   pi.registerProvider("anthropic", {


### PR DESCRIPTION
## Summary

Removes the `ensureClaudeCodeSymlink()` helper from `modules/programs/prism/pi/extensions/anthropic-oauth/index.ts` and all associated imports, after verifying it is dead code.

## Investigation

The function created `~/.Claude Code → ~/.pi` at extension load. Investigation confirms no code path reads through that symlink:

| Concern | Path used | Source |
|---|---|---|
| OAuth credentials | `~/.pi/agent/auth.json` | `credentials.ts:37` |
| Debug log | `~/.pi/agent/pi-anthropic-oauth-debug.log` | `logger.ts:18` |
| Per-session credential override | `$PI_AUTH_JSON` | `credentials.ts:37` |

`grep -rn "Claude Code" modules/programs/prism/pi/extensions/anthropic-oauth/` produces zero reader hits — only the three creator lines (now deleted). The jiti resolver comment did not match jiti's actual behaviour (jiti resolves TypeScript/JS modules, not credential paths). The path `~/.Claude Code` (capital C, space) is also not the real Anthropic Claude Code credential location (`~/.claude` lowercase, no space).

## Changes

- Removed `ensureClaudeCodeSymlink()` function and its comment block
- Removed call site at the extension entry point
- Removed now-unused imports: `existsSync`, `symlinkSync` (node:fs), `homedir` (node:os), `join` (node:path)
- Updated `LICENSE-leohenon` attribution to remove the deleted function

## Static acceptance criteria

- `grep -rn "ensureClaudeCodeSymlink" modules/programs/prism/pi/extensions/anthropic-oauth/` → no hits ✅
- `grep -rn "\.Claude Code" modules/programs/prism/pi/extensions/anthropic-oauth/` → no hits ✅

## Live OAuth flow verification

The four OAuth flows (login, streamSimple turn, token refresh, tool-use round trip) require live credentials and a running prism session. These could not be exercised in this sandbox. The coordinator should arrange manual verification before merging:

1. Remove any existing `~/.Claude Code` symlink: `rm "$HOME/.Claude Code"`
2. `/login anthropic` from a fresh prism session — confirm credentials written to `~/.pi/agent/auth.json`
3. An assistant turn through `streamSimple` — confirm non-empty assistant message
4. Token refresh: set expired `expires_at` in `~/.pi/agent/auth.json`, confirm `refreshAnthropicToken` succeeds and writes new token
5. A tool-use round trip (read/bash) — confirm tool-name deobfuscation in `transformResponseStream` works

Closes #1445