### PR TITLE
fix(mergequeue): reconcile PR state on merge error to avoid false-failure notifications (#1645)

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -295,21 +295,49 @@ func (w *Watcher) tryMerge(ctx context.Context, head *db.PendingMerge) {
 		return
 	}
 
-	// Check for branch-moved race: GitHub returns a message containing
-	// "already merged" or similar when the head SHA moved between our
-	// view and the merge call. Treat as transient — leave watching.
+	// First: reconcile by checking the PR's actual state. Some "errors" are
+	// races where the PR did merge — trusting the observed state is more
+	// reliable than pattern-matching error strings.
+	if state := w.checkPRMergedState(ctx, head.PR); state == "MERGED" {
+		log.Printf("[mergequeue] PR #%d merge mutation errored but PR is MERGED — reconciling as success", head.PR)
+		w.succeedAndNotify(ctx, head)
+		return
+	}
+
+	// Second: existing branch-moved-race keyword check (transient races
+	// where the PR didn't merge but will likely merge on retry).
 	combinedOutput := strings.ToLower(string(out) + err.Error())
 	if isBranchMovedRace(combinedOutput) {
 		log.Printf("[mergequeue] PR #%d branch-moved race detected — leaving watching for next tick", head.PR)
 		return
 	}
 
+	// Third: genuine failure.
 	errMsg := fmt.Sprintf("gh pr merge failed: %s", strings.TrimSpace(string(out)))
 	if len(errMsg) > 500 {
 		errMsg = errMsg[:500]
 	}
 	log.Printf("[mergequeue] PR #%d merge failed: %v", head.PR, errMsg)
 	w.failAndNotify(head, errMsg)
+}
+
+// checkPRMergedState queries the PR's current state from GitHub and returns
+// the state string (e.g. "MERGED", "OPEN", "CLOSED"). Returns "" if the
+// query fails or the response cannot be parsed. This is called on the error
+// path of tryMerge to reconcile cases where the mutation errored but the PR
+// actually merged (e.g. "Merge already in progress" races).
+func (w *Watcher) checkPRMergedState(ctx context.Context, pr int) string {
+	out, err := w.runGH(ctx, "pr", "view", fmt.Sprintf("%d", pr), "--json", "state")
+	if err != nil {
+		return "" // unknown — fall through to existing paths
+	}
+	var v struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &v); err != nil {
+		return ""
+	}
+	return v.State
 }
 
 // succeedAndNotify transitions head to merged and notifies the coordinator.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -459,11 +459,14 @@ func TestMergeQueueForInstance_AbandonedFilter(t *testing.T) {
 // replaces the gh CLI calls with an injectable function.
 
 type fakeWatcher struct {
-	watcher              *Watcher
-	fetchFn              func(ctx context.Context, pr int) (*prInfo, error)
-	mergeFn              func(ctx context.Context, pr int) ([]byte, error)
-	updateFn             func(ctx context.Context, pr int) error
+	watcher               *Watcher
+	fetchFn               func(ctx context.Context, pr int) (*prInfo, error)
+	mergeFn               func(ctx context.Context, pr int) ([]byte, error)
+	updateFn              func(ctx context.Context, pr int) error
 	fetchRequiredChecksFn func(ctx context.Context) ([]string, error)
+	// checkMergedStateFn is called on the error path of tryMerge to reconcile
+	// PR state. When nil, returns "" (unknown / fall-through to keyword check).
+	checkMergedStateFn func(ctx context.Context, pr int) string
 }
 
 // processHead is a test-friendly version of tick() that uses injected functions
@@ -496,6 +499,16 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 			fw.watcher.succeedAndNotify(ctx, head)
 			return
 		}
+		// First: reconcile by checking the PR's actual state.
+		var reconciledState string
+		if fw.checkMergedStateFn != nil {
+			reconciledState = fw.checkMergedStateFn(ctx, head.PR)
+		}
+		if reconciledState == "MERGED" {
+			fw.watcher.succeedAndNotify(ctx, head)
+			return
+		}
+		// Second: keyword-based branch-moved-race check.
 		combined := strings.ToLower(string(out) + mergeErr.Error())
 		if isBranchMovedRace(combined) {
 			return // transient
@@ -532,6 +545,16 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 				fw.watcher.succeedAndNotify(ctx, head)
 				return
 			}
+			// First: reconcile state.
+			var reconciledState string
+			if fw.checkMergedStateFn != nil {
+				reconciledState = fw.checkMergedStateFn(ctx, head.PR)
+			}
+			if reconciledState == "MERGED" {
+				fw.watcher.succeedAndNotify(ctx, head)
+				return
+			}
+			// Second: keyword check.
 			combined := strings.ToLower(string(out) + mergeErr.Error())
 			if isBranchMovedRace(combined) {
 				return
@@ -1982,6 +2005,204 @@ func TestFetchRequiredChecks_CacheTTL(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Errorf("third call (after TTL): callCount = %d, want 2", callCount)
+	}
+}
+
+// ── tryMerge reconciliation tests (issue #1645) ─────────────────────────────
+
+// TestWatcher_MergeAlreadyInProgress_PRIsMerged verifies AC: when gh pr merge
+// returns an error and checkPRMergedState returns "MERGED", the watcher
+// transitions to merged and sends the success notification.
+func TestWatcher_MergeAlreadyInProgress_PRIsMerged(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-reconcile-merged"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-reconcile-merged")
+
+	if _, err := d.EnqueueMerge(2100, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			// Simulate "Merge already in progress" GraphQL error.
+			return []byte("GraphQL: Merge already in progress (mergePullRequest)"),
+				fmt.Errorf("exit status 1")
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	// checkMergedStateFn returns MERGED — PR did actually merge.
+	fw.checkMergedStateFn = func(_ context.Context, pr int) string {
+		return "MERGED"
+	}
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(2100)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "merged" {
+		t.Errorf("status: got %q, want merged", row.Status)
+	}
+	if row.MergedAt == nil {
+		t.Error("merged_at: got nil, want set")
+	}
+	// Success notification must have been sent.
+	if srv.called == 0 {
+		t.Fatal("no success notification sent to coordinator")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(srv.lastBody, &body); err != nil {
+		t.Fatalf("unmarshal notification body: %v", err)
+	}
+	parts, _ := body["parts"].([]interface{})
+	if len(parts) == 0 {
+		t.Fatal("notification body has no parts")
+	}
+	part, _ := parts[0].(map[string]interface{})
+	text, _ := part["text"].(string)
+	if !strings.Contains(text, "PR #2100") {
+		t.Errorf("notification text %q does not mention PR #2100", text)
+	}
+	if !strings.Contains(text, "merged") {
+		t.Errorf("notification text %q does not mention 'merged'", text)
+	}
+}
+
+// TestWatcher_MergeAlreadyInProgress_PRIsOpen verifies AC: when gh pr merge
+// returns an error and checkPRMergedState returns "OPEN" (not merged), the
+// watcher falls through to the keyword check and then to failAndNotify.
+func TestWatcher_MergeAlreadyInProgress_PRIsOpen(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-reconcile-open"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-reconcile-open")
+
+	if _, err := d.EnqueueMerge(2101, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			// Error that doesn't match any keyword.
+			return []byte("GraphQL: Merge already in progress (mergePullRequest)"),
+				fmt.Errorf("exit status 1")
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	// checkMergedStateFn returns OPEN — PR did NOT merge.
+	fw.checkMergedStateFn = func(_ context.Context, pr int) string {
+		return "OPEN"
+	}
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(2101)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+}
+
+// TestWatcher_MergeError_CheckPRStateItself_Fails verifies AC (edge-case):
+// when gh pr merge errors AND checkPRMergedState itself fails (returns ""),
+// the watcher falls through to the keyword check. When neither the state
+// reconciliation nor the keywords match, failAndNotify is called.
+func TestWatcher_MergeError_CheckPRStateItself_Fails(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-reconcile-viewerr"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-reconcile-viewerr")
+
+	if _, err := d.EnqueueMerge(2102, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			// Error that doesn't match any keyword.
+			return []byte("GraphQL: Merge already in progress (mergePullRequest)"),
+				fmt.Errorf("exit status 1")
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	// checkMergedStateFn returns "" — gh pr view failed (network error, etc.).
+	fw.checkMergedStateFn = func(_ context.Context, pr int) string {
+		return ""
+	}
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(2102)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed (checkMergedState failure must fall through to failAndNotify)", row.Status)
+	}
+}
+
+// TestWatcher_GenuineFailure_NoRegression verifies AC: a genuine gh pr merge
+// error (not a race keyword, not reconciled as MERGED) still transitions to
+// failed. This is a non-regression test for the existing failure path.
+func TestWatcher_GenuineFailure_NoRegression(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-genuine-fail"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-genuine-fail")
+
+	if _, err := d.EnqueueMerge(2103, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			// A genuine failure unrelated to any race.
+			return []byte("GraphQL: repository has no pull request with the number 2103"),
+				fmt.Errorf("exit status 1")
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	// checkMergedStateFn returns OPEN — PR was not merged.
+	fw.checkMergedStateFn = func(_ context.Context, pr int) string {
+		return "OPEN"
+	}
+
+	fw.processHead(context.Background())
+
+	row, err := d.PendingMergeByPR(2103)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed (genuine error must not reconcile as merged)", row.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

When `gh pr merge` returns an error, the watcher now reconciles the PR's actual state (via `gh pr view --json state`) before falling through to the keyword check or `failAndNotify`. If the PR is `MERGED` despite the mutation error, the watcher transitions to `merged` and sends the success notification — preventing the false "merge failed" notification described in #1645.

### Root cause
The "Merge already in progress" GraphQL error indicates a concurrent mutation won the race and the PR merged. The keyword list in `isBranchMovedRace` did not cover this phrase, so the watcher called `failAndNotify` for a PR that had actually succeeded.

### Fix shape
Three-step error recovery in `tryMerge`:
1. **State reconciliation** — `checkPRMergedState` calls `gh pr view --json state`. If `MERGED`, call `succeedAndNotify` and return.
2. **Keyword check** — existing `isBranchMovedRace` logic unchanged (transient races where the PR didn't merge).
3. **Genuine failure** — `failAndNotify` with the original error.

`checkPRMergedState` is best-effort: any failure returns `""` and the existing paths run normally.

### Tests added (4 new)
- `TestWatcher_MergeAlreadyInProgress_PRIsMerged` — merge error + `MERGED` state → success notification
- `TestWatcher_MergeAlreadyInProgress_PRIsOpen` — merge error + `OPEN` state → failure
- `TestWatcher_MergeError_CheckPRStateItself_Fails` — merge error + `gh pr view` fails → falls through to failure
- `TestWatcher_GenuineFailure_NoRegression` — genuine merge error + `OPEN` → failure (no regression)

All existing tests pass unchanged.

Closes #1645