### PR TITLE
pi extension: add bash deny list (git worktree prune/remove)

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -371,6 +371,8 @@ prism cleanup --yes --session "nixos-config@update-plex"
 
 Only call this after you have confirmed the PR is merged. The `--yes` path always force-deletes the branch — it does not check whether the branch is reachable from main, because squash-merges produce a different SHA on main than the branch tip.
 
+Pi sessions block `git worktree prune` and `git worktree remove` at the extension layer. When recovering from a failed spawn, use `prism cleanup` — do not reach for git plumbing.
+
 ## Querying prism state — prefer `--json` for scripting
 
 Every list-style and lookup-style prism subcommand supports a `--json` flag that emits a single JSON document to stdout — keys are snake_case, timestamps are RFC 3339, empty lists are `[]` (never null, never absent), and any informational/progress text routes to stderr. **When you need to parse prism output programmatically, always pass `--json`.** Screen-scraping tabular human-readable output is fragile and burns tokens.

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -30,6 +30,9 @@ import {
   similarityKey,
   processDoomLoop,
   isGitPush,
+  // Pre-tool-call bash deny list (#1528)
+  BLOCKED_BASH_PATTERNS,
+  checkBlockedBash,
   newDoomLoopState,
   snapshotGuardState,
   restoreGuardState,
@@ -1302,6 +1305,198 @@ describe("isGitPush", () => {
 
   it("does NOT match a bare 'push' subcommand without git", () => {
     assert.equal(isGitPush("push origin main"), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// BLOCKED_BASH_PATTERNS / checkBlockedBash (#1528)
+// ---------------------------------------------------------------------------
+
+describe("BLOCKED_BASH_PATTERNS", () => {
+  it("contains exactly two entries", () => {
+    assert.equal(BLOCKED_BASH_PATTERNS.length, 2)
+  })
+
+  it("has the git-worktree-prune entry", () => {
+    const ids = BLOCKED_BASH_PATTERNS.map((p) => p.id)
+    assert.ok(ids.includes("git-worktree-prune"))
+  })
+
+  it("has the git-worktree-remove entry", () => {
+    const ids = BLOCKED_BASH_PATTERNS.map((p) => p.id)
+    assert.ok(ids.includes("git-worktree-remove"))
+  })
+
+  it("every entry has id, match, and reason fields", () => {
+    for (const p of BLOCKED_BASH_PATTERNS) {
+      assert.equal(typeof p.id, "string")
+      assert.ok(p.id.length > 0)
+      assert.equal(typeof p.match, "function")
+      assert.equal(typeof p.reason, "string")
+      assert.ok(p.reason.length > 0)
+    }
+  })
+
+  it("every entry's reason names the recommended alternative (prism cleanup --yes --session)", () => {
+    for (const p of BLOCKED_BASH_PATTERNS) {
+      assert.ok(
+        p.reason.includes("prism cleanup --yes --session"),
+        `pattern ${p.id} reason should mention 'prism cleanup --yes --session'`,
+      )
+    }
+  })
+})
+
+describe("checkBlockedBash — git worktree prune (positive cases)", () => {
+  it("blocks plain 'git worktree prune'", () => {
+    const hit = checkBlockedBash("git worktree prune")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+
+  it("blocks 'git worktree prune -v'", () => {
+    const hit = checkBlockedBash("git worktree prune -v")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+
+  it("blocks 'git -C /path worktree prune'", () => {
+    const hit = checkBlockedBash("git -C /some/path worktree prune")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+
+  it("blocks 'git -C ../.bare worktree prune -v' (the incident command)", () => {
+    const hit = checkBlockedBash("git -C ../.bare worktree prune -v")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+
+  it("blocks 'git --git-dir=/p/.git worktree prune'", () => {
+    const hit = checkBlockedBash("git --git-dir=/p/.git worktree prune")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+
+  it("blocks 'git --git-dir /p/.git worktree prune'", () => {
+    const hit = checkBlockedBash("git --git-dir /p/.git worktree prune")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+
+  it("blocks the second segment of 'cd /repo && git worktree prune'", () => {
+    const hit = checkBlockedBash("cd /repo && git worktree prune")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-prune")
+  })
+})
+
+describe("checkBlockedBash — git worktree remove (positive cases)", () => {
+  it("blocks 'git worktree remove /path/to/wt'", () => {
+    const hit = checkBlockedBash("git worktree remove /path/to/wt")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-remove")
+  })
+
+  it("blocks 'git worktree remove --force /path'", () => {
+    const hit = checkBlockedBash("git worktree remove --force /path")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-remove")
+  })
+
+  it("blocks 'git -C /repo worktree remove --force /path'", () => {
+    const hit = checkBlockedBash("git -C /repo worktree remove --force /path")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-remove")
+  })
+
+  it("blocks 'git --git-dir=/p/.git worktree remove /wt'", () => {
+    const hit = checkBlockedBash("git --git-dir=/p/.git worktree remove /wt")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-worktree-remove")
+  })
+})
+
+describe("checkBlockedBash — negative cases (quoted / heredoc / grep)", () => {
+  it("does NOT block double-quoted 'git worktree prune' inside echo", () => {
+    assert.equal(checkBlockedBash('echo "git worktree prune"'), null)
+  })
+
+  it("does NOT block single-quoted 'git worktree prune' inside echo", () => {
+    assert.equal(checkBlockedBash("echo 'git worktree prune'"), null)
+  })
+
+  it("does NOT block rg searching for 'git worktree remove'", () => {
+    assert.equal(checkBlockedBash('rg "git worktree remove"'), null)
+  })
+
+  it("does NOT block grep searching for 'git worktree prune'", () => {
+    assert.equal(
+      checkBlockedBash('grep -r "git worktree prune" modules/'),
+      null,
+    )
+  })
+
+  it("does NOT block awk pattern containing 'git worktree prune'", () => {
+    assert.equal(
+      checkBlockedBash("awk '/git worktree prune/ { print }'"),
+      null,
+    )
+  })
+
+  it("does NOT block git log --grep with the literal string", () => {
+    assert.equal(
+      checkBlockedBash('git log --grep="git worktree prune"'),
+      null,
+    )
+  })
+
+  it("does NOT block heredoc body containing the literal string", () => {
+    const cmd = "cat <<'EOF'\ngit worktree prune\ngit worktree remove /wt\nEOF"
+    assert.equal(checkBlockedBash(cmd), null)
+  })
+
+  it("does NOT block heredoc body with double-quoted delimiter", () => {
+    const cmd = 'cat <<"EOF"\ngit worktree prune -v\nEOF'
+    assert.equal(checkBlockedBash(cmd), null)
+  })
+
+  it("does NOT match the string embedded in a longer word", () => {
+    assert.equal(checkBlockedBash("git worktree pruner"), null)
+    assert.equal(checkBlockedBash("git worktree removed"), null)
+  })
+
+  it("does NOT match unrelated git subcommands", () => {
+    assert.equal(checkBlockedBash("git worktree list"), null)
+    assert.equal(checkBlockedBash("git worktree add ../wt feature"), null)
+    assert.equal(checkBlockedBash("git status"), null)
+  })
+
+  it("does NOT match when there is no command", () => {
+    assert.equal(checkBlockedBash(""), null)
+  })
+})
+
+describe("checkBlockedBash — reason string content", () => {
+  it("returns the prune-pattern reason on a prune match", () => {
+    const hit = checkBlockedBash("git worktree prune")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.includes("git worktree prune"))
+    assert.ok(hit!.reason.includes("prism cleanup --yes --session"))
+    assert.ok(hit!.reason.includes("sandboxed agent"))
+  })
+
+  it("returns the remove-pattern reason on a remove match", () => {
+    const hit = checkBlockedBash("git worktree remove /wt")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.includes("git worktree remove"))
+    assert.ok(hit!.reason.includes("prism cleanup --yes --session"))
+  })
+
+  it("reason is prefixed with 'blocked by prism extension'", () => {
+    const hit = checkBlockedBash("git worktree prune")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.startsWith("blocked by prism extension:"))
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -536,6 +536,94 @@ function segmentIsGitPush(segment: string): boolean {
   return tokens[i] === "push"
 }
 
+// ---------------------------------------------------------------------------
+// Pre-tool-call bash deny list (#1528)
+// ---------------------------------------------------------------------------
+
+/**
+ * One entry in the bash deny list. Each entry is matched against an
+ * already-tokenised command segment (i.e. after `stripQuotedAndHeredocRegions`
+ * + `splitShellSegments` have run on the raw command).
+ *
+ * The `match` predicate receives a single segment string and returns true
+ * when the segment is a real invocation of the blocked command. The `reason`
+ * surfaces verbatim to the agent via pi's tool-result channel and should
+ * name the recommended alternative.
+ */
+export interface BlockedBashPattern {
+  id: string
+  match: (segment: string) => boolean
+  reason: string
+}
+
+/**
+ * Bash commands that the pi extension blocks before pi executes them.
+ *
+ * Add to this list only when a specific incident motivates a new entry.
+ * The opencode permission block has ~50 entries because it is the primary
+ * enforcement surface for opencode agents; the pi extension grows
+ * incrementally as agent behaviour demands. Keep entries tightly scoped
+ * — they are mandatory blocks with no per-session opt-out.
+ *
+ * Patterns match "real" git invocations after stripping quoted and
+ * heredoc regions and splitting on shell separators — same approach as
+ * `isGitPush`. The leading-flag form mirrors `segmentIsGitPush`: each
+ * regex accepts an optional `git -C <path>` and/or `git --git-dir[=]<path>`
+ * prefix before the subcommand.
+ */
+export const BLOCKED_BASH_PATTERNS: readonly BlockedBashPattern[] = [
+  {
+    id: "git-worktree-prune",
+    match: (segment: string) =>
+      /\bgit(\s+-C\s+\S+|\s+--git-dir\S*(\s+\S+)?)*\s+worktree\s+prune\b/.test(
+        segment,
+      ),
+    reason:
+      "blocked by prism extension: `git worktree prune` from inside a " +
+      "sandboxed agent will sever sibling sessions' git trees because " +
+      "their worktrees are not bind-mounted into your view. Use " +
+      "`prism cleanup --yes --session <name>` instead, or escalate " +
+      "to the user if the residual state is from a partial spawn.",
+  },
+  {
+    id: "git-worktree-remove",
+    match: (segment: string) =>
+      /\bgit(\s+-C\s+\S+|\s+--git-dir\S*(\s+\S+)?)*\s+worktree\s+remove\b/.test(
+        segment,
+      ),
+    reason:
+      "blocked by prism extension: `git worktree remove` from inside " +
+      "a sandboxed agent risks removing sibling sessions' worktrees " +
+      "(they are not bind-mounted into your view). Use " +
+      "`prism cleanup --yes --session <name>` instead.",
+  },
+]
+
+/**
+ * Check a raw bash command against the deny list.
+ *
+ * Returns the matching pattern's `{ id, reason }` on the first hit, or
+ * `null` when no pattern matches. The check strips quoted/heredoc regions
+ * and splits on shell separators first, so e.g. `echo "git worktree prune"`
+ * does not fire a block but `cd /repo && git worktree prune` does
+ * (the second segment).
+ *
+ * Exported for unit testing.
+ */
+export function checkBlockedBash(
+  command: string,
+): { id: string; reason: string } | null {
+  const stripped = stripQuotedAndHeredocRegions(command)
+  for (const segment of splitShellSegments(stripped)) {
+    for (const pattern of BLOCKED_BASH_PATTERNS) {
+      if (pattern.match(segment)) {
+        return { id: pattern.id, reason: pattern.reason }
+      }
+    }
+  }
+  return null
+}
+
 /** Per-field byte cap for tool args, tool output, and assistant message deltas. */
 export const TRUNCATION_LIMIT_BYTES = 8 * 1024 // 8 KiB
 
@@ -1625,6 +1713,30 @@ export default function prismExtension(pi: ExtensionAPI): void {
       }
     }
   })
+
+  // Pre-tool-call bash deny list (#1528). Runs on the `tool_call` event
+  // (fires before `tool_execution_start`) so the block is enforced *before*
+  // pi hands the command to the bash tool. Returning `{ block: true,
+  // reason }` causes pi to refuse execution and surface the reason string
+  // to the agent via the tool-result channel.
+  pi.on("tool_call", async (event) => {
+    const toolName =
+      typeof (event as { toolName?: unknown }).toolName === "string"
+        ? (event as { toolName: string }).toolName
+        : ""
+    if (toolName !== "bash") return
+    const input = (event as { input?: unknown }).input
+    const command =
+      typeof input === "object" && input !== null
+        ? (input as Record<string, unknown>).command
+        : undefined
+    if (typeof command !== "string") return
+    const hit = checkBlockedBash(command)
+    if (hit !== null) {
+      return { block: true, reason: hit.reason }
+    }
+  })
+
   pi.on("tool_execution_start", async (event, ctx) => {
     lastCtx = ctx
     if (!writer || !handshakeComplete) return


### PR DESCRIPTION
Adds a small pre-tool-call bash deny list to the prism pi extension at
`modules/programs/prism/pi/extensions/prism.ts`. Pi exposes a `tool_call`
event whose handler return value can include `{ block: true, reason: \"...\" }`
and pi refuses to execute the tool. This PR adds the surface and seeds it
with exactly two patterns motivated by the incident described in the issue:

- `git worktree prune` (any flags, any path argument)
- `git worktree remove` (any flags, any path argument)

Both are dangerous from inside a sandboxed agent because sibling sessions'
worktrees are not bind-mounted into the agent's view. The prune output reads
to the agent as \"stale entries, safe to remove\" but actually means \"the
bind-mount does not include this path\" — and pruning silently severs live
workers' git trees. The reason string surfaced on a block names the
recommended alternative (`prism cleanup --yes --session <name>`).

## Implementation

- `BlockedBashPattern` type, `BLOCKED_BASH_PATTERNS` list, and
  `checkBlockedBash()` exported from `prism.ts`. Patterns reuse the existing
  `stripQuotedAndHeredocRegions` / `splitShellSegments` helpers (PR #1525)
  so quoted strings, heredoc bodies, and grep patterns do not trigger the
  block.
- `pi.on(\"tool_call\", ...)` handler registered in `prismExtension`. No-op
  for non-bash tools and for bash invocations whose command is missing or
  non-string.
- Skill manifest gains a one-line note next to the cleanup section so
  agents reading the skill understand the block when it fires.

## Scope

Exactly the two patterns above — no other git-destructive commands, no
configurable per-session opt-out. Future incidents extend the list one
entry at a time. The point is incremental enforcement, not a
re-implementation of opencode's full permission block.

## Tests

30 new cases in `prism.test.ts` covering:
- Positive matches in every accepted form: bare, flagged, `git -C <path>`,
  `git --git-dir=<path>`, `git --git-dir <path>`, second segment of
  `cd /repo && git worktree prune`.
- Negative cases: double-quoted, single-quoted, rg/grep/awk searching for
  the literal string, `git log --grep`, heredoc bodies, longer-word
  prefixes (`git worktree pruner`), unrelated git subcommands.
- Reason string content (mentions `prism cleanup --yes --session`,
  prefixed with \"blocked by prism extension:\").
- Shape of `BLOCKED_BASH_PATTERNS` (exactly two entries, required fields).

Existing 181 tests still pass; total is now 211.

`nix build .#prism` succeeds.

Closes #1528