### PR TITLE
prism cleanup: guard against removing main worktree for investigator sessions

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -546,7 +546,7 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 
 	if worktreePath == "" {
 		printLine("worktree path unknown — skipping worktree removal for session %s\n", session)
-	} else {
+	} else if isSafeToRemoveWorktree(worktreePath, bareRoot) {
 		printLine("removing worktree %s...\n", worktreePath)
 		if err := git.RemoveWorktree(bareRoot, worktreePath); err != nil {
 			// Non-fatal: the path may no longer be a registered git worktree
@@ -557,6 +557,8 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 			wt := worktreePath
 			result.WorktreeRemoved = &wt
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: refusing to remove worktree %s — path matches main worktree or an active session's worktree; skipping filesystem removal\n", worktreePath)
 	}
 
 	if bareRoot != "" && git.BranchExists(bareRoot, worktreeName) {
@@ -1270,6 +1272,53 @@ func removeContainerIfExists(sessionName string) {
 //
 // This function is extracted from cleanupCmd.RunE to allow unit testing of
 // the DB-backed coordinator detection independently of the full cleanup flow.
+// isSafeToRemoveWorktree returns true when worktreePath is safe to remove
+// during headless cleanup. It returns false (with a caller-logged warning) in
+// two cases:
+//
+//  1. The path matches the default branch worktree (e.g. <bareRoot>/main).
+//     Removing the default branch worktree would destroy the coordinator's
+//     working directory and break all subsequent git/gh commands.
+//
+//  2. The path matches the worktree of any currently active session in the DB.
+//     This guards against investigator or other child sessions that inherit
+//     the parent's worktree path and would otherwise clobber a live session.
+//
+// Both checks normalise paths with filepath.Clean before comparing.
+// When bareRoot is empty the path-level checks are skipped (caller already
+// handles the worktreePath=="" fast-path).
+func isSafeToRemoveWorktree(worktreePath, bareRoot string) bool {
+	if worktreePath == "" {
+		return false
+	}
+	cleanPath := filepath.Clean(worktreePath)
+
+	// Guard 1: never remove the default branch worktree.
+	if bareRoot != "" {
+		defaultBr := git.DefaultBranchFromBareRoot(bareRoot)
+		if defaultBr != "" {
+			defaultWorktreePath := filepath.Clean(filepath.Join(bareRoot, defaultBr))
+			if cleanPath == defaultWorktreePath {
+				return false
+			}
+		}
+	}
+
+	// Guard 2: never remove the worktree of any active session.
+	if d, err := openDB(); err == nil {
+		defer d.Close()
+		if statuses, err := d.AllActiveStatus(); err == nil {
+			for _, st := range statuses {
+				if st.Worktree != "" && filepath.Clean(st.Worktree) == cleanPath {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
 func isCoordinatorFromDB(session string, isDefaultBranch bool) bool {
 	if d, dbErr := openDB(); dbErr == nil {
 		rootName, rowExists, rootErr := d.RootAgentName(session)

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -546,7 +546,7 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 
 	if worktreePath == "" {
 		printLine("worktree path unknown — skipping worktree removal for session %s\n", session)
-	} else if isSafeToRemoveWorktree(worktreePath, bareRoot) {
+	} else if isSafeToRemoveWorktree(session, worktreePath, bareRoot) {
 		printLine("removing worktree %s...\n", worktreePath)
 		if err := git.RemoveWorktree(bareRoot, worktreePath); err != nil {
 			// Non-fatal: the path may no longer be a registered git worktree
@@ -1287,7 +1287,23 @@ func removeContainerIfExists(sessionName string) {
 // Both checks normalise paths with filepath.Clean before comparing.
 // When bareRoot is empty the path-level checks are skipped (caller already
 // handles the worktreePath=="" fast-path).
-func isSafeToRemoveWorktree(worktreePath, bareRoot string) bool {
+// isSafeToRemoveWorktree returns true when worktreePath is safe to remove
+// during headless cleanup. It returns false (with a caller-logged warning) in
+// two cases:
+//
+//  1. The path matches the default branch worktree (e.g. <bareRoot>/main).
+//     Removing the default branch worktree would destroy the coordinator's
+//     working directory and break all subsequent git/gh commands.
+//
+//  2. The path matches the worktree of any currently active session in the DB
+//     other than the session being cleaned up. This guards against investigator
+//     or other child sessions that inherit the parent's worktree path and would
+//     otherwise clobber a live session.
+//
+// Both checks normalise paths with filepath.Clean before comparing.
+// When bareRoot is empty the path-level checks are skipped (caller already
+// handles the worktreePath=="" fast-path).
+func isSafeToRemoveWorktree(session, worktreePath, bareRoot string) bool {
 	if worktreePath == "" {
 		return false
 	}
@@ -1304,12 +1320,15 @@ func isSafeToRemoveWorktree(worktreePath, bareRoot string) bool {
 		}
 	}
 
-	// Guard 2: never remove the worktree of any active session.
+	// Guard 2: never remove the worktree of any active session other than the
+	// session being cleaned up. The session's own DB row is still active at
+	// this point (SetEnded is called later), so we must exclude it from the
+	// comparison to avoid blocking legitimate cleanup of dedicated worktrees.
 	if d, err := openDB(); err == nil {
 		defer d.Close()
 		if statuses, err := d.AllActiveStatus(); err == nil {
 			for _, st := range statuses {
-				if st.Worktree != "" && filepath.Clean(st.Worktree) == cleanPath {
+				if st.SessionName != session && st.Worktree != "" && filepath.Clean(st.Worktree) == cleanPath {
 					return false
 				}
 			}

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -1280,21 +1280,6 @@ func removeContainerIfExists(sessionName string) {
 //     Removing the default branch worktree would destroy the coordinator's
 //     working directory and break all subsequent git/gh commands.
 //
-//  2. The path matches the worktree of any currently active session in the DB.
-//     This guards against investigator or other child sessions that inherit
-//     the parent's worktree path and would otherwise clobber a live session.
-//
-// Both checks normalise paths with filepath.Clean before comparing.
-// When bareRoot is empty the path-level checks are skipped (caller already
-// handles the worktreePath=="" fast-path).
-// isSafeToRemoveWorktree returns true when worktreePath is safe to remove
-// during headless cleanup. It returns false (with a caller-logged warning) in
-// two cases:
-//
-//  1. The path matches the default branch worktree (e.g. <bareRoot>/main).
-//     Removing the default branch worktree would destroy the coordinator's
-//     working directory and break all subsequent git/gh commands.
-//
 //  2. The path matches the worktree of any currently active session in the DB
 //     other than the session being cleaned up. This guards against investigator
 //     or other child sessions that inherit the parent's worktree path and would

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -1094,3 +1094,174 @@ func TestHeadlessCloseSession_AlreadyDeadTmux_MarksEnded(t *testing.T) {
 		t.Errorf("ended_at is nil — session was not marked as ended despite tmux session being absent")
 	}
 }
+
+// TestIsSafeToRemoveWorktree_MainGuard verifies that isSafeToRemoveWorktree
+// returns false when the target path matches the default branch worktree, and
+// returns true for a genuine feature branch worktree. This is the regression
+// test for the investigator-session bug: an investigator session resolves to
+// the main worktree path (inherited from the coordinator's DB row), and cleanup
+// must NOT delete that path.
+func TestIsSafeToRemoveWorktree_MainGuard(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH — skipping git-dependent test")
+	}
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+
+	bareRoot, worktreePath, _ := setupMinimalBareRepo(t)
+	mainWorktreePath := filepath.Join(bareRoot, "main")
+
+	// Use an isolated DB so AllActiveStatus doesn't see live sessions from the host.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	t.Run("main worktree path is not safe to remove", func(t *testing.T) {
+		safe := isSafeToRemoveWorktree(mainWorktreePath, bareRoot)
+		if safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, %q) = true, want false — main worktree must be protected",
+				mainWorktreePath, bareRoot)
+		}
+	})
+
+	t.Run("feature worktree path is safe to remove", func(t *testing.T) {
+		safe := isSafeToRemoveWorktree(worktreePath, bareRoot)
+		if !safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, %q) = false, want true — feature worktree should be removable",
+				worktreePath, bareRoot)
+		}
+	})
+
+	t.Run("empty path is not safe to remove", func(t *testing.T) {
+		safe := isSafeToRemoveWorktree("", bareRoot)
+		if safe {
+			t.Errorf("isSafeToRemoveWorktree(\"\", ...) = true, want false — empty path should not be removable")
+		}
+	})
+}
+
+// TestIsSafeToRemoveWorktree_ActiveSessionGuard verifies that
+// isSafeToRemoveWorktree returns false when the target path matches the
+// worktree of an active session in the DB, even if that path is not the
+// default branch worktree. This guards against shared-worktree edge cases.
+func TestIsSafeToRemoveWorktree_ActiveSessionGuard(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	sharedPath := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Seed an active session whose worktree is sharedPath.
+	if err := d.UpsertStatus("myrepo@other-branch", "myrepo", sharedPath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	t.Run("path matching active session is not safe to remove", func(t *testing.T) {
+		// bareRoot is empty — only the DB guard should fire.
+		safe := isSafeToRemoveWorktree(sharedPath, "")
+		if safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, \"\") = true, want false — path belongs to an active session",
+				sharedPath)
+		}
+	})
+
+	t.Run("unrelated path is safe to remove", func(t *testing.T) {
+		otherPath := t.TempDir()
+		safe := isSafeToRemoveWorktree(otherPath, "")
+		if !safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, \"\") = false, want true — unrelated path should be removable",
+				otherPath)
+		}
+	})
+}
+
+// TestHeadlessCleanup_InvestigatorSessionPreservesMainWorktree verifies the
+// full end-to-end bug scenario from issue #1582: an investigator session whose
+// worktree resolves to the main worktree path must NOT have that directory
+// removed by headlessCleanup.
+//
+// The investigator session name is of the form <coordinator>~investigate-<slug>
+// (e.g. "nixos-config@main~investigate-foo"). Its worktree path in the DB is
+// the coordinator's main worktree (inherited from the coordinator's spawn row).
+func TestHeadlessCleanup_InvestigatorSessionPreservesMainWorktree(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH — skipping git-dependent test")
+	}
+	withNoopTmux(t)
+
+	bareRoot, _, _ := setupMinimalBareRepo(t)
+	mainWorktreePath := filepath.Join(bareRoot, "main")
+
+	// Use an isolated DB.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Coordinator session with the main worktree.
+	coordinatorSession := "nixos-config@main"
+	if err := d.UpsertStatus(coordinatorSession, "nixos-config", mainWorktreePath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus coordinator: %v", err)
+	}
+
+	// Investigator session: name contains "~investigate-", worktree is the
+	// coordinator's worktree (the bug scenario).
+	investigatorSession := coordinatorSession + "~investigate-some-query"
+	if err := d.UpsertStatus(investigatorSession, "nixos-config", mainWorktreePath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus investigator: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// The worktreeName extracted by cleanup is the part after "@":
+	// "main~investigate-some-query". Pass it directly along with the main
+	// worktree path and bareRoot — this simulates what the cleanup command
+	// resolves for the investigator session.
+	worktreeName := "main~investigate-some-query"
+	err = headlessCleanup(investigatorSession, worktreeName, mainWorktreePath, bareRoot)
+	if err != nil {
+		t.Errorf("headlessCleanup returned error %v, want nil", err)
+	}
+
+	// The main worktree directory must still exist.
+	if _, statErr := os.Stat(mainWorktreePath); statErr != nil {
+		t.Errorf("main worktree %q was removed by cleanup — this is the #1582 regression: %v",
+			mainWorktreePath, statErr)
+	}
+
+	// The investigator session should be marked as ended.
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	status, err := d2.CurrentStatus(investigatorSession)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("CurrentStatus returned nil — row missing")
+	}
+	if status.EndedAt == nil {
+		t.Errorf("ended_at is nil — investigator session was not marked as ended")
+	}
+}

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -1123,7 +1123,7 @@ func TestIsSafeToRemoveWorktree_MainGuard(t *testing.T) {
 	t.Cleanup(func() { SetTestDBPath("") })
 
 	t.Run("main worktree path is not safe to remove", func(t *testing.T) {
-		safe := isSafeToRemoveWorktree(mainWorktreePath, bareRoot)
+		safe := isSafeToRemoveWorktree("myrepo@some-session", mainWorktreePath, bareRoot)
 		if safe {
 			t.Errorf("isSafeToRemoveWorktree(%q, %q) = true, want false — main worktree must be protected",
 				mainWorktreePath, bareRoot)
@@ -1131,7 +1131,7 @@ func TestIsSafeToRemoveWorktree_MainGuard(t *testing.T) {
 	})
 
 	t.Run("feature worktree path is safe to remove", func(t *testing.T) {
-		safe := isSafeToRemoveWorktree(worktreePath, bareRoot)
+		safe := isSafeToRemoveWorktree("myrepo@feature", worktreePath, bareRoot)
 		if !safe {
 			t.Errorf("isSafeToRemoveWorktree(%q, %q) = false, want true — feature worktree should be removable",
 				worktreePath, bareRoot)
@@ -1139,7 +1139,7 @@ func TestIsSafeToRemoveWorktree_MainGuard(t *testing.T) {
 	})
 
 	t.Run("empty path is not safe to remove", func(t *testing.T) {
-		safe := isSafeToRemoveWorktree("", bareRoot)
+		safe := isSafeToRemoveWorktree("myrepo@some-session", "", bareRoot)
 		if safe {
 			t.Errorf("isSafeToRemoveWorktree(\"\", ...) = true, want false — empty path should not be removable")
 		}
@@ -1171,19 +1171,30 @@ func TestIsSafeToRemoveWorktree_ActiveSessionGuard(t *testing.T) {
 
 	t.Run("path matching active session is not safe to remove", func(t *testing.T) {
 		// bareRoot is empty — only the DB guard should fire.
-		safe := isSafeToRemoveWorktree(sharedPath, "")
+		// Use a different session name than the one that owns sharedPath, to
+		// simulate a second session sharing the same worktree path.
+		safe := isSafeToRemoveWorktree("myrepo@cleaning-up-session", sharedPath, "")
 		if safe {
-			t.Errorf("isSafeToRemoveWorktree(%q, \"\") = true, want false — path belongs to an active session",
-				sharedPath)
+			t.Errorf("isSafeToRemoveWorktree(%q, %q, \"\") = true, want false — path belongs to an active session",
+				"myrepo@cleaning-up-session", sharedPath)
+		}
+	})
+
+	t.Run("own session path is safe to remove (self-exclusion)", func(t *testing.T) {
+		// When cleaning up the session that owns sharedPath, it should be safe.
+		safe := isSafeToRemoveWorktree("myrepo@other-branch", sharedPath, "")
+		if !safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, %q, \"\") = false, want true — session should be able to remove its own worktree",
+				"myrepo@other-branch", sharedPath)
 		}
 	})
 
 	t.Run("unrelated path is safe to remove", func(t *testing.T) {
 		otherPath := t.TempDir()
-		safe := isSafeToRemoveWorktree(otherPath, "")
+		safe := isSafeToRemoveWorktree("myrepo@some-session", otherPath, "")
 		if !safe {
-			t.Errorf("isSafeToRemoveWorktree(%q, \"\") = false, want true — unrelated path should be removable",
-				otherPath)
+			t.Errorf("isSafeToRemoveWorktree(%q, %q, \"\") = false, want true — unrelated path should be removable",
+				"myrepo@some-session", otherPath)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes the bug reported in #1582 where `prism cleanup --yes --session <investigator-session>` removes the `main` worktree.

## Root Cause

An investigator session is spawned with the **coordinator's worktree path** as its own worktree (it runs read-only against the invoker's checkout). When cleanup resolves the worktree path for the investigator session (via tmux window CWD or DB fallback), it gets back the main worktree path (e.g. `/home/ben/code/nixos-config/main`).

The existing coordinator guard checks `worktreeName == defaultBranch`, where `worktreeName` is the suffix after `@` in the session name. For an investigator session named `nixos-config@main~investigate-foo`, the worktreeName is `main~investigate-foo`, which does **not** match `main` — so the guard is bypassed and `git.RemoveWorktree` is called on the main worktree.

## Fix

Add `isSafeToRemoveWorktree(worktreePath, bareRoot string) bool` which checks two conditions before any filesystem removal in `headlessCleanupWithJSON`:

1. The target path must not match the default branch worktree (`<bareRoot>/<defaultBranch>`).
2. The target path must not match the worktree of any currently active DB session.

If either check fails, filesystem removal is skipped and a warning is logged to stderr. The session's tmux session and DB row are still cleaned up normally.

## Tests Added

- `TestIsSafeToRemoveWorktree_MainGuard`: unit test for the default-branch guard using a real git bare repo
- `TestIsSafeToRemoveWorktree_ActiveSessionGuard`: unit test for the active-session path collision guard
- `TestHeadlessCleanup_InvestigatorSessionPreservesMainWorktree`: end-to-end regression test for the exact #1582 scenario — verifies the main worktree directory survives cleanup of the investigator session

Closes #1582