### PR TITLE
sandbox-exec: widen pi auth rule from literal to subpath for OAuth lockfile mkdir

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -335,21 +335,30 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
-	// ── 6a. PI auth.json targeted allow (pi sessions only) ───────────────
-	// The staging dir contains a symlink <stagingDir>/auth.json →
-	// ~/.pi/agent/auth.json (created by StagePIAgentConfigDir). For the
-	// symlink to resolve inside the sandbox, the real credential file must
-	// also be accessible at its host path. We allow read-write so that OAuth
-	// token refreshes performed inside the session are written back to the
-	// host file. The rule is always emitted for pi sessions even when
-	// ~/.pi/agent/auth.json does not exist — sandbox-exec silently ignores
-	// (literal ...) rules for non-existent paths, so pi simply prompts for
-	// login rather than crashing. The rule is scoped to the specific file
-	// literal (not a subpath) to avoid granting broad ~/.pi/agent/ access.
+	// ── 6a. PI agent dir allow (pi sessions only) ────────────────────────
+	// OAuth token refresh inside pi-coding-agent uses proper-lockfile with
+	// realpath:true, which resolves auth.json through any symlink and then
+	// calls mkdir(<resolved-auth-path>.lock) to acquire the lock. That mkdir
+	// requires write permission on the *parent directory* ~/.pi/agent/, not
+	// just on the auth.json file itself. A (literal ...) rule on auth.json
+	// alone is therefore insufficient — the sandbox denies the mkdir and the
+	// refresh silently fails (EPERM after ~30 s of retries).
+	//
+	// We widen the rule to (subpath ~/.pi/agent) so that:
+	//   - auth.json reads and writes are permitted (token refresh writes back
+	//     to the host file).
+	//   - mkdir auth.json.lock (the proper-lockfile lock dir) is permitted
+	//     because the parent dir is now writable.
+	//
+	// The rule is still gated on Harness == "pi" so non-pi sessions are not
+	// exposed to the pi credential directory. It is always emitted for pi
+	// sessions even when ~/.pi/agent does not yet exist — sandbox-exec
+	// silently ignores (subpath ...) rules for non-existent paths, so pi
+	// simply prompts for /login rather than crashing on a fresh install.
 	if m.cfg.Harness == "pi" && home != "" {
-		piAuthPath := filepath.Join(home, ".pi", "agent", "auth.json")
+		piAgentDir := filepath.Join(home, ".pi", "agent")
 		sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
-		sb.WriteString("  (literal " + quoteSBPL(piAuthPath) + "))\n")
+		sb.WriteString("  (subpath " + quoteSBPL(piAgentDir) + "))\n")
 		sb.WriteString("\n")
 	}
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -1314,13 +1314,25 @@ func TestGenerateProfile_ProfileIncludesSymlinkTargetAllows(t *testing.T) {
 	}
 }
 
-// TestGenerateProfile_PiAuthJSONLiteralRule verifies that generateProfile
-// emits a targeted SBPL rule for ~/.pi/agent/auth.json when Harness == "pi".
-// The rule must use (literal ...) (not subpath) and must include file-write*
-// so that OAuth token refreshes inside the sandbox persist to the host file.
-// The rule is always emitted for pi sessions even when the file does not exist
-// (sandbox-exec silently ignores literals for non-existent paths).
-func TestGenerateProfile_PiAuthJSONLiteralRule(t *testing.T) {
+// TestGenerateProfile_PiAgentDirSubpathRule verifies that generateProfile
+// emits a (subpath ~/.pi/agent) rule when Harness == "pi".
+//
+// Background: OAuth token refresh inside pi-coding-agent uses
+// proper-lockfile.lock(authPath, {realpath: true}), which resolves any symlink
+// in authPath and then calls mkdir(<resolved>.lock) to acquire the lock. That
+// mkdir requires write permission on the *parent directory* ~/.pi/agent/, not
+// just on auth.json. A (literal ...) rule on auth.json alone is therefore
+// insufficient — the sandbox denies the mkdir (EPERM) and the refresh silently
+// fails after ~30 s of retries.
+//
+// The rule is widened to (subpath ~/.pi/agent) so that:
+//   - auth.json reads and writes are permitted (token refresh writes back).
+//   - mkdir auth.json.lock succeeds because the parent dir is writable.
+//
+// The rule is always emitted even when ~/.pi/agent does not yet exist —
+// sandbox-exec silently ignores (subpath ...) rules for non-existent paths, so
+// pi simply prompts for /login rather than crashing on a fresh install.
+func TestGenerateProfile_PiAgentDirSubpathRule(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
 
@@ -1330,31 +1342,45 @@ func TestGenerateProfile_PiAuthJSONLiteralRule(t *testing.T) {
 	})
 	profile := generateProfile(m)
 
-	authPath := filepath.Join(fakeHome, ".pi", "agent", "auth.json")
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
 
-	// The auth.json literal must appear in the profile.
-	if !strings.Contains(profile, authPath) {
-		t.Errorf("profile missing ~/.pi/agent/auth.json path %q; full profile:\n%s", authPath, profile)
+	// The ~/.pi/agent subpath must appear in the profile.
+	if !strings.Contains(profile, piAgentDir) {
+		t.Errorf("profile missing ~/.pi/agent path %q; full profile:\n%s", piAgentDir, profile)
 	}
 
-	// It must appear inside an (allow file-read* file-write* ...) clause.
-	authIdx := strings.Index(profile, authPath)
-	if authIdx < 0 {
-		t.Fatalf("auth.json path not found in profile (checked above)")
+	// It must be a (subpath ...) rule — (literal auth.json) alone is
+	// insufficient because proper-lockfile mkdir(<authPath>.lock) requires
+	// write on the parent directory.
+	subpathRule := "(subpath " + quoteSBPL(piAgentDir) + ")"
+	if !strings.Contains(profile, subpathRule) {
+		t.Errorf("~/.pi/agent must appear as (subpath ...), not (literal ...); full profile:\n%s", profile)
 	}
-	clauseStart := strings.LastIndex(profile[:authIdx], "(allow")
+
+	// The subpath rule must appear inside an (allow file-read* file-write* ...)
+	// clause so that proper-lockfile can mkdir auth.json.lock adjacent to
+	// auth.json.
+	subpathIdx := strings.Index(profile, subpathRule)
+	if subpathIdx < 0 {
+		t.Fatalf("subpath rule not found in profile (checked above)")
+	}
+	clauseStart := strings.LastIndex(profile[:subpathIdx], "(allow")
 	if clauseStart < 0 {
-		t.Errorf("auth.json path not inside an (allow ...) clause; full profile:\n%s", profile)
+		t.Errorf("~/.pi/agent subpath not inside an (allow ...) clause; full profile:\n%s", profile)
 	}
-	clause := profile[clauseStart:authIdx]
+	clause := profile[clauseStart:subpathIdx]
 	if !strings.Contains(clause, "file-write*") {
-		t.Errorf("auth.json allow clause must include file-write* for token refresh; clause: %q; full profile:\n%s", clause, profile)
+		t.Errorf("~/.pi/agent allow clause must include file-write* so proper-lockfile can mkdir auth.json.lock; clause: %q; full profile:\n%s", clause, profile)
 	}
 
-	// It must be a (literal ...) rule, not a (subpath ...) rule, to scope it
-	// tightly to the single file.
-	if !strings.Contains(profile, "(literal "+quoteSBPL(authPath)+")") {
-		t.Errorf("auth.json must appear as (literal %q), not as subpath; full profile:\n%s", authPath, profile)
+	// Regression guard: the (subpath ~/.pi/agent) covers both auth.json and
+	// auth.json.lock (the lock dir that proper-lockfile creates). Confirm both
+	// paths are children of piAgentDir (they are, by construction — the test
+	// documents the invariant explicitly).
+	authJSON := filepath.Join(piAgentDir, "auth.json")
+	authLock := filepath.Join(piAgentDir, "auth.json.lock")
+	if !strings.HasPrefix(authJSON, piAgentDir) || !strings.HasPrefix(authLock, piAgentDir) {
+		t.Errorf("auth.json and auth.json.lock are not children of piAgentDir %q — subpath rule does not cover them", piAgentDir)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_oauth_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_oauth_darwin_test.go
@@ -147,12 +147,13 @@ func TestSandboxExecPIOAuth_LockDirDeniedWithLiteralOnlyRule(t *testing.T) {
 		//   (allow file-read* file-write* file-test-existence file-read-metadata
 		//     (subpath "<piAgentDir>"))
 		//
-		// Replace the indented (subpath ...) line with a (literal auth.json)
+		// Note the double closing paren on the subpath line: the first closes
+		// (subpath ...) and the second closes the surrounding (allow ...) block.
+		// Replace the indented (subpath ...)) line with a (literal auth.json))
 		// line, replicating the old behaviour. The surrounding (allow ...) line
-		// and the closing "))" remain intact so the profile is syntactically
-		// valid SBPL — only the coverage changes.
-		subpathLine := "  (subpath " + sbplQuoteForTest(piAgentDir2) + ")\n"
-		literalLine := "  (literal " + sbplQuoteForTest(authJSONLiteral) + ")\n"
+		// is left intact so the profile remains syntactically valid SBPL.
+		subpathLine := "  (subpath " + sbplQuoteForTest(piAgentDir2) + "))\n"
+		literalLine := "  (literal " + sbplQuoteForTest(authJSONLiteral) + "))\n"
 		return strings.ReplaceAll(p, subpathLine, literalLine)
 	})
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_oauth_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_oauth_darwin_test.go
@@ -1,0 +1,172 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_pi_oauth_darwin_test.go — integration tests for the PI OAuth
+// token-refresh lockfile allow in the SBPL profile (issue #1556).
+//
+// Background:
+//
+//	OAuth token refresh inside pi-coding-agent uses
+//	proper-lockfile.lock(authPath, {realpath: true}). With realpath:true,
+//	proper-lockfile resolves any symlink in authPath and then calls
+//	mkdir(<resolved>.lock) to acquire the lock. That mkdir requires write
+//	permission on the parent directory ~/.pi/agent/, not just on auth.json.
+//
+//	The previous (literal ~/.pi/agent/auth.json) SBPL rule was insufficient:
+//	the sandbox denied the mkdir (EPERM) and the refresh silently failed
+//	after ~30 s of retries. The fix widens the rule to
+//	(subpath ~/.pi/agent) for pi sessions.
+//
+// These tests verify:
+//
+//  1. Positive: in a pi-harness manager config, creating a directory named
+//     auth.json.lock inside ~/.pi/agent/ succeeds under the production SBPL
+//     profile.
+//  2. Negative: mutating the profile back to a (literal auth.json) rule
+//     causes the same mkdir to fail, proving the positive test is not a
+//     no-op.
+//
+// Each positive test is paired with a negative test per the convention in
+// docs/sandbox-exec-testing.md (issue #1192).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// newPIOAuthProfileManager creates a Manager configured for a pi-harness
+// session. Harness is set to "pi" so generateProfile emits the
+// (subpath ~/.pi/agent) allow rule required for proper-lockfile.
+func newPIOAuthProfileManager(t *testing.T) *container.Manager {
+	t.Helper()
+	instanceID := "integ-sbx-pi-oauth-" + strings.ReplaceAll(t.Name(), "/", "-")
+	cfg := container.Config{
+		SessionName: "integ-sandbox-exec-pi-oauth-test",
+		InstanceID:  instanceID,
+		Worktree:    t.TempDir(),
+		Harness:     "pi",
+	}
+	return container.New(cfg)
+}
+
+// TestSandboxExecPIOAuth_LockDirCreatable is the positive integration test.
+// It verifies that mkdir auth.json.lock inside ~/.pi/agent/ succeeds under
+// the production SBPL profile for a pi-harness session. This is the exact
+// operation that proper-lockfile performs when acquiring the lock for the
+// OAuth token refresh.
+func TestSandboxExecPIOAuth_LockDirCreatable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	// Ensure ~/.pi/agent exists so the subpath rule has something to cover.
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if mkErr := os.MkdirAll(piAgentDir, 0o700); mkErr != nil {
+		t.Fatalf("MkdirAll ~/.pi/agent: %v", mkErr)
+	}
+
+	m := newPIOAuthProfileManager(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Confirm the profile contains the (subpath ~/.pi/agent) rule.
+	piAgentSubpath := "(subpath " + sbplQuoteForTest(piAgentDir) + ")"
+	if !strings.Contains(prepared.content, piAgentSubpath) {
+		t.Fatalf("generated profile does not contain %q — the pi agent dir subpath rule was not emitted.\nProfile:\n%s",
+			piAgentSubpath, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// The lock dir that proper-lockfile creates: <authPath>.lock adjacent to
+	// auth.json inside ~/.pi/agent/. We use a unique name so parallel test
+	// runs do not collide.
+	lockDir := filepath.Join(piAgentDir, "auth.json.integ-pi-oauth-positive.lock")
+	t.Cleanup(func() { _ = os.Remove(lockDir) })
+
+	// Run: sandbox-exec mkdir auth.json.lock — this is the operation that
+	// proper-lockfile performs when acquiring the OAuth refresh lock.
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "mkdir "+shQuote(lockDir))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("mkdir auth.json.lock inside ~/.pi/agent/ failed under production profile.\n"+
+			"This is the proper-lockfile operation that OAuth token refresh requires.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, string(out), testProfilePath)
+	}
+}
+
+// TestSandboxExecPIOAuth_LockDirDeniedWithLiteralOnlyRule is the paired
+// negative test. It mutates the profile to replace the (subpath ~/.pi/agent)
+// rule with a (literal auth.json) rule — the previous behaviour that caused
+// the OAuth refresh regression. The same mkdir that the positive test asserts
+// succeeds must fail with the regressed profile.
+//
+// This proves that the positive test is not green by accident: the subpath
+// rule is the specific mechanism that allows the mkdir.
+func TestSandboxExecPIOAuth_LockDirDeniedWithLiteralOnlyRule(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if mkErr := os.MkdirAll(piAgentDir, 0o700); mkErr != nil {
+		t.Fatalf("MkdirAll ~/.pi/agent: %v", mkErr)
+	}
+
+	m := newPIOAuthProfileManager(t)
+
+	// Mutate: replace the (subpath ~/.pi/agent) rule with a (literal
+	// auth.json) rule to replicate the pre-fix profile behaviour. This is
+	// the exact configuration that caused the OAuth refresh regression.
+	piAgentDir2 := piAgentDir // capture for closure
+	authJSONLiteral := filepath.Join(piAgentDir2, "auth.json")
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		// The production profile emits:
+		//   (allow file-read* file-write* file-test-existence file-read-metadata
+		//     (subpath "<piAgentDir>"))
+		//
+		// Replace the indented (subpath ...) line with a (literal auth.json)
+		// line, replicating the old behaviour. The surrounding (allow ...) line
+		// and the closing "))" remain intact so the profile is syntactically
+		// valid SBPL — only the coverage changes.
+		subpathLine := "  (subpath " + sbplQuoteForTest(piAgentDir2) + ")\n"
+		literalLine := "  (literal " + sbplQuoteForTest(authJSONLiteral) + ")\n"
+		return strings.ReplaceAll(p, subpathLine, literalLine)
+	})
+
+	lockDir := filepath.Join(piAgentDir, "auth.json.integ-pi-oauth-negative.lock")
+	t.Cleanup(func() { _ = os.Remove(lockDir) })
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixBash, "-c", "mkdir "+shQuote(lockDir))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("mkdir auth.json.lock succeeded with literal-only auth.json rule.\n"+
+			"The negative test is not catching the regression — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — mkdir auth.json.lock correctly denied with literal-only rule (exit: %v)", runErr)
+	}
+}


### PR DESCRIPTION
## Summary

OAuth token refresh inside pi-coding-agent uses `proper-lockfile.lock(authPath, {realpath: true})`, which resolves any symlink in `authPath` and then calls `mkdir(<resolved>.lock)` to acquire the lock. That mkdir requires write permission on the **parent directory** `~/.pi/agent/`, not just on `auth.json` itself. The previous `(literal ~/.pi/agent/auth.json)` SBPL rule denied the mkdir (EPERM), causing token refresh to silently fail after ~30 s of retries and forcing re-login on every token expiry.

## Changes

- **`sandbox_exec.go`**: Replace `(literal ~/.pi/agent/auth.json)` with `(subpath ~/.pi/agent)` in the pi-session SBPL profile. The rule remains gated on `Harness == "pi"` so non-pi sessions are not exposed to the pi credential directory. Updated comment to explain the proper-lockfile mkdir requirement.
- **`sandbox_exec_test.go`**: Rename `TestGenerateProfile_PiAuthJSONLiteralRule` → `TestGenerateProfile_PiAgentDirSubpathRule` and update assertions to match the new behaviour. `TestGenerateProfile_PiAuthJSONAbsentForNonPiSession` continues to pass unchanged.
- **`sandbox_exec_pi_oauth_darwin_test.go`** (new): Darwin integration test — positive test confirms `mkdir auth.json.lock` inside `~/.pi/agent/` succeeds under the production profile; negative test mutates the profile back to literal-only and confirms the same mkdir fails, proving the positive is not a no-op.

Closes #1556