### PR TITLE
fix: pre-seed sessions row in stdio integration tests; symlink-resolve CWD in macOS review test

### DIFF
--- a/modules/programs/prism/prism/internal/integration/stdio_test.go
+++ b/modules/programs/prism/prism/internal/integration/stdio_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
@@ -59,6 +61,15 @@ func testBinaryPath(t *testing.T) string {
 // newStdioSidecar constructs a sidecar configured for the "fake-stdio" harness
 // with the given binary path. The sidecar is not started; callers must invoke
 // sc.Run(ctx).
+//
+// A deterministic instance_id is minted up-front and a matching row is
+// inserted into the sessions table before the sidecar is returned. Without
+// this pre-seed the FK constraint
+// agent_events.instance_id REFERENCES sessions(instance_id) fails when
+// runStartupStdio writes state_change / startup_error / msg_assistant events,
+// and those events are silently dropped (logged as WriteEvent errors) — which
+// causes the downstream assertions to fail. See #1503 (and the same fix
+// shape in #1496).
 func newStdioSidecar(t *testing.T, d *db.DB, bwrapBin, harnessBinPath string) *sidecar.Sidecar {
 	t.Helper()
 
@@ -66,11 +77,26 @@ func newStdioSidecar(t *testing.T, d *db.DB, bwrapBin, harnessBinPath string) *s
 		sessionName = "test-repo@stdio-test"
 		repo        = "test-repo"
 		worktree    = "/tmp/test-stdio-worktree"
+		harnessName = "fake-stdio"
 	)
 
-	h, err := harness.New("fake-stdio", "", nil, "", "")
+	h, err := harness.New(harnessName, "", nil, "", "")
 	if err != nil {
 		t.Fatalf("harness.New(fake-stdio): %v", err)
+	}
+
+	// Pre-mint the instance_id and seed a matching sessions row so the FK on
+	// agent_events.instance_id REFERENCES sessions(instance_id) is satisfied
+	// for every event runStartupStdio writes.
+	instanceID := uuid.New().String()
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    worktree,
+		Harness:     harnessName,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
 	}
 
 	cfg := sidecar.Config{
@@ -80,9 +106,10 @@ func newStdioSidecar(t *testing.T, d *db.DB, bwrapBin, harnessBinPath string) *s
 		DB:                d,
 		Clock:             sidecar.RealClock(),
 		Harness:           h,
-		HarnessName:       "fake-stdio",
+		HarnessName:       harnessName,
 		HarnessBinaryPath: harnessBinPath,
 		BwrapPath:         bwrapBin,
+		InstanceID:        instanceID,
 	}
 	return sidecar.New(cfg)
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7513,9 +7513,21 @@ exit 0
 	if err != nil {
 		t.Fatalf("read captured CWD: %v", err)
 	}
-	got := strings.TrimSpace(string(capturedCWD))
-	if got != worktreeDir {
-		t.Errorf("subprocess CWD = %q, want %q (must be set to session worktree)", got, worktreeDir)
+	// Resolve symlinks on both sides before comparing so the assertion is
+	// symlink-agnostic on Darwin, where /tmp → /private/tmp and the
+	// subprocess's pwd resolves to the canonical /private/tmp/… form while
+	// t.TempDir() returns the /tmp/… form. See #1489.
+	gotResolved, err := filepath.EvalSymlinks(strings.TrimSpace(string(capturedCWD)))
+	if err != nil {
+		t.Fatalf("EvalSymlinks(captured CWD): %v", err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(worktreeDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(worktreeDir): %v", err)
+	}
+	if gotResolved != wantResolved {
+		t.Errorf("subprocess CWD = %q (resolved %q), want %q (resolved %q) (must be set to session worktree)",
+			strings.TrimSpace(string(capturedCWD)), gotResolved, worktreeDir, wantResolved)
 	}
 }
 


### PR DESCRIPTION
Fixes two pre-existing test-only failures in a single PR. Both are
flake/broken-test cleanup that unblocks dev-shell (#1503) and macOS
(#1489) test runs respectively. They share no code but are batched here
for efficiency.

Closes #1503
Closes #1489

## #1503 — stdio integration tests FK constraint

`TestRunStartupStdio_HappyPath` and `TestRunStartupStdio_SilentExit`
in `internal/integration/stdio_test.go` fail deterministically on any
host with bwrap in PATH (i.e. all NixOS dev shells). The sidecar mints
an `instance_id` internally but the test never seeds a matching
`sessions` row, so the FK
`agent_events.instance_id REFERENCES sessions(instance_id)` drops every
`state_change` / `startup_error` / `msg_assistant` event the test
reads back. CI doesn't catch it because the nix sandbox lacks bwrap
and `requireBwrap(t)` triggers `t.Skip`.

Fix shape mirrors PR #1496: pre-mint a UUID, set `cfg.InstanceID`, and
call `db.InsertSession` before returning the sidecar from
`newStdioSidecar`. No production code under `internal/sidecar/` is
touched.

## #1489 — macOS CWD symlink mismatch

`TestHostAPI_Review_CWDSetToWorktree` fails on macOS because `/tmp` is
symlinked to `/private/tmp`. The subprocess `pwd` resolves to the
canonical `/private/tmp/…` form while `t.TempDir()` returns `/tmp/…`,
so the equality assertion always fails. Linux is unaffected (no such
symlink).

Fix: resolve both the captured CWD and `worktreeDir` through
`filepath.EvalSymlinks` before comparing. Confined to the test
assertion in `internal/sidecar/sidecar_test.go`. No production code
changes.

## Test runs

From `modules/programs/prism/prism/`:

```
$ go test ./internal/integration/ -run TestRunStartupStdio -count=10
ok  	github.com/prismatic-koi/prism/internal/integration	0.247s

$ go test ./internal/integration/ -count=1
ok  	github.com/prismatic-koi/prism/internal/integration	0.368s

$ go test ./internal/sidecar/ -run TestHostAPI_Review_CWDSetToWorktree -count=1 -v
=== RUN   TestHostAPI_Review_CWDSetToWorktree
--- PASS: TestHostAPI_Review_CWDSetToWorktree (0.01s)
PASS
ok  	github.com/prismatic-koi/prism/internal/sidecar	0.012s

$ go test ./...
ok  	github.com/prismatic-koi/prism/cmd	4.179s
ok  	github.com/prismatic-koi/prism/internal/agent	0.004s
… (all packages PASS)
ok  	github.com/prismatic-koi/prism/internal/sidecar	9.987s
ok  	github.com/prismatic-koi/prism/internal/tmux	0.704s
```

No `FOREIGN KEY constraint failed` log lines appear during the
`TestRunStartupStdio` runs (verified via `grep -i FOREIGN`).

## Homeless-shelter gate

From the repo root:

```
$ nix build .#prism
$ ls -la result
lrwxrwxrwx 1 ben users 55 May  8 19:55 result -> /nix/store/b86haaydnwgbdl3n2b23r9pa4111w97k-prism-0.1.0
```

Build succeeded.

## Platform coverage note

I'm working on Linux. The #1489 fix is reasoned about from the
`filepath.EvalSymlinks` semantics (pure stdlib, well-defined on both
platforms) and verified to not regress on Linux. The PR's
`build-and-cache` matrix will exercise the Darwin path on merge.
