### PR TITLE
fix: mute onedark dark theme coloured backgrounds to match everforest brightness

### DIFF
--- a/modules/colour-scheme/onedark.nix
+++ b/modules/colour-scheme/onedark.nix
@@ -32,10 +32,10 @@
     bg3 = "#3b3f4c";
     bg4 = "#3b3f4c";
     bg5 = "#3b3f4c";
-    bg_visual = "#382b2c";
-    bg_red = "#8b3434";
-    bg_green = "#8cc265";
-    bg_blue = "#2c5372";
-    bg_yellow = "#93691d";
+    bg_visual = "#2f2d3a";
+    bg_red = "#3f2a30";
+    bg_green = "#2e3a30";
+    bg_blue = "#26384a";
+    bg_yellow = "#3a3220";
   };
 }


### PR DESCRIPTION
## Motivation

The five `bg_*` slots in `modules/colour-scheme/onedark.nix` were sitting at near-foreground saturation. Most egregiously, `bg_green = "#8cc265"` is a bright, saturated green being used as a diff-add / search-hit background — far too bright against onedark's `#282c34` base.

This is the same problem fixed for `gruvbox-dark` in #1348 (commit `0fc39ab2`). Applying the same treatment to onedark.

## What changed

Only `modules/colour-scheme/onedark.nix` is modified (one-file diff).

| Slot | Before | After |
|---|---|---|
| `bg_visual` | `#382b2c` | `#2f2d3a` |
| `bg_red`    | `#8b3434` | `#3f2a30` |
| `bg_green`  | `#8cc265` | `#2e3a30` |
| `bg_blue`   | `#2c5372` | `#26384a` |
| `bg_yellow` | `#93691d` | `#3a3220` |

The new values:
- Sit at roughly everforest brightness (luminance in the `#2f–#3f` range, matching everforest's `#3a–#54` target range)
- Preserve hue identity — each slot still reads as its named colour when used as a semantic background highlight
- Lean cool to harmonise with onedark's slightly cooler `#282c34` base (vs. gruvbox's warm `#282828`)
- Keep `bg_visual` (a dark muted purple-grey `#2f2d3a`) visually distinct from `bg2`/`bg3` (`#393f4a`/`#3b3f4c`) and from the four colour slots

## Audit

- No consumer hardcodes onedark-specific `bg_*` overrides separately from the slot lookup — the change propagates cleanly.
- `modules/programs/prism/neovim/plugins/theme-onedark.nix` confirmed to reference only `theme.primary`, `theme.green`, `theme.bg0`, etc. — not `theme.bg_green` — so no neovim plugin changes needed.
- `nix build .#nixosConfigurations.tui.config.system.build.toplevel --dry-run` passes.
- `nixfmt .` produces no further changes.

## Prior art

#1348 / commit `0fc39ab2` — same fix for gruvbox-dark.