### PR TITLE
fix: set XDG_STATE_HOME in TestDeliverToSession_PiPath_DeliverAsForwarded to survive Nix sandbox

### DIFF
--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery_test.go
@@ -181,6 +181,19 @@ func TestDeliverToSession_PiPath_DeliverAsForwarded(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run("deliverAs="+tc.deliverAs, func(t *testing.T) {
+			// Redirect XDG_STATE_HOME into a per-subtest temp dir so that
+			// SidecarHostAPIPath never falls back to $HOME — which is
+			// /homeless-shelter (unwritable) inside the Nix build sandbox.
+			// Use os.MkdirTemp with a short prefix rather than t.TempDir() to
+			// keep the resulting socket path under the 108-byte sun_path limit
+			// (t.TempDir embeds the full subtest name which pushes it over).
+			xdgTmp, mkTmpErr := os.MkdirTemp("", "prism-pd-*")
+			if mkTmpErr != nil {
+				t.Fatalf("create temp dir: %v", mkTmpErr)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(xdgTmp) })
+			t.Setenv("XDG_STATE_HOME", xdgTmp)
+
 			// Derive a session name that maps to a socket path we can control.
 			sessionName := "myrepo@feature"
 			sockPath, err := session.SidecarHostAPIPath(sessionName)


### PR DESCRIPTION
## Problem

The test `TestDeliverToSession_PiPath_DeliverAsForwarded` introduced by #1455 calls `os.MkdirAll` on the parent of the socket path returned by `session.SidecarHostAPIPath`. When `XDG_STATE_HOME` is unset, that function falls back to `$HOME/.local/state/prism/...`, which inside the Nix build sandbox is `/homeless-shelter` — an intentionally unwritable directory. This broke `nix build`:

```
--- FAIL: TestDeliverToSession_PiPath_DeliverAsForwarded (0.00s)
    --- FAIL: TestDeliverToSession_PiPath_DeliverAsForwarded/deliverAs=followUp (0.00s)
        promptdelivery_test.go:194: mkdir socket dir: mkdir /homeless-shelter: permission denied
    (and 3 more subtests with the same error)
```

## Fix

At the top of each subtest, create a temp dir with `os.MkdirTemp("", "prism-pd-*")` and set `XDG_STATE_HOME` to it via `t.Setenv`. This redirects socket path resolution into a writable, auto-cleaned directory without relying on `$HOME` at all — the same pattern already used in `internal/session/initial_prompt_test.go`.

`t.TempDir()` is not used here because it embeds the full subtest name in the path, which pushes the socket path over the 108-byte `sun_path` limit on Linux and causes a `bind: invalid argument` failure.

## Verification

Tested with:
```bash
HOME=/homeless-shelter XDG_STATE_HOME="" go test -v -run TestDeliverToSession_PiPath_DeliverAsForwarded ./internal/promptdelivery/...
```
All 4 subtests pass.

Introducing PR: #1455