### PR TITLE
sandbox-exec: fix sops rotation for access-key, .aws/config, .aws/credentials, .kube/config (#1573)

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -131,22 +131,6 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		}
 	}
 
-	// ── Helper: conditionally create symlink if EvalSymlinks succeeds ────────
-	// Used for paths where symlink resolution is required (e.g. Nix store
-	// paths that are themselves symlinks). The symlink points at the resolved
-	// real path so the SBPL profile can allow that literal path.
-	symlinkIfResolvable := func(src, dst string) (resolvedSrc string) {
-		resolved, err := filepath.EvalSymlinks(src)
-		if err != nil {
-			return "" // source does not resolve — skip
-		}
-		if err := makeSymlink(resolved, dst); err != nil {
-			log.Printf("container: sandbox-exec: symlink %s → %s: %v", dst, resolved, err)
-			return ""
-		}
-		return resolved
-	}
-
 	// ── SSH keys ──────────────────────────────────────────────────────────────
 	// Mirror bwrap.go:369-388: resolve via EvalSymlinks and mount at generic
 	// canonical names under $HOME/.ssh/.
@@ -156,7 +140,26 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	if accessKeyName == "" {
 		accessKeyName = "prismatic-koi-ed25519"
 	}
-	symlinkIfResolvable(
+	// Use symlinkIfExists (not symlinkIfResolvable) for the access key so that
+	// the staging HOME symlink points at the stable intermediate sops symlink
+	// (~/.ssh/<accessKeyName>) rather than the fully-resolved sops temp path
+	// (e.g. /private/var/folders/.../secrets.d/<N>/...).
+	//
+	// On Darwin, the access key is managed by sops-nix and its concrete path
+	// rotates on every darwin-rebuild switch (secrets.d/<N>/ increments).
+	// If the staging HOME symlink points at the fully-resolved concrete path,
+	// it becomes dangling after rotation and SSH breaks inside the session
+	// with "Couldn't load public key … No such file or directory" (issue #1573).
+	//
+	// With symlinkIfExists the chain is:
+	//   <stagingHome>/.ssh/access-key
+	//     → ~/.ssh/<accessKeyName>               (stable sops symlink)
+	//     → /private/var/folders/.../secrets.d/<current>/...  (sops resolves this)
+	//
+	// The SBPL profile already grants (allow file-read* (subpath "/private/var/folders"))
+	// so the sandbox can follow the chain to whatever secrets.d/<N> is current,
+	// even after a rotation that occurred after session spawn.
+	symlinkIfExists(
 		filepath.Join(sshDir, accessKeyName),
 		filepath.Join(stagingHome, ".ssh", "access-key"),
 	)
@@ -184,10 +187,6 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// so the sandbox can follow the chain to whatever secrets.d/<N> is current,
 	// even after a rotation that occurred after session spawn.
 	//
-	// Note: symlinkIfResolvable is still used for the access key above because
-	// collectStagingHomeSymlinkTargets resolves the access key symlink to emit
-	// a (literal ...) SBPL rule for it — the access key does not go through
-	// sops and its path does not rotate.
 	symlinkIfExists(
 		filepath.Join(sshDir, signingKeyName),
 		filepath.Join(stagingHome, ".ssh", "signing-key"),
@@ -212,14 +211,21 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	}
 
 	// ── AWS ───────────────────────────────────────────────────────────────────
-	// Match bwrap.go pattern: resolve ~/.config/aws/readonly-config and
-	// ~/.config/aws/credentials via EvalSymlinks; mount ~/.aws/sso and
-	// ~/.aws/cli via os.Stat.
-	symlinkIfResolvable(
+	// Use symlinkIfExists (not symlinkIfResolvable) for the config and
+	// credentials files so the staging HOME symlinks point at the stable
+	// intermediate sops symlinks rather than the fully-resolved concrete path
+	// inside secrets.d/<N>/. On Darwin, darwin-rebuild switch rotates
+	// secrets.d/<N>/ → secrets.d/<N+1>/, invalidating any staging symlink
+	// that captured the old concrete path (issue #1573).
+	//
+	// The SBPL profile already grants (allow file-read* (subpath "/private/var/folders"))
+	// so the sandbox can follow the chain through whatever secrets.d/<current>
+	// is live at read time.
+	symlinkIfExists(
 		filepath.Join(home, ".config", "aws", "readonly-config"),
 		filepath.Join(stagingHome, ".aws", "config"),
 	)
-	symlinkIfResolvable(
+	symlinkIfExists(
 		filepath.Join(home, ".config", "aws", "credentials"),
 		filepath.Join(stagingHome, ".aws", "credentials"),
 	)
@@ -233,7 +239,11 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	)
 
 	// ── Kube ──────────────────────────────────────────────────────────────────
-	symlinkIfResolvable(
+	// Use symlinkIfExists (not symlinkIfResolvable) so the staging symlink
+	// points at the stable intermediate (~/.config/kube/agents-config) rather
+	// than the fully-resolved sops concrete path that rotates on each
+	// darwin-rebuild switch (issue #1573).
+	symlinkIfExists(
 		filepath.Join(home, ".config", "kube", "agents-config"),
 		filepath.Join(stagingHome, ".kube", "config"),
 	)

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -673,9 +673,12 @@ func newFakeHome(t *testing.T) string {
 		}
 	}
 
-	// AWS readonly-config (in XDG location, symlinked by the staging builder).
+	// AWS readonly-config and credentials (in XDG location, symlinked by the staging builder).
 	if err := os.WriteFile(filepath.Join(fakeHome, ".config", "aws", "readonly-config"), []byte("dummy-aws-cfg"), 0o644); err != nil {
 		t.Fatalf("write aws config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fakeHome, ".config", "aws", "credentials"), []byte("dummy-aws-creds"), 0o600); err != nil {
+		t.Fatalf("write aws credentials: %v", err)
 	}
 	// Kube agents-config.
 	if err := os.WriteFile(filepath.Join(fakeHome, ".config", "kube", "agents-config"), []byte("dummy-kube"), 0o644); err != nil {
@@ -921,8 +924,6 @@ func TestPrepareSandboxExecHome_NixCacheAlwaysIncluded(t *testing.T) {
 // rotations (when secrets.d/<N>/ increments), whereas using the resolved path
 // would produce a dangling symlink after the rotation.
 //
-// The access-key symlink is NOT checked here — it still uses symlinkIfResolvable
-// and is expected to point at the resolved real path.
 func TestPrepareSandboxExecHome_SigningKeyUsesIntermediatePath(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
@@ -1065,34 +1066,42 @@ func TestPrepareSandboxExecHome_SigningKeyAbsentNoDanglingSymlink(t *testing.T) 
 	}
 }
 
-// TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath verifies that the
-// access-key symlink in the staging HOME still points at the fully-resolved
-// real path (not an intermediate symlink). This is unchanged from the original
-// behaviour — access-key uses symlinkIfResolvable so that the SBPL profile
-// collectStagingHomeSymlinkTargets can emit a (literal ...) rule for it.
-func TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath(t *testing.T) {
+// TestPrepareSandboxExecHome_AccessKeyUsesIntermediatePath verifies that the
+// access-key symlink in the staging HOME points at the stable intermediate
+// sops symlink (~/.ssh/<accessKeyName>), not the fully-resolved concrete path
+// inside secrets.d/<N>/. This is the fix for issue #1573: on Darwin the access
+// key is managed by sops-nix and its concrete path rotates on each
+// darwin-rebuild switch, so the staging symlink must anchor to the stable
+// intermediate to survive rotations.
+func TestPrepareSandboxExecHome_AccessKeyUsesIntermediatePath(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
-	// Make the access key file a symlink to a "resolved" path, to ensure
-	// symlinkIfResolvable resolves it fully before creating the staging link.
+	// Set up a two-hop chain simulating the sops-managed layout:
+	//   ~/.ssh/prismatic-koi-ed25519  (intermediate)
+	//     → sopsDir1/access-key       (concrete v1)
+	//
+	// After PrepareSandboxExecHome runs, we rotate the intermediate to v2
+	// and verify the staging HOME symlink still resolves.
 	sshDir := filepath.Join(fakeHome, ".ssh")
-	resolvedDir := filepath.Join(fakeHome, "resolved-keys")
-	if err := os.MkdirAll(resolvedDir, 0o700); err != nil {
-		t.Fatalf("create resolved-keys dir: %v", err)
+	sopsDir1 := filepath.Join(fakeHome, "sops-dir-1")
+	if err := os.MkdirAll(sopsDir1, 0o700); err != nil {
+		t.Fatalf("create sops-dir-1: %v", err)
 	}
-	resolvedKey := filepath.Join(resolvedDir, "access-key-real")
-	if err := os.WriteFile(resolvedKey, []byte("access-key-content"), 0o600); err != nil {
-		t.Fatalf("write resolved access key: %v", err)
+	keyPath1 := filepath.Join(sopsDir1, "access-key")
+	if err := os.WriteFile(keyPath1, []byte("access-key-v1"), 0o600); err != nil {
+		t.Fatalf("write access key v1: %v", err)
 	}
-	// Replace the plain access key file with a symlink.
-	_ = os.Remove(filepath.Join(sshDir, "prismatic-koi-ed25519"))
-	if err := os.Symlink(resolvedKey, filepath.Join(sshDir, "prismatic-koi-ed25519")); err != nil {
-		t.Fatalf("symlink access key: %v", err)
+
+	// Replace the plain key file with a symlink pointing at the v1 concrete path.
+	intermediate := filepath.Join(sshDir, "prismatic-koi-ed25519")
+	_ = os.Remove(intermediate)
+	if err := os.Symlink(keyPath1, intermediate); err != nil {
+		t.Fatalf("symlink intermediate access key: %v", err)
 	}
 
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@access-key-test",
-		InstanceID:  "access-key-resolved-test",
+		InstanceID:  "access-key-intermediate-test",
 	})
 
 	stagingHome, err := m.PrepareSandboxExecHome()
@@ -1101,22 +1110,203 @@ func TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// The access-key symlink should point at the fully-resolved path
-	// (symlinkIfResolvable resolves through the intermediate).
+	// The access-key symlink must point at the INTERMEDIATE path, not the
+	// fully-resolved sops-dir-1/access-key path (fix for #1573).
 	accessLink := filepath.Join(stagingHome, ".ssh", "access-key")
 	accessTarget, err := os.Readlink(accessLink)
 	if err != nil {
 		t.Fatalf("access-key is not a symlink: %v", err)
 	}
-	// resolvedKey might itself resolve further on macOS (e.g. /tmp → /private/tmp).
-	expectedTarget, _ := filepath.EvalSymlinks(resolvedKey)
-	if expectedTarget == "" {
-		expectedTarget = resolvedKey
+	if accessTarget != intermediate {
+		t.Errorf("access-key symlink points at %q, want intermediate path %q\n"+
+			"(the symlink must point at the stable sops intermediate, not the resolved concrete path,\n"+
+			"so it stays valid after a sops rotation — issue #1573)",
+			accessTarget, intermediate)
 	}
-	if accessTarget != expectedTarget {
-		t.Errorf("access-key target = %q, want resolved path %q\n"+
-			"(access-key must use symlinkIfResolvable to expose the real path for the SBPL profile)",
-			accessTarget, expectedTarget)
+
+	// Simulate a sops rotation: update the intermediate to point at v2 and
+	// remove v1. The staging HOME symlink must still resolve.
+	sopsDir2 := filepath.Join(fakeHome, "sops-dir-2")
+	if err := os.MkdirAll(sopsDir2, 0o700); err != nil {
+		t.Fatalf("create sops-dir-2: %v", err)
+	}
+	keyPath2 := filepath.Join(sopsDir2, "access-key")
+	if err := os.WriteFile(keyPath2, []byte("access-key-v2"), 0o600); err != nil {
+		t.Fatalf("write access key v2: %v", err)
+	}
+	_ = os.Remove(intermediate)
+	if err := os.Symlink(keyPath2, intermediate); err != nil {
+		t.Fatalf("rotate intermediate to v2: %v", err)
+	}
+	_ = os.RemoveAll(sopsDir1) // simulate rotation removing old secrets.d/<N>
+
+	// After rotation, reads through the staging HOME symlink must succeed.
+	content, err := os.ReadFile(accessLink)
+	if err != nil {
+		t.Fatalf("cannot read access-key through staging HOME after rotation: %v\n"+
+			"(this would break SSH inside running sessions — the fix for #1573)", err)
+	}
+	if string(content) != "access-key-v2" {
+		t.Errorf("access-key after rotation: got %q, want %q", string(content), "access-key-v2")
+	}
+}
+
+// TestPrepareSandboxExecHome_SopsRotation_AllFourSymlinks verifies that the
+// four staging-HOME symlinks introduced by issue #1573 — access-key,
+// .aws/config, .aws/credentials, and .kube/config — survive a sops
+// secrets.d/<N> → secrets.d/<N+1> rotation after PrepareSandboxExecHome has
+// already run.
+//
+// The test follows the same pattern as
+// TestPrepareSandboxExecHome_SigningKeyUsesIntermediatePath (which covers
+// signing-key{,.pub} from issue #1410):
+//  1. Plant v1 concrete files under sopsDir1.
+//  2. Create intermediate symlinks pointing at v1.
+//  3. Run PrepareSandboxExecHome.
+//  4. Verify each staging symlink points at the stable intermediate.
+//  5. Rotate: update the intermediates to point at v2, delete v1.
+//  6. Verify reads through each staging symlink still succeed (resolve to v2).
+func TestPrepareSandboxExecHome_SopsRotation_AllFourSymlinks(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// ── set up v1 concrete files ───────────────────────────────────────
+	sopsDir1 := filepath.Join(fakeHome, "sops-dir-1")
+	if err := os.MkdirAll(filepath.Join(sopsDir1, "aws"), 0o700); err != nil {
+		t.Fatalf("create sops-dir-1/aws: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sopsDir1, "kube"), 0o700); err != nil {
+		t.Fatalf("create sops-dir-1/kube: %v", err)
+	}
+
+	v1Files := map[string]string{
+		"ssh/access-key":   "access-key-v1",
+		"aws/config":       "aws-config-v1",
+		"aws/credentials":  "aws-credentials-v1",
+		"kube/config":      "kube-config-v1",
+	}
+	for rel, content := range v1Files {
+		path := filepath.Join(sopsDir1, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// ── install intermediate symlinks (stable sops intermediates) ────────────
+	// Each intermediate simulates the path that sops-nix keeps stable across
+	// rotations: e.g. ~/.ssh/prismatic-koi-ed25519 → secrets.d/<N>/...
+	intermediates := map[string]string{
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"):          filepath.Join(sopsDir1, "ssh", "access-key"),
+		filepath.Join(fakeHome, ".config", "aws", "readonly-config"):      filepath.Join(sopsDir1, "aws", "config"),
+		filepath.Join(fakeHome, ".config", "aws", "credentials"):          filepath.Join(sopsDir1, "aws", "credentials"),
+		filepath.Join(fakeHome, ".config", "kube", "agents-config"):       filepath.Join(sopsDir1, "kube", "config"),
+	}
+	for intermediate, target := range intermediates {
+		_ = os.Remove(intermediate) // remove plain file from newFakeHome
+		if err := os.Symlink(target, intermediate); err != nil {
+			t.Fatalf("symlink intermediate %s → %s: %v", intermediate, target, err)
+		}
+	}
+
+	// ── run PrepareSandboxExecHome ─────────────────────────────────────────
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@sops-rotation-all",
+		InstanceID:  "sops-rotation-all-four-test",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// ── verify each staging symlink points at the intermediate ──────────────
+	type stagingEntry struct {
+		link         string // path in staging HOME
+		intermediate string // expected symlink target (the stable sops intermediate)
+	}
+	entries := []stagingEntry{
+		{
+			link:         filepath.Join(stagingHome, ".ssh", "access-key"),
+			intermediate: filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"),
+		},
+		{
+			link:         filepath.Join(stagingHome, ".aws", "config"),
+			intermediate: filepath.Join(fakeHome, ".config", "aws", "readonly-config"),
+		},
+		{
+			link:         filepath.Join(stagingHome, ".aws", "credentials"),
+			intermediate: filepath.Join(fakeHome, ".config", "aws", "credentials"),
+		},
+		{
+			link:         filepath.Join(stagingHome, ".kube", "config"),
+			intermediate: filepath.Join(fakeHome, ".config", "kube", "agents-config"),
+		},
+	}
+	for _, e := range entries {
+		target, readErr := os.Readlink(e.link)
+		if readErr != nil {
+			t.Errorf("%s is not a symlink: %v", e.link, readErr)
+			continue
+		}
+		if target != e.intermediate {
+			t.Errorf("%s → %q, want intermediate %q\n"+
+				"(symlink must point at the stable sops intermediate, not the resolved concrete path,\n"+
+				"so it stays valid after a sops rotation — issue #1573)",
+				e.link, target, e.intermediate)
+		}
+	}
+
+	// ── rotate: update intermediates to v2, delete v1 ───────────────────────
+	sopsDir2 := filepath.Join(fakeHome, "sops-dir-2")
+	v2Files := map[string]string{
+		"ssh/access-key":   "access-key-v2",
+		"aws/config":       "aws-config-v2",
+		"aws/credentials":  "aws-credentials-v2",
+		"kube/config":      "kube-config-v2",
+	}
+	for rel, content := range v2Files {
+		path := filepath.Join(sopsDir2, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatalf("mkdir for sops-dir-2/%s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write sops-dir-2/%s: %v", rel, err)
+		}
+	}
+	v2Targets := map[string]string{
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"):          filepath.Join(sopsDir2, "ssh", "access-key"),
+		filepath.Join(fakeHome, ".config", "aws", "readonly-config"):      filepath.Join(sopsDir2, "aws", "config"),
+		filepath.Join(fakeHome, ".config", "aws", "credentials"):          filepath.Join(sopsDir2, "aws", "credentials"),
+		filepath.Join(fakeHome, ".config", "kube", "agents-config"):       filepath.Join(sopsDir2, "kube", "config"),
+	}
+	for intermediate, newTarget := range v2Targets {
+		_ = os.Remove(intermediate)
+		if err := os.Symlink(newTarget, intermediate); err != nil {
+			t.Fatalf("rotate intermediate %s → %s: %v", intermediate, newTarget, err)
+		}
+	}
+	_ = os.RemoveAll(sopsDir1) // simulate sops deleting the old secrets.d/<N>
+
+	// ── verify reads through staging HOME still succeed after rotation ──────
+	v2Contents := map[string]string{
+		filepath.Join(stagingHome, ".ssh", "access-key"):  "access-key-v2",
+		filepath.Join(stagingHome, ".aws", "config"):       "aws-config-v2",
+		filepath.Join(stagingHome, ".aws", "credentials"):  "aws-credentials-v2",
+		filepath.Join(stagingHome, ".kube", "config"):      "kube-config-v2",
+	}
+	for link, wantContent := range v2Contents {
+		content, readErr := os.ReadFile(link)
+		if readErr != nil {
+			t.Errorf("cannot read %s through staging HOME after rotation: %v\n"+
+				"(this means the staging symlink is dangling after sops rotate — issue #1573)",
+				link, readErr)
+			continue
+		}
+		if string(content) != wantContent {
+			t.Errorf("%s after rotation: got %q, want %q", link, string(content), wantContent)
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_sops_rotation_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_sops_rotation_darwin_test.go
@@ -1,0 +1,300 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_sops_rotation_darwin_test.go — integration coverage for the
+// sops-rotation fix applied to access-key, .aws/config, .aws/credentials, and
+// .kube/config (issue #1573, follow-up to #1410).
+//
+// After darwin-rebuild switch, sops rotates secrets.d/<N>/ → secrets.d/<N+1>/
+// and removes the old directory. All four staging-HOME symlinks now use
+// symlinkIfExists (not symlinkIfResolvable), so they point at the stable sops
+// intermediate rather than the concrete secrets.d/<N>/ path. This means reads
+// through the staging HOME symlinks continue to work after a rotation.
+//
+// Test design
+// ───────────
+// Each test entry exercises the two-hop chain:
+//
+//   <stagingHome>/<entry>
+//     → <stableIntermediate>                         (stable sops symlink)
+//     → <concreteFile>                               (simulates secrets.d/<N>/...)
+//
+// The stableIntermediate is placed under HOME (via a temp dir created by
+// hostCredentialDir), and the concreteFile is placed under HOME as well.
+// Using HOME (rather than /private/var/folders) ensures the per-symlink
+// (literal <concreteFile>) allow rule emitted by collectStagingHomeSymlinkTargets
+// is load-bearing for reads — NOT the broad (subpath "/private/var/folders")
+// rule. This makes the negative test meaningful.
+//
+// The positive test generates the production profile, installs the two-hop
+// chain into the staging HOME, then reads the concreteFile via the staging
+// HOME path inside sandbox-exec. The negative test mutates the profile to
+// remove the (literal <concreteFile>) allow and asserts the read fails —
+// proving the positive is not a no-op.
+//
+// Shared helpers:
+//   - requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
+//     preparePositiveProfile, writeAugmentedPositiveProfile, withMutatedProfile
+//     → sandbox_exec_helpers_darwin_test.go
+//   - hostCredentialDir, sbplQuoteForTest
+//     → sandbox_exec_staging_home_darwin_test.go
+//
+// See docs/sandbox-exec-testing.md for the convention (#1192).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// sopsRotationEntry describes one staging-HOME entry to test in the rotation
+// integration tests.
+type sopsRotationEntry struct {
+	// stagingRelPath is the path of the symlink relative to stagingHome
+	// (e.g. ".ssh/access-key").
+	stagingRelPath string
+	// intermediateRelPath is the path of the stable intermediate relative to
+	// HOME (e.g. ".ssh/prismatic-koi-ed25519").
+	intermediateRelPath string
+	// sentinel is written into the concrete v2 file so positive tests can
+	// assert the right content was read.
+	sentinel string
+}
+
+// sopsRotationEntries lists the four staging-HOME entries fixed by #1573.
+var sopsRotationEntries = []sopsRotationEntry{
+	{
+		stagingRelPath:      ".ssh/access-key",
+		intermediateRelPath: ".ssh/prismatic-koi-ed25519",
+		sentinel:            "ssh-ed25519 AAAA1573-access-key-sentinel",
+	},
+	{
+		stagingRelPath:      ".aws/config",
+		intermediateRelPath: ".config/aws/readonly-config",
+		sentinel:            "[default]\nregion = us-east-1  ; sentinel-1573-aws-config",
+	},
+	{
+		stagingRelPath:      ".aws/credentials",
+		intermediateRelPath: ".config/aws/credentials",
+		sentinel:            "[default]\naws_access_key_id = sentinel-1573-creds",
+	},
+	{
+		stagingRelPath:      ".kube/config",
+		intermediateRelPath: ".config/kube/agents-config",
+		sentinel:            "apiVersion: v1  # sentinel-1573-kube-config",
+	},
+}
+
+// setupSopsRotationChain sets up the two-hop symlink chain for a single entry:
+//
+//	<stableIntermediateDir>/<intermediateFileName>
+//	  → <concreteFile>            (contains sentinel content)
+//
+// Both the intermediate dir and the concrete file are placed under HOME (via
+// hostCredentialDir), ensuring the per-symlink (literal ...) allow rule is
+// load-bearing for reads. The function returns (intermediateSymlink, concreteFile).
+//
+// The caller is responsible for installing the staging HOME symlink pointing
+// at intermediateSymlink (simulating the symlinkIfExists behavior).
+func setupSopsRotationChain(t *testing.T, entry sopsRotationEntry) (intermediateSymlink, concreteFile string) {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	// Concrete file under HOME (not /private/var/folders) so the per-symlink
+	// literal rule is load-bearing for the negative test.
+	concreteDir := hostCredentialDir(t)
+	concreteFile = filepath.Join(concreteDir, filepath.Base(entry.stagingRelPath))
+	if err := os.WriteFile(concreteFile, []byte(entry.sentinel), 0o600); err != nil {
+		t.Fatalf("write concrete file for %s: %v", entry.stagingRelPath, err)
+	}
+
+	// Stable intermediate dir under HOME — simulates ~/.ssh/, ~/.config/aws/, etc.
+	// Must be under HOME so the BareRoot ancestor block (subpath HOME) provides
+	// file-read-metadata, letting the kernel follow the symlink stored here.
+	intermediateDir, dirErr := os.MkdirTemp(home, ".prism-1573-intermediate-*")
+	if dirErr != nil {
+		t.Fatalf("MkdirTemp for intermediateDir (%s): %v", entry.stagingRelPath, dirErr)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(intermediateDir) })
+
+	intermediateFileName := filepath.Base(entry.intermediateRelPath)
+	intermediateSymlink = filepath.Join(intermediateDir, intermediateFileName)
+	if err := os.Symlink(concreteFile, intermediateSymlink); err != nil {
+		t.Fatalf("create intermediate symlink for %s: %v", entry.stagingRelPath, err)
+	}
+
+	return intermediateSymlink, concreteFile
+}
+
+// TestSandboxExecSopsRotation_TwoHopChainReadable is the positive integration
+// test for the sops-rotation fix (issue #1573).
+//
+// For each of the four newly-rotation-safe staging entries, it sets up the
+// two-hop chain:
+//
+//	<stagingHome>/<entry>
+//	  → <stableIntermediate>   (simulates ~/.ssh/<key>, ~/.config/aws/<file>, etc.)
+//	  → <concreteFile>         (simulates secrets.d/<N>/...)
+//
+// Generates the production SBPL profile, then reads each file via the staging
+// HOME path inside sandbox-exec. Asserts exit 0 and that the sentinel content
+// is visible — confirming the sandbox can follow the full two-hop chain.
+//
+// Uses newProfileManagerWithBareRoot so the BareRoot ancestor block fires and
+// grants file-read-metadata on (subpath HOME), enabling the kernel to traverse
+// intermediate symlinks under HOME.
+func TestSandboxExecSopsRotation_TwoHopChainReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Install all four two-hop chains in the staging HOME.
+	type installedEntry struct {
+		entry        sopsRotationEntry
+		stagingLink  string
+		concreteFile string
+	}
+	var installed []installedEntry
+	for _, entry := range sopsRotationEntries {
+		intermediateSymlink, concreteFile := setupSopsRotationChain(t, entry)
+
+		stagingLink := filepath.Join(stagingHome, entry.stagingRelPath)
+		_ = os.Remove(stagingLink) // replace whatever PrepareSandboxExecHome placed
+		if linkErr := os.Symlink(intermediateSymlink, stagingLink); linkErr != nil {
+			t.Fatalf("create staging symlink for %s: %v", entry.stagingRelPath, linkErr)
+		}
+		installed = append(installed, installedEntry{
+			entry:        entry,
+			stagingLink:  stagingLink,
+			concreteFile: concreteFile,
+		})
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Verify the profile references the resolved concrete paths (emitted by
+	// collectStagingHomeSymlinkTargets via filepath.EvalSymlinks).
+	for _, ins := range installed {
+		resolved, _ := filepath.EvalSymlinks(ins.concreteFile)
+		if resolved == "" {
+			resolved = ins.concreteFile
+		}
+		if !strings.Contains(prepared.content, resolved) {
+			t.Fatalf("generated profile does not reference resolved concrete path %q for %s.\n"+
+				"collectStagingHomeSymlinkTargets did not pick up the staging symlink chain.\nProfile:\n%s",
+				resolved, ins.entry.stagingRelPath, prepared.content)
+		}
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Read each file from inside the sandbox via the staging HOME path.
+	// The kernel must traverse: stagingLink → intermediate → concreteFile.
+	for _, ins := range installed {
+		cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+			"/usr/bin/env", fmt.Sprintf("HOME=%s", stagingHome), nixBash, "-c",
+			"cat "+shQuote(ins.stagingLink))
+		out, runErr := cmd.CombinedOutput()
+		if runErr != nil {
+			t.Errorf("read %s via two-hop staging-HOME chain failed under production profile.\n"+
+				"This means the sandbox cannot follow the sops-style symlink chain required by #1573.\n"+
+				"Exit: %v\nOutput: %s\nProfile: %s",
+				ins.entry.stagingRelPath, runErr, string(out), testProfilePath)
+			continue
+		}
+		if !strings.Contains(string(out), ins.entry.sentinel[:10]) {
+			t.Errorf("%s read succeeded but output does not contain the sentinel.\nOutput: %s",
+				ins.entry.stagingRelPath, string(out))
+		}
+	}
+}
+
+// TestSandboxExecSopsRotation_TwoHopChainDeniedWithoutConcreteAllow is the
+// paired negative test. For each of the four entries, it removes the
+// (literal <concreteFile>) allow line from the profile and asserts that
+// reading the file via the staging HOME symlink chain fails.
+//
+// This proves TestSandboxExecSopsRotation_TwoHopChainReadable is not green by
+// accident: the read works specifically because of the (literal <concreteFile>)
+// allow emitted by collectStagingHomeSymlinkTargets, not because of a broader
+// rule.
+//
+// The concrete files are under HOME (not /private/var/folders) so the broad
+// (subpath "/private/var/folders") rule does NOT cover them — only the
+// per-symlink literal allow does. Stripping that literal makes reads fail,
+// confirming the two-hop chain is load-bearing.
+func TestSandboxExecSopsRotation_TwoHopChainDeniedWithoutConcreteAllow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	for _, entry := range sopsRotationEntries {
+		entry := entry // capture loop variable
+		t.Run(entry.stagingRelPath, func(t *testing.T) {
+			m := newProfileManagerWithBareRoot(t)
+
+			stagingHome, err := m.PrepareSandboxExecHome()
+			if err != nil {
+				t.Fatalf("PrepareSandboxExecHome: %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+			intermediateSymlink, concreteFile := setupSopsRotationChain(t, entry)
+
+			stagingLink := filepath.Join(stagingHome, entry.stagingRelPath)
+			_ = os.Remove(stagingLink)
+			if linkErr := os.Symlink(intermediateSymlink, stagingLink); linkErr != nil {
+				t.Fatalf("create staging symlink: %v", linkErr)
+			}
+
+			// Resolve to the canonical form generateProfile emits (covers
+			// the /var → /private/var alias on Darwin).
+			resolved, resolveErr := filepath.EvalSymlinks(concreteFile)
+			if resolveErr != nil {
+				resolved = concreteFile
+			}
+
+			mutatedPath := withMutatedProfile(t, m, func(p string) string {
+				// Remove the (literal "<resolved>") line from the allow block.
+				// Match only the indented form to avoid accidentally hitting
+				// unrelated occurrences.
+				toRemove := "  (literal " + sbplQuoteForTest(resolved) + ")\n"
+				return strings.ReplaceAll(p, toRemove, "")
+			})
+
+			cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+				"/usr/bin/env", fmt.Sprintf("HOME=%s", stagingHome), nixBash, "-c",
+				"cat "+shQuote(stagingLink))
+			out, runErr := cmd.CombinedOutput()
+			if runErr == nil {
+				t.Errorf("%s: read via staging-HOME chain succeeded WITHOUT the (literal ...) allow for the concrete file.\n"+
+					"The negative test is not catching the regression — investigate.\n"+
+					"Output: %s\nMutated profile: %s", entry.stagingRelPath, string(out), mutatedPath)
+			} else {
+				t.Logf("ka pai — %s: read correctly denied without concrete-file allow (exit: %v)",
+					entry.stagingRelPath, runErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1573

## Summary

After `darwin-rebuild switch`, sops rotates `secrets.d/<N>/` → `secrets.d/<N+1>/` and removes the old directory. Four staging-HOME symlinks were using `symlinkIfResolvable` which stored the fully-resolved `secrets.d/<N>/...` path — becoming dangling after each rotation. This is the same failure class as #1410 which only fixed `signing-key{,.pub}`.

This PR switches the four remaining entries to `symlinkIfExists` so they point at the stable sops intermediate rather than the rotatable concrete path.

## Acceptance Criteria

- [x] [functional] After `PrepareSandboxExecHome` runs, `<stagingHome>/.ssh/access-key` is a symlink whose target is `<userHome>/.ssh/<accessKeyName>` (the stable intermediate), not the fully-resolved `/private/var/folders/.../secrets.d/<N>/...` path.
- [x] [functional] After `PrepareSandboxExecHome` runs, `<stagingHome>/.aws/config` is a symlink whose target is `<userHome>/.config/aws/readonly-config` (the stable intermediate), not the fully-resolved sops path.
- [x] [functional] After `PrepareSandboxExecHome` runs, `<stagingHome>/.aws/credentials` is a symlink whose target is `<userHome>/.config/aws/credentials` (the stable intermediate), not the fully-resolved sops path.
- [x] [functional] After `PrepareSandboxExecHome` runs, `<stagingHome>/.kube/config` is a symlink whose target is `<userHome>/.config/kube/agents-config` (the stable intermediate), not the fully-resolved sops path.
- [x] [functional] When the host source path does not exist, `PrepareSandboxExecHome` skips the symlink rather than creating a dangling one — matching the existing `symlinkIfExists` skip semantics.
- [x] [functional] The misleading comment block at the previous `// Note: symlinkIfResolvable is still used for the access key…` site is removed or rewritten to state the rotation-safety rationale that matches the new behaviour.
- [x] [edge-case] A unit test (`TestPrepareSandboxExecHome_SopsRotation_AllFourSymlinks`) covers all four newly-rotation-safe symlinks through a v1→v2 rotation: mutates the intermediate → `secrets.d/<v1>` chain to point at `secrets.d/<v2>`, deletes `secrets.d/<v1>`, and asserts reads still succeed.
- [x] [edge-case] A Darwin-only integration test under `internal/integration/` (`sandbox_exec_sops_rotation_darwin_test.go`) with positive and negative companions per the #1192 convention.
- [x] [security] The fix does not widen the SBPL profile. No new `(allow ...)` rules are added; the change is confined to which path is stored in the staging-home symlink.
- [x] [functional] `go build ./...` and `go test ./...` from `modules/programs/prism/prism/` both pass.
- [x] [functional] `nix build .#prism` from the repo root passes.

## Changes

### `internal/container/sandbox_exec_home.go`
- Switch `.ssh/access-key`, `.aws/config`, `.aws/credentials`, `.kube/config` from `symlinkIfResolvable` to `symlinkIfExists` with rotation-safety comments
- Remove the now-unused `symlinkIfResolvable` helper
- Remove the misleading "access key does not rotate" comment

### `internal/container/sandbox_exec_test.go`
- Update `TestPrepareSandboxExecHome_AccessKeyStillUsesResolvedPath` → `TestPrepareSandboxExecHome_AccessKeyUsesIntermediatePath` (verifies intermediate-path behavior + rotation survival)
- Add `credentials` file to `newFakeHome` helper
- Add `TestPrepareSandboxExecHome_SopsRotation_AllFourSymlinks` (v1→v2 rotation across all four entries)

### `internal/integration/sandbox_exec_sops_rotation_darwin_test.go` (new)
- `TestSandboxExecSopsRotation_TwoHopChainReadable` — positive Darwin integration test
- `TestSandboxExecSopsRotation_TwoHopChainDeniedWithoutConcreteAllow` — negative companion (subtest per entry)
