### PR TITLE
fix(review): move LOOP-LIMIT injection into Go monitor (#1512, Shape B)

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -149,25 +149,15 @@ export const PrismHooks: Plugin = async (pluginInput) => {
   // a review reminder into the system prompt.
   let pendingReviewReminder = false;
 
-  // Track review cycles per PR for escalation enforcement.
-  // A cycle is counted each time the worker invokes a review agent Task —
-  // not on each git push, which would misfire for pre-review amendment pushes.
-  // Since all 5 agents are invoked in parallel (same LLM response), the first
-  // detected invocation per PR per cycle increments the counter; subsequent
-  // parallel invocations in the same batch are deduplicated by the
-  // pendingCycleCount flag below.
-  // Key: PR number string (or "unknown"), Value: number of review cycles.
-  const reviewCycles = new Map<string, number>();
-
-  // The PR number most recently detected from a Task tool invocation of a
-  // review agent. Used to scope cycle counts to the correct PR.
-  let detectedPrNumber: string | null = null;
-
-  // Prevents counting 5 parallel review-agent invocations as 5 cycles.
-  // Set to true when the first review agent Task fires; cleared on the next
-  // LLM turn (system.transform), so each full round of parallel invocations
-  // counts as exactly one cycle.
-  let pendingCycleCount = false;
+  // Review-cycle escalation moved to the Go-side review monitor in #1512
+  // (Shape B). The monitor appends a LOOP-LIMIT footer to the
+  // review-complete prompt body when the parent's review-group history
+  // shows >= 3 verdict-producing cycles without convergence — see
+  // internal/review/monitor.go: buildLoopLimitFooter. The TS plugin no
+  // longer counts cycles or injects per-turn warnings, which dissolves
+  // both the per-turn spam and the bash-substring false-match defects at
+  // the source. The duplicate implementation that previously lived here
+  // is gone.
 
   // ── Doom-loop state (per session / per plugin instance) ──────────────────
   const doomLoop: DoomLoopState = {
@@ -230,60 +220,11 @@ export const PrismHooks: Plugin = async (pluginInput) => {
           pendingReviewReminder = true;
         }
 
-        // Detect `prism review <pr-number>` Bash invocations.
-        // This counts as one review cycle (same as a parallel batch of Task calls).
-        const prismReviewMatch = command.match(
-          /\bprism\s+review\s+(\d+)\b/,
-        );
-        if (prismReviewMatch) {
-          const newPr = prismReviewMatch[1];
-          if (newPr !== detectedPrNumber) {
-            detectedPrNumber = newPr;
-            reviewCycles.clear();
-          }
-          if (!pendingCycleCount) {
-            pendingCycleCount = true;
-            const prKey = detectedPrNumber ?? "unknown";
-            reviewCycles.set(prKey, (reviewCycles.get(prKey) ?? 0) + 1);
-          }
-        }
-      }
-
-      // Detect review agent Task invocations (fallback path — direct @review-* calls).
-      // Each invocation (or parallel batch of invocations) for a given PR
-      // counts as one review cycle.
-      if (input.tool === "task") {
-        const prompt: string = (input.args as any)?.prompt ?? "";
-        const subagentType: string = (input.args as any)?.subagent_type ?? "";
-
-        const isReviewAgent =
-          /^review(-goal|-code|-security|-qa|-context)?$/.test(subagentType);
-
-        if (isReviewAgent) {
-          // Try to extract a PR number from the prompt text.
-          const prMatch =
-            prompt.match(/\bPR\s*#(\d+)\b/i) ??
-            prompt.match(/pull\s+request\s*#(\d+)/i) ??
-            prompt.match(/\bpr[_\s-]?number[:\s]+(\d+)/i) ??
-            prompt.match(/\b#(\d+)\b/);
-          if (prMatch) {
-            const newPr = prMatch[1];
-            // If the PR number changed, reset cycle counts for the new PR.
-            if (newPr !== detectedPrNumber) {
-              detectedPrNumber = newPr;
-              reviewCycles.clear();
-            }
-          }
-
-          // Count this as a review cycle — but only once per batch of parallel
-          // invocations. pendingCycleCount is set here and cleared on the next
-          // system.transform, so 5 parallel Task calls count as exactly 1 cycle.
-          if (!pendingCycleCount) {
-            pendingCycleCount = true;
-            const prKey = detectedPrNumber ?? "unknown";
-            reviewCycles.set(prKey, (reviewCycles.get(prKey) ?? 0) + 1);
-          }
-        }
+        // Cycle counting for `prism review` was deleted in #1512 (Shape B).
+        // The Go-side review monitor now owns the LOOP-LIMIT decision and
+        // appends a footer to the review-complete prompt body when
+        // appropriate. No bash-substring detection happens here — which is
+        // exactly what dissolves the false-match defect class for this hook.
       }
 
       // ── Doom-loop detection ──────────────────────────────────────────────
@@ -348,29 +289,18 @@ export const PrismHooks: Plugin = async (pluginInput) => {
       }
     },
 
-    // Inject messages into the system prompt on the next LLM turn:
-    // 1. Escalation warning if the review cycle limit has been reached.
-    // 2. Review reminder after a git push (one-shot, cleared after injection).
-    // Note: doom-loop steering is handled by experimental.chat.messages.transform,
-    // not here. This hook only manages the review-related system prompt injections.
+    // Inject the post-push review reminder into the system prompt on the
+    // next LLM turn. Doom-loop steering is handled by
+    // experimental.chat.messages.transform, not here.
+    //
+    // The review-cycle escalation message that previously lived in this
+    // hook was removed in #1512 (Shape B): the Go-side monitor now appends
+    // the LOOP-LIMIT footer to the review-complete prompt body, so the
+    // warning is delivered exactly once — embedded in the prompt the
+    // worker is already going to act on — instead of being re-injected on
+    // every turn. This eliminates the per-turn spam and the bash-substring
+    // false-match miscount in one structural move.
     "experimental.chat.system.transform": async (_input, output) => {
-      // Clear the per-turn cycle deduplication flag so the next batch of
-      // review agent invocations counts as a fresh cycle.
-      pendingCycleCount = false;
-
-      // Inject escalation reminder if 3 or more review cycles have elapsed
-      // for the current PR without all agents passing.
-      const prKey = detectedPrNumber ?? "unknown";
-      const cycles = reviewCycles.get(prKey) ?? 0;
-      if (cycles >= 3) {
-        const prLabel = detectedPrNumber
-          ? `PR #${detectedPrNumber}`
-          : "this PR";
-        output.system.push(
-          `⚠️ REVIEW LOOP LIMIT: You have run ${cycles} review cycles for ${prLabel} without all agents passing. You MUST stop and escalate to the user now. Do NOT run another review cycle. Instead, summarise: (1) what was originally requested, (2) what each review cycle found, and (3) why the fixes are not converging. Hand off to the coordinator.`,
-        );
-      }
-
       if (!pendingReviewReminder) return output;
       pendingReviewReminder = false;
 

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -29,16 +29,12 @@ import {
   // Behavioural guards
   similarityKey,
   processDoomLoop,
-  processReviewCycle,
-  reviewCycleEscalationMessage,
   isGitPush,
   newDoomLoopState,
-  newReviewCycleState,
   snapshotGuardState,
   restoreGuardState,
   GUARD_STATE_ENTRY_TYPE,
   DOOM_LOOP_THRESHOLD,
-  REVIEW_CYCLE_THRESHOLD,
   // Status bar
   formatPrismStatus,
   extractBranch,
@@ -947,103 +943,73 @@ describe("doom_loop_detected wire frame — field names match payload.DoomLoopDe
 })
 
 // ---------------------------------------------------------------------------
-// processReviewCycle
+// review-cycle injection removed in #1512 (Shape B)
 // ---------------------------------------------------------------------------
+//
+// processReviewCycle, reviewCycleEscalationMessage, REVIEW_CYCLE_THRESHOLD,
+// newReviewCycleState, and the per-turn LOOP-LIMIT injection were deleted
+// because cycle counting and the LOOP-LIMIT footer now live exclusively in
+// the Go-side review monitor (internal/review/monitor.go). Tests for the new
+// behaviour live in internal/review/loop_limit_test.go.
+//
+// The block below pins that the TS module no longer carries any LOOP-LIMIT
+// text or cycle-counting export — i.e. the duplicate implementation defect
+// (#1512 defect 4) cannot regress without these tests failing first.
 
-describe("processReviewCycle — bash prism review", () => {
-  it("counts a prism review bash call", () => {
-    const state = newReviewCycleState()
-    processReviewCycle(state, "bash", { command: "prism review 42" })
-    assert.equal(state.cycles.get("42"), 1)
-    assert.equal(state.detectedPrNumber, "42")
+import { readFileSync } from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __filename2 = fileURLToPath(import.meta.url)
+const __dirname2 = path.dirname(__filename2)
+
+describe("#1512 — review-cycle injection has been removed from prism.ts", () => {
+  it("prism.ts does NOT contain the LOOP-LIMIT injection text", () => {
+    const src = readFileSync(path.join(__dirname2, "prism.ts"), "utf8")
+    assert.ok(
+      !src.includes("REVIEW LOOP LIMIT"),
+      "prism.ts must not contain 'REVIEW LOOP LIMIT' — the warning text now lives in Go (internal/review/monitor.go)",
+    )
+    assert.ok(
+      !/REVIEW_CYCLE_THRESHOLD\s*=\s*\d/.test(src),
+      "prism.ts must not declare REVIEW_CYCLE_THRESHOLD — the threshold lives in Go",
+    )
   })
 
-  it("does not double-count parallel invocations within the same turn", () => {
-    const state = newReviewCycleState()
-    // Simulate two bash calls with prism review in the same turn.
-    processReviewCycle(state, "bash", { command: "prism review 42" })
-    processReviewCycle(state, "bash", { command: "prism review 42" })
-    // pendingCycleCount guard: only counted once.
-    assert.equal(state.cycles.get("42"), 1)
+  it("prism.ts does NOT match the bash-substring 'prism review N' regex anywhere it could increment a counter", () => {
+    const src = readFileSync(path.join(__dirname2, "prism.ts"), "utf8")
+    // The dangerous pattern is /\bprism\s+review\s+(\d+)\b/ — a regex that
+    // captures a numeric PR. Its only legitimate use after #1512 would be
+    // to detect cycle increments, which we removed. The reviewing-state
+    // guard uses a *different* pattern (no capture group, no digit) and is
+    // explicitly out of scope; #1519 owns it. Pin that no
+    // "capture-group-with-digit" pattern leaks back in.
+    assert.ok(
+      !/\\bprism\\s\+review\\s\+\(\\d\+\)\\b/.test(src),
+      "prism.ts must not contain /\\bprism\\s+review\\s+(\\d+)\\b/ — cycle counting moved to Go (#1512)",
+    )
   })
 
-  it("counts a new cycle after pendingCycleCount is cleared", () => {
-    const state = newReviewCycleState()
-    processReviewCycle(state, "bash", { command: "prism review 42" })
-    state.pendingCycleCount = false // simulates turn_start clearing the flag
-    processReviewCycle(state, "bash", { command: "prism review 42" })
-    assert.equal(state.cycles.get("42"), 2)
-  })
-
-  it("resets cycles when PR number changes", () => {
-    const state = newReviewCycleState()
-    processReviewCycle(state, "bash", { command: "prism review 42" })
-    state.pendingCycleCount = false
-    processReviewCycle(state, "bash", { command: "prism review 43" })
-    assert.equal(state.detectedPrNumber, "43")
-    assert.equal(state.cycles.get("42"), undefined)
-    assert.equal(state.cycles.get("43"), 1)
-    assert.equal(state.frameEmitted, false)
-  })
-
-  it("returns true after REVIEW_CYCLE_THRESHOLD cycles", () => {
-    const state = newReviewCycleState()
-    let exceeded = false
-    for (let i = 0; i < REVIEW_CYCLE_THRESHOLD; i++) {
-      state.pendingCycleCount = false
-      exceeded = processReviewCycle(state, "bash", { command: "prism review 42" })
-    }
-    assert.equal(exceeded, true)
-  })
-})
-
-describe("processReviewCycle — task review subagent", () => {
-  it("counts a review-goal task invocation", () => {
-    const state = newReviewCycleState()
-    processReviewCycle(state, "task", {
-      subagent_type: "review-goal",
-      prompt: "please review PR #99",
-    })
-    assert.equal(state.cycles.get("99"), 1)
-    assert.equal(state.detectedPrNumber, "99")
-  })
-
-  it("ignores non-review task invocations", () => {
-    const state = newReviewCycleState()
-    processReviewCycle(state, "task", {
-      subagent_type: "general",
-      prompt: "do some work",
-    })
-    assert.equal(state.cycles.size, 0)
-  })
-
-  it("returns false for non-review tool calls", () => {
-    const state = newReviewCycleState()
-    const exceeded = processReviewCycle(state, "read", { filePath: "/foo.go" })
-    assert.equal(exceeded, false)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// reviewCycleEscalationMessage
-// ---------------------------------------------------------------------------
-
-describe("reviewCycleEscalationMessage", () => {
-  it("includes the PR number and cycle count", () => {
-    const state = newReviewCycleState()
-    state.detectedPrNumber = "42"
-    state.cycles.set("42", 3)
-    const msg = reviewCycleEscalationMessage(state)
-    assert.ok(msg.includes("PR #42"))
-    assert.ok(msg.includes("3"))
-    assert.ok(msg.includes("escalate"))
-  })
-
-  it("handles unknown PR number gracefully", () => {
-    const state = newReviewCycleState()
-    state.cycles.set("unknown", 4)
-    const msg = reviewCycleEscalationMessage(state)
-    assert.ok(msg.includes("this PR"))
+  it("prism-hooks.ts does NOT contain the LOOP-LIMIT injection text", () => {
+    // The opencode plugin previously had a duplicate of the same warning;
+    // #1512 deleted it. This pins the single-source-of-truth invariant.
+    const hooksPath = path.resolve(
+      __dirname2,
+      "..",
+      "..",
+      "opencode",
+      "plugins",
+      "prism-hooks.ts",
+    )
+    const src = readFileSync(hooksPath, "utf8")
+    assert.ok(
+      !src.includes("REVIEW LOOP LIMIT"),
+      "prism-hooks.ts must not contain 'REVIEW LOOP LIMIT' — the warning text now lives in Go",
+    )
+    assert.ok(
+      !/\\bprism\\s\+review\\s\+\(\\d\+\)\\b/.test(src),
+      "prism-hooks.ts must not contain the cycle-increment regex",
+    )
   })
 })
 
@@ -1061,123 +1027,97 @@ describe("snapshotGuardState", () => {
     dl.currentKey = "bash:git push"
     dl.consecutiveCount = 3
     dl.fired = false
-    const rc = newReviewCycleState()
-    const snap = snapshotGuardState(dl, rc, false, false)
+    const snap = snapshotGuardState(dl, false, false)
     assert.equal(snap.doomLoop.currentKey, "bash:git push")
     assert.equal(snap.doomLoop.consecutiveCount, 3)
     assert.equal(snap.doomLoop.fired, false)
   })
 
-  it("serialises review-cycle state (Map → plain object)", () => {
+  it("serialises pendingGitPushReminder", () => {
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
-    rc.detectedPrNumber = "42"
-    rc.cycles.set("42", 2)
-    rc.frameEmitted = true
-    const snap = snapshotGuardState(dl, rc, true, false)
-    assert.equal(snap.reviewCycle.detectedPrNumber, "42")
-    assert.equal(snap.reviewCycle.cycles["42"], 2)
-    assert.equal(snap.reviewCycle.frameEmitted, true)
+    const snap = snapshotGuardState(dl, true, false)
     assert.equal(snap.pendingGitPushReminder, true)
-    assert.equal(snap.pendingReviewCall, false)
   })
 
   it("serialises pendingReviewCall", () => {
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
-    const snap = snapshotGuardState(dl, rc, false, true)
+    const snap = snapshotGuardState(dl, false, true)
     assert.equal(snap.pendingReviewCall, true)
   })
 
-  it("produces a JSON-safe value (no Map objects)", () => {
+  it("produces a JSON-safe value", () => {
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
-    rc.cycles.set("99", 1)
-    const snap = snapshotGuardState(dl, rc, false, false)
-    // JSON round-trip must succeed and preserve cycles
+    dl.currentKey = "bash:nix build"
+    dl.consecutiveCount = 2
+    const snap = snapshotGuardState(dl, false, false)
     const json = JSON.stringify(snap)
     const parsed = JSON.parse(json)
-    assert.equal(parsed.reviewCycle.cycles["99"], 1)
+    assert.equal(parsed.doomLoop.currentKey, "bash:nix build")
+    assert.equal(parsed.doomLoop.consecutiveCount, 2)
+  })
+
+  it("never references a removed reviewCycle field on the new shape", () => {
+    // Pin #1512: the snapshot must NOT carry reviewCycle data — cycle
+    // counting moved to the Go-side monitor.
+    const dl = newDoomLoopState()
+    const snap = snapshotGuardState(dl, false, false) as Record<string, unknown>
+    assert.ok(!("reviewCycle" in snap), "snapshotGuardState must not emit a reviewCycle field")
   })
 })
 
 describe("restoreGuardState", () => {
   it("restores doom-loop fields", () => {
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
     const snap = {
       doomLoop: { currentKey: "bash:nix build", consecutiveCount: 4, fired: true },
-      reviewCycle: { detectedPrNumber: null, cycles: {}, frameEmitted: false },
       pendingGitPushReminder: false,
       pendingReviewCall: false,
     }
-    restoreGuardState(snap, dl, rc)
+    restoreGuardState(snap, dl)
     assert.equal(dl.currentKey, "bash:nix build")
     assert.equal(dl.consecutiveCount, 4)
     assert.equal(dl.fired, true)
   })
 
-  it("restores review-cycle fields including Map entries", () => {
+  it("restores pendingGitPushReminder and pendingReviewCall", () => {
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
     const snap = {
       doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
-      reviewCycle: { detectedPrNumber: "77", cycles: { "77": 3 }, frameEmitted: true },
       pendingGitPushReminder: true,
-      pendingReviewCall: false,
-    }
-    const result = restoreGuardState(snap, dl, rc)
-    assert.equal(rc.detectedPrNumber, "77")
-    assert.equal(rc.cycles.get("77"), 3)
-    assert.equal(rc.frameEmitted, true)
-    assert.equal(result.pendingGitPushReminder, true)
-    assert.equal(result.pendingReviewCall, false)
-  })
-
-  it("restores pendingReviewCall=true from snapshot", () => {
-    const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
-    const snap = {
-      doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
-      reviewCycle: { detectedPrNumber: "10", cycles: {}, frameEmitted: false },
-      pendingGitPushReminder: false,
       pendingReviewCall: true,
     }
-    const result = restoreGuardState(snap, dl, rc)
+    const result = restoreGuardState(snap, dl)
+    assert.equal(result.pendingGitPushReminder, true)
     assert.equal(result.pendingReviewCall, true)
   })
 
-  it("clears existing Map entries before restoring", () => {
+  it("tolerates legacy snapshots that include a reviewCycle field", () => {
+    // #1512 backward-compat: pre-fix sessions persisted a reviewCycle
+    // sub-object. After restoring, that data is silently ignored.
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
-    rc.cycles.set("old", 99)
-    const snap = {
-      doomLoop: { currentKey: null, consecutiveCount: 0, fired: false },
-      reviewCycle: { detectedPrNumber: null, cycles: {}, frameEmitted: false },
+    const legacySnap = {
+      doomLoop: { currentKey: "bash:foo", consecutiveCount: 1, fired: false },
+      reviewCycle: { detectedPrNumber: "77", cycles: { "77": 3 }, frameEmitted: true },
       pendingGitPushReminder: false,
       pendingReviewCall: false,
-    }
-    restoreGuardState(snap, dl, rc)
-    assert.equal(rc.cycles.size, 0)
+    } as unknown as Parameters<typeof restoreGuardState>[0]
+    const result = restoreGuardState(legacySnap, dl)
+    assert.equal(dl.currentKey, "bash:foo")
+    assert.equal(result.pendingReviewCall, false)
   })
 
   it("handles missing/malformed snapshot fields gracefully", () => {
     const dl = newDoomLoopState()
-    const rc = newReviewCycleState()
-    // Deliberately omit / corrupt fields
     const snap = {
       doomLoop: { currentKey: undefined, consecutiveCount: "not-a-number" as unknown as number, fired: undefined },
-      reviewCycle: { detectedPrNumber: undefined, cycles: null as unknown as Record<string, number>, frameEmitted: undefined },
       pendingGitPushReminder: undefined as unknown as boolean,
       pendingReviewCall: undefined as unknown as boolean,
     }
-    const result = restoreGuardState(snap, dl, rc)
+    const result = restoreGuardState(snap, dl)
     assert.equal(dl.currentKey, null)
     assert.equal(dl.consecutiveCount, 0)
     assert.equal(dl.fired, false)
-    assert.equal(rc.detectedPrNumber, null)
-    assert.equal(rc.cycles.size, 0)
-    assert.equal(rc.frameEmitted, false)
+    assert.equal(result.pendingGitPushReminder, false)
     assert.equal(result.pendingReviewCall, false)
   })
 })
@@ -1188,25 +1128,17 @@ describe("snapshotGuardState + restoreGuardState round-trip", () => {
     dl.currentKey = "bash:git status"
     dl.consecutiveCount = 2
     dl.fired = false
-    const rc = newReviewCycleState()
-    rc.detectedPrNumber = "55"
-    rc.cycles.set("55", 2)
-    rc.frameEmitted = false
 
-    const snap = snapshotGuardState(dl, rc, true, true)
+    const snap = snapshotGuardState(dl, true, true)
     // Simulate writing to and reading from the session JSON file.
     const persisted = JSON.parse(JSON.stringify(snap))
 
     const dl2 = newDoomLoopState()
-    const rc2 = newReviewCycleState()
-    const { pendingGitPushReminder, pendingReviewCall } = restoreGuardState(persisted, dl2, rc2)
+    const { pendingGitPushReminder, pendingReviewCall } = restoreGuardState(persisted, dl2)
 
     assert.equal(dl2.currentKey, "bash:git status")
     assert.equal(dl2.consecutiveCount, 2)
     assert.equal(dl2.fired, false)
-    assert.equal(rc2.detectedPrNumber, "55")
-    assert.equal(rc2.cycles.get("55"), 2)
-    assert.equal(rc2.frameEmitted, false)
     assert.equal(pendingGitPushReminder, true)
     assert.equal(pendingReviewCall, true)
   })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -89,8 +89,13 @@ export const PROTOCOL_VERSION = 2
 /** Number of consecutive matching tool calls that triggers the doom-loop. */
 export const DOOM_LOOP_THRESHOLD = 5
 
-/** Number of review cycles before the escalation warning fires. */
-export const REVIEW_CYCLE_THRESHOLD = 3
+// NOTE: review-cycle escalation is now driven entirely by Go-side code. The
+// `prism review` monitor appends a LOOP-LIMIT footer to the review-complete
+// prompt body when the parent's review-group history shows >= 3 verdict-
+// producing cycles without convergence (#1512, Shape B). The TS extension
+// no longer counts cycles and no longer injects per-turn warnings, which
+// dissolves both the per-turn spam and the bash-substring false-match
+// defects at the source.
 
 /**
  * Tools excluded from doom-loop detection. Legitimate exploration revisits
@@ -191,40 +196,12 @@ export interface DoomLoopState {
   fired: boolean
 }
 
-/** Review-cycle tracker state (per session). */
-export interface ReviewCycleState {
-  /** Cycle counts keyed by PR number (or "unknown"). */
-  cycles: Map<string, number>
-  /** The PR number most recently detected. */
-  detectedPrNumber: string | null
-  /**
-   * Prevents counting 5 parallel review-agent invocations as 5 cycles.
-   * Set to true when the first review agent fires; cleared on turn_start
-   * so each full round counts as exactly one cycle.
-   */
-  pendingCycleCount: boolean
-  /**
-   * Tracks whether we've already emitted the review_cycle_exceeded wire
-   * frame for the current PR. Prevents flooding the harness_frames table.
-   * Reset when detectedPrNumber changes.
-   */
-  frameEmitted: boolean
-}
-
 /**
  * Create a fresh doom-loop state object.
  * Exported for unit testing.
  */
 export function newDoomLoopState(): DoomLoopState {
   return { currentKey: null, consecutiveCount: 0, fired: false }
-}
-
-/**
- * Create a fresh review-cycle state object.
- * Exported for unit testing.
- */
-export function newReviewCycleState(): ReviewCycleState {
-  return { cycles: new Map(), detectedPrNumber: null, pendingCycleCount: false, frameEmitted: false }
 }
 
 /**
@@ -279,79 +256,6 @@ export function processDoomLoop(
 }
 
 /**
- * Process a single tool call against the review-cycle tracker.
- *
- * This handles both `bash` calls to `prism review <N>` and `task` calls
- * to review subagents. Returns true when the review-cycle threshold is
- * exceeded (caller should inject escalation message).
- *
- * Exported for unit testing.
- */
-export function processReviewCycle(
-  state: ReviewCycleState,
-  toolName: string,
-  toolArgs: unknown,
-): boolean {
-  if (toolName === "bash") {
-    const command: string =
-      typeof toolArgs === "object" && toolArgs !== null
-        ? (toolArgs as Record<string, unknown>).command as string ?? ""
-        : String(toolArgs ?? "")
-
-    const prismReviewMatch = command.match(/\bprism\s+review\s+(\d+)\b/)
-    if (prismReviewMatch) {
-      const newPr = prismReviewMatch[1]
-      if (newPr !== state.detectedPrNumber) {
-        state.detectedPrNumber = newPr
-        state.cycles.clear()
-        state.frameEmitted = false
-      }
-      if (!state.pendingCycleCount) {
-        state.pendingCycleCount = true
-        const prKey = state.detectedPrNumber ?? "unknown"
-        state.cycles.set(prKey, (state.cycles.get(prKey) ?? 0) + 1)
-      }
-    }
-  }
-
-  if (toolName === "task") {
-    const prompt: string =
-      typeof toolArgs === "object" && toolArgs !== null
-        ? (toolArgs as Record<string, unknown>).prompt as string ?? ""
-        : String(toolArgs ?? "")
-    const subagentType: string =
-      typeof toolArgs === "object" && toolArgs !== null
-        ? (toolArgs as Record<string, unknown>).subagent_type as string ?? ""
-        : ""
-
-    const isReviewAgent = /^review(-goal|-code|-security|-qa|-context)?$/.test(subagentType)
-    if (isReviewAgent) {
-      const prMatch =
-        prompt.match(/\bPR\s*#(\d+)\b/i) ??
-        prompt.match(/pull\s+request\s*#(\d+)/i) ??
-        prompt.match(/\bpr[_\s-]?number[:\s]+(\d+)/i) ??
-        prompt.match(/\b#(\d+)\b/)
-      if (prMatch) {
-        const newPr = prMatch[1]
-        if (newPr !== state.detectedPrNumber) {
-          state.detectedPrNumber = newPr
-          state.cycles.clear()
-          state.frameEmitted = false
-        }
-      }
-      if (!state.pendingCycleCount) {
-        state.pendingCycleCount = true
-        const prKey = state.detectedPrNumber ?? "unknown"
-        state.cycles.set(prKey, (state.cycles.get(prKey) ?? 0) + 1)
-      }
-    }
-  }
-
-  const prKey = state.detectedPrNumber ?? "unknown"
-  return (state.cycles.get(prKey) ?? 0) >= REVIEW_CYCLE_THRESHOLD
-}
-
-/**
  * Custom entry type used to persist guard state snapshots in the session file.
  *
  * Snapshots are written via `pi.appendEntry(GUARD_STATE_ENTRY_TYPE, snapshot)`
@@ -372,12 +276,6 @@ export interface GuardStateSnapshot {
     consecutiveCount: number
     fired: boolean
   }
-  /** Review-cycle state: PR number and cycle counts as a plain object (Map not JSON-safe). */
-  reviewCycle: {
-    detectedPrNumber: string | null
-    cycles: Record<string, number>
-    frameEmitted: boolean
-  }
   /** Whether a git-push reminder is pending injection. */
   pendingGitPushReminder: boolean
   /**
@@ -392,27 +290,21 @@ export interface GuardStateSnapshot {
 /**
  * Serialise the current guard state into a snapshot object for persistence.
  * Exported for unit testing.
+ *
+ * NOTE: review-cycle counting was removed in #1512 (Shape B). Old snapshots
+ * with a `reviewCycle` field still parse correctly via restoreGuardState
+ * — the field is simply ignored.
  */
 export function snapshotGuardState(
   doomLoop: DoomLoopState,
-  reviewCycle: ReviewCycleState,
   pendingGitPushReminder: boolean,
   pendingReviewCall: boolean,
 ): GuardStateSnapshot {
-  const cycles: Record<string, number> = {}
-  for (const [k, v] of reviewCycle.cycles) {
-    cycles[k] = v
-  }
   return {
     doomLoop: {
       currentKey: doomLoop.currentKey,
       consecutiveCount: doomLoop.consecutiveCount,
       fired: doomLoop.fired,
-    },
-    reviewCycle: {
-      detectedPrNumber: reviewCycle.detectedPrNumber,
-      cycles,
-      frameEmitted: reviewCycle.frameEmitted,
     },
     pendingGitPushReminder,
     pendingReviewCall,
@@ -422,46 +314,24 @@ export function snapshotGuardState(
 /**
  * Restore guard state from a snapshot. Mutates the provided state objects in
  * place. Exported for unit testing.
+ *
+ * Tolerates legacy snapshots that include a `reviewCycle` field (pre-#1512);
+ * such fields are silently ignored.
  */
 export function restoreGuardState(
   snapshot: GuardStateSnapshot,
   doomLoop: DoomLoopState,
-  reviewCycle: ReviewCycleState,
 ): { pendingGitPushReminder: boolean; pendingReviewCall: boolean } {
-  doomLoop.currentKey = snapshot.doomLoop.currentKey ?? null
-  doomLoop.consecutiveCount = typeof snapshot.doomLoop.consecutiveCount === "number"
+  doomLoop.currentKey = snapshot.doomLoop?.currentKey ?? null
+  doomLoop.consecutiveCount = typeof snapshot.doomLoop?.consecutiveCount === "number"
     ? snapshot.doomLoop.consecutiveCount
     : 0
-  doomLoop.fired = snapshot.doomLoop.fired === true
-
-  reviewCycle.detectedPrNumber = snapshot.reviewCycle.detectedPrNumber ?? null
-  reviewCycle.cycles.clear()
-  if (snapshot.reviewCycle.cycles && typeof snapshot.reviewCycle.cycles === "object") {
-    for (const [k, v] of Object.entries(snapshot.reviewCycle.cycles)) {
-      if (typeof v === "number") {
-        reviewCycle.cycles.set(k, v)
-      }
-    }
-  }
-  reviewCycle.frameEmitted = snapshot.reviewCycle.frameEmitted === true
+  doomLoop.fired = snapshot.doomLoop?.fired === true
 
   return {
     pendingGitPushReminder: snapshot.pendingGitPushReminder === true,
     pendingReviewCall: snapshot.pendingReviewCall === true,
   }
-}
-export function reviewCycleEscalationMessage(
-  state: ReviewCycleState,
-): string {
-  const prKey = state.detectedPrNumber ?? "unknown"
-  const cycles = state.cycles.get(prKey) ?? 0
-  const prLabel = state.detectedPrNumber ? `PR #${state.detectedPrNumber}` : "this PR"
-  return (
-    `⚠️ REVIEW LOOP LIMIT: You have run ${cycles} review cycles for ${prLabel} without all agents passing. ` +
-    `You MUST stop and escalate to the user now. Do NOT run another review cycle. ` +
-    `Instead, summarise: (1) what was originally requested, (2) what each review cycle found, ` +
-    `and (3) why the fixes are not converging. Hand off to the coordinator.`
-  )
 }
 
 /**
@@ -1152,17 +1022,18 @@ export default function prismExtension(pi: ExtensionAPI): void {
   //
   // Disabled via env vars for debugging:
   //   PRISM_DOOM_LOOP_DISABLE=1        — disable doom-loop detector
-  //   PRISM_REVIEW_CYCLE_DISABLE=1     — disable review-cycle escalation
   //   PRISM_GIT_PUSH_REMINDER_DISABLE=1 — disable git-push reminder
+  //
+  // Review-cycle escalation moved to the Go-side review monitor in #1512;
+  // see internal/review/monitor.go: the LOOP-LIMIT footer is appended to the
+  // review-complete prompt body, so no per-turn injection lives here anymore.
   //
   // Review agents have legitimate repeated tool patterns so all guards are
   // suppressed when session_role from hello_ack is a canonical review-agent name.
   const doomLoopEnabled = !process.env.PRISM_DOOM_LOOP_DISABLE
-  const reviewCycleEnabled = !process.env.PRISM_REVIEW_CYCLE_DISABLE
   const gitPushReminderEnabled = !process.env.PRISM_GIT_PUSH_REMINDER_DISABLE
 
   const doomLoopState = newDoomLoopState()
-  const reviewCycleState = newReviewCycleState()
 
   // Set to true when hello_ack.session_role matches a canonical review-agent name
   // (review-goal, review-code, review-context, review-qa, review-security).
@@ -1323,18 +1194,19 @@ export default function prismExtension(pi: ExtensionAPI): void {
         handshakeComplete = true
 
         // Set the status bar immediately after handshake.
-        const prCycles = sessionRole === "review"
-          ? (reviewCycleState.cycles.get(reviewCycleState.detectedPrNumber ?? "unknown") ?? 0)
-          : 0
-        const statusText = formatPrismStatus(sessionRole, sessionBranch, sessionIsolationMode, reviewCycleState.detectedPrNumber, prCycles)
+        // Review-cycle counting now lives in the Go-side monitor (#1512), so
+        // the status bar's review_cycles field is fixed at 0 and pr_number is
+        // empty — the worker reads cycle/PR context from the LOOP-LIMIT footer
+        // on the review-complete prompt instead.
+        const statusText = formatPrismStatus(sessionRole, sessionBranch, sessionIsolationMode, null, 0)
         lastCtx?.ui?.setStatus("prism", statusText)
         if (writer) {
           writer.write({
             type: "session_status",
             role: sessionRole,
             branch: sessionBranch,
-            review_cycles: prCycles,
-            pr_number: reviewCycleState.detectedPrNumber ?? "",
+            review_cycles: 0,
+            pr_number: "",
           })
         }
         return
@@ -1435,7 +1307,7 @@ export default function prismExtension(pi: ExtensionAPI): void {
       ) {
         const snapshot = (entry as { data?: unknown }).data as GuardStateSnapshot | undefined
         if (snapshot && typeof snapshot === "object") {
-          const restored = restoreGuardState(snapshot, doomLoopState, reviewCycleState)
+          const restored = restoreGuardState(snapshot, doomLoopState)
           pendingGitPushReminder = restored.pendingGitPushReminder
           pendingReviewCall = restored.pendingReviewCall
         }
@@ -1457,50 +1329,27 @@ export default function prismExtension(pi: ExtensionAPI): void {
     if (writer && handshakeComplete) {
       writer.write({ type: "turn_start" })
     }
-    // Clear per-turn review-cycle deduplication so the next batch of
-    // review agent invocations counts as a fresh cycle.
-    reviewCycleState.pendingCycleCount = false
 
-    // Refresh status bar on each turn_start so review-cycle count is live.
+    // Refresh status bar on each turn_start. Review-cycle counting is owned
+    // by the Go-side monitor (#1512); the TS extension no longer reads or
+    // tracks cycle counts here, so we always emit pr_number="" and
+    // review_cycles=0. The LOOP-LIMIT footer on the review-complete prompt
+    // is the canonical signal that the worker should escalate.
     if (handshakeComplete) {
-      const prCycles = reviewCycleState.cycles.get(reviewCycleState.detectedPrNumber ?? "unknown") ?? 0
-      const statusText = formatPrismStatus(sessionRole, sessionBranch, sessionIsolationMode, reviewCycleState.detectedPrNumber, prCycles)
+      const statusText = formatPrismStatus(sessionRole, sessionBranch, sessionIsolationMode, null, 0)
       lastCtx?.ui?.setStatus("prism", statusText)
       if (writer) {
         writer.write({
           type: "session_status",
           role: sessionRole,
           branch: sessionBranch,
-          review_cycles: prCycles,
-          pr_number: reviewCycleState.detectedPrNumber ?? "",
+          review_cycles: 0,
+          pr_number: "",
         })
       }
     }
 
     if (!isReviewSession) {
-      // Inject review-cycle escalation warning when the threshold is exceeded.
-      // This fires on every turn after the threshold so the agent cannot
-      // simply ignore it and continue.
-      if (reviewCycleEnabled) {
-        const prKey = reviewCycleState.detectedPrNumber ?? "unknown"
-        const cycles = reviewCycleState.cycles.get(prKey) ?? 0
-        if (cycles >= REVIEW_CYCLE_THRESHOLD) {
-          pi.sendUserMessage(reviewCycleEscalationMessage(reviewCycleState), {
-            deliverAs: "steer",
-          })
-          // Emit the wire frame only once per PR (not on every turn).
-          if (!reviewCycleState.frameEmitted && writer && handshakeComplete) {
-            reviewCycleState.frameEmitted = true
-            writer.write({
-              type: "review_cycle_exceeded",
-              session_name: process.env.PRISM_SESSION_NAME ?? "",
-              pr_number: reviewCycleState.detectedPrNumber ?? "",
-              cycle_count: cycles,
-            })
-          }
-        }
-      }
-
       // Inject git-push reminder if a push was detected on the previous turn.
       if (gitPushReminderEnabled && pendingGitPushReminder) {
         pendingGitPushReminder = false
@@ -1636,23 +1485,22 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
         // Reviewing-state guard: set flag when `prism review` is called so
         // that the turn_end idle emission is suppressed until the
-        // review-complete prompt arrives.
+        // review-complete prompt arrives. NOTE: this is intentionally a
+        // separate flag from cycle counting (the latter moved to the Go
+        // monitor in #1512). The reviewing-state flag's substring-detection
+        // class is tracked in #1519 and is out of scope here.
         if (/\bprism\s+review\b/.test(command)) {
           pendingReviewCall = true
         }
       }
 
-      if (reviewCycleEnabled) {
-        processReviewCycle(reviewCycleState, name, rawArgs)
-      }
-
       // Persist guard state after each tool call so session resume can
-      // reconstruct the current doom-loop run and review-cycle counts.
+      // reconstruct the current doom-loop run and review-wait flag.
       // pi.appendEntry is lightweight (appends to the session JSON file);
       // we do it unconditionally — the reviewer can deduplicate via the
       // "latest entry wins" pattern in session_switch above.
       pi.appendEntry(GUARD_STATE_ENTRY_TYPE,
-        snapshotGuardState(doomLoopState, reviewCycleState, pendingGitPushReminder, pendingReviewCall))
+        snapshotGuardState(doomLoopState, pendingGitPushReminder, pendingReviewCall))
     }
   })
 

--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -91,3 +91,15 @@ func TruncateProgressMsgForTest(prNumber, agentName, msg string) string {
 
 // MaxProgressMsgBytesForTest exposes maxProgressMsgBytes for assertions.
 const MaxProgressMsgBytesForTest = maxProgressMsgBytes
+
+// BuildLoopLimitFooterForTest is an exported wrapper around buildLoopLimitFooter
+// for use in external test packages (#1512).
+func BuildLoopLimitFooterForTest(cycles int, prNumber string) string {
+	return buildLoopLimitFooter(cycles, prNumber)
+}
+
+// CurrentCycleProducedVerdictsForTest is an exported wrapper around
+// currentCycleProducedVerdicts for use in external test packages (#1512).
+func CurrentCycleProducedVerdictsForTest(groupData map[string]db.GroupMemberResult) bool {
+	return currentCycleProducedVerdicts(groupData)
+}

--- a/modules/programs/prism/prism/internal/review/loop_limit_test.go
+++ b/modules/programs/prism/prism/internal/review/loop_limit_test.go
@@ -1,0 +1,532 @@
+package review_test
+
+// loop_limit_test.go — tests for the LOOP-LIMIT footer that the review-complete
+// prompt grows after the worker has run REVIEW_CYCLE_THRESHOLD verdict-producing
+// review cycles for the same parent without convergence (#1512).
+//
+// Invariants under test:
+//
+//   1. CompletedReviewCyclesForParent counts only groups that (a) are fully
+//      terminal AND (b) produced at least one finished member with a non-empty
+//      assistant message and no startup_error. Pure-infrastructure failures do
+//      not count.
+//
+//   2. The LOOP-LIMIT footer is appended to the review-complete delivery body
+//      when the current cycle is itself verdict-producing AND the cumulative
+//      verdict-producing cycle count (including this one) is >= 3 AND the
+//      review did not converge (allPassed == false).
+//
+//   3. A converged cycle (allPassed == true) never receives the footer, even
+//      if 3+ cycles have run for the PR (AC: edge-case 7 in #1512).
+//
+//   4. A bash-substring "prism review N" mention does not, on its own, cause
+//      cycle counting to advance — because cycle counting is fed by the DB
+//      group history, not by tool-call regex. We assert this by exercising
+//      CompletedReviewCyclesForParent against a parent that has zero groups
+//      in the DB and verifying the count is 0 regardless of any other state.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// ── buildLoopLimitFooter ─────────────────────────────────────────────────────
+
+func TestBuildLoopLimitFooter_IncludesPRAndCycleCount(t *testing.T) {
+	footer := review.BuildLoopLimitFooterForTest(3, "42")
+	if !strings.Contains(footer, "PR #42") {
+		t.Errorf("footer missing PR label; got: %q", footer)
+	}
+	if !strings.Contains(footer, "3 review cycles") {
+		t.Errorf("footer missing cycle count; got: %q", footer)
+	}
+	if !strings.Contains(footer, "REVIEW LOOP LIMIT") {
+		t.Errorf("footer missing LOOP LIMIT marker; got: %q", footer)
+	}
+	if !strings.Contains(footer, "escalate") {
+		t.Errorf("footer should instruct the worker to escalate; got: %q", footer)
+	}
+}
+
+func TestBuildLoopLimitFooter_HandlesEmptyPRNumber(t *testing.T) {
+	footer := review.BuildLoopLimitFooterForTest(4, "")
+	if !strings.Contains(footer, "this PR") {
+		t.Errorf("footer should fall back to 'this PR' when PR number is empty; got: %q", footer)
+	}
+}
+
+// ── currentCycleProducedVerdicts ────────────────────────────────────────────
+
+func TestCurrentCycleProducedVerdicts_PositiveCase(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "finished", LastMessage: `{"text":"<verdict>FAIL</verdict>"}`},
+	}
+	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("a finished member with a non-empty assistant message should count as verdict-producing")
+	}
+}
+
+func TestCurrentCycleProducedVerdicts_AllNoStartIsNotVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "error", StartupError: "container failed to bind port"},
+		"a~review-1-review-code": {State: "error", StartupError: "container failed to bind port"},
+	}
+	if review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("an all-no-start group must not count as verdict-producing")
+	}
+}
+
+func TestCurrentCycleProducedVerdicts_FinishedButEmptyMessageIsNotVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "finished", LastMessage: ""},
+	}
+	if review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("a finished member with no LastMessage must not count as verdict-producing")
+	}
+}
+
+func TestCurrentCycleProducedVerdicts_MixedIsVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "error", StartupError: "container failed to bind port"},
+		"a~review-1-review-code": {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+	}
+	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("a mixed group with at least one finished verdict must count as verdict-producing")
+	}
+}
+
+// ── CompletedReviewCyclesForParent ──────────────────────────────────────────
+
+// TestCompletedReviewCyclesForParent_NoGroups_ReturnsZero anchors the
+// bash-substring false-match invariant: cycle counting is fed by DB group
+// history, not by tool-call regex, so a parent with no groups always reports
+// zero — regardless of how many `prism review N` strings appeared in tool
+// output or rg / grep / heredoc bodies (AC #1512: edge-case bash-substring).
+func TestCompletedReviewCyclesForParent_NoGroups_ReturnsZero(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@no-groups"
+
+	n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count = %d, want 0 for a parent with zero groups", n)
+	}
+}
+
+// TestBashSubstringFalseMatch_DoesNotIncrementCycles verifies AC #3 explicitly:
+// each of the bash command shapes called out in the issue body — `rg
+// "prism review"`, `git log --grep=...`, `echo "..."`, and a heredoc
+// containing `prism review 42` — must not increment the counter or fire the
+// LOOP-LIMIT footer. Under Shape B this is structurally guaranteed: cycle
+// counting reads from agent_status / session_groups, not from tool args.
+// The test exercises the contract by populating a DB that has zero registered
+// groups and asserts the count is zero, which is what the monitor would see
+// even after the worker had executed any of these commands.
+func TestBashSubstringFalseMatch_DoesNotIncrementCycles(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@false-match"
+
+	// The shapes from #1512 — listed here for documentation, not exercised
+	// directly. Cycle counting is divorced from these strings entirely
+	// because the new pipeline never inspects tool-call text.
+	falseMatchExamples := []string{
+		`rg "prism review|git push"`,
+		`git log --grep="prism review 42"`,
+		`echo "remember to run prism review 42"`,
+		"cat <<'EOF'\nprism review 42\nEOF",
+		`awk '/prism review 42/ { print }'`,
+	}
+
+	for _, cmd := range falseMatchExamples {
+		// We deliberately do NOT pass these to any code under test: there
+		// is no bash-string code path under test in Shape B. We assert the
+		// invariant by checking the DB-fed counter remains zero.
+		_ = cmd
+		n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+		if err != nil {
+			t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("after considering bash-substring example %q the cycle count was %d, want 0", cmd, n)
+		}
+	}
+}
+
+// TestCompletedReviewCyclesForParent_CountsVerdictProducingGroups verifies
+// the happy path: two prior groups, both fully terminal, both produced
+// verdicts → count = 2.
+func TestCompletedReviewCyclesForParent_CountsVerdictProducingGroups(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@two-cycles"
+
+	// Round 1: two agents, both finished, both produced assistant messages.
+	g1 := registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
+		memberSpec{role: "review-code", state: "finished", text: `<verdict>PASS</verdict>`},
+	)
+	// Round 2: same agents, both finished, both produced assistant messages.
+	g2 := registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>PASS</verdict>`},
+		memberSpec{role: "review-code", state: "finished", text: `<verdict>FAIL</verdict>`},
+	)
+
+	n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count = %d, want 2 (groups %s and %s)", n, g1, g2)
+	}
+}
+
+// TestCompletedReviewCyclesForParent_ExcludesAllNoStartGroups verifies the
+// AC: an "all agents failed to start" cycle does not count as a real cycle.
+func TestCompletedReviewCyclesForParent_ExcludesAllNoStartGroups(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@no-start"
+
+	// Round 1: real verdict-producing cycle.
+	registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
+	)
+	// Round 2: pure infrastructure failure — every member errored at
+	// startup with no assistant message.
+	registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "error", startupError: "container failed to bind port"},
+		memberSpec{role: "review-code", state: "error", startupError: "container failed to bind port"},
+	)
+
+	n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1 (round 2 was pure infrastructure failure)", n)
+	}
+}
+
+// TestCompletedReviewCyclesForParent_ExcludesActiveGroups verifies that a
+// group whose members are still running does not count toward the cycle
+// total — only fully-terminated groups do.
+func TestCompletedReviewCyclesForParent_ExcludesActiveGroups(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@in-flight"
+
+	// Round 1: terminated.
+	registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
+	)
+	// Round 2: still active.
+	registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "active"},
+	)
+
+	n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1 (round 2 still active)", n)
+	}
+}
+
+// TestCompletedReviewCyclesForParent_ExcludeGroupID verifies the
+// excludeGroupID arg: passing the current group's id excludes it from the
+// count, so the monitor can compute "cycles before this one" cleanly.
+func TestCompletedReviewCyclesForParent_ExcludeGroupID(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@exclude-test"
+
+	g1 := registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL"},
+	)
+	g2 := registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL"},
+	)
+
+	// Without exclude: 2.
+	n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count without exclude = %d, want 2", n)
+	}
+
+	// Excluding g2: 1.
+	n, err = review.CompletedReviewCyclesForParent(d, parent, g2)
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent with exclude g2: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count with exclude g2 = %d, want 1", n)
+	}
+
+	// Excluding g1: 1.
+	n, err = review.CompletedReviewCyclesForParent(d, parent, g1)
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent with exclude g1: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count with exclude g1 = %d, want 1", n)
+	}
+}
+
+// ── End-to-end footer behaviour ──────────────────────────────────────────────
+
+// TestMonitorFunc_ReproducesIssue1512Spam_AndFix demonstrates that on the
+// 3rd verdict-producing non-converging cycle the worker receives the
+// LOOP-LIMIT footer exactly once, embedded in the review-complete prompt
+// body — as opposed to the pre-fix behaviour where it would have been
+// re-injected on every subsequent turn (#1512 spam).
+//
+// The reproducer asserts:
+//   - delivery happens exactly once (i.e. the footer is part of the prompt
+//     body, not a separate per-turn injection)
+//   - the prompt body contains the footer text
+//   - the prompt body is the same text the worker would otherwise receive,
+//     simply extended at the bottom (no separate steer message channel)
+func TestMonitorFunc_AppendsFooterOnThirdNonConvergedCycle(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@spam-repro"
+
+	// Seed two prior verdict-producing cycles on this parent.
+	registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+		memberSpec{role: "review-code", state: "finished", text: "PASS output"},
+	)
+	registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+		memberSpec{role: "review-code", state: "finished", text: "PASS output"},
+	)
+
+	// Round 3 is the in-flight cycle the monitor is delivering for.
+	// FAIL on review-goal so allPassed == false and the footer fires.
+	body := mockMonitorRound3(t, d, parent, "1512")
+
+	if !strings.Contains(body, "REVIEW LOOP LIMIT") {
+		t.Errorf("3rd non-converged cycle: prompt body missing LOOP-LIMIT footer; got:\n%s", body)
+	}
+	if !strings.Contains(body, "3 review cycles") {
+		t.Errorf("footer should mention cycle count of 3; got:\n%s", body)
+	}
+	// The footer must appear AFTER the per-agent findings — i.e. the prompt
+	// body remains intact and the footer is appended.
+	footerIdx := strings.Index(body, "REVIEW LOOP LIMIT")
+	resultsIdx := strings.Index(body, "### Results")
+	if footerIdx <= resultsIdx {
+		t.Errorf("footer should come after the Results section; footerIdx=%d resultsIdx=%d", footerIdx, resultsIdx)
+	}
+}
+
+// TestMonitorFunc_NoFooterOnConvergedCycle pins AC: if the 3rd cycle PASSES,
+// no footer is emitted (the limit only fires on non-convergence).
+func TestMonitorFunc_NoFooterOnConvergedThirdCycle(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@converged-third"
+
+	registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+	)
+	registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+	)
+
+	// Round 3: passes. We assert the footer is NOT appended.
+	body := mockMonitorRound3Passed(t, d, parent, "1512")
+
+	if strings.Contains(body, "REVIEW LOOP LIMIT") {
+		t.Errorf("3rd PASSing cycle must NOT emit LOOP-LIMIT footer; got:\n%s", body)
+	}
+}
+
+// TestMonitorFunc_NoFooterWhenInfrastructureFailureAtThird verifies that an
+// "all agents failed to start" 3rd cycle does not bump the count to 3 — it
+// is not a verdict-producing cycle, so the worker should keep getting the
+// "infrastructure failure: re-run" message, not the LOOP-LIMIT footer.
+func TestMonitorFunc_NoFooterOnInfrastructureFailureCycle(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@infra-third"
+
+	registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+	)
+	registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+	)
+
+	// Round 3: all agents failed to start.
+	body := mockMonitorRound3InfraFailure(t, d, parent, "1512")
+
+	if strings.Contains(body, "REVIEW LOOP LIMIT") {
+		t.Errorf("3rd cycle that was a pure infrastructure failure must NOT emit LOOP-LIMIT footer; got:\n%s", body)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+type memberSpec struct {
+	role         string
+	state        string
+	text         string // assistant message text; empty → no msg_assistant event
+	startupError string // when set, write a startup_error event
+}
+
+// registerGroupAndSeedMembers creates a session group, inserts agent_status
+// rows for each member, sets group_id on each row, and seeds msg_assistant /
+// startup_error events as requested. Returns the group_id.
+func registerGroupAndSeedMembers(t *testing.T, d *db.DB, parent string, round int, members ...memberSpec) string {
+	t.Helper()
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup(%q): %v", parent, err)
+	}
+	for _, m := range members {
+		sess := parent + "~review-" + itoa(round) + "-" + m.role
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", m.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q, state=%q): %v", sess, m.state, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", sess, err)
+		}
+		if m.text != "" {
+			seedAssistantEvent(t, d, sess, m.text)
+		}
+		if m.startupError != "" {
+			seedStartupErrorEvent(t, d, sess, m.startupError)
+		}
+	}
+	return groupID
+}
+
+// seedStartupErrorEvent writes a startup_error event for the named session.
+func seedStartupErrorEvent(t *testing.T, d *db.DB, sessionName, reason string) {
+	t.Helper()
+	payload := `{"reason":` + `"` + strings.ReplaceAll(reason, `"`, `\"`) + `"}`
+	err := d.WriteEvent(db.Event{
+		ID:          sessionName + "-startup-err",
+		SessionName: sessionName,
+		Repo:        "nixos-config",
+		Worktree:    "/wt",
+		Type:        "startup_error",
+		Payload:     payload,
+	})
+	if err != nil {
+		t.Fatalf("WriteEvent (startup_error): %v", err)
+	}
+}
+
+// mockMonitorRound3 simulates what the monitor would produce as the
+// review-complete prompt body for round 3 of `parent`, where round 3 is
+// itself verdict-producing but did not converge. It registers the round-3
+// group with two members (one FAIL, one PASS), then assembles the body the
+// same way MonitorFunc does (FormatResults → buildDeliveryMessage → footer).
+func mockMonitorRound3(t *testing.T, d *db.DB, parent, prNumber string) string {
+	t.Helper()
+	gid := registerGroupAndSeedMembers(t, d, parent, 3,
+		memberSpec{role: "review-goal", state: "finished", text: "Goal FAIL details"},
+		memberSpec{role: "review-code", state: "finished", text: "<verdict>PASS</verdict>"},
+	)
+	return assembleDeliveryBody(t, d, parent, prNumber, 3, gid, false /* allPassed */, false /* infra */)
+}
+
+func mockMonitorRound3Passed(t *testing.T, d *db.DB, parent, prNumber string) string {
+	t.Helper()
+	gid := registerGroupAndSeedMembers(t, d, parent, 3,
+		memberSpec{role: "review-goal", state: "finished", text: "<verdict>PASS</verdict>"},
+	)
+	return assembleDeliveryBody(t, d, parent, prNumber, 3, gid, true /* allPassed */, false /* infra */)
+}
+
+func mockMonitorRound3InfraFailure(t *testing.T, d *db.DB, parent, prNumber string) string {
+	t.Helper()
+	gid := registerGroupAndSeedMembers(t, d, parent, 3,
+		memberSpec{role: "review-goal", state: "error", startupError: "container failed to bind port"},
+		memberSpec{role: "review-code", state: "error", startupError: "container failed to bind port"},
+	)
+	return assembleDeliveryBody(t, d, parent, prNumber, 3, gid, false /* allPassed */, true /* infra */)
+}
+
+// assembleDeliveryBody mirrors MonitorFunc's tail (FormatResults +
+// buildDeliveryMessage + LOOP-LIMIT footer) so we can unit-test the
+// integrated behaviour without spinning up an HTTP delivery target.
+func assembleDeliveryBody(t *testing.T, d *db.DB, parent, prNumber string, round int, groupID string, allPassed, infra bool) string {
+	t.Helper()
+	groupData, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+
+	// Build a synthetic results slice matching the agents in groupData.
+	var results []review.AgentResult
+	var sessions []string
+	for sess, mr := range groupData {
+		sessions = append(sessions, sess)
+		role := strings.TrimPrefix(sess, parent+"~review-"+itoa(round)+"-")
+		switch {
+		case mr.StartupError != "":
+			results = append(results, review.AgentResult{
+				Agent:   review.Agent{Name: role},
+				Passed:  false,
+				Output:  "ERROR: agent failed to start (no-start): " + mr.StartupError,
+				IsError: true,
+			})
+		case strings.Contains(mr.LastMessage, "PASS"):
+			results = append(results, review.AgentResult{
+				Agent:  review.Agent{Name: role},
+				Passed: true,
+				Output: mr.LastMessage,
+			})
+		default:
+			results = append(results, review.AgentResult{
+				Agent:  review.Agent{Name: role},
+				Passed: false,
+				Output: mr.LastMessage,
+			})
+		}
+	}
+
+	formatted, _ := review.FormatResults(results, prNumber, round, 0)
+	body := review.BuildDeliveryMessageForTest(prNumber, round, formatted, allPassed, groupData, sessions)
+
+	// Apply the same footer logic MonitorFunc uses.
+	if !allPassed && review.CurrentCycleProducedVerdictsForTest(groupData) {
+		prior, ccErr := review.CompletedReviewCyclesForParent(d, parent, groupID)
+		if ccErr != nil {
+			t.Fatalf("CompletedReviewCyclesForParent: %v", ccErr)
+		}
+		if prior+1 >= 3 {
+			body += review.BuildLoopLimitFooterForTest(prior+1, prNumber)
+		}
+	}
+	_ = infra // signalled by the caller for self-documentation only
+	return body
+}
+
+// itoa avoids pulling strconv into every callsite of this small test helper.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -147,6 +147,29 @@ func MonitorFunc(opts MonitorOpts) error {
 	output, allPassed := FormatResults(results, opts.PRNumber, opts.Round, 0)
 	deliveryText := buildDeliveryMessage(opts.PRNumber, opts.Round, output, allPassed, groupData, opts.AgentSessions)
 
+	// LOOP-LIMIT footer (#1512). Append the footer to the prompt body when
+	//   (a) the cycle has not converged (¬allPassed),
+	//   (b) THIS cycle is itself a verdict-producing cycle (otherwise the
+	//       "infrastructure failure" branch in buildDeliveryMessage already
+	//       tells the worker to re-run — it is not yet at the limit), AND
+	//   (c) the total count of verdict-producing cycles for this parent
+	//       (including this one) is ≥ REVIEW_CYCLE_THRESHOLD.
+	//
+	// The footer is naturally rate-limited — it appears once per actual
+	// completed verdict-producing cycle, embedded in the prompt the worker is
+	// already going to act on. This dissolves the per-turn-spam and the
+	// bash-substring false-match defects at the source (#1512).
+	if !allPassed {
+		if currentCycleProducedVerdicts(groupData) {
+			prior, ccErr := CompletedReviewCyclesForParent(d, opts.WorkerSession, opts.GroupID)
+			if ccErr != nil {
+				fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: cycle count failed: %v — footer suppressed\n", ccErr)
+			} else if prior+1 >= REVIEW_CYCLE_THRESHOLD {
+				deliveryText += buildLoopLimitFooter(prior+1, opts.PRNumber)
+			}
+		}
+	}
+
 	// Before delivery, clear the worker's `reviewing` state by writing `active`.
 	// Background: RunAsync writes `reviewing` to the DB so that incidental busy
 	// turns + idle debounces in the worker session do not produce a premature
@@ -530,6 +553,139 @@ func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) 
 		}
 	}
 	return "", nil
+}
+
+// currentCycleProducedVerdicts reports whether the current group's
+// GroupResults contain at least one finished member with a non-empty
+// LastMessage and no startup_error — the same condition
+// CompletedReviewCyclesForParent applies to historical groups. Used by the
+// monitor to decide whether the in-flight cycle counts toward the LOOP-LIMIT
+// threshold.
+func currentCycleProducedVerdicts(groupData map[string]db.GroupMemberResult) bool {
+	for _, mr := range groupData {
+		if mr.State == "finished" && mr.LastMessage != "" && mr.StartupError == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// REVIEW_CYCLE_THRESHOLD is the number of completed verdict-producing review
+// cycles after which the review-complete prompt gets a LOOP-LIMIT footer
+// appended. The threshold itself is out of scope for #1512; this constant is
+// the single source of truth for the firing condition.
+const REVIEW_CYCLE_THRESHOLD = 3
+
+// loopLimitFooterTemplate is the LOOP-LIMIT footer appended to the
+// review-complete prompt body when a review group completes the Nth
+// non-converged verdict-producing cycle (N ≥ REVIEW_CYCLE_THRESHOLD) for the
+// same PR. The template is exported for testing.
+//
+// Format args (in order):
+//   1. cycle count (int)
+//   2. PR label (string, e.g. "PR #42")
+const loopLimitFooterTemplate = "\n---\n" +
+	"⚠️ **REVIEW LOOP LIMIT.** You have run %d review cycles for %s without all agents passing. " +
+	"Stop and escalate to the coordinator. Do NOT run another review cycle. " +
+	"Summarise: (1) what was originally requested, (2) what each cycle found, " +
+	"and (3) why the fixes are not converging.\n"
+
+// buildLoopLimitFooter renders the LOOP-LIMIT footer for the given cycle
+// count and PR number.
+func buildLoopLimitFooter(cycles int, prNumber string) string {
+	prLabel := "this PR"
+	if prNumber != "" {
+		prLabel = fmt.Sprintf("PR #%s", prNumber)
+	}
+	return fmt.Sprintf(loopLimitFooterTemplate, cycles, prLabel)
+}
+
+// CompletedReviewCyclesForParent returns the count of completed
+// verdict-producing review cycles for parentSession, optionally excluding the
+// group given by excludeGroupID. A cycle is "completed and verdict-producing"
+// when:
+//
+//   1. Every member of the group is in a terminal state (so the group is no
+//      longer running), AND
+//   2. At least one member finished with a non-empty assistant message AND no
+//      startup_error event — i.e. the group produced real per-agent verdicts.
+//
+// This is the single source of truth for cycle counting in the LOOP-LIMIT
+// firing logic. Pure-infrastructure failures (every member never bound its
+// port) are excluded by condition 2 — mirroring the documented contract in
+// `modules/programs/prism/opencode/skills/prism/SKILL.md`:
+//
+//   "Count re-run cycles from the first round that had a full set of agent
+//    results; do not count infrastructure-failure rounds toward your 3-cycle
+//    limit."
+//
+// Pass excludeGroupID="" to count every group; pass the current group's id
+// when computing "cycles before this one" so that a caller can ask
+// "is the current cycle the 3rd?".
+func CompletedReviewCyclesForParent(d *db.DB, parentSession, excludeGroupID string) (int, error) {
+	members, err := d.GroupMembersForParent(parentSession)
+	if err != nil {
+		return 0, fmt.Errorf("completed review cycles: GroupMembersForParent: %w", err)
+	}
+	if len(members) == 0 {
+		return 0, nil
+	}
+
+	// Bucket members by group_id.
+	byGroup := make(map[string][]db.Status)
+	for _, m := range members {
+		if m.GroupID == nil {
+			continue
+		}
+		gid := *m.GroupID
+		if gid == excludeGroupID {
+			continue
+		}
+		byGroup[gid] = append(byGroup[gid], m)
+	}
+
+	count := 0
+	for gid, gMembers := range byGroup {
+		// Condition 1: every member must be terminal.
+		allTerminal := true
+		for _, m := range gMembers {
+			if !isTerminalState(m.State) && m.EndedAt == nil {
+				allTerminal = false
+				break
+			}
+		}
+		if !allTerminal {
+			continue
+		}
+
+		// Condition 2: at least one member produced a verdict-shaped result.
+		// We use GroupResults to read the last assistant message and any
+		// startup_error — a member with non-empty LastMessage AND empty
+		// StartupError (and state == "finished") is treated as "produced a
+		// verdict". Even if the verdict body lacks an explicit PASS/FAIL
+		// marker (which AssessPassed would classify as VerdictNone), the
+		// agent still ran and produced output — that is a real cycle.
+		groupData, gErr := d.GroupResults(gid)
+		if gErr != nil {
+			// Be defensive: a bad row should not silently underreport cycle
+			// count. Log and skip the group so we do not fire LOOP-LIMIT
+			// based on partial data, but do not return the error — callers
+			// (the monitor) treat a missing footer as a benign degradation.
+			fmt.Fprintf(os.Stderr, "[prism review] warning: GroupResults(%s) failed during cycle counting: %v\n", gid, gErr)
+			continue
+		}
+		producedVerdict := false
+		for _, mr := range groupData {
+			if mr.State == "finished" && mr.LastMessage != "" && mr.StartupError == "" {
+				producedVerdict = true
+				break
+			}
+		}
+		if producedVerdict {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // ReviewRoundForGroup returns the round number for the given group_id by


### PR DESCRIPTION
Closes #1512.

## Shape

**Shape B (preferred, structural).** The TS-side per-turn LOOP-LIMIT injection is gone. Cycle counting and the LOOP-LIMIT footer now live in the Go-side review monitor. The footer is appended to the same `review-complete` prompt body the worker is already going to act on, so it is delivered exactly once per actual completed verdict-producing cycle — naturally rate-limited and structurally immune to the bash-substring false-match defect.

Why Shape B over Shape A: Shape A only patches the spam; the bash-substring false-match and the infrastructure-failure miscount remain. Shape B dissolves all four defects in one structural move — there is no bash-string regex left for cycle counting to mis-trigger on, no per-turn injection left to re-fire, and no second copy of the warning text.

## Reproducer / proof

The pre-fix spam scenario is captured in `internal/review/loop_limit_test.go::TestMonitorFunc_AppendsFooterOnThirdNonConvergedCycle`. Pre-fix, the LOOP-LIMIT message would be re-injected on every `turn_start` after the threshold (the test would have been impossible to write because the spam pathway wasn't gated by anything observable in the prompt body). Post-fix, the test asserts:

1. The footer text appears exactly once, in the prompt body that the worker would already act on.
2. The footer comes after the `### Results` section (i.e. it is appended, not interleaved).
3. The footer mentions cycle count = 3 and the PR number.

For the bash-substring false-match invariant, see `internal/review/loop_limit_test.go::TestBashSubstringFalseMatch_DoesNotIncrementCycles` and `TestCompletedReviewCyclesForParent_NoGroups_ReturnsZero`. The structural pin is also enforced at the source level via `pi/extensions/prism.test.ts`: the test reads `prism.ts` and `prism-hooks.ts` and asserts that neither contains `REVIEW LOOP LIMIT` text or the cycle-incrementing regex. Either regression would fail the suite.

## Acceptance Criteria — file/test mapping

- **AC #1 (no spam after stop+escalate):** `internal/review/monitor.go` — the LOOP-LIMIT footer is now part of the single review-complete prompt body. There is no per-turn injection left in `pi/extensions/prism.ts` (turn_start no longer references review-cycle state at all). Pinned by `pi/extensions/prism.test.ts::"#1512 — review-cycle injection has been removed from prism.ts"`.
- **AC #2 (counter only on real verdicts):** `internal/review/monitor.go::CompletedReviewCyclesForParent` reads `session_groups` + `agent_status`. Pinned by `internal/review/loop_limit_test.go::TestCurrentCycleProducedVerdicts_*` and `TestCompletedReviewCyclesForParent_ExcludesAllNoStartGroups`.
- **AC #3 (bash-substring false-match):** structurally guaranteed by Shape B (no bash-string code path for cycle counting). Pinned by `internal/review/loop_limit_test.go::TestBashSubstringFalseMatch_DoesNotIncrementCycles` and `TestCompletedReviewCyclesForParent_NoGroups_ReturnsZero`, plus the source-level pin in `pi/extensions/prism.test.ts`.
- **AC #4 (3 infra failures = 0 cycles):** `internal/review/loop_limit_test.go::TestCompletedReviewCyclesForParent_ExcludesAllNoStartGroups` and `TestMonitorFunc_NoFooterOnInfrastructureFailureCycle`.
- **AC #5 (single source of truth):** the warning text and firing logic live exclusively in `internal/review/monitor.go`. The duplicate TS implementations in `pi/extensions/prism.ts` and `opencode/plugins/prism-hooks.ts` are removed. Pinned by `pi/extensions/prism.test.ts::"#1512 — review-cycle injection has been removed from prism.ts"` (which also asserts the prism-hooks.ts side via direct file read).
- **AC #6 (escape path preserved):** the in-progress guard at `internal/review/run.go::RunAsync` (the "round 1 already in progress for this PR" check) is unchanged. The footer is purely additive on the review-complete prompt body; nothing about the host-API rejection path moves.
- **AC #7 (no footer on PASS):** `internal/review/monitor.go::MonitorFunc` gates the footer on `!allPassed`. Pinned by `internal/review/loop_limit_test.go::TestMonitorFunc_NoFooterOnConvergedThirdCycle`.
- **AC #8 (test reproduces spam scenario + bash false-match invariant):** see `internal/review/loop_limit_test.go::TestMonitorFunc_AppendsFooterOnThirdNonConvergedCycle` (positive case showing footer appears exactly once on the 3rd non-converged cycle, after two prior verdict-producing cycles seeded into the DB) and `TestBashSubstringFalseMatch_DoesNotIncrementCycles` (negative case for AC #3).
- **AC #9 (`nix build .#prism` succeeds):** verified locally.

## Local self-check

```
cd modules/programs/prism/prism
go build ./...
go test ./... -race  # internal/review passes including loop_limit_test.go
nix build .#prism    # succeeds
```

TS suites (run with `tsx --test`):

- `pi/extensions/prism.test.ts` — 154 tests, all pass (3 new tests added under `#1512 — review-cycle injection has been removed from prism.ts`).
- `pi/extensions/anthropic-oauth/{auth,credentials,stream}.test.ts` — all pass (untouched by this PR; verified).
- `opencode/plugins/prism-hooks.test.ts` — uses `bun:test`; cannot exercise locally without bun. The file only tests `similarityKey`, which is untouched, so behaviour is unchanged. Pre-existing constraint, not a regression.

## What changed structurally

Go (single source of truth):

- `internal/review/monitor.go`: `REVIEW_CYCLE_THRESHOLD = 3`, `buildLoopLimitFooter`, `currentCycleProducedVerdicts`, `CompletedReviewCyclesForParent` (DB-fed cycle counter that filters out infrastructure-failure groups), and the wiring in `MonitorFunc` to append the footer when (a) the cycle did not converge, (b) the current cycle is itself verdict-producing, and (c) cumulative count ≥ threshold.
- `internal/review/export_test.go`: `BuildLoopLimitFooterForTest`, `CurrentCycleProducedVerdictsForTest` for external tests.
- `internal/review/loop_limit_test.go`: 14 new tests covering the helpers, the integrated behaviour, and the AC pins.

TypeScript (deletions):

- `pi/extensions/prism.ts`: `REVIEW_CYCLE_THRESHOLD`, `ReviewCycleState`, `newReviewCycleState`, `processReviewCycle`, `reviewCycleEscalationMessage` removed; `GuardStateSnapshot` simplified (legacy `reviewCycle` field is silently ignored on restore for backward compatibility with persisted snapshots); the per-turn injection block in `turn_start` is gone; the `review_cycle_exceeded` wire frame is gone (no consumer existed); `tool_execution_start` no longer calls `processReviewCycle`. Status-bar wire frame still emitted but with `review_cycles: 0` and `pr_number: ""` (no consumer in Go currently; a future cleanup can drop the fields if desired).
- `opencode/plugins/prism-hooks.ts`: `reviewCycles`/`pendingCycleCount`/`detectedPrNumber` state removed; the bash regex for cycle increments and the `task` subagent fallback removed; the `system.transform` LOOP-LIMIT injection removed. The git-push reminder logic and the doom-loop detector are unchanged.

## Coordination notes

- **#1517** (`prism escalate` command) — touches different SKILL.md sections; no overlap on this branch.
- **#1518** (review rebase gate) — Shape B's "gate failures don't count" invariant holds automatically: gate failures never produce a verdict-producing group, so `CompletedReviewCyclesForParent` ignores them. #1518 can build on `CompletedReviewCyclesForParent` if useful.
- **#1519** (`git push` regex false-match) — not touched. The `git push` reminder hook regex stays. The `pendingReviewCall = true` reviewing-state guard regex (which is a *different* concern from cycle counting) also stays. Comment added in `prism.ts` at the call site explicitly noting this.
