### PR TITLE
Isolate sidecar tests from host bus, DB, and socket state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,15 @@ go test ./...
 nix build .#prism
 ```
 
-This catches build/test failures fast. The full homeless-shelter signal is then exercised by CI on the PR. If you want to reproduce CI's checked build locally:
+This catches build/test failures fast. The full homeless-shelter signal is then exercised by CI on the PR.
+
+**Test-suite isolation (issue #1608).** The test suite under `modules/programs/prism/prism/internal/sidecar/` is fully isolated from host bus / DB / tmux state:
+
+- Tests that construct a `sidecar.Sidecar` must use `sidecartest.NewIsolated(t, ...)` which redirects `$XDG_STATE_HOME` to a `t.TempDir()` and sets the `PRISM_TEST_MODE_RESTRICT_HOSTAPI` guard.
+- Test session names use the `prism-test@` prefix, never `nixos-config@main` or any other slug that matches a live coordinator on the developer's host.
+- Running `go test ./...` will not deliver any notification to a live coordinator, write to the real `prism.db`, create files under `$XDG_STATE_HOME/prism/run/`, or invoke `tmux` against the host server.
+
+If you add a new test that exercises notification delivery, use `sidecartest.NewIsolated` — do not construct a `sidecar.Config` that touches the host environment. If you want to reproduce CI's checked build locally:
 
 ```bash
 # From the repo root

--- a/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
+++ b/modules/programs/prism/prism/internal/promptdelivery/promptdelivery.go
@@ -2,6 +2,16 @@
 // by all out-of-process callers that need to send a follow-up prompt to a
 // running agent session.
 //
+// # Test-mode isolation guard
+//
+// When the environment variable PRISM_TEST_MODE_RESTRICT_HOSTAPI is set to any
+// non-empty value, deliverViaSidecarSocket refuses to dial any socket path that
+// does not reside under the process's $XDG_STATE_HOME directory. This prevents
+// test code from accidentally dialling a live coordinator's host-API socket
+// when a test's XDG_STATE_HOME is redirected to a tempdir but an incorrect
+// socket path is computed. The guard is set automatically by
+// sidecartest.NewIsolated and must never be set in production.
+//
 // # Problem
 //
 // Three delivery paths in prism (review-complete monitor, coordinator notify,
@@ -33,6 +43,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -102,10 +113,31 @@ func DeliverToSession(sessionName string, status *db.Status, text string, buildH
 //
 // Returns an error if the socket does not exist (session ended / socket cleaned
 // up) or the HTTP request fails.
+// EnvRestrictHostAPI is the env-var name of the test-mode isolation guard.
+// When set to a non-empty value, deliverViaSidecarSocket refuses to dial
+// socket paths outside the current XDG_STATE_HOME — see package-level comment.
+const EnvRestrictHostAPI = "PRISM_TEST_MODE_RESTRICT_HOSTAPI"
+
 func deliverViaSidecarSocket(sessionName, text, source, deliverAs string) error {
 	sockPath, err := session.SidecarHostAPIPath(sessionName)
 	if err != nil {
 		return fmt.Errorf("resolve host-API socket path for %q: %w", sessionName, err)
+	}
+
+	// Test-mode isolation guard: when PRISM_TEST_MODE_RESTRICT_HOSTAPI is set,
+	// refuse to dial any socket that does not live under $XDG_STATE_HOME. This
+	// prevents a test from accidentally reaching a live coordinator socket when
+	// XDG_STATE_HOME is redirected to a tempdir (the hash of the session name
+	// is identical between test and production, so the path collision is real).
+	// The guard is set automatically by sidecartest.NewIsolated.
+	if os.Getenv(EnvRestrictHostAPI) != "" {
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome != "" && !hasPathPrefix(sockPath, stateHome) {
+			return fmt.Errorf(
+				"test-mode isolation guard: refusing to dial host-API socket at %s — path is outside XDG_STATE_HOME=%s (set PRISM_TEST_MODE_RESTRICT_HOSTAPI only in tests)",
+				sockPath, stateHome,
+			)
+		}
 	}
 
 	if _, statErr := os.Stat(sockPath); statErr != nil {
@@ -188,6 +220,19 @@ func deliverViaHTTP(status *db.Status, text string, buildBody func(string, *db.S
 		return fmt.Errorf("http status %d from %s", resp.StatusCode, url)
 	}
 	return nil
+}
+
+// hasPathPrefix reports whether path p is equal to or a sub-path of prefix.
+// Both paths are cleaned before comparison so trailing slashes are normalised.
+func hasPathPrefix(p, prefix string) bool {
+	cleanP := filepath.Clean(p)
+	cleanPfx := filepath.Clean(prefix)
+	if cleanP == cleanPfx {
+		return true
+	}
+	// cleanP must start with cleanPfx + "/" to be a sub-path.
+	return len(cleanP) > len(cleanPfx) && cleanP[len(cleanPfx)] == '/' &&
+		cleanP[:len(cleanPfx)] == cleanPfx
 }
 
 // newUnixClient returns an *http.Client that dials sockPath over a Unix socket.

--- a/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
@@ -1,8 +1,21 @@
+// Tests in this file exercise notifyInvestigatorCompletion and related helpers.
+//
+// # Isolation contract
+//
+// Every test that constructs a sidecar.Sidecar MUST:
+//   - Use sidecartest.NewIsolated(t, ...) to redirect XDG_STATE_HOME to a
+//     tempdir and activate the PRISM_TEST_MODE_RESTRICT_HOSTAPI guard.
+//   - Use session names with the "prism-test@" prefix — never "nixos-config@main"
+//     or any other slug that could collide with a real coordinator on the host.
+//
+// These invariants ensure that running `go test ./internal/sidecar/...` on a
+// host with a live nixos-config@main coordinator does NOT deliver any
+// notifications to that coordinator, and does NOT write to the real prism DB.
 package sidecar
 
 import (
-	"net/http"
-	"net/http/httptest"
+	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -10,45 +23,8 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
-	)
-
-// seedSessionWithHarnessPort seeds an agent_status row for sessionName with a
-// harness_port and harness_session_id. Used to set up invoker sessions that
-// accept HTTP-based prompt delivery.
-func seedSessionWithHarnessPort(t *testing.T, database *db.DB, sessionName, repo, sid string, port int) {
-	t.Helper()
-	agentName := "coordinator"
-	modelID := "anthropic/claude-sonnet-4-5"
-	if err := database.UpsertStatusWithAgent(sessionName, repo, "/tmp/test-worktree", "active", nil, &sid, &agentName, &modelID); err != nil {
-		t.Fatalf("seedSessionWithHarnessPort: UpsertStatusWithAgent(%q): %v", sessionName, err)
-	}
-	// Set harness to empty so promptdelivery uses the HTTP fallback path
-	// (these tests use httptest.Server, not a socket-pipe).
-	if err := database.QueryRow(
-		"UPDATE agent_status SET harness_port = ?, harness_session_id = ?, harness = '' WHERE session_name = ? RETURNING session_name",
-		port, sid, sessionName,
-	).Scan(new(string)); err != nil {
-		t.Fatalf("seedSessionWithHarnessPort: set port/sid for %q: %v", sessionName, err)
-	}
-}
-
-// seedEndedSession seeds an agent_status row with ended_at set.
-func seedEndedSession(t *testing.T, database *db.DB, sessionName, repo string) {
-	t.Helper()
-	agentName := "coordinator"
-	modelID := "anthropic/claude-sonnet-4-5"
-	if err := database.UpsertStatusWithAgent(sessionName, repo, "/tmp/test-worktree", "finished", nil, nil, &agentName, &modelID); err != nil {
-		t.Fatalf("seedEndedSession: UpsertStatusWithAgent(%q): %v", sessionName, err)
-	}
-	// Use Unix millisecond timestamp so SQLite can scan it as int64.
-	nowMs := time.Now().UnixMilli()
-	if err := database.QueryRow(
-		"UPDATE agent_status SET ended_at = ? WHERE session_name = ? RETURNING session_name",
-		nowMs, sessionName,
-	).Scan(new(string)); err != nil {
-		t.Fatalf("seedEndedSession: set ended_at for %q: %v", sessionName, err)
-	}
-}
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
 
 // ── investigateAgentInvokerSession ──────────────────────────────────────────
 
@@ -110,46 +86,19 @@ func TestInvestigateAgentInvokerSession(t *testing.T) {
 // finishes with a non-empty final text. The notification body must contain the
 // sender label, the text block verbatim, and the steering-channel hint.
 func TestNotifyInvestigatorCompletion_Delivery(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	invokerSession := repo + "@main"
+	invokerSession := "prism-test@invoker-delivery"
 	investigatorSession := invokerSession + "~investigate-testslug"
-	invokerSID := "invoker-sid-001"
 
-	var mu sync.Mutex
-	var receivedBodies []string
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/session" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
-			return
-		}
-		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
-			body := make([]byte, 4096)
-			n, _ := r.Body.Read(body)
-			mu.Lock()
-			receivedBodies = append(receivedBodies, string(body[:n]))
-			mu.Unlock()
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	srvPort := parseSrvPort(t, srv.URL)
-	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+	bus := sidecartest.NewIsolated(t, invokerSession)
 
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: investigatorSession,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-test-wt",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -160,22 +109,17 @@ func TestNotifyInvestigatorCompletion_Delivery(t *testing.T) {
 	// Allow async HTTP call to complete.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(receivedBodies)
-		mu.Unlock()
-		if n > 0 {
+		if len(bus.CopyBodies()) > 0 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
-
-	if len(receivedBodies) != 1 {
-		t.Fatalf("want 1 delivery, got %d", len(receivedBodies))
+	bodies := bus.CopyBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("want 1 delivery, got %d", len(bodies))
 	}
-	body := receivedBodies[0]
+	body := bodies[0]
 
 	// The body is a JSON-encoded prompt_async payload; the text is inside.
 	// Check that all required elements are present in the delivered payload.
@@ -194,46 +138,19 @@ func TestNotifyInvestigatorCompletion_Delivery(t *testing.T) {
 // final text, a completion notice is still delivered (so the invoker learns
 // the investigation finished, even if no output was recorded).
 func TestNotifyInvestigatorCompletion_EmptyText(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	invokerSession := repo + "@main"
+	invokerSession := "prism-test@invoker-emptytext"
 	investigatorSession := invokerSession + "~investigate-testslug"
-	invokerSID := "invoker-sid-empty"
 
-	var mu sync.Mutex
-	var receivedBodies []string
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/session" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
-			return
-		}
-		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
-			body := make([]byte, 4096)
-			n, _ := r.Body.Read(body)
-			mu.Lock()
-			receivedBodies = append(receivedBodies, string(body[:n]))
-			mu.Unlock()
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	srvPort := parseSrvPort(t, srv.URL)
-	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+	bus := sidecartest.NewIsolated(t, invokerSession)
 
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: investigatorSession,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-test-empty",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -243,22 +160,17 @@ func TestNotifyInvestigatorCompletion_EmptyText(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(receivedBodies)
-		mu.Unlock()
-		if n > 0 {
+		if len(bus.CopyBodies()) > 0 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
-
-	if len(receivedBodies) != 1 {
-		t.Fatalf("want 1 delivery for empty-text finished, got %d", len(receivedBodies))
+	bodies := bus.CopyBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("want 1 delivery for empty-text finished, got %d", len(bodies))
 	}
-	body := receivedBodies[0]
+	body := bodies[0]
 	if !strings.Contains(body, "Investigation complete") {
 		t.Errorf("empty-text completion notice missing expected phrase; got: %s", body)
 	}
@@ -267,46 +179,19 @@ func TestNotifyInvestigatorCompletion_EmptyText(t *testing.T) {
 // TestNotifyInvestigatorCompletion_ErrorState verifies that an error-state
 // completion delivers a notification containing the failure state name.
 func TestNotifyInvestigatorCompletion_ErrorState(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	invokerSession := repo + "@main"
+	invokerSession := "prism-test@invoker-errorstate"
 	investigatorSession := invokerSession + "~investigate-errslug"
-	invokerSID := "invoker-sid-error"
 
-	var mu sync.Mutex
-	var receivedBodies []string
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/session" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
-			return
-		}
-		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
-			body := make([]byte, 4096)
-			n, _ := r.Body.Read(body)
-			mu.Lock()
-			receivedBodies = append(receivedBodies, string(body[:n]))
-			mu.Unlock()
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	srvPort := parseSrvPort(t, srv.URL)
-	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+	bus := sidecartest.NewIsolated(t, invokerSession)
 
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: investigatorSession,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-test-error",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -315,22 +200,17 @@ func TestNotifyInvestigatorCompletion_ErrorState(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(receivedBodies)
-		mu.Unlock()
-		if n > 0 {
+		if len(bus.CopyBodies()) > 0 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
-
-	if len(receivedBodies) != 1 {
-		t.Fatalf("want 1 delivery for error state, got %d", len(receivedBodies))
+	bodies := bus.CopyBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("want 1 delivery for error state, got %d", len(bodies))
 	}
-	body := receivedBodies[0]
+	body := bodies[0]
 	if !strings.Contains(body, string(agent.StateError)) {
 		t.Errorf("error-state notification missing state name; got: %s", body)
 	}
@@ -342,30 +222,22 @@ func TestNotifyInvestigatorCompletion_ErrorState(t *testing.T) {
 // TestNotifyInvestigatorCompletion_InvokerEnded verifies that the notification
 // is dropped silently (no panic, no delivery) when the invoker session has ended.
 func TestNotifyInvestigatorCompletion_InvokerEnded(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	invokerSession := repo + "@main"
+	invokerSession := "prism-test@invoker-ended"
 	investigatorSession := invokerSession + "~investigate-ended"
 
-	var delivered int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			delivered++
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+	// NewIsolated with empty invoker — we seed an ended row manually.
+	bus := sidecartest.NewIsolated(t, "")
 
-	seedEndedSession(t, d, invokerSession, repo)
+	seedEndedSessionInvestigate(t, bus.DB, invokerSession, "prism-test")
 
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: investigatorSession,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-test-ended",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -373,35 +245,25 @@ func TestNotifyInvestigatorCompletion_InvokerEnded(t *testing.T) {
 	s.notifyInvestigatorCompletion(agent.StateFinished, "some findings here")
 	time.Sleep(50 * time.Millisecond)
 
-	if delivered > 0 {
-		t.Errorf("expected no delivery when invoker has ended, got %d", delivered)
+	if bodies := bus.CopyBodies(); len(bodies) > 0 {
+		t.Errorf("expected no delivery when invoker has ended, got %d", len(bodies))
 	}
 }
 
 // TestNotifyInvestigatorCompletion_NotInvestigateSession verifies that a session
 // NOT named with ~investigate does NOT trigger any delivery.
 func TestNotifyInvestigatorCompletion_NotInvestigateSession(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-
-	var delivered int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			delivered++
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+	bus := sidecartest.NewIsolated(t, "")
 
 	clk := newTestClock()
 	cfg := Config{
 		// A plain worker session — no ~investigate in the name.
-		SessionName: repo + "@feature",
-		Repo:        repo,
+		SessionName: "prism-test@feature",
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-test-not-investigate",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -409,8 +271,8 @@ func TestNotifyInvestigatorCompletion_NotInvestigateSession(t *testing.T) {
 	s.notifyInvestigatorCompletion(agent.StateFinished, "some text that should not be delivered")
 	time.Sleep(50 * time.Millisecond)
 
-	if delivered > 0 {
-		t.Errorf("expected no delivery for non-investigate session, got %d", delivered)
+	if bodies := bus.CopyBodies(); len(bodies) > 0 {
+		t.Errorf("expected no delivery for non-investigate session, got %d", len(bodies))
 	}
 }
 
@@ -418,38 +280,29 @@ func TestNotifyInvestigatorCompletion_NotInvestigateSession(t *testing.T) {
 // investigate-agent session does NOT emit a bare "has finished" notification
 // to the coordinator.
 func TestNotifyCoordinator_InvestigateAgentSuppressed(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	coordSID := "coord-sid-investigate-suppressed"
+	// Use a test-prefixed coordinator session that cannot collide with any
+	// live coordinator on the host.
+	coordSession := "prism-test@coordinator-suppressed"
+	investigatorSession := coordSession + "~investigate-abc"
 
-	var notifyCount int
-	var notifyMu sync.Mutex
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/session" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"` + coordSID + `"}]`))
-			return
-		}
-		notifyMu.Lock()
-		notifyCount++
-		notifyMu.Unlock()
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+	bus := sidecartest.NewIsolated(t, coordSession)
 
-	srvPort := parseSrvPort(t, srv.URL)
-	seedCoordinatorWithPort(t, d, repo, srvPort, coordSID)
+	// Mark the coordinator row so CoordinatorForRepo can find it.
+	if err := bus.DB.QueryRow(
+		"UPDATE agent_status SET root_agent_name = 'coordinator' WHERE session_name = ? RETURNING session_name",
+		coordSession,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("set root_agent_name: %v", err)
+	}
 
 	clk := newTestClock()
-	investigatorSession := repo + "@main~investigate-abc"
 	cfg := Config{
 		SessionName: investigatorSession,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-coord-suppressed",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -459,12 +312,8 @@ func TestNotifyCoordinator_InvestigateAgentSuppressed(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	notifyMu.Lock()
-	count := notifyCount
-	notifyMu.Unlock()
-
-	if count != 0 {
-		t.Errorf("investigate-agent should not emit bare_finish notification; got %d notifications", count)
+	if bodies := bus.CopyBodies(); len(bodies) != 0 {
+		t.Errorf("investigate-agent should not emit bare_finish notification; got %d notifications", len(bodies))
 	}
 }
 
@@ -472,56 +321,29 @@ func TestNotifyCoordinator_InvestigateAgentSuppressed(t *testing.T) {
 // concurrent investigator sessions can deliver completion notifications to the
 // same invoker without mangling each other's sender labels.
 func TestNotifyInvestigatorCompletion_ConcurrentDelivery(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	invokerSession := repo + "@main"
+	invokerSession := "prism-test@invoker-concurrent"
 	investigator1 := invokerSession + "~investigate-alpha"
 	investigator2 := invokerSession + "~investigate-beta"
-	invokerSID := "invoker-sid-concurrent"
 
-	var mu sync.Mutex
-	var receivedBodies []string
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/session" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
-			return
-		}
-		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
-			body := make([]byte, 4096)
-			n, _ := r.Body.Read(body)
-			mu.Lock()
-			receivedBodies = append(receivedBodies, string(body[:n]))
-			mu.Unlock()
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	srvPort := parseSrvPort(t, srv.URL)
-	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+	bus := sidecartest.NewIsolated(t, invokerSession)
 
 	clk := newTestClock()
 	cfg1 := Config{
 		SessionName: investigator1,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-concurrent-1",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	cfg2 := Config{
 		SessionName: investigator2,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-concurrent-2",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s1 := New(cfg1)
@@ -535,20 +357,13 @@ func TestNotifyInvestigatorCompletion_ConcurrentDelivery(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(receivedBodies)
-		mu.Unlock()
-		if n >= 2 {
+		if len(bus.CopyBodies()) >= 2 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	mu.Lock()
-	bodies := make([]string, len(receivedBodies))
-	copy(bodies, receivedBodies)
-	mu.Unlock()
-
+	bodies := bus.CopyBodies()
 	if len(bodies) != 2 {
 		t.Fatalf("want 2 deliveries, got %d", len(bodies))
 	}
@@ -580,44 +395,19 @@ func TestNotifyInvestigatorCompletion_ConcurrentDelivery(t *testing.T) {
 // noise notifications. The new code accumulates the text and fires exactly
 // once at terminal state.
 func TestInvestigatorNoIntermediatePings(t *testing.T) {
-	d := openTestDB(t)
-	repo := "nixos-config"
-	invokerSession := repo + "@main"
+	invokerSession := "prism-test@invoker-nopings"
 	investigatorSession := invokerSession + "~investigate-nopings"
-	invokerSID := "invoker-sid-nopings"
 
-	var mu sync.Mutex
-	var deliveryCount int
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/session" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"` + invokerSID + `"}]`))
-			return
-		}
-		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/prompt_async") {
-			mu.Lock()
-			deliveryCount++
-			mu.Unlock()
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	srvPort := parseSrvPort(t, srv.URL)
-	seedSessionWithHarnessPort(t, d, invokerSession, repo, invokerSID, srvPort)
+	bus := sidecartest.NewIsolated(t, invokerSession)
 
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: investigatorSession,
-		Repo:        repo,
+		Repo:        "prism-test",
 		Worktree:    "/tmp/investigate-nopings",
-		DB:          d,
+		DB:          bus.DB,
 		Clock:       clk,
-		HTTPClient:  srv.Client(),
+		HTTPClient:  bus.HTTPServer.Client(),
 		Harness:     newSSEHarness(),
 	}
 	s := New(cfg)
@@ -633,11 +423,8 @@ func TestInvestigatorNoIntermediatePings(t *testing.T) {
 
 	// No deliveries should have happened yet.
 	time.Sleep(50 * time.Millisecond)
-	mu.Lock()
-	countAfterTurns := deliveryCount
-	mu.Unlock()
-	if countAfterTurns != 0 {
-		t.Errorf("expected 0 deliveries after intermediate turns, got %d", countAfterTurns)
+	if n := len(bus.CopyBodies()); n != 0 {
+		t.Errorf("expected 0 deliveries after intermediate turns, got %d", n)
 	}
 
 	// Now fire completion — exactly one delivery should occur.
@@ -649,19 +436,150 @@ func TestInvestigatorNoIntermediatePings(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := deliveryCount
-		mu.Unlock()
-		if n > 0 {
+		if len(bus.CopyBodies()) > 0 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	mu.Lock()
-	finalCount := deliveryCount
-	mu.Unlock()
-	if finalCount != 1 {
-		t.Errorf("expected exactly 1 delivery at completion, got %d", finalCount)
+	if n := len(bus.CopyBodies()); n != 1 {
+		t.Errorf("expected exactly 1 delivery at completion, got %d", n)
 	}
+}
+
+// TestNotifyInvestigatorCompletion_NoHostBusLeak asserts that constructing a
+// sidecar with a session name that looks like a real coordinator
+// ("nixos-config@main~investigate-leakcheck") against an isolated DB + bus
+// does NOT write any file under the process-default $XDG_STATE_HOME/prism/
+// path (i.e. the path that would be used if the test had NOT set the env var).
+//
+// This is the "defence in depth" test for issue #1608: it verifies that the
+// isolation invariants hold even when the test session name collides with a
+// live coordinator slug.
+func TestNotifyInvestigatorCompletion_NoHostBusLeak(t *testing.T) {
+	// Capture the real XDG_STATE_HOME *before* NewIsolated redirects it.
+	// We need to record this now so we can verify it's untouched after the test.
+	realXDGStateHome := os.Getenv("XDG_STATE_HOME")
+	if realXDGStateHome == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			realXDGStateHome = home + "/.local/state"
+		}
+	}
+	realPrismDir := realXDGStateHome + "/prism"
+
+	// Record the current state of the real prism/ directory before the test.
+	beforeSnapshot := snapshotDirNames(realPrismDir + "/run")
+	beforeDBMtime := fileModTime(realPrismDir + "/prism.db")
+
+	// Use a session name that matches a real coordinator slug — this is the
+	// exact scenario that caused the observed leak in issue #1608. The
+	// investigatorSession parses to invokerSession="nixos-config@main", which
+	// is what collided with the live coordinator on the host. We seed that
+	// session in the ISOLATED DB so the delivery path exercises the same code
+	// as the original bug — but routes to our test server, not the real bus.
+	invokerSession := "nixos-config@main"
+	investigatorSession := "nixos-config@main~investigate-leakcheck"
+
+	// NewIsolated redirects XDG_STATE_HOME and sets the isolation guard.
+	// We seed "nixos-config@main" into the isolated DB so that delivery is
+	// attempted and we can verify it lands on the httptest.Server rather than
+	// the real host coordinator socket.
+	bus := sidecartest.NewIsolated(t, invokerSession)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: investigatorSession,
+		Repo:        "prism-test",
+		Worktree:    "/tmp/investigate-leakcheck",
+		DB:          bus.DB,
+		Clock:       clk,
+		HTTPClient:  bus.HTTPServer.Client(),
+		Harness:     newSSEHarness(),
+	}
+	s := New(cfg)
+
+	s.notifyInvestigatorCompletion(agent.StateFinished, "leakcheck findings")
+
+	// Give async delivery a moment to settle.
+	time.Sleep(200 * time.Millisecond)
+
+	// Assert: the real prism/run/ directory is unchanged (no socket files created).
+	afterSnapshot := snapshotDirNames(realPrismDir + "/run")
+	if beforeSnapshot != afterSnapshot {
+		t.Errorf("real $XDG_STATE_HOME/prism/run/ changed during test:\nbefore: %q\nafter:  %q\nThis indicates isolation breach — test wrote to host prism state.", beforeSnapshot, afterSnapshot)
+	}
+
+	// Assert: the real prism.db mtime is unchanged (no writes to the real DB).
+	afterDBMtime := fileModTime(realPrismDir + "/prism.db")
+	if beforeDBMtime != afterDBMtime {
+		t.Errorf("real prism.db mtime changed during test (before=%d after=%d) — DB isolation breach", beforeDBMtime, afterDBMtime)
+	}
+
+	// Assert: all HTTP traffic went to the isolated httptest.Server.
+	// The delivery must have been captured — not dropped silently.
+	bodies := bus.CopyBodies()
+	if len(bodies) == 0 {
+		t.Error("expected delivery to be captured by the isolated httptest.Server, got none — delivery was either dropped or escaped to host")
+		return
+	}
+	found := false
+	for _, body := range bodies {
+		if strings.Contains(body, "leakcheck findings") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("delivery bodies did not contain expected text 'leakcheck findings'; bodies: %v", bodies)
+	}
+}
+
+// ── test DB helpers ──────────────────────────────────────────────────────────
+
+// seedEndedSession seeds an agent_status row with ended_at set.
+// This is used by TestNotifyInvestigatorCompletion_InvokerEnded to set up an
+// invoker session that has already finished — delivery must be dropped.
+func seedEndedSessionInvestigate(t *testing.T, database *db.DB, sessionName, repo string) {
+	t.Helper()
+	agentName := "coordinator"
+	modelID := "anthropic/claude-sonnet-4-5"
+	if err := database.UpsertStatusWithAgent(sessionName, repo, "/tmp/test-worktree", "finished", nil, nil, &agentName, &modelID); err != nil {
+		t.Fatalf("seedEndedSessionInvestigate: UpsertStatusWithAgent(%q): %v", sessionName, err)
+	}
+	// Use Unix millisecond timestamp so SQLite can scan it as int64.
+	nowMs := time.Now().UnixMilli()
+	if err := database.QueryRow(
+		"UPDATE agent_status SET ended_at = ? WHERE session_name = ? RETURNING session_name",
+		nowMs, sessionName,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("seedEndedSessionInvestigate: set ended_at for %q: %v", sessionName, err)
+	}
+}
+
+// ── OS helpers ────────────────────────────────────────────────────────────────
+
+// snapshotDirNames returns a sorted string of all filenames in dir (non-recursive,
+// first level only). Returns "" if the directory does not exist or cannot be read.
+func snapshotDirNames(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Directory doesn't exist — return empty (no files to change).
+		return ""
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, fmt.Sprintf("%s:%v", e.Name(), e.IsDir()))
+	}
+	return strings.Join(names, ",")
+}
+
+// fileModTime returns the modification time of path as Unix nanoseconds.
+// Returns 0 if the file does not exist.
+func fileModTime(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.ModTime().UnixNano()
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
@@ -50,10 +50,10 @@ func newSidecarCoordinatorWithInstance(t *testing.T, sessionName, repo, instance
 func TestHostAPI_Merge_EnqueuesRowWithSidecarIdentity(t *testing.T) {
 	d := openTestDB(t)
 	const (
-		sess     = "nixos-config@main"
+		sess     = "test-repo@main"
 		instance = "11111111-2222-3333-4444-555555555555"
 	)
-	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", instance, d)
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/merge",
 		`{"pr": 1234, "title": "do the mahi"}`)
@@ -102,10 +102,10 @@ func TestHostAPI_Merge_EnqueuesRowWithSidecarIdentity(t *testing.T) {
 func TestHostAPI_Merge_ClientIdentityIsIgnored(t *testing.T) {
 	d := openTestDB(t)
 	const (
-		sess     = "nixos-config@main"
+		sess     = "test-repo@main"
 		instance = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	)
-	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", instance, d)
 
 	// Body contains stray fields that are not part of the schema; they must
 	// be ignored.
@@ -135,7 +135,7 @@ func TestHostAPI_Merge_WorkerForbidden(t *testing.T) {
 
 func TestHostAPI_Merge_RejectsInvalidPR(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo", "i1", d)
 
 	for _, body := range []string{
 		`{"pr": 0, "title": null}`,
@@ -154,7 +154,7 @@ func TestHostAPI_Merge_NoInstanceIDIsServerError(t *testing.T) {
 	// Coordinator sidecar with no InstanceID configured — we should refuse to
 	// enqueue rather than write a row keyed on an empty instance_id (which
 	// would be invisible to a watcher that has a real instance_id).
-	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "", d)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo", "", d)
 	rr := doHostAPI(t, sc, http.MethodPost, "/merge", `{"pr": 5, "title": null}`)
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500 for missing instance_id", rr.Code)
@@ -163,7 +163,7 @@ func TestHostAPI_Merge_NoInstanceIDIsServerError(t *testing.T) {
 
 func TestHostAPI_Merge_RejectsNonPOST(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo", "i1", d)
 	rr := doHostAPI(t, sc, http.MethodGet, "/merge", "")
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want 405", rr.Code)
@@ -175,10 +175,10 @@ func TestHostAPI_Merge_RejectsNonPOST(t *testing.T) {
 func TestHostAPI_Merges_ListWatching(t *testing.T) {
 	d := openTestDB(t)
 	const (
-		sess     = "nixos-config@main"
+		sess     = "test-repo@main"
 		instance = "deadbeef-1111-2222-3333-444444444444"
 	)
-	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", instance, d)
 
 	// Seed a couple of watching rows directly via the DB.
 	t1 := "first"
@@ -211,7 +211,7 @@ func TestHostAPI_Merges_ListWatching(t *testing.T) {
 
 func TestHostAPI_Merges_EmptyArrayWhenEmpty(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo", "i1", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/merges", "")
 	if rr.Code != http.StatusOK {
@@ -240,10 +240,10 @@ func TestHostAPI_Merges_WorkerForbidden(t *testing.T) {
 func TestHostAPI_MergesCancel_HappyPath(t *testing.T) {
 	d := openTestDB(t)
 	const (
-		sess     = "nixos-config@main"
+		sess     = "test-repo@main"
 		instance = "11111111-1111-1111-1111-111111111111"
 	)
-	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", instance, d)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", instance, d)
 
 	if _, err := d.EnqueueMerge(77, sess, instance, nil); err != nil {
 		t.Fatalf("seed EnqueueMerge: %v", err)
@@ -274,7 +274,7 @@ func TestHostAPI_MergesCancel_HappyPath(t *testing.T) {
 
 func TestHostAPI_MergesCancel_NonExistentReturnsFalse(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo", "i1", d)
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 9999}`)
 	if rr.Code != http.StatusOK {
@@ -296,11 +296,11 @@ func TestHostAPI_MergesCancel_NonExistentReturnsFalse(t *testing.T) {
 func TestHostAPI_MergesCancel_DifferentInstanceReturnsRowWatching(t *testing.T) {
 	d := openTestDB(t)
 	const (
-		sess          = "nixos-config@main"
+		sess          = "test-repo@main"
 		ourInstance   = "instance-A"
 		theirInstance = "instance-B"
 	)
-	sc := newSidecarCoordinatorWithInstance(t, sess, "nixos-config", ourInstance, d)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", ourInstance, d)
 
 	// Seed a row owned by a DIFFERENT incarnation.
 	if _, err := d.EnqueueMerge(55, sess, theirInstance, nil); err != nil {
@@ -338,7 +338,7 @@ func TestHostAPI_MergesCancel_WorkerForbidden(t *testing.T) {
 
 func TestHostAPI_MergesCancel_RejectsInvalidPR(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarCoordinatorWithInstance(t, "nixos-config@main", "nixos-config", "i1", d)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo", "i1", d)
 	rr := doHostAPI(t, sc, http.MethodPost, "/merges/cancel", `{"pr": 0}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rr.Code)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_stats_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_stats_test.go
@@ -54,13 +54,13 @@ func TestHostAPI_Stats_Doomloops_HappyPath(t *testing.T) {
 	d := openTestDB(t)
 
 	// Seed status row so WriteEvent does not fail FK constraint.
-	if err := d.UpsertStatus("nixos-config@main", "nixos-config", "/tmp/w", "active", nil, nil); err != nil {
+	if err := d.UpsertStatus("test-repo@main", "test-repo", "/tmp/w", "active", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
 
-	writeDoomLoopEventForSidecar(t, d, "nixos-config@main", "bash", "git status", 5, time.Now().Add(-1*time.Hour))
+	writeDoomLoopEventForSidecar(t, d, "test-repo@main", "bash", "git status", 5, time.Now().Add(-1*time.Hour))
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=doomloops&days=7", "")
 	if rr.Code != http.StatusOK {
@@ -84,7 +84,7 @@ func TestHostAPI_Stats_Doomloops_HappyPath(t *testing.T) {
 // {"events":[]} (not null).
 func TestHostAPI_Stats_Doomloops_EmptyResult(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=doomloops&days=7", "")
 	if rr.Code != http.StatusOK {
@@ -110,12 +110,12 @@ func TestHostAPI_Stats_Doomloops_EmptyResult(t *testing.T) {
 func TestHostAPI_Stats_Denials_HappyPath(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatus("nixos-config@main", "nixos-config", "/tmp/w", "active", nil, nil); err != nil {
+	if err := d.UpsertStatus("test-repo@main", "test-repo", "/tmp/w", "active", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
-	writePermissionEventForSidecar(t, d, "nixos-config@main", "permission_denied", "bash", time.Now().Add(-1*time.Hour))
+	writePermissionEventForSidecar(t, d, "test-repo@main", "permission_denied", "bash", time.Now().Add(-1*time.Hour))
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=denials&days=7", "")
 	if rr.Code != http.StatusOK {
@@ -138,9 +138,9 @@ func TestHostAPI_Stats_Denials_HappyPath(t *testing.T) {
 // matches no known session.
 func TestHostAPI_Stats_Denials_UnknownSession(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
-	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=denials&session=nixos-config%40ghost&days=7", "")
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=denials&session=test-repo%40ghost&days=7", "")
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %q, want 404", rr.Code, rr.Body.String())
 	}
@@ -153,12 +153,12 @@ func TestHostAPI_Stats_Denials_UnknownSession(t *testing.T) {
 func TestHostAPI_Stats_Asks_HappyPath(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatus("nixos-config@main", "nixos-config", "/tmp/w", "active", nil, nil); err != nil {
+	if err := d.UpsertStatus("test-repo@main", "test-repo", "/tmp/w", "active", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
-	writePermissionEventForSidecar(t, d, "nixos-config@main", "permission_ask", "bash", time.Now().Add(-1*time.Hour))
+	writePermissionEventForSidecar(t, d, "test-repo@main", "permission_ask", "bash", time.Now().Add(-1*time.Hour))
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=asks&days=7", "")
 	if rr.Code != http.StatusOK {
@@ -184,8 +184,8 @@ func TestHostAPI_Stats_Summary_HappyPath(t *testing.T) {
 	instanceID := "aaaa1111-2222-3333-4444-555555555555"
 	sess := db.Session{
 		InstanceID:  instanceID,
-		SessionName: "nixos-config@main",
-		Repo:        "nixos-config",
+		SessionName: "test-repo@main",
+		Repo:        "test-repo",
 		Worktree:    "/tmp/w",
 		Harness:     "pi",
 	}
@@ -193,7 +193,7 @@ func TestHostAPI_Stats_Summary_HappyPath(t *testing.T) {
 		t.Fatalf("InsertSession: %v", err)
 	}
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=summary", "")
 	if rr.Code != http.StatusOK {
@@ -207,8 +207,8 @@ func TestHostAPI_Stats_Summary_HappyPath(t *testing.T) {
 	if len(resp.Sessions) != 1 {
 		t.Fatalf("got %d sessions, want 1", len(resp.Sessions))
 	}
-	if resp.Sessions[0].SessionName != "nixos-config@main" {
-		t.Errorf("session name = %q, want nixos-config@main", resp.Sessions[0].SessionName)
+	if resp.Sessions[0].SessionName != "test-repo@main" {
+		t.Errorf("session name = %q, want test-repo@main", resp.Sessions[0].SessionName)
 	}
 }
 
@@ -216,7 +216,7 @@ func TestHostAPI_Stats_Summary_HappyPath(t *testing.T) {
 // returns {"sessions":[]} (not null).
 func TestHostAPI_Stats_Summary_EmptyResult(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=summary", "")
 	if rr.Code != http.StatusOK {
@@ -242,8 +242,8 @@ func TestHostAPI_Stats_Detail_HappyPath(t *testing.T) {
 	instanceID := "bbbb1111-2222-3333-4444-555555555555"
 	sess := db.Session{
 		InstanceID:  instanceID,
-		SessionName: "nixos-config@main",
-		Repo:        "nixos-config",
+		SessionName: "test-repo@main",
+		Repo:        "test-repo",
 		Worktree:    "/tmp/w",
 		Harness:     "pi",
 	}
@@ -251,9 +251,9 @@ func TestHostAPI_Stats_Detail_HappyPath(t *testing.T) {
 		t.Fatalf("InsertSession: %v", err)
 	}
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
-	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=detail&session=nixos-config%40main", "")
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=detail&session=test-repo%40main", "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
 	}
@@ -265,15 +265,15 @@ func TestHostAPI_Stats_Detail_HappyPath(t *testing.T) {
 	if resp.Session == nil {
 		t.Fatal("session field is nil, want non-nil")
 	}
-	if resp.Session.SessionName != "nixos-config@main" {
-		t.Errorf("session name = %q, want nixos-config@main", resp.Session.SessionName)
+	if resp.Session.SessionName != "test-repo@main" {
+		t.Errorf("session name = %q, want test-repo@main", resp.Session.SessionName)
 	}
 }
 
 // TestHostAPI_Stats_Detail_MissingSession returns 400 when session param is absent.
 func TestHostAPI_Stats_Detail_MissingSession(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=detail", "")
 	if rr.Code != http.StatusBadRequest {
@@ -284,9 +284,9 @@ func TestHostAPI_Stats_Detail_MissingSession(t *testing.T) {
 // TestHostAPI_Stats_Detail_UnknownSession returns 404 when the session is not found.
 func TestHostAPI_Stats_Detail_UnknownSession(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
-	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=detail&session=nixos-config%40ghost", "")
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=detail&session=test-repo%40ghost", "")
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, body = %q, want 404", rr.Code, rr.Body.String())
 	}
@@ -297,7 +297,7 @@ func TestHostAPI_Stats_Detail_UnknownSession(t *testing.T) {
 // TestHostAPI_Stats_UnknownView returns 400 for an unknown view parameter.
 func TestHostAPI_Stats_UnknownView(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=badview", "")
 	if rr.Code != http.StatusBadRequest {
@@ -316,7 +316,7 @@ func TestHostAPI_Stats_UnknownView(t *testing.T) {
 // TestHostAPI_Stats_MethodNotAllowed verifies that POST /stats returns 405.
 func TestHostAPI_Stats_MethodNotAllowed(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	rr := doHostAPI(t, sc, http.MethodPost, "/stats", `{}`)
 	if rr.Code != http.StatusMethodNotAllowed {
@@ -328,7 +328,7 @@ func TestHostAPI_Stats_MethodNotAllowed(t *testing.T) {
 // is accessible to worker sessions (read-only, no coordinator restriction).
 func TestHostAPI_Stats_WorkerCanAccessStats(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@feature", "nixos-config", "worker", d)
+	sc := newSidecarWithRole(t, "nixos-config@feature", "test-repo", "worker", d)
 
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=doomloops&days=7", "")
 	if rr.Code != http.StatusOK {
@@ -344,12 +344,12 @@ func TestHostAPI_Stats_WorkerCanAccessStats(t *testing.T) {
 func TestHostAPI_Stats_Doomloops_JSONSchema(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatus("nixos-config@main", "nixos-config", "/tmp/w", "active", nil, nil); err != nil {
+	if err := d.UpsertStatus("test-repo@main", "test-repo", "/tmp/w", "active", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus: %v", err)
 	}
-	writeDoomLoopEventForSidecar(t, d, "nixos-config@main", "bash", "git diff", 3, time.Now().Add(-30*time.Minute))
+	writeDoomLoopEventForSidecar(t, d, "test-repo@main", "bash", "git diff", 3, time.Now().Add(-30*time.Minute))
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=doomloops&days=1", "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %q", rr.Code, rr.Body.String())

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2505,7 +2505,7 @@ func TestIsReviewAgentSession(t *testing.T) {
 		{"round session shape", "nixos-config@feature~review-1", true},
 		// Normal worker — must NOT be suppressed
 		{"normal worker", "nixos-config@feature", false},
-		{"coordinator", "nixos-config@main", false},
+		{"coordinator", "test-repo@main", false},
 		// Session with "review" in branch name but no "~review" (edge case)
 		{"branch named review-fixes", "nixos-config@review-fixes", false},
 		{"branch named my-review", "nixos-config@my-review", false},
@@ -5202,7 +5202,7 @@ func TestHostAPI_RepoFromSession(t *testing.T) {
 		wantErr bool
 	}{
 		{"myrepo@main", "myrepo", false},
-		{"nixos-config@feature/foo", "nixos-config", false},
+		{"test-repo@feature/foo", "test-repo", false},
 		{"norepo", "", true},
 		{"", "", true},
 	}
@@ -5318,7 +5318,7 @@ func TestHostAPI_Checkin_LastParamParsed(t *testing.T) {
 // TestHostAPI_Spawn_ClientRepoIsIgnoredServerUsesOwnRepo verifies the fix for
 // issue #616: when a client sends an arbitrary "repo" value (e.g. a container
 // mount-path name like "prism-git"), the server ignores it and substitutes its
-// own repo derived from its session name ("nixos-config").
+// own repo derived from its session name ("test-repo").
 //
 // The test uses a stub binary that echoes a spawn success line containing the
 // repo argument passed to it, so we can verify which repo was used.
@@ -5339,9 +5339,9 @@ echo "session \"${last}@test-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5352,7 +5352,7 @@ echo "session \"${last}@test-branch\" created"
 	sc := New(cfg)
 
 	// Client sends "repo":"prism-git" (a container mount-path name).
-	// Server must ignore this and use "nixos-config" (from session name).
+	// Server must ignore this and use "test-repo" (from session name).
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
 		`{"repo":"prism-git","branch":"test-branch"}`)
 	if rr.Code != http.StatusOK {
@@ -5361,9 +5361,9 @@ echo "session \"${last}@test-branch\" created"
 	var respBody map[string]string
 	decodeJSONBody(t, rr, &respBody)
 	// Session name must reflect the actual repo, not the mount-path name.
-	if respBody["session_name"] != "nixos-config@test-branch" {
+	if respBody["session_name"] != "test-repo@test-branch" {
 		t.Errorf("session_name = %q, want %q (server must use ownRepo, not client-supplied repo)",
-			respBody["session_name"], "nixos-config@test-branch")
+			respBody["session_name"], "test-repo@test-branch")
 	}
 }
 
@@ -5385,9 +5385,9 @@ echo "session \"${last}@new-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5404,8 +5404,8 @@ echo "session \"${last}@new-branch\" created"
 	}
 	var respBody map[string]string
 	decodeJSONBody(t, rr, &respBody)
-	if respBody["session_name"] != "nixos-config@new-branch" {
-		t.Errorf("session_name = %q, want %q", respBody["session_name"], "nixos-config@new-branch")
+	if respBody["session_name"] != "test-repo@new-branch" {
+		t.Errorf("session_name = %q, want %q", respBody["session_name"], "test-repo@new-branch")
 	}
 }
 
@@ -5413,9 +5413,9 @@ echo "session \"${last}@new-branch\" created"
 // missing or empty "branch" field still returns 400 "branch is required".
 func TestHostAPI_Spawn_EmptyBranchReturns400(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
-	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"repo":"nixos-config"}`)
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"repo":"test-repo"}`)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 for missing branch", rr.Code)
 	}
@@ -5506,9 +5506,9 @@ func TestHostAPI_Spawn_HostModeProduces400(t *testing.T) {
 
 	clk := newTestClock()
 	cfg := Config{
-		SessionName: "nixos-config@main",
-		Repo:        "nixos-config",
-		Worktree:    "/tmp/nixos-config@main",
+		SessionName: "test-repo@main",
+		Repo:        "test-repo",
+		Worktree:    "/tmp/test-repo@main",
 		HarnessURL: "http://localhost:14000",
 		DB:          d,
 		Clock:       clk,
@@ -5543,9 +5543,9 @@ echo "session \"${last}@cap-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5595,9 +5595,9 @@ echo "session \"${last}@iso-branch\" created"
 			}
 			clk := newTestClock()
 			cfg := Config{
-				SessionName:     "nixos-config@main",
-				Repo:            "nixos-config",
-				Worktree:        "/tmp/nixos-config@main",
+				SessionName:     "test-repo@main",
+				Repo:            "test-repo",
+				Worktree:        "/tmp/test-repo@main",
 				HarnessURL:     "http://localhost:14000",
 				DB:              d,
 				Clock:           clk,
@@ -5646,9 +5646,9 @@ echo "session \"${last}@no-iso-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5693,9 +5693,9 @@ exit 99
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5734,7 +5734,7 @@ func TestHostAPI_Spawn_SubprocessOutputIncludedInError(t *testing.T) {
 echo "error: prism concurrency cap reached (6 agent containers already in flight)"
 echo ""
 echo "Active containers:"
-echo "  nixos-config@main   (coordinator)"
+echo "  test-repo@main   (coordinator)"
 exit 1
 `
 	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
@@ -5742,9 +5742,9 @@ exit 1
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5766,7 +5766,7 @@ exit 1
 	if !strings.Contains(errMsg, "concurrency cap reached") {
 		t.Errorf("error %q should include subprocess output (concurrency cap message)", errMsg)
 	}
-	if !strings.Contains(errMsg, "nixos-config@main") {
+	if !strings.Contains(errMsg, "test-repo@main") {
 		t.Errorf("error %q should include subprocess output (active container list)", errMsg)
 	}
 	// Verify trailing whitespace/newlines are trimmed.
@@ -5800,9 +5800,9 @@ echo "session \"${last}@override-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5850,9 +5850,9 @@ echo "session \"${last}@no-override-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -5882,7 +5882,7 @@ echo "session \"${last}@no-override-branch\" created"
 // value (not valid JSON) returns HTTP 400 rather than silently ignoring it.
 func TestHostAPI_Spawn_ModelOverrideMalformedReturns400(t *testing.T) {
 	d := openTestDB(t)
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
 
 	// malformed: not valid JSON-encoded map
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
@@ -6270,9 +6270,9 @@ exit 0
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6329,9 +6329,9 @@ echo "session \"${last}@harness-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6376,9 +6376,9 @@ echo "session \"${last}@no-harness-branch\" created"
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6484,9 +6484,9 @@ exit 0
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6536,9 +6536,9 @@ exit 0
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6584,7 +6584,7 @@ exit 0
 	clk := newTestClock()
 	cfg := Config{
 		SessionName:     "nixos-config@feature",
-		Repo:            "nixos-config",
+		Repo:            "test-repo",
 		Worktree:        "/tmp/nixos-config@feature",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
@@ -6629,7 +6629,7 @@ exit 0
 	clk := newTestClock()
 	cfg := Config{
 		SessionName:     "nixos-config@feature",
-		Repo:            "nixos-config",
+		Repo:            "test-repo",
 		Worktree:        "/tmp/nixos-config@feature",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
@@ -6674,9 +6674,9 @@ exit 0
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6727,9 +6727,9 @@ func TestHostAPI_Review_InfraFailureStreamsSentinelFailed(t *testing.T) {
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6787,7 +6787,7 @@ exit 1
 	clk := newTestClock()
 	cfg := Config{
 		SessionName:     "nixos-config@feature",
-		Repo:            "nixos-config",
+		Repo:            "test-repo",
 		Worktree:        "/tmp/nixos-config@feature",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
@@ -6847,7 +6847,7 @@ exit 0
 	clk := newTestClock()
 	cfg := Config{
 		SessionName:     "nixos-config@feature",
-		Repo:            "nixos-config",
+		Repo:            "test-repo",
 		Worktree:        "/tmp/nixos-config@feature",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
@@ -6890,9 +6890,9 @@ func TestHostAPI_Review_StartFailureReturns500(t *testing.T) {
 
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -6974,7 +6974,7 @@ exit 0
 	clk := newTestClock()
 	cfg := Config{
 		SessionName:     "nixos-config@741-fix",
-		Repo:            "nixos-config",
+		Repo:            "test-repo",
 		Worktree:        "/tmp/nixos-config@741-fix",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
@@ -7023,9 +7023,9 @@ exit 0
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -7080,9 +7080,9 @@ exit 1
 	}
 	clk := newTestClock()
 	cfg := Config{
-		SessionName:     "nixos-config@main",
-		Repo:            "nixos-config",
-		Worktree:        "/tmp/nixos-config@main",
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
 		HarnessURL:     "http://localhost:14000",
 		DB:              d,
 		Clock:           clk,
@@ -8415,7 +8415,7 @@ func TestReviewAgentParentSession(t *testing.T) {
 		{"nixos-config@feature~review-3", "nixos-config@feature", true},
 		// Normal worker — no "~review" in name.
 		{"nixos-config@feature", "", false},
-		{"nixos-config@main", "", false},
+		{"test-repo@main", "", false},
 		// Empty string
 		{"", "", false},
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecartest/sidecartest.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecartest/sidecartest.go
@@ -1,0 +1,303 @@
+// Package sidecartest provides test isolation helpers for sidecar unit tests.
+//
+// # Isolation contract
+//
+// Tests in internal/sidecar/ must use NewIsolated (or at minimum t.Setenv
+// "XDG_STATE_HOME" to a t.TempDir()) before constructing a sidecar.Sidecar.
+// This ensures:
+//
+//   - No file is created under the real $XDG_STATE_HOME/prism/ directory.
+//   - No notification is delivered to any live coordinator on the host.
+//   - The socket-pipe delivery path (deliverViaSidecarSocket) cannot dial any
+//     host socket — a guard env var (PRISM_TEST_MODE_RESTRICT_HOSTAPI) is set
+//     automatically, causing DeliverToSession to refuse socket paths outside
+//     the test's tempdir.
+//
+// Session names used in test fixtures must NOT use real coordinator slugs
+// (e.g. "nixos-config@main"). Use "prism-test@invoker-<testname>" instead so
+// that if isolation is accidentally broken, it cannot collide with a live session.
+package sidecartest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// EnvRestrictHostAPI is the environment variable name that, when set to any
+// non-empty value, causes promptdelivery.deliverViaSidecarSocket to refuse to
+// dial any socket path that does not reside under the process's
+// $XDG_STATE_HOME directory. It is set automatically by NewIsolated.
+//
+// This is a test-mode guard that prevents future regressions where new
+// transport paths accidentally escape the test's tempdir isolation.
+const EnvRestrictHostAPI = "PRISM_TEST_MODE_RESTRICT_HOSTAPI"
+
+// Bus is the in-process test bus for a single isolated sidecar test. It
+// provides an httptest.Server for the HTTP delivery path and a Unix-socket
+// listener for the socket-pipe delivery path. Both listeners reside under a
+// t.TempDir() so they can never interfere with host-side prism state.
+type Bus struct {
+	// HTTPServer is the httptest.Server that captures HTTP deliveries
+	// (the opencode prompt_async path).
+	HTTPServer *httptest.Server
+
+	// SockPath is the Unix socket path for the socket-pipe delivery path.
+	// It lives at $XDG_STATE_HOME/prism/run/<hash>/hostapi.sock (where
+	// XDG_STATE_HOME is the test tempdir set by NewIsolated).
+	SockPath string
+
+	// DB is an isolated test database opened under a private MkdirTemp path.
+	DB *db.DB
+
+	// XDGStateHome is the tempdir that was set as $XDG_STATE_HOME.
+	XDGStateHome string
+
+	// ReceivedBodies records the raw JSON bodies received by the HTTP server.
+	// Access is mutex-protected; use CopyBodies() from tests.
+	mu             sync.Mutex
+	receivedBodies []string
+}
+
+// CopyBodies returns a snapshot of all bodies received by the HTTP server.
+func (b *Bus) CopyBodies() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.receivedBodies))
+	copy(out, b.receivedBodies)
+	return out
+}
+
+// NewIsolated creates a fully isolated test bus for a sidecar test. It:
+//
+//   - Sets XDG_STATE_HOME to a new t.TempDir() path via t.Setenv so that all
+//     path resolution (SidecarHostAPIPath, SidecarHarnessPipePath, etc.) is
+//     redirected to the tempdir.
+//   - Sets PRISM_TEST_MODE_RESTRICT_HOSTAPI=1 so deliverViaSidecarSocket
+//     refuses to dial sockets outside the tempdir.
+//   - Opens an isolated SQLite DB under a private os.MkdirTemp() directory.
+//   - Starts an httptest.Server that records received prompt bodies.
+//   - Starts a Unix-socket listener at the test-session hostapi.sock path so
+//     that the socket-pipe delivery path is also exercised in-process.
+//   - Registers t.Cleanup handlers for graceful shutdown.
+//
+// invokerSession is the session name to seed into the DB as an active invoker
+// row pointing to the httptest.Server. Pass an empty string to skip seeding.
+//
+// All session names used in tests should use the "prism-test@" prefix, e.g.:
+//
+//	invoker := "prism-test@invoker-" + t.Name()
+func NewIsolated(t *testing.T, invokerSession string) *Bus {
+	t.Helper()
+
+	// 1. Point XDG_STATE_HOME at a tempdir so all host-path resolution is
+	//    sandboxed. t.Setenv restores the original value on t.Cleanup.
+	xdgTmp, err := os.MkdirTemp("", "sidecartest-xdg-")
+	if err != nil {
+		t.Fatalf("sidecartest: create XDG temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(xdgTmp) })
+	t.Setenv("XDG_STATE_HOME", xdgTmp)
+
+	// 2. Activate the test-mode guard so deliverViaSidecarSocket refuses to
+	//    dial sockets outside the tempdir.
+	t.Setenv(EnvRestrictHostAPI, "1")
+
+	// 3. Open an isolated DB.
+	dbDir, err := os.MkdirTemp("", "sidecartest-db-")
+	if err != nil {
+		t.Fatalf("sidecartest: create DB temp dir: %v", err)
+	}
+	dbPath := filepath.Join(dbDir, "test.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		_ = os.RemoveAll(dbDir)
+		t.Fatalf("sidecartest: open test DB: %v", err)
+	}
+	t.Cleanup(func() {
+		d.Close()
+		_ = os.RemoveAll(dbDir)
+	})
+
+	bus := &Bus{
+		DB:           d,
+		XDGStateHome: xdgTmp,
+	}
+
+	// 4. Start the HTTP server (captures prompt_async deliveries).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/session" {
+			// Return a minimal session list for GET /session requests from
+			// the promptdelivery HTTP path. The session ID here is a
+			// recognisable placeholder — tests that need to assert on the
+			// session ID should seed the DB explicitly.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"test-sid"}]`))
+			return
+		}
+		if r.Method == http.MethodPost {
+			body := make([]byte, 65536)
+			n, _ := r.Body.Read(body)
+			bus.mu.Lock()
+			bus.receivedBodies = append(bus.receivedBodies, string(body[:n]))
+			bus.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	bus.HTTPServer = srv
+
+	// 5. Seed the invoker row in the DB, pointing to the httptest.Server.
+	if invokerSession != "" {
+		port := testServerPort(t, srv.URL)
+		seedInvoker(t, d, invokerSession, port)
+	}
+
+	// 6. Start a Unix-socket listener for the socket-pipe delivery path.
+	//    The socket lives at $XDG_STATE_HOME/prism/run/<hash>/hostapi.sock —
+	//    the exact path that SidecarHostAPIPath would resolve for the invoker.
+	//    This allows tests that exercise the pi-harness path to also be caught
+	//    by the isolation guard without dialling a real host socket.
+	if invokerSession != "" {
+		sockPath, err := session.SidecarHostAPIPath(invokerSession)
+		if err != nil {
+			t.Fatalf("sidecartest: resolve socket path: %v", err)
+		}
+		sockDir := filepath.Dir(sockPath)
+		if err := os.MkdirAll(sockDir, 0o700); err != nil {
+			t.Fatalf("sidecartest: create socket dir: %v", err)
+		}
+		bus.SockPath = sockPath
+
+		ln, err := net.Listen("unix", sockPath)
+		if err != nil {
+			t.Fatalf("sidecartest: listen on socket %s: %v", sockPath, err)
+		}
+		sockSrv := &http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					body := make([]byte, 65536)
+					n, _ := r.Body.Read(body)
+					bus.mu.Lock()
+					bus.receivedBodies = append(bus.receivedBodies, string(body[:n]))
+					bus.mu.Unlock()
+				}
+				w.WriteHeader(http.StatusOK)
+			}),
+		}
+		go func() { _ = sockSrv.Serve(ln) }()
+		t.Cleanup(func() { _ = sockSrv.Close() })
+	}
+
+	return bus
+}
+
+// seedInvoker writes an active invoker row into d pointing to the HTTP test
+// server at port, using an empty harness so DeliverToSession routes via the
+// HTTP fallback path.
+func seedInvoker(t *testing.T, d *db.DB, invokerSession string, port int) {
+	t.Helper()
+
+	// Derive a repo name from the invoker session name ("prism-test" from
+	// "prism-test@...").
+	repo := invokerSession
+	if idx := len(invokerSession); idx > 0 {
+		for i, c := range invokerSession {
+			if c == '@' {
+				repo = invokerSession[:i]
+				break
+			}
+		}
+	}
+
+	sid := "test-sid-" + invokerSession
+	agentName := "coordinator"
+	modelID := "anthropic/claude-sonnet-4-5"
+	if err := d.UpsertStatusWithAgent(invokerSession, repo, "/tmp/test-worktree", "active", nil, &sid, &agentName, &modelID); err != nil {
+		t.Fatalf("sidecartest: seed invoker %q: %v", invokerSession, err)
+	}
+	// Use empty harness so DeliverToSession uses the HTTP fallback path —
+	// tests use httptest.Server which has a port but no socket.
+	if err := d.QueryRow(
+		"UPDATE agent_status SET harness_port = ?, harness_session_id = ?, harness = '' WHERE session_name = ? RETURNING session_name",
+		port, sid, invokerSession,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("sidecartest: set port/sid for invoker %q: %v", invokerSession, err)
+	}
+}
+
+// testServerPort extracts the port number from an httptest.Server URL of the
+// form "http://127.0.0.1:<port>".
+func testServerPort(t *testing.T, srvURL string) int {
+	t.Helper()
+	var port int
+	_, err := fmt.Sscanf(srvURL, "http://127.0.0.1:%d", &port)
+	if err != nil {
+		_, err = fmt.Sscanf(srvURL, "http://localhost:%d", &port)
+	}
+	if err != nil {
+		t.Fatalf("sidecartest: parse test server port from %q: %v", srvURL, err)
+	}
+	return port
+}
+
+// BodyContains reports whether any received body contains substring.
+func (b *Bus) BodyContains(substring string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, body := range b.receivedBodies {
+		if contains(body, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		jsonContains(s, substr))
+}
+
+// jsonContains is a plain substring check used for assertion helpers.
+func jsonContains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseBodies returns all received bodies unmarshalled as JSON maps. Bodies
+// that fail to unmarshal are returned as raw string maps with key "raw".
+func (b *Bus) ParseBodies() []map[string]json.RawMessage {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]map[string]json.RawMessage, 0, len(b.receivedBodies))
+	for _, body := range b.receivedBodies {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(body), &m); err == nil {
+			out = append(out, m)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Fixes the test leak observed in issue #1608: running `go test ./internal/sidecar/...` on a host with a live `nixos-config@main` coordinator was delivering fixture notifications to the real coordinator.

## Root cause

`notify_investigate_test.go` hardcoded `repo := "nixos-config"` and `invokerSession := repo + "@main"`, colliding with the live coordinator session name. When delivery fell through to `deliverViaSidecarSocket`, the hash of "nixos-config@main" was identical to the live coordinator's socket path, causing the notification to escape to the real host.

## Changes

### New package: `internal/sidecar/sidecartest/`
- `sidecartest.NewIsolated(t, invokerSession)`: redirects `XDG_STATE_HOME` to a `t.TempDir()`, sets `PRISM_TEST_MODE_RESTRICT_HOSTAPI` guard, opens an isolated DB, starts an `httptest.Server`, and starts a Unix-socket listener — all under the temp dir.

### Modified: `internal/promptdelivery/promptdelivery.go`
- Added `PRISM_TEST_MODE_RESTRICT_HOSTAPI` guard to `deliverViaSidecarSocket`: when set, refuses to dial any socket path outside `$XDG_STATE_HOME`. Set automatically by `sidecartest.NewIsolated`.

### Modified: `internal/sidecar/notify_investigate_test.go` (complete rewrite)
- All tests migrated to `sidecartest.NewIsolated`
- Session names now use `prism-test@` prefix — no more `nixos-config@main` as invoker
- New test `TestNotifyInvestigatorCompletion_NoHostBusLeak`: verifies that using `nixos-config@main~investigate-leakcheck` against an isolated DB produces zero changes to the real `$XDG_STATE_HOME/prism/` directory or DB
- Isolation contract documented at top of file

### Modified: `sidecar_stats_test.go`, `sidecar_merge_test.go`, `sidecar_test.go`
- Replaced `nixos-config`/`nixos-config@main` with `test-repo`/`test-repo@main`

### Modified: `AGENTS.md`
- Added test-suite isolation note to the pre-PR self-check section

## AC verification

- `grep -rn '"nixos-config"' modules/programs/prism/prism/internal/sidecar/` → no matches in `_test.go` files ✓
- `go build ./...` ✓
- `go test ./internal/sidecar/... -race` ✓
- `nix build .#prism` ✓
- Pre-existing failures (`cmd`, `container`, `integration`, `tmux`) confirmed pre-existing on `main`

Closes #1608