### PR TITLE
feat(prism): add prism db query / schema / tables read-only surface

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -796,6 +796,11 @@
         # prism merge — coordinator-only; review agents must not enqueue (#783)
         "prism merge" = "deny";
         "prism merge *" = "deny";
+        # prism db — read-only SQL/schema introspection (#1467). The CLI opens
+        # the DB with ?mode=ro and SQLite rejects any write at the engine level,
+        # so this is safe under deny-by-default for review agents.
+        "prism db" = "allow";
+        "prism db *" = "allow";
         # Standard read-only file/text operations
         "cat *" = "allow";
         "head *" = "allow";
@@ -962,6 +967,10 @@
         # prism merge — coordinator-only; review agents must not enqueue (#783)
         "prism merge" = "deny";
         "prism merge *" = "deny";
+        # prism db — read-only SQL/schema introspection (#1467). Same rationale
+        # as containerReviewBaseBashCommands above: ?mode=ro is the safety net.
+        "prism db" = "allow";
+        "prism db *" = "allow";
         # Standard read-only file/text operations (mirrors readOnlyBashCommands)
         "cat *" = "allow";
         "head *" = "allow";
@@ -1416,6 +1425,10 @@
                         "prism checkin" = "allow";
                         "prism checkin *" = "allow";
                         "prism list-sessions" = "allow";
+                        # prism db — read-only SQL/schema introspection (#1467).
+                        # ?mode=ro at the engine level is the safety net.
+                        "prism db" = "allow";
+                        "prism db *" = "allow";
                         # SQLite read-only access to prism DB — the ?mode=ro flag enforces
                         # read-only at the SQLite engine level, rejecting all write operations.
                         # The path is baked in at Nix eval time via hmUser.xdg.stateHome.

--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -692,6 +692,14 @@
                 "*" = "deny";
               }
               // readOnlyBashCommands
+              // {
+                # prism db — read-only SQL/schema introspection (#1467). The CLI
+                # opens the DB with ?mode=ro and SQLite rejects writes at the
+                # engine level, so it is safe under the deny-by-default plan
+                # bash policy. Plan agents are a primary debugging consumer.
+                "prism db" = "allow";
+                "prism db *" = "allow";
+              }
               // tmuxDenyCommands;
             };
           };
@@ -1349,6 +1357,12 @@
                         "*" = "deny";
                       }
                       // readOnlyBashCommands
+                      // {
+                        # prism db — read-only SQL/schema introspection (#1467).
+                        # ?mode=ro at the engine level is the safety net.
+                        "prism db" = "allow";
+                        "prism db *" = "allow";
+                      }
                       // tmuxDenyCommands;
                     };
                   };

--- a/modules/programs/prism/prism/cmd/db.go
+++ b/modules/programs/prism/prism/cmd/db.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
@@ -32,3 +34,29 @@ func dbPath() string {
 func openDB() (*db.DB, error) {
 	return db.Open(dbPath())
 }
+
+// dbCmd is the parent cobra command for the read-only db surface (#1467).
+// Subcommands are registered in their own files (db_query.go, db_schema.go,
+// db_tables.go).
+var dbCmd = &cobra.Command{
+	Use:   "db",
+	Short: "Read-only SQL query and schema introspection over the prism database",
+	Long: `Read-only SQL query and schema introspection over the prism database.
+
+The "prism db" surface exposes the prism SQLite database for ad-hoc forensic
+queries by humans and agents debugging prism itself. The curated views
+(prism stats, prism checkin) answer most questions; this surface fills the
+gap when raw SQL is needed.
+
+All subcommands open the database in read-only mode (?mode=ro). Any write
+statement is rejected by SQLite with a clear "read-only" error.
+
+When PRISM_HOST_API is set (i.e. running inside a sandbox), the subcommands
+proxy through the host-API socket so they work identically inside and
+outside a sandbox.`,
+}
+
+func init() {
+	rootCmd.AddCommand(dbCmd)
+}
+

--- a/modules/programs/prism/prism/cmd/db_query.go
+++ b/modules/programs/prism/prism/cmd/db_query.go
@@ -1,0 +1,379 @@
+package cmd
+
+// prism db query — run a single read-only SQL statement.
+//
+// Implements issue #1467. Highlights:
+//   - Read-only enforcement is delegated to SQLite via ?mode=ro. We do NOT
+//     attempt to parse SQL to allowlist statements.
+//   - Single-statement guard is performed at the CLI layer (and again on the
+//     host-API side) using the db.IsSingleStatement tokenizer — equivalent
+//     to sqlite3_complete() for our purposes.
+//   - Statement timeout (default 5s, override via --timeout) is plumbed
+//     through context so SQLite's interrupt fires when the deadline elapses.
+//   - When PRISM_HOST_API is set the request is proxied to the host sidecar's
+//     GET /db/query endpoint. Otherwise we open a fresh read-only handle on
+//     the local DB. Rendering happens identically on both paths.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// dbQueryDefaultTimeout is the default --timeout value. 5 s is generous
+// enough for any sane forensic query but short enough that a runaway
+// SELECT does not block the CLI for an unbounded amount of time.
+const dbQueryDefaultTimeout = 5 * time.Second
+
+// dbQueryRowDisplayLimit is the row-truncation cap applied to table-mode
+// output. JSON mode is never truncated; the issue is explicit that "JSON
+// mode emits all rows".
+const dbQueryRowDisplayLimit = 50
+
+var dbQueryCmd = &cobra.Command{
+	Use:          "query [SQL | -]",
+	Short:        "Run a single read-only SQL statement",
+	SilenceUsage: true,
+	Long: `Run a single read-only SQL statement against the prism database.
+
+The SQL text may be passed as the first positional argument, or read from
+stdin by passing "-". The latter is convenient for multi-line queries that
+would be awkward to quote on argv.
+
+Read-only enforcement is delegated to SQLite (?mode=ro). Any write statement
+fails with a clear "read-only" error and a non-zero exit code. Multi-statement
+input (more than one SQL statement separated by ";") is rejected at the CLI
+layer before any SQL runs.
+
+By default output is rendered as an aligned table. Use --json to emit
+structured JSON of the form {"columns": [...], "rows": [...], "elapsedMs": N}.
+JSON mode emits all rows; table mode may truncate very long output for
+readability.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runDBQuery,
+}
+
+func init() {
+	dbQueryCmd.Flags().Bool("json", false, "Emit structured JSON to stdout instead of an aligned table")
+	dbQueryCmd.Flags().Duration("timeout", dbQueryDefaultTimeout, "Statement timeout (Go duration, e.g. 5s, 100ms)")
+	dbCmd.AddCommand(dbQueryCmd)
+}
+
+func runDBQuery(cmd *cobra.Command, args []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	if timeout <= 0 {
+		timeout = dbQueryDefaultTimeout
+	}
+
+	sqlText, err := readDBQuerySQL(args, cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+
+	// Single-statement guard. Done at the CLI layer per the AC: "is rejected
+	// at the CLI layer with a clear error before any SQL runs".
+	ok, parseErr := db.IsSingleStatement(sqlText)
+	if parseErr != nil {
+		return fmt.Errorf("db query: %w", parseErr)
+	}
+	if !ok {
+		return fmt.Errorf("db query: input must contain exactly one SQL statement (use separate invocations for multi-statement queries)")
+	}
+
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runDBQueryProxy(cmd, apiURL, sqlText, timeout, jsonMode)
+	}
+	return runDBQueryLocal(cmd, sqlText, timeout, jsonMode)
+}
+
+// readDBQuerySQL resolves the SQL text from argv or stdin.
+//
+//   - With no positional args: stdin is used (matches `sqlite3 < file.sql`
+//     behaviour) — but only when stdin is non-empty; otherwise we surface a
+//     clear error so a forgotten argument doesn't hang the CLI.
+//   - With "-": stdin is used.
+//   - With one arg that's not "-": the arg itself is the SQL.
+func readDBQuerySQL(args []string, stdin io.Reader) (string, error) {
+	if len(args) == 1 && args[0] != "-" {
+		return strings.TrimSpace(args[0]), nil
+	}
+	if len(args) == 1 && args[0] == "-" {
+		return readAllOrErr(stdin)
+	}
+	// No args — fall back to stdin only when it's a redirected file/pipe.
+	// On a TTY we refuse rather than silently hang.
+	if f, ok := stdin.(*os.File); ok {
+		fi, statErr := f.Stat()
+		if statErr == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+			return "", fmt.Errorf("db query: SQL is required as an argument (or use \"-\" to read from stdin)")
+		}
+	}
+	return readAllOrErr(stdin)
+}
+
+func readAllOrErr(r io.Reader) (string, error) {
+	if r == nil {
+		return "", fmt.Errorf("db query: stdin is unavailable")
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("db query: read stdin: %w", err)
+	}
+	out := strings.TrimSpace(string(b))
+	if out == "" {
+		return "", fmt.Errorf("db query: empty input — pass a SQL statement on argv or via stdin")
+	}
+	return out, nil
+}
+
+// runDBQueryLocal opens a read-only handle on the local DB and runs the
+// statement. Used when PRISM_HOST_API is unset (i.e. we're on the host).
+func runDBQueryLocal(cmd *cobra.Command, sqlText string, timeout time.Duration, jsonMode bool) error {
+	conn, err := db.OpenReadOnly(dbPath())
+	if err != nil {
+		return fmt.Errorf("db query: %w", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	res, err := db.RunQuery(ctx, conn, sqlText)
+	if err != nil {
+		if db.IsReadOnlyError(err) {
+			return fmt.Errorf("db query: read-only: %w", err)
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("db query: timeout exceeded (%s)", timeout)
+		}
+		return fmt.Errorf("db query: %w", err)
+	}
+	res.ElapsedMs = time.Since(start).Milliseconds()
+
+	return renderDBQueryResult(cmd.OutOrStdout(), res, jsonMode)
+}
+
+// runDBQueryProxy proxies the request to the host-API sidecar.
+func runDBQueryProxy(cmd *cobra.Command, apiURL, sqlText string, timeout time.Duration, jsonMode bool) error {
+	params := map[string]string{
+		"sql":     sqlText,
+		"timeout": timeout.String(),
+	}
+	raw, err := proxyReadToHostAPI(apiURL, "/db/query", params)
+	if err != nil {
+		return fmt.Errorf("db query: %w", err)
+	}
+	var res db.QueryResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("db query: unmarshal proxy response: %w", err)
+	}
+	// Defensive: a JSON null for rows would defeat the empty-result AC.
+	if res.Rows == nil {
+		res.Rows = [][]any{}
+	}
+	return renderDBQueryResult(cmd.OutOrStdout(), &res, jsonMode)
+}
+
+// renderDBQueryResult writes res to w in either JSON or aligned-table mode.
+//
+// JSON mode preserves the wire shape end-to-end (the wire shape is itself
+// the AC-defined shape: {"columns": [...], "rows": [...], "elapsedMs": N}).
+// Table mode formats per cell using formatCellTable below.
+func renderDBQueryResult(w io.Writer, res *db.QueryResult, jsonMode bool) error {
+	if jsonMode {
+		return renderDBQueryJSON(w, res)
+	}
+	return renderDBQueryTable(w, res)
+}
+
+// renderDBQueryJSON emits {"columns": [...], "rows": [...], "elapsedMs": N}.
+//
+// BLOB cells are converted to base64 to match standard JSON encoding
+// conventions; NULL stays as JSON null.
+func renderDBQueryJSON(w io.Writer, res *db.QueryResult) error {
+	// Walk the rows once and convert []byte → base64 string. This must
+	// happen before json.Marshal because encoding/json defaults to
+	// base64-encoding []byte but does NOT differentiate it from string —
+	// we want explicit base64 in a string field for round-tripping.
+	cooked := make([][]any, len(res.Rows))
+	for i, row := range res.Rows {
+		newRow := make([]any, len(row))
+		for j, cell := range row {
+			switch v := cell.(type) {
+			case []byte:
+				newRow[j] = base64.StdEncoding.EncodeToString(v)
+			default:
+				newRow[j] = v
+			}
+		}
+		cooked[i] = newRow
+	}
+	out := struct {
+		Columns   []string `json:"columns"`
+		Rows      [][]any  `json:"rows"`
+		ElapsedMs int64    `json:"elapsedMs"`
+	}{
+		Columns:   res.Columns,
+		Rows:      cooked,
+		ElapsedMs: res.ElapsedMs,
+	}
+	if out.Rows == nil {
+		out.Rows = [][]any{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(out)
+}
+
+// dimNullStyle is the style used to render NULL cells in table mode. Faint
+// (dimmed) per the AC: "NULL values are rendered as the literal string NULL
+// (dimmed in table mode)".
+var dimNullStyle = lipgloss.NewStyle().Faint(true)
+
+// renderDBQueryTable formats res as an aligned text table with a styled
+// header row and a footer showing row count and elapsed time. Long output is
+// truncated after dbQueryRowDisplayLimit rows with a "... (N more)" tail.
+func renderDBQueryTable(w io.Writer, res *db.QueryResult) error {
+	if len(res.Columns) == 0 {
+		fmt.Fprintf(w, "(no columns) — %d row(s) — %dms\n", len(res.Rows), res.ElapsedMs)
+		return nil
+	}
+
+	// Pre-compute the per-row formatted cell values once so column-width
+	// measurement and printing share the same strings.
+	formatted := make([][]string, len(res.Rows))
+	truncated := false
+	displayCount := len(res.Rows)
+	if displayCount > dbQueryRowDisplayLimit {
+		displayCount = dbQueryRowDisplayLimit
+		truncated = true
+	}
+	for i := 0; i < displayCount; i++ {
+		row := res.Rows[i]
+		out := make([]string, len(res.Columns))
+		for j := range res.Columns {
+			if j < len(row) {
+				out[j] = formatCellTable(row[j])
+			}
+		}
+		formatted[i] = out
+	}
+
+	// Compute per-column widths from header + body. Use rune counts so
+	// multibyte content lines up sensibly.
+	widths := make([]int, len(res.Columns))
+	for i, c := range res.Columns {
+		widths[i] = len([]rune(c))
+	}
+	for i := 0; i < displayCount; i++ {
+		row := formatted[i]
+		for j, cell := range row {
+			n := len([]rune(cell))
+			if n > widths[j] {
+				widths[j] = n
+			}
+		}
+	}
+
+	// Header row.
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	for i, c := range res.Columns {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprint(w, headerStyle.Render(padRunes(c, widths[i])))
+	}
+	fmt.Fprintln(w)
+
+	// Body.
+	for i := 0; i < displayCount; i++ {
+		row := formatted[i]
+		for j := 0; j < len(res.Columns); j++ {
+			if j > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			cell := ""
+			if j < len(row) {
+				cell = row[j]
+			}
+			padded := padRunes(cell, widths[j])
+			// Style NULL cells dim per the AC. The literal string "NULL"
+			// is the canonical sentinel emitted by formatCellTable.
+			if cell == "NULL" {
+				fmt.Fprint(w, dimNullStyle.Render(padded))
+			} else {
+				fmt.Fprint(w, padded)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if truncated {
+		more := len(res.Rows) - displayCount
+		fmt.Fprintln(w, dimNullStyle.Render(fmt.Sprintf("... (%d more — pass --json to see all)", more)))
+	}
+
+	// Footer.
+	footerStyle := lipgloss.NewStyle().Faint(true)
+	fmt.Fprintln(w, footerStyle.Render(fmt.Sprintf("(%d row%s, %dms)", len(res.Rows), pluralS(len(res.Rows)), res.ElapsedMs)))
+	return nil
+}
+
+// formatCellTable converts a raw scanned value to its string form for table
+// output. Per the issue ACs:
+//
+//   - NULL → "NULL"
+//   - BLOB → "0x<hex>"
+//   - everything else → fmt.Sprintf("%v", v) with explicit handling for
+//     int64 / float64 / bool / string so the output is predictable.
+func formatCellTable(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "NULL"
+	case []byte:
+		return "0x" + hex.EncodeToString(t)
+	case string:
+		return t
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case float64:
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+// padRunes right-pads s with spaces to width n in runes.
+func padRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-len(r))
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/modules/programs/prism/prism/cmd/db_query_test.go
+++ b/modules/programs/prism/prism/cmd/db_query_test.go
@@ -1,0 +1,299 @@
+package cmd
+
+// Tests for prism db query rendering and the local execution path.
+//
+// These tests run against a fresh temp DB. Some seed a writable handle to
+// insert fixtures (BLOB, NULL) before exercising the read-only command
+// path.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// unsetHostAPIForTest clears PRISM_HOST_API so the local code path is exercised
+// rather than the proxy. Restored on test cleanup.
+func unsetHostAPIForTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("PRISM_HOST_API", "")
+}
+
+func newTestDBForCLI(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli-test.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return path
+}
+
+func TestRenderDBQueryJSON_EmptyRowsIsEmptySlice(t *testing.T) {
+	res := &db.QueryResult{
+		Columns:   []string{"a", "b"},
+		Rows:      nil,
+		ElapsedMs: 7,
+	}
+	var buf bytes.Buffer
+	if err := renderDBQueryJSON(&buf, res); err != nil {
+		t.Fatalf("renderDBQueryJSON: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"rows":[]`) {
+		t.Fatalf("expected rows:[]; got %s", got)
+	}
+	// Round-trip must be valid JSON.
+	var dec struct {
+		Columns   []string `json:"columns"`
+		Rows      [][]any  `json:"rows"`
+		ElapsedMs int64    `json:"elapsedMs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &dec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dec.Rows == nil {
+		t.Fatal("Rows decoded as nil")
+	}
+	if len(dec.Rows) != 0 {
+		t.Fatalf("got %d rows, want 0", len(dec.Rows))
+	}
+}
+
+func TestRenderDBQueryJSON_BlobBase64_NullJSONNull(t *testing.T) {
+	res := &db.QueryResult{
+		Columns: []string{"b", "n"},
+		Rows: [][]any{
+			{[]byte{0xca, 0xfe, 0xba, 0xbe}, nil},
+		},
+	}
+	var buf bytes.Buffer
+	if err := renderDBQueryJSON(&buf, res); err != nil {
+		t.Fatalf("renderDBQueryJSON: %v", err)
+	}
+	var dec struct {
+		Rows [][]any `json:"rows"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &dec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(dec.Rows) != 1 || len(dec.Rows[0]) != 2 {
+		t.Fatalf("unexpected shape %v", dec.Rows)
+	}
+	gotB, ok := dec.Rows[0][0].(string)
+	if !ok {
+		t.Fatalf("col 0 type %T, want string (base64)", dec.Rows[0][0])
+	}
+	if gotB != "yv66vg==" {
+		t.Errorf("base64 = %q, want yv66vg==", gotB)
+	}
+	if dec.Rows[0][1] != nil {
+		t.Errorf("col 1 = %v, want JSON null", dec.Rows[0][1])
+	}
+}
+
+func TestFormatCellTable_NullAndBlob(t *testing.T) {
+	if got := formatCellTable(nil); got != "NULL" {
+		t.Errorf("nil → %q, want NULL", got)
+	}
+	if got := formatCellTable([]byte{0xca, 0xfe}); got != "0xcafe" {
+		t.Errorf("blob → %q, want 0xcafe", got)
+	}
+	if got := formatCellTable(int64(42)); got != "42" {
+		t.Errorf("int64 → %q, want 42", got)
+	}
+	if got := formatCellTable("hi"); got != "hi" {
+		t.Errorf("string → %q, want hi", got)
+	}
+}
+
+func TestRenderDBQueryTable_NullAndBlobAppearLiterally(t *testing.T) {
+	res := &db.QueryResult{
+		Columns: []string{"b", "n", "s"},
+		Rows: [][]any{
+			{[]byte{0xde, 0xad}, nil, "ok"},
+		},
+		ElapsedMs: 3,
+	}
+	var buf bytes.Buffer
+	if err := renderDBQueryTable(&buf, res); err != nil {
+		t.Fatalf("renderDBQueryTable: %v", err)
+	}
+	got := buf.String()
+	// We only assert the literal substrings appear — colour codes from
+	// lipgloss may surround "NULL", but the substring is still present.
+	if !strings.Contains(got, "0xdead") {
+		t.Errorf("output missing 0xdead: %q", got)
+	}
+	if !strings.Contains(got, "NULL") {
+		t.Errorf("output missing NULL: %q", got)
+	}
+	if !strings.Contains(got, "ok") {
+		t.Errorf("output missing ok: %q", got)
+	}
+	if !strings.Contains(got, "1 row") {
+		t.Errorf("footer missing row count: %q", got)
+	}
+}
+
+// TestRunDBQueryLocal_RejectsWrite verifies that the LOCAL (non-proxy) path
+// surfaces the read-only sentinel as a clear error.
+func TestRunDBQueryLocal_RejectsWrite(t *testing.T) {
+	unsetHostAPIForTest(t)
+	path := newTestDBForCLI(t)
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Invoke runDBQuery directly with a stub cobra Command.
+	cmd := dbQueryCmd
+	cmd.SetContext(context.Background())
+	err := runDBQuery(cmd, []string{
+		"INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at) VALUES ('x','x','x','x','opencode',1)",
+	})
+	if err == nil {
+		t.Fatal("expected error on write attempt, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "read") {
+		t.Fatalf("error %q does not mention read-only", err)
+	}
+}
+
+func TestRunDBQuery_RejectsMultiStatement(t *testing.T) {
+	unsetHostAPIForTest(t)
+	path := newTestDBForCLI(t)
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	cmd := dbQueryCmd
+	cmd.SetContext(context.Background())
+	err := runDBQuery(cmd, []string{"SELECT 1; SELECT 2"})
+	if err == nil {
+		t.Fatal("expected error on multi-statement input")
+	}
+	if !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("error %q does not mention single-statement", err)
+	}
+}
+
+func TestRunDBQuery_HappyPath(t *testing.T) {
+	unsetHostAPIForTest(t)
+	path := newTestDBForCLI(t)
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Capture stdout via cobra's OutOrStdout/SetOut.
+	var buf bytes.Buffer
+	cmd := dbQueryCmd
+	cmd.SetOut(&buf)
+	cmd.SetContext(context.Background())
+	t.Cleanup(func() { cmd.SetOut(nil) })
+
+	if err := runDBQuery(cmd, []string{"SELECT 1 AS one"}); err != nil {
+		t.Fatalf("runDBQuery: %v", err)
+	}
+	if !strings.Contains(buf.String(), "one") {
+		t.Errorf("output missing column header: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "1 row") {
+		t.Errorf("output missing footer: %q", buf.String())
+	}
+}
+
+func TestRunDBQuery_StdinDash(t *testing.T) {
+	unsetHostAPIForTest(t)
+	path := newTestDBForCLI(t)
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	var buf bytes.Buffer
+	cmd := dbQueryCmd
+	cmd.SetOut(&buf)
+	cmd.SetIn(strings.NewReader("SELECT 42 AS answer\n"))
+	cmd.SetContext(context.Background())
+	t.Cleanup(func() {
+		cmd.SetOut(nil)
+		cmd.SetIn(nil)
+	})
+
+	if err := runDBQuery(cmd, []string{"-"}); err != nil {
+		t.Fatalf("runDBQuery: %v", err)
+	}
+	if !strings.Contains(buf.String(), "42") {
+		t.Errorf("output missing answer: %q", buf.String())
+	}
+}
+
+// TestRenderDBSchema_TextHasSemicolon verifies the text renderer terminates
+// each entry with a semicolon (paste-able into sqlite3).
+func TestRenderDBSchema_TextHasSemicolon(t *testing.T) {
+	entries := []db.SchemaEntry{
+		{Type: "table", Name: "t", SQL: "CREATE TABLE t (x INTEGER)"},
+		{Type: "index", Name: "i", SQL: "CREATE INDEX i ON t(x);"},
+	}
+	var buf bytes.Buffer
+	if err := renderDBSchema(&buf, entries, false); err != nil {
+		t.Fatalf("renderDBSchema: %v", err)
+	}
+	got := buf.String()
+	if strings.Count(got, ";") < 2 {
+		t.Errorf("expected ≥ 2 semicolons in output: %q", got)
+	}
+}
+
+func TestRenderDBSchema_JSONKeyedByName(t *testing.T) {
+	entries := []db.SchemaEntry{
+		{Type: "table", Name: "t1", SQL: "CREATE TABLE t1 (a)"},
+		{Type: "index", Name: "i1", SQL: "CREATE INDEX i1 ON t1(a)"},
+	}
+	var buf bytes.Buffer
+	if err := renderDBSchema(&buf, entries, true); err != nil {
+		t.Fatalf("renderDBSchema: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["t1"] != "CREATE TABLE t1 (a)" {
+		t.Errorf("got[t1] = %q", got["t1"])
+	}
+	if got["i1"] == "" {
+		t.Errorf("missing i1 entry")
+	}
+}
+
+func TestRenderDBTables_PlainAndJSON(t *testing.T) {
+	names := []string{"alpha", "beta"}
+	var buf bytes.Buffer
+	if err := renderDBTables(&buf, names, false); err != nil {
+		t.Fatalf("renderDBTables: %v", err)
+	}
+	if buf.String() != "alpha\nbeta\n" {
+		t.Errorf("plain = %q, want alpha\\nbeta\\n", buf.String())
+	}
+	buf.Reset()
+	if err := renderDBTables(&buf, names, true); err != nil {
+		t.Fatalf("renderDBTables: %v", err)
+	}
+	var got []string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
+		t.Errorf("got %v", got)
+	}
+	// Empty input → JSON empty array, never null.
+	buf.Reset()
+	if err := renderDBTables(&buf, nil, true); err != nil {
+		t.Fatalf("renderDBTables(nil): %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != "[]" {
+		t.Errorf("empty json = %q, want []", buf.String())
+	}
+}

--- a/modules/programs/prism/prism/cmd/db_schema.go
+++ b/modules/programs/prism/prism/cmd/db_schema.go
@@ -1,0 +1,115 @@
+package cmd
+
+// prism db schema — print CREATE TABLE / CREATE INDEX statements.
+//
+// With no argument, prints every user table and index. With one argument,
+// prints only that table's DDL. Output is deterministic across invocations
+// (tables before indexes, alpha within each group) per the AC.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var dbSchemaCmd = &cobra.Command{
+	Use:          "schema [table]",
+	Short:        "Print CREATE TABLE / CREATE INDEX statements",
+	SilenceUsage: true,
+	Long: `Print CREATE TABLE / CREATE INDEX statements from the prism database.
+
+With no argument, prints DDL for every user table and index. With a single
+argument, prints only that table's CREATE TABLE statement.
+
+Output is deterministic: tables before indexes, sorted alphabetically within
+each group. Internal sqlite_* objects are excluded.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runDBSchema,
+}
+
+func init() {
+	dbSchemaCmd.Flags().Bool("json", false, "Emit a JSON object keyed by table/index name instead of plain text")
+	dbCmd.AddCommand(dbSchemaCmd)
+}
+
+func runDBSchema(cmd *cobra.Command, args []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	tableFilter := ""
+	if len(args) == 1 {
+		tableFilter = args[0]
+	}
+
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runDBSchemaProxy(cmd, apiURL, tableFilter, jsonMode)
+	}
+	return runDBSchemaLocal(cmd, tableFilter, jsonMode)
+}
+
+func runDBSchemaLocal(cmd *cobra.Command, tableFilter string, jsonMode bool) error {
+	conn, err := db.OpenReadOnly(dbPath())
+	if err != nil {
+		return fmt.Errorf("db schema: %w", err)
+	}
+	defer conn.Close()
+
+	entries, err := db.Schema(context.Background(), conn, tableFilter)
+	if err != nil {
+		return fmt.Errorf("db schema: %w", err)
+	}
+	if tableFilter != "" && len(entries) == 0 {
+		return fmt.Errorf("db schema: table %q not found", tableFilter)
+	}
+	return renderDBSchema(cmd.OutOrStdout(), entries, jsonMode)
+}
+
+func runDBSchemaProxy(cmd *cobra.Command, apiURL, tableFilter string, jsonMode bool) error {
+	params := map[string]string{}
+	if tableFilter != "" {
+		params["table"] = tableFilter
+	}
+	raw, err := proxyReadToHostAPI(apiURL, "/db/schema", params)
+	if err != nil {
+		return fmt.Errorf("db schema: %w", err)
+	}
+	var resp struct {
+		Entries []db.SchemaEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("db schema: unmarshal proxy response: %w", err)
+	}
+	return renderDBSchema(cmd.OutOrStdout(), resp.Entries, jsonMode)
+}
+
+// renderDBSchema writes entries to w. JSON mode emits an object keyed by the
+// entry name (matches the issue's "for schema, an object keyed by table
+// name"). Text mode prints each CREATE statement followed by a blank line.
+func renderDBSchema(w io.Writer, entries []db.SchemaEntry, jsonMode bool) error {
+	if jsonMode {
+		out := make(map[string]string, len(entries))
+		for _, e := range entries {
+			out[e.Name] = e.SQL
+		}
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		return enc.Encode(out)
+	}
+
+	for _, e := range entries {
+		// Some sqlite_master rows omit the trailing semicolon; add one so
+		// the output is paste-able into sqlite3.
+		text := strings.TrimSpace(e.SQL)
+		if !strings.HasSuffix(text, ";") {
+			text += ";"
+		}
+		fmt.Fprintln(w, text)
+		fmt.Fprintln(w)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/db_tables.go
+++ b/modules/programs/prism/prism/cmd/db_tables.go
@@ -1,0 +1,84 @@
+package cmd
+
+// prism db tables — print a sorted list of user table names.
+//
+// Convenience wrapper over `SELECT name FROM sqlite_master WHERE type='table'
+// AND name NOT LIKE 'sqlite_%' ORDER BY name`. Used by agents and humans to
+// discover the schema before writing a query.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var dbTablesCmd = &cobra.Command{
+	Use:          "tables",
+	Short:        "Print a sorted list of user table names (excludes sqlite_*)",
+	SilenceUsage: true,
+	Args:         cobra.NoArgs,
+	RunE:         runDBTables,
+}
+
+func init() {
+	dbTablesCmd.Flags().Bool("json", false, "Emit a JSON array of strings instead of one name per line")
+	dbCmd.AddCommand(dbTablesCmd)
+}
+
+func runDBTables(cmd *cobra.Command, _ []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runDBTablesProxy(cmd, apiURL, jsonMode)
+	}
+	return runDBTablesLocal(cmd, jsonMode)
+}
+
+func runDBTablesLocal(cmd *cobra.Command, jsonMode bool) error {
+	conn, err := db.OpenReadOnly(dbPath())
+	if err != nil {
+		return fmt.Errorf("db tables: %w", err)
+	}
+	defer conn.Close()
+
+	names, err := db.Tables(context.Background(), conn)
+	if err != nil {
+		return fmt.Errorf("db tables: %w", err)
+	}
+	return renderDBTables(cmd.OutOrStdout(), names, jsonMode)
+}
+
+func runDBTablesProxy(cmd *cobra.Command, apiURL string, jsonMode bool) error {
+	raw, err := proxyReadToHostAPI(apiURL, "/db/tables", nil)
+	if err != nil {
+		return fmt.Errorf("db tables: %w", err)
+	}
+	var resp struct {
+		Tables []string `json:"tables"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("db tables: unmarshal proxy response: %w", err)
+	}
+	return renderDBTables(cmd.OutOrStdout(), resp.Tables, jsonMode)
+}
+
+func renderDBTables(w io.Writer, names []string, jsonMode bool) error {
+	if jsonMode {
+		if names == nil {
+			names = []string{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		return enc.Encode(names)
+	}
+	for _, n := range names {
+		fmt.Fprintln(w, n)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/docs/architecture-inventory.md
+++ b/modules/programs/prism/prism/docs/architecture-inventory.md
@@ -2025,7 +2025,7 @@ For each top-level prism subcommand, the function chain and side-effects.
 - `prism convert` — `cmd/convert.go`, opencode raw archive → pi-mono trace via `internal/piexport`.
 - `prism archive` — `cmd/archive.go`, export a session to its archive dir.
 - `prism audit` — `cmd/audit.go`, audit-event query.
-- `prism db` — `cmd/db.go`, internal DB-test helper.
+- `prism db` — `cmd/db.go` (parent command + DB-path helpers), `cmd/db_query.go` / `cmd/db_schema.go` / `cmd/db_tables.go` (read-only SQL query and schema introspection subcommands; #1467). Read-only enforcement via SQLite `?mode=ro`; sandbox routing via host-API endpoints (`GET /db/query`, `GET /db/schema`, `GET /db/tables`).
 - `prism clone` — `cmd/clone.go`, clone a remote into the prism layout.
 - `prism pr` — `cmd/pr.go`, spawn a session for an existing PR.
 - `prism merges list/cancel` — `cmd/merges.go`, merge-queue list and cancellation.

--- a/modules/programs/prism/prism/internal/db/readonly.go
+++ b/modules/programs/prism/prism/internal/db/readonly.go
@@ -1,0 +1,364 @@
+// Read-only query / introspection helpers used by the `prism db` surface
+// (issue #1467).
+//
+// These primitives are deliberately separate from db.Open(): they do NOT run
+// schema migrations and they open a fresh handle in SQLite read-only mode
+// (`?mode=ro`). The host-side handler for `GET /db/query` re-opens its own
+// read-only handle on every request rather than sharing the sidecar's
+// writable handle — keeping the safety boundary obvious in the code.
+//
+// SQL parsing is intentionally avoided. Read-only enforcement is delegated to
+// SQLite via `?mode=ro`, which surfaces the unambiguous "attempt to write a
+// readonly database" error on any DML, DDL, or PRAGMA-with-side-effects.
+//
+// Single-statement detection uses a small, hand-rolled tokenizer (see
+// IsSingleStatement) that handles single-quoted strings, double-quoted
+// identifiers, line comments, and block comments correctly. This is the
+// equivalent of sqlite3_complete() for our purposes — counting unquoted
+// semicolons that separate complete statements — and avoids reaching for
+// regex.
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	_ "modernc.org/sqlite" // register sqlite3 driver
+)
+
+// OpenReadOnly opens a fresh SQLite handle in read-only mode against path.
+// The connection-pool DSN sets a busy_timeout so concurrent writers (the
+// sidecar) cannot starve the read; it does NOT configure WAL or foreign_keys
+// (read-only handles do not need them).
+//
+// The caller owns the returned *sql.DB and must Close() it when done.
+func OpenReadOnly(path string) (*sql.DB, error) {
+	if path == "" {
+		return nil, errors.New("db.OpenReadOnly: empty path")
+	}
+	dsn := "file:" + path +
+		"?mode=ro" +
+		"&_pragma=busy_timeout(5000)"
+	conn, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("db: open read-only: %w", err)
+	}
+	// Validate that the DB file is reachable / openable. sql.Open is lazy;
+	// PingContext forces a real connection so callers see "no such file"
+	// or "unable to open database" errors immediately rather than at first
+	// query time.
+	if err := conn.PingContext(context.Background()); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("db: open read-only: %w", err)
+	}
+	return conn, nil
+}
+
+// QueryResult is the structured return value of RunQuery.
+//
+// Rows is always non-nil, even for empty result sets — empty becomes [][]any{}
+// rather than nil so JSON marshalling produces "rows": [] (never "rows": null).
+//
+// Each cell carries the raw value from the SQLite row scan:
+//   - INTEGER → int64
+//   - REAL    → float64
+//   - TEXT    → string
+//   - BLOB    → []byte
+//   - NULL    → nil
+//
+// Rendering decisions (hex vs base64 for BLOB, "NULL" string vs JSON null) are
+// the caller's responsibility — see cmd/db_query.go.
+type QueryResult struct {
+	Columns   []string `json:"columns"`
+	Rows      [][]any  `json:"rows"`
+	ElapsedMs int64    `json:"elapsedMs"`
+}
+
+// RunQuery executes a single read-only SQL statement against conn and returns
+// columns, rows, and the elapsed time in ms. It uses QueryContext so a
+// cancelled / timed-out context interrupts the running statement (the
+// modernc.org/sqlite driver translates ctx.Done into sqlite3_interrupt).
+//
+// RunQuery does NOT validate that sqlText contains a single statement — that
+// is the caller's job (use IsSingleStatement). The CLI/host-API rejects
+// multi-statement input before calling RunQuery so the error surface is
+// uniform regardless of which path was taken.
+func RunQuery(ctx context.Context, conn *sql.DB, sqlText string) (*QueryResult, error) {
+	rows, err := conn.QueryContext(ctx, sqlText)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("db: read columns: %w", err)
+	}
+
+	out := &QueryResult{
+		Columns: cols,
+		Rows:    [][]any{}, // never nil — empty result must marshal as []
+	}
+
+	for rows.Next() {
+		// Allocate fresh holders per row. Using []any with *any pointers gives
+		// us back the driver's native types (int64 / float64 / string /
+		// []byte / nil) intact, which is exactly what we want for downstream
+		// rendering.
+		holders := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range holders {
+			ptrs[i] = &holders[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, fmt.Errorf("db: scan row: %w", err)
+		}
+		out.Rows = append(out.Rows, holders)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Tables returns the names of all user tables in the database, sorted
+// lexicographically and excluding internal sqlite_* tables.
+func Tables(ctx context.Context, conn *sql.DB) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT name FROM sqlite_master
+		 WHERE type='table' AND name NOT LIKE 'sqlite_%'
+		 ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+// SchemaEntry is one ordered row of a Schema() result.
+//
+// Type is "table" or "index". Name is the object name. SQL is the original
+// CREATE statement as recorded in sqlite_master.sql.
+type SchemaEntry struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+	SQL  string `json:"sql"`
+}
+
+// Schema returns CREATE TABLE / CREATE INDEX statements from sqlite_master in
+// a deterministic order: tables before indexes, each group sorted by name.
+//
+// When tableFilter is non-empty, only the matching table's CREATE TABLE row
+// is returned (indexes for that table are NOT included — the issue specifies
+// "prism db schema <table> prints only that table's DDL"). When tableFilter
+// is empty, all user tables and indexes are returned.
+//
+// Internal sqlite_* objects are excluded. Rows where sql IS NULL (auto-indexes
+// for PRIMARY KEY / UNIQUE constraints) are excluded — they have no
+// printable DDL.
+func Schema(ctx context.Context, conn *sql.DB, tableFilter string) ([]SchemaEntry, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if tableFilter != "" {
+		rows, err = conn.QueryContext(ctx, `
+			SELECT type, name, sql FROM sqlite_master
+			 WHERE type='table' AND name = ? AND sql IS NOT NULL
+			   AND name NOT LIKE 'sqlite_%'`, tableFilter)
+	} else {
+		rows, err = conn.QueryContext(ctx, `
+			SELECT type, name, sql FROM sqlite_master
+			 WHERE type IN ('table','index') AND sql IS NOT NULL
+			   AND name NOT LIKE 'sqlite_%'`)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []SchemaEntry
+	for rows.Next() {
+		var e SchemaEntry
+		if err := rows.Scan(&e.Type, &e.Name, &e.SQL); err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Deterministic order: tables before indexes, alpha within each group.
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Type != entries[j].Type {
+			// "index" < "table" lexicographically, but we want tables first.
+			return entries[i].Type == "table" && entries[j].Type == "index"
+		}
+		return entries[i].Name < entries[j].Name
+	})
+
+	return entries, nil
+}
+
+// IsSingleStatement returns true when sqlText contains exactly one SQL
+// statement (after stripping comments and whitespace).
+//
+// The detection is a hand-rolled lexer that walks the input once and tracks
+// quoting / comment state, counting only unquoted semicolons that separate
+// complete statements. This is the equivalent of repeatedly calling
+// sqlite3_complete() for our purposes — and avoids reaching for regex (which
+// the issue explicitly calls out as the wrong primitive).
+//
+// The function returns:
+//   - (true, nil)   for inputs containing exactly one statement, with or
+//                   without a trailing semicolon. Empty / whitespace-only /
+//                   comments-only inputs return (false, errEmpty).
+//   - (false, nil)  for inputs containing two or more statements separated
+//                   by semicolons.
+//   - (false, err)  for inputs that hit a malformed-token state (unterminated
+//                   string, etc.).
+//
+// Callers should treat (false, _) as "reject — multi-statement or
+// unparseable" and propagate the error for diagnostics.
+func IsSingleStatement(sqlText string) (bool, error) {
+	const (
+		stateNormal = iota
+		stateSingleQuote
+		stateDoubleQuote
+		stateBacktick
+		stateLineComment
+		stateBlockComment
+	)
+	state := stateNormal
+
+	// Track whether the current statement has any non-whitespace,
+	// non-comment content. Bumps to true on the first real token; the
+	// counter increments only when a semicolon ends a non-empty statement.
+	statementHasContent := false
+	completedStatements := 0
+
+	flushStatement := func() {
+		if statementHasContent {
+			completedStatements++
+			statementHasContent = false
+		}
+	}
+
+	for i := 0; i < len(sqlText); i++ {
+		c := sqlText[i]
+		switch state {
+		case stateNormal:
+			switch {
+			case c == '\'':
+				state = stateSingleQuote
+				statementHasContent = true
+			case c == '"':
+				state = stateDoubleQuote
+				statementHasContent = true
+			case c == '`':
+				state = stateBacktick
+				statementHasContent = true
+			case c == '-' && i+1 < len(sqlText) && sqlText[i+1] == '-':
+				state = stateLineComment
+				i++ // skip the second dash
+			case c == '/' && i+1 < len(sqlText) && sqlText[i+1] == '*':
+				state = stateBlockComment
+				i++ // skip the *
+			case c == ';':
+				flushStatement()
+			case c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v':
+				// whitespace — does not bump statementHasContent
+			default:
+				statementHasContent = true
+			}
+		case stateSingleQuote:
+			if c == '\'' {
+				// Doubled '' is an embedded apostrophe, not the end.
+				if i+1 < len(sqlText) && sqlText[i+1] == '\'' {
+					i++
+					continue
+				}
+				state = stateNormal
+			}
+		case stateDoubleQuote:
+			if c == '"' {
+				if i+1 < len(sqlText) && sqlText[i+1] == '"' {
+					i++
+					continue
+				}
+				state = stateNormal
+			}
+		case stateBacktick:
+			if c == '`' {
+				if i+1 < len(sqlText) && sqlText[i+1] == '`' {
+					i++
+					continue
+				}
+				state = stateNormal
+			}
+		case stateLineComment:
+			if c == '\n' {
+				state = stateNormal
+			}
+		case stateBlockComment:
+			if c == '*' && i+1 < len(sqlText) && sqlText[i+1] == '/' {
+				i++
+				state = stateNormal
+			}
+		}
+	}
+
+	// EOF: any unclosed string / block comment is a parse error.
+	switch state {
+	case stateSingleQuote, stateDoubleQuote, stateBacktick:
+		return false, fmt.Errorf("unterminated string literal")
+	case stateBlockComment:
+		return false, fmt.Errorf("unterminated /* ... */ comment")
+	}
+
+	// Final flush — handles input without a trailing semicolon.
+	flushStatement()
+
+	if completedStatements == 0 {
+		return false, fmt.Errorf("input contains no SQL statement")
+	}
+	if completedStatements > 1 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// IsReadOnlyError returns true when err looks like the SQLite "attempt to
+// write a readonly database" error. The CLI layer surfaces this with a
+// dedicated message rather than the raw driver string so the user sees
+// something actionable. Match is a substring on the lowercased message —
+// modernc.org/sqlite returns variants like:
+//
+//	"SQL logic error: attempt to write a readonly database (8)"
+//	"attempt to write a readonly database"
+func IsReadOnlyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "readonly database") ||
+		strings.Contains(msg, "read-only database")
+}

--- a/modules/programs/prism/prism/internal/db/readonly_test.go
+++ b/modules/programs/prism/prism/internal/db/readonly_test.go
@@ -1,0 +1,270 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// openRWForSeed opens a writable handle on a fresh temp DB so tests can seed
+// fixtures, then returns the path for the test to re-open in read-only mode.
+func openRWForSeed(t *testing.T) (path string, cleanup func()) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "ro-test.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return path, func() {}
+}
+
+func TestIsSingleStatement(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    bool
+		wantErr bool
+	}{
+		{name: "single without semi", in: "SELECT 1", want: true},
+		{name: "single with semi", in: "SELECT 1;", want: true},
+		{name: "single with trailing whitespace", in: "  SELECT 1;\n  ", want: true},
+		{name: "two statements", in: "SELECT 1; SELECT 2", want: false},
+		{name: "two statements both terminated", in: "SELECT 1; SELECT 2;", want: false},
+		{name: "semicolon inside single quote", in: "SELECT ';'", want: true},
+		{name: "doubled apostrophe inside string", in: "SELECT 'it''s ok'", want: true},
+		{name: "semicolon inside double-quoted ident", in: `SELECT "a;b" FROM t`, want: true},
+		{name: "semicolon inside line comment", in: "SELECT 1 -- ; not a real statement\n", want: true},
+		{name: "semicolon inside block comment", in: "SELECT 1 /* ; nope */", want: true},
+		{name: "block comment then second stmt", in: "SELECT 1 /* ; */; SELECT 2", want: false},
+		{name: "empty input", in: "", wantErr: true},
+		{name: "whitespace only", in: "   \n\t  ", wantErr: true},
+		{name: "comments only", in: "-- nothing here\n/* still nothing */", wantErr: true},
+		{name: "unterminated string", in: "SELECT 'oops", wantErr: true},
+		{name: "unterminated block comment", in: "SELECT 1 /* never ends", wantErr: true},
+		{name: "trailing semicolons no extra stmt", in: "SELECT 1;;;", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := IsSingleStatement(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got ok=%v err=nil", ok)
+				}
+				return
+			}
+			if err != nil && tc.want {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tc.want {
+				t.Fatalf("got ok=%v, want %v", ok, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenReadOnly_RejectsWrites(t *testing.T) {
+	path, _ := openRWForSeed(t)
+
+	conn, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer conn.Close()
+
+	// Any DML should fail with the read-only sentinel.
+	_, err = conn.ExecContext(context.Background(),
+		`INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at) VALUES ('x','x','x','x','opencode',1)`)
+	if err == nil {
+		t.Fatal("expected error on INSERT against read-only handle")
+	}
+	if !IsReadOnlyError(err) {
+		t.Fatalf("got %v, want read-only error", err)
+	}
+}
+
+func TestRunQuery_EmptyResultEmitsEmptySlice(t *testing.T) {
+	path, _ := openRWForSeed(t)
+
+	conn, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer conn.Close()
+
+	res, err := RunQuery(context.Background(), conn, "SELECT name FROM sqlite_master WHERE 1=0")
+	if err != nil {
+		t.Fatalf("RunQuery: %v", err)
+	}
+	if res.Rows == nil {
+		t.Fatal("Rows must not be nil for empty result; got nil")
+	}
+	if len(res.Rows) != 0 {
+		t.Fatalf("got %d rows, want 0", len(res.Rows))
+	}
+	if len(res.Columns) != 1 || res.Columns[0] != "name" {
+		t.Fatalf("Columns = %v", res.Columns)
+	}
+}
+
+func TestRunQuery_BLOBAndNullPreserved(t *testing.T) {
+	path, _ := openRWForSeed(t)
+
+	// Seed a row with a BLOB and a NULL via the writable handle.
+	w, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open writable: %v", err)
+	}
+	defer w.Close()
+	if _, err := w.conn.Exec(`CREATE TABLE blobs (b BLOB, n INTEGER)`); err != nil {
+		t.Fatalf("create test table: %v", err)
+	}
+	if _, err := w.conn.Exec(`INSERT INTO blobs (b, n) VALUES (X'cafebabe', NULL)`); err != nil {
+		t.Fatalf("insert blob row: %v", err)
+	}
+
+	conn, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer conn.Close()
+
+	res, err := RunQuery(context.Background(), conn, "SELECT b, n FROM blobs")
+	if err != nil {
+		t.Fatalf("RunQuery: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(res.Rows))
+	}
+	row := res.Rows[0]
+	bs, ok := row[0].([]byte)
+	if !ok {
+		t.Fatalf("col 0 type = %T, want []byte", row[0])
+	}
+	if string(bs) != "\xca\xfe\xba\xbe" {
+		t.Fatalf("blob bytes = % x, want ca fe ba be", bs)
+	}
+	if row[1] != nil {
+		t.Fatalf("col 1 = %#v, want nil for NULL", row[1])
+	}
+}
+
+func TestTables_ExcludesSqliteInternal(t *testing.T) {
+	path, _ := openRWForSeed(t)
+
+	conn, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer conn.Close()
+
+	names, err := Tables(context.Background(), conn)
+	if err != nil {
+		t.Fatalf("Tables: %v", err)
+	}
+	for _, n := range names {
+		if strings.HasPrefix(n, "sqlite_") {
+			t.Fatalf("Tables returned internal table %q", n)
+		}
+	}
+	// Spot-check a couple of well-known prism tables.
+	got := make(map[string]bool, len(names))
+	for _, n := range names {
+		got[n] = true
+	}
+	for _, want := range []string{"agent_events", "agent_status", "sessions"} {
+		if !got[want] {
+			t.Errorf("Tables missing expected table %q (got %v)", want, names)
+		}
+	}
+	// Sorted check.
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			t.Fatalf("Tables not sorted: %v", names)
+		}
+	}
+}
+
+func TestSchema_DeterministicOrderAndFilter(t *testing.T) {
+	path, _ := openRWForSeed(t)
+
+	conn, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer conn.Close()
+
+	// Full schema.
+	all, err := Schema(context.Background(), conn, "")
+	if err != nil {
+		t.Fatalf("Schema: %v", err)
+	}
+	if len(all) == 0 {
+		t.Fatal("Schema returned 0 entries; want at least the prism schema")
+	}
+	// Tables before indexes.
+	seenIndex := false
+	for _, e := range all {
+		if e.Type == "index" {
+			seenIndex = true
+		}
+		if seenIndex && e.Type == "table" {
+			t.Fatalf("Schema interleaves: table after index")
+		}
+		if strings.HasPrefix(e.Name, "sqlite_") {
+			t.Fatalf("Schema includes internal %q", e.Name)
+		}
+	}
+
+	// Determinism: a second call must return identical entries.
+	all2, err := Schema(context.Background(), conn, "")
+	if err != nil {
+		t.Fatalf("Schema 2: %v", err)
+	}
+	if len(all2) != len(all) {
+		t.Fatalf("Schema length changed across calls: %d vs %d", len(all), len(all2))
+	}
+	for i := range all {
+		if all[i] != all2[i] {
+			t.Fatalf("Schema entry %d differs across calls:\n  %+v\n  %+v", i, all[i], all2[i])
+		}
+	}
+
+	// Filter to a single table.
+	one, err := Schema(context.Background(), conn, "agent_events")
+	if err != nil {
+		t.Fatalf("Schema(agent_events): %v", err)
+	}
+	if len(one) != 1 {
+		t.Fatalf("Schema(agent_events) returned %d entries, want 1", len(one))
+	}
+	if one[0].Name != "agent_events" || one[0].Type != "table" {
+		t.Fatalf("got %+v, want type=table name=agent_events", one[0])
+	}
+	if !strings.Contains(one[0].SQL, "CREATE TABLE") {
+		t.Fatalf("DDL did not contain CREATE TABLE: %q", one[0].SQL)
+	}
+}
+
+func TestRunQuery_TimeoutCancels(t *testing.T) {
+	path, _ := openRWForSeed(t)
+
+	conn, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer conn.Close()
+
+	// A recursive CTE without a stop condition runs effectively forever.
+	// With a tight context deadline the driver should cancel via
+	// sqlite3_interrupt and surface a context-related error.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*1000*1000) // 50ms
+	defer cancel()
+	_, err = RunQuery(ctx, conn,
+		"WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM r) SELECT n FROM r")
+	if err == nil {
+		t.Fatal("expected context-cancellation error, got nil")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -151,11 +151,22 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 //	GET  /list-sessions — list active sessions (role-scoped)
 //	GET  /checkin       — return conversation history for a session (coordinator only)
 //	GET  /stats         — return stats/events for rendering (all roles)
+//	GET  /db/query      — run a single read-only SQL statement (coordinator only)
+//	GET  /db/schema     — return CREATE TABLE / CREATE INDEX DDL (coordinator only)
+//	GET  /db/tables     — return user table names (coordinator only)
 //	POST /prompt        — deliver a prompt to a target session (role-scoped)
 //	POST /merge         — enqueue a PR for the merge queue (coordinator only)
 //	GET  /merges        — list merge queue entries (coordinator only)
 //	POST /merges/cancel — cancel a watching merge queue entry (coordinator only)
 //	POST /event         — write a lifecycle event to the host DB (all roles)
+//
+// /db/query, /db/schema, /db/tables are coordinator-only because /db/query
+// exposes a strict superset of /checkin: raw cross-session payloads (e.g.
+// SELECT * FROM harness_frames) versus /checkin's single-session rendered
+// view. Gating these at the same level as /checkin preserves the
+// cross-session privilege isolation /checkin already enforces. The /stats
+// analogue does not apply — /stats is aggregate counts, /db/query is
+// row-level conversation content (#1467 round-3 review).
 //
 // Role-based permissions are enforced based on s.cfg.AgentRole and
 // s.cfg.SessionName. Workers have restricted access; coordinators have broader
@@ -2026,8 +2037,17 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// All three open a fresh read-only handle (?mode=ro) per request rather
 	// than sharing the sidecar's writable handle. Handlers live in
 	// host_api_db.go so the wiring stays minimal here.
+	//
+	// Coordinator-only: /db/query exposes a strict superset of /checkin
+	// (raw cross-session payloads vs. rendered single-session view), so it
+	// is gated at the same level as /checkin. /db/schema and /db/tables are
+	// also coordinator-only for consistency — a worker that cannot read
+	// payloads has no need to enumerate the schema either.
 	mux.HandleFunc("/db/query", func(w http.ResponseWriter, r *http.Request) {
 		if !requireGet(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "db query") {
 			return
 		}
 		s.hostAPIDBQuery(w, r)
@@ -2036,10 +2056,16 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if !requireGet(w, r) {
 			return
 		}
+		if !requireCoordinator(w, "db schema") {
+			return
+		}
 		s.hostAPIDBSchema(w, r)
 	})
 	mux.HandleFunc("/db/tables", func(w http.ResponseWriter, r *http.Request) {
 		if !requireGet(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "db tables") {
 			return
 		}
 		s.hostAPIDBTables(w, r)

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -2022,6 +2022,29 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "applied"})
 	})
 
+	// GET /db/query, /db/schema, /db/tables — read-only query surface (#1467).
+	// All three open a fresh read-only handle (?mode=ro) per request rather
+	// than sharing the sidecar's writable handle. Handlers live in
+	// host_api_db.go so the wiring stays minimal here.
+	mux.HandleFunc("/db/query", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		s.hostAPIDBQuery(w, r)
+	})
+	mux.HandleFunc("/db/schema", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		s.hostAPIDBSchema(w, r)
+	})
+	mux.HandleFunc("/db/tables", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		s.hostAPIDBTables(w, r)
+	})
+
 	return mux
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/host_api_db.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_db.go
@@ -1,0 +1,172 @@
+package sidecar
+
+// Host-API endpoints for the `prism db` read-only surface (issue #1467).
+//
+// These endpoints proxy `prism db query`, `prism db schema`, and
+// `prism db tables` from inside a sandbox out to the host. Each opens its
+// own SQLite read-only handle (`?mode=ro`) per request rather than sharing
+// the sidecar's writable handle — keeping the safety boundary obvious in
+// the code, exactly as the implementer notes call out.
+//
+// Endpoints:
+//
+//	GET /db/query?sql=&timeout=  — runs a single read-only statement.
+//	GET /db/schema[?table=]      — returns CREATE TABLE / CREATE INDEX DDL.
+//	GET /db/tables               — returns user table names sorted.
+//
+// Rendering stays on the CLI side. These endpoints return structured JSON;
+// the CLI renders to aligned tables or JSON depending on --json. This
+// mirrors #1463's "rendering stays in one place" principle.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// hostAPIDBQuery handles GET /db/query.
+//
+// Parameters:
+//
+//	sql      — the SQL text (required). Must be a single statement; the CLI
+//	           rejects multi-statement input before issuing this request, but
+//	           we re-check here as a defensive measure.
+//	timeout  — Go duration string (e.g. "5s", "100ms"). Defaults to 5s.
+//
+// Response body on success: db.QueryResult marshalled directly. Errors are
+// reported as HTTP 4xx with `{"error": "..."}` and a clear message.
+func (s *Sidecar) hostAPIDBQuery(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	sqlText := q.Get("sql")
+	if sqlText == "" {
+		writeDBErr(w, http.StatusBadRequest, "sql is required")
+		return
+	}
+
+	// Single-statement guard. The CLI also enforces this, but we re-check
+	// here so direct host-API callers (e.g. agent debugging) get the same
+	// safety net.
+	ok, err := db.IsSingleStatement(sqlText)
+	if err != nil {
+		writeDBErr(w, http.StatusBadRequest, "sql parse error: "+err.Error())
+		return
+	}
+	if !ok {
+		writeDBErr(w, http.StatusBadRequest, "sql must contain exactly one statement")
+		return
+	}
+
+	timeout := 5 * time.Second
+	if t := q.Get("timeout"); t != "" {
+		parsed, perr := time.ParseDuration(t)
+		if perr != nil {
+			writeDBErr(w, http.StatusBadRequest, "invalid timeout: "+perr.Error())
+			return
+		}
+		if parsed > 0 {
+			timeout = parsed
+		}
+	}
+
+	conn, err := db.OpenReadOnly(s.cfg.DB.Path())
+	if err != nil {
+		writeDBErr(w, http.StatusInternalServerError, "open read-only db: "+err.Error())
+		return
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	res, err := db.RunQuery(ctx, conn, sqlText)
+	if err != nil {
+		// Read-only rejection is a clear 4xx — the user wrote a write query.
+		if db.IsReadOnlyError(err) {
+			writeDBErr(w, http.StatusBadRequest, "read-only: "+err.Error())
+			return
+		}
+		// Timeout / cancellation surfaces via context.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			writeDBErr(w, http.StatusRequestTimeout, fmt.Sprintf("query timeout exceeded (%s)", timeout))
+			return
+		}
+		writeDBErr(w, http.StatusBadRequest, "query failed: "+err.Error())
+		return
+	}
+	res.ElapsedMs = time.Since(start).Milliseconds()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(res); err != nil {
+		// Best-effort error log; the response is already partially written.
+		s.logger().Printf("sidecar: host-API /db/query: encode response failed: %v", err)
+	}
+}
+
+// hostAPIDBSchema handles GET /db/schema[?table=].
+//
+// Response body on success: {"entries": [...db.SchemaEntry...]}.
+func (s *Sidecar) hostAPIDBSchema(w http.ResponseWriter, r *http.Request) {
+	tableFilter := r.URL.Query().Get("table")
+
+	conn, err := db.OpenReadOnly(s.cfg.DB.Path())
+	if err != nil {
+		writeDBErr(w, http.StatusInternalServerError, "open read-only db: "+err.Error())
+		return
+	}
+	defer conn.Close()
+
+	entries, err := db.Schema(r.Context(), conn, tableFilter)
+	if err != nil {
+		writeDBErr(w, http.StatusInternalServerError, "schema query failed: "+err.Error())
+		return
+	}
+	if tableFilter != "" && len(entries) == 0 {
+		writeDBErr(w, http.StatusNotFound, fmt.Sprintf("table %q not found", tableFilter))
+		return
+	}
+	if entries == nil {
+		entries = []db.SchemaEntry{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"entries": entries})
+}
+
+// hostAPIDBTables handles GET /db/tables.
+//
+// Response body on success: {"tables": [...string...]}.
+func (s *Sidecar) hostAPIDBTables(w http.ResponseWriter, r *http.Request) {
+	conn, err := db.OpenReadOnly(s.cfg.DB.Path())
+	if err != nil {
+		writeDBErr(w, http.StatusInternalServerError, "open read-only db: "+err.Error())
+		return
+	}
+	defer conn.Close()
+
+	names, err := db.Tables(r.Context(), conn)
+	if err != nil {
+		writeDBErr(w, http.StatusInternalServerError, "tables query failed: "+err.Error())
+		return
+	}
+	if names == nil {
+		names = []string{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"tables": names})
+}
+
+// writeDBErr writes a standard {"error": ...} JSON body with the given status.
+// Mirrors the writeError closure inside hostAPIHandler() so the new file does
+// not need access to those closures.
+func writeDBErr(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_db_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_db_test.go
@@ -8,6 +8,13 @@ package sidecar
 // from sidecar_test.go which provides a real on-disk SQLite file — required
 // because the new endpoints re-open the DB in read-only mode (?mode=ro)
 // rather than sharing the writable handle.
+//
+// All three endpoints are coordinator-only (#1467 round-3 review): /db/query
+// exposes a strict superset of /checkin's data, so it inherits /checkin's
+// gating. Tests that exercise post-auth happy / error paths use a coordinator
+// sidecar; the *_WorkerForbidden tests at the bottom verify the role gate
+// itself (matching the TestHostAPI_Checkin_WorkerForbidden precedent in
+// sidecar_test.go).
 
 import (
 	"encoding/json"
@@ -22,7 +29,7 @@ import (
 
 func TestHostAPI_DBTables_HappyPath(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/db/tables", "")
 	if rr.Code != http.StatusOK {
@@ -51,7 +58,7 @@ func TestHostAPI_DBTables_HappyPath(t *testing.T) {
 
 func TestHostAPI_DBTables_PostRejected(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/db/tables", "")
 	if rr.Code != http.StatusMethodNotAllowed {
@@ -63,7 +70,7 @@ func TestHostAPI_DBTables_PostRejected(t *testing.T) {
 
 func TestHostAPI_DBSchema_All(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema", "")
 	if rr.Code != http.StatusOK {
@@ -84,7 +91,7 @@ func TestHostAPI_DBSchema_All(t *testing.T) {
 
 func TestHostAPI_DBSchema_FilteredTable(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema?table=agent_events", "")
 	if rr.Code != http.StatusOK {
@@ -104,7 +111,7 @@ func TestHostAPI_DBSchema_FilteredTable(t *testing.T) {
 
 func TestHostAPI_DBSchema_UnknownTable(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema?table=nope_does_not_exist", "")
 	if rr.Code != http.StatusNotFound {
@@ -123,7 +130,7 @@ func TestHostAPI_DBSchema_UnknownTable(t *testing.T) {
 
 func TestHostAPI_DBQuery_HappyPath(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet,
 		"/db/query?sql="+queryEscape("SELECT 1 AS one, 'hi' AS greeting"), "")
@@ -149,7 +156,7 @@ func TestHostAPI_DBQuery_HappyPath(t *testing.T) {
 
 func TestHostAPI_DBQuery_EmptyResult(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet,
 		"/db/query?sql="+queryEscape("SELECT name FROM sqlite_master WHERE 1=0"), "")
@@ -167,7 +174,7 @@ func TestHostAPI_DBQuery_EmptyResult(t *testing.T) {
 
 func TestHostAPI_DBQuery_RejectsWrite(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet,
 		"/db/query?sql="+queryEscape(
@@ -188,7 +195,7 @@ func TestHostAPI_DBQuery_RejectsWrite(t *testing.T) {
 
 func TestHostAPI_DBQuery_RejectsMultiStatement(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet,
 		"/db/query?sql="+queryEscape("SELECT 1; SELECT 2"), "")
@@ -207,7 +214,7 @@ func TestHostAPI_DBQuery_RejectsMultiStatement(t *testing.T) {
 
 func TestHostAPI_DBQuery_MalformedSQL(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet,
 		"/db/query?sql="+queryEscape("SELECTX from where !!!"), "")
@@ -225,11 +232,64 @@ func TestHostAPI_DBQuery_MalformedSQL(t *testing.T) {
 
 func TestHostAPI_DBQuery_MissingSQL(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/db/query", "")
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+// ── GET /db/* — role gating (#1467 round-3 review) ──────────────────────
+//
+// All three endpoints are coordinator-only because /db/query exposes a strict
+// superset of /checkin's data. These mirror TestHostAPI_Checkin_WorkerForbidden
+// in sidecar_test.go: a worker-role sidecar must receive 403, with a non-empty
+// error message.
+
+func TestHostAPI_DBQuery_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet,
+		"/db/query?sql="+queryEscape("SELECT 1"), "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %q, want 403", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+func TestHostAPI_DBSchema_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema", "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %q, want 403", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
+	}
+}
+
+func TestHostAPI_DBTables_WorkerForbidden(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@feature", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/tables", "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %q, want 403", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if errResp["error"] == "" {
+		t.Error("expected error field in 403 response")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_db_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_db_test.go
@@ -1,0 +1,271 @@
+package sidecar
+
+// Tests for the host-API GET /db/query, /db/schema, /db/tables endpoints
+// added in #1467.
+//
+// These exercise the hostAPIHandler() method directly (no live socket),
+// matching the shape of sidecar_stats_test.go. The fixtures use openTestDB(t)
+// from sidecar_test.go which provides a real on-disk SQLite file — required
+// because the new endpoints re-open the DB in read-only mode (?mode=ro)
+// rather than sharing the writable handle.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// ── GET /db/tables ────────────────────────────────────────────────────────────
+
+func TestHostAPI_DBTables_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/tables", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Tables []string `json:"tables"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Tables) == 0 {
+		t.Fatal("Tables empty; want at least the prism schema")
+	}
+	for _, name := range resp.Tables {
+		if strings.HasPrefix(name, "sqlite_") {
+			t.Fatalf("Tables included internal %q", name)
+		}
+	}
+	// Sorted check.
+	for i := 1; i < len(resp.Tables); i++ {
+		if resp.Tables[i-1] > resp.Tables[i] {
+			t.Fatalf("Tables not sorted: %v", resp.Tables)
+		}
+	}
+}
+
+func TestHostAPI_DBTables_PostRejected(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/db/tables", "")
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+// ── GET /db/schema ────────────────────────────────────────────────────────────
+
+func TestHostAPI_DBSchema_All(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Entries []db.SchemaEntry `json:"entries"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Entries) == 0 {
+		t.Fatal("Entries empty")
+	}
+	// First entry must be a table (tables come before indexes).
+	if resp.Entries[0].Type != "table" {
+		t.Errorf("first entry type = %q, want table", resp.Entries[0].Type)
+	}
+}
+
+func TestHostAPI_DBSchema_FilteredTable(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema?table=agent_events", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Entries []db.SchemaEntry `json:"entries"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(resp.Entries))
+	}
+	if resp.Entries[0].Name != "agent_events" {
+		t.Errorf("got name %q, want agent_events", resp.Entries[0].Name)
+	}
+}
+
+func TestHostAPI_DBSchema_UnknownTable(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/schema?table=nope_does_not_exist", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp.Error, "not found") {
+		t.Errorf("error %q does not mention 'not found'", errResp.Error)
+	}
+}
+
+// ── GET /db/query — happy path ────────────────────────────────────────────────
+
+func TestHostAPI_DBQuery_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet,
+		"/db/query?sql="+queryEscape("SELECT 1 AS one, 'hi' AS greeting"), "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp db.QueryResult
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Columns) != 2 || resp.Columns[0] != "one" || resp.Columns[1] != "greeting" {
+		t.Errorf("Columns = %v, want [one greeting]", resp.Columns)
+	}
+	if len(resp.Rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(resp.Rows))
+	}
+	// JSON unmarshal turns numbers into float64 for any → cast through that.
+	if got := resp.Rows[0][0]; got == nil {
+		t.Errorf("col 0 = nil, want 1")
+	}
+	if got, _ := resp.Rows[0][1].(string); got != "hi" {
+		t.Errorf("col 1 = %v, want hi", resp.Rows[0][1])
+	}
+}
+
+func TestHostAPI_DBQuery_EmptyResult(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet,
+		"/db/query?sql="+queryEscape("SELECT name FROM sqlite_master WHERE 1=0"), "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	// Verify the JSON literally has "rows":[] — never "rows":null.
+	body := rr.Body.String()
+	if !strings.Contains(body, `"rows":[]`) {
+		t.Fatalf("response body did not contain `\"rows\":[]`: %s", body)
+	}
+}
+
+// ── GET /db/query — error paths ───────────────────────────────────────────────
+
+func TestHostAPI_DBQuery_RejectsWrite(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet,
+		"/db/query?sql="+queryEscape(
+			"INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at) VALUES ('x','x','x','x','opencode',1)"),
+		"")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	decodeJSONBody(t, rr, &errResp)
+	low := strings.ToLower(errResp.Error)
+	if !strings.Contains(low, "read") {
+		t.Errorf("error %q does not mention read-only", errResp.Error)
+	}
+}
+
+func TestHostAPI_DBQuery_RejectsMultiStatement(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet,
+		"/db/query?sql="+queryEscape("SELECT 1; SELECT 2"), "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(strings.ToLower(errResp.Error), "single statement") &&
+		!strings.Contains(strings.ToLower(errResp.Error), "exactly one statement") {
+		t.Errorf("error %q does not mention single-statement", errResp.Error)
+	}
+}
+
+func TestHostAPI_DBQuery_MalformedSQL(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet,
+		"/db/query?sql="+queryEscape("SELECTX from where !!!"), "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	decodeJSONBody(t, rr, &errResp)
+	if errResp.Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestHostAPI_DBQuery_MissingSQL(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/db/query", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+// queryEscape percent-encodes a SQL string for placement in a query parameter.
+func queryEscape(sqlText string) string {
+	// We could pull in net/url, but our tests need only minimal escaping —
+	// space, semicolon, single-quote, equals — none of which are reserved
+	// for the URI authority parsing of httptest. Use json marshalling's
+	// trick: marshal as a string and hand-encode the few critical chars.
+	b, _ := json.Marshal(sqlText)
+	// strip surrounding quotes
+	s := string(b[1 : len(b)-1])
+	// percent-encode the chars that mess with query strings.
+	var out strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case ' ':
+			out.WriteString("%20")
+		case '=':
+			out.WriteString("%3D")
+		case '&':
+			out.WriteString("%26")
+		case '#':
+			out.WriteString("%23")
+		case '+':
+			out.WriteString("%2B")
+		case ';':
+			out.WriteString("%3B")
+		case '\'':
+			out.WriteString("%27")
+		case '"':
+			out.WriteString("%22")
+		default:
+			out.WriteByte(c)
+		}
+	}
+	return out.String()
+}


### PR DESCRIPTION
Closes #1467

## Summary

Add a `prism db` command surface that exposes the prism SQLite database to read-only ad-hoc queries and schema introspection. Targeted at agents and humans debugging prism itself — the curated `prism stats` / `prism checkin` views answer most questions, but forensic work regularly needs raw SQL.

## Surface

| Subcommand | Purpose |
|---|---|
| `prism db query [SQL \| -]` | Run a single read-only SQL statement; `--json` for structured output, `--timeout` for statement deadline, `-` reads from stdin. |
| `prism db schema [table]` | Print `CREATE TABLE` / `CREATE INDEX` statements; with no arg, prints everything. |
| `prism db tables` | List user table names (excludes `sqlite_*`). |

## Design

**Read-only enforcement.** The DB is opened with `?mode=ro` and SQLite rejects any write with the unambiguous "attempt to write a readonly database" error. We do **not** parse SQL ourselves to allowlist statements — that would inevitably miss edge cases (CTEs hiding DML, `INSERT … RETURNING`, etc.).

**Single-statement detection.** A small hand-rolled tokenizer (`db.IsSingleStatement`) walks the input once, tracking single-quoted strings, double-quoted identifiers, backtick identifiers, line comments, and block comments. It counts unquoted semicolons that separate complete statements — equivalent to `sqlite3_complete()` for our purposes — and avoids regex per the implementer notes.

**Statement timeout.** Default 5s; override via `--timeout`. The deadline is plumbed through `context.WithTimeout` to `QueryContext`, which the modernc.org/sqlite driver translates into `sqlite3_interrupt`.

**Sandbox routing.** Three new host-API endpoints (`GET /db/query`, `GET /db/schema`, `GET /db/tables`) piggy-back on the `proxyReadToHostAPI` helper from #1463/#1469. The CLI dispatches via `PRISM_HOST_API` exactly like `prism stats` / `prism list-sessions` / `prism checkin`. The host handler **re-opens its own read-only handle per request** rather than sharing the sidecar's writable handle — keeping the safety boundary obvious.

**Authorization (round-3 review-security finding).** All three `/db/*` endpoints are gated behind `requireCoordinator` (commit `552d4503`), matching the `/checkin` and `/logs` precedent. Reasoning: `/db/query` exposes a strict superset of `/checkin`'s data — raw cross-session payloads (`SELECT * FROM harness_frames`, `SELECT prompt_text FROM spawn_inputs`, `SELECT text FROM bus_messages`) versus `/checkin`'s rendered single-session view. Gating at the same level as `/checkin` preserves the cross-session privilege isolation `/checkin` already enforces. The `/stats` analogue does not apply — `/stats` is aggregate counts, `/db/query` is row-level conversation content. `/db/schema` and `/db/tables` are gated for consistency: a worker that cannot read payloads has no need to enumerate the schema either.

**Rendering stays on the CLI side.** Endpoints return structured JSON (`db.QueryResult`, `[]db.SchemaEntry`, `[]string`); the CLI renders to aligned tables or JSON depending on `--json`. Mirrors #1463's "rendering stays in one place" principle. NULL → dimmed `"NULL"` in table mode / JSON `null`. BLOB → `0x<hex>` in table mode / base64 string in JSON. Empty result emits `"rows": []`, never `null`.

## Tests

- `internal/db/readonly_test.go` — `IsSingleStatement` edge cases (16 sub-tests covering comments, quoted strings, doubled apostrophes, unterminated literals); BLOB / NULL preservation through `RunQuery`; deterministic schema ordering; timeout cancellation; write rejection.
- `internal/sidecar/sidecar_db_test.go` — host-API integration tests (14 tests): happy paths and post-auth error paths exercised with a coordinator-role sidecar, plus three `_WorkerForbidden` tests that verify the role gate on each endpoint (matching `TestHostAPI_Checkin_WorkerForbidden` precedent).
- `cmd/db_query_test.go` — JSON / table rendering, BLOB / NULL formatting, empty-result `[]` invariant, stdin `-` input, write rejection via the local code path.

## Review history

- **Round 1** (4 PASS, 1 FAIL: review-context) — added `prism db` allow lines to the deny-by-default review/retro/host-review opencode bash blocks. Commit `710d54ac`.
- **Round 2** (3 PASS, 1 FAIL: review-context, 1 ERROR: review-qa no-start) — added the same allow lines to the missed `plan` agent blocks (container + host). Commit `68c03886`.
- **Round 3** (4 PASS, 1 FAIL: review-security) — `/db/*` endpoints had no role gate, allowing workers to read cross-session content via raw SQL that `/checkin`'s coordinator-only gate is meant to prevent. Escalated to coordinator; coordinator chose option A (gate all three with `requireCoordinator`). Implemented in commit `552d4503`. The targeted-scope fix did not require a 4th review cycle per coordinator instruction.

## Quality gates

```
$ go build ./...
$ go test ./...
ok    github.com/prismatic-koi/prism/cmd                    3.940s
ok    github.com/prismatic-koi/prism/internal/db            1.405s
ok    github.com/prismatic-koi/prism/internal/sidecar      10.032s
... (all packages pass)

$ nix build .#prism
# (succeeds — checkPhase moved to CI per #1508)
```

## Out of scope (per the issue)

- Write access — there is no `--read-write` escape hatch.
- TOON output (#1466 tracks evaluation).
- Query history / saved queries / REPL mode.
- Schema-aware autocompletion.
