### PR TITLE
Fix case sensitivity for Obsidian project path

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -29,7 +29,7 @@ in
         harness.default = "pi";
         agent.isolation.default = "sandbox-exec";
         projects.isolationOverrides = {
-          "~/documents/obsidian" = "host";
+          "~/Documents/obsidian" = "host";
         };
       };
       # Disable programs that default to enabled but aren't needed/available on Darwin


### PR DESCRIPTION
Update the ~/Documents/obsidian path to use the correct casing for the directory on macOS. This ensures the isolation override is correctly applied to the user's vault.