### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777913624,
-        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
+        "lastModified": 1778248595,
+        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
+        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1777958148,
-        "narHash": "sha256-3yt31oyEHCyK0fCaaql2eRLC6GmRqAdBCbme/DK01/Q=",
+        "lastModified": 1778303898,
+        "narHash": "sha256-UD2MxOeFSkoLB3TToDhZ3FZKbRu0zj/W3dlnrNDFNps=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3b13232390e3c72d8d6fe1214bd406cded4d9d0",
+        "rev": "e036a78dd7d408bf02e3f6e9ccebdd06cb33e26c",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/25592895411

## Closure diff: navi

```
bitwarden-desktop: -192.0 MiB
cfitsio: 4.6.3 → 4.6.4, 8.0 KiB
claude-code: 2.1.123 → 2.1.133, -17.2 MiB
cpptrace: ∅ → 1.0.4, 744.5 KiB
deno: 2.7.13 → 2.7.14, 452.8 KiB
fluxcd: -38.5 MiB
hyprland: 11.6 KiB
hyprutils: 0.12.0 → 0.13.0, 16.3 KiB
kubectl: 1.35.4 → 1.36.0, 469.3 KiB
libXNVCtrl: 595.58.03 → 595.71.05
libdwarf: ∅ → 2.2.0, 665.2 KiB
lp_solve: 5.5.2.11 → 5.5.2.14
mesa: 26.0.5 → 26.0.6
nix: 2.34.6 → 2.34.7, 9.1 KiB
nix-cmd: 2.34.6 → 2.34.7
nix-expr: 2.34.6 → 2.34.7
nix-fetchers: 2.34.6 → 2.34.7
nix-flake: 2.34.6 → 2.34.7
nix-main: 2.34.6 → 2.34.7
nix-manual: 2.34.6 → 2.34.7
nix-nswrapper: 2.34.6 → 2.34.7
nix-store: 2.31.4, 2.34.6 → 2.31.5, 2.34.7
nix-util: 2.31.4, 2.34.6 → 2.31.5, 2.34.7, 17.6 KiB
nixos-manual: 22.0 KiB
nixos-system-navi: 26.05.20260430.15f4ee4 → 26.05.20260505.549bd84
opencode: 2.4 MiB
python3.12-charset-normalizer: ∅ → 3.4.4, 794.9 KiB
python3.13-google-auth-oauthlib: 1.2.4 → 1.3.1
quickshell: 0.2.1 → 0.3.0, 2.5 MiB
rclone: 1.73.5 → 1.74.0, 1.9 MiB
sd-switch: 0.6.2 → 0.6.3, 15.1 KiB
source: 584.1 KiB
unrar: 7.2.5 → 7.2.6
vimplugin-leap.nvim: 0-unstable-2026-04-26 → 0-unstable-2026-05-02
vimplugin-luajit2.1-lualine.nvim-scm: 3-unstable-scm-3 → 4-unstable-scm-4
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-25 → 1.17.0-unstable-2026-04-30
```

## Closure diff: tui

```
bitwarden-desktop: -192.0 MiB
cfitsio: 4.6.3 → 4.6.4, 8.0 KiB
claude-code: 2.1.123 → 2.1.133, -17.2 MiB
cpptrace: ∅ → 1.0.4, 744.5 KiB
deno: 2.7.13 → 2.7.14, 452.8 KiB
fluxcd: -38.5 MiB
hyprland: 11.6 KiB
hyprutils: 0.12.0 → 0.13.0, 16.3 KiB
kubectl: 1.35.4 → 1.36.0, 469.3 KiB
libXNVCtrl: 595.58.03 → 595.71.05
libdwarf: ∅ → 2.2.0, 665.2 KiB
lp_solve: 5.5.2.11 → 5.5.2.14
mesa: 26.0.5 → 26.0.6
nix: 2.34.6 → 2.34.7, 9.1 KiB
nix-cmd: 2.34.6 → 2.34.7
nix-expr: 2.34.6 → 2.34.7
nix-fetchers: 2.34.6 → 2.34.7
nix-flake: 2.34.6 → 2.34.7
nix-main: 2.34.6 → 2.34.7
nix-manual: 2.34.6 → 2.34.7
nix-nswrapper: 2.34.6 → 2.34.7
nix-store: 2.31.4, 2.34.6 → 2.31.5, 2.34.7
nix-util: 2.31.4, 2.34.6 → 2.31.5, 2.34.7, 17.6 KiB
nixos-manual: 22.0 KiB
nixos-system-tui: 26.05.20260430.15f4ee4 → 26.05.20260505.549bd84
opencode: 2.4 MiB
python3.12-charset-normalizer: ∅ → 3.4.4, 794.9 KiB
python3.13-google-auth-oauthlib: 1.2.4 → 1.3.1
quickshell: 0.2.1 → 0.3.0, 2.5 MiB
sd-switch: 0.6.2 → 0.6.3, 15.1 KiB
source: 584.1 KiB
unrar: 7.2.5 → 7.2.6
vimplugin-leap.nvim: 0-unstable-2026-04-26 → 0-unstable-2026-05-02
vimplugin-luajit2.1-lualine.nvim-scm: 3-unstable-scm-3 → 4-unstable-scm-4
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-25 → 1.17.0-unstable-2026-04-30
```