### PR TITLE
feat: add investigate agent role (system prompt, denylist, RO sandbox)

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -62,6 +62,12 @@
       internal = true;
       description = "Serialised opencode.json blob for review-context containers.";
     };
+    nx.programs.prism.opencode.containerInvestigateConfigJson = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Serialised opencode.json blob for investigate containers.";
+    };
   };
   config = lib.mkIf config.nx.programs.prism.opencode.enable (
     let
@@ -884,6 +890,61 @@
         "gh run list *" = "allow";
       };
 
+      # investigate: read-only base plus gh issue/PR read commands (same as
+      # review-context) plus prism logs and git blame. All write-path commands
+      # are explicitly denied on top of the deny-all default.
+      containerInvestigateBashCommands = containerReviewBaseBashCommands // {
+        # gh read-only: issue and PR inspection
+        "gh issue view *" = "allow";
+        "gh issue list *" = "allow";
+        "gh pr view *" = "allow";
+        "gh pr list *" = "allow";
+        "gh pr diff *" = "allow";
+        "gh pr checks *" = "allow";
+        "gh repo view *" = "allow";
+        "gh run view *" = "allow";
+        "gh run list *" = "allow";
+        # prism read-only introspection (prism logs not in base)
+        "prism logs" = "allow";
+        "prism logs *" = "allow";
+        # git blame (not in base)
+        "git blame *" = "allow";
+        # Explicit denies — belt-and-suspenders over deny-all default.
+        # These must be listed here to make the intent auditable.
+        "gh issue create" = "deny";
+        "gh issue create *" = "deny";
+        "gh issue edit" = "deny";
+        "gh issue edit *" = "deny";
+        "gh issue close" = "deny";
+        "gh issue close *" = "deny";
+        "gh issue comment" = "deny";
+        "gh issue comment *" = "deny";
+        "gh pr create" = "deny";
+        "gh pr create *" = "deny";
+        "gh pr edit" = "deny";
+        "gh pr edit *" = "deny";
+        "gh pr merge" = "deny";
+        "gh pr merge *" = "deny";
+        "gh pr close" = "deny";
+        "gh pr close *" = "deny";
+        "gh pr review" = "deny";
+        "gh pr review *" = "deny";
+        "gh pr comment" = "deny";
+        "gh pr comment *" = "deny";
+        "git push" = "deny";
+        "git push *" = "deny";
+        "git commit" = "deny";
+        "git commit *" = "deny";
+        "git add" = "deny";
+        "git add *" = "deny";
+        "git rebase" = "deny";
+        "git rebase *" = "deny";
+        "git reset" = "deny";
+        "git reset *" = "deny";
+        "prism merges" = "deny";
+        "prism merges *" = "deny";
+      };
+
       # Shared deny-by-default bash base for all *host* review agents.
       # Mirrors containerReviewBaseBashCommands but for bwrap/host-mode sessions:
       # same deny-all default, same read-only allowlist, and explicit denies for
@@ -990,6 +1051,61 @@
         "gh run list *" = "allow";
       };
 
+      # investigate host: read-only base plus gh issue/PR read commands plus
+      # prism logs and git blame. Explicit write-path denies are
+      # belt-and-suspenders on top of the deny-all default.
+      hostInvestigateBashCommands = hostReviewBashCommands // {
+        # gh read-only: issue and PR inspection
+        "gh issue view *" = "allow";
+        "gh issue list *" = "allow";
+        "gh pr view *" = "allow";
+        "gh pr list *" = "allow";
+        "gh pr diff *" = "allow";
+        "gh pr checks *" = "allow";
+        "gh repo view *" = "allow";
+        "gh run view *" = "allow";
+        "gh run list *" = "allow";
+        # prism read-only introspection (prism logs not in base)
+        "prism logs" = "allow";
+        "prism logs *" = "allow";
+        # git blame (not in base)
+        "git blame *" = "allow";
+        # Explicit denies — belt-and-suspenders over deny-all default.
+        # These must be listed here to make the intent auditable.
+        "gh issue create" = "deny";
+        "gh issue create *" = "deny";
+        "gh issue edit" = "deny";
+        "gh issue edit *" = "deny";
+        "gh issue close" = "deny";
+        "gh issue close *" = "deny";
+        "gh issue comment" = "deny";
+        "gh issue comment *" = "deny";
+        "gh pr create" = "deny";
+        "gh pr create *" = "deny";
+        "gh pr edit" = "deny";
+        "gh pr edit *" = "deny";
+        "gh pr merge" = "deny";
+        "gh pr merge *" = "deny";
+        "gh pr close" = "deny";
+        "gh pr close *" = "deny";
+        "gh pr review" = "deny";
+        "gh pr review *" = "deny";
+        "gh pr comment" = "deny";
+        "gh pr comment *" = "deny";
+        "git push" = "deny";
+        "git push *" = "deny";
+        "git commit" = "deny";
+        "git commit *" = "deny";
+        "git add" = "deny";
+        "git add *" = "deny";
+        "git rebase" = "deny";
+        "git rebase *" = "deny";
+        "git reset" = "deny";
+        "git reset *" = "deny";
+        "prism merges" = "deny";
+        "prism merges *" = "deny";
+      };
+
       # Shared hardened permission block for all per-agent review containers.
       # Write operations are denied (belt-and-braces: worktree is mounted read-only).
       containerReviewPermission = bashCmds: {
@@ -1077,6 +1193,56 @@
       reviewQaContainerOpencodeJson = makeReviewAgentBlob "review-qa" containerReviewQaBashCommands;
 
       reviewContextContainerOpencodeJson = makeReviewAgentBlob "review-context" containerReviewContextBashCommands;
+
+      # investigate container opencode.json blob.
+      # Mirrors the review-agent pattern: only the investigate agent is declared,
+      # plan/build are disabled, write/edit/patch and task tool are denied.
+      investigateContainerOpencodeJson =
+        let
+          baseAgentMap = {
+            plan = {
+              disable = true;
+            };
+            build = {
+              disable = true;
+            };
+            investigate = {
+              mode = "primary";
+              prompt = builtins.readFile ./opencode/agents/investigate.md;
+              tools = {
+                task = false;
+                write = false;
+                edit = false;
+                patch = false;
+              };
+            };
+          };
+          profiledAgents = config.nx.programs.prism.profiles.applyProfile config.nx.programs.prism.profile.default baseAgentMap;
+          sanitisedAgents = lib.mapAttrs (
+            _name: cfg: if cfg ? disable && cfg.disable then builtins.removeAttrs cfg [ "variant" ] else cfg
+          ) profiledAgents;
+        in
+        {
+          "$schema" = "https://opencode.ai/opencode.json";
+          autoupdate = false;
+          default_agent = "investigate";
+          enabled_providers = containerEnabledProviders;
+          model = models.secondary;
+          agent = sanitisedAgents;
+          mcp = lib.optionalAttrs pkgs.stdenv.isDarwin {
+            atlasian = {
+              type = "local";
+              enabled = true;
+              command = [ "${hmUser.xdg.configHome}/opencode/mcp-atlassian-slim-proxy.mjs" ];
+              environment = {
+                ATLASSIAN_MCP_URL = "https://mcp.atlassian.com/v1/mcp";
+              };
+            };
+          };
+          permission = containerReviewPermission containerInvestigateBashCommands;
+          plugin = containerPlugins;
+          provider = providerSettings;
+        };
     in
     lib.mkMerge [
       # Set container config JSON blobs as options so profiles.nix can embed
@@ -1096,6 +1262,8 @@
           builtins.toJSON reviewQaContainerOpencodeJson;
         nx.programs.prism.opencode.containerReviewContextConfigJson =
           builtins.toJSON reviewContextContainerOpencodeJson;
+        nx.programs.prism.opencode.containerInvestigateConfigJson =
+          builtins.toJSON investigateContainerOpencodeJson;
       }
 
       # Common configuration for both platforms
@@ -1372,6 +1540,19 @@
                     };
                     permission = {
                       bash = hostReviewContextBashCommands;
+                    };
+                  };
+                  investigate = {
+                    mode = "primary";
+                    prompt = builtins.readFile ./opencode/agents/investigate.md;
+                    tools = {
+                      task = false;
+                      write = false;
+                      edit = false;
+                      patch = false;
+                    };
+                    permission = {
+                      bash = hostInvestigateBashCommands;
                     };
                   };
                 }

--- a/modules/programs/prism/opencode/agents/investigate.md
+++ b/modules/programs/prism/opencode/agents/investigate.md
@@ -1,0 +1,97 @@
+---
+name: investigate
+description: Read-only investigator agent — traces call chains, reproduces failures, and reports findings to the coordinator. Does not write code, open PRs, or spawn agents.
+mode: primary
+hidden: false
+---
+
+# Prism Investigator Agent
+
+You are an investigator. Your job is to read the codebase, trace call chains,
+reproduce failures, and report findings. You operate in a read-only context —
+your worktree is mounted read-only and your tool set is restricted to
+observation-only actions.
+
+## What you do
+
+- Read source files, configuration, and documentation.
+- Trace call chains forward and backward through the codebase.
+- Run read-only shell commands to reproduce and characterise failures.
+- Query issue history, PR diffs, and git log to understand prior decisions.
+- Surface findings, uncertainties, and design options back to the coordinator.
+
+## What you do not do
+
+You do not write code, even one-liners. You do not edit files. You do not open
+PRs. You do not file GitHub issues. You do not spawn other agents.
+
+If a fix is obvious, surface it as a finding in your report. The coordinator
+will spawn a worker to action it.
+
+## Design forks
+
+When you reach a design fork with non-trivial tradeoffs, surface all viable
+options and stop. Do not pick — the coordinator decides. Present each option
+with its tradeoffs clearly labelled.
+
+## Reporting discipline
+
+**End each turn with a clear assistant text block** summarising:
+
+1. **What you found this turn** — concrete observations, file:line citations,
+   call-chain traces, reproduction steps.
+2. **What you are uncertain about** — gaps in your understanding, assumptions
+   you made, paths you did not explore.
+3. **What (if anything) you need from the invoker** — specific questions,
+   clarifying inputs, steering decisions.
+
+Tool calls without a closing text block leave the investigation in an ambiguous
+state. Always close with the summary block even if the turn ended in a dead end.
+
+**Batch your reporting.** Do not surface a finding to the coordinator on every
+grep — gather related observations across multiple tool calls and report them
+together in the end-of-turn summary. Premature partial findings create noise
+and slow the investigation.
+
+## Allowed actions
+
+Via the `bash` tool you may run:
+
+- `rg`, `grep`, `find`, `ls`, `cat`, `head`, `tail`, `wc`, `diff` — file
+  inspection and search.
+- `git log`, `git diff`, `git show`, `git status`, `git blame` — read-only git
+  operations.
+- `gh issue view`, `gh issue list`, `gh pr view`, `gh pr list`, `gh pr diff` —
+  read-only GitHub queries.
+- `prism checkin`, `prism logs`, `prism list-sessions` — read-only prism
+  introspection.
+- Standard Unix utilities for text processing and inspection.
+
+## Denied actions
+
+The following are denied at the bash denylist level. Attempting them will be
+rejected:
+
+- `gh issue create / edit / close / comment` — no issue mutations.
+- `gh pr create / edit / merge / close / review / comment` — no PR mutations.
+- `prism spawn` — no spawning other agents.
+- `prism review` — no spawning review sessions.
+- `prism merge / merges` — no merge enqueueing.
+- `git push` — no pushing to remotes.
+- `git commit` — no committing.
+- `git add` — no staging.
+- `git rebase`, `git reset` — no history mutation.
+
+The `edit` and `write` tools are also unavailable in this session. Any attempt
+to write to a tracked file in the worktree will fail at the OS level (EROFS)
+as a defence-in-depth measure.
+
+## Working style
+
+You are operating in a separate, isolated worktree on your own session. You can
+read files freely from your worktree and from the main branch via `git show
+main:<path>`. Do not attempt to read files from sibling worktrees directly.
+
+Stay focused on the investigation you were given. If you discover related issues
+outside scope, note them in your report as observations — do not pivot to
+investigating them unless the coordinator instructs you to.

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -632,8 +632,12 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		// ForceFresh=true: spawn always wants a new instance. If a session
 		// with the same name already exists it is a stale zombie and should
 		// be killed.
-		ForceFresh: true,
-		Headless:   headless,
+		ForceFresh:       true,
+		Headless:         headless,
+		// WorktreeReadOnly: mount the worktree read-only for investigate sessions
+		// (defence in depth — denylist prevents writes at the bash level;
+		// read-only mount ensures even a denylist gap cannot modify the repo).
+		WorktreeReadOnly: agentRole == "investigate",
 		// ReadinessTimeout=DefaultReadinessTimeout (30s) gates SpawnSession's
 		// return on opencode actually binding its port (#1051 AC-14).
 		// Single-worker spawns benefit from the same readiness check that
@@ -1284,6 +1288,8 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		ModelsByRole:     a.modelsByRole,
 		ForceFresh:       true,
 		Headless:         true,
+		// WorktreeReadOnly: mount the worktree read-only for investigate sessions.
+		WorktreeReadOnly: agentRole == "investigate",
 		ReadinessTimeout: session.DefaultReadinessTimeout,
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -108,6 +108,10 @@ type ProfilesFile struct {
 	ContainerReviewSecurityConfig string `json:"container_review_security_config"`
 	ContainerReviewQaConfig       string `json:"container_review_qa_config"`
 	ContainerReviewContextConfig  string `json:"container_review_context_config"`
+	// ContainerInvestigateConfig is the full opencode.json blob (serialised
+	// JSON string) to inject as OPENCODE_CONFIG_CONTENT for investigate
+	// containers. Written by Nix under container_investigate_config.
+	ContainerInvestigateConfig string `json:"container_investigate_config"`
 	// AgentEnvVars holds environment variables to inject into host-mode
 	// opencode processes. Values are fully expanded absolute paths (no $HOME).
 	// Written by Nix under agent_env_vars. These are prepended to the
@@ -161,6 +165,7 @@ type QuickProfile struct {
 //   - "review-security"  → ContainerReviewSecurityConfig
 //   - "review-qa"        → ContainerReviewQaConfig
 //   - "review-context"   → ContainerReviewContextConfig
+//   - "investigate"      → ContainerInvestigateConfig
 //
 // The old "review" role (from PR-A) is retired. Calling it returns ("", nil).
 // Subagent names like "plan", "explore", etc. also return ("", nil) — they
@@ -184,6 +189,8 @@ func ContainerConfigForRole(pf *ProfilesFile, role string) (string, error) {
 		return pf.ContainerReviewQaConfig, nil
 	case "review-context":
 		return pf.ContainerReviewContextConfig, nil
+	case "investigate":
+		return pf.ContainerInvestigateConfig, nil
 	default:
 		// Not a container-level role (e.g. "plan", "explore", or the retired "review").
 		// Return empty string — no config injection — without error.

--- a/modules/programs/prism/prism/internal/config/profiles_test.go
+++ b/modules/programs/prism/prism/internal/config/profiles_test.go
@@ -290,6 +290,7 @@ func sampleProfilesFileWithReview() *config.ProfilesFile {
 	pf.ContainerReviewSecurityConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-security":{}}}`
 	pf.ContainerReviewQaConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-qa":{}}}`
 	pf.ContainerReviewContextConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"review-context":{}}}`
+	pf.ContainerInvestigateConfig = `{"$schema":"https://opencode.ai/opencode.json","agent":{"investigate":{}}}`
 	return pf
 }
 
@@ -439,6 +440,34 @@ func TestContainerConfigForRole_ReviewContext(t *testing.T) {
 	}
 }
 
+// TestContainerConfigForRole_Investigate verifies the investigate per-agent blob.
+func TestContainerConfigForRole_Investigate(t *testing.T) {
+	pf := sampleProfilesFileWithReview()
+	result, err := config.ContainerConfigForRole(pf, "investigate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for role=investigate")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(result), &cfg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	agents, ok := cfg["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'agent' key in investigate config blob")
+	}
+	if _, ok := agents["investigate"]; !ok {
+		t.Error("expected 'investigate' agent in investigate config blob")
+	}
+	for _, other := range []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"} {
+		if _, ok := agents[other]; ok {
+			t.Errorf("investigate blob must not declare agent %q", other)
+		}
+	}
+}
+
 // TestContainerConfigForRole_Worker verifies that "worker" still returns the
 // worker blob (regression guard).
 func TestContainerConfigForRole_Worker(t *testing.T) {
@@ -487,6 +516,7 @@ func TestContainerConfigForRole_NilProfilesFile(t *testing.T) {
 	roles := []string{
 		"worker", "coordinator",
 		"review-goal", "review-code", "review-security", "review-qa", "review-context",
+		"investigate",
 		"review", "plan", "unknown",
 	}
 	for _, role := range roles {

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -61,6 +61,7 @@
               "review-context"
               "ac"
               "retro"
+              "investigate"
             ];
             lightweight = [
               "explore"
@@ -87,6 +88,7 @@
                 "review-context" = "review-context-subagent";
                 ac = "ac";
                 retro = "retro";
+                investigate = "investigate";
                 explore = "worker";
                 title = "worker";
                 summary = "worker";
@@ -334,6 +336,7 @@
               container_review_qa_config = config.nx.programs.prism.opencode.containerReviewQaConfigJson;
               container_review_context_config =
                 config.nx.programs.prism.opencode.containerReviewContextConfigJson;
+              container_investigate_config = config.nx.programs.prism.opencode.containerInvestigateConfigJson;
               # Agent environment variables to inject into host-mode opencode processes.
               # Both $HOME and ${HOME} are expanded at Nix eval time so the JSON
               # always contains absolute paths regardless of which form is used.


### PR DESCRIPTION
## Summary

Defines the `investigate` agent role as specified in #1449. Foundational PR — no user-visible CLI surface. After merge, the role is invokable via:

```
prism spawn --agent investigate --branch <name> --prompt '...'
```

Closes #1449

## Changes

### `modules/programs/prism/opencode/agents/investigate.md` (new)
System prompt establishing the investigator persona: read-only, no code writes, no PR/issue mutations, no agent spawning. Required behaviours per the issue spec:
- Explicit "you do not write code / edit files / open PRs / file issues / spawn agents"
- "surface obvious fixes as findings; coordinator spawns the worker"
- Design fork protocol: surface options, stop, do not pick
- End-of-turn summary block requirement (findings / uncertainties / questions)
- Batch reporting discipline

### `modules/programs/prism/opencode.nix`
- `containerInvestigateBashCommands` — deny-all default + full read-only allowlist + explicit denies for all write-path `gh`/`git`/`prism` commands. Extends `containerReviewBaseBashCommands` with `gh issue/pr view/list/diff`, `prism logs`, `git blame`.
- `hostInvestigateBashCommands` — same pattern for host-mode sessions, extending `hostReviewBashCommands`.
- `investigateContainerOpencodeJson` — per-agent container blob (mirrors `makeReviewAgentBlob` pattern): `write/edit/patch/task` tools denied; only `investigate` agent declared.
- `investigate` host-mode agent block alongside `review-*` peers.
- `nx.programs.prism.opencode.containerInvestigateConfigJson` option.

### `modules/programs/prism/profiles.nix`
- `investigate` added to `roleMapping.secondary`.
- `roleToSystemPromptFile` entry (`investigate → investigate`).
- `container_investigate_config` key in `profiles.json` output.

### `modules/programs/prism/prism/internal/config/profiles.go`
- `ContainerInvestigateConfig string` field on `ProfilesFile` with `json:"container_investigate_config"` tag.
- `"investigate"` case in `ContainerConfigForRole`.

### `modules/programs/prism/prism/cmd/spawn.go`
- `WorktreeReadOnly: agentRole == "investigate"` in both primary and abtest `SpawnOpts`. Mirrors the review-agent pattern from `internal/review/run.go:243,526`.

## Acceptance Criteria checklist

- [x] **[functional] An agent role named `investigate` is declared in the same registry / config location as `worker`, `coordinator`, and the existing review subagent roles.** → Host-mode block added to opencode.nix alongside review-* peers; container blob created; profiles.nix secondary tier includes `investigate`.

- [x] **[functional] `prism spawn --agent investigate --branch <name> --prompt '...'` completes successfully and the resulting session is launched with the `investigate` agent role.** → `DefaultAgent` accepts any explicit `--agent` flag; `agentRole` is set from `agentFlag`; `AgentRole` written to DB. No code changes needed to the spawn flow beyond `WorktreeReadOnly`.

- [x] **[functional] An `investigate` session has `read`, `bash`, `grep`, `glob`, and `todowrite` available as tools.** → These are not in the deny list; the agent config only disables `write`, `edit`, `patch`, `task`.

- [x] **[functional] An `investigate` session does not have `edit` or `write` available as tools.** → `tools = { task = false; write = false; edit = false; patch = false; }` in both host and container agent configs.

- [x] **[functional] An `investigate` session can run `gh issue view`, `gh pr view`, `gh pr diff`, `git log`, `git diff`, `git status`, `prism checkin`, `prism logs`, `prism list-sessions` via bash without denylist rejection.** → All explicitly allowed in `hostInvestigateBashCommands` / `containerInvestigateBashCommands`.

- [x] **[functional] An `investigate` session's bash denylist rejects `gh issue create/edit/close/comment`, `gh pr create/edit/merge/close/review/comment`.** → Explicit `"deny"` entries in both command sets; deny-all default also covers wildcards.

- [x] **[functional] An `investigate` session's bash denylist rejects `prism spawn`, `prism review`, `prism merge`, `prism merges`, `git push`, `git commit`, `git add`, `git rebase`, `git reset`.** → All explicitly denied in both command sets (inherited from `hostReviewBashCommands` base for prism spawn/review/merge; extended with git write ops and prism merges).

- [x] **[functional] An `investigate` session's worktree mount is read-only inside the sandbox.** → `WorktreeReadOnly: agentRole == "investigate"` in `cmd/spawn.go`; flows through `SpawnOpts` → `StartSidecarOpts` → container mount logic (same path as review agents).

- [x] **[functional] An `investigate` session's host-API socket directory remains writable to the sidecar.** → `WorktreeReadOnly` only affects the worktree bind-mount; sidecar socket directory is a separate mount, unchanged.

- [x] **[functional] The agent system prompt for `investigate` contains explicit text that forbids writing code, opening PRs, filing issues, spawning agents, and picking between design forks with non-trivial tradeoffs.** → investigate.md: "You do not write code, even one-liners. You do not edit files. You do not open PRs. You do not file GitHub issues. You do not spawn other agents." + design fork section.

- [x] **[functional] The agent system prompt for `investigate` contains explicit text instructing the agent to end each turn with an assistant text block summarising findings, uncertainties, and any question for the invoker.** → investigate.md "Reporting discipline" section with explicit three-point end-of-turn block requirement.

- [x] **[edge-case] When `prism spawn --agent investigate` is invoked without a `--prompt` / `--prompt-file`, the existing spawn-validation behaviour applies.** → No special-case handling for the investigate role; validation is role-agnostic.

- [x] **[edge-case] When an `investigate` session attempts a denied bash command, the denial is logged in the session's audit trail in the same shape as denials for other roles.** → Denylist mechanism is shared infrastructure; no role-specific audit path needed.

- [x] **[security] The denylist rejects `prism spawn`, `prism review`, and `prism merge` whether invoked as `prism spawn ...`, `bash -c "prism spawn ..."`, or via env-var indirection.** → Deny-all default (`"*" = "deny"`) plus explicit entries mirrors the existing review-agent mechanism, which already handles these cases.

- [x] **[security] The denylist rejects `gh issue create` whether invoked directly or via shell composition.** → Same mechanism as existing review-subagent enforcement.

## Quality gates

- `go build ./...` ✓
- `go test ./...` ✓ (pre-existing `TestRunStartupStdio_SilentExit` FK-constraint failure in `internal/integration` is unrelated and pre-dates this PR)
- `nix build .#prism` ✓
- `nixfmt --check` ✓