### PR TITLE
prism cleanup: treat ~-prefixed sub-sessions as descendants in worktree guard

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -1309,11 +1309,25 @@ func isSafeToRemoveWorktree(session, worktreePath, bareRoot string) bool {
 	// session being cleaned up. The session's own DB row is still active at
 	// this point (SetEnded is called later), so we must exclude it from the
 	// comparison to avoid blocking legitimate cleanup of dedicated worktrees.
+	//
+	// Descendant sessions — review and investigator sub-sessions named
+	// "<session>~<anything>" (e.g. "<session>~review-1-review-code",
+	// "<session>~investigate-<slug>") — inherit the parent's worktree path by
+	// design and are torn down by the same cleanup invocation. They must not
+	// block worktree removal of their parent.
 	if d, err := openDB(); err == nil {
 		defer d.Close()
 		if statuses, err := d.AllActiveStatus(); err == nil {
 			for _, st := range statuses {
-				if st.SessionName != session && st.Worktree != "" && filepath.Clean(st.Worktree) == cleanPath {
+				if st.SessionName == session {
+					continue
+				}
+				// Skip descendant sessions (review / investigator sub-sessions)
+				// that reuse the parent's worktree path.
+				if strings.HasPrefix(st.SessionName, session+"~") {
+					continue
+				}
+				if st.Worktree != "" && filepath.Clean(st.Worktree) == cleanPath {
 					return false
 				}
 			}

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -1199,6 +1199,75 @@ func TestIsSafeToRemoveWorktree_ActiveSessionGuard(t *testing.T) {
 	})
 }
 
+// TestIsSafeToRemoveWorktree_DescendantSessionGuard verifies that
+// isSafeToRemoveWorktree returns true when the only DB rows sharing the
+// target worktree path are descendant sessions of the cleanup target (i.e.
+// sessions whose name starts with "<session>~"). Review and investigator
+// sub-sessions inherit the parent's worktree by design and are torn down
+// by the same cleanup invocation, so they must not block it.
+func TestIsSafeToRemoveWorktree_DescendantSessionGuard(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+
+	sharedPath := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Seed the parent session (cleanup target) and two descendant review
+	// sub-sessions, all with the same worktree path.
+	if err := d.UpsertStatus("myrepo@feature", "myrepo", sharedPath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus parent: %v", err)
+	}
+	if err := d.UpsertStatus("myrepo@feature~review-1-review-code", "myrepo", sharedPath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus review-code: %v", err)
+	}
+	if err := d.UpsertStatus("myrepo@feature~review-1-review-goal", "myrepo", sharedPath, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus review-goal: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	t.Run("descendant sessions do not block parent worktree removal", func(t *testing.T) {
+		// Only the parent and its ~-prefixed descendants share sharedPath.
+		// The guard must return true so cleanup proceeds.
+		safe := isSafeToRemoveWorktree("myrepo@feature", sharedPath, "")
+		if !safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, %q, \"\") = false, want true — descendant review sessions must not block parent worktree removal",
+				"myrepo@feature", sharedPath)
+		}
+	})
+
+	t.Run("unrelated session still blocks worktree removal (regression guard)", func(t *testing.T) {
+		// Add an unrelated session (not a descendant of the target) that also
+		// uses sharedPath — the guard must return false to protect it.
+		dbFile2 := filepath.Join(t.TempDir(), "prism.db")
+		d2, err := db.Open(dbFile2)
+		if err != nil {
+			t.Fatalf("open db2: %v", err)
+		}
+		if err := d2.UpsertStatus("myrepo@feature", "myrepo", sharedPath, "running", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus parent: %v", err)
+		}
+		if err := d2.UpsertStatus("myrepo@other", "myrepo", sharedPath, "running", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus unrelated: %v", err)
+		}
+		d2.Close()
+
+		SetTestDBPath(dbFile2)
+		t.Cleanup(func() { SetTestDBPath("") })
+
+		safe := isSafeToRemoveWorktree("myrepo@feature", sharedPath, "")
+		if safe {
+			t.Errorf("isSafeToRemoveWorktree(%q, %q, \"\") = true, want false — unrelated active session %q must still block removal",
+				"myrepo@feature", sharedPath, "myrepo@other")
+		}
+	})
+}
+
 // TestHeadlessCleanup_InvestigatorSessionPreservesMainWorktree verifies the
 // full end-to-end bug scenario from issue #1582: an investigator session whose
 // worktree resolves to the main worktree path must NOT have that directory


### PR DESCRIPTION
Closes #1592

## Summary

`isSafeToRemoveWorktree`'s Guard 2 excluded only the exact session being cleaned up from the "active session shares this path" check. When a worker ran `prism review`, its review sub-sessions (named `<parent>~review-N-<role>`) and investigator sub-sessions (named `<parent>~investigate-<slug>`) inherit the parent's worktree path and still have `ended_at=NULL` at the point the guard runs (they are cleaned up later in the same invocation). This caused the guard to fire spuriously, leaving the worktree on disk on every coordinator-driven cleanup of a review-running session.

**Fix:** also skip any session whose name starts with `<session>~` in the Guard 2 loop, covering both review and investigator descendants. A comment names the parent-child naming convention so the intent is auditable.

**New test:** `TestIsSafeToRemoveWorktree_DescendantSessionGuard` covers:
- parent + two review sub-sessions sharing the path → returns `true`
- parent + unrelated session sharing the path → returns `false` (regression guard for the legitimate Guard 2 case)

## Acceptance Criteria

- [x] [functional] `isSafeToRemoveWorktree(session, worktreePath, bareRoot)` returns `true` when the only other DB rows sharing `worktreePath` are sessions whose name starts with `session + "~"` (review or investigator descendants of the cleanup target).
- [x] [functional] `isSafeToRemoveWorktree` still returns `false` when an unrelated active session (one whose name is neither equal to `session` nor prefixed by `session + "~"`) has the same worktree path. This protects the legitimate Guard 2 case.
- [x] [functional] `isSafeToRemoveWorktree` still returns `false` for the default-branch worktree (Guard 1 unchanged).
- [x] [functional] A new unit test in `cleanup_test.go` covers the parent-plus-review-descendants scenario described in the prompt, asserting `true`, plus a regression sub-case asserting `false` for an unrelated session sharing the path.
- [x] [functional] The existing `TestIsSafeToRemoveWorktree_*` tests continue to pass with no semantic changes.
- [x] [edge-case] When the active-sessions DB query fails or returns no rows, behaviour is unchanged (the existing code path silently treats this as "no other sessions" — the new prefix exclusion sits on top of that, so the fallback is preserved).
- [x] [functional] `go build ./...` and `go test ./...` from `modules/programs/prism/prism/` succeed.