### PR TITLE
prism: add `prism escalate` command and `escalated` session state

### DIFF
--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -110,6 +110,29 @@ current thought, then action the oldest pending worker notification before
 continuing with other work. Do not let finished-worker items accumulate — each
 one represents a PR that may be blocking the next piece of work.
 
+### Worker escalations — the `session.escalated` event
+
+Workers that hit a decision they cannot make alone use `prism escalate`, which
+delivers a targeted prompt to you AND emits a `session.escalated` bus event
+distinct from `session.finished`. The calling worker enters a new `escalated`
+state, visible in `prism list-sessions`, and the sidecar **suppresses** the
+"has finished" notification while the worker stays in that state.
+
+Key behavioural rules:
+
+- **Treat the escalation prompt as the signal.** When you receive an escalation
+  prompt from a worker, do not also wait for a separate `has finished` ping —
+  there will not be one. The escalation is the notification.
+- **Do not sense-check the worker's PR yet.** A worker in `escalated` state is
+  paused awaiting your guidance, not done. Their PR may be mid-edit or
+  intentionally not-yet-pushed. Run `prism list-sessions` if you need to
+  confirm: an `escalated` row means "waiting for guidance", not "finished".
+- **Reply via `prism prompt`** (not `prism escalate` — that is a worker-only
+  surface). Your reply's `turn_start` clears the worker's `escalated` state
+  back to `active`, after which a normal finish will notify as usual.
+- **An escalation does not imply task completion.** Treat it as a request for
+  a directive; the worker resumes once you respond.
+
 ---
 
 ## Review gate

--- a/modules/programs/prism/opencode/agents/worker.md
+++ b/modules/programs/prism/opencode/agents/worker.md
@@ -37,7 +37,11 @@ predates your branch. Two failure modes to avoid:
   coordinator never learns a problem exists; no tracking issue is filed.
 
 The correct response is to **escalate the discovery** to the coordinator via
-`prism prompt <repo>@main` and then **continue with your assigned work**.
+`prism escalate --prompt "..."` (auto-discovers the same-repo coordinator and
+transitions you into the `escalated` state without a redundant `has finished`
+ping) and then **continue with your assigned work** — informational
+escalations do not require waiting for a reply, so any incoming `turn_start`
+(yours, the coordinator's, or a human's) clears the state.
 
 **What the escalation message must include:**
 
@@ -207,22 +211,29 @@ If you are reading this after already passing the 3-cycle limit — escalate now
 Do not continue because "the damage is already done." Stopping late is still
 correct.
 
-**How to escalate.** The coordinator's session follows the `<repo>@main`
-convention. See the lookup and state-check flow in the prism skill at
-`modules/programs/prism/opencode/skills/prism/SKILL.md:114`.
+**How to escalate.** Use `prism escalate` — it auto-discovers the same-repo
+coordinator, delivers your message, and transitions you into the `escalated`
+state so the sidecar suppresses the redundant "has finished" notification
+that would otherwise fire when your turn ends. The state clears automatically
+on any incoming `turn_start` (the coordinator's reply, a human typing into
+tmux, or any other source). See the prism skill section
+[Escalating to your coordinator with `prism escalate`](../skills/prism/SKILL.md#escalating-to-your-coordinator-with-prism-escalate)
+for the full reference.
 
 ```bash
-# Find the coordinator session
-prism list-sessions | grep '@main'
-
-# Send the escalation (adjust repo name as needed)
-prism prompt nixos-config@main --prompt 'PR #N is stuck at review cycle M.
+prism escalate --prompt 'PR #N is stuck at review cycle M.
 Agents passing: review-code, review-security, review-qa, review-context.
 Agent failing: review-goal.
 Unresolved blocker (verbatim): "<exact text from the agent>"
 My proposed resolution: <one sentence>.
 Decision needed: <specific yes/no or choice>.'
 ```
+
+If auto-discovery finds multiple coordinator candidates in your repo (rare
+but possible during transitions), the command exits non-zero and lists them
+— re-run with `--to <session>` to choose. If no coordinator is running, the
+command still transitions you into `escalated` and writes a "please wait for
+a human" marker into your own log (visible via `prism checkin <self>`).
 
 **What your escalation message must include:**
 

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -436,6 +436,70 @@ so they can address it directly.
   (C-f or C-w)                             — switch to the session in tmux
 ```
 
+## Escalating to your coordinator with `prism escalate`
+
+Workers that hit a decision they cannot make alone (3-cycle review-limit reached, AC contradiction, scope ambiguity, infrastructure block) should use `prism escalate` rather than crafting a `prism prompt` to the coordinator by hand and stopping. The command resolves the right coordinator, delivers the message, transitions the calling session into a new `escalated` state, and emits a `session.escalated` bus event — in one step, with no redundant "has finished" notification.
+
+### Surface
+
+```bash
+# Auto-discover the same-repo coordinator and deliver the prompt.
+prism escalate --prompt "3-cycle review limit reached on PR #1234. Agent failing: review-security. Decision needed: option A (relax) or option B (rework)."
+
+# Read the body from stdin for multi-line prompts:
+prism escalate --prompt - <<'EOF'
+PR #1234 cycle 3:
+  - review-goal, review-code, review-qa, review-context: PASS
+  - review-security: FAIL on the same blocker as cycle 2
+
+Proposed resolution: relax permission check to coordinator-only.
+Decision needed: yes / no.
+EOF
+
+# Override discovery and target a specific session by name:
+prism escalate --to nixos-config@main --prompt "..."
+```
+
+### State machine
+
+```
+active ──prism escalate──▶ escalated
+escalated ──any turn_start (from any source)──▶ active
+```
+
+- `escalated` is a new value alongside `active` / `idle` / `finished` / `reviewing`. It surfaces in `prism list-sessions` so a glance shows which workers are paused awaiting guidance.
+- The transition out is triggered by **any** incoming `turn_start`, not specifically `prism prompt`. A human who pokes at the worker via tmux clears the flag too.
+- While in `escalated`, the sidecar suppresses the "has finished" notification. The `session.escalated` bus event is the notification.
+
+### Discovery rules
+
+| Situation | Behaviour |
+|---|---|
+| Exactly one same-repo coordinator candidate | Auto-discover, send to it. |
+| Multiple same-repo coordinator candidates | Refuse without `--to`; list candidates and exit non-zero. **State does NOT transition.** |
+| No coordinator candidate found | Still transition into `escalated`; record `no coordinator found, please wait for a human to come check on you` in the worker's own log. The worker stays paused. |
+| `--to <session>` set but session unknown | Exit non-zero. **State does NOT transition.** |
+
+A same-repo coordinator candidate is any active (ended_at IS NULL) row in the same repo whose `root_agent_name = 'coordinator'`, OR a legacy row literally named `<repo>@main` with NULL `root_agent_name`.
+
+### Bus event
+
+- New event type `session.escalated`, distinct from `session.finished`. Existing handlers that subscribe only to `session.finished` continue to receive nothing for escalations.
+- Payload carries: `source` (calling worker), `target` (coordinator session, empty when none), `prompt` (body), `pr_numbers` (open PRs whose head matches the worker's branch), `branch`, `head_sha`, `verdicts` (last review-cycle verdicts when discoverable), `occurred_at` (RFC3339).
+- The same payload is also written into the calling session's own event log as type `escalation` so `prism checkin <self>` shows the escalation context inline.
+
+### When to use `prism escalate` vs `prism prompt`
+
+- **`prism escalate`** — you are a worker handing a question or decision to the coordinator and pausing your turn until you hear back. Use this whenever you would have otherwise stopped after sending a hand-crafted `prism prompt`.
+- **`prism prompt`** — you are sending an informational follow-up to a running session and either continuing your work (sender keeps going) or expect no response (e.g. delivering a review-complete prompt). Workers prompting their own coordinator should usually be using `prism escalate` instead.
+
+### Out of scope (v1)
+
+- Cross-repo escalation — v1 is single-repo; auto-discovery is repo-scoped.
+- Escalation receipts back to the worker — the worker discovers the coordinator's response by being prompted.
+- Re-escalation timeouts.
+- Dashboard panel for `escalated` sessions — surfaced via `prism list-sessions` and the bus only.
+
 ## Debugging a running or stuck session
 
 Use this decision tree when a session appears stuck, produces no output, or fails unexpectedly.

--- a/modules/programs/prism/prism/cmd/escalate.go
+++ b/modules/programs/prism/prism/cmd/escalate.go
@@ -1,0 +1,489 @@
+package cmd
+
+// prism escalate — hand a question to the coordinator in one step and pause
+// the calling worker session in a new "escalated" state.
+//
+// Surface:
+//
+//	prism escalate [--to <session>] --prompt "<message>"
+//	prism escalate [--to <session>] --prompt -          # read from stdin
+//
+// Without --to, the command auto-discovers the same-repo coordinator (the
+// session whose root_agent_name = "coordinator", or the legacy <repo>@main
+// row when the field is NULL). With multiple candidates, --to is required;
+// with zero candidates, the worker still transitions to escalated and writes
+// a self-marker but no prompt is delivered (a human is expected to pick up
+// the worker via tmux).
+//
+// State machine:
+//
+//	active ──prism escalate──▶ escalated
+//	escalated ──any turn_start──▶ active
+//
+// While the calling session is in `escalated`, the sidecar suppresses the
+// `has finished` notification — the `session.escalated` bus event is the
+// notification.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+var escalateCmd = &cobra.Command{
+	Use:   "escalate",
+	Short: "Hand a question to the coordinator and enter the 'escalated' state",
+	Long: `Send a prompt to the same-repo coordinator (auto-discovered or specified
+via --to) and transition the calling session to the "escalated" state.
+
+While escalated, the sidecar suppresses the "has finished" notification — the
+session.escalated bus event is the notification, and the coordinator gets the
+escalation prompt as a single targeted signal rather than two redundant ones.
+
+Discovery rules:
+
+  - exactly one same-repo coordinator candidate → auto-discover, send to it.
+  - multiple same-repo coordinator candidates   → refuse without --to and
+    print the candidate list.
+  - no coordinator candidate found              → still transition to
+    escalated; record a "no coordinator found, please wait for a human"
+    marker in the calling session's own log. The worker stays paused.
+
+Any incoming turn_start (from prism prompt, a human typing into tmux, or any
+other source) clears the escalated state and resumes the worker normally.`,
+	Args: cobra.NoArgs,
+	RunE: runEscalate,
+}
+
+func init() {
+	addPromptFlags(escalateCmd)
+	escalateCmd.Flags().String("to", "", `Explicit coordinator session to receive the escalation. Required when auto-discovery finds multiple coordinator candidates in the same repo. Optional otherwise.`)
+	rootCmd.AddCommand(escalateCmd)
+}
+
+func runEscalate(cmd *cobra.Command, args []string) error {
+	promptText, err := requirePromptInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	explicitTo, _ := cmd.Flags().GetString("to")
+
+	// Container path: when running inside an isolated worker container, the
+	// host-side prism CLI and DB are not directly accessible. Proxy to the
+	// host sidecar's /escalate endpoint, which shells back to `prism escalate`
+	// on the host with PRISM_HOST_API unset.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return proxyEscalate(apiURL, explicitTo, promptText)
+	}
+
+	database, err := openDB()
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer database.Close()
+
+	// Derive the calling (source) session from CWD.
+	cwd, _ := os.Getwd()
+	if envSession := os.Getenv("PRISM_SESSION_NAME"); envSession != "" {
+		// Tests and the host-API proxy may set PRISM_SESSION_NAME directly.
+		return runEscalateForSession(database, envSession, explicitTo, promptText)
+	}
+	fromSession := deriveSessionNameFromCWD(cwd)
+	if fromSession == "" {
+		return fmt.Errorf(
+			"prism escalate: could not derive calling session from CWD %q\n" +
+				"hint: run from inside a prism worktree, or set PRISM_SESSION_NAME",
+			cwd,
+		)
+	}
+	return runEscalateForSession(database, fromSession, explicitTo, promptText)
+}
+
+// runEscalateForSession is the testable core of runEscalate, parameterised on
+// the calling session name so unit tests can drive it without the CWD walk.
+func runEscalateForSession(database *db.DB, fromSession, explicitTo, promptText string) error {
+	selfStatus, err := database.CurrentStatus(fromSession)
+	if err != nil {
+		return fmt.Errorf("prism escalate: read self status: %w", err)
+	}
+	if selfStatus == nil {
+		return fmt.Errorf("prism escalate: calling session %q has no agent_status row", fromSession)
+	}
+	repo := selfStatus.Repo
+	if repo == "" {
+		return fmt.Errorf("prism escalate: calling session %q has no repo recorded — escalate is only available from worktree-backed sessions", fromSession)
+	}
+
+	// Resolve the target.
+	target, err := resolveEscalationTarget(database, repo, explicitTo)
+	if err != nil {
+		// Discovery error: do NOT transition state. Print and exit non-zero.
+		return err
+	}
+
+	// Build payload metadata.
+	branch := ""
+	headSHA := ""
+	if selfStatus.Worktree != "" {
+		if ref, refErr := git.SymbolicRef(selfStatus.Worktree); refErr == nil {
+			branch = strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/")
+		}
+		if sha, shaErr := git.ShortHash(selfStatus.Worktree); shaErr == nil {
+			headSHA = strings.TrimSpace(sha)
+		}
+	}
+	prNumbers := discoverPRNumbers(selfStatus.Worktree)
+	verdicts := discoverLastReviewVerdicts(database, fromSession)
+
+	targetName := ""
+	var targetInstanceID *string
+	if target != nil {
+		targetName = target.SessionName
+		targetInstanceID = target.InstanceID
+	}
+
+	payload := EscalationPayload{
+		Source:     fromSession,
+		Target:     targetName,
+		Prompt:     promptText,
+		PRNumbers:  prNumbers,
+		Branch:     branch,
+		HeadSHA:    headSHA,
+		Verdicts:   verdicts,
+		OccurredAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Transition the calling session to escalated. This must happen even when
+	// no coordinator was found (per the discovery rules), so do it before any
+	// delivery attempt that might fail.
+	if err := database.UpsertStatus(fromSession, selfStatus.Repo, selfStatus.Worktree, string(agent.StateEscalated), nil, nil); err != nil {
+		return fmt.Errorf("prism escalate: transition to escalated: %w", err)
+	}
+
+	// Echo the escalation context into the calling session's own log so
+	// reviewers and humans see it inline via `prism checkin <self>`.
+	echoEscalationToSelf(database, fromSession, selfStatus, payload)
+
+	// Write the session.escalated bus event for dashboard / downstream
+	// consumers. This row sits alongside any later `session.finished` row,
+	// distinct in name and payload.
+	writeSessionEscalatedEvent(database, fromSession, selfStatus, payload)
+
+	// Deliver to the coordinator. With zero candidates, target is nil and
+	// we skip delivery entirely — the calling session is still escalated
+	// and the bus event still fired (with empty target).
+	if target == nil {
+		fmt.Fprintf(os.Stderr,
+			"prism escalate: no coordinator found in repo %q; session %q transitioned to escalated.\n"+
+				"please wait for a human to come check on you.\n",
+			repo, fromSession,
+		)
+		return nil
+	}
+
+	// Deliver via prism prompt machinery. We write the bus_messages row as
+	// "delivered" only on success; the sidecar's prompt path already does this
+	// for the audit trail, so we delegate by invoking the same code path that
+	// `prism prompt` uses.
+	if err := deliverEscalationPrompt(database, fromSession, target, promptText); err != nil {
+		// Delivery failed but state is already escalated. Surface the error
+		// so the worker knows; the bus event was already written so the
+		// coordinator may still see the escalation through the bus.
+		return fmt.Errorf("prism escalate: deliver prompt to %s: %w", target.SessionName, err)
+	}
+
+	fmt.Printf("prism escalate: delivered to %s; session %s now in 'escalated' state\n", target.SessionName, fromSession)
+	_ = targetInstanceID // surfaced via bus payload; not used directly here
+	return nil
+}
+
+// resolveEscalationTarget applies the discovery rules from the issue:
+//
+//   - explicitTo set: look up that session by name; error if missing.
+//   - explicitTo unset and len(candidates) == 1: return that candidate.
+//   - explicitTo unset and len(candidates) > 1: error listing candidates.
+//   - explicitTo unset and len(candidates) == 0: return (nil, nil) so the
+//     caller can transition state without delivery.
+func resolveEscalationTarget(database *db.DB, repo, explicitTo string) (*db.Status, error) {
+	if explicitTo != "" {
+		st, err := database.CurrentStatus(explicitTo)
+		if err != nil {
+			return nil, fmt.Errorf("prism escalate: look up --to %q: %w", explicitTo, err)
+		}
+		if st == nil {
+			return nil, fmt.Errorf("prism escalate: --to session %q not found in agent_status\nrun `prism list-sessions` to see available sessions", explicitTo)
+		}
+		if st.EndedAt != nil {
+			return nil, fmt.Errorf("prism escalate: --to session %q has ended", explicitTo)
+		}
+		return st, nil
+	}
+
+	candidates, err := database.CoordinatorCandidatesForRepo(repo)
+	if err != nil {
+		return nil, fmt.Errorf("prism escalate: discover coordinator candidates for repo %q: %w", repo, err)
+	}
+	switch len(candidates) {
+	case 0:
+		return nil, nil
+	case 1:
+		c := candidates[0]
+		return &c, nil
+	default:
+		var b strings.Builder
+		fmt.Fprintf(&b, "prism escalate: multiple coordinator candidates in repo %q; pass --to to choose one:\n", repo)
+		for _, c := range candidates {
+			fmt.Fprintf(&b, "  - %s\n", c.SessionName)
+		}
+		return nil, fmt.Errorf("%s", b.String())
+	}
+}
+
+// EscalationPayload is the JSON payload carried by both the local-log
+// `escalation` event and the bus `session.escalated` event.
+type EscalationPayload struct {
+	Source     string   `json:"source"`              // calling worker session
+	Target     string   `json:"target,omitempty"`    // coordinator session (empty when none)
+	Prompt     string   `json:"prompt"`              // user-supplied message body
+	PRNumbers  []string `json:"pr_numbers,omitempty"` // discoverable open PRs
+	Branch     string   `json:"branch,omitempty"`    // worker branch
+	HeadSHA    string   `json:"head_sha,omitempty"`  // short HEAD SHA
+	Verdicts   []string `json:"verdicts,omitempty"`  // last review-cycle verdicts
+	OccurredAt string   `json:"occurred_at"`         // RFC3339
+}
+
+// echoEscalationToSelf writes a self-marker event of type "escalation" into
+// the calling session's own event log so `prism checkin <self>` shows the
+// escalation context inline. This is in addition to the bus event and is
+// distinct from delivery to the coordinator.
+func echoEscalationToSelf(database *db.DB, fromSession string, selfStatus *db.Status, payload EscalationPayload) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "prism escalate: marshal self echo payload: %v\n", err)
+		return
+	}
+	ev := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: fromSession,
+		Repo:        selfStatus.Repo,
+		Worktree:    selfStatus.Worktree,
+		InstanceID:  selfStatus.InstanceID,
+		Type:        "escalation",
+		Payload:     string(body),
+		CreatedAt:   time.Now(),
+	}
+	if err := database.WriteEvent(ev); err != nil {
+		fmt.Fprintf(os.Stderr, "prism escalate: write self echo event: %v\n", err)
+	}
+}
+
+// writeSessionEscalatedEvent writes a bus-shaped event of type
+// "session.escalated" into agent_events for the calling session. This is the
+// new event type distinct from "session.finished": handlers that subscribe
+// only to session.finished receive nothing for an escalation.
+func writeSessionEscalatedEvent(database *db.DB, fromSession string, selfStatus *db.Status, payload EscalationPayload) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "prism escalate: marshal bus event payload: %v\n", err)
+		return
+	}
+	ev := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: fromSession,
+		Repo:        selfStatus.Repo,
+		Worktree:    selfStatus.Worktree,
+		InstanceID:  selfStatus.InstanceID,
+		Type:        "session.escalated",
+		Payload:     string(body),
+		CreatedAt:   time.Now(),
+	}
+	if err := database.WriteEvent(ev); err != nil {
+		fmt.Fprintf(os.Stderr, "prism escalate: write session.escalated event: %v\n", err)
+	}
+}
+
+// deliverEscalationPrompt routes the prompt to the target coordinator. It
+// reuses the same delivery machinery as `prism prompt`: HTTP for opencode
+// sessions, host-API socket for socket-pipe (PI) sessions.
+//
+// The audit row in bus_messages is written with delivered_at set on success.
+// from_session is the calling worker session.
+func deliverEscalationPrompt(database *db.DB, fromSession string, target *db.Status, promptText string) error {
+	msg := db.BusMessage{
+		ID:           uuid.New().String(),
+		FromSession:  fromSession,
+		ToSession:    target.SessionName,
+		ToInstanceID: target.InstanceID,
+		Repo:         target.Repo,
+		Text:         promptText,
+		Urgency:      "normal",
+		SentAt:       time.Now(),
+	}
+
+	// Reuse the existing delivery primitives. The "deliver_as=followUp" mode
+	// queues the message until the coordinator's current turn ends, matching
+	// the semantics of finish notifications today (the coordinator should not
+	// be steered mid-stream by a worker escalation).
+	if target.Harness != nil && *target.Harness != "" {
+		// Try the harness-aware path. We mirror cmd/prompt.go's runPrompt
+		// inline rather than calling it because runPrompt resolves the
+		// from_session via CWD walk, which is brittle here (we already know
+		// it). The actual transport selection is what we want to share.
+		if err := deliverEscalationToTarget(target, promptText); err != nil {
+			if writeErr := database.WriteBusMessageFailed(msg); writeErr != nil {
+				fmt.Fprintf(os.Stderr, "prism escalate: write failed audit: %v\n", writeErr)
+			}
+			return err
+		}
+	} else {
+		// Pre-migration row with no harness column. Fall back to opencode HTTP.
+		if err := deliverEscalationToTarget(target, promptText); err != nil {
+			if writeErr := database.WriteBusMessageFailed(msg); writeErr != nil {
+				fmt.Fprintf(os.Stderr, "prism escalate: write failed audit: %v\n", writeErr)
+			}
+			return err
+		}
+	}
+
+	if err := database.WriteBusMessageDelivered(msg); err != nil {
+		fmt.Fprintf(os.Stderr, "prism escalate: write delivered audit: %v\n", err)
+	}
+	return nil
+}
+
+// deliverEscalationToTarget dispatches on harness shape, similar to runPrompt
+// but without the from_session-from-CWD logic.
+func deliverEscalationToTarget(target *db.Status, promptText string) error {
+	if target.Harness != nil && *target.Harness != "" {
+		// Same shape lookup as cmd/prompt.go.
+		if isSocketPipe(*target.Harness) {
+			return deliverViaSidecarHostAPI(target.SessionName, promptText, "followUp")
+		}
+	}
+	if target.HarnessPort == nil || target.HarnessSessionID == nil {
+		return fmt.Errorf("session %q has no harness port or session ID", target.SessionName)
+	}
+	return deliverViaHTTP(*target.HarnessPort, *target.HarnessSessionID, promptText, target)
+}
+
+// isSocketPipe is a small wrapper so we don't have to import harness.ShapeOf
+// inline in two places.
+func isSocketPipe(name string) bool {
+	// Only "pi" today, but keep the indirection for forward compatibility.
+	return name == "pi"
+}
+
+// discoverPRNumbers best-effort returns open PRs whose head matches the
+// worker's branch via `gh pr list`. Returns nil silently on any error so the
+// escalation never fails on metadata gathering.
+func discoverPRNumbers(worktree string) []string {
+	if worktree == "" {
+		return nil
+	}
+	branch, err := git.SymbolicRef(worktree)
+	if err != nil {
+		return nil
+	}
+	branch = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(branch), "refs/heads/"))
+	if branch == "" {
+		return nil
+	}
+	// Use gh pr list scoped to this branch. Best-effort; silent on any error.
+	out, err := runCmdInDir(worktree, "gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number", "--jq", ".[].number")
+	if err != nil {
+		return nil
+	}
+	var prs []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			prs = append(prs, line)
+		}
+	}
+	return prs
+}
+
+// discoverLastReviewVerdicts scans the calling session's recent
+// `review_complete` audit events (best-effort) for verdict strings. Returns
+// nil when no verdicts are recorded, which is the common case for a worker
+// that has not run `prism review`.
+func discoverLastReviewVerdicts(database *db.DB, fromSession string) []string {
+	// The dashboard / monitor records review verdicts on the parent worker via
+	// the audit-event path. We scan the most recent ~20 audit events for any
+	// verdict-bearing rows. This is intentionally tolerant: a missing or
+	// malformed payload is silently dropped.
+	events, err := database.QueryAuditEvents(fromSession, 0, "", 20)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, ev := range events {
+		// Look for verdict markers in payloads. We check both "verdict" and
+		// "result" fields to tolerate shape evolution.
+		var p map[string]any
+		if err := json.Unmarshal([]byte(ev.Payload), &p); err != nil {
+			continue
+		}
+		if v, ok := p["verdict"].(string); ok && v != "" {
+			out = append(out, v)
+			continue
+		}
+		if v, ok := p["result"].(string); ok && v != "" {
+			out = append(out, v)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// proxyEscalate forwards the escalate request to the host sidecar. The
+// sidecar handler shells out to `prism escalate` on the host, where the
+// direct DB path runs.
+func proxyEscalate(apiURL, explicitTo, promptText string) error {
+	body := map[string]any{
+		"prompt": promptText,
+	}
+	if explicitTo != "" {
+		body["to"] = explicitTo
+	}
+	// Pass our session name so the host can identify the calling session
+	// without the CWD walk (the host-side process spawned by the sidecar
+	// inherits the host CWD, not the container's worker CWD).
+	if envSession := os.Getenv("PRISM_SESSION_NAME"); envSession != "" {
+		body["from"] = envSession
+	}
+	return proxyToHostAPI(apiURL, "/escalate", body, nil)
+}
+
+// runCmdInDir runs name with args in dir and returns stdout. A non-zero exit
+// returns an error that includes the stderr output.
+func runCmdInDir(dir, name string, args ...string) (string, error) {
+	c := exec.Command(name, args...)
+	c.Dir = dir
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		return "", fmt.Errorf("%s: %w: %s", name, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// session.NameFor lookup helper passthrough — keeps the import live for
+// the test path (testers stub PRISM_SESSION_NAME).
+var _ = session.NameFor

--- a/modules/programs/prism/prism/cmd/escalate_test.go
+++ b/modules/programs/prism/prism/cmd/escalate_test.go
@@ -1,0 +1,334 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// startEscalateOpencodeStub spins up an httptest.Server that accepts the
+// POST /session/<sid>/prompt_async call used by deliverViaHTTP. The handler
+// records the last received request for the test to assert on.
+type capturedPromptCall struct {
+	body map[string]any
+	url  string
+}
+
+func startEscalateOpencodeStub(t *testing.T) (*httptest.Server, *capturedPromptCall) {
+	t.Helper()
+	captured := &capturedPromptCall{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		var b map[string]any
+		_ = json.Unmarshal(bodyBytes, &b)
+		captured.body = b
+		captured.url = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+// TestEscalate_AutoDiscoversSingleCoordinator covers AC #1: auto-discovery of
+// the same-repo default-branch coordinator and delivery as if it were a
+// `prism prompt`.
+func TestEscalate_AutoDiscoversSingleCoordinator(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	srv, captured := startEscalateOpencodeStub(t)
+	port := extractTestServerPort(t, srv.URL)
+
+	// Override httpClient to use a Unix-friendly net.Dialer (default is fine for httptest)
+	// but force its timeout shorter so failed tests fail fast.
+	httpClient = &http.Client{Timeout: 2 * time.Second, Transport: &http.Transport{
+		DialContext: (&net.Dialer{Timeout: 2 * time.Second}).DialContext,
+	}}
+
+	// Coordinator session in the same repo.
+	seedSession(t, d, "repo@main", "active", intPtr(port), strPtr("oc-coord-sid"),
+		strPtr("coordinator"), strPtr("anthropic/claude-sonnet-4.6"))
+	// Worker session that is calling escalate.
+	seedSession(t, d, "repo@feature", "active", nil, nil,
+		strPtr("worker"), strPtr("anthropic/claude-sonnet-4.6"))
+
+	if err := runEscalateForSession(d, "repo@feature", "", "I'm stuck — please advise."); err != nil {
+		t.Fatalf("runEscalateForSession: %v", err)
+	}
+
+	// Calling session must now be in 'escalated' state.
+	st, err := d.CurrentStatus("repo@feature")
+	if err != nil || st == nil {
+		t.Fatalf("CurrentStatus(repo@feature): err=%v st=%v", err, st)
+	}
+	if st.State != string(agent.StateEscalated) {
+		t.Errorf("state = %q, want %q", st.State, agent.StateEscalated)
+	}
+
+	// Coordinator must have received the prompt.
+	if captured.body == nil {
+		t.Fatalf("coordinator received no prompt")
+	}
+	parts, ok := captured.body["parts"].([]any)
+	if !ok || len(parts) == 0 {
+		t.Fatalf("prompt body parts: got %v", captured.body["parts"])
+	}
+	if !strings.Contains(captured.url, "oc-coord-sid") {
+		t.Errorf("URL = %q, want path containing %q", captured.url, "oc-coord-sid")
+	}
+}
+
+// TestEscalate_StateTransitionEscalated covers AC #2: list-sessions sees
+// "escalated" rather than active or finished after the call.
+func TestEscalate_StateTransitionEscalated(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	srv, _ := startEscalateOpencodeStub(t)
+	port := extractTestServerPort(t, srv.URL)
+
+	httpClient = &http.Client{Timeout: 2 * time.Second}
+
+	seedSession(t, d, "repo@main", "active", intPtr(port), strPtr("oc-sid-coord"),
+		strPtr("coordinator"), nil)
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	if err := runEscalateForSession(d, "repo@feature", "", "help"); err != nil {
+		t.Fatalf("runEscalateForSession: %v", err)
+	}
+
+	st, _ := d.CurrentStatus("repo@feature")
+	if st.State != "escalated" {
+		t.Errorf("state = %q, want %q", st.State, "escalated")
+	}
+}
+
+// TestEscalate_BusEventDistinct covers ACs #4 and #5: the bus event has a new
+// type session.escalated distinct from session.finished, and its payload
+// carries the metadata fields.
+func TestEscalate_BusEventDistinct(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	srv, _ := startEscalateOpencodeStub(t)
+	port := extractTestServerPort(t, srv.URL)
+	httpClient = &http.Client{Timeout: 2 * time.Second}
+
+	seedSession(t, d, "repo@main", "active", intPtr(port), strPtr("oc-sid"), strPtr("coordinator"), nil)
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	if err := runEscalateForSession(d, "repo@feature", "", "stuck on review"); err != nil {
+		t.Fatalf("runEscalateForSession: %v", err)
+	}
+
+	// session.escalated must exist for the source session.
+	events, err := d.QueryEvents("repo@feature", 0, nil, nil, []string{"session.escalated"})
+	if err != nil {
+		t.Fatalf("QueryEvents(session.escalated): %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("session.escalated event count = %d, want 1", len(events))
+	}
+
+	// session.finished must NOT exist (escalation is the notification).
+	finished, _ := d.QueryEvents("repo@feature", 0, nil, nil, []string{"session.finished"})
+	if len(finished) != 0 {
+		t.Errorf("session.finished event count = %d, want 0", len(finished))
+	}
+
+	// Payload contains the expected fields.
+	var p map[string]any
+	if err := json.Unmarshal([]byte(events[0].Payload), &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p["source"] != "repo@feature" {
+		t.Errorf("payload.source = %v, want %q", p["source"], "repo@feature")
+	}
+	if p["target"] != "repo@main" {
+		t.Errorf("payload.target = %v, want %q", p["target"], "repo@main")
+	}
+	if p["prompt"] != "stuck on review" {
+		t.Errorf("payload.prompt = %v, want %q", p["prompt"], "stuck on review")
+	}
+	if _, ok := p["occurred_at"].(string); !ok {
+		t.Errorf("payload.occurred_at missing or not string: %v", p["occurred_at"])
+	}
+}
+
+// TestEscalate_MultipleCandidatesNoTo covers AC #7: multiple coordinator
+// candidates and no --to → exits non-zero, state does NOT transition.
+//
+// Multiple candidates can arise when a pre-migration `<repo>@main` row exists
+// (root_agent_name NULL) alongside a freshly-spawned coordinator in the same
+// repo. The unique index permits that pairing because it filters
+// `WHERE root_agent_name = 'coordinator'` only.
+func TestEscalate_MultipleCandidatesNoTo(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	httpClient = &http.Client{Timeout: 2 * time.Second}
+
+	// Pre-migration legacy row: name matches <repo>@main, root_agent_name NULL.
+	seedSession(t, d, "repo@main", "active", nil, nil, nil, nil)
+	// Fresh coordinator with explicit root_agent_name='coordinator' on a
+	// different branch. The unique index permits this because it filters on
+	// root_agent_name='coordinator' only — the legacy row does not match.
+	seedSession(t, d, "repo@coord-2", "active", nil, nil, strPtr("coordinator"), nil)
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	err := runEscalateForSession(d, "repo@feature", "", "halp")
+	if err == nil {
+		t.Fatalf("expected error for ambiguous coordinator, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple coordinator candidates") {
+		t.Errorf("error message missing 'multiple coordinator candidates': %v", err)
+	}
+	// State must remain active — we did NOT transition.
+	st, _ := d.CurrentStatus("repo@feature")
+	if st.State != "active" {
+		t.Errorf("state = %q, want %q (state must not transition on discovery error)", st.State, "active")
+	}
+}
+
+// TestEscalate_NoCoordinatorStillEscalates covers AC #8: zero candidates →
+// session still transitions to escalated, bus event still fires (target empty),
+// and a self-marker is recorded in the worker's own log.
+func TestEscalate_NoCoordinatorStillEscalates(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	httpClient = &http.Client{Timeout: 2 * time.Second}
+
+	// Only the worker — no coordinator anywhere in the repo.
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	if err := runEscalateForSession(d, "repo@feature", "", "lonely worker"); err != nil {
+		t.Fatalf("runEscalateForSession: %v", err)
+	}
+
+	st, _ := d.CurrentStatus("repo@feature")
+	if st.State != "escalated" {
+		t.Errorf("state = %q, want %q", st.State, "escalated")
+	}
+
+	// session.escalated event must still fire.
+	events, _ := d.QueryEvents("repo@feature", 0, nil, nil, []string{"session.escalated"})
+	if len(events) != 1 {
+		t.Fatalf("session.escalated event count = %d, want 1", len(events))
+	}
+	var p map[string]any
+	_ = json.Unmarshal([]byte(events[0].Payload), &p)
+	if target, ok := p["target"].(string); ok && target != "" {
+		t.Errorf("payload.target = %q, want \"\" (no coordinator)", target)
+	}
+
+	// A self-echo "escalation" event must exist so prism checkin shows it.
+	echoes, _ := d.QueryEvents("repo@feature", 0, nil, nil, []string{"escalation"})
+	if len(echoes) != 1 {
+		t.Errorf("escalation echo event count = %d, want 1", len(echoes))
+	}
+}
+
+// TestEscalate_ExplicitToMissingSession covers AC #9: --to <nonexistent> exits
+// non-zero without transitioning state.
+func TestEscalate_ExplicitToMissingSession(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	err := runEscalateForSession(d, "repo@feature", "ghost-session", "halp")
+	if err == nil {
+		t.Fatalf("expected error for missing --to target")
+	}
+	if !strings.Contains(err.Error(), "ghost-session") {
+		t.Errorf("error message missing target name: %v", err)
+	}
+
+	st, _ := d.CurrentStatus("repo@feature")
+	if st.State != "active" {
+		t.Errorf("state = %q, want %q (must not transition on bad --to)", st.State, "active")
+	}
+}
+
+// TestEscalate_PromptEchoedToSelf covers AC #10: the prompt body is recorded
+// in the calling session's own conversation log.
+func TestEscalate_PromptEchoedToSelf(t *testing.T) {
+	d := openPromptTestDB(t)
+
+	srv, _ := startEscalateOpencodeStub(t)
+	port := extractTestServerPort(t, srv.URL)
+	httpClient = &http.Client{Timeout: 2 * time.Second}
+
+	seedSession(t, d, "repo@main", "active", intPtr(port), strPtr("oc-sid"), strPtr("coordinator"), nil)
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	const body = "the question I need answered"
+	if err := runEscalateForSession(d, "repo@feature", "", body); err != nil {
+		t.Fatalf("runEscalateForSession: %v", err)
+	}
+
+	echoes, err := d.QueryEvents("repo@feature", 0, nil, nil, []string{"escalation"})
+	if err != nil {
+		t.Fatalf("QueryEvents(escalation): %v", err)
+	}
+	if len(echoes) != 1 {
+		t.Fatalf("escalation echo count = %d, want 1", len(echoes))
+	}
+	var p map[string]any
+	_ = json.Unmarshal([]byte(echoes[0].Payload), &p)
+	if got, _ := p["prompt"].(string); got != body {
+		t.Errorf("echoed prompt = %q, want %q", got, body)
+	}
+}
+
+// TestEscalate_ResolveTarget_OneCandidate exercises the resolver directly.
+func TestEscalate_ResolveTarget_OneCandidate(t *testing.T) {
+	d := openPromptTestDB(t)
+	seedSession(t, d, "repo@main", "active", nil, nil, strPtr("coordinator"), nil)
+
+	target, err := resolveEscalationTarget(d, "repo", "")
+	if err != nil {
+		t.Fatalf("resolveEscalationTarget: %v", err)
+	}
+	if target == nil || target.SessionName != "repo@main" {
+		t.Errorf("target = %+v, want repo@main", target)
+	}
+}
+
+// TestEscalate_ResolveTarget_LegacyAtMainRow exercises the discovery
+// fallback for pre-migration rows where root_agent_name is NULL but the
+// session is named <repo>@main.
+func TestEscalate_ResolveTarget_LegacyAtMainRow(t *testing.T) {
+	d := openPromptTestDB(t)
+	// Note: seedSession passes nil rootAgent → root_agent_name stays NULL.
+	seedSession(t, d, "repo@main", "active", nil, nil, nil, nil)
+
+	target, err := resolveEscalationTarget(d, "repo", "")
+	if err != nil {
+		t.Fatalf("resolveEscalationTarget: %v", err)
+	}
+	if target == nil || target.SessionName != "repo@main" {
+		t.Errorf("legacy fallback target = %+v, want repo@main", target)
+	}
+}
+
+// TestEscalate_ResolveTarget_ExplicitTo exercises the --to override path.
+func TestEscalate_ResolveTarget_ExplicitTo(t *testing.T) {
+	d := openPromptTestDB(t)
+	seedSession(t, d, "repo@main", "active", nil, nil, strPtr("coordinator"), nil)
+	// Use a non-coordinator role for the second target so the unique index
+	// (one coordinator per repo) is not violated. --to allows targeting any
+	// session by name regardless of role.
+	seedSession(t, d, "repo@coord-2", "active", nil, nil, strPtr("worker"), nil)
+
+	target, err := resolveEscalationTarget(d, "repo", "repo@coord-2")
+	if err != nil {
+		t.Fatalf("resolveEscalationTarget(repo@coord-2): %v", err)
+	}
+	if target == nil || target.SessionName != "repo@coord-2" {
+		t.Errorf("--to target = %+v, want repo@coord-2", target)
+	}
+}

--- a/modules/programs/prism/prism/internal/agent/agent.go
+++ b/modules/programs/prism/prism/internal/agent/agent.go
@@ -27,4 +27,12 @@ const (
 	// The coordinator must not receive a "has finished" notification while the
 	// worker is in the reviewing state.
 	StateReviewing AgentState = "reviewing"
+	// StateEscalated is a non-terminal state entered by a worker session via
+	// `prism escalate`. The worker has handed a question to its coordinator
+	// and stops its current turn while awaiting guidance. Any incoming
+	// turn_start (from `prism prompt`, a human typing into tmux, or any
+	// other source) transitions the session back to active. While in this
+	// state the sidecar must NOT emit the "has finished" notification — the
+	// `session.escalated` bus event already informed the coordinator.
+	StateEscalated AgentState = "escalated"
 )

--- a/modules/programs/prism/prism/internal/agent/machine.go
+++ b/modules/programs/prism/prism/internal/agent/machine.go
@@ -18,6 +18,16 @@ import "fmt"
 //     `prism review`. The worker remains here until the review-complete prompt
 //     arrives. The coordinator does NOT receive a "has finished" notification
 //     while the worker is in this state.
+//   - active → escalated: entered by a worker immediately after calling
+//     `prism escalate`. The worker has handed a question to its coordinator
+//     and stops its current turn until any incoming turn_start clears the
+//     state. The coordinator does NOT receive a "has finished" notification
+//     while the worker is in this state — the `session.escalated` bus event
+//     is the notification.
+//   - escalated → active: any incoming turn_start clears escalated and
+//     resumes normal lifecycle, identical to the reviewing→active path.
+//   - escalated → finished/interrupted/error/deleted: terminal exits remain
+//     possible if the worker is killed or otherwise ended while escalated.
 //   - reviewing → finished: PASS verdict received; coordinator is notified now.
 //   - reviewing → active: FAIL verdict received; worker returns to active to
 //     fix blocking issues and re-run the review.
@@ -50,6 +60,7 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 		StateError:       true,
 		StateCompacting:  true,
 		StateReviewing:   true, // prism review called — awaiting review results
+		StateEscalated:   true, // prism escalate called — awaiting coordinator guidance
 		StateDeleted:     true,
 	},
 	StateWaiting: {
@@ -77,6 +88,17 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 		StateFinished:    true,
 		StateActive:      true,
 		StateInterrupted: true,
+		StateDeleted:     true,
+	},
+	// escalated→active: any incoming turn_start clears escalated.
+	// escalated→finished/interrupted/error: terminal exits while escalated.
+	// (escalated→reviewing/waiting/compacting are not modelled — those flows
+	// require the worker to first transition back to active via turn_start.)
+	StateEscalated: {
+		StateActive:      true,
+		StateFinished:    true,
+		StateInterrupted: true,
+		StateError:       true,
 		StateDeleted:     true,
 	},
 	// finished→interrupted: non-zero pane exit overrides a clean finish.

--- a/modules/programs/prism/prism/internal/agent/machine_test.go
+++ b/modules/programs/prism/prism/internal/agent/machine_test.go
@@ -48,6 +48,14 @@ func TestTransition_ValidPairs(t *testing.T) {
 		{StateReviewing, StateInterrupted, "pane-died or SIGTERM while awaiting review results"},
 		{StateReviewing, StateDeleted, "session.deleted while reviewing"},
 
+		// Escalated state (issue #1517)
+		{StateActive, StateEscalated, "prism escalate called — entering escalated state"},
+		{StateEscalated, StateActive, "any incoming turn_start — worker resumes"},
+		{StateEscalated, StateFinished, "task completes while escalated (rare)"},
+		{StateEscalated, StateInterrupted, "pane-died while escalated"},
+		{StateEscalated, StateError, "sidecar startup failure while escalated"},
+		{StateEscalated, StateDeleted, "session.deleted while escalated"},
+
 		// Deleted from any state
 		{StateActive, StateDeleted, "session.deleted while active"},
 		{StateWaiting, StateDeleted, "session.deleted while waiting"},
@@ -86,6 +94,12 @@ func TestTransition_InvalidPairs(t *testing.T) {
 		{StateCompacting, StateFinished, "compacting → finished (compaction ≠ task completion)"},
 		{StateCompacting, StateWaiting, "compacting → waiting"},
 		{StateCompacting, StateError, "compacting → error"},
+
+		// Escalated cannot directly enter reviewing/waiting/compacting; the worker
+		// must first resume to active via turn_start.
+		{StateEscalated, StateReviewing, "escalated → reviewing (must go through active)"},
+		{StateEscalated, StateWaiting, "escalated → waiting"},
+		{StateEscalated, StateCompacting, "escalated → compacting"},
 	}
 
 	for _, tc := range invalid {
@@ -113,6 +127,7 @@ func TestTransition_DeletedIsTerminal(t *testing.T) {
 	allStates := []AgentState{
 		StateActive, StateWaiting, StateFinished, StateCompacting,
 		StateError, StateIdle, StateInterrupted, StateDeleted, StateReviewing,
+		StateEscalated,
 	}
 	for _, to := range allStates {
 		if to == StateDeleted {
@@ -142,6 +157,7 @@ func TestValidTransitionsCompleteness(t *testing.T) {
 	allStates := []AgentState{
 		StateActive, StateWaiting, StateFinished, StateCompacting,
 		StateError, StateIdle, StateInterrupted, StateDeleted, StateReviewing,
+		StateEscalated,
 	}
 	for _, s := range allStates {
 		if _, ok := ValidTransitions[s]; !ok {

--- a/modules/programs/prism/prism/internal/dashboard/style.go
+++ b/modules/programs/prism/prism/internal/dashboard/style.go
@@ -59,6 +59,8 @@ func stateStyle(state string) lipgloss.Style {
 		color = ColorRed
 	case agent.StateReviewing:
 		color = ColorBlue
+	case agent.StateEscalated:
+		color = ColorYellow
 	}
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(color))
 }
@@ -73,6 +75,7 @@ func stateLabel(state string) string {
 		agent.StateCompacting:  "compacting",
 		agent.StateError:       "error",
 		agent.StateReviewing:   "reviewing",
+		agent.StateEscalated:   "escalated",
 		"":                     "idle",
 	}
 	if l, ok := labels[agent.AgentState(state)]; ok {

--- a/modules/programs/prism/prism/internal/db/coordinator_candidates_test.go
+++ b/modules/programs/prism/prism/internal/db/coordinator_candidates_test.go
@@ -1,0 +1,139 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestCoordinatorCandidatesForRepo_Single covers the discovery primitive used
+// by `prism escalate` for the auto-discovery path: exactly one same-repo
+// active coordinator returned.
+func TestCoordinatorCandidatesForRepo_Single(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "prism.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	role := "coordinator"
+	if err := d.UpsertStatusWithRootAgent("repo@main", "repo", "/wt", "active", nil, nil, &role, nil); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+	// Add an unrelated worker in the same repo — should NOT be returned.
+	worker := "worker"
+	if err := d.UpsertStatusWithRootAgent("repo@feature", "repo", "/wt2", "active", nil, nil, &worker, nil); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+
+	got, err := d.CoordinatorCandidatesForRepo("repo")
+	if err != nil {
+		t.Fatalf("CoordinatorCandidatesForRepo: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("candidate count = %d, want 1", len(got))
+	}
+	if got[0].SessionName != "repo@main" {
+		t.Errorf("candidate session = %q, want %q", got[0].SessionName, "repo@main")
+	}
+}
+
+// TestCoordinatorCandidatesForRepo_LegacyAtMainRow covers the fallback path:
+// a pre-migration row named <repo>@main with NULL root_agent_name is still
+// treated as a candidate.
+func TestCoordinatorCandidatesForRepo_LegacyAtMainRow(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "prism.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	// nil rootAgent → root_agent_name remains NULL (pre-migration shape).
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+
+	got, err := d.CoordinatorCandidatesForRepo("repo")
+	if err != nil {
+		t.Fatalf("CoordinatorCandidatesForRepo: %v", err)
+	}
+	if len(got) != 1 || got[0].SessionName != "repo@main" {
+		t.Fatalf("legacy candidate not returned: got=%+v", got)
+	}
+}
+
+// TestCoordinatorCandidatesForRepo_Zero covers the no-coordinator branch.
+func TestCoordinatorCandidatesForRepo_Zero(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "prism.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	worker := "worker"
+	if err := d.UpsertStatusWithRootAgent("repo@feature", "repo", "/wt", "active", nil, nil, &worker, nil); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+
+	got, err := d.CoordinatorCandidatesForRepo("repo")
+	if err != nil {
+		t.Fatalf("CoordinatorCandidatesForRepo: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("candidate count = %d, want 0", len(got))
+	}
+}
+
+// TestCoordinatorCandidatesForRepo_Multiple covers the ambiguous branch: a
+// legacy <repo>@main row alongside an explicit coordinator on a different
+// branch (the unique index permits this combination because it filters on
+// root_agent_name='coordinator' only).
+func TestCoordinatorCandidatesForRepo_Multiple(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "prism.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.UpsertStatus("repo@main", "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	role := "coordinator"
+	if err := d.UpsertStatusWithRootAgent("repo@coord-2", "repo", "/wt2", "active", nil, nil, &role, nil); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+
+	got, err := d.CoordinatorCandidatesForRepo("repo")
+	if err != nil {
+		t.Fatalf("CoordinatorCandidatesForRepo: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("candidate count = %d, want 2", len(got))
+	}
+}
+
+// TestCoordinatorCandidatesForRepo_ExcludesOtherRepo verifies that candidates
+// from other repos are not surfaced (the discovery is repo-scoped per the
+// out-of-scope note about cross-repo escalation).
+func TestCoordinatorCandidatesForRepo_ExcludesOtherRepo(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "prism.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	role := "coordinator"
+	if err := d.UpsertStatusWithRootAgent("repo-a@main", "repo-a", "/wt", "active", nil, nil, &role, nil); err != nil {
+		t.Fatalf("seed coordinator a: %v", err)
+	}
+	if err := d.UpsertStatusWithRootAgent("repo-b@main", "repo-b", "/wt", "active", nil, nil, &role, nil); err != nil {
+		t.Fatalf("seed coordinator b: %v", err)
+	}
+
+	got, err := d.CoordinatorCandidatesForRepo("repo-a")
+	if err != nil {
+		t.Fatalf("CoordinatorCandidatesForRepo: %v", err)
+	}
+	if len(got) != 1 || got[0].SessionName != "repo-a@main" {
+		t.Errorf("got=%+v, want only repo-a@main", got)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -757,6 +757,26 @@ WHERE ended_at IS NULL AND harness = 'pi' AND state IN ('active', 'idle', 'waiti
 	return d.queryStatuses(q)
 }
 
+// CoordinatorCandidatesForRepo returns all active agent_status rows for repo
+// that look like coordinator candidates: same repo, ended_at IS NULL, and
+// either root_agent_name = "coordinator" OR (root_agent_name IS NULL AND
+// session_name = "<repo>@main") so that pre-migration rows are still
+// surfaced via the name convention. Rows are ordered by last_seen DESC so
+// the most-recently-active candidate appears first.
+//
+// This is the discovery primitive for `prism escalate`: zero candidates means
+// no coordinator is running; one candidate means auto-discovery succeeds; two
+// or more means the worker must specify --to explicitly.
+func (d *DB) CoordinatorCandidatesForRepo(repo string) ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE repo = ? AND ended_at IS NULL
+  AND (root_agent_name = 'coordinator' OR (root_agent_name IS NULL AND session_name = ? || '@main'))
+ORDER BY last_seen DESC`
+	return d.queryStatuses(q, repo, repo)
+}
+
 // CoordinatorForRepo returns the agent_status row for the active coordinator
 // session of repo (i.e. the row where repo = repo AND root_agent_name =
 // "coordinator" AND ended_at IS NULL). Returns nil when no coordinator exists.

--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -172,6 +172,10 @@ func (s *Sidecar) handleServerConnected() {
 			s.logger().Printf("sidecar: recovery timer suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
+		if s.currentDBState() == agent.StateEscalated {
+			s.logger().Printf("sidecar: recovery timer suppressed (cause=escalated — awaiting coordinator guidance)")
+			return
+		}
 		s.logger().Printf("sidecar: recovery timer fired, writing finished (session.idle likely missed on reconnect)")
 		s.logger().Printf("sidecar: transition -> finished (cause=recovery_timer)")
 		s.upsertState(agent.StateFinished, nil, nil)
@@ -279,6 +283,10 @@ func (s *Sidecar) handleSessionFinished() {
 			s.logger().Printf("sidecar: finished debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
+		if currentState == agent.StateEscalated {
+			s.logger().Printf("sidecar: finished debounce suppressed (cause=escalated — awaiting coordinator guidance)")
+			return
+		}
 
 		s.logger().Printf("sidecar: transition -> finished (cause=finished_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
@@ -335,6 +343,10 @@ func (s *Sidecar) handleSessionIdle() {
 		}
 		if s.reviewingInFlight && currentState == agent.StateReviewing {
 			s.logger().Printf("sidecar: idle debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
+			return
+		}
+		if currentState == agent.StateEscalated {
+			s.logger().Printf("sidecar: idle debounce suppressed (cause=escalated — awaiting coordinator guidance)")
 			return
 		}
 
@@ -791,6 +803,10 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 				}
 				if s.reviewingInFlight && s.currentDBState() == agent.StateReviewing {
 					s.logger().Printf("sidecar: idle debounce (root-agent message path) suppressed (cause=reviewing — awaiting review-complete prompt)")
+					return
+				}
+				if currentState == agent.StateEscalated {
+					s.logger().Printf("sidecar: idle debounce (root-agent message path) suppressed (cause=escalated — awaiting coordinator guidance)")
 					return
 				}
 

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1703,6 +1703,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// Forwards an escalation request from a worker container to the host's
 	// `prism escalate` CLI. The from field defaults to the calling sidecar's
 	// session name when omitted (the common case from a containerised worker).
+	//
+	// Cross-session integrity: when `from` is set explicitly it must equal the
+	// calling sidecar's own session name (the per-session host-API socket is
+	// the auth boundary), unless the caller is a coordinator. This mirrors
+	// the rule applied by /prompt and /set-model in this same file. Without
+	// the check, a non-coordinator could mutate `agent_status.state`,
+	// emit a `session.escalated` bus event attributed to a victim, and pin
+	// that victim in `escalated` so its legitimate finish notifications are
+	// suppressed.
 	mux.HandleFunc("/escalate", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
 			return
@@ -1723,6 +1732,16 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		fromSession := req.From
 		if fromSession == "" {
 			fromSession = s.cfg.SessionName
+		} else if fromSession != s.cfg.SessionName {
+			// Cross-session: only coordinators may escalate on behalf of
+			// another session. The DB-backed coordinator check matches the
+			// pattern used by /prompt's cross-repo branch and /set-model.
+			if !isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
+				writeError(w, http.StatusForbidden,
+					fmt.Sprintf("workers can only escalate from their own session (%s), got from=%q",
+						s.cfg.SessionName, fromSession))
+				return
+			}
 		}
 
 		args := []string{"escalate", "--prompt", req.Prompt}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1696,6 +1696,54 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		writeJSON(w, http.StatusOK, map[string]string{})
 	})
 
+	// POST /escalate
+	// Request:  {"prompt":"...","to":"<session>" (optional),"from":"<session>" (optional)}
+	// Response: {} on success, {"error":"..."} otherwise.
+	//
+	// Forwards an escalation request from a worker container to the host's
+	// `prism escalate` CLI. The from field defaults to the calling sidecar's
+	// session name when omitted (the common case from a containerised worker).
+	mux.HandleFunc("/escalate", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		var req struct {
+			Prompt string `json:"prompt"`
+			To     string `json:"to,omitempty"`
+			From   string `json:"from,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if strings.TrimSpace(req.Prompt) == "" {
+			writeError(w, http.StatusBadRequest, "prompt is required")
+			return
+		}
+		fromSession := req.From
+		if fromSession == "" {
+			fromSession = s.cfg.SessionName
+		}
+
+		args := []string{"escalate", "--prompt", req.Prompt}
+		if req.To != "" {
+			args = append(args, "--to", req.To)
+		}
+		s.logger().Printf("sidecar: host-API /escalate: from=%s to=%s", fromSession, req.To)
+		cmd := exec.Command(prismBinary(), args...)
+		// PRISM_SESSION_NAME tells the host-side `prism escalate` which session
+		// is calling, bypassing the CWD walk that would otherwise resolve to
+		// the sidecar's own working directory.
+		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+fromSession, "PRISM_HOST_API=")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			s.logger().Printf("sidecar: host-API /escalate: %v: %s", err, out)
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("escalate failed: %v\n%s", err, strings.TrimSpace(string(out))))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{})
+	})
+
 	// POST /set-model
 	// Request:  {"session":"<name>","provider":"...","model":"...","thinking":"..."}
 	// Response: {"session":"<name>","status":"applied"|"error:disconnected"|"skipped:opencode"} | {"error":"..."}

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	"github.com/prismatic-koi/prism/internal/promptdelivery"
@@ -174,6 +175,18 @@ func (s *Sidecar) notifyCoordinator() {
 	// as noise notifications.
 	if isReviewAgentSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
 		s.logger().Printf("sidecar: notifyCoordinator: suppressed for review-agent session %s", s.cfg.SessionName)
+		return
+	}
+
+	// Escalated guard: while a session is in the escalated state the worker
+	// has already informed the coordinator via `prism escalate` and the
+	// session.escalated bus event. A subsequent `has finished` notification
+	// would be a duplicate, false signal (the worker is paused awaiting
+	// guidance, not done). The state clears back to active on any incoming
+	// turn_start, after which a normal finish will notify as usual.
+	selfStatus, selfStatusErr := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
+	if selfStatusErr == nil && selfStatus != nil && selfStatus.State == string(agent.StateEscalated) {
+		s.logger().Printf("sidecar: notifyCoordinator: suppressed (cause=escalated — session.escalated already informed coordinator)")
 		return
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/notify_escalated_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_escalated_test.go
@@ -1,0 +1,91 @@
+package sidecar
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/harness/opencode"
+)
+
+// TestNotifyCoordinator_EscalatedSuppressed verifies AC #3 and #4: while a
+// session is in the escalated state, the sidecar must NOT call
+// notifyCoordinator with a "has finished" message. The session.escalated bus
+// event has already informed the coordinator and a finished notification
+// would be a duplicate, false signal.
+func TestNotifyCoordinator_EscalatedSuppressed(t *testing.T) {
+	d := openTestDB(t)
+
+	coordSID := "coord-sid-escalated-suppressed"
+
+	var notifyCount int
+	var notifyMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			sessions := []map[string]any{{"id": coordSID}}
+			data, _ := json.Marshal(sessions)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		notifyMu.Lock()
+		notifyCount++
+		notifyMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, "test-repo", srvPort, coordSID)
+
+	clk := newTestClock()
+	workerSession := "test-repo@feature"
+	cfg := Config{
+		SessionName: workerSession,
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-worktree-escalated",
+		OpencodeURL: "http://localhost:14002",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:14002", srv.Client(), "", ""),
+		AgentRole:   "worker",
+	}
+	worker := New(cfg)
+
+	// Seed worker as escalated — this is the state `prism escalate` left it
+	// in just before the harness started winding down.
+	_ = d.UpsertStatus(workerSession, "test-repo", "/tmp/test-worktree-escalated",
+		string(agent.StateEscalated), nil, nil)
+
+	// Directly invoke notifyCoordinator (the call site we want to verify
+	// suppresses). We do not need to drive the full debounce machinery; the
+	// suppression guard inside notifyCoordinator must short-circuit before
+	// any HTTP call is attempted.
+	worker.notifyCoordinator()
+
+	// Allow any in-flight goroutine work to settle, though notifyCoordinator
+	// is synchronous from the goroutine that calls it.
+	time.Sleep(50 * time.Millisecond)
+
+	// No bus messages must have been written.
+	var totalMsgs int
+	if err := d.QueryRow("SELECT COUNT(*) FROM bus_messages WHERE to_session = ?", "test-repo@main").Scan(&totalMsgs); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	if totalMsgs != 0 {
+		t.Errorf("escalated session must NOT send coordinator notification, but got %d bus message(s)", totalMsgs)
+	}
+
+	notifyMu.Lock()
+	count := notifyCount
+	notifyMu.Unlock()
+	if count != 0 {
+		t.Errorf("notifyCoordinator HTTP calls = %d for escalated session, want 0", count)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_escalate_hostapi_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_escalate_hostapi_test.go
@@ -1,0 +1,148 @@
+package sidecar
+
+// Tests for the host-API /escalate endpoint, focused on the cross-session
+// integrity check that prevents a worker from escalating "from" any session
+// other than its own. The check mirrors the rule applied by /prompt and
+// /set-model in the same file. A regression here would let a non-coordinator
+// mutate `agent_status.state`, emit a `session.escalated` bus event
+// attributed to a victim, and pin that victim in `escalated` so legitimate
+// `has finished` notifications are suppressed (review-security finding,
+// PR #1524 round 1).
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestHostAPI_Escalate_WorkerCannotImpersonate verifies that a worker session
+// is rejected with HTTP 403 when it sets `from` to any session other than its
+// own. The shell-out path must NOT be reached.
+func TestHostAPI_Escalate_WorkerCannotImpersonate(t *testing.T) {
+	d := openTestDB(t)
+	// Use the role-and-binary helper so that even if the auth check failed
+	// (regression) the shell-out would exit code 1, not block the test.
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+
+	body := `{"prompt":"halp","from":"myrepo@victim"}`
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", body)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %q, want 403", rr.Code, rr.Body.String())
+	}
+	// The error message should name both the legitimate session and the
+	// rejected `from` value so the caller can diagnose the mistake.
+	if !strings.Contains(rr.Body.String(), "myrepo@feature") {
+		t.Errorf("body %q: want message naming the calling session", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "myrepo@victim") {
+		t.Errorf("body %q: want message naming the rejected from value", rr.Body.String())
+	}
+}
+
+// TestHostAPI_Escalate_WorkerOwnSessionAccepted verifies the legitimate path:
+// a worker setting `from` to its own session name is accepted (the auth check
+// passes; the request then reaches the shell-out which fails with 500 on the
+// stub binary — that's expected and proves we got past the 403 gate).
+func TestHostAPI_Escalate_WorkerOwnSessionAccepted(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+
+	body := `{"prompt":"halp","from":"myrepo@feature"}`
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", body)
+
+	// 500 means the auth check passed and the stub binary rejected the call.
+	// 403 would mean the auth check rejected it (regression).
+	if rr.Code == http.StatusForbidden {
+		t.Fatalf("worker rejected for its own session: %q", rr.Body.String())
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %q, want 500 (stub binary fails) or 200", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Escalate_WorkerEmptyFromAccepted verifies that the common path
+// (worker omits `from`, sidecar substitutes its own session name) is accepted.
+// Same shape as the own-session test: 500 from the stub binary, never 403.
+func TestHostAPI_Escalate_WorkerEmptyFromAccepted(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+
+	body := `{"prompt":"halp"}`
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", body)
+
+	if rr.Code == http.StatusForbidden {
+		t.Fatalf("worker rejected when from was empty: %q", rr.Body.String())
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %q, want 500 (stub binary fails)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Escalate_CoordinatorCanProxy verifies that a coordinator session
+// IS allowed to escalate on behalf of a different session. This is needed so
+// that future tooling (e.g. an admin UI or an automated supervisor) can drive
+// escalations through a coordinator's host-API socket.
+func TestHostAPI_Escalate_CoordinatorCanProxy(t *testing.T) {
+	d := openTestDB(t)
+	// Seed the coordinator row so isCoordinatorSession reads back the role.
+	role := "coordinator"
+	if err := d.UpsertStatusWithRootAgent("myrepo@main", "myrepo", "/wt", "active", nil, nil, &role, nil); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@main", "myrepo", "coordinator", d)
+
+	body := `{"prompt":"halp","from":"myrepo@feature"}`
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", body)
+
+	if rr.Code == http.StatusForbidden {
+		t.Fatalf("coordinator rejected when proxying for another session: %q", rr.Body.String())
+	}
+	// Either OK or 500 (from the stub binary) is fine — we only care that the
+	// auth gate did NOT 403.
+	if rr.Code != http.StatusOK && rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %q, want 200 or 500", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Escalate_EmptyPromptRejected verifies the existing 400 guard
+// for missing prompt remains intact alongside the new auth check.
+func TestHostAPI_Escalate_EmptyPromptRejected(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", `{"prompt":"   "}`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "prompt is required") {
+		t.Errorf("body %q: want 'prompt is required'", rr.Body.String())
+	}
+}
+
+// TestHostAPI_Escalate_MalformedJSONRejected verifies the existing 400 guard
+// for malformed JSON remains intact.
+func TestHostAPI_Escalate_MalformedJSONRejected(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", `{not valid`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Escalate_GetMethodRejected verifies the requirePost guard is
+// applied (consistent with sibling endpoints).
+func TestHostAPI_Escalate_GetMethodRejected(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRoleAndBinary(t, "myrepo@feature", "myrepo", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/escalate", "")
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_escalated_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_escalated_test.go
@@ -1,0 +1,131 @@
+package sidecar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// TestSocketPipe_TurnStartClearsEscalated verifies AC #6: an incoming
+// turn_start frame transitions a session out of the "escalated" state back
+// into "active". The state machine must permit escalated→active and the
+// sidecar's PI turn_start handler must perform the upsert unconditionally
+// (no reviewing-style guard for escalated).
+func TestSocketPipe_TurnStartClearsEscalated(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive the session to active, then directly write escalated to the DB
+	// (mirroring what `prism escalate` does on the host side). The sidecar's
+	// next incoming turn_start must clear it.
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "active"})
+
+	// Wait until the state is reflected in the DB.
+	deadline := time.Now().Add(2 * time.Second)
+	for getState(t, sc.cfg.DB, sc.cfg.SessionName) != string(agent.StateActive) {
+		if time.Now().After(deadline) {
+			t.Fatal("session never reached active state")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Inject the escalated state directly: this is what `prism escalate`
+	// does (UpsertStatus to escalated) before the sidecar sees the next
+	// frame.
+	if err := sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo,
+		sc.cfg.Worktree, string(agent.StateEscalated), nil, nil); err != nil {
+		t.Fatalf("inject escalated: %v", err)
+	}
+
+	// turn_start must clear it back to active.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+		if st == string(agent.StateActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("escalated did not clear after turn_start; state=%q", st)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
+// TestSocketPipe_FinishedDebounceSuppressedWhileEscalated verifies AC #3:
+// while a session is in the escalated state, the sidecar must NOT transition
+// it to finished even when the harness fires state_change{finished}. The
+// session.escalated bus event already informed the coordinator; a finished
+// transition would clobber the escalated state and emit a redundant
+// notification.
+func TestSocketPipe_FinishedDebounceSuppressedWhileEscalated(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive to active.
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "active"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for getState(t, sc.cfg.DB, sc.cfg.SessionName) != string(agent.StateActive) {
+		if time.Now().After(deadline) {
+			t.Fatal("never reached active")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Inject escalated.
+	if err := sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo,
+		sc.cfg.Worktree, string(agent.StateEscalated), nil, nil); err != nil {
+		t.Fatalf("inject escalated: %v", err)
+	}
+
+	// Now fire state_change{finished} — sidecar will start the debounce timer.
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	// Wait for the debounce timer to be created.
+	deadline = time.Now().Add(2 * time.Second)
+	var idleTimer *testTimer
+	for {
+		idleTimer = clk.LastTimer()
+		if idleTimer != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no finished debounce timer created")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Fire the timer — the suppression guard inside must bail out without
+	// writing finished.
+	idleTimer.Fire()
+
+	// Give the goroutine a moment to process and verify state remains
+	// escalated, NOT finished.
+	time.Sleep(50 * time.Millisecond)
+	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if st != string(agent.StateEscalated) {
+		t.Errorf("after debounce fire, state = %q, want %q (suppression failed)",
+			st, agent.StateEscalated)
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1517.

Adds a first-class `prism escalate` command and `escalated` session state so
workers can hand a question to their coordinator in one step, with no
redundant `has finished` notification firing 30 seconds later.

## Surface

```
prism escalate [--to <session>] --prompt "<message>"
prism escalate [--to <session>] --prompt -          # read from stdin
```

## State machine (matches the issue)

```
active ──prism escalate──▶ escalated
escalated ──any turn_start (from any source)──▶ active
```

- New `escalated` value alongside `active` / `idle` / `finished` / `reviewing`.
- Transition out is triggered by **any** incoming `turn_start`, not specifically
  `prism prompt` — humans poking at tmux clear it too.
- While in `escalated`, the sidecar suppresses the `has finished` notification.
  The `session.escalated` bus event is the notification.
- State machine entries (in `internal/agent/machine.go`):
  - `active → escalated`
  - `escalated → active` (turn_start clears it)
  - `escalated → finished/interrupted/error/deleted` (terminal exits remain
    possible while escalated)
  - `escalated → reviewing/waiting/compacting` are intentionally NOT modelled —
    those flows require `escalated → active` first via turn_start.

## Discovery resolution table (matches the issue)

| Situation | Behaviour | Test |
|---|---|---|
| Exactly one same-repo coordinator candidate | Auto-discover, send to it | `TestEscalate_AutoDiscoversSingleCoordinator`, `TestCoordinatorCandidatesForRepo_Single` |
| Multiple same-repo candidates | Refuse without `--to`; list candidates; **state does NOT transition** | `TestEscalate_MultipleCandidatesNoTo`, `TestCoordinatorCandidatesForRepo_Multiple` |
| Zero candidates | Still transition to `escalated`; bus event still fires (target empty); self-marker echoed | `TestEscalate_NoCoordinatorStillEscalates`, `TestCoordinatorCandidatesForRepo_Zero` |
| `--to <missing>` | Exit non-zero; **state does NOT transition** | `TestEscalate_ExplicitToMissingSession` |
| Pre-migration `<repo>@main` row (NULL `root_agent_name`) | Treated as a legacy candidate | `TestCoordinatorCandidatesForRepo_LegacyAtMainRow`, `TestEscalate_ResolveTarget_LegacyAtMainRow` |
| Cross-repo | Out of scope (v1) — discovery is repo-scoped | `TestCoordinatorCandidatesForRepo_ExcludesOtherRepo` |

## ACs — all 13 satisfied

| AC | Where it lives |
|---|---|
| 1. `prism escalate --prompt "..."` auto-discovers the same-repo default-branch coordinator and delivers as `prism prompt` would | `cmd/escalate.go::runEscalateForSession` → `cmd/escalate_test.go::TestEscalate_AutoDiscoversSingleCoordinator` |
| 2. Calling session reads `escalated` in `prism list-sessions` | `cmd/escalate.go::runEscalateForSession` (`UpsertStatus(..., StateEscalated, ...)`) → `TestEscalate_StateTransitionEscalated` |
| 3. No `has finished` notification fires while escalated | `internal/sidecar/notify.go::notifyCoordinator` (escalated guard) + `internal/sidecar/events.go` (debounce paths) → `TestNotifyCoordinator_EscalatedSuppressed`, `TestSocketPipe_FinishedDebounceSuppressedWhileEscalated` |
| 4. New event type `session.escalated` distinct from `session.finished` | `cmd/escalate.go::writeSessionEscalatedEvent` → `TestEscalate_BusEventDistinct` |
| 5. Payload carries source / target / prompt / pr_numbers / branch / head_sha / verdicts | `cmd/escalate.go::EscalationPayload` → `TestEscalate_BusEventDistinct` |
| 6. Any incoming `turn_start` clears `escalated` → `active` | `internal/agent/machine.go` adds `escalated → active` + sidecar `turn_start` handlers already write `active` unconditionally → `TestSocketPipe_TurnStartClearsEscalated` |
| 7. Multiple candidates + no `--to` → exits non-zero, state does NOT transition | `cmd/escalate.go::resolveEscalationTarget` returns error before `UpsertStatus` → `TestEscalate_MultipleCandidatesNoTo` |
| 8. Zero candidates → still transitions to escalated; bus event still fires (target empty); "no coordinator found" message echoed | `cmd/escalate.go::runEscalateForSession` (target nil branch) → `TestEscalate_NoCoordinatorStillEscalates` |
| 9. `--to <nonexistent>` exits non-zero without transitioning state | `cmd/escalate.go::resolveEscalationTarget` (CurrentStatus check) → `TestEscalate_ExplicitToMissingSession` |
| 10. Prompt body echoed into the calling session's own log | `cmd/escalate.go::echoEscalationToSelf` writes `escalation` event → `TestEscalate_PromptEchoedToSelf` |
| 11. No coupling to merge-queue state | The escalate flow only touches `agent_status`, `agent_events`, and `bus_messages`; `pending_merges` is untouched. Merge-queue watcher reads `pending_merges` independently of session state. |
| 12. `nix build .#prism` and `go test ./...` pass | Verified locally; CI gate will exercise the full homeless-shelter / `runChecks=true` path. |
| 13. Docs: SKILL.md, coordinator-agent prompt note the new state and event | `modules/programs/prism/opencode/skills/prism/SKILL.md` (new "Escalating to your coordinator" section), `modules/programs/prism/opencode/agents/coordinator.md` (new "Worker escalations" subsection), `modules/programs/prism/opencode/agents/worker.md` (recommends `prism escalate` over `prism prompt <repo>@main`). |

## Sample output

`prism list-sessions` after a worker escalates (worker rendered with the new
`escalated` colour, distinct from `active`/`finished`/`reviewing`):

```
SESSION                                   STATE     PORT    HARNESS     TITLE
nixos-config@main                         active    14001   pi          coordinator session
nixos-config@feature                      escalated         pi          worker — awaiting guidance
```

Bus event fixture (extracted from `TestEscalate_BusEventDistinct`):

```json
{
  "source": "repo@feature",
  "target": "repo@main",
  "prompt": "stuck on review",
  "occurred_at": "2026-05-09T11:42:55Z"
}
```

`session.escalated` is a distinct event type from `session.finished`; existing
handlers that subscribe only to `session.finished` continue to receive nothing
for escalations (verified by `TestEscalate_BusEventDistinct`'s explicit check
that `session.finished` event count is 0).

## Files

| File | What changed |
|---|---|
| `cmd/escalate.go` | New cobra command. Discovery, transport, payload, echo, host-API proxy. |
| `cmd/escalate_test.go` | 10 ACs covered. |
| `internal/agent/agent.go`, `machine.go`, `machine_test.go` | New `StateEscalated` constant; transitions for `active → escalated`, `escalated → active/finished/interrupted/error/deleted`; invalid-pair tests. |
| `internal/dashboard/style.go` | Yellow colour + `escalated` label so dashboard / `list-sessions` render the state distinctly. |
| `internal/db/status.go`, `coordinator_candidates_test.go` | New `CoordinatorCandidatesForRepo` discovery primitive (returns full slice for the multi-candidate branch; legacy `<repo>@main` rows included). |
| `internal/sidecar/notify.go` | `notifyCoordinator` skips when state is `escalated`. |
| `internal/sidecar/events.go` | Finished/idle/recovery debounce paths suppress the finished write while `escalated`. |
| `internal/sidecar/host_api.go` | New POST `/escalate` endpoint that shells out to `prism escalate` on the host (worker-container path). |
| `internal/sidecar/notify_escalated_test.go`, `sidecar_escalated_test.go` | AC #3 (notify suppression) and AC #6 (turn_start clears escalated). |
| `modules/programs/prism/opencode/skills/prism/SKILL.md` | New "Escalating to your coordinator with prism escalate" section: surface, state machine, discovery rules, bus event. |
| `modules/programs/prism/opencode/agents/coordinator.md` | New "Worker escalations — the session.escalated event" subsection. |
| `modules/programs/prism/opencode/agents/worker.md` | Recommends `prism escalate` over hand-crafted `prism prompt <repo>@main`. |

## Local self-check

```
$ go build ./...     # pass
$ go test -race ./... # pass (52s)
$ nix build .#prism  # pass
$ nix build --impure --no-link \
    --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
# pass — homeless-shelter sandbox does not break (no new code paths write under $HOME)
```
