### PR TITLE
Update Prism configuration and UI theme

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -27,7 +27,7 @@
     };
     programs = {
       prism = {
-        profile.default = "anthropic";
+        profile.default = "anthropic-pi";
         agent.isolation.default = "bwrap";
         bwrapConcurrencyCap = 50;
       };

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -113,8 +113,8 @@
             customMessageText = "";
             customMessageLabel = primary;
             toolPendingBg = bg_dim;
-            toolSuccessBg = colourLib.darken bg_green 25;
-            toolErrorBg = colourLib.darken bg_red 25;
+            toolSuccessBg = colourLib.darken bg_green 35;
+            toolErrorBg = colourLib.darken bg_red 35;
             toolTitle = primary;
             toolOutput = "";
             # Markdown

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -164,7 +164,8 @@
             anthropic-pi = profileFromTiers {
               primary = slot {
                 provider = "anthropic";
-                model = "anthropic/claude-sonnet-4-6";
+                model = "anthropic/claude-opus-4-7";
+                thinking = "medium";
                 harness = "pi";
               };
               secondary = slot {


### PR DESCRIPTION
This change upgrades the default Anthropic profile on navi to use Claude Opus 4.7 with medium thinking enabled. Additionally, it adjusts the tool background colors in the theme to improve visual contrast.