### PR TITLE
fix(feedback): proxy to host-API when invoked from inside a sandbox (#1644)

### DIFF
--- a/modules/programs/prism/prism/cmd/feedback.go
+++ b/modules/programs/prism/prism/cmd/feedback.go
@@ -137,6 +137,17 @@ func runFeedbackRecord(cmd *cobra.Command, args []string) error {
 
 	entry := buildFeedbackEntry(text, time.Now().UTC())
 
+	// Sandbox proxy path: when $PRISM_HOST_API is set the process is running
+	// inside a bwrap worker sandbox whose filesystem namespace is ephemeral.
+	// Writes to ~/.local/state/prism/ inside the sandbox never reach the host,
+	// so the data would be silently lost on sandbox exit (issue #1644).
+	// Route through the host-API instead so the sidecar — which runs on the
+	// host — performs the actual append.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runFeedbackRecordViaHostAPI(cmd, apiURL, entry)
+	}
+
+	// Host path: write directly to the local feedback store.
 	store, err := resolveFeedbackStore()
 	if err != nil {
 		return err
@@ -160,6 +171,28 @@ func runFeedbackRecord(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"feedback recorded locally and sent upstream (status: %d)\n", status)
+	return nil
+}
+
+// runFeedbackRecordViaHostAPI proxies the feedback entry to the host-API
+// sidecar when running inside a bwrap sandbox (PRISM_HOST_API is set).
+// The sidecar appends the entry to the host's feedback.jsonl and returns
+// the resolved path, which is printed in the success message so the
+// worker sees where the data actually landed (AC: "message prints the path
+// the entry actually landed at").
+//
+// On any error (missing socket, HTTP error, malformed response) this
+// function returns a non-nil error and does NOT fall back to the sandbox-
+// internal write path — that fallback is the current failure mode this fix
+// is resolving (issue #1644).
+func runFeedbackRecordViaHostAPI(cmd *cobra.Command, apiURL string, entry feedback.Entry) error {
+	var resp struct {
+		Path string `json:"path"`
+	}
+	if err := proxyToHostAPI(apiURL, "/feedback", entry, &resp); err != nil {
+		return fmt.Errorf("feedback: host-API proxy failed (not writing to sandbox-local path): %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "feedback recorded via host-API (%s)\n", resp.Path)
 	return nil
 }
 

--- a/modules/programs/prism/prism/cmd/feedback_test.go
+++ b/modules/programs/prism/prism/cmd/feedback_test.go
@@ -22,13 +22,19 @@ import (
 )
 
 // withTempFeedbackStore points the feedback store at a tempdir and clears
-// PRISM_FEEDBACK_ENDPOINT so tests don't accidentally hit the real one.
+// PRISM_FEEDBACK_ENDPOINT and PRISM_HOST_API so tests don't accidentally use
+// the real endpoint or proxy through the host-API of the developer's live
+// prism session.
 // Returns the on-disk path so individual tests can inspect the JSONL.
 func withTempFeedbackStore(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", dir)
 	t.Setenv(PRISMFeedbackEndpointEnv, "")
+	// Clear PRISM_HOST_API so tests that exercise the local-write path are not
+	// accidentally routed through the sandbox proxy (which would happen when the
+	// test binary runs inside a prism worker session where PRISM_HOST_API is set).
+	t.Setenv("PRISM_HOST_API", "")
 	return filepath.Join(dir, "prism", "feedback.jsonl")
 }
 
@@ -417,6 +423,139 @@ func TestFeedback_Record_ReadsEndpointFromConfigFile(t *testing.T) {
 	}
 	if _, statErr := os.Stat(storePath); statErr != nil {
 		t.Errorf("local store missing: %v", statErr)
+	}
+}
+
+// ── host-API proxy path (PRISM_HOST_API) ────────────────────────────────────
+
+// TestFeedback_Record_HostAPIProxy_Success verifies that when PRISM_HOST_API
+// is set, the entry is POSTed to the host-API /feedback endpoint and the
+// success message shows the path returned by the server. Nothing is written
+// to the local store (the current process is inside a sandbox and the local
+// path is ephemeral).
+func TestFeedback_Record_HostAPIProxy_Success(t *testing.T) {
+	// Point the local store to a tempdir so we can verify nothing was written
+	// locally by the proxy path.
+	local := withTempFeedbackStore(t)
+
+	var (
+		gotMethod string
+		gotBody   []byte
+	)
+	hostPath := "/host/state/prism/feedback.jsonl"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"path":"` + hostPath + `"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("PRISM_HOST_API", srv.URL)
+
+	out, err := runFeedbackCmd(t, "sandbox note")
+	if err != nil {
+		t.Fatalf("feedback via host-API: %v\nout=%s", err, out)
+	}
+
+	// Success message must show the host path (not the sandbox-local path).
+	if !strings.Contains(out, "host-API") {
+		t.Errorf("output missing 'host-API': %q", out)
+	}
+	if !strings.Contains(out, hostPath) {
+		t.Errorf("output missing host path %q: %q", hostPath, out)
+	}
+
+	// The entry must have been POSTed as JSON.
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	var posted feedback.Entry
+	if err := json.Unmarshal(gotBody, &posted); err != nil {
+		t.Errorf("posted body not valid JSON: %v (raw: %s)", err, gotBody)
+	}
+	if posted.Text != "sandbox note" {
+		t.Errorf("posted text = %q, want 'sandbox note'", posted.Text)
+	}
+
+	// Nothing must have been written locally — the sandbox write path is the
+	// bug this fix resolves.
+	if _, statErr := os.Stat(local); statErr == nil {
+		data, _ := os.ReadFile(local)
+		t.Errorf("data unexpectedly written to local store: %s", data)
+	}
+}
+
+// TestFeedback_Record_HostAPIProxy_ErrorExitsNonZero verifies that when
+// PRISM_HOST_API is set but the host-API returns an error, the CLI exits
+// non-zero and does NOT silently write to the sandbox-internal path.
+func TestFeedback_Record_HostAPIProxy_ErrorExitsNonZero(t *testing.T) {
+	local := withTempFeedbackStore(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"append feedback: disk full"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("PRISM_HOST_API", srv.URL)
+
+	_, err := runFeedbackCmd(t, "will fail")
+	if err == nil {
+		t.Fatalf("expected non-zero exit when host-API returns 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "host-API") {
+		t.Errorf("error %v: want mention of 'host-API'", err)
+	}
+
+	// Crucially: nothing written locally (no silent fallback).
+	if _, statErr := os.Stat(local); statErr == nil {
+		data, _ := os.ReadFile(local)
+		t.Errorf("data written locally despite host-API failure: %s", data)
+	}
+}
+
+// TestFeedback_Record_HostAPIProxy_UnreachableExitsNonZero verifies that when
+// PRISM_HOST_API is set but the socket is missing/unresponsive, the CLI exits
+// non-zero and does NOT silently write to the sandbox-internal path.
+func TestFeedback_Record_HostAPIProxy_UnreachableExitsNonZero(t *testing.T) {
+	local := withTempFeedbackStore(t)
+
+	// Point to a URL where nothing is listening.
+	t.Setenv("PRISM_HOST_API", "http://127.0.0.1:19999")
+
+	_, err := runFeedbackCmd(t, "unreachable")
+	if err == nil {
+		t.Fatalf("expected non-zero exit when host-API is unreachable, got nil")
+	}
+
+	// Nothing written locally.
+	if _, statErr := os.Stat(local); statErr == nil {
+		data, _ := os.ReadFile(local)
+		t.Errorf("data written locally despite unreachable host-API: %s", data)
+	}
+}
+
+// TestFeedback_Record_NoHostAPI_WritesLocally verifies that when PRISM_HOST_API
+// is NOT set (running from a host shell, not inside a sandbox), the existing
+// local-write path applies unchanged — no regression.
+func TestFeedback_Record_NoHostAPI_WritesLocally(t *testing.T) {
+	storePath := withTempFeedbackStore(t)
+	t.Setenv("PRISM_HOST_API", "") // explicitly unset
+
+	out, err := runFeedbackCmd(t, "host note")
+	if err != nil {
+		t.Fatalf("feedback: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "feedback recorded locally") {
+		t.Errorf("output missing 'feedback recorded locally': %q", out)
+	}
+	data, readErr := os.ReadFile(storePath)
+	if readErr != nil {
+		t.Fatalf("ReadFile %s: %v", storePath, readErr)
+	}
+	if !strings.Contains(string(data), "host note") {
+		t.Errorf("local store missing entry: %s", data)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/feedback"
 	"github.com/prismatic-koi/prism/internal/harness"
 	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
 	prismsession "github.com/prismatic-koi/prism/internal/session"
@@ -162,6 +163,7 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 //	POST /event         — write a lifecycle event to the host DB (all roles)
 //	POST /escalate      — escalate to coordinator (worker sessions)
 //	POST /investigate   — spawn an investigate-agent session (worker sessions)
+//	POST /feedback      — append a feedback entry to the host feedback.jsonl (all roles)
 //
 // /db/query, /db/schema, /db/tables are coordinator-only because /db/query
 // exposes a strict superset of /checkin: raw cross-session payloads (e.g.
@@ -1748,6 +1750,60 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		s.logger().Printf("sidecar: host-API /event: kind=%s session=%s written to host DB", req.Kind, req.Session)
 		writeJSON(w, http.StatusOK, map[string]string{})
+	})
+
+	// POST /feedback
+	// Request:  feedback.Entry JSON (same struct used by cmd/feedback.go and
+	//           internal/feedback/feedback.go).
+	// Response: {"path":"<absolute path to feedback.jsonl>"} | {"error":"..."}
+	//
+	// Appends one feedback entry to the host's feedback.jsonl file. This is the
+	// proxy path for `prism feedback` invoked from inside a bwrap worker sandbox
+	// where the sandbox namespace is ephemeral — writes inside the sandbox never
+	// reach the host filesystem (issue #1644). The sidecar runs on the host, so
+	// its Append call lands in the real ~/.local/state/prism/feedback.jsonl.
+	//
+	// All roles (worker and coordinator) are permitted — feedback is intentionally
+	// low-privilege: any sandboxed child that can reach the host-API socket may
+	// record a note.
+	//
+	// The response includes the resolved path so the CLI can print it in the
+	// success message — the worker sees the host path, which is the same path
+	// `prism feedback list` will read from on the host (AC: "message prints the
+	// path the entry actually landed at").
+	mux.HandleFunc("/feedback", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+
+		var entry feedback.Entry
+		if err := json.NewDecoder(r.Body).Decode(&entry); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if strings.TrimSpace(entry.Text) == "" {
+			writeError(w, http.StatusBadRequest, "text is required")
+			return
+		}
+
+		// Resolve the host-side feedback store path. DefaultPath honours
+		// $XDG_STATE_HOME, which the test suite sets to a t.TempDir() so that
+		// the homeless-shelter gate (HOME=/homeless-shelter in nix sandbox) is
+		// avoided. The production path is the user's real state dir.
+		path, err := feedback.DefaultPath()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "resolve feedback path: "+err.Error())
+			return
+		}
+		store := feedback.NewStore(path)
+		if err := store.Append(entry); err != nil {
+			s.logger().Printf("sidecar: host-API /feedback: append: %v", err)
+			writeError(w, http.StatusInternalServerError, "append feedback: "+err.Error())
+			return
+		}
+
+		s.logger().Printf("sidecar: host-API /feedback: entry appended to %s", path)
+		writeJSON(w, http.StatusOK, map[string]string{"path": path})
 	})
 
 	// POST /escalate

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_feedback_hostapi_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_feedback_hostapi_test.go
@@ -1,0 +1,170 @@
+package sidecar
+
+// Tests for the host-API /feedback endpoint (issue #1644).
+//
+// The endpoint accepts a feedback.Entry JSON body, appends it to the host
+// feedback.jsonl, and returns the resolved path. These tests exercise the
+// handler directly via hostAPIHandler() without a real Unix socket.
+//
+// The store path is redirected to a t.TempDir() via XDG_STATE_HOME so the
+// tests pass inside the nix-build sandbox where HOME=/homeless-shelter is
+// intentionally unwritable.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/feedback"
+)
+
+// TestHostAPI_Feedback_AppendsEntryAndReturnsPath verifies that a valid POST
+// to /feedback appends the entry to the host store and returns the resolved
+// path in the response body.
+func TestHostAPI_Feedback_AppendsEntryAndReturnsPath(t *testing.T) {
+	// Redirect the feedback store to a tempdir so the handler writes there
+	// rather than to the real home directory.
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "prism-test@worker-feedback", "prism-test", "worker", d)
+
+	entry := feedback.Entry{
+		Timestamp:    "2026-05-15T10:00:00Z",
+		Text:         "some feedback text",
+		Session:      "prism-test@worker-feedback",
+		PrismVersion: "abc123",
+	}
+	body, _ := json.Marshal(entry)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/feedback", string(body))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+
+	// Response must include the path.
+	var resp struct {
+		Path string `json:"path"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Path == "" {
+		t.Fatalf("response missing path: %q", rr.Body.String())
+	}
+
+	// The entry must actually be on disk at the returned path.
+	data, readErr := os.ReadFile(resp.Path)
+	if readErr != nil {
+		t.Fatalf("ReadFile %s: %v", resp.Path, readErr)
+	}
+	if !strings.Contains(string(data), "some feedback text") {
+		t.Errorf("store missing entry text: %s", data)
+	}
+
+	// Verify the path is under the tempdir (not the real home).
+	if !strings.HasPrefix(resp.Path, dir) {
+		t.Errorf("path %q should be under tempdir %q", resp.Path, dir)
+	}
+}
+
+// TestHostAPI_Feedback_MalformedBodyReturns400 verifies that malformed JSON
+// is rejected with HTTP 400.
+func TestHostAPI_Feedback_MalformedBodyReturns400(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "prism-test@worker-feedback", "prism-test", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/feedback", `{not valid json`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "invalid JSON") {
+		t.Errorf("body %q: want 'invalid JSON'", rr.Body.String())
+	}
+}
+
+// TestHostAPI_Feedback_EmptyTextReturns400 verifies that an entry with no
+// text is rejected with HTTP 400.
+func TestHostAPI_Feedback_EmptyTextReturns400(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "prism-test@worker-feedback", "prism-test", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/feedback",
+		`{"timestamp":"2026-05-15T10:00:00Z","text":"","prism_version":"v1"}`)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "text is required") {
+		t.Errorf("body %q: want 'text is required'", rr.Body.String())
+	}
+}
+
+// TestHostAPI_Feedback_WorkerRoleAllowed verifies that worker-role sidecars
+// (not just coordinators) are permitted to call /feedback.
+func TestHostAPI_Feedback_WorkerRoleAllowed(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	d := openTestDB(t)
+	// Explicitly a worker.
+	sc := newSidecarWithRole(t, "prism-test@worker-feedback", "prism-test", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/feedback",
+		`{"timestamp":"2026-05-15T10:00:00Z","text":"worker note","prism_version":"v1"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("worker should be allowed; status = %d, body = %q", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Feedback_GetMethodNotAllowed verifies that GET /feedback returns
+// HTTP 405 (the handler is POST-only).
+func TestHostAPI_Feedback_GetMethodNotAllowed(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "prism-test@worker-feedback", "prism-test", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/feedback", "")
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, body = %q, want 405", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Feedback_XDGStateHomeHonoured verifies that the handler
+// honours $XDG_STATE_HOME as the store path override — the same mechanism
+// used by tests to avoid writing to the real home directory.
+func TestHostAPI_Feedback_XDGStateHomeHonoured(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "prism-test@worker-xdg", "prism-test", "worker", d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/feedback",
+		`{"timestamp":"2026-05-15T10:00:00Z","text":"xdg test","prism_version":"v1"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q", rr.Code, rr.Body.String())
+	}
+
+	var resp struct{ Path string `json:"path"` }
+	decodeJSONBody(t, rr, &resp)
+
+	expectedPath := filepath.Join(dir, "prism", "feedback.jsonl")
+	if resp.Path != expectedPath {
+		t.Errorf("path = %q, want %q", resp.Path, expectedPath)
+	}
+}


### PR DESCRIPTION
## Summary

`prism feedback` invoked from inside a bwrap worker sandbox was silently discarding data: writes to `~/.local/state/prism/feedback.jsonl` landed in the sandbox's private namespace and vanished on sandbox exit, while the success message printed a host path that never had the data.

## Fix

Uses the existing host-API pattern (same as `prism logs`):

1. **`POST /feedback` host-API endpoint** (`internal/sidecar/host_api.go`): accepts a `feedback.Entry` JSON body, appends it to the host's feedback store via `DefaultPath()` + `Store.Append()`, returns `{"path":"..."}` with the resolved host path.

2. **`cmd/feedback.go` proxy path**: when `$PRISM_HOST_API` is set, `runFeedbackRecord` calls `runFeedbackRecordViaHostAPI` which uses `proxyToHostAPI` to POST the entry. The success message shows the host path returned by the API. On any error the CLI exits non-zero — it does **not** fall back to the sandbox-internal write path (the old failure mode).

3. **No regression on host path**: when `$PRISM_HOST_API` is unset the local-write path is unchanged.

4. **Test isolation fix**: `withTempFeedbackStore` in `cmd/feedback_test.go` now also clears `PRISM_HOST_API` so existing local-path tests don't accidentally proxy through the developer's live prism session.

## Tests added

**`internal/sidecar/sidecar_feedback_hostapi_test.go`:**
- `TestHostAPI_Feedback_AppendsEntryAndReturnsPath` — valid POST appends entry and returns path
- `TestHostAPI_Feedback_MalformedBodyReturns400` — malformed JSON → 400
- `TestHostAPI_Feedback_EmptyTextReturns400` — empty text → 400
- `TestHostAPI_Feedback_WorkerRoleAllowed` — worker-role sidecar is permitted
- `TestHostAPI_Feedback_GetMethodNotAllowed` — GET → 405
- `TestHostAPI_Feedback_XDGStateHomeHonoured` — $XDG_STATE_HOME override works

**`cmd/feedback_test.go`:**
- `TestFeedback_Record_HostAPIProxy_Success` — proxy sends correct POST body, output contains host path, nothing written locally
- `TestFeedback_Record_HostAPIProxy_ErrorExitsNonZero` — 500 from host-API → non-zero exit, no local write
- `TestFeedback_Record_HostAPIProxy_UnreachableExitsNonZero` — unreachable socket → non-zero exit, no local write
- `TestFeedback_Record_NoHostAPI_WritesLocally` — no PRISM_HOST_API → local write (regression guard)

Closes #1644
