### PR TITLE
doom-loop: exclude bash search/read bases from detection

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -30,6 +30,7 @@ import {
   similarityKey,
   processDoomLoop,
   isGitPush,
+  EXCLUDED_BASH_BASES,
   // Pre-tool-call bash deny list (#1528)
   BLOCKED_BASH_PATTERNS,
   checkBlockedBash,
@@ -769,6 +770,49 @@ describe("similarityKey — bash cd-prefix stripping", () => {
   })
 })
 
+describe("similarityKey — EXCLUDED_BASH_BASES", () => {
+  it("grep returns null", () => {
+    assert.equal(similarityKey("bash", { command: "grep foo file1" }), null)
+  })
+
+  it("rg returns null", () => {
+    assert.equal(similarityKey("bash", { command: "rg foo path/to/file" }), null)
+  })
+
+  it("find returns null", () => {
+    assert.equal(similarityKey("bash", { command: "find . -name foo" }), null)
+  })
+
+  it("cat returns null", () => {
+    assert.equal(similarityKey("bash", { command: "cat file" }), null)
+  })
+
+  it("EXCLUDED_BASH_BASES is exported and contains expected members", () => {
+    assert.ok(EXCLUDED_BASH_BASES.has("grep"))
+    assert.ok(EXCLUDED_BASH_BASES.has("rg"))
+    assert.ok(EXCLUDED_BASH_BASES.has("find"))
+    assert.ok(EXCLUDED_BASH_BASES.has("cat"))
+    assert.ok(EXCLUDED_BASH_BASES.has("ag"))
+    assert.ok(EXCLUDED_BASH_BASES.has("fd"))
+  })
+
+  it("grep with leading flags (-r) is still excluded", () => {
+    // baseIdx flag-skipping correctly identifies grep as the base
+    assert.equal(similarityKey("bash", { command: "grep -r \"pat\" dir" }), null)
+  })
+
+  it("cd /foo && grep strips prefix then excludes", () => {
+    // cd-prefix stripping runs before EXCLUDED_BASH_BASES check; effective base = grep
+    assert.equal(similarityKey("bash", { command: "cd /foo && grep \"pat\" file" }), null)
+  })
+
+  it("git is NOT in EXCLUDED_BASH_BASES and produces a non-null key", () => {
+    const key = similarityKey("bash", { command: "git push origin main" })
+    assert.ok(key !== null)
+    assert.ok(key.startsWith("bash:git"))
+  })
+})
+
 describe("similarityKey — edit/write/webfetch", () => {
   it("edit same file produces the same key", () => {
     const a = similarityKey("edit", { filePath: "/foo.go", newString: "a" })
@@ -865,6 +909,77 @@ describe("processDoomLoop — per-session isolation", () => {
     const msgB = processDoomLoop(stateB, "bash", { command: "go test ./..." })
     assert.ok(msgA !== null)
     assert.equal(msgB, null)
+  })
+})
+
+describe("processDoomLoop — EXCLUDED_BASH_BASES exclusion", () => {
+  it("5 grep calls over varying files all return null and do not fire", () => {
+    const state = newDoomLoopState()
+    const files = ["file1.nix", "file2.nix", "file3.nix", "file4.nix", "file5.nix"]
+    for (const f of files) {
+      const result = processDoomLoop(state, "bash", { command: `grep opencode ${f}` })
+      assert.equal(result, null, `expected null for grep on ${f}`)
+    }
+  })
+
+  it("5 grep calls over the same file all return null and do not fire", () => {
+    // grep is in EXCLUDED_BASH_BASES regardless of args — intentional trade-off
+    const state = newDoomLoopState()
+    for (let i = 0; i < 5; i++) {
+      const result = processDoomLoop(state, "bash", { command: "grep opencode same-file.nix" })
+      assert.equal(result, null)
+    }
+  })
+
+  it("edit, grep, edit, grep, edit does NOT fire on the third edit", () => {
+    const state = newDoomLoopState()
+    // edit 1
+    processDoomLoop(state, "edit", { filePath: "foo.go" })
+    // grep — should reset the run
+    processDoomLoop(state, "bash", { command: "grep opencode modules/foo.nix" })
+    // edit 2 — starts a fresh run (count=1)
+    processDoomLoop(state, "edit", { filePath: "foo.go" })
+    // grep again — resets again
+    processDoomLoop(state, "bash", { command: "grep opencode modules/bar.nix" })
+    // edit 3 — fresh run (count=1), should NOT fire
+    const result = processDoomLoop(state, "edit", { filePath: "foo.go" })
+    assert.equal(result, null)
+    assert.ok(state.consecutiveCount < 5)
+  })
+
+  it("grep resets doom-loop state (currentKey, consecutiveCount, fired)", () => {
+    const state = newDoomLoopState()
+    // Build up 4 edits.
+    for (let i = 0; i < 4; i++) {
+      processDoomLoop(state, "edit", { filePath: "foo.go" })
+    }
+    assert.equal(state.consecutiveCount, 4)
+    // Intervening grep must reset.
+    processDoomLoop(state, "bash", { command: "grep opencode modules/foo.nix" })
+    assert.equal(state.currentKey, null)
+    assert.equal(state.consecutiveCount, 0)
+    assert.equal(state.fired, false)
+  })
+
+  it("5 identical edit calls (no intervening tool) still fire at count 5", () => {
+    const state = newDoomLoopState()
+    let msg: string | null = null
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD; i++) {
+      msg = processDoomLoop(state, "edit", { filePath: "foo.go" })
+    }
+    assert.ok(msg !== null, "expected doom-loop to fire")
+    assert.ok(msg.includes("PRISM DOOM-LOOP"))
+  })
+
+  it("5 identical bash:git push calls still fire at count 5", () => {
+    // git is in SUBCOMMAND_CLIS, not EXCLUDED_BASH_BASES — must still detect
+    const state = newDoomLoopState()
+    let msg: string | null = null
+    for (let i = 0; i < DOOM_LOOP_THRESHOLD; i++) {
+      msg = processDoomLoop(state, "bash", { command: "git push origin main" })
+    }
+    assert.ok(msg !== null, "expected doom-loop to fire for git push")
+    assert.ok(msg.includes("PRISM DOOM-LOOP"))
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -105,6 +105,23 @@ export const DOOM_LOOP_THRESHOLD = 5
 export const EXCLUDED_TOOLS = new Set(["read", "grep", "glob", "todowrite"])
 
 /**
+ * Bash command bases that are search/read/inspect operations. Excluded from
+ * doom-loop detection for the same reason EXCLUDED_TOOLS excludes the native
+ * read/grep/glob tools: legitimate exploration revisits the same pattern
+ * across many files, and the bash similarity key collapses
+ * `<base> "<pattern>" <file1>`, `<base> "<pattern>" <file2>`, … to one key
+ * because positional #2+ is discarded by the default bash key formula.
+ */
+export const EXCLUDED_BASH_BASES = new Set([
+  "grep", "rg", "ag",                              // search
+  "find", "fd",                                    // file listing
+  "cat", "head", "tail", "less", "more",           // read
+  "ls", "tree", "stat", "file", "wc",              // inspect
+  "awk", "sed", "cut", "sort", "uniq",             // text munging (read-only when piped)
+  "jq", "yq",                                      // structured read
+])
+
+/**
  * Compute a normalised similarity key for a tool call.
  * Returns null for excluded tools (no detection).
  *
@@ -134,6 +151,10 @@ export function similarityKey(tool: string, args: unknown): string | null {
         baseIdx++
       }
       const base = meaningful[baseIdx] ?? ""
+
+      if (EXCLUDED_BASH_BASES.has(base)) {
+        return null
+      }
 
       const SUBCOMMAND_CLIS = new Set(["gh", "git", "kubectl", "helm", "docker", "podman"])
       if (SUBCOMMAND_CLIS.has(base)) {
@@ -218,16 +239,13 @@ export function processDoomLoop(
   toolName: string,
   toolArgs: unknown,
 ): string | null {
-  if (EXCLUDED_TOOLS.has(toolName)) {
-    // Break the current run without tracking.
+  const key = similarityKey(toolName, toolArgs)
+  if (key === null) {
+    // Excluded by similarityKey (either an excluded tool or an excluded bash
+    // base). Treat as a run-breaker for symmetry with the EXCLUDED_TOOLS path.
     state.currentKey = null
     state.consecutiveCount = 0
     state.fired = false
-    return null
-  }
-
-  const key = similarityKey(toolName, toolArgs)
-  if (key === null) {
     return null
   }
 


### PR DESCRIPTION
## Summary

Fixes the false-positive doom-loop detection observed during #1601, where the agent ran `grep` over many different files and the detector incorrectly fired because the bash similarity key only retained the search pattern (positional #1), discarding the file path (positional #2+).

## Changes

### `prism.ts`
- Add `EXCLUDED_BASH_BASES` export: a set of bash command bases (grep, rg, ag, find, fd, cat, head, tail, less, more, ls, tree, stat, file, wc, awk, sed, cut, sort, uniq, jq, yq) that are excluded from doom-loop detection. This mirrors the existing `EXCLUDED_TOOLS` exclusion for the native grep/read/glob tools.
- In the bash branch of `similarityKey`, short-circuit with `return null` when `base` is in `EXCLUDED_BASH_BASES` (before the SUBCOMMAND_CLIS check).
- Unify the reset-on-null-key path in `processDoomLoop`: remove the `EXCLUDED_TOOLS.has(toolName)` early-return and replace with a single null-key check after `similarityKey`. Any exclusion path now resets the run state, so an intervening `bash:grep ...` between `edit foo.go` calls correctly breaks the edit run.

### `prism.test.ts`
- Import `EXCLUDED_BASH_BASES` from the module.
- Add `describe("similarityKey — EXCLUDED_BASH_BASES")` with 8 tests covering grep, rg, find, cat, flag-prefixed grep, cd-prefixed grep, the export itself, and git as a non-excluded base.
- Add `describe("processDoomLoop — EXCLUDED_BASH_BASES exclusion")` with 6 tests: grep over varying files, grep over same file, edit/grep interleave (no fire), state reset assertion, regression check (5 identical edits still fire), and regression check (5 identical git push still fire).

## Test results

All 159 pure-function tests pass via `tsx --test prism.test.ts`. The tmux and integration test failures are pre-existing on `main` (require tmux fork permission and a running sidecar, respectively).

`go build ./...` from `modules/programs/prism/prism/` passes.

Closes #1607