### PR TITLE
fix(session): sanitise dot/colon/whitespace in branch component; propagate tmux failure

### DIFF
--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -819,14 +819,34 @@ func NameFor(dir, projectRoot string) string {
 
 // worktreeBranchComponent returns the branch component of a session name for
 // the worktree at dir.
+//
+// Sanitisation: tmux uses "." as the session.window.pane target separator, ":" as
+// another separator, and whitespace as a token boundary. All three are replaced
+// with "_" to produce a safe component. "/" is replaced with "--" to preserve
+// the existing convention for branch hierarchies.
 func worktreeBranchComponent(dir string) string {
 	ref, err := git.SymbolicRef(dir)
 	if err == nil {
 		branch := strings.TrimPrefix(ref, "refs/heads/")
-		return strings.ReplaceAll(branch, "/", "--")
+		return sanitiseBranchComponent(branch)
 	}
 	if hash, err := git.ShortHash(dir); err == nil {
-		return hash
+		return sanitiseBranchComponent(hash)
 	}
-	return filepath.Base(dir)
+	return sanitiseBranchComponent(filepath.Base(dir))
+}
+
+// sanitiseBranchComponent replaces characters that are unsafe in tmux session
+// names with safe substitutes:
+//   - "/" → "--"  (preserve existing convention for branch hierarchies)
+//   - "." → "_"   (tmux uses "." as session.window.pane separator)
+//   - ":" → "_"   (tmux uses ":" as a target separator)
+//   - whitespace → "_"
+func sanitiseBranchComponent(s string) string {
+	s = strings.ReplaceAll(s, "/", "--")
+	s = strings.ReplaceAll(s, ".", "_")
+	s = strings.ReplaceAll(s, ":", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "\t", "_")
+	return s
 }

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -639,5 +640,147 @@ func TestHarnessBinary(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("harnessBinary(%q) = %q, want %q", tc.harness, got, tc.want)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests for sanitiseBranchComponent / worktreeBranchComponent (#1479)
+// ---------------------------------------------------------------------------
+
+// TestSanitiseBranchComponent covers the sanitisation rules: "." → "_",
+// "/" → "--", ":" → "_", and whitespace → "_".
+func TestSanitiseBranchComponent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		// want must not contain ".", "/", ":", " ", or "\t"
+		wantSubstrings []string // substrings that must appear
+		wantAbsent     []string // chars/strings that must NOT appear
+	}{
+		{
+			name:       "dot in branch",
+			input:      "prismatic-bot-traefik-40.x",
+			wantSubstrings: []string{"prismatic-bot-traefik-40_x"},
+			wantAbsent:     []string{"."},
+		},
+		{
+			name:       "slash in branch (regression)",
+			input:      "dependabot/foo/bar",
+			wantSubstrings: []string{"dependabot--foo--bar"},
+			wantAbsent:     []string{"/"},
+		},
+		{
+			name:       "combined slash and dot",
+			input:      "dependabot/foo/v2.3.1",
+			wantSubstrings: []string{"dependabot--foo--v2_3_1"},
+			wantAbsent:     []string{".", "/"},
+		},
+		{
+			name:       "all dots",
+			input:      "...",
+			wantAbsent: []string{"."},
+		},
+		{
+			name:       "colon in branch",
+			input:      "feat:my-feature",
+			wantAbsent: []string{":"},
+		},
+		{
+			name:       "whitespace in branch",
+			input:      "feature branch",
+			wantAbsent: []string{" "},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitiseBranchComponent(tc.input)
+			if got == "" {
+				t.Errorf("sanitiseBranchComponent(%q) returned empty string", tc.input)
+			}
+			for _, want := range tc.wantSubstrings {
+				if !strings.Contains(got, want) {
+					t.Errorf("sanitiseBranchComponent(%q) = %q, want substring %q", tc.input, got, want)
+				}
+			}
+			for _, bad := range tc.wantAbsent {
+				if strings.Contains(got, bad) {
+					t.Errorf("sanitiseBranchComponent(%q) = %q, still contains %q", tc.input, got, bad)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitiseBranchComponent_AllUnsafeNoEmpty asserts that a component made
+// entirely of unsafe characters (e.g. "...") produces a non-empty result
+// without panicking.
+func TestSanitiseBranchComponent_AllUnsafeNoEmpty(t *testing.T) {
+	inputs := []string{"...", ". . .", ":/.", "\t\t"}
+	for _, in := range inputs {
+		got := sanitiseBranchComponent(in)
+		if got == "" {
+			// All dots become underscores, so the result should be non-empty.
+			// (The only way to get "" is if the input is ""; that's not the
+			// case here because the substitutions preserve length.)
+			t.Errorf("sanitiseBranchComponent(%q) returned unexpected empty string", in)
+		}
+		for _, bad := range []string{".", "/", ":"} {
+			if strings.Contains(got, bad) {
+				t.Errorf("sanitiseBranchComponent(%q) = %q still contains %q", in, got, bad)
+			}
+		}
+	}
+}
+
+// TestWorktreeBranchComponent_FilepathFallback_SanitisesDot verifies that the
+// filepath.Base fallback path (used when git is not available) also sanitises
+// dots. We pass a directory whose base name contains a dot and is not a git
+// repo.
+func TestWorktreeBranchComponent_FilepathFallback_SanitisesDot(t *testing.T) {
+	// Create a non-git directory whose base name contains a dot.
+	dir := filepath.Join(t.TempDir(), "branch-40.x")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := worktreeBranchComponent(dir)
+	if strings.Contains(got, ".") {
+		t.Errorf("worktreeBranchComponent(%q) = %q, still contains '.'", dir, got)
+	}
+	if got == "" {
+		t.Errorf("worktreeBranchComponent(%q) returned empty string", dir)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: tmux new-session failure propagation (#1479 AC #5, AC #6)
+// ---------------------------------------------------------------------------
+
+// failTmuxBin installs a fake tmux binary that always exits non-zero, returning
+// a fixed stderr message. It redirects tmux.TmuxBin for the duration of the
+// test. Only call this from non-parallel tests.
+func failTmuxBin(t *testing.T, stderrMsg string) {
+	t.Helper()
+	wrapperPath := t.TempDir() + "/tmux"
+	script := fmt.Sprintf("#!/bin/sh\necho '%s' >&2\nexit 1\n", stderrMsg)
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failTmuxBin: write wrapper: %v", err)
+	}
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = wrapperPath
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+}
+
+// TestCreate_TmuxNewSessionFailure verifies that when tmux new-session fails,
+// session.Create returns a non-nil error.
+func TestCreate_TmuxNewSessionFailure(t *testing.T) {
+	failTmuxBin(t, "duplicate session: test-session")
+	dir := t.TempDir()
+	err := Create("test-session", dir, Opts{ForceFresh: true})
+	if err == nil {
+		t.Fatal("expected non-nil error when tmux new-session fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "test-session") {
+		t.Errorf("error %q does not mention the session name", err.Error())
 	}
 }

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -590,7 +590,11 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	}
 	if layoutErr != nil {
 		startup.log("spawn-session: layout setup FAILED: %v", layoutErr)
-		return layoutErr
+		// Wrap the error with a cleanup hint. The DB row, worktree, and any
+		// sidecar process may have been created before the tmux step failed;
+		// tell the operator how to clean up side effects.
+		return fmt.Errorf("%w — to remove side effects run: prism cleanup --yes --session %s",
+			layoutErr, opts.SessionName)
 	}
 	startup.log("spawn-session: tmux session and sidecar kicked off — handing control to agent pane (further bwrap stderr in agent-run.log)")
 


### PR DESCRIPTION
## Summary

Fixes two bugs in prism session naming and error handling.

### Fix 1: Sanitise branch component for tmux safety

`worktreeBranchComponent` previously only replaced `/` → `--` in branch names. tmux uses `.` as the `session.window.pane` target separator, so a session like `home-ops@prismatic-bot-traefik-40.x` would be silently mis-parsed by every subsequent tmux invocation.

The fix extracts a `sanitiseBranchComponent` helper that applies:
- `/` → `--` (existing convention preserved)
- `.` → `_` (tmux target separator)
- `:` → `_` (tmux target separator)
- whitespace → `_`

All three return paths in `worktreeBranchComponent` (SymbolicRef, ShortHash, filepath.Base fallback) now go through sanitisation. This mirrors the existing `strings.ReplaceAll(filepath.Base(projectRoot), ".", "_")` in `NameFor`.

### Fix 2: Propagate tmux new-session failure with cleanup hint

`SpawnSession` wraps the `layoutErr` (which includes tmux new-session failures via `NewSessionDetached` → `Create`) with a cleanup instruction telling the operator to run `prism cleanup --yes --session <name>` to remove side effects (DB row, port allocation) that may have been created before the tmux step failed.

## Tests added

- `TestSanitiseBranchComponent`: table-driven covering dot, slash regression, combined, colon, whitespace
- `TestSanitiseBranchComponent_AllUnsafeNoEmpty`: all-unsafe input (`...`) produces non-empty tmux-safe result
- `TestWorktreeBranchComponent_FilepathFallback_SanitisesDot`: filepath.Base fallback path is also sanitised
- `TestCreate_TmuxNewSessionFailure`: fake failing tmux binary → non-nil error containing session name

Closes #1479