### PR TITLE
Add tsx to pi-coding-agent environment

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -161,6 +161,7 @@
         home.packages = with pkgs; [
           pi-coding-agent
           fd
+          tsx # for testing pi extensions
         ];
 
         programs.zsh.shellAliases = {


### PR DESCRIPTION
Included the tsx package in the pi-coding-agent module to support the local execution and testing of pi extensions. This addition ensures that developers have the necessary runtime available within their environment.