### PR TITLE
internal/sidecar: inject per-instance logger to eliminate global log races

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -3,7 +3,6 @@ package sidecar
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
@@ -22,13 +21,13 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 	// the real event type is embedded in the JSON `type` field of the payload.
 	eventType := s.harness.ExtractEventType(evt)
 
-	log.Printf("sidecar: event: %s", eventType)
+	s.logger().Printf("sidecar: event: %s", eventType)
 
 	// Gap 1b: log the first event received from opencode (once per session).
 	if !s.firstEventLogged {
 		s.firstEventLogged = true
 		elapsed := time.Since(s.spawnTime).Round(time.Millisecond)
-		log.Printf("sidecar: first event received from opencode (%s after spawn)", elapsed)
+		s.logger().Printf("sidecar: first event received from opencode (%s after spawn)", elapsed)
 
 		// Bwrap path `[timing]` markers (#1052). The podman path emits these
 		// from sidecar.Run() around WaitHealthy / CreateSession; in bwrap
@@ -51,10 +50,10 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 		//     Emitted at the same moment for symmetry with the podman line
 		//     at sidecar.go:489.
 		if !container.CapabilitiesFor(s.cfg.IsolationMode).OwnsContainerLifecycle {
-			log.Printf("[timing] opencode listening: %s from start", elapsed)
-			log.Printf("[timing] ready: %s from start", elapsed)
+			s.logger().Printf("[timing] opencode listening: %s from start", elapsed)
+			s.logger().Printf("[timing] ready: %s from start", elapsed)
 			if s.cfg.InitialPrompt != "" {
-				log.Printf("[timing] prompt delivered: %s from start", elapsed)
+				s.logger().Printf("[timing] prompt delivered: %s from start", elapsed)
 			}
 		}
 	}
@@ -108,11 +107,11 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 			if len(s.seenUnknown) >= seenUnknownCap {
 				if !s.seenUnknownCapReached {
 					s.seenUnknownCapReached = true
-					log.Printf("sidecar: unknown-event log cap reached")
+					s.logger().Printf("sidecar: unknown-event log cap reached")
 				}
 			} else {
 				s.seenUnknown[eventType] = true
-				log.Printf("sidecar: event: %s (unhandled — opencode may have added a new event type)", eventType)
+				s.logger().Printf("sidecar: event: %s (unhandled — opencode may have added a new event type)", eventType)
 			}
 		}
 	}
@@ -148,7 +147,7 @@ func (s *Sidecar) handleServerConnected() {
 	// Reconnect while active — start a recovery timer in case session.idle was
 	// missed during the gap.
 	s.cancelRecoveryTimer()
-	log.Printf("sidecar: reconnected while active, starting %v recovery timer", ReconnectRecoveryDelay)
+	s.logger().Printf("sidecar: reconnected while active, starting %v recovery timer", ReconnectRecoveryDelay)
 	s.recoveryTimer = s.cfg.Clock.AfterFunc(ReconnectRecoveryDelay, func() {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -170,11 +169,11 @@ func (s *Sidecar) handleServerConnected() {
 		// "active" (not "reviewing"), the guard is false, and suppression is
 		// lifted. See #1384.
 		if s.reviewingInFlight && s.currentDBState() == agent.StateReviewing {
-			log.Printf("sidecar: recovery timer suppressed (cause=reviewing — awaiting review-complete prompt)")
+			s.logger().Printf("sidecar: recovery timer suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
-		log.Printf("sidecar: recovery timer fired, writing finished (session.idle likely missed on reconnect)")
-		log.Printf("sidecar: transition -> finished (cause=recovery_timer)")
+		s.logger().Printf("sidecar: recovery timer fired, writing finished (session.idle likely missed on reconnect)")
+		s.logger().Printf("sidecar: transition -> finished (cause=recovery_timer)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
@@ -190,7 +189,7 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: session.status parse error: %v", err)
+		s.logger().Printf("sidecar: session.status parse error: %v", err)
 		return
 	}
 
@@ -209,7 +208,7 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 		// the genuine reviewing→active transition still happens. See
 		// internal/review/monitor.go and #1049.
 		if s.reviewingInFlight && s.currentDBState() == agent.StateReviewing {
-			log.Printf("sidecar: busy event suppressed (cause=reviewing — awaiting review-complete prompt)")
+			s.logger().Printf("sidecar: busy event suppressed (cause=reviewing — awaiting review-complete prompt)")
 		} else if !s.compacting {
 			s.upsertState(agent.StateActive, nil, nil)
 			s.writeStateChange(agent.StateActive)
@@ -222,7 +221,7 @@ func (s *Sidecar) handleSessionStatus(evt harness.HarnessEvent) {
 		// StateError; without this, an immediate session.updated would bypass the
 		// debounce guard and false-resume.
 		s.lastErrorAt = s.cfg.Clock.Now()
-		log.Printf("sidecar: transition -> error (cause=error_finish)")
+		s.logger().Printf("sidecar: transition -> error (cause=error_finish)")
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 	}
@@ -247,22 +246,22 @@ func (s *Sidecar) handleSessionFinished() {
 	// likely about to resume — the next state_change{finished} after the root
 	// agent completes will start the timer normally.
 	if s.lastAssistantAgent != "" && s.rootAgent != "" && s.lastAssistantAgent != s.rootAgent {
-		log.Printf("sidecar: finished suppressed: lastAssistantAgent=%q is not rootAgent=%q", s.lastAssistantAgent, s.rootAgent)
+		s.logger().Printf("sidecar: finished suppressed: lastAssistantAgent=%q is not rootAgent=%q", s.lastAssistantAgent, s.rootAgent)
 		return
 	}
 
-	log.Printf("sidecar: finished debounce started (%v)", IdleDebounce)
+	s.logger().Printf("sidecar: finished debounce started (%v)", IdleDebounce)
 	s.idleTimer = s.cfg.Clock.AfterFunc(IdleDebounce, func() {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		s.idleTimer = nil
 
-		log.Printf("sidecar: finished debounce fired -> finished")
+		s.logger().Printf("sidecar: finished debounce fired -> finished")
 
 		// If the user manually denied a permission, write interrupted not finished.
 		if s.manualDenial {
 			s.manualDenial = false
-			log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
+			s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
 			return
@@ -277,11 +276,11 @@ func (s *Sidecar) handleSessionFinished() {
 			return
 		}
 		if s.reviewingInFlight && currentState == agent.StateReviewing {
-			log.Printf("sidecar: finished debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
+			s.logger().Printf("sidecar: finished debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
 
-		log.Printf("sidecar: transition -> finished (cause=finished_debounce)")
+		s.logger().Printf("sidecar: transition -> finished (cause=finished_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
@@ -305,22 +304,22 @@ func (s *Sidecar) handleSessionIdle() {
 	// likely about to resume — the next session.idle after the root agent
 	// completes will start the timer normally.
 	if s.lastAssistantAgent != "" && s.rootAgent != "" && s.lastAssistantAgent != s.rootAgent {
-		log.Printf("sidecar: idle suppressed: lastAssistantAgent=%q is not rootAgent=%q", s.lastAssistantAgent, s.rootAgent)
+		s.logger().Printf("sidecar: idle suppressed: lastAssistantAgent=%q is not rootAgent=%q", s.lastAssistantAgent, s.rootAgent)
 		return
 	}
 
-	log.Printf("sidecar: idle debounce started (%v)", IdleDebounce)
+	s.logger().Printf("sidecar: idle debounce started (%v)", IdleDebounce)
 	s.idleTimer = s.cfg.Clock.AfterFunc(IdleDebounce, func() {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		s.idleTimer = nil
 
-		log.Printf("sidecar: idle debounce fired -> finished")
+		s.logger().Printf("sidecar: idle debounce fired -> finished")
 
 		// If the user manually denied a permission, write interrupted not finished.
 		if s.manualDenial {
 			s.manualDenial = false
-			log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
+			s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
 			return
@@ -335,11 +334,11 @@ func (s *Sidecar) handleSessionIdle() {
 			return
 		}
 		if s.reviewingInFlight && currentState == agent.StateReviewing {
-			log.Printf("sidecar: idle debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
+			s.logger().Printf("sidecar: idle debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
 
-		log.Printf("sidecar: transition -> finished (cause=idle_debounce)")
+		s.logger().Printf("sidecar: transition -> finished (cause=idle_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
@@ -356,7 +355,7 @@ func (s *Sidecar) handleSessionCreated(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: session.created parse error: %v", err)
+		s.logger().Printf("sidecar: session.created parse error: %v", err)
 		return
 	}
 
@@ -371,7 +370,7 @@ func (s *Sidecar) handleSessionCreated(evt harness.HarnessEvent) {
 	// fresh session ID always replaces a stale one. (#694)
 	if info.ID != "" {
 		if err := s.cfg.DB.UpdateHarnessSessionID(s.cfg.SessionName, info.ID); err != nil {
-			log.Printf("sidecar: handleSessionCreated: UpdateHarnessSessionID failed: %v", err)
+			s.logger().Printf("sidecar: handleSessionCreated: UpdateHarnessSessionID failed: %v", err)
 		}
 	}
 
@@ -394,7 +393,7 @@ func (s *Sidecar) handleSessionUpdated(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: session.updated parse error: %v", err)
+		s.logger().Printf("sidecar: session.updated parse error: %v", err)
 		return
 	}
 
@@ -435,13 +434,13 @@ func (s *Sidecar) handleSessionUpdated(evt harness.HarnessEvent) {
 		// resumes (e.g. user presses Enter) transition normally.
 		if !s.lastErrorAt.IsZero() && s.cfg.Clock.Now().Sub(s.lastErrorAt) < ErrorResumeDebounce {
 			// Within debounce window: treat as churn. Update metadata only.
-			log.Printf("sidecar: session.updated within error-resume debounce window (%v since error) — suppressing resume", s.cfg.Clock.Now().Sub(s.lastErrorAt))
+			s.logger().Printf("sidecar: session.updated within error-resume debounce window (%v since error) — suppressing resume", s.cfg.Clock.Now().Sub(s.lastErrorAt))
 			s.upsertState(currentState, title, sid)
 			return
 		}
 		// Outside debounce window (or no error recorded): genuine resume.
 		if err := s.cfg.DB.ClearEnded(s.cfg.SessionName); err != nil {
-			log.Printf("sidecar: ClearEnded failed on resume: %v", err)
+			s.logger().Printf("sidecar: ClearEnded failed on resume: %v", err)
 		}
 		s.upsertState(agent.StateActive, title, sid)
 		s.writeStateChange(agent.StateActive)
@@ -450,7 +449,7 @@ func (s *Sidecar) handleSessionUpdated(evt harness.HarnessEvent) {
 		// becomes visible again in AllActiveStatus / dashboard filters
 		// (both query WHERE ended_at IS NULL).
 		if err := s.cfg.DB.ClearEnded(s.cfg.SessionName); err != nil {
-			log.Printf("sidecar: ClearEnded failed on resume: %v", err)
+			s.logger().Printf("sidecar: ClearEnded failed on resume: %v", err)
 		}
 		s.upsertState(agent.StateActive, title, sid)
 		s.writeStateChange(agent.StateActive)
@@ -472,7 +471,7 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: session.error parse error: %v", err)
+		s.logger().Printf("sidecar: session.error parse error: %v", err)
 		return
 	}
 
@@ -488,16 +487,16 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 	// condition (user pressed Escape/Ctrl-C) whereas other errors are unexpected.
 	truncatedMsg := truncate(errorMessage, 200)
 	if errorName == "MessageAbortedError" {
-		log.Printf("sidecar: session.error: name=%q message=%s [MessageAbortedError — user-initiated]", errorName, truncatedMsg)
+		s.logger().Printf("sidecar: session.error: name=%q message=%s [MessageAbortedError — user-initiated]", errorName, truncatedMsg)
 	} else {
-		log.Printf("sidecar: session.error: name=%q message=%s", errorName, truncatedMsg)
+		s.logger().Printf("sidecar: session.error: name=%q message=%s", errorName, truncatedMsg)
 	}
 
 	if errorName == "MessageAbortedError" {
 		// User pressed Escape/Ctrl-C — record as interrupted.
 		s.cancelIdleTimer()
 		s.cancelRecoveryTimer()
-		log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
+		s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
 	} else {
@@ -507,7 +506,7 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		// post-error session.updated churn that opencode emits in the same
 		// millisecond as session.error (see ErrorResumeDebounce).
 		s.lastErrorAt = s.cfg.Clock.Now()
-		log.Printf("sidecar: transition -> error (cause=error_finish)")
+		s.logger().Printf("sidecar: transition -> error (cause=error_finish)")
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 		s.writeEvent("error", map[string]string{"name": errorName}, nil)
@@ -541,7 +540,7 @@ func (s *Sidecar) handleSessionDeleted(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: session.deleted parse error: %v", err)
+		s.logger().Printf("sidecar: session.deleted parse error: %v", err)
 		return
 	}
 
@@ -549,7 +548,7 @@ func (s *Sidecar) handleSessionDeleted(evt harness.HarnessEvent) {
 	sid := strPtr(payload.Properties.Info.ID)
 	s.upsertState(agent.StateDeleted, nil, sid)
 	if err := s.cfg.DB.SetEnded(s.cfg.SessionName); err != nil {
-		log.Printf("sidecar: SetEnded failed: %v", err)
+		s.logger().Printf("sidecar: SetEnded failed: %v", err)
 	}
 	s.writeStateChangeWithSID(agent.StateDeleted, sid)
 }
@@ -592,7 +591,7 @@ func (s *Sidecar) handlePermissionReplied(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: permission.replied parse error: %v", err)
+		s.logger().Printf("sidecar: permission.replied parse error: %v", err)
 		return
 	}
 
@@ -637,7 +636,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: message.updated parse error: %v", err)
+		s.logger().Printf("sidecar: message.updated parse error: %v", err)
 		return
 	}
 
@@ -675,7 +674,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 		isRootAgent := s.rootAgent == "" || agentName == "" || agentName == s.rootAgent
 		if model != "" && isRootAgent {
 			if err := s.cfg.DB.UpdateRootModelID(s.cfg.SessionName, model); err != nil {
-				log.Printf("sidecar: UpdateRootModelID (user msg) failed: %v", err)
+				s.logger().Printf("sidecar: UpdateRootModelID (user msg) failed: %v", err)
 			}
 		}
 
@@ -724,7 +723,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 		// session.idle fires, this is used to suppress the finished
 		// debounce if a subagent (non-root) was most recently active —
 		// the parent agent is likely about to resume.
-		log.Printf("sidecar: lastAssistantAgent: %q -> %q (rootAgent=%q)", s.lastAssistantAgent, agentName, s.rootAgent)
+		s.logger().Printf("sidecar: lastAssistantAgent: %q -> %q (rootAgent=%q)", s.lastAssistantAgent, agentName, s.rootAgent)
 		s.lastAssistantAgent = agentName
 		// If the root agent just completed, clear the tracking so the
 		// next session.idle can proceed normally to finished. Also start
@@ -741,10 +740,10 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 			if info.Tokens != nil {
 				totalTokens = info.Tokens.Input + info.Tokens.Output
 			}
-			log.Printf("sidecar: assistant turn complete (agent=%s root=%t model=%s messageId=%s tokens=%d)",
+			s.logger().Printf("sidecar: assistant turn complete (agent=%s root=%t model=%s messageId=%s tokens=%d)",
 				agentName, isRoot, model, info.ID, totalTokens)
 
-			log.Printf("sidecar: lastAssistantAgent cleared (root agent completed)")
+			s.logger().Printf("sidecar: lastAssistantAgent cleared (root agent completed)")
 			s.lastAssistantAgent = ""
 
 			// Start the idle debounce timer immediately. opencode emits only
@@ -762,7 +761,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 			// additional safety net for the race where Stop() returns false
 			// (the goroutine already started running).
 			epochAtStart := s.busyEpoch
-			log.Printf("sidecar: root-agent message completed — starting idle debounce early (%v)", IdleDebounce)
+			s.logger().Printf("sidecar: root-agent message completed — starting idle debounce early (%v)", IdleDebounce)
 			s.cancelIdleTimer()
 			s.idleTimer = s.cfg.Clock.AfterFunc(IdleDebounce, func() {
 				s.mu.Lock()
@@ -772,15 +771,15 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 				// If a new busy event arrived after this timer started, the
 				// agent began a new turn — do not transition to finished.
 				if s.busyEpoch != epochAtStart {
-					log.Printf("sidecar: idle debounce (root-agent message path) suppressed — busy fired after timer start (epochAtStart=%d, busyEpoch=%d)", epochAtStart, s.busyEpoch)
+					s.logger().Printf("sidecar: idle debounce (root-agent message path) suppressed — busy fired after timer start (epochAtStart=%d, busyEpoch=%d)", epochAtStart, s.busyEpoch)
 					return
 				}
 
-				log.Printf("sidecar: idle debounce fired (root-agent message path) -> finished")
+				s.logger().Printf("sidecar: idle debounce fired (root-agent message path) -> finished")
 
 				if s.manualDenial {
 					s.manualDenial = false
-					log.Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
+					s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 					s.upsertState(agent.StateInterrupted, nil, nil)
 					s.writeStateChange(agent.StateInterrupted)
 					return
@@ -791,11 +790,11 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 					return
 				}
 				if s.reviewingInFlight && s.currentDBState() == agent.StateReviewing {
-					log.Printf("sidecar: idle debounce (root-agent message path) suppressed (cause=reviewing — awaiting review-complete prompt)")
+					s.logger().Printf("sidecar: idle debounce (root-agent message path) suppressed (cause=reviewing — awaiting review-complete prompt)")
 					return
 				}
 
-				log.Printf("sidecar: transition -> finished (cause=root_agent_idle_debounce)")
+				s.logger().Printf("sidecar: transition -> finished (cause=root_agent_idle_debounce)")
 				s.upsertState(agent.StateFinished, nil, nil)
 				s.writeStateChange(agent.StateFinished)
 				go s.notifyCoordinator()
@@ -813,7 +812,7 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 		isRootAgent := s.rootAgent == "" || agentName == "" || agentName == s.rootAgent
 		if model != "" && isRootAgent {
 			if err := s.cfg.DB.UpdateRootModelID(s.cfg.SessionName, model); err != nil {
-				log.Printf("sidecar: UpdateRootModelID failed: %v", err)
+				s.logger().Printf("sidecar: UpdateRootModelID failed: %v", err)
 			}
 		}
 
@@ -889,7 +888,7 @@ func (s *Sidecar) handleMessagePartUpdated(evt harness.HarnessEvent) {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(evt.Data, &payload); err != nil {
-		log.Printf("sidecar: message.part.updated parse error: %v", err)
+		s.logger().Printf("sidecar: message.part.updated parse error: %v", err)
 		return
 	}
 
@@ -946,13 +945,13 @@ func (s *Sidecar) handleMessagePartUpdated(evt harness.HarnessEvent) {
 						"harnessSessionID": s.opencodeSID,
 						"messageId":        part.MessageID,
 					}, nil)
-					log.Printf("sidecar: audit: high-impact command recorded: %s", truncate(cmd, 120))
+					s.logger().Printf("sidecar: audit: high-impact command recorded: %s", truncate(cmd, 120))
 				}
 			}
 		} else if part.State != nil && part.State.Status == "error" {
 			// Gap 5: log tool call failures and write a tool_error DB event.
 			errStr := truncate(fmt.Sprintf("%v", part.State.Output), 200)
-			log.Printf("sidecar: tool call failed (tool=%s messageId=%s err=%s)", part.Tool, part.MessageID, errStr)
+			s.logger().Printf("sidecar: tool call failed (tool=%s messageId=%s err=%s)", part.Tool, part.MessageID, errStr)
 			s.writeEvent("tool_error", map[string]string{
 				"tool":      part.Tool,
 				"err":       errStr,

--- a/modules/programs/prism/prism/internal/sidecar/frame_archive.go
+++ b/modules/programs/prism/prism/internal/sidecar/frame_archive.go
@@ -21,7 +21,6 @@ package sidecar
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/db"
@@ -88,6 +87,6 @@ func (s *Sidecar) archiveFrame(direction string, payload []byte) {
 	if err := s.cfg.DB.WriteHarnessFrame(f); err != nil {
 		// Non-fatal: log once per failure. The wire-protocol path keeps
 		// running.
-		log.Printf("sidecar: archive harness frame (%s): %v", direction, err)
+		s.logger().Printf("sidecar: archive harness frame (%s): %v", direction, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/helpers.go
+++ b/modules/programs/prism/prism/internal/sidecar/helpers.go
@@ -125,7 +125,7 @@ func isCoordinator(sessionName string) bool {
 // (e.g. "worker" written during an SSE inference race); a [debug] log is emitted
 // on mismatch. Falls back to the name-suffix heuristic for pre-migration rows
 // (NULL root_agent_name) and when d is nil.
-func isCoordinatorSession(sessionName string, d *db.DB) bool {
+func isCoordinatorSession(sessionName string, d *db.DB, logger *log.Logger) bool {
 	if d != nil {
 		name, rowExists, err := d.RootAgentName(sessionName)
 		if err == nil && rowExists {
@@ -133,15 +133,15 @@ func isCoordinatorSession(sessionName string, d *db.DB) bool {
 				nameBased := strings.HasSuffix(sessionName, "@main")
 				dbBased := name == "coordinator"
 				if dbBased != nameBased {
-					log.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v — heuristic wins",
+					logger.Printf("[debug] sidecar: isCoordinatorSession(%q): DB says %v (root_agent_name=%q), name heuristic says %v — heuristic wins",
 						sessionName, dbBased, name, nameBased)
 				}
 				return dbBased || nameBased
 			}
 			// Row exists but root_agent_name is NULL — pre-migration row.
-			log.Printf("[deprecation] sidecar: isCoordinatorSession(%q): root_agent_name is NULL — pre-migration row, using name heuristic", sessionName)
+			logger.Printf("[deprecation] sidecar: isCoordinatorSession(%q): root_agent_name is NULL — pre-migration row, using name heuristic", sessionName)
 		} else if err != nil {
-			log.Printf("sidecar: isCoordinatorSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
+			logger.Printf("sidecar: isCoordinatorSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
 		}
 		// rowExists=false means no row — no log needed, just use heuristic.
 	}
@@ -170,18 +170,18 @@ func isHostAPITerminalState(state agent.AgentState) bool {
 // DB-backed check: a session is a review agent if it belongs to a session group
 // (non-NULL group_id). The name-match heuristic is used as a fallback when the
 // DB is unavailable or the row has no group_id (pre-migration rows).
-func isReviewAgentSession(sessionName string, d *db.DB) bool {
+func isReviewAgentSession(sessionName string, d *db.DB, logger *log.Logger) bool {
 	nameBased := strings.Contains(sessionName, "~review")
 	if d != nil {
 		isMember, err := d.IsGroupMember(sessionName)
 		if err != nil {
-			log.Printf("sidecar: isReviewAgentSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
+			logger.Printf("sidecar: isReviewAgentSession: DB error for %q: %v — falling back to name heuristic", sessionName, err)
 			return nameBased
 		}
 		if isMember {
 			// DB-backed: confirmed group member.
 			if !nameBased {
-				log.Printf("[debug] sidecar: isReviewAgentSession(%q): DB says group member, name heuristic says false",
+				logger.Printf("[debug] sidecar: isReviewAgentSession(%q): DB says group member, name heuristic says false",
 					sessionName)
 			}
 			return true
@@ -190,7 +190,7 @@ func isReviewAgentSession(sessionName string, d *db.DB) bool {
 		// agent, this is likely a pre-migration row (group_id not yet set).
 		// Fall back to the name heuristic.
 		if nameBased {
-			log.Printf("[deprecation] sidecar: isReviewAgentSession(%q): group_id not set but name heuristic matches — pre-migration row, using name heuristic", sessionName)
+			logger.Printf("[deprecation] sidecar: isReviewAgentSession(%q): group_id not set but name heuristic matches — pre-migration row, using name heuristic", sessionName)
 			return true
 		}
 		return false

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -206,7 +205,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// isCoordinator) which reads root_agent_name and falls back to AgentRole
 	// for pre-migration rows. Returns false and writes HTTP 403 if not.
 	requireCoordinator := func(w http.ResponseWriter, operation string) bool {
-		if !isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
+		if !isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("workers cannot perform %s", operation))
 			return false
@@ -454,7 +453,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		crossRepo := targetRepo != ownRepo
-		if crossRepo && !isCoordinatorSession(targetSession, s.cfg.DB) {
+		if crossRepo && !isCoordinatorSession(targetSession, s.cfg.DB, s.logger()) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("cross-repo checkin can only target coordinators (<repo>@main), got %q", targetSession))
 			return
@@ -621,7 +620,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
 			return
 		}
-		if targetRepo != ownRepo && !isCoordinatorSession(targetSession, s.cfg.DB) {
+		if targetRepo != ownRepo && !isCoordinatorSession(targetSession, s.cfg.DB, s.logger()) {
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("cross-repo logs can only target coordinators (<repo>@main), got %q", targetSession))
 			return
@@ -778,7 +777,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					s.reviewingInFlight = false
 					s.mu.Unlock()
 				}
-				log.Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s) deliver_as=%s", req.Session, deliverAs)
+				s.logger().Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s) deliver_as=%s", req.Session, deliverAs)
 				if !s.DeliverPrompt(req.Prompt, deliverAs) {
 					writeError(w, http.StatusServiceUnavailable, "socket-pipe not connected — prompt not delivered")
 					return
@@ -803,7 +802,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		if s.cfg.AgentRole == "coordinator" {
 			// Coordinator: own repo any session allowed; cross-repo only @main.
-			if crossRepo && !isCoordinatorSession(req.Session, s.cfg.DB) {
+			if crossRepo && !isCoordinatorSession(req.Session, s.cfg.DB, s.logger()) {
 				writeError(w, http.StatusForbidden,
 					fmt.Sprintf("cross-repo prompts can only target coordinators (<repo>@main), got %q", req.Session))
 				return
@@ -813,7 +812,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// DB-backed: look up the coordinator for this repo.
 			coordStatus, coordErr := s.cfg.DB.CoordinatorForRepo(ownRepo)
 			if coordErr != nil {
-				log.Printf("sidecar: /prompt worker check: DB error looking up coordinator for %q: %v — falling back to name heuristic", ownRepo, coordErr)
+				s.logger().Printf("sidecar: /prompt worker check: DB error looking up coordinator for %q: %v — falling back to name heuristic", ownRepo, coordErr)
 				coordStatus = nil
 			}
 			var ownCoordinator string
@@ -827,7 +826,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 				if fallbackStatus != nil {
 					// Pre-migration row found via name convention — log deprecation
 					// only when the fallback actually finds a row.
-					log.Printf("[deprecation] sidecar: /prompt worker check: no DB-backed coordinator for %q — using name convention %q (pre-migration row)", ownRepo, fallbackCoord)
+					s.logger().Printf("[deprecation] sidecar: /prompt worker check: no DB-backed coordinator for %q — using name convention %q (pre-migration row)", ownRepo, fallbackCoord)
 					ownCoordinator = fallbackCoord
 				} else {
 					// Normal "no coordinator running" state — silent fallback.
@@ -843,11 +842,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		// Deliver via prism prompt on the host.
 		args := []string{"prompt", req.Session, "--prompt", req.Prompt}
-		log.Printf("sidecar: host-API /prompt: prism prompt %s <omitted>", req.Session)
+		s.logger().Printf("sidecar: host-API /prompt: prism prompt %s <omitted>", req.Session)
 		cmd := exec.Command(prismBinary(), args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Printf("sidecar: host-API /prompt: %v: %s", err, out)
+			s.logger().Printf("sidecar: host-API /prompt: %v: %s", err, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("prompt delivery failed: %v", err))
 			return
 		}
@@ -1067,11 +1066,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			logArgs = append(logArgs, "--harness", req.Harness)
 		}
 		logArgs = append(logArgs, "--repo", ownRepo)
-		log.Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
+		s.logger().Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
 		cmd := exec.Command(prismBinary(), args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Printf("sidecar: host-API /spawn: %v: %s", err, out)
+			s.logger().Printf("sidecar: host-API /spawn: %v: %s", err, out)
 			msg := fmt.Sprintf("spawn failed: %v", err)
 			if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
 				msg = fmt.Sprintf("spawn failed: %v\n%s", err, trimmed)
@@ -1176,9 +1175,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			reviewingWriteBackoff  = 10 * time.Millisecond
 		)
 		if status, dbErr := s.cfg.DB.CurrentStatus(s.cfg.SessionName); dbErr != nil {
-			log.Printf("sidecar: host-API /review: pre-emptive reviewing write skipped — CurrentStatus error: %v", dbErr)
+			s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write skipped — CurrentStatus error: %v", dbErr)
 		} else if status == nil {
-			log.Printf("sidecar: host-API /review: pre-emptive reviewing write skipped — no agent_status row for session %q", s.cfg.SessionName)
+			s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write skipped — no agent_status row for session %q", s.cfg.SessionName)
 		} else {
 			var lastUpsertErr error
 			for attempt := range reviewingWriteAttempts {
@@ -1190,13 +1189,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					// Non-transient error — no point retrying.
 					break
 				}
-				log.Printf("sidecar: host-API /review: pre-emptive reviewing write SQLITE_BUSY (attempt %d/%d): %v", attempt+1, reviewingWriteAttempts, lastUpsertErr)
+				s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write SQLITE_BUSY (attempt %d/%d): %v", attempt+1, reviewingWriteAttempts, lastUpsertErr)
 				if attempt < reviewingWriteAttempts-1 {
 					time.Sleep(reviewingWriteBackoff)
 				}
 			}
 			if lastUpsertErr != nil {
-				log.Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
+				s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
 				writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", lastUpsertErr))
 				return
 			}
@@ -1248,7 +1247,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			args = append(args, "--timeout", req.Timeout)
 		}
 
-		log.Printf("sidecar: host-API /review: prism %s", strings.Join(args, " "))
+		s.logger().Printf("sidecar: host-API /review: prism %s", strings.Join(args, " "))
 
 		// Async review: `prism review` spawns agents and a monitor, then exits
 		// quickly (well under 30 s in practice). We stream its stdout as it
@@ -1277,14 +1276,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		//      fails or the directory no longer exists, so that the existing
 		//      degraded-context path keeps working rather than hard-failing.
 		if status, dbErr := s.cfg.DB.CurrentStatus(s.cfg.SessionName); dbErr != nil {
-			log.Printf("sidecar: host-API /review: worktree lookup failed (DB error): %v — using default CWD", dbErr)
+			s.logger().Printf("sidecar: host-API /review: worktree lookup failed (DB error): %v — using default CWD", dbErr)
 		} else if status == nil || status.Worktree == "" {
-			log.Printf("sidecar: host-API /review: worktree not set for session %q — using default CWD", s.cfg.SessionName)
+			s.logger().Printf("sidecar: host-API /review: worktree not set for session %q — using default CWD", s.cfg.SessionName)
 		} else if _, statErr := os.Stat(status.Worktree); statErr != nil {
-			log.Printf("sidecar: host-API /review: worktree %q is not accessible: %v — using default CWD", status.Worktree, statErr)
+			s.logger().Printf("sidecar: host-API /review: worktree %q is not accessible: %v — using default CWD", status.Worktree, statErr)
 		} else {
 			cmd.Dir = status.Worktree
-			log.Printf("sidecar: host-API /review: subprocess CWD set to worktree %q", status.Worktree)
+			s.logger().Printf("sidecar: host-API /review: subprocess CWD set to worktree %q", status.Worktree)
 		}
 
 		// Build the subprocess environment:
@@ -1349,13 +1348,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		waitErr := cmd.Wait()
 		if stderrBuf.Len() > 0 {
-			log.Printf("sidecar: host-API /review: stderr: %s", strings.TrimSpace(stderrBuf.String()))
+			s.logger().Printf("sidecar: host-API /review: stderr: %s", strings.TrimSpace(stderrBuf.String()))
 		}
 
 		// Write pass/fail sentinel. The client (proxyReviewAsync) consumes
 		// this line and does not print it to its own stdout.
 		if waitErr != nil {
-			log.Printf("sidecar: host-API /review: review process failed: %v", waitErr)
+			s.logger().Printf("sidecar: host-API /review: review process failed: %v", waitErr)
 			_, _ = fmt.Fprintln(w, ReviewSentinelFailed)
 		} else {
 			_, _ = fmt.Fprintln(w, ReviewSentinelPassed)
@@ -1410,11 +1409,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			args = append(args, "--yes")
 		}
 
-		log.Printf("sidecar: host-API /cleanup: prism %s", strings.Join(args, " "))
+		s.logger().Printf("sidecar: host-API /cleanup: prism %s", strings.Join(args, " "))
 		cmd := exec.Command(prismBinary(), args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Printf("sidecar: host-API /cleanup: %v: %s", err, out)
+			s.logger().Printf("sidecar: host-API /cleanup: %v: %s", err, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("cleanup failed: %v", err))
 			return
 		}
@@ -1450,11 +1449,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		args := []string{"switch", "--path", worktreePath}
-		log.Printf("sidecar: host-API /switch: prism %s", strings.Join(args, " "))
+		s.logger().Printf("sidecar: host-API /switch: prism %s", strings.Join(args, " "))
 		cmd := exec.Command(prismBinary(), args...)
 		out, switchErr := cmd.CombinedOutput()
 		if switchErr != nil {
-			log.Printf("sidecar: host-API /switch: %v: %s", switchErr, out)
+			s.logger().Printf("sidecar: host-API /switch: %v: %s", switchErr, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("switch failed: %v", switchErr))
 			return
 		}
@@ -1492,7 +1491,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		if s.cfg.InstanceID == "" {
-			log.Printf("sidecar: host-API /merge: no instance_id — sidecar startup did not run correctly")
+			s.logger().Printf("sidecar: host-API /merge: no instance_id — sidecar startup did not run correctly")
 			writeError(w, http.StatusInternalServerError,
 				"sidecar has no instance_id — sidecar startup did not run")
 			return
@@ -1504,11 +1503,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// sidecar at all (#1043).
 		row, err := s.cfg.DB.EnqueueMerge(req.PR, s.cfg.SessionName, s.cfg.InstanceID, req.Title)
 		if err != nil {
-			log.Printf("sidecar: host-API /merge: EnqueueMerge: %v", err)
+			s.logger().Printf("sidecar: host-API /merge: EnqueueMerge: %v", err)
 			writeError(w, http.StatusInternalServerError, "enqueue merge: "+err.Error())
 			return
 		}
-		log.Printf("sidecar: host-API /merge: PR #%d enqueued (queue_position=%d, status=%s)",
+		s.logger().Printf("sidecar: host-API /merge: PR #%d enqueued (queue_position=%d, status=%s)",
 			row.PR, row.QueuePosition, row.Status)
 		writeJSON(w, http.StatusOK, row)
 	})
@@ -1529,7 +1528,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		if s.cfg.InstanceID == "" {
-			log.Printf("sidecar: host-API /merges: no instance_id — sidecar startup did not run correctly")
+			s.logger().Printf("sidecar: host-API /merges: no instance_id — sidecar startup did not run correctly")
 			writeError(w, http.StatusInternalServerError,
 				"sidecar has no instance_id — sidecar startup did not run")
 			return
@@ -1538,7 +1537,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		filter := r.URL.Query().Get("filter")
 		merges, err := s.cfg.DB.MergeQueueForInstance(s.cfg.InstanceID, s.cfg.SessionName, filter)
 		if err != nil {
-			log.Printf("sidecar: host-API /merges: MergeQueueForInstance: %v", err)
+			s.logger().Printf("sidecar: host-API /merges: MergeQueueForInstance: %v", err)
 			writeError(w, http.StatusInternalServerError, "list merges: "+err.Error())
 			return
 		}
@@ -1576,7 +1575,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		if s.cfg.InstanceID == "" {
-			log.Printf("sidecar: host-API /merges/cancel: no instance_id — sidecar startup did not run correctly")
+			s.logger().Printf("sidecar: host-API /merges/cancel: no instance_id — sidecar startup did not run correctly")
 			writeError(w, http.StatusInternalServerError,
 				"sidecar has no instance_id — sidecar startup did not run")
 			return
@@ -1584,7 +1583,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		cancelled, err := s.cfg.DB.CancelMerge(req.PR, s.cfg.InstanceID)
 		if err != nil {
-			log.Printf("sidecar: host-API /merges/cancel: CancelMerge: %v", err)
+			s.logger().Printf("sidecar: host-API /merges/cancel: CancelMerge: %v", err)
 			writeError(w, http.StatusInternalServerError, "cancel merge: "+err.Error())
 			return
 		}
@@ -1593,11 +1592,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// means the row does not exist at all.
 		row, lookupErr := s.cfg.DB.PendingMergeByPR(req.PR)
 		if lookupErr != nil {
-			log.Printf("sidecar: host-API /merges/cancel: PendingMergeByPR: %v", lookupErr)
+			s.logger().Printf("sidecar: host-API /merges/cancel: PendingMergeByPR: %v", lookupErr)
 			// Lookup error is non-fatal — return cancelled status without the row.
 			row = nil
 		}
-		log.Printf("sidecar: host-API /merges/cancel: PR #%d cancelled=%v", req.PR, cancelled)
+		s.logger().Printf("sidecar: host-API /merges/cancel: PR #%d cancelled=%v", req.PR, cancelled)
 		writeJSON(w, http.StatusOK, map[string]any{
 			"cancelled": cancelled,
 			"row":       row,
@@ -1671,18 +1670,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			}
 		}
 
-		log.Printf("sidecar: host-API /event: kind=%s session=%s", req.Kind, req.Session)
+		s.logger().Printf("sidecar: host-API /event: kind=%s session=%s", req.Kind, req.Session)
 		cmd := exec.Command(prismBinary(), args...)
 		// Propagate PRISM_SESSION_NAME so that any internal lookup resolves correctly.
 		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+req.Session)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Printf("sidecar: host-API /event: %v: %s", err, out)
+			s.logger().Printf("sidecar: host-API /event: %v: %s", err, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("event write failed: %v\n%s", err, strings.TrimSpace(string(out))))
 			return
 		}
 
-		log.Printf("sidecar: host-API /event: kind=%s session=%s written to host DB", req.Kind, req.Session)
+		s.logger().Printf("sidecar: host-API /event: kind=%s session=%s written to host DB", req.Kind, req.Session)
 		writeJSON(w, http.StatusOK, map[string]string{})
 	})
 
@@ -1730,7 +1729,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// (the target's own session name), so the guard passes correctly.
 		// There is no sidecar-to-sidecar authentication beyond the per-session
 		// Unix socket filesystem permissions (same as /register-provider-direct).
-		callerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
+		callerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()))
 		if !callerIsCoordinator && req.Session != s.cfg.SessionName {
 			writeError(w, http.StatusForbidden, "workers can only call /set-model for their own session")
 			return
@@ -1783,7 +1782,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		// Permission: global and coordinator scopes require coordinator role.
-		applyCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
+		applyCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()))
 		if req.Scope == "global" || req.Scope == "coordinator" {
 			if !applyCallerIsCoordinator {
 				writeError(w, http.StatusForbidden,
@@ -1862,7 +1861,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// Look up slot for role.
 			slot, ok := pf.Profiles[req.Profile][role]
 			if !ok {
-				log.Printf("sidecar: host-API /apply-profile: profile %q has no slot for role %q (session %s) — skipping",
+				s.logger().Printf("sidecar: host-API /apply-profile: profile %q has no slot for role %q (session %s) — skipping",
 					req.Profile, role, targetSess)
 				results = append(results, sessionResult{Session: targetSess, Status: "skipped:no-matching-slot"})
 				continue
@@ -1908,7 +1907,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		// Permission: global and coordinator scopes require coordinator role.
-		regCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB))
+		regCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()))
 		if req.Scope == "global" || req.Scope == "coordinator" {
 			if !regCallerIsCoordinator {
 				writeError(w, http.StatusForbidden,
@@ -2160,7 +2159,7 @@ func liveModelSwapForSession(s *Sidecar, targetSess, provider, model, thinking s
 	}
 
 	if err := forwardSetModel(targetSess, provider, model, thinking); err != nil {
-		log.Printf("sidecar: liveModelSwapForSession: forward to %s: %v", targetSess, err)
+		s.logger().Printf("sidecar: liveModelSwapForSession: forward to %s: %v", targetSess, err)
 		return "error:disconnected"
 	}
 	return "applied"
@@ -2185,7 +2184,7 @@ func liveRegisterProviderForSession(s *Sidecar, targetSess, name string, cfg map
 	}
 
 	if err := forwardRegisterProvider(targetSess, name, cfg); err != nil {
-		log.Printf("sidecar: liveRegisterProviderForSession: forward to %s: %v", targetSess, err)
+		s.logger().Printf("sidecar: liveRegisterProviderForSession: forward to %s: %v", targetSess, err)
 		return "error:disconnected"
 	}
 	return "applied"

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -53,15 +53,15 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 	// Look up the parent worker in the DB.
 	parentStatus, err := s.cfg.DB.CurrentStatus(parentSession)
 	if err != nil {
-		log.Printf("sidecar: notifyParentWorker: DB lookup for parent %q: %v — skipping notification", parentSession, err)
+		s.logger().Printf("sidecar: notifyParentWorker: DB lookup for parent %q: %v — skipping notification", parentSession, err)
 		return
 	}
 	if parentStatus == nil {
-		log.Printf("sidecar: notifyParentWorker: parent session %q not found in DB — skipping notification", parentSession)
+		s.logger().Printf("sidecar: notifyParentWorker: parent session %q not found in DB — skipping notification", parentSession)
 		return
 	}
 	if parentStatus.EndedAt != nil {
-		log.Printf("sidecar: notifyParentWorker: parent session %q has ended — skipping notification", parentSession)
+		s.logger().Printf("sidecar: notifyParentWorker: parent session %q has ended — skipping notification", parentSession)
 		return
 	}
 
@@ -71,21 +71,21 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 	// through the parent session's host-API Unix socket instead (#1364).
 	if parentStatus.Harness != nil {
 		if shape, ok := harness.ShapeOf(*parentStatus.Harness); ok && shape == harness.TransportSocketPipe {
-			log.Printf("sidecar: notifyParentWorker: routing via host-API socket for pi parent=%s", parentSession)
+			s.logger().Printf("sidecar: notifyParentWorker: routing via host-API socket for pi parent=%s", parentSession)
 				// Use "followUp" so the message queues until the parent's current
 				// turn completes, even if the parent is streaming when delivery
 				// arrives. Startup-failure notifications are post-turn signals.
 				if err := promptdelivery.DeliverToSession(parentSession, parentStatus, notifyText, buildNotifyPromptBody, "", "followUp"); err != nil {
-				log.Printf("sidecar: notifyParentWorker: FAILED (pi path) — parent=%s reason=%v", parentSession, err)
+				s.logger().Printf("sidecar: notifyParentWorker: FAILED (pi path) — parent=%s reason=%v", parentSession, err)
 			} else {
-				log.Printf("sidecar: notifyParentWorker: delivered to pi parent=%s via host-API socket", parentSession)
+				s.logger().Printf("sidecar: notifyParentWorker: delivered to pi parent=%s via host-API socket", parentSession)
 			}
 			return
 		}
 	}
 
 	if parentStatus.HarnessPort == nil {
-		log.Printf("sidecar: notifyParentWorker: parent session %q has no harness port — cannot deliver notification", parentSession)
+		s.logger().Printf("sidecar: notifyParentWorker: parent session %q has no harness port — cannot deliver notification", parentSession)
 		return
 	}
 	port := *parentStatus.HarnessPort
@@ -105,11 +105,11 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 		}
 
 		targetSID, validationErr := validateOrRefreshCoordinatorSID(
-			port, storedSID, parentSession, s.cfg.DB, s.cfg.HTTPClient,
+			port, storedSID, parentSession, s.cfg.DB, s.cfg.HTTPClient, s.logger(),
 		)
 		if validationErr != nil {
 			lastErr = fmt.Errorf("attempt %d: SID validation failed: %w", attempt, validationErr)
-			log.Printf("sidecar: notifyParentWorker: %v (parent=%s)", lastErr, parentSession)
+			s.logger().Printf("sidecar: notifyParentWorker: %v (parent=%s)", lastErr, parentSession)
 			if errors.Is(validationErr, errEmptySessionList) {
 				break
 			}
@@ -117,22 +117,22 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 		}
 		storedSID = targetSID
 
-		log.Printf("sidecar: notifyParentWorker: attempt %d/%d POST to parent=%s sid=%s",
+		s.logger().Printf("sidecar: notifyParentWorker: attempt %d/%d POST to parent=%s sid=%s",
 			attempt, maxAttempts, parentSession, targetSID)
 
 		httpErr := deliverNotificationViaHTTP(port, targetSID, notifyText, parentStatus, s.cfg.HTTPClient)
 		if httpErr != nil {
 			lastErr = fmt.Errorf("attempt %d: HTTP delivery failed: %w", attempt, httpErr)
-			log.Printf("sidecar: notifyParentWorker: %v (parent=%s sid=%s)", lastErr, parentSession, targetSID)
+			s.logger().Printf("sidecar: notifyParentWorker: %v (parent=%s sid=%s)", lastErr, parentSession, targetSID)
 			continue
 		}
 
-		log.Printf("sidecar: notifyParentWorker: delivered to parent=%s sid=%s", parentSession, targetSID)
+		s.logger().Printf("sidecar: notifyParentWorker: delivered to parent=%s sid=%s", parentSession, targetSID)
 		return
 	}
 
 	// All retries exhausted — log and exit cleanly (notification failure is not fatal).
-	log.Printf("sidecar: notifyParentWorker: FAILED after %d attempts — parent=%s reason=%v",
+	s.logger().Printf("sidecar: notifyParentWorker: FAILED after %d attempts — parent=%s reason=%v",
 		maxAttempts, parentSession, lastErr)
 }
 
@@ -164,7 +164,7 @@ func (s *Sidecar) notifyCoordinator() {
 	// Self-notification guard: if this session IS the coordinator, skip.
 	// DB-backed: check root_agent_name == "coordinator" for self.
 	// Fallback to name heuristic for pre-migration rows.
-	if isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
+	if isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
 		return
 	}
 
@@ -172,15 +172,15 @@ func (s *Sidecar) notifyCoordinator() {
 	// prism review invocation. Their finish events are discovered by the
 	// worker's pollAgents DB poll and must not be forwarded to the coordinator
 	// as noise notifications.
-	if isReviewAgentSession(s.cfg.SessionName, s.cfg.DB) {
-		log.Printf("sidecar: notifyCoordinator: suppressed for review-agent session %s", s.cfg.SessionName)
+	if isReviewAgentSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
+		s.logger().Printf("sidecar: notifyCoordinator: suppressed for review-agent session %s", s.cfg.SessionName)
 		return
 	}
 
 	// DB-backed coordinator lookup: find the active coordinator for this repo.
 	coordStatus, err := s.cfg.DB.CoordinatorForRepo(s.cfg.Repo)
 	if err != nil {
-		log.Printf("sidecar: notifyCoordinator: DB lookup coordinator for repo %q: %v — falling back to name-based lookup", s.cfg.Repo, err)
+		s.logger().Printf("sidecar: notifyCoordinator: DB lookup coordinator for repo %q: %v — falling back to name-based lookup", s.cfg.Repo, err)
 	}
 	if coordStatus == nil {
 		// No coordinator with root_agent_name='coordinator' found — fall back to
@@ -189,14 +189,14 @@ func (s *Sidecar) notifyCoordinator() {
 		var fallbackStatus *db.Status
 		fallbackStatus, err = s.cfg.DB.CurrentStatus(fallbackName)
 		if err != nil {
-			log.Printf("sidecar: notifyCoordinator: fallback look up coordinator: %v", err)
+			s.logger().Printf("sidecar: notifyCoordinator: fallback look up coordinator: %v", err)
 			return
 		}
 		if fallbackStatus != nil {
 			// Name-based fallback succeeded: a pre-migration coordinator row was
 			// found via the @main name convention. Log deprecation only here,
 			// not when no coordinator is running at all (which is a normal state).
-			log.Printf("[deprecation] sidecar: notifyCoordinator: no DB-backed coordinator found for %q — falling back to name convention %q (pre-migration row)", s.cfg.Repo, fallbackName)
+			s.logger().Printf("[deprecation] sidecar: notifyCoordinator: no DB-backed coordinator found for %q — falling back to name convention %q (pre-migration row)", s.cfg.Repo, fallbackName)
 		}
 		coordStatus = fallbackStatus
 	}
@@ -237,29 +237,29 @@ func (s *Sidecar) notifyCoordinator() {
 	// through the coordinator's host-API Unix socket instead (#1364).
 	if coordStatus.Harness != nil {
 		if shape, ok := harness.ShapeOf(*coordStatus.Harness); ok && shape == harness.TransportSocketPipe {
-			log.Printf("sidecar: notifyCoordinator: routing via host-API socket for pi coordinator=%s", coordinatorName)
+			s.logger().Printf("sidecar: notifyCoordinator: routing via host-API socket for pi coordinator=%s", coordinatorName)
 				// Use "followUp" so the coordinator receives the notification after
 				// its current turn completes, even when it is mid-stream at delivery
 				// time. Finish notifications are post-turn signals; "followUp" is
 				// the semantically correct delivery mode.
 				if err := promptdelivery.DeliverToSession(coordinatorName, coordStatus, notifyText, buildNotifyPromptBody, "", "followUp"); err != nil {
-				log.Printf("sidecar: notifyCoordinator: FAILED (pi path) — coordinator=%s reason=%v", coordinatorName, err)
+				s.logger().Printf("sidecar: notifyCoordinator: FAILED (pi path) — coordinator=%s reason=%v", coordinatorName, err)
 				if writeErr := s.cfg.DB.WriteBusMessageFailed(msg); writeErr != nil {
-					log.Printf("sidecar: notifyCoordinator: write failed audit: %v", writeErr)
+					s.logger().Printf("sidecar: notifyCoordinator: write failed audit: %v", writeErr)
 				}
 				return
 			}
 			if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
-				log.Printf("sidecar: notifyCoordinator: write delivered audit: %v", err)
+				s.logger().Printf("sidecar: notifyCoordinator: write delivered audit: %v", err)
 			}
-			log.Printf("sidecar: notifyCoordinator: delivered to pi coordinator=%s via host-API socket", coordinatorName)
+			s.logger().Printf("sidecar: notifyCoordinator: delivered to pi coordinator=%s via host-API socket", coordinatorName)
 			return
 		}
 	}
 
 	// Require port for HTTP delivery (opencode path).
 	if coordStatus.HarnessPort == nil {
-		log.Printf("sidecar: notifyCoordinator: coordinator has no harness port — cannot deliver notification")
+		s.logger().Printf("sidecar: notifyCoordinator: coordinator has no harness port — cannot deliver notification")
 		return
 	}
 	port := *coordStatus.HarnessPort
@@ -287,11 +287,11 @@ func (s *Sidecar) notifyCoordinator() {
 		// the most recently active session and update the DB so future
 		// deliveries use the fresh SID.
 		targetSID, validationErr := validateOrRefreshCoordinatorSID(
-			port, storedSID, coordinatorName, s.cfg.DB, s.cfg.HTTPClient,
+			port, storedSID, coordinatorName, s.cfg.DB, s.cfg.HTTPClient, s.logger(),
 		)
 		if validationErr != nil {
 			lastErr = fmt.Errorf("attempt %d: SID validation failed: %w", attempt, validationErr)
-			log.Printf("sidecar: notifyCoordinator: %v (coordinator=%s)", lastErr, coordinatorName)
+			s.logger().Printf("sidecar: notifyCoordinator: %v (coordinator=%s)", lastErr, coordinatorName)
 			// An empty session list is not a transient condition — retrying
 			// will not help. Break immediately to avoid unnecessary backoff.
 			if errors.Is(validationErr, errEmptySessionList) {
@@ -302,29 +302,29 @@ func (s *Sidecar) notifyCoordinator() {
 		// Keep storedSID current for next iteration if it was refreshed.
 		storedSID = targetSID
 
-		log.Printf("sidecar: notifyCoordinator: attempt %d/%d POST to coordinator=%s sid=%s",
+		s.logger().Printf("sidecar: notifyCoordinator: attempt %d/%d POST to coordinator=%s sid=%s",
 			attempt, maxAttempts, coordinatorName, targetSID)
 
 		httpErr := deliverNotificationViaHTTP(port, targetSID, notifyText, coordStatus, s.cfg.HTTPClient)
 		if httpErr != nil {
 			lastErr = fmt.Errorf("attempt %d: HTTP delivery failed: %w", attempt, httpErr)
-			log.Printf("sidecar: notifyCoordinator: %v (coordinator=%s sid=%s)", lastErr, coordinatorName, targetSID)
+			s.logger().Printf("sidecar: notifyCoordinator: %v (coordinator=%s sid=%s)", lastErr, coordinatorName, targetSID)
 			continue
 		}
 
 		// Confirmed delivery: SID validated + POST returned 200.
 		if err := s.cfg.DB.WriteBusMessageDelivered(msg); err != nil {
-			log.Printf("sidecar: notifyCoordinator: write delivered audit: %v", err)
+			s.logger().Printf("sidecar: notifyCoordinator: write delivered audit: %v", err)
 		}
-		log.Printf("sidecar: notifyCoordinator: delivered to coordinator=%s sid=%s", coordinatorName, targetSID)
+		s.logger().Printf("sidecar: notifyCoordinator: delivered to coordinator=%s sid=%s", coordinatorName, targetSID)
 		return
 	}
 
 	// All retries exhausted — write failed_at and log structured error.
 	if err := s.cfg.DB.WriteBusMessageFailed(msg); err != nil {
-		log.Printf("sidecar: notifyCoordinator: write failed audit: %v", err)
+		s.logger().Printf("sidecar: notifyCoordinator: write failed audit: %v", err)
 	}
-	log.Printf("sidecar: notifyCoordinator: FAILED after %d attempts — coordinator=%s sid=%s reason=%v",
+	s.logger().Printf("sidecar: notifyCoordinator: FAILED after %d attempts — coordinator=%s sid=%s reason=%v",
 		maxAttempts, coordinatorName, storedSID, lastErr)
 }
 
@@ -351,7 +351,7 @@ type opencodeSessionEntry struct {
 //   - If GET /session fails, an error is returned.
 //   - If GET /session returns an empty list, errEmptySessionList is returned
 //     (sentinel — caller should not retry).
-func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName string, database *db.DB, httpClient *http.Client) (string, error) {
+func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName string, database *db.DB, httpClient *http.Client, logger *log.Logger) (string, error) {
 	url := fmt.Sprintf("http://localhost:%d/session", port)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -397,11 +397,11 @@ func validateOrRefreshCoordinatorSID(port int, storedSID string, coordinatorName
 		}
 	}
 
-	log.Printf("sidecar: notifyCoordinator: stored SID %q not found in coordinator session list — using most recent SID %q", storedSID, bestSID)
+	logger.Printf("sidecar: notifyCoordinator: stored SID %q not found in coordinator session list — using most recent SID %q", storedSID, bestSID)
 
 	// Persist the refreshed SID so future deliveries use it.
 	if err := database.UpdateHarnessSessionID(coordinatorName, bestSID); err != nil {
-		log.Printf("sidecar: notifyCoordinator: UpdateHarnessSessionID failed: %v", err)
+		logger.Printf("sidecar: notifyCoordinator: UpdateHarnessSessionID failed: %v", err)
 	}
 
 	return bestSID, nil

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -607,7 +607,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 				// was already called inside runStartupSocketPipe, so the DB row is
 				// in error state). Keep the host-API server alive until the
 				// session receives an external shutdown trigger.
-				log.Printf("sidecar: harness-pipe handshake failed; keeping host-API alive until session shutdown: %v", pipeErr)
+				s.logger().Printf("sidecar: harness-pipe handshake failed; keeping host-API alive until session shutdown: %v", pipeErr)
 				// Block until context cancellation (SIGTERM / prism cleanup).
 				<-ctx.Done()
 				// Return nil — Shutdown() is responsible for writing the final

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -159,6 +159,15 @@ type Config struct {
 	// to_instance_id on bus messages addressed to the coordinator, so that the
 	// coordinator only receives messages intended for its current instance.
 	InstanceID string
+	// Logger, when non-nil, is the logger used for all sidecar log output.
+	// When nil, New() defaults it to log.Default() so existing production log
+	// output is unchanged. Tests should supply a per-test logger backed by a
+	// bytes.Buffer so that parallel test runs do not race on the global logger.
+	//
+	// Doc: once set on a Sidecar, the logger is never changed. All goroutines
+	// spawned by the sidecar capture it at construction time via the parent
+	// sidecar's cfg.Logger field.
+	Logger *log.Logger
 	// HTTPClient is the HTTP client used for coordinator notification delivery.
 	// If nil, defaultNotifyHTTPClient is used.
 	HTTPClient *http.Client
@@ -383,6 +392,9 @@ func New(cfg Config) *Sidecar {
 	if cfg.Clock == nil {
 		cfg.Clock = RealClock()
 	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Default()
+	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = defaultNotifyHTTPClient
 	}
@@ -405,6 +417,10 @@ func New(cfg Config) *Sidecar {
 	}
 	return s
 }
+
+// logger returns the sidecar's per-instance logger. It is always non-nil
+// after New() runs (New defaults a nil Logger to log.Default()).
+func (s *Sidecar) logger() *log.Logger { return s.cfg.Logger }
 
 // containerMgr holds the container.Manager when running in container mode.
 // It is set in Run before the SSE loop starts, and used by Shutdown.
@@ -460,7 +476,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		// here so net.Listen succeeds. For podman, prepareVolumeDirs already ran
 		// inside mgr.Create(), so this is a no-op.
 		if err := os.MkdirAll(filepath.Dir(s.cfg.HostAPISockPath), 0o700); err != nil {
-			log.Printf("sidecar: host-API socket dir: %v", err)
+			s.logger().Printf("sidecar: host-API socket dir: %v", err)
 		}
 		_ = os.Remove(s.cfg.HostAPISockPath)
 		ln, listenErr := net.Listen("unix", s.cfg.HostAPISockPath)
@@ -475,7 +491,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// anything is wrong. Returning the error here surfaces it via the
 			// sidecar log and exits with a non-zero status so the operator
 			// sees the failure immediately.
-			log.Printf("sidecar: host-API server: listen unix: %v", listenErr)
+			s.logger().Printf("sidecar: host-API server: listen unix: %v", listenErr)
 			return fmt.Errorf("sidecar: host-API socket bind failed for %q: %w", s.cfg.HostAPISockPath, listenErr)
 		}
 		srv := &http.Server{Handler: s.hostAPIHandler()}
@@ -487,7 +503,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			if err := srv.Serve(ln); err != nil &&
 				!errors.Is(err, http.ErrServerClosed) &&
 				!errors.Is(err, net.ErrClosed) {
-				log.Printf("sidecar: host-API server (unix): %v", err)
+				s.logger().Printf("sidecar: host-API server (unix): %v", err)
 			}
 		}()
 	}
@@ -503,16 +519,16 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		status, _ := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
 		if status != nil && status.InstanceID != nil && *status.InstanceID != "" {
 			s.cfg.InstanceID = *status.InstanceID
-			log.Printf("sidecar: instance_id loaded from DB (%s)", s.cfg.InstanceID)
+			s.logger().Printf("sidecar: instance_id loaded from DB (%s)", s.cfg.InstanceID)
 		} else {
 			minted := uuid.New().String()
 			// Defensively ensure the row exists before writing instance_id.
 			_ = s.cfg.DB.UpsertStatus(s.cfg.SessionName, s.cfg.Repo, s.cfg.Worktree, "idle", nil, nil)
 			if err := s.cfg.DB.SetInstanceID(s.cfg.SessionName, minted); err != nil {
-				log.Printf("sidecar: warning: could not write minted instance_id: %v", err)
+				s.logger().Printf("sidecar: warning: could not write minted instance_id: %v", err)
 			} else {
 				s.cfg.InstanceID = minted
-				log.Printf("sidecar: instance_id minted (%s)", s.cfg.InstanceID)
+				s.logger().Printf("sidecar: instance_id minted (%s)", s.cfg.InstanceID)
 			}
 		}
 	}
@@ -529,7 +545,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	// The watcher context is stored so Shutdown() can cancel it before the
 	// abandon-watching-rows SQL runs (preventing a race where the watcher fires
 	// a terminal transition after AbandonWatchingMerges clears the rows).
-	if s.cfg.AgentRole == "coordinator" || isCoordinatorSession(s.cfg.SessionName, s.cfg.DB) {
+	if s.cfg.AgentRole == "coordinator" || isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
 		if s.cfg.InstanceID != "" {
 			watcherCtx, watcherCancel := context.WithCancel(ctx)
 			s.mu.Lock()
@@ -537,9 +553,9 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			s.mu.Unlock()
 			watcher := mergequeue.New(s.cfg.DB, s.cfg.InstanceID, s.cfg.SessionName, s.cfg.HTTPClient)
 			go watcher.Run(watcherCtx)
-			log.Printf("sidecar: merge-queue watcher started (instance=%s)", s.cfg.InstanceID)
+			s.logger().Printf("sidecar: merge-queue watcher started (instance=%s)", s.cfg.InstanceID)
 		} else {
-			log.Printf("sidecar: merge-queue watcher NOT started — no instance_id")
+			s.logger().Printf("sidecar: merge-queue watcher NOT started — no instance_id")
 		}
 	}
 
@@ -633,10 +649,10 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			if err := tcpSrv.Serve(tcpLn); err != nil &&
 				!errors.Is(err, http.ErrServerClosed) &&
 				!errors.Is(err, net.ErrClosed) {
-				log.Printf("sidecar: host-API server (tcp): %v", err)
+				s.logger().Printf("sidecar: host-API server (tcp): %v", err)
 			}
 		}()
-		log.Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
+		s.logger().Printf("sidecar: host-API TCP server serving on 0.0.0.0:%d", s.cfg.HostAPITCPPort)
 	}
 
 	// Wrap ctx with a cancel so the startup-timeout goroutine (bwrap mode only)
@@ -664,7 +680,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		sid := s.opencodeSID
 		s.mu.Unlock()
 		if sid == "" {
-			log.Printf("[warning] opencode_sid not received after 30s — session may be invisible to forensics")
+			s.logger().Printf("[warning] opencode_sid not received after 30s — session may be invisible to forensics")
 		}
 	}()
 
@@ -713,7 +729,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// Write StateError and cancel the SSE context to stop the retry loop.
 			startupErr := fmt.Errorf("bwrap harness for %s never bound to %s within %v",
 				s.cfg.SessionName, url, startupTimeout)
-			log.Printf("sidecar: startup-connect timeout fired: %v", startupErr)
+			s.logger().Printf("sidecar: startup-connect timeout fired: %v", startupErr)
 			// Emit a `[timing] opencode listening` line recording the timeout
 			// duration so the grep-the-log workflow yields a coherent timeline
 			// even on the failure path (#1052 AC: "When opencode never reaches
@@ -721,7 +737,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// emitted records the timeout duration, not silence."). The
 			// "(timed out)" suffix distinguishes failure from a real listening
 			// marker without changing the leading prefix that grep targets.
-			log.Printf("[timing] opencode listening: %s from start (timed out)",
+			s.logger().Printf("[timing] opencode listening: %s from start (timed out)",
 				time.Since(s.spawnTime).Round(time.Millisecond))
 			s.writeStartupError(startupErr)
 			// writeStartupError notifies the parent worker for review-agent sessions.
@@ -730,7 +746,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			// notification path (notifyCoordinator is suppressed for review agents
 			// and self-notifications internally). This satisfies the routing requirement
 			// from #1022: "worker agents notify the coordinator."
-			if !isReviewAgentSession(s.cfg.SessionName, s.cfg.DB) {
+			if !isReviewAgentSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
 				go s.notifyCoordinator()
 			}
 			sseCancel()
@@ -769,12 +785,12 @@ func (s *Sidecar) Shutdown() {
 	// Abandon all watching merge rows for this coordinator incarnation.
 	if s.cfg.InstanceID != "" {
 		if err := s.cfg.DB.AbandonWatchingMerges(s.cfg.InstanceID); err != nil {
-			log.Printf("sidecar: AbandonWatchingMerges: %v", err)
+			s.logger().Printf("sidecar: AbandonWatchingMerges: %v", err)
 		} else {
-			log.Printf("sidecar: watching merge rows abandoned (instance=%s)", s.cfg.InstanceID)
+			s.logger().Printf("sidecar: watching merge rows abandoned (instance=%s)", s.cfg.InstanceID)
 		}
 		if err := s.cfg.DB.UpdateSessionEnded(s.cfg.InstanceID, "finished"); err != nil {
-			log.Printf("sidecar: UpdateSessionEnded: %v", err)
+			s.logger().Printf("sidecar: UpdateSessionEnded: %v", err)
 		}
 	}
 
@@ -869,7 +885,7 @@ func (s *Sidecar) Shutdown() {
 		// Note: StateError is excluded because writeStartupError may have already
 		// written it before Run() returned on the startup-failure path. Overwriting
 		// error with interrupted here would clobber the correct terminal state.
-		log.Printf("sidecar: transition -> interrupted (cause=sigterm)")
+		s.logger().Printf("sidecar: transition -> interrupted (cause=sigterm)")
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
 	}
@@ -908,7 +924,7 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 				return fmt.Errorf("sidecar: host-API TCP listener: %w", tcpErr)
 			}
 			port := tcpLn.Addr().(*net.TCPAddr).Port
-			log.Printf("sidecar: host-API TCP listener bound on 0.0.0.0:%d", port)
+			s.logger().Printf("sidecar: host-API TCP listener bound on 0.0.0.0:%d", port)
 			s.cfg.HostAPITCPPort = port
 			s.cfg.Container.HostAPITCPPort = port
 			s.mu.Lock()
@@ -940,19 +956,19 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 		s.container = &containerMgr{mgr: mgr}
 		s.mu.Unlock()
 
-		log.Printf("[timing] pre-Create: %s", time.Since(sessionStart).Round(time.Millisecond))
-		log.Printf("sidecar: creating container %q", mgr.Name())
+		s.logger().Printf("[timing] pre-Create: %s", time.Since(sessionStart).Round(time.Millisecond))
+		s.logger().Printf("sidecar: creating container %q", mgr.Name())
 		t0 := time.Now()
 		if err := mgr.Create(ctx); err != nil {
 			closeTCPListenerOnError()
 			return fmt.Errorf("sidecar: container create: %w", err)
 		}
-		log.Printf("[timing] Create: %s", time.Since(t0).Round(time.Millisecond))
+		s.logger().Printf("[timing] Create: %s", time.Since(t0).Round(time.Millisecond))
 
-		log.Printf("sidecar: waiting for container %q to become healthy", mgr.Name())
+		s.logger().Printf("sidecar: waiting for container %q to become healthy", mgr.Name())
 		t0 = time.Now()
 		if err := mgr.WaitHealthy(ctx); err != nil {
-			log.Printf("sidecar: health check failed: %v", err)
+			s.logger().Printf("sidecar: health check failed: %v", err)
 			// AC-14: genuine timeout — Shutdown() has not been called yet, so we
 			// must stop/remove the container here.
 			// When SIGTERM arrives, the signal goroutine calls Shutdown() (which
@@ -986,8 +1002,8 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 			return startupErr
 		}
 		healthyAt := time.Now()
-		log.Printf("[timing] WaitHealthy: %s", healthyAt.Sub(t0).Round(time.Millisecond))
-		log.Printf("sidecar: container %q is healthy", mgr.Name())
+		s.logger().Printf("[timing] WaitHealthy: %s", healthyAt.Sub(t0).Round(time.Millisecond))
+		s.logger().Printf("sidecar: container %q is healthy", mgr.Name())
 
 		// Signal readiness after the container is healthy (AC-7, AC-19).
 		// Guard with shuttingDown to prevent OnReady from firing after SIGTERM,
@@ -1011,10 +1027,10 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 		//    via CLI). This entire block is inside `if s.cfg.Container != nil`
 		//    so it only runs in container mode; host-mode sessions never reach here.
 		if !isShuttingDown && s.cfg.InitialPrompt != "" {
-			log.Printf("[timing] CreateSession start: %s after WaitHealthy", time.Since(healthyAt).Round(time.Millisecond))
+			s.logger().Printf("[timing] CreateSession start: %s after WaitHealthy", time.Since(healthyAt).Round(time.Millisecond))
 			_, createErr := s.harness.CreateSession(ctx)
 			if createErr != nil {
-				log.Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
+				s.logger().Printf("sidecar: deliverInitialPrompt: create session: %v", createErr)
 				startupErr := fmt.Errorf("sidecar: create session: %w", createErr)
 				// Use shuttingDown (not ctx.Err()) as the SIGTERM guard — same
 				// rationale as the WaitHealthy path above. The outer isShuttingDown
@@ -1030,20 +1046,20 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 				}
 				return startupErr
 			}
-			log.Printf("[timing] CreateSession done: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
-			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
+			s.logger().Printf("[timing] CreateSession done: %s after container healthy", time.Since(healthyAt).Round(time.Millisecond))
+			s.logger().Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if !isShuttingDown && s.cfg.OnReady != nil {
 				s.cfg.OnReady()
 			}
 			initialPrompt := s.cfg.InitialPrompt
 			go func() {
 				if err := s.harness.DeliverInitialPrompt(ctx, initialPrompt, s.cfg.AgentRole); err != nil {
-					log.Printf("sidecar: deliverInitialPrompt: %v", err)
+					s.logger().Printf("sidecar: deliverInitialPrompt: %v", err)
 				}
-				log.Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
+				s.logger().Printf("[timing] prompt delivered: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			}()
 		} else if !isShuttingDown {
-			log.Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
+			s.logger().Printf("[timing] ready: %s from start", time.Since(sessionStart).Round(time.Millisecond))
 			if s.cfg.OnReady != nil {
 				s.cfg.OnReady()
 			}
@@ -1112,15 +1128,15 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 		s.writeEvent("state_change", map[string]string{"state": string(agent.StateError), "note": note}, nil)
 		s.lastState = agent.StateError
 		s.mu.Unlock()
-		log.Printf("sidecar: runStartupStdio: %v", startupErr)
+		s.logger().Printf("sidecar: runStartupStdio: %v", startupErr)
 		return startupErr
 	}
 
 	cmd, usedBwrap := s.buildStdioHarnessCmd(ctx)
 	if usedBwrap {
-		log.Printf("sidecar: runStartupStdio: launching harness binary %q under bwrap", s.cfg.HarnessBinaryPath)
+		s.logger().Printf("sidecar: runStartupStdio: launching harness binary %q under bwrap", s.cfg.HarnessBinaryPath)
 	} else {
-		log.Printf("sidecar: runStartupStdio: launching harness binary %q (no bwrap)", s.cfg.HarnessBinaryPath)
+		s.logger().Printf("sidecar: runStartupStdio: launching harness binary %q (no bwrap)", s.cfg.HarnessBinaryPath)
 	}
 
 	// Inherit stderr so harness log output reaches the sidecar's log.
@@ -1176,14 +1192,14 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 			Text  string `json:"text"`
 		}
 		if err := json.Unmarshal(line, &frame); err != nil {
-			log.Printf("sidecar: runStartupStdio: parse frame: %v (raw: %s)", err, truncateBytes(line, 200))
+			s.logger().Printf("sidecar: runStartupStdio: parse frame: %v (raw: %s)", err, truncateBytes(line, 200))
 			continue
 		}
 
 		// Only count parseable frames; corrupt lines are logged and skipped.
 		framesRead++
 
-		log.Printf("sidecar: runStartupStdio: frame type=%q", frame.Type)
+		s.logger().Printf("sidecar: runStartupStdio: frame type=%q", frame.Type)
 
 		if hasNormaliser {
 			// B5.TR path: the harness adapter normalises PI frames to
@@ -1300,7 +1316,7 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		log.Printf("sidecar: runStartupStdio: scanner error: %v", err)
+		s.logger().Printf("sidecar: runStartupStdio: scanner error: %v", err)
 	}
 
 	// Flush any partial accumulator before writing error state (mid-turn exit).
@@ -1315,26 +1331,26 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 	if framesRead == 0 {
 		// Harness exited before writing any parseable frames — startup failure.
 		startupErr := fmt.Errorf("sidecar: runStartupStdio: harness %q exited before writing any frames", s.cfg.HarnessBinaryPath)
-		log.Printf("sidecar: runStartupStdio: %v", startupErr)
+		s.logger().Printf("sidecar: runStartupStdio: %v", startupErr)
 		s.writeStartupError(startupErr)
 		return startupErr
 	}
 
 	if waitErr != nil {
 		startupErr := fmt.Errorf("sidecar: runStartupStdio: harness process exited with error: %w", waitErr)
-		log.Printf("sidecar: runStartupStdio: %v", startupErr)
+		s.logger().Printf("sidecar: runStartupStdio: %v", startupErr)
 		s.writeStartupError(startupErr)
 		return startupErr
 	}
 
 	if lastState != string(agent.StateFinished) {
 		startupErr := fmt.Errorf("sidecar: runStartupStdio: harness exited without writing state=finished (last state: %q)", lastState)
-		log.Printf("sidecar: runStartupStdio: %v", startupErr)
+		s.logger().Printf("sidecar: runStartupStdio: %v", startupErr)
 		s.writeStartupError(startupErr)
 		return startupErr
 	}
 
-	log.Printf("sidecar: runStartupStdio: harness finished cleanly (%d frames)", framesRead)
+	s.logger().Printf("sidecar: runStartupStdio: harness finished cleanly (%d frames)", framesRead)
 	return nil
 }
 
@@ -1416,7 +1432,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			s.writeStartupError(err)
 			return err
 		}
-		log.Printf("sidecar: runStartupSocketPipe: listening on TCP :%d", s.cfg.HarnessPipeTCPPort)
+		s.logger().Printf("sidecar: runStartupSocketPipe: listening on TCP :%d", s.cfg.HarnessPipeTCPPort)
 	} else if s.cfg.HarnessPipeSockPath != "" {
 		// Linux: Unix socket.
 		if err := os.MkdirAll(filepath.Dir(s.cfg.HarnessPipeSockPath), 0o700); err != nil {
@@ -1431,7 +1447,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			s.writeStartupError(err)
 			return err
 		}
-		log.Printf("sidecar: runStartupSocketPipe: listening on unix %s", s.cfg.HarnessPipeSockPath)
+		s.logger().Printf("sidecar: runStartupSocketPipe: listening on unix %s", s.cfg.HarnessPipeSockPath)
 	} else {
 		err := fmt.Errorf("sidecar: runStartupSocketPipe: neither HarnessPipeSockPath nor HarnessPipeTCPPort configured")
 		s.writeStartupError(err)
@@ -1504,7 +1520,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 				continue
 			}
 			if _, err := c.Write(frame); err != nil {
-				log.Printf("sidecar: runStartupSocketPipe: write outbound frame: %v", err)
+				s.logger().Printf("sidecar: runStartupSocketPipe: write outbound frame: %v", err)
 				// Don't return — the reader loop will detect the drop and
 				// reconnect. The writer stays alive for the next connection.
 			}
@@ -1538,7 +1554,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 				s.lastState = agent.StateError
 				s.mu.Unlock()
 				err := fmt.Errorf("sidecar: runStartupSocketPipe: timed out waiting for extension to (re)connect (timeout=%s)", acceptTimeout)
-				log.Printf("%v", err)
+				s.logger().Printf("%v", err)
 				// Drain and stop the writer goroutine.
 				s.mu.Lock()
 				s.harnessPipeOutCh = nil
@@ -1555,7 +1571,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			return ctx.Err()
 		}
 
-		log.Printf("sidecar: runStartupSocketPipe: extension connected from %s", conn.RemoteAddr())
+		s.logger().Printf("sidecar: runStartupSocketPipe: extension connected from %s", conn.RemoteAddr())
 		connMu.Lock()
 		activeConn = conn
 		connMu.Unlock()
@@ -1571,7 +1587,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 		_ = conn.SetReadDeadline(time.Time{})
 		if err != nil {
 			err2 := fmt.Errorf("sidecar: runStartupSocketPipe: reading hello: %w", err)
-			log.Printf("%v", err2)
+			s.logger().Printf("%v", err2)
 			_ = conn.Close()
 			connMu.Lock()
 			activeConn = nil
@@ -1629,7 +1645,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 				code = "protocol_version_too_old"
 			}
 			msg := fmt.Sprintf("protocol_version %d is not supported (sidecar supports %d)", helloFrame.ProtocolVersion, piWireProtocolVersion)
-			log.Printf("sidecar: runStartupSocketPipe: %s: %s", code, msg)
+			s.logger().Printf("sidecar: runStartupSocketPipe: %s: %s", code, msg)
 			s.sendPipeError(conn, code, msg)
 			startupErr := fmt.Errorf("sidecar: runStartupSocketPipe: protocol version mismatch: extension=%d sidecar=%d", helloFrame.ProtocolVersion, piWireProtocolVersion)
 			s.writeStartupError(startupErr)
@@ -1664,7 +1680,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 		s.archiveOutboundFrame(ackBytes)
 		if _, err := conn.Write(ackBytes); err != nil {
 			startupErr := fmt.Errorf("sidecar: runStartupSocketPipe: write hello_ack: %w", err)
-			log.Printf("%v", startupErr)
+			s.logger().Printf("%v", startupErr)
 			_ = conn.Close()
 			connMu.Lock()
 			activeConn = nil
@@ -1673,7 +1689,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			continue
 		}
 
-		log.Printf("sidecar: runStartupSocketPipe: handshake complete (harness=%q version=%q)", helloFrame.Harness, helloFrame.HarnessVersion)
+		s.logger().Printf("sidecar: runStartupSocketPipe: handshake complete (harness=%q version=%q)", helloFrame.Harness, helloFrame.HarnessVersion)
 
 		// Signal readiness on the first successful handshake only.
 		if !onReadyFired {
@@ -1705,7 +1721,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 				}
 			}
 			if readErr != nil {
-				log.Printf("sidecar: runStartupSocketPipe: connection dropped: %v", readErr)
+				s.logger().Printf("sidecar: runStartupSocketPipe: connection dropped: %v", readErr)
 				s.mu.Lock()
 				s.flushPipeAccum()
 				s.mu.Unlock()
@@ -1725,7 +1741,7 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 
 		// Non-shutdown disconnect: wait for PI to reconnect within
 		// reconnectTimeout (e.g. after /new triggers session_start).
-		log.Printf("sidecar: runStartupSocketPipe: waiting up to %s for reconnect", reconnectTimeout)
+		s.logger().Printf("sidecar: runStartupSocketPipe: waiting up to %s for reconnect", reconnectTimeout)
 		acceptTimeout = reconnectTimeout
 	}
 
@@ -1767,15 +1783,15 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 	}
 	if err := json.Unmarshal(line, &frame); err != nil {
 		// P2.WIRE §7.3: log and skip.
-		log.Printf("sidecar: runStartupSocketPipe: parse frame error: %v (raw: %s)", err, truncateBytes(line, 200))
+		s.logger().Printf("sidecar: runStartupSocketPipe: parse frame error: %v (raw: %s)", err, truncateBytes(line, 200))
 		return false
 	}
 	if frame.Type == "" {
-		log.Printf("sidecar: runStartupSocketPipe: frame missing type field (raw: %s)", truncateBytes(line, 200))
+		s.logger().Printf("sidecar: runStartupSocketPipe: frame missing type field (raw: %s)", truncateBytes(line, 200))
 		return false
 	}
 
-	log.Printf("sidecar: runStartupSocketPipe: inbound frame type=%q", frame.Type)
+	s.logger().Printf("sidecar: runStartupSocketPipe: inbound frame type=%q", frame.Type)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1800,7 +1816,7 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 			s.cancelIdleTimer()
 			s.cancelRecoveryTimer()
 			s.lastErrorAt = s.cfg.Clock.Now()
-			log.Printf("sidecar: transition -> error (cause=pi_state_change)")
+			s.logger().Printf("sidecar: transition -> error (cause=pi_state_change)")
 			s.upsertState(st, nil, nil)
 			s.writeStateChange(st)
 			s.lastState = st
@@ -1844,14 +1860,14 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 			}
 			if prevState == agent.StateError || prevState == agent.StateInterrupted {
 				if err := s.cfg.DB.ClearEnded(s.cfg.SessionName); err != nil {
-					log.Printf("sidecar: ClearEnded failed on pi resume: %v", err)
+					s.logger().Printf("sidecar: ClearEnded failed on pi resume: %v", err)
 				}
 			}
 			s.upsertState(agent.StateActive, nil, nil)
 			s.writeStateChange(agent.StateActive)
 			s.lastState = agent.StateActive
 		} else {
-			log.Printf("sidecar: turn_start suppressed (cause=reviewing — awaiting review-complete prompt)")
+			s.logger().Printf("sidecar: turn_start suppressed (cause=reviewing — awaiting review-complete prompt)")
 		}
 		// Reset the accumulator for the new turn, then persist the frame.
 		empty := ""
@@ -1901,14 +1917,14 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		if agentName == "" {
 			agentName = s.rootAgent
 		}
-		log.Printf("sidecar: pi turn_end: lastAssistantAgent: %q -> %q (rootAgent=%q)",
+		s.logger().Printf("sidecar: pi turn_end: lastAssistantAgent: %q -> %q (rootAgent=%q)",
 			s.lastAssistantAgent, agentName, s.rootAgent)
 		s.lastAssistantAgent = agentName
 		// When the root agent just completed its turn, clear lastAssistantAgent
 		// so the next state_change{finished} starts the debounce normally
 		// (mirrors the opencode handleMessageUpdated behaviour for root-agent completion).
 		if agentName != "" && agentName == s.rootAgent {
-			log.Printf("sidecar: pi turn_end: lastAssistantAgent cleared (root agent completed)")
+			s.logger().Printf("sidecar: pi turn_end: lastAssistantAgent cleared (root agent completed)")
 			s.lastAssistantAgent = ""
 		}
 
@@ -2046,7 +2062,7 @@ func (s *Sidecar) enqueueHarnessPipeFrame(frame []byte) bool {
 	case ch <- frame:
 		return true
 	default:
-		log.Printf("sidecar: enqueueHarnessPipeFrame: outbound queue full, dropping frame")
+		s.logger().Printf("sidecar: enqueueHarnessPipeFrame: outbound queue full, dropping frame")
 		return false
 	}
 }
@@ -2077,7 +2093,7 @@ func (s *Sidecar) DeliverPrompt(text, deliverAs string) bool {
 	}
 	b, err := json.Marshal(frame)
 	if err != nil {
-		log.Printf("sidecar: DeliverPrompt: marshal: %v", err)
+		s.logger().Printf("sidecar: DeliverPrompt: marshal: %v", err)
 		return false
 	}
 	b = append(b, '\n')

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -288,10 +288,7 @@ func TestSocketPipe_TurnStartEmitsStateActive(t *testing.T) {
 	// was processed.
 	deadline = time.Now().Add(2 * time.Second)
 	for {
-		idleTimer.mu.Lock()
-		stopped := idleTimer.stopped
-		idleTimer.mu.Unlock()
-		if stopped {
+		if idleTimer.Stopped() {
 			break
 		}
 		if time.Now().After(deadline) {
@@ -1583,7 +1580,7 @@ func TestSocketPipe_MultipleIdle_OnlyOneTimer(t *testing.T) {
 	if firstTimer == secondTimer {
 		t.Fatal("same timer object — second state_change{finished} did not create a new timer")
 	}
-	if !firstTimer.stopped {
+	if !firstTimer.Stopped() {
 		t.Error("first finished debounce timer was not stopped when second state_change{finished} arrived")
 	}
 
@@ -1629,7 +1626,7 @@ func TestSocketPipe_ErrorState_CancelsTimers(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// The finished debounce timer must be stopped.
-	if !idleTimer.stopped {
+	if !idleTimer.Stopped() {
 		t.Error("finished debounce timer was not stopped by state_change{error}")
 	}
 
@@ -1798,7 +1795,7 @@ func TestSocketPipe_WaitingState_CancelsIdleTimer(t *testing.T) {
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "waiting"})
 	time.Sleep(50 * time.Millisecond)
 
-	if !idleTimer.stopped {
+	if !idleTimer.Stopped() {
 		t.Error("finished debounce timer was not stopped by state_change{waiting}")
 	}
 
@@ -1840,7 +1837,7 @@ func TestSocketPipe_AutoRetryStart_CancelsIdleTimer(t *testing.T) {
 	sendJSON(t, conn, map[string]any{"type": "auto_retry_start", "attempt": 1})
 	time.Sleep(50 * time.Millisecond)
 
-	if !idleTimer.stopped {
+	if !idleTimer.Stopped() {
 		t.Error("finished debounce timer was not stopped by auto_retry_start")
 	}
 
@@ -1934,7 +1931,7 @@ func TestSocketPipe_SessionShutdown_CancelsTimers(t *testing.T) {
 	_ = wait()
 
 	// The idle timer must be stopped.
-	if !idleTimer.stopped {
+	if !idleTimer.Stopped() {
 		t.Error("idle timer was not stopped by session_shutdown")
 	}
 
@@ -2048,7 +2045,7 @@ func TestSocketPipe_ReviewingGuardPreservedAfterGapFixes(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Finished debounce timer must be cancelled.
-	if idleTimer != nil && !idleTimer.stopped {
+	if idleTimer != nil && !idleTimer.Stopped() {
 		t.Error("finished debounce timer was not cancelled by turn_start while reviewing")
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -126,12 +126,29 @@ func (c *testClock) Advance(d time.Duration) {
 
 func openTestDB(t *testing.T) *db.DB {
 	t.Helper()
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(dbPath)
+	// Use os.MkdirTemp rather than t.TempDir() so that we control the removal
+	// order. Background goroutines (notifyCoordinator, idle-debounce timers)
+	// may write to the DB after the test function returns. If those writes
+	// create new WAL frames after d.Close() runs, a TempDir-managed directory
+	// removal would fail with "directory not empty". By managing the directory
+	// ourselves we can close the DB first and then remove — and accept any
+	// removal error as non-fatal rather than failing the test.
+	// Use a fixed prefix rather than t.Name(): subtest names contain '/' which
+	// os.MkdirTemp rejects as an invalid pattern.
+	dir, err := os.MkdirTemp("", "sidecar-test-db-")
 	if err != nil {
-		t.Fatalf("open test db: %v", err)
+		t.Fatalf("openTestDB MkdirTemp: %v", err)
 	}
-	t.Cleanup(func() { d.Close() })
+	dbPath := filepath.Join(dir, "test.db")
+	d, err2 := db.Open(dbPath)
+	if err2 != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("open test db: %v", err2)
+	}
+	t.Cleanup(func() {
+		d.Close()
+		_ = os.RemoveAll(dir) // best-effort; ignore error if WAL files linger
+	})
 	return d
 }
 
@@ -2611,7 +2628,7 @@ func TestIsReviewAgentSession(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Pass nil DB to exercise the name-heuristic fallback path.
-			got := isReviewAgentSession(tc.sessionName, nil)
+			got := isReviewAgentSession(tc.sessionName, nil, log.Default())
 			if got != tc.want {
 				t.Errorf("isReviewAgentSession(%q) = %v, want %v", tc.sessionName, got, tc.want)
 			}
@@ -2657,17 +2674,17 @@ func TestIsReviewAgentSession_DBBackedPath(t *testing.T) {
 	}
 
 	// Conventional reviewer: DB group membership takes precedence over name check.
-	if !isReviewAgentSession(reviewSession, d) {
+	if !isReviewAgentSession(reviewSession, d, log.Default()) {
 		t.Error("isReviewAgentSession(conventional, DB group set): got false, want true")
 	}
 
 	// Unconventional reviewer: DB identifies it without relying on the name heuristic.
-	if !isReviewAgentSession(unconventionalReviewer, d) {
+	if !isReviewAgentSession(unconventionalReviewer, d, log.Default()) {
 		t.Errorf("isReviewAgentSession(%q, DB group set, no ~review in name): got false, want true — DB path must identify group members regardless of name", unconventionalReviewer)
 	}
 
 	// Parent session itself: NOT a group member.
-	if isReviewAgentSession(parentSession, d) {
+	if isReviewAgentSession(parentSession, d, log.Default()) {
 		t.Error("isReviewAgentSession(parent session): got true, want false — parent is not a group member")
 	}
 
@@ -2678,7 +2695,7 @@ func TestIsReviewAgentSession_DBBackedPath(t *testing.T) {
 		t.Fatalf("UpsertStatus pre-migration: %v", err)
 	}
 	// group_id is NOT set — simulates pre-migration row.
-	if !isReviewAgentSession(preMigrationReviewer, d) {
+	if !isReviewAgentSession(preMigrationReviewer, d, log.Default()) {
 		t.Errorf("isReviewAgentSession(pre-migration ~review name, no group_id): got false, want true — name heuristic fallback must fire")
 	}
 }
@@ -2692,7 +2709,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
-	if !isCoordinatorSession("repo@main", d) {
+	if !isCoordinatorSession("repo@main", d, log.Default()) {
 		t.Error("isCoordinatorSession(post-migration coordinator @main): got false, want true")
 	}
 
@@ -2702,7 +2719,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	if err := d.UpsertStatusSeedRootAgentName("other-repo@custom-branch", "other-repo", "/code/custom", "active", nil, nil, "coordinator", ""); err != nil {
 		t.Fatalf("seed coordinator on custom branch: %v", err)
 	}
-	if !isCoordinatorSession("other-repo@custom-branch", d) {
+	if !isCoordinatorSession("other-repo@custom-branch", d, log.Default()) {
 		t.Error("isCoordinatorSession(post-migration coordinator on non-main branch): got false, want true — this is the core correctness assertion of the DB-backed migration")
 	}
 
@@ -2710,7 +2727,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	if err := d.UpsertStatusSeedRootAgentName("repo@feature", "repo", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
-	if isCoordinatorSession("repo@feature", d) {
+	if isCoordinatorSession("repo@feature", d, log.Default()) {
 		t.Error("isCoordinatorSession(post-migration worker): got true, want false")
 	}
 
@@ -2719,7 +2736,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 		t.Fatalf("seed pre-migration coordinator: %v", err)
 	}
 	// repo@main-old does NOT end with "@main", so heuristic returns false.
-	if isCoordinatorSession("repo@main-old", d) {
+	if isCoordinatorSession("repo@main-old", d, log.Default()) {
 		t.Error("isCoordinatorSession(pre-migration non-main): got true, want false")
 	}
 	// Create a session that ends with @main but has NULL root_agent_name.
@@ -2727,15 +2744,15 @@ func TestIsCoordinatorSession(t *testing.T) {
 		t.Fatalf("seed other@main: %v", err)
 	}
 	// Pre-migration row with @main suffix: heuristic returns true.
-	if !isCoordinatorSession("other@main", d) {
+	if !isCoordinatorSession("other@main", d, log.Default()) {
 		t.Error("isCoordinatorSession(pre-migration @main): got false, want true (name heuristic)")
 	}
 
 	// No DB row: falls back to name heuristic.
-	if !isCoordinatorSession("newrepo@main", nil) {
+	if !isCoordinatorSession("newrepo@main", nil, log.Default()) {
 		t.Error("isCoordinatorSession(nil DB, @main): got false, want true")
 	}
-	if isCoordinatorSession("newrepo@feature", nil) {
+	if isCoordinatorSession("newrepo@feature", nil, log.Default()) {
 		t.Error("isCoordinatorSession(nil DB, non-main): got true, want false")
 	}
 }
@@ -2799,7 +2816,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
-	if !isCoordinatorSession(sess, d) {
+	if !isCoordinatorSession(sess, d, log.Default()) {
 		t.Errorf("isCoordinatorSession(%q) = false, want true (@main heuristic must win over stale root_agent_name)", sess)
 	}
 
@@ -2808,7 +2825,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
 	if err := d.UpsertStatusSeedRootAgentName(workerSess, "myrepo", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
-	if isCoordinatorSession(workerSess, d) {
+	if isCoordinatorSession(workerSess, d, log.Default()) {
 		t.Errorf("isCoordinatorSession(%q) = true, want false (non-@main worker must not be promoted)", workerSess)
 	}
 }
@@ -6668,7 +6685,7 @@ func TestValidateOrRefreshCoordinatorSID_SIDPresent(t *testing.T) {
 
 	srvPort := parseSrvPort(t, srv.URL)
 
-	got, err := validateOrRefreshCoordinatorSID(srvPort, storedSID, "test-repo@main", d, srv.Client())
+	got, err := validateOrRefreshCoordinatorSID(srvPort, storedSID, "test-repo@main", d, srv.Client(), log.Default())
 	if err != nil {
 		t.Fatalf("validateOrRefreshCoordinatorSID: unexpected error: %v", err)
 	}
@@ -6702,7 +6719,7 @@ func TestValidateOrRefreshCoordinatorSID_SIDAbsent(t *testing.T) {
 	srvPort := parseSrvPort(t, srv.URL)
 
 	staleSID := "stale-sid"
-	got, err := validateOrRefreshCoordinatorSID(srvPort, staleSID, coordName, d, srv.Client())
+	got, err := validateOrRefreshCoordinatorSID(srvPort, staleSID, coordName, d, srv.Client(), log.Default())
 	if err != nil {
 		t.Fatalf("validateOrRefreshCoordinatorSID: unexpected error: %v", err)
 	}
@@ -6725,7 +6742,7 @@ func TestValidateOrRefreshCoordinatorSID_EmptyList(t *testing.T) {
 	defer srv.Close()
 	srvPort := parseSrvPort(t, srv.URL)
 
-	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client())
+	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client(), log.Default())
 	if err == nil {
 		t.Error("expected error for empty session list, got nil")
 	}
@@ -6744,7 +6761,7 @@ func TestValidateOrRefreshCoordinatorSID_GetFails(t *testing.T) {
 	defer srv.Close()
 	srvPort := parseSrvPort(t, srv.URL)
 
-	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client())
+	_, err := validateOrRefreshCoordinatorSID(srvPort, "some-sid", "test-repo@main", d, srv.Client(), log.Default())
 	if err == nil {
 		t.Error("expected error when GET /session returns 500, got nil")
 	}
@@ -7913,13 +7930,18 @@ func TestSessionError_MessageAbortedError_PathUnchanged(t *testing.T) {
 
 // ── Gap 3: finish-cause annotation ──────────────────────────────────────────
 
-// captureLog redirects the standard logger to a buffer for the duration of the
-// test and returns a function that reads everything logged so far.
-func captureLog(t *testing.T) func() string {
-	t.Helper()
+// captureLog installs a per-sidecar logger backed by an isolated buffer,
+// replacing the sidecar's current logger. It returns a function that reads
+// everything logged so far through that logger.
+//
+// captureLog must be called after the sidecar is constructed (so the sidecar
+// exists) but before any events are dispatched (so no log lines are missed).
+// Because each sidecar owns its logger, parallel test runs can never
+// contaminate each other's buffers, and background goroutines spawned by the
+// sidecar write to the same isolated buffer for the lifetime of that sidecar.
+func captureLog(sc *Sidecar) func() string {
 	var buf strings.Builder
-	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	sc.cfg.Logger = log.New(&buf, "", 0)
 	return func() string { return buf.String() }
 }
 
@@ -7927,7 +7949,7 @@ func captureLog(t *testing.T) func() string {
 // the session.idle debounce emits cause=idle_debounce.
 func TestTransitionCause_IdleDebounce(t *testing.T) {
 	sc, clk := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 	sc.HandleEvent(makeSSE("session.idle", map[string]any{}))
@@ -7952,7 +7974,7 @@ func TestTransitionCause_IdleDebounce(t *testing.T) {
 func TestTransitionCause_RootAgentIdleDebounce(t *testing.T) {
 	sc, clk := newTestSidecar(t)
 	sc.rootAgent = "worker"
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
@@ -7991,7 +8013,7 @@ func TestTransitionCause_RootAgentIdleDebounce(t *testing.T) {
 // cause=error_finish.
 func TestTransitionCause_ErrorFinish(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
@@ -8016,7 +8038,7 @@ func TestTransitionCause_ErrorFinish(t *testing.T) {
 // emits cause=interrupted_by_denial.
 func TestTransitionCause_InterruptedByDenial(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
@@ -8041,7 +8063,7 @@ func TestTransitionCause_InterruptedByDenial(t *testing.T) {
 // emits cause=recovery_timer.
 func TestTransitionCause_RecoveryTimer(t *testing.T) {
 	sc, clk := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	// Pre-set to active so handleServerConnected starts the recovery timer.
 	sc.lastState = agent.StateActive
@@ -8070,7 +8092,7 @@ func TestTransitionCause_RecoveryTimer(t *testing.T) {
 // status=error writes a tool_error event to the DB and logs the failure.
 func TestToolCallFailed_WritesToolErrorEvent(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 	sc.opencodeSID = "sid-abc"
@@ -8170,7 +8192,7 @@ func TestToolCallFailed_ErrTruncated(t *testing.T) {
 // logged exactly once, not on every occurrence.
 func TestUnknownEventType_LoggedOnce(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
@@ -8197,7 +8219,7 @@ func TestUnknownEventType_LoggedOnce(t *testing.T) {
 // type is logged once.
 func TestUnknownEventType_MultipleTypes(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
@@ -8220,7 +8242,7 @@ func TestUnknownEventType_MultipleTypes(t *testing.T) {
 // at seenUnknownCap and a "cap reached" log line fires once.
 func TestUnknownEventType_CapReached(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
 
@@ -8253,7 +8275,7 @@ func TestUnknownEventType_CapReached(t *testing.T) {
 // sending more unique unknown types does not emit additional "cap reached" lines.
 func TestUnknownEventType_CapReachedOnce(t *testing.T) {
 	sc, _ := newTestSidecar(t)
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 
 	// Fill to cap.
 	for i := range seenUnknownCap + 20 {
@@ -9717,7 +9739,7 @@ func TestBwrapTimingMarkers_FirstEvent(t *testing.T) {
 	// Set spawnTime so duration math produces a real value.
 	sc.spawnTime = time.Now().Add(-100 * time.Millisecond)
 
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
 	out := getLogs()
 
@@ -9752,7 +9774,7 @@ func TestBwrapTimingMarkers_PromptDelivered(t *testing.T) {
 	sc := New(cfg)
 	sc.spawnTime = time.Now().Add(-50 * time.Millisecond)
 
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
 	out := getLogs()
 
@@ -9780,7 +9802,7 @@ func TestBwrapTimingMarkers_NoPromptDelivered(t *testing.T) {
 	sc := New(cfg)
 	sc.spawnTime = time.Now().Add(-50 * time.Millisecond)
 
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
 	out := getLogs()
 
@@ -9807,7 +9829,7 @@ func TestBwrapTimingMarkers_OnlyOnFirstEvent(t *testing.T) {
 	sc := New(cfg)
 	sc.spawnTime = time.Now().Add(-100 * time.Millisecond)
 
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 	// First event: emits markers.
 	sc.HandleEvent(makeSSE("server.connected", map[string]any{}))
 	first := getLogs()
@@ -9843,7 +9865,7 @@ func TestStartupConnectTimeout_EmitsTimingMarker(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	getLogs := captureLog(t)
+	getLogs := captureLog(sc)
 	done := make(chan error, 1)
 	go func() { done <- sc.Run(ctx) }()
 	select {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -40,6 +40,16 @@ func (t *testTimer) Stop() bool {
 	return was
 }
 
+// Stopped reports whether Stop or Fire has run on this timer. Safe for
+// concurrent use — mirrors the lock acquisition in Stop/Fire so that test
+// assertions on the stopped state do not race with the sidecar goroutine
+// that may call cancelIdleTimer (and thus Stop) concurrently. See #1483.
+func (t *testTimer) Stopped() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.stopped
+}
+
 func (t *testTimer) Fire() {
 	t.mu.Lock()
 	if t.stopped {

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -2,7 +2,6 @@ package sidecar
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/google/uuid"
 
@@ -14,7 +13,7 @@ import (
 
 func (s *Sidecar) cancelIdleTimer() {
 	if s.idleTimer != nil {
-		log.Printf("sidecar: idle debounce cancelled")
+		s.logger().Printf("sidecar: idle debounce cancelled")
 		s.idleTimer.Stop()
 		s.idleTimer = nil
 	}
@@ -70,7 +69,7 @@ func (s *Sidecar) upsertState(state agent.AgentState, title *string, opencodeSID
 			&effectiveRole,
 			agentModel,
 		); err != nil {
-			log.Printf("sidecar: UpsertStatusWithRootAgent failed: %v", err)
+			s.logger().Printf("sidecar: UpsertStatusWithRootAgent failed: %v", err)
 		}
 		return
 	}
@@ -82,7 +81,7 @@ func (s *Sidecar) upsertState(state agent.AgentState, title *string, opencodeSID
 		title,
 		opencodeSID,
 	); err != nil {
-		log.Printf("sidecar: UpsertStatus failed: %v", err)
+		s.logger().Printf("sidecar: UpsertStatus failed: %v", err)
 	}
 }
 
@@ -92,10 +91,10 @@ func (s *Sidecar) writeStateChange(state agent.AgentState) {
 
 func (s *Sidecar) writeStateChangeWithSID(state agent.AgentState, opencodeSID *string) {
 	if state == s.lastState {
-		log.Printf("sidecar: state dedup: %s (no change)", state)
+		s.logger().Printf("sidecar: state dedup: %s (no change)", state)
 		return
 	}
-	log.Printf("sidecar: state: %s -> %s", s.lastState, state)
+	s.logger().Printf("sidecar: state: %s -> %s", s.lastState, state)
 	s.writeEvent("state_change", map[string]string{"state": string(state)}, opencodeSID)
 	s.lastState = state
 	// Push to the persistent dashboard socket (fire-and-forget, non-blocking).
@@ -110,7 +109,7 @@ func (s *Sidecar) writeStateChangeWithSID(state agent.AgentState, opencodeSID *s
 func (s *Sidecar) writeEvent(eventType string, payload any, opencodeSID *string) {
 	data, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("sidecar: marshal event payload: %v", err)
+		s.logger().Printf("sidecar: marshal event payload: %v", err)
 		return
 	}
 
@@ -137,7 +136,7 @@ func (s *Sidecar) writeEvent(eventType string, payload any, opencodeSID *string)
 		CreatedAt:        s.cfg.Clock.Now(),
 	}
 	if err := s.cfg.DB.WriteEvent(e); err != nil {
-		log.Printf("sidecar: WriteEvent(%s) failed: %v", eventType, err)
+		s.logger().Printf("sidecar: WriteEvent(%s) failed: %v", eventType, err)
 	}
 }
 
@@ -156,7 +155,7 @@ func (s *Sidecar) writeEvent(eventType string, payload any, opencodeSID *string)
 //   - The parent worker is notified when a review-agent container fails to start.
 func (s *Sidecar) writeStartupError(startupErr error) {
 	s.mu.Lock()
-	log.Printf("sidecar: startup failure — writing error state: %v", startupErr)
+	s.logger().Printf("sidecar: startup failure — writing error state: %v", startupErr)
 	s.upsertState(agent.StateError, nil, nil)
 	s.writeStateChange(agent.StateError)
 	// Write a startup_error event recording the failure reason so the review


### PR DESCRIPTION
Closes #1474
Closes #1477
Closes #1483

## What this does

Injects a `*log.Logger` into the `Sidecar` struct (via `Config.Logger`) so each sidecar instance owns its log output. This eliminates the two race mechanisms from #1474:

- **Mechanism 1**: `captureLog` in tests previously called `log.SetOutput` on the global logger, racing with other parallel tests setup/cleanup. Replaced with `captureLog(sc)` which installs a per-sidecar `*log.Logger` backed by an isolated `strings.Builder`.
- **Mechanism 2**: Background goroutines (`notifyCoordinator`, `notifyParentWorkerOnStartupFailure`, idle-debounce timer closures) all capture `s` by closure and call `s.logger()`, so they write to the parent sidecars buffer for their entire lifetime — not to whatever the global log output happens to be at fire time.

Production callers get `log.Default()` when `cfg.Logger` is nil, so log output is unchanged.

The package-level helpers `isCoordinatorSession`, `isReviewAgentSession`, and `validateOrRefreshCoordinatorSID` (which are not methods on `*Sidecar`) take an explicit `*log.Logger` parameter; all call sites pass `s.logger()`.

Also fixed alongside:
- `openTestDB` switched from `t.TempDir()` to `os.MkdirTemp` with a fixed prefix, preventing pre-existing TempDir cleanup failures caused by SQLite WAL files written by background goroutines after `d.Close()` runs (#1477).
- `testTimer.Stopped()` accessor added; replaces unsafe direct reads of `testTimer.stopped` in `sidecar_socketpipe_test.go` that raced with `cancelIdleTimer` writes (#1483). Required for `-race` to be clean.

## Test results

- `go test ./internal/sidecar/ -count=50` — **PASS** (407s, 0 failures)
- `go test ./internal/sidecar/ -count=50 -race` — **PASS** (1647s, 0 failures, 0 data races)
- `go test ./...` — passes all packages; `internal/integration` FK-constraint failures are pre-existing on main and unrelated.
- `nix build .#prism` — **PASS**

### Coordinator scope adjustment

The tickets count=100 bar was relaxed to count=50 by the coordinator: 50 clean iterations is still a strong signal that the underlying races are gone, and halving the run time keeps the fix-rerun loop tractable. The `-race` clean count=50 run takes ~27 minutes; running count=100 -race would push past 50 minutes per iteration, which is impractical for the iterate-fix loop. count=50 -race clean is sufficient evidence that the race mechanisms are eliminated, not just shifted to a smaller window.

## Changes

- `Config.Logger *log.Logger` field with default in `New()` to `log.Default()`
- `Sidecar.logger()` accessor for use throughout the package
- All `log.Printf` calls in non-test sidecar files replaced with `s.logger().Printf` or, for non-method helpers, an explicit logger parameter
- `captureLog(t)` → `captureLog(sc)` in tests, removing the global `log.SetOutput` call and avoiding the race entirely
- The `captureLogMu` mutex referenced in the AC text never existed in this codebase; the relevant global state was `log.SetOutput`, which has been removed.

## Pre-existing bugs surfaced (tracked separately)

- #1477: TempDir cleanup race caused by SQLite WAL files. Worked around in this PR via `os.MkdirTemp` for sidecar test DBs.
- #1483: `testTimer.stopped` data race. Fixed in this PR (required to satisfy the `-race` AC).
