### PR TITLE
prism: error enumeration consistency + idempotent prism spawn --reuse

### DIFF
--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -148,6 +148,7 @@ prism spawn --prompt "run `gh pr view 42` and summarise"
 | `--prompt-file <path>` | Read the prompt from a file instead of passing it as an argument. Mutually exclusive with `--prompt`. A single trailing newline is stripped. |
 | `--agent <name>` | Opencode agent to use (`worker` or `plan`). Defaults to `worker`. |
 | `--attach` | Switch the current tmux client to the new session instead of spawning headlessly. |
+| `--reuse` | If an active session already exists on the requested branch, return its name/port/agent and exit 0 instead of failing. Without `--reuse`, spawning onto an existing branch exits non-zero and tells you to run `prism cleanup` or pass `--reuse`. |
 
 ## Behaviour
 

--- a/modules/programs/prism/prism/cmd/archive.go
+++ b/modules/programs/prism/prism/cmd/archive.go
@@ -13,6 +13,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -108,7 +109,7 @@ func printArchivePathAllJSON(d *db.DB, sessionName string) error {
 		return fmt.Errorf("archive: %w", err)
 	}
 	if len(sessions) == 0 {
-		return fmt.Errorf("archive: no incarnations found for session %q", sessionName)
+		return archiveNotFoundError(d, sessionName)
 	}
 
 	rows := make([]archiveJSONRow, 0, len(sessions))
@@ -141,6 +142,12 @@ func printArchivePathAllJSON(d *db.DB, sessionName string) error {
 func printArchivePath(d *db.DB, arg string, forceInstance bool) error {
 	sess, err := resolveSessionArg(d, arg, forceInstance)
 	if err != nil {
+		if !forceInstance && len(arg) != 36 {
+			// Not a UUID lookup — enrich with available session names.
+			if enriched := archiveNotFoundError(d, arg); enriched != nil {
+				return enriched
+			}
+		}
 		return fmt.Errorf("archive: %w", err)
 	}
 
@@ -162,7 +169,7 @@ func printArchivePathAll(d *db.DB, sessionName string) error {
 	}
 
 	if len(sessions) == 0 {
-		return fmt.Errorf("archive: no incarnations found for session %q", sessionName)
+		return archiveNotFoundError(d, sessionName)
 	}
 
 	for _, s := range sessions {
@@ -173,4 +180,15 @@ func printArchivePathAll(d *db.DB, sessionName string) error {
 		}
 	}
 	return nil
+}
+
+// archiveNotFoundError builds an enum-shaped error for an unknown session/arg,
+// listing recent session names from the DB to aid recovery.
+func archiveNotFoundError(d *db.DB, arg string) error {
+	names, _ := activeSessionNamesForError(d, 10)
+	if len(names) == 0 {
+		return fmt.Errorf("archive: %q not found — no sessions in DB", arg)
+	}
+	return fmt.Errorf("archive: session must be one of: %s (got: %q)",
+		strings.Join(names, ", "), arg)
 }

--- a/modules/programs/prism/prism/cmd/archive_json_test.go
+++ b/modules/programs/prism/prism/cmd/archive_json_test.go
@@ -70,8 +70,8 @@ func TestArchive_AllJSON_UnknownSession(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown session, got nil")
 	}
-	if !strings.Contains(err.Error(), "no incarnations found") {
-		t.Errorf("expected 'no incarnations found' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -360,6 +360,20 @@ var cleanupCmd = &cobra.Command{
 		var session string
 		if sessionFlag != "" {
 			session = sessionFlag
+			// Validate the session name early against the DB so a typo produces
+			// a helpful enumerated error instead of a later "worktree not found".
+			if d, dbErr := openDB(); dbErr == nil {
+				defer d.Close()
+				st, stErr := d.CurrentStatus(session)
+				if stErr == nil && st == nil {
+					// Session not in DB — list active sessions to aid recovery.
+					names, _ := activeSessionNamesForError(d, 10)
+					if len(names) == 0 {
+						return fmt.Errorf("--session %q not found — no active sessions in DB", session)
+					}
+					return fmt.Errorf("--session must be one of: %s (got: %q)", strings.Join(names, ", "), session)
+				}
+			}
 		} else {
 			var err error
 			session, err = tmux.CurrentSession()

--- a/modules/programs/prism/prism/cmd/db.go
+++ b/modules/programs/prism/prism/cmd/db.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -58,5 +59,33 @@ outside a sandbox.`,
 
 func init() {
 	rootCmd.AddCommand(dbCmd)
+}
+
+// activeSessionNamesForError returns a capped list of active session names
+// suitable for inclusion in enum-shaped error messages (e.g.
+// "session must be one of: A, B (got: \"C\")").
+// cap controls the maximum number of names returned. When the full list is
+// longer, an "...and N more" sentinel is appended.
+// d may be nil or produce an error — in both cases an empty slice is returned
+// so callers can safely handle the no-DB case.
+func activeSessionNamesForError(d *db.DB, cap int) ([]string, error) {
+	if d == nil {
+		return nil, nil
+	}
+	statuses, err := d.AllActiveStatus()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		names = append(names, s.SessionName)
+	}
+	if len(names) <= cap {
+		return names, nil
+	}
+	truncated := make([]string, cap+1)
+	copy(truncated, names[:cap])
+	truncated[cap] = fmt.Sprintf("...and %d more", len(names)-cap)
+	return truncated, nil
 }
 

--- a/modules/programs/prism/prism/cmd/profile.go
+++ b/modules/programs/prism/prism/cmd/profile.go
@@ -131,6 +131,15 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Validate the profile name before any side-effects.
+	if _, ok := pf.Profiles[name]; !ok {
+		availableNames := config.AvailableProfileNames(pf)
+		if len(availableNames) == 0 {
+			return fmt.Errorf("no profiles are configured — run the system rebuild to generate ~/.config/prism/profiles.json")
+		}
+		return fmt.Errorf("--profile must be one of: %s (got: %q)",
+			strings.Join(availableNames, ", "), name)
+	}
 	// Determine scope from flags.
 	scope := profileUseFlags.scope
 	verbose := profileUseFlags.verbose

--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -81,8 +81,8 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if !valid {
-		return fmt.Errorf("invalid --deliver-as %q: accepted values are %q",
-			deliverAs, validDeliverAsModes)
+		return fmt.Errorf("--deliver-as must be one of: %s (got: %q)",
+			strings.Join(validDeliverAsModes, ", "), deliverAs)
 	}
 
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
@@ -103,9 +103,16 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	}
 
 	if status == nil {
+		sessionNames, _ := activeSessionNamesForError(database, 10)
+		if len(sessionNames) == 0 {
+			return fmt.Errorf(
+				"session %q not found — no active sessions in DB (run `prism list-sessions` to verify)",
+				sessionName,
+			)
+		}
 		return fmt.Errorf(
-			"session %q not found in DB\nrun `prism list-sessions` to see available sessions",
-			sessionName,
+			"session must be one of: %s (got: %q)",
+			strings.Join(sessionNames, ", "), sessionName,
 		)
 	}
 

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -111,8 +111,8 @@ func runReview(cmd *cobra.Command, args []string) error {
 		// --only was explicitly set. Validate it produces at least one token.
 		names := splitCSV(onlyFlag)
 		if len(names) == 0 {
-			return fmt.Errorf("prism review: --only flag requires at least one agent name (got empty value %q)\navailable: %s",
-				onlyFlag, strings.Join(agentNameStrings(allAgents), ", "))
+			return fmt.Errorf("prism review: --only must be one of: %s (got: %q)",
+				strings.Join(agentNameStrings(allAgents), ", "), onlyFlag)
 		}
 		var err error
 		agents, err = review.AgentsByName(allAgents, names)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -73,6 +73,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 	isolationFlag, _ := cmd.Flags().GetString("isolation")
 	modelOverrideFlag, _ := cmd.Flags().GetStringArray("model-override")
+	reuseFlag, _ := cmd.Flags().GetBool("reuse")
 
 	isolationChanged := cmd.Flags().Changed("isolation")
 
@@ -189,6 +190,7 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"model":                  modelFlag,
 		"variant":                variantFlag,
 		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
+		"reuse":                  reuseFlag,
 	}
 	if len(modelOverrideFlag) > 0 {
 		modelsByRole, parseErr := parseModelOverrides(modelOverrideFlag)
@@ -257,6 +259,7 @@ func init() {
 	spawnCmd.Flags().Bool("wait", false, "Block until the spawned agent finishes its initial prompt (state transitions to finished or error). Without --wait, returns immediately and the agent runs in the background.")
 	spawnCmd.Flags().Duration("wait-timeout", defaultSpawnWaitTimeout, "Timeout for --wait. On expiry, exits non-zero with a status payload distinguishable from a real spawn failure. Ignored when --wait is not set.")
 	spawnCmd.Flags().Bool("json", false, "Emit the terminal status as a JSON object on stdout (only useful with --wait or to script over the spawn output). Suppresses textual output.")
+	spawnCmd.Flags().Bool("reuse", false, "If a healthy session already exists on the requested branch, return its details and exit 0 instead of failing")
 	// --prompt-source is an internal flag used by the host-API /spawn handler
 	// to override the auto-detected prompt source (C.4.SRC, issue #1148).
 	// It is hidden from --help because end users should never pass it directly.
@@ -476,6 +479,52 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	branch, err := resolveBranch(bareRoot, branchFlag, prFlag)
 	if err != nil {
 		return err
+	}
+
+	// Pre-flight dedupe check: refuse (or reuse) when an active session already
+	// exists for this repo+branch. This prevents git/tmux/DB conflicts from
+	// a half-failed retry and gives the caller a structured error pointing at
+	// recovery options. The check is a single DB query — no worktree, no tmux
+	// session, no DB row is created before this point.
+	reuseFlag, _ := cmd.Flags().GetBool("reuse")
+	{
+		d, dbErr := openDB()
+		if dbErr == nil {
+			defer d.Close()
+			repoName := strings.TrimSuffix(filepath.Base(bareRoot), ".git")
+			existing, lookupErr := d.ActiveStatusForRepoBranch(repoName, branch)
+			if lookupErr == nil && existing != nil {
+				// There is an active session for this branch.
+				// Healthy = state not "error" and not "deleted".
+				broken := existing.State == "error" || existing.State == "deleted"
+				if reuseFlag {
+					if broken {
+						return fmt.Errorf(
+							"prism spawn --reuse: existing session %q is in a broken state (%s)\n"+
+							"run: prism cleanup --yes --session %s",
+							existing.SessionName, existing.State, existing.SessionName)
+					}
+					// Healthy session — emit its details and exit 0.
+					agentName := ""
+					if existing.AgentName != nil {
+						agentName = *existing.AgentName
+					}
+					port := 0
+					if existing.HarnessPort != nil {
+						port = *existing.HarnessPort
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "reuse: existing session %q (agent: %s, port: %d)\n",
+						existing.SessionName, agentName, port)
+					return nil
+				}
+				// No --reuse: refuse with a structured error.
+				return fmt.Errorf(
+					"prism spawn: branch %q already has an active session %q\n"+
+					"to clean it up: prism cleanup --yes --session %s\n"+
+					"to reuse it: prism spawn --branch %s --reuse",
+					branch, existing.SessionName, existing.SessionName, branch)
+			}
+		}
 	}
 
 	// Validate the active profile defines a slot for the session's role

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -715,6 +715,25 @@ WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
 }
 
+// ActiveStatusForRepoBranch returns the active (ended_at IS NULL) agent_status
+// row for the given repo and worktree (branch) name, or nil when no such row
+// exists. This is the natural-key dedupe check used by prism spawn --reuse.
+func (d *DB) ActiveStatusForRepoBranch(repo, branch string) (*Status, error) {
+	const q = `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE ended_at IS NULL AND repo = ? AND worktree = ?
+LIMIT 1`
+	statuses, err := d.queryStatuses(q, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	return &statuses[0], nil
+}
+
 // AllStatusesWithPrefix returns all agent_status rows (active and ended)
 // whose session_name starts with the given prefix. Used by `prism checkin
 // <parent>~review` to enumerate all review rounds including completed ones.

--- a/modules/programs/prism/prism/internal/review/agents.go
+++ b/modules/programs/prism/prism/internal/review/agents.go
@@ -109,9 +109,9 @@ func AgentsByName(agents []Agent, allowedNames []string) ([]Agent, error) {
 		}
 	}
 	if len(unknown) > 0 {
-		return nil, fmt.Errorf("unknown agent name(s): %s\navailable: %s",
-			strings.Join(unknown, ", "),
+		return nil, fmt.Errorf("--only must be one of: %s (got: %q)",
 			strings.Join(agentNames(agents), ", "),
+			strings.Join(unknown, ", "),
 		)
 	}
 	return result, nil


### PR DESCRIPTION
Closes #1504

## Audit findings (Part 1 — Error enumeration)

| Location | Issue | Fix |
|---|---|---|
| `cmd/prompt.go` `--deliver-as` | Used `%q` on the slice, printing Go array syntax | `must be one of: steer, followUp, nextTurn (got: "bogus")` |
| `cmd/prompt.go` session not found | Said "not found in DB\nrun prism list-sessions" but no names | Lists active session names (cap 10, +N more) |
| `cmd/cleanup.go` `--session <bad>` | No early validation; failed late with "worktree not found" | Pre-flight DB check: `--session must be one of: <names> (got: "bad")` |
| `cmd/archive.go` unknown session | "no incarnations found for session %q" with no hint | Lists active session names (cap 10) |
| `cmd/review.go` `--only ""` | `"--only flag requires at least one agent name (got empty...)\navailable: ..."` | `--only must be one of: <agents> (got: "")` |
| `internal/review/agents.go` `AgentsByName` | `"unknown agent name(s): X\navailable: Y"` | `--only must be one of: <agents> (got: "X")` |
| `cmd/profile.go` `profile use <bad>` | No validation in `runProfileUse`; relied on `SetActiveProfile` error which wasn't standard shape | `--profile must be one of: <names> (got: "bad")`; explicit "no profiles configured" when list is empty |

**What was already good** (no change needed):
- `prism spawn --isolation <bad>` → `unknown isolation mode "X"; valid values: bwrap, sandbox-exec, host`
- `prism spawn --harness <bad>` → `unknown harness "X": valid harnesses: opencode, pi`
- `prism profile show <bad>` → `unknown profile "X" — available: Y` (non-enum non-flag error, left as-is per scope)

## Part 2 — Idempotent `prism spawn`

New `--reuse` flag and pre-flight dedupe check on spawn:

- **Without `--reuse`**: `prism spawn --branch <existing>` exits non-zero with a structured error naming the existing session and pointing at `prism cleanup` or `--reuse`
- **With `--reuse`**: exits 0 and prints the existing session's name, port, and agent when healthy; exits non-zero with a recovery hint when the session is in a broken state (`error`/`deleted`)
- **No existing session**: proceeds normally (no change in behaviour)
- **Terminal states** (`finished`, `error`, `deleted`): `AllActiveStatus` only returns rows where `ended_at IS NULL`, so terminal sessions are excluded from the dedupe check
- The check is a single DB query (`ActiveStatusForRepoBranch`) — happens after branch resolution, before worktree/tmux/DB row creation

## Files changed

- `internal/db/status.go` — `ActiveStatusForRepoBranch(repo, branch)` method
- `cmd/db.go` — `activeSessionNamesForError(d, cap)` helper
- `cmd/spawn.go` — `--reuse` flag, dedupe check, proxy forwarding
- `cmd/prompt.go` — fixed `--deliver-as` and session-not-found errors
- `cmd/cleanup.go` — early session validation with name listing
- `cmd/archive.go` — `archiveNotFoundError` with name listing
- `cmd/review.go` — standard shape for `--only` empty error
- `internal/review/agents.go` — standard shape for `AgentsByName` error
- `cmd/profile.go` — explicit profile validation with list / no-profiles message
- `SKILL.md` — documented `--reuse` flag