### PR TITLE
prism: forward ATLASSIAN_* env vars into sandboxes so the atlassian CLI works in worker sessions

### DIFF
--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -156,6 +156,81 @@ func TestCredentialEnvVars_LLMKeysForwarded(t *testing.T) {
 	}
 }
 
+func TestCredentialEnvVars_AtlassianKeysForwarded(t *testing.T) {
+	t.Setenv("ATLASSIAN_SITE", "https://myorg.atlassian.net")
+	t.Setenv("ATLASSIAN_EMAIL", "user@example.com")
+	t.Setenv("ATLASSIAN_API_TOKEN", "atl-secret-token")
+
+	m := New(Config{SessionName: "repo@main", AllocatedPort: 14000, AgentRole: "worker"})
+	vars := m.credentialEnvVars()
+
+	want := map[string]string{
+		"ATLASSIAN_SITE":      "https://myorg.atlassian.net",
+		"ATLASSIAN_EMAIL":     "user@example.com",
+		"ATLASSIAN_API_TOKEN": "atl-secret-token",
+	}
+	for key, val := range want {
+		found := false
+		for _, kv := range vars {
+			if kv == key+"="+val {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s not forwarded; vars = %v", key, vars)
+		}
+	}
+}
+
+func TestCredentialEnvVars_AtlassianKeysNotForwardedWhenUnset(t *testing.T) {
+	t.Setenv("ATLASSIAN_SITE", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("ATLASSIAN_API_TOKEN", "")
+
+	m := New(Config{SessionName: "repo@main", AllocatedPort: 14000, AgentRole: "worker"})
+	vars := m.credentialEnvVars()
+
+	for _, kv := range vars {
+		if strings.HasPrefix(kv, "ATLASSIAN_SITE=") {
+			t.Errorf("ATLASSIAN_SITE should not be forwarded when unset; got %q", kv)
+		}
+		if strings.HasPrefix(kv, "ATLASSIAN_EMAIL=") {
+			t.Errorf("ATLASSIAN_EMAIL should not be forwarded when unset; got %q", kv)
+		}
+		if strings.HasPrefix(kv, "ATLASSIAN_API_TOKEN=") {
+			t.Errorf("ATLASSIAN_API_TOKEN should not be forwarded when unset; got %q", kv)
+		}
+	}
+}
+
+func TestCredentialEnvVars_AtlassianPartialConfig(t *testing.T) {
+	// If only some Atlassian vars are set, forward only those that are set.
+	// The atlassian CLI's own error path handles the missing var.
+	t.Setenv("ATLASSIAN_SITE", "https://myorg.atlassian.net")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("ATLASSIAN_API_TOKEN", "")
+
+	m := New(Config{SessionName: "repo@main", AllocatedPort: 14000, AgentRole: "worker"})
+	vars := m.credentialEnvVars()
+
+	foundSite := false
+	for _, kv := range vars {
+		if kv == "ATLASSIAN_SITE=https://myorg.atlassian.net" {
+			foundSite = true
+		}
+		if strings.HasPrefix(kv, "ATLASSIAN_EMAIL=") {
+			t.Errorf("ATLASSIAN_EMAIL should not be forwarded when unset; got %q", kv)
+		}
+		if strings.HasPrefix(kv, "ATLASSIAN_API_TOKEN=") {
+			t.Errorf("ATLASSIAN_API_TOKEN should not be forwarded when unset; got %q", kv)
+		}
+	}
+	if !foundSite {
+		t.Errorf("ATLASSIAN_SITE should be forwarded when set; vars = %v", vars)
+	}
+}
+
 func TestCredentialEnvVars_WorkerGetsWorkerToken(t *testing.T) {
 	// With the new 4-PAT architecture, tokens are keyed by account+role.
 	// When BareRoot is empty (cannot derive account), fall back to GITHUB_TOKEN.

--- a/modules/programs/prism/prism/internal/container/credentials.go
+++ b/modules/programs/prism/prism/internal/container/credentials.go
@@ -125,8 +125,9 @@ func (m *Manager) CredentialEnvVars() []string {
 func (m *Manager) credentialEnvVars() []string {
 	var vars []string
 
-	// LLM API keys — forwarded for all agent roles.
-	llmKeys := []string{
+	// External-tool credentials — forwarded for all agent roles.
+	// Covers LLM API keys and other CLI credentials (e.g. Atlassian).
+	forwardKeys := []string{
 		"ANTHROPIC_API_KEY",
 		"OPENAI_API_KEY",
 		"GEMINI_API_KEY",
@@ -134,8 +135,11 @@ func (m *Manager) credentialEnvVars() []string {
 		"GITHUB_COPILOT_TOKEN",
 		"DEEPSEEK_API_KEY",
 		"OPENROUTER_API_KEY",
+		"ATLASSIAN_SITE",
+		"ATLASSIAN_EMAIL",
+		"ATLASSIAN_API_TOKEN",
 	}
-	for _, k := range llmKeys {
+	for _, k := range forwardKeys {
 		if v := os.Getenv(k); v != "" {
 			vars = append(vars, k+"="+v)
 		}


### PR DESCRIPTION
## Summary

Forward `ATLASSIAN_SITE`, `ATLASSIAN_EMAIL`, and `ATLASSIAN_API_TOKEN` from the host environment into prism sandboxes (bwrap, sandbox-exec, podman) so that the `atlassian` CLI works inside spawned agent sessions.

## Changes

- **`credentials.go`**: Renamed `llmKeys` → `forwardKeys` and updated the comment block to reflect that the slice covers external-tool credentials in general (not just LLM API keys). Added the three Atlassian vars to the slice.
- **`container_test.go`**: Added three new test functions covering forwarding-when-set, not-forwarding-when-unset, and partial-config behaviour.

All three execution backends (bwrap, sandbox-exec, podman) benefit from this single-point change since they all call `credentialEnvVars()`.

## Manual verification

- [ ] Inside a prism-spawned worker, `atlassian whoami` exits 0 against a valid token
- [ ] Inside a prism-spawned worker, `atlassian jira get <KEY>` no longer fails with `ATLASSIAN_SITE is not set`

## Pre-existing test failures

The following test failures exist on `main` without this PR's changes and are out of scope:
- `TestBwrapBuildArgs_FullFixture` — bwrap fixture mismatch (macOS path vs temp path)
- `TestSandboxExecIntegration_*` — sandbox-exec permission issues in this environment
- `TestSandboxExecProfile_*` — same sandbox-exec environment limitations
- tmux fork failures — `Operation not permitted` in this sandboxed worker context

## Future consideration

If we accumulate a fourth or fifth external-tool credential, it may be worth migrating the allowlist to a config-driven `forwardEnvVars: []` mechanism. Three vars is below the threshold where that pays for itself.

Closes #1552