### PR TITLE
Update prism configuration and add Atlassian secrets

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -24,10 +24,13 @@ in
   # Module configuration using nx namespace (matching NixOS pattern)
   nx = {
     programs = {
-      prism.profile.default = "anthropic";
-      prism.agent.isolation.default = "sandbox-exec";
-      prism.projects.isolationOverrides = {
-        "~/documents/obsidian" = "host";
+      prism = {
+        profile.default = "anthropic";
+        harness.default = "pi";
+        agent.isolation.default = "sandbox-exec";
+        projects.isolationOverrides = {
+          "~/documents/obsidian" = "host";
+        };
       };
       # Disable programs that default to enabled but aren't needed/available on Darwin
       podman.enable = false;

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -156,6 +156,7 @@
               secondary = slot {
                 provider = "anthropic";
                 model = "anthropic/claude-sonnet-4-6";
+                thinking = "low";
               };
               lightweight = slot {
                 provider = "anthropic";

--- a/modules/programs/secrets/atlassian.sops.yaml
+++ b/modules/programs/secrets/atlassian.sops.yaml
@@ -1,0 +1,16 @@
+atlassian_token: ENC[AES256_GCM,data:Rt56jw0z46XChvgpR7vpIa64Ur583bs0aMk3iocYh1u+cN+MwzFVMpDXvEYLdaz1q9cvr8BBa/yq2m+WRggCYFdrlVc07P9uwEXYm3s+O/RKU7bYEEuMnwhOx5Jyp0S5ISrgDVGcIJjnV7343ZCxHiZgNFsBCm4JwPsjxTwxX6yFBtiMjxTqGrjldSp3sVnJMaWg/nTH8TCf6SIpOekbOYkaN/EaRV6T+zRJcdOta+Br7774zqcD/w+ekq1YF23d,iv:8u/AIM7z/CmUfBGay1f++VAUb/O6mn/FgvCdzeL3ZyQ=,tag:9mIpe3LvnZKRWHLJkIraIw==,type:str]
+sops:
+  age:
+    - recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTdktHLzdIbFZiL2plYWJ3
+        NlJtSTlGSy9LNEFoZE5hQnBDTFBMWW12NUhJCmZJaE5LK2J2V3ZjWFRmZUxDNzYr
+        K0g4TkRPNXlYbkM3WWF0SzFjOENnQUUKLS0tIEtuZDFTL3NtSmZKVktpSzhJd0R6
+        Sk9Qd0Rva2tyTnVYcXM0VWhmVGQ0dXcKsqZRNIknjiQ8bym+9O33MeMpKh66r01v
+        Auq3dixcPNGUbGy7adm8yaAXhhD5bBrwW9iMdZtZVOL1PtImH1+TBA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-10T21:55:13Z"
+  mac: ENC[AES256_GCM,data:BvwQUiL2iBw4qrfnrqcNV3aJ3ZmDM9GdT9PrdG0z4kpwzVTYJxvhkzEynd9YsuxAgWDhJf2zcGSgJ6EWV2F63nbHkEyTOnl5kDhxshsihPO8NjcJd7PT9Mw/kSyxyg1zvE8mrlAWhlnx23vhwrVbyR52mtDffUBVdsgKJ02NIlQ=,iv:qJ6g+oNArXiBriGLLoshb0NjRdOFCqbZEKyRMfgDb7c=,tag:nAjr8VIZyRa+1n6FFNq7ag==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.2


### PR DESCRIPTION
This change updates the `m4mac` prism configuration to include a harness default and enables low-level thinking for secondary Anthropic profiles. Additionally, it adds the necessary encrypted Atlassian token secret to the module configuration.