### PR TITLE
fix(sidecar): structural fixes for TestSocketPipe_* and TestHarnessPipeTCP_ListenFail flakes

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar_harness_pipe_tcp_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_harness_pipe_tcp_test.go
@@ -248,19 +248,25 @@ func TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort(t *testing.T) {
 
 	// Observe the listen failure via DB state — Run() does NOT return the
 	// error directly under the post-#1490 contract.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if getState(t, sc.cfg.DB, sc.cfg.SessionName) == string(agent.StateError) {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if state := getState(t, sc.cfg.DB, sc.cfg.SessionName); state != string(agent.StateError) {
-		t.Fatalf("session state = %q after TCP listen failure, want %q within 2s", state, agent.StateError)
+	//
+	// Synchronisation (issue #1515): waitForState polls the DB at 1ms intervals
+	// up to a 10s deadline rather than the previous 20ms / 2s loop. The
+	// previous bound was tight enough to flake under the contended scheduling
+	// of the Nix build sandbox, where the path Run() → instance_id mint →
+	// transport switch → net.Listen → writeStartupError can take noticeably
+	// longer than 2s when the host is under heavy load. The fix is structural
+	// because waitForState observes the actual DB transition rather than
+	// trusting an arbitrary timeout magnitude — the only knob that changed is
+	// the upper bound of the wait, which does not affect production behaviour.
+	if state := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateError), 10*time.Second); state != string(agent.StateError) {
+		t.Fatalf("session state = %q after TCP listen failure, want %q within 10s", state, agent.StateError)
 	}
 
 	// Verify the recorded startup-error message contains the port number.
-	errMsg := getStartupErrorMessage(t, sc.cfg.DB, sc.cfg.SessionName)
+	// waitForStartupErrorMessage polls because writeStartupError commits the
+	// state transition (StateError) and the startup_error event in two separate
+	// DB writes — a read between them returns the new state but no event yet.
+	errMsg := waitForStartupErrorMessage(t, sc.cfg.DB, sc.cfg.SessionName, 5*time.Second)
 	if errMsg == "" {
 		t.Fatal("no startup_error event recorded after TCP listen failure")
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -1464,6 +1464,13 @@ func countBusMessages(t *testing.T, d *db.DB, toSession string) int {
 // TestSocketPipe_IdleDebounce_WritesFinishedAfterDebounce verifies that
 // state_change{finished} starts the 2s finished debounce and, when it fires,
 // writes StateFinished and calls notifyCoordinator (Gap 1 fix, protocol v2).
+//
+// Synchronisation (issue #1515): rather than sleeping for a fixed 50ms before
+// calling clk.LastTimer(), this test blocks on clk.WaitForTimerCount(1, ...)
+// which observes the actual AfterFunc registration event. Under load the old
+// 50ms sleep was not always enough for the sidecar goroutine to reach
+// AfterFunc, so LastTimer() returned nil and the test failed deterministically
+// in the Nix sandbox even though the production code was correct.
 func TestSocketPipe_IdleDebounce_WritesFinishedAfterDebounce(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1475,8 +1482,11 @@ func TestSocketPipe_IdleDebounce_WritesFinishedAfterDebounce(t *testing.T) {
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
 
-	// Give the sidecar a moment to process.
-	time.Sleep(50 * time.Millisecond)
+	// Wait deterministically for the finished debounce timer to be registered.
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer was created")
+	}
 
 	// State should NOT be finished yet (debounce has not fired).
 	s := getState(t, sc.cfg.DB, sc.cfg.SessionName)
@@ -1484,11 +1494,6 @@ func TestSocketPipe_IdleDebounce_WritesFinishedAfterDebounce(t *testing.T) {
 		t.Error("state reached finished before finished debounce fired")
 	}
 
-	// Fire the debounce timer manually.
-	timer := clk.LastTimer()
-	if timer == nil {
-		t.Fatal("no finished debounce timer was created")
-	}
 	timer.Fire()
 
 	// State must now be finished.
@@ -1511,6 +1516,11 @@ func TestSocketPipe_IdleDebounce_WritesFinishedAfterDebounce(t *testing.T) {
 // TestSocketPipe_IdleDebounce_CancelledByTurnStart verifies that a turn_start
 // arriving while the finished debounce timer is running cancels the timer and
 // transitions the session to StateActive, not StateFinished (Gap 1 + 2 fix).
+//
+// Synchronisation (issue #1515): waits for timer registration via
+// clk.WaitForTimerCount and for cancellation via timer.WaitStopped — no
+// wall-clock sleeps. The DB-state assertion uses waitForState so a slow handler
+// commit does not race with the assertion.
 func TestSocketPipe_IdleDebounce_CancelledByTurnStart(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1521,23 +1531,24 @@ func TestSocketPipe_IdleDebounce_CancelledByTurnStart(t *testing.T) {
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
 
-	// Give the sidecar time to create the finished debounce timer.
-	time.Sleep(50 * time.Millisecond)
-
-	timer := clk.LastTimer()
+	// Wait for the finished debounce timer to be registered.
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
 	if timer == nil {
 		t.Fatal("no finished debounce timer was created after state_change{finished}")
 	}
 
 	// Send turn_start — must cancel the debounce.
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
-	time.Sleep(50 * time.Millisecond)
+	if !timer.WaitStopped(5 * time.Second) {
+		t.Fatal("finished debounce timer was not stopped by turn_start within 5s")
+	}
 
 	// Firing the (now-cancelled) timer must not write StateFinished.
 	timer.Fire()
-	time.Sleep(50 * time.Millisecond)
 
-	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	// State must be active after the turn_start (waitForState polls the DB to
+	// avoid racing the handler's commit).
+	st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second)
 	if st == string(agent.StateFinished) {
 		t.Errorf("state became finished after cancelled debounce, want active")
 	}
@@ -1553,6 +1564,10 @@ func TestSocketPipe_IdleDebounce_CancelledByTurnStart(t *testing.T) {
 // TestSocketPipe_MultipleIdle_OnlyOneTimer verifies that multiple consecutive
 // state_change{finished} frames result in exactly one debounce timer running
 // at a time — earlier timers are cancelled before a new one starts (Gap 2 fix).
+//
+// Synchronisation (issue #1515): each timer is awaited via WaitForTimerCount
+// (registration) and WaitStopped (cancellation), so the test does not depend
+// on a fixed sleep being long enough for the sidecar goroutine to run.
 func TestSocketPipe_MultipleIdle_OnlyOneTimer(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1562,37 +1577,33 @@ func TestSocketPipe_MultipleIdle_OnlyOneTimer(t *testing.T) {
 
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 
-	// First finished signal.
+	// First finished signal: wait for timer #1 to be registered.
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
-	time.Sleep(50 * time.Millisecond)
-	firstTimer := clk.LastTimer()
+	firstTimer := clk.WaitForTimerCount(1, 5*time.Second)
 	if firstTimer == nil {
 		t.Fatal("no timer after first state_change{finished}")
 	}
 
-	// Second finished signal — first timer must be cancelled before the new one starts.
+	// Second finished signal: wait for timer #2 — the first must already be stopped.
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
-	time.Sleep(50 * time.Millisecond)
-	secondTimer := clk.LastTimer()
+	secondTimer := clk.WaitForTimerCount(2, 5*time.Second)
 	if secondTimer == nil {
 		t.Fatal("no timer after second state_change{finished}")
 	}
 	if firstTimer == secondTimer {
 		t.Fatal("same timer object — second state_change{finished} did not create a new timer")
 	}
-	if !firstTimer.Stopped() {
+	if !firstTimer.WaitStopped(5 * time.Second) {
 		t.Error("first finished debounce timer was not stopped when second state_change{finished} arrived")
 	}
 
 	// Firing the second timer must write StateFinished exactly once.
 	secondTimer.Fire()
-	time.Sleep(50 * time.Millisecond)
 
 	// Also firing the first (already-stopped) timer must be a no-op.
 	firstTimer.Fire()
-	time.Sleep(50 * time.Millisecond)
 
-	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateFinished), 2*time.Second)
 	if st != string(agent.StateFinished) {
 		t.Errorf("state after second debounce = %q, want finished", st)
 	}
@@ -1604,6 +1615,11 @@ func TestSocketPipe_MultipleIdle_OnlyOneTimer(t *testing.T) {
 // TestSocketPipe_ErrorState_CancelsTimers verifies that state_change{error}
 // cancels any in-flight finished-debounce or recovery timer and records
 // lastErrorAt, so a stale debounce cannot overwrite StateError (Gap 3 fix).
+//
+// Synchronisation (issue #1515): WaitForTimerCount + WaitStopped + waitForState
+// replace the previous fixed sleeps so the assertions wait on the actual
+// events (timer registered, timer cancelled, DB state committed) rather than
+// on wall-clock elapsed time.
 func TestSocketPipe_ErrorState_CancelsTimers(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1611,39 +1627,37 @@ func TestSocketPipe_ErrorState_CancelsTimers(t *testing.T) {
 
 	conn, _ := dialAndHandshake(t, sockPath)
 
-	// Start finished debounce.
+	// Start finished debounce and wait for the timer to be registered.
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
-	time.Sleep(50 * time.Millisecond)
-
-	idleTimer := clk.LastTimer()
+	idleTimer := clk.WaitForTimerCount(1, 5*time.Second)
 	if idleTimer == nil {
 		t.Fatal("no finished debounce timer after state_change{finished}")
 	}
 
 	// Send state_change{error} — must cancel the finished debounce timer.
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "error"})
-	time.Sleep(50 * time.Millisecond)
-
-	// The finished debounce timer must be stopped.
-	if !idleTimer.Stopped() {
+	if !idleTimer.WaitStopped(5 * time.Second) {
 		t.Error("finished debounce timer was not stopped by state_change{error}")
 	}
 
 	// Firing the stale timer must not overwrite StateError.
 	idleTimer.Fire()
-	time.Sleep(50 * time.Millisecond)
 
-	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateError), 2*time.Second)
 	if st != string(agent.StateError) {
 		t.Errorf("state after stale debounce fire = %q, want error", st)
 	}
 
-	// lastErrorAt must be set (non-zero).
-	sc.mu.Lock()
-	lastErrorAt := sc.lastErrorAt
-	sc.mu.Unlock()
-	if lastErrorAt.IsZero() {
+	// lastErrorAt must be set (non-zero). Wait for the handler to commit the
+	// field under s.mu — the state-change observation above guarantees the
+	// frame has been processed, but lastErrorAt is set in the same critical
+	// section so a poll under the lock is sufficient and race-free.
+	if !waitForCondition(t, func() bool {
+		sc.mu.Lock()
+		defer sc.mu.Unlock()
+		return !sc.lastErrorAt.IsZero()
+	}, 2*time.Second, "lastErrorAt set after state_change{error}") {
 		t.Error("lastErrorAt was not set after state_change{error}")
 	}
 
@@ -1774,6 +1788,9 @@ func TestSocketPipe_TurnStart_ClearsEndedOnInterruptedResume(t *testing.T) {
 // TestSocketPipe_WaitingState_CancelsIdleTimer verifies that state_change{waiting}
 // cancels any in-flight finished-debounce timer so the session does not spuriously
 // transition to StateFinished while waiting for user input (Gap 5 fix).
+//
+// Synchronisation (issue #1515): WaitForTimerCount + WaitStopped + waitForState
+// replace fixed sleeps; the test now reacts to the actual sidecar transitions.
 func TestSocketPipe_WaitingState_CancelsIdleTimer(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1781,29 +1798,24 @@ func TestSocketPipe_WaitingState_CancelsIdleTimer(t *testing.T) {
 
 	conn, _ := dialAndHandshake(t, sockPath)
 
-	// Start finished debounce.
+	// Start finished debounce and wait for the timer.
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
-	time.Sleep(50 * time.Millisecond)
-
-	idleTimer := clk.LastTimer()
+	idleTimer := clk.WaitForTimerCount(1, 5*time.Second)
 	if idleTimer == nil {
 		t.Fatal("no finished debounce timer after state_change{finished}")
 	}
 
 	// Send state_change{waiting} — must cancel the finished debounce timer.
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "waiting"})
-	time.Sleep(50 * time.Millisecond)
-
-	if !idleTimer.Stopped() {
+	if !idleTimer.WaitStopped(5 * time.Second) {
 		t.Error("finished debounce timer was not stopped by state_change{waiting}")
 	}
 
 	// Firing the stale timer must not write StateFinished.
 	idleTimer.Fire()
-	time.Sleep(50 * time.Millisecond)
 
-	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateWaiting), 2*time.Second)
 	if st == string(agent.StateFinished) {
 		t.Errorf("state became finished after cancelled finished debounce timer during waiting, want waiting")
 	}
@@ -1816,6 +1828,10 @@ func TestSocketPipe_WaitingState_CancelsIdleTimer(t *testing.T) {
 // TestSocketPipe_AutoRetryStart_CancelsIdleTimer verifies that an auto_retry_start
 // frame cancels any in-flight finished-debounce timer so the session does not
 // spuriously finish during the retry window (Gap 6 fix).
+//
+// Synchronisation (issue #1515): WaitForTimerCount + WaitStopped replace fixed
+// sleeps. The trailing state assertion is bounded by waitForCondition so a
+// stray race cannot let StateFinished slip in unnoticed.
 func TestSocketPipe_AutoRetryStart_CancelsIdleTimer(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1823,29 +1839,30 @@ func TestSocketPipe_AutoRetryStart_CancelsIdleTimer(t *testing.T) {
 
 	conn, _ := dialAndHandshake(t, sockPath)
 
-	// Start finished debounce.
+	// Start finished debounce and wait for the timer.
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
-	time.Sleep(50 * time.Millisecond)
-
-	idleTimer := clk.LastTimer()
+	idleTimer := clk.WaitForTimerCount(1, 5*time.Second)
 	if idleTimer == nil {
 		t.Fatal("no finished debounce timer after state_change{finished}")
 	}
 
 	// Send auto_retry_start — must cancel the finished debounce timer.
 	sendJSON(t, conn, map[string]any{"type": "auto_retry_start", "attempt": 1})
-	time.Sleep(50 * time.Millisecond)
-
-	if !idleTimer.Stopped() {
+	if !idleTimer.WaitStopped(5 * time.Second) {
 		t.Error("finished debounce timer was not stopped by auto_retry_start")
 	}
 
-	// Firing the stale timer must not write StateFinished.
+	// Firing the stale timer must not write StateFinished. The state should
+	// remain active (we transitioned via turn_start above and auto_retry_start
+	// does not change the DB state).
 	idleTimer.Fire()
-	time.Sleep(50 * time.Millisecond)
 
-	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	// Assert the state is NOT finished. We wait briefly to give any erroneous
+	// transition a chance to surface, then assert. waitForState returns when
+	// either the target is reached or the deadline passes — we explicitly want
+	// the deadline path here, so we use a short window.
+	st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateFinished), 200*time.Millisecond)
 	if st == string(agent.StateFinished) {
 		t.Errorf("state became finished after cancelled finished debounce timer during retry, want active")
 	}
@@ -1858,6 +1875,10 @@ func TestSocketPipe_AutoRetryStart_CancelsIdleTimer(t *testing.T) {
 // TestSocketPipe_TurnEnd_UpdatesLastAssistantAgent verifies that a turn_end
 // frame updates lastAssistantAgent so that handleSessionFinished()'s subagent-
 // suppression logic works correctly for PI sessions (Gap 7 fix).
+//
+// Synchronisation (issue #1515): turn_end has no observable timer or DB-state
+// effect by itself, so the test polls sc.lastAssistantAgent under sc.mu via
+// waitForCondition rather than racing a 50ms sleep.
 func TestSocketPipe_TurnEnd_UpdatesLastAssistantAgent(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, _ := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1873,13 +1894,16 @@ func TestSocketPipe_TurnEnd_UpdatesLastAssistantAgent(t *testing.T) {
 		"type":  "turn_end",
 		"agent": "subagent",
 	})
-	time.Sleep(50 * time.Millisecond)
 
 	// lastAssistantAgent must be "subagent" (not cleared because it != rootAgent).
-	sc.mu.Lock()
-	laa := sc.lastAssistantAgent
-	sc.mu.Unlock()
-	if laa != "subagent" {
+	if !waitForCondition(t, func() bool {
+		sc.mu.Lock()
+		defer sc.mu.Unlock()
+		return sc.lastAssistantAgent == "subagent"
+	}, 5*time.Second, "lastAssistantAgent==\"subagent\" after subagent turn_end") {
+		sc.mu.Lock()
+		laa := sc.lastAssistantAgent
+		sc.mu.Unlock()
 		t.Errorf("lastAssistantAgent = %q after subagent turn_end, want %q", laa, "subagent")
 	}
 
@@ -1890,13 +1914,16 @@ func TestSocketPipe_TurnEnd_UpdatesLastAssistantAgent(t *testing.T) {
 		"type":  "turn_end",
 		"agent": sc.rootAgent,
 	})
-	time.Sleep(50 * time.Millisecond)
 
 	// lastAssistantAgent must be cleared after root-agent turn_end.
-	sc.mu.Lock()
-	laa = sc.lastAssistantAgent
-	sc.mu.Unlock()
-	if laa != "" {
+	if !waitForCondition(t, func() bool {
+		sc.mu.Lock()
+		defer sc.mu.Unlock()
+		return sc.lastAssistantAgent == ""
+	}, 5*time.Second, "lastAssistantAgent cleared after root turn_end") {
+		sc.mu.Lock()
+		laa := sc.lastAssistantAgent
+		sc.mu.Unlock()
 		t.Errorf("lastAssistantAgent = %q after root turn_end, want empty (cleared)", laa)
 	}
 
@@ -1908,6 +1935,11 @@ func TestSocketPipe_TurnEnd_UpdatesLastAssistantAgent(t *testing.T) {
 // TestSocketPipe_SessionShutdown_CancelsTimers verifies that session_shutdown
 // cancels any in-flight finished-debounce/recovery timer before writing
 // StateFinished so the coordinator receives exactly one notification (Gap 8 fix).
+//
+// Synchronisation (issue #1515): WaitForTimerCount replaces the leading sleep;
+// the post-shutdown assertion that no extra finished event was emitted now
+// uses a brief polling window to give a (would-be-buggy) timer fire a chance
+// to surface, rather than a fixed sleep that may be too short under load.
 func TestSocketPipe_SessionShutdown_CancelsTimers(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1915,12 +1947,10 @@ func TestSocketPipe_SessionShutdown_CancelsTimers(t *testing.T) {
 
 	conn, _ := dialAndHandshake(t, sockPath)
 
-	// Start finished debounce.
+	// Start finished debounce and wait for the timer.
 	sendJSON(t, conn, map[string]any{"type": "turn_start"})
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
-	time.Sleep(50 * time.Millisecond)
-
-	idleTimer := clk.LastTimer()
+	idleTimer := clk.WaitForTimerCount(1, 5*time.Second)
 	if idleTimer == nil {
 		t.Fatal("no finished debounce timer after state_change{finished}")
 	}
@@ -1931,7 +1961,7 @@ func TestSocketPipe_SessionShutdown_CancelsTimers(t *testing.T) {
 	_ = wait()
 
 	// The idle timer must be stopped.
-	if !idleTimer.Stopped() {
+	if !idleTimer.WaitStopped(5 * time.Second) {
 		t.Error("idle timer was not stopped by session_shutdown")
 	}
 
@@ -1942,11 +1972,20 @@ func TestSocketPipe_SessionShutdown_CancelsTimers(t *testing.T) {
 	}
 
 	// Firing the (now-stopped) timer must not produce a second StateFinished write.
-	// We verify indirectly: the timer was stopped so Fire() is a no-op.
+	// We verify indirectly: the timer was stopped so Fire() is a no-op. Use a
+	// short polling window after Fire() so any erroneous extra write would have
+	// time to surface; the loop returns on first observed change or at deadline.
 	beforeCount := countStateChangeEvents(t, sc.cfg.DB, sc.cfg.SessionName, "finished")
 	idleTimer.Fire()
-	time.Sleep(50 * time.Millisecond)
-	afterCount := countStateChangeEvents(t, sc.cfg.DB, sc.cfg.SessionName, "finished")
+	deadline := time.Now().Add(200 * time.Millisecond)
+	afterCount := beforeCount
+	for time.Now().Before(deadline) {
+		afterCount = countStateChangeEvents(t, sc.cfg.DB, sc.cfg.SessionName, "finished")
+		if afterCount != beforeCount {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	if afterCount != beforeCount {
 		t.Errorf("firing stopped idle timer after session_shutdown wrote %d extra finished event(s)",
 			afterCount-beforeCount)
@@ -1980,6 +2019,9 @@ func countStateChangeEvents(t *testing.T, d *db.DB, session, state string) int {
 // the lastErrorAt prerequisite: that a turn_start arriving within the debounce
 // window DOES still proceed normally (since the PI path uses turn_start, not
 // session.updated), but that lastErrorAt is set after an error state.
+// Synchronisation (issue #1515): the test waits for the DB to reflect the
+// state change, then polls sc.lastErrorAt under sc.mu via waitForCondition.
+// This replaces a fixed 50ms sleep that flaked under contended scheduling.
 func TestSocketPipe_ErrorResumeDebounce_LastErrorAtRecorded(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -1988,15 +2030,19 @@ func TestSocketPipe_ErrorResumeDebounce_LastErrorAtRecorded(t *testing.T) {
 	conn, _ := dialAndHandshake(t, sockPath)
 
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "error"})
-	time.Sleep(50 * time.Millisecond)
 
-	// lastErrorAt must be recorded at the clock's current time.
+	// Wait for the handler to commit StateError and lastErrorAt under s.mu.
+	if !waitForCondition(t, func() bool {
+		sc.mu.Lock()
+		defer sc.mu.Unlock()
+		return !sc.lastErrorAt.IsZero()
+	}, 5*time.Second, "lastErrorAt set after state_change{error}") {
+		t.Fatal("lastErrorAt was not set after state_change{error}")
+	}
+
 	sc.mu.Lock()
 	lastErrorAt := sc.lastErrorAt
 	sc.mu.Unlock()
-	if lastErrorAt.IsZero() {
-		t.Fatal("lastErrorAt was not set after state_change{error}")
-	}
 	expectedTime := clk.Now()
 	if !lastErrorAt.Equal(expectedTime) {
 		t.Errorf("lastErrorAt = %v, want %v (clock.Now())", lastErrorAt, expectedTime)
@@ -2064,6 +2110,9 @@ func TestSocketPipe_ReviewingGuardPreservedAfterGapFixes(t *testing.T) {
 // session (AgentRole = "review-goal") reaches StateFinished via the unified
 // turn_end → state_change{finished} path, without requiring the agent_end hook
 // or role-specific branching (issue #1434).
+//
+// Synchronisation (issue #1515): WaitForTimerCount replaces the previous 50ms
+// sleep so the test waits on the actual debounce-timer registration event.
 func TestSocketPipe_ReviewAgent_ReachesFinishedViaTurnEnd(t *testing.T) {
 	sockPath := shortSockPath(t)
 	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
@@ -2080,10 +2129,8 @@ func TestSocketPipe_ReviewAgent_ReachesFinishedViaTurnEnd(t *testing.T) {
 	// Extension emits state_change{finished} directly (protocol v2).
 	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
 
-	// Give the sidecar time to process and create the debounce timer.
-	time.Sleep(50 * time.Millisecond)
-
-	timer := clk.LastTimer()
+	// Wait deterministically for the finished-debounce timer to be registered.
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
 	if timer == nil {
 		t.Fatal("no finished debounce timer created after state_change{finished} from review agent")
 	}
@@ -2096,16 +2143,8 @@ func TestSocketPipe_ReviewAgent_ReachesFinishedViaTurnEnd(t *testing.T) {
 	// Fire the debounce timer — state must become finished.
 	timer.Fire()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if st := getState(t, sc.cfg.DB, sc.cfg.SessionName); st == string(agent.StateFinished) {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("review-agent session never reached finished after debounce, got %q",
-				getState(t, sc.cfg.DB, sc.cfg.SessionName))
-		}
-		time.Sleep(20 * time.Millisecond)
+	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateFinished), 2*time.Second); st != string(agent.StateFinished) {
+		t.Fatalf("review-agent session never reached finished after debounce, got %q", st)
 	}
 
 	conn.Close()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -356,6 +356,29 @@ func getEvents(t *testing.T, d *db.DB, session string) []db.Event {
 	return events
 }
 
+// waitForStartupErrorMessage polls AllSessionEvents until a startup_error
+// event is observed for session, or until timeout elapses. Returns the
+// "reason" field on success or "" on timeout. This is the deterministic
+// alternative to "check getStartupErrorMessage immediately after asserting
+// state==error": writeStartupError writes the state transition before the
+// startup_error event, so the two are observable at slightly different
+// moments — a same-instant read between the two writes returns "". See
+// issue #1515.
+func waitForStartupErrorMessage(t *testing.T, d *db.DB, session string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		msg := getStartupErrorMessage(t, d, session)
+		if msg != "" {
+			return msg
+		}
+		if time.Now().After(deadline) {
+			return ""
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
 // getStartupErrorMessage returns the "reason" field from the most-recent
 // startup_error event for session, or "" if none has been written. The
 // startup_error event is emitted by writeStartupError (state.go) when the

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -27,9 +27,14 @@ import (
 
 // testTimer implements Timer and allows manual firing.
 type testTimer struct {
-	mu      sync.Mutex
-	stopped bool
-	fn      func()
+	mu        sync.Mutex
+	stopped   bool
+	fn        func()
+	// stoppedCh is closed exactly once when the timer transitions to the
+	// stopped state (via Stop or Fire). Tests can use this to synchronise on
+	// timer cancellation deterministically rather than polling the Stopped()
+	// accessor with a wall-clock delay. See issue #1515.
+	stoppedCh chan struct{}
 }
 
 func (t *testTimer) Stop() bool {
@@ -37,6 +42,9 @@ func (t *testTimer) Stop() bool {
 	defer t.mu.Unlock()
 	was := !t.stopped
 	t.stopped = true
+	if was && t.stoppedCh != nil {
+		close(t.stoppedCh)
+	}
 	return was
 }
 
@@ -58,9 +66,35 @@ func (t *testTimer) Fire() {
 	}
 	t.stopped = true
 	fn := t.fn
+	if t.stoppedCh != nil {
+		close(t.stoppedCh)
+	}
 	t.mu.Unlock()
 	if fn != nil {
 		fn()
+	}
+}
+
+// WaitStopped blocks until Stop or Fire has been called on this timer, or
+// until timeout elapses. Returns true on success, false on timeout. This is a
+// deterministic synchronisation seam — preferred over polling Stopped() with
+// a sleep — for tests that assert a sidecar code path cancelled a timer.
+func (t *testTimer) WaitStopped(timeout time.Duration) bool {
+	t.mu.Lock()
+	if t.stopped {
+		t.mu.Unlock()
+		return true
+	}
+	ch := t.stoppedCh
+	t.mu.Unlock()
+	if ch == nil {
+		return false
+	}
+	select {
+	case <-ch:
+		return true
+	case <-time.After(timeout):
+		return false
 	}
 }
 
@@ -71,10 +105,19 @@ type testClock struct {
 	timers []*testTimer
 	// sleeps records the durations passed to Sleep, in call order.
 	sleeps []time.Duration
+	// timerCreatedCh is closed and replaced on every AfterFunc call so that
+	// WaitForTimerCount can block on the next timer creation without polling.
+	// See issue #1515 — the previous "sleep 50ms then call LastTimer" pattern
+	// flaked under load because 50ms was not always enough for the sidecar
+	// goroutine to reach AfterFunc.
+	timerCreatedCh chan struct{}
 }
 
 func newTestClock() *testClock {
-	return &testClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	return &testClock{
+		now:            time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		timerCreatedCh: make(chan struct{}),
+	}
 }
 
 func (c *testClock) Now() time.Time {
@@ -86,8 +129,16 @@ func (c *testClock) Now() time.Time {
 func (c *testClock) AfterFunc(d time.Duration, f func()) Timer {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	t := &testTimer{fn: f}
+	t := &testTimer{fn: f, stoppedCh: make(chan struct{})}
 	c.timers = append(c.timers, t)
+	// Notify any waiter blocked in WaitForTimerCount that a new timer was
+	// registered. Close-and-replace gives a broadcast semantics: every
+	// outstanding waiter wakes up, then we install a fresh channel for the
+	// next round.
+	if c.timerCreatedCh != nil {
+		close(c.timerCreatedCh)
+	}
+	c.timerCreatedCh = make(chan struct{})
 	return t
 }
 
@@ -123,6 +174,90 @@ func (c *testClock) TimerCount() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.timers)
+}
+
+// WaitForTimerCount blocks until the clock has registered at least n timers,
+// or until timeout elapses. Returns the timer at index n-1 on success (i.e.
+// the n-th timer in registration order) or nil on timeout. This is the
+// deterministic alternative to "sleep 50ms then call LastTimer" — it observes
+// the actual creation event and is independent of scheduler load. See #1515.
+func (c *testClock) WaitForTimerCount(n int, timeout time.Duration) *testTimer {
+	deadline := time.Now().Add(timeout)
+	for {
+		c.mu.Lock()
+		if len(c.timers) >= n {
+			t := c.timers[n-1]
+			c.mu.Unlock()
+			return t
+		}
+		ch := c.timerCreatedCh
+		c.mu.Unlock()
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil
+		}
+		select {
+		case <-ch:
+			// A new timer was registered; loop to re-check the count.
+		case <-time.After(remaining):
+			return nil
+		}
+	}
+}
+
+// WaitForNextTimer is a convenience wrapper around WaitForTimerCount that
+// returns the timer registered after the call site's most recent observation
+// of the timer count. It is equivalent to TimerCount() + WaitForTimerCount(n+1).
+func (c *testClock) WaitForNextTimer(timeout time.Duration) *testTimer {
+	c.mu.Lock()
+	n := len(c.timers)
+	c.mu.Unlock()
+	return c.WaitForTimerCount(n+1, timeout)
+}
+
+// waitForCondition polls fn at a short interval until it returns true, or
+// until timeout elapses. Returns true on success, false on timeout. This is a
+// targeted helper for socket-pipe tests that need to wait for a sidecar-side
+// state mutation (e.g. lastAssistantAgent updated, lastErrorAt recorded) for
+// which there is no observable channel — the alternative is a fixed sleep,
+// which flakes under contended scheduling. The polling interval is small (1ms)
+// so the helper still completes promptly when the condition is met quickly.
+// See issue #1515.
+func waitForCondition(t *testing.T, fn func() bool, timeout time.Duration, msg string) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			if msg != "" {
+				t.Logf("waitForCondition timed out after %s: %s", timeout, msg)
+			}
+			return false
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
+// waitForState polls the DB until CurrentStatus reports the given state, or
+// until timeout elapses. Returns the observed state on success or the empty
+// string on timeout. Use this in place of "sleep 50ms then call getState" —
+// the previous pattern flaked under load because the sidecar handler had not
+// yet committed the state change to the DB. See issue #1515.
+func waitForState(t *testing.T, d *db.DB, session, want string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		st := getState(t, d, session)
+		if st == want {
+			return st
+		}
+		if time.Now().After(deadline) {
+			return st
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
 }
 
 // Advance moves the clock forward by d.


### PR DESCRIPTION
## Summary

Fixes the timer/scheduler-race flakes affecting 11 named tests in
`internal/sidecar` that have been blocking unrelated PRs (e.g. #1511) on
the `go-tests` / `nix-build-prism-checked` CI gate.

Closes #1515.

## Synchronisation mechanisms used

The fix is structural: replace fixed wall-clock sleeps with deterministic
synchronisation seams on the existing test clock. No production code
paths change — the new methods live on `testClock` / `testTimer` only,
and the production `realClock` continues to use `time.AfterFunc`.

Per-test mechanism:

| Test | Sync mechanism |
|---|---|
| `TestSocketPipe_IdleDebounce_WritesFinishedAfterDebounce` | `testClock.WaitForTimerCount(1, 5s)` — observable timer-creation seam |
| `TestSocketPipe_IdleDebounce_CancelledByTurnStart` | `WaitForTimerCount` + `testTimer.WaitStopped` (cancellation seam) + `waitForState` |
| `TestSocketPipe_MultipleIdle_OnlyOneTimer` | `WaitForTimerCount(1)` then `WaitForTimerCount(2)` + `WaitStopped` on the first timer |
| `TestSocketPipe_ErrorState_CancelsTimers` | `WaitForTimerCount` + `WaitStopped` + `waitForState` + `waitForCondition` on `lastErrorAt` |
| `TestSocketPipe_WaitingState_CancelsIdleTimer` | `WaitForTimerCount` + `WaitStopped` + `waitForState` |
| `TestSocketPipe_AutoRetryStart_CancelsIdleTimer` | `WaitForTimerCount` + `WaitStopped` |
| `TestSocketPipe_TurnEnd_UpdatesLastAssistantAgent` | `waitForCondition` on `sc.lastAssistantAgent` (no timer in this code path) |
| `TestSocketPipe_SessionShutdown_CancelsTimers` | `WaitForTimerCount` + `WaitStopped` |
| `TestSocketPipe_ErrorResumeDebounce_LastErrorAtRecorded` | `waitForCondition` on `sc.lastErrorAt` |
| `TestSocketPipe_ReviewAgent_ReachesFinishedViaTurnEnd` | `WaitForTimerCount` + `waitForState` |
| `TestHarnessPipeTCP_ListenFail_ReturnsErrorWithPort` | `waitForState` on the DB transition + new `waitForStartupErrorMessage` polling helper for the trailing event read |

## Root causes

Two distinct races, both addressed structurally:

1. **Timer-creation race (10 of 11 tests).** Tests sent a frame, slept
   `50ms`, then called `clk.LastTimer()` to assert a debounce timer was
   created. Under contended scheduling (Nix sandbox, loaded CI runners)
   `50ms` was not always enough for the sidecar goroutine to reach
   `Clock.AfterFunc` — `LastTimer()` returned `nil`, the test failed
   "no finished debounce timer was created". The fix exposes a channel
   that `AfterFunc` notifies on, and `WaitForTimerCount(n, timeout)`
   blocks until the actual creation event.

2. **Two-write race in `TestHarnessPipeTCP_ListenFail`.**
   `writeStartupError` commits the `StateError` transition first, then
   the `startup_error` event in a separate DB write. The test polled the
   state, saw it become `error`, then immediately read the event —
   landing between the two writes under load. Fix: the trailing read
   now uses a polling helper (`waitForStartupErrorMessage`) that returns
   on the first observation of the event.

## What did NOT change

- `Clock` / `Timer` interfaces (still `Now`, `AfterFunc`, `Sleep`, `Stop`)
- Production `realClock` implementation
- Debounce durations (`IdleDebounce`, `ErrorResumeDebounce`,
  `ReconnectRecoveryDelay`)
- Frame-emission timings or ordering on the wire
- Function signatures and types exported from `internal/sidecar`
- Externally observable state-machine semantics

The new methods on `testClock` / `testTimer` (`WaitForTimerCount`,
`WaitForNextTimer`, `WaitStopped`) are test-only — production code
never sees them because production uses `realClock`, which does not
embed the new fields.

## Verification

### `go test ./internal/sidecar/... -race -count=20` under load

Run on the dev host with four `yes >/dev/null` background tasks pushing
load average to ~6–8 throughout the run:

```
ok  	github.com/prismatic-koi/prism/internal/sidecar	939.296s
```

Zero failures across 20 iterations.

### Focused 11-test set, `-race -count=20`

```
ok  	github.com/prismatic-koi/prism/internal/sidecar	50.300s
```

### `go test ./... -race`

```
ok  	github.com/prismatic-koi/prism/cmd	26.075s
ok  	github.com/prismatic-koi/prism/internal/sidecar	38.907s
... (all packages ok)
```

### `nix build .#prism`

Built `/nix/store/51hs55rk97gcm6460ir1lcd5qpxq0b13-prism-0.1.0` cleanly.

### `nix build .#prism { runChecks = true; }`

```
prism> ok       github.com/prismatic-koi/prism/internal/sidecar 143.088s
prism> checkPhase completed in 5 minutes 47 seconds
```

The full Go suite ran inside the Nix sandbox with `$HOME=/homeless-shelter`
and passed — preserving the homeless-shelter signal.

## Files changed

- `internal/sidecar/sidecar_test.go` — `testClock` / `testTimer`
  enhancements + new helpers (`waitForCondition`, `waitForState`,
  `waitForStartupErrorMessage`).
- `internal/sidecar/sidecar_socketpipe_test.go` — updated 10 tests to
  use the new seams.
- `internal/sidecar/sidecar_harness_pipe_tcp_test.go` — updated 1 test
  to use `waitForState` + `waitForStartupErrorMessage`.

No production source files changed.
