### PR TITLE
Update default prism profile for navi

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -27,7 +27,7 @@
     };
     programs = {
       prism = {
-        profile.default = "anthropic-opus";
+        profile.default = "anthropic";
         agent.isolation.default = "bwrap";
 
         bwrapConcurrencyCap = 50;


### PR DESCRIPTION
Updated the default anthropic model profile from opus to a generic anthropic configuration. This change aligns the default profile with available model definitions on the navi machine.