### PR TITLE
sandbox-exec: grant file-read on ~/Library/Keychains so Keychain API works in sandbox

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -353,7 +353,7 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
-	// ── 6c. ~/Library/Keychains read (issue #1487) ───────────────────────
+	// ── 6b. ~/Library/Keychains read (issue #1487) ───────────────────────
 	// The Keychain Services API (Mach IPC via securityd) requires both
 	// file-read* AND file-test-existence on ~/Library/Keychains to service
 	// credential lookups. securityd probes and reads the keychain databases
@@ -376,7 +376,7 @@ func generateProfile(m *Manager) string {
 		}
 	}
 
-	// ── 6b. BareRoot ancestor probe allows ───────────────────────────────
+	// ── 6c. BareRoot ancestor probe allows ───────────────────────────────
 	// opencode's fs.up() walk probes multiple targets (.opencode, .git) at
 	// every ancestor of the worktree with no stop parameter. Under deny-default
 	// any EPERM (not ENOENT) is fatal. We grant file-test-existence on:

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -353,6 +353,29 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
+	// ── 6c. ~/Library/Keychains read (issue #1487) ───────────────────────
+	// The Keychain Services API (Mach IPC via securityd) requires both
+	// file-read* AND file-test-existence on ~/Library/Keychains to service
+	// credential lookups. securityd probes and reads the keychain databases
+	// in this directory even when the lookup is routed over Mach IPC rather
+	// than direct file access. Without this rule, securityd returns "item not
+	// found" (exit 44) from inside the sandbox.
+	// We use (subpath ~/Library/Keychains) rather than a (literal ...) on
+	// login.keychain-db alone, because modern macOS also writes credentials
+	// into UUID-keyed databases in the same directory (e.g. 889FEFC9-.../
+	// keychain-2.db) and securityd needs to probe those too. The Keychains
+	// directory contains only keychain metadata and databases — no unrelated
+	// sensitive files. Rule is omitted when the directory does not exist
+	// (e.g. fresh machine / CI).
+	if home != "" {
+		keychainsDir := filepath.Join(home, "Library", "Keychains")
+		if _, err := os.Stat(keychainsDir); err == nil {
+			sb.WriteString("(allow file-read* file-test-existence\n")
+			sb.WriteString("  (subpath " + quoteSBPL(keychainsDir) + "))\n")
+			sb.WriteString("\n")
+		}
+	}
+
 	// ── 6b. BareRoot ancestor probe allows ───────────────────────────────
 	// opencode's fs.up() walk probes multiple targets (.opencode, .git) at
 	// every ancestor of the worktree with no stop parameter. Under deny-default

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -353,25 +353,25 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
-	// ── 6b. ~/Library/Keychains read (issue #1487) ───────────────────────
-	// The Keychain Services API (Mach IPC via securityd) requires both
-	// file-read* AND file-test-existence on ~/Library/Keychains to service
-	// credential lookups. securityd probes and reads the keychain databases
-	// in this directory even when the lookup is routed over Mach IPC rather
-	// than direct file access. Without this rule, securityd returns "item not
-	// found" (exit 44) from inside the sandbox.
-	// We use (subpath ~/Library/Keychains) rather than a (literal ...) on
-	// login.keychain-db alone, because modern macOS also writes credentials
-	// into UUID-keyed databases in the same directory (e.g. 889FEFC9-.../
-	// keychain-2.db) and securityd needs to probe those too. The Keychains
-	// directory contains only keychain metadata and databases — no unrelated
-	// sensitive files. Rule is omitted when the directory does not exist
-	// (e.g. fresh machine / CI).
+	// ── 6b. ~/Library/Keychains/login.keychain-db read (issue #1487) ──────
+	// The Keychain Services API (Mach IPC via securityd) requires file-read*
+	// access to ~/Library/Keychains/login.keychain-db to service credential
+	// lookups, even when the lookup is routed over Mach IPC to securityd.
+	// Without this, securityd returns "item not found" (exit 44) from inside
+	// the sandbox.
+	//
+	// We use (literal ...) on the specific file rather than (subpath
+	// ~/Library/Keychains) to avoid granting read access to the UUID-keyed
+	// modern keychain databases (keychain-2.db, user.kb, TrustedPeersHelper)
+	// in the same directory. The literal is sufficient — confirmed by direct
+	// sandbox-exec experiments (issue #1487).
+	//
+	// Rule is omitted when the file does not exist (e.g. fresh machine / CI).
 	if home != "" {
-		keychainsDir := filepath.Join(home, "Library", "Keychains")
-		if _, err := os.Stat(keychainsDir); err == nil {
-			sb.WriteString("(allow file-read* file-test-existence\n")
-			sb.WriteString("  (subpath " + quoteSBPL(keychainsDir) + "))\n")
+		keychainDB := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+		if _, err := os.Stat(keychainDB); err == nil {
+			sb.WriteString("(allow file-read*\n")
+			sb.WriteString("  (literal " + quoteSBPL(keychainDB) + "))\n")
 			sb.WriteString("\n")
 		}
 	}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -12,11 +12,12 @@ package container
 // Design decisions locked by the coordinator in issue #1017:
 //
 //  1. .claude/ is a symlink to host ~/.claude (matches bwrap's RW treatment at
-//     bwrap.go:306-308). On Darwin, opencode-claude-auth calls the Keychain API
-//     (Mach IPC) directly from inside the sandbox — no pre-seeded credentials
-//     file is needed. Writes to .credentials.json (e.g. token refreshes) flow
-//     through the symlink to the host's ~/.claude/.credentials.json.
-//     This is the accepted trade-off (simplest, matches bwrap's RW treatment).
+//     bwrap.go:306-308). Writes to .credentials.json (e.g. token refreshes)
+//     flow through the symlink to the host's ~/.claude/.credentials.json.
+//  2. Library/Keychains/login.keychain-db is symlinked so that opencode-claude-auth
+//     (which uses `security dump-keychain` with $HOME to find the keychain search
+//     list) can locate the user's login keychain. The SBPL profile grants
+//     file-read* on the resolved path via (literal login.keychain-db) (#1487).
 //
 //  2. .config/opencode/agents/ is role-conditional: included as a symlink for
 //     non-review roles, omitted for review-prefixed roles. Mirrors bwrap.go:447-448.
@@ -29,6 +30,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -236,16 +238,33 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".kube", "config"),
 	)
 
+	// ── Library/Keychains/login.keychain-db — symlink for Keychain API ──────
+	// On Darwin, opencode-claude-auth uses `security dump-keychain` and
+	// `security find-generic-password` to retrieve Claude credentials from the
+	// macOS Keychain. Both commands use $HOME to locate the keychain search
+	// list, and inside the sandbox $HOME points at the staging directory. By
+	// symlinking $stagingHome/Library/Keychains/login.keychain-db → the real
+	// login.keychain-db, `security` finds the correct search list and can
+	// retrieve credentials. The SBPL profile grants file-read* on the resolved
+	// (real) path via the (literal login.keychain-db) rule (issue #1487).
+	// Token refresh writes go through the `security add-generic-password`
+	// Mach IPC path which is not affected by this symlink.
+	if runtime.GOOS == "darwin" {
+		realKeychain := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+		if _, err := os.Stat(realKeychain); err == nil {
+			keychainLink := filepath.Join(stagingHome, "Library", "Keychains", "login.keychain-db")
+			if mkErr := os.MkdirAll(filepath.Dir(keychainLink), 0o755); mkErr == nil {
+				_ = os.Symlink(realKeychain, keychainLink)
+			}
+		}
+	}
+
 	// ── .claude/ — symlink to host ~/.claude (RW write-through) ──────────────
-	// On Darwin, opencode-claude-auth calls the Keychain API (Mach IPC)
-	// directly from inside the sandbox — no pre-seeded credentials file is
-	// needed at spawn time. Token refreshes performed by opencode-claude-auth
-	// during a session write .credentials.json inside ~/.claude/, and since
-	// this is a symlink to host ~/.claude, those writes flow through to the
-	// host path and are immediately reflected in subsequent sessions.
-	// On Linux, ~/.claude/.credentials.json already lives on disk; the bwrap
-	// path bind-mounts ~/.claude/ with RW access (bwrap.go:306-308), matching
-	// the same write-through semantics via a different mechanism.
+	// opencode-claude-auth token refreshes write .credentials.json inside
+	// ~/.claude/, and since this is a symlink to host ~/.claude, those writes
+	// flow through to the host path and are immediately reflected in subsequent
+	// sessions. On Linux, ~/.claude/.credentials.json already lives on disk;
+	// the bwrap path bind-mounts ~/.claude/ with RW access (bwrap.go:306-308).
 	symlinkIfExists(
 		filepath.Join(home, ".claude"),
 		filepath.Join(stagingHome, ".claude"),

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
@@ -530,9 +530,12 @@ func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 // (literal login.keychain-db) rule is present. This test therefore can only
 // confirm that the Mach IPC path to securityd is reachable (not "Operation not
 // permitted") — NOT that the file-read rule from issue #1487 is working. The
-// authoritative tests for the #1487 SBPL rule are in internal/integration/:
+// authoritative test for the #1487 SBPL rule is in internal/integration/:
 //   - TestSandboxExecProfile_KeychainAPIAccessible (positive, uses real HOME)
-//   - TestSandboxExecProfile_KeychainAPIDeniedWithoutKeychainRule (negative)
+// No paired negative test exists: the withMutatedProfile pattern cannot isolate
+// the Keychains rule on a fully set-up machine because the full production
+// profile grants ~/Library/Keychains access through other rules too. The
+// profile string-content assertion in the positive test is the regression guard.
 //
 // Exit 44 ("item not found") with any HOME value is treated as "API reachable,
 // item absent" and causes a skip — this test cannot distinguish rule-present

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
@@ -470,9 +470,17 @@ func TestSandboxExecIntegration_HomeCodeDirectoryDenied(t *testing.T) {
 	}
 }
 
-// TestSandboxExecIntegration_KeychainDenied verifies that the host
-// ~/Library/Keychains/login.keychain-db is NOT readable from inside the
-// sandbox (N4 in F.1 §3.2).
+// TestSandboxExecIntegration_KeychainDenied verifies that ~/Library/Keychains
+// is accessible from inside the sandbox — specifically that the Keychain
+// Services API can operate, and that login.keychain-db is directly readable
+// (as granted by the (subpath ~/Library/Keychains) rule from issue #1487).
+//
+// This test was updated from N4 in F.1 §3.2 which previously asserted that
+// login.keychain-db is denied. The #1487 fix intentionally grants
+// file-read* + file-test-existence on ~/Library/Keychains so that securityd
+// can service Keychain API lookups from inside the sandbox. The test now
+// confirms the rule is present in the profile and that login.keychain-db is
+// readable (not denied) when the file exists.
 func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 	if !sandboxExecAvailable() {
 		t.Skip("sandbox-exec not available")
@@ -488,14 +496,25 @@ func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 
 	m, stagingHome := newIntegrationManager(t)
 	profilePath := writeProfileForIntegration(t, m)
-	env := baseEnv(stagingHome)
 
-	out, code := runUnderSandbox(t, profilePath, env, "/bin/cat", keychainPath)
-	if code == 0 {
-		t.Errorf("cat login.keychain-db: expected non-zero exit (denied), got exit 0\noutput: %s", out)
+	// Verify the profile contains the (subpath ~/Library/Keychains) rule (#1487).
+	content, readErr := os.ReadFile(profilePath)
+	if readErr != nil {
+		t.Fatalf("read profile: %v", readErr)
 	}
-	if !strings.Contains(out, "Operation not permitted") && !strings.Contains(out, "Permission denied") {
-		t.Errorf("cat login.keychain-db: expected 'Operation not permitted' in output; got: %q", out)
+	keychainsDir := filepath.Join(realHome, "Library", "Keychains")
+	if !strings.Contains(string(content), keychainsDir) {
+		t.Errorf("profile does not contain the ~/Library/Keychains subpath rule (#1487).\n"+
+			"Expected to find %q in profile.", keychainsDir)
+	}
+
+	// login.keychain-db must now be READABLE (not denied) because the
+	// (subpath ~/Library/Keychains) rule grants file-read* on the whole dir.
+	env := baseEnv(stagingHome)
+	out, code := runUnderSandbox(t, profilePath, env, "/bin/cat", keychainPath)
+	if code != 0 && (strings.Contains(out, "Operation not permitted") || strings.Contains(out, "Permission denied")) {
+		t.Errorf("cat login.keychain-db: got sandbox denial — expected the #1487 rule to grant access.\n"+
+			"exit: %d, output: %s", code, out)
 	}
 }
 
@@ -505,17 +524,21 @@ func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 // "Claude Code-credentials" service inside the sandbox and asserts that the
 // command does not fail with a sandbox deny.
 //
-// The Keychain API operates over Mach IPC (securityd/secd), not direct file
-// access. The SBPL profile grants mach-lookup and network*, so the API is
-// reachable from inside the sandbox even when direct file reads of
-// ~/Library/Keychains/ are denied (see TestSandboxExecIntegration_KeychainDenied).
+// Note on test scope: the `security` CLI tool constructs the keychain search
+// path from $HOME, so with $HOME set to the staging home (as this test does),
+// it always returns exit 44 ("item not found") regardless of whether the SBPL
+// (literal login.keychain-db) rule is present. This test therefore can only
+// confirm that the Mach IPC path to securityd is reachable (not "Operation not
+// permitted") — NOT that the file-read rule from issue #1487 is working. The
+// authoritative tests for the #1487 SBPL rule are in internal/integration/:
+//   - TestSandboxExecProfile_KeychainAPIAccessible (positive, uses real HOME)
+//   - TestSandboxExecProfile_KeychainAPIDeniedWithoutKeychainRule (negative)
 //
-// A missing Keychain entry (exit 44 from security, meaning "item not found")
-// is treated as a successful API call — the test skips gracefully when the
-// "Claude Code-credentials" entry is absent so that CI hosts without a Claude
-// login still pass. This is the regression guard ensuring that
-// opencode-claude-auth can call the Keychain API directly from inside the
-// sandbox (issue #1413).
+// Exit 44 ("item not found") with any HOME value is treated as "API reachable,
+// item absent" and causes a skip — this test cannot distinguish rule-present
+// from rule-absent when $HOME doesn't point to the real home directory.
+// See also: TestSandboxExecIntegration_KeychainDenied (confirms the
+// ~/Library/Keychains subpath rule is present in the profile). (#1487)
 func TestSandboxExecIntegration_KeychainAPIAccessible(t *testing.T) {
 	if !sandboxExecAvailable() {
 		t.Skip("sandbox-exec not available")
@@ -531,16 +554,24 @@ func TestSandboxExecIntegration_KeychainAPIAccessible(t *testing.T) {
 		"/usr/bin/security", "find-generic-password", "-l", "Claude Code-credentials", "-w")
 
 	// exit 0: credentials found — Keychain API accessible and entry present.
-	// exit 44: "item not found" — Keychain API accessible but entry absent.
+	// exit 44: "item not found" — Keychain API reachable but the `security`
+	//   CLI uses $HOME to find the keychain search list; with $HOME=stagingHome
+	//   it always returns 44 regardless of the SBPL rule. Skip gracefully.
 	// Any other exit (e.g. sandbox deny producing "Operation not permitted") is a failure.
 	const securityItemNotFound = 44
 	switch code {
 	case 0:
 		// Credentials retrieved successfully — Keychain API is accessible.
 	case securityItemNotFound:
-		// Entry absent from host Keychain. API is still accessible — skip so
-		// the test does not require a Claude login to pass.
-		t.Skipf("Claude Code-credentials entry absent from host Keychain — Keychain API is accessible inside sandbox (security exit 44); skipping")
+		// `security` CLI uses $HOME for its keychain search list. With staging
+		// HOME, it cannot find entries in the host keychain. Skip — this test
+		// cannot distinguish "SBPL rule absent" from "staging HOME mismatch".
+		// See TestSandboxExecProfile_KeychainAPIAccessible in internal/integration/
+		// for the authoritative #1487 rule test (uses real HOME). (#1487)
+		t.Skipf("security find-generic-password returned exit 44 (item not found) — "+
+			"Keychain API is reachable (no sandbox deny) but the security CLI uses $HOME "+
+			"for its keychain search list; with HOME=stagingHome this is expected. "+
+			"See TestSandboxExecProfile_KeychainAPIAccessible for the #1487 SBPL rule test.")
 	default:
 		// Unexpected exit. A sandbox deny would produce "Operation not permitted"
 		// in stderr. Treat any other code as a failure.

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
@@ -470,18 +470,18 @@ func TestSandboxExecIntegration_HomeCodeDirectoryDenied(t *testing.T) {
 	}
 }
 
-// TestSandboxExecIntegration_KeychainDenied verifies that ~/Library/Keychains
-// is accessible from inside the sandbox — specifically that the Keychain
-// Services API can operate, and that login.keychain-db is directly readable
-// (as granted by the (subpath ~/Library/Keychains) rule from issue #1487).
+// TestSandboxExecIntegration_ModernKeychainDBDenied verifies that the
+// UUID-keyed modern keychain database (~/Library/Keychains/<UUID>/keychain-2.db)
+// is NOT readable from inside the sandbox (N4 in F.1 §3.2, updated for #1487).
 //
-// This test was updated from N4 in F.1 §3.2 which previously asserted that
-// login.keychain-db is denied. The #1487 fix intentionally grants
-// file-read* + file-test-existence on ~/Library/Keychains so that securityd
-// can service Keychain API lookups from inside the sandbox. The test now
-// confirms the rule is present in the profile and that login.keychain-db is
-// readable (not denied) when the file exists.
-func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
+// The #1487 fix grants (literal ~/Library/Keychains/login.keychain-db) rather
+// than (subpath ~/Library/Keychains). This preserves the security property that
+// the UUID-keyed keychain-2.db — which holds all keychain item payloads — is
+// not directly readable from inside the sandbox. Only login.keychain-db (needed
+// by securityd to service Mach IPC lookups) is exposed.
+//
+// Skips when no UUID keychain directory exists on this host.
+func TestSandboxExecIntegration_ModernKeychainDBDenied(t *testing.T) {
 	if !sandboxExecAvailable() {
 		t.Skip("sandbox-exec not available")
 	}
@@ -489,32 +489,42 @@ func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 	if err != nil {
 		t.Skip("cannot determine home directory")
 	}
-	keychainPath := filepath.Join(realHome, "Library", "Keychains", "login.keychain-db")
-	if _, err := os.Stat(keychainPath); err != nil {
-		t.Skipf("login.keychain-db does not exist — skipping: %v", err)
+
+	// Find the UUID-keyed keychain-2.db under ~/Library/Keychains/<UUID>/.
+	keychainsDir := filepath.Join(realHome, "Library", "Keychains")
+	entries, readErr := os.ReadDir(keychainsDir)
+	if readErr != nil {
+		t.Skipf("~/Library/Keychains not readable: %v", readErr)
+	}
+	var modernKeychainDB string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(keychainsDir, e.Name(), "keychain-2.db")
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			modernKeychainDB = candidate
+			break
+		}
+	}
+	if modernKeychainDB == "" {
+		t.Skip("no UUID-keyed keychain-2.db found on this host — skipping")
 	}
 
 	m, stagingHome := newIntegrationManager(t)
 	profilePath := writeProfileForIntegration(t, m)
-
-	// Verify the profile contains the (subpath ~/Library/Keychains) rule (#1487).
-	content, readErr := os.ReadFile(profilePath)
-	if readErr != nil {
-		t.Fatalf("read profile: %v", readErr)
-	}
-	keychainsDir := filepath.Join(realHome, "Library", "Keychains")
-	if !strings.Contains(string(content), keychainsDir) {
-		t.Errorf("profile does not contain the ~/Library/Keychains subpath rule (#1487).\n"+
-			"Expected to find %q in profile.", keychainsDir)
-	}
-
-	// login.keychain-db must now be READABLE (not denied) because the
-	// (subpath ~/Library/Keychains) rule grants file-read* on the whole dir.
 	env := baseEnv(stagingHome)
-	out, code := runUnderSandbox(t, profilePath, env, "/bin/cat", keychainPath)
-	if code != 0 && (strings.Contains(out, "Operation not permitted") || strings.Contains(out, "Permission denied")) {
-		t.Errorf("cat login.keychain-db: got sandbox denial — expected the #1487 rule to grant access.\n"+
-			"exit: %d, output: %s", code, out)
+
+	// keychain-2.db must remain inaccessible. The (literal login.keychain-db)
+	// rule added by #1487 does NOT cover the UUID-keyed database. (#1487)
+	out, code := runUnderSandbox(t, profilePath, env, "/bin/cat", modernKeychainDB)
+	if code == 0 {
+		t.Errorf("cat keychain-2.db: expected non-zero exit (denied), got exit 0\n"+
+			"The (literal login.keychain-db) rule must NOT expose UUID keychain databases (#1487).\n"+
+			"output: %s", out)
+	}
+	if !strings.Contains(out, "Operation not permitted") && !strings.Contains(out, "Permission denied") {
+		t.Errorf("cat keychain-2.db: expected 'Operation not permitted' in output; got: %q", out)
 	}
 }
 
@@ -524,24 +534,19 @@ func TestSandboxExecIntegration_KeychainDenied(t *testing.T) {
 // "Claude Code-credentials" service inside the sandbox and asserts that the
 // command does not fail with a sandbox deny.
 //
-// Note on test scope: the `security` CLI tool constructs the keychain search
-// path from $HOME, so with $HOME set to the staging home (as this test does),
-// it always returns exit 44 ("item not found") regardless of whether the SBPL
-// (literal login.keychain-db) rule is present. This test therefore can only
-// confirm that the Mach IPC path to securityd is reachable (not "Operation not
-// permitted") — NOT that the file-read rule from issue #1487 is working. The
-// authoritative test for the #1487 SBPL rule is in internal/integration/:
-//   - TestSandboxExecProfile_KeychainAPIAccessible (positive, uses real HOME)
-// No paired negative test exists: the withMutatedProfile pattern cannot isolate
-// the Keychains rule on a fully set-up machine because the full production
-// profile grants ~/Library/Keychains access through other rules too. The
-// profile string-content assertion in the positive test is the regression guard.
+// The Keychain API operates over Mach IPC (securityd/secd), not direct file
+// access. The SBPL profile grants mach-lookup and network*, so the API is
+// reachable from inside the sandbox even when direct file reads of
+// ~/Library/Keychains/ are denied (see TestSandboxExecIntegration_ModernKeychainDBDenied).
 //
-// Exit 44 ("item not found") with any HOME value is treated as "API reachable,
-// item absent" and causes a skip — this test cannot distinguish rule-present
-// from rule-absent when $HOME doesn't point to the real home directory.
-// See also: TestSandboxExecIntegration_KeychainDenied (confirms the
-// ~/Library/Keychains subpath rule is present in the profile). (#1487)
+// A missing Keychain entry (exit 44 from security, meaning "item not found")
+// is treated as a successful API call — the test skips gracefully when the
+// "Claude Code-credentials" entry is absent so that CI hosts without a Claude
+// login still pass. Note: this test uses $HOME=stagingHome, so the `security`
+// CLI (which uses $HOME to find the keychain search list) always returns exit 44
+// here regardless of the SBPL rule. The authoritative test for the #1487 literal
+// rule is TestSandboxExecProfile_KeychainAPIAccessible in internal/integration/,
+// which passes real HOME to security inside the sandbox. (#1487)
 func TestSandboxExecIntegration_KeychainAPIAccessible(t *testing.T) {
 	if !sandboxExecAvailable() {
 		t.Skip("sandbox-exec not available")
@@ -566,15 +571,11 @@ func TestSandboxExecIntegration_KeychainAPIAccessible(t *testing.T) {
 	case 0:
 		// Credentials retrieved successfully — Keychain API is accessible.
 	case securityItemNotFound:
-		// `security` CLI uses $HOME for its keychain search list. With staging
-		// HOME, it cannot find entries in the host keychain. Skip — this test
-		// cannot distinguish "SBPL rule absent" from "staging HOME mismatch".
-		// See TestSandboxExecProfile_KeychainAPIAccessible in internal/integration/
-		// for the authoritative #1487 rule test (uses real HOME). (#1487)
-		t.Skipf("security find-generic-password returned exit 44 (item not found) — "+
-			"Keychain API is reachable (no sandbox deny) but the security CLI uses $HOME "+
-			"for its keychain search list; with HOME=stagingHome this is expected. "+
-			"See TestSandboxExecProfile_KeychainAPIAccessible for the #1487 SBPL rule test.")
+		// Entry absent from host Keychain (or staging HOME mismatch — see comment
+		// above). API is still accessible — skip so the test does not require a
+		// Claude login to pass.
+		t.Skipf("Claude Code-credentials entry absent from host Keychain (or staging HOME used) — "+
+			"Keychain API is accessible inside sandbox (security exit 44); skipping")
 	default:
 		// Unexpected exit. A sandbox deny would produce "Operation not permitted"
 		// in stderr. Treat any other code as a failure.

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_keychain_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_keychain_darwin_test.go
@@ -3,37 +3,38 @@
 package integration_test
 
 // sandbox_exec_keychain_darwin_test.go — integration coverage for the
-// ~/Library/Keychains file-read rule added to the SBPL profile (issue #1487).
+// login.keychain-db file-read rule added to the SBPL profile (issue #1487).
 //
 // Background: the Keychain Services API routes credential lookups over Mach IPC
-// to securityd, but securityd also requires file-read* + file-test-existence on
-// ~/Library/Keychains to service the lookup. Without the subpath rule, securityd
-// returns exit 44 ("item not found") from inside the sandbox even though the
-// Mach IPC path is open.
+// to securityd, but securityd also requires file-read* access to
+// ~/Library/Keychains/login.keychain-db to service the lookup. Without this,
+// securityd returns exit 44 ("item not found") from inside the sandbox even
+// though the Mach IPC path is open.
 //
 // generateProfile now emits:
 //
-//	(allow file-read* file-test-existence
-//	  (subpath "<home>/Library/Keychains"))
+//	(allow file-read*
+//	  (literal "<home>/Library/Keychains/login.keychain-db"))
 //
-// conditionally, when the directory exists on the host.
+// conditionally, when the file exists on the host.
 //
 // This file tests:
 //
-//  1. Positive case: when ~/Library/Keychains exists, /usr/bin/security
+//  1. Positive case: when login.keychain-db exists, /usr/bin/security
 //     find-generic-password exits 0 (credentials present) or 44 (API
 //     reachable, entry absent). "Operation not permitted" in output is always
-//     a failure. Also asserts the generated profile contains the Keychains
-//     subpath — this string check is the load-bearing regression guard for
-//     the SBPL rule.
+//     a failure. Also asserts the generated profile contains the literal path
+//     (load-bearing regression guard).
+//     Security is invoked with real HOME (not staging HOME) so the CLI can
+//     locate the host keychain search list.
 //
-// Note on negative test: the standard negative-test pattern (mutate profile,
-// assert operation fails) cannot be made to work for this rule because the
-// full production profile (with staging-home symlink targets and the BareRoot
-// ancestor block) grants file-read access to ~/Library/Keychains via other
-// rules on a fully set-up machine. The profile string-content assertion in the
-// positive test serves as the regression guard: if generateProfile stops
-// emitting the Keychains rule, the assertion fails before security even runs.
+// Note on negative test: the withMutatedProfile pattern cannot isolate the
+// keychain literal as load-bearing on a fully set-up machine — the full
+// production profile (with staging-home symlink targets) grants access to
+// ~/Library/Keychains via other rules in this configuration. The profile
+// string-content assertion in the positive test is the regression guard: if
+// generateProfile stops emitting the rule, that assertion fails before the
+// sandbox invocation runs.
 //
 // Shared helpers (requireSandboxExec, newProfileManagerWithBareRoot,
 // preparePositiveProfile, writeAugmentedPositiveProfile) live in
@@ -53,26 +54,25 @@ import (
 // keychainServiceName is the Keychain service name for Claude credentials.
 const keychainServiceName = "Claude Code-credentials"
 
-// keychainsDir returns the path to the user's ~/Library/Keychains directory.
+// loginKeychainPath returns the path to the user's login.keychain-db.
 // Returns an empty string if the user's home directory cannot be determined.
-func keychainsDir(t *testing.T) string {
+func loginKeychainPath(t *testing.T) string {
 	t.Helper()
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ""
 	}
-	return filepath.Join(home, "Library", "Keychains")
+	return filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 }
 
 // TestSandboxExecProfile_KeychainAPIAccessible is the integration test for the
-// ~/Library/Keychains file-read rule (issue #1487).
+// login.keychain-db file-read rule (issue #1487).
 //
 // It asserts that:
-//   - The generated profile contains the (subpath ~/Library/Keychains) rule
-//     (load-bearing regression guard: if generateProfile stops emitting the
-//     rule, this assertion fails before the sandbox invocation even runs).
+//   - The generated profile contains the (literal login.keychain-db) path
+//     (load-bearing regression guard — fails before sandbox runs if missing).
 //   - /usr/bin/security find-generic-password exits 0 or 44 inside the sandbox
-//     (no "Operation not permitted" sandbox denial).
+//     when invoked with real HOME (no "Operation not permitted" sandbox denial).
 func TestSandboxExecProfile_KeychainAPIAccessible(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -83,12 +83,17 @@ func TestSandboxExecProfile_KeychainAPIAccessible(t *testing.T) {
 		t.Skip("/usr/bin/security not present")
 	}
 
-	kDir := keychainsDir(t)
-	if kDir == "" {
+	keychainPath := loginKeychainPath(t)
+	if keychainPath == "" {
 		t.Skip("cannot determine home directory")
 	}
-	if _, err := os.Stat(kDir); err != nil {
-		t.Skipf("~/Library/Keychains does not exist at %s — skipping: %v", kDir, err)
+	if _, err := os.Stat(keychainPath); err != nil {
+		t.Skipf("login.keychain-db does not exist at %s — skipping: %v", keychainPath, err)
+	}
+
+	realHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
 	}
 
 	m := newProfileManagerWithBareRoot(t)
@@ -102,19 +107,21 @@ func TestSandboxExecProfile_KeychainAPIAccessible(t *testing.T) {
 	prepared, _ := preparePositiveProfile(t, m)
 
 	// Load-bearing regression guard: the generated profile must contain the
-	// ~/Library/Keychains subpath rule. If generateProfile stops emitting it,
-	// this check catches the regression before the sandbox invocation below.
-	if !strings.Contains(prepared.content, kDir) {
-		t.Fatalf("generated profile does not contain the ~/Library/Keychains subpath %q.\n"+
-			"The (allow file-read* file-test-existence (subpath ...)) rule was not emitted by generateProfile.\nProfile:\n%s",
-			kDir, prepared.content)
+	// literal login.keychain-db path. If generateProfile stops emitting it,
+	// this assertion fails before the sandbox invocation below.
+	if !strings.Contains(prepared.content, keychainPath) {
+		t.Fatalf("generated profile does not contain the login.keychain-db literal path %q.\n"+
+			"The (allow file-read* (literal ...)) rule was not emitted by generateProfile.\nProfile:\n%s",
+			keychainPath, prepared.content)
 	}
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	// Run /usr/bin/security inside sandbox-exec. Apple-signed binary; uses
-	// Mach IPC to contact securityd — exactly the code path we need to exercise.
+	// Pass real HOME (not staging HOME) so the security CLI can locate the
+	// host keychain search list. With staging HOME the CLI always returns
+	// exit 44 regardless of the SBPL rule.
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+realHome,
 		"/usr/bin/security", "find-generic-password", "-l", keychainServiceName, "-w")
 	out, runErr := cmd.CombinedOutput()
 	output := string(out)
@@ -122,7 +129,7 @@ func TestSandboxExecProfile_KeychainAPIAccessible(t *testing.T) {
 	// "Operation not permitted" means a sandbox denial — always a failure.
 	if strings.Contains(output, "Operation not permitted") {
 		t.Fatalf("Keychain API call produced 'Operation not permitted' inside sandbox.\n"+
-			"This indicates a sandbox denial — the (subpath ~/Library/Keychains) rule is not working.\n"+
+			"This indicates a sandbox denial — the (literal login.keychain-db) rule is not working.\n"+
 			"Exit: %v\nOutput: %s\nProfile: %s",
 			runErr, output, testProfilePath)
 	}
@@ -139,7 +146,6 @@ func TestSandboxExecProfile_KeychainAPIAccessible(t *testing.T) {
 	}
 
 	if exitCode == securityItemNotFound {
-		// Entry absent — API is reachable, item is simply missing. Acceptable on CI.
 		t.Logf("Keychain API accessible inside sandbox (security exit 44: item not found). "+
 			"Claude Code-credentials not present on this host — expected on CI. (#1487)")
 		return

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_keychain_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_keychain_darwin_test.go
@@ -1,0 +1,150 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_keychain_darwin_test.go — integration coverage for the
+// ~/Library/Keychains file-read rule added to the SBPL profile (issue #1487).
+//
+// Background: the Keychain Services API routes credential lookups over Mach IPC
+// to securityd, but securityd also requires file-read* + file-test-existence on
+// ~/Library/Keychains to service the lookup. Without the subpath rule, securityd
+// returns exit 44 ("item not found") from inside the sandbox even though the
+// Mach IPC path is open.
+//
+// generateProfile now emits:
+//
+//	(allow file-read* file-test-existence
+//	  (subpath "<home>/Library/Keychains"))
+//
+// conditionally, when the directory exists on the host.
+//
+// This file tests:
+//
+//  1. Positive case: when ~/Library/Keychains exists, /usr/bin/security
+//     find-generic-password exits 0 (credentials present) or 44 (API
+//     reachable, entry absent). "Operation not permitted" in output is always
+//     a failure. Also asserts the generated profile contains the Keychains
+//     subpath — this string check is the load-bearing regression guard for
+//     the SBPL rule.
+//
+// Note on negative test: the standard negative-test pattern (mutate profile,
+// assert operation fails) cannot be made to work for this rule because the
+// full production profile (with staging-home symlink targets and the BareRoot
+// ancestor block) grants file-read access to ~/Library/Keychains via other
+// rules on a fully set-up machine. The profile string-content assertion in the
+// positive test serves as the regression guard: if generateProfile stops
+// emitting the Keychains rule, the assertion fails before security even runs.
+//
+// Shared helpers (requireSandboxExec, newProfileManagerWithBareRoot,
+// preparePositiveProfile, writeAugmentedPositiveProfile) live in
+// sandbox_exec_helpers_darwin_test.go.
+//
+// See docs/sandbox-exec-testing.md for the convention these tests support (#1192).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// keychainServiceName is the Keychain service name for Claude credentials.
+const keychainServiceName = "Claude Code-credentials"
+
+// keychainsDir returns the path to the user's ~/Library/Keychains directory.
+// Returns an empty string if the user's home directory cannot be determined.
+func keychainsDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Keychains")
+}
+
+// TestSandboxExecProfile_KeychainAPIAccessible is the integration test for the
+// ~/Library/Keychains file-read rule (issue #1487).
+//
+// It asserts that:
+//   - The generated profile contains the (subpath ~/Library/Keychains) rule
+//     (load-bearing regression guard: if generateProfile stops emitting the
+//     rule, this assertion fails before the sandbox invocation even runs).
+//   - /usr/bin/security find-generic-password exits 0 or 44 inside the sandbox
+//     (no "Operation not permitted" sandbox denial).
+func TestSandboxExecProfile_KeychainAPIAccessible(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+
+	if _, err := os.Stat("/usr/bin/security"); err != nil {
+		t.Skip("/usr/bin/security not present")
+	}
+
+	kDir := keychainsDir(t)
+	if kDir == "" {
+		t.Skip("cannot determine home directory")
+	}
+	if _, err := os.Stat(kDir); err != nil {
+		t.Skipf("~/Library/Keychains does not exist at %s — skipping: %v", kDir, err)
+	}
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Load-bearing regression guard: the generated profile must contain the
+	// ~/Library/Keychains subpath rule. If generateProfile stops emitting it,
+	// this check catches the regression before the sandbox invocation below.
+	if !strings.Contains(prepared.content, kDir) {
+		t.Fatalf("generated profile does not contain the ~/Library/Keychains subpath %q.\n"+
+			"The (allow file-read* file-test-existence (subpath ...)) rule was not emitted by generateProfile.\nProfile:\n%s",
+			kDir, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Run /usr/bin/security inside sandbox-exec. Apple-signed binary; uses
+	// Mach IPC to contact securityd — exactly the code path we need to exercise.
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/security", "find-generic-password", "-l", keychainServiceName, "-w")
+	out, runErr := cmd.CombinedOutput()
+	output := string(out)
+
+	// "Operation not permitted" means a sandbox denial — always a failure.
+	if strings.Contains(output, "Operation not permitted") {
+		t.Fatalf("Keychain API call produced 'Operation not permitted' inside sandbox.\n"+
+			"This indicates a sandbox denial — the (subpath ~/Library/Keychains) rule is not working.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, output, testProfilePath)
+	}
+
+	const securityItemNotFound = 44
+	if runErr == nil {
+		t.Logf("ka pai — Keychain API accessible inside sandbox, credentials retrieved (exit 0)")
+		return
+	}
+
+	exitCode := -1
+	if exitErr, ok := runErr.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	}
+
+	if exitCode == securityItemNotFound {
+		// Entry absent — API is reachable, item is simply missing. Acceptable on CI.
+		t.Logf("Keychain API accessible inside sandbox (security exit 44: item not found). "+
+			"Claude Code-credentials not present on this host — expected on CI. (#1487)")
+		return
+	}
+
+	t.Errorf("Keychain API call inside sandbox: expected exit 0 or 44, got %d\nOutput: %s\nProfile: %s",
+		exitCode, output, testProfilePath)
+}


### PR DESCRIPTION
## Summary

opencode-claude-auth couldn't retrieve Claude credentials inside sandbox-exec sessions. Two root causes, both fixed here:

**1. SBPL file-read rule** — securityd requires `file-read*` on `~/Library/Keychains/login.keychain-db` to service Keychain lookups even when the lookup goes over Mach IPC. Without it, securityd returns exit 44 ("item not found"). We use `(literal ...)` on the specific file rather than `(subpath ~/Library/Keychains)` to avoid exposing the UUID-keyed modern keychain databases (`keychain-2.db`, `user.kb`).

**2. Keychain search list** — opencode-claude-auth calls `security dump-keychain` (no args) to discover keychain service names. This command uses `$HOME` to find the keychain search list, and inside the sandbox `$HOME` points at the staging directory. With staging home, the search list only contains `/Library/Keychains/System.keychain` and `Claude Code-credentials` is never found. Fix: symlink `$stagingHome/Library/Keychains/login.keychain-db` → the real `login.keychain-db` so `security` sees the correct search list.

## Changes

- **`sandbox_exec.go`**: adds `(allow file-read* (literal ~/Library/Keychains/login.keychain-db))` to `generateProfile`, guarded by `home != ""` and the file existing
- **`sandbox_exec_home.go`**: creates `$stagingHome/Library/Keychains/login.keychain-db` as a symlink to the real keychain file on Darwin; the existing SBPL literal rule covers the resolved path
- **`sandbox_exec_integration_test.go`**: renames `TestSandboxExecIntegration_KeychainDenied` → `TestSandboxExecIntegration_ModernKeychainDBDenied` to test that `keychain-2.db` (UUID-keyed) remains unreadable — the security property the literal-vs-subpath choice preserves
- **`sandbox_exec_keychain_darwin_test.go`** (new): `TestSandboxExecProfile_KeychainAPIAccessible` — generates production profile, asserts the literal path is present (regression guard), invokes `security find-generic-password` with real HOME inside sandbox-exec and asserts exit 0 or 44

Closes #1487