### PR TITLE
sidecar: suppress intermediate investigator pings; notify once at completion

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -181,6 +181,8 @@ func (s *Sidecar) handleServerConnected() {
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
+		finalText := s.lastInvestigatorText
+		go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
 	})
 }
 
@@ -268,6 +270,8 @@ func (s *Sidecar) handleSessionFinished() {
 			s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
+			finalText := s.lastInvestigatorText
+			go s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText)
 			return
 		}
 
@@ -292,6 +296,8 @@ func (s *Sidecar) handleSessionFinished() {
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
+		finalText := s.lastInvestigatorText
+		go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
 	})
 }
 
@@ -330,6 +336,8 @@ func (s *Sidecar) handleSessionIdle() {
 			s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
+			finalText := s.lastInvestigatorText
+			go s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText)
 			return
 		}
 
@@ -354,6 +362,8 @@ func (s *Sidecar) handleSessionIdle() {
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		go s.notifyCoordinator()
+		finalText := s.lastInvestigatorText
+		go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
 	})
 }
 
@@ -511,6 +521,8 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		s.logger().Printf("sidecar: transition -> interrupted (cause=interrupted_by_denial)")
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
+		finalText := s.lastInvestigatorText
+		go s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText)
 	} else {
 		s.cancelIdleTimer()
 		s.cancelRecoveryTimer()
@@ -522,6 +534,8 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		s.upsertState(agent.StateError, nil, nil)
 		s.writeStateChange(agent.StateError)
 		s.writeEvent("error", map[string]string{"name": errorName}, nil)
+		finalText := s.lastInvestigatorText
+		go s.notifyInvestigatorCompletion(agent.StateError, finalText)
 	}
 }
 
@@ -814,6 +828,8 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 				s.upsertState(agent.StateFinished, nil, nil)
 				s.writeStateChange(agent.StateFinished)
 				go s.notifyCoordinator()
+				finalText := s.lastInvestigatorText
+				go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
 			})
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -50,69 +50,92 @@ func investigateAgentInvokerSession(sessionName string) (string, bool) {
 	return sessionName[:idx], true
 }
 
-// notifyInvestigatorTurnEnd delivers a body-bearing per-turn notification from
-// an investigate-agent session to its recorded invoker session. It is called
-// asynchronously (via go) after each turn_end that carries a non-empty closing
-// assistant text block, so s.mu must NOT be held.
+// notifyInvestigatorCompletion delivers a single terminal notification from
+// an investigate-agent session to its invoker when the investigation reaches a
+// terminal state (finished, interrupted, or error).
+//
+// It is called asynchronously (via go) from the state-transition points in
+// events.go, so s.mu must NOT be held.
+//
+// The finalText parameter is the text of the last completed turn. When the
+// state is not agent.StateFinished (i.e. interrupted or error), an explicit
+// failure notice is prepended regardless of whether finalText is present.
 //
 // Delivery uses promptdelivery.DeliverToSession with deliverAs="followUp" so
-// that the notification queues behind any in-flight invoker turn rather than
-// being dropped.
+// that the notification queues behind any in-flight invoker turn.
 //
 // The notification body contains:
 //   - A sender header: "From investigator session: <name>"
-//   - The final assistant text block of the turn, verbatim.
+//   - The final assistant text (or a failure notice if state != finished).
 //   - A steering-channel hint: "Reply with: prism prompt <name> --prompt '...'"
 //
-// When the invoker session has ended, the notification is dropped silently with
-// a structured log line. When delivery fails, the failure is logged with both
-// session names; the investigator keeps running.
-func (s *Sidecar) notifyInvestigatorTurnEnd(text string) {
+// When the invoker session has ended, the notification is dropped silently.
+// When delivery fails, the failure is logged; the investigator keeps running.
+func (s *Sidecar) notifyInvestigatorCompletion(state agent.AgentState, finalText string) {
 	invokerSession, isInvestigate := investigateAgentInvokerSession(s.cfg.SessionName)
 	if !isInvestigate {
 		// Not an investigate-agent session — nothing to do.
 		return
 	}
 
-	// Trim the text block; skip delivery when empty after trim.
-	trimmed := strings.TrimSpace(text)
-	if trimmed == "" {
-		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: empty text block — skipping (investigator=%s invoker=%s)",
-			s.cfg.SessionName, invokerSession)
-		return
+	// Build the body text.
+	var bodyText string
+	trimmed := strings.TrimSpace(finalText)
+	switch state {
+	case agent.StateFinished:
+		if trimmed == "" {
+			s.logger().Printf("sidecar: notifyInvestigatorCompletion: no final text — delivering empty-completion notice (investigator=%s invoker=%s)",
+				s.cfg.SessionName, invokerSession)
+			bodyText = fmt.Sprintf(
+				"From investigator session: %s\n\nInvestigation complete (no final text recorded).\n\nReply with: prism prompt %s --prompt '...'",
+				s.cfg.SessionName, s.cfg.SessionName,
+			)
+		} else {
+			bodyText = fmt.Sprintf(
+				"From investigator session: %s\n\n%s\n\nReply with: prism prompt %s --prompt '...'",
+				s.cfg.SessionName, trimmed, s.cfg.SessionName,
+			)
+		}
+	default:
+		// Interrupted or error: always notify so the invoker learns of the failure.
+		if trimmed != "" {
+			bodyText = fmt.Sprintf(
+				"From investigator session: %s\n\nInvestigation ended with state %q.\n\nLast output:\n%s\n\nReply with: prism prompt %s --prompt '...'",
+				s.cfg.SessionName, state, trimmed, s.cfg.SessionName,
+			)
+		} else {
+			bodyText = fmt.Sprintf(
+				"From investigator session: %s\n\nInvestigation ended with state %q (no output recorded).\n\nReply with: prism prompt %s --prompt '...'",
+				s.cfg.SessionName, state, s.cfg.SessionName,
+			)
+		}
 	}
 
 	// Look up the invoker session.
 	invokerStatus, err := s.cfg.DB.CurrentStatus(invokerSession)
 	if err != nil {
-		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: DB lookup for invoker %q: %v — skipping (investigator=%s)",
+		s.logger().Printf("sidecar: notifyInvestigatorCompletion: DB lookup for invoker %q: %v — skipping (investigator=%s)",
 			invokerSession, err, s.cfg.SessionName)
 		return
 	}
 	if invokerStatus == nil {
-		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: invoker session %q not found in DB — skipping (investigator=%s)",
+		s.logger().Printf("sidecar: notifyInvestigatorCompletion: invoker session %q not found in DB — skipping (investigator=%s)",
 			invokerSession, s.cfg.SessionName)
 		return
 	}
 	if invokerStatus.EndedAt != nil {
-		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: invoker session %q has ended — dropping notification (investigator=%s reason=invoker_ended)",
+		s.logger().Printf("sidecar: notifyInvestigatorCompletion: invoker session %q has ended — dropping notification (investigator=%s reason=invoker_ended)",
 			invokerSession, s.cfg.SessionName)
 		return
 	}
 
-	// Build the notification body.
-	body := fmt.Sprintf(
-		"From investigator session: %s\n\n%s\n\nReply with: prism prompt %s --prompt '...'",
-		s.cfg.SessionName, trimmed, s.cfg.SessionName,
-	)
-
-	if err := promptdelivery.DeliverToSession(invokerSession, invokerStatus, body, buildNotifyPromptBody, "", "followUp"); err != nil {
-		s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: FAILED — investigator=%s invoker=%s reason=%v",
+	if err := promptdelivery.DeliverToSession(invokerSession, invokerStatus, bodyText, buildNotifyPromptBody, "", "followUp"); err != nil {
+		s.logger().Printf("sidecar: notifyInvestigatorCompletion: FAILED — investigator=%s invoker=%s reason=%v",
 			s.cfg.SessionName, invokerSession, err)
 		return
 	}
-	s.logger().Printf("sidecar: notifyInvestigatorTurnEnd: delivered to invoker=%s (investigator=%s)",
-		invokerSession, s.cfg.SessionName)
+	s.logger().Printf("sidecar: notifyInvestigatorCompletion: delivered state=%s to invoker=%s (investigator=%s)",
+		state, invokerSession, s.cfg.SessionName)
 }
 
 // notifyParentWorkerOnStartupFailure sends a notification to the parent worker

--- a/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness/opencode"
 )
@@ -101,13 +102,13 @@ func TestInvestigateAgentInvokerSession(t *testing.T) {
 	}
 }
 
-// ── notifyInvestigatorTurnEnd ────────────────────────────────────────────────
+// ── notifyInvestigatorCompletion ─────────────────────────────────────────────
 
-// TestNotifyInvestigatorTurnEnd_Delivery verifies that a body-bearing per-turn
-// notification is delivered to the invoker session when the turn ends with a
-// non-empty assistant text block. The notification body must contain the
+// TestNotifyInvestigatorCompletion_Delivery verifies that a completion
+// notification is delivered to the invoker session when the investigation
+// finishes with a non-empty final text. The notification body must contain the
 // sender label, the text block verbatim, and the steering-channel hint.
-func TestNotifyInvestigatorTurnEnd_Delivery(t *testing.T) {
+func TestNotifyInvestigatorCompletion_Delivery(t *testing.T) {
 	d := openTestDB(t)
 	repo := "nixos-config"
 	invokerSession := repo + "@main"
@@ -152,8 +153,8 @@ func TestNotifyInvestigatorTurnEnd_Delivery(t *testing.T) {
 	}
 	s := New(cfg)
 
-	const turnText = "I have found the root cause. The issue is in package X."
-	s.notifyInvestigatorTurnEnd(turnText)
+	const finalText = "I have found the root cause. The issue is in package X."
+	s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
 
 	// Allow async HTTP call to complete.
 	deadline := time.Now().Add(2 * time.Second)
@@ -180,7 +181,7 @@ func TestNotifyInvestigatorTurnEnd_Delivery(t *testing.T) {
 	if !strings.Contains(body, "From investigator session: "+investigatorSession) {
 		t.Errorf("notification body missing sender label; got: %s", body)
 	}
-	if !strings.Contains(body, turnText) {
+	if !strings.Contains(body, finalText) {
 		t.Errorf("notification body missing verbatim text block; got: %s", body)
 	}
 	if !strings.Contains(body, "prism prompt "+investigatorSession+" --prompt") {
@@ -188,25 +189,41 @@ func TestNotifyInvestigatorTurnEnd_Delivery(t *testing.T) {
 	}
 }
 
-// TestNotifyInvestigatorTurnEnd_EmptyText verifies that no notification is
-// delivered when the text block is empty or whitespace-only.
-func TestNotifyInvestigatorTurnEnd_EmptyText(t *testing.T) {
+// TestNotifyInvestigatorCompletion_EmptyText verifies that even with empty
+// final text, a completion notice is still delivered (so the invoker learns
+// the investigation finished, even if no output was recorded).
+func TestNotifyInvestigatorCompletion_EmptyText(t *testing.T) {
 	d := openTestDB(t)
 	repo := "nixos-config"
 	invokerSession := repo + "@main"
 	investigatorSession := invokerSession + "~investigate-testslug"
+	invokerSID := "invoker-sid-empty"
 
-	var delivered int
+	var mu sync.Mutex
+	var receivedBodies []string
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			delivered++
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
+			return
 		}
-		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
+			body := make([]byte, 4096)
+			n, _ := r.Body.Read(body)
+			mu.Lock()
+			receivedBodies = append(receivedBodies, string(body[:n]))
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
 
 	srvPort := parseSrvPort(t, srv.URL)
-	seedSessionWithHarnessPort(t, d, invokerSession, repo, "sid-empty", srvPort)
+	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
 
 	clk := newTestClock()
 	cfg := Config{
@@ -220,22 +237,110 @@ func TestNotifyInvestigatorTurnEnd_EmptyText(t *testing.T) {
 	}
 	s := New(cfg)
 
-	// Empty string — no delivery.
-	s.notifyInvestigatorTurnEnd("")
-	// Whitespace-only — no delivery.
-	s.notifyInvestigatorTurnEnd("   \n\t  ")
+	// Even with empty final text, a completion notice must be delivered.
+	s.notifyInvestigatorCompletion(agent.StateFinished, "")
 
-	// Give any async delivery a chance (there should be none).
-	time.Sleep(50 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(receivedBodies)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 
-	if delivered > 0 {
-		t.Errorf("expected no delivery for empty/whitespace text, got %d", delivered)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(receivedBodies) != 1 {
+		t.Fatalf("want 1 delivery for empty-text finished, got %d", len(receivedBodies))
+	}
+	body := receivedBodies[0]
+	if !strings.Contains(body, "Investigation complete") {
+		t.Errorf("empty-text completion notice missing expected phrase; got: %s", body)
 	}
 }
 
-// TestNotifyInvestigatorTurnEnd_InvokerEnded verifies that the notification is
-// dropped silently (no panic, no delivery) when the invoker session has ended.
-func TestNotifyInvestigatorTurnEnd_InvokerEnded(t *testing.T) {
+// TestNotifyInvestigatorCompletion_ErrorState verifies that an error-state
+// completion delivers a notification containing the failure state name.
+func TestNotifyInvestigatorCompletion_ErrorState(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	invokerSession := repo + "@main"
+	investigatorSession := invokerSession + "~investigate-errslug"
+	invokerSID := "invoker-sid-error"
+
+	var mu sync.Mutex
+	var receivedBodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
+			body := make([]byte, 4096)
+			n, _ := r.Body.Read(body)
+			mu.Lock()
+			receivedBodies = append(receivedBodies, string(body[:n]))
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-test-error",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	s.notifyInvestigatorCompletion(agent.StateError, "partial findings before crash")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(receivedBodies)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(receivedBodies) != 1 {
+		t.Fatalf("want 1 delivery for error state, got %d", len(receivedBodies))
+	}
+	body := receivedBodies[0]
+	if !strings.Contains(body, string(agent.StateError)) {
+		t.Errorf("error-state notification missing state name; got: %s", body)
+	}
+	if !strings.Contains(body, "partial findings before crash") {
+		t.Errorf("error-state notification missing last output; got: %s", body)
+	}
+}
+
+// TestNotifyInvestigatorCompletion_InvokerEnded verifies that the notification
+// is dropped silently (no panic, no delivery) when the invoker session has ended.
+func TestNotifyInvestigatorCompletion_InvokerEnded(t *testing.T) {
 	d := openTestDB(t)
 	repo := "nixos-config"
 	invokerSession := repo + "@main"
@@ -264,7 +369,7 @@ func TestNotifyInvestigatorTurnEnd_InvokerEnded(t *testing.T) {
 	}
 	s := New(cfg)
 
-	s.notifyInvestigatorTurnEnd("some findings here")
+	s.notifyInvestigatorCompletion(agent.StateFinished, "some findings here")
 	time.Sleep(50 * time.Millisecond)
 
 	if delivered > 0 {
@@ -272,9 +377,9 @@ func TestNotifyInvestigatorTurnEnd_InvokerEnded(t *testing.T) {
 	}
 }
 
-// TestNotifyInvestigatorTurnEnd_NotInvestigateSession verifies that a session
+// TestNotifyInvestigatorCompletion_NotInvestigateSession verifies that a session
 // NOT named with ~investigate does NOT trigger any delivery.
-func TestNotifyInvestigatorTurnEnd_NotInvestigateSession(t *testing.T) {
+func TestNotifyInvestigatorCompletion_NotInvestigateSession(t *testing.T) {
 	d := openTestDB(t)
 	repo := "nixos-config"
 
@@ -300,7 +405,7 @@ func TestNotifyInvestigatorTurnEnd_NotInvestigateSession(t *testing.T) {
 	}
 	s := New(cfg)
 
-	s.notifyInvestigatorTurnEnd("some text that should not be delivered")
+	s.notifyInvestigatorCompletion(agent.StateFinished, "some text that should not be delivered")
 	time.Sleep(50 * time.Millisecond)
 
 	if delivered > 0 {
@@ -362,10 +467,10 @@ func TestNotifyCoordinator_InvestigateAgentSuppressed(t *testing.T) {
 	}
 }
 
-// TestNotifyInvestigatorTurnEnd_ConcurrentDelivery verifies that two concurrent
-// investigator sessions can deliver to the same invoker without mangling each
-// other's sender labels.
-func TestNotifyInvestigatorTurnEnd_ConcurrentDelivery(t *testing.T) {
+// TestNotifyInvestigatorCompletion_ConcurrentDelivery verifies that two
+// concurrent investigator sessions can deliver completion notifications to the
+// same invoker without mangling each other's sender labels.
+func TestNotifyInvestigatorCompletion_ConcurrentDelivery(t *testing.T) {
 	d := openTestDB(t)
 	repo := "nixos-config"
 	invokerSession := repo + "@main"
@@ -423,8 +528,8 @@ func TestNotifyInvestigatorTurnEnd_ConcurrentDelivery(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); s1.notifyInvestigatorTurnEnd("alpha findings") }()
-	go func() { defer wg.Done(); s2.notifyInvestigatorTurnEnd("beta findings") }()
+	go func() { defer wg.Done(); s1.notifyInvestigatorCompletion(agent.StateFinished, "alpha findings") }()
+	go func() { defer wg.Done(); s2.notifyInvestigatorCompletion(agent.StateFinished, "beta findings") }()
 	wg.Wait()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -462,5 +567,100 @@ func TestNotifyInvestigatorTurnEnd_ConcurrentDelivery(t *testing.T) {
 	}
 	if !foundBeta {
 		t.Errorf("beta investigator label not found in any delivery; bodies: %v", bodies)
+	}
+}
+
+// TestInvestigatorNoIntermediatePings verifies that intermediate turn_end
+// events on an investigate-agent session do NOT produce notifications to the
+// invoker — only completion should trigger delivery.
+//
+// This is the regression test for issue #1580: the old code called
+// notifyInvestigatorTurnEnd on every turn_end, flooding the coordinator with
+// noise notifications. The new code accumulates the text and fires exactly
+// once at terminal state.
+func TestInvestigatorNoIntermediatePings(t *testing.T) {
+	d := openTestDB(t)
+	repo := "nixos-config"
+	invokerSession := repo + "@main"
+	investigatorSession := invokerSession + "~investigate-nopings"
+	invokerSID := "invoker-sid-nopings"
+
+	var mu sync.Mutex
+	var deliveryCount int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
+			mu.Lock()
+			deliveryCount++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	srvPort := parseSrvPort(t, srv.URL)
+	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        repo,
+		Worktree:    "/tmp/investigate-nopings",
+		DB:          d,
+		Clock:       clk,
+		HTTPClient:  srv.Client(),
+		Harness:     opencode.New("http://localhost:0", srv.Client(), "", ""),
+	}
+	s := New(cfg)
+
+	// Simulate 5 intermediate turns by directly updating lastInvestigatorText
+	// (as the sidecar event loop does on turn_end), without calling any notify
+	// function. None of these should produce deliveries.
+	for i := 0; i < 5; i++ {
+		s.mu.Lock()
+		s.lastInvestigatorText = "intermediate turn text"
+		s.mu.Unlock()
+	}
+
+	// No deliveries should have happened yet.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	countAfterTurns := deliveryCount
+	mu.Unlock()
+	if countAfterTurns != 0 {
+		t.Errorf("expected 0 deliveries after intermediate turns, got %d", countAfterTurns)
+	}
+
+	// Now fire completion — exactly one delivery should occur.
+	s.mu.Lock()
+	s.lastInvestigatorText = "final report text"
+	finalText := s.lastInvestigatorText
+	s.mu.Unlock()
+	s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := deliveryCount
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	finalCount := deliveryCount
+	mu.Unlock()
+	if finalCount != 1 {
+		t.Errorf("expected exactly 1 delivery at completion, got %d", finalCount)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -369,6 +369,12 @@ type Sidecar struct {
 	// Protected by s.mu.
 	pipeAccum *string
 
+	// lastInvestigatorText holds the most recent completed turn text for an
+	// investigate-agent session. Updated on every turn_end; read at completion
+	// time by notifyInvestigatorCompletion to deliver the final report.
+	// Protected by s.mu.
+	lastInvestigatorText string
+
 	// reviewingInFlight is set to true when the /review handler successfully
 	// writes the reviewing state to the DB, and cleared when the monitor
 	// delivers the review-complete prompt via /prompt (same-session,
@@ -1235,10 +1241,10 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 					}
 					stdioFlushPipeAccum(s, line)
 					s.writeEvent(frame.Type, json.RawMessage(line), nil)
-					s.mu.Unlock()
 					if turnText != "" {
-						go s.notifyInvestigatorTurnEnd(turnText)
+						s.lastInvestigatorText = turnText
 					}
+					s.mu.Unlock()
 				}
 				continue
 			}
@@ -1309,10 +1315,10 @@ func (s *Sidecar) runStartupStdio(ctx context.Context) error {
 			}
 			stdioFlushPipeAccum(s, line)
 			s.writeEvent(frame.Type, json.RawMessage(line), nil)
-			s.mu.Unlock()
 			if turnText != "" {
-				go s.notifyInvestigatorTurnEnd(turnText)
+				s.lastInvestigatorText = turnText
 			}
+			s.mu.Unlock()
 
 		case "state_change":
 			st := agent.AgentState(frame.State)
@@ -1957,10 +1963,9 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 			s.writeEvent("msg_assistant", p, nil)
 		}
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
-		// Notify the invoker after the turn_end frame is persisted. Runs async
-		// so that lock-release from handlePipeFrame happens promptly.
+		// Track the most recent turn text for the final completion notification.
 		if text != "" {
-			go s.notifyInvestigatorTurnEnd(text)
+			s.lastInvestigatorText = text
 		}
 
 	case "auto_retry_start":


### PR DESCRIPTION
Closes #1580

## Problem

`prism investigate` was delivering a bus notification to the spawning coordinator on **every single turn** the investigator took — including intermediate turns like "Now let me read the key files." This caused 10–20 noise notifications per investigation.

## Solution

Replace the per-turn `notifyInvestigatorTurnEnd` pattern with a single terminal notification via `notifyInvestigatorCompletion(state, finalText)`.

### Key changes

**`internal/sidecar/notify.go`**
- Rename `notifyInvestigatorTurnEnd(text)` → `notifyInvestigatorCompletion(state, finalText)`
- The new function fires exactly once at terminal state (finished, interrupted, or error)
- For `StateFinished`: delivers the final report text verbatim to the invoker
- For error/interrupted states: delivers a failure notice including the last recorded output so the invoker always learns of failures

**`internal/sidecar/sidecar.go`**
- Add `lastInvestigatorText string` field (protected by `s.mu`)
- All three `turn_end` handler sites now update `s.lastInvestigatorText` instead of dispatching `go s.notifyInvestigatorTurnEnd()`

**`internal/sidecar/events.go`**
- Add `go s.notifyInvestigatorCompletion()` calls at all terminal state transitions:
  - `StateFinished`: recovery_timer, finished_debounce, idle_debounce, root_agent_idle_debounce
  - `StateInterrupted`: both `manualDenial` paths in debounce closures + `handleSessionError` (MessageAbortedError)
  - `StateError`: `handleSessionError` (non-MessageAbortedError)

**`internal/sidecar/notify_investigate_test.go`**
- Rename tests to match new API
- Add `TestInvestigatorNoIntermediatePings` — regression test for #1580 proving intermediate turns produce zero deliveries
- Add `TestNotifyInvestigatorCompletion_ErrorState` — verifies error-state notifications are delivered
- Update empty-text test: a `StateFinished` with no text now delivers a "complete (no final text)" notice rather than being silently dropped

## AC verification

- ✅ Exactly one notification delivered at completion containing final report
- ✅ Intermediate turns produce no notifications (enforced by new regression test)  
- ✅ Error/interrupted states still notify the invoker
- ✅ Worker and coordinator behaviour completely unchanged (no changes to `notifyCoordinator` or its guards)

All tests pass: `go test ./...` ✅  
Build: `go build ./...` ✅  
Nix build: `nix build .#prism` ✅