### PR TITLE
sidecar/pi-extension: fix nextTurn prompts dropped when coordinator is mid-stream

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -421,15 +421,77 @@ describe("dispatchInboundFrame: prompt", () => {
     })
   })
 
-  it("translates nextTurn into an option-less call (PI decides)", async () => {
+  it("nextTurn while idle (isIdle=true) calls bare sendUserMessage", async () => {
     const { api, calls, emit } = makeMockApi()
+    // Default mock: isIdle is undefined (absent, older runtime) — treated as idle=true.
     await dispatchInboundFrame(
       { type: "prompt", text: "now", deliver_as: "nextTurn" },
       api,
       emit,
     )
     assert.equal(calls.sendUserMessage[0].content, "now")
-    assert.equal(calls.sendUserMessage[0].options, undefined)
+    assert.equal(
+      calls.sendUserMessage[0].options,
+      undefined,
+      "nextTurn while idle must call bare sendUserMessage (no deliverAs option)",
+    )
+  })
+
+  it("nextTurn while streaming (isIdle=false) routes to followUp", async () => {
+    const { api, calls, emit } = makeMockApi()
+    // Override isIdle to simulate a mid-stream runtime.
+    api.isIdle = () => false
+    await dispatchInboundFrame(
+      { type: "prompt", text: "queued", deliver_as: "nextTurn" },
+      api,
+      emit,
+    )
+    assert.equal(calls.sendUserMessage[0].content, "queued")
+    assert.deepEqual(
+      calls.sendUserMessage[0].options,
+      { deliverAs: "followUp" },
+      "nextTurn mid-stream must route to followUp to avoid the 'already processing' throw",
+    )
+  })
+
+  it("nextTurn with isIdle absent (older runtime) treats runtime as idle", async () => {
+    const { api, calls, emit } = makeMockApi()
+    // Explicitly ensure isIdle is absent on the api object (edge-case AC).
+    delete (api as Record<string, unknown>)["isIdle"]
+    await dispatchInboundFrame(
+      { type: "prompt", text: "legacy", deliver_as: "nextTurn" },
+      api,
+      emit,
+    )
+    assert.equal(calls.sendUserMessage[0].content, "legacy")
+    assert.equal(
+      calls.sendUserMessage[0].options,
+      undefined,
+      "absent isIdle must fall back to idle=true (bare sendUserMessage)",
+    )
+  })
+
+  it("nextTurn: sendUserMessage throw includes deliver_as and isIdle in error context", async () => {
+    const { api, calls, emit } = makeMockApi()
+    api.isIdle = () => false
+    api.sendUserMessage = () => {
+      throw new Error("invalid content shape")
+    }
+    await dispatchInboundFrame(
+      { type: "prompt", text: "bad", deliver_as: "nextTurn" },
+      api,
+      emit,
+    )
+    assert.equal(calls.errors.length, 1)
+    const errMsg = calls.errors[0].message
+    assert.ok(
+      errMsg.includes("deliver_as=nextTurn"),
+      `error should include deliver_as=nextTurn, got: ${errMsg}`,
+    )
+    assert.ok(
+      errMsg.includes("isIdle=false"),
+      `error should include isIdle=false, got: ${errMsg}`,
+    )
   })
 
   it("converts wire images (mime_type) to PI's mediaType ImageContent", async () => {

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -785,11 +785,21 @@ export interface InboundDispatchAPI {
     content:
       | string
       | Array<{ type: "text"; text: string } | Record<string, unknown>>,
-    // The dispatcher only ever passes "steer" or "followUp"; for the wire
-    // protocol's `nextTurn` it omits options entirely so PI's idle-vs-
-    // streaming logic decides. The narrower union here documents that.
-    options?: { deliverAs?: "steer" | "followUp" },
+    // For "steer" and "followUp" the option is forwarded verbatim.
+    // For "nextTurn", the dispatcher queries isIdle() and routes to
+    // "followUp" mid-stream (when isIdle returns false) or calls bare
+    // sendUserMessage (when idle). The full union is kept here so the
+    // adapter in the factory can forward the value PI actually supports.
+    options?: { deliverAs?: "steer" | "followUp" | "nextTurn" },
   ) => void
+  // isIdle returns true when the PI runtime is not currently streaming a
+  // turn. Used by the dispatcher to choose between bare sendUserMessage
+  // (idle) and sendUserMessage({ deliverAs: "followUp" }) (mid-stream)
+  // when the wire frame carries deliver_as="nextTurn". Implementations on
+  // older PI runtimes that do not expose isIdle may omit the method; the
+  // dispatcher treats its absence as idle=true (pre-streaming behaviour
+  // preserved).
+  isIdle?: () => boolean
   setModel: (model: unknown) => Promise<boolean>
   setThinkingLevel: (level: string) => void
   registerProvider: (name: string, config: ProviderConfig) => void
@@ -862,14 +872,44 @@ export async function dispatchInboundFrame(
           content = text
         }
 
-        // PI's sendUserMessage extension surface accepts steer | followUp; for
-        // nextTurn we omit deliverAs so PI's internal logic decides based on
-        // idle state (immediate when idle; queued when streaming). This is
-        // the closest mapping to the RPC `prompt` command's behaviour.
-        if (deliverAs === "nextTurn") {
-          api.sendUserMessage(content)
-        } else {
-          api.sendUserMessage(content, { deliverAs })
+        // PI's sendUserMessage requires an explicit deliverAs whenever the
+        // runtime is streaming. For the wire's "nextTurn" value, query
+        // isIdle and route to "followUp" mid-stream so the message queues
+        // until the current turn settles. Calling sendUserMessage without
+        // deliverAs while streaming throws "Agent is already processing",
+        // which would silently drop the frame in this dispatcher's outer
+        // try/catch. When isIdle is unavailable (older PI runtime), treat
+        // the runtime as idle and call bare sendUserMessage (pre-streaming
+        // behaviour preserved).
+        let isIdleAtDecision: boolean | undefined
+        try {
+          if (deliverAs === "nextTurn") {
+            isIdleAtDecision =
+              typeof api.isIdle === "function" ? api.isIdle() : true
+            if (isIdleAtDecision) {
+              api.sendUserMessage(content)
+            } else {
+              api.sendUserMessage(content, { deliverAs: "followUp" })
+            }
+          } else {
+            api.sendUserMessage(content, { deliverAs })
+          }
+        } catch (sendErr) {
+          // Re-emit with enough context to diagnose the failure from logs alone:
+          // frame type, the wire deliver_as value, and the isIdle state at the
+          // moment the delivery decision was made.
+          const sendMsg =
+            sendErr instanceof Error ? sendErr.message : String(sendErr)
+          const idleCtx =
+            isIdleAtDecision === undefined
+              ? "(not evaluated)"
+              : String(isIdleAtDecision)
+          emitError(
+            "dispatch_error",
+            `prompt: ${sendMsg} (deliver_as=${deliverAs}, isIdle=${idleCtx})`,
+            "prompt",
+          )
+          break
         }
         break
       }
@@ -1301,6 +1341,14 @@ export default function prismExtension(pi: ExtensionAPI): void {
             content as Parameters<ExtensionAPI["sendUserMessage"]>[0],
             options as Parameters<ExtensionAPI["sendUserMessage"]>[1],
           ),
+        isIdle: () => {
+          // ctx.isIdle is available on PI runtimes that expose it (the same
+          // guard used in the turn_end handler at ~line 1509). Fall back to
+          // true (treat as idle) for older runtimes without the method, which
+          // preserves the pre-streaming sendUserMessage behaviour.
+          const ctx = lastCtx
+          return typeof ctx?.isIdle === "function" ? ctx.isIdle() : true
+        },
         setModel: (model) =>
           pi.setModel(model as Parameters<ExtensionAPI["setModel"]>[0]),
         setThinkingLevel: (level) =>

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -622,11 +622,32 @@ Deliver a user message into the PI session.
 
 The extension's PI runtime call:
 
-| `deliver_as` | PI RPC call |
-|---|---|
-| `steer` | `pi.sendUserMessage(text, {deliverAs: "steer", images})` |
-| `followUp` | `pi.sendUserMessage(text, {deliverAs: "followUp", images})` |
-| `nextTurn` | `pi.sendUserMessage(text, {deliverAs: "nextTurn", images})` |
+| `deliver_as` | PI RPC call (idle) | PI RPC call (streaming) |
+|---|---|---|
+| `steer` | `pi.sendUserMessage(text, {deliverAs: "steer"})` | `pi.sendUserMessage(text, {deliverAs: "steer"})` |
+| `followUp` | `pi.sendUserMessage(text, {deliverAs: "followUp"})` | `pi.sendUserMessage(text, {deliverAs: "followUp"})` |
+| `nextTurn` | `pi.sendUserMessage(text)` *(bare call, idle path)* | `pi.sendUserMessage(text, {deliverAs: "followUp"})` *(resolved mid-stream)* |
+
+**`nextTurn` resolution detail:** PI's `sendUserMessage` requires an explicit
+`deliverAs` whenever the runtime is streaming a turn. Calling it without
+`deliverAs` mid-stream throws `"Agent is already processing. Specify
+streamingBehavior ('steer' or 'followUp') to queue the message."` — the
+throw would propagate into the dispatcher's outer try/catch and silently
+drop the frame. The extension therefore queries `ctx.isIdle()` at delivery
+time and routes:
+- **Idle** (`isIdle() === true` or `ctx.isIdle` not a function on older
+  runtimes): calls bare `sendUserMessage(text)` — equivalent to the
+  `nextTurn` PI RPC command, scheduling the message for the next turn.
+- **Streaming** (`isIdle() === false`): calls
+  `sendUserMessage(text, {deliverAs: "followUp"})` — queues the message
+  to be delivered after the current turn finishes, which is the correct
+  semantic for notification deliveries (coordinator finish-notifications,
+  merge-queue outcomes, startup-failure alerts) that arrive mid-stream.
+
+Callers that want deterministic post-turn queuing regardless of idle state
+should send `deliver_as: "followUp"` explicitly (which is what
+`notifyCoordinator`, `notifyParentWorkerOnStartupFailure`, and the
+merge-queue watcher all do).
 
 ### 6.3 `set_model`
 

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -320,7 +320,10 @@ func (w *Watcher) notify(ctx context.Context, targetSession, targetInstanceID, t
 	if status.Harness != nil {
 		if shape, ok := harness.ShapeOf(*status.Harness); ok && shape == harness.TransportSocketPipe {
 			log.Printf("[mergequeue] notify: routing via host-API socket for pi coordinator=%s", targetSession)
-			if deliverErr := promptdelivery.DeliverToSession(targetSession, status, text, buildNotifyBody, ""); deliverErr != nil {
+				// Use "followUp" so the coordinator receives the merge-queue outcome
+				// after its current turn completes, even when it is mid-stream at
+				// delivery time. Queue outcomes are post-turn signals.
+				if deliverErr := promptdelivery.DeliverToSession(targetSession, status, text, buildNotifyBody, "", "followUp"); deliverErr != nil {
 				log.Printf("[mergequeue] notify: FAILED (pi path) — coordinator=%s reason=%v", targetSession, deliverErr)
 			} else {
 				log.Printf("[mergequeue] notify: delivered to pi coordinator=%s via host-API socket", targetSession)

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
@@ -61,12 +61,19 @@ import (
 // sidecar uses this to gate reviewingInFlight clearing: only
 // source="review-complete" (the monitor's delivery) clears the flag; all other
 // deliveries leave it unchanged. Pass "" for non-monitor callers.
-func DeliverToSession(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any, source string) error {
+//
+// deliverAs controls the prompt delivery mode for pi (TransportSocketPipe)
+// sessions. It is forwarded as the "deliver_as" JSON field to the sidecar's
+// /prompt handler, which validates and passes it through to DeliverPrompt.
+// Accepted values: "steer", "followUp", "nextTurn". Empty string defaults to
+// "nextTurn" (current behaviour, for backward-compatible callers).
+// For opencode sessions the parameter is ignored (opencode uses prompt_async).
+func DeliverToSession(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any, source string, deliverAs string) error {
 	// Determine the transport shape from the harness field.
 	if status.Harness != nil && *status.Harness != "" {
 		shape, ok := harness.ShapeOf(*status.Harness)
 		if ok && shape == harness.TransportSocketPipe {
-			return deliverViaSidecarSocket(sessionName, text, source)
+			return deliverViaSidecarSocket(sessionName, text, source, deliverAs)
 		}
 	}
 
@@ -75,7 +82,8 @@ func DeliverToSession(sessionName string, status *db.Status, text string, buildH
 }
 
 // deliverViaSidecarSocket dials the target session's host-API Unix socket and
-// POSTs /prompt with {"session": sessionName, "prompt": text, "source": source}.
+// POSTs /prompt with {"session": sessionName, "prompt": text, "source": source,
+// "deliver_as": deliverAs}.
 //
 // The sidecar's /prompt handler checks that req.Session == s.cfg.SessionName
 // and that the harness shape is TransportSocketPipe, then calls s.DeliverPrompt
@@ -85,9 +93,14 @@ func DeliverToSession(sessionName string, status *db.Status, text string, buildH
 // reviewingInFlight clearing: only source="review-complete" clears the flag.
 // Pass "" for non-monitor callers (the field is omitted when empty).
 //
+// deliverAs is forwarded as the "deliver_as" JSON field. Pass "followUp" for
+// post-turn notifications (coordinator notify, merge-queue outcome, startup
+// failure). Pass "" to default to "nextTurn" (existing caller behaviour).
+// The sidecar validates the value and rejects unknown strings with HTTP 400.
+//
 // Returns an error if the socket does not exist (session ended / socket cleaned
 // up) or the HTTP request fails.
-func deliverViaSidecarSocket(sessionName, text, source string) error {
+func deliverViaSidecarSocket(sessionName, text, source, deliverAs string) error {
 	sockPath, err := session.SidecarHostAPIPath(sessionName)
 	if err != nil {
 		return fmt.Errorf("resolve host-API socket path for %q: %w", sessionName, err)
@@ -105,6 +118,9 @@ func deliverViaSidecarSocket(sessionName, text, source string) error {
 	}
 	if source != "" {
 		bodyMap["source"] = source
+	}
+	if deliverAs != "" {
+		bodyMap["deliver_as"] = deliverAs
 	}
 	body, err := json.Marshal(bodyMap)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
@@ -6,11 +6,14 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi" // register pi harness for ShapeOf("pi") in tests
 	"github.com/prismatic-koi/prism/internal/promptdelivery"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // TestDeliverToSession_OpencodePath verifies that DeliverToSession routes
@@ -38,7 +41,7 @@ func TestDeliverToSession_OpencodePath(t *testing.T) {
 		HarnessSessionID: &sid,
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello opencode", nil, "")
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello opencode", nil, "", "")
 	if err != nil {
 		t.Fatalf("DeliverToSession: %v", err)
 	}
@@ -59,7 +62,7 @@ func TestDeliverToSession_OpencodePath_NoPort(t *testing.T) {
 		// HarnessPort is nil — cannot deliver.
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil, "")
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing harness port, got nil")
 	}
@@ -79,7 +82,7 @@ func TestDeliverToSession_PiPath_MissingSocket(t *testing.T) {
 	}
 
 	// The socket path doesn't exist — we expect a clear error, not a hang.
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil, "")
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello", nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing socket, got nil")
 	}
@@ -111,7 +114,7 @@ func TestDeliverToSession_NilHarness(t *testing.T) {
 		HarnessSessionID: &sid,
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello nil harness", nil, "")
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "hello nil harness", nil, "", "")
 	if err != nil {
 		t.Fatalf("DeliverToSession: %v", err)
 	}
@@ -148,7 +151,7 @@ func TestDeliverToSession_CustomBodyBuilder(t *testing.T) {
 		return map[string]any{"custom_text": text, "extra": "field"}
 	}
 
-	err := promptdelivery.DeliverToSession("myrepo@feature", status, "custom body test", customBuilder, "")
+	err := promptdelivery.DeliverToSession("myrepo@feature", status, "custom body test", customBuilder, "", "")
 	if err != nil {
 		t.Fatalf("DeliverToSession: %v", err)
 	}
@@ -157,5 +160,82 @@ func TestDeliverToSession_CustomBodyBuilder(t *testing.T) {
 	}
 	if gotBody["extra"] != "field" {
 		t.Errorf("extra = %v, want 'field'", gotBody["extra"])
+	}
+}
+
+// TestDeliverToSession_PiPath_DeliverAsForwarded verifies that DeliverToSession
+// forwards the deliverAs parameter as the "deliver_as" JSON field in the
+// /prompt POST body when the session uses the pi (TransportSocketPipe) harness.
+// This ensures callers that pass "followUp" (e.g. notifyCoordinator) have their
+// intent preserved end-to-end — not overridden with a hardcoded "nextTurn".
+func TestDeliverToSession_PiPath_DeliverAsForwarded(t *testing.T) {
+	tests := []struct {
+		deliverAs string
+		want      string
+	}{
+		{deliverAs: "followUp", want: "followUp"},
+		{deliverAs: "steer", want: "steer"},
+		{deliverAs: "nextTurn", want: "nextTurn"},
+		{deliverAs: "", want: ""}, // empty → field omitted from body; sidecar defaults to nextTurn
+	}
+
+	for _, tc := range tests {
+		t.Run("deliverAs="+tc.deliverAs, func(t *testing.T) {
+			// Derive a session name that maps to a socket path we can control.
+			sessionName := "myrepo@feature"
+			sockPath, err := session.SidecarHostAPIPath(sessionName)
+			if err != nil {
+				t.Fatalf("resolve socket path: %v", err)
+			}
+
+			// Create the parent directory so the socket can be created there.
+			dir := sockPath[:strings.LastIndex(sockPath, "/")]
+			if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+				t.Fatalf("mkdir socket dir: %v", mkErr)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+			// Start a Unix-socket HTTP server that captures the /prompt body.
+			var gotBody map[string]string
+			lns, listenErr := net.Listen("unix", sockPath)
+			if listenErr != nil {
+				t.Fatalf("listen on socket: %v", listenErr)
+			}
+			srv := &http.Server{
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					b, _ := io.ReadAll(r.Body)
+					_ = json.Unmarshal(b, &gotBody)
+					w.WriteHeader(http.StatusOK)
+				}),
+			}
+			go func() { _ = srv.Serve(lns) }()
+			t.Cleanup(func() { _ = srv.Close() })
+
+			piHarness := "pi"
+			status := &db.Status{
+				SessionName: sessionName,
+				Harness:     &piHarness,
+			}
+
+			if deliverErr := promptdelivery.DeliverToSession(sessionName, status, "hello pi", nil, "", tc.deliverAs); deliverErr != nil {
+				t.Fatalf("DeliverToSession: %v", deliverErr)
+			}
+
+			// Verify deliver_as in the captured body.
+			if gotBody == nil {
+				t.Fatal("server received no request body")
+			}
+			if tc.want == "" {
+				// Empty deliverAs → field must be absent from the body.
+				if _, ok := gotBody["deliver_as"]; ok {
+					t.Errorf("deliver_as = %q in body, want absent (empty deliverAs omitted)",
+						gotBody["deliver_as"])
+				}
+			} else {
+				if got := gotBody["deliver_as"]; got != tc.want {
+					t.Errorf("deliver_as = %q, want %q", got, tc.want)
+				}
+			}
+		})
 	}
 }

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -388,7 +388,7 @@ func deliverPrompt(workerSession, text, dbPath string) error {
 		return fmt.Errorf("session %q has ended — cannot deliver review results", workerSession)
 	}
 
-	return promptdelivery.DeliverToSession(workerSession, status, text, buildPromptBodyForMonitor, "review-complete")
+	return promptdelivery.DeliverToSession(workerSession, status, text, buildPromptBodyForMonitor, "review-complete", "")
 }
 
 // buildPromptBodyForMonitor constructs the HTTP request body for prompt_async.

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -540,7 +540,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	})
 
 	// POST /prompt
-	// Request:  {"session":"<target>", "prompt":"<text>"}
+	// Request:  {"session":"<target>", "prompt":"<text>", "deliver_as":"<mode>"}
 	// Permission: worker → own coordinator (@main) only;
 	//             coordinator → own repo any session, cross-repo coordinator only.
 	mux.HandleFunc("/prompt", func(w http.ResponseWriter, r *http.Request) {
@@ -559,6 +559,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// unchanged — clearing on non-review prompts would prematurely end
 			// the reviewing window and reintroduce the race (#1372, AC #7).
 			Source string `json:"source,omitempty"`
+			// DeliverAs controls the delivery mode for same-session PI targets.
+			// Accepted values: "steer", "followUp", "nextTurn". When omitted the
+			// sidecar defaults to "nextTurn" (existing behaviour, backward
+			// compatible with callers that do not set this field). Unknown values
+			// are rejected with HTTP 400 before any frame is enqueued.
+			DeliverAs string `json:"deliver_as,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -570,6 +576,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Prompt == "" {
 			writeError(w, http.StatusBadRequest, "prompt is required")
+			return
+		}
+
+		// Validate deliver_as before any permission checks or delivery. Unknown
+		// values are rejected immediately so the caller gets a clear error
+		// instead of silently using the default.
+		deliverAs := req.DeliverAs
+		if deliverAs == "" {
+			deliverAs = "nextTurn"
+		} else if deliverAs != "steer" && deliverAs != "followUp" && deliverAs != "nextTurn" {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("invalid deliver_as %q: accepted values are \"steer\", \"followUp\", \"nextTurn\"", deliverAs))
 			return
 		}
 
@@ -609,8 +627,8 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					s.reviewingInFlight = false
 					s.mu.Unlock()
 				}
-				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s)", req.Session)
-				if !s.DeliverPrompt(req.Prompt, "nextTurn") {
+				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s) deliver_as=%s", req.Session, deliverAs)
+				if !s.DeliverPrompt(req.Prompt, deliverAs) {
 					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")
 					return
 				}

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -72,7 +72,10 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 	if parentStatus.Harness != nil {
 		if shape, ok := harness.ShapeOf(*parentStatus.Harness); ok && shape == harness.TransportSocketPipe {
 			log.Printf("sidecar: notifyParentWorker: routing via host-API socket for pi parent=%s", parentSession)
-			if err := promptdelivery.DeliverToSession(parentSession, parentStatus, notifyText, buildNotifyPromptBody, ""); err != nil {
+				// Use "followUp" so the message queues until the parent's current
+				// turn completes, even if the parent is streaming when delivery
+				// arrives. Startup-failure notifications are post-turn signals.
+				if err := promptdelivery.DeliverToSession(parentSession, parentStatus, notifyText, buildNotifyPromptBody, "", "followUp"); err != nil {
 				log.Printf("sidecar: notifyParentWorker: FAILED (pi path) — parent=%s reason=%v", parentSession, err)
 			} else {
 				log.Printf("sidecar: notifyParentWorker: delivered to pi parent=%s via host-API socket", parentSession)
@@ -235,7 +238,11 @@ func (s *Sidecar) notifyCoordinator() {
 	if coordStatus.Harness != nil {
 		if shape, ok := harness.ShapeOf(*coordStatus.Harness); ok && shape == harness.TransportSocketPipe {
 			log.Printf("sidecar: notifyCoordinator: routing via host-API socket for pi coordinator=%s", coordinatorName)
-			if err := promptdelivery.DeliverToSession(coordinatorName, coordStatus, notifyText, buildNotifyPromptBody, ""); err != nil {
+				// Use "followUp" so the coordinator receives the notification after
+				// its current turn completes, even when it is mid-stream at delivery
+				// time. Finish notifications are post-turn signals; "followUp" is
+				// the semantically correct delivery mode.
+				if err := promptdelivery.DeliverToSession(coordinatorName, coordStatus, notifyText, buildNotifyPromptBody, "", "followUp"); err != nil {
 				log.Printf("sidecar: notifyCoordinator: FAILED (pi path) — coordinator=%s reason=%v", coordinatorName, err)
 				if writeErr := s.cfg.DB.WriteBusMessageFailed(msg); writeErr != nil {
 					log.Printf("sidecar: notifyCoordinator: write failed audit: %v", writeErr)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
@@ -11,12 +11,31 @@ package sidecar
 // The tests use the hostAPIHandler() directly (no real Unix socket needed).
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
 	pih "github.com/prismatic-koi/prism/internal/harness/pi"
 )
+
+// jsonUnmarshal is a thin wrapper around json.Unmarshal for use in test
+// helpers that pass raw []byte from the pipe channel.
+func jsonUnmarshal(b []byte, v any) error {
+	// The pipe frames are JSONL — strip the trailing newline before unmarshalling.
+	return json.Unmarshal([]byte(strings.TrimRight(string(b), "\n")), v)
+}
+
+// containsAll reports whether s contains all of the provided substrings.
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
 
 // newPiSidecarForHostAPITest creates a Sidecar configured for the pi harness
 // and suitable for hostAPIHandler tests.
@@ -173,6 +192,116 @@ func TestHostAPI_Prompt_ReviewComplete_ClearsReviewingInFlight(t *testing.T) {
 	sc.mu.Unlock()
 	if inFlight {
 		t.Error("reviewingInFlight = true after review-complete delivery, want false")
+	}
+}
+
+// TestHostAPI_Prompt_DeliverAs_ForwardedToFrame verifies that the deliver_as
+// field from the POST /prompt request body is forwarded verbatim into the
+// prompt frame enqueued on the harness pipe channel. This is the key AC:
+// callers that set deliver_as="followUp" (e.g. notifyCoordinator) must have
+// their intent preserved end-to-end, not overridden with a hardcoded "nextTurn".
+func TestHostAPI_Prompt_DeliverAs_ForwardedToFrame(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantMode  string
+	}{
+		{
+			name:     "followUp is forwarded",
+			body:     `{"session":"myrepo@piworker","prompt":"follow","deliver_as":"followUp"}`,
+			wantMode: "followUp",
+		},
+		{
+			name:     "steer is forwarded",
+			body:     `{"session":"myrepo@piworker","prompt":"steer","deliver_as":"steer"}`,
+			wantMode: "steer",
+		},
+		{
+			name:     "nextTurn is forwarded",
+			body:     `{"session":"myrepo@piworker","prompt":"next","deliver_as":"nextTurn"}`,
+			wantMode: "nextTurn",
+		},
+		{
+			name:     "omitted defaults to nextTurn",
+			body:     `{"session":"myrepo@piworker","prompt":"default"}`,
+			wantMode: "nextTurn",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := openTestDB(t)
+			if err := d.UpsertStatus("myrepo@piworker", "myrepo", "/wt", "active", nil, nil); err != nil {
+				t.Fatalf("seed DB: %v", err)
+			}
+
+			sc := newPiSidecarForHostAPITest(t, "myrepo@piworker", "myrepo", "worker", d)
+
+			// Inject a fake pipe channel so DeliverPrompt has somewhere to write.
+			fakePipeCh := make(chan []byte, 10)
+			sc.mu.Lock()
+			sc.harnessPipeOutCh = fakePipeCh
+			sc.mu.Unlock()
+
+			rr := doHostAPI(t, sc, http.MethodPost, "/prompt", tc.body)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200, body=%s", rr.Code, rr.Body.String())
+			}
+
+			var frame map[string]string
+			select {
+			case raw := <-fakePipeCh:
+				if err := jsonUnmarshal(raw, &frame); err != nil {
+					t.Fatalf("unmarshal frame: %v", err)
+				}
+			default:
+				t.Fatal("expected a frame in pipe channel, but channel was empty")
+			}
+
+			if got := frame["deliver_as"]; got != tc.wantMode {
+				t.Errorf("frame deliver_as = %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}
+
+// TestHostAPI_Prompt_DeliverAs_InvalidRejected verifies that the /prompt
+// handler rejects an unknown deliver_as value with HTTP 400 and does not
+// enqueue any frame — no deliver_as value bypasses the validation.
+func TestHostAPI_Prompt_DeliverAs_InvalidRejected(t *testing.T) {
+	d := openTestDB(t)
+	if err := d.UpsertStatus("myrepo@piworker", "myrepo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed DB: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, "myrepo@piworker", "myrepo", "worker", d)
+
+	// Inject a fake pipe channel to detect spurious frame delivery.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"hello","deliver_as":"bogus"}`)
+
+	// Expect 400 Bad Request.
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (invalid deliver_as), body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Error body must mention the invalid value and the accepted set.
+	body := rr.Body.String()
+	if !containsAll(body, "bogus", "steer", "followUp", "nextTurn") {
+		t.Errorf("400 body %q should mention invalid value 'bogus' and accepted values", body)
+	}
+
+	// No frame must have been enqueued.
+	select {
+	case raw := <-fakePipeCh:
+		t.Errorf("unexpected frame enqueued after invalid deliver_as: %s", raw)
+	default:
+		// Good — nothing enqueued.
 	}
 }
 


### PR DESCRIPTION
## Summary

Two bugs combined to silently drop coordinator finish-notifications when the coordinator was mid-turn:

**Bug 1 — extension misread PI's contract**: `pi/extensions/prism.ts` called bare `sendUserMessage()` for `nextTurn` frames, claiming PI's internal logic would decide based on idle state. It does not. `agent-session.ts` throws unconditionally when streaming with no `streamingBehavior`. The throw was caught by the dispatcher's outer try/catch and the frame was silently dropped.

**Bug 2 — sidecar /prompt hardcoded "nextTurn"**: `host_api.go:613` always called `DeliverPrompt(req.Prompt, "nextTurn")` regardless of what the caller wanted. There was no way for any caller to request `followUp` or `steer` via the `/prompt` endpoint.

## Changes

### Change A — extension (`pi/extensions/prism.ts`)
- Add `isIdle?: () => boolean` to `InboundDispatchAPI` so the dispatcher can query PI's runtime idle state without holding a `ctx` reference
- For `nextTurn` frames, query `api.isIdle()` at delivery time: when idle (or `isIdle` absent — older runtime fallback) call bare `sendUserMessage(content)`; when streaming call `sendUserMessage(content, {deliverAs: "followUp"})` so the message queues until the current turn completes instead of throwing
- Add `isIdle()` implementation to the `apiAdapter` in the factory
- Improve error logging for prompt `sendUserMessage` failures: include `deliver_as` value and `isIdle` at decision time
- Update `InboundDispatchAPI.sendUserMessage` options union to include `"nextTurn"`

### Change B — sidecar (`host_api.go`, `promptdelivery.go`, `notify.go`, `watcher.go`)
- Add `deliver_as` field to `POST /prompt` request body. Accepted values: `"steer"`, `"followUp"`, `"nextTurn"`. Unknown values rejected with HTTP 400 before any frame is enqueued
- Default when omitted: `"nextTurn"` (backward-compatible)
- Forward validated value to `s.DeliverPrompt()` instead of hardcoded `"nextTurn"`
- Add `deliverAs` parameter to `promptdelivery.DeliverToSession` and forward as `deliver_as` JSON field
- `notifyCoordinator`: pass `"followUp"` for PI targets
- `notifyParentWorkerOnStartupFailure`: pass `"followUp"` for PI targets
- merge-queue watcher: pass `"followUp"` for PI targets

### Documentation
- `pi-wire-protocol.md` §6.2: update `nextTurn` row to document the actual extension behaviour and remove the incorrect claim that PI's internal logic handles idle-vs-streaming automatically when `deliverAs` is omitted

## Tests
- `prism.test.ts`: 4 new tests for `nextTurn` idle/streaming/absent-isIdle/throw-context paths
- `sidecar_pi_prompt_test.go`: 2 new test functions with 5 subtests covering `deliver_as` forwarding and invalid value rejection
- `promptdelivery_test.go`: 1 new test with 4 subtests verifying `deliver_as` is forwarded correctly over a real Unix socket

Closes #1447