### PR TITLE
docs: coordinator + skill update for prism investigate

### DIFF
--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -61,6 +61,53 @@ Use `prism spawn`. Load the prism skill first if not already loaded. Record the 
 
 ---
 
+## Investigator agents
+
+Use `prism investigate` for read-only research tasks that would otherwise block the coordinator on grep/read work while the bus is idle: tracing call chains, mapping symptoms to a file:line, surveying the scope of a change before spawning a worker. If the answer requires writing code or opening a PR, spawn a worker instead.
+
+### Spawning
+
+```bash
+prism investigate --prompt "what does the sidecar do when a session enters 'escalated' state?"
+```
+
+The command returns a session name within ~2 seconds (shape: `<invoker>~investigate-<slug>`). Record it in your todo list alongside the open question.
+
+### Handling per-turn notifications
+
+After each investigator turn that produces output, the sidecar delivers a body-bearing notification to you. Treat it as high-priority — the same priority as a worker `has finished` notification. Each notification includes:
+
+- **Header:** `From investigator session: <name>` — use this to route the notification to the correct open question when multiple investigators are running.
+- **Body:** the investigator's findings for that turn.
+- **Steering hint:** `Reply with: prism prompt <name> --prompt '...'`
+
+After reading the body, decide whether to:
+
+1. **Send a steering prompt** — `prism prompt <inv-session> --prompt '...'` — to narrow the question or ask a follow-up.
+2. **Conclude the investigation** — the answer is sufficient; proceed without sending another prompt.
+
+Do not let investigator notifications accumulate unread. Each one may contain the answer you need to unblock the next step.
+
+### Multi-investigator streams
+
+When multiple investigators are running concurrently, notifications from different sessions arrive interleaved on the bus. Use the `From investigator session: <name>` header to route each notification to the correct open question. Keep a record of which session was spawned for which question so you can match them up.
+
+### Cleanup discipline
+
+Investigators do not self-terminate. When the investigation is complete and the report consumed, run:
+
+```bash
+prism cleanup --yes --session <inv-session>
+```
+
+Do not leave finished investigator sessions running. They accumulate worktrees and tmux sessions like any other prism session.
+
+### Workers cannot use `prism investigate`
+
+`prism investigate` is denied in the worker deny list. A worker that needs additional research context must escalate to the coordinator via `prism escalate`. The coordinator then decides whether to spawn an investigator or answer the question directly.
+
+---
+
 ## Monitoring
 
 ### Primary signal: the finish notification

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -331,6 +331,52 @@ review to pass. If ANY returns `<verdict>FAIL</verdict>`, fix all blocking
 issues, push, and re-run all five. After 3 full cycles without convergence,
 stop and escalate — do not run a 4th cycle.
 
+## Investigator agents
+
+Use `prism investigate` to spawn a read-only research session from within a prism session. Investigators are well-suited to tasks like tracing call chains, mapping symptoms to a file:line, or surveying scope before spawning a worker. They are denied in the worker deny list — only coordinators can use them.
+
+### Spawning
+
+```bash
+prism investigate --prompt "question"
+prism investigate --prompt-file /tmp/question.txt
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--prompt <text>` | Research question. Mutually exclusive with `--prompt-file`. |
+| `--prompt-file <path>` | Read the question from a file. Mutually exclusive with `--prompt`. |
+
+One of `--prompt` or `--prompt-file` is required. The command returns a session name within ~2 seconds and exits 0. There is no `--wait` flag — `prism investigate` is inherently async.
+
+### Session-naming convention
+
+Spawned sessions are named `<invoker>~investigate-<slug>` where `<slug>` is a short kebab-case slug derived from the prompt.
+
+### Per-turn notification contract
+
+After each investigator turn that produces output, the sidecar delivers a body-bearing notification to the invoking session. Each notification includes:
+
+- **Header:** `From investigator session: <name>` — use this to route the notification to the correct open question when multiple investigators are running concurrently.
+- **Body:** the investigator's findings for that turn.
+- **Steering hint:** `Reply with: prism prompt <name> --prompt '...'` — follow-up steering is done via `prism prompt`.
+
+### Cleanup responsibility
+
+Investigators do not self-terminate. When the investigation is complete and the findings consumed, the coordinator must run:
+
+```bash
+prism cleanup --yes --session <inv-session>
+```
+
+### Constraint
+
+`prism investigate` must be run from within a prism session (errors if no invoker is detectable). Workers have `prism investigate` in their deny list; only coordinators may use it.
+
+---
+
 ## Merge queue (coordinators only)
 
 > **Coordinators only.** Worker agents, container worker agents, bwrap worker agents, and review agents all have `prism merge` and `prism merge *` denied in their bash deny lists. If you are not a coordinator agent, skip this section.


### PR DESCRIPTION
Teaches the coordinator agent prompt and prism skill manifest about `prism investigate`: when to delegate, how to spawn, per-turn notification handling, multi-investigator stream routing, cleanup discipline, and the worker-deny note.

Closes #1563
Closes #1448