### PR TITLE
Update prism default profile to anthropic-opus

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -27,8 +27,10 @@
     };
     programs = {
       prism = {
-        profile.default = "anthropic-pi";
+        profile.default = "anthropic-opus";
+        harness.default = "pi";
         agent.isolation.default = "bwrap";
+
         bwrapConcurrencyCap = 50;
       };
       anki.enable = false; # build broken as of 2025-08-30

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -161,24 +161,6 @@
                 model = "anthropic/claude-haiku-4-5";
               };
             };
-            anthropic-pi = profileFromTiers {
-              primary = slot {
-                provider = "anthropic";
-                model = "anthropic/claude-opus-4-7";
-                thinking = "medium";
-                harness = "pi";
-              };
-              secondary = slot {
-                provider = "anthropic";
-                model = "anthropic/claude-sonnet-4-6";
-                harness = "pi";
-              };
-              lightweight = slot {
-                provider = "anthropic";
-                model = "anthropic/claude-haiku-4-5";
-                harness = "pi";
-              };
-            };
             anthropic-opus = profileFromTiers {
               primary = slot {
                 provider = "anthropic";


### PR DESCRIPTION
This change updates the default prism profile to anthropic-opus and explicitly configures the default harness to pi. The anthropic-pi profile definition was removed to consolidate configuration, cleaning up the profile registry.