### PR TITLE
sidecar: per-turn body-bearing notifications for investigate-agent sessions

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -905,6 +905,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Isolation             string   `json:"isolation"`
 			Harness               string   `json:"harness"`
 			IgnoreConcurrencyCap  bool     `json:"ignore_concurrency_cap"`
+			Reuse                 bool     `json:"reuse"`
 			ModelVariantOverrides string   `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
 			Abtest                []string `json:"abtest"`                  // two-element array of profile names; see #1330
 		}
@@ -1034,6 +1035,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.IgnoreConcurrencyCap {
 			args = append(args, "--ignore-concurrency-cap")
 		}
+		if req.Reuse {
+			args = append(args, "--reuse")
+		}
 		// Forward per-role model overrides as repeating --model-override flags.
 		for role, model := range modelsByRole {
 			args = append(args, "--model-override", role+"="+model)
@@ -1069,6 +1073,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.IgnoreConcurrencyCap {
 			logArgs = append(logArgs, "--ignore-concurrency-cap")
+		}
+		if req.Reuse {
+			logArgs = append(logArgs, "--reuse")
 		}
 		for role, model := range modelsByRole {
 			logArgs = append(logArgs, "--model-override", role+"="+model)

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -34,9 +34,89 @@ func reviewAgentParentSession(sessionName string) (string, bool) {
 	return sessionName[:idx], true
 }
 
+// investigateAgentInvokerSession derives the invoker session name from an
+// investigate-agent session name. Investigate-agent sessions follow the naming
+// convention:
+//
+//	<invoker>~investigate-<slug>   e.g. nixos-config@main~investigate-abc123
+//
+// The invoker session name is the prefix before "~investigate".
+// Returns ("", false) when the session name does not contain "~investigate".
+func investigateAgentInvokerSession(sessionName string) (string, bool) {
+	idx := strings.Index(sessionName, "~investigate")
+	if idx < 0 {
+		return "", false
+	}
+	return sessionName[:idx], true
+}
+
+// notifyInvestigatorTurnEnd delivers a body-bearing per-turn notification from
+// an investigate-agent session to its recorded invoker session. It is called
+// asynchronously (via go) after each turn_end that carries a non-empty closing
+// assistant text block, so s.mu must NOT be held.
+//
+// Delivery uses promptdelivery.DeliverToSession with deliverAs="followUp" so
+// that the notification queues behind any in-flight invoker turn rather than
+// being dropped.
+//
+// The notification body contains:
+//   - A sender header: "From investigator session: <name>"
+//   - The final assistant text block of the turn, verbatim.
+//   - A steering-channel hint: "Reply with: prism prompt <name> --prompt '...'"
+//
+// When the invoker session has ended, the notification is dropped silently with
+// a structured log line. When delivery fails, the failure is logged with both
+// session names; the investigator keeps running.
+func (s *Sidecar) notifyInvestigatorTurnEnd(text string) {
+	invokerSession, isInvestigate := investigateAgentInvokerSession(s.cfg.SessionName)
+	if !isInvestigate {
+		// Not an investigate-agent session — nothing to do.
+		return
+	}
+
+	// Trim the text block; skip delivery when empty after trim.
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: empty text block — skipping (investigator=%s invoker=%s)",
+			s.cfg.SessionName, invokerSession)
+		return
+	}
+
+	// Look up the invoker session.
+	invokerStatus, err := s.cfg.DB.CurrentStatus(invokerSession)
+	if err != nil {
+		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: DB lookup for invoker %q: %v — skipping (investigator=%s)",
+			invokerSession, err, s.cfg.SessionName)
+		return
+	}
+	if invokerStatus == nil {
+		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: invoker session %q not found in DB — skipping (investigator=%s)",
+			invokerSession, s.cfg.SessionName)
+		return
+	}
+	if invokerStatus.EndedAt != nil {
+		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: invoker session %q has ended — dropping notification (investigator=%s reason=invoker_ended)",
+			invokerSession, s.cfg.SessionName)
+		return
+	}
+
+	// Build the notification body.
+	body := fmt.Sprintf(
+		"From investigator session: %s\n\n%s\n\nReply with: prism prompt %s --prompt '...'",
+		s.cfg.SessionName, trimmed, s.cfg.SessionName,
+	)
+
+	if err := promptdelivery.DeliverToSession(invokerSession, invokerStatus, body, buildNotifyPromptBody, "", "followUp"); err != nil {
+		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: FAILED — investigator=%s invoker=%s reason=%v",
+			s.cfg.SessionName, invokerSession, err)
+		return
+	}
+	s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: delivered to invoker=%s (investigator=%s)",
+		invokerSession, s.cfg.SessionName)
+}
+
 // notifyParentWorkerOnStartupFailure sends a notification to the parent worker
 // when a review-agent container fails to start. It is called asynchronously via
-// go from writeStartupError, so s.mu must NOT be held.
 //
 // If the parent worker session cannot be found or has ended, the failure is
 // logged and the sidecar exits cleanly (the notification failure is not fatal).
@@ -175,6 +255,14 @@ func (s *Sidecar) notifyCoordinator() {
 	// as noise notifications.
 	if isReviewAgentSession(s.cfg.SessionName, s.cfg.DB, s.logger()) {
 		s.logger().Printf("sidecar: notifyCoordinator: suppressed for review-agent session %s", s.cfg.SessionName)
+		return
+	}
+
+	// Investigate-agent guard: investigate-agent sessions deliver per-turn
+	// body-bearing notifications to their invoker (via notifyInvestigatorTurnEnd)
+	// and must not also emit a bare "has finished" notification to the coordinator.
+	if _, isInvestigate := investigateAgentInvokerSession(s.cfg.SessionName); isInvestigate {
+		s.logger().Printf("sidecar: notifyCoordinator: suppressed for investigate-agent session %s (bare_finish suppressed)", s.cfg.SessionName)
 		return
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
@@ -1,0 +1,466 @@
+package sidecar
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness/opencode"
+)
+
+// seedSessionWithHarnessPort seeds an agent_status row for sessionName with a
+// harness_port and harness_session_id. Used to set up invoker sessions that
+// accept HTTP-based prompt delivery.
+func seedSessionWithHarnessPort(t *testing.T, database *db.DB, sessionName, repo, sid string, port int) {
+	t.Helper()
+	agentName := "coordinator"
+	modelID := "anthropic/claude-sonnet-4-5"
+	if err := database.UpsertStatusWithAgent(sessionName, repo, "/tmp/test-worktree", "active", nil, &sid, &agentName, &modelID); err != nil {
+		t.Fatalf("seedSessionWithHarnessPort: UpsertStatusWithAgent(%q): %v", sessionName, err)
+	}
+	if err := database.QueryRow(
+		"UPDATE agent_status SET harness_port = ?, harness_session_id = ? WHERE session_name = ? RETURNING session_name",
+		port, sid, sessionName,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("seedSessionWithHarnessPort: set port/sid for %q: %v", sessionName, err)
+	}
+}
+
+// seedEndedSession seeds an agent_status row with ended_at set.
+func seedEndedSession(t *testing.T, database *db.DB, sessionName, repo string) {
+	t.Helper()
+	agentName := "coordinator"
+	modelID := "anthropic/claude-sonnet-4-5"
+	if err := database.UpsertStatusWithAgent(sessionName, repo, "/tmp/test-worktree", "finished", nil, nil, &agentName, &modelID); err != nil {
+		t.Fatalf("seedEndedSession: UpsertStatusWithAgent(%q): %v", sessionName, err)
+	}
+	// Use Unix millisecond timestamp so SQLite can scan it as int64.
+	nowMs := time.Now().UnixMilli()
+	if err := database.QueryRow(
+		"UPDATE agent_status SET ended_at = ? WHERE session_name = ? RETURNING session_name",
+		nowMs, sessionName,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("seedEndedSession: set ended_at for %q: %v", sessionName, err)
+	}
+}
+
+// ── investigateAgentInvokerSession ──────────────────────────────────────────
+
+func TestInvestigateAgentInvokerSession(t *testing.T) {
+	cases := []struct {
+		name        string
+		sessionName string
+		wantInvoker string
+		wantOK      bool
+	}{
+		{
+			name:        "standard investigate session",
+			sessionName: "nixos-config@main~investigate-abc123",
+			wantInvoker: "nixos-config@main",
+			wantOK:      true,
+		},
+		{
+			name:        "investigate session with longer slug",
+			sessionName: "myrepo@feature~investigate-task-abc",
+			wantInvoker: "myrepo@feature",
+			wantOK:      true,
+		},
+		{
+			name:        "review session — not investigate",
+			sessionName: "myrepo@feature~review-2-review-goal",
+			wantInvoker: "",
+			wantOK:      false,
+		},
+		{
+			name:        "plain worker session",
+			sessionName: "myrepo@feature",
+			wantInvoker: "",
+			wantOK:      false,
+		},
+		{
+			name:        "coordinator session",
+			sessionName: "myrepo@main",
+			wantInvoker: "",
+			wantOK:      false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := investigateAgentInvokerSession(tc.sessionName)
+			if ok != tc.wantOK {
+				t.Errorf("investigateAgentInvokerSession(%q): ok=%v want %v", tc.sessionName, ok, tc.wantOK)
+			}
+			if got != tc.wantInvoker {
+				t.Errorf("investigateAgentInvokerSession(%q): invoker=%q want %q", tc.sessionName, got, tc.wantInvoker)
+			}
+		})
+	}
+}
+
+// ── notifyInvestigatorTurnEnd ────────────────────────────────────────────────
+
+// TestNotifyInvestigatorTurnEnd_Delivery verifies that a body-bearing per-turn
+// notification is delivered to the invoker session when the turn ends with a
+// non-empty assistant text block. The notification body must contain the
+// sender label, the text block verbatim, and the steering-channel hint.
+func TestNotifyInvestigatorTurnEnd_Delivery(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	invokerSession := repo + "@main"
+	investigatorSession := invokerSession + "~investigate-testslug"
+	invokerSID := "invoker-sid-001"
+
+	var mu sync.Mutex
+	var receivedBodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
+			body := make([]byte, 4096)
+			n, _ := r.Body.Read(body)
+			mu.Lock()
+			receivedBodies = append(receivedBodies, string(body[:n]))
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-test-wt",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	const turnText = "I have found the root cause. The issue is in package X."
+	s.notifyInvestigatorTurnEnd(turnText)
+
+	// Allow async HTTP call to complete.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(receivedBodies)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(receivedBodies) != 1 {
+		t.Fatalf("want 1 delivery, got %d", len(receivedBodies))
+	}
+	body := receivedBodies[0]
+
+	// The body is a JSON-encoded prompt_async payload; the text is inside.
+	// Check that all required elements are present in the delivered payload.
+	if !strings.Contains(body, "From investigator session: "+investigatorSession) {
+		t.Errorf("notification body missing sender label; got: %s", body)
+	}
+	if !strings.Contains(body, turnText) {
+		t.Errorf("notification body missing verbatim text block; got: %s", body)
+	}
+	if !strings.Contains(body, "prism prompt "+investigatorSession+" --prompt") {
+		t.Errorf("notification body missing steering-channel hint; got: %s", body)
+	}
+}
+
+// TestNotifyInvestigatorTurnEnd_EmptyText verifies that no notification is
+// delivered when the text block is empty or whitespace-only.
+func TestNotifyInvestigatorTurnEnd_EmptyText(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	invokerSession := repo + "@main"
+	investigatorSession := invokerSession + "~investigate-testslug"
+
+	var delivered int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			delivered++
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedSessionWithHarnessPort(t, d, invokerSession, repo, "sid-empty", srvPort)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-test-empty",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	// Empty string — no delivery.
+	s.notifyInvestigatorTurnEnd("")
+	// Whitespace-only — no delivery.
+	s.notifyInvestigatorTurnEnd("   \n\t  ")
+
+	// Give any async delivery a chance (there should be none).
+	time.Sleep(50 * time.Millisecond)
+
+	if delivered > 0 {
+		t.Errorf("expected no delivery for empty/whitespace text, got %d", delivered)
+	}
+}
+
+// TestNotifyInvestigatorTurnEnd_InvokerEnded verifies that the notification is
+// dropped silently (no panic, no delivery) when the invoker session has ended.
+func TestNotifyInvestigatorTurnEnd_InvokerEnded(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	invokerSession := repo + "@main"
+	investigatorSession := invokerSession + "~investigate-ended"
+
+	var delivered int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			delivered++
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	seedEndedSession(t, d, invokerSession, repo)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-test-ended",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	s.notifyInvestigatorTurnEnd("some findings here")
+	time.Sleep(50 * time.Millisecond)
+
+	if delivered > 0 {
+		t.Errorf("expected no delivery when invoker has ended, got %d", delivered)
+	}
+}
+
+// TestNotifyInvestigatorTurnEnd_NotInvestigateSession verifies that a session
+// NOT named with ~investigate does NOT trigger any delivery.
+func TestNotifyInvestigatorTurnEnd_NotInvestigateSession(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+
+	var delivered int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			delivered++
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clk := newTestClock()
+	cfg := Config{
+		// A plain worker session — no ~investigate in the name.
+		SessionName: repo + "@feature",
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-test-not-investigate",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	s.notifyInvestigatorTurnEnd("some text that should not be delivered")
+	time.Sleep(50 * time.Millisecond)
+
+	if delivered > 0 {
+		t.Errorf("expected no delivery for non-investigate session, got %d", delivered)
+	}
+}
+
+// TestNotifyCoordinator_InvestigateAgentSuppressed verifies that an
+// investigate-agent session does NOT emit a bare "has finished" notification
+// to the coordinator.
+func TestNotifyCoordinator_InvestigateAgentSuppressed(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	coordSID := "coord-sid-investigate-suppressed"
+
+	var notifyCount int
+	var notifyMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"` + coordSID + `"}]`))
+			return
+		}
+		notifyMu.Lock()
+		notifyCount++
+		notifyMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedCoordinatorWithPort(t, d, repo, srvPort, coordSID)
+
+	clk := newTestClock()
+	investigatorSession := repo + "@main~investigate-abc"
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-coord-suppressed",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	// Directly call notifyCoordinator — it should be suppressed.
+	s.notifyCoordinator()
+
+	time.Sleep(100 * time.Millisecond)
+
+	notifyMu.Lock()
+	count := notifyCount
+	notifyMu.Unlock()
+
+	if count != 0 {
+		t.Errorf("investigate-agent should not emit bare_finish notification; got %d notifications", count)
+	}
+}
+
+// TestNotifyInvestigatorTurnEnd_ConcurrentDelivery verifies that two concurrent
+// investigator sessions can deliver to the same invoker without mangling each
+// other's sender labels.
+func TestNotifyInvestigatorTurnEnd_ConcurrentDelivery(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	invokerSession := repo + "@main"
+	investigator1 := invokerSession + "~investigate-alpha"
+	investigator2 := invokerSession + "~investigate-beta"
+	invokerSID := "invoker-sid-concurrent"
+
+	var mu sync.Mutex
+	var receivedBodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
+			body := make([]byte, 4096)
+			n, _ := r.Body.Read(body)
+			mu.Lock()
+			receivedBodies = append(receivedBodies, string(body[:n]))
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+
+	clk := newTestClock()
+	cfg1 := Config{
+		SessionName: investigator1,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-concurrent-1",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	cfg2 := Config{
+		SessionName: investigator2,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-concurrent-2",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s1 := New(cfg1)
+	s2 := New(cfg2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); s1.notifyInvestigatorTurnEnd("alpha findings") }()
+	go func() { defer wg.Done(); s2.notifyInvestigatorTurnEnd("beta findings") }()
+	wg.Wait()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(receivedBodies)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	bodies := make([]string, len(receivedBodies))
+	copy(bodies, receivedBodies)
+	mu.Unlock()
+
+	if len(bodies) != 2 {
+		t.Fatalf("want 2 deliveries, got %d", len(bodies))
+	}
+
+	// Each body must contain the correct sender label.
+	foundAlpha, foundBeta := false, false
+	for _, body := range bodies {
+		if strings.Contains(body, "From investigator session: "+investigator1) {
+			foundAlpha = true
+		}
+		if strings.Contains(body, "From investigator session: "+investigator2) {
+			foundBeta = true
+		}
+	}
+	if !foundAlpha {
+		t.Errorf("alpha investigator label not found in any delivery; bodies: %v", bodies)
+	}
+	if !foundBeta {
+		t.Errorf("beta investigator label not found in any delivery; bodies: %v", bodies)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1229,9 +1229,16 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 					s.mu.Unlock()
 				case "turn_end":
 					s.mu.Lock()
+					turnText := ""
+					if s.pipeAccum != nil {
+						turnText = *s.pipeAccum
+					}
 					stdioFlushPipeAccum(s, line)
 					s.writeEvent(frame.Type, json.RawMessage(line), nil)
 					s.mu.Unlock()
+					if turnText != "" {
+						go s.notifyInvestigatorTurnEnd(turnText)
+					}
 				}
 				continue
 			}
@@ -1296,9 +1303,16 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 
 		case "turn_end":
 			s.mu.Lock()
+			turnText := ""
+			if s.pipeAccum != nil {
+				turnText = *s.pipeAccum
+			}
 			stdioFlushPipeAccum(s, line)
 			s.writeEvent(frame.Type, json.RawMessage(line), nil)
 			s.mu.Unlock()
+			if turnText != "" {
+				go s.notifyInvestigatorTurnEnd(turnText)
+			}
 
 		case "state_change":
 			st := agent.AgentState(frame.State)
@@ -1943,6 +1957,11 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 			s.writeEvent("msg_assistant", p, nil)
 		}
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
+		// Notify the invoker after the turn_end frame is persisted. Runs async
+		// so that lock-release from handlePipeFrame happens promptly.
+		if text != "" {
+			go s.notifyInvestigatorTurnEnd(text)
+		}
 
 	case "auto_retry_start":
 		// Gap 6: cancel any in-flight finished debounce so the session does not


### PR DESCRIPTION
Closes #1450. Refs #1448.

## Summary

Implements the sidecar half of `prism investigate`: a body-bearing per-turn notification mode that fires each time an investigate-agent session completes a turn with a closing assistant text block.

## Storage approach: naming convention (option b)

Chose naming convention (`<invoker>~investigate-<slug>`) over DB columns because:
1. Mirrors the existing `reviewAgentParentSession` pattern — zero new infrastructure
2. Avoids a DB migration
3. Invoker is structurally immutable (embedded in session name at spawn time)
4. Security AC satisfied: delivery goes to the prefix extracted from the session name, not a caller-supplied value

## Changes

### `notify.go`
- `investigateAgentInvokerSession()`: derives invoker from `<invoker>~investigate-<slug>` (mirrors `reviewAgentParentSession`)
- `notifyInvestigatorTurnEnd(text)`: delivers body-bearing notification with sender label, verbatim text, and steering-channel hint; uses `deliverAs="followUp"` (since #1447 is resolved)
- Guard in `notifyCoordinator()`: investigate-agent sessions skip bare_finish

### `sidecar.go`
- Hooked `go s.notifyInvestigatorTurnEnd(text)` into all three turn_end paths: pi socket-pipe, FrameNormaliser, and legacy stdio

### `host_api.go`
- Added missing `Reuse bool \`json:"reuse"\`` field to `/spawn` request struct — regression from #1561. Wired through to `--reuse` flag in both args and logArgs.

### `notify_investigate_test.go` (new)
Unit tests covering: helper parsing, delivery body shape, empty text suppression, ended-invoker drop, non-investigate session no-op, coordinator bare_finish suppression, concurrent delivery from two investigators.

## Quality gates
- `go build ./...` ✅
- `go test ./...` ✅ (all 27 packages)
- `nix build .#prism` ✅