### PR TITLE
Replace mysql84 with mariadb and add pup to m4mac packages

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -70,7 +70,7 @@ in
       _1password-cli
       arping
       gnutar
-      mysql84
+      mariadb
       podman # darwin doesn't use virtualisation.podman
       postgresql
       rustup
@@ -150,6 +150,7 @@ in
       "ripgrep" # for plenary in neovim, it can't find the nix binary
       "python"
       "vfkit"
+      "datadog-labs/pack/pup"
     ];
     casks = [
       "bitwarden"


### PR DESCRIPTION
Replaced the deprecated mysql84 package with mariadb to ensure ongoing compatibility. Additionally added the pup CLI tool to the system packages to assist with agentic debugging of datadog logs.