### PR TITLE
Fix PI harness archiving (three bugs)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1489,6 +1489,11 @@ export default function prismExtension(pi: ExtensionAPI): void {
             branch: sessionBranch,
             review_cycles: 0,
             pr_number: "",
+            // session_id: the PI session ID used to locate the session
+            // directory on disk for archiving (bug #1538 fix). Populated
+            // from lastCtx when available; "" when no turn has started yet
+            // (the turn_start session_status will carry the real ID).
+            session_id: lastCtx?.sessionManager?.getSessionId() ?? "",
           })
         }
         return
@@ -1627,6 +1632,11 @@ export default function prismExtension(pi: ExtensionAPI): void {
           branch: sessionBranch,
           review_cycles: 0,
           pr_number: "",
+          // session_id: the PI session ID used by prism cleanup to locate
+          // the session directory for archiving (bug #1538 fix). Sourced
+          // from ctx.sessionManager.getSessionId() which is guaranteed
+          // non-empty on turn_start.
+          session_id: ctx.sessionManager.getSessionId(),
         })
       }
     }

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -550,8 +550,8 @@ start of each turn (`turn_start`), so the sidecar always has an up-to-date
 picture of the session state.
 
 ```json
-{"type":"session_status","role":"worker","branch":"fix-login-redirect","review_cycles":0,"pr_number":""}
-{"type":"session_status","role":"review","branch":"fix-login-redirect","review_cycles":2,"pr_number":"42"}
+{"type":"session_status","role":"worker","branch":"fix-login-redirect","review_cycles":0,"pr_number":"","session_id":"ses_01J..."}
+{"type":"session_status","role":"review","branch":"fix-login-redirect","review_cycles":2,"pr_number":"42","session_id":"ses_01J..."}
 ```
 
 Fields:
@@ -565,10 +565,18 @@ Fields:
   detected PR. Zero when no PR has been detected yet.
 - `pr_number` (string, required) — the PR number most recently detected by
   the review-cycle tracker, or `""` when unknown.
+- `session_id` (string, required) — the PI session ID from
+  `ctx.sessionManager.getSessionId()`. Used by the sidecar to populate
+  `sessions.harness_session_id` so that `prism cleanup` can locate the
+  correct session directory (`~/.pi/agent/sessions/<session_id>/`) for
+  archiving. May be `""` in the post-handshake frame when no turn has
+  started yet; the `turn_start` frame always carries the real ID. Added
+  in #1538 to fix PI archiving.
 
-Sidecar behaviour: store as a harness frame per §8.2 forward-compat rules
-(unknown frames are stored as-is). No active dispatch is required; the
-sidecar may use this frame for monitoring and session metadata.
+Sidecar behaviour: when `session_id` is non-empty, the sidecar calls
+`db.UpdateHarnessSessionID(sessionName, session_id)` to record the PI
+session ID. The frame is also stored as a raw event per §8.2 forward-compat
+rules.
 
 The extension also calls `ctx.ui.setStatus("prism", text)` with a
 human-readable summary at the same points. The status text format is:

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -561,6 +561,27 @@ func (d *DB) ClearInstanceID(sessionName string) error {
 	return nil
 }
 
+// EnsureStatusRow inserts a minimal agent_status row for sessionName if one
+// does not already exist. When the row already exists, it is left completely
+// untouched (INSERT OR IGNORE semantics). This is used by the sidecar to
+// guarantee that UpdateHarnessSessionID finds a row to UPDATE even when the
+// session_status frame arrives before the first state_change or turn_start
+// that would normally create the row via upsertState.
+//
+// The inserted row uses state="active" as a safe default; it will be
+// overwritten by the next upsertState call.
+func (d *DB) EnsureStatusRow(sessionName, repo, worktree string) error {
+	now := time.Now().UnixMilli()
+	const q = `
+INSERT OR IGNORE INTO agent_status (session_name, repo, worktree, state, last_seen)
+VALUES (?, ?, ?, 'active', ?)`
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, now)
+	if err != nil {
+		return fmt.Errorf("db: ensure status row: %w", err)
+	}
+	return nil
+}
+
 // UpdateHarnessSessionID unconditionally sets harness_session_id for sessionName
 // to the given sid value. Unlike UpsertStatus (which only updates harness_session_id
 // via COALESCE when non-nil), this always overwrites — allowing the sidecar to

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -159,16 +159,31 @@ func (a *Adapter) ExtractMessage(_ harness.HarnessEvent) (harness.Message, bool)
 	return harness.Message{}, false
 }
 
-// CreateSession synthesises a prism session ID for the PI session. PI does not
-// have a server-side session API to query, so we derive a stable ID from the
-// configured session name (or return a placeholder).
+// CreateSession returns the PI session ID recorded by SetSessionID, or "" when
+// the real session ID has not been received yet (i.e. the session_status frame
+// has not arrived). Callers should treat "" as "session ID not yet known" and
+// retry after the sidecar has processed the session_status frame from the PI
+// extension.
+//
+// The hardcoded "pi-session" placeholder that was returned here previously is
+// removed (bug #1538 fix #3). The real session ID is now populated by the
+// sidecar's session_status handler via SetSessionID before CreateSession is
+// called from cleanup.
 func (a *Adapter) CreateSession(_ context.Context) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.sessionID == "" {
-		a.sessionID = "pi-session"
-	}
 	return a.sessionID, nil
+}
+
+// SetSessionID records the PI session ID received from the session_status frame.
+// This is called by the sidecar when it processes a session_status frame so
+// that CreateSession can return the real ID instead of a placeholder.
+func (a *Adapter) SetSessionID(id string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if id != "" {
+		a.sessionID = id
+	}
 }
 
 // SessionID returns the most recently created session ID.

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -33,6 +33,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/prismatic-koi/prism/internal/container"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 )
 
@@ -52,10 +53,30 @@ func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
 // The harness_session_id is populated at session-create time when PI starts.
 // When HarnessSessionID is empty (PI failed to start), SourcePath returns the
 // sessions root directory; the caller handles the missing-directory case.
+//
+// For sandbox-exec sessions (IsolationMode == "sandbox-exec"), PI writes to the
+// staging HOME instead of the real home directory. The staging HOME path is:
+//   ~/.local/state/prism/sessions/<instance_id>/home/
+// So PI's session directory is <stagingHome>/.pi/agent/sessions/<harness_session_id>.
+// Bug #1538 fix #2: using os.UserHomeDir() for sandbox-exec sessions pointed at
+// the wrong directory — PI never wrote there.
 func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("pi archive: resolve home: %w", err)
+	var home string
+	if p.IsolationMode == "sandbox-exec" && p.InstanceID != "" {
+		// sandbox-exec: PI writes into the per-session staging HOME, not
+		// the real home directory. Use the same path formula as
+		// container.SandboxExecStagingHomePath.
+		stagingHome, err := container.SandboxExecStagingHomePath(p.InstanceID)
+		if err != nil {
+			return "", fmt.Errorf("pi archive: resolve sandbox-exec staging home: %w", err)
+		}
+		home = stagingHome
+	} else {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("pi archive: resolve home: %w", err)
+		}
 	}
 	sessionsRoot := filepath.Join(home, ".pi", "agent", "sessions")
 	if p.HarnessSessionID == "" {

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -4,11 +4,24 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/harness/pi"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 )
+
+// sandboxExecStagingHome returns the expected staging HOME path for a given
+// instanceID, mirroring container.SandboxExecStagingHomePath without importing
+// the container package (avoids circular imports in tests).
+func sandboxExecStagingHome(t *testing.T, instanceID string) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	return filepath.Join(home, ".local", "state", "prism", "sessions", instanceID, "home")
+}
 
 func TestArchiveAdapter_SourcePath_WithHarnessSessionID(t *testing.T) {
 	a := pi.NewArchiveAdapter()
@@ -126,5 +139,88 @@ func TestArchiveAdapter_Export_NoRawSessionJSONL_NoError(t *testing.T) {
 	// No session.jsonl should be written at archive root.
 	if _, err := os.Stat(filepath.Join(archiveDir, "session.jsonl")); !os.IsNotExist(err) {
 		t.Error("expected session.jsonl NOT to be created when raw/session.jsonl is absent")
+	}
+}
+
+// TestArchiveAdapter_SourcePath_SandboxExec verifies that when IsolationMode
+// is "sandbox-exec", SourcePath uses the per-session staging HOME (not the
+// real home directory). This is bug #1538 fix #2: sandbox-exec sessions write
+// PI data to <stagingHome>/.pi/agent/sessions/<sessionID>/, not ~/.pi/.
+func TestArchiveAdapter_SourcePath_SandboxExec(t *testing.T) {
+	const instanceID = "test-instance-uuid-1234"
+	const sessionID = "pi-ses-abc-sandbox"
+
+	a := pi.NewArchiveAdapter()
+	p := harnessarchive.SourceParams{
+		HarnessSessionID: sessionID,
+		IsolationMode:    "sandbox-exec",
+		InstanceID:       instanceID,
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+
+	// Expected path: <stagingHome>/.pi/agent/sessions/<sessionID>
+	stagingHome := sandboxExecStagingHome(t, instanceID)
+	want := filepath.Join(stagingHome, ".pi", "agent", "sessions", sessionID)
+	if got != want {
+		t.Errorf("SourcePath (sandbox-exec): got %q, want %q", got, want)
+	}
+
+	// Must NOT contain the real home directory.
+	home, _ := os.UserHomeDir()
+	if strings.HasPrefix(got, filepath.Join(home, ".pi")) {
+		t.Errorf("SourcePath (sandbox-exec) returned real home path %q; expected staging home", got)
+	}
+}
+
+// TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID verifies that when
+// IsolationMode is "sandbox-exec" but InstanceID is empty (unusual edge case),
+// SourcePath falls back to the real home directory path rather than returning
+// an error that would abort cleanup entirely.
+func TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID(t *testing.T) {
+	a := pi.NewArchiveAdapter()
+	p := harnessarchive.SourceParams{
+		HarnessSessionID: "some-session",
+		IsolationMode:    "sandbox-exec",
+		InstanceID:       "", // empty — forces fallback
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath with empty InstanceID: %v", err)
+	}
+	// Fallback: uses real home directory.
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".pi", "agent", "sessions", "some-session")
+	if got != want {
+		t.Errorf("SourcePath (sandbox-exec, empty InstanceID): got %q, want %q", got, want)
+	}
+}
+
+// TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome verifies that
+// non-sandbox-exec isolation modes (podman, bwrap, host) continue to use the
+// real home directory, not the staging HOME.
+func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	const sessionID = "pi-ses-xyz"
+
+	for _, mode := range []string{"podman", "bwrap", "host", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			a := pi.NewArchiveAdapter()
+			p := harnessarchive.SourceParams{
+				HarnessSessionID: sessionID,
+				IsolationMode:    mode,
+				InstanceID:       "some-instance-id",
+			}
+			got, err := a.SourcePath(p)
+			if err != nil {
+				t.Fatalf("SourcePath (mode=%q): %v", mode, err)
+			}
+			want := filepath.Join(home, ".pi", "agent", "sessions", sessionID)
+			if got != want {
+				t.Errorf("SourcePath (mode=%q): got %q, want %q", mode, got, want)
+			}
+		})
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1956,6 +1956,44 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		// the existing agent_events payload format (P2.WIRE §8.1).
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
 
+	case "session_status":
+		// Extract the PI session ID from the frame and record it in the DB so
+		// that prism cleanup can locate the correct session directory for
+		// archiving. Bug #1538 fix #1: this frame was previously falling
+		// through to the default case and only stored as a raw event; the
+		// harness_session_id column was never populated for PI sessions.
+		var statusFrame struct {
+			SessionID string `json:"session_id"`
+		}
+		if err := json.Unmarshal(line, &statusFrame); err == nil && statusFrame.SessionID != "" {
+			// Release the lock while calling DB methods (writes) to avoid
+			// holding s.mu across I/O. The lock is re-acquired by the defer
+			// at the top of handlePipeFrame.
+			sessionName := s.cfg.SessionName
+			repo := s.cfg.Repo
+			worktree := s.cfg.Worktree
+			dbConn := s.cfg.DB
+			s.mu.Unlock()
+			// Ensure the agent_status row exists before UpdateHarnessSessionID.
+			// writeStateChange (called at handshake) only writes to agent_events,
+			// not agent_status. If session_status arrives before the first
+			// turn_start or state_change (which call upsertState), the UPDATE
+			// in UpdateHarnessSessionID would affect 0 rows. EnsureStatusRow
+			// guarantees the row is present without clobbering existing values.
+			if err := dbConn.EnsureStatusRow(sessionName, repo, worktree); err != nil {
+				s.logger().Printf("sidecar: session_status: EnsureStatusRow: %v", err)
+			}
+			if err := dbConn.UpdateHarnessSessionID(sessionName, statusFrame.SessionID); err != nil {
+				s.logger().Printf("sidecar: session_status: UpdateHarnessSessionID: %v", err)
+			} else {
+				s.logger().Printf("sidecar: session_status: harness_session_id set to %q", statusFrame.SessionID)
+			}
+			s.mu.Lock()
+		}
+		// Persist the frame as a raw event for forward-compatibility and
+		// diagnostics (P2.WIRE §8.2).
+		s.writeEvent(frame.Type, json.RawMessage(line), nil)
+
 	case "session_shutdown":
 		// Flush any partial accumulator before marking finished.
 		s.flushPipeAccum()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -2502,5 +2502,116 @@ func TestSocketPipe_SessionShutdownHook_NextFrameDispatchedNormally(t *testing.T
 	}
 }
 
+// TestSocketPipe_SessionStatus_PopulatesHarnessSessionID verifies that a
+// session_status frame carrying a non-empty session_id causes the sidecar to
+// call UpdateHarnessSessionID and record the PI session ID in the DB.
+//
+// This is the regression test for bug #1538 fix #1: previously session_status
+// fell through to the default case and the harness_session_id column was never
+// populated for PI sessions, causing prism cleanup to log
+// "raw/session.jsonl not found" and produce an empty archive.
+func TestSocketPipe_SessionStatus_PopulatesHarnessSessionID(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Send a session_status frame with a real PI session ID.
+	const piSessionID = "pi-ses-test-abc-123"
+	sendJSON(t, conn, map[string]any{
+		"type":          "session_status",
+		"role":          "worker",
+		"branch":        "main",
+		"review_cycles": 0,
+		"pr_number":     "",
+		"session_id":    piSessionID,
+	})
+
+	// Poll DB until harness_session_id is populated.
+	deadline := time.Now().Add(2 * time.Second)
+	var gotSID string
+	for {
+		s, err := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+		if err != nil {
+			t.Fatalf("CurrentStatus: %v", err)
+		}
+		if s != nil && s.HarnessSessionID != nil && *s.HarnessSessionID == piSessionID {
+			gotSID = *s.HarnessSessionID
+			break
+		}
+		if time.Now().After(deadline) {
+			var sid string
+			if s != nil && s.HarnessSessionID != nil {
+				sid = *s.HarnessSessionID
+			}
+			t.Fatalf("harness_session_id never set to %q (got %q)", piSessionID, sid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if gotSID != piSessionID {
+		t.Errorf("harness_session_id = %q, want %q", gotSID, piSessionID)
+	}
+
+	// The session_status frame should also be persisted as a raw event.
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var found bool
+	for _, e := range events {
+		if e.Type == "session_status" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected session_status event in agent_events, not found")
+	}
+
+	// Clean shutdown.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
+// TestSocketPipe_SessionStatus_EmptySessionID_NoOp verifies that a
+// session_status frame with an empty session_id does NOT call
+// UpdateHarnessSessionID (which would overwrite a real ID with an empty string).
+func TestSocketPipe_SessionStatus_EmptySessionID_NoOp(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Send a session_status frame with no session_id (post-handshake case).
+	sendJSON(t, conn, map[string]any{
+		"type":          "session_status",
+		"role":          "worker",
+		"branch":        "main",
+		"review_cycles": 0,
+		"pr_number":     "",
+		"session_id":    "",
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// harness_session_id must remain NULL (not set to empty string).
+	s, err := sc.cfg.DB.CurrentStatus(sc.cfg.SessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s != nil && s.HarnessSessionID != nil && *s.HarnessSessionID != "" {
+		t.Errorf("harness_session_id = %q, want NULL (empty session_id should be a no-op)", *s.HarnessSessionID)
+	}
+
+	// Clean shutdown.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+}
+
 // Ensure db import is used.
 var _ *db.DB


### PR DESCRIPTION
Fixes three combined bugs that caused `prism cleanup` on a PI session to log `pi archive: Export: raw/session.jsonl not found — no export produced` and produce an empty archive.

## Fix 1: Handle `session_status` frame in `handlePipeFrame` (`sidecar.go`)

The `session_status` frame carries the real PI session ID in its `session_id` field but previously fell through to the `default` case, so `sessions.harness_session_id` was never populated for PI sessions.

Added an explicit `case "session_status":` that extracts `session_id` and calls `db.UpdateHarnessSessionID()`. Also added `db.EnsureStatusRow()` (INSERT OR IGNORE) to guarantee the `agent_status` row exists before `UpdateHarnessSessionID` runs — `session_status` arrives before the first `turn_start` that normally creates the row.

## Fix 2: Use staging HOME for sandbox-exec sessions (`archive.go`)

For sandbox-exec sessions, PI writes to `<stagingHome>/.pi/agent/sessions/<id>/`, not to `~/.pi/`. `SourcePath` was using `os.UserHomeDir()` unconditionally.

When `IsolationMode == "sandbox-exec"` and `InstanceID` is non-empty, `SourcePath` now resolves the staging HOME via `container.SandboxExecStagingHomePath(instanceID)`.

## Fix 3: Remove hardcoded `"pi-session"` placeholder (`adapter.go`)

`CreateSession` was returning `"pi-session"` when no real session ID had been received. Now returns `""` when no real ID is known (fix #1 populates the real ID via `session_status`).

## Extension: emit `session_id` in `session_status` frame (`prism.ts`)

Added `session_id: ctx.sessionManager.getSessionId()` to both `session_status` emission points (post-handshake and `turn_start`).

## Tests added

- `TestSocketPipe_SessionStatus_PopulatesHarnessSessionID` — sends `session_status`, asserts `harness_session_id` set in DB
- `TestSocketPipe_SessionStatus_EmptySessionID_NoOp` — empty `session_id` is a no-op
- `TestArchiveAdapter_SourcePath_SandboxExec` — sandbox-exec staging HOME path used
- `TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID` — fallback to real home when `InstanceID` empty
- `TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome` — non-sandbox-exec modes use real home

## Quality gates

```
go build ./...    ✓
go test ./...     ✓ (pre-existing failures in cmd/container/integration/tmux reproduce on main unchanged)
nix build .#prism ✓
```

Closes #1538