### PR TITLE
feat(prism): add --json to merges, sessions, audit, status, profile, archive

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -224,6 +224,8 @@ A queued PR moves through states keyed off GitHub's `mergeStateStatus`: `watchin
 | `prism merges list --all` | Include terminal-state history (last 7 days). |
 | `prism merges cancel <pr>` | Remove a `watching` entry from the queue. |
 
+Add `--json` to any `prism merges` / `prism merges list` invocation (including with `--failed`, `--abandoned`, or `--all`) to get a JSON array of merge-queue entries instead of the table — use this when scripting or polling.
+
 ### Notification contract
 
 When a queued PR reaches a terminal outcome, the watcher delivers a bus notification to the coordinator session. The text is:
@@ -305,15 +307,33 @@ prism cleanup --yes --session "nixos-config@update-plex"
 
 Only call this after you have confirmed the PR is merged. The `--yes` path always force-deletes the branch — it does not check whether the branch is reachable from main, because squash-merges produce a different SHA on main than the branch tip.
 
+## Querying prism state — prefer `--json` for scripting
+
+Every list-style and lookup-style prism subcommand supports a `--json` flag that emits a single JSON document to stdout — keys are snake_case, timestamps are RFC 3339, empty lists are `[]` (never null, never absent), and any informational/progress text routes to stderr. **When you need to parse prism output programmatically, always pass `--json`.** Screen-scraping tabular human-readable output is fragile and burns tokens.
+
+| Command | `--json` shape |
+|---|---|
+| `prism list-sessions --json` | array of session-status objects |
+| `prism sessions list --json` | array of session-incarnation objects |
+| `prism checkin <session> --json` | session + events object |
+| `prism stats --json` (and `prism stats <id> --json`) | rows mirroring the host-API |
+| `prism merges --json` (and `prism merges list --json`, `--failed --json`, `--abandoned --json`, `--all --json`) | array of merge-queue entries |
+| `prism audit --json` | object with `events` array, `truncated` bool, optional `hint` |
+| `prism status --json` | object keyed by state (`active`, `waiting`, `idle`, `finished`, `error`) with integer counts (mutually exclusive with `--tmux-format`) |
+| `prism profile list --json` | array of profile objects |
+| `prism profile show [name] --json` | single profile object describing the slot table |
+| `prism archive <session> --all --json` | array of archive-entry objects (instance_id, started_at, archive_path) |
+
 ## Checking in on a running session
 
 Use `prism list-sessions` to see all active agent sessions with their state and current task title:
 
 ```bash
-prism list-sessions
+prism list-sessions          # human-readable table
+prism list-sessions --json   # JSON array (use this when scripting)
 ```
 
-Use `prism checkin <session>` to read the recent conversation history for a session, sourced from the prism DB. The default output is a rich narrative view: assistant messages, state changes, and tool call one-liners interleaved chronologically.
+Use `prism checkin <session>` to read the recent conversation history for a session, sourced from the prism DB. The default output is a rich narrative view: assistant messages, state changes, and tool call one-liners interleaved chronologically. Pass `--json` when you need to parse the events programmatically.
 
 ```bash
 prism checkin nixos-config@update-plex
@@ -423,7 +443,8 @@ Use this decision tree when a session appears stuck, produces no output, or fail
 **Step 1 — Session state check:**
 
 ```bash
-prism list-sessions
+prism list-sessions          # human-readable table
+prism list-sessions --json   # parseable when scripting
 ```
 
 Examine the `state` column (`active`, `waiting`, `idle`, `finished`, `error`), the port, and the `last_seen` timestamp. If a session has a DB row but no live tmux session, it may be a zombie (DB row without a live process). Proceed to step 2.

--- a/modules/programs/prism/prism/cmd/archive.go
+++ b/modules/programs/prism/prism/cmd/archive.go
@@ -7,10 +7,13 @@ package cmd
 //	prism archive <instance-id>                  print archive_path and exit 0
 //	prism archive <session-name>                 print archive_path for most recent incarnation
 //	prism archive <session-name> --all           print one archive_path per line, newest first
+//	prism archive <session-name> --all --json    emit a JSON array of archive entries
 //	prism archive --instance <full-uuid>         force UUID lookup (disambiguate from session name)
 
 import (
+	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -41,12 +44,18 @@ Exits non-zero when the incarnation is unknown or archive_path IS NULL
 func init() {
 	archiveCmd.Flags().Bool("all", false, "Print archive_path for every incarnation of the session name, newest first")
 	archiveCmd.Flags().String("instance", "", "Force UUID instance_id lookup for this full UUID (alternative to positional arg)")
+	archiveCmd.Flags().Bool("json", false, "With --all, emit a JSON array of archive entries (instance_id, started_at, archive_path) instead of one path per line")
 	rootCmd.AddCommand(archiveCmd)
 }
 
 func runArchive(cmd *cobra.Command, args []string) error {
 	all, _ := cmd.Flags().GetBool("all")
 	instanceFlag, _ := cmd.Flags().GetString("instance")
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	if jsonMode && !all {
+		return fmt.Errorf("archive: --json is only supported together with --all")
+	}
 
 	d, err := openDB()
 	if err != nil {
@@ -69,12 +78,61 @@ func runArchive(cmd *cobra.Command, args []string) error {
 
 	// --all: iterate all incarnations of the session name.
 	if all {
+		if jsonMode {
+			return printArchivePathAllJSON(d, arg)
+		}
 		return printArchivePathAll(d, arg)
 	}
 
 	// Disambiguate: full UUID or session name.
 	forceInstance := len(arg) == 36
 	return printArchivePath(d, arg, forceInstance)
+}
+
+// archiveJSONRow is the snake_case JSON shape for one archive entry.
+// archive_path is null when the incarnation has not yet been archived.
+type archiveJSONRow struct {
+	InstanceID  string  `json:"instance_id"`
+	SessionName string  `json:"session_name"`
+	StartedAt   string  `json:"started_at"` // RFC3339
+	EndedAt     *string `json:"ended_at"`
+	ArchivePath *string `json:"archive_path"`
+}
+
+// printArchivePathAllJSON emits a JSON array of archive entries for every
+// incarnation of session_name = arg, ordered newest first. Unarchived rows
+// have archive_path: null. An empty result is `[]` (never null).
+func printArchivePathAllJSON(d *db.DB, sessionName string) error {
+	sessions, err := d.SessionsByName(sessionName)
+	if err != nil {
+		return fmt.Errorf("archive: %w", err)
+	}
+	if len(sessions) == 0 {
+		return fmt.Errorf("archive: no incarnations found for session %q", sessionName)
+	}
+
+	rows := make([]archiveJSONRow, 0, len(sessions))
+	for _, s := range sessions {
+		row := archiveJSONRow{
+			InstanceID:  s.InstanceID,
+			SessionName: s.SessionName,
+			StartedAt:   s.StartedAt.UTC().Format(time.RFC3339),
+		}
+		if s.EndedAt != nil {
+			endedStr := s.EndedAt.UTC().Format(time.RFC3339)
+			row.EndedAt = &endedStr
+		}
+		if s.ArchivePath != nil && *s.ArchivePath != "" {
+			row.ArchivePath = s.ArchivePath
+		}
+		rows = append(rows, row)
+	}
+
+	data, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("archive --json: marshal: %w", err)
+	}
+	return printJSON(data)
 }
 
 // printArchivePath resolves arg to a single sessions row and prints its archive_path.

--- a/modules/programs/prism/prism/cmd/archive_json_test.go
+++ b/modules/programs/prism/prism/cmd/archive_json_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+// Tests for --json flag on prism archive --all (#1499).
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestArchive_AllJSON_HappyPath verifies the JSON array shape with snake_case
+// keys, RFC3339 timestamps, and null archive_path for unarchived rows.
+func TestArchive_AllJSON_HappyPath(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second).UTC()
+
+	iidArchived := uuid.New().String()
+	iidUnarchived := uuid.New().String()
+	insertTestSession(t, d, iidArchived, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-2*time.Hour), base.Add(-1*time.Hour), "finished", "/archive/testrepo/1")
+	insertTestSession(t, d, iidUnarchived, "testrepo@main", "testrepo", "/code", "opencode",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	out := captureStdout(t, func() {
+		if err := printArchivePathAllJSON(d, "testrepo@main"); err != nil {
+			t.Fatalf("printArchivePathAllJSON: %v", err)
+		}
+	})
+
+	var rows []map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+		t.Fatalf("output is not a valid JSON array: %v\n%s", err, out)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Required snake_case keys on every row.
+	for i, row := range rows {
+		for _, k := range []string{"instance_id", "session_name", "started_at", "ended_at", "archive_path"} {
+			if _, ok := row[k]; !ok {
+				t.Errorf("row %d missing required snake_case key %q\n%s", i, k, out)
+			}
+		}
+	}
+
+	// SessionsByName orders newest-first; row 0 is the unarchived
+	// incarnation with archive_path: null.
+	if rows[0]["archive_path"] != nil {
+		t.Errorf("row 0 archive_path should be null (unarchived), got %v", rows[0]["archive_path"])
+	}
+	if rows[1]["archive_path"] != "/archive/testrepo/1" {
+		t.Errorf("row 1 archive_path: want '/archive/testrepo/1', got %v", rows[1]["archive_path"])
+	}
+
+	// started_at is RFC3339 (ends in Z).
+	if s, ok := rows[0]["started_at"].(string); !ok || !strings.HasSuffix(s, "Z") {
+		t.Errorf("started_at must be RFC3339 in UTC, got %v", rows[0]["started_at"])
+	}
+}
+
+// TestArchive_AllJSON_UnknownSession verifies that an unknown session name
+// returns a non-nil error (caller maps this to a non-zero exit + stderr msg).
+func TestArchive_AllJSON_UnknownSession(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	err := printArchivePathAllJSON(d, "no-such-session@nope")
+	if err == nil {
+		t.Fatal("expected error for unknown session, got nil")
+	}
+	if !strings.Contains(err.Error(), "no incarnations found") {
+		t.Errorf("expected 'no incarnations found' in error, got: %v", err)
+	}
+}
+
+// TestArchive_JSONWithoutAll_Errors verifies that --json without --all is
+// rejected (the AC scopes --json to the --all path).
+func TestArchive_JSONWithoutAll_Errors(t *testing.T) {
+	_ = openIncarnationTestDB(t)
+
+	archiveCmd.Flags().Set("json", "true")        //nolint:errcheck
+	defer archiveCmd.Flags().Set("json", "false") //nolint:errcheck
+	// --all defaults to false.
+
+	err := runArchive(archiveCmd, []string{"some-session"})
+	if err == nil {
+		t.Fatal("expected error for --json without --all, got nil")
+	}
+	if !strings.Contains(err.Error(), "--json is only supported together with --all") {
+		t.Errorf("expected explanatory error, got: %v", err)
+	}
+}

--- a/modules/programs/prism/prism/cmd/audit.go
+++ b/modules/programs/prism/prism/cmd/audit.go
@@ -46,13 +46,21 @@ func init() {
 	auditCmd.Flags().Int("days", 0, "Restrict to events from the last N days")
 	auditCmd.Flags().String("pattern", "", "Filter by command substring (case-insensitive)")
 	auditCmd.Flags().Int("limit", 0, "Maximum number of events to return (default 20 when no session filter)")
+	auditCmd.Flags().Bool("json", false, "Emit a JSON object with an events array (and a truncated bool with hint when applicable) to stdout instead of the human-readable table")
 	rootCmd.AddCommand(auditCmd)
 }
+
+// auditDefaultLimit mirrors the implicit default applied by
+// db.QueryAuditEvents when limit == 0 and no session filter is set. We
+// duplicate the value here so --json can know whether the result is
+// likely truncated (i.e. the implicit cap was hit).
+const auditDefaultLimit = 20
 
 func runAudit(cmd *cobra.Command, args []string) error {
 	days, _ := cmd.Flags().GetInt("days")
 	pattern, _ := cmd.Flags().GetString("pattern")
 	limit, _ := cmd.Flags().GetInt("limit")
+	jsonMode, _ := cmd.Flags().GetBool("json")
 
 	sessionName := ""
 	if len(args) == 1 {
@@ -75,6 +83,10 @@ func runAudit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("audit: %w", err)
 	}
 
+	if jsonMode {
+		return renderAuditEventsJSON(events, sessionName, sinceMs, pattern, limit)
+	}
+
 	if len(events) == 0 {
 		if sessionName != "" {
 			fmt.Printf("no audit events found for session %q\n", sessionName)
@@ -89,6 +101,74 @@ func runAudit(cmd *cobra.Command, args []string) error {
 
 	renderAuditEvents(events)
 	return nil
+}
+
+// auditEventJSON is the snake_case JSON shape for a single audit event.
+type auditEventJSON struct {
+	ID          string  `json:"id"`
+	SessionName string  `json:"session_name"`
+	InstanceID  *string `json:"instance_id"`
+	Command     string  `json:"command"`
+	Timestamp   string  `json:"timestamp"` // RFC3339
+	Payload     any     `json:"payload"`
+}
+
+// renderAuditEventsJSON marshals the audit events as a JSON object containing
+// an `events` array and a `truncated` bool (with `hint` when truncated).
+func renderAuditEventsJSON(events []db.Event, sessionName string, sinceMs int64, pattern string, limit int) error {
+	out := make([]auditEventJSON, 0, len(events))
+	for _, e := range events {
+		var p payload.Audit
+		command := ""
+		var payloadAny any = nil
+		if err := json.Unmarshal([]byte(e.Payload), &p); err == nil {
+			command = p.Command
+			// Keep the raw payload available so consumers that need
+			// additional context (cwd, exit_code, etc.) can read it.
+			var generic any
+			if err := json.Unmarshal([]byte(e.Payload), &generic); err == nil {
+				payloadAny = generic
+			}
+		}
+		row := auditEventJSON{
+			ID:          e.ID,
+			SessionName: e.SessionName,
+			InstanceID:  e.InstanceID,
+			Command:     command,
+			Timestamp:   e.CreatedAt.UTC().Format(time.RFC3339),
+			Payload:     payloadAny,
+		}
+		out = append(out, row)
+	}
+
+	// Truncation heuristic: we hit the cap when the result count equals the
+	// effective limit. The DB layer applies an implicit default cap of 20
+	// when limit == 0 and no session filter is set.
+	effectiveLimit := limit
+	if effectiveLimit == 0 && sessionName == "" {
+		effectiveLimit = auditDefaultLimit
+	}
+	truncated := effectiveLimit > 0 && len(events) >= effectiveLimit
+
+	resp := struct {
+		Events    []auditEventJSON `json:"events"`
+		Truncated bool             `json:"truncated"`
+		Hint      *string          `json:"hint"`
+	}{
+		Events:    out,
+		Truncated: truncated,
+		Hint:      nil,
+	}
+	if truncated {
+		hint := "results capped — pass --limit=N to raise, or refine with --pattern, --days, or a session argument"
+		resp.Hint = &hint
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("audit --json: marshal: %w", err)
+	}
+	return printJSON(data)
 }
 
 func renderAuditEvents(events []db.Event) {

--- a/modules/programs/prism/prism/cmd/audit_json_test.go
+++ b/modules/programs/prism/prism/cmd/audit_json_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+// Tests for --json flag on prism audit (#1499).
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestRenderAuditEventsJSON_EmptyEnvelope verifies that an empty result still
+// renders the {events: [], truncated: false, hint: null} envelope, never
+// null and never absent.
+func TestRenderAuditEventsJSON_EmptyEnvelope(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := renderAuditEventsJSON(nil, "", 0, "", 0); err != nil {
+			t.Fatalf("renderAuditEventsJSON: %v", err)
+		}
+	})
+
+	var resp struct {
+		Events    []map[string]interface{} `json:"events"`
+		Truncated bool                     `json:"truncated"`
+		Hint      *string                  `json:"hint"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if resp.Events == nil {
+		t.Errorf("events must be an array, not null")
+	}
+	if len(resp.Events) != 0 {
+		t.Errorf("expected empty events array, got %d entries", len(resp.Events))
+	}
+	if resp.Truncated {
+		t.Errorf("expected truncated=false, got true")
+	}
+	if resp.Hint != nil {
+		t.Errorf("expected hint=null when not truncated, got %q", *resp.Hint)
+	}
+}
+
+// TestRenderAuditEventsJSON_HappyPath verifies snake_case keys, RFC3339
+// timestamps, and that command/payload are extracted correctly.
+func TestRenderAuditEventsJSON_HappyPath(t *testing.T) {
+	created := time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC)
+	iid := "instance-1"
+	events := []db.Event{
+		{
+			ID:          "event-1",
+			SessionName: "nixos-config@main",
+			Repo:        "nixos-config",
+			Worktree:    "/code/nixos-config/main",
+			InstanceID:  &iid,
+			Type:        "audit",
+			Payload:     `{"command":"gh pr merge 1484 --squash","sessionName":"nixos-config@main","cwd":"/tmp"}`,
+			CreatedAt:   created,
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderAuditEventsJSON(events, "", 0, "", 0); err != nil {
+			t.Fatalf("renderAuditEventsJSON: %v", err)
+		}
+	})
+
+	var resp struct {
+		Events    []map[string]interface{} `json:"events"`
+		Truncated bool                     `json:"truncated"`
+		Hint      *string                  `json:"hint"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(resp.Events))
+	}
+
+	ev := resp.Events[0]
+	for _, k := range []string{"id", "session_name", "instance_id", "command", "timestamp", "payload"} {
+		if _, ok := ev[k]; !ok {
+			t.Errorf("missing required snake_case key %q in %s", k, out)
+		}
+	}
+	if ev["command"] != "gh pr merge 1484 --squash" {
+		t.Errorf("command: got %v, want 'gh pr merge 1484 --squash'", ev["command"])
+	}
+	if ev["timestamp"] != "2026-04-01T12:30:00Z" {
+		t.Errorf("timestamp: got %v, want '2026-04-01T12:30:00Z'", ev["timestamp"])
+	}
+	if ev["instance_id"] != "instance-1" {
+		t.Errorf("instance_id: got %v, want 'instance-1'", ev["instance_id"])
+	}
+}
+
+// TestRenderAuditEventsJSON_TruncatedSetsHint verifies that when the result
+// count equals the implicit default cap, truncated=true and hint is set.
+func TestRenderAuditEventsJSON_TruncatedSetsHint(t *testing.T) {
+	// Build exactly auditDefaultLimit events; with no session filter and
+	// limit=0, the default cap is hit so truncated should be true.
+	created := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	events := make([]db.Event, auditDefaultLimit)
+	for i := 0; i < auditDefaultLimit; i++ {
+		events[i] = db.Event{
+			ID:          "id",
+			SessionName: "s",
+			Type:        "audit",
+			Payload:     `{"command":"git push"}`,
+			CreatedAt:   created,
+		}
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderAuditEventsJSON(events, "", 0, "", 0); err != nil {
+			t.Fatalf("renderAuditEventsJSON: %v", err)
+		}
+	})
+
+	var resp struct {
+		Events    []map[string]interface{} `json:"events"`
+		Truncated bool                     `json:"truncated"`
+		Hint      *string                  `json:"hint"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Truncated {
+		t.Errorf("expected truncated=true at default cap, got false")
+	}
+	if resp.Hint == nil || *resp.Hint == "" {
+		t.Errorf("expected hint to be set when truncated=true, got nil/empty")
+	}
+}
+
+// TestRenderAuditEventsJSON_NotTruncatedWithSession verifies that with a
+// session filter, the implicit cap does not apply, so truncated stays false
+// even when len(events) == 20.
+func TestRenderAuditEventsJSON_NotTruncatedWithSession(t *testing.T) {
+	created := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	events := make([]db.Event, auditDefaultLimit)
+	for i := 0; i < auditDefaultLimit; i++ {
+		events[i] = db.Event{ID: "id", SessionName: "s", Type: "audit", Payload: `{"command":"git push"}`, CreatedAt: created}
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderAuditEventsJSON(events, "nixos-config@main", 0, "", 0); err != nil {
+			t.Fatalf("renderAuditEventsJSON: %v", err)
+		}
+	})
+
+	var resp struct {
+		Truncated bool    `json:"truncated"`
+		Hint      *string `json:"hint"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if resp.Truncated {
+		t.Errorf("expected truncated=false with session filter (no implicit cap), got true")
+	}
+}

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -12,6 +12,7 @@ package cmd
 //	prism merges cancel <pr>             cancel a watching entry
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -61,12 +62,14 @@ func init() {
 	mergesListCmd.Flags().Bool("failed", false, "Show failed entries")
 	mergesListCmd.Flags().Bool("abandoned", false, "Show abandoned entries from previous coordinator incarnations")
 	mergesListCmd.Flags().Bool("all", false, "Show all non-abandoned entries from the last 7 days")
+	mergesListCmd.Flags().Bool("json", false, "Emit a JSON array of merge-queue entries to stdout instead of the human-readable table")
 
 	// Also add the filter flags to the root mergesCmd so `prism merges --failed`
 	// works as a shorthand for `prism merges list --failed`.
 	mergesCmd.Flags().Bool("failed", false, "Show failed entries")
 	mergesCmd.Flags().Bool("abandoned", false, "Show abandoned entries from previous coordinator incarnations")
 	mergesCmd.Flags().Bool("all", false, "Show all non-abandoned entries from the last 7 days")
+	mergesCmd.Flags().Bool("json", false, "Emit a JSON array of merge-queue entries to stdout instead of the human-readable table")
 
 	mergesCmd.AddCommand(mergesListCmd)
 	mergesCmd.AddCommand(mergesCancelCmd)
@@ -77,6 +80,7 @@ func runMergesList(cmd *cobra.Command, _ []string) error {
 	failed, _ := cmd.Flags().GetBool("failed")
 	abandoned, _ := cmd.Flags().GetBool("abandoned")
 	all, _ := cmd.Flags().GetBool("all")
+	jsonMode, _ := cmd.Flags().GetBool("json")
 
 	filter := ""
 	switch {
@@ -104,6 +108,9 @@ func runMergesList(cmd *cobra.Command, _ []string) error {
 		if proxyErr := proxyGetFromHostAPI(apiURL, "/merges", params, &merges); proxyErr != nil {
 			return fmt.Errorf("prism merges list: %w", proxyErr)
 		}
+		if jsonMode {
+			return renderMergesListJSON(merges)
+		}
 		return renderMergesList(merges, filter)
 	}
 
@@ -125,7 +132,63 @@ func runMergesList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("prism merges list: %w", err)
 	}
 
+	if jsonMode {
+		return renderMergesListJSON(merges)
+	}
 	return renderMergesList(merges, filter)
+}
+
+// mergeJSONRow is the snake_case JSON shape for a single merge-queue entry.
+// Defined explicitly so the JSON contract is decoupled from db.PendingMerge
+// (which has no struct tags). RFC3339 timestamps; null for absent fields.
+type mergeJSONRow struct {
+	QueuePosition      int64   `json:"queue_position"`
+	PR                 int     `json:"pr"`
+	Title              *string `json:"title"`
+	Status             string  `json:"status"`
+	Error              *string `json:"error"`
+	EnqueuedAt         string  `json:"enqueued_at"`
+	LastCheckedAt      *string `json:"last_checked_at"`
+	MergedAt           *string `json:"merged_at"`
+	EndedAt            *string `json:"ended_at"`
+	CoordinatorSession string  `json:"coordinator_session"`
+	InstanceID         string  `json:"instance_id"`
+}
+
+// renderMergesListJSON marshals merges to a JSON array (snake_case keys,
+// RFC3339 timestamps) and writes it to stdout. An empty list renders as `[]`.
+func renderMergesListJSON(merges []db.PendingMerge) error {
+	rows := make([]mergeJSONRow, 0, len(merges))
+	for _, m := range merges {
+		row := mergeJSONRow{
+			QueuePosition:      m.QueuePosition,
+			PR:                 m.PR,
+			Title:              m.Title,
+			Status:             m.Status,
+			Error:              m.Error,
+			EnqueuedAt:         m.QueuedAt.UTC().Format(time.RFC3339),
+			CoordinatorSession: m.SessionName,
+			InstanceID:         m.InstanceID,
+		}
+		if m.LastCheckedAt != nil {
+			s := m.LastCheckedAt.UTC().Format(time.RFC3339)
+			row.LastCheckedAt = &s
+		}
+		if m.MergedAt != nil {
+			s := m.MergedAt.UTC().Format(time.RFC3339)
+			row.MergedAt = &s
+		}
+		if m.EndedAt != nil {
+			s := m.EndedAt.UTC().Format(time.RFC3339)
+			row.EndedAt = &s
+		}
+		rows = append(rows, row)
+	}
+	data, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("prism merges list --json: marshal: %w", err)
+	}
+	return printJSON(data)
 }
 
 func runMergesCancel(cmd *cobra.Command, args []string) error {

--- a/modules/programs/prism/prism/cmd/merges_json_test.go
+++ b/modules/programs/prism/prism/cmd/merges_json_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+// Tests for --json flag on prism merges (#1499).
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestRenderMergesListJSON_EmptyArray verifies that an empty merge queue
+// renders as a bare JSON array "[]" (never null, never absent — AC #1499).
+func TestRenderMergesListJSON_EmptyArray(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := renderMergesListJSON(nil); err != nil {
+			t.Fatalf("renderMergesListJSON: %v", err)
+		}
+	})
+
+	trimmed := strings.TrimSpace(out)
+	if trimmed != "[]" {
+		t.Errorf("expected empty JSON array '[]' for empty merges list, got %q", trimmed)
+	}
+}
+
+// TestRenderMergesListJSON_SnakeCaseKeysAndRFC3339 verifies the JSON shape:
+// snake_case keys, RFC3339 timestamps, optional fields rendered as null
+// (not absent) per the issue conventions.
+func TestRenderMergesListJSON_SnakeCaseKeysAndRFC3339(t *testing.T) {
+	queuedAt := time.Date(2026, 5, 8, 7, 18, 33, 0, time.UTC)
+	title := "feat: foo"
+	merges := []db.PendingMerge{
+		{
+			PR:                 1484,
+			SessionName:        "nixos-config@main",
+			InstanceID:         "abc-123",
+			QueuePosition:      1778224434415,
+			Status:             "watching",
+			Title:              &title,
+			QueuedAt:           queuedAt,
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := renderMergesListJSON(merges); err != nil {
+			t.Fatalf("renderMergesListJSON: %v", err)
+		}
+	})
+
+	var rows []map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+		t.Fatalf("output is not a valid JSON array: %v\noutput: %s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+
+	row := rows[0]
+
+	// Required snake_case keys.
+	for _, k := range []string{"queue_position", "pr", "title", "status", "error", "enqueued_at", "last_checked_at", "merged_at", "ended_at", "coordinator_session", "instance_id"} {
+		if _, ok := row[k]; !ok {
+			t.Errorf("missing required snake_case key %q in %s", k, out)
+		}
+	}
+
+	// RFC3339 timestamp.
+	if got := row["enqueued_at"]; got != "2026-05-08T07:18:33Z" {
+		t.Errorf("enqueued_at: want 2026-05-08T07:18:33Z, got %v", got)
+	}
+
+	// Coordinator session and instance_id propagated.
+	if got := row["coordinator_session"]; got != "nixos-config@main" {
+		t.Errorf("coordinator_session: want nixos-config@main, got %v", got)
+	}
+	if got := row["instance_id"]; got != "abc-123" {
+		t.Errorf("instance_id: want abc-123, got %v", got)
+	}
+
+	// Optional fields not set on the input row are null, not absent.
+	for _, k := range []string{"error", "last_checked_at", "merged_at", "ended_at"} {
+		v, ok := row[k]
+		if !ok {
+			t.Errorf("optional key %q must be present (as null), not absent", k)
+		}
+		if v != nil {
+			t.Errorf("optional key %q must be null when unset, got %v", k, v)
+		}
+	}
+
+	// pr is a number, not a string.
+	if pr, ok := row["pr"].(float64); !ok || int(pr) != 1484 {
+		t.Errorf("pr must be a JSON number with value 1484, got %v", row["pr"])
+	}
+}

--- a/modules/programs/prism/prism/cmd/merges_json_test.go
+++ b/modules/programs/prism/prism/cmd/merges_json_test.go
@@ -34,13 +34,13 @@ func TestRenderMergesListJSON_SnakeCaseKeysAndRFC3339(t *testing.T) {
 	title := "feat: foo"
 	merges := []db.PendingMerge{
 		{
-			PR:                 1484,
-			SessionName:        "nixos-config@main",
-			InstanceID:         "abc-123",
-			QueuePosition:      1778224434415,
-			Status:             "watching",
-			Title:              &title,
-			QueuedAt:           queuedAt,
+			PR:            1484,
+			SessionName:   "nixos-config@main",
+			InstanceID:    "abc-123",
+			QueuePosition: 1778224434415,
+			Status:        "watching",
+			Title:         &title,
+			QueuedAt:      queuedAt,
 		},
 	}
 

--- a/modules/programs/prism/prism/cmd/profile.go
+++ b/modules/programs/prism/prism/cmd/profile.go
@@ -290,11 +290,11 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 
 // profileSlotJSON is the snake_case JSON shape for a single role slot.
 type profileSlotJSON struct {
-	Provider           string `json:"provider"`
-	Model              string `json:"model"`
-	Thinking           string `json:"thinking"`
-	Harness            string `json:"harness"`
-	SystemPromptPath   string `json:"system_prompt_path"`
+	Provider         string `json:"provider"`
+	Model            string `json:"model"`
+	Thinking         string `json:"thinking"`
+	Harness          string `json:"harness"`
+	SystemPromptPath string `json:"system_prompt_path"`
 }
 
 // profileJSON is the snake_case JSON shape for a single profile entry. The

--- a/modules/programs/prism/prism/cmd/profile.go
+++ b/modules/programs/prism/prism/cmd/profile.go
@@ -27,14 +27,15 @@ package cmd
 //   prism profile list         Print every profile defined in profiles.json,
 //                              one per line, with the active profile marked
 //                              by a leading "*".
+//                              Use --json to emit a JSON array of profile
+//                              objects (snake_case keys).
 //
 //   prism profile show [name]  Print the per-role slot table for the named
 //                              profile, defaulting to the active profile.
 //                              Output is plain TSV-friendly text: one row per
 //                              role, columns role | provider | model |
-//                              thinking. The intent is human-readable
-//                              diagnosis, not machine consumption — there
-//                              is no JSON output flag in this issue.
+//                              thinking. Use --json to emit a single JSON
+//                              object describing the profile's slot table.
 //
 // Resolution order for "the active profile" (mirrors spawn.go):
 //   1. Runtime state file at $XDG_STATE_HOME/prism/active-profile
@@ -42,6 +43,7 @@ package cmd
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -105,6 +107,9 @@ func init() {
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileShowCmd)
 	rootCmd.AddCommand(profileCmd)
+
+	profileListCmd.Flags().Bool("json", false, "Emit a JSON array of profile objects to stdout instead of the human-readable list")
+	profileShowCmd.Flags().Bool("json", false, "Emit a JSON object describing the profile's slot table to stdout instead of the human-readable view")
 
 	profileUseCmd.Flags().StringVar(&profileUseFlags.scope, "scope", "",
 		`Live-session swap scope: session=<name>, coordinator, global, or all.
@@ -283,8 +288,47 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// profileSlotJSON is the snake_case JSON shape for a single role slot.
+type profileSlotJSON struct {
+	Provider           string `json:"provider"`
+	Model              string `json:"model"`
+	Thinking           string `json:"thinking"`
+	Harness            string `json:"harness"`
+	SystemPromptPath   string `json:"system_prompt_path"`
+}
+
+// profileJSON is the snake_case JSON shape for a single profile entry. The
+// `slots` map is keyed by role name ("coordinator", "worker", "plan", ...).
+type profileJSON struct {
+	Name   string                     `json:"name"`
+	Active bool                       `json:"active"`
+	Slots  map[string]profileSlotJSON `json:"slots"`
+}
+
+// buildProfileJSON converts a config.ProfileEntry to the snake_case JSON
+// shape, with `active` set when the profile is the resolved active one.
+func buildProfileJSON(name string, entry config.ProfileEntry, active string) profileJSON {
+	slots := make(map[string]profileSlotJSON, len(entry))
+	for role, slot := range entry {
+		slots[role] = profileSlotJSON{
+			Provider:         slot.Provider,
+			Model:            slot.Model,
+			Thinking:         slot.Thinking,
+			Harness:          slot.Harness,
+			SystemPromptPath: slot.SystemPromptPath,
+		}
+	}
+	return profileJSON{
+		Name:   name,
+		Active: name == active && active != "",
+		Slots:  slots,
+	}
+}
+
 func runProfileList(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+
+	jsonMode, _ := cmd.Flags().GetBool("json")
 
 	pf, err := config.LoadProfiles()
 	if err != nil {
@@ -302,6 +346,18 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", resolveErr)
 	}
 
+	if jsonMode {
+		rows := make([]profileJSON, 0, len(pf.Profiles))
+		for _, name := range config.AvailableProfileNames(pf) {
+			rows = append(rows, buildProfileJSON(name, pf.Profiles[name], active))
+		}
+		data, mErr := json.Marshal(rows)
+		if mErr != nil {
+			return fmt.Errorf("prism profile list --json: marshal: %w", mErr)
+		}
+		return printJSON(data)
+	}
+
 	w := cmd.OutOrStdout()
 	for _, name := range config.AvailableProfileNames(pf) {
 		marker := "  "
@@ -315,6 +371,8 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 
 func runProfileShow(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+
+	jsonMode, _ := cmd.Flags().GetBool("json")
 
 	pf, err := config.LoadProfiles()
 	if err != nil {
@@ -339,6 +397,16 @@ func runProfileShow(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("unknown profile %q — available: %s",
 			name, strings.Join(config.AvailableProfileNames(pf), ", "))
+	}
+
+	if jsonMode {
+		active, _, _ := config.ResolveActiveProfile(pf, "")
+		obj := buildProfileJSON(name, entry, active)
+		data, mErr := json.Marshal(obj)
+		if mErr != nil {
+			return fmt.Errorf("prism profile show --json: marshal: %w", mErr)
+		}
+		return printJSON(data)
 	}
 
 	// Sort roles for stable output.

--- a/modules/programs/prism/prism/cmd/profile_json_test.go
+++ b/modules/programs/prism/prism/cmd/profile_json_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+// Tests for --json flag on prism profile list / show (#1499).
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// TestBuildProfileJSON_SnakeCaseAndActiveFlag verifies the JSON shape of a
+// single profile object.
+func TestBuildProfileJSON_SnakeCaseAndActiveFlag(t *testing.T) {
+	entry := config.ProfileEntry{
+		"coordinator": config.RoleSlot{
+			Provider: "anthropic",
+			Model:    "anthropic/claude-sonnet-4-6",
+			Thinking: "high",
+			Harness:  "opencode",
+		},
+		"worker": config.RoleSlot{
+			Model: "anthropic/claude-sonnet-4-6",
+		},
+	}
+
+	row := buildProfileJSON("anthropic", entry, "anthropic")
+
+	data, err := json.Marshal(row)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, k := range []string{"name", "active", "slots"} {
+		if _, ok := obj[k]; !ok {
+			t.Errorf("missing required snake_case key %q", k)
+		}
+	}
+	if obj["name"] != "anthropic" {
+		t.Errorf("name: want 'anthropic', got %v", obj["name"])
+	}
+	if obj["active"] != true {
+		t.Errorf("active: want true, got %v", obj["active"])
+	}
+
+	slots, ok := obj["slots"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("slots must be an object, got %T", obj["slots"])
+	}
+	if _, ok := slots["coordinator"]; !ok {
+		t.Errorf("missing coordinator role in slots: %v", slots)
+	}
+
+	coord := slots["coordinator"].(map[string]interface{})
+	for _, k := range []string{"provider", "model", "thinking", "harness", "system_prompt_path"} {
+		if _, ok := coord[k]; !ok {
+			t.Errorf("slots.coordinator missing snake_case key %q", k)
+		}
+	}
+	// Reject camelCase leftovers.
+	for _, badK := range []string{"systemPromptPath"} {
+		if _, ok := coord[badK]; ok {
+			t.Errorf("slots.coordinator must not have camelCase key %q", badK)
+		}
+	}
+}
+
+// TestBuildProfileJSON_NotActive verifies that active=false when the profile
+// is not the resolved active profile.
+func TestBuildProfileJSON_NotActive(t *testing.T) {
+	entry := config.ProfileEntry{}
+	row := buildProfileJSON("other", entry, "anthropic")
+	if row.Active {
+		t.Errorf("active: want false for non-active profile, got true")
+	}
+}
+
+// TestRenderProfileListJSON_EmptyArrayWhenNoProfiles is a sanity check on
+// the JSON shape when no profiles are configured (encoded by buildProfileJSON
+// over an empty slice). The empty case is not exercised through the CLI
+// because profiles.json must declare at least one profile, but the JSON
+// renderer must still produce `[]`.
+func TestRenderProfileListJSON_EmptyArray(t *testing.T) {
+	rows := make([]profileJSON, 0)
+	data, err := json.Marshal(rows)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "[]" {
+		t.Errorf("expected '[]' for empty profile list, got %q", string(data))
+	}
+}

--- a/modules/programs/prism/prism/cmd/sessions.go
+++ b/modules/programs/prism/prism/cmd/sessions.go
@@ -7,7 +7,7 @@ package cmd
 //	prism sessions list                  tabular listing of all sessions rows
 //	prism sessions list --repo <name>    filter by repo
 //	prism sessions list --since <date>   filter by started_at
-//	prism sessions list --json           emit one JSON object per line (JSONL)
+//	prism sessions list --json           emit a JSON array of session-incarnation objects (snake_case keys, RFC3339 timestamps)
 
 import (
 	"encoding/json"
@@ -33,7 +33,8 @@ var sessionsListCmd = &cobra.Command{
 	Long: `List all rows in the sessions table as a tabular display.
 
 Use --repo to filter by repo name, --since to filter by start date, and
---json to emit one JSON object per line (JSONL) for scripting.`,
+--json to emit a JSON array of session-incarnation objects with snake_case
+keys and RFC3339 timestamps.`,
 	Args: cobra.NoArgs,
 	RunE: runSessionsList,
 }
@@ -41,27 +42,29 @@ Use --repo to filter by repo name, --since to filter by start date, and
 func init() {
 	sessionsListCmd.Flags().String("repo", "", "Filter by repo name")
 	sessionsListCmd.Flags().String("since", "", "Filter by started_at >= date (ISO 8601 or YYYY-MM-DD)")
-	sessionsListCmd.Flags().Bool("json", false, "Emit one JSON object per line (JSONL)")
+	sessionsListCmd.Flags().Bool("json", false, "Emit a JSON array of session-incarnation objects to stdout (snake_case keys, RFC3339 timestamps)")
 	sessionsCmd.AddCommand(sessionsListCmd)
 	rootCmd.AddCommand(sessionsCmd)
 }
 
-// sessionJSONRow is the JSONL schema for one sessions row.
+// sessionJSONRow is the snake_case JSON schema for a single sessions row.
+// Null is preferred over omitting optional keys so consumers see a stable
+// key set across rows.
 type sessionJSONRow struct {
-	InstanceID       string  `json:"instanceId"`
-	SessionName      string  `json:"sessionName"`
-	AgentRole        *string `json:"agentRole"`
-	RootAgentName    *string `json:"rootAgentName"`
+	InstanceID       string  `json:"instance_id"`
+	SessionName      string  `json:"session_name"`
+	AgentRole        *string `json:"agent_role"`
+	RootAgentName    *string `json:"root_agent_name"`
 	Repo             string  `json:"repo"`
 	Worktree         string  `json:"worktree"`
 	Harness          string  `json:"harness"`
-	HarnessSessionID *string `json:"harnessSessionId,omitempty"`
-	GroupID          *string `json:"groupId,omitempty"`
-	StartedAt        string  `json:"startedAt"` // RFC3339
-	EndedAt          *string `json:"endedAt,omitempty"`
-	EndState         *string `json:"endState,omitempty"`
-	ArchivePath      *string `json:"archivePath,omitempty"`
-	PrismVersion     *string `json:"prismVersion,omitempty"`
+	HarnessSessionID *string `json:"harness_session_id"`
+	GroupID          *string `json:"group_id"`
+	StartedAt        string  `json:"started_at"` // RFC3339
+	EndedAt          *string `json:"ended_at"`
+	EndState         *string `json:"end_state"`
+	ArchivePath      *string `json:"archive_path"`
+	PrismVersion     *string `json:"prism_version"`
 }
 
 func runSessionsList(cmd *cobra.Command, _ []string) error {
@@ -103,6 +106,7 @@ func runSessionsList(cmd *cobra.Command, _ []string) error {
 }
 
 func renderSessionsListJSON(sessions []db.Session) error {
+	rows := make([]sessionJSONRow, 0, len(sessions))
 	for _, s := range sessions {
 		row := sessionJSONRow{
 			InstanceID:       s.InstanceID,
@@ -123,13 +127,13 @@ func renderSessionsListJSON(sessions []db.Session) error {
 			endedStr := s.EndedAt.UTC().Format(time.RFC3339)
 			row.EndedAt = &endedStr
 		}
-		b, err := json.Marshal(row)
-		if err != nil {
-			return fmt.Errorf("sessions list: marshal: %w", err)
-		}
-		fmt.Println(string(b))
+		rows = append(rows, row)
 	}
-	return nil
+	data, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("sessions list: marshal: %w", err)
+	}
+	return printJSON(data)
 }
 
 func renderSessionsListTable(sessions []db.Session) error {

--- a/modules/programs/prism/prism/cmd/sessions_test.go
+++ b/modules/programs/prism/prism/cmd/sessions_test.go
@@ -129,7 +129,8 @@ func TestRunSessionsList_SinceFilter(t *testing.T) {
 	}
 }
 
-// TestRunSessionsList_JSONOutput verifies that --json emits valid JSONL.
+// TestRunSessionsList_JSONOutput verifies that --json emits a JSON array of
+// session-incarnation objects with snake_case keys (issue #1499).
 func TestRunSessionsList_JSONOutput(t *testing.T) {
 	d := openIncarnationTestDB(t)
 	base := time.Now().Truncate(time.Second)
@@ -152,30 +153,33 @@ func TestRunSessionsList_JSONOutput(t *testing.T) {
 		}
 	})
 
-	// Every line must be independently parseable as a JSON object.
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) != 2 {
-		t.Errorf("expected 2 JSONL lines, got %d\n%s", len(lines), out)
+	var rows []map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+		t.Fatalf("--json output is not a valid JSON array: %v\noutput: %s", err, out)
 	}
-	for i, line := range lines {
-		if line == "" {
-			continue
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows in JSON array, got %d\n%s", len(rows), out)
+	}
+	// Required snake_case fields must be present on every row (null is OK
+	// for optional fields, but the keys themselves must be there).
+	for i, row := range rows {
+		for _, field := range []string{"instance_id", "session_name", "repo", "harness", "started_at", "ended_at", "end_state", "archive_path", "agent_role", "root_agent_name", "harness_session_id", "group_id", "prism_version"} {
+			if _, ok := row[field]; !ok {
+				t.Errorf("row %d missing required snake_case JSON field %q\n%s", i, field, out)
+			}
 		}
-		var obj map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &obj); err != nil {
-			t.Errorf("line %d is not valid JSON: %v\nline: %s", i, err, line)
-		}
-		// Required fields must be present.
-		for _, field := range []string{"instanceId", "sessionName", "repo", "harness", "startedAt"} {
-			if _, ok := obj[field]; !ok {
-				t.Errorf("line %d missing required JSON field %q\n%s", i, field, line)
+		// Reject any leftover camelCase keys.
+		for _, badField := range []string{"instanceId", "sessionName", "startedAt", "endedAt", "endState", "archivePath", "agentRole", "rootAgentName", "harnessSessionId", "groupId", "prismVersion"} {
+			if _, ok := row[badField]; ok {
+				t.Errorf("row %d has unexpected camelCase JSON field %q (must be snake_case)\n%s", i, badField, out)
 			}
 		}
 	}
 }
 
 // TestRunSessionsList_JSONOutput_Empty verifies that --json with no sessions
-// produces no output (empty JSONL is valid).
+// emits an empty JSON array "[]", never null and never absent (AC: empty
+// list is `[]`).
 func TestRunSessionsList_JSONOutput_Empty(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := renderSessionsListJSON(nil); err != nil {
@@ -183,9 +187,9 @@ func TestRunSessionsList_JSONOutput_Empty(t *testing.T) {
 		}
 	})
 
-	// Should produce no output (valid empty JSONL).
-	if strings.TrimSpace(out) != "" {
-		t.Errorf("expected empty output for empty sessions list, got: %q", out)
+	trimmed := strings.TrimSpace(out)
+	if trimmed != "[]" {
+		t.Errorf("expected empty JSON array '[]' for empty sessions list, got: %q", trimmed)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/status.go
+++ b/modules/programs/prism/prism/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -15,16 +16,28 @@ var statusCmd = &cobra.Command{
 	Long: `Print counts of agent sessions by state.
 
 Without flags, prints a human-readable summary of all states.
-Use --waiting to restrict output to the waiting count, and
+Use --waiting to restrict output to the waiting count,
 --tmux-format to emit a tmux-style colour-formatted string
-suitable for embedding in status-right.`,
+suitable for embedding in status-right, or --json to emit a
+JSON object keyed by state with integer counts.
+
+--json and --tmux-format are mutually exclusive.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		waitingOnly, _ := cmd.Flags().GetBool("waiting")
 		tmuxFormat, _ := cmd.Flags().GetBool("tmux-format")
+		jsonMode, _ := cmd.Flags().GetBool("json")
+
+		if jsonMode && tmuxFormat {
+			return fmt.Errorf("prism status: --json and --tmux-format are mutually exclusive")
+		}
 
 		d, err := openDB()
 		if err != nil {
 			// Silently produce no output — status bar should not show errors.
+			// Exception: --json must always emit a parseable document.
+			if jsonMode {
+				return renderStatusJSON(0, 0, 0, 0, 0)
+			}
 			return nil
 		}
 		defer d.Close()
@@ -32,10 +45,13 @@ suitable for embedding in status-right.`,
 		statuses, err := d.AllActiveStatus()
 		if err != nil {
 			// Silently produce no output — status bar should not show errors.
+			if jsonMode {
+				return renderStatusJSON(0, 0, 0, 0, 0)
+			}
 			return nil
 		}
 
-		var nActive, nWaiting, nFinished, nIdle int
+		var nActive, nWaiting, nFinished, nIdle, nError int
 		for _, s := range statuses {
 			switch agent.AgentState(s.State) {
 			case agent.StateActive:
@@ -44,9 +60,15 @@ suitable for embedding in status-right.`,
 				nWaiting++
 			case agent.StateFinished:
 				nFinished++
+			case agent.StateError:
+				nError++
 			default:
 				nIdle++
 			}
+		}
+
+		if jsonMode {
+			return renderStatusJSON(nActive, nWaiting, nIdle, nFinished, nError)
 		}
 
 		if waitingOnly {
@@ -99,5 +121,23 @@ suitable for embedding in status-right.`,
 func init() {
 	statusCmd.Flags().Bool("waiting", false, "Only output the waiting count")
 	statusCmd.Flags().Bool("tmux-format", false, "Emit tmux #[fg=...] colour-formatted output")
+	statusCmd.Flags().Bool("json", false, "Emit a JSON object keyed by state with integer counts (mutually exclusive with --tmux-format)")
 	rootCmd.AddCommand(statusCmd)
+}
+
+// renderStatusJSON emits the snake_case JSON object for `prism status --json`.
+// Keys: active, waiting, idle, finished, error.
+func renderStatusJSON(active, waiting, idle, finished, errored int) error {
+	obj := map[string]int{
+		"active":   active,
+		"waiting":  waiting,
+		"idle":     idle,
+		"finished": finished,
+		"error":    errored,
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("prism status --json: marshal: %w", err)
+	}
+	return printJSON(data)
 }

--- a/modules/programs/prism/prism/cmd/status.go
+++ b/modules/programs/prism/prism/cmd/status.go
@@ -84,6 +84,13 @@ JSON object keyed by state with integer counts.
 		}
 
 		// Default: human-readable summary of all states.
+		//
+		// Errored sessions must remain visible in both renderers. Pre-#1499
+		// they were folded into the `idle` bucket via the `default:` arm of
+		// the state switch, so they showed up as "N idle" — the new dedicated
+		// `nError` counter (added for --json) must be rendered explicitly
+		// here, otherwise error sessions silently disappear from the status
+		// bar. Render in red so they're visually distinct from idle.
 		if tmuxFormat {
 			var parts []string
 			if nWaiting > 0 {
@@ -94,6 +101,9 @@ JSON object keyed by state with integer counts.
 			}
 			if nFinished > 0 {
 				parts = append(parts, fmt.Sprintf("#[fg=%s]%d done", ColorGreen, nFinished))
+			}
+			if nError > 0 {
+				parts = append(parts, fmt.Sprintf("#[fg=%s]%d error", ColorRed, nError))
 			}
 			if len(parts) > 0 {
 				fmt.Printf("%s #[fg=%s]| ", strings.Join(parts, " "), ColorPrimary)
@@ -108,6 +118,9 @@ JSON object keyed by state with integer counts.
 			}
 			if nFinished > 0 {
 				parts = append(parts, fmt.Sprintf("%d done", nFinished))
+			}
+			if nError > 0 {
+				parts = append(parts, fmt.Sprintf("%d error", nError))
 			}
 			if nIdle > 0 || len(parts) == 0 {
 				parts = append(parts, fmt.Sprintf("%d idle", nIdle))

--- a/modules/programs/prism/prism/cmd/status_json_test.go
+++ b/modules/programs/prism/prism/cmd/status_json_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+// Tests for --json flag on prism status (#1499).
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// TestRenderStatusJSON_AllStateKeysPresent verifies the JSON object exposes
+// every required state key as an integer, even when the count is zero.
+func TestRenderStatusJSON_AllStateKeysPresent(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := renderStatusJSON(2, 0, 1, 0, 0); err != nil {
+			t.Fatalf("renderStatusJSON: %v", err)
+		}
+	})
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+
+	for _, k := range []string{"active", "waiting", "idle", "finished", "error"} {
+		v, ok := obj[k]
+		if !ok {
+			t.Errorf("missing required key %q in %s", k, out)
+			continue
+		}
+		if _, ok := v.(float64); !ok {
+			t.Errorf("key %q must be a JSON number, got %T (%v)", k, v, v)
+		}
+	}
+
+	if obj["active"].(float64) != 2 {
+		t.Errorf("active: want 2, got %v", obj["active"])
+	}
+	if obj["idle"].(float64) != 1 {
+		t.Errorf("idle: want 1, got %v", obj["idle"])
+	}
+	if obj["error"].(float64) != 0 {
+		t.Errorf("error: want 0, got %v", obj["error"])
+	}
+}
+
+// TestStatusCmd_JSONAndTmuxFormatMutuallyExclusive verifies that combining
+// --json and --tmux-format returns an error per AC #1499.
+func TestStatusCmd_JSONAndTmuxFormatMutuallyExclusive(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	statusCmd.Flags().Set("json", "true")        //nolint:errcheck
+	statusCmd.Flags().Set("tmux-format", "true") //nolint:errcheck
+	defer func() {
+		statusCmd.Flags().Set("json", "false")        //nolint:errcheck
+		statusCmd.Flags().Set("tmux-format", "false") //nolint:errcheck
+	}()
+
+	err := statusCmd.RunE(statusCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --json and --tmux-format are combined, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' in error, got: %v", err)
+	}
+}
+
+// TestStatusCmd_JSON_DBOpenFailureStillEmitsJSON verifies that a DB open
+// failure still produces a parseable empty-shape JSON document when --json
+// is set (defence-in-depth: stdout must be a valid JSON object even on
+// failure).
+func TestStatusCmd_JSON_DBOpenFailureStillEmitsJSON(t *testing.T) {
+	// Force openDB to point at an unwritable / nonexistent path.
+	t.Setenv("PRISM_HOST_API", "")
+	SetTestDBPath("/proc/1/no-such-prism.db")
+	defer SetTestDBPath("")
+
+	statusCmd.Flags().Set("json", "true")        //nolint:errcheck
+	defer statusCmd.Flags().Set("json", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		_ = statusCmd.RunE(statusCmd, nil)
+	})
+
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		// On a successful openDB (e.g. dev shell where the path doesn't
+		// matter and openDB returns nil), the "empty" branch isn't hit.
+		// In that case the test is a no-op, which is fine.
+		return
+	}
+	var obj map[string]int
+	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+		t.Fatalf("--json output must be a valid JSON object, got %q (err: %v)", trimmed, err)
+	}
+	for _, k := range []string{"active", "waiting", "idle", "finished", "error"} {
+		if _, ok := obj[k]; !ok {
+			t.Errorf("missing key %q in fallback JSON: %s", k, trimmed)
+		}
+	}
+}
+
+// TestStatusCmd_JSON_StateAggregation verifies that statuses bucket into the
+// expected JSON keys.
+func TestStatusCmd_JSON_StateAggregation(t *testing.T) {
+	d := openStatsTestDB(t) // unsets PRISM_HOST_API
+
+	if err := d.UpsertStatus("repo@a", "repo", "/code", string(agent.StateActive), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus("repo@b", "repo", "/code", string(agent.StateActive), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus("repo@c", "repo", "/code", string(agent.StateWaiting), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpsertStatus("repo@d", "repo", "/code", string(agent.StateError), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	statusCmd.Flags().Set("json", "true")        //nolint:errcheck
+	defer statusCmd.Flags().Set("json", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := statusCmd.RunE(statusCmd, nil); err != nil {
+			t.Errorf("statusCmd.RunE: %v", err)
+		}
+	})
+
+	var obj map[string]int
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if obj["active"] != 2 {
+		t.Errorf("active: want 2, got %d", obj["active"])
+	}
+	if obj["waiting"] != 1 {
+		t.Errorf("waiting: want 1, got %d", obj["waiting"])
+	}
+	if obj["error"] != 1 {
+		t.Errorf("error: want 1, got %d", obj["error"])
+	}
+}

--- a/modules/programs/prism/prism/cmd/status_json_test.go
+++ b/modules/programs/prism/prism/cmd/status_json_test.go
@@ -102,6 +102,44 @@ func TestStatusCmd_JSON_DBOpenFailureStillEmitsJSON(t *testing.T) {
 	}
 }
 
+// TestStatusCmd_HumanRenderer_ShowsErrorSessions is a regression test for
+// the bug where introducing a dedicated nError counter (for --json) made
+// error-state sessions silently disappear from the human-readable summary
+// and the tmux status bar (review-code blocker on PR #1511 round 2).
+//
+// Both renderers must surface error sessions; they should never be silently
+// rolled into idle or omitted entirely.
+func TestStatusCmd_HumanRenderer_ShowsErrorSessions(t *testing.T) {
+	d := openStatsTestDB(t)
+
+	if err := d.UpsertStatus("repo@bad", "repo", "/code", string(agent.StateError), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Plain human-readable summary.
+	out := captureStdout(t, func() {
+		if err := statusCmd.RunE(statusCmd, nil); err != nil {
+			t.Errorf("statusCmd.RunE (plain): %v", err)
+		}
+	})
+	if !strings.Contains(out, "1 error") {
+		t.Errorf("plain summary must surface error sessions, got: %q", out)
+	}
+
+	// Tmux-format renderer.
+	statusCmd.Flags().Set("tmux-format", "true")        //nolint:errcheck
+	defer statusCmd.Flags().Set("tmux-format", "false") //nolint:errcheck
+
+	out = captureStdout(t, func() {
+		if err := statusCmd.RunE(statusCmd, nil); err != nil {
+			t.Errorf("statusCmd.RunE (tmux-format): %v", err)
+		}
+	})
+	if !strings.Contains(out, "1 error") {
+		t.Errorf("tmux-format must surface error sessions, got: %q", out)
+	}
+}
+
 // TestStatusCmd_JSON_StateAggregation verifies that statuses bucket into the
 // expected JSON keys.
 func TestStatusCmd_JSON_StateAggregation(t *testing.T) {


### PR DESCRIPTION
Closes #1499.

Principle 2 of the #1497 audit: every list-style and lookup-style prism subcommand now supports `--json`, following the established `prism stats --json` / `prism list-sessions --json` precedent.

## Convention applied across all new `--json` modes

- Keys are **snake_case**.
- Timestamps are **RFC 3339** (UTC, `Z` suffix).
- List outputs are **bare arrays**; metadata-bearing outputs use an object with the array under a stable key (e.g. `audit`: `{events, truncated, hint}`).
- Empty lists are `[]` — never null, never absent.
- `null` is preferred over omitting optional keys.
- stdout contains exclusively the JSON document; informational/progress text routes to stderr.
- `--json` errors keep exit code non-zero; the human-readable error message stays on stderr.

## New flags

| Command | Shape |
|---|---|
| `prism merges --json` (also `merges list`, `--failed`, `--abandoned`, `--all`) | array of merge-queue entries |
| `prism sessions list --json` | array of session-incarnation objects |
| `prism audit --json` | object `{events: [...], truncated: bool, hint: string\|null}` (honours `--days`, `--limit`, `--pattern`, `[session]`) |
| `prism status --json` | object keyed by state (`active`, `waiting`, `idle`, `finished`, `error`) with int counts; mutually exclusive with `--tmux-format` |
| `prism profile list --json` | array of profile objects (`name`, `active`, `slots`) |
| `prism profile show [name] --json` | single profile object |
| `prism archive <session> --all --json` | array of archive-entry objects (`instance_id`, `session_name`, `started_at`, `ended_at`, `archive_path`) |

## Breaking change

`prism sessions list --json` previously emitted JSONL with camelCase keys (`instanceId`, `sessionName`, `startedAt`, …). It now emits a **JSON array** with **snake_case** keys to match the convention shared with the new flags. The existing test was updated to assert the new contract; no other in-tree consumers parsed the old shape.

The other pre-existing `--json` precedents (`prism list-sessions`, `prism checkin`, `prism stats`) are unchanged: their existing shapes flow through proxy code paths and are kept stable.

## `prism status` regression fix (round-2 review-code blocker)

Round 2 of `prism review` flagged a behavioural regression in the `prism status` change: introducing a dedicated `nError` counter (needed for `--json`) without rendering it elsewhere meant error sessions silently disappeared from the human-readable summary and the tmux status bar (pre-#1499 they fell through `default:` → `nIdle` and at least surfaced as "1 idle"). Fixed by rendering `nError` explicitly in both renderers — in red on the tmux status bar so error sessions are now visually distinct from idle. New regression test asserts both renderers surface error sessions.

## Skill manifest

`modules/programs/prism/opencode/skills/prism/SKILL.md` gains a new "Querying prism state — prefer `--json` for scripting" section listing every command that supports `--json` and its shape, plus targeted updates to the merge-queue table and the debugging decision tree to point agents at `--json` when scripting.

## Sample output

```
$ prism status --json
{"active":0,"error":0,"finished":0,"idle":0,"waiting":0}

$ prism audit --json | jq
{
  "events": [],
  "truncated": false,
  "hint": null
}

$ prism sessions list --json
[]

$ prism archive --json
Error: archive: --json is only supported together with --all

$ prism status --json --tmux-format
Error: prism status: --json and --tmux-format are mutually exclusive
```

## Tests

Five new test files cover every new `--json` shape end-to-end (renderer + flag wiring), plus an updated test for the breaking sessions-list change and a new regression test for the `status` error-rendering fix:

- `cmd/merges_json_test.go` — empty `[]`, snake_case keys, RFC3339 timestamps, optional fields render as null
- `cmd/audit_json_test.go` — empty envelope, happy path, truncation hint, no implicit cap with session filter
- `cmd/status_json_test.go` — every state key present, `--json` + `--tmux-format` rejected, DB-failure fallback emits parseable JSON, full state aggregation, error sessions visible in both human renderers
- `cmd/profile_json_test.go` — snake_case keys, `active` flag, empty `[]`
- `cmd/archive_json_test.go` — happy path with mixed archived/unarchived rows, unknown session error, `--json` without `--all` rejected
- `cmd/sessions_test.go` — updated to assert snake_case array shape, rejecting any leftover camelCase keys

`go build ./...` and `go test ./...` are clean from `modules/programs/prism/prism/`.

## Build gate

The branch is rebased onto current `origin/main` (post-#1508) so the new prism CI gate runs against this code:

- `nix build .#prism` succeeds locally (default `runChecks = false` — fast, no test execution).
- `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'` (the homeless-shelter equivalent of the new `nix-build-prism-checked` CI job) also succeeds locally.
- The required `pr-gate` fan-in CI check needs both `go-tests` and `nix-build-prism-checked` to pass on the PR; both should now run because this branch is rebased onto a base that includes #1508.

The earlier PR-body framing about "pre-existing flakes in `internal/sidecar` blocking `nix build .#prism`" (and tracking issue #1515) is now obsolete: under the post-#1508 contract the default `nix build .#prism` doesn't run tests at all, and the checked build passes locally for this PR's code.