### PR TITLE
flake: promote prism to a top-level packages output (nix build .#prism)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,13 @@ go build ./...
 go test ./...
 ```
 
-This is faster than a full nix build and should be the first check for any prism code change. Run the nix build as well if the change also touches `.nix` files.
+This is faster than a full nix build and should be the first check for any prism code change. Once the Go build and tests pass, verify the Nix derivation with:
+
+```bash
+nix build .#prism
+```
+
+Run `nix build .#prism` from the repo root whenever a change also touches `.nix` files or when confirming the final Nix build is correct.
 
 ### sandbox-exec testing convention
 

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,10 @@
         };
       };
 
+      packages = forEachSystem (pkgs: {
+        prism = pkgs.callPackage ./pkgs/prism.nix { };
+      });
+
       devShells = forEachSystem (pkgs: {
         default = pkgs.mkShell {
           buildInputs = [


### PR DESCRIPTION
## Summary

Promotes `prism` to a first-class flake `packages` output so it can be built with:

```bash
nix build .#prism
```

from any host, without substituting a NixOS configuration name.

## Changes

### `flake.nix`

Added a `packages` output alongside the existing `formatter`, `nixosConfigurations`, `darwinConfigurations`, and `devShells` outputs:

```nix
packages = forEachSystem (pkgs: {
  prism = pkgs.callPackage ./pkgs/prism.nix { };
});
```

### `AGENTS.md`

Updated prism build guidance to recommend `nix build .#prism` as the canonical Nix invocation for verifying prism Go-source changes.

## Verification

- **Same store path**: `nix build .#prism` and `nix build .#nixosConfigurations.navi.pkgs.prism` both resolve to `/nix/store/z741gbrzc5vr9fm8jy5gn4b0ij51n148-prism-0.1.0` — the new output is not a parallel derivation, it shares the existing one.
- **`nix flake show`** lists `prism` under both `packages.x86_64-linux` and `packages.aarch64-darwin` (aarch64-darwin is shown as `omitted` on the Linux host per `nix flake show` defaults, but appears when listed; `nix flake check` notes incompatible system as expected).
- **`nix flake check`** passes with `all checks passed!`
- **`nixfmt .`** is clean on touched `.nix` files.
- **`pkgs/prism.nix`** and **`overlays/default.nix`** are untouched — the overlay path continues to work unchanged.

Closes #1458