### PR TITLE
fix(cmd-tests): structural reset for cobra rootCmd flag bleed (#1521)

### DIFF
--- a/modules/programs/prism/prism/cmd/event_doomloop_test.go
+++ b/modules/programs/prism/prism/cmd/event_doomloop_test.go
@@ -16,6 +16,7 @@ import (
 // `prism event doom-loop-detected` writes a doom_loop_detected event to the DB
 // with the correct payload fields.
 func TestEventDoomLoopDetected_WritesEvent(t *testing.T) {
+	resetRootCmdFlags(t) // #1521: wipe leftover cobra flag state
 	// Unset PRISM_HOST_API so the direct DB path is exercised (#1254 — proxy
 	// tests are in event_proxy_test.go).
 	t.Setenv("PRISM_HOST_API", "")
@@ -86,6 +87,7 @@ func TestEventDoomLoopDetected_WritesEvent(t *testing.T) {
 // event even when the session does not have an agent_status row (repo/worktree
 // default to empty strings in that case).
 func TestEventDoomLoopDetected_UnknownSession(t *testing.T) {
+	resetRootCmdFlags(t) // #1521: wipe leftover cobra flag state
 	t.Setenv("PRISM_HOST_API", "")
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)
@@ -129,6 +131,7 @@ func TestEventDoomLoopDetected_UnknownSession(t *testing.T) {
 // TestEventDoomLoopDetected_DefaultCount verifies that the default count is 5
 // when not specified.
 func TestEventDoomLoopDetected_DefaultCount(t *testing.T) {
+	resetRootCmdFlags(t) // #1521: wipe leftover cobra flag state
 	t.Setenv("PRISM_HOST_API", "")
 	const session = "testrepo@main"
 
@@ -182,6 +185,7 @@ func TestEventDoomLoopDetected_DefaultCount(t *testing.T) {
 // TestEventDoomLoopDetected_PayloadContainsFields verifies the raw JSON payload
 // contains the expected field names.
 func TestEventDoomLoopDetected_PayloadContainsFields(t *testing.T) {
+	resetRootCmdFlags(t) // #1521: wipe leftover cobra flag state
 	t.Setenv("PRISM_HOST_API", "")
 	const session = "testrepo@main"
 

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -28,6 +28,10 @@ import (
 // event_proxy_test.go).
 func setupEventTestDB(t *testing.T, session string) string {
 	t.Helper()
+	// Wipe any rootCmd flag values left behind by a previous test (or a
+	// previous iteration under `go test -count=N`) before this test drives
+	// the cobra tree via rootCmd.SetArgs / rootCmd.Execute. See #1521.
+	resetRootCmdFlags(t)
 	t.Setenv("PRISM_HOST_API", "")
 	dbFile := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbFile)

--- a/modules/programs/prism/prism/cmd/incarnation_stats_test.go
+++ b/modules/programs/prism/prism/cmd/incarnation_stats_test.go
@@ -74,6 +74,10 @@ func writeSessionEvent(t *testing.T, d *db.DB, instanceID, sessionName, model st
 // It also clears PRISM_HOST_API so stats commands use the direct-DB path.
 func openIncarnationTestDB(t *testing.T) *db.DB {
 	t.Helper()
+	// Wipe any rootCmd flag values left behind by a previous test (or a
+	// previous iteration under `go test -count=N`) before this test drives
+	// the cobra tree via rootCmd.SetArgs / rootCmd.Execute. See #1521.
+	resetRootCmdFlags(t)
 	// Unset PRISM_HOST_API so stats commands use the direct-DB path.
 	t.Setenv("PRISM_HOST_API", "")
 	path := filepath.Join(t.TempDir(), "prism.db")

--- a/modules/programs/prism/prism/cmd/prompt_test.go
+++ b/modules/programs/prism/prism/cmd/prompt_test.go
@@ -19,8 +19,14 @@ import (
 // openPromptTestDB opens a temp DB, registers cleanup, and overrides the
 // package-level testDBPath so openDB() uses it. It also unsets PRISM_HOST_API
 // so runPrompt uses the local DB path, not the host-API proxy.
+//
+// As a deflake measure (#1521) it also calls resetRootCmdFlags so any
+// rootCmd flag values left behind by a previous test (or a previous iteration
+// under `go test -count=N`) are wiped before this test drives the cobra tree
+// via rootCmd.SetArgs / rootCmd.Execute.
 func openPromptTestDB(t *testing.T) *db.DB {
 	t.Helper()
+	resetRootCmdFlags(t)
 	// Ensure the host-API proxy is not active for these unit tests.
 	t.Setenv("PRISM_HOST_API", "")
 	path := filepath.Join(t.TempDir(), "prism.db")

--- a/modules/programs/prism/prism/cmd/rootcmd_reset_internal_test.go
+++ b/modules/programs/prism/prism/cmd/rootcmd_reset_internal_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+// Internal regression tests for resetRootCmdFlags itself.
+//
+// These tests target the helper directly, exercising both the scalar-flag
+// reset path and the slice/array-flag reset path. The slice path is the
+// subtle one: pflag's StringArray and StringSlice values track an internal
+// `changed` bit, and once it is set, Value.Set() *appends* rather than
+// *replaces*. Calling Set(DefValue) — where DefValue is "[]" for an empty
+// default — therefore appends the literal string "[]" to the slice, which
+// is precisely the corruption we want to prevent.
+
+import (
+	"testing"
+)
+
+// TestResetRootCmdFlags_ScalarFlagRestored verifies the basic scalar-flag
+// reset path: a string flag mutated by Execute() is restored to its
+// declared default after resetRootCmdFlags runs.
+func TestResetRootCmdFlags_ScalarFlagRestored(t *testing.T) {
+	// promptCmd's --deliver-as has a non-empty declared default ("steer").
+	// This is the exact flag whose bleed produced the #1521 flake.
+	flag := promptCmd.Flags().Lookup("deliver-as")
+	if flag == nil {
+		t.Fatal("--deliver-as flag not found on promptCmd")
+	}
+
+	// Mutate it as if a previous test had run.
+	if err := flag.Value.Set("bogus"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	flag.Changed = true
+	if got := flag.Value.String(); got != "bogus" {
+		t.Fatalf("pre-reset value = %q, want %q", got, "bogus")
+	}
+
+	// Reset and verify.
+	resetRootCmdFlags(t)
+	if got := flag.Value.String(); got != "steer" {
+		t.Errorf("post-reset value = %q, want %q (declared default)", got, "steer")
+	}
+	if flag.Changed {
+		t.Errorf("post-reset Changed = true, want false")
+	}
+}
+
+// TestResetRootCmdFlags_SliceFlagReplacedNotAppended verifies that for
+// pflag.SliceValue flags (StringArray, StringSlice), reset clears the slice
+// outright rather than appending to it. This is the bug the review caught:
+// without SliceValue.Replace(nil), the slice grows on every reset call,
+// silently corrupting the global flag tree.
+func TestResetRootCmdFlags_SliceFlagReplacedNotAppended(t *testing.T) {
+	// --abtest is a StringArray on spawnCmd with default nil ("[]").
+	flag := spawnCmd.Flags().Lookup("abtest")
+	if flag == nil {
+		t.Fatal("--abtest flag not found on spawnCmd")
+	}
+
+	// Mutate it as if a previous test had run with --abtest A --abtest B.
+	if err := flag.Value.Set("profileA"); err != nil {
+		t.Fatalf("Set profileA: %v", err)
+	}
+	if err := flag.Value.Set("profileB"); err != nil {
+		t.Fatalf("Set profileB: %v", err)
+	}
+	flag.Changed = true
+
+	// Round-trip the reset twice to prove the slice does not grow on
+	// repeated calls — exactly the corruption mode the previous review
+	// flagged. If the implementation ever regresses to Set(DefValue) on a
+	// slice, the second reset would observe a non-empty slice on entry.
+	resetRootCmdFlags(t)
+	if got := flag.Value.String(); got != "[]" {
+		t.Errorf("after first reset: --abtest = %q, want %q", got, "[]")
+	}
+	if flag.Changed {
+		t.Errorf("after first reset: Changed = true, want false")
+	}
+
+	// Second reset on an already-clean slice must remain clean.
+	resetRootCmdFlags(t)
+	if got := flag.Value.String(); got != "[]" {
+		t.Errorf("after second reset: --abtest = %q, want %q (slice grew on idempotent reset)",
+			got, "[]")
+	}
+}

--- a/modules/programs/prism/prism/cmd/rootcmd_reset_test.go
+++ b/modules/programs/prism/prism/cmd/rootcmd_reset_test.go
@@ -80,6 +80,23 @@ func resetRootCmdFlags(t *testing.T) {
 
 	doReset := func() {
 		walkAllFlags(rootCmd, func(f *pflag.Flag) {
+			// Slice / array flags need special handling. For these,
+			// pflag's Value.Set() *appends* (not replaces) once the
+			// underlying value's internal `changed` bit has been set,
+			// so calling Set(DefValue) corrupts the slice instead of
+			// resetting it (DefValue for an empty default is "[]",
+			// which would also be appended literally). The pflag
+			// SliceValue interface exposes Replace() which assigns
+			// outright and clears the internal changed bit — use it.
+			if sv, ok := f.Value.(pflag.SliceValue); ok {
+				if err := sv.Replace(nil); err != nil {
+					t.Fatalf("resetRootCmdFlags: cannot Replace --%s slice: %v",
+						f.Name, err)
+				}
+				f.Changed = false
+				return
+			}
+
 			def, ok := rootCmdFlagDefaults[f]
 			if !ok {
 				// A flag that did not exist at capture time. Cobra/pflag

--- a/modules/programs/prism/prism/cmd/rootcmd_reset_test.go
+++ b/modules/programs/prism/prism/cmd/rootcmd_reset_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+// Test seam for the shared cobra command tree.
+//
+// The cmd package uses a single global `rootCmd` (and its sub-command tree)
+// for both production and tests. Test cases drive the CLI by calling
+// rootCmd.SetArgs(...) followed by rootCmd.Execute(). Cobra/pflag stores the
+// parsed value of each flag on the *pflag.Flag object itself — once a flag
+// has been set, that value persists on the global object until something
+// explicitly resets it.
+//
+// This is the source of a real, reproducible test-bleed flake (#1521):
+//
+//   - TestRunPrompt_DeliverAs_InvalidValueRejected runs `prompt ... --deliver-as bogus`.
+//     After Execute() returns, the persistent --deliver-as flag value on the
+//     `prompt` sub-command is "bogus".
+//   - On the next iteration of `go test ./cmd/ -count=N` (N>1), cobra is not
+//     re-initialised (init() runs once per process). The "bogus" value is
+//     still live, so any later TestRunPrompt_* that invokes `prompt` without
+//     specifying --deliver-as inherits "bogus" and fails the client-side
+//     validation.
+//
+// The fix is purely structural: snapshot every flag's default value once,
+// and reset all `Changed` flags back to their declared default at the start
+// of each test that drives the cobra tree via rootCmd.SetArgs / rootCmd.Execute.
+// No production code changes — this is a test-only helper.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// rootCmdFlagDefaults captures the declared default value of every flag in
+// the rootCmd tree at process start. It is populated lazily (once) on first
+// use and never mutated thereafter, so it is safe to read from multiple
+// goroutines.
+var (
+	rootCmdFlagDefaultsOnce sync.Once
+	rootCmdFlagDefaults     = map[*pflag.Flag]string{}
+)
+
+// captureRootCmdFlagDefaults walks the rootCmd tree and records each flag's
+// declared default value (DefValue). This snapshot is the source of truth for
+// resetRootCmdFlags — it is taken before any test has a chance to mutate the
+// flags via SetArgs/Execute.
+func captureRootCmdFlagDefaults() {
+	rootCmdFlagDefaultsOnce.Do(func() {
+		walkAllFlags(rootCmd, func(f *pflag.Flag) {
+			rootCmdFlagDefaults[f] = f.DefValue
+		})
+	})
+}
+
+// walkAllFlags invokes fn on every flag (persistent + local) on c and on
+// every flag of every command reachable from c. Flags shared by multiple
+// commands are visited multiple times; that is harmless for both capture
+// (idempotent) and reset (idempotent).
+func walkAllFlags(c *cobra.Command, fn func(*pflag.Flag)) {
+	c.Flags().VisitAll(fn)
+	c.PersistentFlags().VisitAll(fn)
+	for _, sub := range c.Commands() {
+		walkAllFlags(sub, fn)
+	}
+}
+
+// resetRootCmdFlagsTo restores every flag in the rootCmd tree to its captured
+// default value and clears the Changed bit. Call this before a test that
+// drives rootCmd via SetArgs/Execute, to immunise it against any persistent
+// state left behind by a previous test (or a previous iteration under
+// `go test -count=N`). t.Cleanup also re-resets after the test so the next
+// test starts from a clean slate even if this test fails mid-flight.
+//
+// Only call this from non-parallel tests — rootCmd is a package-level global.
+func resetRootCmdFlags(t *testing.T) {
+	t.Helper()
+	captureRootCmdFlagDefaults()
+
+	doReset := func() {
+		walkAllFlags(rootCmd, func(f *pflag.Flag) {
+			def, ok := rootCmdFlagDefaults[f]
+			if !ok {
+				// A flag that did not exist at capture time. Cobra/pflag
+				// guarantees DefValue is the declared default, so falling
+				// back to f.DefValue is correct.
+				def = f.DefValue
+			}
+			// Set() is the public API for restoring a flag value. It also
+			// records Changed=true, so after the loop we explicitly clear
+			// Changed back to false to match the pristine post-init state.
+			if err := f.Value.Set(def); err != nil {
+				// A default value should always parse — if it does not,
+				// the flag was declared with an invalid default and that
+				// is a bug in the production code, not in the helper.
+				t.Fatalf("resetRootCmdFlags: cannot reset --%s to default %q: %v",
+					f.Name, def, err)
+			}
+			f.Changed = false
+		})
+		// Clear any leftover args from a prior SetArgs() call.
+		rootCmd.SetArgs(nil)
+	}
+
+	doReset()
+	t.Cleanup(doReset)
+}


### PR DESCRIPTION
## Summary

Deflake `cmd/` package tests under `go test ./cmd/ -count=N` (N>1) by adding
a test-only structural seam that resets the global `rootCmd` flag tree to
its declared defaults before each test that drives the CLI via
`rootCmd.SetArgs / rootCmd.Execute`.

## Culprit test and mechanism

**Culprit test:** `TestRunPrompt_DeliverAs_InvalidValueRejected` in
`cmd/prompt_test.go`. It runs `prompt ... --deliver-as bogus`, asserts the
CLI rejects the value, and exits.

**Mechanism — cobra/pflag global-state bleed:** the `cmd` package uses a
single global `rootCmd` for both production and tests. Cobra/pflag stores
the parsed value of each flag on the `*pflag.Flag` object itself — once a
flag has been set, that value persists on the global until something
explicitly resets it.

After `TestRunPrompt_DeliverAs_InvalidValueRejected` runs, the persistent
`--deliver-as` flag value on the `prompt` sub-command is `"bogus"`. On the
next iteration of `go test ./cmd/ -count=N`, `init()` does NOT re-run
(it ran once per process), so the `"bogus"` value is still live. Any later
`TestRunPrompt_*` that invokes `prompt` without specifying `--deliver-as`
inherits `"bogus"` and fails the client-side validation:

```
Error: invalid --deliver-as "bogus": accepted values are ["steer" "followUp" "nextTurn"]
```

Tests affected on `-count=20` (deterministic 9-test failure on iteration 2+,
before this change):

- `TestRunPrompt_PISession_RoutesThroughSidecarHostAPI`
- `TestRunPrompt_PISession_SocketMissingReturnsClearError`
- `TestRunPrompt_HTTPDelivery`
- `TestRunPrompt_NoPort_ReturnsError`
- `TestRunPrompt_HTTPError_ReturnsError`
- `TestRunPrompt_WaitingStateGuard`
- `TestRunPrompt_EndedSession`
- `TestRunPrompt_SessionNotFound`
- `TestRunPrompt_DeliverAs_DefaultIsSteer`

## Fix shape — test-only structural seam

Mirrors #1520's discipline: a small test seam, no production change.

`cmd/rootcmd_reset_test.go` (new file) provides:

- `captureRootCmdFlagDefaults` — snapshots every flag's declared default
  (`pflag.Flag.DefValue`) once via `sync.Once`. Walks the full tree:
  root + sub-commands, both `Flags()` and `PersistentFlags()`.
- `resetRootCmdFlags(t)` — restores each flag to its captured default,
  clears the `Changed` bit, and clears any leftover `SetArgs()` state.
  Schedules a `t.Cleanup` that re-resets after the test so the next test
  starts pristine even if this test fails mid-flight.

Wired into existing test fixtures (no per-test boilerplate):

- `openPromptTestDB` (`cmd/prompt_test.go`) — used by every `TestRunPrompt_*`
  and the `prompt_pi_test.go` tests.
- `setupEventTestDB` (`cmd/event_test.go`) — used by the `TestEvent*` family.
- `openIncarnationTestDB` (`cmd/incarnation_stats_test.go`) — used by
  `TestRunStats_*` and `TestRunStatsIncarnations_*`.
- The four `TestEventDoomLoopDetected_*` tests do their own setup, so each
  gets an explicit `resetRootCmdFlags(t)` call at the top.

## Verification

All from `modules/programs/prism/prism/`:

- `go test ./cmd/ -count=20` — passes (was failing on iteration 2+ before).
- `go test ./cmd/ -race -count=20` — passes (~7m30s on this host).
- `go test ./... -race` — passes.
- From repo root: `nix build .#prism` — succeeds.
- Homeless-shelter signal:
  `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'`
  — succeeds.

Reproducer confirmation: with the fix removed (`git stash`), the same
9 `TestRunPrompt_*` tests fail on iteration 2; restoring the fix makes
them pass deterministically across all 20 iterations.

## On the issue's `require-slot-ok~review-1-review-qa` symptom

The originally-reported `require-slot-ok~review-1-review-qa` leak-guard
symptom did **not** reproduce in this investigation. The cobra-flag bleed
above is the deterministic flake that reproduces under
`go test ./cmd/ -count=20`, and AC #2 in the issue
(`go test ./cmd/ -race -count=20` passes with zero failures across all 20
iterations) is now satisfied by this fix.

The two symptoms may share a root cause (test-bleed via shared globals
across iterations) but I cannot prove that without reproducing the
leak-guard variant. Marked `Refs #1521` rather than `Closes #1521` so the
coordinator can decide whether to keep the issue open for the
leak-guard symptom or close it after verifying the AC checklist.

## Out of scope

- Production code paths in `internal/session/`, `internal/sidecar/`,
  host-API `/spawn`, `cmd/spawn.go` — these are #1507's surface and were
  not touched.
- Other cobra-driven tests in adjacent packages — only the `cmd/` package
  uses the shared `rootCmd` global.

Refs #1521