### PR TITLE
feat(iris): D-4 — per-tool sandbox for six file tools (#1635)

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -325,7 +325,7 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// (bwrap evaluates arguments left-to-right but each --bind is
 	// independent), so this is a behaviour-preserving reordering.
 	for _, spec := range StandardSandboxMounts(cfg, home, home, isolationBwrap) {
-		args = appendBwrapBind(args, spec)
+		args = AppendBwrapBind(args, spec)
 	}
 
 	// NOTE: An unconditional --bind of ~/.local/share/pi used to live here as

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -276,7 +276,7 @@ func appendPodmanVolume(args []string, spec MountSpec) []string {
 	return append(args, "--volume", src+":"+spec.SandboxPath+flags)
 }
 
-// appendBwrapBind appends a bwrap --ro-bind or --bind argument triple for the
+// AppendBwrapBind appends a bwrap --ro-bind or --bind argument triple for the
 // given MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
 // resolveMountHostPath and emits the correct flag based on spec.ReadOnly.
 // SELinuxRelabel is ignored — bwrap does not participate in SELinux labelling.
@@ -284,7 +284,10 @@ func appendPodmanVolume(args []string, spec MountSpec) []string {
 //
 // Free function (not a method on bwrapIsolator) — the emitter is stateless
 // and a free function is symmetric with appendPodmanVolume above.
-func appendBwrapBind(args []string, spec MountSpec) []string {
+//
+// Exported so that the iris package can reuse the MountSpec emission machinery
+// without depending on bwrapIsolator directly (D-4 requirement).
+func AppendBwrapBind(args []string, spec MountSpec) []string {
 	src, ok := resolveMountHostPath(spec)
 	if !ok {
 		return args

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_iris_file_tools_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_iris_file_tools_darwin_test.go
@@ -1,0 +1,536 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_iris_file_tools_darwin_test.go — integration coverage for the
+// iris D-4 per-tool sandbox-exec SBPL profile.
+//
+// Per the sandbox-exec testing convention (docs/sandbox-exec-testing.md,
+// issue #1192), every change to a sandbox-exec profile generator must be
+// paired with:
+//
+//  1. A positive integration test that invokes /usr/bin/sandbox-exec against
+//     a Nix-built test binary with the generated profile and asserts expected
+//     behaviour.
+//
+//  2. A negative test that mutates the profile (removes a specific allow rule)
+//     and asserts the same operation fails — proving the positive is not a
+//     no-op.
+//
+// This file covers the iris file-tool SBPL profile from
+// internal/iris/file_sandbox_darwin.go::generateFileToolSBPLProfile.
+//
+// Test pairs:
+//
+//   TestIrisFileTool_WorktreeReadAllowed / TestIrisFileTool_WorktreeReadAllowed_Negative
+//     Positive: cat a sentinel file under the worktree; succeeds.
+//     Negative: remove the worktree allow rule; same cat fails.
+//
+//   TestIrisFileTool_WorktreeWriteAllowed / TestIrisFileTool_WorktreeWriteAllowed_Negative
+//     Positive: write a file under the worktree (RW profile); succeeds.
+//     Negative: remove the worktree write allow; same write fails.
+//
+//   TestIrisFileTool_TmpReadWrite / TestIrisFileTool_TmpReadWrite_Negative
+//     Positive: write and read a file in /tmp (via tmpDir allow); succeeds.
+//     Negative: remove the /tmp allow; same write fails.
+//
+//   TestIrisFileTool_EtcSSHDenied / TestIrisFileTool_EtcSSHDenied_Negative
+//     Positive: cat /etc/ssh/ssh_config fails under the profile (deny rule).
+//     Negative: remove the /etc/ssh deny; same cat succeeds.
+//
+//   TestIrisFileTool_NetworkPermitted
+//     Positive: curl/nc-style check that outbound TCP is not blocked.
+//     (No negative test needed — (allow network*) is the last line.)
+//
+// Profile content assertions (substring checks, necessary but not sufficient):
+//   TestIrisFileTool_ProfileContent_WorktreeRO
+//   TestIrisFileTool_ProfileContent_WorktreeRW
+//   TestIrisFileTool_ProfileContent_DenyRules
+//
+// All tests skip when:
+//   - Not on Darwin (build tag enforces this but check defensively).
+//   - /usr/bin/sandbox-exec is absent.
+//   - bash does not resolve to a /nix/store/... path.
+//   - Inside the Nix build sandbox (NIX_BUILD_TOP is set).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// generateIrisROProfile generates a RO-worktree iris file-tool SBPL profile
+// using the production generator for the given worktree and tmpDir.
+func generateIrisROProfile(worktree, tmpDir string) string {
+	return iris.GenerateFileToolSBPLProfile(worktree, tmpDir, true)
+}
+
+// generateIrisRWProfile generates a RW-worktree iris file-tool SBPL profile.
+func generateIrisRWProfile(worktree, tmpDir string) string {
+	return iris.GenerateFileToolSBPLProfile(worktree, tmpDir, false)
+}
+
+// writeIrisProfile writes a SBPL profile to a temp file, augments it with
+// test-harness extras, and returns the path.  Registers a cleanup for the
+// temp file.
+func writeIrisProfile(t *testing.T, profile string) string {
+	t.Helper()
+	augmented := augmentProfileForTest(profile)
+	f, err := os.CreateTemp("", "iris-file-tool-test-*.sb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	path := f.Name()
+	if _, err := f.WriteString(augmented); err != nil {
+		f.Close()
+		os.Remove(path)
+		t.Fatalf("write profile: %v", err)
+	}
+	f.Close()
+	t.Cleanup(func() { _ = os.Remove(path) })
+	return path
+}
+
+// mutateThenWrite applies mutate to the profile, augments, writes to a temp
+// file, and returns the path.
+func mutateThenWrite(t *testing.T, profile string, mutate func(string) string) string {
+	t.Helper()
+	mutated := mutate(profile)
+	if mutated == profile {
+		t.Fatalf("mutateThenWrite: mutate returned identical content — the substitution did not match.\nProfile:\n%s", profile)
+	}
+	return writeIrisProfile(t, mutated)
+}
+
+// --- Profile content assertions ---
+
+// TestIrisFileTool_ProfileContent_WorktreeRO asserts that the RO profile
+// contains the expected allow rules for the worktree (file-read* only) and
+// the expected deny rules for sensitive /etc subtrees.
+func TestIrisFileTool_ProfileContent_WorktreeRO(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+
+	worktree, err := os.MkdirTemp("", "iris-d4-worktree-ro-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	profile := generateIrisROProfile(worktree, "")
+
+	// RO worktree rule: file-read* (no file-write*).
+	roRule := "(allow file-read* file-test-existence file-read-metadata\n  (subpath " + sbplQuoteForTest(worktree) + "))"
+	if !strings.Contains(profile, roRule) {
+		t.Errorf("RO profile missing worktree read-only rule.\nWant substring: %q\nProfile:\n%s", roRule, profile)
+	}
+
+	// Must NOT contain a write allow for the worktree.
+	rwRule := "(allow file-read* file-write* file-test-existence file-read-metadata\n  (subpath " + sbplQuoteForTest(worktree) + "))"
+	if strings.Contains(profile, rwRule) {
+		t.Errorf("RO profile unexpectedly contains a write allow for the worktree.\nProfile:\n%s", profile)
+	}
+}
+
+// TestIrisFileTool_ProfileContent_WorktreeRW asserts that the RW profile
+// contains the expected allow rules for the worktree (file-read* + file-write*).
+func TestIrisFileTool_ProfileContent_WorktreeRW(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+
+	worktree, err := os.MkdirTemp("", "iris-d4-worktree-rw-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	profile := generateIrisRWProfile(worktree, "")
+
+	rwRule := "(allow file-read* file-write* file-test-existence file-read-metadata\n  (subpath " + sbplQuoteForTest(worktree) + "))"
+	if !strings.Contains(profile, rwRule) {
+		t.Errorf("RW profile missing worktree read-write rule.\nWant substring: %q\nProfile:\n%s", rwRule, profile)
+	}
+}
+
+// TestIrisFileTool_ProfileContent_DenyRules asserts that the deny rules for
+// sensitive /etc subtrees are present in the generated profile.
+func TestIrisFileTool_ProfileContent_DenyRules(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+
+	worktree, err := os.MkdirTemp("", "iris-d4-deny-rules-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	profile := generateIrisROProfile(worktree, "")
+
+	expected := []string{
+		"  (subpath \"/etc/wireguard\")",
+		"  (subpath \"/etc/wpa_supplicant\")",
+		"  (subpath \"/etc/ssh\")",
+		"  (subpath \"/private/etc/wireguard\")",
+		"  (subpath \"/private/etc/wpa_supplicant\")",
+		"  (subpath \"/private/etc/ssh\"))",
+	}
+	for _, exp := range expected {
+		if !strings.Contains(profile, exp) {
+			t.Errorf("profile missing deny rule: %q\nProfile:\n%s", exp, profile)
+		}
+	}
+
+	denyHeader := "(deny file-read* file-write*\n"
+	if !strings.Contains(profile, denyHeader) {
+		t.Errorf("profile missing (deny file-read* file-write*) block.\nProfile:\n%s", profile)
+	}
+}
+
+// --- Positive integration tests ---
+
+// TestIrisFileTool_WorktreeReadAllowed verifies that a file under the worktree
+// can be read by a Nix-built binary under the RO iris file-tool profile.
+func TestIrisFileTool_WorktreeReadAllowed(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	worktree, err := os.MkdirTemp("", "iris-d4-wt-read-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	sentinel := filepath.Join(worktree, "sentinel.txt")
+	const sentinelContent = "iris-d4-worktree-read-sentinel"
+	if err := os.WriteFile(sentinel, []byte(sentinelContent), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	profile := generateIrisROProfile(worktree, "")
+	profilePath := writeIrisProfile(t, profile)
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(sentinel))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("read of sentinel %q failed under RO iris profile.\nExit: %v\nOutput: %s\nProfile: %s",
+			sentinel, runErr, string(out), profilePath)
+	}
+	if !strings.Contains(string(out), sentinelContent) {
+		t.Errorf("read output does not contain sentinel content.\nOutput: %q", string(out))
+	}
+}
+
+// TestIrisFileTool_WorktreeReadAllowed_Negative verifies that removing the
+// worktree allow rule causes reads to fail, proving the positive is non-trivial.
+func TestIrisFileTool_WorktreeReadAllowed_Negative(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	worktree, err := os.MkdirTemp("", "iris-d4-wt-read-neg-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	sentinel := filepath.Join(worktree, "sentinel.txt")
+	const sentinelContent = "iris-d4-worktree-read-sentinel-neg"
+	if err := os.WriteFile(sentinel, []byte(sentinelContent), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	profile := generateIrisROProfile(worktree, "")
+
+	// Remove the worktree read allow rule from the profile.
+	worktreeRule := "(allow file-read* file-test-existence file-read-metadata\n  (subpath " + sbplQuoteForTest(worktree) + "))\n"
+	profilePath := mutateThenWrite(t, profile, func(p string) string {
+		return strings.ReplaceAll(p, worktreeRule, "")
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(sentinel))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read of sentinel %q succeeded even with worktree allow rule removed.\n"+
+			"The positive test was a no-op — investigate the profile.\nOutput: %s\nProfile: %s",
+			sentinel, string(out), profilePath)
+	} else {
+		t.Logf("ka pai — read correctly blocked without worktree allow (exit: %v)", runErr)
+	}
+}
+
+// TestIrisFileTool_WorktreeWriteAllowed verifies that a file can be written
+// under the worktree when the profile is RW.
+func TestIrisFileTool_WorktreeWriteAllowed(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	worktree, err := os.MkdirTemp("", "iris-d4-wt-write-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	target := filepath.Join(worktree, "write-test.txt")
+	const writeContent = "iris-d4-write-test"
+
+	profile := generateIrisRWProfile(worktree, "")
+	profilePath := writeIrisProfile(t, profile)
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "echo -n "+shQuote(writeContent)+" > "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("write to %q failed under RW iris profile.\nExit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	}
+
+	// Verify the file was actually written.
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Errorf("post-write ReadFile %q: %v", target, readErr)
+	} else if string(got) != writeContent {
+		t.Errorf("post-write content = %q, want %q", string(got), writeContent)
+	}
+}
+
+// TestIrisFileTool_WorktreeWriteAllowed_Negative verifies that removing the
+// worktree write allow causes writes to fail.
+func TestIrisFileTool_WorktreeWriteAllowed_Negative(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	worktree, err := os.MkdirTemp("", "iris-d4-wt-write-neg-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	target := filepath.Join(worktree, "write-neg-test.txt")
+	profile := generateIrisRWProfile(worktree, "")
+
+	// Remove the RW worktree allow rule.
+	rwRule := "(allow file-read* file-write* file-test-existence file-read-metadata\n  (subpath " + sbplQuoteForTest(worktree) + "))\n"
+	profilePath := mutateThenWrite(t, profile, func(p string) string {
+		return strings.ReplaceAll(p, rwRule, "")
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "echo hi > "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write to %q succeeded even with worktree write allow rule removed.\n"+
+			"The positive write test was a no-op.\nOutput: %s\nProfile: %s",
+			target, string(out), profilePath)
+	} else {
+		t.Logf("ka pai — write correctly blocked without RW worktree allow (exit: %v)", runErr)
+	}
+}
+
+// TestIrisFileTool_TmpReadWrite verifies that /tmp is accessible (RW) under
+// the iris file-tool profile when tmpDir is configured.
+func TestIrisFileTool_TmpReadWrite(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	worktree, err := os.MkdirTemp("", "iris-d4-tmp-rw-wt-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(worktree): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	tmpDir, err := os.MkdirTemp("", "iris-d4-tmp-rw-session-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(tmpDir): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	profile := generateIrisROProfile(worktree, tmpDir)
+	profilePath := writeIrisProfile(t, profile)
+
+	// Write and read back a file in the tmpDir (the session's /tmp backing dir).
+	target := filepath.Join(tmpDir, "iris-d4-tmp-sentinel.txt")
+	const tmpContent = "iris-d4-tmp-rw-sentinel"
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "echo -n "+shQuote(tmpContent)+" > "+shQuote(target)+" && cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("write+read to tmpDir %q failed under iris profile.\nExit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	}
+	if !strings.Contains(string(out), tmpContent) {
+		t.Errorf("tmp read output does not contain sentinel.\nOutput: %q", string(out))
+	}
+}
+
+// TestIrisFileTool_TmpReadWrite_Negative verifies that removing the tmpDir
+// allow causes writes to tmpDir to fail.
+func TestIrisFileTool_TmpReadWrite_Negative(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	worktree, err := os.MkdirTemp("", "iris-d4-tmp-neg-wt-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(worktree): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	tmpDir, err := os.MkdirTemp("", "iris-d4-tmp-neg-session-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(tmpDir): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	target := filepath.Join(tmpDir, "iris-d4-tmp-neg.txt")
+	profile := generateIrisROProfile(worktree, tmpDir)
+
+	// Remove the tmpDir subpath allow rule.
+	tmpRule := "  (subpath " + sbplQuoteForTest(tmpDir) + ")\n"
+	profilePath := mutateThenWrite(t, profile, func(p string) string {
+		return strings.ReplaceAll(p, tmpRule, "")
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "echo hi > "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write to tmpDir %q succeeded even with tmpDir allow rule removed.\n"+
+			"The positive tmp test was a no-op.\nOutput: %s\nProfile: %s",
+			target, string(out), profilePath)
+	} else {
+		t.Logf("ka pai — tmpDir write correctly blocked without allow (exit: %v)", runErr)
+	}
+}
+
+// TestIrisFileTool_EtcSSHDenied verifies that reads of /etc/ssh/ssh_config
+// are blocked by the deny rule in the iris file-tool profile.
+// Skips if /etc/ssh/ssh_config does not exist on the host (can't distinguish
+// sandbox deny from ENOENT).
+func TestIrisFileTool_EtcSSHDenied(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	target := "/private/etc/ssh/ssh_config"
+	if _, err := os.Stat(target); err != nil {
+		t.Skipf("%s does not exist on this host — cannot distinguish sandbox deny from ENOENT: %v", target, err)
+	}
+
+	worktree, err := os.MkdirTemp("", "iris-d4-etc-ssh-deny-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	profile := generateIrisROProfile(worktree, "")
+	profilePath := writeIrisProfile(t, profile)
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read of %s succeeded (exit 0) under iris profile — /etc/ssh deny is not enforced.\n"+
+			"Output: %s\nProfile: %s", target, string(out), profilePath)
+	} else {
+		t.Logf("ka pai — /etc/ssh read correctly blocked (exit: %v)", runErr)
+	}
+}
+
+// TestIrisFileTool_EtcSSHDenied_Negative verifies that removing the /etc/ssh
+// deny allows reading /etc/ssh/ssh_config, proving the deny is load-bearing.
+func TestIrisFileTool_EtcSSHDenied_Negative(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	target := "/private/etc/ssh/ssh_config"
+	if _, err := os.Stat(target); err != nil {
+		t.Skipf("%s does not exist on this host — cannot distinguish sandbox deny from ENOENT: %v", target, err)
+	}
+
+	worktree, err := os.MkdirTemp("", "iris-d4-etc-ssh-neg-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	profile := generateIrisROProfile(worktree, "")
+
+	// Remove both the /etc/ssh and /private/etc/ssh deny subpath lines.
+	profilePath := mutateThenWrite(t, profile, func(p string) string {
+		// Remove /etc/ssh line from the deny block.
+		p = strings.ReplaceAll(p, "  (subpath \"/etc/ssh\")\n", "")
+		// /private/etc/ssh is the last entry in the block (has closing "))").
+		// Promote /private/etc/wpa_supplicant to be the last entry.
+		p = strings.ReplaceAll(p,
+			"  (subpath \"/private/etc/wpa_supplicant\")\n  (subpath \"/private/etc/ssh\"))\n",
+			"  (subpath \"/private/etc/wpa_supplicant\"))\n")
+		return p
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("read of %s failed even with /etc/ssh deny rules removed.\n"+
+			"The /private/etc allow should permit this read.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	} else {
+		t.Logf("ka pai — read succeeded without deny rules (expected)")
+	}
+}
+
+// TestIrisFileTool_NetworkPermitted verifies that (allow network*) is present
+// in the iris file-tool profile, consistent with the design doc §5/§6.3.
+// We test this via profile-content assertion (actual network tests are
+// environment-dependent and not appropriate for the test suite).
+func TestIrisFileTool_NetworkPermitted(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+
+	worktree, err := os.MkdirTemp("", "iris-d4-net-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(worktree) })
+
+	profile := generateIrisROProfile(worktree, "")
+
+	if !strings.Contains(profile, "(allow network*)") {
+		t.Errorf("iris file-tool profile does not contain '(allow network*)'\n"+
+			"Network is required to be permitted per design doc §5/§6.3.\nProfile:\n%s", profile)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/bwrap_test_linux_test.go
+++ b/modules/programs/prism/prism/internal/iris/bwrap_test_linux_test.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package iris_test
+
+// bwrap_test_linux_test.go — bwrap skip guard for tests that exercise the
+// Linux bwrap file-tool sandbox.
+//
+// Tests that call into the live bwrap path (TestReadTool, TestEditToolUniqueness)
+// must call requireBwrap(t) at the start.  This skips the test when:
+//
+//   - bwrap is not installed on the host
+//   - The kernel does not permit unprivileged user namespaces (common on
+//     GitHub Actions ubuntu runners and inside the Nix build sandbox)
+//
+// The probe is a minimal bwrap invocation that mounts /bin and /nix (needed
+// to exec /bin/sh from the Nix store) and runs a no-op shell:
+//
+//	bwrap --ro-bind /bin /bin --ro-bind /nix /nix \
+//	      --ro-bind /dev/null /dev/null -- /bin/sh -c "exit 0"
+//
+// If it exits non-zero or errors (permission denied, executable not found),
+// the test is skipped with a clear message.  This mirrors the Darwin
+// requireSandboxExec convention in internal/integration/sandbox_exec_helpers_darwin_test.go.
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// requireBwrap skips t when bwrap cannot execute unprivileged user namespaces.
+// Call this at the start of any test that exercises runInFileSandbox on Linux.
+func requireBwrap(t *testing.T) {
+	t.Helper()
+
+	// Check for bwrap in PATH first.
+	bwrapPath, err := exec.LookPath("bwrap")
+	if err != nil {
+		t.Skipf("bwrap not found in PATH — skipping sandbox test: %v", err)
+	}
+
+	// Probe: attempt a minimal bwrap invocation that requires user-namespace
+	// support.  We bind /bin (for /bin/sh) and /nix (for the Nix store path
+	// that /bin/sh resolves to on NixOS) so the inner command can actually
+	// exec.  /dev/null is bound as a write target for the shell's stdout.
+	// If the kernel blocks unprivileged user namespaces (as on GitHub Actions
+	// or inside the Nix build sandbox), bwrap exits non-zero with
+	// "setting up uid map: Permission denied" or similar.
+	cmd := exec.Command(bwrapPath,
+		"--ro-bind", "/bin", "/bin",
+		"--ro-bind", "/nix", "/nix",
+		"--ro-bind", "/dev/null", "/dev/null",
+		"--",
+		"/bin/sh", "-c", "exit 0",
+	)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("bwrap probe failed (%v) — kernel likely does not permit unprivileged user namespaces; skipping sandbox test", err)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/file_sandbox_darwin.go
+++ b/modules/programs/prism/prism/internal/iris/file_sandbox_darwin.go
@@ -1,0 +1,195 @@
+// file_sandbox_darwin.go — macOS implementation of the per-tool file sandbox.
+//
+// On macOS we use Apple's sandbox-exec with a generated SBPL profile to
+// create an isolated subprocess with the per-tool access set described in
+// the daemon-mode design doc §5.
+//
+// macOS does not have bwrap's bind-mount mechanism; the profile grants
+// read/write access to the host paths directly instead of remapping them.
+// The profile is built from scratch; StandardSandboxMounts is NOT used.
+
+package iris
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// runInFileSandbox runs name+argv inside a sandbox-exec file-tool sandbox.
+// worktreeReadOnly controls whether the worktree is accessible read-only or
+// read-write in the SBPL profile.
+// Returns (combined stdout+stderr, exitOK, error).
+func (d *toolDispatcher) runInFileSandbox(ctx context.Context, worktreeReadOnly bool, name string, argv ...string) (string, bool, error) {
+	profile := GenerateFileToolSBPLProfile(d.worktree, d.tmpDir, worktreeReadOnly)
+
+	resolvedName, err := resolveBinaryPath(name)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve binary %q: %w", name, err)
+	}
+
+	return runInSandboxExecImpl(ctx, profile, d.worktree, nil, resolvedName, argv...)
+}
+
+// runInFileSandboxWithStdin is like runInFileSandbox but pipes stdin into the
+// subprocess.  Used by the edit and write executors which pass file content
+// via stdin rather than as a command-line argument.
+func (d *toolDispatcher) runInFileSandboxWithStdin(ctx context.Context, worktreeReadOnly bool, stdin string, name string, argv ...string) (string, bool, error) {
+	profile := GenerateFileToolSBPLProfile(d.worktree, d.tmpDir, worktreeReadOnly)
+
+	resolvedName, err := resolveBinaryPath(name)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve binary %q: %w", name, err)
+	}
+
+	return runInSandboxExecImpl(ctx, profile, d.worktree, strings.NewReader(stdin), resolvedName, argv...)
+}
+
+// GenerateFileToolSBPLProfile generates a minimal SBPL (version 3) profile
+// for a file tool subprocess on macOS.
+//
+// Exported so that the integration test package can generate profiles for
+// assertion without constructing a toolDispatcher (D-4 testing convention).
+//
+// worktree is accessible RO or RW depending on worktreeReadOnly.
+// tmpDir is the per-session tmpfs backing directory on the host.
+// The profile follows the same deny-default → specific-allows pattern as
+// the existing container/sandbox_exec.go but is built from scratch without
+// pi-process credentials.
+func GenerateFileToolSBPLProfile(worktree, tmpDir string, worktreeReadOnly bool) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+
+	var sb strings.Builder
+
+	// ── Version 3 header and deny-default ────────────────────────────────────
+	sb.WriteString("(version 3)\n")
+	sb.WriteString("(deny default)\n")
+	sb.WriteString("\n")
+
+	// ── Cryptex graft points (macOS 15+) ─────────────────────────────────────
+	sb.WriteString("(allow file-read* file-test-existence file-map-executable\n")
+	sb.WriteString("  (subpath \"/System/Volumes/Preboot/Cryptexes\")\n")
+	sb.WriteString("  (subpath \"/System/Cryptexes\"))\n")
+	sb.WriteString("\n")
+
+	// ── Standard system read-only roots ──────────────────────────────────────
+	// These allow Nix-built binaries (the actual tools — cat, grep, find, ls)
+	// to start under the sandbox.
+	sb.WriteString("(allow file-read* file-test-existence file-map-executable file-read-metadata\n")
+	sb.WriteString("  (subpath \"/nix\")\n")
+	sb.WriteString("  (subpath \"/usr\")\n")
+	sb.WriteString("  (subpath \"/bin\")\n")
+	sb.WriteString("  (subpath \"/sbin\")\n")
+	sb.WriteString("  (subpath \"/System\")\n")
+	sb.WriteString("  (subpath \"/Library\")\n")
+	sb.WriteString("  (subpath \"/Applications/Xcode.app\")\n")
+	sb.WriteString("  (subpath \"/etc\")\n")
+	sb.WriteString("  (subpath \"/private/etc\")\n")
+	sb.WriteString("  (subpath \"/var\")\n")
+	sb.WriteString("  (subpath \"/private/var\")\n")
+	sb.WriteString("  (subpath \"/run/current-system\")\n")
+	sb.WriteString("  (subpath \"/opt\")\n")
+	sb.WriteString("  (literal \"/\")\n")
+	sb.WriteString("  (literal \"/dev\")\n")
+	sb.WriteString("  (subpath \"/dev\"))\n")
+	sb.WriteString("\n")
+
+	// ── Deny sensitive /etc subtrees ─────────────────────────────────────────
+	// These override the broad /etc allow above, preventing exfiltration of
+	// SSH host keys, VPN configs, and Wi-Fi credentials.
+	sb.WriteString("(deny file-read* file-write*\n")
+	sb.WriteString("  (subpath \"/etc/wireguard\")\n")
+	sb.WriteString("  (subpath \"/etc/wpa_supplicant\")\n")
+	sb.WriteString("  (subpath \"/etc/ssh\")\n")
+	sb.WriteString("  (subpath \"/private/etc/wireguard\")\n")
+	sb.WriteString("  (subpath \"/private/etc/wpa_supplicant\")\n")
+	sb.WriteString("  (subpath \"/private/etc/ssh\"))\n")
+	sb.WriteString("\n")
+
+	// ── ~/.nix-profile (RO) ──────────────────────────────────────────────────
+	nixProfile := filepath.Join(home, ".nix-profile")
+	sb.WriteString("(allow file-read* file-test-existence file-read-metadata\n")
+	sb.WriteString("  (subpath " + sbplQuote(nixProfile) + "))\n")
+	sb.WriteString("\n")
+
+	// ── Worktree (RO or RW) ──────────────────────────────────────────────────
+	if worktreeReadOnly {
+		sb.WriteString("(allow file-read* file-test-existence file-read-metadata\n")
+	} else {
+		sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
+	}
+	sb.WriteString("  (subpath " + sbplQuote(worktree) + "))\n")
+	sb.WriteString("\n")
+
+	// ── Per-session /tmp (RW) ────────────────────────────────────────────────
+	// On macOS there is no bind-mount mechanism; we allow both the host
+	// backing dir (tmpDir) and the canonical /tmp and /private/tmp paths.
+	sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
+	if tmpDir != "" {
+		sb.WriteString("  (subpath " + sbplQuote(tmpDir) + ")\n")
+	}
+	sb.WriteString("  (subpath \"/tmp\")\n")
+	sb.WriteString("  (subpath \"/private/tmp\"))\n")
+	sb.WriteString("\n")
+
+	// ── Process and IPC primitives (required by dyld, AMFI) ─────────────────
+	sb.WriteString("(allow process-exec process-fork signal)\n")
+	sb.WriteString("(allow mach-lookup)\n")
+	sb.WriteString("(allow ipc-posix-shm-read-data ipc-posix-shm-write-data ipc-posix-shm-write-create)\n")
+	sb.WriteString("(allow syscall-unix syscall-mach system-mac-syscall system-fcntl)\n")
+	sb.WriteString("(allow sysctl-read sysctl-write)\n")
+	sb.WriteString("\n")
+
+	// ── Network (permitted per design doc §5 and §6.3) ───────────────────────
+	sb.WriteString("(allow network*)\n")
+	sb.WriteString("\n")
+
+	// ── File metadata / iokit / misc required by dynamic linker ─────────────
+	sb.WriteString("(allow file-read-metadata (subpath \"/\"))\n")
+	sb.WriteString("(allow iokit-open iokit-get-properties iokit-issue-command)\n")
+	sb.WriteString("(allow lsopen)\n")
+
+	return sb.String()
+}
+
+// runInSandboxExecImpl runs a command under sandbox-exec with the given SBPL profile.
+// stdinReader, if non-nil, is piped to the subprocess's stdin.
+func runInSandboxExecImpl(ctx context.Context, profile string, cwd string, stdinReader interface{ Read([]byte) (int, error) }, name string, argv ...string) (string, bool, error) {
+	f, err := os.CreateTemp("", "iris-file-tool-*.sb")
+	if err != nil {
+		return "", false, fmt.Errorf("sandbox-exec: create profile temp file: %w", err)
+	}
+	profilePath := f.Name()
+	if _, err := f.WriteString(profile); err != nil {
+		f.Close()
+		os.Remove(profilePath)
+		return "", false, fmt.Errorf("sandbox-exec: write profile: %w", err)
+	}
+	f.Close()
+	defer os.Remove(profilePath)
+
+	allArgs := []string{"-f", profilePath, name}
+	allArgs = append(allArgs, argv...)
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/sandbox-exec", allArgs...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	if stdinReader != nil {
+		cmd.Stdin = stdinReader
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return string(out), false, nil
+		}
+		return string(out), false, fmt.Errorf("sandbox-exec: %w", err)
+	}
+	return string(out), true, nil
+}

--- a/modules/programs/prism/prism/internal/iris/file_sandbox_linux.go
+++ b/modules/programs/prism/prism/internal/iris/file_sandbox_linux.go
@@ -1,0 +1,192 @@
+// file_sandbox_linux.go — Linux implementation of the per-tool file sandbox.
+//
+// On Linux we use bubblewrap (bwrap) to create an isolated subprocess with
+// the per-tool mount set described in the daemon-mode design doc §5.
+//
+// The mount set is assembled using the MountSpec machinery from
+// internal/container/mounts.go (specifically container.AppendBwrapBind).
+// StandardSandboxMounts is NOT called — D-4 builds a fresh minimal list
+// that deliberately excludes pi-process credentials.
+
+package iris
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// runInFileSandbox runs name+argv inside a bwrap file-tool sandbox.
+// worktreeReadOnly controls whether the worktree is mounted RO or RW.
+// Returns (combined stdout+stderr, exitOK, error).
+func (d *toolDispatcher) runInFileSandbox(ctx context.Context, worktreeReadOnly bool, name string, argv ...string) (string, bool, error) {
+	mountArgs := fileToolMounts(d.worktree, d.tmpDir, worktreeReadOnly)
+
+	// Look up the tool binary path and resolve through symlinks — bwrap needs
+	// the real /nix/store/... path for some tools on NixOS.
+	resolvedName, err := resolveBinaryPath(name)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve binary %q: %w", name, err)
+	}
+
+	return runInBwrap(ctx, mountArgs, d.worktree, nil, resolvedName, argv...)
+}
+
+// runInFileSandboxWithStdin is like runInFileSandbox but pipes stdin into the
+// subprocess.  Used by the edit and write executors which pass file content
+// via stdin rather than as a command-line argument.
+func (d *toolDispatcher) runInFileSandboxWithStdin(ctx context.Context, worktreeReadOnly bool, stdin string, name string, argv ...string) (string, bool, error) {
+	mountArgs := fileToolMounts(d.worktree, d.tmpDir, worktreeReadOnly)
+
+	resolvedName, err := resolveBinaryPath(name)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve binary %q: %w", name, err)
+	}
+
+	return runInBwrap(ctx, mountArgs, d.worktree, strings.NewReader(stdin), resolvedName, argv...)
+}
+
+// runInBwrap builds and executes the bwrap command.
+// stdinReader, if non-nil, is piped to the subprocess's stdin.
+func runInBwrap(ctx context.Context, mountArgs []string, cwd string, stdinReader interface{ Read([]byte) (int, error) }, name string, argv ...string) (string, bool, error) {
+	args := []string{
+		"--clearenv",
+		"--unshare-pid",
+		"--proc", "/proc",
+		"--dev", "/dev",
+		"--die-with-parent",
+	}
+	args = append(args, mountArgs...)
+	args = append(args, fileToolEnvArgs()...)
+	if cwd != "" {
+		args = append(args, "--chdir", cwd)
+	}
+	args = append(args, "--")
+	args = append(args, name)
+	args = append(args, argv...)
+
+	cmd := exec.CommandContext(ctx, "bwrap", args...)
+	if stdinReader != nil {
+		cmd.Stdin = stdinReader
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return string(out), false, nil
+		}
+		return string(out), false, fmt.Errorf("bwrap: %w", err)
+	}
+	return string(out), true, nil
+}
+
+// fileToolMounts returns the bwrap mount argument list for a file tool
+// subprocess.  It uses container.AppendBwrapBind (the shared mounts.go
+// emitter) to translate each MountSpec into the correct --ro-bind / --bind
+// triple, satisfying the AC requiring MountSpec plumbing reuse.
+//
+// The mount set is built from scratch (not from StandardSandboxMounts) so
+// that pi-process credentials are deliberately excluded.
+//
+// Mount ordering matters in bwrap — later mounts shadow earlier ones on
+// overlapping paths.  The ordering used here is:
+//
+//  1. System RO roots (/nix, /etc, /bin, /run/current-system, ~/.nix-profile)
+//  2. Per-session /tmp (backed by tmpDir) — replaces the sandbox's /tmp
+//  3. Sensitive /etc subtrees shadowed by empty tmpfs
+//  4. Worktree (LAST) — placed after the /tmp replacement so that when the
+//     worktree is under /tmp (e.g. t.TempDir() in tests), this bind-mount
+//     restores the worktree path inside the sandbox namespace.
+//
+// In production, worktrees are never under /tmp, so the ordering is
+// invisible.  In tests, we also pre-create the parent directory inside
+// tmpDir so the mount-point destination exists.
+func fileToolMounts(worktree, tmpDir string, worktreeReadOnly bool) []string {
+	var args []string
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+
+	// System RO roots via MountSpec -> AppendBwrapBind.
+	// Emitted first so they can be shadowed by later mounts.
+	systemSpecs := []container.MountSpec{
+		{HostPath: "/nix", SandboxPath: "/nix", ReadOnly: true},
+		{HostPath: "/etc", SandboxPath: "/etc", ReadOnly: true},
+		{HostPath: "/bin", SandboxPath: "/bin", ReadOnly: true},
+		{
+			HostPath:          "/run/current-system",
+			SandboxPath:       "/run/current-system",
+			ReadOnly:          true,
+			OptionalIfMissing: true,
+		},
+		{
+			HostPath:          home + "/.nix-profile",
+			SandboxPath:       home + "/.nix-profile",
+			ReadOnly:          true,
+			OptionalIfMissing: true,
+		},
+	}
+	for _, spec := range systemSpecs {
+		args = container.AppendBwrapBind(args, spec)
+	}
+
+	// Per-session /tmp (RW) backed by tmpDir on the host.
+	// --bind maps the host tmpDir to the sandbox /tmp so that writes to /tmp
+	// inside the sandbox persist to tmpDir on the host and survive across
+	// tool calls in the same session.
+	if tmpDir != "" {
+		if mkErr := os.MkdirAll(tmpDir, 0o755); mkErr == nil {
+			args = append(args, "--bind", tmpDir, "/tmp")
+		}
+	} else {
+		args = append(args, "--tmpfs", "/tmp")
+	}
+
+	// When the worktree is under the host's /tmp (which happens in tests using
+	// t.TempDir()), the worktree bind below will try to mount at a destination
+	// path inside the sandbox's /tmp (= tmpDir).  bwrap requires the
+	// mount-point destination directory to exist inside the sandbox namespace.
+	// Since tmpDir is a fresh empty directory, we pre-create the parent
+	// directories for the worktree inside tmpDir so the mount point is valid.
+	if tmpDir != "" && worktree != "" && strings.HasPrefix(worktree, "/tmp/") {
+		relToTmp := worktree[len("/tmp/"):]
+		mountPoint := filepath.Join(tmpDir, relToTmp)
+		// Create the directory that will serve as the bind-mount destination.
+		// If this fails (permissions, disk space), bwrap will produce a
+		// descriptive error at mount time.
+		_ = os.MkdirAll(mountPoint, 0o755)
+	}
+
+	// Shadow sensitive /etc subtrees with empty tmpfs.
+	// Applied after the /etc ro-bind so bwrap's ordered mount processing
+	// shadows these subtrees inside the sandbox.
+	for _, sensitiveDir := range []string{
+		"/etc/wireguard",
+		"/etc/wpa_supplicant",
+		"/etc/ssh",
+	} {
+		if _, err := os.Stat(sensitiveDir); err == nil {
+			args = append(args, "--tmpfs", sensitiveDir)
+		}
+	}
+
+	// Worktree (RO or RW) — mounted LAST.
+	// Placing the worktree bind last ensures it shadows the /tmp replacement
+	// when the worktree is under /tmp (which happens in tests using
+	// t.TempDir()).  In production, worktrees are never under /tmp.
+	if worktree != "" {
+		spec := container.MountSpec{
+			HostPath:    worktree,
+			SandboxPath: worktree,
+			ReadOnly:    worktreeReadOnly,
+		}
+		args = container.AppendBwrapBind(args, spec)
+	}
+
+	return args
+}

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -302,10 +302,19 @@ func (h *HarnessSocketServer) dispatchToolExec(ctx context.Context, w *jsonlWrit
 	h.writeEvent("tool_call", payloadBytes)
 
 	// Execute the tool.
+	//
+	// Derive tmpDir from the harness socket path:
+	//   sessionDir = filepath.Dir(sess.HarnessSockPath)
+	//   tmpDir     = filepath.Join(sessionDir, "tmp")
+	// This is the host-side backing directory for the in-sandbox /tmp mount
+	// (design doc §10.1: ~/.local/state/iris/run/<instance_id>/tmp/).
+	sessionDir := filepath.Dir(h.sess.HarnessSockPath)
+	tmpDir := filepath.Join(sessionDir, "tmp")
 	dispatcher := &toolDispatcher{
-		worktree: h.sess.Worktree,
-		writer:   w,
-		abortCh:  abortCh,
+		worktree:   h.sess.Worktree,
+		tmpDir:     tmpDir,
+		writer:     w,
+		abortCh:    abortCh,
 		toolExecID: frame.ID,
 	}
 	result := dispatcher.dispatch(ctx, frame)

--- a/modules/programs/prism/prism/internal/iris/harness_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket_test.go
@@ -425,7 +425,11 @@ func TestDBEventWritten(t *testing.T) {
 }
 
 // TestReadTool verifies the read tool executor.
+// Requires bwrap with unprivileged user namespaces (skipped in CI environments
+// that lack this capability, e.g. GitHub Actions ubuntu runners and the Nix
+// build sandbox).
 func TestReadTool(t *testing.T) {
+	requireBwrap(t)
 	tmp := t.TempDir()
 
 	// Write a test file.
@@ -509,7 +513,10 @@ func TestSupervisorRestartPolicy(t *testing.T) {
 }
 
 // TestEditToolUniqueness verifies that runEdit rejects non-unique old_string.
+// Requires bwrap with unprivileged user namespaces (skipped in CI environments
+// that lack this capability).
 func TestEditToolUniqueness(t *testing.T) {
+	requireBwrap(t)
 	tmp := t.TempDir()
 
 	// Write a file with the target string appearing twice.

--- a/modules/programs/prism/prism/internal/iris/sandbox_file_tools.go
+++ b/modules/programs/prism/prism/internal/iris/sandbox_file_tools.go
@@ -1,0 +1,164 @@
+// Package iris — sandbox_file_tools.go
+//
+// D-4: per-tool sandbox for the six file tools (read, edit, write, grep, find, ls).
+//
+// This file contains the OS-independent helpers:
+//   - validateToolPath — Go-side path validation (primary enforcement)
+//   - isUnder, resolvePartial — helpers for the validator
+//   - sbplQuote — SBPL path quoting (used by Darwin profile generator)
+//   - fileToolEnvArgs — minimal env vars for file tool subprocesses
+//   - resolveBinaryPath — resolve a tool name to its /nix/store/... path
+//
+// OS-specific sandbox implementations live in:
+//   - file_sandbox_linux.go  — bwrap
+//   - file_sandbox_darwin.go — sandbox-exec
+
+package iris
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// validateToolPath validates that a tool's path argument is safe to execute
+// against.  It:
+//
+//  1. Converts relative paths to absolute using worktree as the base.
+//  2. Resolves symlinks (filepath.EvalSymlinks) to detect symlink traversal.
+//  3. Collapses ".." segments on the result of (2) via filepath.Clean.
+//  4. Rejects the path if it is not rooted under worktree OR under tmpDir.
+//
+// tmpDir is the per-session /tmp backing directory on the host
+// (~/.local/state/iris/run/<instance_id>/tmp/).  Paths inside it are allowed
+// because the sandbox maps it to /tmp inside the subprocess.
+//
+// On success the resolved absolute path is returned.
+// On failure a nil string and a descriptive error are returned.
+func validateToolPath(worktree, tmpDir, rawPath string) (string, error) {
+	// Make absolute relative to the worktree.
+	abs := rawPath
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(worktree, rawPath)
+	}
+	abs = filepath.Clean(abs)
+
+	// Resolve symlinks to detect traversal via symlinks.
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// If the path doesn't exist yet (e.g. write to a new file), EvalSymlinks
+		// will fail.  Walk up the tree to find the deepest existing ancestor,
+		// then re-join the suffix.
+		resolved, err = resolvePartial(abs)
+		if err != nil {
+			return "", fmt.Errorf("path %q: cannot resolve: %w", rawPath, err)
+		}
+	}
+	resolved = filepath.Clean(resolved)
+
+	// Check whether the resolved path is under worktree or tmpDir.
+	if isUnder(resolved, worktree) || (tmpDir != "" && isUnder(resolved, tmpDir)) {
+		return resolved, nil
+	}
+
+	return "", fmt.Errorf("path %q is outside the session worktree and not under /tmp", rawPath)
+}
+
+// isUnder reports whether child is equal to base or is a descendant of it.
+func isUnder(child, base string) bool {
+	if child == base {
+		return true
+	}
+	return strings.HasPrefix(child, base+string(filepath.Separator))
+}
+
+// resolvePartial resolves symlinks as deep as possible for a path that may
+// not fully exist yet (e.g. a file that is about to be written).  It walks
+// upward until it finds an existing prefix, resolves that prefix through
+// EvalSymlinks, then re-attaches the non-existing suffix.
+func resolvePartial(abs string) (string, error) {
+	// Split the path into parts and find the deepest existing ancestor.
+	dir := abs
+	var suffix []string
+	for {
+		if _, err := os.Lstat(dir); err == nil {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached root without finding anything — fall back to Clean.
+			return abs, nil
+		}
+		suffix = append([]string{filepath.Base(dir)}, suffix...)
+		dir = parent
+	}
+
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return abs, nil
+	}
+	return filepath.Join(append([]string{resolved}, suffix...)...), nil
+}
+
+// sbplQuote wraps a path in SBPL double-quote syntax, escaping backslashes
+// and double-quotes.  This is a copy of the unexported quoteSBPL in
+// internal/container/sandbox_exec.go — reproduced here so the iris package
+// does not need to import the container package just for quoting.
+func sbplQuote(path string) string {
+	escaped := strings.ReplaceAll(path, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
+	return "\"" + escaped + "\""
+}
+
+// fileToolEnvArgs returns the --setenv pairs for the standard set of
+// environment variables that file tools need.  This is a minimal set:
+// PATH, HOME, USER — enough for binary resolution and basic operations.
+// Credentials are explicitly excluded.
+func fileToolEnvArgs() []string {
+	var args []string
+
+	pathVal := os.Getenv("PATH")
+	if pathVal == "" {
+		pathVal = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+	}
+	args = append(args, "--setenv", "PATH", pathVal)
+
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL"} {
+		if val := os.Getenv(key); val != "" {
+			args = append(args, "--setenv", key, val)
+		}
+	}
+
+	return args
+}
+
+// resolveBinaryPath resolves a binary name (e.g. "cat", "grep", "sh") to its
+// absolute path on the host.  It intentionally does NOT follow symlinks to
+// the final target: on NixOS, tools like 'cat' are symlinks to 'coreutils'
+// which uses argv[0] to determine which tool to run.  If we resolved 'cat'
+// all the way to 'coreutils', the binary would not know it should behave as
+// 'cat'.  Instead we return the first-level absolute path from LookPath
+// (e.g. /run/current-system/sw/bin/cat), which is accessible inside the
+// sandbox because we mount /run/current-system RO.
+func resolveBinaryPath(name string) (string, error) {
+	// If it's already absolute, use it directly.
+	if filepath.IsAbs(name) {
+		return name, nil
+	}
+
+	// Look up in PATH — returns the absolute path without following symlinks.
+	found, err := exec.LookPath(name)
+	if err != nil {
+		// Fallback: try common well-known locations for basic tools.
+		for _, prefix := range []string{"/bin", "/usr/bin", "/run/current-system/sw/bin"} {
+			candidate := filepath.Join(prefix, name)
+			if _, statErr := os.Stat(candidate); statErr == nil {
+				return candidate, nil
+			}
+		}
+		return "", fmt.Errorf("binary %q not found in PATH: %w", name, err)
+	}
+	return found, nil
+}

--- a/modules/programs/prism/prism/internal/iris/sandbox_file_tools_test.go
+++ b/modules/programs/prism/prism/internal/iris/sandbox_file_tools_test.go
@@ -1,0 +1,248 @@
+package iris
+
+// sandbox_file_tools_test.go — unit tests for validateToolPath and related helpers.
+//
+// These are plain Go unit tests (no build tags, no network, no subprocess).
+// They exercise the path validator's normalisation, symlink resolution, and
+// worktree-containment logic.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeTree is a test helper that creates a directory structure under a temp
+// dir and returns the temp dir path.
+func makeTree(t *testing.T, entries map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range entries {
+		abs := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("makeTree MkdirAll %q: %v", filepath.Dir(abs), err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatalf("makeTree WriteFile %q: %v", abs, err)
+		}
+	}
+	return root
+}
+
+func TestValidateToolPath_AcceptsWorktreeFile(t *testing.T) {
+	worktree := makeTree(t, map[string]string{
+		"README.md": "hello",
+	})
+	tmpDir := t.TempDir()
+
+	resolved, err := validateToolPath(worktree, tmpDir, "README.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(worktree, "README.md")
+	if resolved != want {
+		t.Errorf("resolved = %q, want %q", resolved, want)
+	}
+}
+
+func TestValidateToolPath_AcceptsAbsoluteWorktreePath(t *testing.T) {
+	worktree := makeTree(t, map[string]string{
+		"sub/file.txt": "content",
+	})
+	tmpDir := t.TempDir()
+
+	abs := filepath.Join(worktree, "sub/file.txt")
+	resolved, err := validateToolPath(worktree, tmpDir, abs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != abs {
+		t.Errorf("resolved = %q, want %q", resolved, abs)
+	}
+}
+
+func TestValidateToolPath_AcceptsTmpPath(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := makeTree(t, map[string]string{
+		"scratch.txt": "data",
+	})
+
+	abs := filepath.Join(tmpDir, "scratch.txt")
+	resolved, err := validateToolPath(worktree, tmpDir, abs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != abs {
+		t.Errorf("resolved = %q, want %q", resolved, abs)
+	}
+}
+
+func TestValidateToolPath_RejectsEtcPasswd(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	_, err := validateToolPath(worktree, tmpDir, "/etc/passwd")
+	if err == nil {
+		t.Error("expected error for /etc/passwd, got nil")
+	}
+}
+
+func TestValidateToolPath_RejectsSSHKey(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	// Simulate a path like /home/user/.ssh/id_ed25519
+	home, _ := os.UserHomeDir()
+	sshKey := filepath.Join(home, ".ssh", "id_ed25519")
+
+	_, err := validateToolPath(worktree, tmpDir, sshKey)
+	if err == nil {
+		t.Error("expected error for SSH key path, got nil")
+	}
+}
+
+func TestValidateToolPath_RejectsDotDotTraversal(t *testing.T) {
+	worktree := makeTree(t, map[string]string{
+		"file.txt": "content",
+	})
+	tmpDir := t.TempDir()
+
+	// Attempt ../../../etc/passwd relative to worktree.
+	traversal := "../../etc/passwd"
+	_, err := validateToolPath(worktree, tmpDir, traversal)
+	if err == nil {
+		t.Errorf("expected error for dot-dot traversal %q, got nil", traversal)
+	}
+}
+
+func TestValidateToolPath_RejectsSymlinkTraversal(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	// Create a symlink inside the worktree that points at /etc/passwd.
+	symlink := filepath.Join(worktree, "evil-link")
+	if err := os.Symlink("/etc/passwd", symlink); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	_, err := validateToolPath(worktree, tmpDir, symlink)
+	if err == nil {
+		t.Error("expected error for symlink pointing to /etc/passwd, got nil")
+	}
+}
+
+func TestValidateToolPath_RejectsSymlinkInsideTmpPointingOutside(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	// Create a symlink inside tmpDir that points at /etc/passwd.
+	symlink := filepath.Join(tmpDir, "link-to-etc")
+	if err := os.Symlink("/etc/passwd", symlink); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	_, err := validateToolPath(worktree, tmpDir, symlink)
+	if err == nil {
+		t.Error("expected error for symlink in tmpDir pointing to /etc/passwd, got nil")
+	}
+}
+
+func TestValidateToolPath_AcceptsNonExistentFileUnderWorktree(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	// Path doesn't exist yet — should be accepted (write creates it).
+	newFile := filepath.Join(worktree, "new-file.txt")
+	resolved, err := validateToolPath(worktree, tmpDir, newFile)
+	if err != nil {
+		t.Fatalf("unexpected error for non-existent worktree file: %v", err)
+	}
+	if resolved != newFile {
+		t.Errorf("resolved = %q, want %q", resolved, newFile)
+	}
+}
+
+func TestValidateToolPath_AcceptsNonExistentFileUnderTmpDir(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	newFile := filepath.Join(tmpDir, "new-scratch.txt")
+	resolved, err := validateToolPath(worktree, tmpDir, newFile)
+	if err != nil {
+		t.Fatalf("unexpected error for non-existent tmpDir file: %v", err)
+	}
+	if resolved != newFile {
+		t.Errorf("resolved = %q, want %q", resolved, newFile)
+	}
+}
+
+func TestValidateToolPath_RejectsWorktreeParent(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	// The parent of the worktree is outside the worktree.
+	parent := filepath.Dir(worktree)
+	_, err := validateToolPath(worktree, tmpDir, parent)
+	if err == nil {
+		t.Errorf("expected error for worktree parent %q, got nil", parent)
+	}
+}
+
+func TestValidateToolPath_RejectsHomeDir(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	home, _ := os.UserHomeDir()
+	_, err := validateToolPath(worktree, tmpDir, home)
+	if err == nil {
+		t.Error("expected error for home dir, got nil")
+	}
+}
+
+func TestIsUnder(t *testing.T) {
+	cases := []struct {
+		child string
+		base  string
+		want  bool
+	}{
+		{"/a/b/c", "/a/b", true},
+		{"/a/b", "/a/b", true},
+		{"/a/bc", "/a/b", false},
+		{"/a/b", "/a/bc", false},
+		{"/a", "/a/b", false},
+		{"/", "/a", false},
+	}
+	for _, c := range cases {
+		got := isUnder(c.child, c.base)
+		if got != c.want {
+			t.Errorf("isUnder(%q, %q) = %v, want %v", c.child, c.base, got, c.want)
+		}
+	}
+}
+
+func TestValidateToolPath_ErrorMessageNamesPath(t *testing.T) {
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	_, err := validateToolPath(worktree, tmpDir, "/etc/hosts")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	errMsg := err.Error()
+	// The error message should name the rejected path.
+	if !contains(errMsg, "/etc/hosts") && !contains(errMsg, "outside") {
+		t.Errorf("error message does not name path or say 'outside': %q", errMsg)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/modules/programs/prism/prism/internal/iris/tool_dispatcher.go
+++ b/modules/programs/prism/prism/internal/iris/tool_dispatcher.go
@@ -1,19 +1,26 @@
 package iris
 
-// tool_dispatcher.go — host-mode tool execution for D-3.
+// tool_dispatcher.go — per-tool sandboxed execution (D-4).
 //
-// In D-3 all tool subprocesses run directly on the host with no sandbox.
-// This is the deliberate intermediate state before D-4 (worktree-scoped
-// subprocess) and D-5 (bash restricted subprocess). The point is to prove the
-// dispatch loop end-to-end; sandboxing is layered on later without changing
-// the protocol.
+// D-3 proved the dispatch loop end-to-end with host-mode (unsandboxed)
+// executors.  D-4 replaces the six file-tool executors with sandboxed
+// subprocess wrappers:
 //
-// Each tool call runs in its own subprocess. The tool dispatcher:
-//  1. Selects the executor for the named tool.
-//  2. Runs the executor in a subprocess, capturing stdout+stderr.
-//  3. Streams partial output via tool_exec_update frames.
-//  4. Watches for a tool_abort signal and kills the subprocess + descendants.
-//  5. Returns a toolResult with success/isError/output/details.
+//   - Linux:  bwrap (bubblewrap)
+//   - macOS:  sandbox-exec with a generated SBPL profile
+//
+// The bash executor remains unsandboxed (that is D-5's scope).
+//
+// Each tool call runs in its own subprocess.  The tool dispatcher:
+//  1. Validates the path argument (Go-side, before starting any subprocess).
+//  2. Selects the executor for the named tool.
+//  3. Runs the executor in a sandboxed subprocess, capturing stdout+stderr.
+//  4. Streams partial output via tool_exec_update frames.
+//  5. Watches for a tool_abort signal and kills the subprocess + descendants.
+//  6. Returns a toolResult with success/isError/output/details.
+//
+// Path validation is the primary enforcement mechanism; the sandbox is
+// defence-in-depth.
 
 import (
 	"context"
@@ -39,6 +46,12 @@ type toolResult struct {
 // toolDispatcher holds the context for a single tool_exec dispatch.
 type toolDispatcher struct {
 	worktree   string
+	// tmpDir is the per-session host-side backing directory for the in-sandbox
+	// /tmp mount.  Computed from the harness socket path:
+	//   sessionDir = filepath.Dir(sess.HarnessSockPath)
+	//   tmpDir     = filepath.Join(sessionDir, "tmp")
+	// Populated by the harness socket server before dispatching.
+	tmpDir     string
 	writer     *jsonlWriter
 	abortCh    <-chan struct{}
 	toolExecID string
@@ -235,8 +248,10 @@ func sigkillProcessGroup(pid int) {
 	_ = syscall.Kill(pgid, syscall.SIGKILL)
 }
 
-// --- Tool executors (D-3: host-mode, no sandbox) ---
+// --- Tool executors (D-4: sandboxed subprocesses for file tools) ---
 
+// runBash remains unsandboxed in D-4.  D-5 will add the restricted
+// subprocess sandbox for bash.
 func (d *toolDispatcher) runBash(ctx context.Context, frame ToolExecFrame) toolResult {
 	command := stringArg(frame.Args, "command")
 	if command == "" {
@@ -245,6 +260,7 @@ func (d *toolDispatcher) runBash(ctx context.Context, frame ToolExecFrame) toolR
 	return d.runSubprocess(ctx, d.worktree, nil, "bash", "-c", command)
 }
 
+// runRead executes the read tool in a sandboxed subprocess (worktree RO).
 func (d *toolDispatcher) runRead(ctx context.Context, frame ToolExecFrame) toolResult {
 	filePath := stringArg(frame.Args, "file_path")
 	if filePath == "" {
@@ -253,14 +269,28 @@ func (d *toolDispatcher) runRead(ctx context.Context, frame ToolExecFrame) toolR
 	if filePath == "" {
 		return toolResult{Success: false, IsError: true, Output: "read: missing 'file_path' argument"}
 	}
-	abs := resolveWorktreePath(d.worktree, filePath)
-	data, err := os.ReadFile(abs)
+
+	// Path validation — primary enforcement (sandbox is defence-in-depth).
+	resolved, err := validateToolPath(d.worktree, d.tmpDir, filePath)
 	if err != nil {
 		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("read: %v", err)}
 	}
-	content := string(data)
 
-	// Apply offset/limit if provided.
+	// Build argv: cat for reading (handles binary; offset/limit applied in Go
+	// after capture).  We cat the resolved path so the subprocess sees the
+	// symlink-resolved location — the sandbox bind-mount covers the resolved
+	// location, so the cat will succeed.
+	output, ok, sandboxErr := d.runInFileSandbox(ctx, true, "cat", resolved)
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("read: sandbox: %v", sandboxErr)}
+	}
+	if !ok {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("read: %s", output)}
+	}
+
+	content := output
+
+	// Apply offset/limit if provided (applied after capture in Go).
 	offset := intArg(frame.Args, "offset")
 	limit := intArg(frame.Args, "limit")
 	if offset > 0 || limit > 0 {
@@ -283,6 +313,7 @@ func (d *toolDispatcher) runRead(ctx context.Context, frame ToolExecFrame) toolR
 	return toolResult{Success: true, IsError: false, Output: content}
 }
 
+// runEdit executes the edit tool in a sandboxed subprocess (worktree RW).
 func (d *toolDispatcher) runEdit(ctx context.Context, frame ToolExecFrame) toolResult {
 	filePath := stringArg(frame.Args, "file_path")
 	if filePath == "" {
@@ -294,12 +325,25 @@ func (d *toolDispatcher) runEdit(ctx context.Context, frame ToolExecFrame) toolR
 		return toolResult{Success: false, IsError: true, Output: "edit: missing 'file_path' argument"}
 	}
 
-	abs := resolveWorktreePath(d.worktree, filePath)
-	data, err := os.ReadFile(abs)
+	// Path validation — primary enforcement.
+	resolved, err := validateToolPath(d.worktree, d.tmpDir, filePath)
 	if err != nil {
-		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: read: %v", err)}
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: %v", err)}
 	}
-	content := string(data)
+
+	// Read the file content in a RO sandbox, then perform the edit in-process,
+	// then write the result via a RW sandbox.  This keeps the actual file
+	// manipulation logic in Go (clear error messages, count checks) while
+	// ensuring both reads and writes go through the sandbox path.
+	readOutput, readOK, sandboxErr := d.runInFileSandbox(ctx, true, "cat", resolved)
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: sandbox read: %v", sandboxErr)}
+	}
+	if !readOK {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: read: %s", readOutput)}
+	}
+
+	content := readOutput
 	if oldText != "" {
 		count := strings.Count(content, oldText)
 		if count == 0 {
@@ -319,12 +363,22 @@ func (d *toolDispatcher) runEdit(ctx context.Context, frame ToolExecFrame) toolR
 	} else {
 		newContent = strings.Replace(content, oldText, newText, 1)
 	}
-	if err := os.WriteFile(abs, []byte(newContent), 0o644); err != nil {
-		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: write: %v", err)}
+
+	// Write the new content via a sandboxed tee/dd into the resolved path.
+	// We use a shell invocation via the RW sandbox to write the file.
+	// The content is passed via stdin.
+	writeOutput, writeOK, sandboxErr := d.runInFileSandboxWithStdin(ctx, false, newContent, "sh", "-c", "cat > "+shellQuote(resolved))
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: sandbox write: %v", sandboxErr)}
 	}
+	if !writeOK {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("edit: write: %s", writeOutput)}
+	}
+
 	return toolResult{Success: true, IsError: false, Output: "file edited successfully"}
 }
 
+// runWrite executes the write tool in a sandboxed subprocess (worktree RW).
 func (d *toolDispatcher) runWrite(ctx context.Context, frame ToolExecFrame) toolResult {
 	filePath := stringArg(frame.Args, "file_path")
 	if filePath == "" {
@@ -335,41 +389,81 @@ func (d *toolDispatcher) runWrite(ctx context.Context, frame ToolExecFrame) tool
 		return toolResult{Success: false, IsError: true, Output: "write: missing 'file_path' argument"}
 	}
 
-	abs := resolveWorktreePath(d.worktree, filePath)
+	// Path validation — primary enforcement.
+	_, err := validateToolPath(d.worktree, d.tmpDir, filePath)
+	if err != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("write: %v", err)}
+	}
+
+	// Resolve to absolute for the sandboxed write.
+	abs := filePath
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(d.worktree, filePath)
+	}
+	abs = filepath.Clean(abs)
+
+	// The parent directory may not exist; create it on the host before entering
+	// the sandbox (the sandbox's worktree RW bind-mount allows directory creation,
+	// but mkdir -p is simpler to do in Go).
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("write: mkdir: %v", err)}
 	}
-	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
-		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("write: %v", err)}
+
+	// Write via a sandboxed subprocess with content on stdin.
+	writeOutput, writeOK, sandboxErr := d.runInFileSandboxWithStdin(ctx, false, content, "sh", "-c", "cat > "+shellQuote(abs))
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("write: sandbox: %v", sandboxErr)}
+	}
+	if !writeOK {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("write: %s", writeOutput)}
 	}
 	return toolResult{Success: true, IsError: false, Output: "file written successfully"}
 }
 
+// runGrep executes the grep tool in a sandboxed subprocess (worktree RO).
 func (d *toolDispatcher) runGrep(ctx context.Context, frame ToolExecFrame) toolResult {
 	pattern := stringArg(frame.Args, "pattern")
 	path := stringArg(frame.Args, "path")
 	if pattern == "" {
 		return toolResult{Success: false, IsError: true, Output: "grep: missing 'pattern' argument"}
 	}
+
 	target := d.worktree
 	if path != "" {
-		target = resolveWorktreePath(d.worktree, path)
+		// Validate the path argument.
+		resolved, err := validateToolPath(d.worktree, d.tmpDir, path)
+		if err != nil {
+			return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("grep: %v", err)}
+		}
+		target = resolved
 	}
-	args := []string{"-rn", "--", pattern, target}
-	return d.runSubprocess(ctx, d.worktree, nil, "grep", args...)
+
+	output, ok, sandboxErr := d.runInFileSandbox(ctx, true, "grep", "-rn", "--", pattern, target)
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("grep: sandbox: %v", sandboxErr)}
+	}
+	// grep exits 1 when no matches found — treat as success with empty output.
+	if !ok && output == "" {
+		return toolResult{Success: true, IsError: false, Output: ""}
+	}
+	return toolResult{Success: ok || output != "", IsError: false, Output: output}
 }
 
+// runFind executes the find tool in a sandboxed subprocess (worktree RO).
 func (d *toolDispatcher) runFind(ctx context.Context, frame ToolExecFrame) toolResult {
 	path := stringArg(frame.Args, "path")
 	if path == "" {
 		path = "."
 	}
-	target := resolveWorktreePath(d.worktree, path)
+
+	// Validate the path argument.
+	resolved, err := validateToolPath(d.worktree, d.tmpDir, path)
+	if err != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("find: %v", err)}
+	}
 
 	var argv []string
-	argv = append(argv, target)
-
-	// Optional name pattern filter.
+	argv = append(argv, resolved)
 	if name := stringArg(frame.Args, "name"); name != "" {
 		argv = append(argv, "-name", name)
 	}
@@ -377,16 +471,36 @@ func (d *toolDispatcher) runFind(ctx context.Context, frame ToolExecFrame) toolR
 		argv = append(argv, "-type", typeFilter)
 	}
 
-	return d.runSubprocess(ctx, d.worktree, nil, "find", argv...)
+	output, ok, sandboxErr := d.runInFileSandbox(ctx, true, "find", argv...)
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("find: sandbox: %v", sandboxErr)}
+	}
+	return toolResult{Success: ok, IsError: !ok, Output: output}
 }
 
+// runLs executes the ls tool in a sandboxed subprocess (worktree RO).
 func (d *toolDispatcher) runLs(ctx context.Context, frame ToolExecFrame) toolResult {
 	path := stringArg(frame.Args, "path")
 	if path == "" {
 		path = "."
 	}
-	target := resolveWorktreePath(d.worktree, path)
-	return d.runSubprocess(ctx, d.worktree, nil, "ls", "-la", target)
+
+	// Validate the path argument.
+	resolved, err := validateToolPath(d.worktree, d.tmpDir, path)
+	if err != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("ls: %v", err)}
+	}
+
+	output, ok, sandboxErr := d.runInFileSandbox(ctx, true, "ls", "-la", resolved)
+	if sandboxErr != nil {
+		return toolResult{Success: false, IsError: true, Output: fmt.Sprintf("ls: sandbox: %v", sandboxErr)}
+	}
+	return toolResult{Success: ok, IsError: !ok, Output: output}
+}
+
+// shellQuote wraps s in single quotes, escaping embedded single quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // resolveWorktreePath resolves a (potentially relative) path against the

--- a/pkgs/iris.nix
+++ b/pkgs/iris.nix
@@ -14,7 +14,7 @@
 
 buildGoModule {
   pname = "iris";
-  version = "0.1.0-d3";
+  version = "0.1.0-d4";
 
   src = ../modules/programs/prism/prism;
 


### PR DESCRIPTION
## Summary

Implements D-4 of the daemon-mode rollout. Each of the six file tools (`read`, `edit`, `write`, `grep`, `find`, `ls`) now executes in a worktree-scoped subprocess sandbox when invoked via the iris harness-socket dispatch. The sandbox is bwrap on Linux and sandbox-exec on macOS.

Refs #1625, Closes #1635, references #1634/#1643 (D-3).

## What changed

### Path validation (primary enforcement)

`validateToolPath()` in `sandbox_file_tools.go`:
- Normalises the input path (relative → absolute, collapse `...`)
- Resolves symlinks via `filepath.EvalSymlinks` to detect traversal through symlinks
- Rejects paths outside the worktree or per-session `/tmp`
- Returns a clear error naming the rejected path (e.g. `path "/etc/passwd" is outside the session worktree and not under /tmp`)

### Linux sandbox (bwrap)

`file_sandbox_linux.go` implements `runInFileSandbox` / `runInFileSandboxWithStdin`:
- Mount set assembled using `container.AppendBwrapBind` (MountSpec machinery from `mounts.go`) — built **from scratch**, NOT from `StandardSandboxMounts`
- Mount order: system roots → per-session `/tmp` → worktree last (so the worktree bind-mount shadows the `/tmp` replacement when the worktree is under `/tmp`, which happens in tests)
- Sensitive `/etc` subtrees shadowed by empty tmpfs: `/etc/wireguard`, `/etc/wpa_supplicant`, `/etc/ssh`

### macOS sandbox (sandbox-exec)

`file_sandbox_darwin.go` implements the macOS path:
- `GenerateFileToolSBPLProfile()` generates a (version 3) SBPL profile
- Worktree RO or RW depending on tool
- Network permitted (`(allow network*)`) per design doc §5/§6.3
- Deny rules for all three sensitive `/etc` subtrees (both `/etc/...` and `/private/etc/...` forms)

### Mount set (design doc §5)

| Path | Mode |
|------|------|
| Worktree | RO for read/grep/find/ls; RW for edit/write |
| Per-session `/tmp` | RW (backed by `~/.local/state/iris/run/<id>/tmp/`) |
| `/nix/store` | RO |
| `/etc` | RO (sensitive subtrees shadowed) |
| `/bin` | RO |
| `/run/current-system` | RO |
| `~/.nix-profile` | RO |

**Explicit exclusions** (pi-process credentials per §5):
- `~/.claude`, `~/.mcp-auth`, `~/.pi/agent/*`, `~/.cache/bun`, `~/.config/pi/*`
- `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GITHUB_TOKEN`, `PRISM_GITHUB_TOKEN_*`
- SSH keys, AWS config, kube config

### Tool execution strategy

The six tools use a subprocess + stdin approach:
- `read`, `grep`, `find`, `ls`: run the native tool binary inside the sandbox
- `edit`, `write`: read/write via `sh -c "cat > <path>"` with content on stdin

The D-3 bash executor remains unsandboxed (D-5's scope).

### Infrastructure changes

- `container.AppendBwrapBind` exported (was `appendBwrapBind`) to allow iris package to reuse MountSpec emission machinery
- `harness_socket.go` derives `tmpDir` from `HarnessSockPath` so it can be passed to the `toolDispatcher` without touching `session.go`
- `pkgs/iris.nix` version bumped to `0.1.0-d4`

## Tests

- `sandbox_file_tools_test.go`: 14 unit tests for `validateToolPath` (worktree, tmpDir, symlink traversal, `...` traversal, non-existent paths)
- `sandbox_exec_iris_file_tools_darwin_test.go`: Darwin integration tests per the sandbox-exec testing convention (#1192):
  - `TestIrisFileTool_WorktreeReadAllowed` + negative: worktree read allow / deny
  - `TestIrisFileTool_WorktreeWriteAllowed` + negative: worktree write allow / deny
  - `TestIrisFileTool_TmpReadWrite` + negative: tmpDir access allow / deny
  - `TestIrisFileTool_EtcSSHDenied` + negative: /etc/ssh deny / allow
  - Profile content assertions for RO/RW worktree rules and deny rules
- All 14 path-validator unit tests pass
- All existing iris harness tests pass (`TestReadTool`, `TestEditToolUniqueness`, etc.)
- `go test ./... -race` passes (all packages)
- `nix build .#iris` succeeds

## Out of scope

- Bash sandbox (D-5, sequenced after this PR)
- Credential brokering (D-7)
- Network restriction (permitted per design doc §5/§6.3)