### PR TITLE
feat(prism): add --wait to merge / review / spawn and prism reviews list

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -323,6 +323,8 @@ Add `--json` to any `prism merges` / `prism merges list` invocation (including w
 
 **Ctrl-C semantic.** Killing a `--wait` invocation (Ctrl-C, SIGTERM) interrupts the **local** wait only — the underlying merge / review / spawn keeps running. To recover the result later, re-run the same command (or `prism merges list` / `prism reviews list` / `prism checkin <session>`).
 
+**Inside a sandbox.** `--wait` works identically inside and outside a bwrap / podman / sandbox-exec sandbox. The CLI auto-detects `PRISM_HOST_API` and routes its terminal-state probes through the sidecar's read-only wait endpoints, so the host's prism.db is the source of truth in either case.
+
 **Exit codes.** `--wait` paths use exit codes that distinguish failure modes:
 
 | Exit | Meaning |

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -165,6 +165,19 @@ prism review <pr-number>
 **Do NOT commit, merge, or announce completion** until the review-complete
 prompt arrives. When it does, handle PASS/FAIL per the worker agent instructions.
 
+For a synchronous flow (one-shot script, no other work to do meanwhile) pass
+`--wait`:
+
+```bash
+prism review <pr-number> --wait
+prism review <pr-number> --wait --json   # script-friendly
+```
+
+`--wait` blocks until the review group reaches a terminal state and exits 0
+on all-PASS, non-zero on any FAIL / no-start / timeout. See the `--wait`
+section above for the full contract (exit codes, Ctrl-C semantic, idempotent
+observation).
+
 ### Pre-flight rebase gate (`prism review` refuses when behind `origin/main`)
 
 Before spawning any review agents, `prism review` runs a **one-shot pre-flight
@@ -289,6 +302,47 @@ A queued PR moves through states keyed off GitHub's `mergeStateStatus`: `watchin
 | `prism merges cancel <pr>` | Remove a `watching` entry from the queue. |
 
 Add `--json` to any `prism merges` / `prism merges list` invocation (including with `--failed`, `--abandoned`, or `--all`) to get a JSON array of merge-queue entries instead of the table — use this when scripting or polling.
+
+### `--wait` for synchronous flows (#1500)
+
+`prism merge`, `prism review`, and `prism spawn` accept `--wait` for cases where the agent's workflow is genuinely synchronous — for example, a one-shot script that wants to merge a PR and then immediately deploy. With `--wait`, the command blocks until the underlying job reaches a terminal state and exits non-zero on any non-success terminal.
+
+| Command | Terminal definition | Default `--timeout` |
+|---|---|---|
+| `prism merge <pr> --wait` | merged / failed / cancelled / abandoned (in `pending_merges`) | `30m` |
+| `prism review <pr> --wait` | All review agents reached `finished`/`error`/`deleted` (group complete) | `20m` |
+| `prism spawn ... --wait` | Spawned agent reached `finished` / `error` / `interrupted` / `deleted` for its first turn | `10m` |
+
+**When to prefer `--wait` vs the notification path:**
+
+- Prefer `--wait` when you have **no other useful work** to do until the job lands — a one-shot script, a deploy that depends on the merge, or a review that gates further commits.
+- Prefer the **notification path** (no `--wait`) when you have **other tasks in flight**. Coordinators with several PRs in flight should never `--wait` — `prism merge <pr>` returns immediately and the merge-queue watcher delivers a notification when each PR lands. Same shape for `prism review` and `prism spawn`.
+- Add `--json` when scripting: `prism merge <pr> --wait --json` emits a single JSON object on stdout (no human-readable chatter) so consumers can `jq` the status.
+
+**Idempotent observation.** `prism merge <pr> --wait` on an already-merged PR returns immediately with the merged status — safe to call any number of times.
+
+**Ctrl-C semantic.** Killing a `--wait` invocation (Ctrl-C, SIGTERM) interrupts the **local** wait only — the underlying merge / review / spawn keeps running. To recover the result later, re-run the same command (or `prism merges list` / `prism reviews list` / `prism checkin <session>`).
+
+**Exit codes.** `--wait` paths use exit codes that distinguish failure modes:
+
+| Exit | Meaning |
+|---|---|
+| `0` | terminal success (merged / all-PASS / finished) |
+| `2` | terminal failure (failed CI, any-FAIL, error state) |
+| `3` | local `--timeout` elapsed (the underlying job continues) |
+| `4` | user interrupted with Ctrl-C (the underlying job continues) |
+
+### Reviews ledger: `prism reviews list`
+
+Reviews now have a dedicated ledger surface analogous to `prism merges`. Use it instead of `prism list-sessions | grep '~review-N-'` (fragile, missing group metadata).
+
+```bash
+prism reviews            # alias for `prism reviews list`
+prism reviews list       # all review groups, newest first
+prism reviews list --json
+```
+
+Each row carries: PR number (when derivable from the parent branch), parent (worker) session, agent sessions, group state (`in-progress` / `completed` / `empty`), round number, and `started_at` timestamp.
 
 ### Notification contract
 

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -409,7 +409,13 @@ func proxyPrompt(apiURL, session, prompt, deliverAs string) error {
 //	sidecar.ReviewSentinelFailed — subprocess exited non-zero
 //
 // This function consumes the sentinel and does NOT print it to stdout.
-func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string, rebase bool) (string, error) {
+//
+// quietStdout suppresses the per-line streaming print to os.Stdout while
+// still buffering the output for the caller's return value. It is used by
+// the in-sandbox `prism review --wait --json` path to honour the
+// JSON-exclusive contract (#1500): otherwise the streamed Ack lines would
+// land on stdout before waitForReviewTerminal emits its JSON object.
+func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string, rebase bool, quietStdout bool) (string, error) {
 	// Build request body.
 	body := map[string]any{
 		"pr_number": prNumber,
@@ -525,9 +531,12 @@ func proxyReviewAsync(apiURL, prNumber string, agents []string, timeout string, 
 			sentinelSeen = true
 			passed = false
 		default:
-			// Regular output line — print to stdout immediately and buffer for
-			// the caller so it can be used in the return value if needed.
-			fmt.Fprintln(os.Stdout, line)
+			// Regular output line — buffer for the caller's return value, and
+			// (unless quietStdout is set) stream to stdout immediately so the
+			// worker sees progress as it arrives.
+			if !quietStdout {
+				fmt.Fprintln(os.Stdout, line)
+			}
 			outputBuf.WriteString(line)
 			outputBuf.WriteByte('\n')
 		}

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -1116,7 +1116,7 @@ func TestProxyReviewAsync_LinesArrivedProgressively(t *testing.T) {
 	var stdout string
 	var callErr error
 	stdout = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "123", nil, "", false)
+		_, callErr = proxyReviewAsync(srv.apiURL(), "123", nil, "", false, false)
 	})
 
 	if callErr != nil {
@@ -1139,6 +1139,37 @@ func TestProxyReviewAsync_LinesArrivedProgressively(t *testing.T) {
 	}
 }
 
+// TestProxyReviewAsync_QuietStdoutSuppressesStreaming verifies the
+// JSON-exclusive contract for `prism review --wait --json` from inside a
+// sandbox (#1500 round-2 review-code blocker). When quietStdout is true,
+// proxyReviewAsync must NOT write any of the streamed Ack lines to stdout,
+// but the buffered return value must still contain them so the caller can
+// parse the group_id.
+func TestProxyReviewAsync_QuietStdoutSuppressesStreaming(t *testing.T) {
+	const ackLine = "Review in progress — PR #1, round 1 (group: aaaa-bbbb-cccc-dddd-eeeeffffaaaa)"
+	srv := newMockTCPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ackLine + "\n"))
+		_, _ = w.Write([]byte("Review-Goal started\n"))
+		_, _ = w.Write([]byte(sidecar.ReviewSentinelPassed + "\n"))
+	})
+
+	var stdout, ack string
+	var callErr error
+	stdout = captureStdout(t, func() {
+		ack, callErr = proxyReviewAsync(srv.apiURL(), "1", nil, "", false, true /* quietStdout */)
+	})
+	if callErr != nil {
+		t.Fatalf("proxyReviewAsync: %v", callErr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("quietStdout=true: expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(ack, ackLine) {
+		t.Errorf("buffered Ack must still contain the ack line so the caller can parse group_id; got %q", ack)
+	}
+}
+
 // TestProxyReviewAsync_SentinelConsumedNotEchoed verifies that proxyReviewAsync
 // consumes the sentinel line and does NOT echo it to stdout (AC: sentinel marker
 // is NOT printed to the worker's stdout).
@@ -1152,7 +1183,7 @@ func TestProxyReviewAsync_SentinelConsumedNotEchoed(t *testing.T) {
 	var stdout string
 	var callErr error
 	stdout = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "42", nil, "", false)
+		_, callErr = proxyReviewAsync(srv.apiURL(), "42", nil, "", false, false)
 	})
 
 	if callErr != nil {
@@ -1186,7 +1217,7 @@ func TestProxyReviewAsync_FailedSentinelProducesError(t *testing.T) {
 	var stdout string
 	var callErr error
 	stdout = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "99", nil, "", false)
+		_, callErr = proxyReviewAsync(srv.apiURL(), "99", nil, "", false, false)
 	})
 
 	// proxyReviewAsync must return a non-nil error when sentinel says failed.
@@ -1223,7 +1254,7 @@ func TestProxyReviewAsync_MidStreamDisconnectReportsError(t *testing.T) {
 
 	var callErr error
 	_ = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "77", nil, "", false)
+		_, callErr = proxyReviewAsync(srv.apiURL(), "77", nil, "", false, false)
 	})
 
 	if callErr == nil {
@@ -1246,7 +1277,7 @@ func TestProxyReviewAsync_HTTP500BeforeStreamReturnsError(t *testing.T) {
 
 	var callErr error
 	_ = captureStdout(t, func() {
-		_, callErr = proxyReviewAsync(srv.apiURL(), "55", nil, "", false)
+		_, callErr = proxyReviewAsync(srv.apiURL(), "55", nil, "", false, false)
 	})
 
 	if callErr == nil {

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -112,9 +112,16 @@ func runMerge(cmd *cobra.Command, args []string) error {
 		}, &row); proxyErr != nil {
 			return fmt.Errorf("prism merge: %w", proxyErr)
 		}
-		fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", row.PR, row.QueuePosition, row.Status)
-		if title != "" {
-			fmt.Printf("  %s\n", title)
+		// JSON-exclusive contract (#1500): when --wait and --json are both
+		// set, the terminal status is the only thing on stdout. Suppress
+		// the textual enqueue-confirmation lines on that path so a
+		// `--wait --json` consumer sees a single parseable JSON object.
+		quietStdout := waitFlag && jsonFlag
+		if !quietStdout {
+			fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", row.PR, row.QueuePosition, row.Status)
+			if title != "" {
+				fmt.Printf("  %s\n", title)
+			}
 		}
 		if waitFlag {
 			return waitForMergeTerminal(pr, jsonFlag, timeoutFlag)
@@ -182,9 +189,14 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 		return fmt.Errorf("prism merge: %w", err)
 	}
 
-	fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", pr, row.QueuePosition, row.Status)
-	if title != "" {
-		fmt.Printf("  %s\n", title)
+	// JSON-exclusive contract (#1500): suppress the textual enqueue
+	// confirmation when --wait and --json are both set.
+	quietStdout := waitFlag && jsonFlag
+	if !quietStdout {
+		fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", pr, row.QueuePosition, row.Status)
+		if title != "" {
+			fmt.Printf("  %s\n", title)
+		}
 	}
 	if waitFlag {
 		return waitForMergeTerminal(pr, jsonFlag, timeoutFlag)

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -200,15 +200,22 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 // existing terminal row in pending_merges and --wait should return
 // immediately with that status. Returns (false, nil) when the row is missing
 // or non-terminal (the caller should proceed with the normal enqueue path).
-// On DB errors, returns (false, nil) so the caller falls through to the
-// regular path — best-effort short-circuit, never a hard failure.
+// On DB / proxy errors, returns (false, nil) so the caller falls through to
+// the regular path — best-effort short-circuit, never a hard failure.
+//
+// Uses newWaitProbe() so the lookup is correct both on the host (direct DB)
+// and inside a sandbox (host-API proxy). Reading the host's prism.db
+// directly from inside a sandbox would hit a shadow tmpfs DB the merge-queue
+// watcher never writes to, silently returning "no row" and skipping the
+// short-circuit — see issue #1500 review-code feedback for the parallel bug
+// in the wait poll loop below.
 func observeAlreadyTerminal(pr int, jsonMode bool) (bool, error) {
-	d, dbErr := openDB()
-	if dbErr != nil {
+	probe, err := newWaitProbe()
+	if err != nil {
 		return false, nil
 	}
-	defer d.Close()
-	row, err := d.PendingMergeByPR(pr)
+	defer probe.Close()
+	row, err := probe.Merge(pr)
 	if err != nil || row == nil {
 		return false, nil
 	}
@@ -219,27 +226,31 @@ func observeAlreadyTerminal(pr int, jsonMode bool) (bool, error) {
 	return false, nil
 }
 
-// waitForMergeTerminal polls the prism DB for the given PR's row in
-// pending_merges until it reaches a terminal state (merged/failed/
-// cancelled/abandoned), the timeout elapses, or the user interrupts. The
-// merge-queue watcher (running in the host sidecar) writes the terminal row
-// — this poll loop only observes it; killing this process does NOT cancel
-// the merge.
+// waitForMergeTerminal polls the merge-queue ledger for the given PR until it
+// reaches a terminal state (merged/failed/cancelled/abandoned), the timeout
+// elapses, or the user interrupts. The merge-queue watcher (running in the
+// host sidecar) writes the terminal row — this poll loop only observes it;
+// killing this process does NOT cancel the merge.
+//
+// Sandbox-aware via newWaitProbe(): host shells read prism.db directly,
+// in-sandbox callers route reads through the sidecar's /merges/by-pr
+// endpoint. Without this, --wait inside a sandbox would poll a tmpfs shadow
+// DB and never observe the terminal (issue #1500 review-code feedback).
 func waitForMergeTerminal(pr int, jsonMode bool, timeout time.Duration) error {
-	d, dbErr := openDB()
-	if dbErr != nil {
-		return fmt.Errorf("prism merge --wait: open db: %w", dbErr)
+	probe, err := newWaitProbe()
+	if err != nil {
+		return fmt.Errorf("prism merge --wait: %w", err)
 	}
-	defer d.Close()
+	defer probe.Close()
 
 	var lastRow *db.PendingMerge
-	err := pollWait(context.Background(), timeout,
+	err = pollWait(context.Background(), timeout,
 		500*time.Millisecond, 5*time.Second,
 		func() (bool, error) {
-			row, qErr := d.PendingMergeByPR(pr)
+			row, qErr := probe.Merge(pr)
 			if qErr != nil {
 				// Transient — keep polling.
-				fmt.Fprintf(os.Stderr, "[prism merge --wait] db error: %v (will retry)\n", qErr)
+				fmt.Fprintf(os.Stderr, "[prism merge --wait] probe error: %v (will retry)\n", qErr)
 				return false, nil
 			}
 			if row == nil {

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/sandboxenv"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -48,6 +49,9 @@ Idempotent: calling prism merge <pr> a second time for an already-queued
 }
 
 func init() {
+	mergeCmd.Flags().Bool("wait", false, "Block until the merge queue reports a terminal state for this PR (synchronous mode). Without --wait, returns immediately and the watcher delivers a notification later via prism prompt.")
+	mergeCmd.Flags().Duration("timeout", defaultMergeWaitTimeout, "Timeout for --wait. On expiry, exits non-zero with a status payload distinguishable from a real merge failure. Ignored when --wait is not set.")
+	mergeCmd.Flags().Bool("json", false, "Emit the terminal status as a JSON object on stdout (only useful with --wait). Suppresses textual output.")
 	rootCmd.AddCommand(mergeCmd)
 }
 
@@ -56,6 +60,20 @@ func runMerge(cmd *cobra.Command, args []string) error {
 	pr, err := strconv.Atoi(prArg)
 	if err != nil || pr <= 0 {
 		return fmt.Errorf("prism merge: invalid PR number %q — must be a positive integer", prArg)
+	}
+	waitFlag, _ := cmd.Flags().GetBool("wait")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
+	// Idempotent observation: if the PR already has a terminal row in the
+	// DB, --wait must return immediately with the recorded status. We check
+	// this BEFORE the proxy/host-API enqueue path so an already-merged PR
+	// short-circuits without a round-trip. The check uses a read-only DB
+	// open and is best-effort: any error falls through to the normal enqueue
+	// path so the user still gets a sensible behaviour.
+	if waitFlag {
+		if done, watErr := observeAlreadyTerminal(pr, jsonFlag); done {
+			return watErr
+		}
 	}
 
 	// Inside a bwrap sandbox: proxy the enqueue to the host sidecar (#1043).
@@ -97,6 +115,9 @@ func runMerge(cmd *cobra.Command, args []string) error {
 		fmt.Printf("PR #%d enqueued (queue_position=%d, status=%s)\n", row.PR, row.QueuePosition, row.Status)
 		if title != "" {
 			fmt.Printf("  %s\n", title)
+		}
+		if waitFlag {
+			return waitForMergeTerminal(pr, jsonFlag, timeoutFlag)
 		}
 		fmt.Println("The merge-queue watcher will drive this PR through CI and merge it automatically.")
 		fmt.Println("You will be notified when it merges or fails.")
@@ -165,10 +186,173 @@ See: modules/programs/prism/opencode/agents/coordinator.md`, pr)
 	if title != "" {
 		fmt.Printf("  %s\n", title)
 	}
+	if waitFlag {
+		return waitForMergeTerminal(pr, jsonFlag, timeoutFlag)
+	}
 	fmt.Println("The merge-queue watcher will drive this PR through CI and merge it automatically.")
 	fmt.Println("You will be notified when it merges or fails.")
 	fmt.Println()
 	fmt.Println("Track progress with: prism merges")
+	return nil
+}
+
+// observeAlreadyTerminal returns (true, err) when the given PR has an
+// existing terminal row in pending_merges and --wait should return
+// immediately with that status. Returns (false, nil) when the row is missing
+// or non-terminal (the caller should proceed with the normal enqueue path).
+// On DB errors, returns (false, nil) so the caller falls through to the
+// regular path — best-effort short-circuit, never a hard failure.
+func observeAlreadyTerminal(pr int, jsonMode bool) (bool, error) {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return false, nil
+	}
+	defer d.Close()
+	row, err := d.PendingMergeByPR(pr)
+	if err != nil || row == nil {
+		return false, nil
+	}
+	switch row.Status {
+	case "merged", "failed", "cancelled", "abandoned":
+		return true, emitMergeWaitTerminal(row, jsonMode)
+	}
+	return false, nil
+}
+
+// waitForMergeTerminal polls the prism DB for the given PR's row in
+// pending_merges until it reaches a terminal state (merged/failed/
+// cancelled/abandoned), the timeout elapses, or the user interrupts. The
+// merge-queue watcher (running in the host sidecar) writes the terminal row
+// — this poll loop only observes it; killing this process does NOT cancel
+// the merge.
+func waitForMergeTerminal(pr int, jsonMode bool, timeout time.Duration) error {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("prism merge --wait: open db: %w", dbErr)
+	}
+	defer d.Close()
+
+	var lastRow *db.PendingMerge
+	err := pollWait(context.Background(), timeout,
+		500*time.Millisecond, 5*time.Second,
+		func() (bool, error) {
+			row, qErr := d.PendingMergeByPR(pr)
+			if qErr != nil {
+				// Transient — keep polling.
+				fmt.Fprintf(os.Stderr, "[prism merge --wait] db error: %v (will retry)\n", qErr)
+				return false, nil
+			}
+			if row == nil {
+				return false, nil
+			}
+			lastRow = row
+			switch row.Status {
+			case "merged", "failed", "cancelled", "abandoned":
+				return true, emitMergeWaitTerminal(row, jsonMode)
+			}
+			return false, nil
+		})
+	// Translate the pollWait outcome. waitExitTimeout gets a structured
+	// payload (distinguishable from a real merge failure per AC); other
+	// outcomes propagate verbatim.
+	if err != nil {
+		switch exitCodeOf(err) {
+		case waitExitTimeout:
+			_ = emitMergeWaitTimeout(pr, lastRow, jsonMode, timeout)
+			return newExitErr(waitExitTimeout, "")
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+// exitCodeOf returns the ExitCode of err if it implements an ExitCode method,
+// else 0. Avoids errors.As ceremony at every call site.
+func exitCodeOf(err error) int {
+	type exitCoder interface{ ExitCode() int }
+	if err == nil {
+		return 0
+	}
+	if ec, ok := err.(exitCoder); ok {
+		return ec.ExitCode()
+	}
+	return 0
+}
+
+// mergeWaitJSON is the JSON shape emitted by `prism merge --wait --json`.
+// Stable schema: every key is always present (zero values for absent
+// timestamps so consumers do not need to handle key-missing).
+type mergeWaitJSON struct {
+	PR       int     `json:"pr"`
+	Status   string  `json:"status"`
+	Title    *string `json:"title"`
+	Error    *string `json:"error"`
+	MergedAt *string `json:"merged_at"`
+	EndedAt  *string `json:"ended_at"`
+}
+
+func emitMergeWaitTerminal(row *db.PendingMerge, jsonMode bool) error {
+	if row == nil {
+		return fmt.Errorf("prism merge --wait: terminal row is nil")
+	}
+	if jsonMode {
+		payload := mergeWaitJSON{PR: row.PR, Status: row.Status, Title: row.Title, Error: row.Error}
+		if row.MergedAt != nil {
+			s := row.MergedAt.UTC().Format(time.RFC3339)
+			payload.MergedAt = &s
+		}
+		if row.EndedAt != nil {
+			s := row.EndedAt.UTC().Format(time.RFC3339)
+			payload.EndedAt = &s
+		}
+		data, mErr := json.Marshal(payload)
+		if mErr != nil {
+			return fmt.Errorf("prism merge --wait: marshal JSON: %w", mErr)
+		}
+		if pErr := printJSON(data); pErr != nil {
+			return pErr
+		}
+	} else {
+		if row.Status == "merged" {
+			fmt.Printf("PR #%d merged.\n", row.PR)
+		} else {
+			fmt.Printf("PR #%d ended with status %q", row.PR, row.Status)
+			if row.Error != nil && *row.Error != "" {
+				fmt.Printf(": %s", *row.Error)
+			}
+			fmt.Println()
+		}
+	}
+	if row.Status == "merged" {
+		return nil
+	}
+	return newExitErr(waitExitTerminalFail, "")
+}
+
+func emitMergeWaitTimeout(pr int, lastRow *db.PendingMerge, jsonMode bool, timeout time.Duration) error {
+	if jsonMode {
+		payload := struct {
+			PR             int    `json:"pr"`
+			Status         string `json:"status"`
+			Waited         string `json:"waited"`
+			LastRowStatus  string `json:"last_row_status"`
+			LastCheckedAt  string `json:"last_checked_at"`
+		}{PR: pr, Status: "timeout", Waited: timeout.String()}
+		if lastRow != nil {
+			payload.LastRowStatus = lastRow.Status
+			if lastRow.LastCheckedAt != nil {
+				payload.LastCheckedAt = lastRow.LastCheckedAt.UTC().Format(time.RFC3339)
+			}
+		}
+		data, mErr := json.Marshal(payload)
+		if mErr != nil {
+			return fmt.Errorf("prism merge --wait timeout: marshal: %w", mErr)
+		}
+		return printJSON(data)
+	}
+	fmt.Fprintf(os.Stderr, "prism merge --wait: timed out after %s; merge queue continues running.\n", formatDurationShort(timeout))
+	fmt.Fprintf(os.Stderr, "  Track progress with: prism merges list\n")
 	return nil
 }
 

--- a/modules/programs/prism/prism/cmd/merge_wait_test.go
+++ b/modules/programs/prism/prism/cmd/merge_wait_test.go
@@ -193,6 +193,59 @@ func captureStdoutAndStderr(t *testing.T, fn func()) string {
 	return out
 }
 
+// TestRunMerge_WaitJSON_StdoutIsJSONOnly is the regression test for the
+// JSON-exclusive contract on the host-direct path (#1500 round-2
+// review-code blocker). When --wait and --json are both set, the only
+// thing on stdout must be the single JSON object emitted by
+// emitMergeWaitTerminal — not the textual "PR #N enqueued ..." line.
+func TestRunMerge_WaitJSON_StdoutIsJSONOnly(t *testing.T) {
+	openMergeTestDB(t)
+
+	// Seed the row in the terminal state up front so observeAlreadyTerminal
+	// short-circuits without going through gh / preflight. This isolates
+	// the test to the JSON-output assertion.
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if _, err := d.EnqueueMerge(777, "nixos-config@main", "inst", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(777, "merged", ""); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+	d.Close()
+
+	// Set the flags on the cobra command.
+	t.Cleanup(func() {
+		_ = mergeCmd.Flags().Set("wait", "false")
+		_ = mergeCmd.Flags().Set("json", "false")
+	})
+	if err := mergeCmd.Flags().Set("wait", "true"); err != nil {
+		t.Fatalf("set --wait: %v", err)
+	}
+	if err := mergeCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runMerge(mergeCmd, []string{"777"}); err != nil {
+			t.Fatalf("runMerge: %v", err)
+		}
+	})
+	trimmed := strings.TrimSpace(out)
+	if !strings.HasPrefix(trimmed, "{") || !strings.HasSuffix(trimmed, "}") {
+		t.Errorf("stdout is not pure JSON — textual chatter leaked through:\n%s", out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		t.Fatalf("stdout not parseable as JSON: %v\nout: %s", err, out)
+	}
+	if payload["status"] != "merged" {
+		t.Errorf("status: want merged, got %v", payload["status"])
+	}
+}
+
 // TestEmitMergeWaitTerminal_JSONShape verifies the JSON contract for the
 // merged terminal payload.
 func TestEmitMergeWaitTerminal_JSONShape(t *testing.T) {

--- a/modules/programs/prism/prism/cmd/merge_wait_test.go
+++ b/modules/programs/prism/prism/cmd/merge_wait_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+// Tests for `prism merge --wait` (#1500).
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestObserveAlreadyTerminal_MergedRow exercises the idempotent-observation
+// AC: calling --wait on a PR that is already merged returns immediately
+// with the merged status (exit 0).
+func TestObserveAlreadyTerminal_MergedRow(t *testing.T) {
+	openMergeTestDB(t)
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer d.Close()
+
+	title := "feat: thing"
+	if _, err := d.EnqueueMerge(99, "nixos-config@main", "inst-1", &title); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(99, "merged", ""); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+	d.Close()
+
+	out := captureStdout(t, func() {
+		done, observeErr := observeAlreadyTerminal(99, false)
+		if !done {
+			t.Fatal("expected observeAlreadyTerminal to short-circuit on merged row")
+		}
+		if observeErr != nil {
+			t.Errorf("expected nil error on merged row, got %v", observeErr)
+		}
+	})
+	if !strings.Contains(out, "PR #99 merged") {
+		t.Errorf("expected merged summary on stdout, got %q", out)
+	}
+}
+
+// TestObserveAlreadyTerminal_FailedRow returns waitExitTerminalFail for a
+// non-merged terminal status.
+func TestObserveAlreadyTerminal_FailedRow(t *testing.T) {
+	openMergeTestDB(t)
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if _, err := d.EnqueueMerge(101, "nixos-config@main", "inst-1", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(101, "failed", "CI failed"); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+	d.Close()
+
+	_ = captureStdout(t, func() {
+		done, observeErr := observeAlreadyTerminal(101, false)
+		if !done {
+			t.Fatal("expected short-circuit on failed terminal row")
+		}
+		if observeErr == nil {
+			t.Fatal("expected non-nil error on failed terminal row")
+		}
+		var ec *exitCodeError
+		if !errors.As(observeErr, &ec) {
+			t.Fatalf("expected *exitCodeError, got %T: %v", observeErr, observeErr)
+		}
+		if ec.code != waitExitTerminalFail {
+			t.Errorf("expected exit code %d (terminal-fail), got %d", waitExitTerminalFail, ec.code)
+		}
+	})
+}
+
+// TestObserveAlreadyTerminal_WatchingRowDoesNotShortCircuit — a non-terminal
+// row must NOT trigger the idempotent path. The caller should proceed with
+// the normal poll.
+func TestObserveAlreadyTerminal_WatchingRowDoesNotShortCircuit(t *testing.T) {
+	openMergeTestDB(t)
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if _, err := d.EnqueueMerge(202, "nixos-config@main", "inst-1", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	d.Close()
+
+	done, observeErr := observeAlreadyTerminal(202, false)
+	if done {
+		t.Errorf("expected no short-circuit on watching row, got done=true err=%v", observeErr)
+	}
+}
+
+// TestWaitForMergeTerminal_PollsUntilTerminal exercises the poll loop:
+// start with a watching row, flip it to merged in a goroutine, and verify
+// that --wait observes the flip and returns nil (exit 0).
+func TestWaitForMergeTerminal_PollsUntilTerminal(t *testing.T) {
+	openMergeTestDB(t)
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if _, err := d.EnqueueMerge(303, "nixos-config@main", "inst-1", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	d.Close()
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		d2, dErr := openDB()
+		if dErr != nil {
+			t.Errorf("openDB in goroutine: %v", dErr)
+			return
+		}
+		defer d2.Close()
+		if err := d2.TerminateMerge(303, "merged", ""); err != nil {
+			t.Errorf("TerminateMerge in goroutine: %v", err)
+		}
+	}()
+
+	out := captureStdout(t, func() {
+		err := waitForMergeTerminal(303, false, 5*time.Second)
+		if err != nil {
+			t.Errorf("waitForMergeTerminal: expected nil on merged, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "PR #303 merged") {
+		t.Errorf("expected merged summary on stdout, got %q", out)
+	}
+}
+
+// TestWaitForMergeTerminal_TimeoutPath exercises the timeout AC: if the
+// row never reaches a terminal state within the timeout, the wait returns
+// waitExitTimeout (3) — distinct from the terminal-fail code (2).
+func TestWaitForMergeTerminal_TimeoutPath(t *testing.T) {
+	openMergeTestDB(t)
+
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	if _, err := d.EnqueueMerge(404, "nixos-config@main", "inst-1", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	d.Close()
+
+	out := captureStdoutAndStderr(t, func() {
+		err := waitForMergeTerminal(404, true /* json */, 100*time.Millisecond)
+		if err == nil {
+			t.Fatal("expected timeout error")
+		}
+		if exitCodeOf(err) != waitExitTimeout {
+			t.Errorf("expected timeout exit code %d, got %d (%v)", waitExitTimeout, exitCodeOf(err), err)
+		}
+	})
+	// JSON timeout payload is on stdout; the human-readable line goes to stderr.
+	// We don't separate them in this helper, so just check both ways.
+	var payload map[string]any
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(line), &payload); err == nil && payload["status"] == "timeout" {
+			break
+		}
+	}
+	if payload["status"] != "timeout" {
+		t.Errorf("expected JSON status=timeout, got payload=%v\nfull output: %s", payload, out)
+	}
+	if int(payload["pr"].(float64)) != 404 {
+		t.Errorf("expected pr=404, got %v", payload["pr"])
+	}
+}
+
+// captureStdoutAndStderr captures combined stdout+stderr. Used when a test
+// emits to both streams and we want to scan a JSON line regardless of which
+// file descriptor it landed on.
+func captureStdoutAndStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	out := captureStdout(t, fn)
+	return out
+}
+
+// TestEmitMergeWaitTerminal_JSONShape verifies the JSON contract for the
+// merged terminal payload.
+func TestEmitMergeWaitTerminal_JSONShape(t *testing.T) {
+	openMergeTestDB(t)
+	d, err := openDB()
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer d.Close()
+	if _, err := d.EnqueueMerge(555, "nixos-config@main", "inst", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(555, "merged", ""); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+	row, _ := d.PendingMergeByPR(555)
+
+	out := captureStdout(t, func() {
+		if err := emitMergeWaitTerminal(row, true); err != nil {
+			t.Errorf("emitMergeWaitTerminal: %v", err)
+		}
+	})
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &payload); err != nil {
+		t.Fatalf("not JSON: %v\nout: %s", err, out)
+	}
+	if payload["status"] != "merged" {
+		t.Errorf("status: want merged, got %v", payload["status"])
+	}
+	if int(payload["pr"].(float64)) != 555 {
+		t.Errorf("pr: want 555, got %v", payload["pr"])
+	}
+	for _, k := range []string{"pr", "status", "title", "error", "merged_at", "ended_at"} {
+		if _, ok := payload[k]; !ok {
+			t.Errorf("missing required key %q in JSON payload: %v", k, payload)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -151,10 +152,23 @@ func runReview(cmd *cobra.Command, args []string) error {
 		}
 		// proxyReviewAsync streams each output line to os.Stdout as it
 		// arrives — no further printing is needed here. The returned string
-		// is the buffered copy used for error context only.
-		_, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr, rebaseFlag)
+		// is the buffered Ack copy; we parse the group_id from it so that
+		// --wait can poll the group via the host-API probe (issue #1500
+		// review-code feedback: --wait was silently dropped on this proxy
+		// path before this fix).
+		waitFlag, _ := cmd.Flags().GetBool("wait")
+		jsonFlag, _ := cmd.Flags().GetBool("json")
+		waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+		ackOutput, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr, rebaseFlag)
 		if err != nil {
 			return fmt.Errorf("prism review: host API: %w", err)
+		}
+		if waitFlag {
+			groupID := parseReviewGroupIDFromAck(ackOutput)
+			if groupID == "" {
+				return fmt.Errorf("prism review --wait: could not parse group_id from review acknowledgement; cannot poll for completion")
+			}
+			return waitForReviewTerminal(prNumber, groupID, jsonFlag, waitTimeout)
 		}
 		return nil
 	}
@@ -366,6 +380,27 @@ func runReview(cmd *cobra.Command, args []string) error {
 	fmt.Print(result.Ack)
 	_ = os.Stdout.Sync()
 	return nil
+}
+
+// reviewGroupIDInAck matches the "(group: <uuid>)" segment in the Ack
+// header line emitted by review.RunAsync, e.g.:
+//
+//	Review in progress — PR #1533, round 1 (group: 5103f218-...-2448dac6ab26)
+//
+// We pull the group_id out of the streamed Ack so the in-sandbox --wait
+// path can poll the group via the sidecar's /groups/poll endpoint without
+// the sidecar having to thread the ID back through a side-channel.
+var reviewGroupIDInAck = regexp.MustCompile(`\(group:\s+([0-9a-f-]{36})\)`)
+
+// parseReviewGroupIDFromAck extracts the review group_id from the buffered
+// Ack output. Returns "" when no match is found — the caller surfaces this
+// as an error so --wait does not silently hang on a missing ID.
+func parseReviewGroupIDFromAck(ack string) string {
+	m := reviewGroupIDInAck.FindStringSubmatch(ack)
+	if len(m) != 2 {
+		return ""
+	}
+	return m[1]
 }
 
 // progressLineEager writes and flushes a single progress line to stdout.

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -159,7 +159,11 @@ func runReview(cmd *cobra.Command, args []string) error {
 		waitFlag, _ := cmd.Flags().GetBool("wait")
 		jsonFlag, _ := cmd.Flags().GetBool("json")
 		waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
-		ackOutput, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr, rebaseFlag)
+		// Suppress the streamed-stdout print when --wait --json is set so
+		// the JSON terminal status is the only thing on stdout. The Ack is
+		// still buffered in ackOutput so we can parse the group_id from it.
+		quietStdout := waitFlag && jsonFlag
+		ackOutput, err := proxyReviewAsync(apiURL, prNumber, agentNames, timeoutStr, rebaseFlag, quietStdout)
 		if err != nil {
 			return fmt.Errorf("prism review: host API: %w", err)
 		}

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -63,6 +63,9 @@ func init() {
 		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
 	reviewCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro); takes precedence over --model for the named role")
 	reviewCmd.Flags().Bool("rebase", false, "Fetch origin/main, rebase HEAD onto it, and force-push before running the review (inline fix for the rebase-gate refusal)")
+	reviewCmd.Flags().Bool("wait", false, "Block until the review group reaches a terminal state (all-PASS, any-FAIL, or no-start). Without --wait, returns immediately and the monitor delivers results later via prism prompt.")
+	reviewCmd.Flags().Duration("wait-timeout", defaultReviewWaitTimeout, "Timeout for --wait. On expiry, exits non-zero with a status payload distinguishable from a real review failure. Ignored when --wait is not set.")
+	reviewCmd.Flags().Bool("json", false, "Emit the terminal verdict as a JSON object on stdout (only useful with --wait). Suppresses textual output.")
 	rootCmd.AddCommand(reviewCmd)
 }
 
@@ -342,6 +345,21 @@ func runReview(cmd *cobra.Command, args []string) error {
 	result, runErr := review.RunAsync(opts, "")
 	if runErr != nil {
 		return fmt.Errorf("prism review: %w", runErr)
+	}
+
+	// --wait: block until the review group reaches a terminal state.
+	waitFlag, _ := cmd.Flags().GetBool("wait")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+	if waitFlag {
+		// In --wait mode and --json, we suppress the ack to keep stdout
+		// JSON-only. In textual mode the ack is still useful so the user
+		// can see which agents were spawned before the wait begins.
+		if !jsonFlag {
+			fmt.Print(result.Ack)
+			_ = os.Stdout.Sync()
+		}
+		return waitForReviewTerminal(prNumber, result.GroupID, jsonFlag, waitTimeout)
 	}
 
 	// Print acknowledgement to stdout immediately.

--- a/modules/programs/prism/prism/cmd/review_wait.go
+++ b/modules/programs/prism/prism/cmd/review_wait.go
@@ -47,6 +47,11 @@ type reviewWaitAgentJSON struct {
 // waitForReviewTerminal polls the review group until db.GroupCompleted
 // returns true, then aggregates per-agent verdicts and emits the result.
 //
+// Sandbox-aware via newWaitProbe(): in-sandbox callers route reads through
+// the sidecar's /groups/poll endpoint so the host's session_groups table is
+// visible. Without this, --wait inside a sandbox would poll a tmpfs shadow
+// DB and never observe completion (issue #1500 review-code feedback).
+//
 // Exit codes:
 //
 //   - all-PASS: 0
@@ -54,18 +59,18 @@ type reviewWaitAgentJSON struct {
 //   - timeout:                          waitExitTimeout (3)
 //   - user interrupt:                   waitExitUserInterrupt (4)
 func waitForReviewTerminal(prNumber, groupID string, jsonMode bool, timeout time.Duration) error {
-	d, dbErr := openDB()
-	if dbErr != nil {
-		return fmt.Errorf("prism review --wait: open db: %w", dbErr)
+	probe, err := newWaitProbe()
+	if err != nil {
+		return fmt.Errorf("prism review --wait: %w", err)
 	}
-	defer d.Close()
+	defer probe.Close()
 
 	pollErr := pollWait(context.Background(), timeout,
 		1*time.Second, 10*time.Second,
 		func() (bool, error) {
-			done, gErr := d.GroupCompleted(groupID)
+			done, _, _, gErr := probe.GroupPoll(groupID)
 			if gErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism review --wait] db error: %v (will retry)\n", gErr)
+				fmt.Fprintf(os.Stderr, "[prism review --wait] probe error: %v (will retry)\n", gErr)
 				return false, nil
 			}
 			return done, nil
@@ -73,7 +78,7 @@ func waitForReviewTerminal(prNumber, groupID string, jsonMode bool, timeout time
 
 	switch exitCodeOf(pollErr) {
 	case waitExitTimeout:
-		_ = emitReviewWaitTimeout(prNumber, groupID, d, jsonMode, timeout)
+		_ = emitReviewWaitTimeout(prNumber, groupID, probe, jsonMode, timeout)
 		return newExitErr(waitExitTimeout, "")
 	case waitExitUserInterrupt:
 		return pollErr
@@ -82,25 +87,38 @@ func waitForReviewTerminal(prNumber, groupID string, jsonMode bool, timeout time
 		return pollErr
 	}
 
-	// Group is complete. Aggregate verdicts.
-	return emitReviewWaitTerminal(prNumber, groupID, d, jsonMode)
+	// Group is complete. Fetch the final state once and aggregate verdicts.
+	_, allMembers, members, gErr := probe.GroupPoll(groupID)
+	if gErr != nil {
+		return fmt.Errorf("prism review --wait: final group poll: %w", gErr)
+	}
+	return emitReviewWaitTerminalAgg(prNumber, groupID, allMembers, members, jsonMode)
 }
 
-// emitReviewWaitTerminal aggregates per-agent verdicts from db.GroupResults
-// and emits a JSON object or a textual summary, then returns 0 on all-PASS
-// or waitExitTerminalFail (2) on any FAIL / NONE / missing.
+// emitReviewWaitTerminal is kept for tests that pre-date the probe
+// abstraction. Production code calls emitReviewWaitTerminalAgg with
+// pre-fetched member data so the live path never opens a DB handle behind
+// the probe's back.
 func emitReviewWaitTerminal(prNumber, groupID string, d *db.DB, jsonMode bool) error {
 	members, mErr := d.GroupResults(groupID)
 	if mErr != nil {
 		return fmt.Errorf("prism review --wait: aggregate group results: %w", mErr)
 	}
-	// We also need the full member list (including ended_at-set rows that
-	// GroupResults intentionally drops) so the JSON output reports every
-	// agent that was spawned, even when one was cleaned up mid-run.
 	allMembers, allErr := d.GroupMembersForGroup(groupID)
 	if allErr != nil {
 		return fmt.Errorf("prism review --wait: list group members: %w", allErr)
 	}
+	return emitReviewWaitTerminalAgg(prNumber, groupID, allMembers, members, jsonMode)
+}
+
+// emitReviewWaitTerminalAgg aggregates per-agent verdicts from already-fetched
+// group state and emits a JSON object or a textual summary. Returns 0 on
+// all-PASS or waitExitTerminalFail (2) on any FAIL / NONE / missing.
+//
+// allMembers is the raw agent_status rows for the group (including ones
+// whose ended_at is set, which `members` intentionally drops). members is
+// the GroupResults map keyed by session name.
+func emitReviewWaitTerminalAgg(prNumber, groupID string, allMembers []db.Status, members map[string]db.GroupMemberResult, jsonMode bool) error {
 
 	allPass := true
 	rows := make([]reviewWaitAgentJSON, 0, len(allMembers))
@@ -203,8 +221,12 @@ func emitReviewWaitTerminal(prNumber, groupID string, d *db.DB, jsonMode bool) e
 	return newExitErr(waitExitTerminalFail, "")
 }
 
-func emitReviewWaitTimeout(prNumber, groupID string, d *db.DB, jsonMode bool, timeout time.Duration) error {
-	allMembers, _ := d.GroupMembersForGroup(groupID)
+func emitReviewWaitTimeout(prNumber, groupID string, probe waitProbe, jsonMode bool, timeout time.Duration) error {
+	var allMembers []db.Status
+	if probe != nil {
+		_, m, _, _ := probe.GroupPoll(groupID)
+		allMembers = m
+	}
 	rows := make([]reviewWaitAgentJSON, 0, len(allMembers))
 	for _, m := range allMembers {
 		rows = append(rows, reviewWaitAgentJSON{

--- a/modules/programs/prism/prism/cmd/review_wait.go
+++ b/modules/programs/prism/prism/cmd/review_wait.go
@@ -1,0 +1,245 @@
+package cmd
+
+// review_wait.go — `prism review --wait` blocking poll loop (#1500).
+//
+// After RunAsync spawns the review group and returns, --wait polls the prism
+// DB for group completion. Termination is determined by db.GroupCompleted —
+// the same condition the async monitor process uses — so the wait loop sees
+// exactly the same terminal as the notification path. We do not duplicate
+// the monitor's verdict-aggregation logic; we re-use db.GroupResults +
+// review.ExtractAssistantText + review.AssessPassed to reach the same
+// PASS/FAIL/NONE verdicts the notification message would carry.
+//
+// The wait loop is a thin observer: killing it does NOT cancel the review
+// (the agents keep running, the monitor keeps watching). The user can re-run
+// `prism review <pr>` (without --wait) to get the notification when it
+// arrives, or read `prism reviews list` to find the group.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// reviewWaitJSON is the JSON shape emitted by `prism review --wait --json`.
+// Stable schema — every key is always present.
+type reviewWaitJSON struct {
+	PR      string                 `json:"pr"`
+	GroupID string                 `json:"group_id"`
+	Verdict string                 `json:"verdict"` // "PASS" | "FAIL" | "TIMEOUT" | "NO_VERDICT"
+	Agents  []reviewWaitAgentJSON  `json:"agents"`
+	Status  string                 `json:"status"`  // mirrors Verdict for symmetry with merge --wait
+}
+
+type reviewWaitAgentJSON struct {
+	Agent   string `json:"agent"`
+	Session string `json:"session"`
+	State   string `json:"state"`   // finished / error / interrupted / deleted / unknown
+	Verdict string `json:"verdict"` // PASS / FAIL / NONE
+	Error   string `json:"error,omitempty"`
+}
+
+// waitForReviewTerminal polls the review group until db.GroupCompleted
+// returns true, then aggregates per-agent verdicts and emits the result.
+//
+// Exit codes:
+//
+//   - all-PASS: 0
+//   - any-FAIL or any-NONE / no-start: waitExitTerminalFail (2)
+//   - timeout:                          waitExitTimeout (3)
+//   - user interrupt:                   waitExitUserInterrupt (4)
+func waitForReviewTerminal(prNumber, groupID string, jsonMode bool, timeout time.Duration) error {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("prism review --wait: open db: %w", dbErr)
+	}
+	defer d.Close()
+
+	pollErr := pollWait(context.Background(), timeout,
+		1*time.Second, 10*time.Second,
+		func() (bool, error) {
+			done, gErr := d.GroupCompleted(groupID)
+			if gErr != nil {
+				fmt.Fprintf(os.Stderr, "[prism review --wait] db error: %v (will retry)\n", gErr)
+				return false, nil
+			}
+			return done, nil
+		})
+
+	switch exitCodeOf(pollErr) {
+	case waitExitTimeout:
+		_ = emitReviewWaitTimeout(prNumber, groupID, d, jsonMode, timeout)
+		return newExitErr(waitExitTimeout, "")
+	case waitExitUserInterrupt:
+		return pollErr
+	}
+	if pollErr != nil {
+		return pollErr
+	}
+
+	// Group is complete. Aggregate verdicts.
+	return emitReviewWaitTerminal(prNumber, groupID, d, jsonMode)
+}
+
+// emitReviewWaitTerminal aggregates per-agent verdicts from db.GroupResults
+// and emits a JSON object or a textual summary, then returns 0 on all-PASS
+// or waitExitTerminalFail (2) on any FAIL / NONE / missing.
+func emitReviewWaitTerminal(prNumber, groupID string, d *db.DB, jsonMode bool) error {
+	members, mErr := d.GroupResults(groupID)
+	if mErr != nil {
+		return fmt.Errorf("prism review --wait: aggregate group results: %w", mErr)
+	}
+	// We also need the full member list (including ended_at-set rows that
+	// GroupResults intentionally drops) so the JSON output reports every
+	// agent that was spawned, even when one was cleaned up mid-run.
+	allMembers, allErr := d.GroupMembersForGroup(groupID)
+	if allErr != nil {
+		return fmt.Errorf("prism review --wait: list group members: %w", allErr)
+	}
+
+	allPass := true
+	rows := make([]reviewWaitAgentJSON, 0, len(allMembers))
+	for _, m := range allMembers {
+		row := reviewWaitAgentJSON{
+			Agent:   agentNameFromSession(m.SessionName),
+			Session: m.SessionName,
+			State:   m.State,
+		}
+		if mr, ok := members[m.SessionName]; ok {
+			switch mr.State {
+			case "finished":
+				if mr.LastMessage == "" {
+					row.Verdict = "NONE"
+					row.Error = "no output produced"
+					allPass = false
+				} else {
+					text := review.ExtractAssistantText(mr.LastMessage)
+					passed, kind := review.AssessPassed(text)
+					switch {
+					case passed:
+						row.Verdict = "PASS"
+					case kind == review.VerdictFail:
+						row.Verdict = "FAIL"
+						allPass = false
+					default:
+						row.Verdict = "NONE"
+						row.Error = "no recognised verdict in agent output"
+						allPass = false
+					}
+				}
+			case "error":
+				row.Verdict = "FAIL"
+				row.Error = "agent reached error state"
+				if mr.StartupError != "" {
+					row.Error = "startup error: " + mr.StartupError
+				}
+				allPass = false
+			default:
+				row.Verdict = "NONE"
+				allPass = false
+			}
+		} else {
+			// Member was cleaned up before result aggregation; treat as failure.
+			row.Verdict = "NONE"
+			row.Error = "session not present in group results (likely cleaned up mid-run)"
+			allPass = false
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) == 0 {
+		// No members were ever spawned — definitely a fail.
+		allPass = false
+	}
+
+	verdict := "PASS"
+	if !allPass {
+		verdict = "FAIL"
+	}
+
+	if jsonMode {
+		payload := reviewWaitJSON{
+			PR:      prNumber,
+			GroupID: groupID,
+			Verdict: verdict,
+			Agents:  rows,
+			Status:  verdict,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("prism review --wait: marshal JSON: %w", err)
+		}
+		if pErr := printJSON(data); pErr != nil {
+			return pErr
+		}
+	} else {
+		if allPass {
+			fmt.Printf("\nReview PR #%s — verdict: PASS (%d/%d agents passed)\n", prNumber, len(rows), len(rows))
+		} else {
+			passN := 0
+			for _, r := range rows {
+				if r.Verdict == "PASS" {
+					passN++
+				}
+			}
+			fmt.Printf("\nReview PR #%s — verdict: FAIL (%d/%d agents passed)\n", prNumber, passN, len(rows))
+		}
+		for _, r := range rows {
+			if r.Error != "" {
+				fmt.Printf("  • %s — %s [%s]: %s\n", r.Agent, r.Verdict, r.State, r.Error)
+			} else {
+				fmt.Printf("  • %s — %s [%s]\n", r.Agent, r.Verdict, r.State)
+			}
+		}
+	}
+
+	if allPass {
+		return nil
+	}
+	return newExitErr(waitExitTerminalFail, "")
+}
+
+func emitReviewWaitTimeout(prNumber, groupID string, d *db.DB, jsonMode bool, timeout time.Duration) error {
+	allMembers, _ := d.GroupMembersForGroup(groupID)
+	rows := make([]reviewWaitAgentJSON, 0, len(allMembers))
+	for _, m := range allMembers {
+		rows = append(rows, reviewWaitAgentJSON{
+			Agent:   agentNameFromSession(m.SessionName),
+			Session: m.SessionName,
+			State:   m.State,
+			Verdict: "PENDING",
+		})
+	}
+	if jsonMode {
+		payload := reviewWaitJSON{
+			PR:      prNumber,
+			GroupID: groupID,
+			Verdict: "TIMEOUT",
+			Agents:  rows,
+			Status:  "timeout",
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("prism review --wait timeout: marshal: %w", err)
+		}
+		return printJSON(data)
+	}
+	fmt.Fprintf(os.Stderr, "prism review --wait: timed out after %s; review continues running.\n", formatDurationShort(timeout))
+	fmt.Fprintf(os.Stderr, "  Track progress with: prism reviews list\n")
+	return nil
+}
+
+// agentNameFromSession recovers the per-agent role from a review session name
+// of the form "<parent>~review-<N>-<agent>". Falls back to the full session
+// name when no match is found.
+func agentNameFromSession(sessionName string) string {
+	m := reviewSessionPattern.FindStringSubmatch(sessionName)
+	if len(m) == 4 {
+		return m[3]
+	}
+	return sessionName
+}

--- a/modules/programs/prism/prism/cmd/review_wait_test.go
+++ b/modules/programs/prism/prism/cmd/review_wait_test.go
@@ -1,0 +1,222 @@
+package cmd
+
+// Tests for `prism review --wait` (#1500). We test the wait-and-aggregate
+// path directly (waitForReviewTerminal / emitReviewWaitTerminal) — runReview
+// itself is exercised by review_test.go and its full wiring is out of scope
+// here. The wait loop's contract is "given a registered group and seeded
+// agent_status rows, observe completion via db.GroupCompleted and aggregate
+// verdicts via db.GroupResults".
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func openReviewWaitTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "review_wait.db")
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+	t.Setenv("PRISM_HOST_API", "")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// linkAgentToGroup is a small helper that mirrors the SQL used in internal/db
+// tests. Avoids exporting a test-only helper from the db package.
+func linkAgentToGroup(t *testing.T, d *db.DB, sessionName, groupID string) {
+	t.Helper()
+	var one int
+	if err := d.QueryRow(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+		groupID, sessionName,
+	).Scan(&one); err != nil {
+		t.Fatalf("link group_id: %v", err)
+	}
+}
+
+// writeAssistantEvent inserts a msg_assistant event whose payload's text
+// field carries the supplied verdict marker. Tests use this to seed PASS /
+// FAIL verdicts for the aggregator.
+func writeAssistantEvent(t *testing.T, d *db.DB, session, text string) {
+	t.Helper()
+	payload := `{"text":` + jsonString(text) + `}`
+	now := time.Now()
+	if err := d.WriteEvent(db.Event{
+		ID:          "evt-" + session + "-" + now.Format("150405.000000"),
+		SessionName: session,
+		Repo:        "repo",
+		Worktree:    "/wt",
+		Type:        "msg_assistant",
+		Payload:     payload,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestEmitReviewWaitTerminal_AllPass verifies the all-PASS aggregation:
+// every member finished with a <verdict>PASS</verdict> marker → exit 0.
+func TestEmitReviewWaitTerminal_AllPass(t *testing.T) {
+	d := openReviewWaitTestDB(t)
+	groupID, err := d.RegisterGroup("repo@pr-1500")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	const s1 = "repo@pr-1500~review-1-review-goal"
+	const s2 = "repo@pr-1500~review-1-review-code"
+	for _, s := range []string{s1, s2} {
+		if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+			t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+		}
+		linkAgentToGroup(t, d, s, groupID)
+		writeAssistantEvent(t, d, s, "<verdict>PASS</verdict> looks good")
+	}
+
+	out := captureStdout(t, func() {
+		if err := emitReviewWaitTerminal("1500", groupID, d, false); err != nil {
+			t.Errorf("emitReviewWaitTerminal: expected nil for all-PASS, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "verdict: PASS") {
+		t.Errorf("expected PASS summary, got %q", out)
+	}
+}
+
+// TestEmitReviewWaitTerminal_AnyFailReturnsTerminalFail — one FAIL among
+// PASSes flips the overall verdict to FAIL with exit code 2.
+func TestEmitReviewWaitTerminal_AnyFailReturnsTerminalFail(t *testing.T) {
+	d := openReviewWaitTestDB(t)
+	groupID, _ := d.RegisterGroup("repo@pr-1500")
+	const s1 = "repo@pr-1500~review-1-review-goal"
+	const s2 = "repo@pr-1500~review-1-review-code"
+	if err := d.UpsertStatusSeedRootAgentName(s1, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	linkAgentToGroup(t, d, s1, groupID)
+	writeAssistantEvent(t, d, s1, "<verdict>PASS</verdict>")
+
+	if err := d.UpsertStatusSeedRootAgentName(s2, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	linkAgentToGroup(t, d, s2, groupID)
+	writeAssistantEvent(t, d, s2, "<verdict>FAIL</verdict> needs work")
+
+	_ = captureStdout(t, func() {
+		err := emitReviewWaitTerminal("1500", groupID, d, false)
+		if err == nil {
+			t.Fatal("expected non-nil error for any-FAIL")
+		}
+		var ec *exitCodeError
+		if !errors.As(err, &ec) {
+			t.Fatalf("expected *exitCodeError, got %T: %v", err, err)
+		}
+		if ec.code != waitExitTerminalFail {
+			t.Errorf("expected exit code %d, got %d", waitExitTerminalFail, ec.code)
+		}
+	})
+}
+
+// TestEmitReviewWaitTerminal_JSONShape verifies the --json contract.
+func TestEmitReviewWaitTerminal_JSONShape(t *testing.T) {
+	d := openReviewWaitTestDB(t)
+	groupID, _ := d.RegisterGroup("repo@pr-1500")
+	const s = "repo@pr-1500~review-1-review-goal"
+	if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	linkAgentToGroup(t, d, s, groupID)
+	writeAssistantEvent(t, d, s, "<verdict>PASS</verdict>")
+
+	out := captureStdout(t, func() {
+		if err := emitReviewWaitTerminal("1500", groupID, d, true /* json */); err != nil {
+			t.Errorf("emitReviewWaitTerminal: %v", err)
+		}
+	})
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &payload); err != nil {
+		t.Fatalf("not JSON: %v\nout: %s", err, out)
+	}
+	for _, k := range []string{"pr", "group_id", "verdict", "agents", "status"} {
+		if _, ok := payload[k]; !ok {
+			t.Errorf("missing required key %q in JSON: %v", k, payload)
+		}
+	}
+	if payload["verdict"] != "PASS" {
+		t.Errorf("verdict: want PASS, got %v", payload["verdict"])
+	}
+	agents, ok := payload["agents"].([]any)
+	if !ok || len(agents) != 1 {
+		t.Fatalf("agents: expected 1-element array, got %v", payload["agents"])
+	}
+	a := agents[0].(map[string]any)
+	if a["session"] != s {
+		t.Errorf("agents[0].session: want %q, got %v", s, a["session"])
+	}
+	if a["verdict"] != "PASS" {
+		t.Errorf("agents[0].verdict: want PASS, got %v", a["verdict"])
+	}
+}
+
+// TestWaitForReviewTerminal_PollsUntilGroupCompleted exercises the full
+// poll loop: start with one active member, flip to finished+PASS in a
+// goroutine, observe terminal.
+func TestWaitForReviewTerminal_PollsUntilGroupCompleted(t *testing.T) {
+	d := openReviewWaitTestDB(t)
+	groupID, _ := d.RegisterGroup("repo@pr-1500")
+	const s = "repo@pr-1500~review-1-review-goal"
+	if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "active", nil, nil, "review", ""); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	linkAgentToGroup(t, d, s, groupID)
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		d2, _ := openDB()
+		defer d2.Close()
+		_ = d2.UpsertStatus(s, "repo", "/wt", "finished", nil, nil)
+		writeAssistantEvent(t, d2, s, "<verdict>PASS</verdict>")
+	}()
+
+	out := captureStdout(t, func() {
+		if err := waitForReviewTerminal("1500", groupID, false, 5*time.Second); err != nil {
+			t.Errorf("waitForReviewTerminal: expected nil for PASS, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "PASS") {
+		t.Errorf("expected PASS in output, got %q", out)
+	}
+}
+
+// TestAgentNameFromSession recovers the agent role from a review session name.
+func TestAgentNameFromSession(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"repo@pr-1500~review-1-review-goal", "review-goal"},
+		{"repo@pr-1500~review-3-review-security", "review-security"},
+		{"repo@main", "repo@main"},
+		{"weird-name", "weird-name"},
+	}
+	for _, tc := range cases {
+		if got := agentNameFromSession(tc.in); got != tc.want {
+			t.Errorf("agentNameFromSession(%q): got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/reviews.go
+++ b/modules/programs/prism/prism/cmd/reviews.go
@@ -1,0 +1,254 @@
+package cmd
+
+// prism reviews — inspect the review-group ledger (#1500).
+//
+// Mirrors the shape of `prism merges` but for review groups. The
+// session_groups table records every review round prism has spawned; this
+// command exposes that ledger so coordinators and workers don't have to
+// `prism list-sessions | grep '~review-N-'` and reconstruct the metadata.
+//
+// Subcommands:
+//
+//   prism reviews             alias for `prism reviews list`
+//   prism reviews list        all review groups, newest first
+//   prism reviews list --json JSON array suitable for scripting
+//
+// The list shows: PR number (parsed from agent session names), parent
+// session, agent sessions, group state (in-progress / completed / empty),
+// and the started-at timestamp.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var reviewsCmd = &cobra.Command{
+	Use:   "reviews",
+	Short: "Inspect the review-group ledger",
+	Long: `Inspect the review-group ledger.
+
+Defaults to listing all review groups, newest first. Each row shows the
+review's PR number, parent (worker) session, agent sessions, group state,
+and the started-at timestamp.
+
+The session_groups table is the authoritative source. Use this command
+instead of 'prism list-sessions | grep ~review-' — that workaround is
+fragile and lacks group-level metadata.`,
+	Args: cobra.NoArgs,
+	RunE: runReviewsList,
+}
+
+var reviewsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List review groups",
+	Long: `List review groups in the prism database, newest first.
+
+Each row shows: PR number, parent (worker) session, agent sessions, group
+state, and started-at timestamp. With --json, emits a JSON array of review
+group objects suitable for scripting and polling.`,
+	Args: cobra.NoArgs,
+	RunE: runReviewsList,
+}
+
+func init() {
+	reviewsCmd.Flags().Bool("json", false, "Emit a JSON array of review-group entries to stdout instead of the human-readable table")
+	reviewsCmd.Flags().Int("limit", 0, "Limit the number of rows returned (default: all)")
+	reviewsListCmd.Flags().Bool("json", false, "Emit a JSON array of review-group entries to stdout instead of the human-readable table")
+	reviewsListCmd.Flags().Int("limit", 0, "Limit the number of rows returned (default: all)")
+
+	reviewsCmd.AddCommand(reviewsListCmd)
+	rootCmd.AddCommand(reviewsCmd)
+}
+
+// reviewSessionPattern matches per-agent review session names of the form
+// "<parent>~review-<N>-<agent>". We use it to recover the PR number's parent
+// branch from any one member; the actual PR number is not encoded in the
+// session name (the round number N is) so PR is left unknown unless we can
+// derive it from the parent's branch suffix.
+var reviewSessionPattern = regexp.MustCompile(`^(.+)~review-(\d+)-(.+)$`)
+
+// reviewParentBranchPattern extracts the branch component from a parent
+// session name "<repo>@<branch>". Used as a heuristic for surfacing the PR
+// number when the branch happens to be of the form "pr-<N>".
+var reviewParentBranchPattern = regexp.MustCompile(`@(.+)$`)
+
+func runReviewsList(cmd *cobra.Command, _ []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("prism reviews list: open db: %w", err)
+	}
+	defer d.Close()
+
+	groups, err := d.ReviewGroupsList(limit)
+	if err != nil {
+		return fmt.Errorf("prism reviews list: %w", err)
+	}
+
+	if jsonMode {
+		return renderReviewsListJSON(groups)
+	}
+	return renderReviewsList(groups)
+}
+
+// reviewsJSONRow is the snake_case JSON shape for one review-group row.
+// Defined explicitly so the JSON contract is decoupled from
+// db.ReviewGroupSummary's field naming.
+type reviewsJSONRow struct {
+	GroupID        string   `json:"group_id"`
+	PR             *int     `json:"pr"`
+	ParentSession  string   `json:"parent_session"`
+	AgentSessions  []string `json:"agent_sessions"`
+	AgentStates    []string `json:"agent_states"`
+	GroupState     string   `json:"group_state"`
+	StartedAt      string   `json:"started_at"` // RFC3339
+	Round          *int     `json:"round"`      // round number derived from agent session names
+}
+
+func renderReviewsListJSON(groups []db.ReviewGroupSummary) error {
+	rows := make([]reviewsJSONRow, 0, len(groups))
+	for _, g := range groups {
+		row := reviewsJSONRow{
+			GroupID:       g.GroupID,
+			ParentSession: g.ParentSession,
+			AgentSessions: append([]string(nil), g.Members...),
+			AgentStates:   append([]string(nil), g.AgentStates...),
+			GroupState:    g.GroupState,
+			StartedAt:     g.CreatedAt.UTC().Format(time.RFC3339),
+		}
+		if pr := inferPRFromGroup(g); pr > 0 {
+			row.PR = &pr
+		}
+		if round := inferRoundFromGroup(g); round > 0 {
+			row.Round = &round
+		}
+		rows = append(rows, row)
+	}
+	data, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("prism reviews list --json: marshal: %w", err)
+	}
+	return printJSON(data)
+}
+
+// inferPRFromGroup returns the PR number for a review group when it is
+// derivable from the parent session's branch component (e.g. "repo@pr-123").
+// Returns 0 when no PR number can be inferred — the JSON contract represents
+// this as a null `pr` field.
+func inferPRFromGroup(g db.ReviewGroupSummary) int {
+	m := reviewParentBranchPattern.FindStringSubmatch(g.ParentSession)
+	if len(m) != 2 {
+		return 0
+	}
+	branch := m[1]
+	// Common conventions:
+	//   pr-<N>   → PR #N
+	//   pr<N>    → PR #N
+	for _, prefix := range []string{"pr-", "pr"} {
+		if strings.HasPrefix(branch, prefix) {
+			rest := strings.TrimPrefix(branch, prefix)
+			if n, err := strconv.Atoi(rest); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// inferRoundFromGroup returns the review round number derived from any one
+// member's session name (`<parent>~review-<N>-<agent>`). All members of a
+// group share the same round, so we can return the first one we parse.
+func inferRoundFromGroup(g db.ReviewGroupSummary) int {
+	for _, name := range g.Members {
+		m := reviewSessionPattern.FindStringSubmatch(name)
+		if len(m) == 4 {
+			if n, err := strconv.Atoi(m[2]); err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+func renderReviewsList(groups []db.ReviewGroupSummary) error {
+	if len(groups) == 0 {
+		fmt.Println("no review groups recorded")
+		return nil
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+
+	const (
+		wPR     = 6
+		wRound  = 5
+		wState  = 12
+		wParent = 30
+		wAgents = 4
+		wAge    = 8
+	)
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
+		wPR, "PR",
+		wRound, "ROUND",
+		wState, "STATE",
+		wParent, "PARENT",
+		wAgents, "N",
+		wAge, "AGE",
+		"AGENTS",
+	)
+	fmt.Println(styleHeader.Render(header))
+	fmt.Println(styleDim.Render(strings.Repeat("─", len(header)+5)))
+
+	now := time.Now()
+	for _, g := range groups {
+		prStr := "—"
+		if pr := inferPRFromGroup(g); pr > 0 {
+			prStr = fmt.Sprintf("#%d", pr)
+		}
+		roundStr := "—"
+		if r := inferRoundFromGroup(g); r > 0 {
+			roundStr = fmt.Sprintf("%d", r)
+		}
+		parent := truncateStr(g.ParentSession, wParent)
+		ageStr := formatAge(now, g.CreatedAt)
+		agents := truncateStr(strings.Join(g.Members, ","), 80)
+		state := reviewGroupStateStyle(g.GroupState).Render(fmt.Sprintf("%-*s", wState, truncateStr(g.GroupState, wState)))
+		fmt.Printf("%-*s  %-*s  %s  %-*s  %-*d  %-*s  %s\n",
+			wPR, prStr,
+			wRound, roundStr,
+			state,
+			wParent, parent,
+			wAgents, len(g.Members),
+			wAge, ageStr,
+			agents,
+		)
+	}
+	fmt.Fprintln(os.Stdout)
+	return nil
+}
+
+// reviewGroupStateStyle returns the lipgloss style for a review group state.
+func reviewGroupStateStyle(state string) lipgloss.Style {
+	switch state {
+	case "in-progress":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("33")) // yellow
+	case "completed":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("32")) // green
+	case "empty":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	default:
+		return lipgloss.NewStyle()
+	}
+}

--- a/modules/programs/prism/prism/cmd/reviews.go
+++ b/modules/programs/prism/prism/cmd/reviews.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
 )
 
 var reviewsCmd = &cobra.Command{
@@ -85,6 +86,29 @@ var reviewParentBranchPattern = regexp.MustCompile(`@(.+)$`)
 func runReviewsList(cmd *cobra.Command, _ []string) error {
 	jsonMode, _ := cmd.Flags().GetBool("json")
 	limit, _ := cmd.Flags().GetInt("limit")
+
+	// Inside a bwrap / podman / sandbox-exec sandbox: proxy the list to
+	// the host sidecar (#1043 pattern). The host's prism.db is invisible
+	// to direct reads from inside the sandbox — falling through to the DB
+	// path would silently return an empty list (the shadow tmpfs DB has
+	// no rows the host watcher writes). The sibling `prism merges list`
+	// already does this; without the same branch, `prism reviews list`
+	// inside a sandbox would silently return [] (#1500 round-2
+	// review-context blocker).
+	if apiURL := sandboxenv.HostAPISocket(); apiURL != "" {
+		params := map[string]string{}
+		if limit > 0 {
+			params["limit"] = strconv.Itoa(limit)
+		}
+		var groups []db.ReviewGroupSummary
+		if proxyErr := proxyGetFromHostAPI(apiURL, "/groups/list", params, &groups); proxyErr != nil {
+			return fmt.Errorf("prism reviews list: %w", proxyErr)
+		}
+		if jsonMode {
+			return renderReviewsListJSON(groups)
+		}
+		return renderReviewsList(groups)
+	}
 
 	d, err := openDB()
 	if err != nil {

--- a/modules/programs/prism/prism/cmd/reviews_test.go
+++ b/modules/programs/prism/prism/cmd/reviews_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+// Tests for `prism reviews list` (#1500). Verifies the ledger surface
+// returns rows from session_groups + agent_status, and that the JSON
+// shape carries the documented fields.
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func openReviewsTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "reviews_test.db")
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+	t.Setenv("PRISM_HOST_API", "")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// TestReviewsList_EmptyLedger renders an empty-ledger message in textual
+// mode and "[]" in JSON mode.
+func TestReviewsList_EmptyLedger(t *testing.T) {
+	openReviewsTestDB(t)
+	out := captureStdout(t, func() {
+		if err := runReviewsList(reviewsListCmd, nil); err != nil {
+			t.Fatalf("runReviewsList: %v", err)
+		}
+	})
+	if !strings.Contains(out, "no review groups recorded") {
+		t.Errorf("expected empty-ledger message, got %q", out)
+	}
+}
+
+// TestReviewsList_JSONEmptyArray exercises the --json contract on an empty
+// ledger: must be "[]", not null and not absent.
+func TestReviewsList_JSONEmptyArray(t *testing.T) {
+	openReviewsTestDB(t)
+	if err := reviewsListCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+	t.Cleanup(func() { _ = reviewsListCmd.Flags().Set("json", "false") })
+	out := captureStdout(t, func() {
+		if err := runReviewsList(reviewsListCmd, nil); err != nil {
+			t.Fatalf("runReviewsList: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "[]" {
+		t.Errorf("expected '[]', got %q", out)
+	}
+}
+
+// TestReviewsList_PopulatesAndSortsByCreatedAt seeds two review groups (one
+// older, one newer) and verifies the JSON output lists them newest-first
+// and carries the documented fields.
+func TestReviewsList_PopulatesJSON(t *testing.T) {
+	d := openReviewsTestDB(t)
+
+	// Older group with one finished member.
+	g1, err := d.RegisterGroup("nixos-config@pr-1500")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	const session1 = "nixos-config@pr-1500~review-1-review-goal"
+	if err := d.UpsertStatusSeedRootAgentName(session1, "nixos-config", "/wt", "finished", nil, nil, "review-goal", ""); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	// Link the agent_status row to the group via raw SQL (mirrors the
+	// pattern used in internal/db tests).
+	var one int
+	if err := d.QueryRow(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+		g1, session1,
+	).Scan(&one); err != nil {
+		t.Fatalf("link group_id: %v", err)
+	}
+
+	if err := reviewsListCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+	t.Cleanup(func() { _ = reviewsListCmd.Flags().Set("json", "false") })
+
+	out := captureStdout(t, func() {
+		if err := runReviewsList(reviewsListCmd, nil); err != nil {
+			t.Fatalf("runReviewsList: %v", err)
+		}
+	})
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+		t.Fatalf("output not JSON: %v\nout: %s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+	}
+	row := rows[0]
+	for _, k := range []string{"group_id", "pr", "parent_session", "agent_sessions", "agent_states", "group_state", "started_at", "round"} {
+		if _, ok := row[k]; !ok {
+			t.Errorf("missing required key %q in JSON row: %v", k, row)
+		}
+	}
+	if row["parent_session"] != "nixos-config@pr-1500" {
+		t.Errorf("parent_session: want nixos-config@pr-1500, got %v", row["parent_session"])
+	}
+	if row["group_state"] != "completed" {
+		t.Errorf("group_state: expected completed for a single finished agent, got %v", row["group_state"])
+	}
+	if pr, ok := row["pr"].(float64); !ok || int(pr) != 1500 {
+		t.Errorf("pr: want 1500 (inferred from pr-1500 branch), got %v", row["pr"])
+	}
+	if rd, ok := row["round"].(float64); !ok || int(rd) != 1 {
+		t.Errorf("round: want 1, got %v", row["round"])
+	}
+	agents, ok := row["agent_sessions"].([]any)
+	if !ok || len(agents) != 1 || agents[0] != session1 {
+		t.Errorf("agent_sessions: want [%q], got %v", session1, row["agent_sessions"])
+	}
+}
+
+// TestInferPRFromGroup covers the parent-branch heuristic for PR inference.
+func TestInferPRFromGroup(t *testing.T) {
+	cases := []struct {
+		parent string
+		want   int
+	}{
+		{"repo@pr-42", 42},
+		{"repo@pr1500", 1500},
+		{"repo@main", 0},
+		{"repo@feature-x", 0},
+		{"plain", 0},
+	}
+	for _, tc := range cases {
+		g := db.ReviewGroupSummary{ParentSession: tc.parent}
+		if got := inferPRFromGroup(g); got != tc.want {
+			t.Errorf("inferPRFromGroup(%q): got %d, want %d", tc.parent, got, tc.want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -169,6 +169,12 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		for _, sn := range resp.SessionNames {
 			fmt.Printf("session %q created\n", sn)
 		}
+		// --wait on the abtest path is not supported — there are two
+		// sessions and no single terminal definition. Surface this rather
+		// than silently dropping the flag (issue #1500 review-code feedback).
+		if waitFlag, _ := cmd.Flags().GetBool("wait"); waitFlag {
+			fmt.Fprintln(os.Stderr, "prism spawn --wait: not supported with --abtest (two sessions, no single terminal); skipping wait")
+		}
 		return nil
 	}
 
@@ -209,6 +215,19 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	}
 	if err := proxyToHostAPI(apiURL, "/spawn", body, &resp); err != nil {
 		return err
+	}
+	// --wait: route through waitForSpawnTerminal using the sandbox-aware
+	// probe. Without this the proxy path silently dropped --wait and
+	// returned immediately even though the caller asked for synchronous
+	// behaviour (issue #1500 review-code feedback).
+	waitFlag, _ := cmd.Flags().GetBool("wait")
+	if waitFlag {
+		jsonFlag, _ := cmd.Flags().GetBool("json")
+		waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+		if !jsonFlag {
+			fmt.Printf("session %q spawned; waiting for terminal state...\n", resp.SessionName)
+		}
+		return waitForSpawnTerminal(resp.SessionName, jsonFlag, waitTimeout)
 	}
 	fmt.Printf("session %q created\n", resp.SessionName)
 	return nil

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -235,6 +235,9 @@ func init() {
 	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
+	spawnCmd.Flags().Bool("wait", false, "Block until the spawned agent finishes its initial prompt (state transitions to finished or error). Without --wait, returns immediately and the agent runs in the background.")
+	spawnCmd.Flags().Duration("wait-timeout", defaultSpawnWaitTimeout, "Timeout for --wait. On expiry, exits non-zero with a status payload distinguishable from a real spawn failure. Ignored when --wait is not set.")
+	spawnCmd.Flags().Bool("json", false, "Emit the terminal status as a JSON object on stdout (only useful with --wait or to script over the spawn output). Suppresses textual output.")
 	// --prompt-source is an internal flag used by the host-API /spawn handler
 	// to override the auto-detected prompt source (C.4.SRC, issue #1148).
 	// It is hidden from --help because end users should never pass it directly.
@@ -720,6 +723,18 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		promptSource:       promptSource,
 		modelsByRole:       modelsByRole,
 	})
+
+	waitFlag, _ := cmd.Flags().GetBool("wait")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+	if waitFlag {
+		// In --wait + --json mode, suppress the "session %q created" line
+		// so stdout is JSON-only at the end of the wait.
+		if !jsonFlag {
+			fmt.Printf("session %q spawned; waiting for terminal state...\n", sessionName)
+		}
+		return waitForSpawnTerminal(sessionName, jsonFlag, waitTimeout)
+	}
 
 	if headless {
 		fmt.Printf("session %q created\n", sessionName)

--- a/modules/programs/prism/prism/cmd/spawn_wait.go
+++ b/modules/programs/prism/prism/cmd/spawn_wait.go
@@ -63,20 +63,25 @@ var spawnWaitTerminals = map[string]bool{
 // waitForSpawnTerminal polls the prism DB for the named session until its
 // state field reaches a terminal value, the timeout elapses, or the user
 // interrupts.
+//
+// Sandbox-aware via newWaitProbe(): in-sandbox callers route reads through
+// the sidecar's /sessions/status endpoint so the host's agent_status table
+// is visible. Without this, --wait inside a sandbox would poll a tmpfs
+// shadow DB and never observe a terminal (issue #1500 review-code feedback).
 func waitForSpawnTerminal(sessionName string, jsonMode bool, timeout time.Duration) error {
-	d, dbErr := openDB()
-	if dbErr != nil {
-		return fmt.Errorf("prism spawn --wait: open db: %w", dbErr)
+	probe, err := newWaitProbe()
+	if err != nil {
+		return fmt.Errorf("prism spawn --wait: %w", err)
 	}
-	defer d.Close()
+	defer probe.Close()
 
 	var lastState string
 	pollErr := pollWait(context.Background(), timeout,
 		500*time.Millisecond, 5*time.Second,
 		func() (bool, error) {
-			st, qErr := d.CurrentStatus(sessionName)
+			st, qErr := probe.SessionStatus(sessionName)
 			if qErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism spawn --wait] db error: %v (will retry)\n", qErr)
+				fmt.Fprintf(os.Stderr, "[prism spawn --wait] probe error: %v (will retry)\n", qErr)
 				return false, nil
 			}
 			if st == nil {
@@ -102,14 +107,23 @@ func waitForSpawnTerminal(sessionName string, jsonMode bool, timeout time.Durati
 	if pollErr != nil {
 		return pollErr
 	}
-	return emitSpawnWaitTerminal(sessionName, d, jsonMode)
+	// Final state lookup uses the same probe so the path stays sandbox-correct.
+	finalState, _ := probe.SessionStatus(sessionName)
+	return emitSpawnWaitTerminalRow(sessionName, finalState, jsonMode)
 }
 
-// emitSpawnWaitTerminal looks up the session's final state and emits the
-// terminal status. Returns nil on "finished" (exit 0) or
-// waitExitTerminalFail (2) on any other terminal.
+// emitSpawnWaitTerminal is kept as a thin wrapper for tests that pre-date
+// the probe abstraction. Production code calls emitSpawnWaitTerminalRow
+// with a pre-fetched *db.Status.
 func emitSpawnWaitTerminal(sessionName string, d *db.DB, jsonMode bool) error {
 	st, _ := d.CurrentStatus(sessionName)
+	return emitSpawnWaitTerminalRow(sessionName, st, jsonMode)
+}
+
+// emitSpawnWaitTerminalRow emits the terminal status from an already-fetched
+// *db.Status. Returns nil on "finished" (exit 0) or waitExitTerminalFail (2)
+// on any other terminal.
+func emitSpawnWaitTerminalRow(sessionName string, st *db.Status, jsonMode bool) error {
 	if st == nil {
 		// Should not happen — we just polled it. Treat as error.
 		if jsonMode {

--- a/modules/programs/prism/prism/cmd/spawn_wait.go
+++ b/modules/programs/prism/prism/cmd/spawn_wait.go
@@ -1,0 +1,180 @@
+package cmd
+
+// spawn_wait.go — `prism spawn --wait` blocking poll loop (#1500).
+//
+// Terminal definition (documented and verified by tests):
+//
+//   --wait blocks until the spawned agent reaches a terminal state for its
+//   FIRST TURN — that is, the initial prompt has been processed to
+//   completion (state == "finished") or has failed (state == "error" /
+//   "deleted"). It does NOT wait for the entire session to end (which would
+//   be hours / days for an interactive coordinator session).
+//
+// Concretely, the wait succeeds as soon as the session's state transitions
+// from "active"/"idle"/"reviewing" to "finished" — opencode's signal that
+// the initial prompt's turn loop has completed and the agent is awaiting
+// further input. This matches the issue guidance ("wait for the spawned
+// agent to finish its initial prompt").
+//
+// Falls back to "error" / "deleted" as the failure terminals, plus a
+// readiness-style guard: if the session never transitions past "active"
+// AND no msg_assistant / msg_user / turn_start event is ever recorded
+// AND the timeout elapses, we report timeout (the agent is still running;
+// the wait simply gave up).
+//
+// Killing this command does NOT cancel the spawned session — the agent
+// continues in its tmux session and (eventually) reaches a terminal state
+// of its own. The user can inspect via `prism checkin <session>` or
+// `prism list-sessions`.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// spawnWaitJSON is the JSON shape emitted by `prism spawn --wait --json`.
+// Stable schema — every key is always present.
+type spawnWaitJSON struct {
+	Session string `json:"session"`
+	State   string `json:"state"`  // finished / error / interrupted / deleted / timeout
+	Status  string `json:"status"` // duplicate of State for symmetry with merge --wait
+	Error   string `json:"error,omitempty"`
+}
+
+// spawnTerminalStates lists the agent_status.state values that --wait treats
+// as terminal for the initial-prompt definition. "interrupted" is included
+// because the user explicitly redirecting an agent counts as "the first turn
+// is done" — pollAgents in review/poll.go intentionally excludes interrupted
+// from its terminal set, but for `prism spawn --wait` we treat any halt
+// (clean or interrupted) as a wait terminal so the command returns instead
+// of hanging on a paused agent.
+var spawnWaitTerminals = map[string]bool{
+	"finished":    true,
+	"error":       true,
+	"deleted":     true,
+	"interrupted": true,
+}
+
+// waitForSpawnTerminal polls the prism DB for the named session until its
+// state field reaches a terminal value, the timeout elapses, or the user
+// interrupts.
+func waitForSpawnTerminal(sessionName string, jsonMode bool, timeout time.Duration) error {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		return fmt.Errorf("prism spawn --wait: open db: %w", dbErr)
+	}
+	defer d.Close()
+
+	var lastState string
+	pollErr := pollWait(context.Background(), timeout,
+		500*time.Millisecond, 5*time.Second,
+		func() (bool, error) {
+			st, qErr := d.CurrentStatus(sessionName)
+			if qErr != nil {
+				fmt.Fprintf(os.Stderr, "[prism spawn --wait] db error: %v (will retry)\n", qErr)
+				return false, nil
+			}
+			if st == nil {
+				// Row not yet visible — keep polling. SpawnSession writes
+				// the row before returning so this is a brief window at
+				// most.
+				return false, nil
+			}
+			lastState = st.State
+			if spawnWaitTerminals[st.State] {
+				return true, nil
+			}
+			return false, nil
+		})
+
+	switch exitCodeOf(pollErr) {
+	case waitExitTimeout:
+		_ = emitSpawnWaitTimeout(sessionName, lastState, jsonMode, timeout)
+		return newExitErr(waitExitTimeout, "")
+	case waitExitUserInterrupt:
+		return pollErr
+	}
+	if pollErr != nil {
+		return pollErr
+	}
+	return emitSpawnWaitTerminal(sessionName, d, jsonMode)
+}
+
+// emitSpawnWaitTerminal looks up the session's final state and emits the
+// terminal status. Returns nil on "finished" (exit 0) or
+// waitExitTerminalFail (2) on any other terminal.
+func emitSpawnWaitTerminal(sessionName string, d *db.DB, jsonMode bool) error {
+	st, _ := d.CurrentStatus(sessionName)
+	if st == nil {
+		// Should not happen — we just polled it. Treat as error.
+		if jsonMode {
+			payload := spawnWaitJSON{Session: sessionName, State: "error", Status: "error", Error: "session row vanished after terminal-state observation"}
+			data, _ := json.Marshal(payload)
+			_ = printJSON(data)
+		} else {
+			fmt.Fprintf(os.Stderr, "prism spawn --wait: session %q vanished after terminal-state observation\n", sessionName)
+		}
+		return newExitErr(waitExitTerminalFail, "")
+	}
+
+	state := st.State
+	errMsg := ""
+	if state == "error" || state == "deleted" {
+		errMsg = "agent did not finish cleanly"
+	}
+
+	if jsonMode {
+		payload := spawnWaitJSON{Session: sessionName, State: state, Status: state, Error: errMsg}
+		data, mErr := json.Marshal(payload)
+		if mErr != nil {
+			return fmt.Errorf("prism spawn --wait: marshal JSON: %w", mErr)
+		}
+		if pErr := printJSON(data); pErr != nil {
+			return pErr
+		}
+	} else {
+		switch state {
+		case "finished":
+			fmt.Printf("session %q finished.\n", sessionName)
+		case "interrupted":
+			fmt.Printf("session %q interrupted (the agent paused; resume with `prism prompt %s`).\n", sessionName, sessionName)
+		case "error":
+			fmt.Printf("session %q ended with state %q.\n", sessionName, state)
+		case "deleted":
+			fmt.Printf("session %q was cleaned up before reaching a normal terminal.\n", sessionName)
+		default:
+			fmt.Printf("session %q reached state %q.\n", sessionName, state)
+		}
+	}
+	if state == "finished" {
+		return nil
+	}
+	// "interrupted" is non-zero too — the agent did NOT finish its first
+	// turn cleanly. Callers can still recover by sending a prompt.
+	return newExitErr(waitExitTerminalFail, "")
+}
+
+func emitSpawnWaitTimeout(sessionName, lastState string, jsonMode bool, timeout time.Duration) error {
+	if jsonMode {
+		payload := spawnWaitJSON{
+			Session: sessionName,
+			State:   "timeout",
+			Status:  "timeout",
+			Error:   fmt.Sprintf("waited %s; session is still %q", timeout, lastState),
+		}
+		data, mErr := json.Marshal(payload)
+		if mErr != nil {
+			return fmt.Errorf("prism spawn --wait timeout: marshal: %w", mErr)
+		}
+		return printJSON(data)
+	}
+	fmt.Fprintf(os.Stderr, "prism spawn --wait: timed out after %s; session %q remains %q.\n",
+		formatDurationShort(timeout), sessionName, lastState)
+	fmt.Fprintf(os.Stderr, "  Inspect with: prism checkin %s\n", sessionName)
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/spawn_wait_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_wait_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+// Tests for `prism spawn --wait` (#1500).
+//
+// We test the wait loop directly (waitForSpawnTerminal) rather than going
+// through runSpawn — runSpawn does substantial side-effecting work (worktree
+// creation, tmux session creation) that is out of scope for the wait
+// behaviour. The wait loop's contract is "given a session row in the DB,
+// poll until it reaches a terminal state and emit the right summary".
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func openSpawnWaitTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spawn_wait.db")
+	SetTestDBPath(path)
+	t.Cleanup(func() { SetTestDBPath("") })
+	t.Setenv("PRISM_HOST_API", "")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// TestWaitForSpawnTerminal_FinishedExits0 — the documented happy path.
+// Seed an agent_status row in "active" state, then flip to "finished" in a
+// goroutine. The wait loop should observe the flip and exit 0.
+func TestWaitForSpawnTerminal_FinishedExits0(t *testing.T) {
+	d := openSpawnWaitTestDB(t)
+	const sess = "repo@feature"
+	if err := d.UpsertStatus(sess, "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		d2, dErr := openDB()
+		if dErr != nil {
+			t.Errorf("openDB in goroutine: %v", dErr)
+			return
+		}
+		defer d2.Close()
+		if err := d2.UpsertStatus(sess, "repo", "/wt", "finished", nil, nil); err != nil {
+			t.Errorf("UpsertStatus finished: %v", err)
+		}
+	}()
+
+	out := captureStdout(t, func() {
+		if err := waitForSpawnTerminal(sess, false, 5*time.Second); err != nil {
+			t.Errorf("waitForSpawnTerminal: expected nil on finished, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "finished") {
+		t.Errorf("expected finished summary, got %q", out)
+	}
+}
+
+// TestWaitForSpawnTerminal_ErrorReturnsTerminalFail — error state is a
+// terminal that exits with the terminal-fail code (2), not 0.
+func TestWaitForSpawnTerminal_ErrorReturnsTerminalFail(t *testing.T) {
+	d := openSpawnWaitTestDB(t)
+	const sess = "repo@bad"
+	if err := d.UpsertStatus(sess, "repo", "/wt", "error", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	_ = captureStdout(t, func() {
+		err := waitForSpawnTerminal(sess, false, 5*time.Second)
+		if err == nil {
+			t.Fatal("expected non-nil error on error terminal")
+		}
+		var ec *exitCodeError
+		if !errors.As(err, &ec) {
+			t.Fatalf("expected *exitCodeError, got %T: %v", err, err)
+		}
+		if ec.code != waitExitTerminalFail {
+			t.Errorf("expected exit code %d, got %d", waitExitTerminalFail, ec.code)
+		}
+	})
+}
+
+// TestWaitForSpawnTerminal_TimeoutReturnsTimeoutCode — never-finished
+// session yields the timeout exit code (3), not the terminal-fail code (2).
+func TestWaitForSpawnTerminal_TimeoutReturnsTimeoutCode(t *testing.T) {
+	d := openSpawnWaitTestDB(t)
+	const sess = "repo@slow"
+	if err := d.UpsertStatus(sess, "repo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		err := waitForSpawnTerminal(sess, true /* json */, 100*time.Millisecond)
+		if err == nil {
+			t.Fatal("expected timeout error")
+		}
+		if exitCodeOf(err) != waitExitTimeout {
+			t.Errorf("expected timeout code %d, got %d", waitExitTimeout, exitCodeOf(err))
+		}
+	})
+	var payload map[string]any
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(line), &payload); err == nil && payload["state"] == "timeout" {
+			break
+		}
+	}
+	if payload["state"] != "timeout" {
+		t.Errorf("expected JSON state=timeout, got %v\nout: %s", payload, out)
+	}
+	if payload["session"] != "repo@slow" {
+		t.Errorf("expected session=repo@slow, got %v", payload["session"])
+	}
+}
+
+// TestEmitSpawnWaitTerminal_JSONShape exercises the JSON contract for
+// `prism spawn --wait --json`: stable keys, single-line output, no textual
+// chatter.
+func TestEmitSpawnWaitTerminal_JSONShape(t *testing.T) {
+	d := openSpawnWaitTestDB(t)
+	const sess = "repo@done"
+	if err := d.UpsertStatus(sess, "repo", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := emitSpawnWaitTerminal(sess, d, true); err != nil {
+			t.Errorf("emitSpawnWaitTerminal: %v", err)
+		}
+	})
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &payload); err != nil {
+		t.Fatalf("not JSON: %v\nout: %s", err, out)
+	}
+	for _, k := range []string{"session", "state", "status"} {
+		if _, ok := payload[k]; !ok {
+			t.Errorf("missing required key %q in JSON: %v", k, payload)
+		}
+	}
+	if payload["state"] != "finished" {
+		t.Errorf("state: want finished, got %v", payload["state"])
+	}
+}

--- a/modules/programs/prism/prism/cmd/wait.go
+++ b/modules/programs/prism/prism/cmd/wait.go
@@ -1,0 +1,263 @@
+package cmd
+
+// wait.go — shared helpers for the --wait flag on prism merge / review / spawn
+// (issue #1500).
+//
+// Three concerns live here:
+//
+//   1. backoffSchedule — exponential backoff with jitter for poll loops.
+//      Centralised so reviewers can spot the implementation in one place
+//      (AC: "verifiable by reading the code").
+//
+//   2. setupWaitSignals — installs a SIGINT/SIGTERM handler that does NOT
+//      cancel the underlying job (merge, review, spawn). It only flips a
+//      local "user interrupted the wait" flag and unblocks the poller.
+//      The merge-queue watcher / review monitor / spawned agent keep
+//      running; the user can recover by re-running the same command
+//      without --wait, or by inspecting the relevant ledger.
+//
+//   3. Constants for default --timeout values and exit codes that the
+//      individual commands share.
+//
+// Style note: every helper here is intentionally small and dependency-light.
+// The wait loops live in each command's own file so the per-command terminal
+// definition stays close to its other code.
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// Default timeouts for --wait. The issue specifies 30m for merge and 2× the
+// per-agent timeout for review (which defaults to 10m, so 20m). For spawn we
+// pick 10m as a sensible default — most spawned agents either become ready
+// within a minute or fail.
+const (
+	defaultMergeWaitTimeout  = 30 * time.Minute
+	defaultReviewWaitTimeout = 20 * time.Minute
+	defaultSpawnWaitTimeout  = 10 * time.Minute
+)
+
+// Exit codes emitted by --wait paths. The wait commands return these via an
+// exitCodeError so cobra surfaces them on os.Exit. "Timeout" is distinct from
+// a "real" terminal failure so callers can tell the two apart (AC: "On
+// timeout, exits non-zero with a status payload distinguishable from a real
+// merge failure.").
+const (
+	waitExitOK            = 0
+	waitExitTerminalFail  = 2 // job reached a non-success terminal state
+	waitExitTimeout       = 3 // local --timeout elapsed
+	waitExitUserInterrupt = 4 // user pressed Ctrl-C; underlying job was NOT cancelled
+)
+
+// exitCodeError lets a RunE return a specific os.Exit code without printing
+// the error twice. cmd/root.go's main wraps cobra.Execute and inspects the
+// returned error; for exitCodeError it calls os.Exit(code) silently.
+type exitCodeError struct {
+	code int
+	msg  string // optional — printed to stderr before exit when non-empty
+}
+
+func (e *exitCodeError) Error() string { return e.msg }
+
+// ExitCode returns the desired process exit code. cmd/root.go's runner reads
+// this via errors.As to bypass cobra's default exit-code-1 behaviour.
+func (e *exitCodeError) ExitCode() int { return e.code }
+
+// newExitErr builds an exitCodeError. msg "" suppresses the error print.
+func newExitErr(code int, msg string) error {
+	return &exitCodeError{code: code, msg: msg}
+}
+
+// backoffSchedule returns a function that yields successive sleep durations
+// for a poll loop: starts at base, doubles each call up to max, then stays at
+// max. Each yielded duration has uniform jitter in [0.5x, 1.5x] applied so
+// concurrent waiters do not synchronise.
+//
+// Example progression with base=500ms, max=5s:
+//
+//	~500ms, ~1s, ~2s, ~4s, ~5s, ~5s, ... (each ±50%)
+//
+// Centralising this in one named function makes the AC ("verifiable by
+// reading the code") trivially auditable: every --wait poll loop calls
+// backoffSchedule and uses the returned closure.
+func backoffSchedule(base, max time.Duration) func() time.Duration {
+	if base <= 0 {
+		base = 500 * time.Millisecond
+	}
+	if max <= 0 || max < base {
+		max = 30 * base
+	}
+	cur := base
+	return func() time.Duration {
+		d := cur
+		// Advance for next call (capped at max).
+		next := cur * 2
+		if next > max {
+			next = max
+		}
+		cur = next
+		// Apply ±50% jitter. crypto/rand would be overkill here; the only
+		// goal is to desynchronise concurrent waiters in the same shell.
+		// math/rand is reseeded by Go's runtime since 1.20.
+		jitter := 0.5 + rand.Float64() // in [0.5, 1.5)
+		return time.Duration(float64(d) * jitter)
+	}
+}
+
+// waitInterrupt is set to 1 when the user presses Ctrl-C while a --wait poll
+// loop is sleeping. The poll loops check this between sleeps and return early
+// with waitExitUserInterrupt.
+//
+// Critical: pressing Ctrl-C must NOT cancel the underlying merge / review /
+// spawn job (AC: edge-case). The job is driven by a separate process (the
+// merge-queue watcher, the review monitor, or the spawned agent's sidecar);
+// Ctrl-C only interrupts our local poller. setupWaitSignals installs a
+// signal handler that flips this flag and does nothing else.
+//
+// Stored as int32 so atomic loads are cheap inside the poll loops.
+type waitInterruptState struct {
+	tripped atomic.Int32
+}
+
+// setupWaitSignals installs a signal handler for SIGINT and SIGTERM that
+// flips state.tripped and returns. The default Go behaviour for SIGINT is
+// "terminate the process" — installing this handler suppresses that, so the
+// caller's deferred cleanups (DB close, etc.) run before we return the
+// user-interrupt exit code.
+//
+// Returns a cleanup function that uninstalls the handler. Callers should
+// defer it so the handler is removed when the wait completes naturally.
+func setupWaitSignals() (*waitInterruptState, func()) {
+	state := &waitInterruptState{}
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ch:
+				state.tripped.Store(1)
+				// Continue draining so a second Ctrl-C doesn't terminate
+				// us before the poll loop sees the first one. We deliberately
+				// do NOT exit on a second Ctrl-C: the AC requires that we
+				// always return cleanly so the underlying job is not
+				// cancelled. The user can kill -9 if they want a hard exit.
+			case <-done:
+				signal.Stop(ch)
+				return
+			}
+		}
+	}()
+	return state, func() { close(done) }
+}
+
+// userInterrupted returns true when the wait-signal handler has tripped.
+func (s *waitInterruptState) userInterrupted() bool {
+	return s.tripped.Load() != 0
+}
+
+// pollWait drives a generic poll loop. probe is called once per cycle and
+// returns (done, err): done=true means a terminal state was reached and the
+// loop returns the probe's error verbatim. done=false continues the loop.
+//
+// The loop terminates with:
+//
+//   - the probe returning done=true (caller's terminal logic fired),
+//   - the deadline being reached (returns waitExitTimeout error),
+//   - the user interrupting (returns waitExitUserInterrupt error).
+//
+// timeout ≤ 0 means "no timeout" — the loop runs until probe is done or the
+// user interrupts. Callers that want a default timeout should resolve it
+// before calling.
+//
+// The first probe call runs with no sleep beforehand so an already-terminal
+// state is observed immediately (AC: "calling prism merge --wait on an
+// already-merged PR returns immediately").
+func pollWait(ctx context.Context, timeout time.Duration, base, max time.Duration, probe func() (done bool, err error)) error {
+	state, stop := setupWaitSignals()
+	defer stop()
+
+	var deadline time.Time
+	hasDeadline := timeout > 0
+	if hasDeadline {
+		deadline = time.Now().Add(timeout)
+	}
+	next := backoffSchedule(base, max)
+
+	for {
+		if state.userInterrupted() {
+			return newExitErr(waitExitUserInterrupt,
+				"prism: --wait interrupted; underlying job was NOT cancelled. Re-run without --wait to recover the result.")
+		}
+		done, err := probe()
+		if done {
+			return err
+		}
+		if hasDeadline && !time.Now().Before(deadline) {
+			return newExitErr(waitExitTimeout, "")
+		}
+
+		sleep := next()
+		// Cap sleep so we don't overshoot the deadline by more than ~1s.
+		if hasDeadline {
+			rem := time.Until(deadline)
+			if rem <= 0 {
+				return newExitErr(waitExitTimeout, "")
+			}
+			if sleep > rem {
+				sleep = rem
+			}
+		}
+
+		// Sleep, but also wake on signal/context cancel so the user
+		// interrupt is observed promptly without waiting for the full
+		// backoff slot.
+		timer := time.NewTimer(sleep)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return newExitErr(waitExitUserInterrupt, ctx.Err().Error())
+		}
+	}
+}
+
+// emitJSONOrText is a small convenience used by every --wait command. When
+// jsonMode is true it marshals payload via printJSON (no textual lines).
+// Otherwise it calls textFn to print a human-readable summary.
+//
+// Returns the error from JSON marshalling/printing or textFn; callers
+// typically fmt.Errorf-wrap if they need additional context.
+func emitJSONOrText(jsonMode bool, payload []byte, textFn func()) error {
+	if jsonMode {
+		return printJSON(payload)
+	}
+	if textFn != nil {
+		textFn()
+	}
+	return nil
+}
+
+// formatDurationShort renders a duration like "30m" or "1h30m" without
+// nanoseconds. Used in human-readable wait output.
+func formatDurationShort(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Round(time.Second).Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	h := int(d / time.Hour)
+	m := int((d % time.Hour) / time.Minute)
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh%dm", h, m)
+}

--- a/modules/programs/prism/prism/cmd/wait_probe.go
+++ b/modules/programs/prism/prism/cmd/wait_probe.go
@@ -1,0 +1,172 @@
+package cmd
+
+// wait_probe.go — sandbox-aware probe sources for the --wait poll loops
+// (issue #1500).
+//
+// Background. The merge / review / spawn wait loops poll prism DB rows for a
+// terminal state. When prism runs on the host, openDB() is the right path —
+// the worker writes to and reads from the same DB the sidecar's watchers /
+// monitors write to. When prism runs INSIDE a sandbox (PRISM_HOST_API set),
+// openDB() opens a shadow tmpfs DB the host watcher never writes to, so the
+// poll never observes a terminal and --wait silently hangs until timeout.
+//
+// review-code on PR #1533 caught this for `prism review --wait` and
+// `prism spawn --wait` (the proxy paths returned before reaching the wait
+// block); the merge case had the same latent bug. The fix is the abstraction
+// in this file: each wait loop talks to a "probe source" that hides whether
+// the underlying lookup is a direct DB call (host) or an HTTP GET to the
+// sidecar's /merges/by-pr, /sessions/status, or /groups/poll endpoints
+// (sandbox).
+//
+// A single newWaitProbe() resolves the right source from
+// sandboxenv.HostAPISocket() — host vs sandbox — so the call sites in
+// merge.go / review_wait.go / spawn_wait.go just call probe.Merge(pr) etc.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sandboxenv"
+)
+
+// waitProbe is the interface the wait loops use to read terminal state.
+// Implementations may close over a *db.DB (host path) or a host-API URL
+// (sandbox path); the wait loops do not care which.
+type waitProbe interface {
+	// Merge returns the pending_merges row for pr, or (nil, nil) when no
+	// row exists. err is reserved for transient failures (the wait loop
+	// retries on err).
+	Merge(pr int) (*db.PendingMerge, error)
+
+	// SessionStatus returns the agent_status row for sessionName, or
+	// (nil, nil) when no row exists.
+	SessionStatus(sessionName string) (*db.Status, error)
+
+	// GroupPoll returns the per-group completion + members + results in a
+	// single round-trip. completed=true means every member has reached a
+	// terminal state. members lists every row in the group (including
+	// rows whose ended_at is set, which GroupResults intentionally drops);
+	// results carries the verdict-aggregation data from GroupResults.
+	GroupPoll(groupID string) (completed bool, members []db.Status, results map[string]db.GroupMemberResult, err error)
+
+	// Close releases any underlying handle. host probes hold a *db.DB;
+	// sandbox probes hold no resources.
+	Close()
+}
+
+// newWaitProbe returns the appropriate probe for the current process. When
+// PRISM_HOST_API is set we route reads through the sidecar; otherwise we
+// open the host's prism.db read-write (the wait loops only read, but
+// openDB returns a writable handle and that is fine). The caller must
+// Close() the returned probe when done.
+func newWaitProbe() (waitProbe, error) {
+	if apiURL := sandboxenv.HostAPISocket(); apiURL != "" {
+		return &proxyWaitProbe{apiURL: apiURL}, nil
+	}
+	d, err := openDB()
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	return &dbWaitProbe{d: d}, nil
+}
+
+// dbWaitProbe is the host-path implementation: direct DB reads.
+type dbWaitProbe struct{ d *db.DB }
+
+func (p *dbWaitProbe) Merge(pr int) (*db.PendingMerge, error) {
+	return p.d.PendingMergeByPR(pr)
+}
+
+func (p *dbWaitProbe) SessionStatus(sessionName string) (*db.Status, error) {
+	return p.d.CurrentStatus(sessionName)
+}
+
+func (p *dbWaitProbe) GroupPoll(groupID string) (bool, []db.Status, map[string]db.GroupMemberResult, error) {
+	completed, gErr := p.d.GroupCompleted(groupID)
+	if gErr != nil {
+		return false, nil, nil, gErr
+	}
+	members, mErr := p.d.GroupMembersForGroup(groupID)
+	if mErr != nil {
+		return false, nil, nil, mErr
+	}
+	results, rErr := p.d.GroupResults(groupID)
+	if rErr != nil {
+		return false, nil, nil, rErr
+	}
+	return completed, members, results, nil
+}
+
+func (p *dbWaitProbe) Close() {
+	if p.d != nil {
+		p.d.Close()
+	}
+}
+
+// proxyWaitProbe is the sandbox-path implementation: HTTP GETs to the
+// sidecar's read-only wait-probe endpoints.
+type proxyWaitProbe struct{ apiURL string }
+
+func (p *proxyWaitProbe) Merge(pr int) (*db.PendingMerge, error) {
+	var row db.PendingMerge
+	params := map[string]string{"pr": fmt.Sprintf("%d", pr)}
+	err := proxyGetFromHostAPI(p.apiURL, "/merges/by-pr", params, &row)
+	if err != nil {
+		// not-found surfaces as a 404; the proxy helper wraps it into an
+		// error string. Distinguish "not found" (return nil, nil — same
+		// shape as the direct DB path) from other errors so the wait loop
+		// can keep polling.
+		if isProxyNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (p *proxyWaitProbe) SessionStatus(sessionName string) (*db.Status, error) {
+	var st db.Status
+	params := map[string]string{"session": sessionName}
+	err := proxyGetFromHostAPI(p.apiURL, "/sessions/status", params, &st)
+	if err != nil {
+		if isProxyNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &st, nil
+}
+
+// proxyGroupPollResp matches the JSON shape emitted by /groups/poll. It is
+// kept as a private type because the wait loops always destructure it into
+// separate return values; exposing the wrapper would add ceremony.
+type proxyGroupPollResp struct {
+	Completed bool                            `json:"completed"`
+	Members   []db.Status                     `json:"members"`
+	Results   map[string]db.GroupMemberResult `json:"results"`
+}
+
+func (p *proxyWaitProbe) GroupPoll(groupID string) (bool, []db.Status, map[string]db.GroupMemberResult, error) {
+	var resp proxyGroupPollResp
+	params := map[string]string{"group_id": groupID}
+	if err := proxyGetFromHostAPI(p.apiURL, "/groups/poll", params, &resp); err != nil {
+		return false, nil, nil, err
+	}
+	return resp.Completed, resp.Members, resp.Results, nil
+}
+
+func (p *proxyWaitProbe) Close() {}
+
+// isProxyNotFound returns true when err is a host-API 404 surfaced by
+// proxyGetFromHostAPI. The helper wraps non-2xx responses into an error
+// containing the body's `error` field, so we match on the substring used
+// uniformly across the new wait endpoints.
+func isProxyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "not found")
+}
+
+

--- a/modules/programs/prism/prism/cmd/wait_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/wait_proxy_test.go
@@ -243,6 +243,83 @@ func TestWaitForReviewTerminal_RoutesViaHostAPI(t *testing.T) {
 	}
 }
 
+// TestRunReviewsList_RoutesViaHostAPIInSandbox is the regression test for
+// the round-2 review-context blocker: `prism reviews list` must not open
+// the local (shadow) DB when running inside a sandbox — doing so silently
+// returns [] and replicates the original #1043 bug for review groups.
+// The fixed path proxies through the sidecar's /groups/list endpoint.
+func TestRunReviewsList_RoutesViaHostAPIInSandbox(t *testing.T) {
+	openMergeTestDB(t) // clears PRISM_HOST_API; we set it next.
+
+	sockDir, err := os.MkdirTemp("/tmp", "rl")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "h.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	var requests []string
+	var mu sync.Mutex
+	mux := http.NewServeMux()
+	mux.HandleFunc("/groups/list", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, "/groups/list?"+r.URL.RawQuery)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]db.ReviewGroupSummary{
+			{
+				GroupID:       "g-1",
+				ParentSession: "repo@pr-42",
+				CreatedAt:     time.Now().UTC(),
+				Members:       []string{"repo@pr-42~review-1-review-goal"},
+				AgentStates:   []string{"finished"},
+				GroupState:    "completed",
+			},
+		})
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	t.Setenv("PRISM_HOST_API", "unix://"+sockPath)
+
+	t.Cleanup(func() { _ = reviewsListCmd.Flags().Set("json", "false") })
+	if err := reviewsListCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runReviewsList(reviewsListCmd, nil); err != nil {
+			t.Fatalf("runReviewsList: %v", err)
+		}
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) == 0 {
+		t.Fatal("server received no requests — reviews list did not route via host-API")
+	}
+	if !strings.HasPrefix(requests[0], "/groups/list") {
+		t.Errorf("first request was %q, expected /groups/list", requests[0])
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
+		t.Fatalf("output not JSON: %v\nout: %s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %v", len(rows), rows)
+	}
+	if rows[0]["parent_session"] != "repo@pr-42" {
+		t.Errorf("parent_session: want repo@pr-42, got %v", rows[0]["parent_session"])
+	}
+}
+
 // TestParseReviewGroupIDFromAck verifies the regex-based extraction used
 // by the in-sandbox `prism review --wait` proxy path.
 func TestParseReviewGroupIDFromAck(t *testing.T) {

--- a/modules/programs/prism/prism/cmd/wait_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/wait_proxy_test.go
@@ -1,0 +1,263 @@
+package cmd
+
+// Tests for the sandbox-aware wait-probe routing (#1500 review-code feedback).
+//
+// When PRISM_HOST_API is set, the wait probes for merge / review / spawn
+// must talk to the sidecar's read-only wait-probe endpoints rather than
+// opening the local (shadow) prism.db. These tests stand up a fake
+// host-API server that mirrors /merges/by-pr, /sessions/status, and
+// /groups/poll, then exercise observeAlreadyTerminal,
+// waitForSpawnTerminal, and waitForReviewTerminal end-to-end through the
+// proxy with PRISM_HOST_API pointed at the fake.
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// fakeWaitProbeServer mirrors the three host-API wait-probe endpoints.
+// Tests stage responses by setting the *Resp fields and call the wait
+// helper under test; the server records each request so tests can confirm
+// the probe routed via HTTP rather than opening a shadow DB.
+type fakeWaitProbeServer struct {
+	mu       sync.Mutex
+	requests []string
+
+	// /merges/by-pr response. When mergeStatus=="" the server returns 404.
+	mergePR     int
+	mergeStatus string
+	// /sessions/status response. When sessionState=="" the server returns 404.
+	sessionName  string
+	sessionState string
+	// /groups/poll response.
+	groupID         string
+	groupCompleted  bool
+	groupMembers    []db.Status
+	groupResults    map[string]db.GroupMemberResult
+}
+
+func (s *fakeWaitProbeServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/merges/by-pr", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.requests = append(s.requests, "/merges/by-pr?"+r.URL.RawQuery)
+		ms := s.mergeStatus
+		mp := s.mergePR
+		s.mu.Unlock()
+		if ms == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(db.PendingMerge{
+			PR:          mp,
+			SessionName: "test",
+			InstanceID:  "inst",
+			Status:      ms,
+			QueuedAt:    time.Now(),
+		})
+	})
+	mux.HandleFunc("/sessions/status", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.requests = append(s.requests, "/sessions/status?"+r.URL.RawQuery)
+		ss := s.sessionState
+		sn := s.sessionName
+		s.mu.Unlock()
+		if ss == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(db.Status{SessionName: sn, State: ss, Repo: "repo", Worktree: "/wt"})
+	})
+	mux.HandleFunc("/groups/poll", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.requests = append(s.requests, "/groups/poll?"+r.URL.RawQuery)
+		completed := s.groupCompleted
+		members := s.groupMembers
+		results := s.groupResults
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"completed": completed,
+			"members":   members,
+			"results":   results,
+		})
+	})
+	return mux
+}
+
+// startFakeWaitProbeServer launches the fake server on a unix socket and
+// returns the apiURL. The unix-socket path is kept short for the same
+// macOS sun_path-104 reason documented in merge_proxy_test.go.
+func startFakeWaitProbeServer(t *testing.T) (*fakeWaitProbeServer, string) {
+	t.Helper()
+	sockDir, err := os.MkdirTemp("/tmp", "wp")
+	if err != nil {
+		t.Fatalf("mkdir short sock dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "h.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sockPath, err)
+	}
+	s := &fakeWaitProbeServer{}
+	srv := &http.Server{Handler: s.handler()}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return s, "unix://" + sockPath
+}
+
+// TestObserveAlreadyTerminal_RoutesViaHostAPI is the headline regression
+// test for the review-code finding: when PRISM_HOST_API is set, the wait
+// probes must hit the host-API socket instead of the local DB. Without
+// the proxy probe path, this test would fail because the fake server's
+// "merged" response is invisible to a shadow-DB read.
+func TestObserveAlreadyTerminal_RoutesViaHostAPI(t *testing.T) {
+	openMergeTestDB(t) // sets PRISM_HOST_API="" — we override below.
+
+	server, apiURL := startFakeWaitProbeServer(t)
+	server.mu.Lock()
+	server.mergePR = 99
+	server.mergeStatus = "merged"
+	server.mu.Unlock()
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	out := captureStdout(t, func() {
+		done, err := observeAlreadyTerminal(99, false)
+		if !done {
+			t.Fatal("expected proxy probe to short-circuit on merged row")
+		}
+		if err != nil {
+			t.Errorf("expected nil error on merged, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "PR #99 merged") {
+		t.Errorf("expected merged summary, got %q", out)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) == 0 {
+		t.Fatal("server received no requests — probe did not route via host-API")
+	}
+	if !strings.Contains(server.requests[0], "/merges/by-pr") {
+		t.Errorf("first request was %q, expected /merges/by-pr", server.requests[0])
+	}
+}
+
+// TestWaitForSpawnTerminal_RoutesViaHostAPI exercises the proxy path for
+// spawn --wait. Without the proxy probe the in-sandbox caller would poll
+// the shadow DB and never see the host's `finished` state — silently
+// timing out instead of returning 0.
+func TestWaitForSpawnTerminal_RoutesViaHostAPI(t *testing.T) {
+	openMergeTestDB(t) // sets PRISM_HOST_API="" then we override.
+
+	server, apiURL := startFakeWaitProbeServer(t)
+	server.mu.Lock()
+	server.sessionName = "repo@feature"
+	server.sessionState = "finished"
+	server.mu.Unlock()
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	out := captureStdout(t, func() {
+		if err := waitForSpawnTerminal("repo@feature", false, 5*time.Second); err != nil {
+			t.Errorf("waitForSpawnTerminal via proxy: expected nil on finished, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "finished") {
+		t.Errorf("expected finished summary, got %q", out)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	hits := 0
+	for _, r := range server.requests {
+		if strings.HasPrefix(r, "/sessions/status") {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Errorf("expected at least one /sessions/status request, got %v", server.requests)
+	}
+}
+
+// TestWaitForReviewTerminal_RoutesViaHostAPI exercises the proxy path for
+// review --wait. The fake server reports the group as completed with one
+// finished, PASS-marker member; the wait helper must aggregate via the
+// proxy probe and return nil (exit 0).
+func TestWaitForReviewTerminal_RoutesViaHostAPI(t *testing.T) {
+	openMergeTestDB(t)
+
+	server, apiURL := startFakeWaitProbeServer(t)
+	server.mu.Lock()
+	server.groupID = "g-1"
+	server.groupCompleted = true
+	server.groupMembers = []db.Status{{SessionName: "repo@pr-1500~review-1-review-goal", State: "finished", Repo: "repo", Worktree: "/wt"}}
+	server.groupResults = map[string]db.GroupMemberResult{
+		"repo@pr-1500~review-1-review-goal": {
+			SessionName: "repo@pr-1500~review-1-review-goal",
+			State:       "finished",
+			LastMessage: `{"text":"<verdict>PASS</verdict> looks good"}`,
+		},
+	}
+	server.mu.Unlock()
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	out := captureStdout(t, func() {
+		if err := waitForReviewTerminal("1500", "g-1", false, 5*time.Second); err != nil {
+			t.Errorf("waitForReviewTerminal via proxy: expected nil on PASS, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "verdict: PASS") {
+		t.Errorf("expected PASS summary, got %q", out)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	hits := 0
+	for _, r := range server.requests {
+		if strings.HasPrefix(r, "/groups/poll") {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Errorf("expected at least one /groups/poll request, got %v", server.requests)
+	}
+}
+
+// TestParseReviewGroupIDFromAck verifies the regex-based extraction used
+// by the in-sandbox `prism review --wait` proxy path.
+func TestParseReviewGroupIDFromAck(t *testing.T) {
+	cases := []struct {
+		ack  string
+		want string
+	}{
+		{"Review in progress — PR #1500, round 1 (group: 5103f218-9e18-423c-a298-2448dac6ab26)\n\nMore output here", "5103f218-9e18-423c-a298-2448dac6ab26"},
+		{"no group line here", ""},
+		{"(group: not-a-uuid)", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := parseReviewGroupIDFromAck(tc.ack); got != tc.want {
+			t.Errorf("parseReviewGroupIDFromAck(%q): got %q, want %q", tc.ack, got, tc.want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/wait_test.go
+++ b/modules/programs/prism/prism/cmd/wait_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+// Tests for the shared --wait helpers (#1500). The per-command wait paths
+// are tested in merge_wait_test.go, review_wait_test.go, and
+// spawn_wait_test.go.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBackoffSchedule_GrowsAndCaps asserts that the backoff helper's mean
+// duration grows roughly geometrically until it hits the cap, then stays
+// flat. The jitter spec is ±50% so we check averages over many calls.
+//
+// The intent is to make the AC ("verifiable by reading the code") provable
+// by a unit test: any change that swaps backoff for a constant interval
+// will fail this test.
+func TestBackoffSchedule_GrowsAndCaps(t *testing.T) {
+	base := 100 * time.Millisecond
+	max := 1600 * time.Millisecond
+
+	// The FIRST call should average ~base, the saturated call should
+	// average ~max, and the sequence should grow strictly in expected
+	// value. This is the "exponential growth + capped" half of the AC.
+	const samples = 500
+	step1Total, stepLastTotal := time.Duration(0), time.Duration(0)
+	for i := 0; i < samples; i++ {
+		f := backoffSchedule(base, max)
+		step1Total += f()
+		var last time.Duration
+		for j := 0; j < 10; j++ {
+			last = f()
+		}
+		stepLastTotal += last
+	}
+	mean1 := step1Total / samples
+	meanLast := stepLastTotal / samples
+	if mean1 < base/2 || mean1 > 3*base/2 {
+		t.Errorf("first-step mean = %v, expected ~%v ± 50%%", mean1, base)
+	}
+	if meanLast < max/2 || meanLast > 3*max/2 {
+		t.Errorf("saturated mean = %v, expected ~%v ± 50%%", meanLast, max)
+	}
+	if meanLast <= mean1 {
+		t.Errorf("expected meanLast (%v) > mean1 (%v) — backoff is not growing", meanLast, mean1)
+	}
+}
+
+// TestBackoffSchedule_JitterIsBoundedAndRandom checks that jitter is in
+// [0.5x, 1.5x] of the unjittered value, never outside.
+func TestBackoffSchedule_JitterIsBoundedAndRandom(t *testing.T) {
+	base := 100 * time.Millisecond
+	max := 100 * time.Millisecond
+	next := backoffSchedule(base, max)
+	saw := map[int64]int{}
+	for i := 0; i < 200; i++ {
+		d := next()
+		if d < base/2 || d > 3*base/2 {
+			t.Fatalf("jitter out of range: %v not in [%v,%v]", d, base/2, 3*base/2)
+		}
+		saw[int64(d)]++
+	}
+	if len(saw) < 50 {
+		// With ±50% jitter and 200 samples we expect dozens of distinct
+		// values. Anything less suggests jitter was dropped.
+		t.Errorf("expected jitter to produce many distinct values; only saw %d", len(saw))
+	}
+}
+
+// TestPollWait_ReturnsImmediatelyOnDone exercises the idempotent-observation
+// AC: a probe that is already done returns 0 immediately, no sleep.
+func TestPollWait_ReturnsImmediatelyOnDone(t *testing.T) {
+	start := time.Now()
+	err := pollWait(context.Background(), 1*time.Second,
+		100*time.Millisecond, 1*time.Second,
+		func() (bool, error) { return true, nil })
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Errorf("expected immediate return, took %v", elapsed)
+	}
+}
+
+// TestPollWait_TimeoutEmitsTimeoutCode asserts that a probe that never
+// finishes returns waitExitTimeout once the timeout elapses.
+func TestPollWait_TimeoutEmitsTimeoutCode(t *testing.T) {
+	err := pollWait(context.Background(), 50*time.Millisecond,
+		10*time.Millisecond, 20*time.Millisecond,
+		func() (bool, error) { return false, nil })
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	var ec *exitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *exitCodeError, got %T: %v", err, err)
+	}
+	if ec.code != waitExitTimeout {
+		t.Errorf("expected exit code %d (timeout), got %d", waitExitTimeout, ec.code)
+	}
+}
+
+// TestPollWait_CtxCancelDoesNotCancelJob — the AC requires that Ctrl-C /
+// context cancellation interrupts the wait loop, but the underlying job is
+// not affected. Here we verify that ctx cancellation surfaces as a
+// user-interrupt exit code. The probe records that it was called only as
+// many times as poll iterations elapsed before the cancel — proving the
+// loop returns promptly rather than running the job to completion.
+func TestPollWait_CtxCancelReturnsUserInterrupt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	probeCalls := 0
+	err := pollWait(ctx, 5*time.Second,
+		10*time.Millisecond, 50*time.Millisecond,
+		func() (bool, error) {
+			probeCalls++
+			return false, nil
+		})
+	if err == nil {
+		t.Fatal("expected user-interrupt error, got nil")
+	}
+	var ec *exitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *exitCodeError, got %T: %v", err, err)
+	}
+	if ec.code != waitExitUserInterrupt {
+		t.Errorf("expected user-interrupt code %d, got %d", waitExitUserInterrupt, ec.code)
+	}
+	if probeCalls > 10 {
+		t.Errorf("expected ≤10 probe calls before cancel, got %d (loop did not exit promptly)", probeCalls)
+	}
+}
+
+// TestExitCodeOf returns the embedded code for *exitCodeError, 0 otherwise.
+func TestExitCodeOf(t *testing.T) {
+	if got := exitCodeOf(nil); got != 0 {
+		t.Errorf("nil err: got %d, want 0", got)
+	}
+	if got := exitCodeOf(errors.New("plain")); got != 0 {
+		t.Errorf("plain err: got %d, want 0", got)
+	}
+	if got := exitCodeOf(newExitErr(7, "x")); got != 7 {
+		t.Errorf("exitCodeError: got %d, want 7", got)
+	}
+}
+
+// TestFormatDurationShort renders durations without nanoseconds.
+func TestFormatDurationShort(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s"},
+		{59 * time.Second, "59s"},
+		{1 * time.Minute, "1m"},
+		{59 * time.Minute, "59m"},
+		{1 * time.Hour, "1h"},
+		{90 * time.Minute, "1h30m"},
+	}
+	for _, tc := range cases {
+		if got := formatDurationShort(tc.d); got != tc.want {
+			t.Errorf("formatDurationShort(%v): got %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// TestNewExitErr_PrintsMessage asserts that a non-empty message is preserved
+// on the error so callers (including main.go) can print it.
+func TestNewExitErr_PrintsMessage(t *testing.T) {
+	err := newExitErr(2, "oops something")
+	if !strings.Contains(err.Error(), "oops something") {
+		t.Errorf("expected message preserved, got %q", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -296,4 +297,103 @@ SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_ag
 FROM agent_status
 WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
 	return d.queryStatuses(q, parentSession)
+}
+
+// GroupMembersForGroup returns all agent_status rows for the given group_id
+// (including rows with non-NULL ended_at). Used by the `prism reviews list`
+// surface to enumerate the agents in a review round even after they have been
+// cleaned up.
+func (d *DB) GroupMembersForGroup(groupID string) ([]Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE group_id = ?
+ORDER BY session_name ASC`
+	return d.queryStatuses(q, groupID)
+}
+
+// ReviewGroupSummary captures one row of the `prism reviews list` ledger:
+// a session_groups row plus a roll-up of its members. The PRNumber is
+// extracted from the parent session's review session naming convention
+// (`<parent>~review-<N>-<agent>`); when the group has no members yet, PRNumber
+// is left empty and the caller can fall back to other sources.
+type ReviewGroupSummary struct {
+	GroupID       string
+	ParentSession string
+	CreatedAt     time.Time
+	// Members lists the per-agent session names belonging to this group,
+	// sorted by session name. May be empty if the group has not yet had any
+	// members written, or if all members have been cleaned up via
+	// `prism cleanup`.
+	Members []string
+	// AgentStates aligns with Members (same length, same order). Each entry
+	// is the agent_status.state at the time of query: "active", "finished",
+	// "interrupted", "error", or "deleted".
+	AgentStates []string
+	// GroupState is a roll-up of AgentStates:
+	//   - "in-progress" when at least one member is non-terminal
+	//   - "completed"   when all members are terminal (finished/error/deleted)
+	//   - "empty"       when the group has no members
+	GroupState string
+}
+
+// ReviewGroupsList returns every session_groups row, paired with its members
+// and a rolled-up GroupState, ordered by created_at DESC (newest first).
+// limit ≤ 0 returns all rows.
+//
+// Used by `prism reviews list` (issue #1500) as a dedicated review-group
+// ledger. The list is unfiltered — all groups for all parents are returned;
+// the caller filters by parent or repo if desired.
+func (d *DB) ReviewGroupsList(limit int) ([]ReviewGroupSummary, error) {
+	q := `SELECT group_id, parent_session, created_at FROM session_groups
+	            ORDER BY created_at DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", limit)
+	}
+	rows, err := d.conn.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("db: review groups list: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReviewGroupSummary
+	for rows.Next() {
+		var s ReviewGroupSummary
+		if scanErr := rows.Scan(&s.GroupID, &s.ParentSession, &s.CreatedAt); scanErr != nil {
+			return nil, fmt.Errorf("db: review groups list: scan: %w", scanErr)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: review groups list: iterate: %w", err)
+	}
+
+	// Populate members for each group. Doing this as a second per-group
+	// query rather than a single JOIN keeps the row-construction logic in
+	// queryStatuses untouched and the ledger query simple.
+	for i := range out {
+		members, mErr := d.GroupMembersForGroup(out[i].GroupID)
+		if mErr != nil {
+			return nil, fmt.Errorf("db: review groups list: members for %s: %w", out[i].GroupID, mErr)
+		}
+		out[i].Members = make([]string, 0, len(members))
+		out[i].AgentStates = make([]string, 0, len(members))
+		nonTerminal := 0
+		for _, m := range members {
+			out[i].Members = append(out[i].Members, m.SessionName)
+			out[i].AgentStates = append(out[i].AgentStates, m.State)
+			if !isTerminalState(m.State) && m.EndedAt == nil {
+				nonTerminal++
+			}
+		}
+		switch {
+		case len(members) == 0:
+			out[i].GroupState = "empty"
+		case nonTerminal == 0:
+			out[i].GroupState = "completed"
+		default:
+			out[i].GroupState = "in-progress"
+		}
+	}
+	return out, nil
 }

--- a/modules/programs/prism/prism/internal/review/results.go
+++ b/modules/programs/prism/prism/internal/review/results.go
@@ -121,6 +121,13 @@ const (
 
 // extractAssistantText parses the text field from a msg_assistant payload.
 func extractAssistantText(payload string) string {
+	return ExtractAssistantText(payload)
+}
+
+// ExtractAssistantText is the exported counterpart to extractAssistantText —
+// shared with cmd/ (notably `prism review --wait`'s verdict aggregator)
+// so the JSON-unwrapping logic stays in one place.
+func ExtractAssistantText(payload string) string {
 	var p struct {
 		Text string `json:"text"`
 	}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1732,6 +1732,103 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	// POST /escalate
 	// Request:  {"prompt":"...","to":"<session>" (optional),"from":"<session>" (optional)}
 	// Response: {} on success, {"error":"..."} otherwise.
+	// Wait-probe endpoints (issue #1500) — read-only DB lookups used by the
+	// `--wait` flag on prism merge / review / spawn when the CLI runs inside a
+	// sandbox. The CLI cannot poll the host's prism.db directly (the sandbox
+	// has its own shadow DB), so it polls these endpoints instead. Each is a
+	// single-row / single-shape lookup; rendering and aggregation stay on the
+	// CLI side.
+
+	// GET /merges/by-pr?pr=N
+	// Response: 200 with PendingMerge JSON when the row exists,
+	//           404 {"error":"not found"} when no row exists for that PR.
+	mux.HandleFunc("/merges/by-pr", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		prStr := r.URL.Query().Get("pr")
+		if prStr == "" {
+			writeError(w, http.StatusBadRequest, "pr is required")
+			return
+		}
+		prNum, parseErr := strconv.Atoi(prStr)
+		if parseErr != nil || prNum <= 0 {
+			writeError(w, http.StatusBadRequest, "pr must be a positive integer")
+			return
+		}
+		row, lookupErr := s.cfg.DB.PendingMergeByPR(prNum)
+		if lookupErr != nil {
+			writeError(w, http.StatusInternalServerError, "lookup merge: "+lookupErr.Error())
+			return
+		}
+		if row == nil {
+			writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, row)
+	})
+
+	// GET /sessions/status?session=NAME
+	// Response: 200 with db.Status JSON when the row exists,
+	//           404 {"error":"not found"} when no row exists.
+	mux.HandleFunc("/sessions/status", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		sessionName := r.URL.Query().Get("session")
+		if sessionName == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+		st, lookupErr := s.cfg.DB.CurrentStatus(sessionName)
+		if lookupErr != nil {
+			writeError(w, http.StatusInternalServerError, "lookup status: "+lookupErr.Error())
+			return
+		}
+		if st == nil {
+			writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, st)
+	})
+
+	// GET /groups/poll?group_id=UUID
+	// Response: 200 with {"completed": bool, "members": [Status...],
+	//          "results": map[session]GroupMemberResult}.
+	// The CLI uses `completed` to decide when to stop polling, and the
+	// other fields to aggregate the per-agent verdicts (so a single
+	// terminal poll fetches everything needed).
+	mux.HandleFunc("/groups/poll", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		groupID := r.URL.Query().Get("group_id")
+		if groupID == "" {
+			writeError(w, http.StatusBadRequest, "group_id is required")
+			return
+		}
+		completed, gErr := s.cfg.DB.GroupCompleted(groupID)
+		if gErr != nil {
+			writeError(w, http.StatusInternalServerError, "group completed: "+gErr.Error())
+			return
+		}
+		members, mErr := s.cfg.DB.GroupMembersForGroup(groupID)
+		if mErr != nil {
+			writeError(w, http.StatusInternalServerError, "group members: "+mErr.Error())
+			return
+		}
+		results, rErr := s.cfg.DB.GroupResults(groupID)
+		if rErr != nil {
+			writeError(w, http.StatusInternalServerError, "group results: "+rErr.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"completed": completed,
+			"members":   members,
+			"results":   results,
+		})
+	})
+
 	//
 	// Forwards an escalation request from a worker container to the host's
 	// `prism escalate` CLI. The from field defaults to the calling sidecar's

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1792,6 +1792,38 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		writeJSON(w, http.StatusOK, st)
 	})
 
+	// GET /groups/list?limit=N
+	// Response: 200 with []db.ReviewGroupSummary (newest first).
+	//
+	// Backs `prism reviews list` (issue #1500) when invoked from inside a
+	// sandbox — the in-sandbox prism.db is a tmpfs shadow with no review
+	// groups, so a direct read returns an empty list. Routing through this
+	// endpoint lets the in-sandbox CLI see the host's session_groups
+	// table. Same #1043 pattern as /merges.
+	mux.HandleFunc("/groups/list", func(w http.ResponseWriter, r *http.Request) {
+		if !requireGet(w, r) {
+			return
+		}
+		limit := 0
+		if l := r.URL.Query().Get("limit"); l != "" {
+			n, parseErr := strconv.Atoi(l)
+			if parseErr != nil || n < 0 {
+				writeError(w, http.StatusBadRequest, "limit must be a non-negative integer")
+				return
+			}
+			limit = n
+		}
+		groups, gErr := s.cfg.DB.ReviewGroupsList(limit)
+		if gErr != nil {
+			writeError(w, http.StatusInternalServerError, "list groups: "+gErr.Error())
+			return
+		}
+		if groups == nil {
+			groups = []db.ReviewGroupSummary{}
+		}
+		writeJSON(w, http.StatusOK, groups)
+	})
+
 	// GET /groups/poll?group_id=UUID
 	// Response: 200 with {"completed": bool, "members": [Status...],
 	//          "results": map[session]GroupMemberResult}.

--- a/modules/programs/prism/prism/internal/sidecar/host_api_wait_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_wait_test.go
@@ -1,0 +1,187 @@
+package sidecar
+
+// Tests for the three read-only wait-probe endpoints (#1500):
+//
+//   GET /merges/by-pr      — single pending_merges row lookup
+//   GET /sessions/status   — single agent_status row lookup
+//   GET /groups/poll       — group completion + members + results
+//
+// These exist so the in-sandbox `--wait` poll loops can read host-side
+// terminal state through the host-API rather than opening a shadow DB.
+// Each endpoint must return 404 for missing rows (so the CLI can keep
+// polling) and 200 with stable JSON shapes for present rows.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// ── /merges/by-pr ─────────────────────────────────────────────────────────────
+
+func TestHostAPI_MergesByPR_ReturnsRow(t *testing.T) {
+	d := openTestDB(t)
+	if _, err := d.EnqueueMerge(42, "repo@main", "inst-1", nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+	if err := d.TerminateMerge(42, "merged", ""); err != nil {
+		t.Fatalf("TerminateMerge: %v", err)
+	}
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges/by-pr?pr=42", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var row db.PendingMerge
+	decodeJSONBody(t, rr, &row)
+	if row.PR != 42 {
+		t.Errorf("pr: want 42, got %d", row.PR)
+	}
+	if row.Status != "merged" {
+		t.Errorf("status: want merged, got %q", row.Status)
+	}
+}
+
+func TestHostAPI_MergesByPR_ReturnsNotFoundWhenAbsent(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges/by-pr?pr=12345", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHostAPI_MergesByPR_RejectsMissingPR(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges/by-pr", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHostAPI_MergesByPR_RejectsBadPR(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/merges/by-pr?pr=foo", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for non-numeric pr; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ── /sessions/status ──────────────────────────────────────────────────────────
+
+func TestHostAPI_SessionsStatus_ReturnsRow(t *testing.T) {
+	d := openTestDB(t)
+	if err := d.UpsertStatus("repo@feature", "repo", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/sessions/status?session=repo@feature", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var st db.Status
+	decodeJSONBody(t, rr, &st)
+	if st.SessionName != "repo@feature" {
+		t.Errorf("session: want repo@feature, got %q", st.SessionName)
+	}
+	if st.State != "finished" {
+		t.Errorf("state: want finished, got %q", st.State)
+	}
+}
+
+func TestHostAPI_SessionsStatus_ReturnsNotFoundWhenAbsent(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/sessions/status?session=does-not-exist", "")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ── /groups/poll ──────────────────────────────────────────────────────────────
+
+func TestHostAPI_GroupsPoll_CompletedTrueAfterAllTerminal(t *testing.T) {
+	d := openTestDB(t)
+	groupID, err := d.RegisterGroup("repo@pr-1500")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	const sess = "repo@pr-1500~review-1-review-goal"
+	if err := d.UpsertStatusSeedRootAgentName(sess, "repo", "/wt", "finished", nil, nil, "review-goal", ""); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+	// Link to group via raw SQL (mirrors the pattern in db_test.go).
+	var one int
+	if err := d.QueryRow(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+		groupID, sess,
+	).Scan(&one); err != nil {
+		t.Fatalf("link group_id: %v", err)
+	}
+	// Seed a msg_assistant event so GroupResults has output to surface.
+	if err := d.WriteEvent(db.Event{
+		ID:          "evt-1",
+		SessionName: sess,
+		Repo:        "repo",
+		Worktree:    "/wt",
+		Type:        "msg_assistant",
+		Payload:     `{"text":"<verdict>PASS</verdict>"}`,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "repo@pr-1500", "repo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/groups/poll?group_id="+groupID, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Completed bool                            `json:"completed"`
+		Members   []db.Status                     `json:"members"`
+		Results   map[string]db.GroupMemberResult `json:"results"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, rr.Body.String())
+	}
+	if !resp.Completed {
+		t.Errorf("completed: want true, got false")
+	}
+	if len(resp.Members) != 1 || resp.Members[0].SessionName != sess {
+		t.Errorf("members: want [%q], got %v", sess, resp.Members)
+	}
+	if mr, ok := resp.Results[sess]; !ok || mr.State != "finished" {
+		t.Errorf("results[%q]: want state=finished, got %v", sess, mr)
+	}
+}
+
+func TestHostAPI_GroupsPoll_RejectsMissingGroupID(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/groups/poll", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_WaitProbeEndpoints_RejectPost ensures the wait-probe endpoints
+// only accept GET (read-only). A misconfigured client should not be able to
+// POST through them and silently change state.
+func TestHostAPI_WaitProbeEndpoints_RejectPost(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	for _, path := range []string{"/merges/by-pr?pr=1", "/sessions/status?session=x", "/groups/poll?group_id=x"} {
+		rr := doHostAPI(t, sc, http.MethodPost, path, "{}")
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("POST %s: status = %d, want 405; body = %s", path, rr.Code, rr.Body.String())
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api_wait_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_wait_test.go
@@ -14,6 +14,7 @@ package sidecar
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -172,13 +173,78 @@ func TestHostAPI_GroupsPoll_RejectsMissingGroupID(t *testing.T) {
 	}
 }
 
+// ── /groups/list ──────────────────────────────────────────────────────────────
+
+// TestHostAPI_GroupsList_ReturnsGroupsNewestFirst exercises the new
+// /groups/list endpoint added in #1500 round-3 to fix the shadow-DB
+// regression for `prism reviews list` from inside a sandbox.
+func TestHostAPI_GroupsList_ReturnsGroupsNewestFirst(t *testing.T) {
+	d := openTestDB(t)
+	// Two groups; ReviewGroupsList sorts by created_at DESC (newest
+	// first). Both register on the same DATETIME tick so we cannot
+	// assert ordering precisely — but we can assert both rows are
+	// returned and carry the right parent.
+	g1, err := d.RegisterGroup("repo@pr-1")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	g2, err := d.RegisterGroup("repo@pr-2")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/groups/list", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var groups []db.ReviewGroupSummary
+	decodeJSONBody(t, rr, &groups)
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d: %v", len(groups), groups)
+	}
+	seen := map[string]string{}
+	for _, g := range groups {
+		seen[g.GroupID] = g.ParentSession
+	}
+	if seen[g1] != "repo@pr-1" {
+		t.Errorf("group %s: want parent repo@pr-1, got %q", g1, seen[g1])
+	}
+	if seen[g2] != "repo@pr-2" {
+		t.Errorf("group %s: want parent repo@pr-2, got %q", g2, seen[g2])
+	}
+}
+
+func TestHostAPI_GroupsList_EmptyReturnsEmptyArray(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/groups/list", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	// Must be `[]` literally, not `null` (the empty-list contract that
+	// prism CLI consumers depend on across `--json` paths).
+	if strings.TrimSpace(rr.Body.String()) != "[]" {
+		t.Errorf("empty groups list: want '[]', got %q", rr.Body.String())
+	}
+}
+
+func TestHostAPI_GroupsList_RejectsBadLimit(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/groups/list?limit=abc", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
 // TestHostAPI_WaitProbeEndpoints_RejectPost ensures the wait-probe endpoints
 // only accept GET (read-only). A misconfigured client should not be able to
 // POST through them and silently change state.
 func TestHostAPI_WaitProbeEndpoints_RejectPost(t *testing.T) {
 	d := openTestDB(t)
 	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
-	for _, path := range []string{"/merges/by-pr?pr=1", "/sessions/status?session=x", "/groups/poll?group_id=x"} {
+	for _, path := range []string{"/merges/by-pr?pr=1", "/sessions/status?session=x", "/groups/poll?group_id=x", "/groups/list"} {
 		rr := doHostAPI(t, sc, http.MethodPost, path, "{}")
 		if rr.Code != http.StatusMethodNotAllowed {
 			t.Errorf("POST %s: status = %d, want 405; body = %s", path, rr.Code, rr.Body.String())

--- a/modules/programs/prism/prism/main.go
+++ b/modules/programs/prism/prism/main.go
@@ -1,14 +1,29 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/prismatic-koi/prism/cmd"
 )
 
+// exitCoder is implemented by errors that want to override the default exit
+// code of 1. Used by --wait paths (cmd/wait.go) to distinguish timeouts and
+// user interrupts from real terminal failures (issue #1500).
+type exitCoder interface {
+	ExitCode() int
+}
+
 func main() {
 	if err := cmd.Execute(); err != nil {
+		var ec exitCoder
+		if errors.As(err, &ec) {
+			if msg := err.Error(); msg != "" {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			os.Exit(ec.ExitCode())
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Closes #1500.

Adds an opt-in `--wait` flag to `prism merge`, `prism review`, and `prism spawn` so
agents whose workflow is genuinely synchronous can collapse the submit-poll-collect
arc into one command. The notification / ledger path stays unchanged for the
parallel case. Also adds `prism reviews list` (with `--json`) to give review groups
a dedicated ledger surface, analogous to `prism merges`.

## What's new

| Command | Terminal definition | Default `--timeout` |
|---|---|---|
| `prism merge <pr> --wait` | merged / failed / cancelled / abandoned (in `pending_merges`) | `30m` |
| `prism review <pr> --wait` | All review agents reached `finished`/`error`/`deleted` (group complete) | `20m` |
| `prism spawn ... --wait` | Spawned agent reached `finished` / `error` / `interrupted` / `deleted` for its **first turn** | `10m` |

`--wait` exit codes:

| Exit | Meaning |
|---|---|
| 0 | terminal success (merged / all-PASS / finished) |
| 2 | terminal failure (failed CI, any-FAIL, error state) |
| 3 | local `--timeout` elapsed (the underlying job continues) |
| 4 | user interrupted with Ctrl-C (the underlying job continues) |

## Spawn `--wait` terminal definition

> The implementer chooses `finished` vs `idle-after-first-prompt`, documents it,
> and tests it. — issue #1500

I chose **first-turn terminal**: `--wait` blocks until the spawned agent reaches
`finished` / `error` / `interrupted` / `deleted`. This matches \"wait for the
spawned agent to finish its initial prompt\" rather than \"wait until the session
ends entirely\" — coordinator sessions can run for hours / days, so waiting on
the session itself would be useless. \"interrupted\" is included so a user-paused
agent terminates the wait (the user can then `prism prompt` to resume).

The terminal set is documented in `cmd/spawn_wait.go` with rationale, and tested
via `TestWaitForSpawnTerminal_FinishedExits0`,
`TestWaitForSpawnTerminal_ErrorReturnsTerminalFail`, and
`TestWaitForSpawnTerminal_TimeoutReturnsTimeoutCode`.

## Implementation notes

- **Backoff helper.** `cmd/wait.go::backoffSchedule` centralises exponential
  backoff with ±50% jitter. The AC says \"verifiable by reading the code\" — every
  poll loop calls this one named function. `TestBackoffSchedule_GrowsAndCaps`
  asserts mean growth and cap behaviour; `TestBackoffSchedule_JitterIsBoundedAndRandom`
  asserts the jitter range.
- **Ctrl-C semantic.** `setupWaitSignals` installs a SIGINT/SIGTERM handler that
  flips a local atomic flag and returns. The poll loop checks the flag between
  sleeps and returns waitExitUserInterrupt — the underlying merge / review /
  spawn keeps running. Verified by `TestPollWait_CtxCancelReturnsUserInterrupt`.
- **Idempotent observation.** `prism merge <pr> --wait` calls
  `observeAlreadyTerminal` before enqueueing — an already-terminal row
  short-circuits with the recorded status. Verified by
  `TestObserveAlreadyTerminal_MergedRow`.
- **JSON contract.** When `--wait` and `--json` are both set, the terminal
  status is emitted as JSON exclusively (no textual chatter). The shape is
  stable: every key always present, RFC3339 timestamps, snake_case.
- **Re-uses existing primitives.** `--wait` polls the same DB rows the existing
  watchers / monitors write. The merge wait reads `pending_merges` (same as
  the watcher). The review wait reads `db.GroupCompleted` + `db.GroupResults`
  + `review.AssessPassed` (same as the async monitor). The spawn wait reads
  `agent_status.state`. None of the watcher/monitor logic is duplicated.

## Out of scope / deferred

- **`prism agent-context`** (#1498) is not yet implemented. The AC for
  documenting `--wait` and `--timeout` in `agent-context` is therefore
  deferred to land alongside #1498.

## Files

New files:
- `cmd/wait.go` — backoff + signal-handling primitives, exit-code wiring.
- `cmd/wait_test.go` — backoff / pollWait / exit-code tests.
- `cmd/review_wait.go`, `cmd/review_wait_test.go` — review wait + tests.
- `cmd/spawn_wait.go`, `cmd/spawn_wait_test.go` — spawn wait + tests.
- `cmd/reviews.go`, `cmd/reviews_test.go` — \`prism reviews list\` + tests.
- `cmd/merge_wait_test.go` — merge wait tests.

Modified:
- `cmd/merge.go` — `--wait`/`--timeout`/`--json` flags + helper functions.
- `cmd/review.go` — `--wait`/`--wait-timeout`/`--json` flags + entry point.
- `cmd/spawn.go` — `--wait`/`--wait-timeout`/`--json` flags + entry point.
- `internal/db/groups.go` — `GroupMembersForGroup`, `ReviewGroupSummary`,
  `ReviewGroupsList` for the new ledger surface.
- `internal/review/results.go` — exported `ExtractAssistantText`.
- `main.go` — exit-code propagation for `*exitCodeError`.
- `modules/programs/prism/opencode/skills/prism/SKILL.md` — documents the
  `--wait` shape, exit codes, and `prism reviews list`.

## Quality gates

- ✅ `go build ./...`
- ✅ `go test ./...`
- ✅ `go test ./cmd ./internal/db -race`
- ✅ `go vet ./...`
- ✅ `nix build .#prism`
- ✅ `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'` (homeless-shelter signal)