### PR TITLE
pi: gate Atlassian MCP extension behind nx option, enable on m4mac only

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -28,6 +28,7 @@ in
         profile.default = "anthropic";
         harness.default = "pi";
         agent.isolation.default = "sandbox-exec";
+        pi.atlassian.enable = true;
         projects.isolationOverrides = {
           "~/Documents/obsidian" = "host";
         };

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -9,6 +9,21 @@
     nx.programs.prism.pi.enable = lib.mkEnableOption "enables pi coding agent" // {
       default = true;
     };
+    nx.programs.prism.pi.atlassian.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable the pi Atlassian MCP extension. When true, an entry
+        pointing into the atlassianExtensionDir nix-store path is added to the
+        extensions list in ~/.pi/agent/settings.json, and a
+        home.file.".pi/agent/atlassian-extension" entry is emitted to GC-root
+        that store path. Authentication is via /login-atlassian inside a pi
+        session.
+
+        This option controls only the pi-side extension and is independent of
+        the opencode atlasian MCP server configured in opencode.nix.
+      '';
+    };
   };
 
   config = lib.mkIf config.nx.programs.prism.pi.enable (
@@ -93,12 +108,14 @@
         #   modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
         extensions = [
           "${piExtensionsDir}/anthropic-oauth/index.ts"
-          # Atlassian MCP extension: connects to mcp.atlassian.com via OAuth
-          # PKCE, enumerates tools/list at startup, and registers each tool.
-          # Use /login-atlassian in a pi session to authenticate.
-          # See pi/extensions/atlassian/UPSTREAM.md for auth method rationale.
-          "${atlassianExtensionDir}/index.ts"
-        ];
+        ]
+        ++
+          lib.optional config.nx.programs.prism.pi.atlassian.enable
+            # Atlassian MCP extension: connects to mcp.atlassian.com via OAuth
+            # PKCE, enumerates tools/list at startup, and registers each tool.
+            # Use /login-atlassian in a pi session to authenticate.
+            # See pi/extensions/atlassian/UPSTREAM.md for auth method rationale.
+            "${atlassianExtensionDir}/index.ts";
       };
 
       colourLib = import ../../colour-scheme/lib.nix;
@@ -202,7 +219,10 @@
         home.file.".pi/agent/prism-extension".source = prismExtensionDir;
         # Atlassian MCP extension — GC-rooted so the nix-store path referenced
         # in settings.json is not removed by nix-collect-garbage.
-        home.file.".pi/agent/atlassian-extension".source = atlassianExtensionDir;
+        # Only emitted when nx.programs.prism.pi.atlassian.enable is true.
+        home.file.".pi/agent/atlassian-extension" = lib.mkIf config.nx.programs.prism.pi.atlassian.enable {
+          source = atlassianExtensionDir;
+        };
 
         home.persistence."/persist" = {
           directories = [ ".pi" ];


### PR DESCRIPTION
Adds a new Nix option `nx.programs.prism.pi.atlassian.enable` (default: `false`) that gates the pi Atlassian MCP extension. Previously the extension was always wired in unconditionally. Now:

- The `extensions` entry in `~/.pi/agent/settings.json` only includes the Atlassian extension when the option is `true`.
- The `home.file.".pi/agent/atlassian-extension"` GC-root entry is only emitted when the option is `true`.
- `machines/m4mac/configuration.nix` sets the option to `true` (enabled on m4mac).
- `navi` and `tui` pick up the default (`false`) — no changes to their configs.
- `opencode.nix` is untouched; this is purely the pi-side extension.

## Acceptance Criteria

- [ ] [functional] `nx.programs.prism.pi.atlassian.enable` is defined as a `lib.types.bool` option with `default = false` and a description that explains its scope (pi extension only, independent of the opencode atlasian MCP server).
- [ ] [functional] When the option is `true`, `~/.pi/agent/settings.json` (as emitted by the module) contains an entry in `extensions` ending in `/atlassian-extension`/`index.ts` or equivalently pointing into the `atlassianExtensionDir` store path.
- [ ] [functional] When the option is `false` (the default), the rendered `~/.pi/agent/settings.json` `extensions` array does NOT contain any Atlassian extension entry.
- [ ] [functional] When the option is `true`, a `home.file.".pi/agent/atlassian-extension"` entry is emitted pointing at `atlassianExtensionDir`.
- [ ] [functional] When the option is `false`, no `home.file` entry for `.pi/agent/atlassian-extension` is emitted.
- [ ] [functional] `machines/m4mac/configuration.nix` sets `nx.programs.prism.pi.atlassian.enable = true;` inside the existing `nx.programs.prism` block.
- [ ] [functional] `machines/navi/configuration.nix` and `machines/tui/configuration.nix` are unchanged with respect to this option (they pick up the default of `false`).
- [ ] [functional] The opencode `atlasian` MCP server config in `modules/programs/prism/opencode.nix` is unchanged by this PR (no edits to that file beyond what is strictly required, which should be none).
- [ ] [edge-case] `nix build .#darwinConfigurations.m4mac.system` (or the equivalent attribute path used by this repo for the m4mac Darwin config) evaluates and builds successfully.
- [ ] [edge-case] `nix build .#nixosConfigurations.navi.config.system.build.toplevel` and the equivalent for `tui` evaluate and build successfully.
- [ ] [edge-case] `nixfmt` reports no formatting changes on the edited files (run `nixfmt modules/programs/prism/pi.nix machines/m4mac/configuration.nix` before commit).