### PR TITLE
Update Google Gemini model identifiers to stable versions

### DIFF
--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -236,22 +236,22 @@
             google = profileFromTiers {
               primary = slot {
                 provider = "google";
-                model = "google/gemini-3-flash-preview";
+                model = "google/gemini-3-flash";
               };
               secondary = slot {
                 provider = "google";
-                model = "google/gemini-3.1-flash-lite-preview";
+                model = "google/gemini-3.1-flash-lite";
               };
               lightweight = slot {
                 provider = "google";
-                model = "google/gemini-3.1-flash-lite-preview";
+                model = "google/gemini-3.1-flash-lite";
               };
             };
           };
 
           quickProfiles = {
             pr = {
-              model = "google/gemini-3.1-flash-lite-preview";
+              model = "google/gemini-3.1-flash-lite";
               providerOrder = [
                 "google"
                 "google-vertex"


### PR DESCRIPTION
This change updates the Google model identifiers in the prism profiles configuration by removing the "-preview" suffix. These updates ensure the use of production-ready model strings as the preview variants are deprecated or superseded.