### PR TITLE
feat(review): pre-flight rebase gate for prism review (#1518)

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -165,6 +165,70 @@ prism review <pr-number>
 **Do NOT commit, merge, or announce completion** until the review-complete
 prompt arrives. When it does, handle PASS/FAIL per the worker agent instructions.
 
+### Pre-flight rebase gate (`prism review` refuses when behind `origin/main`)
+
+Before spawning any review agents, `prism review` runs a **one-shot pre-flight
+check**:
+
+1. `git fetch origin main` (one network round-trip).
+2. Strict ancestor check: `git merge-base --is-ancestor origin/main HEAD`.
+3. If `origin/main` is an ancestor of `HEAD`: proceed unchanged.
+4. If not: refuse, exit non-zero, **no agents spawn**, and **no cycle counter
+   increment**. The error message names the number of commits behind and the
+   recommended fix:
+
+   ```
+   prism review: branch is N commits behind origin/main
+
+       git fetch origin main
+       git rebase origin/main
+       git push --force-with-lease
+
+   Or rerun with --rebase to do this inline.
+   ```
+
+The `--rebase` flag is the inline opt-in fix:
+
+```bash
+prism review <pr> --rebase
+```
+
+It performs the fetch + rebase + force-push inline and then proceeds to the
+review against the rebased HEAD. If the rebase produces conflicts, the rebase
+is aborted, the worktree is restored to the original `HEAD`, and the command
+exits non-zero — never leaves the worktree mid-rebase. Resolve conflicts
+manually and re-run.
+
+**Why this gate exists.** Reviewers regularly produce noisy findings of the
+form "you should also update X" when X landed on `main` after the branch was
+cut. A simple rebase makes the diff smaller and the finding disappear, but
+discovering this from a FAIL verdict burns a full 5-agent cycle. The gate
+catches drift in one fetch, before any agent spawns.
+
+**Cycle-counter contract.** Gate failures (behind-main refusal, fetch failure,
+missing `origin/main`, rebase conflict abort) **do not increment** the
+review-cycle counter. They are the same category as "round already in
+progress" / pure-infrastructure failures: no agents spawned, no verdicts
+produced. A worker that hits the gate three times in a row and then runs
+three real reviews still has all three real cycles available before the
+LOOP-LIMIT footer fires.
+
+**Design notes:**
+
+- **Strict ancestor check, not loose.** A "files-touched-in-common" variant
+  sounds clever but breaks on renames, deletes, and cross-cutting helper
+  introductions. Strict `is-ancestor` is unambiguous and cheap.
+- **Refuse-by-default + opt-in `--rebase`, not auto-rebase.** A `review` verb
+  that silently mutates the branch is a footgun if the worker has uncommitted
+  work or local-only commits. Default refusal forces a deliberate choice.
+- **One-shot at the start, not continuous.** `main` can advance during a
+  review run; we do not chase that. The gate is a snapshot at review-spawn
+  time, consistent with how CI works.
+- **Same gate in host-direct and container-routed paths.** A container worker
+  routes through `/review` on the host sidecar; the gate runs on the host
+  side, and the refusal streams back to the container worker as a non-zero
+  review exit — same UX as a host-direct refusal.
+
 ### Handling no-start errors in review-complete prompts
 
 When a review-complete prompt says **"One or more review agents failed to start

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -301,8 +301,9 @@ func proxyPrompt(apiURL, session, prompt, deliverAs string) error {
 //
 // prNumber is the PR number to review (e.g. "123"). agents is an optional
 // list of agent names for --only filtering. timeout is an optional duration
-// string (e.g. "10m"). Returns an error if the host-side subprocess failed or
-// the connection was lost mid-stream.
+// string (e.g. "10m"). rebase requests an inline rebase onto origin/main
+// before the review (issue #1518). Returns an error if the host-side
+// subprocess failed or the connection was lost mid-stream.
 //
 // The response from the sidecar /review endpoint is a plain-text chunked stream
 // terminated by one of two sentinel lines:
@@ -311,7 +312,7 @@ func proxyPrompt(apiURL, session, prompt, deliverAs string) error {
 //	sidecar.ReviewSentinelFailed — subprocess exited non-zero
 //
 // This function consumes the sentinel and does NOT print it to stdout.
-func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) (string, error) {
+func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string, rebase bool) (string, error) {
 	// Build request body.
 	body := map[string]any{
 		"pr_number": prNumber,
@@ -321,6 +322,9 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string) 
 	}
 	if timeout != "" {
 		body["timeout"] = timeout
+	}
+	if rebase {
+		body["rebase"] = true
 	}
 
 	// The sidecar streams output as it arrives and closes the response body

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -1116,7 +1116,7 @@ func TestProxyReviewAsync_LinesArrivedProgressively(t *testing.T) {
 	var stdout string
 	var callErr error
 	stdout = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "123", nil, "")
+		_, callErr = proxyReviewAsync(srv.apiURL(), "123", nil, "", false)
 	})
 
 	if callErr != nil {
@@ -1152,7 +1152,7 @@ func TestProxyReviewAsync_SentinelConsumedNotEchoed(t *testing.T) {
 	var stdout string
 	var callErr error
 	stdout = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "42", nil, "")
+		_, callErr = proxyReviewAsync(srv.apiURL(), "42", nil, "", false)
 	})
 
 	if callErr != nil {
@@ -1186,7 +1186,7 @@ func TestProxyReviewAsync_FailedSentinelProducesError(t *testing.T) {
 	var stdout string
 	var callErr error
 	stdout = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "99", nil, "")
+		_, callErr = proxyReviewAsync(srv.apiURL(), "99", nil, "", false)
 	})
 
 	// proxyReviewAsync must return a non-nil error when sentinel says failed.
@@ -1223,7 +1223,7 @@ func TestProxyReviewAsync_MidStreamDisconnectReportsError(t *testing.T) {
 
 	var callErr error
 	_ = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "77", nil, "")
+		_, callErr = proxyReviewAsync(srv.apiURL(), "77", nil, "", false)
 	})
 
 	if callErr == nil {
@@ -1246,7 +1246,7 @@ func TestProxyReviewAsync_HTTP500BeforeStreamReturnsError(t *testing.T) {
 
 	var callErr error
 	_ = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "55", nil, "")
+		_, callErr = proxyReviewAsync(srv.apiURL(), "55", nil, "", false)
 	})
 
 	if callErr == nil {

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -16,6 +16,7 @@ package cmd
 //	--harness <name>    Runtime harness (default: "opencode")
 //	--timeout <dur>     Per-agent timeout (default: 10m)
 //	--only <csv>        Run only the named agents (e.g. review-goal,review-code)
+//	--rebase            Inline-rebase onto origin/main (fetch + rebase + force-push) before review
 
 import (
 	"fmt"
@@ -61,6 +62,7 @@ func init() {
 	reviewCmd.Flags().Int("diff-inline-max", 0,
 		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
 	reviewCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro); takes precedence over --model for the named role")
+	reviewCmd.Flags().Bool("rebase", false, "Fetch origin/main, rebase HEAD onto it, and force-push before running the review (inline fix for the rebase-gate refusal)")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -82,6 +84,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
 	onlyFlag, _ := cmd.Flags().GetString("only")
 	onlyChanged := cmd.Flags().Changed("only")
+	rebaseFlag, _ := cmd.Flags().GetBool("rebase")
 	diffInlineMaxFlag, _ := cmd.Flags().GetInt("diff-inline-max")
 	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
 	modelsByRole, err := parseModelOverrides(modelOverrideRaw)
@@ -123,6 +126,13 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// Container-mode detection: when PRISM_HOST_API is set the process is
 	// running inside a container where tmux is not available. Route the review
 	// through the host sidecar instead of calling review.RunAsync() directly.
+	//
+	// The pre-flight rebase gate runs on the host side, inside the subprocess
+	// spawned by the sidecar's /review handler (which sets cmd.Dir to the
+	// session's worktree). When the gate refuses, the host subprocess exits
+	// non-zero, the sidecar emits ReviewSentinelFailed, and proxyReviewAsync
+	// returns an error to the container worker — same UX as a host-direct
+	// refusal. See internal/review/preflight.go for the gate implementation.
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
 		// Agent list was already resolved and validated above (client-side,
 		// inside the container). This ensures that the --only flag is applied
@@ -139,7 +149,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		// proxyReviewAsync streams each output line to os.Stdout as it
 		// arrives — no further printing is needed here. The returned string
 		// is the buffered copy used for error context only.
-		_, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr)
+		_, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr, rebaseFlag)
 		if err != nil {
 			return fmt.Errorf("prism review: host API: %w", err)
 		}
@@ -161,6 +171,25 @@ func runReview(cmd *cobra.Command, args []string) error {
 	worktree, wtErr := resolveReviewWorktree(parentSession)
 	if wtErr != nil {
 		return wtErr
+	}
+
+	// Pre-flight rebase gate (#1518). Runs BEFORE any review-agent sessions
+	// are spawned and BEFORE any DB rows are written for this round, so a
+	// gate failure (refusal, fetch failure, conflict abort, missing upstream)
+	// cannot increment the review-cycle counter — that counter is derived
+	// from per-agent session rows by review.NextRoundNumber, and no such
+	// rows exist on the gate-failure path.
+	//
+	// Strict ancestor check: `git merge-base --is-ancestor origin/main HEAD`.
+	// On --rebase, the gate also performs fetch + rebase + force-push inline;
+	// on rebase conflict it aborts the rebase and restores HEAD before
+	// returning a non-zero error. Never leaves the worktree mid-rebase.
+	if gateErr := review.Preflight(review.PreflightOpts{
+		Worktree:   worktree,
+		Rebase:     rebaseFlag,
+		OnProgress: progressLineEager,
+	}); gateErr != nil {
+		return gateErr
 	}
 
 	// Resolve the effective isolation mode for spawning review agents.
@@ -221,10 +250,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 	// Flushing after each write is critical: the enclosing bash tool invocation
 	// makes stdout a pipe (not a TTY), so Go's default buffering would hold
 	// lines until the buffer fills. os.Stdout.Sync() forces an immediate flush.
-	progressLine := func(line string) {
-		fmt.Fprintln(os.Stdout, line)
-		_ = os.Stdout.Sync()
-	}
+	progressLine := progressLineEager
 
 	// Resolve the inline-max threshold from flag → env var → default.
 	// PRISM_REVIEW_DIFF_INLINE_MAX overrides the compiled-in default.
@@ -322,6 +348,18 @@ func runReview(cmd *cobra.Command, args []string) error {
 	fmt.Print(result.Ack)
 	_ = os.Stdout.Sync()
 	return nil
+}
+
+// progressLineEager writes and flushes a single progress line to stdout.
+// Flushing after each write is critical: the enclosing bash tool invocation
+// makes stdout a pipe (not a TTY), so Go's default buffering would hold
+// lines until the buffer fills. os.Stdout.Sync() forces an immediate flush.
+//
+// Used by both the pre-flight rebase gate (review.Preflight) and the
+// review-agent spawn loop (review.Opts.OnProgress).
+func progressLineEager(line string) {
+	fmt.Fprintln(os.Stdout, line)
+	_ = os.Stdout.Sync()
 }
 
 // agentsForHarness returns the agent list for the given harness.

--- a/modules/programs/prism/prism/internal/review/preflight.go
+++ b/modules/programs/prism/prism/internal/review/preflight.go
@@ -1,0 +1,317 @@
+package review
+
+// preflight.go — pre-flight rebase gate for `prism review`.
+//
+// Issue #1518: Reviews regularly produce noisy findings of the form "you should
+// also update X" when X landed on main after the branch was cut. A pre-flight
+// ancestor check on origin/main catches this in one fetch, before any agent
+// spawns, and either refuses the review or (with --rebase) fixes it inline.
+//
+// The gate is a snapshot at review-spawn time. It is not continuous — main can
+// advance during a review run; we do not chase that. This is consistent with
+// how CI works.
+//
+// Strict ancestor check via `git merge-base --is-ancestor origin/main HEAD`.
+// No "files-touched-in-common" / loose variant — that breaks on renames,
+// deletes, and cross-cutting helper introductions and gives different verdicts
+// in equivalent situations.
+//
+// Gate failures (refusal, fetch failure, conflict abort) MUST NOT increment the
+// review-cycle counter. The counter is computed by NextRoundNumber from
+// ~review-<N>-<agent> session rows in the DB; since the gate runs before
+// RunAsync spawns any agent sessions, no DB rows are created on a gate
+// failure and the counter is structurally unaffected.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// PreflightOpts configures the rebase gate.
+type PreflightOpts struct {
+	// Worktree is the absolute path to the git worktree. Required.
+	Worktree string
+	// Rebase, when true, performs fetch + rebase + force-push inline before
+	// the ancestor check. On rebase conflict the rebase is aborted, the
+	// worktree is restored to the original HEAD, and the gate returns an
+	// error — never leaving the worktree mid-rebase.
+	Rebase bool
+	// Remote is the git remote to fetch from. Defaults to "origin".
+	Remote string
+	// Branch is the upstream branch to check against. Defaults to "main".
+	Branch string
+	// OnProgress is an optional callback invoked for each progress event
+	// (fetch starting, rebase starting, etc.). When nil, progress is silent.
+	OnProgress func(line string)
+	// gitRunner is an injectable runner for tests; nil = real git.
+	gitRunner gitRunner
+}
+
+// gitRunner is the test seam for executing git in a specific worktree.
+type gitRunner interface {
+	run(worktree string, args ...string) (stdout string, stderr string, exitCode int, err error)
+}
+
+// realGit shells out to the system git binary.
+type realGit struct{}
+
+func (realGit) run(worktree string, args ...string) (string, string, int, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = worktree
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+			// Treat non-zero exit as a structured outcome rather than an
+			// error — callers inspect exitCode for git's pass/fail signal.
+			err = nil
+		}
+	}
+	return stdout.String(), stderr.String(), exitCode, err
+}
+
+// PreflightError is returned by Preflight when the gate refuses the review.
+// It carries a Refused flag so callers can distinguish gate refusals from
+// infrastructure errors (fetch failure, missing upstream) — both must exit
+// non-zero, but only refusal carries the "behind main" rebase guidance.
+type PreflightError struct {
+	// Msg is the user-facing error message, ready to display.
+	Msg string
+	// Refused is true when the gate refused because origin/main is not an
+	// ancestor of HEAD. False for infrastructure errors (fetch failure,
+	// missing upstream, conflict abort).
+	Refused bool
+	// CommitsBehind is the number of commits HEAD is behind the remote
+	// branch (origin/main..HEAD vs HEAD..origin/main). Populated only when
+	// Refused is true. Zero otherwise.
+	CommitsBehind int
+}
+
+func (e *PreflightError) Error() string { return e.Msg }
+
+// Preflight runs the rebase gate. It returns nil when origin/main is an
+// ancestor of HEAD (the review may proceed). On any failure (fetch failure,
+// missing upstream, behind-main refusal, rebase conflict) it returns a
+// *PreflightError with a ready-to-display message; the caller should print it
+// to stderr and exit non-zero. Preflight does not spawn any review agents and
+// does not touch the prism DB, so a Preflight failure cannot affect the
+// review-cycle counter (the counter is derived from per-agent session rows
+// written by RunAsync).
+func Preflight(opts PreflightOpts) error {
+	if opts.Worktree == "" {
+		return &PreflightError{Msg: "prism review: preflight: worktree path is required"}
+	}
+	remote := opts.Remote
+	if remote == "" {
+		remote = "origin"
+	}
+	branch := opts.Branch
+	if branch == "" {
+		branch = "main"
+	}
+	runner := opts.gitRunner
+	if runner == nil {
+		runner = realGit{}
+	}
+	progress := opts.OnProgress
+	if progress == nil {
+		progress = func(string) {}
+	}
+
+	// Step 1: capture original HEAD (only used to restore on conflict abort).
+	origHead, _, _, err := runOrErr(runner, opts.Worktree, "rev-parse", "HEAD")
+	if err != nil {
+		return &PreflightError{Msg: fmt.Sprintf("prism review: preflight: could not resolve HEAD: %v", err)}
+	}
+	origHead = strings.TrimSpace(origHead)
+
+	// Step 2: fetch the remote branch. One network round-trip; fast.
+	progress(fmt.Sprintf("preflight: fetching %s/%s …", remote, branch))
+	if _, stderr, code, fetchErr := runner.run(opts.Worktree, "fetch", remote, branch); fetchErr != nil || code != 0 {
+		// Fetch failure is fatal — no fallback to running the review against an
+		// unverified branch. Surface the underlying error verbatim so the user
+		// can see network/auth diagnostics.
+		var detail string
+		switch {
+		case fetchErr != nil:
+			detail = fetchErr.Error()
+		default:
+			detail = strings.TrimSpace(stderr)
+			if detail == "" {
+				detail = fmt.Sprintf("git fetch exited with code %d", code)
+			}
+		}
+		return &PreflightError{Msg: fmt.Sprintf("prism review: could not verify branch is up to date: git fetch %s %s failed: %s",
+			remote, branch, detail)}
+	}
+
+	remoteRef := remote + "/" + branch
+
+	// Step 3: verify the remote ref now exists (catches the "no origin/main
+	// configured" case where fetch is silently a no-op because the remote
+	// itself does not advertise main, or the local checkout has no origin).
+	if _, stderr, code, _ := runner.run(opts.Worktree, "rev-parse", "--verify", remoteRef); code != 0 {
+		return &PreflightError{Msg: fmt.Sprintf(`prism review: no %s ref configured.
+
+After 'git fetch %s %s' the ref %s is still not present. The branch has no
+upstream main configured (this is unusual but possible in local-only setups).
+
+Configure the remote:
+
+    git remote add %s <url>
+    git fetch %s %s
+
+Or, if origin already exists, ensure it advertises a 'main' branch.
+
+git stderr: %s`, remoteRef, remote, branch, remoteRef, remote, remote, branch, strings.TrimSpace(stderr))}
+	}
+
+	// Step 4 (optional): inline rebase. We do this BEFORE the ancestor check so
+	// that a successful rebase causes the ancestor check to pass naturally on
+	// the same Preflight call.
+	if opts.Rebase {
+		progress(fmt.Sprintf("preflight: rebasing onto %s …", remoteRef))
+		if _, stderr, code, runErr := runner.run(opts.Worktree, "rebase", remoteRef); runErr != nil || code != 0 {
+			// Rebase failed — abort it and restore HEAD to the original state.
+			// `git rebase --abort` is a no-op (exit 128 with "no rebase in
+			// progress") if the rebase did not actually start, so we run it
+			// unconditionally and ignore its exit code.
+			_, _, _, _ = runner.run(opts.Worktree, "rebase", "--abort")
+			// Defence in depth: if --abort somehow left HEAD shifted, force it
+			// back. `reset --hard <origHead>` is idempotent and safe.
+			if origHead != "" {
+				_, _, _, _ = runner.run(opts.Worktree, "reset", "--hard", origHead)
+			}
+			detail := strings.TrimSpace(stderr)
+			if detail == "" && runErr != nil {
+				detail = runErr.Error()
+			}
+			if detail == "" {
+				detail = fmt.Sprintf("git rebase exited with code %d", code)
+			}
+			return &PreflightError{Msg: fmt.Sprintf(`prism review: --rebase produced conflicts; rebase aborted, worktree restored to original HEAD.
+
+Resolve conflicts manually:
+
+    git fetch %s %s
+    git rebase %s
+    # resolve conflicts in the listed files
+    git add <files>
+    git rebase --continue
+    git push --force-with-lease
+
+Then re-run 'prism review <pr>'.
+
+git stderr (truncated):
+%s`, remote, branch, remoteRef, truncate(detail, 2000))}
+		}
+		// Rebase succeeded. Push with --force-with-lease so a concurrent push
+		// from another worker on the same branch is not silently overwritten.
+		progress("preflight: pushing rebased HEAD with --force-with-lease …")
+		if _, stderr, code, runErr := runner.run(opts.Worktree, "push", "--force-with-lease"); runErr != nil || code != 0 {
+			detail := strings.TrimSpace(stderr)
+			if detail == "" && runErr != nil {
+				detail = runErr.Error()
+			}
+			if detail == "" {
+				detail = fmt.Sprintf("git push exited with code %d", code)
+			}
+			return &PreflightError{Msg: fmt.Sprintf("prism review: --rebase succeeded locally but git push --force-with-lease failed: %s",
+				truncate(detail, 2000))}
+		}
+	}
+
+	// Step 5: strict ancestor check.
+	// `git merge-base --is-ancestor <ancestor> <descendant>` returns 0 when
+	// the first arg is an ancestor of the second, 1 when it is not, other
+	// codes on error (e.g. unknown ref).
+	_, stderr, code, runErr := runner.run(opts.Worktree, "merge-base", "--is-ancestor", remoteRef, "HEAD")
+	if runErr != nil {
+		return &PreflightError{Msg: fmt.Sprintf("prism review: preflight: merge-base failed: %v", runErr)}
+	}
+	switch code {
+	case 0:
+		// Up to date — proceed.
+		return nil
+	case 1:
+		// Not an ancestor — refuse with a clear message.
+		behind := countCommitsBehind(runner, opts.Worktree, remoteRef)
+		return &PreflightError{
+			Refused:       true,
+			CommitsBehind: behind,
+			Msg: fmt.Sprintf(`prism review: branch is %s behind %s
+
+main has advanced since this branch was cut. Reviewers will see drift
+that is not part of your change. Rebase first:
+
+    git fetch %s %s
+    git rebase %s
+    git push --force-with-lease
+
+Or rerun with --rebase to do this inline (only safe if your local branch
+has no uncommitted or local-only state worth preserving).`,
+				pluralCommits(behind), remoteRef, remote, branch, remoteRef),
+		}
+	default:
+		// Unknown ref or other git failure.
+		return &PreflightError{Msg: fmt.Sprintf("prism review: preflight: merge-base --is-ancestor exited with code %d: %s",
+			code, strings.TrimSpace(stderr))}
+	}
+}
+
+// countCommitsBehind returns the number of commits in remoteRef that are not in
+// HEAD (i.e. commits HEAD is missing). Best effort — returns 0 on any error.
+func countCommitsBehind(runner gitRunner, worktree, remoteRef string) int {
+	out, _, code, _ := runner.run(worktree, "rev-list", "--count", "HEAD.."+remoteRef)
+	if code != 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// pluralCommits formats a commit count for display.
+func pluralCommits(n int) string {
+	if n == 1 {
+		return "1 commit"
+	}
+	return fmt.Sprintf("%d commits", n)
+}
+
+// truncate clips s to maxLen runes, appending an ellipsis marker when clipped.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "\n… (truncated)"
+}
+
+// runOrErr is a thin wrapper that promotes a non-zero git exit to an error.
+// Used for "the command must succeed" steps where the caller does not want
+// to inspect the exit code separately.
+func runOrErr(r gitRunner, worktree string, args ...string) (string, string, int, error) {
+	stdout, stderr, code, err := r.run(worktree, args...)
+	if err != nil {
+		return stdout, stderr, code, err
+	}
+	if code != 0 {
+		detail := strings.TrimSpace(stderr)
+		if detail == "" {
+			detail = fmt.Sprintf("git %s exited with code %d", strings.Join(args, " "), code)
+		}
+		return stdout, stderr, code, errors.New(detail)
+	}
+	return stdout, stderr, code, nil
+}

--- a/modules/programs/prism/prism/internal/review/preflight_test.go
+++ b/modules/programs/prism/prism/internal/review/preflight_test.go
@@ -1,0 +1,507 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// ── fake gitRunner: scripted responses keyed by argv ──────────────────────────
+
+// scriptedResponse is one entry in the fakeGit script.
+type scriptedResponse struct {
+	stdout   string
+	stderr   string
+	exitCode int
+	err      error
+}
+
+// fakeGit is a gitRunner that returns scripted responses based on the args
+// (joined with spaces) it receives. Calls without a registered script entry
+// return a "no script for: ..." error so missing setup is loud.
+type fakeGit struct {
+	script map[string]scriptedResponse
+	calls  []string
+}
+
+func newFakeGit() *fakeGit {
+	return &fakeGit{script: map[string]scriptedResponse{}}
+}
+
+func (f *fakeGit) on(args string, resp scriptedResponse) *fakeGit {
+	f.script[args] = resp
+	return f
+}
+
+func (f *fakeGit) run(_ string, args ...string) (string, string, int, error) {
+	key := strings.Join(args, " ")
+	f.calls = append(f.calls, key)
+	resp, ok := f.script[key]
+	if !ok {
+		return "", "", 1, fmt.Errorf("fakeGit: no script for: %s", key)
+	}
+	return resp.stdout, resp.stderr, resp.exitCode, resp.err
+}
+
+func (f *fakeGit) called(args string) bool {
+	for _, c := range f.calls {
+		if c == args {
+			return true
+		}
+	}
+	return false
+}
+
+// ── unit tests against fakeGit ────────────────────────────────────────────────
+
+// TestPreflight_AncestorPasses verifies that when origin/main is an ancestor
+// of HEAD, Preflight returns nil (review may proceed).
+func TestPreflight_AncestorPasses(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin main", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/main", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("merge-base --is-ancestor origin/main HEAD", scriptedResponse{exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		gitRunner: fg,
+	})
+	if err != nil {
+		t.Fatalf("Preflight: unexpected error: %v", err)
+	}
+}
+
+// TestPreflight_AncestorFailsRefuses verifies that when origin/main is NOT an
+// ancestor of HEAD, Preflight returns a *PreflightError with Refused=true and
+// a message naming the commits-behind count and the rebase invocation.
+func TestPreflight_AncestorFailsRefuses(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin main", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/main", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("merge-base --is-ancestor origin/main HEAD", scriptedResponse{exitCode: 1}).
+		on("rev-list --count HEAD..origin/main", scriptedResponse{stdout: "4\n", exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight: expected error for behind-main branch, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if !pe.Refused {
+		t.Errorf("Preflight: expected Refused=true; got %+v", pe)
+	}
+	if pe.CommitsBehind != 4 {
+		t.Errorf("Preflight: expected CommitsBehind=4; got %d", pe.CommitsBehind)
+	}
+	for _, want := range []string{
+		"4 commits",
+		"behind origin/main",
+		"git rebase origin/main",
+		"--rebase",
+		"git push --force-with-lease",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight: refusal message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+}
+
+// TestPreflight_FetchFailureExitsNonZero verifies that a fetch failure exits
+// non-zero with a "could not verify branch is up to date" message and the
+// underlying error. No fallback to running the review against an unverified
+// branch.
+func TestPreflight_FetchFailureExitsNonZero(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin main", scriptedResponse{
+			stderr:   "fatal: unable to access 'https://example.com/repo.git/': Could not resolve host: example.com",
+			exitCode: 128,
+		})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight: expected fetch-failure error, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if pe.Refused {
+		t.Errorf("Preflight: fetch-failure must not be Refused=true; got %+v", pe)
+	}
+	for _, want := range []string{
+		"could not verify branch is up to date",
+		"git fetch origin main failed",
+		"Could not resolve host",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight: fetch-failure message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+	// Ancestor check must NOT have been called when fetch failed.
+	if fg.called("merge-base --is-ancestor origin/main HEAD") {
+		t.Error("Preflight: merge-base must not run when fetch fails")
+	}
+}
+
+// TestPreflight_NoOriginMainConfigured verifies that when the remote ref does
+// not exist after fetch (e.g. local-only setup with no origin/main), the gate
+// exits non-zero with a clear message instructing the user to configure origin.
+func TestPreflight_NoOriginMainConfigured(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin main", scriptedResponse{exitCode: 0}). // fetch is silently a no-op
+		on("rev-parse --verify origin/main", scriptedResponse{
+			stderr:   "fatal: Needed a single revision",
+			exitCode: 128,
+		})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight: expected missing-upstream error, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if pe.Refused {
+		t.Errorf("Preflight: missing-upstream must not be Refused=true; got %+v", pe)
+	}
+	for _, want := range []string{
+		"no origin/main ref configured",
+		"git remote add origin",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight: missing-upstream message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+}
+
+// TestPreflight_RebaseHappyPath verifies that --rebase runs fetch + rebase +
+// push --force-with-lease and that the ancestor check runs against the
+// (now-rebased) HEAD.
+func TestPreflight_RebaseHappyPath(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin main", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/main", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("rebase origin/main", scriptedResponse{exitCode: 0}).
+		on("push --force-with-lease", scriptedResponse{exitCode: 0}).
+		on("merge-base --is-ancestor origin/main HEAD", scriptedResponse{exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		Rebase:    true,
+		gitRunner: fg,
+	})
+	if err != nil {
+		t.Fatalf("Preflight (--rebase happy path): unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"fetch origin main",
+		"rebase origin/main",
+		"push --force-with-lease",
+		"merge-base --is-ancestor origin/main HEAD",
+	} {
+		if !fg.called(want) {
+			t.Errorf("Preflight (--rebase): expected %q to be called; calls=%v", want, fg.calls)
+		}
+	}
+}
+
+// TestPreflight_RebaseConflictAbortsAndRestores verifies that an inline-rebase
+// conflict triggers `git rebase --abort` and a `reset --hard <origHead>` to
+// restore the worktree, and returns a non-zero error instructing the worker to
+// resolve manually. The worktree must NEVER be left mid-rebase.
+func TestPreflight_RebaseConflictAbortsAndRestores(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin main", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/main", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("rebase origin/main", scriptedResponse{
+			stderr:   "CONFLICT (content): Merge conflict in foo.txt\nfatal: ...",
+			exitCode: 1,
+		}).
+		on("rebase --abort", scriptedResponse{exitCode: 0}).
+		on("reset --hard deadbeef", scriptedResponse{exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		Rebase:    true,
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight (--rebase conflict): expected error, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight (--rebase conflict): error is not *PreflightError: %T %v", err, err)
+	}
+	if pe.Refused {
+		t.Errorf("Preflight (--rebase conflict): must not be Refused=true; got %+v", pe)
+	}
+	for _, want := range []string{
+		"--rebase produced conflicts",
+		"rebase aborted",
+		"Resolve conflicts manually",
+		"CONFLICT (content)",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight (--rebase conflict): message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+	// The abort + reset must have been issued so the worktree is not
+	// left mid-rebase.
+	if !fg.called("rebase --abort") {
+		t.Errorf("Preflight (--rebase conflict): expected `rebase --abort`; calls=%v", fg.calls)
+	}
+	if !fg.called("reset --hard deadbeef") {
+		t.Errorf("Preflight (--rebase conflict): expected `reset --hard deadbeef` to restore HEAD; calls=%v", fg.calls)
+	}
+	// Ancestor check must NOT have been called after a conflict abort —
+	// the gate exits before reaching that step.
+	if fg.called("merge-base --is-ancestor origin/main HEAD") {
+		t.Errorf("Preflight (--rebase conflict): merge-base must not run after conflict abort; calls=%v", fg.calls)
+	}
+}
+
+// TestPreflight_NoIncrementsCounter is the explicit no-counter-increment test
+// required by the AC and by issue #1518. It exercises the contract that a
+// worker hitting the gate three times in a row (refusal, fetch failure,
+// conflict abort) and then running three real reviews must still have all
+// three real cycles available before the LOOP-LIMIT fires.
+//
+// The gate is implemented in Preflight, which runs BEFORE RunAsync writes
+// any per-agent session rows for a new round. The cycle counter
+// (NextRoundNumber) is derived purely from `<parent>~review-<N>-<agent>`
+// rows in agent_status — so the structural property is: as long as
+// Preflight does not write any such rows, the counter cannot move. This
+// test asserts that property by:
+//
+//  1. running Preflight three times against scripted gate failures, and
+//  2. verifying NextRoundNumber for the parent session still returns 1.
+//
+// This guards against a future refactor that, e.g., starts seeding round
+// rows from inside the gate or shares numbering with NextRoundNumber.
+func TestPreflight_NoIncrementsCounter(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	parent := "test-repo@feature"
+
+	// Sanity: counter starts at 1 (no prior rounds).
+	if got := NextRoundNumber(d, parent); got != 1 {
+		t.Fatalf("NextRoundNumber baseline: got %d, want 1", got)
+	}
+
+	cases := []struct {
+		name string
+		fg   *fakeGit
+		opts PreflightOpts
+	}{
+		{
+			name: "behind-main refusal",
+			fg: newFakeGit().
+				on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+				on("fetch origin main", scriptedResponse{exitCode: 0}).
+				on("rev-parse --verify origin/main", scriptedResponse{stdout: "abc\n", exitCode: 0}).
+				on("merge-base --is-ancestor origin/main HEAD", scriptedResponse{exitCode: 1}).
+				on("rev-list --count HEAD..origin/main", scriptedResponse{stdout: "2\n", exitCode: 0}),
+		},
+		{
+			name: "fetch failure",
+			fg: newFakeGit().
+				on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+				on("fetch origin main", scriptedResponse{stderr: "fatal: net", exitCode: 128}),
+		},
+		{
+			name: "rebase conflict abort",
+			fg: newFakeGit().
+				on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+				on("fetch origin main", scriptedResponse{exitCode: 0}).
+				on("rev-parse --verify origin/main", scriptedResponse{stdout: "abc\n", exitCode: 0}).
+				on("rebase origin/main", scriptedResponse{stderr: "CONFLICT", exitCode: 1}).
+				on("rebase --abort", scriptedResponse{exitCode: 0}).
+				on("reset --hard deadbeef", scriptedResponse{exitCode: 0}),
+		},
+	}
+
+	for _, tc := range cases {
+		opts := tc.opts
+		opts.Worktree = "/fake/worktree"
+		opts.gitRunner = tc.fg
+		// Conflict-abort case requires Rebase=true to take that branch.
+		if tc.name == "rebase conflict abort" {
+			opts.Rebase = true
+		}
+		if err := Preflight(opts); err == nil {
+			t.Errorf("%s: expected gate error, got nil", tc.name)
+		}
+		// After every gate failure, the counter must still be 1 — no
+		// per-agent session rows have been written.
+		if got := NextRoundNumber(d, parent); got != 1 {
+			t.Errorf("%s: NextRoundNumber after gate failure: got %d, want 1 (gate must not advance counter)", tc.name, got)
+		}
+	}
+
+	// Final assertion: three gate failures back to back must leave the
+	// counter exactly where it started.
+	if got := NextRoundNumber(d, parent); got != 1 {
+		t.Fatalf("after 3 gate failures: NextRoundNumber=%d, want 1 (gate failures must not consume cycles)", got)
+	}
+}
+
+// TestPreflight_WorktreeRequired verifies that Preflight refuses to run with
+// an empty worktree path (defence in depth — callers should always supply one).
+func TestPreflight_WorktreeRequired(t *testing.T) {
+	err := Preflight(PreflightOpts{})
+	if err == nil {
+		t.Fatal("Preflight: expected error for empty worktree, got nil")
+	}
+	if !strings.Contains(err.Error(), "worktree") {
+		t.Errorf("Preflight: empty-worktree error missing 'worktree': %v", err)
+	}
+}
+
+// ── integration test against a real local git repo ────────────────────────────
+
+// TestPreflight_RealGit_AncestorPasses creates a real local git repo with two
+// branches (main and feature), where feature is up to date with main, and
+// verifies Preflight passes against the real git binary. This exercises the
+// `realGit` runner end-to-end (the unit tests above use the fake runner).
+func TestPreflight_RealGit_AncestorPasses(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	worktree, _ := setupRealRepo(t)
+
+	if err := Preflight(PreflightOpts{Worktree: worktree}); err != nil {
+		t.Fatalf("Preflight: unexpected error on up-to-date branch: %v", err)
+	}
+}
+
+// TestPreflight_RealGit_BehindMainRefuses creates a real repo where main has
+// advanced past the feature branch (feature does not contain main's tip) and
+// verifies Preflight returns a Refused error.
+func TestPreflight_RealGit_BehindMainRefuses(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	worktree, advanceMain := setupRealRepo(t)
+	advanceMain(t, "extra commit on main")
+
+	err := Preflight(PreflightOpts{Worktree: worktree})
+	if err == nil {
+		t.Fatal("Preflight: expected refusal when main has advanced, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if !pe.Refused {
+		t.Errorf("Preflight: expected Refused=true; got %+v", pe)
+	}
+	if pe.CommitsBehind < 1 {
+		t.Errorf("Preflight: expected CommitsBehind >= 1; got %d", pe.CommitsBehind)
+	}
+}
+
+// setupRealRepo creates a bare "remote" plus a local clone, makes an initial
+// commit on main, branches a feature, and checks out feature. It returns the
+// feature worktree path and a helper that advances main on the bare remote so
+// that origin/main moves past feature after `git fetch origin main`.
+//
+// The helper also takes care of `t.TempDir()` cleanup; callers should not
+// inspect the returned remote.
+func setupRealRepo(t *testing.T) (worktree string, advanceMain func(t *testing.T, msg string)) {
+	t.Helper()
+
+	// Don't let any user-level git config (e.g. signing) interfere.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+
+	root := t.TempDir()
+	bare := filepath.Join(root, "remote.git")
+	mustGit(t, "", "init", "--bare", "-b", "main", bare)
+
+	// Local clone: this is our "feature" worktree.
+	worktree = filepath.Join(root, "local")
+	mustGit(t, "", "clone", bare, worktree)
+	mustGit(t, worktree, "config", "user.email", "test@example.com")
+	mustGit(t, worktree, "config", "user.name", "Test")
+	mustGit(t, worktree, "config", "commit.gpgsign", "false")
+	mustGit(t, worktree, "config", "tag.gpgsign", "false")
+
+	// Initial commit on main.
+	if err := os.WriteFile(filepath.Join(worktree, "README.md"), []byte("init\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustGit(t, worktree, "add", ".")
+	mustGit(t, worktree, "commit", "-m", "init")
+	mustGit(t, worktree, "push", "origin", "main")
+
+	// Branch off as `feature`. The clone's HEAD is now `feature` but
+	// origin/main is at the same commit (so the gate passes initially).
+	mustGit(t, worktree, "checkout", "-b", "feature")
+
+	// advanceMain: append a commit to main on the bare remote so that
+	// `git fetch origin main` from the worktree pulls a new origin/main
+	// that is NOT an ancestor of the feature HEAD.
+	advanceMain = func(t *testing.T, msg string) {
+		t.Helper()
+
+		// Use a separate scratch worktree on the bare remote to push from.
+		scratch := filepath.Join(root, "scratch-"+msg)
+		mustGit(t, "", "clone", bare, scratch)
+		mustGit(t, scratch, "config", "user.email", "test@example.com")
+		mustGit(t, scratch, "config", "user.name", "Test")
+		mustGit(t, scratch, "config", "commit.gpgsign", "false")
+		mustGit(t, scratch, "checkout", "main")
+		if err := os.WriteFile(filepath.Join(scratch, "advance.txt"), []byte(msg+"\n"), 0o644); err != nil {
+			t.Fatalf("write advance: %v", err)
+		}
+		mustGit(t, scratch, "add", ".")
+		mustGit(t, scratch, "commit", "-m", msg)
+		mustGit(t, scratch, "push", "origin", "main")
+	}
+	return worktree, advanceMain
+}
+
+// mustGit runs git with the given args in cwd (or the default cwd if empty),
+// failing the test if it returns non-zero.
+func mustGit(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1222,6 +1222,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			PRNumber string   `json:"pr_number"`
 			Agents   []string `json:"agents"`
 			Timeout  string   `json:"timeout"`
+			Rebase   bool     `json:"rebase"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -1256,6 +1257,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Timeout != "" {
 			args = append(args, "--timeout", req.Timeout)
+		}
+		if req.Rebase {
+			// Forward the inline-rebase request from the container worker so
+			// the host-side subprocess runs the gate with --rebase. The gate
+			// itself runs in the host subprocess (issue #1518).
+			args = append(args, "--rebase")
 		}
 
 		s.logger().Printf("sidecar: host-API /review: prism %s", strings.Join(args, " "))

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7275,6 +7275,98 @@ exit 0
 	}
 }
 
+// TestHostAPI_Review_RebaseForwarded verifies that when {"rebase": true} is
+// supplied in the /review request body, --rebase is appended to the prism
+// review subprocess argv. This is the container-routed path of the rebase
+// gate (issue #1518): the gate itself runs in the host subprocess, but the
+// rebase opt-in must thread through from the container worker.
+func TestHostAPI_Review_RebaseForwarded(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+echo "✓ review-code          passed"
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@feature",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@feature",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "worker",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "worker", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review",
+		`{"pr_number":"123","rebase":true}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "--rebase") {
+		t.Errorf("captured args %q do not contain '--rebase'", string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Review_RebaseDefaultOmitted verifies that when {"rebase":false}
+// (or when the field is absent) the --rebase flag is NOT forwarded to the
+// host subprocess. Defence against accidentally turning the opt-in into a
+// default.
+func TestHostAPI_Review_RebaseDefaultOmitted(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "nixos-config@feature",
+		Repo:            "nixos-config",
+		Worktree:        "/tmp/nixos-config@feature",
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "worker",
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, "worker", ""),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/review",
+		`{"pr_number":"123"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if strings.Contains(string(capturedArgs), "--rebase") {
+		t.Errorf("captured args %q must NOT contain '--rebase' when rebase=false", string(capturedArgs))
+	}
+}
+
 // TestHostAPI_Review_AckReturnedOnSuccess verifies that when `prism review`
 // exits 0 with an ack message (async model), the streaming response body
 // contains the ack lines followed by ReviewSentinelPassed.


### PR DESCRIPTION
## Summary

Add a pre-flight gate to `prism review <pr>` that runs `git fetch origin main` and refuses if `origin/main` is not an ancestor of HEAD. A new `--rebase` flag does fetch + rebase + force-push inline as the opt-in fix.

## Why

Reviewers regularly produce noisy findings of the form "you should also update X" when X landed on `main` after the branch was cut. The cleanest fix is a rebase, but discovering this from a FAIL verdict burns a full 5-agent cycle. The gate catches drift in one fetch, before any agent spawns.

## Behaviour

- **Strict ancestor check** via `git merge-base --is-ancestor origin/main HEAD`. No loose / files-touched-in-common variant.
- **Refuse-by-default; `--rebase` is opt-in.** Never silently mutates the branch.
- **One-shot at review-spawn time.** Snapshot, not continuous — consistent with how CI works.
- **Gate failures do NOT increment the review-cycle counter.** Refusal, fetch failure, conflict abort, and missing-upstream all exit non-zero before any per-agent session rows are written, so `NextRoundNumber` (the cycle counter) is structurally unaffected. Explicit test for this property: 3 gate failures × counter stays at 1.
- **`--rebase` conflict path:** `git rebase --abort` + `git reset --hard <origHead>` to restore the worktree, then exit non-zero with a clear "resolve manually" message. Never leaves the worktree mid-rebase.
- **Fetch failure:** exit non-zero with the underlying error. No fallback to running review against an unverified branch.
- **Missing `origin/main`:** exit non-zero with a clear message instructing the user to configure `origin`.
- **Same gate in host-direct AND container-routed paths.** Container workers invoke `/review` on the host sidecar; the host subprocess runs the gate (because `cmd.Dir = worktree`), and a refusal streams back to the container as a non-zero review exit.

## Files

- `internal/review/preflight.go` — `Preflight` + `PreflightOpts` + `PreflightError`. Injectable `gitRunner` for tests; production uses real git.
- `cmd/review.go` — calls `review.Preflight` after worktree resolution and before any concurrency-cap or `RunAsync` side effects. New `--rebase` flag.
- `internal/sidecar/host_api.go` — accepts `{"rebase":true}` in `/review` body and forwards `--rebase` to the host subprocess.
- `cmd/hostapi.go` — `proxyReviewAsync` threads the rebase flag through.
- `modules/programs/prism/opencode/skills/prism/SKILL.md` — documents the gate, the `--rebase` flag, the cycle-counter contract, and the rationale.

## Tests

- **`internal/review/preflight_test.go`** — ancestor pass, refusal (with commits-behind count and rebase guidance), fetch failure, missing `origin/main`, `--rebase` happy path, `--rebase` conflict abort + restore, no-counter-increment property, plus real-git integration tests for ancestor pass and behind-main refusal.
- **`internal/sidecar/sidecar_test.go`** — `TestHostAPI_Review_RebaseForwarded` and `TestHostAPI_Review_RebaseDefaultOmitted` verify the container-routed path forwards `--rebase` only when explicitly requested.

## Quality gates

- `go build ./...` ✓
- `go test ./...` ✓
- `nix build .#prism` ✓
- `nix build … prism.override { runChecks = true; }` (homeless-shelter sandbox) ✓ — tests use `t.TempDir()` for any $HOME / repo state.

Closes #1518