### PR TITLE
Remove invalid bind mount for pi data directory

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -328,20 +328,14 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = appendBwrapBind(args, spec)
 	}
 
-	// ── opencode shared state dir (read-write) ─────────────────────────────
-	// bwrap sessions share the host's ~/.local/share/opencode/ directly: a
-	// single SQLite DB across all sessions (host mode, bwrap mode, and the
-	// non-prism opencode CLI). The per-session isolation used by the podman
-	// path exists solely to work around a virtiofs WAL-mode locking issue on
-	// Darwin — that path doesn't apply here because bwrap is Linux-only and
-	// SQLite WAL works correctly across concurrent processes on a shared
-	// filesystem.
-	//
-	// Kept inline: the mount semantics differ from podman's per-session
-	// state dir (which lives at /root/.local/share/opencode under a
-	// per-container subdir), so no shared spec entry exists.
-	piDataDir := filepath.Join(home, ".local", "share", "pi")
-	args = append(args, "--bind", piDataDir, piDataDir)
+	// NOTE: An unconditional --bind of ~/.local/share/pi used to live here as
+	// part of the opencode→pi rename in #1609. PI does NOT use that XDG path —
+	// it lives at ~/.pi/agent/ (see internal/harness/pi/archive.go). The mount
+	// was dead and broke fresh installs where the source directory did not
+	// exist (bwrap aborts on missing --bind sources). Removed locally to
+	// unblock `nh switch`; proper cleanup of the sandbox_exec.go SBPL rules,
+	// container.go per-session subdir, and dispatch.go archiveSharedStorageRoot
+	// to follow in a PR.
 
 	// ── Nix daemon socket dir (read-write) ──────────────────────────────────
 	// Mount the parent directory, not the socket file directly (same pattern

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -91,8 +91,6 @@ func bwrapFixture(t *testing.T, cfg Config) (m *Manager, fakeHome string, cleanu
 	dirs := []string{
 		filepath.Join(fakeHome, ".claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
-		// Shared opencode data dir — bound directly into the bwrap sandbox.
-		filepath.Join(fakeHome, ".local", "share", "pi"),
 		filepath.Join(fakeHome, ".cache", "nix"),
 	}
 	for _, d := range dirs {
@@ -402,12 +400,12 @@ func TestBwrapBuildArgs_McpAuthBound(t *testing.T) {
 	}
 }
 
-func TestBwrapBuildArgs_OpencodeSharedDirBound(t *testing.T) {
-	// bwrap mode binds the shared host opencode data dir
-	// (~/.local/share/pi/) directly into the sandbox so all sessions
-	// share a single SQLite DB. The per-session prism-sessions/<name>/
-	// isolation used by the podman path is not needed on Linux (no virtiofs
-	// WAL-mode locking issue) and is intentionally omitted here.
+func TestBwrapBuildArgs_PiXDGDirNotBound(t *testing.T) {
+	// ~/.local/share/pi is NOT bound into the bwrap sandbox. PI does not use
+	// that XDG path (it lives at ~/.pi/agent/); the old unconditional --bind
+	// was a dead mount from the opencode→pi rename that broke fresh installs
+	// where the source directory did not exist (bwrap aborts on missing
+	// --bind sources). Removed in #1622.
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -418,16 +416,9 @@ func TestBwrapBuildArgs_OpencodeSharedDirBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	sharedDir := filepath.Join(fakeHome, ".local", "share", "pi")
-	if !hasBind(args, sharedDir) {
-		t.Errorf("opencode shared data dir %q not found as --bind SRC SRC in args: %v", sharedDir, args)
-	}
-
-	// Confirm the per-session prism-sessions path is NOT bound — bwrap
-	// must use the shared dir, not the per-session one.
-	perSessionDir := filepath.Join(fakeHome, ".local", "share", "pi", "prism-sessions", m.name)
-	if hasBind(args, perSessionDir) {
-		t.Errorf("per-session opencode dir %q should NOT be bound in bwrap mode, but was: %v", perSessionDir, args)
+	xdgDir := filepath.Join(fakeHome, ".local", "share", "pi")
+	if hasBind(args, xdgDir) {
+		t.Errorf("~/.local/share/pi %q should NOT be bound in bwrap args (dead mount removed in #1622), but was: %v", xdgDir, args)
 	}
 }
 


### PR DESCRIPTION
The hardcoded bind mount of ~/.local/share/pi was incorrect, as the PI agent stores data in ~/.pi/agent/. This invalid path caused container startup failures on fresh installs where the source directory did not exist. Removing this mount unblocks the development environment while we prepare a more comprehensive cleanup of the sandbox orchestration.