### PR TITLE
fix(pi archive): correct SourcePath to encoded-cwd layout (#1629)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -984,6 +984,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 		SessionName:   sessionName,
 		InstanceID:    instanceID,
 		IsolationMode: statusIsolationMode,
+		Worktree:      sess.Worktree,
 	}
 	if sess.HarnessSessionID != nil {
 		srcParams.HarnessSessionID = *sess.HarnessSessionID

--- a/modules/programs/prism/prism/internal/harness/archive/archive.go
+++ b/modules/programs/prism/prism/internal/harness/archive/archive.go
@@ -26,6 +26,12 @@ type SourceParams struct {
 	HarnessSessionID string
 	// IsolationMode is "podman", "bwrap", "sandbox-exec", or "host".
 	IsolationMode string
+	// Worktree is the absolute path of the session's worktree (e.g.
+	// "/home/ben/code/nixos-config/feature"). Used by harnesses that
+	// organise on-disk session storage by cwd (e.g. pi encodes the cwd into
+	// the session directory name). May be empty for non-worktree sessions or
+	// when the harness does not need it.
+	Worktree string
 }
 
 // ArchiveAdapter is the interface each harness implements to plug into the

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -2,26 +2,40 @@ package pi
 
 // archive.go — PI implementation of harness/archive.ArchiveAdapter (B6.PI).
 //
-// PI stores session data as JSONL files on disk (RFC #606 "Session persistence":
-// "JSONL files with a tree structure (parent/child IDs for branching)").
+// PI stores session data as JSONL files on disk.
 // Unlike some harnesses, PI has no SQLite database — it is a pure flat-file store.
 //
-// Source path layout (confirmed via PI_CODING_AGENT_SESSION_DIR env var and
-// PI's --help which shows "~/.pi/agent/sessions/" as the export example path):
+// Source path layout (authoritative reference: docs/pi-rpc-interface.md Q5,
+// confirmed against pi 0.72.1 dist/core/session-manager.js line 213):
 //
-//   ~/.pi/agent/sessions/<harness_session_id>/
-//       session.jsonl        — the full conversation transcript
-//       [additional *.jsonl files per branch or compaction round]
+//	~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl
 //
-// The PI_CODING_AGENT_DIR defaults to ~/.pi/agent and session storage is a
-// subdirectory of it. The XDG path ~/.local/share/pi/sessions/ does NOT
-// exist — it was incorrectly assumed in issue #1419.
+// The <encoded-cwd> directory name is derived from the session's working
+// directory (p.Worktree) via encodePiCWD. The formula mirrors pi's own JS:
 //
-// Archive copies all *.jsonl files from the session directory into raw/.
-// Export normalises the raw JSONL to pi-mono v3 session.jsonl (currently a
-// near-identity pass since PI's JSONL is already pi-mono-shaped; the main
-// operation is stripping PI-internal fields prism does not consume and
-// canonicalising timestamps).
+//	--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--
+//
+// Strip the leading '/' (or '\'), replace every '/', '\', and ':' with '-',
+// wrap in "--…--". Example:
+//
+//	/home/ben/code/nixos-config/main → --home-ben-code-nixos-config-main--
+//
+// The session UUID (HarnessSessionID) is embedded in the filename, NOT used as
+// a directory name. The adapter locates the session file by scanning the
+// encoded-cwd directory for an entry matching "*_<HarnessSessionID>.jsonl".
+//
+// For sandbox-exec sessions (IsolationMode == "sandbox-exec"), PI writes to the
+// per-session staging HOME instead of the real home directory (bug #1538 fix).
+// The staging HOME is ~/.local/state/prism/sessions/<instance_id>/home/.
+// The worktree path that pi sees as its CWD is the same as the host worktree
+// path (sandbox-exec mounts it at its native path, only $HOME is remapped).
+// Therefore the encoded-cwd is derived from p.Worktree in both cases; only the
+// sessions root base (home) differs between host and sandbox-exec modes.
+//
+// Archive copies the single matched JSONL file into rawDir/session.jsonl so
+// that Export (which expects raw/session.jsonl) finds it without further change.
+// Export currently performs a near-identity normalisation pass (PI's on-disk
+// JSONL is already pi-mono v3 shaped).
 
 import (
 	"context"
@@ -45,23 +59,33 @@ func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
 	return &piArchiveAdapter{}
 }
 
-// SourcePath returns the host-side PI session directory for the session.
+// SourcePath returns the host-side PI session JSONL file path for the session.
 //
-// PI stores sessions under $HOME/.pi/agent/sessions/<harness_session_id>/.
-// This matches PI_CODING_AGENT_DIR (defaults to ~/.pi/agent) with the sessions/
-// subdirectory appended, and is confirmed by PI's own --help example path.
-// The harness_session_id is populated at session-create time when PI starts.
-// When HarnessSessionID is empty (PI failed to start), SourcePath returns the
-// sessions root directory; the caller handles the missing-directory case.
+// PI stores sessions at:
 //
-// For sandbox-exec sessions (IsolationMode == "sandbox-exec"), PI writes to the
-// staging HOME instead of the real home directory. The staging HOME path is:
-//   ~/.local/state/prism/sessions/<instance_id>/home/
-// So PI's session directory is <stagingHome>/.pi/agent/sessions/<harness_session_id>.
-// Bug #1538 fix #2: using os.UserHomeDir() for sandbox-exec sessions pointed at
-// the wrong directory — PI never wrote there.
+//	~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl
+//
+// where <encoded-cwd> is derived from p.Worktree via encodePiCWD, and <uuid>
+// matches p.HarnessSessionID. The adapter scans the encoded-cwd directory for
+// a file whose name ends in "_<HarnessSessionID>.jsonl" and returns its path.
+// If no match is found, a sentinel path inside the encoded-cwd dir is returned;
+// Archive treats non-existent paths as a no-op.
+//
+// When HarnessSessionID is empty (harness failed to start), or Worktree is
+// empty (non-worktree session), SourcePath returns the sessions root; Archive's
+// os.IsNotExist handling treats it as a no-op.
+//
+// For sandbox-exec sessions (IsolationMode == "sandbox-exec"), PI writes under
+// the staging HOME (<stagingHome>/.pi/agent/sessions/...) instead of the real
+// home directory. The worktree path pi uses as its CWD is the same host path in
+// both modes (sandbox-exec mounts the worktree at its native path), so the
+// encoded-cwd is derived from p.Worktree in both cases. Bug #1538 fix: only
+// the home base differs for sandbox-exec sessions.
+//
+// See docs/pi-rpc-interface.md Q5 for the authoritative path specification.
 func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, error) {
 	var home string
+
 	if p.IsolationMode == "sandbox-exec" && p.InstanceID != "" {
 		// sandbox-exec: PI writes into the per-session staging HOME, not
 		// the real home directory. Use the same path formula as
@@ -78,44 +102,60 @@ func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, er
 			return "", fmt.Errorf("pi archive: resolve home: %w", err)
 		}
 	}
+
 	sessionsRoot := filepath.Join(home, ".pi", "agent", "sessions")
-	if p.HarnessSessionID == "" {
+
+	if p.HarnessSessionID == "" || p.Worktree == "" {
+		// No session ID or no worktree: return sessions root.
+		// Archive's os.IsNotExist tolerance handles the missing-dir case.
 		return sessionsRoot, nil
 	}
-	return filepath.Join(sessionsRoot, p.HarnessSessionID), nil
-}
 
-// Archive copies PI's JSONL session files from srcPath into rawDir.
-//
-// All *.jsonl files found in srcPath are copied flat into rawDir. Subdirectory
-// traversal is intentionally shallow (RFC #606 describes the session directory
-// as a flat set of JSONL files). Missing files within srcPath are tolerated;
-// real I/O errors are propagated.
-//
-// When srcPath does not exist (PI failed to start or produced no output),
-// Archive returns nil and rawDir is left empty.
-func (a *piArchiveAdapter) Archive(_ context.Context, srcPath, rawDir string, _ harnessarchive.SourceParams) error {
-	entries, err := os.ReadDir(srcPath)
+	// Compute the encoded-cwd directory name from the worktree path.
+	encodedCWD := encodePiCWD(p.Worktree)
+	cwdDir := filepath.Join(sessionsRoot, encodedCWD)
+
+	// Scan the encoded-cwd directory for a file matching *_<HarnessSessionID>.jsonl.
+	suffix := "_" + p.HarnessSessionID + ".jsonl"
+	entries, err := os.ReadDir(cwdDir)
 	if os.IsNotExist(err) {
-		return nil
+		// Directory doesn't exist yet — return a sentinel path that Archive
+		// will treat as missing (os.IsNotExist → no-op).
+		return filepath.Join(cwdDir, "session_"+p.HarnessSessionID+".jsonl"), nil
 	}
 	if err != nil {
-		return fmt.Errorf("pi archive: read dir %q: %w", srcPath, err)
+		return "", fmt.Errorf("pi archive: scan session dir %q: %w", cwdDir, err)
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), suffix) {
+			return filepath.Join(cwdDir, e.Name()), nil
 		}
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".jsonl") {
-			continue
-		}
-		src := filepath.Join(srcPath, name)
-		dst := filepath.Join(rawDir, name)
-		if err := copyFile(src, dst); err != nil {
-			return fmt.Errorf("pi archive: copy %q → %q: %w", src, dst, err)
-		}
+	}
+
+	// No matching file — return a sentinel; Archive's IsNotExist path applies.
+	log.Printf("pi archive: SourcePath: no file matching *%s in %q — session may not have written any data", suffix, cwdDir)
+	return filepath.Join(cwdDir, "session_"+p.HarnessSessionID+".jsonl"), nil
+}
+
+// Archive copies PI's JSONL session file from srcPath into rawDir/session.jsonl.
+//
+// srcPath is expected to be a single file (the session JSONL), as returned by
+// SourcePath. If the file does not exist (PI never started or produced no
+// output), Archive returns nil and rawDir is left empty.
+//
+// The destination is always named "session.jsonl" so that Export's expectation
+// is met regardless of the timestamp prefix in the source filename.
+func (a *piArchiveAdapter) Archive(_ context.Context, srcPath, rawDir string, _ harnessarchive.SourceParams) error {
+	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("pi archive: stat %q: %w", srcPath, err)
+	}
+
+	dst := filepath.Join(rawDir, "session.jsonl")
+	if err := copyFile(srcPath, dst); err != nil {
+		return fmt.Errorf("pi archive: copy %q → %q: %w", srcPath, dst, err)
 	}
 	return nil
 }
@@ -153,6 +193,22 @@ func (a *piArchiveAdapter) Version(_ context.Context) (string, error) {
 		return "", nil
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// encodePiCWD encodes an absolute directory path to the directory name pi uses
+// for its session storage. The formula mirrors pi 0.72.1
+// dist/core/session-manager.js line 213:
+//
+//	--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--
+//
+// In Go terms: strip the leading '/' or '\', replace every occurrence of '/',
+// '\', and ':' with '-', then wrap in "--…--".
+func encodePiCWD(cwd string) string {
+	// Strip leading slash or backslash.
+	stripped := strings.TrimLeft(cwd, "/\\")
+	// Replace path separators and Windows drive colons with dashes.
+	replaced := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(stripped)
+	return "--" + replaced + "--"
 }
 
 // copyFile copies the file at src to dst, creating dst if necessary.

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -141,16 +141,25 @@ func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, er
 // Archive copies PI's JSONL session file from srcPath into rawDir/session.jsonl.
 //
 // srcPath is expected to be a single file (the session JSONL), as returned by
-// SourcePath. If the file does not exist (PI never started or produced no
-// output), Archive returns nil and rawDir is left empty.
+// SourcePath. If the path does not exist or is a directory (the latter occurs
+// when HarnessSessionID was empty and SourcePath returned the sessions root),
+// Archive returns nil and rawDir is left empty — preserving the no-op contract
+// for sessions where PI never started.
 //
 // The destination is always named "session.jsonl" so that Export's expectation
 // is met regardless of the timestamp prefix in the source filename.
 func (a *piArchiveAdapter) Archive(_ context.Context, srcPath, rawDir string, _ harnessarchive.SourceParams) error {
-	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+	fi, err := os.Stat(srcPath)
+	if os.IsNotExist(err) {
 		return nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return fmt.Errorf("pi archive: stat %q: %w", srcPath, err)
+	}
+	if fi.IsDir() {
+		// SourcePath returned a directory (e.g. sessions root when
+		// HarnessSessionID is empty). Nothing to copy — no-op.
+		return nil
 	}
 
 	dst := filepath.Join(rawDir, "session.jsonl")

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -11,18 +11,6 @@ import (
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 )
 
-// sandboxExecStagingHome returns the expected staging HOME path for a given
-// instanceID, mirroring container.SandboxExecStagingHomePath without importing
-// the container package (avoids circular imports in tests).
-func sandboxExecStagingHome(t *testing.T, instanceID string) string {
-	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("UserHomeDir: %v", err)
-	}
-	return filepath.Join(home, ".local", "state", "prism", "sessions", instanceID, "home")
-}
-
 // encodePiCWDForTest mirrors the encodePiCWD logic in archive.go for use in
 // test assertions without exporting the function.
 func encodePiCWDForTest(cwd string) string {
@@ -54,7 +42,12 @@ func TestEncodePiCWD(t *testing.T) {
 // TestArchiveAdapter_SourcePath_HostMode verifies that SourcePath resolves to
 // the correct file inside the encoded-cwd directory for a host-mode session.
 func TestArchiveAdapter_SourcePath_HostMode(t *testing.T) {
-	home, _ := os.UserHomeDir()
+	// Redirect $HOME to a temp dir so this test does not write to the real
+	// home directory (or /homeless-shelter in the Nix sandbox CI build).
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	home := fakeHome
+
 	const worktree = "/tmp/test-my-repo"
 	const sessionID = "d13cc856-f919-4ce9-b733-cf0e25493e62"
 
@@ -64,7 +57,6 @@ func TestArchiveAdapter_SourcePath_HostMode(t *testing.T) {
 	if err := os.MkdirAll(sessDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(sessDir) })
 
 	fileName := "2026-04-13T09-58-35-623Z_" + sessionID + ".jsonl"
 	filePath := filepath.Join(sessDir, fileName)
@@ -161,6 +153,22 @@ func TestArchiveAdapter_SourcePath_NoCWDDir(t *testing.T) {
 	entries, _ := os.ReadDir(rawDir)
 	if len(entries) != 0 {
 		t.Errorf("rawDir must be empty after no-op Archive; got %d entry/entries", len(entries))
+	}
+}
+
+// TestArchiveAdapter_Archive_Directory_NoOp verifies that when srcPath is a
+// directory (the AC4 case: HarnessSessionID empty → SourcePath returns sessionsRoot),
+// Archive returns nil without attempting to copy and leaves rawDir empty.
+func TestArchiveAdapter_Archive_Directory_NoOp(t *testing.T) {
+	srcDir := t.TempDir() // a real, existing directory
+	rawDir := t.TempDir()
+	a := pi.NewArchiveAdapter()
+	if err := a.Archive(context.Background(), srcDir, rawDir, harnessarchive.SourceParams{}); err != nil {
+		t.Fatalf("Archive with directory srcPath: expected nil error, got %v", err)
+	}
+	entries, _ := os.ReadDir(rawDir)
+	if len(entries) != 0 {
+		t.Errorf("rawDir must be empty after directory no-op; got %d entry/entries", len(entries))
 	}
 }
 
@@ -261,19 +269,27 @@ func TestArchiveAdapter_Export_NoRawSessionJSONL_NoError(t *testing.T) {
 // mounts the worktree at its native path (only $HOME is remapped to the staging
 // HOME inside the sandbox).
 func TestArchiveAdapter_SourcePath_SandboxExec(t *testing.T) {
+	// Redirect $HOME to a temp dir so that SandboxExecStagingHomePath (which
+	// calls os.UserHomeDir internally) writes into a temp dir rather than the
+	// real home directory or /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
 	const instanceID = "test-instance-uuid-1234"
 	const sessionID = "d13cc856-f919-4ce9-b733-cf0e25493e62"
 	const worktree = "/tmp/test-sandbox-worktree"
 
+	// Compute where SandboxExecStagingHomePath will resolve, now that $HOME
+	// points at fakeHome.
+	stagingHome := filepath.Join(fakeHome, ".local", "state", "prism", "sessions", instanceID, "home")
+
 	// Create the encoded-cwd directory inside the staging HOME and plant a
 	// matching session file so SourcePath can find it.
-	stagingHome := sandboxExecStagingHome(t, instanceID)
 	encodedDir := encodePiCWDForTest(worktree) // --tmp-test-sandbox-worktree--
 	sessDir := filepath.Join(stagingHome, ".pi", "agent", "sessions", encodedDir)
 	if err := os.MkdirAll(sessDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(stagingHome) })
 
 	fileName := "2026-05-01T12-00-00-000Z_" + sessionID + ".jsonl"
 	filePath := filepath.Join(sessDir, fileName)
@@ -296,9 +312,9 @@ func TestArchiveAdapter_SourcePath_SandboxExec(t *testing.T) {
 		t.Errorf("SourcePath (sandbox-exec): got %q, want %q", got, filePath)
 	}
 
-	// Must NOT point into the real home .pi directory.
-	home, _ := os.UserHomeDir()
-	if strings.HasPrefix(got, filepath.Join(home, ".pi")) {
+	// Must NOT point into the real (fakeHome) .pi directory (only the staging
+	// home inside fakeHome is acceptable).
+	if strings.HasPrefix(got, filepath.Join(fakeHome, ".pi")) {
 		t.Errorf("SourcePath (sandbox-exec) returned real home path %q; expected staging home", got)
 	}
 }
@@ -365,7 +381,12 @@ func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome(t *testing.T) {
 // exercises the full Archive → Export pipeline with a realistic pi session
 // file (encoded-cwd layout with <ts>_<uuid>.jsonl filename).
 func TestArchiveAdapter_EndToEnd_HostMode(t *testing.T) {
-	home, _ := os.UserHomeDir()
+	// Redirect $HOME to a temp dir to avoid writing to the real home
+	// directory or /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	home := fakeHome
+
 	const worktree = "/tmp/prism-e2e-test-worktree"
 	const sessionID = "ffffffff-aaaa-bbbb-cccc-dddddddddddd"
 
@@ -375,7 +396,6 @@ func TestArchiveAdapter_EndToEnd_HostMode(t *testing.T) {
 	if err := os.MkdirAll(sessDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(sessDir) })
 
 	sessionContent := `{"type":"session","version":3,"id":"` + sessionID + `"}` + "\n" +
 		`{"type":"msg_user","content":"hello"}` + "\n"

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -23,80 +23,190 @@ func sandboxExecStagingHome(t *testing.T, instanceID string) string {
 	return filepath.Join(home, ".local", "state", "prism", "sessions", instanceID, "home")
 }
 
-func TestArchiveAdapter_SourcePath_WithHarnessSessionID(t *testing.T) {
-	a := pi.NewArchiveAdapter()
-	home, _ := os.UserHomeDir()
+// encodePiCWDForTest mirrors the encodePiCWD logic in archive.go for use in
+// test assertions without exporting the function.
+func encodePiCWDForTest(cwd string) string {
+	stripped := strings.TrimLeft(cwd, "/\\")
+	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-")
+	return "--" + r.Replace(stripped) + "--"
+}
 
+// TestEncodePiCWD verifies the encoding formula matches pi 0.72.1
+// dist/core/session-manager.js line 213.
+func TestEncodePiCWD(t *testing.T) {
+	cases := []struct {
+		cwd  string
+		want string
+	}{
+		{"/home/ben/code/nixos-config/main", "--home-ben-code-nixos-config-main--"},
+		{"/home/ben", "--home-ben--"},
+		{"/tmp/test-foo", "--tmp-test-foo--"},
+		{"/", "----"},
+	}
+	for _, tc := range cases {
+		got := encodePiCWDForTest(tc.cwd)
+		if got != tc.want {
+			t.Errorf("encodePiCWD(%q): got %q, want %q", tc.cwd, got, tc.want)
+		}
+	}
+}
+
+// TestArchiveAdapter_SourcePath_HostMode verifies that SourcePath resolves to
+// the correct file inside the encoded-cwd directory for a host-mode session.
+func TestArchiveAdapter_SourcePath_HostMode(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	const worktree = "/tmp/test-my-repo"
+	const sessionID = "d13cc856-f919-4ce9-b733-cf0e25493e62"
+
+	// Create the directory and a matching session file on disk.
+	encodedDir := encodePiCWDForTest(worktree) // --tmp-test-my-repo--
+	sessDir := filepath.Join(home, ".pi", "agent", "sessions", encodedDir)
+	if err := os.MkdirAll(sessDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(sessDir) })
+
+	fileName := "2026-04-13T09-58-35-623Z_" + sessionID + ".jsonl"
+	filePath := filepath.Join(sessDir, fileName)
+	if err := os.WriteFile(filePath, []byte(`{"type":"session"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := pi.NewArchiveAdapter()
 	p := harnessarchive.SourceParams{
-		HarnessSessionID: "sess-abc-123",
+		HarnessSessionID: sessionID,
+		Worktree:         worktree,
 	}
 	got, err := a.SourcePath(p)
 	if err != nil {
 		t.Fatalf("SourcePath: %v", err)
 	}
-	want := filepath.Join(home, ".pi", "agent", "sessions", "sess-abc-123")
-	if got != want {
-		t.Errorf("SourcePath: want %q got %q", want, got)
+	if got != filePath {
+		t.Errorf("SourcePath: got %q, want %q", got, filePath)
 	}
 }
 
+// TestArchiveAdapter_SourcePath_EmptyHarnessSessionID verifies that when
+// HarnessSessionID is empty (harness failed to start), SourcePath returns the
+// sessions root, which Archive's os.IsNotExist path treats as a no-op.
 func TestArchiveAdapter_SourcePath_EmptyHarnessSessionID(t *testing.T) {
 	a := pi.NewArchiveAdapter()
 	home, _ := os.UserHomeDir()
 
-	p := harnessarchive.SourceParams{}
+	p := harnessarchive.SourceParams{
+		Worktree: "/tmp/test-my-repo",
+	}
 	got, err := a.SourcePath(p)
 	if err != nil {
 		t.Fatalf("SourcePath: %v", err)
 	}
 	want := filepath.Join(home, ".pi", "agent", "sessions")
 	if got != want {
-		t.Errorf("SourcePath (empty ID): want %q got %q", want, got)
+		t.Errorf("SourcePath (empty ID): got %q, want %q", got, want)
 	}
 }
 
-func TestArchiveAdapter_Archive_CopiesJSONLFiles(t *testing.T) {
-	tmpSrc := t.TempDir()
-	tmpDst := t.TempDir()
-
-	// Create some JSONL files and a non-JSONL file in the source.
-	if err := os.WriteFile(filepath.Join(tmpSrc, "session.jsonl"), []byte(`{"type":"state_change"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpSrc, "branch-1.jsonl"), []byte(`{"type":"msg_assistant"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpSrc, "README.txt"), []byte("not jsonl"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
+// TestArchiveAdapter_SourcePath_EmptyWorktree verifies that when Worktree is
+// empty (non-worktree session), SourcePath returns the sessions root.
+func TestArchiveAdapter_SourcePath_EmptyWorktree(t *testing.T) {
 	a := pi.NewArchiveAdapter()
-	if err := a.Archive(context.Background(), tmpSrc, tmpDst, harnessarchive.SourceParams{}); err != nil {
+	home, _ := os.UserHomeDir()
+
+	p := harnessarchive.SourceParams{
+		HarnessSessionID: "some-uuid",
+		Worktree:         "",
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+	want := filepath.Join(home, ".pi", "agent", "sessions")
+	if got != want {
+		t.Errorf("SourcePath (empty worktree): got %q, want %q", got, want)
+	}
+}
+
+// TestArchiveAdapter_SourcePath_NoCWDDir verifies that when the encoded-cwd
+// directory does not exist on disk, SourcePath returns a sentinel path (not an
+// error), and Archive treats it as a no-op via os.IsNotExist.
+func TestArchiveAdapter_SourcePath_NoCWDDir(t *testing.T) {
+	a := pi.NewArchiveAdapter()
+	home, _ := os.UserHomeDir()
+	const sessionID = "aabbccdd-0000-0000-0000-000000000000"
+	// Use a worktree path unlikely to have a real session directory.
+	const worktree = "/tmp/nonexistent-prism-test-worktree-xyzzy"
+
+	p := harnessarchive.SourceParams{
+		HarnessSessionID: sessionID,
+		Worktree:         worktree,
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: unexpected error %v", err)
+	}
+	// Should be inside the encoded-cwd dir (which doesn't exist), not the sessions root.
+	encodedDir := encodePiCWDForTest(worktree)
+	expectedPrefix := filepath.Join(home, ".pi", "agent", "sessions", encodedDir)
+	if !strings.HasPrefix(got, expectedPrefix) {
+		t.Errorf("SourcePath (no dir): got %q, expected prefix %q", got, expectedPrefix)
+	}
+
+	// Archive should treat the sentinel path as a no-op.
+	rawDir := t.TempDir()
+	archiveAdapter := pi.NewArchiveAdapter()
+	if err := archiveAdapter.Archive(context.Background(), got, rawDir, p); err != nil {
+		t.Fatalf("Archive with sentinel path: expected nil error, got %v", err)
+	}
+	// rawDir must remain empty.
+	entries, _ := os.ReadDir(rawDir)
+	if len(entries) != 0 {
+		t.Errorf("rawDir must be empty after no-op Archive; got %d entry/entries", len(entries))
+	}
+}
+
+// TestArchiveAdapter_Archive_CopiesFileAsSessionJSONL verifies that Archive
+// copies the single source file into rawDir/session.jsonl.
+func TestArchiveAdapter_Archive_CopiesFileAsSessionJSONL(t *testing.T) {
+	// Create a fake pi session file (pi layout: <ts>_<uuid>.jsonl).
+	tmpSrc := t.TempDir()
+	sessionFile := filepath.Join(tmpSrc, "2026-04-13T09-58-35-623Z_d13cc856-f919-4ce9-b733-cf0e25493e62.jsonl")
+	content := `{"type":"session","version":3}` + "\n" + `{"type":"msg_assistant"}` + "\n"
+	if err := os.WriteFile(sessionFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rawDir := t.TempDir()
+	a := pi.NewArchiveAdapter()
+	if err := a.Archive(context.Background(), sessionFile, rawDir, harnessarchive.SourceParams{}); err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
 
-	// session.jsonl and branch-1.jsonl should be copied; README.txt should not.
-	for _, name := range []string{"session.jsonl", "branch-1.jsonl"} {
-		if _, err := os.Stat(filepath.Join(tmpDst, name)); err != nil {
-			t.Errorf("expected %q in rawDir: %v", name, err)
-		}
+	// Must produce rawDir/session.jsonl with the correct content.
+	dst := filepath.Join(rawDir, "session.jsonl")
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read rawDir/session.jsonl: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(tmpDst, "README.txt")); !os.IsNotExist(err) {
-		t.Error("expected README.txt NOT to be copied")
+	if string(got) != content {
+		t.Errorf("rawDir/session.jsonl content: got %q, want %q", got, content)
 	}
 }
 
+// TestArchiveAdapter_Archive_MissingSrcPath_NoError verifies that a
+// non-existent source path is a no-op (preserving existing tolerance for
+// sessions where pi never produced output).
 func TestArchiveAdapter_Archive_MissingSrcPath_NoError(t *testing.T) {
-	tmpDst := t.TempDir()
+	rawDir := t.TempDir()
 	a := pi.NewArchiveAdapter()
 
-	// Non-existent source directory should be a no-op, not an error.
-	err := a.Archive(context.Background(), "/nonexistent/pi/sessions/sess-xyz", tmpDst, harnessarchive.SourceParams{})
+	err := a.Archive(context.Background(), "/nonexistent/pi/sessions/--tmp-test-foo--/session_xyz.jsonl", rawDir, harnessarchive.SourceParams{})
 	if err != nil {
 		t.Fatalf("Archive with missing src: expected nil error, got %v", err)
 	}
 }
 
+// TestArchiveAdapter_Export_CopiesSessionJSONL verifies that Export produces
+// archiveDir/session.jsonl from raw/session.jsonl.
 func TestArchiveAdapter_Export_CopiesSessionJSONL(t *testing.T) {
 	archiveDir := t.TempDir()
 	rawDir := filepath.Join(archiveDir, "raw")
@@ -120,10 +230,12 @@ func TestArchiveAdapter_Export_CopiesSessionJSONL(t *testing.T) {
 		t.Fatalf("read session.jsonl: %v", err)
 	}
 	if string(got) != content {
-		t.Errorf("session.jsonl content: want %q got %q", content, got)
+		t.Errorf("session.jsonl content: got %q, want %q", content, got)
 	}
 }
 
+// TestArchiveAdapter_Export_NoRawSessionJSONL_NoError verifies that Export
+// returns nil when raw/session.jsonl is absent, and writes nothing.
 func TestArchiveAdapter_Export_NoRawSessionJSONL_NoError(t *testing.T) {
 	archiveDir := t.TempDir()
 	rawDir := filepath.Join(archiveDir, "raw")
@@ -132,11 +244,9 @@ func TestArchiveAdapter_Export_NoRawSessionJSONL_NoError(t *testing.T) {
 	}
 
 	a := pi.NewArchiveAdapter()
-	// No session.jsonl in raw/ — should return nil, not error.
 	if err := a.Export(context.Background(), archiveDir, harnessarchive.SourceParams{}); err != nil {
 		t.Fatalf("Export with missing session.jsonl: expected nil, got %v", err)
 	}
-	// No session.jsonl should be written at archive root.
 	if _, err := os.Stat(filepath.Join(archiveDir, "session.jsonl")); !os.IsNotExist(err) {
 		t.Error("expected session.jsonl NOT to be created when raw/session.jsonl is absent")
 	}
@@ -144,31 +254,49 @@ func TestArchiveAdapter_Export_NoRawSessionJSONL_NoError(t *testing.T) {
 
 // TestArchiveAdapter_SourcePath_SandboxExec verifies that when IsolationMode
 // is "sandbox-exec", SourcePath uses the per-session staging HOME (not the
-// real home directory). This is bug #1538 fix #2: sandbox-exec sessions write
-// PI data to <stagingHome>/.pi/agent/sessions/<sessionID>/, not ~/.pi/.
+// real home directory). This is bug #1538 fix: sandbox-exec sessions write PI
+// data under <stagingHome>/.pi/agent/sessions/<encoded-cwd>/, not ~/.pi/.
+//
+// The encoded-cwd is derived from the host worktree path because sandbox-exec
+// mounts the worktree at its native path (only $HOME is remapped to the staging
+// HOME inside the sandbox).
 func TestArchiveAdapter_SourcePath_SandboxExec(t *testing.T) {
 	const instanceID = "test-instance-uuid-1234"
-	const sessionID = "pi-ses-abc-sandbox"
+	const sessionID = "d13cc856-f919-4ce9-b733-cf0e25493e62"
+	const worktree = "/tmp/test-sandbox-worktree"
+
+	// Create the encoded-cwd directory inside the staging HOME and plant a
+	// matching session file so SourcePath can find it.
+	stagingHome := sandboxExecStagingHome(t, instanceID)
+	encodedDir := encodePiCWDForTest(worktree) // --tmp-test-sandbox-worktree--
+	sessDir := filepath.Join(stagingHome, ".pi", "agent", "sessions", encodedDir)
+	if err := os.MkdirAll(sessDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(stagingHome) })
+
+	fileName := "2026-05-01T12-00-00-000Z_" + sessionID + ".jsonl"
+	filePath := filepath.Join(sessDir, fileName)
+	if err := os.WriteFile(filePath, []byte(`{"type":"session"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	a := pi.NewArchiveAdapter()
 	p := harnessarchive.SourceParams{
 		HarnessSessionID: sessionID,
 		IsolationMode:    "sandbox-exec",
 		InstanceID:       instanceID,
+		Worktree:         worktree,
 	}
 	got, err := a.SourcePath(p)
 	if err != nil {
-		t.Fatalf("SourcePath: %v", err)
+		t.Fatalf("SourcePath (sandbox-exec): %v", err)
+	}
+	if got != filePath {
+		t.Errorf("SourcePath (sandbox-exec): got %q, want %q", got, filePath)
 	}
 
-	// Expected path: <stagingHome>/.pi/agent/sessions/<sessionID>
-	stagingHome := sandboxExecStagingHome(t, instanceID)
-	want := filepath.Join(stagingHome, ".pi", "agent", "sessions", sessionID)
-	if got != want {
-		t.Errorf("SourcePath (sandbox-exec): got %q, want %q", got, want)
-	}
-
-	// Must NOT contain the real home directory.
+	// Must NOT point into the real home .pi directory.
 	home, _ := os.UserHomeDir()
 	if strings.HasPrefix(got, filepath.Join(home, ".pi")) {
 		t.Errorf("SourcePath (sandbox-exec) returned real home path %q; expected staging home", got)
@@ -176,34 +304,39 @@ func TestArchiveAdapter_SourcePath_SandboxExec(t *testing.T) {
 }
 
 // TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID verifies that when
-// IsolationMode is "sandbox-exec" but InstanceID is empty (unusual edge case),
-// SourcePath falls back to the real home directory path rather than returning
-// an error that would abort cleanup entirely.
+// IsolationMode is "sandbox-exec" but InstanceID is empty, SourcePath falls
+// back to the real home directory rather than returning an error.
 func TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID(t *testing.T) {
 	a := pi.NewArchiveAdapter()
+	home, _ := os.UserHomeDir()
+	const worktree = "/tmp/test-fallback"
+	const sessionID = "some-session-uuid"
+
 	p := harnessarchive.SourceParams{
-		HarnessSessionID: "some-session",
+		HarnessSessionID: sessionID,
 		IsolationMode:    "sandbox-exec",
-		InstanceID:       "", // empty — forces fallback
+		InstanceID:       "", // empty — forces fallback to host home
+		Worktree:         worktree,
 	}
 	got, err := a.SourcePath(p)
 	if err != nil {
-		t.Fatalf("SourcePath with empty InstanceID: %v", err)
+		t.Fatalf("SourcePath (sandbox-exec, empty InstanceID): %v", err)
 	}
-	// Fallback: uses real home directory.
-	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, ".pi", "agent", "sessions", "some-session")
-	if got != want {
-		t.Errorf("SourcePath (sandbox-exec, empty InstanceID): got %q, want %q", got, want)
+	// Fallback: resolves under the real home.
+	encodedDir := encodePiCWDForTest(worktree)
+	expectedPrefix := filepath.Join(home, ".pi", "agent", "sessions", encodedDir)
+	if !strings.HasPrefix(got, expectedPrefix) {
+		t.Errorf("SourcePath (sandbox-exec, empty InstanceID): got %q, expected prefix %q", got, expectedPrefix)
 	}
 }
 
 // TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome verifies that
-// non-sandbox-exec isolation modes (podman, bwrap, host) continue to use the
-// real home directory, not the staging HOME.
+// non-sandbox-exec isolation modes (podman, bwrap, host) use the real home
+// directory for the sessions root.
 func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome(t *testing.T) {
 	home, _ := os.UserHomeDir()
-	const sessionID = "pi-ses-xyz"
+	const sessionID = "pi-ses-xyz-nonse"
+	const worktree = "/tmp/test-non-sandbox"
 
 	for _, mode := range []string{"podman", "bwrap", "host", ""} {
 		t.Run("mode="+mode, func(t *testing.T) {
@@ -212,15 +345,84 @@ func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome(t *testing.T) {
 				HarnessSessionID: sessionID,
 				IsolationMode:    mode,
 				InstanceID:       "some-instance-id",
+				Worktree:         worktree,
 			}
 			got, err := a.SourcePath(p)
 			if err != nil {
 				t.Fatalf("SourcePath (mode=%q): %v", mode, err)
 			}
-			want := filepath.Join(home, ".pi", "agent", "sessions", sessionID)
-			if got != want {
-				t.Errorf("SourcePath (mode=%q): got %q, want %q", mode, got, want)
+			// Must be rooted in the real home, not a staging home.
+			encodedDir := encodePiCWDForTest(worktree)
+			expectedPrefix := filepath.Join(home, ".pi", "agent", "sessions", encodedDir)
+			if !strings.HasPrefix(got, expectedPrefix) {
+				t.Errorf("SourcePath (mode=%q): got %q, expected prefix %q", mode, got, expectedPrefix)
 			}
 		})
+	}
+}
+
+// TestArchiveAdapter_EndToEnd_HostMode is an integration-style test that
+// exercises the full Archive → Export pipeline with a realistic pi session
+// file (encoded-cwd layout with <ts>_<uuid>.jsonl filename).
+func TestArchiveAdapter_EndToEnd_HostMode(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	const worktree = "/tmp/prism-e2e-test-worktree"
+	const sessionID = "ffffffff-aaaa-bbbb-cccc-dddddddddddd"
+
+	// Plant a pi session file at the real layout path.
+	encodedDir := encodePiCWDForTest(worktree)
+	sessDir := filepath.Join(home, ".pi", "agent", "sessions", encodedDir)
+	if err := os.MkdirAll(sessDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(sessDir) })
+
+	sessionContent := `{"type":"session","version":3,"id":"` + sessionID + `"}` + "\n" +
+		`{"type":"msg_user","content":"hello"}` + "\n"
+	piFile := filepath.Join(sessDir, "2026-05-15T10-00-00-000Z_"+sessionID+".jsonl")
+	if err := os.WriteFile(piFile, []byte(sessionContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := pi.NewArchiveAdapter()
+	p := harnessarchive.SourceParams{
+		HarnessSessionID: sessionID,
+		Worktree:         worktree,
+	}
+
+	srcPath, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+	if srcPath != piFile {
+		t.Errorf("SourcePath: got %q, want %q", srcPath, piFile)
+	}
+
+	archiveDir := t.TempDir()
+	rawDir := filepath.Join(archiveDir, "raw")
+	if err := os.MkdirAll(rawDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.Archive(context.Background(), srcPath, rawDir, p); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	rawJSONL := filepath.Join(rawDir, "session.jsonl")
+	if _, err := os.Stat(rawJSONL); err != nil {
+		t.Fatalf("raw/session.jsonl missing after Archive: %v", err)
+	}
+
+	if err := a.Export(context.Background(), archiveDir, p); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	exportedJSONL := filepath.Join(archiveDir, "session.jsonl")
+	got, err := os.ReadFile(exportedJSONL)
+	if err != nil {
+		t.Fatalf("read exported session.jsonl: %v", err)
+	}
+	if string(got) != sessionContent {
+		t.Errorf("exported session.jsonl: got %q, want %q", got, sessionContent)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug where every `prism cleanup` for a pi session discarded the session JSONL. `piArchiveAdapter.SourcePath` constructed `~/.pi/agent/sessions/<HarnessSessionID>/` which never exists — pi 0.72.1 actually stores sessions at `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`.

## Root cause

`SourcePath` used the session UUID as a directory name. Pi uses it in the **filename** inside a per-cwd directory. The constructed path always passed through `os.IsNotExist` in `Archive()`, leaving `rawDir` empty. `Export()` then logged `raw/session.jsonl not found — no export produced` and returned nil. Every cleanup since pi was introduced hit this path.

## Changes

- **`internal/harness/archive/archive.go`**: `SourceParams` gains a `Worktree` field (the session worktree path) so the pi adapter can derive the encoded-cwd directory name.
- **`cmd/cleanup.go`**: Populates `srcParams.Worktree` from `sess.Worktree` (already in scope).
- **`internal/harness/pi/archive.go`**:
  - `SourcePath` computes `encodePiCWD(p.Worktree)`, scans `~/.pi/agent/sessions/<encoded-cwd>/` for `*_<HarnessSessionID>.jsonl`, and returns the matched file path. Sentinel path returned (not error) when no match found.
  - `Archive()` copies the single JSONL file as `rawDir/session.jsonl` (replacing the directory walk). Missing file still a no-op.
  - `encodePiCWD()` helper implements the formula from `dist/core/session-manager.js` line 213.
  - The sandbox-exec staging-HOME branch (bug #1538 fix) is preserved: `IsolationMode=="sandbox-exec"` uses `<stagingHome>/.pi/...`; the encoded-cwd is derived from the same host worktree path since sandbox-exec mounts the worktree at its native path.
- **`internal/harness/pi/archive_test.go`**: Rewritten to use the real pi on-disk layout (encoded-cwd directory + `<ts>_<uuid>.jsonl` filenames), with host-mode and sandbox-exec branches both exercised.

## Testing

```bash
cd modules/programs/prism/prism
go build ./...   # passes
go test ./...    # all pass
```

`nix build .#prism` also passes.

Closes #1629
Refs #1625