### PR TITLE
fix(prism): tokenise git push detector to ignore quoted/heredoc substrings

### DIFF
--- a/modules/programs/prism/opencode/plugins/prism-hooks.test.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.test.ts
@@ -4,7 +4,12 @@
  * Run with: bun test prism-hooks.test.ts
  */
 import { describe, expect, test } from "bun:test";
-import { similarityKey } from "./prism-hooks";
+import {
+  similarityKey,
+  isGitPush,
+  stripQuotedAndHeredocRegions,
+  splitShellSegments,
+} from "./prism-hooks";
 
 // ── similarityKey tests ──────────────────────────────────────────────────────
 
@@ -206,6 +211,175 @@ describe("similarityKey — webfetch similarity", () => {
   test("key is prefixed with 'webfetch:'", () => {
     const key = similarityKey("webfetch", { url: "https://example.com" });
     expect(key).toMatch(/^webfetch:/);
+  });
+});
+
+// ── isGitPush tests (issue #1519) ───────────────────────────────────────────
+//
+// The detector is duplicated in pi/extensions/prism.ts — keep these tests in
+// step with prism.test.ts's `isGitPush` describe block.
+
+describe("isGitPush — positive cases", () => {
+  test("matches plain git push", () => {
+    expect(isGitPush("git push")).toBe(true);
+  });
+  test("matches git push origin main", () => {
+    expect(isGitPush("git push origin main")).toBe(true);
+  });
+  test("matches git push -u origin feat/x", () => {
+    expect(isGitPush("git push -u origin feat/x")).toBe(true);
+  });
+  test("matches git push --force-with-lease", () => {
+    expect(isGitPush("git push --force-with-lease")).toBe(true);
+  });
+  test("matches git -C /worktree push", () => {
+    expect(isGitPush("git -C /worktree push")).toBe(true);
+  });
+  test("matches git --git-dir=/path/.git push", () => {
+    expect(isGitPush("git --git-dir=/path/.git push")).toBe(true);
+  });
+  test("matches git --git-dir /path/.git push", () => {
+    expect(isGitPush("git --git-dir /path/.git push")).toBe(true);
+  });
+  test("matches cd /worktree && git push", () => {
+    expect(isGitPush("cd /worktree && git push")).toBe(true);
+  });
+  test("matches git status && git push (sequence)", () => {
+    expect(isGitPush("git status && git push")).toBe(true);
+  });
+  test("matches git status; git push (semicolon)", () => {
+    expect(isGitPush("git status; git push")).toBe(true);
+  });
+  test("matches a real git push at the end of a multi-line script", () => {
+    expect(
+      isGitPush("set -e\ngit add .\ngit commit -m wip\ngit push"),
+    ).toBe(true);
+  });
+});
+
+describe("isGitPush — false-positive guards (#1519)", () => {
+  test("echo with double-quoted git push does not match", () => {
+    expect(isGitPush('echo "git push"')).toBe(false);
+  });
+  test("echo with single-quoted git push does not match", () => {
+    expect(isGitPush("echo 'git push'")).toBe(false);
+  });
+  test("rg with quoted git push pattern does not match", () => {
+    expect(isGitPush('rg "git push"')).toBe(false);
+  });
+  test("rg with single-quoted git push pattern does not match", () => {
+    expect(isGitPush("rg 'git push'")).toBe(false);
+  });
+  test("grep with quoted git push pattern does not match", () => {
+    expect(isGitPush('grep -r "git push" modules/')).toBe(false);
+  });
+  test("ag with quoted git push pattern does not match", () => {
+    expect(isGitPush('ag "git push" .')).toBe(false);
+  });
+  test("awk with single-quoted git push pattern does not match", () => {
+    expect(isGitPush("awk '/git push/ { print }'")).toBe(false);
+  });
+  test("sed with single-quoted git push pattern does not match", () => {
+    expect(isGitPush("sed -n '/git push/p' file")).toBe(false);
+  });
+  test('git log --grep="git push" does not match', () => {
+    expect(isGitPush('git log --grep="git push"')).toBe(false);
+  });
+  test("heredoc body containing git push does not match", () => {
+    expect(isGitPush("cat <<'EOF'\ngit push\nEOF")).toBe(false);
+  });
+  test("multi-line heredoc issue template does not match", () => {
+    const cmd = [
+      "cat > /tmp/issue.md <<'EOF'",
+      "## Reproducer",
+      "",
+      "    git rebase origin/main",
+      "    git push --force-with-lease",
+      "",
+      "That is the recommended workflow.",
+      "EOF",
+    ].join("\n");
+    expect(isGitPush(cmd)).toBe(false);
+  });
+  test("<<-EOF heredoc body does not match", () => {
+    expect(isGitPush("cat <<-EOF\n\tgit push\n\tEOF")).toBe(false);
+  });
+  test('<<"EOF" heredoc body does not match', () => {
+    expect(isGitPush('cat <<"EOF"\ngit push\nEOF')).toBe(false);
+  });
+  test('echo "remember to git push" does not match', () => {
+    expect(isGitPush('echo "remember to git push"')).toBe(false);
+  });
+  test('git status | tee >(echo "git push") does not match', () => {
+    expect(isGitPush('git status | tee >(echo "git push")')).toBe(false);
+  });
+  test('git status | grep "git push" does not match', () => {
+    expect(isGitPush('git status | grep "git push"')).toBe(false);
+  });
+  test("git pushy (longer word) does not match", () => {
+    expect(isGitPush("git pushy")).toBe(false);
+  });
+  test("mygit push (different leading command) does not match", () => {
+    expect(isGitPush("mygit push")).toBe(false);
+  });
+  test("bare push (no git) does not match", () => {
+    expect(isGitPush("push origin main")).toBe(false);
+  });
+  test("git pull does not match", () => {
+    expect(isGitPush("git pull")).toBe(false);
+  });
+});
+
+describe("stripQuotedAndHeredocRegions", () => {
+  test("removes single-quoted body", () => {
+    expect(stripQuotedAndHeredocRegions("echo 'git push'")).not.toContain(
+      "git push",
+    );
+  });
+  test("removes double-quoted body", () => {
+    expect(stripQuotedAndHeredocRegions('echo "git push"')).not.toContain(
+      "git push",
+    );
+  });
+  test("removes heredoc body and marker", () => {
+    const out = stripQuotedAndHeredocRegions("cat <<'EOF'\ngit push\nEOF");
+    expect(out).not.toContain("git push");
+    expect(out).not.toContain("EOF");
+  });
+  test("preserves the rest of the heredoc command line", () => {
+    const out = stripQuotedAndHeredocRegions(
+      "cat > /tmp/x.md <<'EOF'\nbody\nEOF",
+    );
+    expect(out).toContain("cat");
+    expect(out).toContain("/tmp/x.md");
+    expect(out).not.toContain("body");
+  });
+});
+
+describe("splitShellSegments", () => {
+  test("splits on &&", () => {
+    expect(splitShellSegments("a && b")).toEqual(["a", "b"]);
+  });
+  test("splits on ||, |, ;, newline", () => {
+    expect(splitShellSegments("a || b | c ; d\ne")).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+    ]);
+  });
+  test("promotes process substitution body to its own segment", () => {
+    // After stripping the inner quoted region, `tee >(echo )` would split
+    // into ["tee", "echo"]. Verify against a concrete case.
+    const segs = splitShellSegments("tee >(echo hi)");
+    expect(segs).toContain("tee");
+    expect(segs).toContain("echo hi");
+  });
+  test("promotes $(...) body to its own segment", () => {
+    const segs = splitShellSegments("echo $(date +%s)");
+    expect(segs).toContain("echo");
+    expect(segs).toContain("date +%s");
   });
 });
 

--- a/modules/programs/prism/opencode/plugins/prism-hooks.ts
+++ b/modules/programs/prism/opencode/plugins/prism-hooks.ts
@@ -144,6 +144,182 @@ interface DoomLoopState {
   fired: boolean;
 }
 
+/**
+ * Check whether a bash command string is a real `git push` invocation.
+ *
+ * The previous implementation matched the literal substring `git ... push`
+ * anywhere in the raw command, which produced false positives for quoted
+ * arguments, heredoc bodies, and grep / awk / sed patterns (issue #1519).
+ *
+ * Strategy:
+ *   1. Strip heredoc bodies, single-quoted regions, and double-quoted
+ *      regions from the command — these never contain a real invocation.
+ *   2. Split what remains on shell separators (`;`, newline, `&&`, `||`,
+ *      `|`, `&`, and command/process substitution boundaries) so each
+ *      pipeline / sequence stage is examined independently.
+ *   3. Tokenise each segment on whitespace and check whether the leading
+ *      tokens form `git [-C <path>] [--git-dir=...|--git-dir <path>] push`.
+ *
+ * The implementation is intentionally duplicated in
+ * `modules/programs/prism/pi/extensions/prism.ts` (`isGitPush`,
+ * `stripQuotedAndHeredocRegions`, `splitShellSegments`) — the two files
+ * live in different package trees and a shared-package refactor is out of
+ * scope for #1519. Keep the two implementations in sync.
+ *
+ * Exported for unit testing.
+ */
+export function isGitPush(command: string): boolean {
+  const stripped = stripQuotedAndHeredocRegions(command);
+  for (const segment of splitShellSegments(stripped)) {
+    if (segmentIsGitPush(segment)) return true;
+  }
+  return false;
+}
+
+/**
+ * Remove heredoc bodies, single-quoted strings, and double-quoted strings
+ * from a bash command. Heredoc start tokens (`<<EOF`, `<<-EOF`, `<<'EOF'`,
+ * `<<"EOF"`) are also removed so they do not pollute the surrounding
+ * segment, but the rest of the command line containing them is preserved.
+ *
+ * Exported for unit testing.
+ */
+export function stripQuotedAndHeredocRegions(command: string): string {
+  // Pass 1: strip heredocs.
+  const lines = command.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const heredocRe = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/;
+    const m = line.match(heredocRe);
+    if (m && m.index !== undefined) {
+      const word = m[2];
+      // Keep the line with the marker removed.
+      out.push(line.slice(0, m.index) + line.slice(m.index + m[0].length));
+      i++;
+      while (i < lines.length && lines[i].trim() !== word) {
+        i++;
+      }
+      if (i < lines.length) i++;
+      continue;
+    }
+    out.push(line);
+    i++;
+  }
+
+  // Pass 2: strip quoted regions.
+  const text = out.join("\n");
+  let result = "";
+  let j = 0;
+  while (j < text.length) {
+    const ch = text[j];
+    if (ch === "\\" && j + 1 < text.length) {
+      result += " ";
+      j += 2;
+      continue;
+    }
+    if (ch === "'") {
+      const end = text.indexOf("'", j + 1);
+      if (end === -1) break;
+      result += " ";
+      j = end + 1;
+      continue;
+    }
+    if (ch === '"') {
+      let k = j + 1;
+      while (k < text.length) {
+        if (text[k] === "\\" && k + 1 < text.length) {
+          k += 2;
+          continue;
+        }
+        if (text[k] === '"') break;
+        k++;
+      }
+      if (k >= text.length) break;
+      result += " ";
+      j = k + 1;
+      continue;
+    }
+    result += ch;
+    j++;
+  }
+  return result;
+}
+
+/**
+ * Split a (quote-stripped) command string into individual command segments
+ * along shell separators. Process substitutions `<(...)` and `>(...)`,
+ * command substitutions `$(...)`, and backtick `` `...` `` regions are
+ * promoted to their own segments.
+ *
+ * Exported for unit testing.
+ */
+export function splitShellSegments(command: string): string[] {
+  const SEP = "\x00";
+  let s = "";
+  for (let i = 0; i < command.length; i++) {
+    const c = command[i];
+    const next = command[i + 1];
+    if ((c === "&" && next === "&") || (c === "|" && next === "|")) {
+      s += SEP;
+      i++;
+      continue;
+    }
+    if ((c === "<" || c === ">" || c === "$") && next === "(") {
+      s += SEP;
+      i++;
+      continue;
+    }
+    if (
+      c === "|" ||
+      c === "&" ||
+      c === ";" ||
+      c === "\n" ||
+      c === "(" ||
+      c === ")" ||
+      c === "`"
+    ) {
+      s += SEP;
+      continue;
+    }
+    s += c;
+  }
+  return s
+    .split(SEP)
+    .map((seg) => seg.trim())
+    .filter((seg) => seg.length > 0);
+}
+
+/**
+ * Decide whether a single tokenised command segment is a `git push`
+ * invocation. Accepts the leading-flag forms the prior regex accepted:
+ *   git push ...
+ *   git -C <path> push ...
+ *   git --git-dir <path> push ...
+ *   git --git-dir=<path> push ...
+ */
+function segmentIsGitPush(segment: string): boolean {
+  const tokens = segment.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length < 2) return false;
+  if (tokens[0] !== "git") return false;
+  let i = 1;
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (t === "-C" || t === "--git-dir") {
+      if (i + 1 >= tokens.length) return false;
+      i += 2;
+      continue;
+    }
+    if (t.startsWith("--git-dir=")) {
+      i += 1;
+      continue;
+    }
+    break;
+  }
+  return tokens[i] === "push";
+}
+
 export const PrismHooks: Plugin = async (pluginInput) => {
   // Set when a git push is detected; consumed on the next LLM turn to inject
   // a review reminder into the system prompt.
@@ -211,12 +387,11 @@ export const PrismHooks: Plugin = async (pluginInput) => {
     "tool.execute.after": async (input) => {
       if (input.tool === "bash") {
         const command: string = (input.args as any)?.command ?? "";
-        // Match push commands: `git push`, `git push <remote> <branch>`, etc.
-        // Also match `git -C <path> push` and `git --git-dir=... push` variants.
-        const isPush = /\bgit(\s+-C\s+\S+|\s+--git-dir\S*)*\s+push\b/.test(
-          command,
-        );
-        if (isPush) {
+        // Match real `git push` invocations only — see isGitPush() below for
+        // the tokenised check that ignores quoted arguments and heredoc
+        // bodies (issue #1519). The previous raw-string regex fired on
+        // commands such as `echo "git push"` and `rg "git push"`.
+        if (isGitPush(command)) {
           pendingReviewReminder = true;
         }
 

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -1152,6 +1152,7 @@ describe("GUARD_STATE_ENTRY_TYPE", () => {
 })
 
 describe("isGitPush", () => {
+  // ── Existing positive cases (preserved) ──────────────────────────────────
   it("matches plain git push", () => {
     assert.equal(isGitPush("git push"), true)
   })
@@ -1174,6 +1175,133 @@ describe("isGitPush", () => {
 
   it("does not match unrelated commands", () => {
     assert.equal(isGitPush("go test ./..."), false)
+  })
+
+  // ── #1519: additional positive cases ─────────────────────────────────────
+  it("matches git push --force-with-lease", () => {
+    assert.equal(isGitPush("git push --force-with-lease"), true)
+  })
+
+  it("matches git push -u origin feat/x", () => {
+    assert.equal(isGitPush("git push -u origin feat/x"), true)
+  })
+
+  it("matches git --git-dir=/path/.git push", () => {
+    assert.equal(isGitPush("git --git-dir=/path/.git push"), true)
+  })
+
+  it("matches git --git-dir /path/.git push (space form)", () => {
+    assert.equal(isGitPush("git --git-dir /path/.git push"), true)
+  })
+
+  it("matches cd /worktree && git push", () => {
+    assert.equal(isGitPush("cd /worktree && git push"), true)
+  })
+
+  it("matches git status && git push (sequence)", () => {
+    assert.equal(isGitPush("git status && git push"), true)
+  })
+
+  it("matches git status; git push origin main (semicolon)", () => {
+    assert.equal(isGitPush("git status; git push origin main"), true)
+  })
+
+  it("matches git push at the end of a multi-line script", () => {
+    assert.equal(isGitPush("set -e\ngit add .\ngit commit -m wip\ngit push"), true)
+  })
+
+  // ── #1519: false positives the old regex accepted ────────────────────────
+  it("does NOT match echo with double-quoted git push", () => {
+    assert.equal(isGitPush('echo "git push"'), false)
+  })
+
+  it("does NOT match echo with single-quoted git push", () => {
+    assert.equal(isGitPush("echo 'git push'"), false)
+  })
+
+  it("does NOT match rg with quoted git push pattern", () => {
+    assert.equal(isGitPush('rg "git push"'), false)
+  })
+
+  it("does NOT match rg with single-quoted git push pattern", () => {
+    assert.equal(isGitPush("rg 'git push'"), false)
+  })
+
+  it("does NOT match grep with quoted git push pattern", () => {
+    assert.equal(isGitPush('grep -r "git push" modules/'), false)
+  })
+
+  it("does NOT match ag with quoted git push pattern", () => {
+    assert.equal(isGitPush('ag "git push" .'), false)
+  })
+
+  it("does NOT match awk with single-quoted git push pattern", () => {
+    assert.equal(isGitPush("awk '/git push/ { print }'"), false)
+  })
+
+  it("does NOT match sed with single-quoted git push pattern", () => {
+    assert.equal(isGitPush("sed -n '/git push/p' file"), false)
+  })
+
+  it("does NOT match git log --grep=\"git push\"", () => {
+    assert.equal(isGitPush('git log --grep="git push"'), false)
+  })
+
+  it("does NOT match a heredoc body containing git push (single-line)", () => {
+    const cmd = "cat <<'EOF'\ngit push\nEOF"
+    assert.equal(isGitPush(cmd), false)
+  })
+
+  it("does NOT match a heredoc body containing git push (multi-line issue template)", () => {
+    const cmd = [
+      "cat > /tmp/issue.md <<'EOF'",
+      "## Reproducer",
+      "",
+      "    git rebase origin/main",
+      "    git push --force-with-lease",
+      "",
+      "That is the recommended workflow.",
+      "EOF",
+    ].join("\n")
+    assert.equal(isGitPush(cmd), false)
+  })
+
+  it("does NOT match a <<-EOF heredoc body", () => {
+    const cmd = "cat <<-EOF\n\tgit push\n\tEOF"
+    assert.equal(isGitPush(cmd), false)
+  })
+
+  it("does NOT match a <<\"EOF\" heredoc body", () => {
+    const cmd = 'cat <<"EOF"\ngit push\nEOF'
+    assert.equal(isGitPush(cmd), false)
+  })
+
+  it("does NOT match echo \"remember to git push\"", () => {
+    assert.equal(isGitPush('echo "remember to git push"'), false)
+  })
+
+  // ── #1519: pipeline / process-substitution edge cases ────────────────────
+  it("does NOT match git status | tee >(echo \"git push\")", () => {
+    assert.equal(isGitPush('git status | tee >(echo "git push")'), false)
+  })
+
+  it("does NOT match git status when piped to a quoted-arg consumer", () => {
+    assert.equal(isGitPush('git status | grep "git push"'), false)
+  })
+
+  it("matches git push at the end of a real pipeline", () => {
+    // Contrived but verifies pipeline tokenisation: a real git push as the
+    // tail stage of a pipeline still triggers.
+    assert.equal(isGitPush("true | git push"), true)
+  })
+
+  it("does NOT match the string 'git push' embedded in a longer word", () => {
+    assert.equal(isGitPush("git pushy"), false)
+    assert.equal(isGitPush("mygit push"), false)
+  })
+
+  it("does NOT match a bare 'push' subcommand without git", () => {
+    assert.equal(isGitPush("push origin main"), false)
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -335,11 +335,205 @@ export function restoreGuardState(
 }
 
 /**
- * Check whether a bash command string is a git push.
+ * Check whether a bash command string is a real `git push` invocation.
+ *
+ * The previous implementation matched the literal substring `git ... push`
+ * anywhere in the raw command, which produced false positives for:
+ *   - quoted arguments:  echo "git push", rg "git push"
+ *   - heredoc bodies:    cat <<'EOF' ... git push ... EOF
+ *   - log filters:       git log --grep="git push"
+ *   - awk/sed patterns:  awk '/git push/ { ... }'
+ *
+ * The principled fix (issue #1519) is to:
+ *   1. Strip heredoc bodies, single-quoted regions, and double-quoted
+ *      regions from the command — these never contain a real invocation.
+ *   2. Split what remains on shell separators (`;`, newline, `&&`, `||`,
+ *      `|`, `&`, and command/process substitution boundaries) so each
+ *      pipeline / sequence stage is examined independently.
+ *   3. Tokenise each segment on whitespace and check whether the leading
+ *      tokens form `git [-C <path>] [--git-dir=...|--git-dir <path>] push`.
+ *
  * Exported for unit testing.
  */
 export function isGitPush(command: string): boolean {
-  return /\bgit(\s+-C\s+\S+|\s+--git-dir\S*)*\s+push\b/.test(command)
+  const stripped = stripQuotedAndHeredocRegions(command)
+  for (const segment of splitShellSegments(stripped)) {
+    if (segmentIsGitPush(segment)) return true
+  }
+  return false
+}
+
+/**
+ * Remove heredoc bodies, single-quoted strings, and double-quoted strings
+ * from a bash command. Heredoc start tokens (`<<EOF`, `<<-EOF`, `<<'EOF'`,
+ * `<<"EOF"`) are also removed so they do not pollute the surrounding
+ * segment, but the rest of the command line containing them is preserved.
+ *
+ * This is a deliberately small lexer — it does not implement full POSIX
+ * shell quoting (no `$'...'`, no parameter expansion). It targets the
+ * dominant false-match cases described in #1519.
+ *
+ * Exported for unit testing.
+ */
+export function stripQuotedAndHeredocRegions(command: string): string {
+  // Pass 1: strip heredocs.
+  // Find each `<<[-]?(['"]?)WORD\1` marker on a line, drop the marker, then
+  // drop subsequent lines until a line whose trimmed content equals WORD.
+  const lines = command.split("\n")
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]
+    // Match the first heredoc opener on this line. We do not try to handle
+    // multiple heredocs on a single line — that is a vanishingly rare shape
+    // in agent-issued commands and stripping the first marker is sufficient
+    // to avoid a false match on its body.
+    const heredocRe = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/
+    const m = line.match(heredocRe)
+    if (m && m.index !== undefined) {
+      const word = m[2]
+      // Keep the line with the marker removed.
+      out.push(line.slice(0, m.index) + line.slice(m.index + m[0].length))
+      i++
+      // Skip body lines until we see the terminator. For `<<-WORD` the
+      // terminator may be indented; for `<<WORD` it must be flush. We treat
+      // both the same because being lenient errs on the side of stripping.
+      while (i < lines.length && lines[i].trim() !== word) {
+        i++
+      }
+      // Skip the terminator line itself if present.
+      if (i < lines.length) i++
+      continue
+    }
+    out.push(line)
+    i++
+  }
+
+  // Pass 2: strip quoted regions on the surviving text.
+  const text = out.join("\n")
+  let result = ""
+  let j = 0
+  while (j < text.length) {
+    const ch = text[j]
+    if (ch === "\\" && j + 1 < text.length) {
+      // Preserve escaped characters as-is so e.g. `\"` does not open a
+      // double-quoted region. We replace with a space so token boundaries
+      // are not accidentally created/removed.
+      result += " "
+      j += 2
+      continue
+    }
+    if (ch === "'") {
+      // Single quotes: no escapes inside; consume to next `'`.
+      const end = text.indexOf("'", j + 1)
+      if (end === -1) {
+        // Unterminated — drop the rest.
+        break
+      }
+      result += " " // placeholder to preserve token boundaries
+      j = end + 1
+      continue
+    }
+    if (ch === '"') {
+      // Double quotes: skip to next unescaped `"`.
+      let k = j + 1
+      while (k < text.length) {
+        if (text[k] === "\\" && k + 1 < text.length) {
+          k += 2
+          continue
+        }
+        if (text[k] === '"') break
+        k++
+      }
+      if (k >= text.length) break
+      result += " "
+      j = k + 1
+      continue
+    }
+    result += ch
+    j++
+  }
+  return result
+}
+
+/**
+ * Split a (quote-stripped) command string into individual command segments
+ * along shell separators. Process substitutions `<(...)` and `>(...)`,
+ * command substitutions `$(...)`, and backtick `` `...` `` regions are
+ * promoted to their own segments so a `git push` nested inside one is
+ * still considered a real invocation, while the surrounding command is
+ * also examined.
+ */
+export function splitShellSegments(command: string): string[] {
+  // Replace top-level shell separators with a sentinel \x00, while also
+  // splitting out substitution bodies as their own segments by replacing
+  // their delimiters with sentinels too.
+  const SEP = "\x00"
+  let s = ""
+  for (let i = 0; i < command.length; i++) {
+    const c = command[i]
+    const next = command[i + 1]
+    // Two-char operators first.
+    if ((c === "&" && next === "&") || (c === "|" && next === "|")) {
+      s += SEP
+      i++
+      continue
+    }
+    // Process / command substitution openers: `<(`, `>(`, `$(`.
+    if ((c === "<" || c === ">" || c === "$") && next === "(") {
+      s += SEP
+      i++
+      continue
+    }
+    if (
+      c === "|" ||
+      c === "&" ||
+      c === ";" ||
+      c === "\n" ||
+      c === "(" ||
+      c === ")" ||
+      c === "`"
+    ) {
+      s += SEP
+      continue
+    }
+    s += c
+  }
+  return s
+    .split(SEP)
+    .map((seg) => seg.trim())
+    .filter((seg) => seg.length > 0)
+}
+
+/**
+ * Decide whether a single tokenised command segment is a `git push`
+ * invocation. Accepts the leading-flag forms the prior regex accepted:
+ *   git push ...
+ *   git -C <path> push ...
+ *   git --git-dir <path> push ...
+ *   git --git-dir=<path> push ...
+ * and any combination/repetition of -C and --git-dir before `push`.
+ */
+function segmentIsGitPush(segment: string): boolean {
+  const tokens = segment.split(/\s+/).filter((t) => t.length > 0)
+  if (tokens.length < 2) return false
+  if (tokens[0] !== "git") return false
+  let i = 1
+  while (i < tokens.length) {
+    const t = tokens[i]
+    if (t === "-C" || t === "--git-dir") {
+      // Two-token form: skip the option and its argument.
+      if (i + 1 >= tokens.length) return false
+      i += 2
+      continue
+    }
+    if (t.startsWith("--git-dir=")) {
+      i += 1
+      continue
+    }
+    break
+  }
+  return tokens[i] === "push"
 }
 
 /** Per-field byte cap for tool args, tool output, and assistant message deltas. */


### PR DESCRIPTION
## Summary

The `git push` reminder hook fired on bash commands that merely *mentioned*
`git push` inside quoted args, heredoc bodies, or grep / rg / awk / sed
patterns — the previous detector matched the literal `git ... push` substring
anywhere in the raw command string. Real-world false matches observed:
authoring an issue body via heredoc that documented `git push --force-with-lease`,
and `rg "git push|prism review"` to investigate something.

## Fix

Replace the raw-string regex in both implementations with a tokenised check:

1. Strip heredoc bodies, single-quoted strings, and double-quoted strings from
   the command. These never contain a real invocation.
2. Split the remainder on shell separators (`;`, newline, `&&`, `||`, `|`, `&`)
   and command/process substitution boundaries (`<(...)`, `>(...)`, `$(...)`,
   `` `...` ``), so each pipeline / sequence stage is examined independently.
3. Tokenise each segment on whitespace and check whether the leading tokens
   form `git [-C <path>] [--git-dir=...|--git-dir <path>] push`.

Applied identically in:
- `modules/programs/prism/opencode/plugins/prism-hooks.ts`
- `modules/programs/prism/pi/extensions/prism.ts`

Detection logic is duplicated rather than shared because the two files live in
different package trees and a shared-package refactor is out of scope for #1519
(per the issue's "Out of scope" section). The two implementations are kept
byte-equivalent in behaviour and structure, with cross-references in their doc
comments so a future divergence is obvious.

## Tests

Test coverage extended in:
- `modules/programs/prism/opencode/plugins/prism-hooks.test.ts` — new
  `isGitPush`, `stripQuotedAndHeredocRegions`, `splitShellSegments` describe
  blocks (33 new test cases).
- `modules/programs/prism/pi/extensions/prism.test.ts` — existing `isGitPush`
  describe block extended (24 new test cases; existing 6 positives preserved).

All AC-mandated cases verified:
- `echo "git push"` / `echo 'git push'` / `rg "git push"` / `grep` / `ag` /
  `awk` / `sed` / `git log --grep="git push"` — do NOT trigger.
- Heredoc bodies (`'EOF'`, `"EOF"`, `-EOF`, multi-line issue template) —
  do NOT trigger.
- `git status | tee >(echo "git push")` — does NOT trigger.
- All real invocations including `-C`, `--git-dir=`, `--git-dir <p>`, `-u`,
  `--force-with-lease`, `cd /worktree && git push`, `git status && git push` —
  continue to trigger.

## Verification

- `bun test prism-hooks.test.ts` — 85 pass, 0 fail.
- `node --test --import tsx prism.test.ts` — 181 pass, 0 fail.
- `nix build .#prism` — succeeds.

No Go, `go.mod`, or workflow files changed, so the `go-tests` and
`nix-build-prism-checked` CI gates do not apply.

## Out of scope (per issue)

- Did NOT touch the `prism review <N>` cycle-counter regex (#1512 handles that
  structurally via the wire-frame source-of-truth approach).
- Did NOT consolidate the two implementations into a shared package — only the
  small `isGitPush` / `stripQuotedAndHeredocRegions` / `splitShellSegments` /
  `segmentIsGitPush` helpers were duplicated, with explicit doc-comment notes
  pointing each at its sibling.

Closes #1519