### PR TITLE
Move atlassian site and email settings to sops secrets

### DIFF
--- a/modules/programs/atlassian/default.nix
+++ b/modules/programs/atlassian/default.nix
@@ -13,16 +13,6 @@ in
       enable = lib.mkEnableOption "enables the atlassian CLI" // {
         default = true;
       };
-      site = lib.mkOption {
-        type = lib.types.str;
-        default = "tinfoilforest.atlassian.net";
-        description = "Atlassian cloud site hostname (e.g. mycompany.atlassian.net)";
-      };
-      email = lib.mkOption {
-        type = lib.types.str;
-        default = "ben@tinfoilforest.nz";
-        description = "Atlassian account email address";
-      };
     };
   };
 
@@ -42,6 +32,16 @@ in
       # Linux: sops secret via system config
       (lib.mkIf isLinux {
         sops.secrets = {
+          "atlassian_site" = {
+            owner = username;
+            mode = "0600";
+            sopsFile = ../secrets/atlassian.sops.yaml;
+          };
+          "atlassian_email" = {
+            owner = username;
+            mode = "0600";
+            sopsFile = ../secrets/atlassian.sops.yaml;
+          };
           "atlassian_token" = {
             owner = username;
             mode = "0600";
@@ -50,8 +50,8 @@ in
         };
 
         environment.sessionVariables = {
-          ATLASSIAN_SITE = config.nx.programs.atlassian.site;
-          ATLASSIAN_EMAIL = config.nx.programs.atlassian.email;
+          ATLASSIAN_SITE = "$(cat ${config.sops.secrets.atlassian_site.path})";
+          ATLASSIAN_EMAIL = "$(cat ${config.sops.secrets.atlassian_email.path})";
           ATLASSIAN_API_TOKEN = "$(cat ${config.sops.secrets.atlassian_token.path})";
         };
       })
@@ -60,14 +60,22 @@ in
       (lib.mkIf isDarwin {
         home-manager.users.${username} = {
           sops.secrets = {
+            "atlassian_site" = {
+              sopsFile = ../secrets/atlassian.sops.yaml;
+            };
+            "atlassian_email" = {
+              sopsFile = ../secrets/atlassian.sops.yaml;
+            };
             "atlassian_token" = {
               sopsFile = ../secrets/atlassian.sops.yaml;
             };
           };
 
           home.sessionVariables = {
-            ATLASSIAN_SITE = config.nx.programs.atlassian.site;
-            ATLASSIAN_EMAIL = config.nx.programs.atlassian.email;
+            ATLASSIAN_SITE = "$(cat ${config.home-manager.users.${username}.sops.secrets.atlassian_site.path})";
+            ATLASSIAN_EMAIL = "$(cat ${
+              config.home-manager.users.${username}.sops.secrets.atlassian_email.path
+            })";
             ATLASSIAN_API_TOKEN = "$(cat ${
               config.home-manager.users.${username}.sops.secrets.atlassian_token.path
             })";

--- a/modules/programs/secrets/atlassian.sops.yaml
+++ b/modules/programs/secrets/atlassian.sops.yaml
@@ -1,16 +1,18 @@
-atlassian_token: ENC[AES256_GCM,data:Rt56jw0z46XChvgpR7vpIa64Ur583bs0aMk3iocYh1u+cN+MwzFVMpDXvEYLdaz1q9cvr8BBa/yq2m+WRggCYFdrlVc07P9uwEXYm3s+O/RKU7bYEEuMnwhOx5Jyp0S5ISrgDVGcIJjnV7343ZCxHiZgNFsBCm4JwPsjxTwxX6yFBtiMjxTqGrjldSp3sVnJMaWg/nTH8TCf6SIpOekbOYkaN/EaRV6T+zRJcdOta+Br7774zqcD/w+ekq1YF23d,iv:8u/AIM7z/CmUfBGay1f++VAUb/O6mn/FgvCdzeL3ZyQ=,tag:9mIpe3LvnZKRWHLJkIraIw==,type:str]
+atlassian_token: ENC[AES256_GCM,data:K/VBEhzuS52X5jqMC6l5IN4lt+0sn6E4NdssKN3iyOPf+5vBSm7orUoDvjuPFy+n4EzOI9SzXM/TNX9HZ9TexzxGAIEvL2+tAIVVwqESh9YH2ylARbqe2ewjuDou5bMh9kwe5a3QavUm/Uh9njx7DFexWr2qWvd+6p9nM+Y8U1GiPCa6bXWsUFCCj7iRd3obng59nFgR0ORn1YbRwE4zLDUTOeIr1HzvKv2qVPtG8tgeLcJD5jVeU8L8m1epGZMv,iv:F1aTz25BaUduuOgriii0+ldZWfemExSpr7AjiHMAA1E=,tag:fSwM9Jg9a1Poz/DzL7SaBA==,type:str]
+atlassian_email: ENC[AES256_GCM,data:nnLIPTLQnQGQJJfbWFC61U1tiyaJGP2sS+A7YjXC,iv:EX+d5USOgce+WQ0uSI+i3L2bwsunK+npSuhRbDHB9cM=,tag:zZoxMu++0DGaGtVgm10/cQ==,type:str]
+atlassian_site: ENC[AES256_GCM,data:mv8eQCCrwBJLxxieIbJBu6Bkuam+dhx7nUA4HWE=,iv:gelO5fL3iiZjpb51AMuYdwJMaWwAeGG0GB7Zwv2o2fM=,tag:q4kmirqE1SOB3d6EJWXwuA==,type:str]
 sops:
   age:
     - recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTdktHLzdIbFZiL2plYWJ3
-        NlJtSTlGSy9LNEFoZE5hQnBDTFBMWW12NUhJCmZJaE5LK2J2V3ZjWFRmZUxDNzYr
-        K0g4TkRPNXlYbkM3WWF0SzFjOENnQUUKLS0tIEtuZDFTL3NtSmZKVktpSzhJd0R6
-        Sk9Qd0Rva2tyTnVYcXM0VWhmVGQ0dXcKsqZRNIknjiQ8bym+9O33MeMpKh66r01v
-        Auq3dixcPNGUbGy7adm8yaAXhhD5bBrwW9iMdZtZVOL1PtImH1+TBA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVQzYrak9BT3N0bWhub1BF
+        NmRwbW1pNnBtZGwzNmlQYnlObXNTU2V0ZXdnCm5uMHFueklLU0NpUGhCeGVHb0tS
+        MGxwcEd5VEtUbFQ4dGwvTWN0RU9xOVEKLS0tIHpFUGloTlZaeVN3NVo3dDRaenZW
+        dU5MOEhpaDJhVHlBWmdjVmRtWUZyYVkKAiSx3FeuSzAz0ZbE+Y0Th1aHxYTNgijn
+        9p095qDXjoD5u+nQxt4Z2dhVYeCxWo5Sslrx59qelsX3mGq48RIeeQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-05-10T21:55:13Z"
-  mac: ENC[AES256_GCM,data:BvwQUiL2iBw4qrfnrqcNV3aJ3ZmDM9GdT9PrdG0z4kpwzVTYJxvhkzEynd9YsuxAgWDhJf2zcGSgJ6EWV2F63nbHkEyTOnl5kDhxshsihPO8NjcJd7PT9Mw/kSyxyg1zvE8mrlAWhlnx23vhwrVbyR52mtDffUBVdsgKJ02NIlQ=,iv:qJ6g+oNArXiBriGLLoshb0NjRdOFCqbZEKyRMfgDb7c=,tag:nAjr8VIZyRa+1n6FFNq7ag==,type:str]
+  lastmodified: "2026-05-10T22:32:19Z"
+  mac: ENC[AES256_GCM,data:MNPJifhegASYbJryUK25aBrSOMW7qgU35eHD59x52vokl+PTkHS1DtsdTPQkj3urnHfjim1SlLW+s1120gdgeJ7zJLp/joRFt5nlSZ1cp7mxn+RjeQBAL4jCMETUt0coS7P2SHNOJ5JH/i6+1R4G7AYcv5B57F6FZmuAgyIPHCs=,iv:YecDZNP7ZH90f5gWAXqSfHW1UXE1JS0+RCP89fwllmI=,tag:U/daBwmqydphe1Swi2L4kQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.2


### PR DESCRIPTION
This change migrates the Atlassian site and email configuration from plain-text Nix options into the existing sops-nix secrets file. This improves security by ensuring sensitive account identifiers are encrypted alongside the existing API token.