### PR TITLE
sandbox-exec: grant file-write* to ~/.aws/sso and ~/.aws/cli carve-outs (#1558)

### DIFF
--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -132,18 +132,23 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 		}
 	}
 
-	// Per-mode RO/RW divergence for the AWS SSO/CLI cache directories:
+	// Per-mode RO/RW classification for the AWS SSO/CLI cache directories.
 	//
-	//   - podman mounts them read-only because the container has its own net
-	//     namespace; the SSO token is consumed inside the container but
-	//     refresh happens host-side via `aws sso login`.
-	//   - bwrap mounts them read-write because the bwrap sandbox shares the
-	//     host net namespace and may itself perform an SSO refresh that
-	//     writes to the cache (the original bwrap.go used --bind, not
-	//     --ro-bind).
+	// These mounts are read-write (awsSSOReadOnly = false, awsCLIReadOnly =
+	// false) because the aws CLI must be able to write STS token cache entries
+	// to ~/.aws/cli/cache/ and refresh SSO tokens in ~/.aws/sso/ from inside
+	// the sandbox. Without write access the CLI fails with EPERM, and kubectl
+	// against EKS also breaks (its exec-credential plugin shells out to aws).
 	//
-	// Both bwrap and sandbox-exec accept reads from the cache; mounts are
-	// read-write for both modes.
+	// bwrap uses --bind (RW) for both dirs. sandbox-exec mirrors this by
+	// emitting (allow file-read* file-write* (subpath ~/.aws/sso)) and
+	// (allow file-read* file-write* (subpath ~/.aws/cli)) in generateProfile
+	// (issue #1558) and by listing .aws/sso and .aws/cli as writable in
+	// collectStagingHomeSymlinkTargets.
+	//
+	// Note: podman support was removed in #1327. This slice is only walked by
+	// bwrap (appendBwrapBind). The mode parameter is retained for potential
+	// future per-mode divergences.
 	awsSSOReadOnly := false
 	awsCLIReadOnly := false
 	_ = mode // mode is retained for future per-mode mount tweaks

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -284,9 +284,15 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 		// Carve-outs: allow sso/ and cli/ subtrees within ~/.aws. These
 		// more-specific allow rules override the broad deny above.
+		// file-write* is required: the aws CLI writes STS token cache entries
+		// to ~/.aws/cli/cache/ and refreshes SSO tokens in ~/.aws/sso/. Without
+		// write access the CLI fails with EPERM (no STS token cache), and kubectl
+		// against EKS also breaks because its exec-credential plugin shells out
+		// to aws and gets EPERM. Mirrors bwrap's --bind (RW) treatment — see the
+		// comment above awsSSOReadOnly/awsCLIReadOnly in mounts.go. (issue #1558).
 		awsSSOPath := filepath.Join(home, ".aws", "sso")
 		awsCLIPath := filepath.Join(home, ".aws", "cli")
-		sb.WriteString("(allow file-read*\n")
+		sb.WriteString("(allow file-read* file-write*\n")
 		sb.WriteString("  (subpath " + quoteSBPL(awsSSOPath) + ")\n")
 		sb.WriteString("  (subpath " + quoteSBPL(awsCLIPath) + "))\n")
 		sb.WriteString("\n")

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -615,6 +615,14 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 		".mcp-auth":                     true, // MCP auth token writes
 		".npm":                          true, // npx package cache (mcp-remote et al.)
 		".config/opencode/node_modules": true, // bun may update lockfile entries during plugin load
+		// AWS SSO and CLI cache dirs must be writable so the aws CLI can write
+		// STS token cache entries (~/.aws/cli/cache/) and refresh SSO tokens
+		// (~/.aws/sso/). Without write access the CLI gets EPERM and kubectl
+		// against EKS also fails (its exec-credential plugin shells out to aws).
+		// Mirrors bwrap's --bind (RW) treatment — awsSSOReadOnly/awsCLIReadOnly
+		// are both false in mounts.go (issue #1558).
+		".aws/sso":                      true, // AWS SSO token refresh writes
+		".aws/cli":                      true, // AWS CLI STS token cache writes
 	}
 
 	seen := map[string]bool{}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -269,10 +269,11 @@ func TestGenerateProfile_AWSHomePathDenied(t *testing.T) {
 }
 
 // TestGenerateProfile_AWSSSOAndCLICarveouts verifies that the profile contains
-// explicit (allow file-read* (subpath ".../.aws/sso")) and
-// (allow file-read* (subpath ".../.aws/cli")) rules after the broad ~/.aws deny.
-// These more-specific allow rules let AWS SSO tokens and kubectl credential
-// files be read through the staging HOME symlinks (issue #1380).
+// explicit (allow file-read* file-write* (subpath ".../.aws/sso")) and
+// (allow file-read* file-write* (subpath ".../.aws/cli")) rules after the
+// broad ~/.aws deny. These more-specific allow rules let AWS SSO tokens and
+// kubectl credential files be read and written through the staging HOME
+// symlinks (issue #1380, #1558).
 func TestGenerateProfile_AWSSSOAndCLICarveouts(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
@@ -326,6 +327,13 @@ func TestGenerateProfile_AWSSSOAndCLICarveouts(t *testing.T) {
 	if ssoAllowStart < 0 || ssoDenyStart > ssoAllowStart {
 		t.Errorf("~/.aws/sso path is not inside an (allow ...) block; full profile:\n%s", profile)
 	}
+	// Verify the allow block for ~/.aws/sso includes file-write* (issue #1558).
+	// The block header is on the line preceding the first subpath entry.
+	ssoAllowHeader := profile[ssoAllowStart:ssoIdx]
+	if !strings.Contains(ssoAllowHeader, "file-write*") {
+		t.Errorf("~/.aws/sso carve-out allow block must include file-write* (needed for aws CLI STS token cache writes, issue #1558); allow header: %q; full profile:\n%s",
+			ssoAllowHeader, profile)
+	}
 
 	cliIdx := strings.Index(profile, awsCLIPath)
 	if cliIdx < 0 {
@@ -340,12 +348,19 @@ func TestGenerateProfile_AWSSSOAndCLICarveouts(t *testing.T) {
 	if cliAllowStart < 0 || cliDenyStart > cliAllowStart {
 		t.Errorf("~/.aws/cli path is not inside an (allow ...) block; full profile:\n%s", profile)
 	}
+	// Verify the allow block for ~/.aws/cli includes file-write* (issue #1558).
+	cliAllowHeader := profile[cliAllowStart:cliIdx]
+	if !strings.Contains(cliAllowHeader, "file-write*") {
+		t.Errorf("~/.aws/cli carve-out allow block must include file-write* (needed for aws CLI STS token cache writes, issue #1558); allow header: %q; full profile:\n%s",
+			cliAllowHeader, profile)
+	}
 }
 
 // TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded verifies that when
 // ~/.aws/sso and ~/.aws/cli symlinks exist in the staging HOME, their resolved
 // targets are included in the collected set (not excluded by the deniedPrefixes
-// logic). This exercises the carve-out in isDenied (issue #1380).
+// logic), and that both targets are classified as Writable=true so that the
+// per-symlink allow block emits file-write* for them (issue #1380, #1558).
 func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
@@ -391,19 +406,28 @@ func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
 		awsCLIPath = awsCLIPathRaw
 	}
 	foundSSO, foundCLI := false, false
+	ssoWritable, cliWritable := false, false
 	for _, target := range targets {
 		if target.ResolvedPath == awsSSOPath {
 			foundSSO = true
+			ssoWritable = target.Writable
 		}
 		if target.ResolvedPath == awsCLIPath {
 			foundCLI = true
+			cliWritable = target.Writable
 		}
 	}
 	if !foundSSO {
 		t.Errorf("~/.aws/sso resolved path %q not found in collectStagingHomeSymlinkTargets output; got: %v", awsSSOPath, targets)
+	} else if !ssoWritable {
+		// Both sso and cli must be Writable=true so the per-symlink allow block
+		// emits file-write* for them (issue #1558).
+		t.Errorf("~/.aws/sso target %q must have Writable=true (needed for aws CLI STS token cache writes); got Writable=false", awsSSOPath)
 	}
 	if !foundCLI {
 		t.Errorf("~/.aws/cli resolved path %q not found in collectStagingHomeSymlinkTargets output; got: %v", awsCLIPath, targets)
+	} else if !cliWritable {
+		t.Errorf("~/.aws/cli target %q must have Writable=true (needed for aws CLI STS token cache writes); got Writable=false", awsCLIPath)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_cache_writable_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_cache_writable_darwin_test.go
@@ -1,0 +1,370 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_aws_cache_writable_darwin_test.go — integration coverage for
+// the write-access fix to the ~/.aws/sso and ~/.aws/cli carve-outs in the
+// SBPL profile (issue #1558).
+//
+// Background: the SBPL profile §5 previously emitted only:
+//
+//	(allow file-read*
+//	  (subpath "~/.aws/sso")
+//	  (subpath "~/.aws/cli"))
+//
+// This allowed the sandbox to READ through the staging HOME symlinks for
+// those two dirs but not WRITE. The aws CLI writes STS token cache entries
+// to ~/.aws/cli/cache/ and refreshes SSO tokens in ~/.aws/sso/. Without
+// file-write* the CLI fails with EPERM, and kubectl against EKS breaks too
+// (its exec-credential plugin shells out to aws and gets EPERM). The fix
+// adds file-write* to the carve-out:
+//
+//	(allow file-read* file-write*
+//	  (subpath "~/.aws/sso")
+//	  (subpath "~/.aws/cli"))
+//
+// Additionally, collectStagingHomeSymlinkTargets previously did not list
+// .aws/sso or .aws/cli in writableStagingPaths, so the per-symlink allow
+// block emitted the resolved host paths in the RO group. The fix adds
+// them to writableStagingPaths so the per-symlink allow emits file-write*
+// for their resolved targets too.
+//
+// This file tests:
+//
+//  1. Positive case (SSO write): with the production profile, writing a
+//     file inside ~/.aws/sso via the staging HOME symlink chain succeeds.
+//
+//  2. Negative case (SSO write denied without file-write*): removing the
+//     file-write* from the carve-out causes the same write to fail —
+//     proving the positive is not green by accident and that file-write*
+//     is load-bearing.
+//
+//  3. Positive case (CLI write): symmetric to SSO, but for ~/.aws/cli.
+//
+//  4. Negative case (CLI write denied without file-write*): symmetric
+//     negative pair for CLI.
+//
+//  5. Security case: a write attempt to ~/.aws/<other> (a path inside the
+//     broad deny but outside the carve-outs) must still fail. This guards
+//     against the carve-out being accidentally widened to cover the entire
+//     ~/.aws subtree.
+//
+// Shared helpers (requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
+// withMutatedProfile, preparePositiveProfile, writeAugmentedPositiveProfile,
+// realUserHome, prepareSSOSentinel, prepareCLISentinel, sbplQuoteForTest,
+// shQuote) live in sandbox_exec_helpers_darwin_test.go and
+// sandbox_exec_aws_sso_darwin_test.go.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// awsCacheSSOWriteContent is the content written to the test file inside
+// ~/.aws/sso during the write-positive tests.
+const awsCacheSSOWriteContent = "prism-1558-aws-sso-write-sentinel"
+
+// awsCacheCLIWriteContent is the analogous content for the ~/.aws/cli tests.
+const awsCacheCLIWriteContent = "prism-1558-aws-cli-write-sentinel"
+
+// TestSandboxExecProfile_AWSSSOWritable is the positive integration test for
+// write access to ~/.aws/sso (issue #1558). It:
+//
+//  1. Creates ~/.aws/sso under the real user HOME (so the write attempt
+//     targets the deny-covered path, not /private/var/folders).
+//  2. Calls PrepareSandboxExecHome so the staging HOME contains
+//     <stagingHome>/.aws/sso → ~/.aws/sso.
+//  3. Generates the production profile (which emits file-read* file-write*
+//     for both ~/.aws/sso and ~/.aws/cli).
+//  4. Writes a file inside ~/.aws/sso via the staging HOME symlink from
+//     inside the sandbox and asserts exit 0.
+func TestSandboxExecProfile_AWSSSOWritable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	ssoDir, _ := prepareSSOSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Verify the staging HOME has the sso symlink before generating the profile.
+	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
+	if _, lstatErr := os.Lstat(ssoLink); lstatErr != nil {
+		t.Fatalf("staging HOME must have a .aws/sso symlink after PrepareSandboxExecHome: %v", lstatErr)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The carve-out must include file-write* in the generated profile.
+	realHome := realUserHome(t)
+	awsSSOPath := filepath.Join(realHome, ".aws", "sso")
+	expectedWriteRule := "(allow file-read* file-write*\n  (subpath " + sbplQuoteForTest(awsSSOPath)
+	if !strings.Contains(prepared.content, expectedWriteRule) {
+		t.Fatalf("generated profile does not contain a file-write* carve-out for ~/.aws/sso.\n"+
+			"Expected to find: %q\nProfile:\n%s", expectedWriteRule, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Write a sentinel file inside <stagingHome>/.aws/sso from inside the sandbox.
+	// The write targets the host path via the staging HOME symlink.
+	writeTarget := filepath.Join(ssoLink, ".prism-1558-write-test")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) })
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo "+shQuote(awsCacheSSOWriteContent)+" > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("write to ~/.aws/sso failed under production profile with file-write* carve-out.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
+			runErr, string(out), testProfilePath, writeTarget)
+	}
+
+	// Verify the write actually landed on the host.
+	got, readErr := os.ReadFile(writeTarget)
+	if readErr != nil {
+		t.Fatalf("sentinel not found on host after sandbox write: %v", readErr)
+	}
+	if !strings.Contains(string(got), awsCacheSSOWriteContent) {
+		t.Errorf("written file does not contain expected content.\nGot: %s", string(got))
+	}
+
+	_ = ssoDir
+}
+
+// TestSandboxExecProfile_AWSSSOWriteDeniedWithoutFileWrite is the paired
+// negative test for AWSSSOWritable. It removes file-write* from the
+// ~/.aws/sso carve-out line and asserts the same write fails — proving
+// that file-write* is load-bearing and the positive is not green by accident.
+func TestSandboxExecProfile_AWSSSOWriteDeniedWithoutFileWrite(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	ssoDir, _ := prepareSSOSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
+
+	// Remove file-write* from the carve-out allow block. The production
+	// profile emits:
+	//   (allow file-read* file-write*
+	//     (subpath "<awsSSOPath>")
+	//     (subpath "<awsCLIPath>"))
+	// We replace it with the read-only form to simulate the pre-fix state.
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p,
+			"(allow file-read* file-write*\n  (subpath "+sbplQuoteForTest(filepath.Join(realUserHome(t), ".aws", "sso")),
+			"(allow file-read*\n  (subpath "+sbplQuoteForTest(filepath.Join(realUserHome(t), ".aws", "sso")),
+		)
+	})
+
+	writeTarget := filepath.Join(ssoLink, ".prism-1558-write-test-neg")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) })
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo "+shQuote(awsCacheSSOWriteContent)+" > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write to ~/.aws/sso succeeded WITHOUT file-write* in the carve-out.\n"+
+			"file-write* is not the load-bearing rule — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — ~/.aws/sso write correctly denied without file-write* (exit: %v)", runErr)
+	}
+
+	_ = ssoDir
+}
+
+// TestSandboxExecProfile_AWSCLIWritable is the positive integration test for
+// write access to ~/.aws/cli (issue #1558), symmetric to AWSSSOWritable.
+func TestSandboxExecProfile_AWSCLIWritable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	cliDir, _ := prepareCLISentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	cliLink := filepath.Join(stagingHome, ".aws", "cli")
+	if _, lstatErr := os.Lstat(cliLink); lstatErr != nil {
+		t.Fatalf("staging HOME must have a .aws/cli symlink after PrepareSandboxExecHome: %v", lstatErr)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The carve-out must include file-write* and the cli path.
+	realHome := realUserHome(t)
+	awsCLIPath := filepath.Join(realHome, ".aws", "cli")
+	if !strings.Contains(prepared.content, "file-write*") {
+		t.Fatalf("generated profile does not contain file-write* anywhere — the carve-out fix was not applied.\nProfile:\n%s",
+			prepared.content)
+	}
+	if !strings.Contains(prepared.content, awsCLIPath) {
+		t.Fatalf("generated profile does not contain the ~/.aws/cli carve-out path %q.\nProfile:\n%s",
+			awsCLIPath, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	writeTarget := filepath.Join(cliLink, ".prism-1558-write-test")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) })
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo "+shQuote(awsCacheCLIWriteContent)+" > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("write to ~/.aws/cli failed under production profile with file-write* carve-out.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
+			runErr, string(out), testProfilePath, writeTarget)
+	}
+
+	got, readErr := os.ReadFile(writeTarget)
+	if readErr != nil {
+		t.Fatalf("sentinel not found on host after sandbox write: %v", readErr)
+	}
+	if !strings.Contains(string(got), awsCacheCLIWriteContent) {
+		t.Errorf("written file does not contain expected content.\nGot: %s", string(got))
+	}
+
+	_ = cliDir
+}
+
+// TestSandboxExecProfile_AWSCLIWriteDeniedWithoutFileWrite is the paired
+// negative test for AWSCLIWritable. It removes file-write* from the carve-out
+// and asserts the same write fails.
+func TestSandboxExecProfile_AWSCLIWriteDeniedWithoutFileWrite(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	cliDir, _ := prepareCLISentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	cliLink := filepath.Join(stagingHome, ".aws", "cli")
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p,
+			"(allow file-read* file-write*\n  (subpath "+sbplQuoteForTest(filepath.Join(realUserHome(t), ".aws", "sso")),
+			"(allow file-read*\n  (subpath "+sbplQuoteForTest(filepath.Join(realUserHome(t), ".aws", "sso")),
+		)
+	})
+
+	writeTarget := filepath.Join(cliLink, ".prism-1558-write-test-neg")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) })
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo "+shQuote(awsCacheCLIWriteContent)+" > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write to ~/.aws/cli succeeded WITHOUT file-write* in the carve-out.\n"+
+			"file-write* is not the load-bearing rule — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — ~/.aws/cli write correctly denied without file-write* (exit: %v)", runErr)
+	}
+
+	_ = cliDir
+}
+
+// TestSandboxExecProfile_AWSOutsideCarveoutDenied is the security test for
+// issue #1558 AC #5: a write attempt to ~/.aws/<other> (a path inside the
+// broad deny but outside the ~/.aws/sso and ~/.aws/cli carve-outs) must
+// still fail. This guards against the carve-out being accidentally widened
+// to cover the entire ~/.aws subtree.
+//
+// The test creates a temporary directory directly under ~/.aws (NOT under
+// sso/ or cli/) and attempts to write a file into it from inside the
+// sandbox. The (deny file-read* file-write* (subpath ~/.aws)) rule must
+// block the write even though the (allow file-read* file-write* (subpath
+// ~/.aws/sso)) and (allow file-read* file-write* (subpath ~/.aws/cli))
+// carve-outs exist.
+func TestSandboxExecProfile_AWSOutsideCarveoutDenied(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home := realUserHome(t)
+	awsDir := filepath.Join(home, ".aws")
+	if mkErr := os.MkdirAll(awsDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.aws for test: %v", mkErr)
+	}
+
+	// Create a dir directly under ~/.aws that is NOT sso/ or cli/.
+	otherDir, err := os.MkdirTemp(awsDir, ".prism-1558-other-*")
+	if err != nil {
+		t.Skipf("cannot create temp dir under ~/.aws (may be running inside a restricted sandbox): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(otherDir) })
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Attempt to write directly into otherDir (which is under ~/.aws but
+	// outside the sso/ and cli/ carve-outs). The broad deny must block this.
+	writeTarget := filepath.Join(otherDir, ".prism-1558-security-test")
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo prism-1558-security > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write to ~/.aws/<other> succeeded — the deny is not tight enough.\n"+
+			"A path outside the sso/ and cli/ carve-outs was writable from inside the sandbox.\n"+
+			"Output: %s\nProfile: %s\nTarget: %s", string(out), testProfilePath, writeTarget)
+	} else {
+		t.Logf("ka pai — write to ~/.aws/<other> correctly denied (exit: %v)", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_cache_writable_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_cache_writable_darwin_test.go
@@ -49,6 +49,14 @@ package integration_test
 //     against the carve-out being accidentally widened to cover the entire
 //     ~/.aws subtree.
 //
+//  6. Edge-case: when ~/.aws/cli and ~/.aws/sso do NOT exist on the host
+//     at session-spawn time, PrepareSandboxExecHome creates no symlinks for
+//     them (symlinkIfExists skips missing sources), the generated profile
+//     still loads under /usr/bin/sandbox-exec, and a non-AWS workload exits 0.
+//     This validates that the carve-out rules (which reference non-existent
+//     paths) do not break sandbox initialisation — sandbox-exec silently ignores
+//     (subpath ...) rules for paths that do not exist on the host.
+//
 // Shared helpers (requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
 // withMutatedProfile, preparePositiveProfile, writeAugmentedPositiveProfile,
 // realUserHome, prepareSSOSentinel, prepareCLISentinel, sbplQuoteForTest,
@@ -367,4 +375,88 @@ func TestSandboxExecProfile_AWSOutsideCarveoutDenied(t *testing.T) {
 	} else {
 		t.Logf("ka pai — write to ~/.aws/<other> correctly denied (exit: %v)", runErr)
 	}
+}
+
+// TestSandboxExecProfile_AWSCarveoutAbsent_ProfileLoads is the edge-case
+// integration test for issue #1558: when ~/.aws/cli and ~/.aws/sso do NOT
+// exist on the host at session-spawn time, the generated profile still loads
+// under /usr/bin/sandbox-exec and a non-AWS workload exits 0.
+//
+// PrepareSandboxExecHome uses symlinkIfExists for the sso/ and cli/ entries,
+// so when the host directories are absent no symlinks are created — but
+// generateProfile still unconditionally emits the carve-out rules with the
+// host paths (filepath.Join(home, ".aws", "sso") and ".aws", "cli").
+// sandbox-exec silently ignores (subpath ...) rules for paths that do not
+// exist, so the profile must still load and allow a simple non-AWS workload
+// (echo) to succeed.
+//
+// This guards against a regression where the carve-out rules cause sandbox
+// initialisation to fail when the host has no ~/.aws/sso or ~/.aws/cli.
+func TestSandboxExecProfile_AWSCarveoutAbsent_ProfileLoads(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home := realUserHome(t)
+	awsSSOPath := filepath.Join(home, ".aws", "sso")
+	awsCLIPath := filepath.Join(home, ".aws", "cli")
+
+	// If either directory exists, temporarily rename it so this test can
+	// simulate a host without ~/.aws/sso and ~/.aws/cli. This is a best-effort
+	// skip rather than a skip-if-absent because the test is specifically about
+	// profile loading when the dirs are absent; we don't want to silently skip
+	// on developer machines where they always exist.
+	for _, p := range []string{awsSSOPath, awsCLIPath} {
+		if _, statErr := os.Stat(p); statErr == nil {
+			// Temporarily rename out of the way.
+			tmp := p + ".prism-1558-absent-test-rename"
+			if renErr := os.Rename(p, tmp); renErr != nil {
+				t.Skipf("cannot temporarily rename %s to simulate absence: %v", p, renErr)
+			}
+			restorePath := p // capture for closure
+			tmpPath := tmp   // capture for closure
+			t.Cleanup(func() { _ = os.Rename(tmpPath, restorePath) })
+		}
+	}
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Verify that no sso/cli symlinks were created in the staging HOME
+	// (they should be absent since symlinkIfExists skips missing sources).
+	for _, rel := range []string{".aws/sso", ".aws/cli"} {
+		link := filepath.Join(stagingHome, rel)
+		if _, lstatErr := os.Lstat(link); lstatErr == nil {
+			t.Errorf("staging HOME has %s symlink even though host dir is absent — symlinkIfExists should have skipped it", rel)
+		}
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Run a simple non-AWS workload (echo) to verify the profile loads and
+	// the sandbox initialises without error even when the carve-out paths
+	// do not exist on the host.
+	const echoSentinel = "prism-1558-absent-carveout-ok"
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo "+shQuote(echoSentinel))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("non-AWS workload failed even though ~/.aws/sso and ~/.aws/cli are absent.\n"+
+			"The carve-out rules for non-existent paths must not break profile loading.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), echoSentinel) {
+		t.Errorf("workload exited 0 but output does not contain expected sentinel.\nOutput: %s", string(out))
+	}
+	t.Logf("ka pai — profile loads correctly when ~/.aws/sso and ~/.aws/cli are absent (exit: %v)", runErr)
 }


### PR DESCRIPTION
## Summary

Inside a prism sandbox-exec session on macOS, the `aws` CLI cannot write to `~/.aws/cli/cache/`, breaking both `aws` (no STS token cache) and `kubectl` against EKS (its exec-credential plugin shells out to `aws` and gets EPERM).

Two cooperating gaps fixed:

### Fix 1: `sandbox_exec.go` §5 carve-out

The `(allow file-read* (subpath ~/.aws/sso))` and `(allow file-read* (subpath ~/.aws/cli))` carve-outs lacked `file-write*`. Changed to `(allow file-read* file-write* ...)` to mirror bwrap's `--bind` (RW) treatment.

### Fix 2: `sandbox_exec_home.go` `writableStagingPaths`

`.aws/sso` and `.aws/cli` were missing from the `writableStagingPaths` map, so `collectStagingHomeSymlinkTargets` classified their resolved host paths as RO and emitted them in the read-only per-symlink allow block. Added both entries to the writable map.

### Comment update: `mounts.go`

The comment above `awsSSOReadOnly`/`awsCLIReadOnly` referenced podman, which was removed in #1327. Updated to accurately describe the bwrap + sandbox-exec RW rationale.

## Tests

- **`TestGenerateProfile_AWSSSOAndCLICarveouts`** (updated): now asserts the carve-out allow block includes `file-write*`
- **`TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded`** (updated): now asserts both SSO and CLI targets have `Writable=true`
- **`sandbox_exec_aws_cache_writable_darwin_test.go`** (new): five Darwin-only integration tests per the [sandbox-exec-testing.md](modules/programs/prism/prism/docs/sandbox-exec-testing.md) convention:
  1. `AWSSSOWritable` — positive write via staging HOME symlink succeeds
  2. `AWSSSOWriteDeniedWithoutFileWrite` — removing `file-write*` causes failure (negative pair)
  3. `AWSCLIWritable` — symmetric positive for `~/.aws/cli`
  4. `AWSCLIWriteDeniedWithoutFileWrite` — symmetric negative pair
  5. `AWSOutsideCarveoutDenied` — security AC: write to `~/.aws/<other>` (outside carve-outs) is still denied

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅ (pre-existing failures in `internal/tmux`, `cmd`, and macOS bwrap path-resolution tests reproduce on `main`)
- `nix build .#prism` ✅

Closes #1558