### PR TITLE
Drop -subagent suffix from review agents (#1619)

### DIFF
--- a/modules/programs/prism/agents/ac.md
+++ b/modules/programs/prism/agents/ac.md
@@ -1,7 +1,6 @@
 ---
 name: ac
 description: Writes or reviews acceptance criteria for a ticket, issue, or prompt. Invoke before coding starts to produce a tagged AC checklist, or against an existing AC list to critique and improve it.
-mode: subagent
 hidden: true
 ---
 

--- a/modules/programs/prism/agents/coordinator.md
+++ b/modules/programs/prism/agents/coordinator.md
@@ -1,7 +1,6 @@
 ---
 name: coordinator
 description: Repo coordinator — orchestrates agents, reviews PRs, and merges completed work.
-mode: primary
 hidden: false
 ---
 

--- a/modules/programs/prism/agents/investigate.md
+++ b/modules/programs/prism/agents/investigate.md
@@ -1,7 +1,6 @@
 ---
 name: investigate
 description: Read-only investigator agent — traces call chains, reproduces failures, and reports findings to the coordinator. Does not write code, open PRs, or spawn agents.
-mode: primary
 hidden: false
 ---
 

--- a/modules/programs/prism/agents/retro.md
+++ b/modules/programs/prism/agents/retro.md
@@ -1,7 +1,6 @@
 ---
 name: retro
 description: Analyses agent sessions for quality patterns and improvement opportunities. Invoke for periodic retrospectives or to diagnose a specific session that went badly.
-mode: subagent
 hidden: true
 ---
 

--- a/modules/programs/prism/agents/review-code.md
+++ b/modules/programs/prism/agents/review-code.md
@@ -1,13 +1,12 @@
 ---
-name: review-code-subagent
-description: Code quality and bugs subagent — reviews the diff and changed files for correctness, patterns, and structural issues. Invoke in parallel with other review-* agents before merging.
-mode: subagent
+name: review-code
+description: Code quality and bugs reviewer — reviews the diff and changed files for correctness, patterns, and structural issues. Invoke in parallel with other review-* agents before merging.
 hidden: true
 ---
 
 You are a code quality reviewer. Your sole concern is: **is this code correct and well-written?**
 
-You do not check whether the right thing was built (that is `@review-goal-subagent`), whether it is secure (that is `@review-security-subagent`), or whether it works end-to-end (that is `@review-qa-subagent`). Focus exclusively on code quality, correctness, and structure.
+You do not check whether the right thing was built (that is `@review-goal`), whether it is secure (that is `@review-security`), or whether it works end-to-end (that is `@review-qa`). Focus exclusively on code quality, correctness, and structure.
 
 ---
 

--- a/modules/programs/prism/agents/review-context.md
+++ b/modules/programs/prism/agents/review-context.md
@@ -1,7 +1,6 @@
 ---
-name: review-context-subagent
-description: Context and completeness subagent — investigates whether the implementation missed context from git history, GitHub issues, or related code. Invoke in parallel with other review-* agents before merging.
-mode: subagent
+name: review-context
+description: Context and completeness reviewer — investigates whether the implementation missed context from git history, GitHub issues, or related code. Invoke in parallel with other review-* agents before merging.
 hidden: true
 ---
 

--- a/modules/programs/prism/agents/review-goal.md
+++ b/modules/programs/prism/agents/review-goal.md
@@ -1,7 +1,6 @@
 ---
-name: review-goal-subagent
-description: Requirements verification subagent — validates that the implementation satisfies the original issue and acceptance criteria. Invoke in parallel with other review-* agents before merging.
-mode: subagent
+name: review-goal
+description: Requirements verification reviewer — validates that the implementation satisfies the original issue and acceptance criteria. Invoke in parallel with other review-* agents before merging.
 hidden: true
 ---
 

--- a/modules/programs/prism/agents/review-qa.md
+++ b/modules/programs/prism/agents/review-qa.md
@@ -1,7 +1,6 @@
 ---
-name: review-qa-subagent
-description: Functional validation subagent — verifies the change actually works by running project-appropriate tests and validation. Invoke in parallel with other review-* agents before merging.
-mode: subagent
+name: review-qa
+description: Functional validation reviewer — verifies the change actually works by running project-appropriate tests and validation. Invoke in parallel with other review-* agents before merging.
 hidden: true
 ---
 

--- a/modules/programs/prism/agents/review-security.md
+++ b/modules/programs/prism/agents/review-security.md
@@ -1,7 +1,6 @@
 ---
-name: review-security-subagent
-description: Security audit subagent — exclusively reviews for security vulnerabilities. Invoke in parallel with other review-* agents before merging.
-mode: subagent
+name: review-security
+description: Security audit reviewer — exclusively reviews for security vulnerabilities. Invoke in parallel with other review-* agents before merging.
 hidden: true
 ---
 

--- a/modules/programs/prism/agents/worker.md
+++ b/modules/programs/prism/agents/worker.md
@@ -1,7 +1,6 @@
 ---
 name: worker
 description: Default worker agent — implements features, fixes bugs, and opens PRs.
-mode: primary
 hidden: false
 ---
 
@@ -158,32 +157,6 @@ Prefer actioning observations that:
 
 Avoid cosmetic bikeshedding that invites another full review round for no
 substantive gain. When in doubt, ship the PR as-is — review rounds aren't free.
-
-### Fallback: Task-call subagents
-
-**This fallback is only applicable when the `task` tool is present in your active toolset (i.e. you are running under a non-pi harness). If you are running under the pi harness (the primary harness), the `task` tool is not available — `prism review` is the only supported review path. Pi harness agents must NOT attempt to invoke Task subagents.**
-
-If `prism review` is unavailable or the environment does not support it, invoke
-the five review subagents **in parallel** (in a single response with 5 Task tool
-calls) as a fallback:
-
-1. `@review-goal-subagent` — pass the original issue/ACs and the PR number
-2. `@review-code-subagent` — pass the PR number
-3. `@review-security-subagent` — pass the PR number
-4. `@review-qa-subagent` — pass the PR number
-5. `@review-context-subagent` — pass the PR number
-
-Wait for all 5 to complete. **ALL must return `<verdict>PASS</verdict>` for the
-review to pass.**
-
-If ANY agent returns `<verdict>FAIL</verdict>`:
-
-1. Read each agent's `<blocking_issues>` carefully
-2. Fix every blocking issue identified
-3. Commit and push your fixes
-4. Re-run all 5 review subagents in parallel — not just the ones that failed.
-   A fix in one area can create issues in another, so the full set must re-run
-   every cycle.
 
 ### Escalating to the coordinator — a first-class outcome
 

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -22,8 +22,8 @@ func TestAgentsForHarness_ReturnsAllFive(t *testing.T) {
 		t.Fatalf("agentsForHarness(pi): got %d agents, want %d", len(agents), len(want))
 	}
 	for i, a := range agents {
-		if a.Name != want[i].Name || a.OpencodeName != want[i].OpencodeName {
-			t.Errorf("agent[%d]: got {%q, %q}, want {%q, %q}", i, a.Name, a.OpencodeName, want[i].Name, want[i].OpencodeName)
+		if a.Name != want[i].Name {
+			t.Errorf("agent[%d]: got %q, want %q", i, a.Name, want[i].Name)
 		}
 	}
 }
@@ -46,9 +46,7 @@ func TestAgentsForHarness_AgentNames(t *testing.T) {
 		if agents[i].Name != name {
 			t.Errorf("agents[%d].Name = %q, want %q", i, agents[i].Name, name)
 		}
-		if agents[i].OpencodeName != name {
-			t.Errorf("agents[%d].OpencodeName = %q, want %q", i, agents[i].OpencodeName, name)
-		}
+
 	}
 }
 
@@ -427,9 +425,7 @@ func TestCheckAgentAvailability_PassesWhenAllFilesPresent(t *testing.T) {
 
 	agents := review.Agents()
 	for _, ag := range agents {
-		// Pre-flight checks <ValidationName>.md (i.e. "review-goal-subagent.md"),
-		// not <Name>.md — see #1231.
-		path := agentsDir + "/" + ag.ValidationName + ".md"
+		path := agentsDir + "/" + ag.Name + ".md"
 		if err := os.WriteFile(path, []byte("# "+ag.Name), 0o644); err != nil {
 			t.Fatalf("WriteFile %s: %v", path, err)
 		}

--- a/modules/programs/prism/prism/internal/review/agents.go
+++ b/modules/programs/prism/prism/internal/review/agents.go
@@ -17,34 +17,19 @@ import (
 type Agent struct {
 	// Name is the agent identifier, e.g. "review-goal". Used for session
 	// names (~review-N-<Name>), root_agent_name in the DB, progress
-	// display, and as the AgentRole passed to the sidecar.
+	// display, as the AgentRole passed to the sidecar, and as the
+	// on-disk filename (<Name>.md) looked up by CheckAgentAvailability.
 	Name string
-	// OpencodeName is the opencode --agent flag value, e.g. "review-goal".
-	// This resolves to the primary agent definition declared in
-	// ~/.config/opencode/opencode.json.
-	OpencodeName string
-	// ValidationName is the bare role name whose <name>.md definition file
-	// the host-mode pre-flight check looks for under
-	// $XDG_CONFIG_HOME/opencode/agents/. The five review agents are
-	// declared as primaries in opencode.json (resolved via OpencodeName)
-	// but their on-disk markdown bodies live under "-subagent" filenames
-	// to avoid the name-collision regression described in #1231 — so
-	// validation must look at "<role>-subagent.md", not "<role>.md".
-	ValidationName string
 }
 
 // Agents returns the five-agent review set.
-// Each agent corresponds to a specialised opencode agent definition under
-// modules/programs/prism/opencode/agents/. The bare-name primaries are
-// declared in opencode.json; the on-disk markdown subagent bodies are
-// named "<role>-subagent.md" — see ValidationName.
 func Agents() []Agent {
 	return []Agent{
-		{Name: "review-goal", OpencodeName: "review-goal", ValidationName: "review-goal-subagent"},
-		{Name: "review-code", OpencodeName: "review-code", ValidationName: "review-code-subagent"},
-		{Name: "review-security", OpencodeName: "review-security", ValidationName: "review-security-subagent"},
-		{Name: "review-qa", OpencodeName: "review-qa", ValidationName: "review-qa-subagent"},
-		{Name: "review-context", OpencodeName: "review-context", ValidationName: "review-context-subagent"},
+		{Name: "review-goal"},
+		{Name: "review-code"},
+		{Name: "review-security"},
+		{Name: "review-qa"},
+		{Name: "review-context"},
 	}
 }
 
@@ -60,10 +45,8 @@ type RoleValidator func(role string) error
 // the active harness adapter. Returns a descriptive error listing any
 // invalid agents; returns nil when all are valid.
 //
-// Validation is performed against ValidationName when set (i.e. the
-// "-subagent" form for review agents), falling back to Name when empty.
-// This decouples the on-disk filename from the role identifier — see the
-// Agent struct doc and #1231.
+// Validation is performed against Agent.Name, which matches the on-disk
+// filename (<Name>.md) directly.
 //
 // This is intentionally skipped in container mode because the check cannot
 // reliably inspect the container filesystem.
@@ -71,11 +54,7 @@ func CheckAgentAvailability(agents []Agent, validate RoleValidator) error {
 	var invalid []string
 	var firstErr error
 	for _, ag := range agents {
-		validationName := ag.ValidationName
-		if validationName == "" {
-			validationName = ag.Name
-		}
-		if err := validate(validationName); err != nil {
+		if err := validate(ag.Name); err != nil {
 			invalid = append(invalid, ag.Name)
 			if firstErr == nil {
 				firstErr = err

--- a/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
@@ -77,7 +77,7 @@ func TestMonitor_FailedReadyAgent_DoesNotBlockGroupCompleted(t *testing.T) {
 	// "error". Drive the same code path here by running the gate with a
 	// short timeout and no readiness signal for sessFailed.
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-goal"},
 	}
 	sessions := []string{sessFailed}
 	spawnErr := make([]error, 1)

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -37,8 +37,8 @@ func TestMonitorFunc_DetectsCompletionAndDelivers(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@monitor-test"
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
-		{Name: "review-code", OpencodeName: "review-code"},
+		{Name: "review-goal"},
+		{Name: "review-code"},
 	}
 
 	// Register a group.
@@ -141,7 +141,7 @@ func TestMonitorFunc_FlipsReviewingToActiveBeforeDelivery(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@monitor-flip-test"
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-goal"},
 	}
 
 	groupID, err := d.RegisterGroup(parent)
@@ -225,7 +225,7 @@ func TestMonitorFunc_DeliveryFailure_WritesFallbackFile(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@delivery-fail-test"
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-goal"},
 	}
 
 	groupID, err := d.RegisterGroup(parent)
@@ -294,8 +294,8 @@ func TestMonitorFunc_MissingSession(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@missing-session-test"
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
-		{Name: "review-code", OpencodeName: "review-code"},
+		{Name: "review-goal"},
+		{Name: "review-code"},
 	}
 
 	groupID, err := d.RegisterGroup(parent)
@@ -789,8 +789,8 @@ func TestLoadMonitorOptsFromFile_RoundTrip(t *testing.T) {
 		PRNumber:      "864",
 		Round:         2,
 		Agents: []review.Agent{
-			{Name: "review-goal", OpencodeName: "review-goal"},
-			{Name: "review-code", OpencodeName: "review-code"},
+			{Name: "review-goal"},
+			{Name: "review-code"},
 		},
 		AgentSessions: []string{
 			"nixos-config@test~review-2-review-goal",

--- a/modules/programs/prism/prism/internal/review/prompt.go
+++ b/modules/programs/prism/prism/internal/review/prompt.go
@@ -25,8 +25,7 @@ import (
 // that agents read full context first and role directives second.
 //
 // roleFile is the filename stem for the agent's definition file under
-// $XDG_CONFIG_HOME/prism/agents/ (e.g. "review-goal-subagent", which
-// is Agent.ValidationName). The file contents are spliced into the prompt
+// $XDG_CONFIG_HOME/prism/agents/ (e.g. "review-goal"). The file contents are spliced into the prompt
 // in place of the former "Your role-specific instructions follow below."
 // trailer so that every harness (including PI) receives the full role rubric
 // inline.
@@ -182,10 +181,8 @@ func buildReviewPrompt(prNumber string, prCtx *PRContext, roleFile string) strin
 // resolveRoleDefinition reads the role definition file for the given agent
 // from the opencode agents directory ($XDG_CONFIG_HOME/prism/agents/).
 //
-// roleFile is the filename stem (without the .md extension). For the five
-// standard review agents this is Agent.ValidationName — the "-subagent"
-// form (e.g. "review-goal-subagent"), because the on-disk files are named
-// after the subagent declaration, not the primary agent name (#1231).
+// roleFile is the filename stem (without the .md extension), e.g. "review-goal".
+// It matches Agent.Name directly — the on-disk file is <roleFile>.md.
 //
 // When the file is present and non-empty its contents are returned verbatim.
 // When the file is missing or empty a clearly-marked notice is returned instead

--- a/modules/programs/prism/prism/internal/review/prompt_test.go
+++ b/modules/programs/prism/prism/internal/review/prompt_test.go
@@ -35,19 +35,15 @@ func setupAgentsDir(t *testing.T) string {
 // definition file exists and is non-empty, its full content appears in the
 // prompt under the "## Your role-specific instructions" heading.
 //
-// The file is named using the ValidationName form ("review-security-subagent.md")
-// to match the actual on-disk layout (#1231).
 func TestBuildReviewPrompt_RoleFilePresentAndSpliced(t *testing.T) {
 	agentsDir := setupAgentsDir(t)
 
 	const roleContent = "# review-security\n\nYou are a security auditor. Check for vulnerabilities.\n"
-	// Files on disk use the "-subagent" suffix (Agent.ValidationName form).
-	if err := os.WriteFile(filepath.Join(agentsDir, "review-security-subagent.md"), []byte(roleContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(agentsDir, "review-security.md"), []byte(roleContent), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	// Pass the ValidationName ("review-security-subagent") as the roleFile argument.
-	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-security-subagent")
+	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-security")
 
 	// Role-section header must be present.
 	if !findSubstring(prompt, "## Your role-specific instructions") {
@@ -67,20 +63,17 @@ func TestBuildReviewPrompt_RoleFilePresentAndSpliced(t *testing.T) {
 // the five review agents receives the content of its own definition file,
 // not a shared or empty block.
 //
-// Files are written using the ValidationName ("-subagent") suffix to match
-// the actual on-disk layout rendered by the NixOS module (#1231).
 func TestBuildReviewPrompt_AllFiveRolesGetTheirOwnRubric(t *testing.T) {
 	agentsDir := setupAgentsDir(t)
 
-	// validationNames mirrors Agent.ValidationName for each review agent.
-	validationNames := []string{
-		"review-goal-subagent",
-		"review-code-subagent",
-		"review-security-subagent",
-		"review-qa-subagent",
-		"review-context-subagent",
+	roles := []string{
+		"review-goal",
+		"review-code",
+		"review-security",
+		"review-qa",
+		"review-context",
 	}
-	for _, vn := range validationNames {
+	for _, vn := range roles {
 		content := "# " + vn + " unique rubric content\n"
 		if err := os.WriteFile(filepath.Join(agentsDir, vn+".md"), []byte(content), 0o644); err != nil {
 			t.Fatalf("WriteFile for %s: %v", vn, err)
@@ -88,14 +81,14 @@ func TestBuildReviewPrompt_AllFiveRolesGetTheirOwnRubric(t *testing.T) {
 	}
 
 	ctx := samplePRContext()
-	for _, vn := range validationNames {
+	for _, vn := range roles {
 		prompt := review.BuildReviewPromptForTest("99", ctx, vn)
 		expectedContent := vn + " unique rubric content"
 		if !findSubstring(prompt, expectedContent) {
 			t.Errorf("role %q: prompt missing expected rubric content %q\nprompt:\n%s", vn, expectedContent, prompt)
 		}
 		// Other roles' content must NOT appear (each prompt is distinct).
-		for _, otherVN := range validationNames {
+		for _, otherVN := range roles {
 			if otherVN == vn {
 				continue
 			}
@@ -130,20 +123,18 @@ func TestBuildReviewPrompt_MissingRoleFile_NoErrorNoPanic(t *testing.T) {
 // role definition file is absent, the prompt includes a clearly-marked notice
 // so the receiving agent and human readers can see what happened.
 //
-// The roleFile argument uses the ValidationName form ("review-goal-subagent")
-// since that is what the call sites pass.
 func TestBuildReviewPrompt_MissingRoleFile_ContainsNotice(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-goal-subagent")
+	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-goal")
 
 	// Must contain a notice mentioning the roleFile stem and "not found".
-	if !findSubstring(prompt, "role definition for review-goal-subagent not found") {
-		t.Errorf("prompt should contain 'role definition for review-goal-subagent not found'\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "role definition for review-goal not found") {
+		t.Errorf("prompt should contain 'role definition for review-goal not found'\nprompt:\n%s", prompt)
 	}
 	// The notice must name the path so readers know where to look.
-	if !findSubstring(prompt, "prism/agents/review-goal-subagent.md") {
+	if !findSubstring(prompt, "prism/agents/review-goal.md") {
 		t.Errorf("prompt should include the expected path in the notice\nprompt:\n%s", prompt)
 	}
 }
@@ -157,16 +148,15 @@ func TestBuildReviewPrompt_MissingRoleFile_ContainsNotice(t *testing.T) {
 func TestBuildReviewPrompt_EmptyRoleFile_ContainsSameNoticeAsMissing(t *testing.T) {
 	agentsDir := setupAgentsDir(t)
 
-	// Write a whitespace-only file using the ValidationName ("-subagent") suffix.
-	if err := os.WriteFile(filepath.Join(agentsDir, "review-code-subagent.md"), []byte("   \n\t\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(agentsDir, "review-code.md"), []byte("   \n\t\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-code-subagent")
+	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-code")
 
 	// Must contain the same "not found" notice as the missing-file case.
-	if !findSubstring(prompt, "role definition for review-code-subagent not found") {
-		t.Errorf("prompt should contain 'role definition for review-code-subagent not found' for empty file\nprompt:\n%s", prompt)
+	if !findSubstring(prompt, "role definition for review-code not found") {
+		t.Errorf("prompt should contain 'role definition for review-code not found' for empty file\nprompt:\n%s", prompt)
 	}
 }
 
@@ -176,12 +166,11 @@ func TestBuildReviewPrompt_EmptyRoleFile_ContainsSameNoticeAsMissing(t *testing.
 func TestBuildReviewPrompt_EmptyRoleFile_NoBlanksOnly(t *testing.T) {
 	agentsDir := setupAgentsDir(t)
 
-	// Use the ValidationName ("-subagent") suffix to match production layout.
-	if err := os.WriteFile(filepath.Join(agentsDir, "review-qa-subagent.md"), []byte(""), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(agentsDir, "review-qa.md"), []byte(""), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-qa-subagent")
+	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-qa")
 
 	// The role section must contain a notice, not just trailing whitespace.
 	if !findSubstring(prompt, "not found") {
@@ -197,12 +186,11 @@ func TestBuildReviewPrompt_EmptyRoleFile_NoBlanksOnly(t *testing.T) {
 func TestBuildReviewPrompt_TrailerAbsentWhenFilePresent(t *testing.T) {
 	agentsDir := setupAgentsDir(t)
 
-	// Use the ValidationName ("-subagent") suffix to match production layout.
-	if err := os.WriteFile(filepath.Join(agentsDir, "review-context-subagent.md"), []byte("# context rubric\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(agentsDir, "review-context.md"), []byte("# context rubric\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-context-subagent")
+	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-context")
 
 	if findSubstring(prompt, "Your role-specific instructions follow below.") {
 		t.Errorf("prompt must not contain the old dangling trailer\nprompt:\n%s", prompt)
@@ -215,7 +203,7 @@ func TestBuildReviewPrompt_TrailerAbsentWhenFileMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-security-subagent")
+	prompt := review.BuildReviewPromptForTest("42", samplePRContext(), "review-security")
 
 	if findSubstring(prompt, "Your role-specific instructions follow below.") {
 		t.Errorf("prompt must not contain the old dangling trailer\nprompt:\n%s", prompt)
@@ -230,13 +218,12 @@ func TestBuildReviewPrompt_TrailerAbsentWhenFileMissing(t *testing.T) {
 func TestBuildReviewPrompt_ContextSectionsUnchanged(t *testing.T) {
 	agentsDir := setupAgentsDir(t)
 
-	// Use the ValidationName ("-subagent") suffix to match production layout.
-	if err := os.WriteFile(filepath.Join(agentsDir, "review-goal-subagent.md"), []byte("role rubric\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(agentsDir, "review-goal.md"), []byte("role rubric\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
 	ctx := samplePRContext()
-	prompt := review.BuildReviewPromptForTest("819", ctx, "review-goal-subagent")
+	prompt := review.BuildReviewPromptForTest("819", ctx, "review-goal")
 
 	// All core context sections must still be present.
 	required := []string{

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -676,13 +676,7 @@ func TestAgents_AgentNames(t *testing.T) {
 		if agents[i].Name != name {
 			t.Errorf("agents[%d].Name = %q, want %q", i, agents[i].Name, name)
 		}
-		if agents[i].OpencodeName != name {
-			t.Errorf("agents[%d].OpencodeName = %q, want %q", i, agents[i].OpencodeName, name)
-		}
-		wantValidation := name + "-subagent"
-		if agents[i].ValidationName != wantValidation {
-			t.Errorf("agents[%d].ValidationName = %q, want %q", i, agents[i].ValidationName, wantValidation)
-		}
+
 	}
 }
 
@@ -711,9 +705,7 @@ func TestCheckAgentAvailability_AllPresent(t *testing.T) {
 
 	agents := review.Agents()
 	for _, ag := range agents {
-		// Pre-flight checks <ValidationName>.md (i.e. "review-goal-subagent.md"),
-		// not <Name>.md — see #1231.
-		if err := os.WriteFile(agentsDir+"/"+ag.ValidationName+".md", []byte("# "+ag.Name), 0o644); err != nil {
+		if err := os.WriteFile(agentsDir+"/"+ag.Name+".md", []byte("# "+ag.Name), 0o644); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
 	}
@@ -733,10 +725,8 @@ func TestCheckAgentAvailability_SomeMissing(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	// Only create review-goal-subagent.md; the other 4 are missing.
-	// Pre-flight checks <ValidationName>.md (i.e. the "-subagent" form),
-	// not <Name>.md — see #1231.
-	if err := os.WriteFile(agentsDir+"/review-goal-subagent.md", []byte("# review-goal"), 0o644); err != nil {
+	// Only create review-goal.md; the other 4 are missing.
+	if err := os.WriteFile(agentsDir+"/review-goal.md", []byte("# review-goal"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -745,7 +735,7 @@ func TestCheckAgentAvailability_SomeMissing(t *testing.T) {
 	if err == nil {
 		t.Fatal("CheckAgentAvailability: expected error for missing agents, got nil")
 	}
-	// Error should mention the missing agents (by Name, not ValidationName).
+	// Error should mention the missing agents by Name.
 	for _, ag := range agents[1:] {
 		if !findSubstring(err.Error(), ag.Name) {
 			t.Errorf("CheckAgentAvailability error does not mention missing agent %q: %v", ag.Name, err)
@@ -1413,8 +1403,8 @@ func TestPollAgents_ProgressCallback_HappyPath(t *testing.T) {
 	d := openTestDB(t)
 
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
-		{Name: "review-code", OpencodeName: "review-code"},
+		{Name: "review-goal"},
+		{Name: "review-code"},
 	}
 	sessions := []string{
 		"test@parent~review-1-review-goal",
@@ -1479,8 +1469,8 @@ func TestPollAgents_ProgressCallback_OnlySubset(t *testing.T) {
 
 	// Only 2 agents (simulating --only review-code,review-qa).
 	agents := []review.Agent{
-		{Name: "review-code", OpencodeName: "review-code"},
-		{Name: "review-qa", OpencodeName: "review-qa"},
+		{Name: "review-code"},
+		{Name: "review-qa"},
 	}
 	sessions := []string{
 		"test@parent~review-1-review-code",
@@ -1540,8 +1530,8 @@ func TestPollAgents_ProgressCallback_Timeout(t *testing.T) {
 	d := openTestDB(t)
 
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
-		{Name: "review-code", OpencodeName: "review-code"},
+		{Name: "review-goal"},
+		{Name: "review-code"},
 	}
 	sessions := []string{
 		"test@parent~review-5-review-goal",
@@ -1599,7 +1589,7 @@ func TestRun_ProgressCallback_SpawnFailure(t *testing.T) {
 
 	// Single agent to keep the test focused.
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
+		{Name: "review-goal"},
 	}
 
 	// podman mode with nil ProfilesFile: with the RequireSlot gate (#1224),
@@ -1723,11 +1713,11 @@ func TestPollAgents_SidecarPIDFilesNotRemovedAfterCompletion(t *testing.T) {
 	d := openTestDB(t)
 
 	agents := []review.Agent{
-		{Name: "review-goal", OpencodeName: "review-goal"},
-		{Name: "review-code", OpencodeName: "review-code"},
-		{Name: "review-security", OpencodeName: "review-security"},
-		{Name: "review-qa", OpencodeName: "review-qa"},
-		{Name: "review-context", OpencodeName: "review-context"},
+		{Name: "review-goal"},
+		{Name: "review-code"},
+		{Name: "review-security"},
+		{Name: "review-qa"},
+		{Name: "review-context"},
 	}
 	sessions := []string{
 		"test@parent~review-1-review-goal",
@@ -1950,13 +1940,12 @@ func TestBuildReviewPrompt_ContextBeforeRoleSection(t *testing.T) {
 	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	// Files on disk use the "-subagent" suffix (Agent.ValidationName form, #1231).
 	roleDef := "# Test role rubric\n\nReview carefully."
-	if err := os.WriteFile(filepath.Join(agentsDir, "review-goal-subagent.md"), []byte(roleDef), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(agentsDir, "review-goal.md"), []byte(roleDef), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	prompt := review.BuildReviewPromptForTest("819", ctx, "review-goal-subagent")
+	prompt := review.BuildReviewPromptForTest("819", ctx, "review-goal")
 
 	contextHeaderIdx := findLineIndex(prompt, "## Context for your review")
 	separatorIdx := findLineIndex(prompt, "---")

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -123,9 +123,7 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			ctxCopy.WorktreePath = worktree
 			prCtxWithWorktree = &ctxCopy
 		}
-		// Pass ag.ValidationName (the "-subagent" filename stem) so that
-		// resolveRoleDefinition finds the correct on-disk file (#1231).
-		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree, ag.ValidationName)
+		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree, ag.Name)
 
 		// Resolve the per-agent config blob. Each agent gets its own hardened
 		// opencode.json that declares only that one review agent.
@@ -436,9 +434,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			ctxCopy.WorktreePath = worktree
 			prCtxWithWorktree = &ctxCopy
 		}
-		// Pass ag.ValidationName (the "-subagent" filename stem) so that
-		// resolveRoleDefinition finds the correct on-disk file (#1231).
-		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree, ag.ValidationName)
+		prompt := buildReviewPrompt(opts.PRNumber, prCtxWithWorktree, ag.Name)
 
 		agentConfigContent, configErr := ResolveAgentConfigContent(opts.IsolationMode, opts.ProfilesFile, ag.Name, activeProfile)
 		if configErr != nil {

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -55,18 +55,8 @@
           ];
 
           # Map a role name to its agent prompt file (sans .md extension).
-          roleToAgentFile = {
-            coordinator = "coordinator";
-            worker = "worker";
-            ac = "ac";
-            retro = "retro";
-            investigate = "investigate";
-            "review-goal" = "review-goal-subagent";
-            "review-code" = "review-code-subagent";
-            "review-security" = "review-security-subagent";
-            "review-qa" = "review-qa-subagent";
-            "review-context" = "review-context-subagent";
-          };
+          # Since filenames now match role names directly, this is an identity map.
+          roleToAgentFile = lib.genAttrs piRoles (role: role);
 
           # Convenience: build a slot with a systemPromptPath derived from
           # the role's agent file. `thinking` defaults to "off" (the PI

--- a/modules/programs/prism/review-prompts/review-code.md
+++ b/modules/programs/prism/review-prompts/review-code.md
@@ -1,6 +1,6 @@
 You are a code quality reviewer. Your sole concern is: **is this code correct and well-written?**
 
-You do not check whether the right thing was built (that is `@review-goal-subagent`), whether it is secure (that is `@review-security-subagent`), or whether it works end-to-end (that is `@review-qa-subagent`). Focus exclusively on code quality, correctness, and structure.
+You do not check whether the right thing was built (that is `@review-goal`), whether it is secure (that is `@review-security`), or whether it works end-to-end (that is `@review-qa`). Focus exclusively on code quality, correctness, and structure.
 
 ---
 

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -196,7 +196,7 @@ prism spawn \
 
 ## Running code review
 
-> **Scope:** `prism review` and the Task-call fallback below are for **worker
+> **Scope:** `prism review` is for **worker
 > agents and spawned sessions only**. Coordinator agents must never call
 > `prism review` directly. When a user asks a coordinator to review a PR, the
 > coordinator should use `prism pr <number> --prompt 'review this PR'` to spawn
@@ -311,25 +311,6 @@ If no review-complete prompt arrives within 30 minutes, check progress with:
 ```bash
 prism checkin <session>~review-<N>-review-goal
 ```
-
-### Fallback: Task-call subagents
-
-> **Scope:** This fallback is for **worker and spawned sessions only** — not for
-> coordinators. Coordinator agents must use `prism pr` as described above.
-
-If `prism review` is unavailable, invoke the five subagents **in parallel** —
-all five as Task tool calls in a single response:
-
-1. `@review-goal-subagent` — pass the original issue/ACs and the PR number
-2. `@review-code-subagent` — pass the PR number
-3. `@review-security-subagent` — pass the PR number
-4. `@review-qa-subagent` — pass the PR number
-5. `@review-context-subagent` — pass the PR number
-
-Wait for all 5 to complete. ALL must return `<verdict>PASS</verdict>` for the
-review to pass. If ANY returns `<verdict>FAIL</verdict>`, fix all blocking
-issues, push, and re-run all five. After 3 full cycles without convergence,
-stop and escalate — do not run a 4th cycle.
 
 ## Investigator agents
 


### PR DESCRIPTION
Closes #1619

## Summary

Removes the opencode-era `-subagent` naming from the five review agent files and cleans up all associated dead code.

## Changes

**File renames (via git mv)**
- `review-{goal,code,security,qa,context}-subagent.md` → `review-{goal,code,security,qa,context}.md`

**Frontmatter cleanup**
- `mode:` line removed from all 10 agent files
- `name:` fields updated to match new filenames (no `-subagent` suffix)

**Go struct simplification**
- `Agent` struct collapses to single `Name` field; `OpencodeName` and `ValidationName` deleted
- `Agents()` returns bare role names (`review-goal`, etc.)
- `CheckAgentAvailability` looks up `<Name>.md` directly
- `run.go`: passes `ag.Name` to `buildReviewPrompt` (was `ag.ValidationName`)

**Test updates**
- All `OpencodeName`/`ValidationName` literals and assertions removed
- On-disk filename expectations updated to `<role>.md`
- `BuildReviewPromptForTest` callsites pass bare role names

**Profile/reference updates**
- `profiles.nix`: `roleToAgentFile` replaced with identity map (`lib.genAttrs piRoles (role: role)`)
- `review-prompts/review-code.md`: `@review-*-subagent` prose refs updated

**Task-call fallback deletion**
- Removed from `agents/worker.md`
- Removed from `skills/prism/SKILL.md`
- "and the Task-call fallback below" phrase removed from Scope note in SKILL.md

## ⚠️ Action required after merge

`nh switch` is required on every machine after merge to regenerate `~/.config/prism/profiles.json` with the new agent filenames. Until that switch happens, existing sessions may fail to find their system prompts.