### PR TITLE
fix(prism): surface PRISM_GITHUB_TOKEN_* vars on macOS via home-manager sops

### DIFF
--- a/modules/programs/prism/container-tokens.nix
+++ b/modules/programs/prism/container-tokens.nix
@@ -15,36 +15,84 @@
 #
 # The Go code in container.go derives the account from the repo's git remote URL
 # and builds the env var name at runtime to look up the correct token.
+#
+# Platform split:
+#   Linux  — sops-nix system secrets + environment.sessionVariables (NixOS/systemd).
+#   Darwin — home-manager sops secrets + home.sessionVariables (nix-darwin).
+let
+  username = config.nx.username;
+  secretsFile = ../secrets/github.sops.yaml;
+in
 {
-  config = lib.mkIf (config.nx.programs.prism.enable && pkgs.stdenv.isLinux) {
-    sops.secrets = {
-      "github_token_prismatic_koi_coordinator" = {
-        owner = config.nx.username;
-        mode = "0600";
-        sopsFile = ../secrets/github.sops.yaml;
-      };
-      "github_token_prismatic_koi_worker" = {
-        owner = config.nx.username;
-        mode = "0600";
-        sopsFile = ../secrets/github.sops.yaml;
-      };
-      "github_token_thankyou_payroll_coordinator" = {
-        owner = config.nx.username;
-        mode = "0600";
-        sopsFile = ../secrets/github.sops.yaml;
-      };
-      "github_token_thankyou_payroll_worker" = {
-        owner = config.nx.username;
-        mode = "0600";
-        sopsFile = ../secrets/github.sops.yaml;
-      };
-    };
+  config = lib.mkIf config.nx.programs.prism.enable (
+    lib.mkMerge [
+      # Linux: system-level sops + environment.sessionVariables
+      (lib.mkIf pkgs.stdenv.isLinux {
+        sops.secrets = {
+          "github_token_prismatic_koi_coordinator" = {
+            owner = username;
+            mode = "0600";
+            sopsFile = secretsFile;
+          };
+          "github_token_prismatic_koi_worker" = {
+            owner = username;
+            mode = "0600";
+            sopsFile = secretsFile;
+          };
+          "github_token_thankyou_payroll_coordinator" = {
+            owner = username;
+            mode = "0600";
+            sopsFile = secretsFile;
+          };
+          "github_token_thankyou_payroll_worker" = {
+            owner = username;
+            mode = "0600";
+            sopsFile = secretsFile;
+          };
+        };
 
-    environment.sessionVariables = {
-      PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR = "$(cat ${config.sops.secrets.github_token_prismatic_koi_coordinator.path})";
-      PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER = "$(cat ${config.sops.secrets.github_token_prismatic_koi_worker.path})";
-      PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_COORDINATOR = "$(cat ${config.sops.secrets.github_token_thankyou_payroll_coordinator.path})";
-      PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER = "$(cat ${config.sops.secrets.github_token_thankyou_payroll_worker.path})";
-    };
-  };
+        environment.sessionVariables = {
+          PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR = "$(cat ${config.sops.secrets.github_token_prismatic_koi_coordinator.path})";
+          PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER = "$(cat ${config.sops.secrets.github_token_prismatic_koi_worker.path})";
+          PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_COORDINATOR = "$(cat ${config.sops.secrets.github_token_thankyou_payroll_coordinator.path})";
+          PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER = "$(cat ${config.sops.secrets.github_token_thankyou_payroll_worker.path})";
+        };
+      })
+
+      # Darwin: home-manager sops secrets + home.sessionVariables
+      (lib.mkIf pkgs.stdenv.isDarwin {
+        home-manager.users.${username} = {
+          sops.secrets = {
+            "github_token_prismatic_koi_coordinator" = {
+              sopsFile = secretsFile;
+            };
+            "github_token_prismatic_koi_worker" = {
+              sopsFile = secretsFile;
+            };
+            "github_token_thankyou_payroll_coordinator" = {
+              sopsFile = secretsFile;
+            };
+            "github_token_thankyou_payroll_worker" = {
+              sopsFile = secretsFile;
+            };
+          };
+
+          home.sessionVariables = {
+            PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR = "$(cat ${
+              config.home-manager.users.${username}.sops.secrets.github_token_prismatic_koi_coordinator.path
+            })";
+            PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER = "$(cat ${
+              config.home-manager.users.${username}.sops.secrets.github_token_prismatic_koi_worker.path
+            })";
+            PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_COORDINATOR = "$(cat ${
+              config.home-manager.users.${username}.sops.secrets.github_token_thankyou_payroll_coordinator.path
+            })";
+            PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER = "$(cat ${
+              config.home-manager.users.${username}.sops.secrets.github_token_thankyou_payroll_worker.path
+            })";
+          };
+        };
+      })
+    ]
+  );
 }


### PR DESCRIPTION
## Problem

`container-tokens.nix` was guarded by `pkgs.stdenv.isLinux`, so the four `PRISM_GITHUB_TOKEN_*` environment variables were never set on Darwin. Workers running under sandbox-exec on macOS could not authenticate with `gh` CLI because `credentialEnvVars()` in `credentials.go` reads those vars from the host environment.

## Fix

Split the module into two platform blocks, following the same pattern used in `secrets.nix` and other modules in this repo:

| Platform | Secret delivery | Env injection |
|----------|----------------|---------------|
| Linux (unchanged) | `sops.secrets` (NixOS/systemd) | `environment.sessionVariables` |
| Darwin (new) | `home-manager.users.${username}.sops.secrets` | `home.sessionVariables` |

On Darwin, sops-nix delivers each secret to `~/.config/sops-nix/secrets/github_token_<name>` and `home.sessionVariables` expands them via `$(cat <path>)` in zsh, which tmux inherits. `credentialEnvVars()` then reads the vars from the process environment and injects the correct `GITHUB_TOKEN` into the sandbox-exec child.

**Edge case:** If a secret file is missing (not yet provisioned), the `$(cat ...)` expression returns an empty string at shell startup — the session opens normally and `gh` fails with a clear auth error rather than crashing prism.

## Verification

```
nix eval .#darwinConfigurations.m4mac.config.home-manager.users.bensherman.home.sessionVariables
```

Output includes all four `PRISM_GITHUB_TOKEN_*` variables pointing to `~/.config/sops-nix/secrets/github_token_*`.

`nix build .#prism` passes. Go build/tests pass (no Go changes in this PR).

Closes #1540