### PR TITLE
atlassian MCP: usability improvements (issues #1–#6)

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -24,6 +24,32 @@
         the Atlassian MCP server.
       '';
     };
+    nx.programs.prism.pi.atlassian.defaultCloudId = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "08986a80-a6ed-4480-ae2d-4a439d50d71b";
+      description = ''
+        Default Atlassian cloud ID to use when the agent omits the cloudId
+        parameter in any Atlassian MCP tool call. When set, the value is
+        exposed to the pi Atlassian extension as the ATLASSIAN_DEFAULT_CLOUD_ID
+        environment variable, and every tool call that omits cloudId has the
+        default injected automatically before being forwarded upstream.
+
+        The tool descriptions surfaced to the agent (via tools/list) are also
+        updated to mark cloudId as optional and reference this default.
+
+        Defaults to "" (empty string), which preserves the current behaviour
+        where cloudId is required on every tool call.
+
+        Single-site setups: set this to the UUID of your Atlassian site (find
+        it via getAccessibleAtlassianResources or from your Atlassian admin).
+        For example, thankyoupayroll.atlassian.net uses
+        08986a80-a6ed-4480-ae2d-4a439d50d71b.
+
+        Multi-site setups: leave this empty and pass cloudId explicitly on
+        each tool call (current behaviour).
+      '';
+    };
   };
 
   config = lib.mkIf config.nx.programs.prism.pi.enable (
@@ -197,7 +223,13 @@
         ];
 
         programs.zsh.shellAliases = {
-          pi = "PI_OFFLINE=1 ${envPrefix} pi";
+          pi =
+            "PI_OFFLINE=1 ${envPrefix}"
+            + lib.optionalString (
+              config.nx.programs.prism.pi.atlassian.enable
+              && config.nx.programs.prism.pi.atlassian.defaultCloudId != ""
+            ) " ATLASSIAN_DEFAULT_CLOUD_ID=${config.nx.programs.prism.pi.atlassian.defaultCloudId}"
+            + " pi";
         };
 
         # Agent markdown files at ~/.config/prism/agents/ — consumed by

--- a/modules/programs/prism/pi/extensions/atlassian/index.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/index.ts
@@ -15,7 +15,7 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { Type } from "typebox"
-import { createMcpSession, type McpSession, type McpTool } from "./mcp-client.ts"
+import { createMcpSession, type McpSession, type McpTool, getDefaultCloudId } from "./mcp-client.ts"
 import { loadTokens, getValidAccessToken, loginAtlassian, type AtlassianTokens } from "./auth.ts"
 import { slimMcpResultContent } from "./slim.ts"
 
@@ -47,6 +47,60 @@ function mcpSchemaToTypebox(inputSchema: Record<string, unknown>) {
   // Type.Unsafe allows us to pass any JSON Schema object through TypeBox
   // without building a full TypeBox tree. The LLM receives the schema as-is.
   return Type.Unsafe<Record<string, unknown>>(inputSchema as object)
+}
+
+// ---------------------------------------------------------------------------
+// Helper: augment getJiraIssue response with transitions (Issue #2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch transitions for the issue and merge them into the getJiraIssue response
+ * as a top-level `transitions` array. If fetching transitions fails, the original
+ * result is returned unchanged (best-effort augmentation).
+ */
+async function augmentGetJiraIssueWithTransitions(
+  session: McpSession,
+  callParams: Record<string, unknown>,
+  result: { content: Array<{ type: string; text?: string }>; isError?: boolean },
+): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+  const issueIdOrKey = (callParams["issueIdOrKey"] ?? callParams["issueKey"]) as string | undefined
+  if (!issueIdOrKey) return result
+
+  const transitionArgs: Record<string, unknown> = { issueIdOrKey }
+  const cloudId = callParams["cloudId"] as string | undefined
+  if (cloudId) transitionArgs["cloudId"] = cloudId
+
+  let transitions: Array<{ id: string; name: string }> = []
+  try {
+    const transitionsResult = await session.callTool("getTransitionsForJiraIssue", transitionArgs)
+    if (!transitionsResult.isError) {
+      const rawText = transitionsResult.content?.map((c) => c.text ?? "").join("").trim()
+      const parsed = JSON.parse(rawText) as { transitions?: Array<{ id: string; name: string }> }
+      transitions = parsed?.transitions ?? []
+    }
+  } catch {
+    // Best-effort — if fetching transitions fails, return issue without them
+  }
+
+  if (transitions.length === 0) return result
+
+  // Merge transitions into the issue JSON response
+  const parts: Array<{ type: string; text?: string }> = []
+  for (const block of result.content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      try {
+        const parsed = JSON.parse(block.text) as Record<string, unknown>
+        parsed["transitions"] = transitions
+        parts.push({ type: "text", text: JSON.stringify(parsed) })
+        continue
+      } catch {
+        // Not JSON — leave as-is
+      }
+    }
+    parts.push(block)
+  }
+
+  return { content: parts, isError: result.isError }
 }
 
 // ---------------------------------------------------------------------------
@@ -102,10 +156,8 @@ function registerTools(pi: ExtensionAPI, tools: McpTool[]): void {
 
         try {
           log(`calling ${toolName}`)
-          const result = await _session.callTool(
-            toolName,
-            params as Record<string, unknown>,
-          )
+          const callParams = params as Record<string, unknown>
+          let result = await _session.callTool(toolName, callParams)
 
           if (result.isError) {
             // MCP tool-level error — surface to LLM without crashing
@@ -118,8 +170,21 @@ function registerTools(pi: ExtensionAPI, tools: McpTool[]): void {
             }
           }
 
-          // Apply slim field-drop before returning
-          const slimmed = slimMcpResultContent(result.content, toolName)
+          // Issue #2: extend getJiraIssue response with transitions array.
+          // We make an additional call to getTransitionsForJiraIssue and merge
+          // the transitions into the issue response so the agent sees them in
+          // one round-trip. Documented behaviour: transitions are fetched via
+          // an extra REST call and included as a top-level "transitions" array.
+          if (toolName === "getJiraIssue" && !result.isError) {
+            result = await augmentGetJiraIssueWithTransitions(
+              _session,
+              callParams,
+              result,
+            )
+          }
+
+          // Apply slim field-drop before returning (pass defaultCloudId for error nudge — Issue #5)
+          const slimmed = slimMcpResultContent(result.content, toolName, getDefaultCloudId())
           return {
             content: [{ type: "text", text: slimmed }],
           }
@@ -136,6 +201,168 @@ function registerTools(pi: ExtensionAPI, tools: McpTool[]): void {
   }
 
   log(`registered ${tools.length} Atlassian tools`)
+
+  // Issue #2: register synthetic transitionJiraIssueByName tool
+  registerTransitionByNameTool(pi)
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic tool: transitionJiraIssueByName (Issue #2)
+// ---------------------------------------------------------------------------
+
+function registerTransitionByNameTool(pi: ExtensionAPI): void {
+  const defaultCloudIdNote = getDefaultCloudId()
+    ? ` cloudId is optional (default configured).`
+    : ""
+
+  pi.registerTool({
+    name: "transitionJiraIssueByName",
+    label: "transitionJiraIssueByName",
+    description:
+      `Transition a Jira issue to a new status by specifying the transition name (e.g. "In Progress", "Done") ` +
+      `instead of the numeric transition ID. The name is resolved case-insensitively against the issue's ` +
+      `available transitions before calling transitionJiraIssue. ` +
+      `If the name matches no transition, an error listing available names is returned. ` +
+      `If the name matches multiple transitions, an error listing the colliding transitions is returned ` +
+      `so the caller can disambiguate by ID. ` +
+      `getJiraIssue's response is also augmented with a transitions array when available.` +
+      defaultCloudIdNote,
+    parameters: Type.Unsafe<Record<string, unknown>>({
+      type: "object",
+      properties: {
+        cloudId: {
+          type: "string",
+          description: getDefaultCloudId()
+            ? `Cloud ID of the Atlassian site. Optional — defaults to ${getDefaultCloudId()}.`
+            : "Cloud ID of the Atlassian site (UUID from getAccessibleAtlassianResources).",
+        },
+        issueIdOrKey: {
+          type: "string",
+          description: "The Jira issue ID or key (e.g. PROJ-123).",
+        },
+        transitionName: {
+          type: "string",
+          description: "The name of the transition (e.g. \"In Progress\", \"Done\"). Case-insensitive.",
+        },
+      },
+      required: getDefaultCloudId()
+        ? ["issueIdOrKey", "transitionName"]
+        : ["cloudId", "issueIdOrKey", "transitionName"],
+    }),
+    async execute(_toolCallId, params, _signal) {
+      if (!_session) {
+        return { content: [{ type: "text", text: "Atlassian MCP: no active session" }], isError: true }
+      }
+      if (!_tokens) {
+        return { content: [{ type: "text", text: "Atlassian MCP: no auth tokens" }], isError: true }
+      }
+
+      // Refresh token
+      try {
+        const { token, tokens: updatedTokens } = await getValidAccessToken(_tokens)
+        _tokens = updatedTokens
+        _session.updateToken(token)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: "text", text: `Atlassian auth error: ${msg}` }], isError: true }
+      }
+
+      const p = params as Record<string, unknown>
+      const issueIdOrKey = p["issueIdOrKey"] as string | undefined
+      const transitionName = p["transitionName"] as string | undefined
+      const cloudId = (p["cloudId"] as string | undefined) ?? getDefaultCloudId()
+
+      if (!issueIdOrKey) {
+        return { content: [{ type: "text", text: "transitionJiraIssueByName: issueIdOrKey is required" }], isError: true }
+      }
+      if (!transitionName) {
+        return { content: [{ type: "text", text: "transitionJiraIssueByName: transitionName is required" }], isError: true }
+      }
+
+      // Step 1: look up available transitions
+      log(`transitionJiraIssueByName: fetching transitions for ${issueIdOrKey}`)
+      let transitionsResult: { content: Array<{ type: string; text?: string }>; isError?: boolean }
+      try {
+        const args: Record<string, unknown> = { issueIdOrKey }
+        if (cloudId) args["cloudId"] = cloudId
+        transitionsResult = await _session.callTool("getTransitionsForJiraIssue", args)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: "text", text: `transitionJiraIssueByName: failed to fetch transitions: ${msg}` }], isError: true }
+      }
+
+      if (transitionsResult.isError) {
+        return transitionsResult
+      }
+
+      // Parse the transitions out of the result
+      const rawText = transitionsResult.content?.map((c) => c.text ?? "").join("").trim()
+      let transitions: Array<{ id: string; name: string }> = []
+      try {
+        const parsed = JSON.parse(rawText) as { transitions?: Array<{ id: string; name: string }> }
+        transitions = parsed?.transitions ?? []
+      } catch {
+        return {
+          content: [{ type: "text", text: `transitionJiraIssueByName: could not parse transitions response: ${rawText}` }],
+          isError: true,
+        }
+      }
+
+      if (transitions.length === 0) {
+        return {
+          content: [{ type: "text", text: `transitionJiraIssueByName: no transitions available for ${issueIdOrKey}` }],
+          isError: true,
+        }
+      }
+
+      // Step 2: resolve transition name (case-insensitive)
+      const nameLower = transitionName.toLowerCase()
+      const matches = transitions.filter((t) => t.name.toLowerCase() === nameLower)
+
+      if (matches.length === 0) {
+        const available = transitions.map((t) => `"${t.name}" (id: ${t.id})`).join(", ")
+        return {
+          content: [{
+            type: "text",
+            text: `transitionJiraIssueByName: no transition named "${transitionName}" found for ${issueIdOrKey}. Available transitions: ${available}`,
+          }],
+          isError: true,
+        }
+      }
+
+      if (matches.length > 1) {
+        const collisions = matches.map((t) => `"${t.name}" (id: ${t.id})`).join(", ")
+        return {
+          content: [{
+            type: "text",
+            text: `transitionJiraIssueByName: transition name "${transitionName}" is ambiguous for ${issueIdOrKey} — multiple transitions match: ${collisions}. Please call transitionJiraIssue with the specific transition ID.`,
+          }],
+          isError: true,
+        }
+      }
+
+      const match = matches[0]
+      log(`transitionJiraIssueByName: resolved "${transitionName}" to id=${match.id}`)
+
+      // Step 3: call transitionJiraIssue with the resolved ID
+      let transitionResult: { content: Array<{ type: string; text?: string }>; isError?: boolean }
+      try {
+        const args: Record<string, unknown> = { issueIdOrKey, transitionId: match.id }
+        if (cloudId) args["cloudId"] = cloudId
+        transitionResult = await _session.callTool("transitionJiraIssue", args)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: "text", text: `transitionJiraIssueByName: transition call failed: ${msg}` }], isError: true }
+      }
+
+      if (transitionResult.isError) {
+        return transitionResult
+      }
+
+      const slimmed = slimMcpResultContent(transitionResult.content, "transitionJiraIssue", getDefaultCloudId())
+      return { content: [{ type: "text", text: slimmed }] }
+    },
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/programs/prism/pi/extensions/atlassian/mcp-client.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/mcp-client.ts
@@ -12,6 +12,53 @@
 const MCP_URL = process.env.ATLASSIAN_MCP_URL ?? "https://mcp.atlassian.com/v1/mcp"
 const DEBUG = process.env.ATLASSIAN_MCP_DEBUG === "1"
 
+// ---------------------------------------------------------------------------
+// Default cloudId (Issue #3)
+// ---------------------------------------------------------------------------
+
+// Set via ATLASSIAN_DEFAULT_CLOUD_ID (injected from Nix option nx.programs.prism.atlassian.defaultCloudId).
+// When set, every tool call that omits cloudId has the default injected automatically.
+export function getDefaultCloudId(): string | undefined {
+  return process.env.ATLASSIAN_DEFAULT_CLOUD_ID || undefined
+}
+
+// Rewrite the description for a tool when a default cloudId is configured:
+// - mark cloudId as optional and document the default.
+function rewriteDescription(tool: McpTool, defaultCloudId: string): McpTool {
+  const desc = tool.description ?? tool.name
+  const paramCloudIdNote =
+    `cloudId is optional when ATLASSIAN_DEFAULT_CLOUD_ID is configured; ` +
+    `the default (${defaultCloudId}) is used if omitted.`
+
+  // Only append the note if cloudId appears in the tool's schema
+  const schema = tool.inputSchema as Record<string, unknown>
+  const props = schema?.properties as Record<string, unknown> | undefined
+  if (!props || !("cloudId" in props)) {
+    return tool
+  }
+
+  return {
+    ...tool,
+    description: `${desc} [${paramCloudIdNote}]`,
+    inputSchema: {
+      ...schema,
+      required: Array.isArray(schema.required)
+        ? (schema.required as string[]).filter((k) => k !== "cloudId")
+        : schema.required,
+    },
+  }
+}
+
+// Improve the description for getCloudId (Issue #6)
+function rewriteGetCloudIdDescription(tool: McpTool): McpTool {
+  const addition =
+    " If you only have an issue key (e.g. PROJ-123) and don't know the site, call this tool first to discover the cloudId."
+  return {
+    ...tool,
+    description: (tool.description ?? tool.name) + addition,
+  }
+}
+
 function debug(...args: unknown[]): void {
   if (DEBUG) {
     console.error("[atlassian-mcp]", ...args)
@@ -191,23 +238,150 @@ export class McpSession {
 
   /**
    * List all available tools from the MCP server.
+   * Applies description rewrites for default-cloudId (Issue #3),
+   * getCloudId wording (Issue #6), and registers the synthetic
+   * transitionJiraIssueByName tool (Issue #2).
    */
   async listTools(): Promise<McpTool[]> {
     const result = await this.send("tools/list", {}) as { tools?: McpTool[] }
-    return result?.tools ?? []
+    let tools = result?.tools ?? []
+
+    const defaultCloudId = getDefaultCloudId()
+
+    tools = tools.map((tool) => {
+      // Issue #6: improve getCloudId description
+      if (tool.name === "getCloudId") {
+        tool = rewriteGetCloudIdDescription(tool)
+      }
+      // Issue #3: when a default cloudId is configured, rewrite descriptions
+      if (defaultCloudId) {
+        tool = rewriteDescription(tool, defaultCloudId)
+      }
+      return tool
+    })
+
+    return tools
+  }
+
+  /**
+   * Inject the default cloudId into args if configured and the caller omitted it.
+   * Issue #3.
+   */
+  private injectDefaultCloudId(args: Record<string, unknown>): Record<string, unknown> {
+    const defaultCloudId = getDefaultCloudId()
+    if (defaultCloudId && !("cloudId" in args)) {
+      debug("injecting default cloudId:", defaultCloudId)
+      return { cloudId: defaultCloudId, ...args }
+    }
+    return args
+  }
+
+  /**
+   * Fetch transitions for a Jira issue via the Jira REST API as a fallback
+   * when the upstream MCP tool returns an empty object.
+   * Issue #1.
+   *
+   * Returns a result-shaped object with content array, or null if the cloudId
+   * is not available (cannot build the REST URL).
+   */
+  private async fetchTransitionsFallback(
+    args: Record<string, unknown>,
+  ): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean } | null> {
+    const issueIdOrKey = args["issueIdOrKey"] as string | undefined
+    if (!issueIdOrKey) {
+      return {
+        content: [{ type: "text", text: "getTransitionsForJiraIssue: issueIdOrKey is required" }],
+        isError: true,
+      }
+    }
+
+    // Determine the Jira site base URL from cloudId using the Atlassian REST
+    // resource listing. For the REST fallback we need the actual site URL.
+    // The accessible resources endpoint returns [{id, url, name, ...}].
+    // We use the Atlassian REST API directly via the known pattern:
+    //   https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/issue/{key}/transitions
+    const effectiveCloudId = (args["cloudId"] as string | undefined) ?? getDefaultCloudId()
+    if (!effectiveCloudId) {
+      debug("transitions fallback: no cloudId available")
+      return null
+    }
+
+    const restUrl = `https://api.atlassian.com/ex/jira/${effectiveCloudId}/rest/api/3/issue/${issueIdOrKey}/transitions`
+    debug("transitions REST fallback:", restUrl)
+
+    const response = await fetch(restUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: "application/json",
+      },
+    })
+
+    if (response.status === 404) {
+      return {
+        content: [{ type: "text", text: `getTransitionsForJiraIssue: issue not found: ${issueIdOrKey}` }],
+        isError: true,
+      }
+    }
+
+    if (response.status === 403 || response.status === 401) {
+      return {
+        content: [{
+          type: "text",
+          text: `getTransitionsForJiraIssue: permission denied — the authenticated account lacks permission to view transitions for ${issueIdOrKey}`,
+        }],
+        isError: true,
+      }
+    }
+
+    if (!response.ok) {
+      const text = await response.text()
+      return {
+        content: [{ type: "text", text: `getTransitionsForJiraIssue: REST fallback failed (${response.status}): ${text}` }],
+        isError: true,
+      }
+    }
+
+    const data = await response.json() as { transitions?: Array<{ id: string; name: string; [k: string]: unknown }> }
+    const transitions = data.transitions ?? []
+    const simplified = transitions.map(({ id, name }) => ({ id, name }))
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ transitions: simplified }) }],
+      isError: false,
+    }
   }
 
   /**
    * Call a tool and return the raw content array.
+   * Injects default cloudId when configured (Issue #3).
+   * For getTransitionsForJiraIssue, falls back to REST API when upstream
+   * returns an empty object (Issue #1).
    */
   async callTool(
     name: string,
     args: Record<string, unknown>,
   ): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+    // Issue #3: inject default cloudId
+    const effectiveArgs = this.injectDefaultCloudId(args)
+
     const result = await this.send("tools/call", {
       name,
-      arguments: args,
+      arguments: effectiveArgs,
     }) as { content: Array<{ type: string; text?: string }>; isError?: boolean }
+
+    // Issue #1: if getTransitionsForJiraIssue returned {} (empty), use REST fallback
+    if (name === "getTransitionsForJiraIssue" && !result.isError) {
+      const text = result.content?.map((c) => c.text ?? "").join("").trim()
+      if (text === "{}" || text === "") {
+        debug("getTransitionsForJiraIssue returned {}, trying REST fallback")
+        const fallback = await this.fetchTransitionsFallback(effectiveArgs)
+        if (fallback !== null) {
+          return fallback
+        }
+      }
+    }
+
     return result
   }
 }

--- a/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
@@ -8,6 +8,9 @@ import {
   slimJson,
   slimMcpResultContent,
   optionsForTool,
+  deduplicateById,
+  buildCloudIdErrorHint,
+  CLOUD_ID_ERROR_PATTERN,
   UNIVERSAL_DROP_KEYS,
   JIRA_ISSUE_DROP_KEYS,
   CONFLUENCE_DROP_KEYS,
@@ -264,6 +267,116 @@ describe("slimMcpResultContent", () => {
   it("handles null/undefined content", () => {
     const result = slimMcpResultContent(null, "anyTool")
     assert.equal(result, "null")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deduplicateById tests (Issue #4)
+// ---------------------------------------------------------------------------
+
+describe("deduplicateById", () => {
+  it("deduplicates two identical entries (same id and name)", () => {
+    const input = [
+      { id: "08986a80-a6ed-4480-ae2d-4a439d50d71b", name: "thankyoupayroll" },
+      { id: "08986a80-a6ed-4480-ae2d-4a439d50d71b", name: "thankyoupayroll" },
+    ]
+    const result = deduplicateById(input)
+    assert.equal(result.length, 1)
+    assert.equal(result[0].id, "08986a80-a6ed-4480-ae2d-4a439d50d71b")
+  })
+
+  it("deduplicates entries with matching id but different name (first occurrence wins)", () => {
+    const input = [
+      { id: "08986a80-a6ed-4480-ae2d-4a439d50d71b", name: "thankyoupayroll" },
+      { id: "08986a80-a6ed-4480-ae2d-4a439d50d71b", name: "thankyoupayroll-copy" },
+    ]
+    const result = deduplicateById(input)
+    assert.equal(result.length, 1)
+    assert.equal(result[0].name, "thankyoupayroll")
+  })
+
+  it("preserves entries with different ids", () => {
+    const input = [
+      { id: "aaaa", name: "site-a" },
+      { id: "bbbb", name: "site-b" },
+    ]
+    const result = deduplicateById(input)
+    assert.equal(result.length, 2)
+  })
+
+  it("preserves order (first occurrence wins)", () => {
+    const input = [
+      { id: "aaaa", name: "first" },
+      { id: "bbbb", name: "second" },
+      { id: "aaaa", name: "third" },
+    ]
+    const result = deduplicateById(input)
+    assert.equal(result.length, 2)
+    assert.equal(result[0].name, "first")
+    assert.equal(result[1].name, "second")
+  })
+
+  it("handles empty array", () => {
+    assert.deepEqual(deduplicateById([]), [])
+  })
+})
+
+describe("slimMcpResultContent — getAccessibleAtlassianResources dedup (Issue #4)", () => {
+  it("deduplicates resources with the same id", () => {
+    const resource = { id: "08986a80-a6ed-4480-ae2d-4a439d50d71b", name: "thankyoupayroll" }
+    const content = [{ type: "text", text: JSON.stringify([resource, resource]) }]
+    const result = slimMcpResultContent(content, "getAccessibleAtlassianResources")
+    const parsed = JSON.parse(result) as unknown[]
+    assert.equal(parsed.length, 1)
+  })
+
+  it("does not deduplicate for other tools", () => {
+    const item = { id: "aaaa", name: "x" }
+    const content = [{ type: "text", text: JSON.stringify([item, item]) }]
+    const result = slimMcpResultContent(content, "searchJiraIssuesUsingJql")
+    const parsed = JSON.parse(result) as unknown[]
+    assert.equal(parsed.length, 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildCloudIdErrorHint tests (Issue #5)
+// ---------------------------------------------------------------------------
+
+describe("buildCloudIdErrorHint", () => {
+  it("returns getAccessibleAtlassianResources hint when no default cloudId", () => {
+    const hint = buildCloudIdErrorHint(undefined)
+    assert.ok(hint.includes("getAccessibleAtlassianResources"))
+  })
+
+  it("returns default cloud ID hint when default is set", () => {
+    const hint = buildCloudIdErrorHint("08986a80-a6ed-4480-ae2d-4a439d50d71b")
+    assert.ok(hint.includes("configured default cloud ID"))
+    assert.ok(hint.includes("omit the cloudId parameter"))
+  })
+})
+
+describe("slimMcpResultContent — cloudId error nudge (Issue #5)", () => {
+  it("appends hint to plain text cloudId error without default", () => {
+    const errText = `${CLOUD_ID_ERROR_PATTERN}: abc-123. Status: 404`
+    const content = [{ type: "text", text: errText }]
+    const result = slimMcpResultContent(content, "getJiraIssue")
+    assert.ok(result.includes(CLOUD_ID_ERROR_PATTERN))
+    assert.ok(result.includes("getAccessibleAtlassianResources"))
+  })
+
+  it("appends default-cloudId hint when default is configured", () => {
+    const errText = `${CLOUD_ID_ERROR_PATTERN}: abc-123. Status: 404`
+    const content = [{ type: "text", text: errText }]
+    const result = slimMcpResultContent(content, "getJiraIssue", "08986a80-a6ed-4480-ae2d-4a439d50d71b")
+    assert.ok(result.includes("configured default cloud ID"))
+    assert.ok(!result.includes("getAccessibleAtlassianResources"))
+  })
+
+  it("does not append hint when no cloudId error", () => {
+    const content = [{ type: "text", text: "Some normal response" }]
+    const result = slimMcpResultContent(content, "getJiraIssue")
+    assert.ok(!result.includes("Hint:"))
   })
 })
 

--- a/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
@@ -357,20 +357,26 @@ describe("buildCloudIdErrorHint", () => {
 })
 
 describe("slimMcpResultContent — cloudId error nudge (Issue #5)", () => {
-  it("appends hint to plain text cloudId error without default", () => {
+  it("appends hint exactly once to plain text cloudId error without default", () => {
     const errText = `${CLOUD_ID_ERROR_PATTERN}: abc-123. Status: 404`
     const content = [{ type: "text", text: errText }]
     const result = slimMcpResultContent(content, "getJiraIssue")
     assert.ok(result.includes(CLOUD_ID_ERROR_PATTERN))
     assert.ok(result.includes("getAccessibleAtlassianResources"))
+    // Hint must appear exactly once, not twice
+    const hintText = "getAccessibleAtlassianResources to discover valid cloud IDs"
+    assert.equal(result.indexOf(hintText), result.lastIndexOf(hintText), "hint appeared more than once")
   })
 
-  it("appends default-cloudId hint when default is configured", () => {
+  it("appends default-cloudId hint exactly once when default is configured", () => {
     const errText = `${CLOUD_ID_ERROR_PATTERN}: abc-123. Status: 404`
     const content = [{ type: "text", text: errText }]
     const result = slimMcpResultContent(content, "getJiraIssue", "08986a80-a6ed-4480-ae2d-4a439d50d71b")
     assert.ok(result.includes("configured default cloud ID"))
     assert.ok(!result.includes("getAccessibleAtlassianResources"))
+    // Hint must appear exactly once, not twice
+    const hintText = "configured default cloud ID"
+    assert.equal(result.indexOf(hintText), result.lastIndexOf(hintText), "hint appeared more than once")
   })
 
   it("does not append hint when no cloudId error", () => {

--- a/modules/programs/prism/pi/extensions/atlassian/slim.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.ts
@@ -14,9 +14,11 @@ export const UNIVERSAL_DROP_KEYS = new Set(
     .filter(Boolean),
 )
 
-// Fields to drop from Jira issue responses
+// Fields to drop from Jira issue responses.
+// Note: "transitions" is intentionally NOT in this list because the getJiraIssue
+// response is augmented with a transitions array (Issue #2) and we want it preserved.
 export const JIRA_ISSUE_DROP_KEYS = new Set(
-  "renderedFields,operations,permissions,transitions,watchers,worklog,attachments,properties,names,subtask,hierarchyLevel,editmeta,versionedRepresentations,colorName"
+  "renderedFields,operations,permissions,watchers,worklog,attachments,properties,names,subtask,hierarchyLevel,editmeta,versionedRepresentations,colorName"
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean),
@@ -159,14 +161,53 @@ export function slimJson(value: unknown, options: SlimOptions, depth = 0): unkno
 }
 
 /**
+ * Deduplicate an array of resources (e.g. from getAccessibleAtlassianResources)
+ * by their `id` field. Order is preserved; first occurrence wins.
+ */
+export function deduplicateById<T extends Record<string, unknown>>(items: T[]): T[] {
+  const seen = new Set<unknown>()
+  const result: T[] = []
+  for (const item of items) {
+    const id = item["id"]
+    if (!seen.has(id)) {
+      seen.add(id)
+      result.push(item)
+    }
+  }
+  return result
+}
+
+/**
+ * Pattern that indicates a wrong/missing cloudId error from the upstream MCP.
+ */
+export const CLOUD_ID_ERROR_PATTERN = "Failed to fetch tenant info for cloud ID"
+
+/**
+ * Build the hint to append when a cloudId error is detected.
+ * If defaultCloudId is set, the hint points to using the default.
+ * Otherwise it points to getAccessibleAtlassianResources.
+ */
+export function buildCloudIdErrorHint(defaultCloudId: string | undefined): string {
+  if (defaultCloudId) {
+    return "\nHint: this site has a configured default cloud ID — omit the cloudId parameter to use it."
+  }
+  return "\nHint: call getAccessibleAtlassianResources to discover valid cloud IDs."
+}
+
+/**
  * Apply slim field-drop logic to the text content of an MCP tool result.
  * The MCP result content is an array of {type, text} blocks.
  * For each text block, parse as JSON (if possible) and apply slimJson.
  * Returns a string (the slimmed text content).
+ *
+ * Also applies post-processing:
+ * - Deduplicates resources by id for getAccessibleAtlassianResources.
+ * - Appends a hint when a cloudId error is detected.
  */
 export function slimMcpResultContent(
   content: unknown,
   toolName: string,
+  defaultCloudId?: string,
 ): string {
   if (!Array.isArray(content)) {
     return typeof content === "string" ? content : JSON.stringify(content)
@@ -186,15 +227,35 @@ export function slimMcpResultContent(
         // Try to parse as JSON and slim
         try {
           const parsed = JSON.parse(text)
-          const slimmed = slimJson(parsed, options)
+
+          // Issue #4: deduplicate resources for getAccessibleAtlassianResources
+          let processed: unknown = parsed
+          if (
+            toolName === "getAccessibleAtlassianResources" &&
+            Array.isArray(parsed)
+          ) {
+            processed = deduplicateById(parsed as Record<string, unknown>[])
+          }
+
+          const slimmed = slimJson(processed, options)
           parts.push(JSON.stringify(slimmed))
         } catch {
           // Not JSON — pass through as-is
-          parts.push(text)
+          // Issue #5: append hint for cloudId errors
+          if (text.includes(CLOUD_ID_ERROR_PATTERN)) {
+            parts.push(text + buildCloudIdErrorHint(defaultCloudId))
+          } else {
+            parts.push(text)
+          }
         }
       }
     }
   }
 
-  return parts.join("\n")
+  // Issue #5: also check if the joined result contains the error pattern (JSON-parsed path)
+  const joined = parts.join("\n")
+  if (joined.includes(CLOUD_ID_ERROR_PATTERN)) {
+    return joined + buildCloudIdErrorHint(defaultCloudId)
+  }
+  return joined
 }

--- a/modules/programs/prism/pi/extensions/atlassian/slim.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.ts
@@ -241,12 +241,7 @@ export function slimMcpResultContent(
           parts.push(JSON.stringify(slimmed))
         } catch {
           // Not JSON — pass through as-is
-          // Issue #5: append hint for cloudId errors
-          if (text.includes(CLOUD_ID_ERROR_PATTERN)) {
-            parts.push(text + buildCloudIdErrorHint(defaultCloudId))
-          } else {
-            parts.push(text)
-          }
+          parts.push(text)
         }
       }
     }

--- a/modules/programs/prism/skills/atlassian/SKILL.md
+++ b/modules/programs/prism/skills/atlassian/SKILL.md
@@ -40,6 +40,39 @@ The `ATLASSIAN_SITE`, `ATLASSIAN_EMAIL`, and `ATLASSIAN_API_TOKEN` environment
 variables are **not used** by the pi MCP extension and are not forwarded into
 agent sandboxes.
 
+### cloudId — single-site vs multi-site setup
+
+Most Atlassian MCP tools require a `cloudId` parameter (UUID identifying your
+Atlassian site). How you handle this depends on how the host is configured:
+
+**Single-site setup (default cloud ID configured)**
+
+If `nx.programs.prism.pi.atlassian.defaultCloudId` is set in the NixOS config
+(exposed as `ATLASSIAN_DEFAULT_CLOUD_ID`), the extension automatically injects
+the default cloud ID into every tool call that omits it. In this setup:
+
+- **Do not pass `cloudId`** on tool calls — it is injected automatically.
+- **Do not call `getCloudId` or `getAccessibleAtlassianResources` first** —
+  those round-trips are unnecessary.
+- Tool descriptions will mark `cloudId` as optional and document the default.
+
+Example for `thankyoupayroll.atlassian.net` (cloudId `08986a80-a6ed-4480-ae2d-4a439d50d71b`):
+```
+getJiraIssue(issueIdOrKey: "PLAT-182")
+# cloudId is omitted — the default is injected automatically
+```
+
+**Multi-site setup (no default configured)**
+
+If no default is configured, `cloudId` is required on every call. Discover
+valid cloud IDs with:
+```
+getAccessibleAtlassianResources()
+# or
+getCloudId()  # if you have a site link or only an issue key
+```
+Then pass the UUID explicitly on each tool call.
+
 ### Available tools (31 tools via OAuth)
 
 The extension exposes the full Jira and Confluence CRUD surface:
@@ -54,8 +87,9 @@ The extension exposes the full Jira and Confluence CRUD surface:
 - `createJiraIssue` — file a new issue
 - `editJiraIssue` — update issue fields
 - `addCommentToJiraIssue` — comment on an issue
-- `getTransitionsForJiraIssue` — list available transitions
-- `transitionJiraIssue` — move an issue to a new status
+- `getTransitionsForJiraIssue` — list available transitions (falls back to REST API if upstream returns empty)
+- `transitionJiraIssue` — move an issue to a new status by transition ID
+- `transitionJiraIssueByName` — move an issue to a new status by transition name (preferred; resolves name to ID automatically)
 - `getJiraIssueRemoteIssueLinks` — remote links
 - `getVisibleJiraProjects` — list projects
 - `getJiraProjectIssueTypesMetadata` — issue type metadata for a project
@@ -114,10 +148,19 @@ createJiraIssue(
 # Comment
 addCommentToJiraIssue(issueKey: "FOO-123", comment: "Confirmed fixed in staging.")
 
-# List transitions, then transition
+# Transition by name (preferred — no need to look up transition IDs)
+transitionJiraIssueByName(issueIdOrKey: "FOO-123", transitionName: "In Progress")
+
+# Or: list transitions, then transition by ID
 getTransitionsForJiraIssue(issueKey: "FOO-123")
 transitionJiraIssue(issueKey: "FOO-123", transitionId: "31")
 ```
+
+The `transitionJiraIssueByName` tool resolves the transition name
+case-insensitively and calls through to `transitionJiraIssue` automatically.
+If the name matches no available transition, it returns an error listing the
+available names. `getJiraIssue` also returns a `transitions` array so you
+can see available transitions alongside the issue data.
 
 ### Confluence: fetch-edit-push
 


### PR DESCRIPTION
Closes #1615

## Summary

All six usability issues from #1615 addressed in a single PR.

### Issue #1 — transition discovery fallback
- `getTransitionsForJiraIssue` now falls back to `GET /rest/api/3/issue/{key}/transitions` when the upstream MCP tool returns `{}`
- Returns clear error strings: `"issue not found"` (404), `"permission"` (403/401)
- Non-empty upstream results pass through unchanged

### Issue #2 — transition by name
- New synthetic tool `transitionJiraIssueByName`: accepts `{cloudId, issueIdOrKey, transitionName}`, resolves name case-insensitively, calls `transitionJiraIssue`
- Returns error listing available names when name not found; lists colliding transitions when ambiguous
- `getJiraIssue` response augmented with a `transitions` array (extra REST call, best-effort)
- Removed `transitions` from `JIRA_ISSUE_DROP_KEYS` so the injected array is preserved

### Issue #3 — default cloudId
- New Nix option `nx.programs.prism.pi.atlassian.defaultCloudId` (str, default `""`)
- Exposed as `ATLASSIAN_DEFAULT_CLOUD_ID` env var in the pi shell alias
- When set: cloudId injected into every tool call that omits it; tool descriptions updated to mark cloudId optional
- Atlassian skill updated with single-site (no cloudId needed) vs multi-site guidance

### Issue #4 — deduplicate resources
- `slim.ts`: `deduplicateById()` deduplicates `getAccessibleAtlassianResources` response by `id` (first occurrence wins)
- Unit tests cover: two identical entries, matching id + different name, order preservation

### Issue #5 — error-message nudge
- When error matches `"Failed to fetch tenant info for cloud ID"`, appends:
  - Without default: `"Hint: call getAccessibleAtlassianResources to discover valid cloud IDs."`
  - With default: `"Hint: this site has a configured default cloud ID — omit the cloudId parameter to use it."`

### Issue #6 — getCloudId wording
- Added: `"If you only have an issue key and don't know the site, call this tool first."`

## Quality gates

- `tsx --test slim.test.ts`: 32/32 pass
- `go build ./...` and `go test ./...` (prism): pass (tmux/integration pre-existing failures on main)
- `nix build .#prism`: succeeds
- `nixfmt .` applied to pi.nix