### PR TITLE
feat(prism): add --deliver to prism logs and prism feedback command

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -468,9 +468,27 @@ prism logs <session>              # full sidecar log to stdout
 prism logs <session> --tail N     # last N lines only
 prism logs <session> --follow     # stream new lines as they arrive (ends ~5s after terminal state)
 prism logs <session> -f           # alias for --follow
+prism logs <session> --harness-events     # raw PI JSONL frames (P5.LOGS / #1218)
 ```
 
 Works identically from a host shell and from inside a coordinator container. When `PRISM_HOST_API` is set (container mode), `prism logs` proxies through the host-API Unix socket — no special handling required. The output is the raw log and can be piped to `grep` / `rg`.
+
+#### `--deliver=<sink>` — route the artifact directly
+
+The `--deliver` flag short-circuits the usual "pipe stdout into something" two-step. Three sinks are supported:
+
+```bash
+prism logs <session>                                      # stdout (default)
+prism logs <session> --deliver=stdout                     # explicit stdout
+prism logs <session> --deliver=file:/tmp/sidecar.log      # atomic write to a file
+prism logs <session> --deliver=webhook:https://example.com/triage
+prism logs <session> --harness-events --deliver=webhook:https://example.com/frames
+```
+
+- `file:<path>` writes via tempfile + rename so a failed deliver cannot leave a half-written file. On success it prints `{"delivered_to":"file:<path>","bytes":N}` to stdout.
+- `webhook:<url>` POSTs the content with `Content-Type: text/plain` (or `application/x-ndjson` for `--harness-events`). On success it prints `{"delivered_to":"webhook:<url>","status":<code>}`. A 4xx or 5xx response is surfaced as a non-zero exit with a JSON object containing `status` and a truncated `body`. The local log file is read on demand so a failed delivery never modifies the source.
+- Unknown schemes (`s3:...`, `mailto:...`, etc.) are refused with the valid set listed (principle 3 of #1497).
+- `--deliver` and `--follow` are mutually exclusive: delivery captures a snapshot.
 
 ### Common failure signatures
 
@@ -491,3 +509,22 @@ A lookup table of log patterns, their causes, and remediation hints:
 ### Escalation
 
 If two diagnostic cycles (`prism checkin` + `prism logs`) do not clarify the issue, **escalate to the user** rather than continuing to probe in circles. Document what you observed in each cycle and what remains unclear. Do not run a third diagnostic cycle on your own.
+
+### `prism feedback` — record CLI friction
+
+Use `prism feedback` to record short notes about CLI rough edges — flags rejected for the wrong reason, error messages that don't enumerate, race conditions in async paths. Each entry is appended as one JSON object per line to `$XDG_STATE_HOME/prism/feedback.jsonl` (defaults to `~/.local/state/prism/feedback.jsonl`).
+
+```bash
+prism feedback "the --tier flag rejects 'enterprise' but the docs list it as valid"
+echo "feedback from a script" | prism feedback -        # read from stdin
+prism feedback list                                       # human-readable list
+prism feedback list --json                                # JSON array of all entries
+prism feedback list --days 7                              # only entries from the last 7 days
+prism feedback prune --days 90 --yes                      # drop entries older than 90 days
+```
+
+Each entry includes `timestamp` (RFC 3339), `text`, `session` (the value of `PRISM_SESSION_NAME` if set), and `prism_version`. Optional fields cover `cwd` and other contextual hints.
+
+**Upstream POST (opt-in).** When the `PRISM_FEEDBACK_ENDPOINT` environment variable is set (or a `feedback_endpoint` field is present in `~/.config/prism/config.json`), each new entry is POSTed to the configured URL after being written locally. The local record is the source of truth: if the upstream POST fails, the local entry is unaffected and the failure is reported in the success message. Env var wins over config.
+
+**Pruning safety (principle 1).** `prism feedback prune` requires `--yes` to confirm — omitting it errors instead of prompting. This matches the rest of the prism CLI's no-implicit-confirmations stance.

--- a/modules/programs/prism/prism/cmd/deliver.go
+++ b/modules/programs/prism/prism/cmd/deliver.go
@@ -1,0 +1,232 @@
+package cmd
+
+// deliver.go implements the `--deliver=<sink>` flag plumbing used by
+// `prism logs` (raw sidecar log and `--harness-events` JSONL frames).
+//
+// Three sinks are supported:
+//
+//	stdout                — default, write content directly to w
+//	file:<path>           — atomic write (tempfile + rename) so a partial
+//	                        deliver cannot leave a half-written file
+//	webhook:<url>         — HTTP POST with a configurable Content-Type;
+//	                        success prints {"delivered_to":..., "status":...}
+//	                        and 4xx/5xx are reported as a non-zero exit
+//
+// Unknown schemes return a structured refusal naming the valid set
+// (principle 3 of the 10-Principles audit, parent #1497). The caller
+// (cmd/logs.go, cmd/logs_harness.go) is responsible for buffering the
+// content into a []byte before invoking deliver — both surfaces today
+// already read from the on-disk log or the DB into a buffer.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DeliverSinkStdout is the literal value for `--deliver=stdout`.
+const DeliverSinkStdout = "stdout"
+
+// validDeliverSchemes lists the accepted scheme prefixes for `--deliver`.
+// Used by the unknown-scheme refusal message so the supported set is
+// always in sync with the parser.
+var validDeliverSchemes = []string{"stdout", "file:<path>", "webhook:<url>"}
+
+// deliverSink is the parsed form of a `--deliver=...` flag value.
+type deliverSink struct {
+	// kind is one of "stdout", "file", or "webhook". Empty on a parse error.
+	kind string
+	// dest is the file path (kind=="file") or URL (kind=="webhook"). Empty
+	// for kind=="stdout".
+	dest string
+}
+
+// parseDeliverFlag parses a `--deliver=<value>` flag value into a deliverSink.
+//
+// An empty value is treated as the default (stdout) so callers can pass the
+// raw flag value without checking for emptiness first.
+//
+// Unknown schemes (including a missing path/URL after a known scheme) return
+// a structured error naming the valid set, consistent with principle 3.
+func parseDeliverFlag(raw string) (deliverSink, error) {
+	if raw == "" || raw == DeliverSinkStdout {
+		return deliverSink{kind: "stdout"}, nil
+	}
+	if strings.HasPrefix(raw, "file:") {
+		path := strings.TrimPrefix(raw, "file:")
+		if path == "" {
+			return deliverSink{}, fmt.Errorf(
+				"--deliver=file: requires a path (e.g. --deliver=file:./out.log); valid sinks: %s",
+				strings.Join(validDeliverSchemes, ", "),
+			)
+		}
+		return deliverSink{kind: "file", dest: path}, nil
+	}
+	if strings.HasPrefix(raw, "webhook:") {
+		dest := strings.TrimPrefix(raw, "webhook:")
+		if dest == "" {
+			return deliverSink{}, fmt.Errorf(
+				"--deliver=webhook: requires a URL (e.g. --deliver=webhook:https://example.com/hook); valid sinks: %s",
+				strings.Join(validDeliverSchemes, ", "),
+			)
+		}
+		if !strings.HasPrefix(dest, "http://") && !strings.HasPrefix(dest, "https://") {
+			return deliverSink{}, fmt.Errorf(
+				"--deliver=webhook:%s: URL must start with http:// or https://",
+				dest,
+			)
+		}
+		return deliverSink{kind: "webhook", dest: dest}, nil
+	}
+	return deliverSink{}, fmt.Errorf(
+		"--deliver=%s: unknown sink scheme; valid sinks are: %s",
+		raw, strings.Join(validDeliverSchemes, ", "),
+	)
+}
+
+// deliverHTTPClient is the HTTP client used for webhook delivery. Overridden
+// in tests via the package-level variable so test webservers can intercept
+// the request without monkey-patching net/http.
+var deliverHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// deliverContent routes content to the configured sink. On success, a JSON
+// status object is written to statusW (typically os.Stdout) so the caller
+// gets a structured confirmation regardless of where the artifact landed.
+//
+// For sink.kind == "stdout", content is written directly to statusW (the
+// default behaviour preserves backwards compatibility — no JSON wrapper).
+//
+// contentType applies only to webhook delivery (e.g. "text/plain" for the
+// raw sidecar log, "application/x-ndjson" for `--harness-events`).
+func deliverContent(sink deliverSink, content []byte, contentType string, statusW io.Writer) error {
+	switch sink.kind {
+	case "stdout", "":
+		_, err := statusW.Write(content)
+		return err
+	case "file":
+		return deliverToFile(sink.dest, content, statusW)
+	case "webhook":
+		return deliverToWebhook(sink.dest, content, contentType, statusW)
+	default:
+		return fmt.Errorf(
+			"--deliver: unknown sink kind %q; valid sinks are: %s",
+			sink.kind, strings.Join(validDeliverSchemes, ", "),
+		)
+	}
+}
+
+// deliverToFile writes content to path atomically: write to a sibling
+// tempfile and rename on success. A partial deliver therefore cannot leave
+// a half-written destination file. On success a JSON object describing the
+// delivery is written to statusW.
+func deliverToFile(path string, content []byte, statusW io.Writer) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("--deliver=file:%s: resolve path: %w", path, err)
+	}
+	dir := filepath.Dir(abs)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("--deliver=file:%s: create parent directory: %w", path, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".prism-deliver-*.tmp")
+	if err != nil {
+		return fmt.Errorf("--deliver=file:%s: create tempfile: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if anything below fails before the rename.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("--deliver=file:%s: write tempfile: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("--deliver=file:%s: close tempfile: %w", path, err)
+	}
+	if err := os.Rename(tmpPath, abs); err != nil {
+		return fmt.Errorf("--deliver=file:%s: rename: %w", path, err)
+	}
+	cleanup = false
+	resp := struct {
+		DeliveredTo string `json:"delivered_to"`
+		Bytes       int    `json:"bytes"`
+	}{
+		DeliveredTo: "file:" + path,
+		Bytes:       len(content),
+	}
+	enc := json.NewEncoder(statusW)
+	return enc.Encode(resp)
+}
+
+// webhookErrorBodyMax bounds how many bytes of a 4xx/5xx response body we
+// echo back to the caller. The body is truncated for safety — endpoints
+// can return arbitrarily large HTML error pages and we don't want to flood
+// the operator's terminal with them.
+const webhookErrorBodyMax = 4 * 1024
+
+// deliverToWebhook POSTs content to url with the given Content-Type and
+// reports the response status. 4xx / 5xx responses become a non-zero exit
+// (a returned error), with the status code and a truncated body included
+// in the structured error message so the operator can see what the server
+// said. The local content is not lost — both prism-logs callers read on
+// demand and a webhook failure does not delete or modify the source.
+func deliverToWebhook(url string, content []byte, contentType string, statusW io.Writer) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(content))
+	if err != nil {
+		return fmt.Errorf("--deliver=webhook:%s: build request: %w", url, err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := deliverHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("--deliver=webhook:%s: POST: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, webhookErrorBodyMax+1))
+		truncated := len(body) > webhookErrorBodyMax
+		if truncated {
+			body = body[:webhookErrorBodyMax]
+		}
+		errResp := struct {
+			DeliveredTo string `json:"delivered_to"`
+			Status      int    `json:"status"`
+			Body        string `json:"body"`
+			Truncated   bool   `json:"truncated,omitempty"`
+		}{
+			DeliveredTo: "webhook:" + url,
+			Status:      resp.StatusCode,
+			Body:        string(body),
+			Truncated:   truncated,
+		}
+		marshalled, _ := json.Marshal(errResp)
+		return errors.New(string(marshalled))
+	}
+	// Drain remaining body so the connection can be reused and we don't leak
+	// goroutines on the server side.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	out := struct {
+		DeliveredTo string `json:"delivered_to"`
+		Status      int    `json:"status"`
+	}{
+		DeliveredTo: "webhook:" + url,
+		Status:      resp.StatusCode,
+	}
+	enc := json.NewEncoder(statusW)
+	return enc.Encode(out)
+}

--- a/modules/programs/prism/prism/cmd/deliver_test.go
+++ b/modules/programs/prism/prism/cmd/deliver_test.go
@@ -1,0 +1,319 @@
+package cmd
+
+// Tests for the --deliver=<sink> plumbing used by `prism logs` (and any
+// future commands that opt in). Covers parsing, atomic file write, webhook
+// success / failure, and the unknown-scheme refusal.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── parseDeliverFlag ─────────────────────────────────────────────────────────
+
+func TestParseDeliverFlag_DefaultsToStdout(t *testing.T) {
+	cases := []string{"", "stdout"}
+	for _, raw := range cases {
+		s, err := parseDeliverFlag(raw)
+		if err != nil {
+			t.Errorf("raw=%q: unexpected error: %v", raw, err)
+		}
+		if s.kind != "stdout" {
+			t.Errorf("raw=%q: kind = %q, want stdout", raw, s.kind)
+		}
+	}
+}
+
+func TestParseDeliverFlag_File(t *testing.T) {
+	s, err := parseDeliverFlag("file:./out.log")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.kind != "file" || s.dest != "./out.log" {
+		t.Errorf("got %+v, want kind=file dest=./out.log", s)
+	}
+}
+
+func TestParseDeliverFlag_FileMissingPath(t *testing.T) {
+	_, err := parseDeliverFlag("file:")
+	if err == nil {
+		t.Fatal("expected error for empty file path")
+	}
+	if !strings.Contains(err.Error(), "requires a path") {
+		t.Errorf("err = %v; want path-required message", err)
+	}
+}
+
+func TestParseDeliverFlag_Webhook(t *testing.T) {
+	s, err := parseDeliverFlag("webhook:https://example.com/hook")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.kind != "webhook" || s.dest != "https://example.com/hook" {
+		t.Errorf("got %+v, want kind=webhook dest=https://example.com/hook", s)
+	}
+}
+
+func TestParseDeliverFlag_WebhookHTTP(t *testing.T) {
+	s, err := parseDeliverFlag("webhook:http://localhost:8080/hook")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.kind != "webhook" || s.dest != "http://localhost:8080/hook" {
+		t.Errorf("got %+v", s)
+	}
+}
+
+func TestParseDeliverFlag_WebhookMissingURL(t *testing.T) {
+	_, err := parseDeliverFlag("webhook:")
+	if err == nil {
+		t.Fatal("expected error for empty webhook URL")
+	}
+	if !strings.Contains(err.Error(), "requires a URL") {
+		t.Errorf("err = %v; want URL-required message", err)
+	}
+}
+
+func TestParseDeliverFlag_WebhookBadScheme(t *testing.T) {
+	_, err := parseDeliverFlag("webhook:ftp://example.com")
+	if err == nil {
+		t.Fatal("expected error for ftp:// webhook URL")
+	}
+	if !strings.Contains(err.Error(), "http://") {
+		t.Errorf("err = %v; want http://-required message", err)
+	}
+}
+
+func TestParseDeliverFlag_UnknownScheme(t *testing.T) {
+	_, err := parseDeliverFlag("s3://bucket/key")
+	if err == nil {
+		t.Fatal("expected error for unknown scheme")
+	}
+	if !strings.Contains(err.Error(), "unknown sink scheme") {
+		t.Errorf("err = %v; want 'unknown sink scheme'", err)
+	}
+	// Refusal must enumerate the valid set (principle 3).
+	for _, want := range []string{"stdout", "file:<path>", "webhook:<url>"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal does not mention %q: %v", want, err)
+		}
+	}
+}
+
+// ── deliverContent — stdout sink ─────────────────────────────────────────────
+
+func TestDeliverContent_Stdout_WritesContentVerbatim(t *testing.T) {
+	var buf bytes.Buffer
+	sink, _ := parseDeliverFlag("stdout")
+	if err := deliverContent(sink, []byte("hello world\n"), "text/plain", &buf); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+	if buf.String() != "hello world\n" {
+		t.Errorf("got %q, want %q", buf.String(), "hello world\n")
+	}
+}
+
+// ── deliverContent — file sink ───────────────────────────────────────────────
+
+func TestDeliverContent_File_WritesAtomicallyAndReportsBytes(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.log")
+	sink, err := parseDeliverFlag("file:" + target)
+	if err != nil {
+		t.Fatalf("parseDeliverFlag: %v", err)
+	}
+	content := []byte("line1\nline2\nline3\n")
+
+	var status bytes.Buffer
+	if err := deliverContent(sink, content, "text/plain", &status); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+
+	// File contents match input.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("file content = %q, want %q", got, content)
+	}
+
+	// Status JSON has the expected shape.
+	var resp struct {
+		DeliveredTo string `json:"delivered_to"`
+		Bytes       int    `json:"bytes"`
+	}
+	if err := json.Unmarshal(status.Bytes(), &resp); err != nil {
+		t.Fatalf("status JSON parse: %v (raw: %s)", err, status.String())
+	}
+	if resp.DeliveredTo != "file:"+target {
+		t.Errorf("delivered_to = %q, want %q", resp.DeliveredTo, "file:"+target)
+	}
+	if resp.Bytes != len(content) {
+		t.Errorf("bytes = %d, want %d", resp.Bytes, len(content))
+	}
+
+	// No leftover tempfile in the destination directory.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".prism-deliver-") {
+			t.Errorf("tempfile leftover: %s", e.Name())
+		}
+	}
+}
+
+func TestDeliverContent_File_CreatesParentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "nested", "deeper", "out.log")
+	sink, _ := parseDeliverFlag("file:" + target)
+	if err := deliverContent(sink, []byte("x"), "text/plain", io.Discard); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("destination not created: %v", err)
+	}
+}
+
+// ── deliverContent — webhook sink ────────────────────────────────────────────
+
+func TestDeliverContent_Webhook_Success(t *testing.T) {
+	var (
+		gotMethod      string
+		gotContentType string
+		gotBody        []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	sink, _ := parseDeliverFlag("webhook:" + srv.URL)
+	var status bytes.Buffer
+	if err := deliverContent(sink, []byte("payload"), "text/plain", &status); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotContentType != "text/plain" {
+		t.Errorf("Content-Type = %q, want text/plain", gotContentType)
+	}
+	if string(gotBody) != "payload" {
+		t.Errorf("body = %q, want payload", gotBody)
+	}
+
+	var resp struct {
+		DeliveredTo string `json:"delivered_to"`
+		Status      int    `json:"status"`
+	}
+	if err := json.Unmarshal(status.Bytes(), &resp); err != nil {
+		t.Fatalf("parse status: %v (raw: %s)", err, status.String())
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Errorf("status = %d, want %d", resp.Status, http.StatusAccepted)
+	}
+	if resp.DeliveredTo != "webhook:"+srv.URL {
+		t.Errorf("delivered_to = %q, want %q", resp.DeliveredTo, "webhook:"+srv.URL)
+	}
+}
+
+func TestDeliverContent_Webhook_NDJSONContentType(t *testing.T) {
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink, _ := parseDeliverFlag("webhook:" + srv.URL)
+	if err := deliverContent(sink, []byte(`{"f":1}`+"\n"), "application/x-ndjson", io.Discard); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+	if gotContentType != "application/x-ndjson" {
+		t.Errorf("Content-Type = %q, want application/x-ndjson", gotContentType)
+	}
+}
+
+func TestDeliverContent_Webhook_4xxIsNonZeroExit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad request: missing field"))
+	}))
+	defer srv.Close()
+
+	sink, _ := parseDeliverFlag("webhook:" + srv.URL)
+	err := deliverContent(sink, []byte("x"), "text/plain", io.Discard)
+	if err == nil {
+		t.Fatal("expected error for 4xx response")
+	}
+	// Error payload should be a JSON object with status + body.
+	var resp struct {
+		DeliveredTo string `json:"delivered_to"`
+		Status      int    `json:"status"`
+		Body        string `json:"body"`
+	}
+	if jsonErr := json.Unmarshal([]byte(err.Error()), &resp); jsonErr != nil {
+		t.Fatalf("error not JSON: %v (raw: %s)", jsonErr, err.Error())
+	}
+	if resp.Status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.Status)
+	}
+	if !strings.Contains(resp.Body, "bad request") {
+		t.Errorf("body = %q, want to contain 'bad request'", resp.Body)
+	}
+}
+
+func TestDeliverContent_Webhook_5xxIsNonZeroExit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sink, _ := parseDeliverFlag("webhook:" + srv.URL)
+	err := deliverContent(sink, []byte("x"), "text/plain", io.Discard)
+	if err == nil {
+		t.Fatal("expected error for 5xx response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("err = %v; want to mention 500", err)
+	}
+}
+
+func TestDeliverContent_Webhook_BodyTruncated(t *testing.T) {
+	// Server returns a body larger than webhookErrorBodyMax.
+	huge := strings.Repeat("A", webhookErrorBodyMax*2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer srv.Close()
+
+	sink, _ := parseDeliverFlag("webhook:" + srv.URL)
+	err := deliverContent(sink, []byte("x"), "text/plain", io.Discard)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var resp struct {
+		Body      string `json:"body"`
+		Truncated bool   `json:"truncated"`
+	}
+	if jsonErr := json.Unmarshal([]byte(err.Error()), &resp); jsonErr != nil {
+		t.Fatalf("error not JSON: %v (raw: %s)", jsonErr, err.Error())
+	}
+	if !resp.Truncated {
+		t.Errorf("expected truncated=true")
+	}
+	if len(resp.Body) != webhookErrorBodyMax {
+		t.Errorf("body length = %d, want %d", len(resp.Body), webhookErrorBodyMax)
+	}
+}

--- a/modules/programs/prism/prism/cmd/feedback.go
+++ b/modules/programs/prism/prism/cmd/feedback.go
@@ -1,0 +1,334 @@
+package cmd
+
+// prism feedback — a friction log for agents and humans (issue #1505 /
+// principle 10 of #1497). Records short notes about CLI rough edges to a
+// local JSONL store at $XDG_STATE_HOME/prism/feedback.jsonl, with optional
+// upstream POST when PRISM_FEEDBACK_ENDPOINT is set.
+//
+// Surface:
+//
+//	prism feedback "<text>"          # record one note
+//	prism feedback -                  # read note from stdin (mirrors --prompt -)
+//	prism feedback list               # list local notes (human-readable)
+//	prism feedback list --json        # JSON array of all notes
+//	prism feedback list --days N      # only entries newer than N days
+//	prism feedback prune --days N --yes  # drop entries older than N days
+//
+// The store is local-first: a missing or failing upstream endpoint never
+// loses the local record. Upstream HTTP status (when configured) is
+// surfaced in the success message so the operator can see what happened.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/archive"
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/feedback"
+)
+
+// PRISMFeedbackEndpointEnv is the environment variable that, when non-empty,
+// causes `prism feedback` to POST each newly-recorded entry to the named URL
+// after writing it locally. A failure to POST does not affect the local
+// record (the local copy is the source of truth).
+const PRISMFeedbackEndpointEnv = "PRISM_FEEDBACK_ENDPOINT"
+
+// feedbackUpstreamTimeout caps how long a single upstream POST can run
+// before we give up and report the timeout in the success message. The
+// local record is already on disk before the POST is attempted.
+const feedbackUpstreamTimeout = 30 * time.Second
+
+// feedbackUpstreamClient is the HTTP client used for the upstream POST.
+// Overridable from tests via the package-level variable so test servers
+// can intercept requests without monkey-patching net/http.
+var feedbackUpstreamClient = &http.Client{Timeout: feedbackUpstreamTimeout}
+
+// feedbackStorePathFn lets tests inject a writable store path. When nil
+// (production) the path is resolved from $XDG_STATE_HOME via
+// feedback.DefaultPath. The injection point exists because the nix-build
+// sandbox has HOME=/homeless-shelter; tests set XDG_STATE_HOME to a
+// t.TempDir() and the production code path picks that up automatically.
+var feedbackStorePathFn = func() (string, error) { return feedback.DefaultPath() }
+
+// resolveFeedbackStore returns a Store rooted at the configured path.
+func resolveFeedbackStore() (*feedback.Store, error) {
+	path, err := feedbackStorePathFn()
+	if err != nil {
+		return nil, err
+	}
+	return feedback.NewStore(path), nil
+}
+
+var feedbackCmd = &cobra.Command{
+	Use:   "feedback [text|-]",
+	Short: "Record a short note about CLI friction (local JSONL log)",
+	Long: `Record a short note about CLI friction.
+
+Each entry is appended as one JSON object per line to
+$XDG_STATE_HOME/prism/feedback.jsonl. The store is local-first: a missing
+or failing upstream endpoint never loses the local record.
+
+  prism feedback "the --tier flag rejects 'enterprise' but the docs list it"
+  echo "feedback from a script" | prism feedback -
+
+When PRISM_FEEDBACK_ENDPOINT is set, the entry is also POSTed upstream
+after being written locally. The HTTP status is reported in the success
+message.
+
+Subcommands:
+  prism feedback list              human-readable list of local entries
+  prism feedback list --json       JSON array of all entries
+  prism feedback list --days N     only entries within the last N days
+  prism feedback prune --days N --yes
+                                   drop entries older than N days
+`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runFeedbackRecord,
+	// SilenceUsage so a usage message is not appended to every error from
+	// this command (matches the convention used by the other write-side
+	// commands like spawn / merge).
+	SilenceUsage: true,
+}
+
+var feedbackListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List recorded feedback entries",
+	Args:         cobra.NoArgs,
+	RunE:         runFeedbackList,
+	SilenceUsage: true,
+}
+
+var feedbackPruneCmd = &cobra.Command{
+	Use:          "prune --days N --yes",
+	Short:        "Remove feedback entries older than N days (requires --yes)",
+	Args:         cobra.NoArgs,
+	RunE:         runFeedbackPrune,
+	SilenceUsage: true,
+}
+
+func init() {
+	feedbackListCmd.Flags().Bool("json", false, "Emit the JSONL contents as a JSON array")
+	feedbackListCmd.Flags().Int("days", 0, "Only show entries within the last N days (0 = no filter)")
+
+	feedbackPruneCmd.Flags().Int("days", 0, "Remove entries older than N days (required, must be > 0)")
+	feedbackPruneCmd.Flags().Bool("yes", false, "Confirm the prune. Without --yes, prune errors instead of prompting (principle 1)")
+
+	feedbackCmd.AddCommand(feedbackListCmd)
+	feedbackCmd.AddCommand(feedbackPruneCmd)
+	rootCmd.AddCommand(feedbackCmd)
+}
+
+// runFeedbackRecord handles `prism feedback "<text>"` and `prism feedback -`.
+func runFeedbackRecord(cmd *cobra.Command, args []string) error {
+	text, err := readFeedbackText(args, os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	entry := buildFeedbackEntry(text, time.Now().UTC())
+
+	store, err := resolveFeedbackStore()
+	if err != nil {
+		return err
+	}
+	if err := store.Append(entry); err != nil {
+		return err
+	}
+
+	endpoint := resolveFeedbackEndpoint()
+	if endpoint == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "feedback recorded locally (%s)\n", store.Path)
+		return nil
+	}
+	status, postErr := postFeedbackUpstream(endpoint, entry)
+	if postErr != nil {
+		// Local record is unaffected; surface the upstream failure but exit 0.
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"feedback recorded locally (%s); upstream POST failed: %v\n",
+			store.Path, postErr)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"feedback recorded locally and sent upstream (status: %d)\n", status)
+	return nil
+}
+
+// readFeedbackText resolves the feedback text from either the positional
+// argument or stdin (when the argument is "-"). Returns an error when no
+// argument is supplied and stdin is a terminal — the AC requires a
+// non-zero exit with usage in that case.
+func readFeedbackText(args []string, stdin io.Reader) (string, error) {
+	if len(args) == 0 {
+		return "", errors.New(
+			"a feedback text is required — supply one of:\n" +
+				"  prism feedback \"<text>\"\n" +
+				"  prism feedback - (read from stdin)",
+		)
+	}
+	arg := args[0]
+	if arg != "-" {
+		s := strings.TrimSpace(arg)
+		if s == "" {
+			return "", errors.New("feedback text is empty")
+		}
+		return s, nil
+	}
+	// Stdin path. Refuse if stdin is a terminal so the user gets a clear
+	// error rather than a hung command.
+	if f, ok := stdin.(*os.File); ok {
+		info, statErr := f.Stat()
+		if statErr == nil && (info.Mode()&os.ModeCharDevice) != 0 {
+			return "", errors.New(
+				"prism feedback -: stdin is a terminal; pipe text or use prism feedback \"<text>\"",
+			)
+		}
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return "", errors.New("prism feedback -: stdin produced no text")
+	}
+	return s, nil
+}
+
+// buildFeedbackEntry assembles an Entry from the recording context. The
+// minimum required fields (timestamp, text, session, prism_version) are
+// always populated; optional fields are filled when discoverable.
+func buildFeedbackEntry(text string, now time.Time) feedback.Entry {
+	e := feedback.Entry{
+		Timestamp:    now.Format(time.RFC3339),
+		Text:         text,
+		Session:      os.Getenv("PRISM_SESSION_NAME"),
+		PrismVersion: archive.PrismGitSHA(),
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		e.CWD = cwd
+	}
+	return e
+}
+
+// postFeedbackUpstream POSTs a single entry to endpoint as JSON. Returns
+// the HTTP status code on success. A non-2xx response is treated as an
+// error so the caller can surface it (the local record is already saved).
+func postFeedbackUpstream(endpoint string, e feedback.Entry) (int, error) {
+	body, err := json.Marshal(e)
+	if err != nil {
+		return 0, fmt.Errorf("marshal entry: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), feedbackUpstreamTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := feedbackUpstreamClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	// Drain so the connection can be reused.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 400 {
+		return resp.StatusCode, fmt.Errorf("upstream returned HTTP %d", resp.StatusCode)
+	}
+	return resp.StatusCode, nil
+}
+
+// resolveFeedbackEndpoint returns the configured upstream URL: the
+// PRISM_FEEDBACK_ENDPOINT environment variable wins over the
+// feedback_endpoint config key, matching the precedence used elsewhere
+// in the codebase (env > config). Returns "" when neither is set.
+func resolveFeedbackEndpoint() string {
+	if env := strings.TrimSpace(os.Getenv(PRISMFeedbackEndpointEnv)); env != "" {
+		return env
+	}
+	// LoadFresh (not Load) so a test that sets PRISM_CONFIG_FILE between
+	// invocations sees the new value; Load is sync.Once-cached.
+	return strings.TrimSpace(config.LoadFresh().FeedbackEndpoint)
+}
+
+// runFeedbackList implements `prism feedback list [--json] [--days N]`.
+func runFeedbackList(cmd *cobra.Command, _ []string) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	days, _ := cmd.Flags().GetInt("days")
+	if days < 0 {
+		return fmt.Errorf("--days must be a non-negative integer")
+	}
+
+	store, err := resolveFeedbackStore()
+	if err != nil {
+		return err
+	}
+	entries, err := store.List()
+	if err != nil {
+		return err
+	}
+	if days > 0 {
+		cutoff := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+		entries = feedback.FilterSince(entries, cutoff)
+	}
+
+	w := cmd.OutOrStdout()
+	if jsonOut {
+		// AC: --json emits a JSON array. Use a non-nil slice so the empty
+		// case marshals to [] rather than null.
+		if entries == nil {
+			entries = []feedback.Entry{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+	for _, e := range entries {
+		fmt.Fprintf(w, "%s  %s\n", e.Timestamp, e.Text)
+	}
+	return nil
+}
+
+// runFeedbackPrune implements `prism feedback prune --days N --yes`.
+//
+// Per principle 1 (no implicit confirmations), --yes is mandatory. Without
+// it we error out instead of prompting; the operator has to opt in
+// explicitly.
+func runFeedbackPrune(cmd *cobra.Command, _ []string) error {
+	days, _ := cmd.Flags().GetInt("days")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if days <= 0 {
+		return fmt.Errorf("--days must be a positive integer (e.g. --days 30)")
+	}
+	if !yes {
+		return fmt.Errorf(
+			"prism feedback prune requires --yes to confirm (principle 1: no implicit confirmations)\n" +
+				"    re-run with --yes to drop entries older than the cutoff",
+		)
+	}
+
+	store, err := resolveFeedbackStore()
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+	kept, removed, err := store.Prune(cutoff)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"feedback pruned: removed %d entries older than %s; kept %d (%s)\n",
+		removed, cutoff.Format(time.RFC3339), kept, store.Path)
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/feedback_test.go
+++ b/modules/programs/prism/prism/cmd/feedback_test.go
@@ -1,0 +1,458 @@
+package cmd
+
+// Tests for `prism feedback`. All tests redirect the store path to a
+// t.TempDir() via XDG_STATE_HOME so they pass inside the nix-build
+// sandbox where HOME=/homeless-shelter is unwritable.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/feedback"
+)
+
+// withTempFeedbackStore points the feedback store at a tempdir and clears
+// PRISM_FEEDBACK_ENDPOINT so tests don't accidentally hit the real one.
+// Returns the on-disk path so individual tests can inspect the JSONL.
+func withTempFeedbackStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	t.Setenv(PRISMFeedbackEndpointEnv, "")
+	return filepath.Join(dir, "prism", "feedback.jsonl")
+}
+
+// buildFreshFeedbackTree returns a freshly-constructed `feedback` cobra
+// subtree so flag state from one test does not leak into another. The
+// real production tree (cmd.feedbackCmd / feedbackListCmd / feedbackPruneCmd)
+// is a package singleton; building a parallel one for tests sidesteps that.
+func buildFreshFeedbackTree(t *testing.T) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "prism", SilenceUsage: true, SilenceErrors: true}
+
+	rec := &cobra.Command{
+		Use:          "feedback",
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runFeedbackRecord,
+		SilenceUsage: true,
+	}
+
+	list := &cobra.Command{Use: "list", Args: cobra.NoArgs, RunE: runFeedbackList, SilenceUsage: true}
+	list.Flags().Bool("json", false, "")
+	list.Flags().Int("days", 0, "")
+
+	prune := &cobra.Command{Use: "prune", Args: cobra.NoArgs, RunE: runFeedbackPrune, SilenceUsage: true}
+	prune.Flags().Int("days", 0, "")
+	prune.Flags().Bool("yes", false, "")
+
+	rec.AddCommand(list, prune)
+	root.AddCommand(rec)
+	return root
+}
+
+// runFeedbackCmd executes the test-only feedback tree with the given args.
+// Returns combined stdout+stderr and the RunE error.
+func runFeedbackCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	root := buildFreshFeedbackTree(t)
+	root.SetArgs(append([]string{"feedback"}, args...))
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// ── record ──────────────────────────────────────────────────────────────────
+
+func TestFeedback_Record_AppendsLocallyAndPrintsConfirmation(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+
+	out, err := runFeedbackCmd(t, "the --tier flag rejects 'enterprise'")
+	if err != nil {
+		t.Fatalf("feedback: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "feedback recorded locally") {
+		t.Errorf("output missing confirmation: %q", out)
+	}
+
+	data, readErr := os.ReadFile(storePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile %s: %v", storePath, readErr)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1: %q", len(lines), data)
+	}
+	var e feedback.Entry
+	if err := json.Unmarshal([]byte(lines[0]), &e); err != nil {
+		t.Fatalf("parse entry: %v (raw: %s)", err, lines[0])
+	}
+	if e.Text != "the --tier flag rejects 'enterprise'" {
+		t.Errorf("text = %q", e.Text)
+	}
+	if e.Timestamp == "" {
+		t.Errorf("timestamp is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, e.Timestamp); err != nil {
+		t.Errorf("timestamp not RFC3339: %v", err)
+	}
+}
+
+// AC edge-case: invoked with no argument prism feedback should refuse with
+// a clear usage hint and a non-zero exit.
+func TestFeedback_Record_NoArgErrors(t *testing.T) {
+	withTempFeedbackStore(t)
+
+	out, err := runFeedbackCmd(t)
+	if err == nil {
+		t.Fatalf("expected error for no-arg invocation, got out=%q", out)
+	}
+	if !strings.Contains(err.Error(), "feedback text is required") {
+		t.Errorf("err = %v; want 'feedback text is required'", err)
+	}
+}
+
+// AC: prism feedback - reads from stdin.
+func TestFeedback_Record_StdinDash(t *testing.T) {
+	withTempFeedbackStore(t)
+
+	stdin := strings.NewReader("piped feedback text\n")
+	got, err := readFeedbackText([]string{"-"}, stdin)
+	if err != nil {
+		t.Fatalf("readFeedbackText: %v", err)
+	}
+	if got != "piped feedback text" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFeedback_Record_StdinDash_EmptyErrors(t *testing.T) {
+	withTempFeedbackStore(t)
+	_, err := readFeedbackText([]string{"-"}, strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected error for empty stdin")
+	}
+}
+
+// AC: when PRISM_FEEDBACK_ENDPOINT is set, feedback is also POSTed upstream
+// after being recorded locally. The local record is unaffected by upstream
+// failure; HTTP status is reported in the success message.
+func TestFeedback_Record_PostsUpstreamWhenConfigured(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+
+	var (
+		gotMethod      string
+		gotContentType string
+		gotBody        []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv(PRISMFeedbackEndpointEnv, srv.URL)
+
+	out, err := runFeedbackCmd(t, "test note")
+	if err != nil {
+		t.Fatalf("feedback: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "sent upstream") || !strings.Contains(out, "200") {
+		t.Errorf("output missing upstream confirmation: %q", out)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q", gotContentType)
+	}
+	var posted feedback.Entry
+	if err := json.Unmarshal(gotBody, &posted); err != nil {
+		t.Errorf("posted body not JSON: %v (raw: %s)", err, gotBody)
+	}
+	if posted.Text != "test note" {
+		t.Errorf("posted text = %q", posted.Text)
+	}
+
+	data, _ := os.ReadFile(storePath)
+	if !strings.Contains(string(data), "test note") {
+		t.Errorf("local record missing: %q", data)
+	}
+}
+
+func TestFeedback_Record_UpstreamFailureDoesNotLoseLocal(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv(PRISMFeedbackEndpointEnv, srv.URL)
+
+	out, err := runFeedbackCmd(t, "test note")
+	if err != nil {
+		t.Fatalf("feedback should not fail on upstream 500, got: %v", err)
+	}
+	if !strings.Contains(out, "upstream POST failed") {
+		t.Errorf("output should report upstream failure: %q", out)
+	}
+	data, _ := os.ReadFile(storePath)
+	if !strings.Contains(string(data), "test note") {
+		t.Errorf("local record missing despite upstream failure: %q", data)
+	}
+}
+
+// ── list ────────────────────────────────────────────────────────────────────
+
+func TestFeedback_List_HumanReadable(t *testing.T) {
+	withTempFeedbackStore(t)
+	if _, err := runFeedbackCmd(t, "first note"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runFeedbackCmd(t, "second note"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runFeedbackCmd(t, "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "first note") || !strings.Contains(out, "second note") {
+		t.Errorf("list output missing entries: %q", out)
+	}
+}
+
+func TestFeedback_List_JSON(t *testing.T) {
+	withTempFeedbackStore(t)
+	if _, err := runFeedbackCmd(t, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runFeedbackCmd(t, "beta"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runFeedbackCmd(t, "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	var entries []feedback.Entry
+	if jerr := json.Unmarshal([]byte(out), &entries); jerr != nil {
+		t.Fatalf("not JSON: %v\nout=%s", jerr, out)
+	}
+	if len(entries) != 2 {
+		t.Errorf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestFeedback_List_JSON_EmptyIsArrayNotNull(t *testing.T) {
+	withTempFeedbackStore(t)
+	out, err := runFeedbackCmd(t, "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed != "[]" {
+		t.Errorf("empty list --json should be []; got %q", trimmed)
+	}
+}
+
+func TestFeedback_List_DaysFilter(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+
+	old := feedback.Entry{
+		Timestamp:    time.Now().Add(-30 * 24 * time.Hour).Format(time.RFC3339),
+		Text:         "old note",
+		PrismVersion: "v",
+	}
+	recent := feedback.Entry{
+		Timestamp:    time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+		Text:         "recent note",
+		PrismVersion: "v",
+	}
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	_ = enc.Encode(old)
+	_ = enc.Encode(recent)
+	_ = f.Close()
+
+	out, err := runFeedbackCmd(t, "list", "--days", "7")
+	if err != nil {
+		t.Fatalf("list --days 7: %v", err)
+	}
+	if !strings.Contains(out, "recent note") {
+		t.Errorf("output missing recent note: %q", out)
+	}
+	if strings.Contains(out, "old note") {
+		t.Errorf("output unexpectedly contains old note: %q", out)
+	}
+}
+
+// ── prune ───────────────────────────────────────────────────────────────────
+
+// AC: prune without --yes errors instead of prompting (principle 1).
+func TestFeedback_Prune_RequiresYes(t *testing.T) {
+	withTempFeedbackStore(t)
+	out, err := runFeedbackCmd(t, "prune", "--days", "30")
+	if err == nil {
+		t.Fatalf("expected error without --yes; got out=%q", out)
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("err = %v; want --yes-required message", err)
+	}
+}
+
+func TestFeedback_Prune_RequiresPositiveDays(t *testing.T) {
+	withTempFeedbackStore(t)
+	out, err := runFeedbackCmd(t, "prune", "--yes")
+	if err == nil {
+		t.Fatalf("expected error without --days; got out=%q", out)
+	}
+	if !strings.Contains(err.Error(), "--days") {
+		t.Errorf("err = %v; want --days-required message", err)
+	}
+}
+
+func TestFeedback_Prune_DropsOldEntries(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, _ := os.Create(storePath)
+	enc := json.NewEncoder(f)
+	_ = enc.Encode(feedback.Entry{
+		Timestamp:    time.Now().Add(-60 * 24 * time.Hour).Format(time.RFC3339),
+		Text:         "old",
+		PrismVersion: "v",
+	})
+	_ = enc.Encode(feedback.Entry{
+		Timestamp:    time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+		Text:         "recent",
+		PrismVersion: "v",
+	})
+	_ = f.Close()
+
+	out, err := runFeedbackCmd(t, "prune", "--days", "30", "--yes")
+	if err != nil {
+		t.Fatalf("prune: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "removed 1") {
+		t.Errorf("output missing removed-1: %q", out)
+	}
+
+	data, _ := os.ReadFile(storePath)
+	if strings.Contains(string(data), `"text":"old"`) {
+		t.Errorf("old entry not pruned: %s", data)
+	}
+	if !strings.Contains(string(data), `"text":"recent"`) {
+		t.Errorf("recent entry pruned by mistake: %s", data)
+	}
+}
+
+// AC: feedback entry includes the calling session name when
+// PRISM_SESSION_NAME is set.
+func TestFeedback_BuildEntry_IncludesSessionFromEnv(t *testing.T) {
+	t.Setenv("PRISM_SESSION_NAME", "myrepo@feature")
+	e := buildFeedbackEntry("hi", time.Now().UTC())
+	if e.Session != "myrepo@feature" {
+		t.Errorf("session = %q, want myrepo@feature", e.Session)
+	}
+}
+
+func TestFeedback_BuildEntry_OmitsSessionWhenUnset(t *testing.T) {
+	t.Setenv("PRISM_SESSION_NAME", "")
+	e := buildFeedbackEntry("hi", time.Now().UTC())
+	if e.Session != "" {
+		t.Errorf("session = %q, want empty", e.Session)
+	}
+}
+
+// AC: when feedback_endpoint is set in the config file (and
+// PRISM_FEEDBACK_ENDPOINT is unset), the upstream POST is still attempted.
+func TestFeedback_Record_ReadsEndpointFromConfigFile(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+
+	var gotPosted bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPosted = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Write a config file with feedback_endpoint set.
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config.json")
+	cfg := []byte(`{"feedback_endpoint":"` + srv.URL + `"}`)
+	if err := os.WriteFile(cfgPath, cfg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+	t.Setenv(PRISMFeedbackEndpointEnv, "") // env unset; config wins
+
+	out, err := runFeedbackCmd(t, "config-key note")
+	if err != nil {
+		t.Fatalf("feedback: %v\nout=%s", err, out)
+	}
+	if !gotPosted {
+		t.Errorf("upstream was not POSTed despite config feedback_endpoint")
+	}
+	if !strings.Contains(out, "sent upstream") {
+		t.Errorf("output missing 'sent upstream': %q", out)
+	}
+	if _, statErr := os.Stat(storePath); statErr != nil {
+		t.Errorf("local store missing: %v", statErr)
+	}
+}
+
+// AC: PRISM_FEEDBACK_ENDPOINT (env) takes precedence over the config key.
+func TestFeedback_Record_EnvOverridesConfigEndpoint(t *testing.T) {
+	withTempFeedbackStore(t)
+
+	var (
+		envHit    bool
+		configHit bool
+	)
+	envSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		envHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer envSrv.Close()
+	cfgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		configHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cfgSrv.Close()
+
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config.json")
+	cfg := []byte(`{"feedback_endpoint":"` + cfgSrv.URL + `"}`)
+	_ = os.WriteFile(cfgPath, cfg, 0o644)
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+	t.Setenv(PRISMFeedbackEndpointEnv, envSrv.URL)
+
+	if _, err := runFeedbackCmd(t, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if !envHit {
+		t.Errorf("env endpoint should have been hit")
+	}
+	if configHit {
+		t.Errorf("config endpoint should NOT have been hit when env is set")
+	}
+}

--- a/modules/programs/prism/prism/cmd/logs.go
+++ b/modules/programs/prism/prism/cmd/logs.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -84,6 +85,14 @@ func init() {
 	logsCmd.Flags().Bool("harness-events", false, "Print raw PI JSONL frames recorded for this session (P5.LOGS / #1218)")
 	logsCmd.Flags().String("direction", "", "With --harness-events: filter frames by direction (in|out)")
 	logsCmd.Flags().String("types", "", "With --harness-events: comma-separated list of frame types to include")
+	logsCmd.Flags().String(
+		"deliver", "stdout",
+		"Where to send the log content. Valid sinks:\n"+
+			"    stdout              (default) write to stdout\n"+
+			"    file:<path>         atomic write to <path>; prints {\"delivered_to\":..., \"bytes\":N}\n"+
+			"    webhook:<url>       POST content to <url>; prints {\"delivered_to\":..., \"status\":N}\n"+
+			"    Unknown schemes are refused with the valid set listed.",
+	)
 	rootCmd.AddCommand(logsCmd)
 }
 
@@ -98,6 +107,12 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	harnessEvents, _ := cmd.Flags().GetBool("harness-events")
 	direction, _ := cmd.Flags().GetString("direction")
 	typesCSV, _ := cmd.Flags().GetString("types")
+	deliverFlag, _ := cmd.Flags().GetString("deliver")
+
+	sink, err := parseDeliverFlag(deliverFlag)
+	if err != nil {
+		return err
+	}
 
 	// --harness-events is its own pipeline (DB-backed, not a log file). It
 	// supersedes --agent-run / --startup / --tail and only honours --follow,
@@ -109,7 +124,10 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		if tailSet {
 			return fmt.Errorf("--harness-events does not support --tail (use --follow to stream new frames)")
 		}
-		return runHarnessEvents(sessionName, direction, typesCSV, follow, os.Stdout)
+		if sink.kind != "stdout" && follow {
+			return fmt.Errorf("--deliver and --follow are mutually exclusive (delivery captures a snapshot)")
+		}
+		return runHarnessEvents(sessionName, direction, typesCSV, follow, sink, os.Stdout)
 	}
 
 	if direction != "" || typesCSV != "" {
@@ -128,16 +146,28 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--tail must be a non-negative integer")
 	}
 
+	if sink.kind != "stdout" && follow {
+		return fmt.Errorf("--deliver and --follow are mutually exclusive (delivery captures a snapshot)")
+	}
+
 	// Container proxy path: delegate to the host-API sidecar.
 	// (--startup is host-only because the agent-startup log is written by
 	// the host-side SpawnSession; container coordinators have no use for it.)
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" && !startup {
+		if sink.kind != "stdout" {
+			// Buffer the proxied content so we can hand the whole artifact
+			// to deliverContent atomically (file rename / single POST).
+			var buf bytes.Buffer
+			if err := proxyLogsFromHostAPI(apiURL, sessionName, tailN, tailSet, follow, agentRun, &buf); err != nil {
+				return err
+			}
+			return deliverContent(sink, buf.Bytes(), "text/plain", os.Stdout)
+		}
 		return proxyLogsFromHostAPI(apiURL, sessionName, tailN, tailSet, follow, agentRun, os.Stdout)
 	}
 
 	// Host path: resolve the appropriate log file.
 	var logPath string
-	var err error
 	switch {
 	case startup:
 		logPath, err = session.AgentStartupLogPath(sessionName)
@@ -177,6 +207,17 @@ func runLogs(cmd *cobra.Command, args []string) error {
 
 	if follow {
 		return runLogsFollow(sessionName, logPath)
+	}
+
+	// Non-stdout sinks: read the resolved log into memory and hand it to
+	// deliverContent. Atomic file delivery and webhook POST both want the
+	// whole artifact in one shot, so the buffering is unavoidable here.
+	if sink.kind != "stdout" {
+		content, readErr := readLogForDelivery(logPath, tailSet, tailN)
+		if readErr != nil {
+			return readErr
+		}
+		return deliverContent(sink, content, "text/plain", os.Stdout)
 	}
 
 	if tailSet {
@@ -253,6 +294,34 @@ func sidecarLogIsStuckOnSSERetries(logPath string) bool {
 		break
 	}
 	return !hasRealEvent
+}
+
+// readLogForDelivery reads the log file at logPath into a byte slice,
+// honouring --tail when set. Used by the --deliver pipeline so the file
+// or webhook sink receives the same content the operator would have seen
+// on stdout.
+func readLogForDelivery(logPath string, tailSet bool, tailN int) ([]byte, error) {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("open log: %w", err)
+	}
+	defer f.Close()
+	if !tailSet {
+		return io.ReadAll(f)
+	}
+	if tailN == 0 {
+		return nil, nil
+	}
+	lines, err := tailLinesFromReader(f, tailN)
+	if err != nil {
+		return nil, fmt.Errorf("tail log: %w", err)
+	}
+	var buf bytes.Buffer
+	for _, line := range lines {
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), nil
 }
 
 // runLogsFull prints the full contents of the log file to stdout.

--- a/modules/programs/prism/prism/cmd/logs_deliver_test.go
+++ b/modules/programs/prism/prism/cmd/logs_deliver_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+// Tests for the `prism logs --deliver=...` integration: ensures the log file
+// content reaches the configured sink with the right shape and that
+// readLogForDelivery honours --tail.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadLogForDelivery_FullFile(t *testing.T) {
+	logFile := writeTempLogFile(t, "alpha\nbeta\ngamma\n")
+	got, err := readLogForDelivery(logFile, false, 0)
+	if err != nil {
+		t.Fatalf("readLogForDelivery: %v", err)
+	}
+	if string(got) != "alpha\nbeta\ngamma\n" {
+		t.Errorf("got %q", string(got))
+	}
+}
+
+func TestReadLogForDelivery_TailZero_ReturnsEmpty(t *testing.T) {
+	logFile := writeTempLogFile(t, "alpha\nbeta\n")
+	got, err := readLogForDelivery(logFile, true, 0)
+	if err != nil {
+		t.Fatalf("readLogForDelivery: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty bytes, got %q", got)
+	}
+}
+
+func TestReadLogForDelivery_TailN(t *testing.T) {
+	logFile := writeTempLogFile(t, "alpha\nbeta\ngamma\ndelta\n")
+	got, err := readLogForDelivery(logFile, true, 2)
+	if err != nil {
+		t.Fatalf("readLogForDelivery: %v", err)
+	}
+	if string(got) != "gamma\ndelta\n" {
+		t.Errorf("got %q, want gamma\\ndelta\\n", string(got))
+	}
+}
+
+// End-to-end: `prism logs --deliver=file:<path>` must atomically write the
+// resolved log file content to <path> and print the structured success JSON
+// to stdout. We exercise this by routing the deliver pipeline directly
+// through readLogForDelivery + deliverContent (the same code path runLogs
+// takes once flags are parsed).
+func TestRunLogs_DeliverFile_EndToEnd(t *testing.T) {
+	src := writeTempLogFile(t, "[prism sidecar] starting\n2026-01-01 sidecar: event\n")
+	target := filepath.Join(t.TempDir(), "delivered.log")
+
+	sink, err := parseDeliverFlag("file:" + target)
+	if err != nil {
+		t.Fatalf("parseDeliverFlag: %v", err)
+	}
+	content, err := readLogForDelivery(src, false, 0)
+	if err != nil {
+		t.Fatalf("readLogForDelivery: %v", err)
+	}
+	var status bytes.Buffer
+	if err := deliverContent(sink, content, "text/plain", &status); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("delivered content mismatch")
+	}
+
+	var resp struct {
+		DeliveredTo string `json:"delivered_to"`
+		Bytes       int    `json:"bytes"`
+	}
+	if err := json.Unmarshal(status.Bytes(), &resp); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if resp.Bytes != len(content) {
+		t.Errorf("bytes = %d, want %d", resp.Bytes, len(content))
+	}
+}
+
+// End-to-end webhook delivery: assert the body equals the file content and
+// the Content-Type header matches the sink's expectations for the raw log.
+func TestRunLogs_DeliverWebhook_EndToEnd(t *testing.T) {
+	src := writeTempLogFile(t, "logline1\nlogline2\n")
+
+	var (
+		gotMethod      string
+		gotContentType string
+		gotBody        []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody = readAllBody(r)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink, _ := parseDeliverFlag("webhook:" + srv.URL)
+	content, _ := readLogForDelivery(src, false, 0)
+	var status bytes.Buffer
+	if err := deliverContent(sink, content, "text/plain", &status); err != nil {
+		t.Fatalf("deliverContent: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("method = %q", gotMethod)
+	}
+	if gotContentType != "text/plain" {
+		t.Errorf("Content-Type = %q", gotContentType)
+	}
+	if string(gotBody) != "logline1\nlogline2\n" {
+		t.Errorf("body = %q", gotBody)
+	}
+	if !strings.Contains(status.String(), `"status":200`) {
+		t.Errorf("status JSON missing status:200: %s", status.String())
+	}
+}
+
+func readAllBody(r *http.Request) []byte {
+	buf := new(bytes.Buffer)
+	if r.Body != nil {
+		_, _ = buf.ReadFrom(r.Body)
+		_ = r.Body.Close()
+	}
+	return buf.Bytes()
+}

--- a/modules/programs/prism/prism/cmd/logs_harness.go
+++ b/modules/programs/prism/prism/cmd/logs_harness.go
@@ -21,6 +21,7 @@ package cmd
 // to pipe into jq, grep, etc.
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -37,7 +38,7 @@ import (
 // hint to stderr and returns a non-zero error so the caller's shell sees an
 // exit code distinguishable from "session has zero frames yet" — this matches
 // the edge-case AC.
-func runHarnessEvents(sessionName, direction, typesCSV string, follow bool, w io.Writer) error {
+func runHarnessEvents(sessionName, direction, typesCSV string, follow bool, sink deliverSink, w io.Writer) error {
 	if direction != "" && direction != directionIn && direction != directionOut {
 		return fmt.Errorf("--direction must be %q or %q (got %q)", directionIn, directionOut, direction)
 	}
@@ -69,6 +70,19 @@ func runHarnessEvents(sessionName, direction, typesCSV string, follow bool, w io
 	frames, err := d.QueryHarnessFrames(sessionName, direction, types, "")
 	if err != nil {
 		return fmt.Errorf("query harness frames: %w", err)
+	}
+
+	// Non-stdout sink: collect all current frames into a single buffer and
+	// hand it to deliverContent. JSONL frames go out with the
+	// application/x-ndjson content type for consumers that key off it.
+	// --follow is rejected upstream when --deliver != stdout.
+	if sink.kind != "stdout" && sink.kind != "" {
+		var buf bytes.Buffer
+		for _, f := range frames {
+			buf.WriteString(f.Payload)
+			buf.WriteByte('\n')
+		}
+		return deliverContent(sink, buf.Bytes(), "application/x-ndjson", w)
 	}
 
 	// Print the existing frames (one JSONL object per line).

--- a/modules/programs/prism/prism/cmd/logs_harness_test.go
+++ b/modules/programs/prism/prism/cmd/logs_harness_test.go
@@ -52,7 +52,7 @@ func TestRunHarnessEvents_NonPISession(t *testing.T) {
 	setUpHarnessFramesDB(t)
 
 	var buf bytes.Buffer
-	err := runHarnessEvents("opencode-session@main", "", "", false, &buf)
+	err := runHarnessEvents("opencode-session@main", "", "", false, deliverSink{kind:"stdout"}, &buf)
 	if err == nil {
 		t.Fatal("expected error for non-PI session, got nil")
 	}
@@ -75,7 +75,7 @@ func TestRunHarnessEvents_PrintsAllFramesChronologically(t *testing.T) {
 	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"type":"tool_call","i":3}`, t0.Add(2*time.Millisecond))
 
 	var buf bytes.Buffer
-	if err := runHarnessEvents("s@main", "", "", false, &buf); err != nil {
+	if err := runHarnessEvents("s@main", "", "", false, deliverSink{kind:"stdout"}, &buf); err != nil {
 		t.Fatalf("runHarnessEvents: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
 	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"d":"in2"}`, t0.Add(2*time.Millisecond))
 
 	var inBuf bytes.Buffer
-	if err := runHarnessEvents("s@main", "in", "", false, &inBuf); err != nil {
+	if err := runHarnessEvents("s@main", "in", "", false, deliverSink{kind:"stdout"}, &inBuf); err != nil {
 		t.Fatalf("runHarnessEvents in: %v", err)
 	}
 	if !strings.Contains(inBuf.String(), "in1") || !strings.Contains(inBuf.String(), "in2") {
@@ -111,7 +111,7 @@ func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
 	}
 
 	var outBuf bytes.Buffer
-	if err := runHarnessEvents("s@main", "out", "", false, &outBuf); err != nil {
+	if err := runHarnessEvents("s@main", "out", "", false, deliverSink{kind:"stdout"}, &outBuf); err != nil {
 		t.Fatalf("runHarnessEvents out: %v", err)
 	}
 	if !strings.Contains(outBuf.String(), "out1") {
@@ -125,7 +125,7 @@ func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
 func TestRunHarnessEvents_DirectionInvalid(t *testing.T) {
 	setUpHarnessFramesDB(t)
 	var buf bytes.Buffer
-	err := runHarnessEvents("s@main", "sideways", "", false, &buf)
+	err := runHarnessEvents("s@main", "sideways", "", false, deliverSink{kind:"stdout"}, &buf)
 	if err == nil {
 		t.Fatal("expected error for invalid direction")
 	}
@@ -145,7 +145,7 @@ func TestRunHarnessEvents_TypesFilter(t *testing.T) {
 	writeFrameForCLI(t, d, "s@main", "in", "msg_assistant", `{"t":"msg_assistant"}`, t0.Add(3*time.Millisecond))
 
 	var buf bytes.Buffer
-	if err := runHarnessEvents("s@main", "", "tool_call,tool_result", false, &buf); err != nil {
+	if err := runHarnessEvents("s@main", "", "tool_call,tool_result", false, deliverSink{kind:"stdout"}, &buf); err != nil {
 		t.Fatalf("runHarnessEvents: %v", err)
 	}
 	out := buf.String()
@@ -200,7 +200,7 @@ func TestRunHarnessEvents_FollowStreamsNewFrames(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runHarnessEvents("s@main", "", "", true, sb)
+		done <- runHarnessEvents("s@main", "", "", true, deliverSink{kind:"stdout"}, sb)
 	}()
 
 	// Wait for the initial frame to appear.

--- a/modules/programs/prism/prism/cmd/logs_harness_test.go
+++ b/modules/programs/prism/prism/cmd/logs_harness_test.go
@@ -52,7 +52,7 @@ func TestRunHarnessEvents_NonPISession(t *testing.T) {
 	setUpHarnessFramesDB(t)
 
 	var buf bytes.Buffer
-	err := runHarnessEvents("opencode-session@main", "", "", false, deliverSink{kind:"stdout"}, &buf)
+	err := runHarnessEvents("opencode-session@main", "", "", false, deliverSink{kind: "stdout"}, &buf)
 	if err == nil {
 		t.Fatal("expected error for non-PI session, got nil")
 	}
@@ -75,7 +75,7 @@ func TestRunHarnessEvents_PrintsAllFramesChronologically(t *testing.T) {
 	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"type":"tool_call","i":3}`, t0.Add(2*time.Millisecond))
 
 	var buf bytes.Buffer
-	if err := runHarnessEvents("s@main", "", "", false, deliverSink{kind:"stdout"}, &buf); err != nil {
+	if err := runHarnessEvents("s@main", "", "", false, deliverSink{kind: "stdout"}, &buf); err != nil {
 		t.Fatalf("runHarnessEvents: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
 	writeFrameForCLI(t, d, "s@main", "in", "tool_call", `{"d":"in2"}`, t0.Add(2*time.Millisecond))
 
 	var inBuf bytes.Buffer
-	if err := runHarnessEvents("s@main", "in", "", false, deliverSink{kind:"stdout"}, &inBuf); err != nil {
+	if err := runHarnessEvents("s@main", "in", "", false, deliverSink{kind: "stdout"}, &inBuf); err != nil {
 		t.Fatalf("runHarnessEvents in: %v", err)
 	}
 	if !strings.Contains(inBuf.String(), "in1") || !strings.Contains(inBuf.String(), "in2") {
@@ -111,7 +111,7 @@ func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
 	}
 
 	var outBuf bytes.Buffer
-	if err := runHarnessEvents("s@main", "out", "", false, deliverSink{kind:"stdout"}, &outBuf); err != nil {
+	if err := runHarnessEvents("s@main", "out", "", false, deliverSink{kind: "stdout"}, &outBuf); err != nil {
 		t.Fatalf("runHarnessEvents out: %v", err)
 	}
 	if !strings.Contains(outBuf.String(), "out1") {
@@ -125,7 +125,7 @@ func TestRunHarnessEvents_DirectionFilter(t *testing.T) {
 func TestRunHarnessEvents_DirectionInvalid(t *testing.T) {
 	setUpHarnessFramesDB(t)
 	var buf bytes.Buffer
-	err := runHarnessEvents("s@main", "sideways", "", false, deliverSink{kind:"stdout"}, &buf)
+	err := runHarnessEvents("s@main", "sideways", "", false, deliverSink{kind: "stdout"}, &buf)
 	if err == nil {
 		t.Fatal("expected error for invalid direction")
 	}
@@ -145,7 +145,7 @@ func TestRunHarnessEvents_TypesFilter(t *testing.T) {
 	writeFrameForCLI(t, d, "s@main", "in", "msg_assistant", `{"t":"msg_assistant"}`, t0.Add(3*time.Millisecond))
 
 	var buf bytes.Buffer
-	if err := runHarnessEvents("s@main", "", "tool_call,tool_result", false, deliverSink{kind:"stdout"}, &buf); err != nil {
+	if err := runHarnessEvents("s@main", "", "tool_call,tool_result", false, deliverSink{kind: "stdout"}, &buf); err != nil {
 		t.Fatalf("runHarnessEvents: %v", err)
 	}
 	out := buf.String()
@@ -200,7 +200,7 @@ func TestRunHarnessEvents_FollowStreamsNewFrames(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runHarnessEvents("s@main", "", "", true, deliverSink{kind:"stdout"}, sb)
+		done <- runHarnessEvents("s@main", "", "", true, deliverSink{kind: "stdout"}, sb)
 	}()
 
 	// Wait for the initial frame to appear.

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -151,28 +151,28 @@ type Config struct {
 // parsedConfig mirrors Config but uses pointer slices so that a JSON null or
 // absent key is distinguishable from an explicit empty array [].
 type parsedConfig struct {
-	ColorPrimary                   string    `json:"color_primary"`
-	ColorSecondary                 string    `json:"color_secondary"`
-	ColorPurple                    string    `json:"color_purple"`
-	ColorYellow                    string    `json:"color_yellow"`
-	ColorGreen                     string    `json:"color_green"`
-	ColorBlue                      string    `json:"color_blue"`
-	ColorRed                       string    `json:"color_red"`
-	ColorForeground                string    `json:"color_foreground"`
-	ColorBg0                       string    `json:"color_bg0"`
-	KittyBin                       string    `json:"kitty_bin"`
-	DefaultIsolationMode           string    `json:"default_isolation_mode"`
-	SidecarPluginPath              string    `json:"sidecar_plugin_path"`
-	GitUserName                    string    `json:"git_user_name"`
-	GitUserEmail                   string    `json:"git_user_email"`
-	SshAccessKeyName               string    `json:"ssh_access_key_name"`
-	SshSigningKeyName              string    `json:"ssh_signing_key_name"`
-	SshBin                         string    `json:"ssh_bin"`
-	PIExtensionDir                 string    `json:"pi_extension_dir"`
-	RestoreStaggerDelayMs          *int      `json:"restore_stagger_delay_ms"`
-	SidecarCircuitBreakerThreshold *int      `json:"sidecar_circuit_breaker_threshold"`
-	BwrapConcurrencyCap            *int      `json:"bwrap_concurrency_cap"`
-	SandboxExecConcurrencyCap      *int      `json:"sandbox_exec_concurrency_cap"`
+	ColorPrimary                   string             `json:"color_primary"`
+	ColorSecondary                 string             `json:"color_secondary"`
+	ColorPurple                    string             `json:"color_purple"`
+	ColorYellow                    string             `json:"color_yellow"`
+	ColorGreen                     string             `json:"color_green"`
+	ColorBlue                      string             `json:"color_blue"`
+	ColorRed                       string             `json:"color_red"`
+	ColorForeground                string             `json:"color_foreground"`
+	ColorBg0                       string             `json:"color_bg0"`
+	KittyBin                       string             `json:"kitty_bin"`
+	DefaultIsolationMode           string             `json:"default_isolation_mode"`
+	SidecarPluginPath              string             `json:"sidecar_plugin_path"`
+	GitUserName                    string             `json:"git_user_name"`
+	GitUserEmail                   string             `json:"git_user_email"`
+	SshAccessKeyName               string             `json:"ssh_access_key_name"`
+	SshSigningKeyName              string             `json:"ssh_signing_key_name"`
+	SshBin                         string             `json:"ssh_bin"`
+	PIExtensionDir                 string             `json:"pi_extension_dir"`
+	RestoreStaggerDelayMs          *int               `json:"restore_stagger_delay_ms"`
+	SidecarCircuitBreakerThreshold *int               `json:"sidecar_circuit_breaker_threshold"`
+	BwrapConcurrencyCap            *int               `json:"bwrap_concurrency_cap"`
+	SandboxExecConcurrencyCap      *int               `json:"sandbox_exec_concurrency_cap"`
 	WorktreeExclude                *[]string          `json:"worktree_exclude"`
 	ProjectLocations               *[]string          `json:"project_locations"`
 	ProjectSpecific                *[]string          `json:"project_specific"`
@@ -198,24 +198,24 @@ const DefaultSandboxExecConcurrencyCap = 20
 // standard paths). These values are used whenever no config file is found.
 func defaults() Config {
 	return Config{
-		ColorPrimary:         "#d4be98",
-		ColorSecondary:       "#a89984",
-		ColorPurple:          "#d3869b",
-		ColorYellow:          "#d8a657",
-		ColorGreen:           "#a9b665",
-		ColorBlue:            "#7daea3",
-		ColorRed:             "#ea6962",
-		ColorForeground:      "#d3c6aa",
-		ColorBg0:             "#2d353b",
+		ColorPrimary:              "#d4be98",
+		ColorSecondary:            "#a89984",
+		ColorPurple:               "#d3869b",
+		ColorYellow:               "#d8a657",
+		ColorGreen:                "#a9b665",
+		ColorBlue:                 "#7daea3",
+		ColorRed:                  "#ea6962",
+		ColorForeground:           "#d3c6aa",
+		ColorBg0:                  "#2d353b",
 		KittyBin:                  "kitty",
 		DefaultIsolationMode:      IsolationHost,
 		SshAccessKeyName:          "prismatic-koi-ed25519",
 		SshSigningKeyName:         "prismatic-koi-ed25519-signingkey",
 		BwrapConcurrencyCap:       DefaultBwrapConcurrencyCap,
 		SandboxExecConcurrencyCap: DefaultSandboxExecConcurrencyCap,
-		WorktreeExclude:  []string{"obsidian"},
-		ProjectLocations: []string{"~/code"},
-		ProjectSpecific:  []string{"~/documents/obsidian"},
+		WorktreeExclude:           []string{"obsidian"},
+		ProjectLocations:          []string{"~/code"},
+		ProjectSpecific:           []string{"~/documents/obsidian"},
 		ProjectIsolationOverrides: map[string]string{
 			"~/documents/obsidian": "host",
 		},

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -131,6 +131,14 @@ type Config struct {
 	// When empty, agent-run falls back to a relative-to-executable heuristic.
 	PIExtensionDir string `json:"pi_extension_dir"`
 
+	// FeedbackEndpoint is the upstream URL that `prism feedback` POSTs each
+	// new entry to (in addition to writing it locally). Empty means upstream
+	// reporting is disabled — the local JSONL store remains the source of
+	// truth. The PRISM_FEEDBACK_ENDPOINT environment variable takes
+	// precedence over this config key, so a one-off `PRISM_FEEDBACK_ENDPOINT=...
+	// prism feedback ...` invocation works without editing config.json.
+	FeedbackEndpoint string `json:"feedback_endpoint,omitempty"`
+
 	// ProjectIsolationOverrides maps path strings (with optional "~/" prefix)
 	// to isolation mode strings. When a session path matches a key (after "~/"
 	// expansion), the associated mode is used instead of DefaultIsolationMode.
@@ -169,6 +177,7 @@ type parsedConfig struct {
 	ProjectLocations               *[]string          `json:"project_locations"`
 	ProjectSpecific                *[]string          `json:"project_specific"`
 	ProjectIsolationOverrides      *map[string]string `json:"project_isolation_overrides"`
+	FeedbackEndpoint               string             `json:"feedback_endpoint"`
 }
 
 // DefaultBwrapConcurrencyCap is the compiled-in default maximum number of
@@ -313,6 +322,9 @@ func load() Config {
 	}
 	if parsed.PIExtensionDir != "" {
 		cfg.PIExtensionDir = parsed.PIExtensionDir
+	}
+	if parsed.FeedbackEndpoint != "" {
+		cfg.FeedbackEndpoint = parsed.FeedbackEndpoint
 	}
 
 	// For integer pointer fields: nil means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/feedback/feedback.go
+++ b/modules/programs/prism/prism/internal/feedback/feedback.go
@@ -1,0 +1,224 @@
+// Package feedback implements the local-first JSONL store used by
+// `prism feedback` (issue #1505 / principle 10 of #1497).
+//
+// Each entry is one JSON object on its own line; the file is append-only.
+// The default location is $XDG_STATE_HOME/prism/feedback.jsonl, falling
+// back to $HOME/.local/state/prism/feedback.jsonl. Callers can override
+// the path entirely via the StorePath field of Store, which is what the
+// test suite uses to keep the nix sandbox (HOME=/homeless-shelter) happy.
+//
+// The store deliberately does not depend on the prism DB: feedback is a
+// local-first record by design (principle 10), and avoiding the DB means
+// a corrupted DB or a missing schema migration cannot prevent an operator
+// from recording friction.
+package feedback
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Entry is a single feedback record, written one-per-line in feedback.jsonl.
+//
+// Required fields (per AC): Timestamp, Text, Session (may be ""), PrismVersion.
+// Optional fields are kept omitempty so older readers see only the fields
+// they expect, and so a future schema bump can add fields without breaking
+// existing files.
+type Entry struct {
+	Timestamp    string `json:"timestamp"`
+	Text         string `json:"text"`
+	Session      string `json:"session,omitempty"`
+	PrismVersion string `json:"prism_version"`
+	Repo         string `json:"repo,omitempty"`
+	CWD          string `json:"cwd,omitempty"`
+	LastCommand  string `json:"last_command,omitempty"`
+}
+
+// Store is the on-disk feedback log. The zero value is invalid; use
+// NewStore to construct one.
+type Store struct {
+	// Path is the absolute path to feedback.jsonl. Tests pass a t.TempDir()
+	// path; the production caller resolves this from $XDG_STATE_HOME via
+	// DefaultPath().
+	Path string
+}
+
+// NewStore constructs a Store at path. The file is not opened or created
+// until the first Append/List/Prune call so the constructor is cheap and
+// safe to call when the user does not yet have a writable state dir.
+func NewStore(path string) *Store { return &Store{Path: path} }
+
+// DefaultPath returns the canonical feedback.jsonl path for the current
+// user, honouring $XDG_STATE_HOME first and falling back to
+// $HOME/.local/state/prism/feedback.jsonl. Returns ("", error) when neither
+// is discoverable — the caller (cmd/feedback.go) should surface a clear
+// error rather than silently writing to an unexpected location.
+//
+// Order of resolution:
+//
+//  1. $XDG_STATE_HOME/prism/feedback.jsonl (if XDG_STATE_HOME is non-empty)
+//  2. $HOME/.local/state/prism/feedback.jsonl (if HOME is non-empty)
+//
+// Reading $XDG_STATE_HOME first matters for the nix-build sandbox where
+// HOME=/homeless-shelter is intentionally unwritable; tests override
+// XDG_STATE_HOME to a writable t.TempDir() to avoid that path entirely.
+func DefaultPath() (string, error) {
+	if state := os.Getenv("XDG_STATE_HOME"); state != "" {
+		return filepath.Join(state, "prism", "feedback.jsonl"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("feedback: cannot resolve store path — neither XDG_STATE_HOME nor HOME is set")
+	}
+	return filepath.Join(home, ".local", "state", "prism", "feedback.jsonl"), nil
+}
+
+// Append writes one entry as a JSONL line. The parent directory is created
+// on demand. Returns the path it wrote to so the caller can include it in
+// the user-facing confirmation message (matching the cleanup-style "wrote
+// N entries to <path>" pattern the existing CLI uses).
+func (s *Store) Append(e Entry) error {
+	if s.Path == "" {
+		return errors.New("feedback: Store.Path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {
+		return fmt.Errorf("feedback: create parent dir: %w", err)
+	}
+	f, err := os.OpenFile(s.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("feedback: open store: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	// json.Encoder.Encode appends a newline, which is exactly the JSONL
+	// framing we want.
+	if err := enc.Encode(e); err != nil {
+		return fmt.Errorf("feedback: encode entry: %w", err)
+	}
+	return nil
+}
+
+// List reads all entries from the store. Returns an empty slice (not nil
+// error) when the file does not yet exist — `prism feedback list` on a
+// fresh machine should print nothing without an error.
+//
+// Malformed lines are skipped with a non-fatal warning to stderr; one
+// corrupt line shouldn't render the whole log unreadable.
+func (s *Store) List() ([]Entry, error) {
+	if s.Path == "" {
+		return nil, errors.New("feedback: Store.Path is empty")
+	}
+	f, err := os.Open(s.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("feedback: open store: %w", err)
+	}
+	defer f.Close()
+	return readEntries(f)
+}
+
+// readEntries parses one Entry per line, skipping blanks and JSON-parse
+// failures. Exposed as a package-level helper so Prune can re-use it
+// without re-opening the file.
+func readEntries(r io.Reader) ([]Entry, error) {
+	var out []Entry
+	sc := bufio.NewScanner(r)
+	// Allow long lines — feedback text plus context fields can exceed the
+	// default 64 KiB buffer.
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			fmt.Fprintf(os.Stderr, "feedback: skipping malformed line: %v\n", err)
+			continue
+		}
+		out = append(out, e)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("feedback: read store: %w", err)
+	}
+	return out, nil
+}
+
+// FilterSince returns the subset of entries whose Timestamp is at or after
+// cutoff. Entries with an unparseable Timestamp are kept (defence-in-depth:
+// if we can't tell whether a record is too old, we don't drop it).
+func FilterSince(entries []Entry, cutoff time.Time) []Entry {
+	out := entries[:0:0]
+	for _, e := range entries {
+		t, err := time.Parse(time.RFC3339, e.Timestamp)
+		if err != nil {
+			out = append(out, e)
+			continue
+		}
+		if !t.Before(cutoff) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Prune removes entries with Timestamp older than cutoff. Returns the
+// number of entries kept, the number removed, and any error. The on-disk
+// file is rewritten atomically (tempfile + rename) so a crash mid-prune
+// cannot corrupt the store.
+func (s *Store) Prune(cutoff time.Time) (kept, removed int, err error) {
+	if s.Path == "" {
+		return 0, 0, errors.New("feedback: Store.Path is empty")
+	}
+	all, err := s.List()
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(all) == 0 {
+		return 0, 0, nil
+	}
+	keepers := FilterSince(all, cutoff)
+	removed = len(all) - len(keepers)
+	if removed == 0 {
+		return len(all), 0, nil
+	}
+	dir := filepath.Dir(s.Path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return 0, 0, fmt.Errorf("feedback: create parent dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".feedback-prune-*.tmp")
+	if err != nil {
+		return 0, 0, fmt.Errorf("feedback: create tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	enc := json.NewEncoder(tmp)
+	for _, e := range keepers {
+		if err := enc.Encode(e); err != nil {
+			_ = tmp.Close()
+			return 0, 0, fmt.Errorf("feedback: encode kept entry: %w", err)
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return 0, 0, fmt.Errorf("feedback: close tempfile: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.Path); err != nil {
+		return 0, 0, fmt.Errorf("feedback: rename: %w", err)
+	}
+	cleanup = false
+	return len(keepers), removed, nil
+}

--- a/modules/programs/prism/prism/internal/feedback/feedback_test.go
+++ b/modules/programs/prism/prism/internal/feedback/feedback_test.go
@@ -1,0 +1,237 @@
+package feedback
+
+// Tests for the local feedback JSONL store. All tests use t.TempDir() for
+// the storage path so the suite passes inside the nix-build sandbox where
+// HOME=/homeless-shelter is unwritable.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore(filepath.Join(t.TempDir(), "feedback.jsonl"))
+}
+
+func TestStore_Append_CreatesFileAndAppendsJSONL(t *testing.T) {
+	s := newTestStore(t)
+
+	e := Entry{
+		Timestamp:    "2026-01-02T03:04:05Z",
+		Text:         "the --tier flag rejects 'enterprise'",
+		Session:      "nixos-config@feature",
+		PrismVersion: "abcdef0",
+	}
+	if err := s.Append(e); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	got, err := os.ReadFile(s.Path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	line := strings.TrimRight(string(got), "\n")
+	if strings.Contains(line, "\n") {
+		t.Errorf("expected single line, got: %q", line)
+	}
+	var parsed Entry
+	if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %s)", err, line)
+	}
+	if parsed != e {
+		t.Errorf("got %+v, want %+v", parsed, e)
+	}
+}
+
+func TestStore_Append_AppendsMultipleEntries(t *testing.T) {
+	s := newTestStore(t)
+	for i := 0; i < 3; i++ {
+		if err := s.Append(Entry{
+			Timestamp:    "2026-01-02T03:04:05Z",
+			Text:         "line " + string(rune('a'+i)),
+			PrismVersion: "v1",
+		}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	entries, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("len = %d, want 3", len(entries))
+	}
+	for i, e := range entries {
+		want := "line " + string(rune('a'+i))
+		if e.Text != want {
+			t.Errorf("entries[%d].Text = %q, want %q", i, e.Text, want)
+		}
+	}
+}
+
+func TestStore_List_MissingFile_ReturnsEmpty(t *testing.T) {
+	s := newTestStore(t)
+	entries, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestStore_List_SkipsBlankAndMalformedLines(t *testing.T) {
+	s := newTestStore(t)
+	// Hand-craft a file containing one good line, one blank, one malformed.
+	content := `{"timestamp":"2026-01-01T00:00:00Z","text":"ok","prism_version":"v"}` + "\n" +
+		"\n" +
+		"this is not JSON\n" +
+		`{"timestamp":"2026-01-02T00:00:00Z","text":"also ok","prism_version":"v"}` + "\n"
+	if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.Path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("len = %d, want 2", len(entries))
+	}
+	if entries[0].Text != "ok" || entries[1].Text != "also ok" {
+		t.Errorf("got %+v", entries)
+	}
+}
+
+func TestFilterSince_KeepsEqualOrAfterCutoff(t *testing.T) {
+	cutoff := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	entries := []Entry{
+		{Timestamp: "2026-01-09T23:59:59Z", Text: "old"},
+		{Timestamp: "2026-01-10T00:00:00Z", Text: "boundary"},
+		{Timestamp: "2026-01-11T00:00:00Z", Text: "new"},
+	}
+	got := FilterSince(entries, cutoff)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Text != "boundary" || got[1].Text != "new" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestFilterSince_KeepsUnparseableTimestamps(t *testing.T) {
+	cutoff := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	entries := []Entry{
+		{Timestamp: "not-a-time", Text: "weird"},
+	}
+	got := FilterSince(entries, cutoff)
+	if len(got) != 1 {
+		t.Errorf("expected 1, got %d", len(got))
+	}
+}
+
+func TestStore_Prune_DropsOldEntriesAtomically(t *testing.T) {
+	s := newTestStore(t)
+	mustAppend(t, s, "2026-01-01T00:00:00Z", "old1")
+	mustAppend(t, s, "2026-01-02T00:00:00Z", "old2")
+	mustAppend(t, s, "2026-01-15T00:00:00Z", "kept1")
+	mustAppend(t, s, "2026-01-20T00:00:00Z", "kept2")
+
+	cutoff := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	kept, removed, err := s.Prune(cutoff)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if kept != 2 || removed != 2 {
+		t.Errorf("kept=%d removed=%d, want 2,2", kept, removed)
+	}
+	entries, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 2 || entries[0].Text != "kept1" || entries[1].Text != "kept2" {
+		t.Errorf("got %+v", entries)
+	}
+
+	// Atomic rewrite: no leftover tempfile.
+	dirEntries, _ := os.ReadDir(filepath.Dir(s.Path))
+	for _, de := range dirEntries {
+		if strings.HasPrefix(de.Name(), ".feedback-prune-") {
+			t.Errorf("tempfile leftover: %s", de.Name())
+		}
+	}
+}
+
+func TestStore_Prune_NoOpWhenNothingToRemove(t *testing.T) {
+	s := newTestStore(t)
+	mustAppend(t, s, "2026-02-01T00:00:00Z", "kept")
+	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	kept, removed, err := s.Prune(cutoff)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if kept != 1 || removed != 0 {
+		t.Errorf("kept=%d removed=%d, want 1,0", kept, removed)
+	}
+}
+
+func TestStore_Prune_EmptyStore(t *testing.T) {
+	s := newTestStore(t)
+	kept, removed, err := s.Prune(time.Now())
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if kept != 0 || removed != 0 {
+		t.Errorf("kept=%d removed=%d, want 0,0", kept, removed)
+	}
+}
+
+// DefaultPath honours XDG_STATE_HOME when set. We deliberately avoid
+// asserting the HOME-fallback branch here because the nix sandbox sets
+// HOME=/homeless-shelter; the production fallback is exercised by the
+// non-sandbox dev shell only.
+func TestDefaultPath_HonoursXDGStateHome(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/xdg-test")
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := "/tmp/xdg-test/prism/feedback.jsonl"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// When XDG_STATE_HOME is empty and HOME is set to a normal value, the path
+// resolves to $HOME/.local/state/prism/feedback.jsonl. We force HOME via
+// t.Setenv so this test works inside the nix sandbox too.
+func TestDefaultPath_FallsBackToHomeLocalState(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "/tmp/home-test")
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := "/tmp/home-test/.local/state/prism/feedback.jsonl"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func mustAppend(t *testing.T, s *Store, ts, text string) {
+	t.Helper()
+	if err := s.Append(Entry{
+		Timestamp:    ts,
+		Text:         text,
+		PrismVersion: "v",
+	}); err != nil {
+		t.Fatalf("Append %q: %v", text, err)
+	}
+}


### PR DESCRIPTION
Closes #1505.

Two-way I/O surfaces from principle 10 of #1497.

## Part 1 — `--deliver=<sink>` on `prism logs`

Routes the log artifact directly to a sink instead of going through stdout-then-pipe.

```
--deliver=stdout                # default
--deliver=file:<path>           # atomic write (tempfile + rename)
--deliver=webhook:<url>         # POST with text/plain (or application/x-ndjson for --harness-events)
```

- `file:` prints `{"delivered_to":"file:<path>","bytes":N}` on success.
- `webhook:` prints `{"delivered_to":"webhook:<url>","status":<code>}` on success.
- 4xx / 5xx surfaces as a non-zero exit with a JSON object containing `status`, `body`, and `truncated`.
- Unknown schemes are refused with the valid set listed (principle 3).
- Works for both raw `prism logs` and `prism logs --harness-events`.
- `--deliver` and `--follow` are mutually exclusive (delivery is a snapshot).
- Container-mode proxy path buffers the host-API response so the file/webhook artifact still ships atomically.

## Part 2 — `prism feedback`

Local-first JSONL friction log at `$XDG_STATE_HOME/prism/feedback.jsonl`.

```
prism feedback "<text>"
prism feedback -                        # read from stdin
prism feedback list [--json] [--days N]
prism feedback prune --days N --yes     # --yes mandatory; principle 1
```

Each entry: `timestamp` (RFC 3339), `text`, `session` (from `PRISM_SESSION_NAME`), `prism_version` (VCS revision), plus optional `cwd`. Optional upstream POST when `PRISM_FEEDBACK_ENDPOINT` is set (env wins over the `feedback_endpoint` config key). Local record is the source of truth — upstream failure does not fail the local record; the HTTP status is reported in the success message.

## Homeless-shelter gate

`feedback.DefaultPath()` reads `$XDG_STATE_HOME` first and only falls back to `$HOME/.local/state` when it's unset. Tests inject the path via `t.Setenv("XDG_STATE_HOME", t.TempDir())` so the suite passes inside the sandbox where `HOME=/homeless-shelter`. Verified via the local checked build:

```
nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
```

Pre-existing sandbox flakes in `internal/sidecar` (Test{HarnessPipeTCP_ListenFail_ReturnsErrorWithPort,SocketPipe_*}) reproduce on main without my changes — they are concurrency contention under sandbox load and pass cleanly when run alone (`go test ./internal/sidecar -run ... -count=1`). My code touches `cmd/`, `internal/feedback/`, and `internal/config/` only.

## Local gates

```
go build ./...        # ok
go test ./...         # ok (full suite)
nix build .#prism     # ok (post-#1508 fast path, doCheck=false)
```

## Salient test output

```
$ go test ./cmd/ -run "TestDeliver|TestParseDeliver|TestFeedback|TestReadLog" -count=1
ok  	github.com/prismatic-koi/prism/cmd	0.063s

$ go test ./internal/feedback/... -count=1
ok  	github.com/prismatic-koi/prism/internal/feedback	0.007s
```

## Skill manifest

`modules/programs/prism/opencode/skills/prism/SKILL.md` documents both surfaces:
- `prism logs` section gains a `--deliver=<sink>` subsection with examples.
- New `prism feedback` section under the logs/escalation block, with examples and a note on principle-1 prune safety.

## Out of scope (per the issue)

- `--deliver` on commands beyond `prism logs` — others return small structured data where stdout is the right default.
- A maintainer-side aggregator over `feedback.jsonl` — future work; this PR ships the producer side only.
- A project-hosted upstream feedback endpoint — `feedback_endpoint` is opt-in.
- Webhook retries / backoff — single attempt with status surfaced; local record is durable.
- `prism agent-context` reflection of these flags — handled in #1498.
