### PR TITLE
prism cli: bounded responses and tightened help text

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin.go
+++ b/modules/programs/prism/prism/cmd/checkin.go
@@ -214,18 +214,23 @@ func runCheckinSessionJSON(session string, limit int, before, after *string, typ
 
 	// Fetch events using the same logic as the host-API /checkin handler.
 	var events []db.Event
+	// assistantCount tracks how many assistant turns were fetched so we can
+	// determine whether the result was truncated at the limit.
+	assistantCount := 0
 	if len(types) > 0 {
 		evts, qerr := d.QueryEvents(session, limit, before, after, types)
 		if qerr != nil {
 			return fmt.Errorf("checkin --json: query events: %w", qerr)
 		}
 		events = evts
+		assistantCount = len(evts)
 	} else {
 		// Default assistant-turn-centric mode: mirror host-API logic.
 		assistantEvents, qerr := d.QueryEvents(session, limit, before, after, []string{"msg_assistant"})
 		if qerr != nil {
 			return fmt.Errorf("checkin --json: query events: %w", qerr)
 		}
+		assistantCount = len(assistantEvents)
 		if len(assistantEvents) > 0 {
 			// Collect messageIds and fetch child events.
 			messageIDs := make([]string, 0, len(assistantEvents))
@@ -273,17 +278,32 @@ func runCheckinSessionJSON(session string, limit int, before, after *string, typ
 	if events == nil {
 		events = []db.Event{}
 	}
+
+	// Truncation: when assistantCount == limit the DB may have more turns.
+	// The agent can page backward via --before=<next_before>.
+	truncated := limit > 0 && assistantCount >= limit
 	out := map[string]any{
-		"session": session,
-		"state":   state,
-		"events":  events,
+		"session":   session,
+		"state":     state,
+		"events":    events,
+		"truncated": truncated,
+	}
+	if truncated && len(events) > 0 {
+		out["hint"] = "more turns may exist — pass --before=<next_before> to page backward"
+		// Find the oldest event ID in the returned window.
+		oldest := events[0]
+		for _, e := range events[1:] {
+			if e.CreatedAt.Before(oldest.CreatedAt) {
+				oldest = e
+			}
+		}
+		out["next_before"] = oldest.ID
 	}
 	data, merr := json.Marshal(out)
 	if merr != nil {
 		return fmt.Errorf("checkin --json: marshal: %w", merr)
 	}
-	fmt.Println(string(data))
-	return nil
+	return printJSON(data)
 }
 
 // runCheckinSessionRaw is the legacy raw-event query path, used when --types

--- a/modules/programs/prism/prism/cmd/checkin_json_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_json_test.go
@@ -68,7 +68,7 @@ func TestCheckin_JSONFlag_DirectPath(t *testing.T) {
 		t.Fatalf("--json output is not valid JSON: %v\noutput: %s", err, out)
 	}
 
-	for _, key := range []string{"session", "state", "events"} {
+	for _, key := range []string{"session", "state", "events", "truncated"} {
 		if _, ok := resp[key]; !ok {
 			t.Errorf("--json output missing key %q; got: %s", key, out)
 		}

--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -104,7 +104,14 @@ func runListSessions(cmd *cobra.Command, _ []string) error {
 		if ss == nil {
 			ss = []db.Status{}
 		}
-		data, merr := json.Marshal(ss)
+		out := struct {
+			Sessions  []db.Status `json:"sessions"`
+			Truncated bool        `json:"truncated"`
+		}{
+			Sessions:  ss,
+			Truncated: false,
+		}
+		data, merr := json.Marshal(out)
 		if merr != nil {
 			return fmt.Errorf("sessions list --json: marshal: %w", merr)
 		}

--- a/modules/programs/prism/prism/cmd/list_sessions_json_test.go
+++ b/modules/programs/prism/prism/cmd/list_sessions_json_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TestListSessions_JSONFlag_DirectPath verifies that list-sessions --json
-// (no PRISM_HOST_API) emits a valid JSON array of session status objects.
+// (no PRISM_HOST_API) emits a valid JSON object with a sessions array.
 func TestListSessions_JSONFlag_DirectPath(t *testing.T) {
 	d := openStatsTestDB(t) // also unsets PRISM_HOST_API
 
@@ -37,9 +37,24 @@ func TestListSessions_JSONFlag_DirectPath(t *testing.T) {
 	})
 
 	trimmed := strings.TrimSpace(out)
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	sessionsVal, ok := obj["sessions"]
+	if !ok {
+		t.Fatalf("expected 'sessions' key in output")
+	}
+	_ = sessionsVal // type check not needed here
+	if _, ok := obj["truncated"]; !ok {
+		t.Errorf("expected 'truncated' key in output")
+	}
+
+	// Find our session by re-marshalling.
+	data, _ := json.Marshal(sessionsVal)
 	var sessions []db.Status
-	if err := json.Unmarshal([]byte(trimmed), &sessions); err != nil {
-		t.Fatalf("--json output is not valid JSON array: %v\noutput: %s", err, out)
+	if err := json.Unmarshal(data, &sessions); err != nil {
+		t.Fatalf("sessions is not a valid []db.Status: %v", err)
 	}
 	if len(sessions) == 0 {
 		t.Error("expected at least 1 session")

--- a/modules/programs/prism/prism/cmd/merges.go
+++ b/modules/programs/prism/prism/cmd/merges.go
@@ -155,8 +155,9 @@ type mergeJSONRow struct {
 	InstanceID         string  `json:"instance_id"`
 }
 
-// renderMergesListJSON marshals merges to a JSON array (snake_case keys,
-// RFC3339 timestamps) and writes it to stdout. An empty list renders as `[]`.
+// renderMergesListJSON marshals merges to a JSON object with a `merges` array
+// (snake_case keys, RFC3339 timestamps) and a `truncated` bool.
+// An empty list renders with `"merges":[]` and `"truncated":false`.
 func renderMergesListJSON(merges []db.PendingMerge) error {
 	rows := make([]mergeJSONRow, 0, len(merges))
 	for _, m := range merges {
@@ -184,7 +185,14 @@ func renderMergesListJSON(merges []db.PendingMerge) error {
 		}
 		rows = append(rows, row)
 	}
-	data, err := json.Marshal(rows)
+	out := struct {
+		Merges    []mergeJSONRow `json:"merges"`
+		Truncated bool           `json:"truncated"`
+	}{
+		Merges:    rows,
+		Truncated: false, // merge queue is never implicitly capped
+	}
+	data, err := json.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("prism merges list --json: marshal: %w", err)
 	}

--- a/modules/programs/prism/prism/cmd/merges_json_test.go
+++ b/modules/programs/prism/prism/cmd/merges_json_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestRenderMergesListJSON_EmptyArray verifies that an empty merge queue
-// renders as a bare JSON array "[]" (never null, never absent — AC #1499).
+// renders as a JSON object with an empty merges array and truncated:false.
 func TestRenderMergesListJSON_EmptyArray(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := renderMergesListJSON(nil); err != nil {
@@ -20,9 +20,20 @@ func TestRenderMergesListJSON_EmptyArray(t *testing.T) {
 		}
 	})
 
-	trimmed := strings.TrimSpace(out)
-	if trimmed != "[]" {
-		t.Errorf("expected empty JSON array '[]' for empty merges list, got %q", trimmed)
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	mergesVal, ok := obj["merges"]
+	if !ok {
+		t.Fatalf("expected 'merges' key in output, got %s", out)
+	}
+	arr, ok := mergesVal.([]interface{})
+	if !ok || len(arr) != 0 {
+		t.Errorf("expected empty merges array, got %v", mergesVal)
+	}
+	if truncated, _ := obj["truncated"].(bool); truncated {
+		t.Errorf("expected truncated:false for empty list")
 	}
 }
 
@@ -50,15 +61,23 @@ func TestRenderMergesListJSON_SnakeCaseKeysAndRFC3339(t *testing.T) {
 		}
 	})
 
-	var rows []map[string]interface{}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
-		t.Fatalf("output is not a valid JSON array: %v\noutput: %s", err, out)
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
 	}
-	if len(rows) != 1 {
-		t.Fatalf("expected 1 row, got %d", len(rows))
+	rowsVal, ok := obj["merges"]
+	if !ok {
+		t.Fatalf("expected 'merges' key in output")
+	}
+	rowsArr, ok := rowsVal.([]interface{})
+	if !ok || len(rowsArr) != 1 {
+		t.Fatalf("expected 1 row in merges array, got %v", rowsVal)
 	}
 
-	row := rows[0]
+	row, ok := rowsArr[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("merges[0] is not an object")
+	}
 
 	// Required snake_case keys.
 	for _, k := range []string{"queue_position", "pr", "title", "status", "error", "enqueued_at", "last_checked_at", "merged_at", "ended_at", "coordinator_session", "instance_id"} {

--- a/modules/programs/prism/prism/cmd/prompt.go
+++ b/modules/programs/prism/prism/cmd/prompt.go
@@ -56,7 +56,7 @@ uses prompt_async and does not support delivery modes.`,
 
 func init() {
 	addPromptFlags(promptCmd)
-	promptCmd.Flags().String("deliver-as", "steer", `Delivery mode for socket-pipe (PI) sessions: steer, followUp, nextTurn. Default "steer" injects the prompt mid-turn for immediate visibility. No-op for opencode (HTTP) sessions.`)
+	promptCmd.Flags().String("deliver-as", "steer", `Delivery mode for socket-pipe (PI) sessions: steer (mid-turn), followUp, or nextTurn. No-op for opencode (HTTP) sessions.`)
 	rootCmd.AddCommand(promptCmd)
 }
 

--- a/modules/programs/prism/prism/cmd/prompt_input.go
+++ b/modules/programs/prism/prism/cmd/prompt_input.go
@@ -23,18 +23,11 @@ import (
 func addPromptFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"prompt", "",
-		"Text to send to the agent.\n"+
-			"    Wrap values containing shell metacharacters in single quotes:\n"+
-			"      --prompt 'run `gh pr view 42` and review the diff'\n"+
-			"    The literal value \"-\" is reserved: it reads the prompt from stdin.\n"+
-			"      echo 'my prompt' | prism ... --prompt -\n"+
-			"    Use --prompt-file to read from a file (safest for complex prompts).",
+		"Text to send to the agent. Use --prompt-file for complex strings or to avoid shell-escaping issues.",
 	)
 	cmd.Flags().String(
 		"prompt-file", "",
-		"Path to a file containing the prompt text.\n"+
-			"    Mutually exclusive with --prompt.\n"+
-			"    Internal newlines are preserved; a single trailing newline is stripped.",
+		"Path to a file containing the prompt text. Mutually exclusive with --prompt.",
 	)
 	cmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
 }

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -62,10 +62,10 @@ func init() {
 	reviewCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	reviewCmd.Flags().Int("diff-inline-max", 0,
 		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
-	reviewCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro); takes precedence over --model for the named role")
-	reviewCmd.Flags().Bool("rebase", false, "Fetch origin/main, rebase HEAD onto it, and force-push before running the review (inline fix for the rebase-gate refusal)")
-	reviewCmd.Flags().Bool("wait", false, "Block until the review group reaches a terminal state (all-PASS, any-FAIL, or no-start). Without --wait, returns immediately and the monitor delivers results later via prism prompt.")
-	reviewCmd.Flags().Duration("wait-timeout", defaultReviewWaitTimeout, "Timeout for --wait. On expiry, exits non-zero with a status payload distinguishable from a real review failure. Ignored when --wait is not set.")
+	reviewCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
+	reviewCmd.Flags().Bool("rebase", false, "Fetch origin/main, rebase HEAD onto it, and force-push before running the review")
+	reviewCmd.Flags().Bool("wait", false, "Block until the review group reaches a terminal state (all-PASS, any-FAIL, or no-start)")
+	reviewCmd.Flags().Duration("wait-timeout", defaultReviewWaitTimeout, "Timeout for --wait. Ignored when --wait is not set.")
 	reviewCmd.Flags().Bool("json", false, "Emit the terminal verdict as a JSON object on stdout (only useful with --wait). Suppresses textual output.")
 	rootCmd.AddCommand(reviewCmd)
 }

--- a/modules/programs/prism/prism/cmd/sessions.go
+++ b/modules/programs/prism/prism/cmd/sessions.go
@@ -119,7 +119,14 @@ func renderSessionsListJSON(sessions []db.Session) error {
 		}
 		rows = append(rows, row)
 	}
-	data, err := json.Marshal(rows)
+	out := struct {
+		Sessions  []sessionJSONRow `json:"sessions"`
+		Truncated bool             `json:"truncated"`
+	}{
+		Sessions:  rows,
+		Truncated: false, // sessions list is never implicitly capped
+	}
+	data, err := json.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("sessions list: marshal: %w", err)
 	}

--- a/modules/programs/prism/prism/cmd/sessions_test.go
+++ b/modules/programs/prism/prism/cmd/sessions_test.go
@@ -129,8 +129,8 @@ func TestRunSessionsList_SinceFilter(t *testing.T) {
 	}
 }
 
-// TestRunSessionsList_JSONOutput verifies that --json emits a JSON array of
-// session-incarnation objects with snake_case keys (issue #1499).
+// TestRunSessionsList_JSONOutput verifies that --json emits a JSON object
+// with a sessions array and truncated bool (issue #1502).
 func TestRunSessionsList_JSONOutput(t *testing.T) {
 	d := openIncarnationTestDB(t)
 	base := time.Now().Truncate(time.Second)
@@ -153,16 +153,31 @@ func TestRunSessionsList_JSONOutput(t *testing.T) {
 		}
 	})
 
-	var rows []map[string]interface{}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &rows); err != nil {
-		t.Fatalf("--json output is not a valid JSON array: %v\noutput: %s", err, out)
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\noutput: %s", err, out)
 	}
-	if len(rows) != 2 {
-		t.Errorf("expected 2 rows in JSON array, got %d\n%s", len(rows), out)
+	if _, ok := obj["truncated"]; !ok {
+		t.Errorf("expected 'truncated' key in output")
+	}
+	rowsVal, ok := obj["sessions"]
+	if !ok {
+		t.Fatalf("expected 'sessions' key in output")
+	}
+	rowsArr, ok := rowsVal.([]interface{})
+	if !ok {
+		t.Fatalf("sessions is not an array")
+	}
+	if len(rowsArr) != 2 {
+		t.Errorf("expected 2 rows in JSON array, got %d\n%s", len(rowsArr), out)
 	}
 	// Required snake_case fields must be present on every row (null is OK
 	// for optional fields, but the keys themselves must be there).
-	for i, row := range rows {
+	for i, r := range rowsArr {
+		row, ok := r.(map[string]interface{})
+		if !ok {
+			t.Fatalf("row %d is not an object", i)
+		}
 		for _, field := range []string{"instance_id", "session_name", "repo", "harness", "started_at", "ended_at", "end_state", "archive_path", "agent_role", "root_agent_name", "harness_session_id", "group_id", "prism_version"} {
 			if _, ok := row[field]; !ok {
 				t.Errorf("row %d missing required snake_case JSON field %q\n%s", i, field, out)
@@ -178,8 +193,7 @@ func TestRunSessionsList_JSONOutput(t *testing.T) {
 }
 
 // TestRunSessionsList_JSONOutput_Empty verifies that --json with no sessions
-// emits an empty JSON array "[]", never null and never absent (AC: empty
-// list is `[]`).
+// emits a JSON object with an empty sessions array and truncated:false.
 func TestRunSessionsList_JSONOutput_Empty(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := renderSessionsListJSON(nil); err != nil {
@@ -187,9 +201,20 @@ func TestRunSessionsList_JSONOutput_Empty(t *testing.T) {
 		}
 	})
 
-	trimmed := strings.TrimSpace(out)
-	if trimmed != "[]" {
-		t.Errorf("expected empty JSON array '[]' for empty sessions list, got: %q", trimmed)
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	rowsVal, ok := obj["sessions"]
+	if !ok {
+		t.Fatalf("expected 'sessions' key in output")
+	}
+	arr, ok := rowsVal.([]interface{})
+	if !ok || len(arr) != 0 {
+		t.Errorf("expected empty sessions array, got %v", rowsVal)
+	}
+	if truncated, _ := obj["truncated"].(bool); truncated {
+		t.Errorf("expected truncated:false for empty list")
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -252,13 +252,13 @@ func init() {
 	spawnCmd.Flags().StringArray("abtest", nil, "A/B test: spawn two sessions with the given profile names (e.g. --abtest profileA --abtest profileB); mutually exclusive with --profile")
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
-	spawnCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro); takes precedence over --model for the named role")
+	spawnCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
 	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().String("harness", "opencode", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
-	spawnCmd.Flags().Bool("wait", false, "Block until the spawned agent finishes its initial prompt (state transitions to finished or error). Without --wait, returns immediately and the agent runs in the background.")
-	spawnCmd.Flags().Duration("wait-timeout", defaultSpawnWaitTimeout, "Timeout for --wait. On expiry, exits non-zero with a status payload distinguishable from a real spawn failure. Ignored when --wait is not set.")
-	spawnCmd.Flags().Bool("json", false, "Emit the terminal status as a JSON object on stdout (only useful with --wait or to script over the spawn output). Suppresses textual output.")
+	spawnCmd.Flags().Bool("wait", false, "Block until the spawned agent finishes its initial prompt. Without --wait, returns immediately.")
+	spawnCmd.Flags().Duration("wait-timeout", defaultSpawnWaitTimeout, "Timeout for --wait. Ignored when --wait is not set.")
+	spawnCmd.Flags().Bool("json", false, "Emit the terminal status as a JSON object on stdout (only useful with --wait). Suppresses textual output.")
 	spawnCmd.Flags().Bool("reuse", false, "If a healthy session already exists on the requested branch, return its details and exit 0 instead of failing")
 	// --prompt-source is an internal flag used by the host-API /spawn handler
 	// to override the auto-detected prompt source (C.4.SRC, issue #1148).

--- a/modules/programs/prism/prism/cmd/stats_aggregate.go
+++ b/modules/programs/prism/prism/cmd/stats_aggregate.go
@@ -43,13 +43,15 @@ func runStatsIncarnations(repoFilter string, sinceMs int64, jsonMode bool) error
 		if sessions == nil {
 			sessions = []db.Session{}
 		}
-		out := map[string]any{"sessions": sessions}
+		out := map[string]any{
+			"sessions":  sessions,
+			"truncated": false,
+		}
 		data, merr := json.Marshal(out)
 		if merr != nil {
 			return fmt.Errorf("stats --json: marshal sessions: %w", merr)
 		}
-		fmt.Println(string(data))
-		return nil
+		return printJSON(data)
 	}
 
 	// Direct-DB path: render with token/cost data from the DB.


### PR DESCRIPTION
Closes #1502

## Changes

### Truncation metadata on list commands
- **`prism audit --json`** — already had `truncated`/`hint` from #1499; confirmed working
- **`prism stats --json`** — wraps the sessions array in `{sessions:[...], truncated:false}`
- **`prism merges list --json`** — wraps array in `{merges:[...], truncated:false}`
- **`prism sessions list --json`** — wraps array in `{sessions:[...], truncated:false}`
- **`prism list-sessions --json`** (hidden alias) — same wrapper
- **`prism checkin --json`** — adds `truncated` bool; when true adds `hint` and `next_before` (oldest event ID for backward paging via `--before`)

### Tightened --help flag descriptions
- `prompt_input.go`: `--prompt` and `--prompt-file` reduced to single lines
- `spawn.go`: `--wait`, `--wait-timeout`, `--json`, `--model-override` each reduced to 1 line
- `review.go`: `--wait`, `--wait-timeout`, `--rebase`, `--model-override` each reduced to 1 line
- `prompt.go`: `--deliver-as` tightened to 1 line

The prompt-escaping guidance removed from `--help` already lives in the prism SKILL.md under "Passing prompts safely — shell escaping" (added by prior PRs).

### Tests
Updated `merges_json_test.go`, `sessions_test.go`, `list_sessions_json_test.go`, and `checkin_json_test.go` for the new object-wrapped shapes. Added `truncated` key assertion to checkin JSON test.
