### PR TITLE
container: persist PI Atlassian MCP OAuth tokens across Darwin sandbox-exec sessions

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -384,7 +384,81 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".nix-profile"),
 	)
 
+	// ── PI Atlassian MCP OAuth token persistence (Darwin only) ───────────────
+	// The Atlassian MCP extension stores OAuth tokens at
+	// homedir()/.pi/agent/atlassian-mcp-oauth.json. On Darwin sandbox-exec,
+	// $HOME inside the session is the per-session staging HOME, so writes to
+	// that path land in the staging dir and are destroyed when the session
+	// ends. To persist tokens across sessions we:
+	//
+	//  1. Create <stagingHome>/.pi/agent/ as a real directory (so the
+	//     extension's mkdirSync({ recursive: true }) is a no-op).
+	//  2. Touch ~/.pi/agent/atlassian-mcp-oauth.json on the host with mode
+	//     0600 if absent — bwrap does the same in appendPIBwrapMounts.
+	//  3. Symlink <stagingHome>/.pi/agent/atlassian-mcp-oauth.json to the
+	//     real host path so reads and writes flow through to the host.
+	//
+	// The SBPL profile already emits
+	//   (allow file-read* file-write* ... (subpath ~/.pi/agent))
+	// for Harness == "pi" sessions, so no profile changes are required.
+	//
+	// The change is gated on BOTH runtime.GOOS == "darwin" AND
+	// m.cfg.Harness == "pi" so that non-pi sessions are unaffected.
+	if runtime.GOOS == "darwin" && m.cfg.Harness == "pi" {
+		if err := m.stagePIOAuthToken(home, stagingHome); err != nil {
+			log.Printf("container: sandbox-exec: stage PI OAuth token: %v", err)
+		}
+	}
+
 	return stagingHome, nil
+}
+
+// stagePIOAuthToken creates the staging HOME infrastructure for the
+// Atlassian MCP OAuth token under a pi harness Darwin session:
+//
+//  1. Creates <stagingHome>/.pi/agent/ as a real directory (mode 0700).
+//  2. Ensures ~/.pi/agent/ exists on the host (mode 0700).
+//  3. Touches ~/.pi/agent/atlassian-mcp-oauth.json on the host with
+//     mode 0600 if absent (existing files are never modified).
+//  4. Symlinks <stagingHome>/.pi/agent/atlassian-mcp-oauth.json →
+//     ~/.pi/agent/atlassian-mcp-oauth.json (idempotent).
+//
+// This mirrors the bwrap touch-and-bind pattern in
+// pi_invocation.go::appendPIBwrapMounts.
+func (m *Manager) stagePIOAuthToken(home, stagingHome string) error {
+	// 1. Create <stagingHome>/.pi/agent/ as a real directory.
+	stagingAgentDir := filepath.Join(stagingHome, ".pi", "agent")
+	if err := os.MkdirAll(stagingAgentDir, 0o700); err != nil {
+		return fmt.Errorf("create staging .pi/agent dir %s: %w", stagingAgentDir, err)
+	}
+
+	// 2. Ensure ~/.pi/agent/ exists on the host.
+	hostAgentDir := filepath.Join(home, ".pi", "agent")
+	if err := os.MkdirAll(hostAgentDir, 0o700); err != nil {
+		return fmt.Errorf("create host .pi/agent dir %s: %w", hostAgentDir, err)
+	}
+
+	// 3. Touch ~/.pi/agent/atlassian-mcp-oauth.json on the host if absent.
+	// Use O_CREATE|O_EXCL so an existing file is never truncated or modified.
+	hostTokenPath := filepath.Join(hostAgentDir, "atlassian-mcp-oauth.json")
+	if _, statErr := os.Stat(hostTokenPath); os.IsNotExist(statErr) {
+		f, createErr := os.OpenFile(hostTokenPath, os.O_CREATE|os.O_EXCL, 0o600)
+		if createErr == nil {
+			_ = f.Close()
+		} else if !os.IsExist(createErr) {
+			return fmt.Errorf("touch host token file %s: %w", hostTokenPath, createErr)
+		}
+	}
+
+	// 4. Symlink <stagingHome>/.pi/agent/atlassian-mcp-oauth.json → host path.
+	// Remove any existing entry first (file, symlink, or otherwise) so
+	// the operation is idempotent.
+	stagingTokenPath := filepath.Join(stagingAgentDir, "atlassian-mcp-oauth.json")
+	_ = os.Remove(stagingTokenPath)
+	if err := os.Symlink(hostTokenPath, stagingTokenPath); err != nil {
+		return fmt.Errorf("symlink %s → %s: %w", stagingTokenPath, hostTokenPath, err)
+	}
+	return nil
 }
 
 // isWritable returns true when the path exists and is accessible for writing

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -1362,6 +1363,316 @@ func TestPrepareSandboxExecHome_PiAgentDirMissingSkipped(t *testing.T) {
 	symlinkPath := filepath.Join(stagingHome, ".pi", "agent")
 	if _, err := os.Lstat(symlinkPath); err == nil {
 		t.Errorf(".pi/agent must not exist when ~/.pi/agent is absent")
+	}
+}
+
+// ── PI Atlassian MCP OAuth token staging (Darwin + pi harness) ─────────────
+
+// TestPrepareSandboxExecHome_PiOAuthTokenSymlinked verifies that after
+// PrepareSandboxExecHome runs for a Harness=="pi" Manager on Darwin,
+// <stagingHome>/.pi/agent/atlassian-mcp-oauth.json exists as a symlink
+// whose target equals the host path ~/.pi/agent/atlassian-mcp-oauth.json.
+func TestPrepareSandboxExecHome_PiOAuthTokenSymlinked(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-token-test",
+		InstanceID:  "pi-oauth-token-symlink-test",
+		Harness:     "pi",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+	})
+
+	// <stagingHome>/.pi/agent/atlassian-mcp-oauth.json must be a symlink.
+	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	info, err := os.Lstat(stagingTokenPath)
+	if err != nil {
+		t.Fatalf("%s must exist: %v", stagingTokenPath, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s must be a symlink, got mode %v", stagingTokenPath, info.Mode())
+	}
+
+	// The symlink target must be the real host path.
+	target, err := os.Readlink(stagingTokenPath)
+	if err != nil {
+		t.Fatalf("Readlink %s: %v", stagingTokenPath, err)
+	}
+	wantTarget := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	if target != wantTarget {
+		t.Errorf("symlink target = %q, want %q", target, wantTarget)
+	}
+}
+
+// TestPrepareSandboxExecHome_PiOAuthAgentDirIsRealDir verifies that after
+// PrepareSandboxExecHome runs for a Harness=="pi" Manager on Darwin,
+// <stagingHome>/.pi/agent is a real directory (not a symlink).
+func TestPrepareSandboxExecHome_PiOAuthAgentDirIsRealDir(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-agent-dir",
+		InstanceID:  "pi-oauth-agent-dir-test",
+		Harness:     "pi",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+	})
+
+	// <stagingHome>/.pi/agent must be a real directory, not a symlink.
+	agentPath := filepath.Join(stagingHome, ".pi", "agent")
+	info, err := os.Lstat(agentPath)
+	if err != nil {
+		t.Fatalf("%s must exist: %v", agentPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("%s must be a real directory, not a symlink", agentPath)
+	}
+	if !info.IsDir() {
+		t.Errorf("%s must be a directory, got mode %v", agentPath, info.Mode())
+	}
+}
+
+// TestPrepareSandboxExecHome_PiOAuthHostFileMode verifies that when
+// PrepareSandboxExecHome creates ~/.pi/agent/atlassian-mcp-oauth.json because
+// it was absent, the file has mode 0600.
+func TestPrepareSandboxExecHome_PiOAuthHostFileMode(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+
+	// Ensure the token file does not exist before the test.
+	hostTokenPath := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-mode",
+		InstanceID:  "pi-oauth-mode-test",
+		Harness:     "pi",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+	})
+
+	// Suppress the "declared and not used" warning for hostTokenPath.
+	info, err := os.Stat(hostTokenPath)
+	if err != nil {
+		t.Fatalf("host token file %s must exist: %v", hostTokenPath, err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("host token file mode = %04o, want 0600", info.Mode().Perm())
+	}
+}
+
+// TestPrepareSandboxExecHome_PiOAuthExistingFileNotOverwritten verifies that
+// when ~/.pi/agent/atlassian-mcp-oauth.json already exists with non-empty
+// content, PrepareSandboxExecHome does NOT truncate or overwrite it.
+func TestPrepareSandboxExecHome_PiOAuthExistingFileNotOverwritten(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+
+	// Pre-create the token file with sentinel content.
+	hostAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(hostAgentDir, 0o700); err != nil {
+		t.Fatalf("create host agent dir: %v", err)
+	}
+	hostTokenPath := filepath.Join(hostAgentDir, "atlassian-mcp-oauth.json")
+	const sentinel = `{"access_token":"sentinel-do-not-overwrite"}`
+	if err := os.WriteFile(hostTokenPath, []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("write sentinel token: %v", err)
+	}
+	origStat, err := os.Stat(hostTokenPath)
+	if err != nil {
+		t.Fatalf("stat sentinel token: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-existing",
+		InstanceID:  "pi-oauth-existing-test",
+		Harness:     "pi",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.Remove(hostTokenPath)
+	})
+
+	// Verify content unchanged.
+	got, err := os.ReadFile(hostTokenPath)
+	if err != nil {
+		t.Fatalf("read host token: %v", err)
+	}
+	if string(got) != sentinel {
+		t.Errorf("host token content changed: got %q, want %q", string(got), sentinel)
+	}
+
+	// Verify mtime unchanged.
+	afterStat, err := os.Stat(hostTokenPath)
+	if err != nil {
+		t.Fatalf("stat host token after: %v", err)
+	}
+	if !afterStat.ModTime().Equal(origStat.ModTime()) {
+		t.Errorf("host token mtime changed: orig %v, after %v", origStat.ModTime(), afterStat.ModTime())
+	}
+}
+
+// TestPrepareSandboxExecHome_PiOAuthMissingHostAgentDirAutoCreated verifies
+// that when ~/.pi/agent/ does not exist on the host, PrepareSandboxExecHome
+// creates it with mode 0700 and returns nil error.
+func TestPrepareSandboxExecHome_PiOAuthMissingHostAgentDirAutoCreated(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+
+	// Ensure ~/.pi/agent does not exist.
+	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-mkdir",
+		InstanceID:  "pi-oauth-mkdir-test",
+		Harness:     "pi",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome with missing host agent dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+	})
+
+	// Host agent dir must now exist with mode 0700.
+	hostAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	info, err := os.Stat(hostAgentDir)
+	if err != nil {
+		t.Fatalf("host agent dir %s must exist after autocreate: %v", hostAgentDir, err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Errorf("host agent dir mode = %04o, want 0700", info.Mode().Perm())
+	}
+
+	// The symlink in the staging dir must also be created.
+	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	if _, err := os.Lstat(stagingTokenPath); err != nil {
+		t.Errorf("staging token symlink must exist after autocreate: %v", err)
+	}
+}
+
+// TestPrepareSandboxExecHome_PiOAuthNonPiHarnessNoOp verifies that when
+// Harness != "pi", PrepareSandboxExecHome does NOT create
+// <stagingHome>/.pi/agent and does NOT touch ~/.pi/agent/atlassian-mcp-oauth.json.
+func TestPrepareSandboxExecHome_PiOAuthNonPiHarnessNoOp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+
+	for _, harness := range []string{"", "opencode"} {
+		t.Run("harness="+harness, func(t *testing.T) {
+			m := newSandboxExecManagerWithInstance(Config{
+				SessionName: "repo@non-pi-" + harness,
+				InstanceID:  "pi-oauth-non-pi-" + harness,
+				Harness:     harness,
+			})
+			stagingHome, err := m.PrepareSandboxExecHome()
+			if err != nil {
+				t.Fatalf("PrepareSandboxExecHome: %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+			// <stagingHome>/.pi/agent must NOT be created for non-pi harness.
+			agentPath := filepath.Join(stagingHome, ".pi", "agent")
+			if _, err := os.Lstat(agentPath); err == nil {
+				t.Errorf("<stagingHome>/.pi/agent must not exist for harness=%q", harness)
+			}
+
+			// ~/.pi/agent/atlassian-mcp-oauth.json must NOT be created.
+			hostTokenPath := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+			if _, err := os.Stat(hostTokenPath); err == nil {
+				t.Errorf("host token file must not be created for harness=%q", harness)
+			}
+		})
+	}
+}
+
+// TestPrepareSandboxExecHome_PiOAuthIdempotent verifies that calling
+// PrepareSandboxExecHome twice on the same staging HOME leaves the symlink
+// at <stagingHome>/.pi/agent/atlassian-mcp-oauth.json valid and pointing at
+// the same host path; no error is returned on the second call.
+func TestPrepareSandboxExecHome_PiOAuthIdempotent(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PI OAuth token staging is Darwin-only")
+	}
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-idem",
+		InstanceID:  "pi-oauth-idempotent-test",
+		Harness:     "pi",
+	})
+
+	// First call.
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("first PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(stagingHome)
+		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+	})
+
+	wantTarget := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	getTarget := func() string {
+		t.Helper()
+		target, err := os.Readlink(filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"))
+		if err != nil {
+			t.Fatalf("Readlink after first call: %v", err)
+		}
+		return target
+	}
+	firstTarget := getTarget()
+	if firstTarget != wantTarget {
+		t.Errorf("first call: symlink target = %q, want %q", firstTarget, wantTarget)
+	}
+
+	// Second call — must not fail and symlink must still point at same host path.
+	_, err = m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("second PrepareSandboxExecHome: %v", err)
+	}
+	secondTarget := getTarget()
+	if secondTarget != wantTarget {
+		t.Errorf("second call: symlink target = %q, want %q", secondTarget, wantTarget)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go
@@ -1,0 +1,254 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_pi_atlassian_oauth_darwin_test.go — integration tests for the
+// PI Atlassian MCP OAuth token persistence via sandbox-exec symlink (issue #1597).
+//
+// Background:
+//
+//	The Atlassian MCP extension stores OAuth tokens at
+//	homedir()/.pi/agent/atlassian-mcp-oauth.json. Inside a Darwin
+//	sandbox-exec pi session, $HOME is overridden to a per-session staging
+//	HOME, so writes to that path land in the staging dir and are destroyed
+//	when the session ends. The fix in PrepareSandboxExecHome (for Harness ==
+//	"pi" on Darwin):
+//
+//	  1. Creates <stagingHome>/.pi/agent/ as a real directory.
+//	  2. Touches ~/.pi/agent/atlassian-mcp-oauth.json on the host with mode
+//	     0600 if absent.
+//	  3. Symlinks <stagingHome>/.pi/agent/atlassian-mcp-oauth.json → the
+//	     real host path.
+//
+//	The SBPL profile already emits (allow file-read* file-write* ...
+//	(subpath ~/.pi/agent)) for pi sessions, so writes inside the sandbox go
+//	through the symlink to the real host path.
+//
+// These tests verify:
+//
+//  1. Positive: a bash command running inside sandbox-exec (with the
+//     production SBPL profile for Harness == "pi") writes JSON bytes to
+//     $HOME/.pi/agent/atlassian-mcp-oauth.json; those exact bytes are
+//     readable from the real host ~/.pi/agent/atlassian-mcp-oauth.json
+//     after sandbox-exec exits. This confirms the symlink write-through
+//     works end-to-end.
+//
+//  2. Negative: when the symlink at <stagingHome>/.pi/agent/atlassian-mcp-oauth.json
+//     is removed (breaking the write-through), the same write either fails
+//     or does NOT appear at the real host path, proving the positive test
+//     is not a no-op. (Per docs/sandbox-exec-testing.md, issue #1192.)
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// newPIOAuthPersistenceManager creates a Manager configured for a pi-harness
+// session with a BareRoot (required for the pi agent dir subpath allow in the
+// SBPL profile).
+func newPIOAuthPersistenceManager(t *testing.T) *container.Manager {
+	t.Helper()
+	instanceID := "integ-sbx-pi-atlassian-oauth-" + strings.ReplaceAll(t.Name(), "/", "-")
+	cfg := container.Config{
+		SessionName: "integ-sandbox-exec-pi-atlassian-oauth-test",
+		InstanceID:  instanceID,
+		Worktree:    t.TempDir(),
+		Harness:     "pi",
+		BareRoot:    t.TempDir(), // needed for the BareRoot-ancestor allow block
+	}
+	return container.New(cfg)
+}
+
+// TestSandboxExecPIAtlassianOAuth_WriteThrough is the positive integration
+// test. It verifies that:
+//
+//  1. PrepareSandboxExecHome for Harness=="pi" creates a symlink at
+//     <stagingHome>/.pi/agent/atlassian-mcp-oauth.json pointing at the real
+//     host ~/.pi/agent/atlassian-mcp-oauth.json.
+//  2. A bash command inside sandbox-exec (using the production SBPL profile)
+//     can write JSON bytes to $HOME/.pi/agent/atlassian-mcp-oauth.json.
+//  3. Those exact bytes are readable from the real host path after sandbox-exec
+//     exits, confirming the symlink write-through is functional end-to-end.
+func TestSandboxExecPIAtlassianOAuth_WriteThrough(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	// Ensure ~/.pi/agent/ exists on the host so PrepareSandboxExecHome can
+	// create the host token file.
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if mkErr := os.MkdirAll(piAgentDir, 0o700); mkErr != nil {
+		t.Fatalf("MkdirAll ~/.pi/agent: %v", mkErr)
+	}
+
+	// Stash any existing atlassian-mcp-oauth.json so we can restore it and
+	// so we start with a clean state for the write-through assertion.
+	hostTokenPath := filepath.Join(piAgentDir, "atlassian-mcp-oauth.json")
+	stashPath := hostTokenPath + ".integ-pi-atlassian-oauth-stash"
+	stashed := false
+	if _, statErr := os.Lstat(hostTokenPath); statErr == nil {
+		if renErr := os.Rename(hostTokenPath, stashPath); renErr == nil {
+			stashed = true
+			t.Cleanup(func() {
+				_ = os.Remove(hostTokenPath)
+				_ = os.Rename(stashPath, hostTokenPath)
+			})
+		}
+	}
+	if !stashed {
+		t.Cleanup(func() { _ = os.Remove(hostTokenPath) })
+	}
+
+	m := newPIOAuthPersistenceManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Verify the symlink exists in the staging HOME before running sandbox-exec.
+	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	linkTarget, readlinkErr := os.Readlink(stagingTokenPath)
+	if readlinkErr != nil {
+		t.Fatalf("staging token symlink not created by PrepareSandboxExecHome: %v", readlinkErr)
+	}
+	if linkTarget != hostTokenPath {
+		t.Fatalf("staging token symlink target = %q, want %q", linkTarget, hostTokenPath)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Confirm the profile contains the (subpath ~/.pi/agent) rule.
+	piAgentSubpath := "(subpath " + sbplQuoteForTest(piAgentDir) + ")"
+	if !strings.Contains(prepared.content, piAgentSubpath) {
+		t.Fatalf("generated profile does not contain %q\nProfile:\n%s", piAgentSubpath, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Use a unique sentinel value for this test run so we can assert the
+	// specific bytes were written (not a leftover from a previous run).
+	const sentinel = `{"access_token":"integ-pi-atlassian-oauth-positive-sentinel"}`
+
+	// Inside sandbox-exec with HOME=<stagingHome>, write the sentinel JSON to
+	// $HOME/.pi/agent/atlassian-mcp-oauth.json. The symlink routes the write
+	// through to the real host path.
+	script := "printf '%s' " + shQuote(sentinel) + " > " +
+		shQuote(filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"))
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("write to $HOME/.pi/agent/atlassian-mcp-oauth.json inside sandbox failed.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s\nStagingTokenPath: %s",
+			runErr, string(out), testProfilePath, stagingTokenPath)
+	}
+
+	// Assert the sentinel bytes are readable from the real host path.
+	got, readErr := os.ReadFile(hostTokenPath)
+	if readErr != nil {
+		t.Fatalf("cannot read host token file %s after sandbox write: %v", hostTokenPath, readErr)
+	}
+	if string(got) != sentinel {
+		t.Errorf("host token content = %q, want %q\n"+
+			"(write inside sandbox-exec did not reach the host path via symlink)",
+			string(got), sentinel)
+	}
+}
+
+// TestSandboxExecPIAtlassianOAuth_WriteThroughBroken is the paired negative
+// test. It removes the symlink at <stagingHome>/.pi/agent/atlassian-mcp-oauth.json
+// (breaking the write-through) and asserts that the same write either fails or
+// does NOT appear at the real host path. This proves the positive test is not
+// green by accident — the symlink is the specific mechanism that routes writes
+// from the staging HOME to the host.
+func TestSandboxExecPIAtlassianOAuth_WriteThroughBroken(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if mkErr := os.MkdirAll(piAgentDir, 0o700); mkErr != nil {
+		t.Fatalf("MkdirAll ~/.pi/agent: %v", mkErr)
+	}
+
+	// Stash any existing token file so we start clean.
+	hostTokenPath := filepath.Join(piAgentDir, "atlassian-mcp-oauth.json")
+	stashPath := hostTokenPath + ".integ-pi-atlassian-oauth-neg-stash"
+	stashed := false
+	if _, statErr := os.Lstat(hostTokenPath); statErr == nil {
+		if renErr := os.Rename(hostTokenPath, stashPath); renErr == nil {
+			stashed = true
+			t.Cleanup(func() {
+				_ = os.Remove(hostTokenPath)
+				_ = os.Rename(stashPath, hostTokenPath)
+			})
+		}
+	}
+	if !stashed {
+		t.Cleanup(func() { _ = os.Remove(hostTokenPath) })
+	}
+
+	m := newPIOAuthPersistenceManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Break the write-through: remove the symlink from the staging HOME.
+	// The directory entry <stagingHome>/.pi/agent/atlassian-mcp-oauth.json
+	// becomes absent; the sandbox write will either fail or create a file
+	// inside the ephemeral staging dir rather than at the host path.
+	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
+	if err := os.Remove(stagingTokenPath); err != nil {
+		t.Fatalf("remove staging token symlink: %v", err)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	const sentinel = `{"access_token":"integ-pi-atlassian-oauth-negative-sentinel"}`
+
+	// Allow the sandbox write to fail OR succeed into the staging dir — either
+	// outcome is acceptable for the negative test; what matters is that the
+	// host path does NOT contain the sentinel.
+	script := "printf '%s' " + shQuote(sentinel) + " > " +
+		shQuote(filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"))
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
+	_, _ = cmd.CombinedOutput() // ignore exit code — the sandbox may deny or permit the write
+
+	// The host token file must NOT contain the negative sentinel: without the
+	// symlink, the sandbox write cannot reach the host path.
+	got, readErr := os.ReadFile(hostTokenPath)
+	if readErr == nil && string(got) == sentinel {
+		t.Errorf("host token contains negative sentinel %q even though the staging symlink was removed.\n"+
+			"The positive test is not catching the write-through — investigate.\n"+
+			"Host token path: %s", sentinel, hostTokenPath)
+	} else {
+		t.Logf("ka pai — write did NOT reach host path without staging symlink (host content: %q)", string(got))
+	}
+}


### PR DESCRIPTION
Closes #1597

## Summary

The PI Atlassian MCP extension stores OAuth tokens at `homedir()/.pi/agent/atlassian-mcp-oauth.json`. On Darwin sandbox-exec, `$HOME` inside a pi session is the per-session staging HOME, so tokens written there are destroyed when the session ends. This PR fixes that by wiring a write-through symlink.

## Changes

### `internal/container/sandbox_exec_home.go`
- Added `stagePIOAuthToken(home, stagingHome string) error` method to `Manager`.
- `PrepareSandboxExecHome` now calls `stagePIOAuthToken` when `runtime.GOOS == "darwin" && m.cfg.Harness == "pi"`.
- The method: (1) creates `<stagingHome>/.pi/agent/` as a real directory; (2) ensures `~/.pi/agent/` exists on the host; (3) touches `~/.pi/agent/atlassian-mcp-oauth.json` with mode 0600 if absent; (4) symlinks `<stagingHome>/.pi/agent/atlassian-mcp-oauth.json` → host path (idempotent via `os.Remove` before `os.Symlink`).
- No SBPL profile changes — the existing `(subpath ~/.pi/agent)` rule already covers reads and writes.

### `internal/container/sandbox_exec_test.go`
New unit tests (Darwin-gated via `runtime.GOOS` skip):
- `TestPrepareSandboxExecHome_PiOAuthTokenSymlinked` — symlink exists with correct target
- `TestPrepareSandboxExecHome_PiOAuthAgentDirIsRealDir` — `.pi/agent` is a real dir not a symlink
- `TestPrepareSandboxExecHome_PiOAuthHostFileMode` — created file has mode 0600
- `TestPrepareSandboxExecHome_PiOAuthExistingFileNotOverwritten` — pre-existing content and mtime unchanged
- `TestPrepareSandboxExecHome_PiOAuthMissingHostAgentDirAutoCreated` — missing host dir autocreated with 0700
- `TestPrepareSandboxExecHome_PiOAuthNonPiHarnessNoOp` — empty/opencode harness: no staging dir or host file created
- `TestPrepareSandboxExecHome_PiOAuthIdempotent` — second call leaves symlink valid and pointing at same host path

### `internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go` (new)
Darwin-only integration test pair per `docs/sandbox-exec-testing.md`:
- `TestSandboxExecPIAtlassianOAuth_WriteThrough` (positive): runs bash inside sandbox-exec with the production SBPL profile for `Harness == "pi"`, writes JSON bytes to `$HOME/.pi/agent/atlassian-mcp-oauth.json`, asserts those exact bytes are readable from the real host path.
- `TestSandboxExecPIAtlassianOAuth_WriteThroughBroken` (negative): removes the staging symlink, runs the same write, asserts it does NOT appear at the real host path — proving the positive test is not a no-op.

## Acceptance Criteria

- [ ] [functional] In a Darwin sandbox-exec pi session, completing `/login-atlassian` once causes `~/.pi/agent/atlassian-mcp-oauth.json` to exist on the host with the OAuth token JSON written by the extension.
- [ ] [functional] A subsequent Darwin sandbox-exec pi session (different `<instance_id>`) reads valid tokens via `loadTokens()` in `pi/extensions/atlassian/auth.ts` and does NOT emit the "No auth tokens. Use /login-atlassian to authenticate." warning.
- [ ] [functional] After `PrepareSandboxExecHome` runs for a `Harness == "pi"` Manager on Darwin, `<stagingHome>/.pi/agent/atlassian-mcp-oauth.json` exists as a symlink whose `os.Readlink` target equals `filepath.Join(home, ".pi", "agent", "atlassian-mcp-oauth.json")`.
- [ ] [functional] After `PrepareSandboxExecHome` runs for a `Harness == "pi"` Manager on Darwin, `<stagingHome>/.pi/agent` is a real directory (not a symlink) — `os.Lstat` reports `ModeDir` with no `ModeSymlink` bit.
- [ ] [security] When `PrepareSandboxExecHome` creates `~/.pi/agent/atlassian-mcp-oauth.json` because it was absent, the file has mode `0600` (verified by `os.Stat().Mode().Perm() == 0o600`).
- [ ] [edge-case] When `~/.pi/agent/atlassian-mcp-oauth.json` already exists on the host with non-empty content, `PrepareSandboxExecHome` does NOT truncate, overwrite, or alter the file's content or mtime.
- [ ] [edge-case] When `~/.pi/agent/` does not exist on the host, `PrepareSandboxExecHome` creates it with mode `0700` and proceeds to create the placeholder file and symlink; the function returns nil error.
- [ ] [edge-case] When `Harness != "pi"` (e.g. opencode), `PrepareSandboxExecHome` does NOT create `<stagingHome>/.pi/agent` and does NOT touch `~/.pi/agent/atlassian-mcp-oauth.json` on the host.
- [ ] [edge-case] Calling `PrepareSandboxExecHome` twice on the same staging HOME (idempotency) leaves the symlink at `<stagingHome>/.pi/agent/atlassian-mcp-oauth.json` valid and pointing at the same host path; no error is returned on the second call.
- [ ] [functional] A Darwin-only integration test under `modules/programs/prism/prism/internal/integration/` invokes `/usr/bin/sandbox-exec` against a Nix-built test binary, runs the binary inside the production SBPL profile (`Harness == "pi"`), has the test binary write JSON bytes to `$HOME/.pi/agent/atlassian-mcp-oauth.json`, and asserts those exact bytes are readable from the real host `~/.pi/agent/atlassian-mcp-oauth.json` after sandbox-exec exits.
- [ ] [functional] A paired negative integration test removes the symlink (or otherwise breaks the write-through) and asserts the same write either fails or does NOT appear at the real host path, proving the positive test is not a no-op. (Per `modules/programs/prism/prism/docs/sandbox-exec-testing.md`.)
- [ ] [functional] Existing tests `TestPrepareSandboxExecHome_PiAgentDirNotSymlinked` and `TestPrepareSandboxExecHome_PiAgentDirMissingSkipped` continue to pass unchanged.
- [ ] [functional] `go test ./...` from `modules/programs/prism/prism/` passes locally, and the CI `pr-gate` status check (`go-tests` + `nix-build-prism-checked`) passes on the PR.