### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778248595,
-        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
+        "lastModified": 1778728372,
+        "narHash": "sha256-8pArLaovyMHR9VHa6eVk4e5vgvDS+Dg9J8pxPBjAE18=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
+        "rev": "f04b141d1a0d6d7d62aa9678aef602dfb61e8bb1",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778303898,
-        "narHash": "sha256-UD2MxOeFSkoLB3TToDhZ3FZKbRu0zj/W3dlnrNDFNps=",
+        "lastModified": 1778732910,
+        "narHash": "sha256-6pPSj/37ycKGyDqKe3+qgWz7cl8q+nl6O+KvTQPaMsU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e036a78dd7d408bf02e3f6e9ccebdd06cb33e26c",
+        "rev": "62b115397ad52504108116da8e005821e4632185",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/25843770269

## Closure diff: navi

```
attica: 6.25.0 → 6.26.0
breeze-icons: 6.25.0 → 6.26.0
cachix: 1.11.0 → 1.11.1, 33.5 KiB
calibre: 9.7.0 → 9.8.0, 176.9 KiB
chromium: 147.0.7727.137 → 148.0.7778.96
chromium-unwrapped: 147.0.7727.137 → 148.0.7778.96, 6.9 MiB
claude-code: 2.1.133 → 2.1.140, 1.8 MiB
discord: 0.0.134 → 1.0.137, 293.6 MiB
discord-stage: ∅ → ε
extra-cmake-modules: 6.25.0 → 6.26.0
firefox: 150.0.1 → 150.0.2, 27.6 KiB
firefox-unwrapped: 150.0.1 → 150.0.2, 169.2 KiB
frameworkintegration: 6.25.0 → 6.26.0
hyprutils: 0.13.0 → 0.13.1, 12.7 KiB
initrd-linux: 7.0.3 → 7.0.5
inkscape: 1.4.3 → 1.4.4, 2.8 MiB
karchive: 6.25.0 → 6.26.0
kauth: 6.25.0 → 6.26.0
kbookmarks: 6.25.0 → 6.26.0
kcmutils: 6.25.0 → 6.26.0
kcodecs: 6.25.0 → 6.26.0
kcolorscheme: 6.25.0 → 6.26.0
kcompletion: 6.25.0 → 6.26.0
kconfig: 6.25.0 → 6.26.0
kconfigwidgets: 6.25.0 → 6.26.0
kcoreaddons: 6.25.0 → 6.26.0, 87.5 KiB
kcrash: 6.25.0 → 6.26.0
kdbusaddons: 6.25.0 → 6.26.0
kdoctools: 6.25.0 → 6.26.0
kglobalaccel: 6.25.0 → 6.26.0
kguiaddons: 6.25.0 → 6.26.0
ki18n: 6.25.0 → 6.26.0
kiconthemes: 6.25.0 → 6.26.0
kio: 6.25.0 → 6.26.0, -15.8 KiB
kirigami: 6.25.0 → 6.26.0, 1.1 MiB
kitemviews: 6.25.0 → 6.26.0
kjobwidgets: 6.25.0 → 6.26.0
knewstuff: 6.25.0 → 6.26.0
knotifications: 6.25.0 → 6.26.0
kpackage: 6.25.0 → 6.26.0
kservice: 6.25.0 → 6.26.0
ktextwidgets: 6.25.0 → 6.26.0
kwallet: 6.25.0 → 6.26.0
kwidgetsaddons: 6.25.0 → 6.26.0
kwindowsystem: 6.25.0 → 6.26.0
kxmlgui: 6.25.0 → 6.26.0
lib3mf: 2.4.1 → 2.5.0, 112.0 KiB
libinput: 1.29.2 → 1.31.1, 67.2 KiB
libplacebo: 7.351.0 → 7.360.1, 41.0 KiB
linux: 7.0.3 → 7.0.5, -123.2 KiB
mangohud: 0.8.2 → 0.8.3, 5.5 MiB
mesa: 26.0.6 → 26.1.0, 24.0 MiB
mpd: 0.24.9 → 0.24.10
nixos-system-navi: 26.05.20260505.549bd84 → 26.05.20260510.da5ad66
opencode: 44.0 KiB
openrazer: 3.12.2-7.0.3 → 3.12.2-7.0.5
plexamp: 4.13.1, 4.13.1-fhsenv → 4.13.2, 4.13.2-fhsenv
podofo: 0.10.5 → 0.10.6
python3.13-inkex: 1.4.3 → 1.4.4
python3.13-lxml-html-clean: 0.4.3 → 0.4.4
qqc2-desktop-style: 6.25.0 → 6.26.0
solid: 6.25.0 → 6.26.0, 220.8 KiB
sonnet: 6.25.0 → 6.26.0
sops: 3.12.2 → 3.13.0, 763.8 KiB
sops-install-secrets: 24.0 KiB
source: 485.6 KiB
syndication: 6.25.0 → 6.26.0
yaml-language-server: 1.22.0 → 1.23.0, 8.4 MiB
```

## Closure diff: tui

```
attica: 6.25.0 → 6.26.0
breeze-icons: 6.25.0 → 6.26.0
cachix: 1.11.0 → 1.11.1, 33.5 KiB
calibre: 9.7.0 → 9.8.0, 176.9 KiB
chromium: 147.0.7727.137 → 148.0.7778.96
chromium-unwrapped: 147.0.7727.137 → 148.0.7778.96, 6.9 MiB
claude-code: 2.1.133 → 2.1.140, 1.8 MiB
discord: 0.0.134 → 1.0.137, 293.6 MiB
discord-stage: ∅ → ε
extra-cmake-modules: 6.25.0 → 6.26.0
firefox: 150.0.1 → 150.0.2, 27.6 KiB
firefox-unwrapped: 150.0.1 → 150.0.2, 169.2 KiB
frameworkintegration: 6.25.0 → 6.26.0
hyprutils: 0.13.0 → 0.13.1, 12.7 KiB
initrd-linux: 7.0.3 → 7.0.5, 64.3 KiB
inkscape: 1.4.3 → 1.4.4, 2.8 MiB
karchive: 6.25.0 → 6.26.0
kauth: 6.25.0 → 6.26.0
kbookmarks: 6.25.0 → 6.26.0
kcmutils: 6.25.0 → 6.26.0
kcodecs: 6.25.0 → 6.26.0
kcolorscheme: 6.25.0 → 6.26.0
kcompletion: 6.25.0 → 6.26.0
kconfig: 6.25.0 → 6.26.0
kconfigwidgets: 6.25.0 → 6.26.0
kcoreaddons: 6.25.0 → 6.26.0, 87.5 KiB
kcrash: 6.25.0 → 6.26.0
kdbusaddons: 6.25.0 → 6.26.0
kdoctools: 6.25.0 → 6.26.0
kglobalaccel: 6.25.0 → 6.26.0
kguiaddons: 6.25.0 → 6.26.0
ki18n: 6.25.0 → 6.26.0
kiconthemes: 6.25.0 → 6.26.0
kio: 6.25.0 → 6.26.0, -15.8 KiB
kirigami: 6.25.0 → 6.26.0, 1.1 MiB
kitemviews: 6.25.0 → 6.26.0
kjobwidgets: 6.25.0 → 6.26.0
knewstuff: 6.25.0 → 6.26.0
knotifications: 6.25.0 → 6.26.0
kpackage: 6.25.0 → 6.26.0
kservice: 6.25.0 → 6.26.0
ktextwidgets: 6.25.0 → 6.26.0
kwallet: 6.25.0 → 6.26.0
kwidgetsaddons: 6.25.0 → 6.26.0
kwindowsystem: 6.25.0 → 6.26.0
kxmlgui: 6.25.0 → 6.26.0
lib3mf: 2.4.1 → 2.5.0, 112.0 KiB
libinput: 1.29.2 → 1.31.1, 67.2 KiB
libplacebo: 7.351.0 → 7.360.1, 41.0 KiB
linux: 7.0.3 → 7.0.5, -123.2 KiB
mangohud: 0.8.2 → 0.8.3, 5.5 MiB
mesa: 26.0.6 → 26.1.0, 24.0 MiB
mpd: 0.24.9 → 0.24.10
nbd: 3.25 → 3.27.1, 15.4 KiB
nixos-system-tui: 26.05.20260505.549bd84 → 26.05.20260510.da5ad66
opencode: 44.0 KiB
openrazer: 3.12.2-7.0.3 → 3.12.2-7.0.5
plexamp: 4.13.1, 4.13.1-fhsenv → 4.13.2, 4.13.2-fhsenv
podofo: 0.10.5 → 0.10.6
python3.13-inkex: 1.4.3 → 1.4.4
python3.13-lxml-html-clean: 0.4.3 → 0.4.4
qqc2-desktop-style: 6.25.0 → 6.26.0
solid: 6.25.0 → 6.26.0, 220.8 KiB
sonnet: 6.25.0 → 6.26.0
sops: 3.12.2 → 3.13.0, 763.8 KiB
sops-install-secrets: 24.0 KiB
source: 485.6 KiB
syndication: 6.25.0 → 6.26.0
xen: 4.20.2 → 4.20.3
yaml-language-server: 1.22.0 → 1.23.0, 8.4 MiB
```