### PR TITLE
Prune speculative env var injections from sandbox credential forwarding (#1603)

### DIFF
--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -137,7 +137,7 @@ func TestNew_UsesProvidedHTTPClient(t *testing.T) {
 
 func TestCredentialEnvVars_LLMKeysForwarded(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
 
 	m := New(Config{SessionName: "repo@main", AllocatedPort: 14000, AgentRole: "worker"})
 	vars := m.credentialEnvVars()
@@ -147,8 +147,8 @@ func TestCredentialEnvVars_LLMKeysForwarded(t *testing.T) {
 		if kv == "ANTHROPIC_API_KEY=sk-ant-test" {
 			found = true
 		}
-		if strings.HasPrefix(kv, "OPENAI_API_KEY=") {
-			t.Errorf("OPENAI_API_KEY should not be forwarded when empty; got %q", kv)
+		if strings.HasPrefix(kv, "OPENROUTER_API_KEY=") {
+			t.Errorf("OPENROUTER_API_KEY should not be forwarded when empty; got %q", kv)
 		}
 	}
 	if !found {
@@ -176,6 +176,37 @@ func TestCredentialEnvVars_AtlassianKeysNotForwarded(t *testing.T) {
 		}
 		if strings.HasPrefix(kv, "ATLASSIAN_API_TOKEN=") {
 			t.Errorf("ATLASSIAN_API_TOKEN should not be forwarded (CLI removed); got %q", kv)
+		}
+	}
+}
+
+func TestCredentialEnvVars_SpeculativeKeysNotForwarded(t *testing.T) {
+	// These keys were removed from forwardKeys because they are speculative:
+	// not populated on the host and not consumed by any in-repo agent/skill/config.
+	//   OPENAI_API_KEY    — no OpenAI provider configured in opencode.nix.
+	//   GEMINI_API_KEY    — Google auth uses opencode-gemini-auth OAuth plugin.
+	//   GOOGLE_API_KEY    — same rationale as GEMINI_API_KEY.
+	//   GITHUB_COPILOT_TOKEN — Copilot provider uses its own auth flow.
+	//   DEEPSEEK_API_KEY  — user-confirmed speculative; no consumer in-repo.
+	speculative := []string{
+		"OPENAI_API_KEY",
+		"GEMINI_API_KEY",
+		"GOOGLE_API_KEY",
+		"GITHUB_COPILOT_TOKEN",
+		"DEEPSEEK_API_KEY",
+	}
+	for _, k := range speculative {
+		t.Setenv(k, "should-not-appear")
+	}
+
+	m := New(Config{SessionName: "repo@main", AllocatedPort: 14000, AgentRole: "worker"})
+	vars := m.credentialEnvVars()
+
+	for _, kv := range vars {
+		for _, k := range speculative {
+			if strings.HasPrefix(kv, k+"=") {
+				t.Errorf("%s should not be forwarded (speculative key removed); got %q", k, kv)
+			}
 		}
 	}
 }

--- a/modules/programs/prism/prism/internal/container/credentials.go
+++ b/modules/programs/prism/prism/internal/container/credentials.go
@@ -127,17 +127,16 @@ func (m *Manager) credentialEnvVars() []string {
 
 	// External-tool credentials — forwarded for all agent roles.
 	// Covers LLM API keys and other API credentials.
-	// Note: ATLASSIAN_SITE/EMAIL/API_TOKEN are intentionally excluded — the
-	// atlassian CLI has been removed. The pi atlassian-mcp extension uses
-	// OAuth PKCE (tokens stored in ~/.pi/agent/atlassian-mcp-oauth.json)
-	// and does not require these env vars.
+	//
+	// Keys intentionally NOT forwarded:
+	//   ATLASSIAN_SITE/EMAIL/API_TOKEN — atlassian CLI removed; OAuth PKCE used.
+	//   OPENAI_API_KEY    — speculative; no OpenAI provider configured.
+	//   GEMINI_API_KEY    — speculative; Google auth uses opencode-gemini-auth OAuth.
+	//   GOOGLE_API_KEY    — speculative; same as GEMINI_API_KEY.
+	//   GITHUB_COPILOT_TOKEN — speculative; Copilot provider uses its own auth flow.
+	//   DEEPSEEK_API_KEY  — speculative; not populated and no consumer in-repo.
 	forwardKeys := []string{
 		"ANTHROPIC_API_KEY",
-		"OPENAI_API_KEY",
-		"GEMINI_API_KEY",
-		"GOOGLE_API_KEY",
-		"GITHUB_COPILOT_TOKEN",
-		"DEEPSEEK_API_KEY",
 		"OPENROUTER_API_KEY",
 	}
 	for _, k := range forwardKeys {


### PR DESCRIPTION
Closes #1603

## Summary

Audit and prune speculative LLM/credential env var injections from the `forwardKeys` slice in `internal/container/credentials.go`. Removes five keys that are neither populated on the host nor consumed by any in-repo code.

## Per-key decision table

| key | populated on host? | referenced by in-repo code? | decision | rationale |
|-----|-------------------|-----------------------------|----------|-----------|
| `ANTHROPIC_API_KEY` | No (OAuth via opencode-claude-auth plugin) | Yes — pi-wire-protocol.md describes it as a valid provider config mechanism; agent_run.go comment mentions it; tests explicitly verify it is forwarded | **keep** | Referenced in harness docs and verified by tests as a legitimate forwarding path |
| `OPENAI_API_KEY` | No | No — no OpenAI provider in opencode.nix providerSettings; only appears in test fixtures incidentally | **remove** | Speculative: not populated, no OpenAI provider configured in-repo |
| `GEMINI_API_KEY` | No | No — only in credentials.go | **remove** | Speculative: Google auth uses `opencode-gemini-auth@latest` OAuth plugin, not an API key |
| `GOOGLE_API_KEY` | No | No — only in credentials.go | **remove** | Speculative: same rationale as GEMINI_API_KEY; alternative Google key form, also unused |
| `GITHUB_COPILOT_TOKEN` | No | No — only in credentials.go | **remove** | Speculative: github-copilot provider uses its own auth flow, not this env var |
| `DEEPSEEK_API_KEY` | No | No — only in credentials.go (plus a mention in daemon-mode-design.md as an *example* of a speculative key) | **remove** | User-confirmed speculative; not populated, no consumer in-repo |
| `OPENROUTER_API_KEY` | Yes — sops secret via `modules/programs/secrets/openrouter.sops.yaml` + `secrets.nix` | Yes — `internal/quick/pr.go` reads it to call OpenRouter API for PR descriptions; sanitization tests reference it | **keep** | Populated and actively consumed |

## Changes

- **`internal/container/credentials.go`**: Removed `OPENAI_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GITHUB_COPILOT_TOKEN`, `DEEPSEEK_API_KEY` from `forwardKeys`. Added explanatory comments for why each class of key is not forwarded.
- **`internal/container/container_test.go`**:
  - `TestCredentialEnvVars_LLMKeysForwarded`: replaced the empty-`OPENAI_API_KEY` assertion with an equivalent empty-`OPENROUTER_API_KEY` assertion (same 'empty keys are not forwarded' property using a remaining key).
  - Added `TestCredentialEnvVars_SpeculativeKeysNotForwarded`: documents and asserts that the five removed keys are not forwarded even when set on the host.

## Test results

`go test ./internal/container/... -run TestCredentialEnvVars|TestMinimalBwrapExecEnv` — all pass. Pre-existing failures in `cmd`, `internal/container` (SSH remap, sandbox-exec integration), and `internal/integration` reproduce on `main` without my changes.