### PR TITLE
fix(cleanup,restart,restore): success-side observability for mutating commands

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -330,18 +331,25 @@ var cleanupCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 		sessionFlag, _ := cmd.Flags().GetString("session")
+		jsonFlag, _ := cmd.Flags().GetBool("json")
+
+		// --json implies --yes: emitting a single structured object is
+		// incompatible with an interactive TUI.
+		if jsonFlag && !yesFlag {
+			return fmt.Errorf("--json requires --yes (interactive cleanup is incompatible with structured output)")
+		}
 
 		// Inside a container: proxy all cleanup invocations to the host sidecar.
 		// The proxy handles both --yes (headless) and any future interactive paths.
+		// stdout and stderr from the host-side subprocess are forwarded verbatim,
+		// so the container caller sees the same per-resource progress lines as a
+		// host invocation (issue #1527).
 		if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
 			target := sessionFlag
 			if target == "" {
 				return fmt.Errorf("--session is required when running inside a container")
 			}
-			return proxyToHostAPI(apiURL, "/cleanup", map[string]any{
-				"session": target,
-				"yes":     yesFlag,
-			}, nil)
+			return proxyCleanupToHostAPI(apiURL, target, yesFlag, jsonFlag)
 		}
 
 		// Only require tmux when we need to auto-detect the current session.
@@ -365,7 +373,7 @@ var cleanupCmd = &cobra.Command{
 			// kill the tmux session, kill the sidecar, mark the DB as ended.
 			// No git operations (no worktree removal, no branch deletion).
 			if yesFlag {
-				return headlessCloseSession(session)
+				return headlessCloseSessionWithJSON(session, jsonFlag)
 			}
 			// Interactive path: simplified confirmation (no worktree/branch prompts).
 			if os.Getenv("TMUX") == "" {
@@ -406,7 +414,7 @@ var cleanupCmd = &cobra.Command{
 				} else {
 					fmt.Fprintf(os.Stderr, "[prism] warning: could not determine worktree path for session %q — skipping worktree removal\n", session)
 				}
-				return headlessCleanup(session, worktreeName, "", "")
+				return headlessCleanupWithJSON(session, worktreeName, "", "", jsonFlag)
 			} else {
 				return fmt.Errorf("could not determine worktree path for session %q (not found in tmux windows or DB)", session)
 			}
@@ -430,7 +438,7 @@ var cleanupCmd = &cobra.Command{
 			// session and mark the DB as ended, but keep the worktree
 			// and branch intact.
 			if yesFlag {
-				return headlessCloseSession(session)
+				return headlessCloseSessionWithJSON(session, jsonFlag)
 			}
 			// Interactive path: simplified confirmation (no worktree/branch prompts).
 			if os.Getenv("TMUX") == "" {
@@ -448,7 +456,7 @@ var cleanupCmd = &cobra.Command{
 
 		// Non-interactive path: --yes skips all prompts and runs headlessly.
 		if yesFlag {
-			return headlessCleanup(session, worktreeName, worktreePath, bareRoot)
+			return headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot, jsonFlag)
 		}
 
 		// Interactive TUI requires tmux (bubbletea needs a real TTY).
@@ -463,6 +471,33 @@ var cleanupCmd = &cobra.Command{
 	},
 }
 
+// cleanupResult tracks per-resource outcomes for one headless cleanup. It is
+// the source of truth for both the textual progress lines (host-path output)
+// and the structured --json object. Empty/false fields mean the corresponding
+// resource was not touched (e.g. worktree path unknown — see
+// worktreeRemoved=nil for the JSON encoding).
+type cleanupResult struct {
+	Session         string  `json:"session"`
+	WorktreeRemoved *string `json:"worktree_removed"` // nil when no worktree was touched
+	BranchDeleted   *string `json:"branch_deleted"`   // nil when no branch was deleted
+	SessionKilled   bool    `json:"session_killed"`
+}
+
+// emitCleanupJSON writes the cleanup result as a single JSON object on a line
+// to os.Stdout. Used by the --json path; mutually exclusive with the textual
+// per-step lines.
+func emitCleanupJSON(r cleanupResult) {
+	data, err := json.Marshal(r)
+	if err != nil {
+		// Marshal of a small fixed-shape struct should never fail; surface
+		// the error on stderr so the caller has something to work with
+		// rather than empty stdout.
+		fmt.Fprintf(os.Stderr, "[prism] warning: cleanup --json: marshal: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
 // headlessCleanup removes the worktree and session without any TUI interaction.
 // It always force-deletes the branch, relying on the orchestrator-trust
 // contract: the orchestrator should only call this after confirming the PR has
@@ -475,29 +510,48 @@ var cleanupCmd = &cobra.Command{
 // missing on disk).  In that case the worktree and branch removal steps are
 // skipped, and cleanup continues with sidecar teardown and DB updates.
 func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error {
+	return headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot, false)
+}
+
+// headlessCleanupWithJSON is the JSON-aware form of headlessCleanup. When
+// jsonMode is true, per-step textual progress lines are suppressed and a
+// single JSON object is emitted on success. Stderr warnings (e.g. branch
+// delete failure, archive collision) are preserved in both modes per AC.
+func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot string, jsonMode bool) error {
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyToHostAPI(apiURL, "/cleanup", map[string]any{
-			"session": session,
-			"yes":     true,
-		}, nil)
+		return proxyCleanupToHostAPI(apiURL, session, true, jsonMode)
+	}
+
+	result := cleanupResult{Session: session}
+
+	printLine := func(format string, a ...any) {
+		if !jsonMode {
+			fmt.Printf(format, a...)
+		}
 	}
 
 	if worktreePath == "" {
-		fmt.Printf("worktree path unknown — skipping worktree removal for session %s\n", session)
+		printLine("worktree path unknown — skipping worktree removal for session %s\n", session)
 	} else {
-		fmt.Printf("removing worktree %s...\n", worktreePath)
+		printLine("removing worktree %s...\n", worktreePath)
 		if err := git.RemoveWorktree(bareRoot, worktreePath); err != nil {
 			// Non-fatal: the path may no longer be a registered git worktree
 			// (e.g. already removed, or pointing at the prism source dir).
 			// Log a warning and continue so sidecar/DB cleanup still happens.
 			fmt.Fprintf(os.Stderr, "[prism] warning: worktree remove: %v — continuing cleanup\n", err)
+		} else {
+			wt := worktreePath
+			result.WorktreeRemoved = &wt
 		}
 	}
 
 	if bareRoot != "" && git.BranchExists(bareRoot, worktreeName) {
-		fmt.Printf("deleting branch %s...\n", worktreeName)
+		printLine("deleting branch %s...\n", worktreeName)
 		if err := git.ForceDeleteBranch(bareRoot, worktreeName); err != nil {
 			fmt.Fprintf(os.Stderr, "[prism] warning: branch delete: %v — continuing cleanup\n", err)
+		} else {
+			bn := worktreeName
+			result.BranchDeleted = &bn
 		}
 	}
 
@@ -518,9 +572,21 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		}
 	}
 
-	fmt.Printf("killing session %s\n", session)
+	printLine("killing session %s\n", session)
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
+	// session_killed reflects the post-condition (tmux session is gone),
+	// which is true whether the session was alive or already-dead before this
+	// call. KillSession's error is intentionally ignored above (it returns
+	// non-nil for already-dead sessions, which is not a failure for our
+	// purposes), so we set the field unconditionally here.
+	result.SessionKilled = true
+	// archiveCollisionWarning records a non-fatal archive-already-exists
+	// outcome so it can be surfaced as a stderr warning at the end of cleanup
+	// rather than aborting (per the issue-comment AC: archive.ErrAlreadyExists
+	// is a benign collision once worktree/branch/session are already torn
+	// down). Other steps continue as normal.
+	var archiveCollisionWarning string
 	if d, err := openDB(); err == nil {
 		// Stop and remove child review-agent containers BEFORE removing their
 		// DB rows — so a failed stop still has a record to retry against.
@@ -549,9 +615,13 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 			// Archive the session storage after recording the end state.
 			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
 				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
-					_ = d.PurgeBusMessages(session)
-					d.Close()
-					return archiveErr
+					// Non-fatal: by this point the worktree, branch, tmux
+					// session, and DB rows are already torn down. The collision
+					// just means a previous cleanup attempt for the same
+					// instance_id already wrote the archive directory. Surface
+					// it as a stderr warning instead of aborting (issue #1527
+					// follow-up).
+					archiveCollisionWarning = archiveErr.Error()
 				}
 				// Other archive errors are non-fatal — cleanup continues.
 			}
@@ -568,7 +638,14 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 		review.KillReviewSessionsForParent(session)
 		removeContainerIfExists(session)
 	}
-	fmt.Println("done")
+	if archiveCollisionWarning != "" {
+		fmt.Fprintf(os.Stderr, "[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
+	}
+	if jsonMode {
+		emitCleanupJSON(result)
+	} else {
+		fmt.Println("done")
+	}
 	return nil
 }
 
@@ -639,14 +716,26 @@ func closeSession(session string) error {
 // It kills the tmux session and marks the DB as ended without touching the
 // worktree or branch (for @main) or without any git operations (for non-@ sessions).
 func headlessCloseSession(session string) error {
+	return headlessCloseSessionWithJSON(session, false)
+}
+
+// headlessCloseSessionWithJSON is the JSON-aware form of headlessCloseSession.
+// When jsonMode is true, per-step textual progress lines are suppressed and a
+// single JSON object is emitted on success (worktree_removed=null,
+// branch_deleted=null since this path never touches them).
+func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyToHostAPI(apiURL, "/cleanup", map[string]any{
-			"session": session,
-			"yes":     true,
-		}, nil)
+		return proxyCleanupToHostAPI(apiURL, session, true, jsonMode)
 	}
 
-	fmt.Printf("closing session %s...\n", session)
+	result := cleanupResult{Session: session}
+	printLine := func(format string, a ...any) {
+		if !jsonMode {
+			fmt.Printf(format, a...)
+		}
+	}
+
+	printLine("closing session %s...\n", session)
 
 	// Ensure scratchpad exists.
 	if !tmux.HasSession("scratchpad") {
@@ -664,9 +753,11 @@ func headlessCloseSession(session string) error {
 		}
 	}
 
-	fmt.Printf("killing session %s\n", session)
+	printLine("killing session %s\n", session)
+	result.SessionKilled = true
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
+	var archiveCollisionWarning string
 	if d, err := openDB(); err == nil {
 		// Stop and remove child review-agent containers BEFORE removing their
 		// DB rows — so a failed stop still has a record to retry against.
@@ -693,9 +784,8 @@ func headlessCloseSession(session string) error {
 			// Archive the session storage after recording the end state.
 			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
 				if errors.Is(archiveErr, archive.ErrAlreadyExists) {
-					_ = d.PurgeBusMessages(session)
-					d.Close()
-					return archiveErr
+					// Non-fatal: see headlessCleanup for rationale.
+					archiveCollisionWarning = archiveErr.Error()
 				}
 				// Other archive errors are non-fatal — cleanup continues.
 			}
@@ -710,7 +800,14 @@ func headlessCloseSession(session string) error {
 		review.KillReviewSessionsForParent(session)
 		removeContainerIfExists(session)
 	}
-	fmt.Println("done")
+	if archiveCollisionWarning != "" {
+		fmt.Fprintf(os.Stderr, "[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
+	}
+	if jsonMode {
+		emitCleanupJSON(result)
+	} else {
+		fmt.Println("done")
+	}
 	return nil
 }
 
@@ -985,6 +1082,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 func init() {
 	cleanupCmd.Flags().Bool("yes", false, "Non-interactive: skip all prompts and clean up immediately")
 	cleanupCmd.Flags().String("session", "", "Target session name (default: current session)")
+	cleanupCmd.Flags().Bool("json", false, "Emit a single JSON object describing per-resource outcomes (requires --yes)")
 	rootCmd.AddCommand(cleanupCmd)
 }
 

--- a/modules/programs/prism/prism/cmd/cleanup_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_proxy_test.go
@@ -1,0 +1,158 @@
+// Tests for the container-side cleanup proxy (proxyCleanupToHostAPI).
+//
+// These tests stand up a mock host-API on a Unix socket, send a cleanup
+// request through proxyCleanupToHostAPIWithWriters, and assert that the
+// stdout/stderr returned by the host are forwarded byte-for-byte to the
+// caller's writers. This is the inverse direction of the host-side test in
+// internal/sidecar/host_api_cleanup_test.go: together they cover both ends
+// of the wire (issue #1527 AC #1).
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestProxyCleanupToHostAPI_ForwardsStdoutAndStderr verifies that on a 200 OK
+// response carrying stdout/stderr fields, the proxy writes both to the
+// caller's writers verbatim.
+func TestProxyCleanupToHostAPI_ForwardsStdoutAndStderr(t *testing.T) {
+	wantStdout := "removing worktree /tmp/wt...\n" +
+		"deleting branch some-branch\n" +
+		"killing session myrepo@some-branch\n" +
+		"done\n"
+	wantStderr := "[prism] warning: branch delete: stale ref\n"
+
+	// Capture the request so we can assert the body shape too.
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":` + jsonStringMust(wantStdout) +
+			`,"stderr":` + jsonStringMust(wantStderr) + `}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@some-branch", true, false, &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyCleanupToHostAPI: %v", err)
+	}
+	if stdoutBuf.String() != wantStdout {
+		t.Errorf("stdout forwarded mismatch:\n  got:  %q\n  want: %q", stdoutBuf.String(), wantStdout)
+	}
+	if stderrBuf.String() != wantStderr {
+		t.Errorf("stderr forwarded mismatch:\n  got:  %q\n  want: %q", stderrBuf.String(), wantStderr)
+	}
+
+	// Body shape: yes=true, json=false, session=...
+	select {
+	case body := <-gotBody:
+		if body["session"] != "myrepo@some-branch" {
+			t.Errorf("session = %v, want myrepo@some-branch", body["session"])
+		}
+		if body["yes"] != true {
+			t.Errorf("yes = %v, want true", body["yes"])
+		}
+		if body["json"] != false {
+			t.Errorf("json = %v, want false", body["json"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+}
+
+// TestProxyCleanupToHostAPI_ForwardsErrorWithStdoutStderr verifies that on a
+// non-2xx response carrying stdout/stderr alongside an error, the proxy
+// forwards both streams to the caller's writers AND returns an error
+// containing the underlying message. This addresses the
+// "error message names the wrong layer" observation in the comment on
+// issue #1527: the agent must see the underlying cause, not just the outer
+// transport's exit shape.
+func TestProxyCleanupToHostAPI_ForwardsErrorWithStdoutStderr(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{` +
+			`"error":"cleanup failed: exit status 1",` +
+			`"stdout":"removing worktree /tmp/wt...\n",` +
+			`"stderr":"archive directory already exists: /home/u/abc\n"` +
+			`}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@some-branch", true, false, &stdoutBuf, &stderrBuf)
+	if err == nil {
+		t.Fatal("expected error from proxyCleanupToHostAPI on 500 response")
+	}
+	if !strings.Contains(err.Error(), "cleanup failed: exit status 1") {
+		t.Errorf("error %q should contain underlying cause", err.Error())
+	}
+	if stdoutBuf.String() != "removing worktree /tmp/wt...\n" {
+		t.Errorf("stdout on error: got %q, want %q", stdoutBuf.String(), "removing worktree /tmp/wt...\n")
+	}
+	if stderrBuf.String() != "archive directory already exists: /home/u/abc\n" {
+		t.Errorf("stderr on error: got %q", stderrBuf.String())
+	}
+}
+
+// TestProxyCleanupToHostAPI_PassesJSONFlag verifies the proxy sends the
+// json flag through the request body so the host invokes `prism cleanup`
+// with --json.
+func TestProxyCleanupToHostAPI_PassesJSONFlag(t *testing.T) {
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Mimic a JSON-mode cleanup result on stdout.
+		_, _ = w.Write([]byte(`{"stdout":"{\"session\":\"myrepo@b\",\"worktree_removed\":\"/tmp/wt\",\"branch_deleted\":\"b\",\"session_killed\":true}\n","stderr":""}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@b", true, true, &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyCleanupToHostAPI: %v", err)
+	}
+	select {
+	case body := <-gotBody:
+		if body["json"] != true {
+			t.Errorf("json flag = %v, want true", body["json"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+	// And the JSON body the host emitted on stdout is forwarded verbatim.
+	want := `{"session":"myrepo@b","worktree_removed":"/tmp/wt","branch_deleted":"b","session_killed":true}` + "\n"
+	if stdoutBuf.String() != want {
+		t.Errorf("forwarded stdout mismatch:\n  got:  %q\n  want: %q", stdoutBuf.String(), want)
+	}
+}
+
+// jsonStringMust returns a JSON-encoded string literal of s. Used by the
+// inline string-builder responses in this file so callers don't need to
+// worry about escaping the embedded newlines.
+func jsonStringMust(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// Compile-time guard: io.Discard must satisfy io.Writer (used by some helpers
+// elsewhere). Keeps the import live without affecting test behaviour.
+var _ io.Writer = io.Discard

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -281,6 +281,103 @@ func proxyCheckin(apiURL, session string, limit int, before, after *string, type
 	return raw, nil
 }
 
+// cleanupResponse is the host-API /cleanup response shape. stdout/stderr are
+// the captured byte streams of the host-side `prism cleanup` subprocess. The
+// container-side caller writes them verbatim to its own stdout/stderr so that
+// the byte content is identical to a host invocation (modulo trailing
+// whitespace from the buffer). On success Error is empty; on failure the
+// host-API still returns stdout/stderr alongside Error so the caller can
+// surface the underlying cause. See issue #1527.
+type cleanupResponse struct {
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+	Error  string `json:"error,omitempty"`
+}
+
+// proxyCleanupToHostAPI sends a cleanup request to the host-API sidecar and
+// forwards the host-side stdout and stderr to the caller's stdout/stderr.
+//
+// This makes the container-path output of `prism cleanup` byte-equivalent to
+// the host-path output (modulo trailing whitespace), per issue #1527 AC #1.
+// Without this forwarding, the container path was silent on success because
+// the previous handler discarded the captured CombinedOutput.
+func proxyCleanupToHostAPI(apiURL, session string, yes, jsonMode bool) error {
+	return proxyCleanupToHostAPIWithWriters(apiURL, session, yes, jsonMode, os.Stdout, os.Stderr)
+}
+
+// proxyCleanupToHostAPIWithWriters is the testable form of
+// proxyCleanupToHostAPI: stdout/stderr destinations are injectable so unit
+// tests can capture forwarded output without redirecting os.Stdout.
+func proxyCleanupToHostAPIWithWriters(apiURL, session string, yes, jsonMode bool, stdout, stderr io.Writer) error {
+	body := map[string]any{
+		"session": session,
+		"yes":     yes,
+		"json":    jsonMode,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("proxyCleanupToHostAPI: marshal request body: %w", err)
+	}
+
+	var client *http.Client
+	var reqURL string
+	if strings.HasPrefix(apiURL, "http://") {
+		client = newTCPHostAPIClient()
+		reqURL = apiURL + "/cleanup"
+	} else {
+		sockPath, parseErr := parseUnixSocketURL(apiURL)
+		if parseErr != nil {
+			return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+		}
+		client = newHostAPIClient(sockPath)
+		reqURL = "http://prism-hostapi/cleanup"
+	}
+
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("proxyCleanupToHostAPI: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("host-API /cleanup: read response: %w", readErr)
+	}
+
+	var parsed cleanupResponse
+	// Tolerate empty bodies; we'll surface a clearer error below.
+	if len(respBody) > 0 {
+		if unmarshalErr := json.Unmarshal(respBody, &parsed); unmarshalErr != nil {
+			return fmt.Errorf("host-API /cleanup: unmarshal response: %w (body=%s)", unmarshalErr, strings.TrimSpace(string(respBody)))
+		}
+	}
+
+	// Forward the host-side streams unconditionally — even on error — so the
+	// caller can see partial-success progress lines and stderr warnings
+	// (e.g. archive collision). This addresses both the silent-success defect
+	// and the error-message-names-the-wrong-layer issue noted in the comment
+	// on issue #1527.
+	if parsed.Stdout != "" {
+		_, _ = io.WriteString(stdout, parsed.Stdout)
+	}
+	if parsed.Stderr != "" {
+		_, _ = io.WriteString(stderr, parsed.Stderr)
+	}
+
+	if resp.StatusCode >= 400 {
+		if parsed.Error != "" {
+			return fmt.Errorf("host-API /cleanup: %s", parsed.Error)
+		}
+		return fmt.Errorf("host-API /cleanup: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
 // proxyPrompt proxies a prompt delivery request to the host-API sidecar.
 // apiURL is the value of PRISM_HOST_API. deliverAs controls the delivery mode
 // ("steer", "followUp", or "nextTurn") and is forwarded as the "deliver_as"

--- a/modules/programs/prism/prism/cmd/restart.go
+++ b/modules/programs/prism/prism/cmd/restart.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"syscall"
 	"time"
@@ -10,6 +11,23 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
+
+// restartSummaryLine is the single success-side summary line emitted by
+// `prism restart` immediately before the re-exec into `launch`. Defined as
+// a package-level constant so tests can assert on the exact byte content
+// without duplicating the string literal. Issue #1527 AC: the destructive
+// command must not be silent on success.
+const restartSummaryLine = "prism restart: tmux server killed, sessions restored, re-execing into launch"
+
+// emitRestartSummary writes the success-side restart summary to w and flushes
+// it. Extracted from runRestart so unit tests can exercise the print without
+// performing the surrounding tmux-server kill / restore / re-exec sequence.
+func emitRestartSummary(w io.Writer) {
+	fmt.Fprintln(w, restartSummaryLine)
+	if f, ok := w.(*os.File); ok {
+		_ = f.Sync()
+	}
+}
 
 // waitForTmuxServerDead polls until tmux info fails (server gone) or
 // the deadline is exceeded. Returns true if the server died within the timeout.
@@ -62,6 +80,15 @@ func runRestart(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("could not determine executable path: %w", err)
 	}
+
+	// Emit a single summary line on the success path before syscall.Exec so
+	// the line survives the re-exec boundary (the new launch process inherits
+	// our stdout fd but does not flush our buffered writes for us; fmt.Println
+	// to os.Stdout is unbuffered on a tty/pipe, but Sync is called inside
+	// emitRestartSummary as belt-and-braces for the unusual case where stdout
+	// is a regular file). Per issue #1527: the destructive command must not
+	// be silent on success.
+	emitRestartSummary(os.Stdout)
 
 	// Re-exec with "launch"
 	return syscall.Exec(executable, []string{executable, "launch"}, os.Environ())

--- a/modules/programs/prism/prism/cmd/restart_test.go
+++ b/modules/programs/prism/prism/cmd/restart_test.go
@@ -1,0 +1,53 @@
+// Tests for the success-side summary line emitted by `prism restart`
+// (issue #1527).
+//
+// runRestart itself calls syscall.Exec at the end of the success path, which
+// replaces the test process and is therefore not directly unit-testable. We
+// instead test the extracted emitRestartSummary helper, which is the same
+// call that runRestart makes immediately before syscall.Exec. This is the
+// last byte of the parent process's stdout; if it appears in the test's
+// captured output, then in production it appears on the user's terminal
+// before the re-exec boundary.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestEmitRestartSummary_WritesExactLine verifies that emitRestartSummary
+// writes exactly the documented summary string followed by a newline. Tests
+// the byte content rather than just substring presence so any future drift
+// (e.g. punctuation change) is caught.
+func TestEmitRestartSummary_WritesExactLine(t *testing.T) {
+	var buf bytes.Buffer
+	emitRestartSummary(&buf)
+
+	got := buf.String()
+	want := restartSummaryLine + "\n"
+	if got != want {
+		t.Errorf("emitRestartSummary output mismatch:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+// TestRestartSummaryLine_NamesKeyActions guards the user-facing wording so a
+// future refactor doesn't accidentally drop the per-action breadcrumbs an
+// agent or human relies on to confirm "what happened" before the re-exec.
+//
+// Per AC: the line must name the session-related actions (tmux killed and
+// sessions restored). The exact wording is allowed to evolve, but the
+// substrings are part of the behavioural contract.
+func TestRestartSummaryLine_NamesKeyActions(t *testing.T) {
+	for _, want := range []string{
+		"prism restart",
+		"tmux",
+		"sessions",
+	} {
+		if !strings.Contains(restartSummaryLine, want) {
+			t.Errorf("restartSummaryLine %q must contain %q to satisfy issue #1527 AC",
+				restartSummaryLine, want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -135,6 +135,12 @@ func Restore(dryRun bool) error {
 	// *pendingStagger is true, then resets it to false.
 	pendingStagger := false
 
+	// Aggregate counts for the final summary line (issue #1527 AC).
+	// restored:  outcome == restoreOutcomeCreated
+	// skipped:   outcome == restoreOutcomeSkipped or restoreOutcomeCircuitOpen
+	// failed:    restErr != nil (per-session error from restoreSession)
+	var restored, skipped, failed int
+
 	for _, s := range statuses {
 		if dryRun {
 			// In dry-run mode, show what would happen but never sleep or write.
@@ -148,16 +154,26 @@ func Restore(dryRun bool) error {
 				if failures >= threshold {
 					fmt.Printf("would skip (circuit breaker): %s — %d consecutive sidecar failure(s); run `prism restart %s` or `prism cleanup` to unblock\n",
 						s.SessionName, failures, s.SessionName)
+					skipped++
 					continue
 				}
 			}
 			fmt.Printf("would restore: %s (worktree=%s)\n", s.SessionName, s.Worktree)
+			restored++
 			continue
 		}
 
 		outcome, restErr := restoreSession(d, s, threshold, &pendingStagger, staggerDelay)
 		if restErr != nil {
 			fmt.Fprintf(os.Stderr, "restore %q: %v\n", s.SessionName, restErr)
+			failed++
+		} else {
+			switch outcome {
+			case restoreOutcomeCreated:
+				restored++
+			case restoreOutcomeSkipped, restoreOutcomeCircuitOpen:
+				skipped++
+			}
 		}
 
 		// A created session sets pendingStagger so that the NEXT actual create
@@ -177,6 +193,12 @@ func Restore(dryRun bool) error {
 			fmt.Fprintf(os.Stderr, "prism restore: ensure dashboard session: %v\n", err)
 		}
 	}
+
+	// Final aggregate summary line (issue #1527 AC). Emitted on stdout after
+	// all per-session lines so callers can grep for the totals reliably. Also
+	// emitted in dry-run mode so dry-run output is non-empty when there are
+	// no sessions.
+	fmt.Printf("restore complete: %d restored, %d skipped, %d failed\n", restored, skipped, failed)
 
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/restore_summary_test.go
+++ b/modules/programs/prism/prism/cmd/restore_summary_test.go
@@ -1,0 +1,87 @@
+// Tests for the aggregate "restore complete: ..." summary line emitted at
+// the end of `prism restore` (issue #1527). The line must always be printed,
+// even when there are zero sessions to restore, so callers can grep for the
+// totals reliably.
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// captureStdout is shared with checkin_test.go (defined there).
+
+// TestRestore_AggregateSummary_NoSessions verifies that the summary line is
+// emitted even when there are zero sessions in the DB. This is the
+// agent-friendly shape: empty stdout would force callers to special-case
+// "no output means success".
+func TestRestore_AggregateSummary_NoSessions(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdout(t, func() {
+		if err := Restore(true); err != nil {
+			t.Fatalf("Restore(dryRun=true): %v", err)
+		}
+	})
+
+	// The summary line must be present and report 0/0/0.
+	want := "restore complete: 0 restored, 0 skipped, 0 failed\n"
+	if !strings.Contains(out, want) {
+		t.Errorf("summary line missing or wrong:\n  got:  %q\n  want substring: %q", out, want)
+	}
+}
+
+// TestRestore_AggregateSummary_DryRun verifies the counts are correct in
+// dry-run mode when there are real rows. We use dryRun=true so no tmux/DB
+// side effects are required.
+func TestRestore_AggregateSummary_DryRun(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Seed three sessions; in dry-run mode all of them count as "would restore".
+	for i := 0; i < 3; i++ {
+		name := fmt.Sprintf("testrepo@feature-%d", i)
+		wt := t.TempDir()
+		if err := d.UpsertStatus(name, "testrepo", wt, "idle", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", name, err)
+		}
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdout(t, func() {
+		if err := Restore(true); err != nil {
+			t.Fatalf("Restore(dryRun=true): %v", err)
+		}
+	})
+
+	// Summary line: 3 restored, 0 skipped, 0 failed.
+	want := "restore complete: 3 restored, 0 skipped, 0 failed\n"
+	if !strings.Contains(out, want) {
+		t.Errorf("summary line missing or wrong:\n  got:  %q\n  want substring: %q", out, want)
+	}
+
+	// Per-session "would restore" lines must still be present alongside the
+	// summary (not replaced by it).
+	matches := regexp.MustCompile(`would restore: testrepo@feature-\d`).FindAllString(out, -1)
+	if len(matches) != 3 {
+		t.Errorf("expected 3 'would restore' lines, got %d:\n%s", len(matches), out)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1383,8 +1383,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	})
 
 	// POST /cleanup
-	// Request:  {"session":"nixos-config@my-feature","yes":true}
-	// Response: {} | {"error":"..."}
+	// Request:  {"session":"nixos-config@my-feature","yes":true,"json":false}
+	// Response: {"stdout":"...","stderr":"..."} | {"error":"...","stdout":"...","stderr":"..."}
+	//
+	// stdout/stderr from the spawned `prism cleanup` subprocess are captured
+	// separately and forwarded to the caller. The container-side proxy
+	// (proxyCleanupToHostAPI) writes them verbatim to its own stdout/stderr so
+	// that an agent running inside a coordinator container sees the same
+	// per-resource progress lines a host invocation would print. Without this
+	// forwarding, the container path was silent on success — issue #1527.
 	mux.HandleFunc("/cleanup", func(w http.ResponseWriter, r *http.Request) {
 		if !requirePost(w, r) {
 			return
@@ -1395,6 +1402,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			Session string `json:"session"`
 			Yes     bool   `json:"yes"`
+			JSON    bool   `json:"json"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -1426,17 +1434,35 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.Yes {
 			args = append(args, "--yes")
 		}
+		if req.JSON {
+			args = append(args, "--json")
+		}
 
 		s.logger().Printf("sidecar: host-API /cleanup: prism %s", strings.Join(args, " "))
 		cmd := exec.Command(prismBinary(), args...)
-		out, err := cmd.CombinedOutput()
+		var stdoutBuf, stderrBuf bytes.Buffer
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		err := cmd.Run()
+		stdoutStr := stdoutBuf.String()
+		stderrStr := stderrBuf.String()
 		if err != nil {
-			s.logger().Printf("sidecar: host-API /cleanup: %v: %s", err, out)
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("cleanup failed: %v", err))
+			s.logger().Printf("sidecar: host-API /cleanup: %v: stdout=%q stderr=%q", err, stdoutStr, stderrStr)
+			// Forward stdout and stderr alongside the error so the caller can
+			// surface the underlying cause (e.g. archive collision) instead of
+			// just the outer transport's exit shape.
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"error":  fmt.Sprintf("cleanup failed: %v", err),
+				"stdout": stdoutStr,
+				"stderr": stderrStr,
+			})
 			return
 		}
 
-		writeJSON(w, http.StatusOK, map[string]string{})
+		writeJSON(w, http.StatusOK, map[string]any{
+			"stdout": stdoutStr,
+			"stderr": stderrStr,
+		})
 	})
 
 	// POST /switch

--- a/modules/programs/prism/prism/internal/sidecar/host_api_cleanup_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_cleanup_test.go
@@ -1,0 +1,143 @@
+// Tests for the /cleanup host-API endpoint's stdout/stderr forwarding
+// behaviour (issue #1527). Without this, the container path was silent on
+// success because the previous handler captured CombinedOutput and discarded
+// the captured bytes before returning {}.
+//
+// These tests use a stub binary that writes deterministic content to stdout
+// and/or stderr and either exits 0 (success) or non-zero (failure) so we can
+// assert the response shape independently of a real `prism cleanup` run.
+
+package sidecar
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/harness/opencode"
+)
+
+// newSidecarWithCleanupStub returns a Sidecar whose host-API /cleanup handler
+// will exec a shell script we control instead of the real prism binary. The
+// caller supplies the script body (which is wrapped in a `#!/bin/sh` header).
+func newSidecarWithCleanupStub(t *testing.T, sessionName, repo, role, scriptBody string) *Sidecar {
+	t.Helper()
+	d := openTestDB(t)
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\n"+scriptBody+"\n"), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+	cfg := Config{
+		SessionName:     sessionName,
+		Repo:            repo,
+		Worktree:        "/tmp/" + sessionName,
+		OpencodeURL:     "http://localhost:14000",
+		DB:              d,
+		Clock:           newTestClock(),
+		AgentRole:       role,
+		PrismBinaryPath: stubPath,
+		Harness:         opencode.New("http://localhost:14000", nil, role, ""),
+	}
+	return New(cfg)
+}
+
+// TestHostAPI_Cleanup_ForwardsStdoutAndStderr_Success verifies that the
+// /cleanup handler captures stdout and stderr from the spawned subprocess
+// separately and surfaces both in the JSON response. Issue #1527 AC #1.
+func TestHostAPI_Cleanup_ForwardsStdoutAndStderr_Success(t *testing.T) {
+	// Stub writes the AC-required progress lines to stdout and a warning to
+	// stderr, then exits 0. The handler must put the stdout content into the
+	// response's "stdout" field and the stderr content into "stderr".
+	script := `printf 'removing worktree /tmp/wt...\n'
+printf 'deleting branch some-branch\n'
+printf 'killing session myrepo@some-branch\n'
+printf 'done\n'
+printf '[prism] warning: branch delete: stale ref\n' 1>&2
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/cleanup",
+		`{"session":"myrepo@some-branch","yes":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+		Stderr string `json:"stderr"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	wantStdout := "removing worktree /tmp/wt...\n" +
+		"deleting branch some-branch\n" +
+		"killing session myrepo@some-branch\n" +
+		"done\n"
+	if resp.Stdout != wantStdout {
+		t.Errorf("stdout mismatch:\n  got:  %q\n  want: %q", resp.Stdout, wantStdout)
+	}
+	wantStderr := "[prism] warning: branch delete: stale ref\n"
+	if resp.Stderr != wantStderr {
+		t.Errorf("stderr mismatch:\n  got:  %q\n  want: %q", resp.Stderr, wantStderr)
+	}
+}
+
+// TestHostAPI_Cleanup_ForwardsStdoutAndStderr_Failure verifies that even on
+// non-zero exit the captured stdout and stderr are forwarded alongside the
+// error string. This addresses the "error message names the wrong layer"
+// observation in the comment on issue #1527: the agent must see the underlying
+// cause (e.g. "archive directory already exists") rather than just the outer
+// transport's "exit status 1".
+func TestHostAPI_Cleanup_ForwardsStdoutAndStderr_Failure(t *testing.T) {
+	script := `printf 'removing worktree /tmp/wt...\n'
+printf 'archive directory already exists: /home/u/.local/share/prism/archive/myrepo/abc\n' 1>&2
+exit 1`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/cleanup",
+		`{"session":"myrepo@some-branch","yes":true}`)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Error  string `json:"error"`
+		Stdout string `json:"stdout"`
+		Stderr string `json:"stderr"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Error == "" {
+		t.Errorf("expected non-empty error field; got empty")
+	}
+	if resp.Stdout != "removing worktree /tmp/wt...\n" {
+		t.Errorf("stdout mismatch on failure: got %q", resp.Stdout)
+	}
+	if resp.Stderr == "" || resp.Stderr != "archive directory already exists: /home/u/.local/share/prism/archive/myrepo/abc\n" {
+		t.Errorf("stderr mismatch on failure: got %q", resp.Stderr)
+	}
+}
+
+// TestHostAPI_Cleanup_ForwardsJSONFlag verifies that the json flag from the
+// request body is propagated to the spawned subprocess as --json, so that
+// container-side `prism cleanup --yes --json` reaches the host-side process
+// with --json set.
+func TestHostAPI_Cleanup_ForwardsJSONFlag(t *testing.T) {
+	// Stub echoes its argv to stdout so we can assert --json was forwarded.
+	script := `printf '%s\n' "$@"
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/cleanup",
+		`{"session":"myrepo@some-branch","yes":true,"json":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	want := "cleanup\n--session\nmyrepo@some-branch\n--yes\n--json\n"
+	if resp.Stdout != want {
+		t.Errorf("forwarded argv mismatch:\n  got:  %q\n  want: %q", resp.Stdout, want)
+	}
+}


### PR DESCRIPTION
## Summary

Three related defects on the success-side observability of mutating commands (issue #1527):

1. **`prism cleanup` was silent on success in the container path.** The host-API `/cleanup` handler at `internal/sidecar/host_api.go` captured `CombinedOutput()` and discarded it before returning `{}`. Workers running inside coordinator containers saw empty stdout, exit 0, with no observable to confirm what (if anything) had happened.

2. **`prism restart` was silent** until `syscall.Exec` re-execed into `launch`.

3. **`prism restore` had per-session lines but no aggregate summary.**

## Changes

### Cleanup container-path forwarding (primary defect)

- Host-API `/cleanup` handler now captures stdout and stderr separately and returns them in the JSON response: `{stdout, stderr}` on 200, `{error, stdout, stderr}` on 5xx.
- New `proxyCleanupToHostAPI` (cmd-side) forwards both streams verbatim to the caller's stdout/stderr. The byte content of stdout now matches between host and container paths (modulo trailing whitespace).
- The proxy forwards stdout/stderr **even on error**, so the agent sees the underlying cause (e.g. `archive directory already exists`) rather than just the outer transport's `exit status 1`. This addresses point (2) of the issue-follow-up comment.

### `--json` flag on `cleanup` (new)

- Mutually exclusive with textual progress lines: when `--json` is set, a single JSON object is emitted on stdout with `session`, `worktree_removed` (path or null), `branch_deleted` (name or null), `session_killed` (bool).
- Requires `--yes` (interactive cleanup is incompatible with structured output).
- Forwarded through the host-API proxy: the container-side flag becomes `--json` on the host-side `prism cleanup` invocation, and the JSON object the host emits flows back through the same stdout-forwarding path.
- `worktree_removed` is null when the worktree path is unknown (per the edge-case AC); the existing `worktree path unknown \u2014 skipping ...` line is preserved on stdout in textual mode.

### `archive.ErrAlreadyExists` no longer fatal

- Treated as a non-fatal warning by `headlessCleanup` and `headlessCloseSession`. The other cleanup steps complete normally; a warning on stderr names the existing archive path. This addresses point (3) of the issue-follow-up comment \u2014 by the time the archive step runs, the worktree, branch, tmux session, and DB rows are already torn down, so the collision is benign.

### Restart summary

- Single line emitted to stdout immediately before `syscall.Exec`: `prism restart: tmux server killed, sessions restored, re-execing into launch`. `os.Stdout.Sync()` is called as belt-and-braces in case stdout is a regular file.
- Refactored the print into `emitRestartSummary(w io.Writer)` so it's unit-testable independently of the surrounding `tmux kill-server` / `Restore` / `syscall.Exec` sequence.

### Restore aggregate summary

- Tracks `restored`/`skipped`/`failed` counts as the loop progresses, then emits `restore complete: N restored, M skipped, K failed` on stdout.
- Emitted in dry-run mode as well, so dry-run output is non-empty when there are no sessions.

## Tests

- `internal/sidecar/host_api_cleanup_test.go` (new) \u2014 host-side handler captures stdout/stderr separately and surfaces both in the response (success and failure paths); `--json` flag is propagated to the spawned subprocess as `--json`.
- `cmd/cleanup_proxy_test.go` (new) \u2014 container-side proxy writes forwarded stdout/stderr to caller's writers verbatim, both on 200 and on error; `--json` is sent in the request body.
- `cmd/restart_test.go` (new) \u2014 `emitRestartSummary` writes the exact documented byte content and the wording names the key actions (tmux + sessions).
- `cmd/restore_summary_test.go` (new) \u2014 aggregate summary line is emitted with correct counts both when there are zero sessions and when there are real rows in dry-run mode.

All existing tests pass. `go test ./... -race` is clean. `nix build .#prism` and the homeless-shelter checked build (`runChecks=true`) both succeed locally.

## ACs (issue #1527)

- [x] [functional] cleanup container path prints same per-resource progress lines on success regardless of `PRISM_HOST_API`. Byte-equivalent.
- [x] [functional] cleanup writes at least one stdout line naming the session on success.
- [x] [functional] `--json` emits a single JSON object with required keys; mutually exclusive with textual lines.
- [x] [edge-case] worktree path unknown still emits the `worktree path unknown \u2014 skipping ...` line on stdout in container path; `--json` form sets `worktree_removed` to null.
- [x] [edge-case] partial-failure stderr warnings preserved and forwarded through container path; exit code 0 for partial success.
- [x] [functional] `prism restart` prints summary line before `syscall.Exec`.
- [x] [functional] `prism restore` prints aggregate summary line.
- [x] [functional] `nix build .#prism` and `go test ./...` pass; new tests cover the additions.

## Issue-follow-up coverage

The comment on #1527 flagged two further candidate ACs (informational). Both are addressed here:

- **Partial success exits 0 with stderr warnings** \u2014 already true in `headlessCleanup` (warn-and-continue on worktree-remove and branch-delete failures) and now extended to archive-collision. The container path no longer hides these because stderr is forwarded.
- **`archive.ErrAlreadyExists` is non-fatal** \u2014 treated as a stderr warning by both `headlessCleanup` and `headlessCloseSession`; cleanup completes normally.

## Related

- #1527 \u2014 closes
- #1500 \u2014 concurrent work on `--wait`. No file overlap (this PR doesn't touch the prism skill).
- #1528 \u2014 concurrent TS-only PR. No conflict.

Closes #1527