### PR TITLE
prism: add prism investigate to worker bash denylist

### DIFF
--- a/modules/programs/prism/opencode.nix
+++ b/modules/programs/prism/opencode.nix
@@ -466,6 +466,8 @@
         # Coordinator-domain operations — deny
         "prism spawn" = "deny";
         "prism spawn *" = "deny";
+        "prism investigate" = "deny";
+        "prism investigate *" = "deny";
         "prism pr" = "deny";
         "prism pr *" = "deny";
         "gh pr merge" = "deny";
@@ -741,6 +743,8 @@
                 # Spawning agents is a coordinator responsibility, never a worker's (#557).
                 "prism spawn" = "deny";
                 "prism spawn *" = "deny";
+                "prism investigate" = "deny";
+                "prism investigate *" = "deny";
                 "prism pr" = "deny";
                 "prism pr *" = "deny";
                 # prism merge — enqueuing is a coordinator responsibility (#783)
@@ -1488,6 +1492,8 @@
                         "gh pr merge *" = "deny";
                         "prism spawn" = "deny";
                         "prism spawn *" = "deny";
+                        "prism investigate" = "deny";
+                        "prism investigate *" = "deny";
                         "prism pr" = "deny";
                         "prism pr *" = "deny";
                         # prism merge — enqueuing is a coordinator responsibility (#783)


### PR DESCRIPTION
Add `prism investigate` and `prism investigate *` to the worker bash denylist in `opencode.nix`, alongside the existing `prism spawn` deny entries. This prevents workers from invoking `prism investigate` directly — investigate is a coordinator-only surface. Workers that need research context should escalate to the coordinator via `prism escalate`.

Three worker denylist locations were updated:
- `containerWorkerBashCommands` (standalone container worker)
- The inline host worker overrides (alongside `prism spawn` / `prism pr` denies)
- The second host worker inline block

Closes #1577