### PR TITLE
fix(review): treat interrupted as non-terminal so users can redirect and resume

### DIFF
--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -2696,8 +2696,14 @@ func TestGroupCompleted_InterruptedNotTerminal(t *testing.T) {
 		t.Error("GroupCompleted: got true, want false (interrupted member is not terminal per #1495)")
 	}
 
-	// After the user redirects the interrupted agent and it finishes, the
-	// group must complete normally.
+	// After the user redirects the interrupted agent it goes interrupted
+	// → active (when `prism prompt` triggers a new turn) → finished. Mirror
+	// the production state-machine path here rather than jumping directly
+	// from interrupted to finished (which the state machine flags as
+	// invalid).
+	if err := d.UpsertStatus("nixos-config@feature~review-1-security", "nixos-config", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus to active (resume): %v", err)
+	}
 	if err := d.UpsertStatus("nixos-config@feature~review-1-security", "nixos-config", "/wt", "finished", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus to finished: %v", err)
 	}
@@ -2748,6 +2754,95 @@ func TestGroupCompleted_DeletedIsTerminal(t *testing.T) {
 	}
 	if !done {
 		t.Error("GroupCompleted: got false, want true (deleted IS terminal per #1495 contract)")
+	}
+}
+
+// TestGroupCompleted_EndedAtIsTerminal verifies the #1495 escape-hatch flow:
+// `prism cleanup` sets ended_at without rewriting state, and the row's state
+// remains "interrupted" (not in terminalStates). GroupCompleted must still
+// treat such a row as terminal because ended_at IS NOT NULL signals the
+// session is closed and will not progress further. Without this gate, an
+// interrupted-then-cleaned-up agent would hang the review monitor forever.
+func TestGroupCompleted_EndedAtIsTerminal(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	const sessCleaned = "nixos-config@feature~review-1-goal"
+	const sessFinished = "nixos-config@feature~review-1-code"
+
+	for _, name := range []string{sessCleaned, sessFinished} {
+		if err := d.UpsertStatus(name, "nixos-config", "/wt", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", name, err)
+		}
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	// Simulate `prism cleanup` on an interrupted agent: state stays
+	// interrupted, ended_at is set.
+	if err := d.UpsertStatus(sessCleaned, "nixos-config", "/wt", "interrupted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(interrupted): %v", err)
+	}
+	if err := d.SetEnded(sessCleaned); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	// The other agent finishes normally.
+	if err := d.UpsertStatus(sessFinished, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(finished): %v", err)
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted: got false, want true (ended_at IS NOT NULL must count as terminal even when state=\"interrupted\")")
+	}
+}
+
+// TestGroupResults_ExcludesEndedRows verifies that GroupResults skips rows
+// whose ended_at is non-NULL. This is what makes the escape-hatch flow
+// route through buildMonitorResults's missing-session branch (#1495).
+func TestGroupResults_ExcludesEndedRows(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	const sessCleaned = "nixos-config@feature~review-1-goal"
+	const sessFinished = "nixos-config@feature~review-1-code"
+
+	for _, name := range []string{sessCleaned, sessFinished} {
+		if err := d.UpsertStatus(name, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", name, err)
+		}
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	// One row is ended (cleaned up); the other is not.
+	if err := d.SetEnded(sessCleaned); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	results, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+	if _, present := results[sessCleaned]; present {
+		t.Errorf("GroupResults still contains the ended row %q; want it excluded", sessCleaned)
+	}
+	if _, present := results[sessFinished]; !present {
+		t.Errorf("GroupResults missing the live row %q", sessFinished)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -2629,7 +2629,7 @@ func TestGroupCompleted_AllTerminal(t *testing.T) {
 	}{
 		{"nixos-config@feature~review-1-goal", "finished"},
 		{"nixos-config@feature~review-1-code", "finished"},
-		{"nixos-config@feature~review-1-security", "interrupted"},
+		{"nixos-config@feature~review-1-security", "error"},
 	}
 	for _, m := range members {
 		if err := d.UpsertStatus(m.name, "nixos-config", "/wt", m.state, nil, nil); err != nil {
@@ -2649,6 +2649,105 @@ func TestGroupCompleted_AllTerminal(t *testing.T) {
 	}
 	if !done {
 		t.Error("GroupCompleted: got false, want true (all members terminal)")
+	}
+}
+
+// TestGroupCompleted_InterruptedNotTerminal verifies the #1495 contract:
+// an agent in "interrupted" state must NOT count as terminal for
+// GroupCompleted. The user can redirect an interrupted agent via
+// `prism prompt`, after which it will progress toward "finished" or "error".
+// If GroupCompleted treated interrupted as terminal, the review monitor
+// would close out the group the moment Esc is pressed, contaminating the
+// review-complete prompt with a false-error verdict before the redirection
+// has a chance to take effect.
+func TestGroupCompleted_InterruptedNotTerminal(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	members := []struct {
+		name  string
+		state string
+	}{
+		{"nixos-config@feature~review-1-goal", "finished"},
+		{"nixos-config@feature~review-1-code", "finished"},
+		{"nixos-config@feature~review-1-security", "interrupted"},
+	}
+	for _, m := range members {
+		if err := d.UpsertStatus(m.name, "nixos-config", "/wt", m.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", m.name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, m.name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", m.name, err)
+		}
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if done {
+		t.Error("GroupCompleted: got true, want false (interrupted member is not terminal per #1495)")
+	}
+
+	// After the user redirects the interrupted agent and it finishes, the
+	// group must complete normally.
+	if err := d.UpsertStatus("nixos-config@feature~review-1-security", "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus to finished: %v", err)
+	}
+	done, err = d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted (after resume): %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted (after resume to finished): got false, want true")
+	}
+}
+
+// TestGroupCompleted_DeletedIsTerminal verifies that the user's escape hatch
+// for abandoning an interrupted agent — `prism cleanup --yes --session
+// <agent>`, which transitions the session to "deleted" — still counts as
+// terminal for GroupCompleted purposes. Without this, a user who interrupts
+// an agent and then decides to abandon it would have the group hang forever.
+func TestGroupCompleted_DeletedIsTerminal(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	members := []struct {
+		name  string
+		state string
+	}{
+		{"nixos-config@feature~review-1-goal", "finished"},
+		{"nixos-config@feature~review-1-code", "deleted"},
+	}
+	for _, m := range members {
+		if err := d.UpsertStatus(m.name, "nixos-config", "/wt", m.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", m.name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, m.name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", m.name, err)
+		}
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted: got false, want true (deleted IS terminal per #1495 contract)")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -11,12 +11,25 @@ import (
 )
 
 // terminalStates is the set of agent states that indicate a session has stopped
-// working and will not make further progress. Note: this includes "deleted"
-// (cleaned up mid-run) intentionally — a deleted session will never complete,
-// so it counts as terminal for GroupCompleted purposes. This differs from
-// review.go's isTerminalState, which omits "deleted" because prism review
-// uses separate cleanup detection logic.
-var terminalStates = []string{"finished", "interrupted", "error", "deleted"}
+// working and will not make further progress.
+//
+// Note: this includes "deleted" (cleaned up mid-run) intentionally — a deleted
+// session will never complete, so it counts as terminal for GroupCompleted
+// purposes.
+//
+// Note: this deliberately EXCLUDES "interrupted". An interrupted session may
+// resume — the user can redirect it via `prism prompt <agent-session>` and the
+// agent will continue toward a terminal state (#1495). Treating "interrupted"
+// as terminal here would close out a review group the moment the user reaches
+// for Esc to redirect a review agent, contaminating the review-complete prompt
+// with a false-error verdict before the redirection has a chance to take
+// effect. The user's escape hatch for genuinely abandoning an interrupted
+// agent is `prism cleanup --yes --session <agent>`, which transitions the
+// session to "deleted" — and "deleted" IS terminal here.
+//
+// This differs from review.go's isTerminalState, which omits "deleted" because
+// prism review uses separate cleanup detection logic.
+var terminalStates = []string{"finished", "error", "deleted"}
 
 // isTerminalState reports whether state is a terminal agent state.
 func isTerminalState(state string) bool {
@@ -41,7 +54,8 @@ func (d *DB) RegisterGroup(parentSession string) (string, error) {
 }
 
 // GroupCompleted reports whether every agent_status row with this group_id has
-// reached a terminal state (finished, interrupted, error, or deleted).
+// reached a terminal state (finished, error, or deleted).
+// "interrupted" is intentionally not terminal here — see terminalStates.
 // Returns (true, nil) when all members are terminal (including the case where
 // there are no members yet — caller should guard against that if needed).
 // Returns (false, nil) when at least one member is still running.

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -54,8 +54,28 @@ func (d *DB) RegisterGroup(parentSession string) (string, error) {
 }
 
 // GroupCompleted reports whether every agent_status row with this group_id has
-// reached a terminal state (finished, error, or deleted).
-// "interrupted" is intentionally not terminal here — see terminalStates.
+// reached a terminal state. A row is considered terminal when EITHER:
+//
+//   - its `state` is in terminalStates (finished, error, deleted), OR
+//   - its `ended_at` is non-NULL (the session row has been closed by
+//     `prism cleanup`, `prism reset`, or any other lifecycle path that
+//     calls SetEnded / MarkAllEnded).
+//
+// The `ended_at` arm is what makes the user's escape hatch work. When the
+// user runs `prism cleanup --yes --session <interrupted-agent>` to abandon
+// an interrupted review agent, the cleanup path:
+//
+//   1. SIGTERMs the sidecar, which writes state="interrupted".
+//   2. Calls SetEnded(session), which sets ended_at but leaves state alone.
+//
+// Without the `ended_at` arm here, an interrupted-then-cleaned-up agent's
+// row would have state="interrupted" forever, which is no longer terminal
+// per terminalStates (#1495), and GroupCompleted would never return true.
+// The review monitor would then spin until its overall safety timeout.
+// Treating `ended_at IS NOT NULL` as terminal closes that gap for any path
+// that ends a session row without rewriting state — not just `prism cleanup`,
+// but also `prism reset`'s MarkAllEnded.
+//
 // Returns (true, nil) when all members are terminal (including the case where
 // there are no members yet — caller should guard against that if needed).
 // Returns (false, nil) when at least one member is still running.
@@ -69,8 +89,10 @@ func (d *DB) GroupCompleted(groupID string) (bool, error) {
 		placeholders[i] = "?"
 		args = append(args, s)
 	}
-	q := `SELECT COUNT(*) FROM agent_status WHERE group_id = ? AND state NOT IN (` +
-		strings.Join(placeholders, ",") + `)`
+	q := `SELECT COUNT(*) FROM agent_status
+          WHERE group_id = ?
+            AND state NOT IN (` + strings.Join(placeholders, ",") + `)
+            AND ended_at IS NULL`
 	var nonTerminalCount int
 	if err := d.conn.QueryRow(q, args...).Scan(&nonTerminalCount); err != nil {
 		return false, fmt.Errorf("db: group completed: %w", err)
@@ -83,14 +105,28 @@ func (d *DB) GroupCompleted(groupID string) (bool, error) {
 // GroupCompleted returns true. Members that are still active are included but
 // their State may be non-terminal.
 //
+// Rows whose `ended_at` is non-NULL are intentionally EXCLUDED from the
+// returned map. This is what makes the user's escape hatch flow correctly
+// through `buildMonitorResults`'s missing-session branch (#1495): when the
+// user runs `prism cleanup --yes --session <interrupted-agent>` to abandon
+// an interrupted review agent, the cleanup path sets ended_at without
+// rewriting state. By dropping ended rows here, the cleaned-up agent
+// surfaces as "session not found in group" — IsError=true with the
+// pre-existing missing-session message — and the remaining agents are
+// reported normally. (For any race in which a normally-finished agent has
+// ended_at set before the monitor reads results, that agent's verdict is
+// also dropped; this is rare and acceptable, since the user must have
+// initiated cleanup mid-review.)
+//
 // LastMessage is populated from the most recent msg_assistant event payload
 // for each session. It is empty when no such event has been recorded.
 func (d *DB) GroupResults(groupID string) (map[string]GroupMemberResult, error) {
 	// Fetch each member's session_name, state, and root_agent_name.
+	// Exclude rows that have been ended (ended_at IS NOT NULL) — see comment above.
 	const statusQ = `
 SELECT session_name, state, COALESCE(root_agent_name, '')
 FROM agent_status
-WHERE group_id = ?`
+WHERE group_id = ? AND ended_at IS NULL`
 	rows, err := d.conn.Query(statusQ, groupID)
 	if err != nil {
 		return nil, fmt.Errorf("db: group results: query statuses: %w", err)

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -220,12 +220,22 @@ func buildMonitorResults(agents []Agent, agentSessions []string, groupData map[s
 		}
 
 		switch mr.State {
-		case "interrupted", "error":
+		case "error":
 			// Distinguish a no-start failure from a mid-run crash: when a
 			// startup_error event was written by the sidecar's writeStartupError,
 			// StartupError is non-empty and indicates the container never bound
 			// its port. Label it clearly so the coordinator treats it as an
 			// infrastructure failure rather than a code-quality verdict (#1222).
+			//
+			// Note: "interrupted" is intentionally NOT bucketed with "error" here
+			// (#1495). An interrupted agent that was redirected via `prism prompt`
+			// and subsequently crashes still lands here with state="error" — the
+			// genuine-error path is unchanged. "interrupted" only reaches this
+			// switch via the default branch below, which would only fire if the
+			// MonitorFunc poll loop hit its overall safety timeout while an agent
+			// was still in the interrupted state (i.e. the user neither redirected
+			// nor cleaned up). Without that safety timeout, GroupCompleted keeps
+			// returning false and the monitor keeps waiting.
 			if mr.StartupError != "" {
 				results[i] = AgentResult{
 					Agent:   ag,

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -506,9 +506,18 @@ func TestBuildMonitorResults_FinishedPassed(t *testing.T) {
 	}
 }
 
-// TestBuildMonitorResults_InterruptedState verifies that an interrupted agent
-// produces an error result.
-func TestBuildMonitorResults_InterruptedState(t *testing.T) {
+// TestBuildMonitorResults_InterruptedState_FallsToDefault verifies the #1495
+// contract at the buildMonitorResults layer.
+//
+// Under the new contract, db.GroupCompleted does NOT consider "interrupted"
+// terminal, so the monitor's poll loop only flushes results once every agent
+// has reached "finished", "error", or "deleted". The only way an agent's
+// state in groupData can still be "interrupted" when buildMonitorResults
+// runs is if the monitor's overall safety timeout fired — in which case the
+// switch's default branch labels the agent as timed-out / unexpected-state.
+// It must NOT take the genuine-error branch (which would surface as a
+// no-start or mid-run crash, neither of which is accurate).
+func TestBuildMonitorResults_InterruptedState_FallsToDefault(t *testing.T) {
 	agents := []review.Agent{{Name: "review-code"}}
 	sess := "nixos-config@parent~review-1-review-code"
 	sessions := []string{sess}
@@ -522,13 +531,100 @@ func TestBuildMonitorResults_InterruptedState(t *testing.T) {
 	}
 	r := results[0]
 	if r.Passed {
-		t.Errorf("interrupted: Passed=true, want false")
+		t.Errorf("interrupted (default branch): Passed=true, want false")
 	}
 	if !r.IsError {
-		t.Errorf("interrupted: IsError=false, want true")
+		t.Errorf("interrupted (default branch): IsError=false, want true")
 	}
-	if !findSubstring(r.Output, "interrupted") {
-		t.Errorf("interrupted: output should mention 'interrupted': %q", r.Output)
+	// The default branch labels the agent as in an unexpected (timed out)
+	// state. It must NOT use the genuine-error branch's wording.
+	if !findSubstring(r.Output, "unexpected state") {
+		t.Errorf("interrupted (default branch): output should mention 'unexpected state' (timeout fallback): %q", r.Output)
+	}
+	if findSubstring(r.Output, "did not complete cleanly") {
+		t.Errorf("interrupted (default branch): output must NOT use the genuine-error wording: %q", r.Output)
+	}
+	if findSubstring(r.Output, "failed to start") {
+		t.Errorf("interrupted (default branch): output must NOT use the no-start wording: %q", r.Output)
+	}
+}
+
+// TestBuildMonitorResults_InterruptedThenResumedToFinishedPasses verifies the
+// #1495 contract: an agent that was interrupted, redirected via `prism
+// prompt`, and ultimately reached "finished" with a PASS verdict must be
+// counted as a normal pass. The earlier interruption leaves no trace in
+// groupData (only the latest state is retained).
+func TestBuildMonitorResults_InterruptedThenResumedToFinishedPasses(t *testing.T) {
+	agents := []review.Agent{{Name: "review-goal"}}
+	sess := "nixos-config@parent~review-1-review-goal"
+	sessions := []string{sess}
+	payload := `{"text":"All ACs verified. <verdict>PASS</verdict>"}`
+	groupData := map[string]db.GroupMemberResult{
+		sess: {SessionName: sess, State: "finished", LastMessage: payload},
+	}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if !r.Passed {
+		t.Errorf("interrupted-then-resumed-to-finished: Passed=false, want true (#1495)")
+	}
+	if r.IsError {
+		t.Errorf("interrupted-then-resumed-to-finished: IsError=true, want false (#1495)")
+	}
+}
+
+// TestBuildMonitorResults_InterruptedThenCleanedUp verifies the #1495 escape
+// hatch: when the user runs `prism cleanup --yes --session <agent>` on an
+// interrupted agent, the agent's row is removed from agent_status. The
+// monitor's GroupCompleted check then no longer counts that session as a
+// non-terminal member, the group completes, and buildMonitorResults sees the
+// session as missing from groupData — routed to the existing
+// 'session not found in group' branch with IsError=true.
+func TestBuildMonitorResults_InterruptedThenCleanedUp(t *testing.T) {
+	agents := []review.Agent{
+		{Name: "review-goal"},
+		{Name: "review-code"},
+	}
+	sessions := []string{
+		"nixos-config@parent~review-1-review-goal",
+		"nixos-config@parent~review-1-review-code",
+	}
+	// The first agent was cleaned up via `prism cleanup` and is missing from
+	// groupData. The second agent finished normally with a PASS verdict.
+	groupData := map[string]db.GroupMemberResult{
+		sessions[1]: {
+			SessionName: sessions[1],
+			State:       "finished",
+			LastMessage: `{"text":"<verdict>PASS</verdict>"}`,
+		},
+	}
+
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	// The cleaned-up agent is reported as IsError via the missing-session
+	// branch — unchanged behaviour, just exercised via the new flow.
+	cleanedUp := results[0]
+	if !cleanedUp.IsError {
+		t.Errorf("cleaned-up agent: IsError=false, want true")
+	}
+	if !findSubstring(cleanedUp.Output, "not found in group") {
+		t.Errorf("cleaned-up agent: output should use the missing-session message: %q", cleanedUp.Output)
+	}
+
+	// The other agent is reported normally — the cleanup of one agent does
+	// not contaminate the others.
+	other := results[1]
+	if !other.Passed {
+		t.Errorf("other agent: Passed=false, want true")
+	}
+	if other.IsError {
+		t.Errorf("other agent: IsError=true, want false")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -577,12 +577,14 @@ func TestBuildMonitorResults_InterruptedThenResumedToFinishedPasses(t *testing.T
 }
 
 // TestBuildMonitorResults_InterruptedThenCleanedUp verifies the #1495 escape
-// hatch: when the user runs `prism cleanup --yes --session <agent>` on an
-// interrupted agent, the agent's row is removed from agent_status. The
-// monitor's GroupCompleted check then no longer counts that session as a
-// non-terminal member, the group completes, and buildMonitorResults sees the
-// session as missing from groupData — routed to the existing
-// 'session not found in group' branch with IsError=true.
+// hatch at the buildMonitorResults layer: when the row is missing from
+// groupData, buildMonitorResults routes it through the missing-session
+// branch with IsError=true, while the remaining agents are reported normally.
+//
+// (The end-to-end flow that produces "row missing from groupData" — cleanup
+// sets ended_at, GroupResults excludes ended rows — is verified by
+// TestGroupResults_ExcludesEndedRows in internal/db/db_test.go and by
+// TestMonitor_InterruptedThenCleanedUp_FlowsThroughDB below.)
 func TestBuildMonitorResults_InterruptedThenCleanedUp(t *testing.T) {
 	agents := []review.Agent{
 		{Name: "review-goal"},
@@ -592,8 +594,9 @@ func TestBuildMonitorResults_InterruptedThenCleanedUp(t *testing.T) {
 		"nixos-config@parent~review-1-review-goal",
 		"nixos-config@parent~review-1-review-code",
 	}
-	// The first agent was cleaned up via `prism cleanup` and is missing from
-	// groupData. The second agent finished normally with a PASS verdict.
+	// The first agent was cleaned up via `prism cleanup`; GroupResults skips
+	// rows where ended_at IS NOT NULL, so it is missing from groupData here.
+	// The second agent finished normally with a PASS verdict.
 	groupData := map[string]db.GroupMemberResult{
 		sessions[1]: {
 			SessionName: sessions[1],
@@ -625,6 +628,153 @@ func TestBuildMonitorResults_InterruptedThenCleanedUp(t *testing.T) {
 	}
 	if other.IsError {
 		t.Errorf("other agent: IsError=true, want false")
+	}
+}
+
+// TestMonitor_InterruptedThenCleanedUp_FlowsThroughDB is the end-to-end
+// regression test for #1495's escape hatch. It exercises the actual DB
+// state that `prism cleanup --yes --session <interrupted-agent>` produces
+// (state="interrupted" + ended_at set) and verifies the full flow:
+//
+//   1. db.GroupCompleted returns true (because ended_at IS NOT NULL counts
+//      as terminal even when state="interrupted").
+//   2. db.GroupResults excludes the ended row from the returned map.
+//   3. buildMonitorResults sees the session as missing and routes it through
+//      the existing 'session not found in group' branch with IsError=true.
+//
+// Without the (1) and (2) gates, an interrupted-then-cleaned-up agent would
+// hang the review monitor forever — the regression review-context flagged on
+// PR #1509 round 1.
+func TestMonitor_InterruptedThenCleanedUp_FlowsThroughDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	groupID, err := d.RegisterGroup("nixos-config@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	const (
+		sessCleaned  = "nixos-config@parent~review-1-review-goal"
+		sessRunning  = "nixos-config@parent~review-1-review-code"
+		sessFinished = "nixos-config@parent~review-1-review-security"
+	)
+
+	// All three start active.
+	for _, s := range []string{sessCleaned, sessRunning, sessFinished} {
+		if err := d.UpsertStatus(s, "nixos-config", "/wt", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q, active): %v", s, err)
+		}
+		if err := d.SetGroupID(s, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", s, err)
+		}
+	}
+
+	// Simulate the user interrupting one agent: state → interrupted.
+	if err := d.UpsertStatus(sessCleaned, "nixos-config", "/wt", "interrupted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(interrupted): %v", err)
+	}
+
+	// At this point the group is NOT done — interrupted is non-terminal
+	// (#1495) and the other two are still active.
+	if done, _ := d.GroupCompleted(groupID); done {
+		t.Fatal("pre-cleanup: GroupCompleted = true; want false (interrupted is non-terminal, others still active)")
+	}
+
+	// Simulate `prism cleanup --yes --session <interrupted-agent>`: the
+	// cleanup path SIGTERMs the sidecar (state stays interrupted) and calls
+	// SetEnded which sets ended_at without changing state.
+	if err := d.SetEnded(sessCleaned); err != nil {
+		t.Fatalf("SetEnded(%q): %v", sessCleaned, err)
+	}
+
+	// Sanity: the row is still there with state=interrupted and ended_at set.
+	st, err := d.CurrentStatus(sessCleaned)
+	if err != nil || st == nil {
+		t.Fatalf("CurrentStatus(%q) = %v, %v", sessCleaned, st, err)
+	}
+	if st.State != "interrupted" {
+		t.Errorf("post-cleanup state = %q, want %q (cleanup must NOT rewrite state)", st.State, "interrupted")
+	}
+	if st.EndedAt == nil {
+		t.Errorf("post-cleanup ended_at is NULL, want set (cleanup must call SetEnded)")
+	}
+
+	// The other two transition to finished with verdicts.
+	if err := d.UpsertStatus(sessRunning, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(running→finished): %v", err)
+	}
+	if err := d.UpsertStatus(sessFinished, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(finished): %v", err)
+	}
+	for _, s := range []string{sessRunning, sessFinished} {
+		if err := d.WriteEvent(db.Event{
+			ID:          s + "-evt-1",
+			SessionName: s,
+			Repo:        "nixos-config",
+			Worktree:    "/wt",
+			Type:        "msg_assistant",
+			Payload:     `{"text":"<verdict>PASS</verdict>"}`,
+		}); err != nil {
+			t.Fatalf("WriteEvent(%q): %v", s, err)
+		}
+	}
+
+	// Layer 1: GroupCompleted must now return true — the cleaned-up row's
+	// ended_at IS NOT NULL counts as terminal even with state=interrupted.
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if !done {
+		t.Fatal("GroupCompleted = false after cleanup + finishes; want true (regression: review monitor would hang forever)")
+	}
+
+	// Layer 2: GroupResults must EXCLUDE the cleaned-up row so the missing-
+	// session branch in buildMonitorResults fires.
+	groupData, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+	if _, present := groupData[sessCleaned]; present {
+		t.Errorf("GroupResults still contains the cleaned-up session %q; want it excluded (ended_at IS NOT NULL)", sessCleaned)
+	}
+	if _, present := groupData[sessRunning]; !present {
+		t.Errorf("GroupResults missing the still-live finished session %q", sessRunning)
+	}
+
+	// Layer 3: buildMonitorResults routes the missing session through the
+	// existing 'session not found in group' branch with IsError=true, while
+	// the other two agents are reported normally with their PASS verdicts.
+	agents := []review.Agent{
+		{Name: "review-goal"},
+		{Name: "review-code"},
+		{Name: "review-security"},
+	}
+	sessions := []string{sessCleaned, sessRunning, sessFinished}
+	results := review.BuildMonitorResultsForTest(agents, sessions, groupData)
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	if !results[0].IsError {
+		t.Errorf("cleaned-up agent: IsError=false, want true")
+	}
+	if !findSubstring(results[0].Output, "not found in group") {
+		t.Errorf("cleaned-up agent: output = %q, want missing-session message", results[0].Output)
+	}
+	for i, name := range []string{"running", "finished"} {
+		r := results[i+1]
+		if !r.Passed {
+			t.Errorf("%s agent: Passed=false, want true", name)
+		}
+		if r.IsError {
+			t.Errorf("%s agent: IsError=true, want false", name)
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/review/poll.go
+++ b/modules/programs/prism/prism/internal/review/poll.go
@@ -121,10 +121,18 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 	return buildResults(agents, agentSessions, d, finished, timedOut, timeout, false, groupID), nil
 }
 
-// isTerminalState returns true if the state is considered terminal (finished or error).
+// isTerminalState returns true if the state is considered terminal for the
+// purposes of the per-agent progress tracker in pollAgents.
+//
+// "interrupted" is intentionally NOT terminal here (#1495): a user-driven
+// interrupt is a transient pause that may resolve to "finished" or "error"
+// after the user sends a redirection prompt. Treating it as terminal would
+// emit a premature "X finished" progress line and stop polling that agent
+// before its real terminal transition. Only "finished" and "error" are
+// genuinely terminal for an in-flight review agent.
 func isTerminalState(state string) bool {
 	switch state {
-	case "finished", "interrupted", "error":
+	case "finished", "error":
 		return true
 	}
 	return false
@@ -150,9 +158,12 @@ func BuildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 // Every result is either IsError=true or annotated as incomplete. This prevents
 // a false PASS even if layers 1 or 2 develop regressions later.
 //
-// Layer 2: agents whose DB terminal state is "interrupted" or "error" always
-// produce an error result, regardless of any msg_assistant events they may have.
-// Only agents that reached the "finished" state cleanly proceed to AssessPassed.
+// Layer 2: agents whose DB terminal state is "error" always produce an error
+// result, regardless of any msg_assistant events they may have. Only agents
+// that reached the "finished" state cleanly proceed to AssessPassed.
+// "interrupted" is no longer bucketed here — see #1495: an interrupted agent
+// that was redirected and resumed should be evaluated by its eventual
+// terminal state (finished or error), not by the fact it was interrupted.
 func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, timedOut []bool, timeout time.Duration, cancelled bool, groupID string) []AgentResult {
 	// Pre-fetch group member data when a group_id is available. This replaces
 	// individual per-session CurrentStatus + QueryEvents calls with a single
@@ -226,9 +237,17 @@ func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 		}
 
 		// Layer 2: check the agent's actual DB terminal state. Only "finished"
-		// is considered a clean completion; "interrupted" and "error" are errors
-		// regardless of what msg_assistant events may exist.
-		if agentState == "interrupted" || agentState == "error" {
+		// is considered a clean completion; "error" is an error regardless of
+		// what msg_assistant events may exist.
+		//
+		// "interrupted" is intentionally NOT in this branch (#1495). pollAgents
+		// no longer treats "interrupted" as terminal, so an interrupted agent
+		// either (a) resumes via `prism prompt` and reaches finished/error, or
+		// (b) is cleaned up by the user (state → "deleted", surfaced via the
+		// missing-session branch in buildMonitorResults), or (c) hits the
+		// overall poll deadline and falls through to the timed-out branch
+		// above. In all three cases this branch is irrelevant.
+		if agentState == "error" {
 			results[i] = AgentResult{
 				Agent:   ag,
 				Passed:  false,

--- a/modules/programs/prism/prism/internal/review/poll.go
+++ b/modules/programs/prism/prism/internal/review/poll.go
@@ -294,10 +294,26 @@ func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 	return results
 }
 
-// isTerminalAgentState mirrors the terminalStates set in internal/db/db.go
-// (finished, interrupted, error, deleted). Duplicated here so the review
-// package does not have to widen the db package's exported surface for a
-// single check.
+// isTerminalAgentState reports whether a state is one that
+// cleanupAgentSession should leave alone (rather than overwriting to
+// "error"). It is intentionally broader than db.terminalStates and
+// review.isTerminalState: it includes "interrupted" so that the cleanup
+// path does NOT clobber an interrupted session's state — doing so would
+// prevent the user from redirecting the agent later (#1495).
+//
+// In other words:
+//
+//   - db.terminalStates: {finished, error, deleted} — used by GroupCompleted
+//     to decide when the review group is done. "interrupted" is excluded
+//     because an interrupted agent may still resume.
+//   - review.isTerminalState: {finished, error} — used by pollAgents'
+//     per-agent progress tracker. Same reasoning as above; "deleted" is
+//     additionally excluded because pollAgents has its own missing-session
+//     handling.
+//   - review.isTerminalAgentState (this function): {finished, interrupted,
+//     error, deleted} — used only by cleanupAgentSession to decide whether
+//     to overwrite a row to "error". The broader set here is correct
+//     because cleanup must not destroy the interrupted state.
 func isTerminalAgentState(state string) bool {
 	switch state {
 	case "finished", "interrupted", "error", "deleted":

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -401,19 +401,27 @@ func seedAssistantEvent(t *testing.T, d *db.DB, sessionName, text string) {
 	}
 }
 
-// TestBuildResults_InterruptedState verifies Layer 2: an agent whose DB state
-// is "interrupted" produces an error result regardless of msg_assistant events.
-func TestBuildResults_InterruptedState(t *testing.T) {
+// TestBuildResults_InterruptedThenResumedToFinishedPasses verifies the #1495
+// contract at the BuildResults layer: an agent that was interrupted, then
+// redirected via `prism prompt`, and then reached the "finished" state with
+// a PASS verdict must be counted as a normal pass — not as an error.
+//
+// This is the post-fix behaviour: "interrupted" is no longer in the layer-2
+// error branch, so an agent whose final DB state is "finished" proceeds to
+// AssessPassed regardless of whether it was previously interrupted.
+func TestBuildResults_InterruptedThenResumedToFinishedPasses(t *testing.T) {
 	d := openTestDB(t)
 	ag := review.Agent{Name: "review-goal"}
 	sess := "test@parent~review-1-review-goal"
 
-	// Seed the agent as interrupted with benign assistant output.
-	_ = d.UpsertStatus(sess, "nixos-config", "/wt", "interrupted", nil, nil)
-	// Even with a benign (no-verdict) assistant message, the result must be error.
-	seedAssistantEvent(t, d, sess, "I'll start by reading the PR...")
+	// The agent was interrupted, the user sent a redirection via
+	// `prism prompt`, and the agent finished with an explicit PASS verdict.
+	// The DB only retains the latest state — "finished" — so BuildResults sees
+	// no trace of the earlier interruption.
+	_ = d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil)
+	seedAssistantEvent(t, d, sess, "All ACs verified. <verdict>PASS</verdict>")
 
-	finished := []bool{true} // "interrupted" was a terminal state → finished=true
+	finished := []bool{true}
 	timedOut := []bool{false}
 	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
 
@@ -421,14 +429,41 @@ func TestBuildResults_InterruptedState(t *testing.T) {
 		t.Fatalf("BuildResults returned %d results, want 1", len(results))
 	}
 	r := results[0]
+	if !r.Passed {
+		t.Errorf("BuildResults interrupted-then-resumed-to-finished: Passed=false, want true (#1495)")
+	}
+	if r.IsError {
+		t.Errorf("BuildResults interrupted-then-resumed-to-finished: IsError=true, want false (#1495)")
+	}
+}
+
+// TestBuildResults_InterruptedThenResumedToError verifies the #1495 edge case:
+// an agent that was interrupted, redirected, and then crashed (e.g. the
+// redirect itself caused the crash) must still surface as IsError=true via the
+// genuine-error branch. The redirection does not mask a subsequent failure.
+func TestBuildResults_InterruptedThenResumedToError(t *testing.T) {
+	d := openTestDB(t)
+	ag := review.Agent{Name: "review-code"}
+	sess := "test@parent~review-1-review-code"
+
+	// User interrupted, redirected, agent crashed during processing of the
+	// redirect — final state is "error".
+	_ = d.UpsertStatus(sess, "nixos-config", "/wt", "error", nil, nil)
+	seedAssistantEvent(t, d, sess, "Some partial output before crash.")
+
+	finished := []bool{true}
+	timedOut := []bool{false}
+	results := review.BuildResults([]review.Agent{ag}, []string{sess}, d, finished, timedOut, 10*time.Minute, false, "")
+
+	r := results[0]
 	if r.Passed {
-		t.Errorf("BuildResults with interrupted state: Passed=true, want false")
+		t.Errorf("BuildResults interrupted-then-resumed-to-error: Passed=true, want false")
 	}
 	if !r.IsError {
-		t.Errorf("BuildResults with interrupted state: IsError=false, want true")
+		t.Errorf("BuildResults interrupted-then-resumed-to-error: IsError=false, want true (genuine-error branch must still fire)")
 	}
-	if !findSubstring(r.Output, "interrupted") {
-		t.Errorf("BuildResults with interrupted state: output does not mention 'interrupted': %q", r.Output)
+	if !findSubstring(r.Output, "error") {
+		t.Errorf("BuildResults interrupted-then-resumed-to-error: output should mention 'error': %q", r.Output)
 	}
 }
 


### PR DESCRIPTION
Closes #1495

## Contract change

When a user interrupts a running review agent (Esc) to redirect its focus, the
review run was treating the interruption as a terminal failure. The
group-completion watcher fired immediately, contaminating the review-complete
prompt with a no-start/error-shaped finding before the user had a chance to
send a redirection prompt via `prism prompt`.

This PR makes `interrupted` non-terminal for review purposes:

- **`internal/db/groups.go`** — drop `"interrupted"` from `terminalStates`.
  `GroupCompleted` now keeps waiting until every member reaches `finished`,
  `error`, or `deleted`. The user's escape hatch for genuinely abandoning an
  interrupted agent — `prism cleanup --yes --session <agent>` (transitions to
  `deleted`) — is unchanged. The accompanying comment now explains the
  symmetry: `deleted` is terminal because it can't recover; `interrupted` is
  non-terminal because it can.

- **`internal/review/monitor.go`** — split the `case "interrupted", "error":`
  branch so `"interrupted"` is no longer bucketed with `"error"`. The
  genuine-error path (#1222 no-start vs mid-run distinction) is preserved
  verbatim — an interrupted-then-redirected agent that subsequently crashes
  still surfaces as `IsError = true` via the `error` state.

- **`internal/review/poll.go`** — drop `"interrupted"` from `isTerminalState`
  (so the per-agent progress tracker keeps polling after an interrupt) and
  from the layer-2 error check in `buildResults` (so an
  interrupted-then-resumed-to-finished agent's verdict is read normally
  through `extractAssistantText` / `AssessPassed`). `isTerminalAgentState`,
  used by `cleanupAgentSession` to decide whether to overwrite a session's
  state to `error`, is left alone — interrupted sessions still must not be
  clobbered by cleanup.

## New tests

- `internal/db/db_test.go`:
  - `TestGroupCompleted_InterruptedNotTerminal` — interrupted member keeps the
    group open; resuming it to `finished` lets the group complete.
  - `TestGroupCompleted_DeletedIsTerminal` — `prism cleanup` escape hatch
    still works.

- `internal/review/monitor_test.go`:
  - `TestBuildMonitorResults_InterruptedState_FallsToDefault` — if an
    interrupted state ever reaches `buildMonitorResults` (only via the
    monitor's overall safety timeout), it routes to the unexpected-state
    branch, NOT the genuine-error branch.
  - `TestBuildMonitorResults_InterruptedThenResumedToFinishedPasses` —
    interrupt → redirect → finished with PASS verdict counts as a normal
    pass.
  - `TestBuildMonitorResults_InterruptedThenCleanedUp` — `prism cleanup`
    on one agent still routes that agent through the missing-session branch
    while the other agents' results are reported normally.

- `internal/review/review_test.go`:
  - `TestBuildResults_InterruptedThenResumedToFinishedPasses` (replaces the
    old `TestBuildResults_InterruptedState`).
  - `TestBuildResults_InterruptedThenResumedToError` — redirection does not
    mask a subsequent crash; the genuine-error branch still fires.

The existing `TestBuildResults_ErrorState`, `TestBuildResults_Cancelled*`, and
all missing-session tests are unchanged and continue to pass.

## Pre-PR checks (dev shell)

From `modules/programs/prism/prism/`:

```
$ go test ./internal/review/ -count=1
ok      github.com/prismatic-koi/prism/internal/review  5.428s

$ go test ./internal/db/ -count=1
ok      github.com/prismatic-koi/prism/internal/db      1.145s

$ go test ./...
# All packages pass except the pre-existing failures called out in the
# spawn prompt (TestRunStartupStdio_HappyPath, TestRunStartupStdio_SilentExit,
# TestHostAPI_Review_CWDSetToWorktree on Darwin) — those are being fixed in
# a parallel PR and are not regressions from this change.
```

## `nix build .#prism`

The build runs go test inside the homeless-shelter sandbox per the AGENTS.md
gate. The Go compiler and the Go test phase complete; the only failures
observed are pre-existing timing flakes in `internal/sidecar/sidecar_socketpipe_test.go`
(`TestSocketPipe_*` tests that depend on `clk.LastTimer()` being populated
within a 50ms window after a `state_change{finished}` frame — racy under
nix-sandbox load). The failure set differs between consecutive builds of
the same derivation, which is the smoking gun of timing flakiness rather
than a determined-by-source-change failure.

These tests:

- live in `internal/sidecar/` (not touched by this PR)
- do not reference `GroupCompleted`, `terminalStates`, `isTerminalState`,
  or any of the changed APIs (verified via `grep -rn`)
- pass cleanly in `go test ./internal/sidecar/ -count=1` on the dev shell
  (~9.8s total)

The same tests fail (with a varying subset) on the same hardware regardless
of whether my changes are applied, which I confirmed by stashing the diff
and observing main-of-main also fails the same way under load. The
`fix-stdio-fk-and-darwin-cwd-tests` parallel branch (#1506, now merged as
`dd229d8a`) addresses one cluster of pre-existing sandbox-load flakes; this
socket-pipe cluster appears to be a separate issue out of scope for this PR.

I'll re-run `nix build .#prism` once and capture the output if/when one
attempt produces a clean pass.
