### PR TITLE
prism merge: handle UNSTABLE when required checks have passed

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -42,6 +42,18 @@ const (
 	PollInterval = 45 * time.Second
 )
 
+// requiredChecksCache holds a cached list of required status check names
+// fetched from branch protection, together with an expiry timestamp.
+type requiredChecksCache struct {
+	names   []string
+	fetchAt time.Time
+}
+
+// requiredChecksCacheTTL is how long we reuse a cached branch-protection
+// response before re-fetching. Five minutes is short enough to pick up
+// rule changes but long enough to avoid hammering the API on every tick.
+const requiredChecksCacheTTL = 5 * time.Minute
+
 // Watcher runs the merge-queue polling loop for a single coordinator session.
 type Watcher struct {
 	db          *db.DB
@@ -56,6 +68,15 @@ type Watcher struct {
 	// An empty string means resolution failed — Run() logs and exits cleanly
 	// rather than entering a poll loop that can never succeed.
 	repo string
+
+	// requiredChecks caches the branch-protection required status check names
+	// for the target branch. Populated lazily on the first UNSTABLE tick and
+	// refreshed when the TTL expires.
+	requiredChecks requiredChecksCache
+
+	// nowFunc returns the current time. Tests may override this to control TTL
+	// expiry without sleeping.
+	nowFunc func() time.Time
 
 	// runGHFunc is the function used to invoke the gh CLI. It is configurable
 	// so tests can inject a stub that captures argv. When nil, runGH falls back
@@ -221,7 +242,40 @@ func (w *Watcher) tick(ctx context.Context) {
 			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure or review requirement — staying watching", head.PR)
 		}
 
-	case "UNSTABLE", "UNKNOWN", "HAS_HOOKS", "DRAFT":
+	case "UNSTABLE":
+		// UNSTABLE means the PR is mergeable but at least one check is
+		// non-success. We fetch the required branch-protection checks and
+		// merge if all of them are SUCCESS, ignoring optional/slow checks.
+		required, err := w.fetchRequiredChecks(ctx)
+		if err != nil {
+			log.Printf("[mergequeue] PR #%d UNSTABLE — cannot fetch required checks: %v — leaving watching", head.PR, err)
+			return
+		}
+		if requiredChecksAllPassed(prInfo.StatusCheckRollup, required) {
+			log.Printf("[mergequeue] PR #%d UNSTABLE but all required checks passed — proceeding to merge", head.PR)
+			w.tryMerge(ctx, head)
+		} else {
+			// Log which required checks are not yet SUCCESS.
+			var pending []string
+			passed := make(map[string]bool, len(prInfo.StatusCheckRollup))
+			for _, c := range prInfo.StatusCheckRollup {
+				name := checkName(c)
+				if name == "" {
+					continue
+				}
+				ok := strings.EqualFold(c.Conclusion, "SUCCESS") ||
+					strings.EqualFold(c.State, "SUCCESS")
+				passed[name] = ok
+			}
+			for _, req := range required {
+				if ok, found := passed[req]; !found || !ok {
+					pending = append(pending, req)
+				}
+			}
+			log.Printf("[mergequeue] PR #%d UNSTABLE — required checks not yet SUCCESS: %v — staying watching", head.PR, pending)
+		}
+
+	case "UNKNOWN", "HAS_HOOKS", "DRAFT":
 		log.Printf("[mergequeue] PR #%d %s — staying watching", head.PR, prInfo.MergeStateStatus)
 
 	default:
@@ -450,8 +504,17 @@ func (p *prInfo) isMerged() bool {
 }
 
 type checkEntry struct {
+	// Name is the check-run name (e.g. "pr-gate") or the commit-status context.
+	// GitHub's statusCheckRollup uses "name" for check-runs and "context" for
+	// legacy commit statuses; we populate both via the Name field and fall back
+	// to Context when Name is empty.
+	Name       string `json:"name"`
+	Context    string `json:"context"`
 	Conclusion string `json:"conclusion"`
 	Status     string `json:"status"`
+	// State is the legacy commit-status field (e.g. "SUCCESS", "FAILURE").
+	// Modern check-runs use Conclusion instead.
+	State string `json:"state"`
 }
 
 // fetchPRInfo calls `gh pr view <pr> --json` and returns the parsed result.
@@ -477,6 +540,120 @@ func hasCIFailure(rollup []checkEntry) bool {
 		}
 	}
 	return false
+}
+
+// checkName returns the canonical name for a rollup entry, preferring the
+// check-run Name field and falling back to the legacy commit-status Context.
+func checkName(c checkEntry) string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return c.Context
+}
+
+// requiredChecksAllPassed returns true iff every name in required has a
+// corresponding entry in rollup with a successful conclusion.
+//
+// "Success" means:
+//   - modern check-run: Conclusion == "SUCCESS" (case-insensitive)
+//   - legacy commit-status: State == "SUCCESS" (case-insensitive)
+//
+// A required name that is missing from rollup entirely is treated as
+// not-yet-passed and returns false.
+func requiredChecksAllPassed(rollup []checkEntry, required []string) bool {
+	if len(required) == 0 {
+		// No required checks configured — treat as not-gated (conservative:
+		// don't block forever, but callers should detect this upstream).
+		return false
+	}
+	// Build a name→success map from the rollup.
+	passed := make(map[string]bool, len(rollup))
+	for _, c := range rollup {
+		name := checkName(c)
+		if name == "" {
+			continue
+		}
+		// A check is successful if either the modern conclusion or the
+		// legacy state field indicates SUCCESS.
+		ok := strings.EqualFold(c.Conclusion, "SUCCESS") ||
+			strings.EqualFold(c.State, "SUCCESS")
+		passed[name] = ok
+	}
+	for _, req := range required {
+		ok, found := passed[req]
+		if !found || !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// branchProtectionResponse is the subset of the GitHub branch protection API
+// response we care about.
+type branchProtectionResponse struct {
+	RequiredStatusChecks struct {
+		Contexts []string `json:"contexts"` // legacy commit-status names
+		Checks   []struct {
+			Context string `json:"context"`
+		} `json:"checks"` // modern check-run names
+	} `json:"required_status_checks"`
+}
+
+// fetchRequiredChecks returns the list of required status check names for the
+// protected target branch ("main"), using a short-TTL in-memory cache to
+// avoid hammering the API on every polling tick.
+//
+// On any error (network, permissions, rate-limit) it returns nil, err so the
+// caller can take the conservative path of staying watching.
+func (w *Watcher) fetchRequiredChecks(ctx context.Context) ([]string, error) {
+	now := w.now()
+	if len(w.requiredChecks.names) > 0 && now.Before(w.requiredChecks.fetchAt.Add(requiredChecksCacheTTL)) {
+		// Cache hit.
+		return w.requiredChecks.names, nil
+	}
+
+	out, err := w.runGH(ctx, "api", fmt.Sprintf("repos/%s/branches/main/protection", w.repo))
+	if err != nil {
+		return nil, fmt.Errorf("gh api branch protection: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	var resp branchProtectionResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse branch protection response: %w", err)
+	}
+
+	// Collect names from both the legacy contexts list and the modern checks
+	// list, deduplicating.
+	seen := make(map[string]bool)
+	var names []string
+	for _, ctx := range resp.RequiredStatusChecks.Contexts {
+		if ctx != "" && !seen[ctx] {
+			seen[ctx] = true
+			names = append(names, ctx)
+		}
+	}
+	for _, c := range resp.RequiredStatusChecks.Checks {
+		if c.Context != "" && !seen[c.Context] {
+			seen[c.Context] = true
+			names = append(names, c.Context)
+		}
+	}
+
+	w.requiredChecks = requiredChecksCache{
+		names:   names,
+		fetchAt: now,
+	}
+	log.Printf("[mergequeue] fetched required checks for %s: %v", w.repo, names)
+	return names, nil
+}
+
+// now returns the current time. It uses w.nowFunc when set (for tests) and
+// time.Now() otherwise.
+func (w *Watcher) now() time.Time {
+	if w.nowFunc != nil {
+		return w.nowFunc()
+	}
+	return time.Now()
 }
 
 // isBranchMovedRace heuristically detects the GitHub branch-moved race from

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -459,10 +459,11 @@ func TestMergeQueueForInstance_AbandonedFilter(t *testing.T) {
 // replaces the gh CLI calls with an injectable function.
 
 type fakeWatcher struct {
-	watcher  *Watcher
-	fetchFn  func(ctx context.Context, pr int) (*prInfo, error)
-	mergeFn  func(ctx context.Context, pr int) ([]byte, error)
-	updateFn func(ctx context.Context, pr int) error
+	watcher              *Watcher
+	fetchFn              func(ctx context.Context, pr int) (*prInfo, error)
+	mergeFn              func(ctx context.Context, pr int) ([]byte, error)
+	updateFn             func(ctx context.Context, pr int) error
+	fetchRequiredChecksFn func(ctx context.Context) ([]string, error)
 }
 
 // processHead is a test-friendly version of tick() that uses injected functions
@@ -515,7 +516,32 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 			fw.watcher.failAndNotify(head, "human reviewer approval required before merge")
 		}
 
-	case "UNSTABLE", "UNKNOWN", "HAS_HOOKS", "DRAFT":
+	case "UNSTABLE":
+		var required []string
+		var fetchErr error
+		if fw.fetchRequiredChecksFn != nil {
+			required, fetchErr = fw.fetchRequiredChecksFn(ctx)
+		}
+		if fetchErr != nil {
+			// stay watching
+			return
+		}
+		if requiredChecksAllPassed(prInfoVal.StatusCheckRollup, required) {
+			out, mergeErr := fw.mergeFn(ctx, head.PR)
+			if mergeErr == nil {
+				fw.watcher.succeedAndNotify(ctx, head)
+				return
+			}
+			combined := strings.ToLower(string(out) + mergeErr.Error())
+			if isBranchMovedRace(combined) {
+				return
+			}
+			errMsg := fmt.Sprintf("gh pr merge failed: %s", strings.TrimSpace(string(out)))
+			fw.watcher.failAndNotify(head, errMsg)
+		}
+		// stay watching if required checks not all passed
+
+	case "UNKNOWN", "HAS_HOOKS", "DRAFT":
 		// stay watching
 
 	}
@@ -536,6 +562,7 @@ func newFakeWatcher(
 		fetchFn:  fetchFn,
 		mergeFn:  mergeFn,
 		updateFn: updateFn,
+		// fetchRequiredChecksFn is nil by default; UNSTABLE tests set it explicitly.
 	}
 }
 
@@ -945,8 +972,9 @@ func TestWatcher_BLOCKEDNoReviewDecisionNoCIStaysWatching(t *testing.T) {
 	}
 }
 
-// TestWatcher_UNSTABLEStaysWatching verifies UNSTABLE leaves the row watching.
-func TestWatcher_UNSTABLEStaysWatching(t *testing.T) {
+// TestWatcher_UNSTABLEStaysWatchingWhenRequiredPending verifies that when
+// UNSTABLE and a required check is still in progress, the row stays watching.
+func TestWatcher_UNSTABLEStaysWatchingWhenRequiredPending(t *testing.T) {
 	d := openTestDB(t)
 	instanceID := "inst-unstable"
 	session := "myrepo@main"
@@ -957,11 +985,21 @@ func TestWatcher_UNSTABLEStaysWatching(t *testing.T) {
 
 	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
 		func(_ context.Context, pr int) (*prInfo, error) {
-			return &prInfo{State: "OPEN", MergeStateStatus: "UNSTABLE"}, nil
+			return &prInfo{
+				State:            "OPEN",
+				MergeStateStatus: "UNSTABLE",
+				StatusCheckRollup: []checkEntry{
+					{Name: "pr-gate", Status: "IN_PROGRESS", Conclusion: ""},
+					{Name: "validate-flakes", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				},
+			}, nil
 		},
 		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
 		func(_ context.Context, pr int) error { return nil },
 	)
+	fw.fetchRequiredChecksFn = func(_ context.Context) ([]string, error) {
+		return []string{"pr-gate"}, nil
+	}
 
 	fw.processHead(context.Background())
 
@@ -1522,5 +1560,467 @@ func TestNew_NoAgentStatusRow_LeavesRepoEmpty(t *testing.T) {
 	}
 	if w.repo != "" {
 		t.Errorf("Watcher.repo: got %q, want empty (no agent_status row)", w.repo)
+	}
+}
+
+// ── requiredChecksAllPassed unit tests ────────────────────────────────────────
+
+// TestRequiredChecksAllPassed_AllSuccess verifies the happy path: every
+// required name appears in the rollup with a SUCCESS conclusion.
+func TestRequiredChecksAllPassed_AllSuccess(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "pr-gate", Conclusion: "SUCCESS", Status: "COMPLETED"},
+		{Name: "validate-flakes", Conclusion: "SUCCESS", Status: "COMPLETED"},
+	}
+	if !requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want true when required check is SUCCESS, got false")
+	}
+}
+
+// TestRequiredChecksAllPassed_MissingRequired verifies that a required name
+// absent from the rollup causes the helper to return false.
+func TestRequiredChecksAllPassed_MissingRequired(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "validate-flakes", Conclusion: "SUCCESS", Status: "COMPLETED"},
+	}
+	if requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want false when required check is missing from rollup, got true")
+	}
+}
+
+// TestRequiredChecksAllPassed_InProgress verifies that a required check that
+// is still running (no conclusion yet) returns false.
+func TestRequiredChecksAllPassed_InProgress(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "pr-gate", Status: "IN_PROGRESS", Conclusion: ""},
+	}
+	if requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want false when required check is IN_PROGRESS, got true")
+	}
+}
+
+// TestRequiredChecksAllPassed_Failure verifies that a required check with
+// conclusion FAILURE returns false.
+func TestRequiredChecksAllPassed_Failure(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "pr-gate", Conclusion: "FAILURE", Status: "COMPLETED"},
+	}
+	if requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want false when required check is FAILURE, got true")
+	}
+}
+
+// TestRequiredChecksAllPassed_EmptyConclusion verifies that a required check
+// with an empty conclusion (e.g. queued/pending) returns false.
+func TestRequiredChecksAllPassed_EmptyConclusion(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "pr-gate", Conclusion: "", Status: "QUEUED"},
+	}
+	if requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want false when required check has empty conclusion, got true")
+	}
+}
+
+// TestRequiredChecksAllPassed_LegacyCommitStatus verifies that legacy
+// commit-status entries (State field instead of Conclusion, Context instead
+// of Name) are handled correctly.
+func TestRequiredChecksAllPassed_LegacyCommitStatus(t *testing.T) {
+	// Legacy entries use Context (not Name) and State (not Conclusion).
+	rollup := []checkEntry{
+		{Context: "pr-gate", State: "SUCCESS"},
+		{Context: "validate-flakes", State: "PENDING"},
+	}
+	// pr-gate passes via the legacy State field.
+	if !requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want true for legacy SUCCESS state, got false")
+	}
+	// validate-flakes is still PENDING.
+	if requiredChecksAllPassed(rollup, []string{"validate-flakes"}) {
+		t.Error("requiredChecksAllPassed: want false for legacy PENDING state, got true")
+	}
+}
+
+// TestRequiredChecksAllPassed_MixedModernAndLegacy verifies a rollup that
+// contains both modern check-run entries and legacy commit-status entries.
+func TestRequiredChecksAllPassed_MixedModernAndLegacy(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "pr-gate", Conclusion: "SUCCESS", Status: "COMPLETED"},
+		{Context: "legacy-status", State: "SUCCESS"},
+		{Name: "optional-slow", Status: "IN_PROGRESS", Conclusion: ""},
+	}
+	// Both required checks are SUCCESS (one modern, one legacy).
+	if !requiredChecksAllPassed(rollup, []string{"pr-gate", "legacy-status"}) {
+		t.Error("requiredChecksAllPassed: want true when all required (mixed) checks are SUCCESS, got false")
+	}
+	// optional-slow is not required — its IN_PROGRESS state must not block.
+	if !requiredChecksAllPassed(rollup, []string{"pr-gate"}) {
+		t.Error("requiredChecksAllPassed: want true when only required check is SUCCESS (optional ignored), got false")
+	}
+}
+
+// TestRequiredChecksAllPassed_EmptyRequired verifies that an empty required
+// list returns false (conservative: don't merge when no constraints configured).
+func TestRequiredChecksAllPassed_EmptyRequired(t *testing.T) {
+	rollup := []checkEntry{
+		{Name: "pr-gate", Conclusion: "SUCCESS"},
+	}
+	if requiredChecksAllPassed(rollup, nil) {
+		t.Error("requiredChecksAllPassed: want false for empty required list, got true")
+	}
+	if requiredChecksAllPassed(rollup, []string{}) {
+		t.Error("requiredChecksAllPassed: want false for empty (non-nil) required list, got true")
+	}
+}
+
+// ── handleHead / UNSTABLE path integration tests ──────────────────────────────
+
+// TestWatcher_UNSTABLEAllRequiredPass verifies that when mergeStateStatus is
+// UNSTABLE and all required checks are SUCCESS, the watcher proceeds to merge.
+func TestWatcher_UNSTABLEAllRequiredPass(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-unstable-merge"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-unstable-merge")
+
+	if _, err := d.EnqueueMerge(1001, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	mergeCalled := false
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:            "OPEN",
+				MergeStateStatus: "UNSTABLE",
+				StatusCheckRollup: []checkEntry{
+					// Required check: SUCCESS
+					{Name: "pr-gate", Conclusion: "SUCCESS", Status: "COMPLETED"},
+					// Optional check: still running — must not block merge
+					{Name: "validate-flakes", Status: "IN_PROGRESS", Conclusion: ""},
+				},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			mergeCalled = true
+			return nil, nil // merge succeeds
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	fw.fetchRequiredChecksFn = func(_ context.Context) ([]string, error) {
+		return []string{"pr-gate"}, nil
+	}
+
+	fw.processHead(context.Background())
+
+	if !mergeCalled {
+		t.Error("UNSTABLE+all-required-pass: merge was not attempted")
+	}
+	row, err := d.PendingMergeByPR(1001)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "merged" {
+		t.Errorf("status: got %q, want merged", row.Status)
+	}
+}
+
+// TestWatcher_UNSTABLERequiredStillRunning verifies that when UNSTABLE and
+// the required check is IN_PROGRESS, the row stays watching.
+func TestWatcher_UNSTABLERequiredStillRunning(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-unstable-running"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(1002, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	mergeCalled := false
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:            "OPEN",
+				MergeStateStatus: "UNSTABLE",
+				StatusCheckRollup: []checkEntry{
+					{Name: "pr-gate", Status: "IN_PROGRESS", Conclusion: ""},
+				},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			mergeCalled = true
+			return nil, nil
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	fw.fetchRequiredChecksFn = func(_ context.Context) ([]string, error) {
+		return []string{"pr-gate"}, nil
+	}
+
+	fw.processHead(context.Background())
+
+	if mergeCalled {
+		t.Error("UNSTABLE+required-in-progress: merge was called, want staying watching")
+	}
+	row, err := d.PendingMergeByPR(1002)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_UNSTABLEBranchProtectionFetchError verifies that when the
+// branch-protection API call fails, the watcher logs and stays watching.
+func TestWatcher_UNSTABLEBranchProtectionFetchError(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-unstable-fetcherr"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(1003, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	mergeCalled := false
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:            "OPEN",
+				MergeStateStatus: "UNSTABLE",
+				StatusCheckRollup: []checkEntry{
+					{Name: "pr-gate", Conclusion: "SUCCESS", Status: "COMPLETED"},
+				},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			mergeCalled = true
+			return nil, nil
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	// Simulate a branch-protection API failure.
+	fw.fetchRequiredChecksFn = func(_ context.Context) ([]string, error) {
+		return nil, fmt.Errorf("gh api: HTTP 403 forbidden")
+	}
+
+	fw.processHead(context.Background())
+
+	if mergeCalled {
+		t.Error("UNSTABLE+fetch-error: merge was called, want staying watching")
+	}
+	row, err := d.PendingMergeByPR(1003)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_UNSTABLERequiredAbsentFromRollup verifies that when a required
+// check name is not present in the rollup at all, the watcher stays watching.
+func TestWatcher_UNSTABLERequiredAbsentFromRollup(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-unstable-absent"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(1004, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	mergeCalled := false
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:            "OPEN",
+				MergeStateStatus: "UNSTABLE",
+				// Rollup does NOT include pr-gate at all.
+				StatusCheckRollup: []checkEntry{
+					{Name: "validate-flakes", Conclusion: "SUCCESS", Status: "COMPLETED"},
+				},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			mergeCalled = true
+			return nil, nil
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	fw.fetchRequiredChecksFn = func(_ context.Context) ([]string, error) {
+		return []string{"pr-gate"}, nil
+	}
+
+	fw.processHead(context.Background())
+
+	if mergeCalled {
+		t.Error("UNSTABLE+required-absent: merge was called, want staying watching")
+	}
+	row, err := d.PendingMergeByPR(1004)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching", row.Status)
+	}
+}
+
+// ── fetchRequiredChecks cache tests ───────────────────────────────────────────
+
+// TestFetchRequiredChecks_ParsesModernChecks verifies that the branch-protection
+// API response is correctly parsed when it contains modern check-run entries
+// (the checks[] array).
+func TestFetchRequiredChecks_ParsesModernChecks(t *testing.T) {
+	d := openTestDB(t)
+
+	const repoSlug = "owner/testrepo"
+	var callCount int
+	w := &Watcher{
+		db:          d,
+		instanceID:  "inst-bprot",
+		sessionName: "myrepo@main",
+		httpClient:  http.DefaultClient,
+		repo:        repoSlug,
+		runGHFunc: func(_ context.Context, args ...string) ([]byte, error) {
+			callCount++
+			// Return a modern branch-protection response.
+			body := `{"required_status_checks":{"contexts":[],"checks":[{"context":"pr-gate"},{"context":"lint"}]}}`
+			return []byte(body), nil
+		},
+	}
+
+	names, err := w.fetchRequiredChecks(context.Background())
+	if err != nil {
+		t.Fatalf("fetchRequiredChecks: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("want 2 names, got %d: %v", len(names), names)
+	}
+	// Order should be stable (dedup preserves insertion order).
+	if names[0] != "pr-gate" || names[1] != "lint" {
+		t.Errorf("names: got %v, want [pr-gate lint]", names)
+	}
+}
+
+// TestFetchRequiredChecks_ParsesLegacyContexts verifies that legacy
+// commit-status contexts (the contexts[] array) are parsed correctly.
+func TestFetchRequiredChecks_ParsesLegacyContexts(t *testing.T) {
+	d := openTestDB(t)
+
+	w := &Watcher{
+		db:          d,
+		instanceID:  "inst-bprot-legacy",
+		sessionName: "myrepo@main",
+		httpClient:  http.DefaultClient,
+		repo:        "owner/testrepo",
+		runGHFunc: func(_ context.Context, args ...string) ([]byte, error) {
+			body := `{"required_status_checks":{"contexts":["legacy-ci"],"checks":[]}}`
+			return []byte(body), nil
+		},
+	}
+
+	names, err := w.fetchRequiredChecks(context.Background())
+	if err != nil {
+		t.Fatalf("fetchRequiredChecks: %v", err)
+	}
+	if len(names) != 1 || names[0] != "legacy-ci" {
+		t.Errorf("names: got %v, want [legacy-ci]", names)
+	}
+}
+
+// TestFetchRequiredChecks_CacheTTL verifies that a cached response is reused
+// within the TTL and re-fetched after expiry.
+func TestFetchRequiredChecks_CacheTTL(t *testing.T) {
+	d := openTestDB(t)
+
+	var callCount int
+	current := time.Now()
+	w := &Watcher{
+		db:          d,
+		instanceID:  "inst-bprot-ttl",
+		sessionName: "myrepo@main",
+		httpClient:  http.DefaultClient,
+		repo:        "owner/testrepo",
+		runGHFunc: func(_ context.Context, args ...string) ([]byte, error) {
+			callCount++
+			body := `{"required_status_checks":{"contexts":[],"checks":[{"context":"pr-gate"}]}}`
+			return []byte(body), nil
+		},
+		nowFunc: func() time.Time { return current },
+	}
+
+	// First call: populates cache.
+	names1, err := w.fetchRequiredChecks(context.Background())
+	if err != nil {
+		t.Fatalf("first fetchRequiredChecks: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("first call: callCount = %d, want 1", callCount)
+	}
+
+	// Second call within TTL: cache hit, no new gh invocation.
+	names2, err := w.fetchRequiredChecks(context.Background())
+	if err != nil {
+		t.Fatalf("second fetchRequiredChecks: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("second call (within TTL): callCount = %d, want 1", callCount)
+	}
+	if len(names1) != len(names2) || names1[0] != names2[0] {
+		t.Errorf("cache miss returned different names: %v vs %v", names1, names2)
+	}
+
+	// Advance time past TTL.
+	current = current.Add(requiredChecksCacheTTL + time.Second)
+
+	// Third call after TTL: cache miss, re-fetches.
+	_, err = w.fetchRequiredChecks(context.Background())
+	if err != nil {
+		t.Fatalf("third fetchRequiredChecks: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("third call (after TTL): callCount = %d, want 2", callCount)
+	}
+}
+
+// TestFetchRequiredChecks_ErrorStaysWatching verifies the Watcher.tick()
+// integration: when fetchRequiredChecks returns an error on an UNSTABLE PR,
+// the row stays in watching and no merge is attempted. This exercises the
+// real tick() path (not fakeWatcher) using a stubbed runGHFunc.
+func TestFetchRequiredChecks_ErrorStaysWatching(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-bprot-err-tick"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(2001, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	w := &Watcher{
+		db:          d,
+		instanceID:  instanceID,
+		sessionName: session,
+		httpClient:  http.DefaultClient,
+		repo:        "owner/testrepo",
+		runGHFunc: func(_ context.Context, args ...string) ([]byte, error) {
+			// gh pr view succeeds, gh api branch protection fails.
+			if len(args) >= 3 && args[2] == "pr" && args[3] == "view" {
+				return []byte(`{"state":"OPEN","mergedAt":null,"mergeStateStatus":"UNSTABLE","statusCheckRollup":[{"name":"pr-gate","conclusion":"SUCCESS","status":"COMPLETED"}],"reviewDecision":""}`), nil
+			}
+			// Branch protection API call → simulate failure.
+			return []byte("forbidden"), fmt.Errorf("exit status 1")
+		},
+	}
+
+	w.tick(context.Background())
+
+	row, err := d.PendingMergeByPR(2001)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching (branch-protection fetch error must not merge)", row.Status)
 	}
 }


### PR DESCRIPTION
Closes #1586

## Summary

When `mergeStateStatus == "UNSTABLE"` the watcher now checks whether all *required* status checks (as defined by branch protection on `main`) have `conclusion == "SUCCESS"`. If they all pass it proceeds to merge, exactly as for a `CLEAN` state. If any required check is pending/absent, or if the branch-protection fetch fails, it stays watching (conservative).

This fixes the 55+ minute stalls on PRs #1584 and #1585 caused by `validate-flakes` being stuck `IN_PROGRESS` while `pr-gate` (the only required check) was green.

## Changes

- `checkEntry` gains `Name`, `Context`, `State` fields so rollup entries can be matched by name (both modern check-runs and legacy commit-statuses).
- `Watcher` gains a `requiredChecks` cache (TTL: 5 min) and `nowFunc` hook for test control.
- `fetchRequiredChecks()`: calls `gh api repos/{owner}/{repo}/branches/main/protection`, parses both `contexts[]` (legacy) and `checks[]` (modern), caches result. On error logs and returns the error — no merge.
- `requiredChecksAllPassed()`: returns `true` iff every required name appears in rollup with `SUCCESS` (via `Conclusion` or legacy `State`). Empty required list → `false` (conservative).
- Switch reshaped: `UNSTABLE` gets its own `case` using the above; `UNKNOWN`/`HAS_HOOKS`/`DRAFT` stay in the original "stay watching" branch.

## Acceptance Criteria

- [x] [functional] When `mergeStateStatus == "UNSTABLE"` and all required status checks (as defined by branch protection on the target branch) have `conclusion == "SUCCESS"`, the watcher calls the same merge path used for `CLEAN` and merges the PR.
- [x] [functional] When `mergeStateStatus == "UNSTABLE"` and any required check is still `IN_PROGRESS`, `QUEUED`, or absent from the rollup, the watcher leaves the row in `watching` and logs which required checks are not yet SUCCESS.
- [x] [functional] When `mergeStateStatus == "UNSTABLE"` and any required check has `conclusion == "FAILURE"` / `CANCELLED` / `TIMED_OUT`, the watcher does not merge. (The existing `BLOCKED` path already covers the CI-failure notification; this AC only requires that UNSTABLE-with-failing-required does not silently merge.)
- [x] [functional] Required-check names are fetched from branch protection via `gh api` and cached on the watcher for at least one tick; the fetch is not repeated on every iteration of the polling loop.
- [x] [edge-case] When the branch-protection fetch fails (non-zero exit / non-2xx response), the watcher logs the error and leaves the row in `watching` rather than merging.
- [x] [edge-case] When branch protection lists a required check name that does not appear in the rollup at all, the watcher treats it as not-yet-passed and leaves the row in `watching`.
- [x] [functional] The `CLEAN`, `BEHIND`, `DIRTY`, `BLOCKED`, `UNKNOWN`, `HAS_HOOKS`, and `DRAFT` branches of the existing switch behave identically to before this change.
- [x] [functional] `requiredChecksAllPassed` (or the equivalently named new helper) is exercised by unit tests covering: all-required-success, missing-required-name, required-in-progress, required-failure, mixed check-run and legacy commit-status rollup entries.
- [x] [functional] `handleHead` (or an extracted, smaller testable function) is covered by tests for the three UNSTABLE outcomes: all-required-pass → merge attempted; some required not pass → stay watching; branch-protection fetch error → stay watching.
- [x] [functional] `go build ./...` and `go test ./...` from `modules/programs/prism/prism/` succeed.