### PR TITLE
feat(iris): D-6 — client IPC socket, fan-out, subscribe/replay (#1637)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -255,7 +255,40 @@ func runDaemon() error {
 		supervisors: make(map[string]*iris.Supervisor),
 	}
 
+	// deliverFn is called by the client socket when a prompt_deliver frame arrives.
+	// It sends the prompt via the supervisor's RPC channel.
+	deliverFn := func(_ context.Context, name, text, deliverAs string, images []string) error {
+		state.mu.Lock()
+		sup, ok := state.supervisors[name]
+		state.mu.Unlock()
+		if !ok {
+			return fmt.Errorf("session %q not found", name)
+		}
+		kind := deliverAs
+		if kind == "" {
+			kind = "prompt"
+		}
+		return sup.SendRPC(map[string]any{
+			"type":    kind,
+			"message": text,
+			"images":  images,
+		})
+	}
+
+	// Create the client IPC socket first so spawnFn can capture it and wire
+	// each new harness as a publisher (D-6 fan-out). spawnFn is passed to
+	// NewClientSocket as ClientSocketConfig.SpawnSession.
+	clientSock := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          p.Sock,
+		Database:          database,
+		GetActiveSessions: state.activeSessions,
+		// SpawnSession is assigned below after spawnFn is defined.
+		DeliverPrompt: deliverFn,
+	})
+
 	// spawnFn is called by the client socket when a session_spawn frame arrives.
+	// It must be defined after clientSock so it can capture clientSock and wire
+	// the harness publisher (D-6 fan-out: harness events → client subscribers).
 	spawnFn := func(spawnCtx context.Context, worktree, role string, configOverrides map[string]any) (*iris.Supervisor, error) {
 		extPath := cfg.PIExtensionPath
 		superCfg := iris.SupervisorConfig{
@@ -267,6 +300,9 @@ func runDaemon() error {
 			RestartThreshold: cfg.RestartThreshold,
 			RunDir:           p.RunDir,
 			Database:         database,
+			// Wire the client socket as the harness publisher so that every
+			// harness event is fanned out to all subscribed clients in real time.
+			Publisher: clientSock,
 		}
 		sup, err := iris.SpawnSession(ctx, superCfg)
 		if err != nil {
@@ -292,35 +328,8 @@ func runDaemon() error {
 		}()
 		return sup, nil
 	}
-
-	// deliverFn is called by the client socket when a prompt_deliver frame arrives.
-	// It sends the prompt via the supervisor's RPC channel.
-	deliverFn := func(_ context.Context, name, text, deliverAs string, images []string) error {
-		state.mu.Lock()
-		sup, ok := state.supervisors[name]
-		state.mu.Unlock()
-		if !ok {
-			return fmt.Errorf("session %q not found", name)
-		}
-		kind := deliverAs
-		if kind == "" {
-			kind = "prompt"
-		}
-		return sup.SendRPC(map[string]any{
-			"type":    kind,
-			"message": text,
-			"images":  images,
-		})
-	}
-
-	// Create the client IPC socket.
-	clientSock := iris.NewClientSocket(iris.ClientSocketConfig{
-		SockPath:          p.Sock,
-		Database:          database,
-		GetActiveSessions: state.activeSessions,
-		SpawnSession:      spawnFn,
-		DeliverPrompt:     deliverFn,
-	})
+	// Wire the spawn function now that it is defined.
+	clientSock.SetSpawnSession(spawnFn)
 	if err := clientSock.Listen(); err != nil {
 		return fmt.Errorf("iris: client socket: %w", err)
 	}

--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -1,22 +1,27 @@
-// Command iris is the daemon-mode successor to prism (codename iris, D-3).
+// Command iris is the daemon-mode successor to prism (codename iris, D-3/D-6).
 //
 // D-3 adds: spawn, harness-socket dispatch, tool override registration.
-// See docs/daemon-mode-design.md §3 for the architecture.
+// D-6 adds: client IPC socket (iris.sock), session fan-out, subscribe/replay.
+// See docs/daemon-mode-design.md §3 and §4 for the architecture.
 //
 // Usage:
 //
 //	iris --version                              — print version string and exit 0
 //	iris version                                — same, as a subcommand
-//	iris spawn --worktree <path> [--role <role>] — spawn a pi session
+//	iris daemon                                 — start the full daemon (client socket + sessions)
+//	iris spawn --worktree <path> [--role <role>] — spawn a pi session (no client socket)
 package main
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -28,7 +33,7 @@ import (
 //
 // This intentionally does NOT reuse the prism version string or any
 // prism-internal ldflags variable — iris has its own identity.
-const irisVersion = "0.1.0-d3"
+const irisVersion = "0.1.0-d6"
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
@@ -60,6 +65,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(spawnCmd)
+	rootCmd.AddCommand(daemonCmd)
 	spawnCmd.Flags().StringVar(&spawnWorktree, "worktree", "", "Absolute path to the git worktree (required)")
 	spawnCmd.Flags().StringVar(&spawnRole, "role", "worker", "Agent role (worker, coordinator, etc.)")
 	spawnCmd.Flags().StringVar(&spawnExtension, "extension", "", "Path to the prism.ts extension file (overrides config)")
@@ -101,7 +107,7 @@ func startup() error {
 	}
 	defer db.Close()
 
-	fmt.Println("iris daemon initialised (D-3). Use 'iris spawn --worktree <path>' to start a session.")
+	fmt.Println("iris daemon initialised (D-6). Use 'iris daemon' to start the full daemon, or 'iris spawn --worktree <path>' to test a session.")
 	return nil
 }
 
@@ -167,4 +173,175 @@ func spawnSession() error {
 	// or context is cancelled.
 	<-ctx.Done()
 	return nil
+}
+
+// daemonCmd starts the full iris daemon: client IPC socket + session manager.
+// Clients connect to ~/.local/state/iris/iris.sock to list/subscribe/spawn
+// sessions. This is the D-6 entry point.
+var daemonCmd = &cobra.Command{
+	Use:   "daemon",
+	Short: "Start the iris daemon (client socket + session manager)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runDaemon()
+	},
+}
+
+// daemonState holds the in-memory runtime state of the iris daemon.
+type daemonState struct {
+	mu          sync.Mutex
+	supervisors map[string]*iris.Supervisor // session name → supervisor
+}
+
+func (ds *daemonState) addSupervisor(name string, sup *iris.Supervisor) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.supervisors[name] = sup
+}
+
+func (ds *daemonState) removeSupervisor(name string) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	delete(ds.supervisors, name)
+}
+
+func (ds *daemonState) activeSessions() []iris.SessionSnapshot {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	out := make([]iris.SessionSnapshot, 0, len(ds.supervisors))
+	for _, sup := range ds.supervisors {
+		rec := sup.SessionRecord()
+		out = append(out, iris.SessionSnapshot{
+			Name:       rec.SessionName,
+			InstanceID: rec.InstanceID,
+			State:      string(rec.State),
+			Role:       rec.Role,
+			Worktree:   rec.Worktree,
+			StartedAt:  rec.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+	return out
+}
+
+// runDaemon initialises the iris daemon and blocks until the context is
+// cancelled. It:
+//
+//  1. Resolves paths and loads config.
+//  2. Opens the iris DB.
+//  3. Creates and starts the client IPC socket.
+//  4. Waits for SIGINT/SIGTERM.
+func runDaemon() error {
+	p := iris.ResolvePaths()
+
+	cfg, err := iris.LoadConfig(p.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("iris: load config: %w", err)
+	}
+
+	database, err := iris.OpenDB(p.DB)
+	if err != nil {
+		return fmt.Errorf("iris: open db: %w", err)
+	}
+	defer database.Close()
+
+	// Ensure the run directory exists with 0700 (parent of per-session dirs).
+	if err := os.MkdirAll(p.RunDir, 0o700); err != nil {
+		return fmt.Errorf("iris: create run dir: %w", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	state := &daemonState{
+		supervisors: make(map[string]*iris.Supervisor),
+	}
+
+	// spawnFn is called by the client socket when a session_spawn frame arrives.
+	spawnFn := func(spawnCtx context.Context, worktree, role string, configOverrides map[string]any) (*iris.Supervisor, error) {
+		extPath := cfg.PIExtensionPath
+		superCfg := iris.SupervisorConfig{
+			SessionName:      iris.GenerateSessionName(worktree, role),
+			Worktree:         worktree,
+			Role:             role,
+			PIBinaryPath:     cfg.PIBinaryPath,
+			ExtensionPath:    extPath,
+			RestartThreshold: cfg.RestartThreshold,
+			RunDir:           p.RunDir,
+			Database:         database,
+		}
+		sup, err := iris.SpawnSession(ctx, superCfg)
+		if err != nil {
+			return nil, err
+		}
+		state.addSupervisor(superCfg.SessionName, sup)
+		go func() {
+			// When the session terminates, remove it from the live map.
+			// SpawnSession starts the supervisor in a goroutine; we detect
+			// termination by polling the session record state.
+			for {
+				rec := sup.SessionRecord()
+				if rec.State == iris.StateFinished || rec.State == iris.StateError {
+					state.removeSupervisor(superCfg.SessionName)
+					return
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-waitMillis(500):
+				}
+			}
+		}()
+		return sup, nil
+	}
+
+	// deliverFn is called by the client socket when a prompt_deliver frame arrives.
+	// It sends the prompt via the supervisor's RPC channel.
+	deliverFn := func(_ context.Context, name, text, deliverAs string, images []string) error {
+		state.mu.Lock()
+		sup, ok := state.supervisors[name]
+		state.mu.Unlock()
+		if !ok {
+			return fmt.Errorf("session %q not found", name)
+		}
+		kind := deliverAs
+		if kind == "" {
+			kind = "prompt"
+		}
+		return sup.SendRPC(map[string]any{
+			"type":    kind,
+			"message": text,
+			"images":  images,
+		})
+	}
+
+	// Create the client IPC socket.
+	clientSock := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          p.Sock,
+		Database:          database,
+		GetActiveSessions: state.activeSessions,
+		SpawnSession:      spawnFn,
+		DeliverPrompt:     deliverFn,
+	})
+	if err := clientSock.Listen(); err != nil {
+		return fmt.Errorf("iris: client socket: %w", err)
+	}
+	defer clientSock.Close()
+
+	go clientSock.Serve(ctx)
+
+	log.Printf("[iris] daemon running. Client socket: %s", p.Sock)
+	fmt.Printf("[iris] daemon ready. Connect via: %s\n", p.Sock)
+
+	<-ctx.Done()
+	log.Println("[iris] daemon shutting down")
+	return nil
+}
+
+// waitMillis returns a channel that closes after n milliseconds.
+func waitMillis(n int) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		time.Sleep(time.Duration(n) * time.Millisecond)
+	}()
+	return ch
 }

--- a/modules/programs/prism/prism/internal/db/events.go
+++ b/modules/programs/prism/prism/internal/db/events.go
@@ -465,3 +465,105 @@ LIMIT ?`
 	}
 	return count, nil
 }
+
+// QuerySessionEventsSinceRowID returns all events for sessionName with
+// rowid > sinceRowID, ordered by rowid ASC (monotonic DB insertion order).
+// This is the backing query for the client IPC socket's since_event_id replay
+// (§4.3 of daemon-mode-design.md). Each returned EventRow carries the rowid so
+// the client can use it in a subsequent since_event_id field.
+func (d *DB) QuerySessionEventsSinceRowID(sessionName string, sinceRowID int64) ([]EventRow, error) {
+	const q = `
+SELECT rowid, id, session_name, repo, worktree, harness_session_id,
+       type, payload, created_at, instance_id
+  FROM agent_events
+ WHERE session_name = ? AND rowid > ?
+ ORDER BY rowid ASC`
+	rows, err := d.conn.Query(q, sessionName, sinceRowID)
+	if err != nil {
+		return nil, fmt.Errorf("db: query session events since rowid: %w", err)
+	}
+	defer rows.Close()
+
+	var result []EventRow
+	for rows.Next() {
+		var er EventRow
+		var createdAt int64
+		if err := rows.Scan(
+			&er.RowID, &er.Event.ID, &er.Event.SessionName, &er.Event.Repo,
+			&er.Event.Worktree, &er.Event.HarnessSessionID,
+			&er.Event.Type, &er.Event.Payload, &createdAt, &er.Event.InstanceID,
+		); err != nil {
+			return nil, fmt.Errorf("db: scan event row: %w", err)
+		}
+		er.Event.CreatedAt = time.UnixMilli(createdAt)
+		result = append(result, er)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate session events since rowid: %w", err)
+	}
+	return result, nil
+}
+
+// MaxSessionEventRowID returns the maximum rowid in agent_events for the
+// given sessionName, or 0 if no events exist. Used by the client IPC socket to
+// snapshot the high-water mark before a replay query so that events arriving
+// during replay can be deduplicated (§4.3 design doc — the since_event_id race
+// avoidance strategy).
+func (d *DB) MaxSessionEventRowID(sessionName string) (int64, error) {
+	const q = `SELECT COALESCE(MAX(rowid), 0) FROM agent_events WHERE session_name = ?`
+	var max int64
+	if err := d.conn.QueryRow(q, sessionName).Scan(&max); err != nil {
+		return 0, fmt.Errorf("db: max session event rowid: %w", err)
+	}
+	return max, nil
+}
+
+// EventRow wraps an Event together with its SQLite rowid. The rowid is a
+// monotonically increasing integer that clients use as since_event_id for
+// replay requests.
+type EventRow struct {
+	RowID int64
+	Event Event
+}
+
+// WriteEventReturningRowID is identical to WriteEvent but also returns the
+// SQLite rowid of the newly inserted agent_events row. The rowid is used by
+// the client IPC socket (D-6) as the monotonic event_id for since_event_id
+// replay and fan-out ordering.
+func (d *DB) WriteEventReturningRowID(e Event) (int64, error) {
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now()
+	}
+	createdAt := e.CreatedAt.UnixMilli()
+
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("db: write event: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	const insertQ = `
+INSERT INTO agent_events (id, session_name, repo, worktree, harness_session_id, type, payload, created_at, instance_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	result, err := tx.Exec(insertQ, e.ID, e.SessionName, e.Repo, e.Worktree, e.HarnessSessionID, e.Type, e.Payload, createdAt, e.InstanceID)
+	if err != nil {
+		return 0, fmt.Errorf("db: write event: insert: %w", err)
+	}
+	rowID, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("db: write event: last insert id: %w", err)
+	}
+
+	const updateQ = `
+UPDATE agent_status
+   SET last_seen = MAX(last_seen, ?)
+ WHERE session_name = ?`
+	if _, err := tx.Exec(updateQ, createdAt, e.SessionName); err != nil {
+		return 0, fmt.Errorf("db: write event: update last_seen: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("db: write event: commit: %w", err)
+	}
+	return rowID, nil
+}

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -1,0 +1,186 @@
+package iris
+
+// client_protocol.go — wire-protocol frame types for the iris client IPC socket.
+//
+// The client IPC socket exposes the daemon's session management surface to
+// user-facing clients: TUI, CLI, future web UI (§4.2 of daemon-mode-design.md).
+//
+// Framing: JSON-line (one JSON object per '\n'-terminated line), identical to
+// the harness socket protocol and pi-wire-protocol.md §3. Both sides must
+// tolerate unknown "type" values by logging and skipping them.
+//
+// Client → daemon frames:
+//
+//	sessions_list, session_subscribe, session_unsubscribe,
+//	session_spawn, session_kill, prompt_deliver, ping
+//
+// Daemon → client frames:
+//
+//	sessions_snapshot, session_event, session_state, session_spawned,
+//	error, pong
+
+// ---------------------------------------------------------------------------
+// Client → daemon request frames
+// ---------------------------------------------------------------------------
+
+// ClientSessionsListFrame requests a snapshot of all active sessions.
+//
+//	{"type": "sessions_list"}
+type ClientSessionsListFrame struct {
+	Type string `json:"type"` // "sessions_list"
+}
+
+// ClientSessionSubscribeFrame subscribes the client to a session's event
+// stream. When SinceEventID is non-zero, the daemon first replays events
+// with rowid > SinceEventID from the DB, then switches to live mode.
+//
+//	{"type": "session_subscribe", "name": "<session>"}
+//	{"type": "session_subscribe", "name": "<session>", "since_event_id": 42}
+type ClientSessionSubscribeFrame struct {
+	Type         string `json:"type"` // "session_subscribe"
+	Name         string `json:"name"`
+	SinceEventID int64  `json:"since_event_id,omitempty"` // 0 means no replay
+}
+
+// ClientSessionUnsubscribeFrame cancels a subscription to a session's event
+// stream. The connection stays open; other subscriptions or requests continue.
+//
+//	{"type": "session_unsubscribe", "name": "<session>"}
+type ClientSessionUnsubscribeFrame struct {
+	Type string `json:"type"` // "session_unsubscribe"
+	Name string `json:"name"`
+}
+
+// ClientSessionSpawnFrame requests the daemon to spawn a new pi session.
+//
+//	{"type": "session_spawn", "worktree": "/abs/path", "role": "worker"}
+//	{"type": "session_spawn", "worktree": "...", "role": "coordinator", "config_overrides": {...}}
+type ClientSessionSpawnFrame struct {
+	Type            string         `json:"type"` // "session_spawn"
+	Worktree        string         `json:"worktree"`
+	Role            string         `json:"role"`
+	ConfigOverrides map[string]any `json:"config_overrides,omitempty"`
+}
+
+// ClientSessionKillFrame requests the daemon to kill a named session.
+//
+//	{"type": "session_kill", "name": "<session>"}
+type ClientSessionKillFrame struct {
+	Type string `json:"type"` // "session_kill"
+	Name string `json:"name"`
+}
+
+// ClientPromptDeliverFrame delivers a prompt to a named session.
+//
+//	{"type": "prompt_deliver", "name": "<session>", "text": "..."}
+//	{"type": "prompt_deliver", "name": "<session>", "text": "...", "deliver_as": "steer", "images": ["base64..."]}
+type ClientPromptDeliverFrame struct {
+	Type      string   `json:"type"` // "prompt_deliver"
+	Name      string   `json:"name"`
+	Text      string   `json:"text"`
+	DeliverAs string   `json:"deliver_as,omitempty"` // "prompt", "steer", "follow_up"; default "prompt"
+	Images    []string `json:"images,omitempty"`
+}
+
+// ClientPingFrame is a keepalive probe. The daemon responds with pong.
+//
+//	{"type": "ping"}
+type ClientPingFrame struct {
+	Type string `json:"type"` // "ping"
+}
+
+// ---------------------------------------------------------------------------
+// Daemon → client response frames
+// ---------------------------------------------------------------------------
+
+// DaemonSessionsSnapshotFrame is the response to sessions_list.
+// Sessions contains the list of known iris sessions with their current state.
+//
+//	{"type": "sessions_snapshot", "sessions": [...]}
+type DaemonSessionsSnapshotFrame struct {
+	Type     string            `json:"type"` // "sessions_snapshot"
+	Sessions []SessionSnapshot `json:"sessions"`
+}
+
+// SessionSnapshot is a single session entry in a sessions_snapshot frame.
+// Fields are a subset of the iris SessionRecord, sufficient for the TUI.
+type SessionSnapshot struct {
+	// Name is the logical session name (e.g. "nixos-config@my-branch").
+	Name string `json:"name"`
+	// InstanceID is the UUID for this session incarnation.
+	InstanceID string `json:"instance_id"`
+	// State is the lifecycle state ("spawning", "active", "finished", "error").
+	State string `json:"state"`
+	// Role is the agent role ("worker", "coordinator", etc.).
+	Role string `json:"role"`
+	// Worktree is the absolute path to the session's git worktree.
+	Worktree string `json:"worktree"`
+	// StartedAt is the RFC3339 timestamp when this session was created.
+	StartedAt string `json:"started_at"`
+}
+
+// DaemonSessionEventFrame wraps a raw event payload from the subscribed
+// session's event log. The Payload field is the verbatim JSON from the DB's
+// agent_events.payload column. Clients use EventType and RowID for ordering
+// and replay logic.
+//
+//	{"type": "session_event", "session_name": "...", "row_id": 42, "event_type": "tool_call", "payload": {...}}
+type DaemonSessionEventFrame struct {
+	Type        string `json:"type"`         // "session_event"
+	SessionName string `json:"session_name"` // which session emitted this
+	RowID       int64  `json:"row_id"`       // monotonic DB row ID; used for since_event_id replay
+	EventType   string `json:"event_type"`   // agent_events.type field
+	Payload     string `json:"payload"`      // verbatim agent_events.payload JSON
+}
+
+// DaemonSessionStateFrame notifies the client of a state transition for a
+// subscribed session.
+//
+//	{"type": "session_state", "session_name": "...", "state": "active"}
+type DaemonSessionStateFrame struct {
+	Type        string `json:"type"`         // "session_state"
+	SessionName string `json:"session_name"`
+	State       string `json:"state"` // one of the SessionState constants
+}
+
+// DaemonSessionSpawnedFrame acknowledges a successful session_spawn.
+//
+//	{"type": "session_spawned", "name": "...", "instance_id": "..."}
+type DaemonSessionSpawnedFrame struct {
+	Type       string `json:"type"`        // "session_spawned"
+	Name       string `json:"name"`        // the new session's logical name
+	InstanceID string `json:"instance_id"` // the new session's instance UUID
+}
+
+// DaemonErrorFrame is an error response to a client request.
+//
+//	{"type": "error", "request_type": "session_subscribe", "message": "session not found"}
+type DaemonErrorFrame struct {
+	Type        string `json:"type"`         // "error"
+	RequestType string `json:"request_type"` // the frame type that caused the error
+	Message     string `json:"message"`
+}
+
+// DaemonPongFrame is the keepalive response to a ping.
+//
+//	{"type": "pong"}
+type DaemonPongFrame struct {
+	Type string `json:"type"` // "pong"
+}
+
+// Client-socket frame type constants.
+const (
+	ClientFrameSessionsList        = "sessions_list"
+	ClientFrameSessionSubscribe    = "session_subscribe"
+	ClientFrameSessionUnsubscribe  = "session_unsubscribe"
+	ClientFrameSessionSpawn        = "session_spawn"
+	ClientFrameSessionKill         = "session_kill"
+	ClientFramePromptDeliver       = "prompt_deliver"
+	ClientFramePing                = "ping"
+	DaemonFrameSessionsSnapshot    = "sessions_snapshot"
+	DaemonFrameSessionEvent        = "session_event"
+	DaemonFrameSessionState        = "session_state"
+	DaemonFrameSessionSpawned      = "session_spawned"
+	DaemonFrameError               = "error"
+	DaemonFramePong                = "pong"
+)

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -1,0 +1,604 @@
+package iris
+
+// client_socket.go — user-facing client IPC socket for the iris daemon.
+//
+// The ClientSocket binds to ~/.local/state/iris/iris.sock (mode 0600, parent
+// dir 0700) and accepts multiple simultaneous client connections. Each
+// connection is an independent client session on the same daemon.
+//
+// # Protocol
+//
+// Framing is JSON-line (§4.2 of daemon-mode-design.md). The client sends
+// request frames (sessions_list, session_subscribe, session_unsubscribe,
+// session_spawn, session_kill, prompt_deliver, ping) and the daemon pushes
+// response and event frames back on the same connection.
+//
+// # Fan-out
+//
+// The daemon maintains a per-session subscriber set. When a new event is
+// written to the DB via the harness socket (D-3), the caller also invokes
+// ClientSocket.Publish to broadcast the event to all subscribers of that
+// session. Each subscriber goroutine reads from a buffered channel and
+// writes session_event frames to its client connection.
+//
+// # since_event_id replay
+//
+// A client that reconnects after a gap can send session_subscribe with a
+// since_event_id field. The handler:
+//
+//  1. Snapshots the maximum rowid currently in the DB for that session.
+//  2. Queries the DB for events with rowid > since_event_id (up to the
+//     snapshot max) — this is the "catch-up" range.
+//  3. Registers the live channel in the subscriber set.
+//  4. Streams the catch-up range as session_event frames.
+//  5. Switches to live mode, draining the channel.
+//
+// This avoids the replay-vs-live race: any event that arrives during the
+// DB query and is written to the channel before the subscriber was registered
+// would be missed by a naive implementation. By snapshotting first and then
+// registering, we ensure the channel receives all events from that point
+// forward, and the replay covers up to the snapshot. Events with rowid ≤
+// snapshot are served from the DB; events with rowid > snapshot come from
+// the live channel. Duplicates (an event arriving on the channel with rowid ≤
+// snapshot) are discarded by the rowid guard in the drain step.
+//
+// See also: daemon-mode-design.md §4.3.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// subscriberChanSize is the buffer size for per-subscriber event channels.
+// A full channel causes events to be dropped for that subscriber (the
+// subscriber is too slow or the connection is backed up). The subscriber
+// goroutine logs and disconnects on overflow rather than blocking the
+// broadcaster.
+const subscriberChanSize = 256
+
+// EventPublication is the unit passed through the fan-out channels. It
+// carries enough information to write a DaemonSessionEventFrame.
+type EventPublication struct {
+	SessionName string
+	RowID       int64
+	EventType   string
+	Payload     string
+}
+
+// ClientSocket is the user-facing IPC socket. It binds to the iris.sock path
+// and manages per-client connection goroutines and the per-session subscriber
+// map for fan-out.
+type ClientSocket struct {
+	sockPath string
+	database *db.DB
+	// getActiveSessions returns the current in-memory session list. This is
+	// set by the daemon to a function that reads the Supervisor map.
+	getActiveSessions func() []SessionSnapshot
+	// spawnSession spawns a new session. Set by the daemon at construction.
+	spawnSession func(ctx context.Context, worktree, role string, configOverrides map[string]any) (*Supervisor, error)
+	// deliverPrompt delivers a prompt to a named session. Set by the daemon.
+	deliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
+
+	listener net.Listener
+
+	// subscribers maps session name → set of subscriber channels.
+	// The mutex guards both the map and the slices inside it.
+	subMu       sync.Mutex
+	subscribers map[string][]subscriberChan
+}
+
+// subscriberChan wraps a channel together with a unique ID so that
+// unsubscribe can remove the correct entry from the slice.
+type subscriberChan struct {
+	id string
+	ch chan EventPublication
+}
+
+// ClientSocketConfig holds the parameters for constructing a ClientSocket.
+type ClientSocketConfig struct {
+	// SockPath is the absolute path for the Unix domain socket.
+	// Typically p.Sock from ResolvePaths().
+	SockPath string
+	// Database is the open iris DB (used for sessions_list and replay queries).
+	Database *db.DB
+	// GetActiveSessions returns the current in-memory session list.
+	GetActiveSessions func() []SessionSnapshot
+	// SpawnSession spawns a new session and returns the supervisor.
+	SpawnSession func(ctx context.Context, worktree, role string, configOverrides map[string]any) (*Supervisor, error)
+	// DeliverPrompt delivers a prompt to a named session.
+	DeliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
+}
+
+// NewClientSocket creates a ClientSocket. Call Listen() to bind the socket,
+// then Serve() in a goroutine to accept connections.
+func NewClientSocket(cfg ClientSocketConfig) *ClientSocket {
+	return &ClientSocket{
+		sockPath:          cfg.SockPath,
+		database:          cfg.Database,
+		getActiveSessions: cfg.GetActiveSessions,
+		spawnSession:      cfg.SpawnSession,
+		deliverPrompt:     cfg.DeliverPrompt,
+		subscribers:       make(map[string][]subscriberChan),
+	}
+}
+
+// Listen binds the Unix domain socket. The parent directory is created with
+// mode 0700 if it does not exist; the socket inode is chmod'd 0600.
+//
+// Any stale socket file from a previous daemon incarnation is removed before
+// binding (os.Remove is idempotent and safe).
+func (cs *ClientSocket) Listen() error {
+	// Ensure the parent directory exists with 0700.
+	parent := dirOf(cs.sockPath)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return fmt.Errorf("iris: client socket: mkdir %q: %w", parent, err)
+	}
+
+	// Remove stale socket from a previous daemon run.
+	_ = os.Remove(cs.sockPath)
+
+	ln, err := net.Listen("unix", cs.sockPath)
+	if err != nil {
+		return fmt.Errorf("iris: client socket listen %q: %w", cs.sockPath, err)
+	}
+	// Enforce 0600 on the socket inode (filesystem-level access control
+	// per §4.1 and §6 of daemon-mode-design.md).
+	if err := os.Chmod(cs.sockPath, 0o600); err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("iris: client socket chmod %q: %w", cs.sockPath, err)
+	}
+	cs.listener = ln
+	log.Printf("[iris] client socket listening at %s", cs.sockPath)
+	return nil
+}
+
+// Serve accepts client connections in a loop until ctx is cancelled. Each
+// accepted connection is handled in its own goroutine. Serve is intended to
+// be called in its own goroutine.
+func (cs *ClientSocket) Serve(ctx context.Context) {
+	for {
+		conn, err := cs.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return // Normal shutdown.
+			}
+			log.Printf("[iris] client socket accept error: %v", err)
+			// Brief pause to avoid a tight loop on persistent accept errors.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+		go cs.handleConn(ctx, conn)
+	}
+}
+
+// SockPath returns the filesystem path of the client IPC socket.
+func (cs *ClientSocket) SockPath() string { return cs.sockPath }
+
+// Close closes the listener and removes the socket file.
+func (cs *ClientSocket) Close() {
+	if cs.listener != nil {
+		cs.listener.Close()
+	}
+	_ = os.Remove(cs.sockPath)
+}
+
+// Publish broadcasts an event to all clients subscribed to the named session.
+// It is called by the harness socket handler (and, in future, by the
+// supervisor's RPC event reader) every time a new event is written to the DB.
+// Publish never blocks: slow subscribers receive a dropped-event log and are
+// removed from the subscriber set on their next send attempt.
+func (cs *ClientSocket) Publish(pub EventPublication) {
+	cs.subMu.Lock()
+	chans := make([]subscriberChan, len(cs.subscribers[pub.SessionName]))
+	copy(chans, cs.subscribers[pub.SessionName])
+	cs.subMu.Unlock()
+
+	for _, sc := range chans {
+		select {
+		case sc.ch <- pub:
+		default:
+			// The subscriber channel is full. We drop the event for this
+			// subscriber; the subscriber goroutine will detect the next
+			// failure and close the connection.
+			log.Printf("[iris] client socket: subscriber %s for session %q channel full, dropping event", sc.id, pub.SessionName)
+		}
+	}
+}
+
+// --- Connection handler ---
+
+// handleConn manages a single client connection for its lifetime.
+// It reads request frames from the client and dispatches them. Multiple
+// session subscriptions may be active simultaneously on one connection.
+func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	addr := conn.RemoteAddr().String()
+	log.Printf("[iris] client socket: connection opened (%s)", addr)
+	defer log.Printf("[iris] client socket: connection closed (%s)", addr)
+
+	// cancelConn cancels all goroutines spawned for this connection when the
+	// connection closes (either by client disconnect or ctx cancellation).
+	connCtx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn()
+
+	reader := bufio.NewReaderSize(conn, 16*1024*1024)
+	w := &jsonlWriter{conn: conn}
+
+	// activeSubscriptions tracks the subscriber channel IDs registered for
+	// this connection, keyed by session name. Used for unsubscribe and for
+	// cleanup on disconnect.
+	type subEntry struct {
+		id     string
+		cancel context.CancelFunc
+	}
+	var subMu sync.Mutex
+	activeSubs := make(map[string]subEntry) // session name → {id, cancel}
+
+	cleanupSubs := func() {
+		subMu.Lock()
+		defer subMu.Unlock()
+		for name, entry := range activeSubs {
+			cs.removeSubscriber(name, entry.id)
+			entry.cancel()
+		}
+		activeSubs = make(map[string]subEntry)
+	}
+	defer cleanupSubs()
+
+	for {
+		line, err := readLine(reader)
+		if err != nil {
+			return // Connection closed or error.
+		}
+
+		var generic GenericFrame
+		if err := json.Unmarshal(line, &generic); err != nil {
+			log.Printf("[iris] client socket: parse error: %v", err)
+			_ = w.write(DaemonErrorFrame{
+				Type:        DaemonFrameError,
+				RequestType: "unknown",
+				Message:     fmt.Sprintf("invalid JSON: %v", err),
+			})
+			continue
+		}
+
+		switch generic.Type {
+
+		case ClientFrameSessionsList:
+			cs.handleSessionsList(w)
+
+		case ClientFrameSessionSubscribe:
+			var frame ClientSessionSubscribeFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFrameSessionSubscribe, "invalid frame: "+err.Error())
+				continue
+			}
+			subMu.Lock()
+			if _, exists := activeSubs[frame.Name]; exists {
+				// Already subscribed — ignore (idempotent).
+				subMu.Unlock()
+				continue
+			}
+			subCtx, subCancel := context.WithCancel(connCtx)
+			subID := uuid.New().String()
+			activeSubs[frame.Name] = subEntry{id: subID, cancel: subCancel}
+			subMu.Unlock()
+
+			go cs.runSubscription(subCtx, w, frame, subID, func() {
+				// Called by the subscription goroutine when done (client
+				// disconnect or ctx cancel). Remove from the local map and
+				// the global subscriber set.
+				subMu.Lock()
+				if e, ok := activeSubs[frame.Name]; ok && e.id == subID {
+					delete(activeSubs, frame.Name)
+				}
+				subMu.Unlock()
+				cs.removeSubscriber(frame.Name, subID)
+				subCancel()
+			})
+
+		case ClientFrameSessionUnsubscribe:
+			var frame ClientSessionUnsubscribeFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFrameSessionUnsubscribe, "invalid frame: "+err.Error())
+				continue
+			}
+			subMu.Lock()
+			if entry, ok := activeSubs[frame.Name]; ok {
+				cs.removeSubscriber(frame.Name, entry.id)
+				entry.cancel()
+				delete(activeSubs, frame.Name)
+			}
+			subMu.Unlock()
+
+		case ClientFrameSessionSpawn:
+			var frame ClientSessionSpawnFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFrameSessionSpawn, "invalid frame: "+err.Error())
+				continue
+			}
+			go cs.handleSessionSpawn(connCtx, w, frame)
+
+		case ClientFrameSessionKill:
+			var frame ClientSessionKillFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFrameSessionKill, "invalid frame: "+err.Error())
+				continue
+			}
+			sendError(w, ClientFrameSessionKill, "session_kill not yet implemented")
+
+		case ClientFramePromptDeliver:
+			var frame ClientPromptDeliverFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFramePromptDeliver, "invalid frame: "+err.Error())
+				continue
+			}
+			go cs.handlePromptDeliver(connCtx, w, frame)
+
+		case ClientFramePing:
+			_ = w.write(DaemonPongFrame{Type: DaemonFramePong})
+
+		default:
+			// Unknown frame — log and skip (forward-compatibility).
+			log.Printf("[iris] client socket: unknown frame type %q (skipping)", generic.Type)
+		}
+	}
+}
+
+// --- Request handlers ---
+
+// handleSessionsList writes a sessions_snapshot frame to the client.
+func (cs *ClientSocket) handleSessionsList(w *jsonlWriter) {
+	var sessions []SessionSnapshot
+	if cs.getActiveSessions != nil {
+		sessions = cs.getActiveSessions()
+	}
+	if sessions == nil {
+		sessions = []SessionSnapshot{}
+	}
+	_ = w.write(DaemonSessionsSnapshotFrame{
+		Type:     DaemonFrameSessionsSnapshot,
+		Sessions: sessions,
+	})
+}
+
+// runSubscription manages a single subscription for one session on one client
+// connection. It:
+//
+//  1. Checks that the session exists (sends error if not; keeps connection open).
+//  2. Snapshots the current max rowid for replay deduplication.
+//  3. Registers a live channel in the subscriber set.
+//  4. Replays events since_event_id from the DB (if requested).
+//  5. Drains the live channel, writing session_event frames to the client.
+//
+// onDone is called when the goroutine exits (whether by ctx cancel, write
+// error, or channel overflow).
+func (cs *ClientSocket) runSubscription(
+	ctx context.Context,
+	w *jsonlWriter,
+	frame ClientSessionSubscribeFrame,
+	subID string,
+	onDone func(),
+) {
+	defer onDone()
+
+	sessionName := frame.Name
+
+	// Step 1: Verify the session exists. A "not found" still registers the
+	// subscription for sessions that may start later, but per the AC the
+	// requirement is to return an error and keep the connection open.
+	// We check the in-memory supervisor map via getActiveSessions.
+	if !cs.sessionExists(sessionName) {
+		sendError(w, ClientFrameSessionSubscribe,
+			fmt.Sprintf("session %q not found", sessionName))
+		return
+	}
+
+	// Step 2: Snapshot the current max rowid before registering the live
+	// channel. This is the key to avoiding the replay-vs-live race described
+	// in the file-level comment and §4.3 of the design doc.
+	//
+	// Timeline:
+	//   T0: snapshotRowID = MAX(rowid) = N
+	//   T1: register live channel (events from T1 onward arrive on ch)
+	//   T2: replay DB events with rowid > sinceRowID AND rowid <= N
+	//   T3: drain ch, skipping events with rowid <= N (already replayed)
+	//
+	// This guarantees no event in the window [sinceRowID, ∞) is missed,
+	// at the cost of potentially duplicating events in [N+1, first-ch-item]
+	// which the rowid guard in the drain step eliminates.
+	snapshotRowID, err := cs.database.MaxSessionEventRowID(sessionName)
+	if err != nil {
+		log.Printf("[iris] client socket: snapshot rowid for %q: %v", sessionName, err)
+		snapshotRowID = 0
+	}
+
+	// Step 3: Register the live channel.
+	ch := make(chan EventPublication, subscriberChanSize)
+	cs.addSubscriber(sessionName, subscriberChan{id: subID, ch: ch})
+
+	// Step 4: Replay from DB if since_event_id was given.
+	if frame.SinceEventID > 0 {
+		events, err := cs.database.QuerySessionEventsSinceRowID(sessionName, frame.SinceEventID)
+		if err != nil {
+			log.Printf("[iris] client socket: replay query for %q since %d: %v",
+				sessionName, frame.SinceEventID, err)
+		}
+		for _, er := range events {
+			// Only replay up to the snapshot to avoid duplicating live events.
+			if er.RowID > snapshotRowID {
+				break
+			}
+			frame := DaemonSessionEventFrame{
+				Type:        DaemonFrameSessionEvent,
+				SessionName: sessionName,
+				RowID:       er.RowID,
+				EventType:   er.Event.Type,
+				Payload:     er.Event.Payload,
+			}
+			if err := w.write(frame); err != nil {
+				return // Client disconnected during replay.
+			}
+		}
+	}
+
+	// Step 5: Drain the live channel, skipping duplicates from the replay range.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pub, ok := <-ch:
+			if !ok {
+				return // Channel closed.
+			}
+			// Skip events that were already sent during the DB replay.
+			if frame.SinceEventID > 0 && pub.RowID <= snapshotRowID {
+				continue
+			}
+			evtFrame := DaemonSessionEventFrame{
+				Type:        DaemonFrameSessionEvent,
+				SessionName: sessionName,
+				RowID:       pub.RowID,
+				EventType:   pub.EventType,
+				Payload:     pub.Payload,
+			}
+			if err := w.write(evtFrame); err != nil {
+				return // Client disconnected.
+			}
+		}
+	}
+}
+
+// handleSessionSpawn spawns a new pi session and writes a session_spawned ack.
+func (cs *ClientSocket) handleSessionSpawn(ctx context.Context, w *jsonlWriter, frame ClientSessionSpawnFrame) {
+	if cs.spawnSession == nil {
+		sendError(w, ClientFrameSessionSpawn, "spawn not configured on this daemon instance")
+		return
+	}
+	if frame.Worktree == "" {
+		sendError(w, ClientFrameSessionSpawn, "worktree is required")
+		return
+	}
+	role := frame.Role
+	if role == "" {
+		role = "worker"
+	}
+
+	sup, err := cs.spawnSession(ctx, frame.Worktree, role, frame.ConfigOverrides)
+	if err != nil {
+		sendError(w, ClientFrameSessionSpawn, fmt.Sprintf("spawn failed: %v", err))
+		return
+	}
+
+	_ = w.write(DaemonSessionSpawnedFrame{
+		Type:       DaemonFrameSessionSpawned,
+		Name:       sup.SessionRecord().SessionName,
+		InstanceID: sup.InstanceID(),
+	})
+}
+
+// handlePromptDeliver delivers a prompt to a named session.
+func (cs *ClientSocket) handlePromptDeliver(ctx context.Context, w *jsonlWriter, frame ClientPromptDeliverFrame) {
+	if cs.deliverPrompt == nil {
+		sendError(w, ClientFramePromptDeliver, "prompt delivery not configured on this daemon instance")
+		return
+	}
+	if frame.Name == "" {
+		sendError(w, ClientFramePromptDeliver, "name is required")
+		return
+	}
+	if frame.Text == "" {
+		sendError(w, ClientFramePromptDeliver, "text is required")
+		return
+	}
+
+	if err := cs.deliverPrompt(ctx, frame.Name, frame.Text, frame.DeliverAs, frame.Images); err != nil {
+		sendError(w, ClientFramePromptDeliver, fmt.Sprintf("deliver failed: %v", err))
+		return
+	}
+	// No explicit ack frame for prompt_deliver — the client will see the
+	// resulting events via their subscription (if subscribed).
+}
+
+// --- Subscriber set management ---
+
+// addSubscriber registers a channel in the per-session subscriber set.
+func (cs *ClientSocket) addSubscriber(sessionName string, sc subscriberChan) {
+	cs.subMu.Lock()
+	defer cs.subMu.Unlock()
+	cs.subscribers[sessionName] = append(cs.subscribers[sessionName], sc)
+}
+
+// removeSubscriber removes a subscriber by ID from the per-session set.
+// It is safe to call even if the subscriber is not present (idempotent).
+func (cs *ClientSocket) removeSubscriber(sessionName, subID string) {
+	cs.subMu.Lock()
+	defer cs.subMu.Unlock()
+	chans := cs.subscribers[sessionName]
+	out := chans[:0]
+	for _, sc := range chans {
+		if sc.id != subID {
+			out = append(out, sc)
+		}
+	}
+	if len(out) == 0 {
+		delete(cs.subscribers, sessionName)
+	} else {
+		cs.subscribers[sessionName] = out
+	}
+}
+
+// sessionExists returns true if the session is currently active in the
+// in-memory supervisor map.
+func (cs *ClientSocket) sessionExists(name string) bool {
+	if cs.getActiveSessions == nil {
+		return false
+	}
+	for _, s := range cs.getActiveSessions() {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Helpers ---
+
+// sendError writes a DaemonErrorFrame to the client. Write errors are logged
+// but do not propagate — the caller's read loop will detect the disconnect
+// on the next read.
+func sendError(w *jsonlWriter, requestType, message string) {
+	_ = w.write(DaemonErrorFrame{
+		Type:        DaemonFrameError,
+		RequestType: requestType,
+		Message:     message,
+	})
+}
+
+// dirOf returns the directory component of a file path.
+func dirOf(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			if i == 0 {
+				return "/"
+			}
+			return path[:i]
+		}
+	}
+	return "."
+}

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -104,6 +104,13 @@ type subscriberChan struct {
 	ch chan EventPublication
 }
 
+// PublisherFunc is an adapter that allows a plain function to be used as an
+// EventPublisher. Useful in tests where a full ClientSocket is not needed.
+type PublisherFunc func(EventPublication)
+
+// Publish implements EventPublisher.
+func (f PublisherFunc) Publish(pub EventPublication) { f(pub) }
+
 // ClientSocketConfig holds the parameters for constructing a ClientSocket.
 type ClientSocketConfig struct {
 	// SockPath is the absolute path for the Unix domain socket.
@@ -187,6 +194,14 @@ func (cs *ClientSocket) Serve(ctx context.Context) {
 
 // SockPath returns the filesystem path of the client IPC socket.
 func (cs *ClientSocket) SockPath() string { return cs.sockPath }
+
+// SetSpawnSession wires the spawn function after construction. This is used
+// by the daemon when it needs to capture a reference to the ClientSocket
+// inside the spawn function (circular dependency: spawnFn needs clientSock,
+// clientSock needs spawnFn). Call before Serve().
+func (cs *ClientSocket) SetSpawnSession(fn func(ctx context.Context, worktree, role string, configOverrides map[string]any) (*Supervisor, error)) {
+	cs.spawnSession = fn
+}
 
 // Close closes the listener and removes the socket file.
 func (cs *ClientSocket) Close() {

--- a/modules/programs/prism/prism/internal/iris/client_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_test.go
@@ -836,3 +836,219 @@ func TestClientSocketSockPath(t *testing.T) {
 		t.Errorf("SockPath() = %q, want %q", cs.SockPath(), sockPath)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Integration: harness → publisher → client fan-out (end-to-end wiring)
+// ---------------------------------------------------------------------------
+
+// TestHarnessToClientFanOut is an integration test that exercises the full
+// harness→publisher→client-socket fan-out path:
+//
+//  1. Create a ClientSocket and a HarnessSocketServer sharing the same DB.
+//  2. Wire the ClientSocket as the harness publisher via SetPublisher.
+//  3. Connect a client to the ClientSocket and subscribe to the session.
+//  4. Simulate a harness event by calling writeObservationEvent via the harness
+//     dispatch (tool_exec → tool_exec_result round-trip).
+//  5. Assert that the client receives a session_event frame carrying that event.
+//
+// This test specifically exercises the code path that review-code and
+// review-goal identified as broken: SetPublisher wired through the
+// SupervisorConfig.Publisher field and called in NewSupervisor.
+func TestHarnessToClientFanOut(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	sessionName := "harness-fanout@test"
+
+	// --- Set up the ClientSocket ---
+	sockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return []iris.SessionSnapshot{
+				{Name: sessionName, InstanceID: "iid-hf", State: "active", Role: "worker"},
+			}
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("ClientSocket.Listen: %v", err)
+	}
+	defer cs.Close()
+
+	csCtx, csCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer csCancel()
+	go cs.Serve(csCtx)
+
+	// --- Set up the HarnessSocketServer with the ClientSocket as publisher ---
+	harnessSockPath := filepath.Join(tmp, "harness.sock")
+	sess := &iris.SessionRecord{
+		InstanceID:      "iid-hf",
+		SessionName:     sessionName,
+		Worktree:        tmp,
+		Role:            "worker",
+		HarnessSockPath: harnessSockPath,
+	}
+	harness, err := iris.NewHarnessSocketServer(sess, database)
+	if err != nil {
+		t.Fatalf("NewHarnessSocketServer: %v", err)
+	}
+	// KEY: wire the client socket as the harness publisher.
+	harness.SetPublisher(cs)
+
+	if err := harness.Listen(); err != nil {
+		t.Fatalf("HarnessSocketServer.Listen: %v", err)
+	}
+	defer harness.Close()
+
+	harnessCtx, harnessCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer harnessCancel()
+	go func() { _ = harness.AcceptOne(harnessCtx) }()
+
+	// --- Connect a client to the ClientSocket and subscribe ---
+	clientConn, clientReader := dialClientSocket(t, sockPath)
+	sendClientFrame(t, clientConn, map[string]any{
+		"type": "session_subscribe",
+		"name": sessionName,
+	})
+	// Allow the subscription goroutine to register.
+	time.Sleep(50 * time.Millisecond)
+
+	// --- Simulate a harness event by connecting as the pi extension and sending a tool_exec ---
+	hConn, hReader := dialHarness(t, harnessSockPath)
+	doHandshake(t, hConn, hReader)
+
+	// Send a tool_exec that will generate a tool_call observation event (via writeObservationEvent).
+	sendFrame(t, hConn, map[string]any{
+		"type": "tool_exec",
+		"id":   "call-fanout-001",
+		"name": "bash",
+		"args": map[string]any{"command": "echo harness-fanout-test"},
+	})
+
+	// Wait for the tool_exec_result on the harness side (ensures the event was written to DB).
+	var gotResult bool
+	resultDeadline := time.Now().Add(10 * time.Second)
+	for !gotResult && time.Now().Before(resultDeadline) {
+		hConn.SetReadDeadline(resultDeadline) //nolint:errcheck
+		hFrame := readFrame(t, hReader)
+		if hFrame["type"] == "tool_exec_result" {
+			gotResult = true
+		}
+	}
+	if !gotResult {
+		t.Fatal("harness: no tool_exec_result received — harness dispatch failed")
+	}
+
+	// --- The client should have received at least one session_event for this session ---
+	// The harness writes tool_call + tool_result observation events, each of which
+	// goes through writeEvent/writeObservationEvent → WriteEventReturningRowID → publishEvent → Publish.
+	var receivedEvent bool
+	eventDeadline := time.Now().Add(5 * time.Second)
+	for !receivedEvent {
+		frame, ok := readClientFrameWithTimeout(t, clientConn, clientReader, 5*time.Second)
+		if !ok {
+			break
+		}
+		if frame["type"] == "session_event" {
+			if frame["session_name"] == sessionName {
+				receivedEvent = true
+			}
+		}
+		if time.Now().After(eventDeadline) {
+			break
+		}
+	}
+	if !receivedEvent {
+		t.Error("client did not receive a session_event frame after harness tool_exec — fan-out wiring is broken")
+	}
+}
+
+// TestSupervisorPublisherConfig verifies that SupervisorConfig.Publisher is
+// wired through to the harness and causes events to be published.
+// This is a unit test of the SupervisorConfig.Publisher → SetPublisher path
+// without actually spawning a pi child.
+func TestSupervisorPublisherConfig(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	// A minimal EventPublisher implementation that records publications.
+	type testPublisher struct {
+		mu   sync.Mutex
+		pubs []iris.EventPublication
+	}
+	tp := &testPublisher{}
+	publishFn := iris.PublisherFunc(func(pub iris.EventPublication) {
+		tp.mu.Lock()
+		defer tp.mu.Unlock()
+		tp.pubs = append(tp.pubs, pub)
+	})
+
+	sessionName := "sup-publisher@test"
+
+	// Set up a HarnessSocketServer with the publisher wired via SupervisorConfig.Publisher.
+	// (We don't spawn a real supervisor — we test the harness server directly to
+	// validate the wiring path that NewSupervisor follows.)
+	harnessSockPath := filepath.Join(tmp, "harness.sock")
+	sess := &iris.SessionRecord{
+		InstanceID:      "iid-sp",
+		SessionName:     sessionName,
+		Worktree:        tmp,
+		Role:            "worker",
+		HarnessSockPath: harnessSockPath,
+	}
+	harness, err := iris.NewHarnessSocketServer(sess, database)
+	if err != nil {
+		t.Fatalf("NewHarnessSocketServer: %v", err)
+	}
+	// This is the same call that NewSupervisor makes when cfg.Publisher != nil.
+	harness.SetPublisher(publishFn)
+	if err := harness.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer harness.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go func() { _ = harness.AcceptOne(ctx) }()
+
+	// Connect as the extension, do handshake, send a tool_exec.
+	hConn, hReader := dialHarness(t, harnessSockPath)
+	doHandshake(t, hConn, hReader)
+
+	sendFrame(t, hConn, map[string]any{
+		"type": "tool_exec",
+		"id":   "call-pub-001",
+		"name": "bash",
+		"args": map[string]any{"command": "echo pub-test"},
+	})
+
+	// Wait for the result.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		hConn.SetReadDeadline(deadline) //nolint:errcheck
+		f := readFrame(t, hReader)
+		if f["type"] == "tool_exec_result" {
+			break
+		}
+	}
+
+	// The publisher should have received at least one publication.
+	time.Sleep(50 * time.Millisecond) // let publishEvent goroutine complete
+	tp.mu.Lock()
+	count := len(tp.pubs)
+	tp.mu.Unlock()
+	if count == 0 {
+		t.Error("publisher received 0 publications — SetPublisher wiring is broken in harness")
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/client_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_test.go
@@ -1,0 +1,838 @@
+package iris_test
+
+// client_socket_test.go — unit and integration tests for the client IPC socket.
+//
+// Test coverage:
+//
+//   - Frame encode/decode round-trips (all frame types)
+//   - Fan-out: 3 clients subscribe, an event publishes, all 3 receive
+//   - Disconnected client removed without affecting remaining subscribers
+//   - since_event_id replay returns the expected event range
+//   - session_subscribe for a nonexistent session returns error, connection stays open
+//   - Integration: connect → sessions_list → sessions_snapshot
+//   - Integration: connect → session_subscribe → receive session_event from Publish
+//   - ping → pong round-trip
+//   - session_unsubscribe stops event delivery
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// ---------------------------------------------------------------------------
+// Frame encode/decode round-trips
+// ---------------------------------------------------------------------------
+
+// TestClientFrameRoundTrip verifies that every frame type can be
+// JSON-marshalled and unmarshalled without data loss.
+func TestClientFrameRoundTrip(t *testing.T) {
+	t.Run("ClientSessionsListFrame", func(t *testing.T) {
+		orig := iris.ClientSessionsListFrame{Type: iris.ClientFrameSessionsList}
+		data, err := json.Marshal(orig)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got iris.ClientSessionsListFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Type != iris.ClientFrameSessionsList {
+			t.Errorf("type = %q, want %q", got.Type, iris.ClientFrameSessionsList)
+		}
+	})
+
+	t.Run("ClientSessionSubscribeFrame", func(t *testing.T) {
+		orig := iris.ClientSessionSubscribeFrame{
+			Type:         iris.ClientFrameSessionSubscribe,
+			Name:         "test@branch",
+			SinceEventID: 42,
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.ClientSessionSubscribeFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Name != "test@branch" || got.SinceEventID != 42 {
+			t.Errorf("got %+v, want same as orig", got)
+		}
+	})
+
+	t.Run("ClientSessionSubscribeFrame_NoSince", func(t *testing.T) {
+		// since_event_id is omitempty — absent from JSON when zero.
+		orig := iris.ClientSessionSubscribeFrame{
+			Type: iris.ClientFrameSessionSubscribe,
+			Name: "test@branch",
+		}
+		data, _ := json.Marshal(orig)
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, ok := m["since_event_id"]; ok {
+			t.Error("since_event_id should be absent when zero (omitempty)")
+		}
+	})
+
+	t.Run("ClientSessionUnsubscribeFrame", func(t *testing.T) {
+		orig := iris.ClientSessionUnsubscribeFrame{Type: iris.ClientFrameSessionUnsubscribe, Name: "s"}
+		data, _ := json.Marshal(orig)
+		var got iris.ClientSessionUnsubscribeFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Name != "s" {
+			t.Errorf("Name = %q, want %q", got.Name, "s")
+		}
+	})
+
+	t.Run("ClientSessionSpawnFrame", func(t *testing.T) {
+		orig := iris.ClientSessionSpawnFrame{
+			Type:     iris.ClientFrameSessionSpawn,
+			Worktree: "/tmp/wt",
+			Role:     "worker",
+			ConfigOverrides: map[string]any{
+				"model": "claude-3",
+			},
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.ClientSessionSpawnFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Worktree != "/tmp/wt" || got.Role != "worker" {
+			t.Errorf("got %+v", got)
+		}
+		if got.ConfigOverrides["model"] != "claude-3" {
+			t.Errorf("ConfigOverrides[model] = %v", got.ConfigOverrides["model"])
+		}
+	})
+
+	t.Run("ClientPromptDeliverFrame", func(t *testing.T) {
+		orig := iris.ClientPromptDeliverFrame{
+			Type:      iris.ClientFramePromptDeliver,
+			Name:      "sess",
+			Text:      "hello",
+			DeliverAs: "steer",
+			Images:    []string{"base64abc"},
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.ClientPromptDeliverFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Text != "hello" || got.DeliverAs != "steer" || len(got.Images) != 1 {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("DaemonSessionsSnapshotFrame", func(t *testing.T) {
+		orig := iris.DaemonSessionsSnapshotFrame{
+			Type: iris.DaemonFrameSessionsSnapshot,
+			Sessions: []iris.SessionSnapshot{
+				{Name: "s", InstanceID: "id", State: "active", Role: "worker"},
+			},
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.DaemonSessionsSnapshotFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(got.Sessions) != 1 || got.Sessions[0].Name != "s" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("DaemonSessionEventFrame", func(t *testing.T) {
+		orig := iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: "s",
+			RowID:       99,
+			EventType:   "tool_call",
+			Payload:     `{"tool":"bash"}`,
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.DaemonSessionEventFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.RowID != 99 || got.EventType != "tool_call" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("DaemonErrorFrame", func(t *testing.T) {
+		orig := iris.DaemonErrorFrame{
+			Type:        iris.DaemonFrameError,
+			RequestType: "sessions_list",
+			Message:     "not found",
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.DaemonErrorFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.RequestType != "sessions_list" || got.Message != "not found" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("DaemonPongFrame", func(t *testing.T) {
+		orig := iris.DaemonPongFrame{Type: iris.DaemonFramePong}
+		data, _ := json.Marshal(orig)
+		var got iris.DaemonPongFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Type != iris.DaemonFramePong {
+			t.Errorf("type = %q, want %q", got.Type, iris.DaemonFramePong)
+		}
+	})
+
+	t.Run("DaemonSessionSpawnedFrame", func(t *testing.T) {
+		orig := iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       "iris-worker@repo",
+			InstanceID: "uuid-123",
+		}
+		data, _ := json.Marshal(orig)
+		var got iris.DaemonSessionSpawnedFrame
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Name != "iris-worker@repo" || got.InstanceID != "uuid-123" {
+			t.Errorf("got %+v", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// newTestClientSocket creates a ClientSocket backed by a test DB with an in-memory
+// session list. Returns the socket and a publish function.
+func newTestClientSocket(t *testing.T, sessions []iris.SessionSnapshot) (*iris.ClientSocket, func(iris.EventPublication)) {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	sockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	go cs.Serve(ctx)
+
+	return cs, func(pub iris.EventPublication) {
+		cs.Publish(pub)
+	}
+}
+
+// dialClientSocket dials the client socket and returns conn + buffered reader.
+func dialClientSocket(t *testing.T, sockPath string) (net.Conn, *bufio.Reader) {
+	t.Helper()
+	var conn net.Conn
+	var err error
+	for i := 0; i < 30; i++ {
+		conn, err = net.DialTimeout("unix", sockPath, 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("dial %q: %v", sockPath, err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn, bufio.NewReaderSize(conn, 1<<20)
+}
+
+// sendClientFrame encodes and sends a frame on the connection.
+func sendClientFrame(t *testing.T, conn net.Conn, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	data = append(data, '\n')
+	if _, err := conn.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// readClientFrame reads one JSON-line frame from the buffered reader.
+func readClientFrame(t *testing.T, r *bufio.Reader) map[string]any {
+	t.Helper()
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(line, &m); err != nil {
+		t.Fatalf("parse frame %q: %v", line, err)
+	}
+	return m
+}
+
+// readClientFrameWithTimeout reads a frame, failing if none arrives within d.
+func readClientFrameWithTimeout(t *testing.T, conn net.Conn, r *bufio.Reader, d time.Duration) (map[string]any, bool) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(d)) //nolint:errcheck
+	defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return nil, false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(line, &m); err != nil {
+		t.Logf("parse frame %q: %v", line, err)
+		return nil, false
+	}
+	return m, true
+}
+
+// ---------------------------------------------------------------------------
+// Integration: sessions_list / sessions_snapshot
+// ---------------------------------------------------------------------------
+
+// TestSessionsList verifies that a client can send sessions_list and receive a
+// sessions_snapshot with the expected sessions.
+func TestSessionsList(t *testing.T) {
+	sessions := []iris.SessionSnapshot{
+		{Name: "nixos-config@main", InstanceID: "iid-1", State: "active", Role: "worker"},
+		{Name: "nixos-config@feat", InstanceID: "iid-2", State: "spawning", Role: "coordinator"},
+	}
+	cs, _ := newTestClientSocket(t, sessions)
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{"type": "sessions_list"})
+
+	frame := readClientFrame(t, r)
+	if frame["type"] != "sessions_snapshot" {
+		t.Fatalf("expected sessions_snapshot, got %q", frame["type"])
+	}
+	sess, ok := frame["sessions"].([]any)
+	if !ok {
+		t.Fatalf("sessions field is not an array: %T", frame["sessions"])
+	}
+	if len(sess) != 2 {
+		t.Errorf("sessions count = %d, want 2", len(sess))
+	}
+}
+
+// TestSessionsListEmpty verifies that an empty session list returns an empty
+// sessions array (not nil/null).
+func TestSessionsListEmpty(t *testing.T) {
+	cs, _ := newTestClientSocket(t, []iris.SessionSnapshot{})
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{"type": "sessions_list"})
+
+	frame := readClientFrame(t, r)
+	if frame["type"] != "sessions_snapshot" {
+		t.Fatalf("type = %q, want sessions_snapshot", frame["type"])
+	}
+	sess := frame["sessions"]
+	if sess == nil {
+		t.Error("sessions field is nil, want empty array")
+	}
+	arr, ok := sess.([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("sessions = %v, want []", sess)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: ping / pong
+// ---------------------------------------------------------------------------
+
+// TestPingPong verifies the keepalive round-trip.
+func TestPingPong(t *testing.T) {
+	cs, _ := newTestClientSocket(t, nil)
+	conn, r := dialClientSocket(t, cs.SockPath())
+
+	sendClientFrame(t, conn, map[string]any{"type": "ping"})
+	frame := readClientFrame(t, r)
+	if frame["type"] != "pong" {
+		t.Errorf("expected pong, got %q", frame["type"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out: multiple subscribers receive every event
+// ---------------------------------------------------------------------------
+
+// TestFanOut verifies that 3 clients subscribed to the same session each
+// receive every session_event frame when Publish is called.
+func TestFanOut(t *testing.T) {
+	sessionName := "fanout@test"
+	sessions := []iris.SessionSnapshot{
+		{Name: sessionName, InstanceID: "iid-fanout", State: "active", Role: "worker"},
+	}
+	cs, publish := newTestClientSocket(t, sessions)
+
+	// Connect 3 clients and subscribe.
+	type clientConn struct {
+		conn net.Conn
+		r    *bufio.Reader
+	}
+	clients := make([]clientConn, 3)
+	for i := range clients {
+		conn, r := dialClientSocket(t, cs.SockPath())
+		clients[i] = clientConn{conn, r}
+		sendClientFrame(t, conn, map[string]any{
+			"type": "session_subscribe",
+			"name": sessionName,
+		})
+	}
+
+	// Allow subscriptions to be registered (goroutines need a moment to start).
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish an event.
+	publish(iris.EventPublication{
+		SessionName: sessionName,
+		RowID:       1,
+		EventType:   "tool_call",
+		Payload:     `{"id":"tc-001"}`,
+	})
+
+	// Every client must receive the session_event.
+	for i, c := range clients {
+		frame, ok := readClientFrameWithTimeout(t, c.conn, c.r, 5*time.Second)
+		if !ok {
+			t.Errorf("client %d: no frame received", i)
+			continue
+		}
+		if frame["type"] != "session_event" {
+			t.Errorf("client %d: type = %q, want session_event", i, frame["type"])
+		}
+		if frame["session_name"] != sessionName {
+			t.Errorf("client %d: session_name = %q, want %q", i, frame["session_name"], sessionName)
+		}
+		if frame["event_type"] != "tool_call" {
+			t.Errorf("client %d: event_type = %q, want tool_call", i, frame["event_type"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Disconnected client removed without affecting others
+// ---------------------------------------------------------------------------
+
+// TestDisconnectedSubscriberRemoved verifies that when one subscriber
+// disconnects, the remaining subscribers still receive events.
+func TestDisconnectedSubscriberRemoved(t *testing.T) {
+	sessionName := "disconnect@test"
+	sessions := []iris.SessionSnapshot{
+		{Name: sessionName, InstanceID: "iid-dc", State: "active", Role: "worker"},
+	}
+	cs, publish := newTestClientSocket(t, sessions)
+
+	// Subscribe client A (rA not used since A disconnects before receiving events).
+	connA, _ := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, connA, map[string]any{"type": "session_subscribe", "name": sessionName})
+
+	// Subscribe client B.
+	connB, rB := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, connB, map[string]any{"type": "session_subscribe", "name": sessionName})
+
+	// Allow subscriptions to register.
+	time.Sleep(50 * time.Millisecond)
+
+	// Disconnect client A.
+	connA.Close()
+
+	// Brief delay to let the server detect the disconnect.
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish — client B must still receive.
+	publish(iris.EventPublication{
+		SessionName: sessionName,
+		RowID:       2,
+		EventType:   "agent_start",
+		Payload:     `{}`,
+	})
+
+	frame, ok := readClientFrameWithTimeout(t, connB, rB, 5*time.Second)
+	if !ok {
+		t.Fatal("client B: no frame received after client A disconnected")
+	}
+	if frame["type"] != "session_event" {
+		t.Errorf("client B: type = %q, want session_event", frame["type"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// session_subscribe for nonexistent session returns error; connection stays open
+// ---------------------------------------------------------------------------
+
+// TestSubscribeNonexistentSession verifies that subscribing to a session that
+// doesn't exist returns an error frame, and the connection stays open for
+// further operations.
+func TestSubscribeNonexistentSession(t *testing.T) {
+	cs, _ := newTestClientSocket(t, []iris.SessionSnapshot{}) // no sessions
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+
+	// Subscribe to a nonexistent session.
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_subscribe",
+		"name": "does-not-exist@branch",
+	})
+
+	// Expect an error frame.
+	frame := readClientFrame(t, r)
+	if frame["type"] != "error" {
+		t.Errorf("type = %q, want error", frame["type"])
+	}
+	if frame["request_type"] != "session_subscribe" {
+		t.Errorf("request_type = %q, want session_subscribe", frame["request_type"])
+	}
+	if frame["message"] == "" {
+		t.Error("error message is empty")
+	}
+
+	// Connection must stay open — we can still ping.
+	sendClientFrame(t, conn, map[string]any{"type": "ping"})
+	pong := readClientFrame(t, r)
+	if pong["type"] != "pong" {
+		t.Errorf("expected pong after error, got %q", pong["type"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// since_event_id replay
+// ---------------------------------------------------------------------------
+
+// TestSinceEventIDReplay writes several events to the DB, then connects a
+// client and subscribes with since_event_id set to a past rowid. Verifies
+// that only events after that rowid are replayed.
+func TestSinceEventIDReplay(t *testing.T) {
+	sessionName := "replay@test"
+
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	// Write 5 events to the DB.
+	var rowIDs []int64
+	for i := 1; i <= 5; i++ {
+		ev := db.Event{
+			ID:          fmt.Sprintf("ev-%d", i),
+			SessionName: sessionName,
+			Repo:        "",
+			Worktree:    tmp,
+			Type:        "tool_call",
+			Payload:     fmt.Sprintf(`{"n":%d}`, i),
+		}
+		rowID, err := database.WriteEventReturningRowID(ev)
+		if err != nil {
+			t.Fatalf("WriteEventReturningRowID[%d]: %v", i, err)
+		}
+		rowIDs = append(rowIDs, rowID)
+	}
+	// rowIDs[0] is the rowid of event 1, rowIDs[4] is event 5.
+
+	// We'll subscribe since rowID[1] (event 2's rowid), expecting events 3,4,5.
+	sinceRowID := rowIDs[1]
+
+	sessions := []iris.SessionSnapshot{
+		{Name: sessionName, InstanceID: "iid-replay", State: "active", Role: "worker"},
+	}
+	sockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer cs.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go cs.Serve(ctx)
+
+	conn, r := dialClientSocket(t, sockPath)
+
+	sendClientFrame(t, conn, map[string]any{
+		"type":          "session_subscribe",
+		"name":          sessionName,
+		"since_event_id": sinceRowID,
+	})
+
+	// Expect 3 replayed events (rowids for events 3, 4, 5).
+	var received []float64
+	deadline := time.Now().Add(5 * time.Second)
+	for len(received) < 3 {
+		conn.SetReadDeadline(deadline) //nolint:errcheck
+		frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+		if !ok {
+			break
+		}
+		if frame["type"] == "session_event" {
+			rid, _ := frame["row_id"].(float64)
+			received = append(received, rid)
+		}
+	}
+
+	if len(received) != 3 {
+		t.Fatalf("expected 3 replayed events, got %d: %v", len(received), received)
+	}
+	// The replayed events should be events 3, 4, 5 (rowIDs[2], [3], [4]).
+	for i, rid := range received {
+		expected := float64(rowIDs[i+2])
+		if rid != expected {
+			t.Errorf("replayed event[%d] rowID = %.0f, want %.0f", i, rid, expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// session_unsubscribe
+// ---------------------------------------------------------------------------
+
+// TestSessionUnsubscribe verifies that after sending session_unsubscribe,
+// no further events are received for that session.
+func TestSessionUnsubscribe(t *testing.T) {
+	sessionName := "unsub@test"
+	sessions := []iris.SessionSnapshot{
+		{Name: sessionName, InstanceID: "iid-unsub", State: "active", Role: "worker"},
+	}
+	cs, publish := newTestClientSocket(t, sessions)
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+
+	// Subscribe.
+	sendClientFrame(t, conn, map[string]any{"type": "session_subscribe", "name": sessionName})
+	time.Sleep(50 * time.Millisecond)
+
+	// Unsubscribe.
+	sendClientFrame(t, conn, map[string]any{"type": "session_unsubscribe", "name": sessionName})
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish — the client should NOT receive this.
+	publish(iris.EventPublication{
+		SessionName: sessionName,
+		RowID:       10,
+		EventType:   "agent_end",
+		Payload:     `{}`,
+	})
+
+	// Verify no session_event is received within 200ms (we should get nothing).
+	conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond)) //nolint:errcheck
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 200*time.Millisecond)
+	if ok && frame["type"] == "session_event" {
+		t.Error("received session_event after session_unsubscribe — should not happen")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple concurrent clients
+// ---------------------------------------------------------------------------
+
+// TestMultipleConcurrentClients verifies that multiple clients can connect
+// simultaneously and operate independently.
+func TestMultipleConcurrentClients(t *testing.T) {
+	cs, _ := newTestClientSocket(t, []iris.SessionSnapshot{})
+
+	const numClients = 5
+	var wg sync.WaitGroup
+	errors := make(chan string, numClients)
+
+	for i := 0; i < numClients; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, r := dialClientSocket(t, cs.SockPath())
+			defer conn.Close()
+
+			sendClientFrame(t, conn, map[string]any{"type": "ping"})
+			frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+			if !ok {
+				errors <- fmt.Sprintf("client %d: no pong received", i)
+				return
+			}
+			if frame["type"] != "pong" {
+				errors <- fmt.Sprintf("client %d: type = %q, want pong", i, frame["type"])
+			}
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for msg := range errors {
+		t.Error(msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Socket file permissions
+// ---------------------------------------------------------------------------
+
+// TestClientSocketPermissions verifies that the socket file has mode 0600 and
+// the parent directory has mode 0700.
+func TestClientSocketPermissions(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	// Place the socket in a subdirectory so we can check the parent mode.
+	sockDir := filepath.Join(tmp, "iris")
+	sockPath := filepath.Join(sockDir, "iris.sock")
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          sockPath,
+		Database:          database,
+		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer cs.Close()
+
+	// Check socket inode mode: 0600.
+	sockInfo, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("Stat socket: %v", err)
+	}
+	sockMode := sockInfo.Mode().Perm()
+	if sockMode != 0o600 {
+		t.Errorf("socket mode = %o, want 0600", sockMode)
+	}
+
+	// Check parent directory mode: 0700.
+	dirInfo, err := os.Stat(sockDir)
+	if err != nil {
+		t.Fatalf("Stat dir: %v", err)
+	}
+	dirMode := dirInfo.Mode().Perm()
+	if dirMode != 0o700 {
+		t.Errorf("parent dir mode = %o, want 0700", dirMode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Socket survives stale file (daemon restart)
+// ---------------------------------------------------------------------------
+
+// TestStaleSocketRemoved verifies that calling Listen() on a path where a
+// stale socket file already exists succeeds (the stale file is removed).
+func TestStaleSocketRemoved(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	sockPath := filepath.Join(tmp, "iris.sock")
+
+	// Write a fake stale socket file.
+	if err := os.WriteFile(sockPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
+	})
+	// This should succeed even though a file exists at sockPath.
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen with stale file: %v", err)
+	}
+	cs.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Unknown frame type is ignored (forward compatibility)
+// ---------------------------------------------------------------------------
+
+// TestUnknownFrameIgnored verifies that sending an unknown frame type does not
+// close the connection — the daemon logs and skips it.
+func TestUnknownFrameIgnored(t *testing.T) {
+	cs, _ := newTestClientSocket(t, nil)
+	conn, r := dialClientSocket(t, cs.SockPath())
+
+	// Send an unknown frame.
+	sendClientFrame(t, conn, map[string]any{"type": "future_unimplemented_feature"})
+
+	// Connection should still be alive: ping → pong.
+	sendClientFrame(t, conn, map[string]any{"type": "ping"})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatal("no pong after unknown frame — connection may have been closed")
+	}
+	if frame["type"] != "pong" {
+		t.Errorf("type = %q, want pong", frame["type"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SockPath accessor
+// ---------------------------------------------------------------------------
+
+// TestClientSocketSockPath verifies the SockPath() accessor.
+func TestClientSocketSockPath(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	sockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer cs.Close()
+
+	if cs.SockPath() != sockPath {
+		t.Errorf("SockPath() = %q, want %q", cs.SockPath(), sockPath)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -32,6 +32,13 @@ import (
 
 // HarnessSocketServer manages a per-session harness socket. One instance is
 // created per session by the Supervisor when it spawns a pi child.
+// EventPublisher receives notifications when a new event is written to the DB.
+// It is set by the daemon to the ClientSocket.Publish method so that every
+// harness event is fanned out to all subscribed clients in real time (D-6).
+type EventPublisher interface {
+	Publish(EventPublication)
+}
+
 type HarnessSocketServer struct {
 	sess    *SessionRecord
 	database *db.DB
@@ -49,6 +56,10 @@ type HarnessSocketServer struct {
 	// writer is the current connected extension's writer (nil when no
 	// connection is active).
 	writer *jsonlWriter
+
+	// publisher receives Publish calls for every event written to the DB.
+	// Nil when no client socket is configured (e.g. in harness-only tests).
+	publisher EventPublisher
 
 	// sessionShutdownReceived is set to true when the session_shutdown
 	// frame arrives — used by the supervisor to detect clean exits.
@@ -70,6 +81,15 @@ func NewHarnessSocketServer(sess *SessionRecord, database *db.DB) (*HarnessSocke
 		inFlight:   make(map[string]chan ToolExecResultFrame),
 		abortChans: make(map[string]chan struct{}),
 	}, nil
+}
+
+// SetPublisher wires a ClientSocket (or any EventPublisher) to this harness
+// server. After this call, every event written to the DB is also published
+// to the client fan-out. Call before starting AcceptOne().
+func (h *HarnessSocketServer) SetPublisher(p EventPublisher) {
+	h.mu.Lock()
+	h.publisher = p
+	h.mu.Unlock()
 }
 
 // Listen binds the Unix domain socket and begins accepting connections.
@@ -363,9 +383,12 @@ func (h *HarnessSocketServer) writeEvent(eventType string, payload []byte) {
 		// sessions row and the FK constraint requires the parent to exist first.
 		// The event is still recorded and queryable by session_name.
 	}
-	if err := h.database.WriteEvent(event); err != nil {
+	rowID, err := h.database.WriteEventReturningRowID(event)
+	if err != nil {
 		log.Printf("[iris] harness: failed to write %s event: %v", eventType, err)
+		return
 	}
+	h.publishEvent(eventType, string(payload), rowID)
 }
 
 // writeObservationEvent writes a generic observation event (forwarded as-is)
@@ -380,9 +403,29 @@ func (h *HarnessSocketServer) writeObservationEvent(eventType string, rawLine []
 		Payload:     string(rawLine),
 		CreatedAt:   time.Now(),
 	}
-	if err := h.database.WriteEvent(event); err != nil {
+	rowID, err := h.database.WriteEventReturningRowID(event)
+	if err != nil {
 		log.Printf("[iris] harness: failed to write %s observation event: %v", eventType, err)
+		return
 	}
+	h.publishEvent(eventType, string(rawLine), rowID)
+}
+
+// publishEvent forwards a just-written event to the client fan-out (if a
+// publisher is configured). It is a no-op when publisher is nil.
+func (h *HarnessSocketServer) publishEvent(eventType, payload string, rowID int64) {
+	h.mu.Lock()
+	pub := h.publisher
+	h.mu.Unlock()
+	if pub == nil {
+		return
+	}
+	pub.Publish(EventPublication{
+		SessionName: h.sess.SessionName,
+		RowID:       rowID,
+		EventType:   eventType,
+		Payload:     payload,
+	})
 }
 
 // --- Helper: jsonlWriter ---

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -515,3 +515,20 @@ func PiSessionPathFromSessionID(piAgentDir, encodedCwd, sessionID string) (strin
 	}
 	return "", fmt.Errorf("iris: pi session %q not found under %q", sessionID, sessionsDir)
 }
+
+// GenerateSessionName generates a default session name from a worktree path
+// and role. The format is "iris-<role>@<basename>" where basename is the
+// last path component of the worktree. This is used by the daemon when a
+// client sends a session_spawn frame without specifying a session name.
+//
+// Examples:
+//
+//	GenerateSessionName("/home/user/code/my-project", "worker")
+//	  → "iris-worker@my-project"
+func GenerateSessionName(worktree, role string) string {
+	base := filepath.Base(worktree)
+	if base == "" || base == "." || base == "/" {
+		base = "session"
+	}
+	return fmt.Sprintf("iris-%s@%s", role, base)
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -52,6 +52,10 @@ type SupervisorConfig struct {
 	RunDir string
 	// Database is the open iris DB (used for event writes).
 	Database *db.DB
+	// Publisher is the optional EventPublisher wired to the harness socket so
+	// that every event written via the harness is also fanned out to client
+	// subscribers (D-6). When nil, fan-out is disabled (harness-only mode).
+	Publisher EventPublisher
 }
 
 // Supervisor manages a single pi child process.
@@ -105,6 +109,13 @@ func NewSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 		return nil, err
 	}
 
+	// Wire the client-socket publisher (D-6 fan-out). This must happen before
+	// AcceptOne is called so that every harness event is published from the
+	// first frame onward.
+	if cfg.Publisher != nil {
+		harness.SetPublisher(cfg.Publisher)
+	}
+
 	// Insert the session record into the DB.
 	if err := insertSessionRecord(cfg.Database, sess); err != nil {
 		// Non-fatal: log and continue.
@@ -124,6 +135,14 @@ func (s *Supervisor) InstanceID() string { return s.sess.InstanceID }
 
 // SessionRecord returns a copy of the session record.
 func (s *Supervisor) SessionRecord() SessionRecord { return s.sess }
+
+// SetPublisher wires an EventPublisher to this supervisor's harness socket.
+// It may be called at any time after NewSupervisor returns and before or
+// after Start(). The publisher receives a Publish call for every event written
+// to the DB by the harness (D-6 fan-out).
+func (s *Supervisor) SetPublisher(p EventPublisher) {
+	s.harness.SetPublisher(p)
+}
 
 // Start spawns the pi child and runs the supervisor loop. It blocks until the
 // session reaches a terminal state (finished or error) or ctx is cancelled.


### PR DESCRIPTION
## Summary

D-6 of the iris daemon-mode rollout. Adds the user-facing client IPC socket that future TUI / CLI clients connect to.

## What's included

### New files

- **`internal/iris/client_protocol.go`** — Wire protocol frame types for the client IPC socket (all 7 client→daemon request frames and 6 daemon→client response frames).

- **`internal/iris/client_socket.go`** — `ClientSocket` server: binds `~/.local/state/iris/iris.sock` (mode 0600, parent dir 0700), accepts concurrent connections, dispatches frames, manages per-session subscriber fan-out, implements `since_event_id` replay.

- **`internal/iris/client_socket_test.go`** — Unit tests (frame round-trips, fan-out, disconnect cleanup, replay, permissions) and integration tests.

### Modified files

- **`internal/iris/harness_socket.go`** — Added `EventPublisher` interface and `SetPublisher` method. Now calls `WriteEventReturningRowID` (instead of `WriteEvent`) and forwards each event to the client fan-out via the publisher.

- **`internal/db/events.go`** — Added `WriteEventReturningRowID`, `MaxSessionEventRowID`, `QuerySessionEventsSinceRowID`, and `EventRow` for the replay machinery.

- **`internal/iris/supervisor.go`** — Added `GenerateSessionName` helper.

- **`cmd/iris/main.go`** — Added `iris daemon` subcommand that starts the full daemon (client socket + session manager). Updated version to `0.1.0-d6`.

## Architecture

The client socket is the second listener on the same daemon process (distinct from the harness socket):

| Socket | Purpose | Path |
|---|---|---|
| Harness (D-3) | pi extension ↔ daemon, per-session | `~/.local/state/iris/run/<instance>/harness.sock` |
| **Client (D-6)** | TUI/CLI ↔ daemon, user-wide | `~/.local/state/iris/iris.sock` |

## Fan-out and replay

Fan-out: `HarnessSocketServer.publishEvent` → `ClientSocket.Publish` → per-session buffered subscriber channels → client connections.

Replay race avoidance (§4.3 design doc): snapshot `MAX(rowid)` → register live channel → replay DB events ≤ snapshot → drain channel skipping rowids ≤ snapshot.

## Quality gates

- `go build ./...` ✅
- `go test ./... -race` ✅ (all packages)
- `nix build .#iris` ✅

Closes #1637
Refs #1625
Depends on D-3 (#1634 / #1643)