### PR TITLE
fix(sidecar): decouple host-API lifetime from PI harness-pipe handshake outcome

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -32,6 +33,13 @@ import (
 
 // newHostAPIClient returns an *http.Client that dials sockPath over a Unix
 // socket. Used when PRISM_HOST_API begins with "unix://".
+//
+// Tombstone hygiene: when the dial returns ECONNREFUSED and the socket file
+// still exists on disk, the sidecar process has exited abnormally without
+// removing the socket. In that case we surface a clearer diagnostic so the
+// user sees "sidecar has exited" rather than the raw "connection refused" with
+// no additional context. This is the client-side branch of the tombstone
+// hygiene described in issue #1486.
 func newHostAPIClient(sockPath string) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
@@ -39,6 +47,14 @@ func newHostAPIClient(sockPath string) *http.Client {
 				d := &net.Dialer{Timeout: 5 * time.Second}
 				conn, dialErr := d.DialContext(ctx, "unix", sockPath)
 				if dialErr != nil {
+					// Check for the tombstone case: socket file exists on disk
+					// but connect() returned ECONNREFUSED — the sidecar has
+					// exited abnormally without cleaning up the socket file.
+					// Surface a more informative error than the raw syscall
+					// message so diagnostics are immediately actionable.
+					if isStaleTombstoneSocket(sockPath, dialErr) {
+						return nil, fmt.Errorf("host-API socket at %s is a stale tombstone — sidecar has exited without cleanup (ECONNREFUSED on existing socket file): %w", sockPath, dialErr)
+					}
 					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
 				}
 				return conn, nil
@@ -46,6 +62,17 @@ func newHostAPIClient(sockPath string) *http.Client {
 		},
 		Timeout: 60 * time.Second,
 	}
+}
+
+// isStaleTombstoneSocket returns true when the dial error is ECONNREFUSED and
+// the socket file at sockPath exists on disk. This indicates the sidecar
+// exited abnormally, leaving a stale socket file — the "tombstone" case.
+func isStaleTombstoneSocket(sockPath string, dialErr error) bool {
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return false
+	}
+	_, statErr := os.Stat(sockPath)
+	return statErr == nil
 }
 
 // newTCPHostAPIClient returns a standard *http.Client that dials over TCP.
@@ -328,6 +355,9 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) 
 					d := &net.Dialer{Timeout: 5 * time.Second}
 					conn, dialErr := d.DialContext(ctx, "unix", sockPath)
 					if dialErr != nil {
+						if isStaleTombstoneSocket(sockPath, dialErr) {
+							return nil, fmt.Errorf("host-API socket at %s is a stale tombstone — sidecar has exited without cleanup (ECONNREFUSED on existing socket file): %w", sockPath, dialErr)
+						}
 						return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, dialErr)
 					}
 					return conn, nil

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
@@ -28,10 +28,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
@@ -189,6 +191,10 @@ func deliverViaHTTP(status *db.Status, text string, buildBody func(string, *db.S
 }
 
 // newUnixClient returns an *http.Client that dials sockPath over a Unix socket.
+//
+// Tombstone hygiene: when the dial returns ECONNREFUSED and the socket file
+// exists on disk, the sidecar has exited abnormally without removing the
+// socket. A clearer diagnostic is surfaced in that case.
 func newUnixClient(sockPath string) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
@@ -196,6 +202,9 @@ func newUnixClient(sockPath string) *http.Client {
 				d := &net.Dialer{Timeout: 5 * time.Second}
 				conn, err := d.DialContext(ctx, "unix", sockPath)
 				if err != nil {
+					if isStaleTombstoneSocket(sockPath, err) {
+						return nil, fmt.Errorf("host-API socket at %s is a stale tombstone — sidecar has exited without cleanup (ECONNREFUSED on existing socket file): %w", sockPath, err)
+					}
 					return nil, fmt.Errorf("host-API socket not available at %s: %w", sockPath, err)
 				}
 				return conn, nil
@@ -203,4 +212,15 @@ func newUnixClient(sockPath string) *http.Client {
 		},
 		Timeout: 10 * time.Second,
 	}
+}
+
+// isStaleTombstoneSocket returns true when dialErr is ECONNREFUSED and the
+// socket file at sockPath still exists on disk — the "tombstone" case where
+// the sidecar exited abnormally without removing the socket file.
+func isStaleTombstoneSocket(sockPath string, dialErr error) bool {
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return false
+	}
+	_, statErr := os.Stat(sockPath)
+	return statErr == nil
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -563,7 +563,45 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		case harness.TransportStdioPipe:
 			return s.runStartupStdio(ctx)
 		case harness.TransportSocketPipe:
-			return s.runStartupSocketPipe(ctx)
+			// The host-API and harness-pipe are independent surfaces. When the
+			// harness-pipe handshake fails (extension never dials, bad hello,
+			// version mismatch, timeout), we must NOT tear down the host-API
+			// server — the in-sandbox `prism` CLI depends on it for the full
+			// session lifetime. Instead: log/record the failure, transition
+			// the harness to error state, and then hold until the external
+			// shutdown trigger arrives (context cancel, SIGTERM, prism cleanup).
+			//
+			// runStartupSocketPipe already records the error state in the DB and
+			// logs via writeStartupError before returning. Here we just need to
+			// decide whether to propagate the error (fatal path) or absorb it
+			// (harness-error, host-API still alive path).
+			//
+			// When runStartupSocketPipe returns nil (clean session_shutdown or
+			// ctx cancellation), we fall through to ctx.Err() at the bottom —
+			// same as the clean path today.
+			//
+			// When it returns a non-nil error, we absorb it: the harness has
+			// already been placed in error state; the host-API listener is still
+			// running. We block on ctx.Done() so Run() outlives the handshake
+			// failure and the host-API server keeps accepting connections.
+			if pipeErr := s.runStartupSocketPipe(ctx); pipeErr != nil {
+				// The harness-pipe loop failed. Log the failure (writeStartupError
+				// was already called inside runStartupSocketPipe, so the DB row is
+				// in error state). Keep the host-API server alive until the
+				// session receives an external shutdown trigger.
+				log.Printf("sidecar: harness-pipe handshake failed; keeping host-API alive until session shutdown: %v", pipeErr)
+				// Block until context cancellation (SIGTERM / prism cleanup).
+				<-ctx.Done()
+				// Return nil — Shutdown() is responsible for writing the final
+				// state and cleaning up the host-API listener. Returning nil
+				// (rather than the pipe error) prevents cmd/sidecar.go from
+				// treating this as a fatal error exit; the normal deferred
+				// Shutdown() path handles all cleanup.
+				return nil
+			}
+			// Clean pipe exit (session_shutdown or ctx cancel): fall through to
+			// return ctx.Err() at the bottom of Run().
+			return ctx.Err()
 		default:
 			return fmt.Errorf("sidecar: unsupported transport shape %q for harness %q", shape, s.cfg.HarnessName)
 		}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_hostapi_bind_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_hostapi_bind_test.go
@@ -1,30 +1,130 @@
 package sidecar
 
-// Tests for the host-API socket bind path (#1050).
+// Tests for the host-API socket bind path (#1050) and lifetime decoupling from
+// the harness-pipe handshake (#1486).
 //
-// Two concerns are covered here:
+// Concerns covered:
 //
-//   - AC-3: a session whose name would historically have produced a
-//     >104-byte sun_path (e.g. a long worker session composed with
-//     ~review-N-review-<role>) must now bind successfully — i.e. the path
-//     scheme does not return EINVAL for the worst-case name.
-//   - AC-4: if net.Listen("unix", ...) fails for any reason, Run() must
-//     surface the error rather than continuing with a nil listener.
+//   - AC-3 (#1050): worst-case session name must not produce EINVAL.
+//   - AC-4 (#1050): bind failure must surface as a fatal Run() error.
+//   - AC-1 (#1486): host-API keeps serving after harness-pipe failure.
+//   - AC-2 (#1486): harness-pipe failure logs error, does NOT call Shutdown().
+//   - AC-3 (#1486): Shutdown removes socket; subsequent connect returns ENOENT.
+//   - AC-4 (#1486): stale socket tombstone → ECONNREFUSED → clearer diagnostic.
+//   - AC-8 (#1486): no goroutine leak after harness-pipe failure + Shutdown.
+//   - AC-9 (#1486): socket permissions unchanged (0o700 on parent dir).
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	opencode "github.com/prismatic-koi/prism/internal/harness/opencode"
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
 	prismsession "github.com/prismatic-koi/prism/internal/session"
 )
+
+// ── helpers (AC-1 / #1486) ───────────────────────────────────────────────────
+
+// newPI1486Sidecar creates a Sidecar with both a host-API socket and a
+// harness-pipe socket, suitable for #1486 lifetime-decoupling tests.
+// StartupConnectTimeout is set short so tests that simulate a handshake failure
+// do not wait the full 5 m.
+func newPI1486Sidecar(t *testing.T, hostAPISockPath, pipeSockPath string) *Sidecar {
+	t.Helper()
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@main",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "worker",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   pipeSockPath,
+		HostAPISockPath:       hostAPISockPath,
+		StartupConnectTimeout: 200 * time.Millisecond, // short for tests
+		PipeReconnectTimeout:  50 * time.Millisecond,
+		Harness:               pih.New("", "", ""),
+	}
+	return New(cfg)
+}
+
+// dialHostAPIHTTP dials hostAPISockPath as a Unix socket and sends a GET
+// request to the host-API server, returning the HTTP status code and body.
+func dialHostAPIHTTP(t *testing.T, hostAPISockPath, endpoint string) (int, string) {
+	t.Helper()
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", hostAPISockPath)
+			},
+		},
+		Timeout: 3 * time.Second,
+	}
+	resp, err := client.Get("http://prism-hostapi" + endpoint)
+	if err != nil {
+		t.Fatalf("dialHostAPIHTTP GET %s: %v", endpoint, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// waitForHostAPISock polls until the host-API socket file appears.
+func waitForHostAPISock(t *testing.T, sockPath string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(sockPath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("host-API socket never appeared at %s", sockPath)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// waitForHostAPIReady polls until a GET /list-sessions to the host-API socket
+// returns 200.
+func waitForHostAPIReady(t *testing.T, sockPath string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		client := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", sockPath)
+				},
+			},
+			Timeout: 500 * time.Millisecond,
+		}
+		resp, err := client.Get("http://prism-hostapi/list-sessions")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("host-API socket at %s never became ready", sockPath)
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+}
 
 // TestHostAPIBind_WorstCaseSessionName_DoesNotEINVAL is the AC-3 regression
 // test. It exercises the actual net.Listen("unix", ...) call against a path
@@ -152,4 +252,501 @@ func TestSidecarRun_BindFailureReturnsError(t *testing.T) {
 	if ln != nil {
 		t.Error("hostAPIListener was set despite bind failure")
 	}
+}
+
+// ── #1486 tests ──────────────────────────────────────────────────────────────
+
+// TestHostAPI_SurvivesHarnessPipeHandshakeFailure_NeverConnects is the
+// primary regression test for #1486 (AC-1).
+//
+// It creates a PI sidecar with both a host-API socket and a harness-pipe
+// socket, then never connects to the harness pipe (triggering a startup
+// timeout). After the handshake times out, the host-API socket must still
+// accept and serve HTTP requests.
+func TestHostAPI_SurvivesHarnessPipeHandshakeFailure_NeverConnects(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sc.Run(ctx)
+	}()
+
+	// Wait for the host-API socket to appear.
+	waitForHostAPISock(t, hostAPISockPath)
+
+	// Wait for the host-API to be ready (it starts serving before the harness-pipe
+	// handshake even begins — this exercises that it remains alive after failure).
+	waitForHostAPIReady(t, hostAPISockPath)
+
+	// Never connect to the harness pipe — let the startup timeout expire.
+	// StartupConnectTimeout is 200ms for this test.
+	// The sidecar should record error state in the DB but NOT tear down the
+	// host-API socket.
+	time.Sleep(300 * time.Millisecond) // > StartupConnectTimeout (200ms)
+
+	// The host-API must still be serving.
+	code, body := dialHostAPIHTTP(t, hostAPISockPath, "/list-sessions")
+	if code != http.StatusOK {
+		t.Errorf("host-API /list-sessions after harness-pipe timeout: status=%d body=%q, want 200", code, body)
+	}
+
+	// The DB state must be error (written by runStartupSocketPipe timeout path).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+		if s == "error" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("DB state after harness-pipe timeout = %q, want error", s)
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Trigger external shutdown — only NOW should the host-API go down.
+	// Per the production lifecycle: Shutdown() is called first (to write state
+	// and clean up listeners), then cancel() to stop Run().
+	sc.Shutdown()
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run() did not finish within 3s after Shutdown+cancel")
+	}
+
+	// After Shutdown(), the socket file must be removed.
+	if _, err := os.Stat(hostAPISockPath); !os.IsNotExist(err) {
+		t.Errorf("host-API socket still exists after Shutdown: %v", err)
+	}
+}
+
+// TestHostAPI_SurvivesHarnessPipeHandshakeFailure_MalformedHello is a
+// second variant of AC-1: the extension connects but sends a malformed hello.
+func TestHostAPI_SurvivesHarnessPipeHandshakeFailure_MalformedHello(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sc.Run(ctx)
+	}()
+
+	// Wait for the host-API socket and the harness-pipe socket.
+	waitForHostAPISock(t, hostAPISockPath)
+	waitForHostAPIReady(t, hostAPISockPath)
+
+	// Wait for harness-pipe socket to appear.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(pipeSockPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("harness-pipe socket never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Connect to the harness pipe and send a malformed hello (not valid JSON).
+	conn, err := net.Dial("unix", pipeSockPath)
+	if err != nil {
+		t.Fatalf("dial harness pipe: %v", err)
+	}
+	// Send malformed JSON — the sidecar will reject it and call writeStartupError.
+	fmt.Fprintf(conn, "this is not json\n")
+	conn.Close()
+
+	// Wait for the error state to propagate (runStartupSocketPipe returns err).
+	time.Sleep(200 * time.Millisecond)
+
+	// The host-API must still be serving after the malformed hello.
+	code, body := dialHostAPIHTTP(t, hostAPISockPath, "/list-sessions")
+	if code != http.StatusOK {
+		t.Errorf("host-API /list-sessions after malformed hello: status=%d body=%q, want 200", code, body)
+	}
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run() did not finish within 3s after ctx cancel")
+	}
+}
+
+// TestHostAPI_HarnessPipeFailureRecordsErrorState verifies AC-2 (#1486):
+// when the harness-pipe handshake fails, the sidecar records an error state in
+// the DB and does NOT call Shutdown() prematurely — shuttingDown remains false
+// until an external trigger.
+func TestHostAPI_HarnessPipeFailureRecordsErrorState(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() { sc.Run(ctx) }() //nolint:errcheck
+
+	// Wait for harness-pipe socket, then let the startup timeout expire.
+	waitForHostAPISock(t, hostAPISockPath)
+	time.Sleep(350 * time.Millisecond) // > StartupConnectTimeout (200ms) + reconnect (50ms)
+
+	// DB must show error state.
+	s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if s != "error" {
+		t.Errorf("DB state after harness-pipe timeout = %q, want error", s)
+	}
+
+	// shuttingDown must still be false — Shutdown() has not been called.
+	sc.mu.Lock()
+	shuttingDown := sc.shuttingDown
+	sc.mu.Unlock()
+	if shuttingDown {
+		t.Error("shuttingDown = true after harness-pipe failure — Shutdown() must not be called on pipe failure")
+	}
+
+	// Trigger external shutdown to clean up.
+	sc.Shutdown()
+	cancel()
+}
+
+// TestHostAPI_ShutdownRemovesSocket verifies AC-3 (#1486): when the sidecar
+// receives a real Shutdown trigger (SIGTERM / sc.Shutdown()), the host-API
+// Unix socket file is removed from disk and a subsequent connect() returns
+// ENOENT, not ECONNREFUSED.
+//
+// Per the production lifecycle, Shutdown() is called before cancel(), so this
+// test mirrors that ordering.
+func TestHostAPI_ShutdownRemovesSocket(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sc.Run(ctx)
+	}()
+
+	// Wait for the host-API to be ready.
+	waitForHostAPISock(t, hostAPISockPath)
+	waitForHostAPIReady(t, hostAPISockPath)
+
+	// Trigger Shutdown — mirrors the production signal handler: Shutdown() first,
+	// then cancel() to stop Run(). The harness-pipe startup timeout is 200ms;
+	// we haven't connected so Run() is blocked in <-ctx.Done() inside our
+	// pipe-failure path. Shutdown() signals the graceful exit.
+	sc.Shutdown()
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not finish within 5s after Shutdown+cancel")
+	}
+
+	// The socket file must be gone.
+	if _, err := os.Stat(hostAPISockPath); !os.IsNotExist(err) {
+		t.Errorf("host-API socket still exists after Shutdown: %v", err)
+	}
+
+	// A subsequent connect() must return ENOENT (no such file), not ECONNREFUSED.
+	_, dialErr := net.DialTimeout("unix", hostAPISockPath, time.Second)
+	if dialErr == nil {
+		t.Fatal("expected dial error after Shutdown, got nil")
+	}
+	// ECONNREFUSED would mean the socket file is still there (tombstone).
+	if errors.Is(dialErr, syscall.ECONNREFUSED) {
+		t.Errorf("connect after Shutdown returned ECONNREFUSED (stale socket), want ENOENT: %v", dialErr)
+	}
+}
+
+// TestHostAPI_StaleTombstoneSocket verifies AC-4 (edge case, #1486): when
+// the sidecar exits abnormally and a stale socket file remains on disk, a dial
+// to that socket returns ECONNREFUSED rather than ENOENT. The
+// isStaleTombstoneSocket helper (used in cmd/hostapi.go and
+// internal/promptdelivery) must detect this condition.
+//
+// This test creates a dangling socket file — a socket that exists on disk but
+// has no listener — using raw syscalls so the file is NOT automatically removed
+// when the file descriptor is closed (Go's net.Listen does remove it on Close).
+//
+// It verifies:
+//  1. The raw dial error is ECONNREFUSED (not ENOENT).
+//  2. The isStaleTombstoneSocketForTest function correctly identifies a tombstone.
+//  3. For a missing socket, isStaleTombstoneSocketForTest returns false.
+func TestHostAPI_StaleTombstoneSocket(t *testing.T) {
+	// Use raw syscalls to create the socket file without Go's auto-cleanup.
+	// Go's net.Listen("unix", ...).Close() automatically removes the socket file,
+	// which doesn't simulate the abnormal-exit tombstone case.
+	dir, err := os.MkdirTemp("", "tombstone-test")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	sockPath := filepath.Join(dir, "dead.sock")
+
+	// Create, bind, listen, and close at the syscall level.
+	fd, sErr := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if sErr != nil {
+		t.Fatalf("syscall.Socket: %v", sErr)
+	}
+	sa := &syscall.SockaddrUnix{Name: sockPath}
+	if bErr := syscall.Bind(fd, sa); bErr != nil {
+		syscall.Close(fd) //nolint:errcheck
+		t.Fatalf("syscall.Bind: %v", bErr)
+	}
+	if lErr := syscall.Listen(fd, 1); lErr != nil {
+		syscall.Close(fd) //nolint:errcheck
+		t.Fatalf("syscall.Listen: %v", lErr)
+	}
+	// Close the fd without removing the file — leaves a tombstone on disk.
+	syscall.Close(fd) //nolint:errcheck
+
+	// Verify the socket file exists.
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("socket file missing after raw close: %v", err)
+	}
+
+	// Dial the tombstone socket.
+	_, dialErr := net.DialTimeout("unix", sockPath, time.Second)
+	if dialErr == nil {
+		t.Fatal("expected dial error for tombstone socket, got nil")
+	}
+
+	// On Linux and Darwin, a closed-but-existing Unix socket returns ECONNREFUSED.
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		t.Skipf("platform returned %v (not ECONNREFUSED) for tombstone socket; skipping tombstone classification test", dialErr)
+	}
+
+	// isStaleTombstoneSocketForTest must return true for the tombstone case.
+	if !isStaleTombstoneSocketForTest(sockPath, dialErr) {
+		t.Errorf("isStaleTombstoneSocketForTest returned false for tombstone socket; want true")
+	}
+
+	// For a missing socket with ECONNREFUSED, isStaleTombstoneSocketForTest
+	// must return false (the file does not exist, so it is not a tombstone).
+	missingPath := filepath.Join(dir, "missing.sock")
+	fakeConnRefused := syscall.ECONNREFUSED
+	if isStaleTombstoneSocketForTest(missingPath, fakeConnRefused) {
+		t.Errorf("isStaleTombstoneSocketForTest returned true for missing socket; want false")
+	}
+}
+
+// TestHostAPI_SocketDirPermissions verifies AC-9 (#1486 security invariant):
+// the host-API socket directory continues to be created with mode 0o700.
+// This is the regression guard that the lifetime change (PR #1486) does not
+// widen the on-disk permissions.
+func TestHostAPI_SocketDirPermissions(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sc.Run(ctx)
+	}()
+
+	// Wait for the host-API socket to appear.
+	waitForHostAPISock(t, hostAPISockPath)
+
+	// Check the directory permissions.
+	sockDir := filepath.Dir(hostAPISockPath)
+	info, err := os.Stat(sockDir)
+	if err != nil {
+		t.Fatalf("stat socket dir %s: %v", sockDir, err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o700 {
+		t.Errorf("socket dir permissions = %04o, want 0700", perm)
+	}
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not finish within 5s after ctx cancel")
+	}
+}
+
+// TestHostAPI_NoGoroutineLeak verifies AC-8 (#1486): when the session is shut
+// down after a harness-pipe failure, Shutdown() cleanly stops every goroutine
+// it started — the host-API serve goroutine, the harness-pipe writer goroutine,
+// and the Run() goroutine itself.
+//
+// The test measures goroutines before starting the sidecar and asserts that
+// after Shutdown()+cancel() the count returns to within a small delta of the
+// pre-start baseline.
+func TestHostAPI_NoGoroutineLeak(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	// Allow any in-flight goroutines from prior tests to drain before measuring.
+	time.Sleep(50 * time.Millisecond)
+	baselineGoroutines := goroutineCount()
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sc.Run(ctx)
+	}()
+
+	// Wait for the host-API socket (proves Run() has started listeners).
+	waitForHostAPISock(t, hostAPISockPath)
+
+	// Let the harness-pipe startup timeout expire (harness-pipe failure path).
+	time.Sleep(350 * time.Millisecond)
+
+	// Host-API must still be serving at this point (primary regression check).
+	code, _ := dialHostAPIHTTP(t, hostAPISockPath, "/list-sessions")
+	if code != http.StatusOK {
+		t.Errorf("host-API status after pipe failure = %d, want 200", code)
+	}
+
+	// Trigger external shutdown (mirrors the signal handler: Shutdown first,
+	// then cancel).
+	sc.Shutdown()
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not finish within 5s after Shutdown+cancel")
+	}
+
+	// Allow a brief window for goroutines to exit.
+	// We allow a slack of 3 goroutines above the pre-start baseline to account
+	// for the merge-queue watcher goroutine (which may still be draining) and
+	// any test-framework goroutines.
+	deadline := time.Now().Add(3 * time.Second)
+	var finalGoroutines int
+	for time.Now().Before(deadline) {
+		finalGoroutines = goroutineCount()
+		if finalGoroutines <= baselineGoroutines+3 {
+			return // goroutines cleaned up within acceptable slack
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("goroutine count after Shutdown = %d, baseline = %d (possible goroutine leak: delta=%d > slack=3)",
+		finalGoroutines, baselineGoroutines, finalGoroutines-baselineGoroutines)
+}
+
+// TestHostAPI_FullHandshake_BothSurfacesWork verifies AC-6 (#1486): on a fresh
+// PI session where the harness-pipe handshake succeeds, both surfaces work:
+// the harness pipe completes its handshake AND a host-API GET /list-sessions
+// succeeds after the handshake.
+func TestHostAPI_FullHandshake_BothSurfacesWork(t *testing.T) {
+	pipeSockPath := shortSockPath(t)
+	dir := filepath.Dir(pipeSockPath)
+	hostAPISockPath := filepath.Join(dir, "hostapi.sock")
+	if len(hostAPISockPath) > maxSunPath {
+		t.Fatalf("hostapi socket path too long: %s", hostAPISockPath)
+	}
+
+	sc := newPI1486Sidecar(t, hostAPISockPath, pipeSockPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sc.Run(ctx)
+	}()
+
+	// Wait for both sockets.
+	waitForHostAPISock(t, hostAPISockPath)
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(pipeSockPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("harness-pipe socket never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Complete the harness-pipe handshake (stub PI peer).
+	conn, _ := dialAndHandshake(t, pipeSockPath)
+	defer conn.Close()
+
+	// Both surfaces should work: the harness-pipe handshake has completed AND
+	// the host-API is serving.
+	code, body := dialHostAPIHTTP(t, hostAPISockPath, "/list-sessions")
+	if code != http.StatusOK {
+		t.Errorf("host-API /list-sessions after successful handshake: status=%d body=%q, want 200", code, body)
+	}
+
+	// Clean shutdown via session_shutdown from the fake peer.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run() did not finish within 3s after session_shutdown")
+	}
+}
+
+// ── helper functions for #1486 tests ────────────────────────────────────────
+
+// goroutineCount returns the current number of goroutines.
+func goroutineCount() int {
+	return runtime.NumGoroutine()
+}
+
+// isStaleTombstoneSocketForTest is a test-visible wrapper that lets tests
+// exercise the tombstone detection logic. The real implementations live in
+// cmd/hostapi.go and internal/promptdelivery/promptdelivery.go; here we
+// replicate the same logic for package-internal testing.
+//
+// This avoids importing cmd from internal/sidecar (which would be a cycle).
+func isStaleTombstoneSocketForTest(sockPath string, dialErr error) bool {
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return false
+	}
+	_, statErr := os.Stat(sockPath)
+	return statErr == nil
 }


### PR DESCRIPTION
## Summary

On Darwin (sandbox-exec) PI sessions, when the harness-pipe handshake failed,
the host-API Unix socket listener was also torn down — because `Run()`
returned early from `runStartupSocketPipe`, triggering the deferred
`Shutdown()`. This left in-sandbox `prism` CLI calls with a stale socket file
and `connection refused` for the rest of the session.

The host-API and the harness pipe are independent surfaces serving different
clients (in-sandbox `prism` CLI vs. PI extension) and must have independent
lifetimes within a session.

## Changes

1. **Decoupled host-API lifetime from harness-pipe handshake outcome.**
   `Run()` no longer propagates `runStartupSocketPipe` errors as fatal. When
   the helper returns an error, the harness state has already been written
   via `writeStartupError`; we log the failure and block on `ctx.Done()` so
   the host-API server keeps serving until an external shutdown trigger
   arrives (SIGTERM, `prism cleanup`, ctx cancel). `Shutdown()` then handles
   cleanup.

2. **Tombstone hygiene at dial time.** When the host-API socket file exists
   on disk but `connect()` returns ECONNREFUSED, surface a clearer
   diagnostic ("sidecar has exited without cleanup") rather than the raw
   syscall error. Applied to both `cmd/hostapi.go` (the prism CLI proxy) and
   `internal/promptdelivery` (the in-process prompt delivery path).

## Tests

New tests in `sidecar_hostapi_bind_test.go` cover:

- **AC-1**: Host-API survives harness-pipe handshake timeout (extension never
  connects) and malformed hello frame variants.
- **AC-2**: DB records error state on pipe failure; `shuttingDown` stays
  false (no premature `Shutdown()`).
- **AC-3**: `Shutdown()` cleanly removes socket; subsequent `connect()`
  returns ENOENT, not ECONNREFUSED.
- **AC-4** (edge case): Tombstone classification correctly identifies stale
  socket files (uses raw syscalls to bypass Go's auto-cleanup so the test
  actually exercises the tombstone path).
- **AC-6**: Both surfaces work after a successful handshake (regression
  guard).
- **AC-8**: No goroutine leak after pipe failure + `Shutdown()`.
- **AC-9** (security): Socket dir permissions remain 0o700.

## Verification

- ✅ `go build ./...` from `modules/programs/prism/prism/`
- ✅ `go test ./internal/sidecar/...` passes (one pre-existing failure
  `TestHostAPI_Review_CWDSetToWorktree` reproduces on `main` — `/tmp` vs
  `/private/tmp` symlink issue, escalated separately)
- ✅ `nix build .#prism` from the repo root passes

Closes #1486