### PR TITLE
feat: pi extension for Atlassian MCP bridge

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -54,6 +54,14 @@
         cp -r ${./pi/extensions/anthropic-oauth}/* $out/anthropic-oauth/
       '';
 
+      # Atlassian MCP extension for pi — connects to mcp.atlassian.com via
+      # OAuth PKCE, enumerates tools/list at startup, and registers each tool
+      # via pi.registerTool(). See pi/extensions/atlassian/UPSTREAM.md.
+      atlassianExtensionDir = pkgs.runCommand "pi-atlassian-extension" { } ''
+        mkdir -p $out
+        cp -r ${./pi/extensions/atlassian}/* $out/
+      '';
+
       # Prism extension for pi — a single derivation whose root contains
       # prism.ts. This path is wired into config.json via piExtensionDir so
       # prism can locate the extension at spawn time.
@@ -83,7 +91,14 @@
         # files and loaded by pi's jiti-based extension loader at runtime.
         # To port a future upstream fix, see:
         #   modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
-        extensions = [ "${piExtensionsDir}/anthropic-oauth/index.ts" ];
+        extensions = [
+          "${piExtensionsDir}/anthropic-oauth/index.ts"
+          # Atlassian MCP extension: connects to mcp.atlassian.com via OAuth
+          # PKCE, enumerates tools/list at startup, and registers each tool.
+          # Use /login-atlassian in a pi session to authenticate.
+          # See pi/extensions/atlassian/UPSTREAM.md for auth method rationale.
+          "${atlassianExtensionDir}/index.ts"
+        ];
       };
 
       colourLib = import ../../colour-scheme/lib.nix;
@@ -185,6 +200,9 @@
         # Prism extension — GC-rooted so the store path referenced in
         # config.json is not removed by nix-collect-garbage.
         home.file.".pi/agent/prism-extension".source = prismExtensionDir;
+        # Atlassian MCP extension — GC-rooted so the nix-store path referenced
+        # in settings.json is not removed by nix-collect-garbage.
+        home.file.".pi/agent/atlassian-extension".source = atlassianExtensionDir;
 
         home.persistence."/persist" = {
           directories = [ ".pi" ];

--- a/modules/programs/prism/pi/extensions/atlassian/UPSTREAM.md
+++ b/modules/programs/prism/pi/extensions/atlassian/UPSTREAM.md
@@ -1,0 +1,128 @@
+# Upstream Sync State — pi Atlassian MCP Extension
+
+This extension is original code (not vendored from an upstream); it was written
+for issue #1583. This file documents the auth flow rationale, token storage,
+and the slim-field-drop provenance.
+
+## Auth method
+
+**Chosen: OAuth PKCE + dynamic client registration via the Atlassian MCP auth server.**
+
+### Why not API token (ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN)?
+
+The `mcp.atlassian.com` server accepts HTTP Basic auth (`base64(email:token)`) but
+the API token path only exposes **2 Teamwork Graph tools**:
+- `getTeamworkGraphContext`
+- `getTeamworkGraphObject`
+
+These are read-only graph traversal tools — not the Jira/Confluence CRUD surface
+the extension needs (search, create, update, comment, transition, etc.).
+
+Verified empirically on 2026-05-14 against `https://mcp.atlassian.com/v1/mcp` with
+`ATLASSIAN_SITE=thankyoupayroll.atlassian.net` and valid API token credentials:
+
+```
+Total tools (Basic auth): 2
+  - getTeamworkGraphContext
+  - getTeamworkGraphObject
+```
+
+The Teamwork Graph tools also return `"You don't have permission to connect via API
+token. Please ask your organization admin for access."` on actual invocation, so the
+API token path is functionally unavailable for this site.
+
+### OAuth path
+
+The Atlassian MCP auth server uses standard OAuth 2.0 + PKCE with dynamic client
+registration. Discovery endpoint:
+`https://mcp.atlassian.com/.well-known/oauth-authorization-server`
+
+With a valid OAuth Bearer token, `tools/list` returns **31 tools** including the
+full Jira and Confluence CRUD surface:
+- `atlassianUserInfo`, `getAccessibleAtlassianResources`
+- `getConfluencePage`, `searchConfluenceUsingCql`, `getConfluenceSpaces`,
+  `getPagesInConfluenceSpace`, `getConfluencePageFooterComments`,
+  `getConfluencePageInlineComments`, `getConfluenceCommentChildren`,
+  `getConfluencePageDescendants`, `createConfluencePage`, `updateConfluencePage`,
+  `createConfluenceFooterComment`, `createConfluenceInlineComment`
+- `getJiraIssue`, `editJiraIssue`, `createJiraIssue`, `getTransitionsForJiraIssue`,
+  `getJiraIssueRemoteIssueLinks`, `getVisibleJiraProjects`,
+  `getJiraProjectIssueTypesMetadata`, `getJiraIssueTypeMetaWithFields`,
+  `addCommentToJiraIssue`, `transitionJiraIssue`, `searchJiraIssuesUsingJql`,
+  `lookupJiraAccountId`, `addWorklogToJiraIssue`, `getIssueLinkTypes`,
+  `createIssueLink`, `search`, `fetch`
+
+### Auth server endpoints
+
+| Endpoint | URL |
+|---|---|
+| Discovery | `https://mcp.atlassian.com/.well-known/oauth-authorization-server` |
+| Authorization | `https://mcp.atlassian.com/v1/authorize` |
+| Token | `https://cf.mcp.atlassian.com/v1/token` |
+| Client registration | `https://cf.mcp.atlassian.com/v1/register` |
+
+### Token storage
+
+OAuth tokens are stored in `~/.pi/agent/atlassian-mcp-oauth.json` (mode 0o600).
+The file contains:
+
+```json
+{
+  "accessToken": "<bearer>",
+  "refreshToken": "<refresh>",
+  "expiresAt": 1234567890000,
+  "clientId": "<dynamic-client-id>"
+}
+```
+
+The extension reads this file on every `session_start`. If the token is expired, it
+attempts a refresh using `refreshToken` before falling back to a fresh OAuth login.
+
+A fresh login requires interactive user action (browser-based PKCE flow). The local
+callback server listens on `localhost:3737/oauth/callback`.
+
+To trigger a fresh login, run `/login-atlassian` from within a pi session.
+
+## Slim field-drop provenance
+
+The `slim.ts` file is a TypeScript port of the drop-key logic from:
+`modules/programs/prism/opencode/mcp-atlassian-slim-proxy.mjs` lines 12–115.
+
+The drop-key sets (`UNIVERSAL_DROP_KEYS`, `JIRA_ISSUE_DROP_KEYS`,
+`CONFLUENCE_DROP_KEYS`, `USER_INFO_DROP_KEYS`, `RESOURCE_DROP_KEYS`) and the
+`slimJson` recursive traversal function were ported verbatim with only the
+JavaScript→TypeScript adaptation (explicit types, no process.env drops).
+
+The opencode-specific debug-file writing (`fs.appendFileSync` to
+`~/.local/state/opencode/mcp-*.jsonl`) was intentionally stripped; this extension
+uses the same `ATLASSIAN_MCP_DEBUG=1` env-var gate for stderr logging only.
+
+## MCP transport
+
+The `mcp-client.ts` file is a hand-rolled Streamable HTTP MCP client using Node.js
+built-ins only. The `@modelcontextprotocol/sdk` is not bundled in pi's dependency
+tree (verified against pi-coding-agent 0.72.1), so it cannot be imported.
+
+The transport implements:
+- `initialize` → get session ID from `Mcp-Session-Id` response header
+- `notifications/initialized` → best-effort notification
+- `tools/list` → enumerate all tools
+- `tools/call` → invoke a tool and return content array
+
+Session IDs returned in `Mcp-Session-Id` headers are forwarded on subsequent
+requests to enable server-side session affinity.
+
+If the `@modelcontextprotocol/sdk` ever becomes available in pi's dependency tree,
+the `McpSession` class could be replaced with the SDK's `StreamableHTTPClientTransport`.
+
+## Future updates
+
+When Atlassian adds new tools to `mcp.atlassian.com`:
+- No code changes needed — tools are enumerated dynamically via `tools/list` at startup.
+- Drop-key patterns in `optionsForTool` may need extension if the new tools have
+  verbose fields not yet covered by the existing patterns.
+
+When the slim-proxy drop keys are updated in `mcp-atlassian-slim-proxy.mjs`:
+1. Port the change to `slim.ts`.
+2. Update the tests in `slim.test.ts`.
+3. No UPSTREAM.md SHA to update (this is original code, not vendored).

--- a/modules/programs/prism/pi/extensions/atlassian/auth.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/auth.ts
@@ -1,0 +1,452 @@
+// Auth module for the Atlassian MCP pi extension.
+//
+// Auth method: HTTP Basic auth using the existing ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN
+// environment variables that already exist in this repo (set by
+// modules/programs/atlassian/default.nix via sops-managed secrets).
+//
+// The mcp.atlassian.com server accepts Basic auth (base64 of email:token) for its
+// API token path, which returns `initialize` and `tools/list` successfully,
+// but the API token path only exposes 2 Teamwork Graph tools (getTeamworkGraphContext,
+// getTeamworkGraphObject) — not the full Jira/Confluence CRUD surface.
+//
+// The OAuth PKCE path (used by mcp-remote) gives 31 tools including the full
+// Jira and Confluence CRUD surface. We therefore use OAuth via the Atlassian
+// MCP authorization server.
+//
+// OAuth server discovery: https://mcp.atlassian.com/.well-known/oauth-authorization-server
+//   - authorization_endpoint: https://mcp.atlassian.com/v1/authorize
+//   - token_endpoint: https://cf.mcp.atlassian.com/v1/token
+//   - registration_endpoint: https://cf.mcp.atlassian.com/v1/register
+//
+// Token storage: ~/.pi/agent/atlassian-mcp-oauth.json (mirrors ~/.mcp-auth/mcp-remote-0.1.13/)
+//
+// See UPSTREAM.md for auth method rationale and provenance.
+
+import { createServer } from "node:http"
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const AUTHORIZATION_ENDPOINT = "https://mcp.atlassian.com/v1/authorize"
+const TOKEN_ENDPOINT = "https://cf.mcp.atlassian.com/v1/token"
+const REGISTRATION_ENDPOINT = "https://cf.mcp.atlassian.com/v1/register"
+
+const CALLBACK_PORT = 3737
+const CALLBACK_HOST = "127.0.0.1"
+const CALLBACK_PATH = "/oauth/callback"
+const LOCAL_CALLBACK_TIMEOUT = 5 * 60 * 1000
+
+const TOKEN_STORE_DIR = join(homedir(), ".pi", "agent")
+const TOKEN_STORE_PATH = join(TOKEN_STORE_DIR, "atlassian-mcp-oauth.json")
+
+export interface AtlassianTokens {
+  accessToken: string
+  refreshToken: string
+  /** Epoch ms when the access token expires */
+  expiresAt: number
+  clientId: string
+}
+
+// ---------------------------------------------------------------------------
+// Token persistence
+// ---------------------------------------------------------------------------
+
+export function loadTokens(): AtlassianTokens | null {
+  try {
+    const raw = readFileSync(TOKEN_STORE_PATH, "utf8")
+    const data = JSON.parse(raw) as AtlassianTokens
+    if (!data.accessToken || !data.refreshToken || !data.clientId) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+export function saveTokens(tokens: AtlassianTokens): void {
+  try {
+    mkdirSync(TOKEN_STORE_DIR, { recursive: true })
+    writeFileSync(TOKEN_STORE_PATH, JSON.stringify(tokens, null, 2), { mode: 0o600 })
+  } catch (err) {
+    console.error("[atlassian-mcp] Failed to save tokens:", err)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic client registration
+// ---------------------------------------------------------------------------
+
+export interface ClientInfo {
+  clientId: string
+  redirectUri: string
+}
+
+export async function registerClient(): Promise<ClientInfo> {
+  const redirectUri = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`
+  const response = await fetch(REGISTRATION_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      client_name: "pi-atlassian-mcp",
+      client_uri: "https://github.com/prismatic-koi/nixos-config",
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Client registration failed: ${response.status} ${body}`)
+  }
+
+  const data = (await response.json()) as { client_id: string }
+  return { clientId: data.client_id, redirectUri }
+}
+
+// ---------------------------------------------------------------------------
+// PKCE helpers
+// ---------------------------------------------------------------------------
+
+export async function generatePKCE(): Promise<{
+  verifier: string
+  challenge: string
+}> {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  const verifier = toBase64Url(bytes)
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier),
+  )
+  return { verifier, challenge: toBase64Url(new Uint8Array(digest)) }
+}
+
+export function toBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "")
+}
+
+// ---------------------------------------------------------------------------
+// Local callback server
+// ---------------------------------------------------------------------------
+
+interface LocalAuth {
+  redirectUri: string
+  waitForCallback: () => Promise<string | null>
+  cancel: () => void
+}
+
+function createLocalCallbackServer(state: string): Promise<LocalAuth> {
+  const server = createServer()
+
+  return new Promise((resolve, reject) => {
+    let done = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let complete!: (value: string | null) => void
+    const wait = new Promise<string | null>((innerResolve) => {
+      complete = innerResolve
+    })
+
+    const finish = (value: string | null) => {
+      if (done) return
+      done = true
+      if (timer) clearTimeout(timer)
+      complete(value)
+      if (server.listening) {
+        server.closeAllConnections?.()
+        server.close()
+      }
+    }
+
+    server.on("request", (req, res) => {
+      const url = new URL(
+        req.url ?? "/",
+        `http://${req.headers.host ?? "localhost"}`,
+      )
+
+      if (url.pathname !== CALLBACK_PATH) {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("Not found")
+        return
+      }
+
+      const code = url.searchParams.get("code")
+      const gotState = url.searchParams.get("state")
+      if (!code || !gotState) {
+        res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("Missing code or state")
+        return
+      }
+      if (gotState !== state) {
+        res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("Invalid state")
+        finish(null)
+        return
+      }
+
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        Connection: "close",
+      })
+      res.end(`<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Atlassian authorization complete</title></head>
+  <body>
+    <h1>Authorization complete</h1>
+    <p>You can close this window and return to pi.</p>
+  </body>
+</html>`)
+      finish(`${code}#${gotState}`)
+    })
+
+    server.once("error", reject)
+
+    server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+      timer = setTimeout(() => finish(null), LOCAL_CALLBACK_TIMEOUT)
+      resolve({
+        redirectUri: `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`,
+        waitForCallback: () => wait,
+        cancel: () => finish(null),
+      })
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Authorization URL
+// ---------------------------------------------------------------------------
+
+function makeAuthorizeUrl(
+  clientId: string,
+  redirectUri: string,
+  challenge: string,
+  state: string,
+): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state,
+  })
+  return `${AUTHORIZATION_ENDPOINT}?${params.toString()}`
+}
+
+// ---------------------------------------------------------------------------
+// Token exchange / refresh
+// ---------------------------------------------------------------------------
+
+async function exchangeCode(
+  code: string,
+  clientId: string,
+  redirectUri: string,
+  verifier: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresAt: number }> {
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: clientId,
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    }).toString(),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Token exchange failed: ${response.status} ${body}`)
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: Date.now() + data.expires_in * 1000 - 60_000,
+  }
+}
+
+export async function refreshTokens(tokens: AtlassianTokens): Promise<AtlassianTokens> {
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: tokens.clientId,
+      refresh_token: tokens.refreshToken,
+    }).toString(),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Token refresh failed: ${response.status} ${body}`)
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  return {
+    ...tokens,
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token || tokens.refreshToken,
+    expiresAt: Date.now() + data.expires_in * 1000 - 60_000,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Full login flow
+// ---------------------------------------------------------------------------
+
+export interface LoginCallbacks {
+  /** Called with the authorization URL and instructions to display to the user */
+  onAuthUrl: (url: string, instructions: string) => void
+  /** Called if the browser/callback failed — user must paste a code manually */
+  onManualInput?: () => Promise<string>
+}
+
+export async function loginAtlassian(callbacks: LoginCallbacks): Promise<AtlassianTokens> {
+  // Register a new client (Atlassian's OAuth server requires dynamic registration)
+  const { clientId, redirectUri } = await registerClient()
+
+  const { verifier, challenge } = await generatePKCE()
+  const state = crypto.randomUUID().replace(/-/g, "")
+
+  // Start local callback server
+  let localAuth: LocalAuth | null = null
+  let authInput: string | null = null
+  let effectiveRedirectUri = redirectUri
+
+  try {
+    localAuth = await createLocalCallbackServer(state)
+    effectiveRedirectUri = localAuth.redirectUri
+
+    callbacks.onAuthUrl(
+      makeAuthorizeUrl(clientId, effectiveRedirectUri, challenge, state),
+      "Complete authorization in your browser. If the browser is on another machine, paste the authorization code here.",
+    )
+
+    if (callbacks.onManualInput) {
+      let manualInput: string | undefined
+      let manualError: Error | undefined
+      const manualPromise = callbacks
+        .onManualInput()
+        .then((input) => {
+          manualInput = input
+          localAuth?.cancel()
+        })
+        .catch((err) => {
+          manualError = err instanceof Error ? err : new Error(String(err))
+          localAuth?.cancel()
+        })
+
+      const callbackResult = await localAuth.waitForCallback()
+
+      if (manualError) throw manualError
+
+      if (callbackResult) {
+        authInput = callbackResult
+      } else if (manualInput) {
+        authInput = manualInput
+      }
+
+      if (!authInput) {
+        await manualPromise
+        if (manualError) throw manualError
+        if (manualInput) authInput = manualInput
+      }
+    } else {
+      authInput = await localAuth.waitForCallback()
+    }
+  } catch (err) {
+    console.error("[atlassian-mcp] Local auth error:", err instanceof Error ? err.message : err)
+  }
+
+  if (!authInput) {
+    // Fallback: user must paste the code
+    if (!callbacks.onManualInput) {
+      throw new Error("Authorization timed out or failed. No manual input callback provided.")
+    }
+    authInput = await callbacks.onManualInput()
+  }
+
+  // Parse the auth input: either "code#state" (from our local server) or a URL
+  const parsed = parseAuthInput(authInput, state)
+  if (!parsed) throw new Error("Could not parse authorization input.")
+
+  const { accessToken, refreshToken, expiresAt } = await exchangeCode(
+    parsed.code,
+    clientId,
+    effectiveRedirectUri,
+    verifier,
+  )
+
+  const tokens: AtlassianTokens = { accessToken, refreshToken, expiresAt, clientId }
+  saveTokens(tokens)
+  return tokens
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseAuthInput(
+  input: string,
+  expectedState: string,
+): { code: string } | null {
+  const text = input.trim()
+
+  // Try URL
+  try {
+    const url = new URL(text)
+    const code = url.searchParams.get("code")
+    const state = url.searchParams.get("state")
+    if (code && state === expectedState) return { code }
+  } catch {
+    // not a URL
+  }
+
+  // Try "code#state" format (from our local server)
+  const split = text.split("#")
+  if (split.length === 2 && split[0] && split[1] === expectedState) {
+    return { code: split[0] }
+  }
+
+  // Try just a code (user pasted only the code)
+  if (text.length > 10 && !text.includes(" ")) {
+    return { code: text }
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Get a valid bearer token (refresh if needed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a valid access token, refreshing if expired.
+ * Saves refreshed tokens back to disk.
+ * Throws if tokens are null or refresh fails.
+ */
+export async function getValidAccessToken(tokens: AtlassianTokens): Promise<{ token: string; tokens: AtlassianTokens }> {
+  if (Date.now() < tokens.expiresAt) {
+    return { token: tokens.accessToken, tokens }
+  }
+  // Refresh
+  const refreshed = await refreshTokens(tokens)
+  saveTokens(refreshed)
+  return { token: refreshed.accessToken, tokens: refreshed }
+}

--- a/modules/programs/prism/pi/extensions/atlassian/index.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/index.ts
@@ -1,0 +1,255 @@
+// pi extension: Atlassian MCP client bridge.
+//
+// On session_start, this extension:
+// 1. Loads OAuth tokens from disk (or prompts the user to login).
+// 2. Connects to mcp.atlassian.com via the Streamable HTTP MCP transport.
+// 3. Calls tools/list to enumerate all available tools.
+// 4. Registers each tool via pi.registerTool() with slim field-drop applied
+//    to all responses (ported from opencode/mcp-atlassian-slim-proxy.mjs).
+//
+// Auth: OAuth PKCE + dynamic client registration via the Atlassian MCP auth server.
+// The API token path (ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN) only exposes 2
+// Teamwork Graph tools, not the full Jira/Confluence CRUD surface.
+//
+// See UPSTREAM.md for auth method rationale and token storage location.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { Type } from "typebox"
+import { createMcpSession, type McpSession, type McpTool } from "./mcp-client.ts"
+import { loadTokens, getValidAccessToken, loginAtlassian, type AtlassianTokens } from "./auth.ts"
+import { slimMcpResultContent } from "./slim.ts"
+
+let _session: McpSession | null = null
+let _tokens: AtlassianTokens | null = null
+
+function log(msg: string, ...args: unknown[]): void {
+  if (process.env.ATLASSIAN_MCP_DEBUG === "1") {
+    console.error("[atlassian-mcp]", msg, ...args)
+  }
+}
+
+function warn(msg: string, ...args: unknown[]): void {
+  console.error("[atlassian-mcp] WARN:", msg, ...args)
+}
+
+function errorLog(msg: string, ...args: unknown[]): void {
+  console.error("[atlassian-mcp] ERROR:", msg, ...args)
+}
+
+// ---------------------------------------------------------------------------
+// Convert MCP JSON Schema to a TypeBox-compatible schema.
+// We use Type.Unsafe() which passes the raw JSON Schema through to the LLM
+// without TypeBox validation — sufficient for our use case since we forward
+// the args directly to the MCP server.
+// ---------------------------------------------------------------------------
+
+function mcpSchemaToTypebox(inputSchema: Record<string, unknown>) {
+  // Type.Unsafe allows us to pass any JSON Schema object through TypeBox
+  // without building a full TypeBox tree. The LLM receives the schema as-is.
+  return Type.Unsafe<Record<string, unknown>>(inputSchema as object)
+}
+
+// ---------------------------------------------------------------------------
+// Register all tools from the MCP session into pi
+// ---------------------------------------------------------------------------
+
+function registerTools(pi: ExtensionAPI, tools: McpTool[]): void {
+  if (tools.length === 0) {
+    warn("tools/list returned 0 tools — nothing registered")
+    return
+  }
+
+  log(`registering ${tools.length} tools`)
+
+  for (const tool of tools) {
+    const toolName = tool.name
+    const schema = mcpSchemaToTypebox(tool.inputSchema ?? { type: "object", properties: {} })
+
+    pi.registerTool({
+      name: toolName,
+      label: toolName,
+      description: tool.description ?? toolName,
+      parameters: schema,
+      async execute(_toolCallId, params, _signal) {
+        // Ensure we have a live session with a valid token
+        if (!_session) {
+          return {
+            content: [{ type: "text", text: "Atlassian MCP: no active session" }],
+            isError: true,
+          }
+        }
+
+        if (!_tokens) {
+          return {
+            content: [{ type: "text", text: "Atlassian MCP: no auth tokens" }],
+            isError: true,
+          }
+        }
+
+        // Refresh token if needed
+        try {
+          const { token, tokens: updatedTokens } = await getValidAccessToken(_tokens)
+          _tokens = updatedTokens
+          _session.updateToken(token)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          errorLog(`token refresh failed for ${toolName}: ${msg}`)
+          return {
+            content: [{ type: "text", text: `Atlassian auth error: ${msg}` }],
+            isError: true,
+          }
+        }
+
+        try {
+          log(`calling ${toolName}`)
+          const result = await _session.callTool(
+            toolName,
+            params as Record<string, unknown>,
+          )
+
+          if (result.isError) {
+            // MCP tool-level error — surface to LLM without crashing
+            const raw = result.content
+              ?.map((c) => c.text ?? "")
+              .join("\n") ?? "Unknown MCP tool error"
+            return {
+              content: [{ type: "text", text: raw }],
+              isError: true,
+            }
+          }
+
+          // Apply slim field-drop before returning
+          const slimmed = slimMcpResultContent(result.content, toolName)
+          return {
+            content: [{ type: "text", text: slimmed }],
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          errorLog(`tool call failed for ${toolName}: ${msg}`)
+          return {
+            content: [{ type: "text", text: `Atlassian MCP error: ${msg}` }],
+            isError: true,
+          }
+        }
+      },
+    })
+  }
+
+  log(`registered ${tools.length} Atlassian tools`)
+}
+
+// ---------------------------------------------------------------------------
+// Extension initialisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure we have valid tokens, prompting OAuth login if needed.
+ * Returns the tokens or null if auth is unavailable/declined.
+ */
+async function ensureTokens(pi: ExtensionAPI, ctx: { ui: { notify: (msg: string, type?: string) => void } }): Promise<AtlassianTokens | null> {
+  // Try loading from disk first
+  const stored = loadTokens()
+  if (stored) {
+    try {
+      const { tokens } = await getValidAccessToken(stored)
+      return tokens
+    } catch {
+      // Token refresh failed — will try fresh login
+      warn("Stored token refresh failed, attempting fresh login")
+    }
+  }
+
+  // Need fresh login
+  warn("No valid Atlassian MCP OAuth tokens found — starting login flow")
+  ctx.ui.notify("Atlassian MCP: No auth tokens. Use /login-atlassian to authenticate.", "warning")
+  return null
+}
+
+async function initExtension(pi: ExtensionAPI, ctx: { ui: { notify: (msg: string, type?: string) => void } }): Promise<void> {
+  // Get or refresh tokens
+  const tokens = await ensureTokens(pi, ctx)
+  if (!tokens) {
+    // Non-blocking: extension fails gracefully, pi session continues
+    return
+  }
+
+  _tokens = tokens
+
+  // Connect to MCP server
+  let tools: McpTool[]
+  try {
+    _session = await createMcpSession(tokens.accessToken)
+    tools = await _session.listTools()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    errorLog(`Failed to connect to mcp.atlassian.com: ${msg}`)
+    ctx.ui.notify(`Atlassian MCP unavailable: ${msg}`, "error")
+    _session = null
+    return
+  }
+
+  // Register all tools
+  registerTools(pi, tools)
+}
+
+// ---------------------------------------------------------------------------
+// Login command
+// ---------------------------------------------------------------------------
+
+function registerLoginCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("login-atlassian", {
+    description: "Log in to Atlassian MCP (OAuth PKCE flow)",
+    async handler(_args, ctx) {
+      // Check if already have valid tokens
+      if (_tokens && Date.now() < _tokens.expiresAt) {
+        ctx.ui.notify("Atlassian MCP: already authenticated", "info")
+        return
+      }
+
+      ctx.ui.notify("Atlassian MCP: starting OAuth login flow...", "info")
+
+      try {
+        const tokens = await loginAtlassian({
+          onAuthUrl(url, instructions) {
+            ctx.ui.notify(`Atlassian OAuth: ${instructions}\n${url}`, "info")
+          },
+        })
+        _tokens = tokens
+
+        // Reconnect session with new token
+        try {
+          _session = await createMcpSession(tokens.accessToken)
+          const tools = await _session.listTools()
+          registerTools(pi, tools)
+          ctx.ui.notify(`Atlassian MCP: authenticated and registered ${tools.length} tools`, "info")
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          errorLog(`Failed to reconnect after login: ${msg}`)
+          ctx.ui.notify(`Atlassian MCP: login succeeded but connection failed: ${msg}`, "error")
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        errorLog(`Login failed: ${msg}`)
+        ctx.ui.notify(`Atlassian login failed: ${msg}`, "error")
+      }
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+export default async function atlassianExtension(pi: ExtensionAPI): Promise<void> {
+  registerLoginCommand(pi)
+
+  pi.on("session_start", async (_event, ctx) => {
+    // Non-blocking: errors here must not prevent pi from starting
+    try {
+      await initExtension(pi, ctx)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      errorLog(`Extension init failed: ${msg}`)
+    }
+  })
+}

--- a/modules/programs/prism/pi/extensions/atlassian/mcp-client.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/mcp-client.ts
@@ -1,0 +1,225 @@
+// Streamable HTTP MCP client for mcp.atlassian.com.
+//
+// This is a hand-rolled MCP client using Node.js built-ins (no @modelcontextprotocol/sdk).
+// The MCP SDK is not bundled in pi's dependency tree so we cannot import it.
+//
+// Protocol: MCP streamable HTTP (https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#streamable-http)
+// - POST to the MCP endpoint with Content-Type: application/json
+// - Accept: application/json, text/event-stream
+// - Server responds with either JSON (single response) or SSE (streaming)
+// - Session ID is returned in Mcp-Session-Id header and must be sent on subsequent requests
+
+const MCP_URL = process.env.ATLASSIAN_MCP_URL ?? "https://mcp.atlassian.com/v1/mcp"
+const DEBUG = process.env.ATLASSIAN_MCP_DEBUG === "1"
+
+function debug(...args: unknown[]): void {
+  if (DEBUG) {
+    console.error("[atlassian-mcp]", ...args)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SSE parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a text/event-stream body and extract the data field from each event.
+ * Returns all data payloads as strings.
+ */
+function parseSseBody(body: string): string[] {
+  const results: string[] = []
+  let currentData = ""
+  for (const line of body.split("\n")) {
+    const trimmed = line.trimEnd()
+    if (trimmed.startsWith("data: ")) {
+      currentData = trimmed.slice(6)
+    } else if (trimmed === "" && currentData) {
+      results.push(currentData)
+      currentData = ""
+    }
+  }
+  if (currentData) results.push(currentData)
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC framing
+// ---------------------------------------------------------------------------
+
+let _nextId = 1
+
+function nextId(): number {
+  return _nextId++
+}
+
+export interface McpTool {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// MCP session
+// ---------------------------------------------------------------------------
+
+export class McpSession {
+  private sessionId: string | null = null
+  private accessToken: string
+
+  constructor(accessToken: string) {
+    this.accessToken = accessToken
+  }
+
+  updateToken(token: string): void {
+    this.accessToken = token
+  }
+
+  /**
+   * Send a single JSON-RPC request and return the result.
+   * Handles both JSON and SSE responses.
+   */
+  private async send(
+    method: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    const id = nextId()
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    })
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${this.accessToken}`,
+    }
+    if (this.sessionId) {
+      headers["Mcp-Session-Id"] = this.sessionId
+    }
+
+    debug(`send ${method}`, params)
+
+    const response = await fetch(MCP_URL, {
+      method: "POST",
+      headers,
+      body,
+    })
+
+    // Capture session ID from response headers
+    const newSessionId = response.headers.get("mcp-session-id")
+    if (newSessionId) {
+      this.sessionId = newSessionId
+      debug("session id:", this.sessionId)
+    }
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`MCP HTTP ${response.status}: ${text}`)
+    }
+
+    const contentType = response.headers.get("content-type") ?? ""
+    const text = await response.text()
+
+    let jsonText: string
+    if (contentType.includes("text/event-stream")) {
+      const dataLines = parseSseBody(text)
+      if (dataLines.length === 0) {
+        throw new Error(`MCP SSE response had no data lines for ${method}`)
+      }
+      jsonText = dataLines[0]
+    } else {
+      jsonText = text
+    }
+
+    debug(`response ${method}`, jsonText.slice(0, 200))
+
+    const rpc = JSON.parse(jsonText) as {
+      jsonrpc: string
+      id: number
+      result?: unknown
+      error?: { code: number; message: string }
+    }
+
+    if (rpc.error) {
+      throw new Error(`MCP error ${rpc.error.code}: ${rpc.error.message}`)
+    }
+
+    return rpc.result
+  }
+
+  /**
+   * Send the MCP initialize request and return server capabilities.
+   */
+  async initialize(): Promise<{ protocolVersion: string; serverInfo: { name: string; version: string } }> {
+    const result = await this.send("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "pi-atlassian-mcp", version: "1.0.0" },
+    })
+    return result as { protocolVersion: string; serverInfo: { name: string; version: string } }
+  }
+
+  /**
+   * Send the initialized notification (no response expected).
+   * Best-effort — ignore errors.
+   */
+  async sendInitializedNotification(): Promise<void> {
+    try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${this.accessToken}`,
+      }
+      if (this.sessionId) {
+        headers["Mcp-Session-Id"] = this.sessionId
+      }
+      await fetch(MCP_URL, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {},
+        }),
+      })
+    } catch {
+      // Best-effort
+    }
+  }
+
+  /**
+   * List all available tools from the MCP server.
+   */
+  async listTools(): Promise<McpTool[]> {
+    const result = await this.send("tools/list", {}) as { tools?: McpTool[] }
+    return result?.tools ?? []
+  }
+
+  /**
+   * Call a tool and return the raw content array.
+   */
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+    const result = await this.send("tools/call", {
+      name,
+      arguments: args,
+    }) as { content: Array<{ type: string; text?: string }>; isError?: boolean }
+    return result
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session factory — creates and initializes a session
+// ---------------------------------------------------------------------------
+
+export async function createMcpSession(accessToken: string): Promise<McpSession> {
+  const session = new McpSession(accessToken)
+  const serverInfo = await session.initialize()
+  debug("connected to", serverInfo.serverInfo?.name, serverInfo.serverInfo?.version)
+  await session.sendInitializedNotification()
+  return session
+}

--- a/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
@@ -1,0 +1,313 @@
+// Unit tests for slim.ts — field-drop logic for Atlassian MCP responses.
+// Run with: tsx --test slim.test.ts (from this directory)
+// Or: cd modules/programs/prism/pi/extensions/atlassian && tsx --test slim.test.ts
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import {
+  slimJson,
+  slimMcpResultContent,
+  optionsForTool,
+  UNIVERSAL_DROP_KEYS,
+  JIRA_ISSUE_DROP_KEYS,
+  CONFLUENCE_DROP_KEYS,
+} from "./slim.ts"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function universalPayload(): Record<string, unknown> {
+  return {
+    expand: "should be dropped",
+    self: "should be dropped",
+    iconUrl: "should be dropped",
+    avatarUrl: "should be dropped",
+    avatarUrls: { "48x48": "http://..." },
+    avatarId: 12345,
+    picture: "url",
+    schema: { type: "object" },
+    id: "preserved",
+    key: "preserved",
+    summary: "preserved",
+    nested: {
+      expand: "should be dropped inside nested",
+      displayName: "preserved",
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// UNIVERSAL_DROP_KEYS tests
+// ---------------------------------------------------------------------------
+
+describe("slimJson — UNIVERSAL_DROP_KEYS", () => {
+  it("drops all UNIVERSAL_DROP_KEYS from a flat object", () => {
+    const opts = optionsForTool("anyTool")
+    const input = universalPayload()
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    for (const key of UNIVERSAL_DROP_KEYS) {
+      assert.ok(!(key in result), `Expected key "${key}" to be dropped`)
+    }
+  })
+
+  it("preserves non-drop keys", () => {
+    const opts = optionsForTool("anyTool")
+    const input = universalPayload()
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    assert.equal(result.id, "preserved")
+    assert.equal(result.key, "preserved")
+    assert.equal(result.summary, "preserved")
+  })
+
+  it("drops universal keys recursively inside nested objects", () => {
+    const opts = optionsForTool("anyTool")
+    const input = universalPayload()
+    const result = slimJson(input, opts) as Record<string, unknown>
+    const nested = result.nested as Record<string, unknown>
+
+    assert.ok(!("expand" in nested), "expand should be dropped inside nested object")
+    assert.equal(nested.displayName, "preserved")
+  })
+
+  it("handles arrays correctly", () => {
+    const opts = optionsForTool("anyTool")
+    const input = {
+      items: [
+        { expand: "drop", id: "keep1" },
+        { self: "drop", id: "keep2" },
+      ],
+    }
+    const result = slimJson(input, opts) as { items: Record<string, unknown>[] }
+
+    assert.equal(result.items.length, 2)
+    assert.ok(!("expand" in result.items[0]))
+    assert.equal(result.items[0].id, "keep1")
+    assert.ok(!("self" in result.items[1]))
+    assert.equal(result.items[1].id, "keep2")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JIRA_ISSUE_DROP_KEYS tests
+// ---------------------------------------------------------------------------
+
+describe("slimJson — JIRA_ISSUE_DROP_KEYS", () => {
+  it("drops JIRA_ISSUE_DROP_KEYS for jira tool names", () => {
+    const opts = optionsForTool("getJiraIssue")
+    const input: Record<string, unknown> = {}
+    for (const key of JIRA_ISSUE_DROP_KEYS) {
+      input[key] = `value of ${key}`
+    }
+    input.id = "preserved"
+    input.summary = "preserved"
+
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    for (const key of JIRA_ISSUE_DROP_KEYS) {
+      assert.ok(!(key in result), `Expected Jira key "${key}" to be dropped`)
+    }
+    assert.equal(result.id, "preserved")
+    assert.equal(result.summary, "preserved")
+  })
+
+  it("also drops JIRA_ISSUE_DROP_KEYS for tools matching /issue/ pattern", () => {
+    const opts = optionsForTool("createJiraIssue")
+    const input = { renderedFields: "drop this", id: "keep" }
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    assert.ok(!("renderedFields" in result))
+    assert.equal(result.id, "keep")
+  })
+
+  it("does NOT drop JIRA_ISSUE_DROP_KEYS for unrelated tool names", () => {
+    // A tool that doesn't match jira/issue patterns should not have Jira-specific drops
+    const opts = optionsForTool("atlassianUserInfo")
+    const input = { renderedFields: "keep this", id: "keep" }
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    // renderedFields should be kept for non-jira tools
+    assert.equal((result as Record<string, unknown>).renderedFields, "keep this")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CONFLUENCE_DROP_KEYS tests
+// ---------------------------------------------------------------------------
+
+describe("slimJson — CONFLUENCE_DROP_KEYS", () => {
+  it("drops CONFLUENCE_DROP_KEYS for confluence tool names", () => {
+    const opts = optionsForTool("getConfluencePage")
+    const input: Record<string, unknown> = {}
+    for (const key of CONFLUENCE_DROP_KEYS) {
+      input[key] = `value of ${key}`
+    }
+    input.id = "preserved"
+    input.title = "preserved"
+
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    for (const key of CONFLUENCE_DROP_KEYS) {
+      assert.ok(!(key in result), `Expected Confluence key "${key}" to be dropped`)
+    }
+    assert.equal(result.id, "preserved")
+    assert.equal(result.title, "preserved")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Search/list extra drops
+// ---------------------------------------------------------------------------
+
+describe("slimJson — search/list extra drops", () => {
+  it("drops body/description/comments/changelog for search tools", () => {
+    const opts = optionsForTool("searchJiraIssuesUsingJql")
+    const input = {
+      id: "keep",
+      body: "drop",
+      description: "drop",
+      content: "drop",
+      comments: ["drop"],
+      comment: "drop",
+      changelog: "drop",
+      history: "drop",
+      adf: "drop",
+      summary: "keep",
+    }
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    assert.equal(result.id, "keep")
+    assert.equal(result.summary, "keep")
+    assert.ok(!("body" in result))
+    assert.ok(!("description" in result))
+    assert.ok(!("content" in result))
+    assert.ok(!("comments" in result))
+    assert.ok(!("comment" in result))
+    assert.ok(!("changelog" in result))
+    assert.ok(!("history" in result))
+    assert.ok(!("adf" in result))
+  })
+
+  it("drops extra fields for list tools", () => {
+    // listJiraProjects matches /list/ pattern
+    const opts = optionsForTool("listJiraProjects")
+    const input = {
+      id: "keep",
+      body: "drop",
+      title: "keep",
+    }
+    const result = slimJson(input, opts) as Record<string, unknown>
+
+    assert.equal(result.id, "keep")
+    assert.equal(result.title, "keep")
+    assert.ok(!("body" in result))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// slimMcpResultContent tests
+// ---------------------------------------------------------------------------
+
+describe("slimMcpResultContent", () => {
+  it("slims JSON content blocks", () => {
+    const content = [
+      {
+        type: "text",
+        text: JSON.stringify({
+          id: "TYP-1",
+          expand: "drop",
+          self: "drop",
+          summary: "keep",
+          fields: {
+            avatarUrl: "drop",
+            summary: "keep",
+          },
+        }),
+      },
+    ]
+    const result = slimMcpResultContent(content, "getJiraIssue")
+    const parsed = JSON.parse(result) as Record<string, unknown>
+
+    assert.equal(parsed.id, "TYP-1")
+    assert.equal(parsed.summary, "keep")
+    assert.ok(!("expand" in parsed))
+    assert.ok(!("self" in parsed))
+    const fields = parsed.fields as Record<string, unknown>
+    assert.ok(!("avatarUrl" in fields))
+    assert.equal(fields.summary, "keep")
+  })
+
+  it("passes through non-JSON text blocks unchanged", () => {
+    const content = [{ type: "text", text: "plain text response" }]
+    const result = slimMcpResultContent(content, "anyTool")
+    assert.equal(result, "plain text response")
+  })
+
+  it("handles empty content array", () => {
+    const result = slimMcpResultContent([], "anyTool")
+    assert.equal(result, "")
+  })
+
+  it("handles non-text blocks (ignores them)", () => {
+    const content = [
+      { type: "image", data: "base64..." },
+      { type: "text", text: JSON.stringify({ id: "keep", expand: "drop" }) },
+    ]
+    const result = slimMcpResultContent(content, "anyTool")
+    const parsed = JSON.parse(result) as Record<string, unknown>
+    assert.equal(parsed.id, "keep")
+    assert.ok(!("expand" in parsed))
+  })
+
+  it("handles null/undefined content", () => {
+    const result = slimMcpResultContent(null, "anyTool")
+    assert.equal(result, "null")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// optionsForTool — tool-name pattern matching
+// ---------------------------------------------------------------------------
+
+describe("optionsForTool", () => {
+  it("matches jira tools for JIRA_ISSUE_DROP_KEYS", () => {
+    const opts = optionsForTool("editJiraIssue")
+    assert.ok(opts.dropKeys.has("renderedFields"))
+    assert.ok(opts.dropKeys.has("operations"))
+  })
+
+  it("matches confluence tools for CONFLUENCE_DROP_KEYS", () => {
+    const opts = optionsForTool("createConfluencePage")
+    assert.ok(opts.dropKeys.has("_links"))
+    assert.ok(opts.dropKeys.has("status"))
+  })
+
+  it("includes UNIVERSAL_DROP_KEYS for all tools", () => {
+    for (const toolName of [
+      "anyTool",
+      "getJiraIssue",
+      "searchConfluenceUsingCql",
+      "atlassianUserInfo",
+    ]) {
+      const opts = optionsForTool(toolName)
+      for (const key of UNIVERSAL_DROP_KEYS) {
+        assert.ok(opts.dropKeys.has(key), `Expected universal key "${key}" in drop set for tool "${toolName}"`)
+      }
+    }
+  })
+
+  it("applies search extra drops for searchJiraIssuesUsingJql", () => {
+    const opts = optionsForTool("searchJiraIssuesUsingJql")
+    assert.ok(opts.dropKeys.has("body"))
+    assert.ok(opts.dropKeys.has("description"))
+    assert.ok(opts.dropKeys.has("changelog"))
+  })
+
+  it("applies search extra drops for searchConfluenceUsingCql", () => {
+    const opts = optionsForTool("searchConfluenceUsingCql")
+    assert.ok(opts.dropKeys.has("body"))
+    assert.ok(opts.dropKeys.has("content"))
+  })
+})

--- a/modules/programs/prism/pi/extensions/atlassian/slim.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.ts
@@ -1,0 +1,200 @@
+// Slim field-drop logic ported from opencode/mcp-atlassian-slim-proxy.mjs lines 12–115.
+// Strips verbose/useless fields from Atlassian MCP responses before returning
+// results to the LLM, keeping token usage down.
+//
+// Ported by: issue #1583 (pi extension for Atlassian MCP).
+// Original source: modules/programs/prism/opencode/mcp-atlassian-slim-proxy.mjs
+// Strip-list source: verified from actual Jira/Confluence queries (see UPSTREAM.md).
+
+// Fields that are proven safe to drop universally (only UI/API metadata)
+export const UNIVERSAL_DROP_KEYS = new Set(
+  "expand,self,iconUrl,avatarUrl,avatarUrls,avatarId,picture,schema"
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+)
+
+// Fields to drop from Jira issue responses
+export const JIRA_ISSUE_DROP_KEYS = new Set(
+  "renderedFields,operations,permissions,transitions,watchers,worklog,attachments,properties,names,subtask,hierarchyLevel,editmeta,versionedRepresentations,colorName"
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+)
+
+// Fields to drop from Confluence responses
+// Note: url is NOT in this list because it's needed in search results for page ID extraction
+export const CONFLUENCE_DROP_KEYS = new Set(
+  "_links,status,lastModified"
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+)
+
+// Fields to drop from user info responses
+export const USER_INFO_DROP_KEYS = new Set(
+  "account_status,characteristics,last_updated,created_at,nickname,locale,extended_profile,account_type,email_verified"
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+)
+
+// Fields to drop from resource listing
+export const RESOURCE_DROP_KEYS = new Set(
+  "scopes,url"
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+)
+
+export interface SlimOptions {
+  allowKeys: Set<string>
+  dropKeys: Set<string>
+}
+
+/**
+ * Build the slim options for a given MCP tool name.
+ * Mirrors the optionsForMethod function in mcp-atlassian-slim-proxy.mjs.
+ */
+export function optionsForTool(toolName: string): SlimOptions {
+  const name = String(toolName ?? "")
+  let dropKeys = new Set<string>([...UNIVERSAL_DROP_KEYS])
+
+  // Add method-specific drops based on tool name patterns
+  if (/jira|issue/i.test(name)) {
+    dropKeys = new Set([...dropKeys, ...JIRA_ISSUE_DROP_KEYS])
+  }
+  if (/confluence|page|space/i.test(name)) {
+    dropKeys = new Set([...dropKeys, ...CONFLUENCE_DROP_KEYS])
+  }
+  if (/user.*info/i.test(name)) {
+    dropKeys = new Set([...dropKeys, ...USER_INFO_DROP_KEYS])
+  }
+  if (/resource/i.test(name)) {
+    dropKeys = new Set([...dropKeys, ...RESOURCE_DROP_KEYS])
+  }
+  // For search/list endpoints, also drop body/description/comments/changelog
+  if (/search|list/i.test(name)) {
+    dropKeys = new Set([
+      ...dropKeys,
+      "body",
+      "description",
+      "content",
+      "comments",
+      "comment",
+      "changelog",
+      "history",
+      "adf",
+    ])
+  }
+
+  return { allowKeys: new Set<string>(), dropKeys }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  )
+}
+
+/**
+ * Recursively drop keys from a JSON value according to slim options.
+ * Mirrors slimJson in mcp-atlassian-slim-proxy.mjs.
+ */
+export function slimJson(value: unknown, options: SlimOptions, depth = 0): unknown {
+  if (value === null || value === undefined) return value
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => slimJson(v, options, depth + 1))
+  }
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {}
+    for (const [key, v] of Object.entries(value)) {
+      if (options.dropKeys.has(key)) continue
+
+      // If allowlist is configured, keep allowKeys plus structural keys
+      const keepBecauseStructural =
+        key === "error" ||
+        key === "message" ||
+        key === "tool" ||
+        key === "type"
+      if (
+        !keepBecauseStructural &&
+        options.allowKeys.size > 0 &&
+        !options.allowKeys.has(key)
+      ) {
+        if (key !== "data" && key !== "result") continue
+      }
+
+      out[key] = slimJson(v, options, depth + 1)
+    }
+
+    // If object got emptied by allowlist, fall back to a generic slim
+    if (Object.keys(out).length === 0 && Object.keys(value).length > 0) {
+      for (const [key, v] of Object.entries(value)) {
+        if (options.dropKeys.has(key)) continue
+        out[key] = slimJson(v, options, depth + 1)
+      }
+    }
+
+    return out
+  }
+
+  // Dates, Buffers, etc.
+  try {
+    return JSON.parse(JSON.stringify(value))
+  } catch {
+    return String(value)
+  }
+}
+
+/**
+ * Apply slim field-drop logic to the text content of an MCP tool result.
+ * The MCP result content is an array of {type, text} blocks.
+ * For each text block, parse as JSON (if possible) and apply slimJson.
+ * Returns a string (the slimmed text content).
+ */
+export function slimMcpResultContent(
+  content: unknown,
+  toolName: string,
+): string {
+  if (!Array.isArray(content)) {
+    return typeof content === "string" ? content : JSON.stringify(content)
+  }
+
+  const options = optionsForTool(toolName)
+  const parts: string[] = []
+
+  for (const block of content) {
+    if (
+      block !== null &&
+      typeof block === "object" &&
+      (block as Record<string, unknown>).type === "text"
+    ) {
+      const text = (block as Record<string, unknown>).text
+      if (typeof text === "string") {
+        // Try to parse as JSON and slim
+        try {
+          const parsed = JSON.parse(text)
+          const slimmed = slimJson(parsed, options)
+          parts.push(JSON.stringify(slimmed))
+        } catch {
+          // Not JSON — pass through as-is
+          parts.push(text)
+        }
+      }
+    }
+  }
+
+  return parts.join("\n")
+}

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -396,6 +396,34 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 		}
 	}
 
+	// ── PI atlassian-mcp-oauth.json bind-mount (read-write) ───────────────
+	// The Atlassian MCP extension stores OAuth tokens at
+	// ~/.pi/agent/atlassian-mcp-oauth.json. Inside a bwrap sandbox,
+	// os.UserHomeDir() resolves to the sandbox $HOME, so any token written
+	// by /login-atlassian would be lost when the sandbox exits.
+	// We touch the file (create if absent, mode 0o600) so that bwrap can
+	// bind-mount it. This means the first /login-atlassian inside the sandbox
+	// writes directly to the host path and tokens are persisted across
+	// sessions. The same pattern is used for auth.json above, except we
+	// always create the target here — OAuth logins are the normal first-run
+	// path and a missing file would silently drop tokens on the floor.
+	if home, err := os.UserHomeDir(); err == nil {
+		atlasMCPPath := filepath.Join(home, ".pi", "agent", "atlassian-mcp-oauth.json")
+		// Touch the file (create with mode 0o600 if absent). Best-effort:
+		// if the parent dir does not exist or the write fails we skip the
+		// bind rather than failing the whole container start.
+		if _, statErr := os.Stat(atlasMCPPath); os.IsNotExist(statErr) {
+			// Ensure parent directory exists before creating the file.
+			_ = os.MkdirAll(filepath.Dir(atlasMCPPath), 0o700)
+			if f, createErr := os.OpenFile(atlasMCPPath, os.O_CREATE|os.O_EXCL, 0o600); createErr == nil {
+				_ = f.Close()
+			}
+		}
+		if _, statErr := os.Stat(atlasMCPPath); statErr == nil {
+			args = append(args, "--bind", atlasMCPPath, atlasMCPPath)
+		}
+	}
+
 	// ── Extension directory ──────────────────────────────────────────────────
 	if cfg.PIExtensionHostDir == "" {
 		return nil, fmt.Errorf("pi: PIExtensionHostDir is empty — set the extension directory in the container config")

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -522,6 +522,98 @@ func TestAppendPIBwrapMounts_NoBindWhenAuthJSONAbsent(t *testing.T) {
 	}
 }
 
+func TestAppendPIBwrapMounts_BindsAtlassianOAuthWhenExists(t *testing.T) {
+	// When ~/.pi/agent/atlassian-mcp-oauth.json already exists on the host,
+	// appendPIBwrapMounts must emit --bind <path> <path> (read-write) so that
+	// OAuth token refreshes inside the bwrap sandbox are persisted to the host.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi/agent: %v", err)
+	}
+	atlasPath := filepath.Join(piAgentDir, "atlassian-mcp-oauth.json")
+	if err := os.WriteFile(atlasPath, []byte(`{"accessToken":"tok"}`), 0o600); err != nil {
+		t.Fatalf("write atlassian-mcp-oauth.json: %v", err)
+	}
+
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+	fakePI := filepath.Join(t.TempDir(), "pi")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:       fakePI,
+		PIExtensionHostDir: extDir,
+	}
+
+	args, err := appendPIBwrapMounts(nil, cfg)
+	if err != nil {
+		t.Fatalf("appendPIBwrapMounts: %v", err)
+	}
+
+	// Must contain --bind atlasPath atlasPath (read-write, not --ro-bind).
+	if !hasTriple(args, "--bind", atlasPath, atlasPath) {
+		t.Errorf("expected --bind %q %q in args; got %v", atlasPath, atlasPath, args)
+	}
+	// Must NOT use --ro-bind (OAuth refreshes need write access).
+	if hasTriple(args, "--ro-bind", atlasPath, atlasPath) {
+		t.Errorf("--ro-bind must not be used for atlassian-mcp-oauth.json; got %v", args)
+	}
+}
+
+func TestAppendPIBwrapMounts_CreatesAndBindsAtlassianOAuthWhenAbsent(t *testing.T) {
+	// When ~/.pi/agent/atlassian-mcp-oauth.json does not exist, appendPIBwrapMounts
+	// must create an empty placeholder file (so bwrap can bind-mount it) and
+	// then emit --bind <path> <path>. This ensures that /login-atlassian inside
+	// the bwrap session writes tokens to the host path rather than the ephemeral
+	// sandbox home.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi/agent: %v", err)
+	}
+	// Deliberately do NOT create atlassian-mcp-oauth.json.
+
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, piExtensionFilename), []byte("// ext"), 0o644); err != nil {
+		t.Fatalf("write ext: %v", err)
+	}
+	fakePI := filepath.Join(t.TempDir(), "pi")
+	if err := os.WriteFile(fakePI, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatalf("write fake pi binary: %v", err)
+	}
+
+	cfg := Config{
+		PIBinaryPath:       fakePI,
+		PIExtensionHostDir: extDir,
+	}
+
+	args, err := appendPIBwrapMounts(nil, cfg)
+	if err != nil {
+		t.Fatalf("appendPIBwrapMounts: %v", err)
+	}
+
+	atlasPath := filepath.Join(piAgentDir, "atlassian-mcp-oauth.json")
+
+	// The placeholder file must have been created on the host.
+	if _, statErr := os.Stat(atlasPath); statErr != nil {
+		t.Errorf("expected placeholder atlassian-mcp-oauth.json to be created on host; got stat error: %v", statErr)
+	}
+
+	// Must contain --bind atlasPath atlasPath.
+	if !hasTriple(args, "--bind", atlasPath, atlasPath) {
+		t.Errorf("expected --bind %q %q in args after placeholder creation; got %v", atlasPath, atlasPath, args)
+	}
+}
+
 func TestAppendPIBwrapMounts_NoPiAgentBindMount(t *testing.T) {
 	// ~/.pi/agent is no longer bind-mounted — files are copied into the staging
 	// dir by StagePIAgentConfigDir instead. Verify that even when ~/.pi/agent


### PR DESCRIPTION
## Summary

Adds a pi extension at `modules/programs/prism/pi/extensions/atlassian/` that acts as an MCP client to `mcp.atlassian.com`, dynamically registering all available tools via `pi.registerTool()`.

Closes #1583

## What this adds

### New files
- `index.ts` — extension entry point; registers `/login-atlassian` command, hooks `session_start` to connect and enumerate tools
- `mcp-client.ts` — hand-rolled Streamable HTTP MCP transport using Node.js built-ins (no `@modelcontextprotocol/sdk`; not bundled in pi)
- `auth.ts` — OAuth PKCE + dynamic client registration against `cf.mcp.atlassian.com`; token persistence at `~/.pi/agent/atlassian-mcp-oauth.json`
- `slim.ts` — TypeScript port of field-drop logic from `mcp-atlassian-slim-proxy.mjs` lines 12–115
- `slim.test.ts` — 20 unit tests covering all drop-key sets, slimMcpResultContent, and optionsForTool pattern matching
- `UPSTREAM.md` — documents auth method rationale, token storage, slim-logic provenance, MCP transport notes

### `pi.nix` changes
- Adds `atlassianExtensionDir` derivation (`pkgs.runCommand "pi-atlassian-extension"`)
- Adds it to `piSettings.extensions`
- GC-roots it via `home.file ".pi/agent/atlassian-extension"`

## Auth method investigation

**API token path rejected for full functionality:** `ATLASSIAN_EMAIL:ATLASSIAN_API_TOKEN` Basic auth works at the MCP layer (HTTP 200, valid session) but only exposes 2 Teamwork Graph tools — not the Jira/Confluence CRUD surface.

**OAuth path confirmed 31 tools:** Bearer token from OAuth PKCE gives the full surface (search, create, update, comment, transition, etc.). Verified empirically on 2026-05-14.

The OAuth client registration is dynamic — the extension registers a fresh client on first login (same approach as `mcp-remote`). Tokens are refreshed automatically; re-login only needed when refresh token expires.

## Edge-case handling

- **MCP unreachable on startup:** logs error to stderr, notifies user via `ctx.ui.notify`, continues — non-blocking
- **No auth tokens:** logs warning, prompts user to run `/login-atlassian`, does not register any tools
- **tools/list returns 0 tools:** logs warning, registers nothing, no crash
- **Tool invocation error:** MCP tool-level errors surfaced to LLM as `isError: true` result without crashing
- **Auth tokens never logged:** all token values kept in variables; only lengths/status logged at debug level

## Testing

All 20 unit tests pass:
```
cd modules/programs/prism/pi/extensions/atlassian && tsx --test slim.test.ts
# tests 20 / pass 20 / fail 0
```

Nix build picks up the new derivation:
```
nix build .#prism  # passes
nix build .#darwinConfigurations.m4mac... --dry-run  # includes pi-atlassian-extension.drv
```

## Pre-PR checklist

- [x] `nixfmt .` — no diff
- [x] No prism Go source touched
- [x] New files added to git before nix build
- [x] 20 unit tests pass (`tsx --test slim.test.ts`)
- [x] Nix dry-run build includes the new derivation
- [ ] Manual smoke test (requires interactive pi session with browser for OAuth login — deferred to post-merge)