### PR TITLE
prism investigate: add --name flag and improve auto-slug truncation

### DIFF
--- a/modules/programs/prism/opencode/agents/coordinator.md
+++ b/modules/programs/prism/opencode/agents/coordinator.md
@@ -69,7 +69,12 @@ Use `prism investigate` for read-only research tasks that would otherwise block 
 
 ```bash
 prism investigate --prompt "what does the sidecar do when a session enters 'escalated' state?"
+
+# Use --name for a readable slug instead of an auto-derived one:
+prism investigate --name escalated-state-flow --prompt "what does the sidecar do when a session enters 'escalated' state?"
 ```
+
+The `--name` flag sets the slug portion of the session name directly (`<invoker>~investigate-<name>`). Only `[a-z0-9-]` is allowed, max 40 chars, no leading/trailing dash. When omitted, the slug is derived automatically from the prompt.
 
 The command returns a session name within ~2 seconds (shape: `<invoker>~investigate-<slug>`). Record it in your todo list alongside the open question.
 

--- a/modules/programs/prism/opencode/skills/prism/SKILL.md
+++ b/modules/programs/prism/opencode/skills/prism/SKILL.md
@@ -340,6 +340,7 @@ Use `prism investigate` to spawn a read-only research session from within a pris
 ```bash
 prism investigate --prompt "question"
 prism investigate --prompt-file /tmp/question.txt
+prism investigate --name my-analysis --prompt "question"
 ```
 
 ### Flags
@@ -348,12 +349,13 @@ prism investigate --prompt-file /tmp/question.txt
 |---|---|
 | `--prompt <text>` | Research question. Mutually exclusive with `--prompt-file`. |
 | `--prompt-file <path>` | Read the question from a file. Mutually exclusive with `--prompt`. |
+| `--name <slug>` | Human-readable slug for the session name. When provided, the session is named `<invoker>~investigate-<slug>` exactly. Only `[a-z0-9-]` allowed, max 40 chars, no leading/trailing dash. When omitted, the slug is derived automatically from the prompt text. |
 
 One of `--prompt` or `--prompt-file` is required. The command returns a session name within ~2 seconds and exits 0. There is no `--wait` flag — `prism investigate` is inherently async.
 
 ### Session-naming convention
 
-Spawned sessions are named `<invoker>~investigate-<slug>` where `<slug>` is a short kebab-case slug derived from the prompt.
+Spawned sessions are named `<invoker>~investigate-<slug>`. When `--name` is provided, `<slug>` is the supplied name exactly. When `--name` is omitted, `<slug>` is a short kebab-case token derived automatically from the prompt text (word-boundary truncated at 30 chars).
 
 ### Per-turn notification contract
 

--- a/modules/programs/prism/prism/cmd/investigate.go
+++ b/modules/programs/prism/prism/cmd/investigate.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/opencode"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -40,13 +41,27 @@ and return the session name immediately. The agent runs against the invoker's
 worktree in read-only mode.
 
 Per-turn notifications are delivered back to the invoker session automatically
-via the sidecar. No --wait flag is provided — this command is always async.`,
+via the sidecar. No --wait flag is provided — this command is always async.
+
+The --name flag sets the slug portion of the session name directly:
+
+    prism investigate --name my-analysis --prompt "..."
+
+results in a session named <invoker>~investigate-my-analysis.
+
+Validation rules for --name:
+  - Only lowercase alphanumerics and dashes ([a-z0-9-]) are allowed.
+  - Must not start or end with a dash.
+  - Maximum 40 characters.
+
+When --name is omitted, the slug is derived automatically from the prompt text.`,
 	Args: cobra.NoArgs,
 	RunE: runInvestigate,
 }
 
 func init() {
 	addPromptFlags(investigateCmd)
+	investigateCmd.Flags().String("name", "", "Human-readable slug for the session name (only [a-z0-9-], max 40 chars, no leading/trailing dash)")
 	rootCmd.AddCommand(investigateCmd)
 }
 
@@ -58,11 +73,22 @@ func runInvestigate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	suppliedName, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+	suppliedName = strings.TrimSpace(suppliedName)
+	if suppliedName != "" {
+		if err := validateInvestigateName(suppliedName); err != nil {
+			return err
+		}
+	}
+
 	// Container path: when running inside a sandboxed session, proxy to the
 	// host sidecar's /spawn endpoint with agent set to "investigate" and the
 	// session name pre-computed.
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyInvestigate(apiURL, promptText)
+		return proxyInvestigate(apiURL, promptText, suppliedName)
 	}
 
 	// Resolve the invoker session name.
@@ -78,11 +104,16 @@ func runInvestigate(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	return spawnInvestigateSession(invokerSession, promptText)
+	return spawnInvestigateSession(invokerSession, promptText, suppliedName)
+}
+
+// validateInvestigateName is a thin wrapper around the shared validation helper.
+func validateInvestigateName(name string) error {
+	return investigatepkg.ValidateName(name)
 }
 
 // spawnInvestigateSession is the testable core of runInvestigate.
-func spawnInvestigateSession(invokerSession, promptText string) error {
+func spawnInvestigateSession(invokerSession, promptText, suppliedName string) error {
 	database, err := openDB()
 	if err != nil {
 		return fmt.Errorf("open db: %w", err)
@@ -100,7 +131,12 @@ func spawnInvestigateSession(invokerSession, promptText string) error {
 	repo := status.Repo
 	worktree := status.Worktree
 
-	slug := investigateSlug(promptText)
+	var slug string
+	if suppliedName != "" {
+		slug = suppliedName
+	} else {
+		slug = investigateSlug(promptText)
+	}
 	sessionName := invokerSession + "~investigate-" + slug
 
 	cfg := config.Load()
@@ -177,9 +213,14 @@ func investigateSlug(prompt string) string {
 	// Strip leading dash.
 	s = strings.TrimLeft(s, "-")
 
-	// Truncate to 30 chars.
+	// Truncate to 30 chars at a word boundary (last "-" at or before 30).
 	if len(s) > 30 {
-		s = s[:30]
+		cap := s[:30]
+		if idx := strings.LastIndex(cap, "-"); idx >= 0 {
+			s = s[:idx]
+		} else {
+			s = cap
+		}
 	}
 
 	// Trim trailing dash.
@@ -194,7 +235,7 @@ func investigateSlug(prompt string) string {
 // proxyInvestigate forwards the investigate request to the host sidecar via
 // a dedicated /investigate endpoint that shells out to `prism investigate`
 // on the host with PRISM_SESSION_NAME set to the invoker session.
-func proxyInvestigate(apiURL, promptText string) error {
+func proxyInvestigate(apiURL, promptText, suppliedName string) error {
 	invokerSession := os.Getenv("PRISM_SESSION_NAME")
 	if invokerSession == "" {
 		cwd, _ := os.Getwd()
@@ -213,6 +254,9 @@ func proxyInvestigate(apiURL, promptText string) error {
 	body := map[string]any{
 		"prompt": promptText,
 		"from":   invokerSession,
+	}
+	if suppliedName != "" {
+		body["name"] = suppliedName
 	}
 	if err := proxyToHostAPI(apiURL, "/investigate", body, &resp); err != nil {
 		return err

--- a/modules/programs/prism/prism/cmd/investigate_test.go
+++ b/modules/programs/prism/prism/cmd/investigate_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -10,9 +11,11 @@ func TestInvestigateSlug(t *testing.T) {
 		want   string
 	}{
 		{
-			// Issue example — slug is ≤30 chars from the start of the prompt.
+			// Word-boundary truncation: last dash at or before 30 chars is used.
+			// "trace-the-call-chain-for-ssh-auth" = 34 chars; cap at 30 gives
+			// "trace-the-call-chain-for-ssh-a", last dash at index 28 → cut there.
 			prompt: "trace the call chain for SSH auth",
-			want:   "trace-the-call-chain-for-ssh-a",
+			want:   "trace-the-call-chain-for-ssh",
 		},
 		{
 			prompt: "What is happening?",
@@ -35,8 +38,10 @@ func TestInvestigateSlug(t *testing.T) {
 			want:   "punctuation-only",
 		},
 		{
+			// "a-very-long-prompt-that-goes-well-..." → cap at 30 = "a-very-long-prompt-that-goes-w";
+			// last dash at index 28 → cut to "a-very-long-prompt-that-goes".
 			prompt: "a very long prompt that goes well beyond the thirty character limit set for slugs",
-			want:   "a-very-long-prompt-that-goes-w",
+			want:   "a-very-long-prompt-that-goes",
 		},
 		{
 			prompt: "",
@@ -61,6 +66,81 @@ func TestInvestigateSlug(t *testing.T) {
 				t.Errorf("investigateSlug(%q) length %d exceeds 30", tc.prompt, len(got))
 			}
 		})
+	}
+}
+
+// TestInvestigateSlugWordBoundary specifically exercises the word-boundary
+// truncation: a prompt that produces a normalised string of exactly 30 chars
+// with no dash must fall back to the hard cut.
+func TestInvestigateSlugWordBoundary(t *testing.T) {
+	// 31 lowercase letters with no spaces/dashes: must hard-cut at 30.
+	prompt := "abcdefghijklmnopqrstuvwxyzabcde"
+	got := investigateSlug(prompt)
+	if got != "abcdefghijklmnopqrstuvwxyzabcd" {
+		t.Errorf("no-dash fallback: got %q, want %q", got, "abcdefghijklmnopqrstuvwxyzabcd")
+	}
+
+	// A prompt whose normalised form has a dash within the 30-char window:
+	// "hello world-foo-barbarbarbarbarbarbarbar" → "hello-world-foo-barbarbarbarba"[:30]
+	// The last dash in the 30-char cap should determine the cut point.
+	prompt2 := "hello world foo" + strings.Repeat("x", 20)
+	got2 := investigateSlug(prompt2)
+	// normalised: "hello-world-foo" + 20 x's = "hello-world-fooxxxxxxxxxxxxxxxxxxxx"
+	// cap[:30]   = "hello-world-fooxxxxxxxxxxxxxxx"
+	// last dash at index 11 → "hello-world"
+	if got2 != "hello-world" {
+		t.Errorf("word-boundary: got %q, want %q", got2, "hello-world")
+	}
+}
+
+func TestValidateInvestigateName(t *testing.T) {
+	valid := []string{
+		"foo",
+		"foo-bar",
+		"my-analysis",
+		"abc123",
+		"a",
+		"z",
+		// exactly 40 chars
+		strings.Repeat("a", 40),
+		"pi-removal-analysis-2024-deep-dive-v1-ok",
+	}
+	for _, name := range valid {
+		if err := validateInvestigateName(name); err != nil {
+			t.Errorf("validateInvestigateName(%q) unexpected error: %v", name, err)
+		}
+	}
+
+	invalid := []struct {
+		name        string
+		mustContain string // substring expected in error message
+	}{
+		// Too long
+		{strings.Repeat("a", 41), "maximum is 40"},
+		// Leading dash
+		{"-leading", "start or end with a dash"},
+		// Trailing dash
+		{"trailing-", "start or end with a dash"},
+		// Uppercase
+		{"UPPER", "disallowed characters"},
+		// Spaces
+		{"has spaces", "disallowed characters"},
+		// Mixed: uppercase and special
+		{"Has Spaces", "disallowed characters"},
+		// Underscore
+		{"under_score", "disallowed characters"},
+		// Special chars
+		{"foo@bar", "disallowed characters"},
+	}
+	for _, tc := range invalid {
+		err := validateInvestigateName(tc.name)
+		if err == nil {
+			t.Errorf("validateInvestigateName(%q) expected error, got nil", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.mustContain) {
+			t.Errorf("validateInvestigateName(%q): error %q does not contain %q", tc.name, err.Error(), tc.mustContain)
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/investigate/name.go
+++ b/modules/programs/prism/prism/internal/investigate/name.go
@@ -1,0 +1,36 @@
+// Package investigate provides shared helpers for the investigate command and
+// the host-API /investigate endpoint.
+package investigate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateName returns an error if the user-supplied --name value violates
+// the slug constraints:
+//   - Only lowercase alphanumerics and dashes ([a-z0-9-]).
+//   - Must not start or end with a dash.
+//   - Maximum 40 characters.
+func ValidateName(name string) error {
+	if len(name) > 40 {
+		return fmt.Errorf("prism investigate: --name %q is %d characters; maximum is 40", name, len(name))
+	}
+	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") {
+		return fmt.Errorf("prism investigate: --name %q must not start or end with a dash", name)
+	}
+	var bad []rune
+	seen := map[rune]bool{}
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+			if !seen[r] {
+				bad = append(bad, r)
+				seen[r] = true
+			}
+		}
+	}
+	if len(bad) > 0 {
+		return fmt.Errorf("prism investigate: --name %q contains disallowed characters: %q (only [a-z0-9-] is allowed)", name, string(bad))
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/internal/investigate/name_test.go
+++ b/modules/programs/prism/prism/internal/investigate/name_test.go
@@ -1,0 +1,49 @@
+package investigate_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/investigate"
+)
+
+func TestValidateName(t *testing.T) {
+	valid := []string{
+		"foo",
+		"foo-bar",
+		"my-analysis",
+		"abc123",
+		"a",
+		"z",
+		strings.Repeat("a", 40), // exactly 40 chars
+	}
+	for _, name := range valid {
+		if err := investigate.ValidateName(name); err != nil {
+			t.Errorf("ValidateName(%q) unexpected error: %v", name, err)
+		}
+	}
+
+	invalid := []struct {
+		name        string
+		mustContain string
+	}{
+		{strings.Repeat("a", 41), "maximum is 40"},
+		{"-leading", "start or end with a dash"},
+		{"trailing-", "start or end with a dash"},
+		{"UPPER", "disallowed characters"},
+		{"has spaces", "disallowed characters"},
+		{"Has Spaces", "disallowed characters"},
+		{"under_score", "disallowed characters"},
+		{"foo@bar", "disallowed characters"},
+	}
+	for _, tc := range invalid {
+		err := investigate.ValidateName(tc.name)
+		if err == nil {
+			t.Errorf("ValidateName(%q) expected error, got nil", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.mustContain) {
+			t.Errorf("ValidateName(%q): error %q does not contain %q", tc.name, err.Error(), tc.mustContain)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
+	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
 	prismsession "github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -1960,6 +1961,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			Prompt string `json:"prompt"`
 			From   string `json:"from,omitempty"`
+			Name   string `json:"name,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -1969,11 +1971,21 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			writeError(w, http.StatusBadRequest, "prompt is required")
 			return
 		}
+		req.Name = strings.TrimSpace(req.Name)
+		if req.Name != "" {
+			if err := investigatepkg.ValidateName(req.Name); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
 		fromSession := req.From
 		if fromSession == "" {
 			fromSession = s.cfg.SessionName
 		}
 		args := []string{"investigate", "--prompt", req.Prompt}
+		if req.Name != "" {
+			args = append(args, "--name", req.Name)
+		}
 		s.logger().Printf("sidecar: host-API /investigate: from=%s", fromSession)
 		cmd := exec.Command(prismBinary(), args...)
 		// PRISM_SESSION_NAME tells the host-side `prism investigate` which session


### PR DESCRIPTION
Closes #1581

## Summary

Adds a `--name` flag to `prism investigate` for human-readable session names, plumbs it through the proxy/host-API path, validates it consistently, and improves the auto-slug fallback to truncate at word boundaries.

## Changes

- **`cmd/investigate.go`**: `--name` flag, validation wrapper, `suppliedName` threaded through `runInvestigate` → `spawnInvestigateSession` and `proxyInvestigate`. Auto-slug improved to cut at last dash at/before 30 chars instead of mid-word.
- **`internal/investigate/name.go`**: Shared `ValidateName` function (only `[a-z0-9-]`, max 40 chars, no leading/trailing dash). Shared so the host-API handler can reuse it without importing the `cmd` package.
- **`internal/sidecar/host_api.go`**: `/investigate` handler accepts `name` field in the request JSON, validates it, and passes `--name` to the subprocess invocation. Returns HTTP 400 on validation failure.
- **`cmd/investigate_test.go`**: Updated slug tests to reflect word-boundary behaviour; added `TestInvestigateSlugWordBoundary` and `TestValidateInvestigateName`.
- **`internal/investigate/name_test.go`**: Package-level unit tests for `ValidateName`.

## Acceptance Criteria

- [ ] [functional] `prism investigate --name foo --prompt 'anything'` produces a session whose name ends in `~investigate-foo` regardless of prompt content.
- [ ] [functional] `prism investigate --prompt 'anything'` (no `--name`) continues to derive the slug from the prompt, preserving existing behaviour for the no-flag case.
- [ ] [functional] The improved auto-slug truncates at the last `-` at or before 30 chars when a dash exists in that window, rather than slicing mid-word.
- [ ] [functional] The auto-slug still returns `"query"` when the normalised prompt is empty, and still trims trailing dashes.
- [ ] [edge-case] `prism investigate --name '' --prompt 'x'` is treated identically to omitting `--name` (falls back to the auto-slug path).
- [ ] [edge-case] `prism investigate --name 'Has Spaces' --prompt 'x'` exits non-zero with an error naming the disallowed characters; no session is created.
- [ ] [edge-case] `prism investigate --name 'UPPER' --prompt 'x'` exits non-zero with an error (uppercase rejected).
- [ ] [edge-case] `prism investigate --name '-leading' --prompt 'x'` and `prism investigate --name 'trailing-' --prompt 'x'` both exit non-zero with a clear error.
- [ ] [edge-case] A `--name` of 41+ characters is rejected with a clear error; a 40-character valid name is accepted.
- [ ] [functional] When invoked via the proxy path (inside a container with `PRISM_HOST_API` set), `--name` is forwarded to the host and the resulting session name reflects the supplied name.
- [ ] [functional] Validation failures on the host-API path return a non-2xx response and the client exits non-zero with the server's error message visible to the user.
- [ ] [functional] The help text for `prism investigate --help` documents the `--name` flag, including its validation rules.
- [ ] [functional] `go build ./...` and `go test ./...` from `modules/programs/prism/prism/` succeed.