### PR TITLE
feat(prism prompt): default deliver_as to steer for mid-flight corrections

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -385,6 +385,17 @@ see [Passing prompts safely](#passing-prompts-safely--shell-escaping) above.
 |---|---|
 | `--prompt <text>` | Prompt text to send. Supports `-` to read from stdin. |
 | `--prompt-file <path>` | Read prompt from a file. Mutually exclusive with `--prompt`. |
+| `--deliver-as <mode>` | Delivery mode for socket-pipe (PI) sessions: `steer` (default), `followUp`, or `nextTurn`. Has no effect for opencode (HTTP) sessions. |
+
+**Delivery modes** (relevant for PI / socket-pipe sessions):
+
+| Mode | Behaviour |
+|---|---|
+| `steer` **(default)** | Injects the prompt mid-turn so the agent sees it immediately, even during a long tool-call sequence. Use for coordinator mid-flight corrections and scope changes. |
+| `followUp` | Queues the prompt as the next user turn, delivered after the current turn completes. Use when the message is informational and does not need to interrupt the current turn. |
+| `nextTurn` | Alias for `followUp`; the sidecar's own default when `deliver_as` is absent from the request body. |
+
+The CLI validates the mode client-side before making any network call. An invalid value exits non-zero with a message listing the accepted values.
 
 The prompt is delivered directly via HTTP to the opencode session. The session must exist and have an active opencode port — use `prism list-sessions` to check first.
 

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -255,11 +255,14 @@ func proxyCheckin(apiURL, session string, limit int, before, after *string, type
 }
 
 // proxyPrompt proxies a prompt delivery request to the host-API sidecar.
-// apiURL is the value of PRISM_HOST_API.
-func proxyPrompt(apiURL, session, prompt string) error {
+// apiURL is the value of PRISM_HOST_API. deliverAs controls the delivery mode
+// ("steer", "followUp", or "nextTurn") and is forwarded as the "deliver_as"
+// JSON field so the sidecar can inject the prompt at the right time.
+func proxyPrompt(apiURL, session, prompt, deliverAs string) error {
 	return proxyToHostAPI(apiURL, "/prompt", map[string]any{
-		"session": session,
-		"prompt":  prompt,
+		"session":    session,
+		"prompt":     prompt,
+		"deliver_as": deliverAs,
 	}, nil)
 }
 

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -825,11 +825,12 @@ func TestProxyCheckin_SendsCorrectQueryParams(t *testing.T) {
 // ── proxyPrompt unit tests ────────────────────────────────────────────────────
 
 // TestProxyPrompt_SendsCorrectPayload verifies that proxyPrompt POSTs to
-// /prompt with the correct JSON body.
+// /prompt with the correct JSON body, including the deliver_as field.
 func TestProxyPrompt_SendsCorrectPayload(t *testing.T) {
 	type promptReq struct {
-		Session string `json:"session"`
-		Prompt  string `json:"prompt"`
+		Session   string `json:"session"`
+		Prompt    string `json:"prompt"`
+		DeliverAs string `json:"deliver_as"`
 	}
 
 	reqCh := make(chan promptReq, 1)
@@ -847,7 +848,7 @@ func TestProxyPrompt_SendsCorrectPayload(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	if err := proxyPrompt(srv.apiURL(), "myrepo@main", "do the thing"); err != nil {
+	if err := proxyPrompt(srv.apiURL(), "myrepo@main", "do the thing", "steer"); err != nil {
 		t.Fatalf("proxyPrompt: %v", err)
 	}
 
@@ -858,6 +859,9 @@ func TestProxyPrompt_SendsCorrectPayload(t *testing.T) {
 		}
 		if req.Prompt != "do the thing" {
 			t.Errorf("prompt = %q, want 'do the thing'", req.Prompt)
+		}
+		if req.DeliverAs != "steer" {
+			t.Errorf("deliver_as = %q, want \"steer\"", req.DeliverAs)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for request")
@@ -873,12 +877,61 @@ func TestProxyPrompt_Returns403AsError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"workers can only prompt their own coordinator"}`))
 	})
 
-	err := proxyPrompt(srv.apiURL(), "otherrepo@main", "hello")
+	err := proxyPrompt(srv.apiURL(), "otherrepo@main", "hello", "steer")
 	if err == nil {
 		t.Fatal("expected non-nil error for 403 response")
 	}
 	if !strings.Contains(err.Error(), "workers can only prompt") {
 		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}
+
+// TestProxyPrompt_DeliverAsModes verifies that proxyPrompt forwards the
+// deliverAs argument as the "deliver_as" JSON field for all accepted modes.
+// This is the container-mode (PRISM_HOST_API set) path — the CLI validates
+// the mode client-side before calling proxyPrompt, so by the time proxyPrompt
+// is called the value is already known to be valid.
+func TestProxyPrompt_DeliverAsModes(t *testing.T) {
+	cases := []struct {
+		deliverAs string
+	}{
+		{"steer"},
+		{"followUp"},
+		{"nextTurn"},
+	}
+
+	for _, tc := range cases {
+		t.Run("deliverAs="+tc.deliverAs, func(t *testing.T) {
+			type promptReq struct {
+				Session   string `json:"session"`
+				Prompt    string `json:"prompt"`
+				DeliverAs string `json:"deliver_as"`
+			}
+
+			reqCh := make(chan promptReq, 1)
+
+			srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+				var req promptReq
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				reqCh <- req
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			})
+
+			if err := proxyPrompt(srv.apiURL(), "myrepo@main", "test prompt", tc.deliverAs); err != nil {
+				t.Fatalf("proxyPrompt: %v", err)
+			}
+
+			select {
+			case req := <-reqCh:
+				if req.DeliverAs != tc.deliverAs {
+					t.Errorf("deliver_as = %q, want %q", req.DeliverAs, tc.deliverAs)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for request")
+			}
+		})
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -39,15 +39,29 @@ session. The session must already exist and have an agent window.
 
 The prompt is delivered directly via POST /session/:id/prompt_async for
 instant delivery. A record is also written to bus_messages (with delivered_at
-set) for audit. If HTTP delivery fails, an error is returned.`,
+set) for audit. If HTTP delivery fails, an error is returned.
+
+The --deliver-as flag controls the delivery mode for socket-pipe (PI) sessions:
+
+  steer     — inject mid-turn so the agent sees the correction immediately
+              (default — use for coordinator mid-flight redirections)
+  followUp  — queue as the next user turn after the current turn completes
+  nextTurn  — alias for followUp; the sidecar's own default when no mode is set
+
+For opencode (HTTP) sessions the flag is accepted but has no effect — opencode
+uses prompt_async and does not support delivery modes.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runPrompt,
 }
 
 func init() {
 	addPromptFlags(promptCmd)
+	promptCmd.Flags().String("deliver-as", "steer", `Delivery mode for socket-pipe (PI) sessions: steer, followUp, nextTurn. Default "steer" injects the prompt mid-turn for immediate visibility. No-op for opencode (HTTP) sessions.`)
 	rootCmd.AddCommand(promptCmd)
 }
+
+// validDeliverAsModes lists the accepted values for --deliver-as.
+var validDeliverAsModes = []string{"steer", "followUp", "nextTurn"}
 
 func runPrompt(cmd *cobra.Command, args []string) error {
 	sessionName := args[0]
@@ -57,8 +71,22 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Validate --deliver-as client-side before any network call.
+	deliverAs, _ := cmd.Flags().GetString("deliver-as")
+	valid := false
+	for _, m := range validDeliverAsModes {
+		if deliverAs == m {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("invalid --deliver-as %q: accepted values are %q",
+			deliverAs, validDeliverAsModes)
+	}
+
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyPrompt(apiURL, sessionName, promptText)
+		return proxyPrompt(apiURL, sessionName, promptText, deliverAs)
 	}
 
 	// Open DB.
@@ -136,7 +164,7 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	// via the active pipe connection (P2.SIDECAR).
 	if status.Harness != nil {
 		if shape, ok := harness.ShapeOf(*status.Harness); ok && shape == harness.TransportSocketPipe {
-			if err := deliverViaSidecarHostAPI(sessionName, promptText); err != nil {
+			if err := deliverViaSidecarHostAPI(sessionName, promptText, deliverAs); err != nil {
 				return fmt.Errorf("socket-pipe delivery failed: %w", err)
 			}
 			if err := database.WriteBusMessageDelivered(msg); err != nil {
@@ -171,11 +199,15 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 // socket-pipe path bypasses the HTTP harness API used for opencode and
 // instead routes through the sidecar's pipe-frame queue.
 //
+// deliverAs controls the delivery mode ("steer", "followUp", or "nextTurn").
+// It is forwarded as the "deliver_as" JSON field so the sidecar knows how to
+// inject the prompt. The sidecar validates unknown values and returns HTTP 400.
+//
 // The function dials the socket directly rather than going through the
 // PRISM_HOST_API proxy mechanism: PRISM_HOST_API is only set inside
 // containerised agent processes; the host-side prism CLI must look up the
 // per-session socket itself via session.SidecarHostAPIPath.
-func deliverViaSidecarHostAPI(sessionName, promptText string) error {
+func deliverViaSidecarHostAPI(sessionName, promptText, deliverAs string) error {
 	sockPath, err := session.SidecarHostAPIPath(sessionName)
 	if err != nil {
 		return fmt.Errorf("resolve sidecar host-api socket: %w", err)
@@ -186,8 +218,9 @@ func deliverViaSidecarHostAPI(sessionName, promptText string) error {
 	client := newHostAPIClient(sockPath)
 
 	body, err := json.Marshal(map[string]string{
-		"session": sessionName,
-		"prompt":  promptText,
+		"session":    sessionName,
+		"prompt":     promptText,
+		"deliver_as": deliverAs,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal prompt: %w", err)

--- a/modules/programs/prism/prism/cmd/prompt_test.go
+++ b/modules/programs/prism/prism/cmd/prompt_test.go
@@ -3,14 +3,17 @@ package cmd
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // openPromptTestDB opens a temp DB, registers cleanup, and overrides the
@@ -385,6 +388,224 @@ func TestRunPrompt_SessionNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention not found: got %q", err.Error())
+	}
+}
+
+// TestRunPrompt_DeliverAs_DefaultIsSteer verifies that prism prompt with no
+// --deliver-as flag sends deliver_as=steer in the sidecar host-API request body.
+func TestRunPrompt_DeliverAs_DefaultIsSteer(t *testing.T) {
+	stateHome, err := os.MkdirTemp("", "da")
+	if err != nil {
+		t.Fatalf("mkdir state home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	sessionName := "repo@da-steer"
+	sockPath, err := session.SidecarHostAPIPath(sessionName)
+	if err != nil {
+		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+
+	type req struct {
+		DeliverAs string `json:"deliver_as"`
+	}
+	reqCh := make(chan req, 1)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got req
+		_ = json.Unmarshal(body, &got)
+		reqCh <- got
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	d := openPromptTestDB(t)
+	seedSession(t, d, sessionName, "active", nil, nil, strPtr("worker"), nil)
+	setStatusHarness(t, d, sessionName, "pi")
+
+	// No --deliver-as flag — default should be steer.
+	rootCmd.SetArgs([]string{"prompt", sessionName, "--prompt", "mid-flight correction"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	select {
+	case got := <-reqCh:
+		if got.DeliverAs != "steer" {
+			t.Errorf("deliver_as = %q, want \"steer\" (default)", got.DeliverAs)
+		}
+	default:
+		t.Fatal("did not receive a /prompt request on the per-session socket")
+	}
+}
+
+// TestRunPrompt_DeliverAs_ExplicitFollowUp verifies that --deliver-as followUp
+// sends deliver_as=followUp in the request body.
+func TestRunPrompt_DeliverAs_ExplicitFollowUp(t *testing.T) {
+	stateHome, err := os.MkdirTemp("", "da")
+	if err != nil {
+		t.Fatalf("mkdir state home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	sessionName := "repo@da-follow"
+	sockPath, err := session.SidecarHostAPIPath(sessionName)
+	if err != nil {
+		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+
+	type req struct {
+		DeliverAs string `json:"deliver_as"`
+	}
+	reqCh := make(chan req, 1)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got req
+		_ = json.Unmarshal(body, &got)
+		reqCh <- got
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	d := openPromptTestDB(t)
+	seedSession(t, d, sessionName, "active", nil, nil, strPtr("worker"), nil)
+	setStatusHarness(t, d, sessionName, "pi")
+
+	rootCmd.SetArgs([]string{"prompt", sessionName, "--prompt", "follow-up message", "--deliver-as", "followUp"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	select {
+	case got := <-reqCh:
+		if got.DeliverAs != "followUp" {
+			t.Errorf("deliver_as = %q, want \"followUp\"", got.DeliverAs)
+		}
+	default:
+		t.Fatal("did not receive a /prompt request on the per-session socket")
+	}
+}
+
+// TestRunPrompt_DeliverAs_ExplicitNextTurn verifies that --deliver-as nextTurn
+// sends deliver_as=nextTurn in the request body.
+func TestRunPrompt_DeliverAs_ExplicitNextTurn(t *testing.T) {
+	stateHome, err := os.MkdirTemp("", "da")
+	if err != nil {
+		t.Fatalf("mkdir state home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateHome) })
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	sessionName := "repo@da-next"
+	sockPath, err := session.SidecarHostAPIPath(sessionName)
+	if err != nil {
+		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+
+	type req struct {
+		DeliverAs string `json:"deliver_as"`
+	}
+	reqCh := make(chan req, 1)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got req
+		_ = json.Unmarshal(body, &got)
+		reqCh <- got
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	d := openPromptTestDB(t)
+	seedSession(t, d, sessionName, "active", nil, nil, strPtr("worker"), nil)
+	setStatusHarness(t, d, sessionName, "pi")
+
+	rootCmd.SetArgs([]string{"prompt", sessionName, "--prompt", "queued message", "--deliver-as", "nextTurn"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	select {
+	case got := <-reqCh:
+		if got.DeliverAs != "nextTurn" {
+			t.Errorf("deliver_as = %q, want \"nextTurn\"", got.DeliverAs)
+		}
+	default:
+		t.Fatal("did not receive a /prompt request on the per-session socket")
+	}
+}
+
+// TestRunPrompt_DeliverAs_InvalidValueRejected verifies that --deliver-as bogus
+// exits non-zero with a clear error before any HTTP request is made.
+func TestRunPrompt_DeliverAs_InvalidValueRejected(t *testing.T) {
+	// Ensure the host-API proxy is not active.
+	t.Setenv("PRISM_HOST_API", "")
+
+	// We use an HTTP server to verify no request is made.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not receive a request for an invalid --deliver-as value")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	port := extractTestServerPort(t, srv.URL)
+	oldClient := httpClient
+	httpClient = srv.Client()
+	defer func() { httpClient = oldClient }()
+
+	d := openPromptTestDB(t)
+	seedSession(t, d, "repo@bogus", "active", intPtr(port), strPtr("oc-sid-x"), strPtr("worker"), strPtr("anthropic/claude-sonnet-4.6"))
+
+	rootCmd.SetArgs([]string{"prompt", "repo@bogus", "--prompt", "test", "--deliver-as", "bogus"})
+	execErr := rootCmd.Execute()
+	if execErr == nil {
+		t.Fatal("expected error for invalid --deliver-as value, got nil")
+	}
+	if !strings.Contains(execErr.Error(), "bogus") {
+		t.Errorf("error should mention the invalid value: got %q", execErr.Error())
+	}
+	// Error must name the accepted values.
+	for _, m := range []string{"steer", "followUp", "nextTurn"} {
+		if !strings.Contains(execErr.Error(), m) {
+			t.Errorf("error should mention accepted value %q: got %q", m, execErr.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

A coordinator sent a scope-relaxation prompt to an active worker via `prism prompt`, and the worker did not see it because it was still in its current turn. The coordinator had to manually re-send with steering. The root cause: `prism prompt` was sending no `deliver_as` field, causing the sidecar's `/prompt` handler to fall through to the `nextTurn` default — meaning the correction was queued and only seen after the current (potentially long) turn finished.

The right default for the CLI is `steer`, which injects the prompt mid-turn so the agent sees it immediately.

## What changed

### `cmd/prompt.go`
- Added `--deliver-as` flag (default: `steer`, accepted: `steer`, `followUp`, `nextTurn`)
- Client-side validation before any network call — bogus values exit non-zero with a clear message listing accepted values
- Passes the resolved value to `deliverViaSidecarHostAPI` (socket-pipe path) and `proxyPrompt` (container `PRISM_HOST_API` path)
- Updated `Long` description to document the flag and delivery modes

### `cmd/hostapi.go`
- Extended `proxyPrompt` signature to accept `deliverAs string` and forward it as `deliver_as` in the JSON body to the host-API sidecar
- Comment explains the no-op for opencode HTTP sessions

### Tests
- `cmd/prompt_test.go`: new tests for default `steer`, explicit `followUp`, explicit `nextTurn`, and client-side rejection of bogus values
- `cmd/hostapi_test.go`: updated existing `proxyPrompt` call sites to pass `deliverAs`; added `TestProxyPrompt_DeliverAsModes` covering all three modes

### `skills/prism/SKILL.md`
- Added `--deliver-as` to the `prism prompt` flags table
- Added a delivery modes reference table explaining steer / followUp / nextTurn

## Scope boundary — unchanged callers

The sidecar `/prompt` handler default remains `nextTurn` when `deliver_as` is absent. No other delivery path was modified:

- `internal/promptdelivery.DeliverToSession` — signature, defaults, behaviour unchanged ✓
- `notifyCoordinator` / `notifyParentWorkerOnStartupFailure` in `internal/sidecar/notify.go` — still pass `"followUp"` explicitly ✓
- Merge-queue watcher (`internal/mergequeue/watcher.go`) — still passes `"followUp"` explicitly ✓
- Review-complete monitor (`internal/review/monitor.go`) — still passes `""`, relies on sidecar's `nextTurn` default ✓
- No changes to `internal/sidecar/host_api.go` ✓

## Audit output

```
rg -n 'deliverAs|deliver_as' --type go
```

Modified files: `cmd/prompt.go`, `cmd/hostapi.go`, `cmd/prompt_test.go`, `cmd/hostapi_test.go`

All other matches are in pre-existing files (`internal/sidecar/`, `internal/promptdelivery/`, `internal/review/`, `internal/mergequeue/`) which were NOT modified.

## Caller audit

Checked all invocations of `prism prompt` in:
- `modules/programs/prism/opencode/agents/coordinator.md` — uses `prism prompt` for mid-flight corrections; `steer` default is correct
- `modules/programs/prism/opencode/agents/worker.md` — uses `prism prompt` for escalation; `steer` default is correct
- `modules/programs/prism/opencode/skills/prism/SKILL.md` — updated to document the new flag
- No shell scripts use `prism prompt` with an implicit `nextTurn` requirement

No callers needed to be updated with explicit `--deliver-as` flags.

## Quality gates

- `go test ./...` passes (excepting pre-existing `internal/integration` failures: DB foreign key constraint issues unrelated to this PR, verified against main)
- `nix build .#prism` passes ✓