### PR TITLE
fix(sidecar): update TestHarnessPipeTCP_ListenFail to post-#1490 contract

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar_harness_pipe_tcp_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_harness_pipe_tcp_test.go
@@ -25,7 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
 	pih "github.com/prismatic-koi/prism/internal/harness/pi"
 )
 
@@ -185,16 +188,27 @@ func TestHarnessPipeTCP_ListenerBinds127001(t *testing.T) {
 }
 
 // TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort verifies that when the
-// harness-pipe TCP listen fails (e.g. the port is already in use),
-// runStartupSocketPipe returns an error whose message contains the port number,
-// and the session is moved to error state.
+// harness-pipe TCP listen fails (e.g. the port is already in use), the sidecar
 //
-// This is the edge-case AC from issue #1482:
+//   - records the failure as a startup_error event whose reason contains the
+//     port number, and
+//   - transitions the session to StateError,
+//
+// and that Run() then exits promptly when the outer context is cancelled.
+//
+// Originally written for the edge-case AC from issue #1482:
 //
 //	[edge-case] When the sidecar's harness-pipe TCP listen fails (e.g. port
 //	already in use), runStartupSocketPipe returns an error whose message
 //	contains the port number, the session is moved to error, and no extension
 //	is left dialling a non-existent listener.
+//
+// Updated for #1493 to match the post-#1490 contract: a non-nil return from
+// runStartupSocketPipe is absorbed by Run() (host-API stays alive for the
+// in-sandbox `prism` CLI) and Run() blocks on ctx.Done() rather than returning
+// the listen error directly. The contract under test is therefore the
+// observable side effects (DB state + startup_error event) plus prompt exit on
+// context cancel — not Run()'s return value during the listen failure itself.
 func TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort(t *testing.T) {
 	port := allocateFreePort(t)
 
@@ -207,28 +221,65 @@ func TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort(t *testing.T) {
 
 	sc := newTCPPortSidecar(t, port)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Pre-seed an instance_id and a matching sessions row so that the
+	// startup_error event written by writeStartupError satisfies the
+	// agent_events.instance_id REFERENCES sessions(instance_id) FK constraint.
+	// Without this, the startup_error event would be silently dropped (logged
+	// as a WriteEvent error), leaving the test unable to read back the
+	// recorded error reason. The instance_id is the contract bridge between
+	// agent_status (FK-free) and agent_events (FK-enforced).
+	instanceID := uuid.New().String()
+	sc.cfg.InstanceID = instanceID
+	if err := sc.cfg.DB.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sc.cfg.SessionName,
+		Repo:        sc.cfg.Repo,
+		Worktree:    sc.cfg.Worktree,
+		Harness:     sc.cfg.HarnessName,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	errc := make(chan error, 1)
 	go func() { errc <- sc.Run(ctx) }()
 
+	// Observe the listen failure via DB state — Run() does NOT return the
+	// error directly under the post-#1490 contract.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if getState(t, sc.cfg.DB, sc.cfg.SessionName) == string(agent.StateError) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if state := getState(t, sc.cfg.DB, sc.cfg.SessionName); state != string(agent.StateError) {
+		t.Fatalf("session state = %q after TCP listen failure, want %q within 2s", state, agent.StateError)
+	}
+
+	// Verify the recorded startup-error message contains the port number.
+	errMsg := getStartupErrorMessage(t, sc.cfg.DB, sc.cfg.SessionName)
+	if errMsg == "" {
+		t.Fatal("no startup_error event recorded after TCP listen failure")
+	}
+	portStr := fmt.Sprintf("%d", port)
+	if !strings.Contains(errMsg, portStr) {
+		t.Errorf("startup_error reason %q does not contain port number %q", errMsg, portStr)
+	}
+
+	// Cancel the context and assert Run() exits promptly. Post-#1490 the
+	// host-API is held open until external shutdown; cancel is the trigger.
+	cancel()
 	select {
-	case runErr := <-errc:
-		if runErr == nil {
-			t.Fatal("Run() returned nil — expected an error when TCP port is already in use")
-		}
-		portStr := fmt.Sprintf("%d", port)
-		if !strings.Contains(runErr.Error(), portStr) {
-			t.Errorf("error %q does not contain port number %q", runErr.Error(), portStr)
-		}
-		// Verify the session is in error state.
-		state := getState(t, sc.cfg.DB, sc.cfg.SessionName)
-		if state != string(agent.StateError) {
-			t.Errorf("session state = %q after TCP listen failure, want %q", state, agent.StateError)
-		}
-	case <-ctx.Done():
-		t.Fatal("Run() did not exit within 10s after TCP listen failure")
+	case err := <-errc:
+		// Run() may return nil or ctx.Err() after cancel; either is acceptable
+		// per the post-#1490 absorb contract. We deliberately do NOT require
+		// the listen error to surface here.
+		_ = err
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not exit within 2s after context cancel")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -221,6 +221,34 @@ func getEvents(t *testing.T, d *db.DB, session string) []db.Event {
 	return events
 }
 
+// getStartupErrorMessage returns the "reason" field from the most-recent
+// startup_error event for session, or "" if none has been written. The
+// startup_error event is emitted by writeStartupError (state.go) when the
+// sidecar transitions a session to StateError during startup; its payload is
+// {"reason":"<error.Error()>"}. See #1222 for the producer side and #1493 for
+// the consumer side that motivated this helper.
+func getStartupErrorMessage(t *testing.T, d *db.DB, session string) string {
+	t.Helper()
+	events, err := d.AllSessionEvents(session)
+	if err != nil {
+		t.Fatalf("AllSessionEvents: %v", err)
+	}
+	// Walk newest-last events backwards to find the most recent startup_error.
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Type != "startup_error" {
+			continue
+		}
+		var p struct {
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal([]byte(events[i].Payload), &p); err != nil {
+			return events[i].Payload
+		}
+		return p.Reason
+	}
+	return ""
+}
+
 // ── tests ───────────────────────────────────────────────────────────────────
 
 func TestSessionStatusBusy_WritesActive(t *testing.T) {


### PR DESCRIPTION
Closes #1493

## Why

`TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort` (added in #1485) has been failing on `main` since #1485 merged at 81b5c636, turning `build-and-cache` red. The test was written against the pre-#1490 contract — listen failure ⇒ `Run()` returns the error promptly. After #1490 (host-API decoupled from harness-pipe handshake outcome), a non-nil return from `runStartupSocketPipe` is **absorbed**: the failure is logged and recorded in the DB, then `Run()` blocks on `ctx.Done()` so the in-sandbox `prism` CLI keeps a live host-API. The contract is correct; the test is what needed updating.

## What changed

Test-only — no production code under `internal/sidecar/` is touched.

`internal/sidecar/sidecar_harness_pipe_tcp_test.go`:
- Reshape `TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort` to assert the observable post-#1490 contract:
  1. Within 2 s, the session reaches `StateError` in the DB.
  2. The recorded `startup_error` event's reason contains the port number.
  3. After cancelling the context, `Run()` exits within 2 s.
- Stop asserting on `Run()`'s return value during the listen failure — the post-#1490 absorb path returns `nil` (or `ctx.Err()`) after cancel.
- Pre-seed an `instance_id` and matching `sessions` row before launching `Run()`, so the `agent_events.instance_id REFERENCES sessions(instance_id)` FK is satisfied and the `startup_error` event is actually persisted (rather than dropped with a `WriteEvent` error and leaving nothing for the test to read back).

`internal/sidecar/sidecar_test.go`:
- Add a small `getStartupErrorMessage(t, db, session)` helper next to `getState`, mirroring the JSON-extraction pattern already used by `db/groups.go` for the `startup_error` event.

## Test runs (from `modules/programs/prism/prism/`)

```
$ go test ./internal/sidecar/ -run TestHarnessPipeTCP -count=10
ok      github.com/prismatic-koi/prism/internal/sidecar 0.525s

$ go test ./internal/sidecar/ -count=1
ok      github.com/prismatic-koi/prism/internal/sidecar 9.807s

$ go test ./...
# all packages pass except internal/integration's TestRunStartupStdio_SilentExit,
# which is the pre-existing FK-constraint failure noted as out-of-scope in #1493
# (verified to fail on clean main as well — unrelated to this change).
```

## Mandatory prism gate

```
$ nix build .#prism
# (no output — succeeded)
$ ls -la result
... -> /nix/store/a5n7clifwy6lh2kgskgz68fkh4v2qpsb-prism-0.1.0
```

## Acceptance criteria coverage

- [x] Test passes on main without modifying `internal/sidecar/sidecar.go`.
- [x] Asserts session moves to `StateError` in DB within 2 s.
- [x] Asserts startup-error reason contains the port number.
- [x] Asserts `Run()` exits within 2 s after `cancel()`.
- [x] Does not depend on `Run()` returning the listen error directly.
- [x] `-run TestHarnessPipeTCP -count=10` passes 10/10.
- [x] Wider sidecar suite (`./internal/sidecar/ -count=1`) green.
- [x] `nix build .#prism` succeeds.
- [x] No production code under `internal/sidecar/` changed.