### PR TITLE
fix(prism): restrict subPackages to prism entrypoint, avoid iris binary collision (D-2 follow-up)

### DIFF
--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -19,6 +19,14 @@ buildGoModule {
 
   src = ../modules/programs/prism/prism;
 
+  # Build only the prism entrypoint from the shared Go module.
+  # subPackages restricts what buildGoModule compiles into the output,
+  # so the derivation produces only the prism binary (not iris or any
+  # other cmd/ entrypoints). This avoids a bin/iris collision with
+  # pkgs/iris.nix when Home Manager merges both packages into the user
+  # profile (see issue #1633).
+  subPackages = [ "." ];
+
   doCheck = runChecks;
 
   vendorHash = "sha256-tU+rnXKz3ALl7pJx7GYTo1hdr3CFMQS4Ih3UYLr4v54=";


### PR DESCRIPTION
## Summary

Fast-follow fix for D-2 (#1633): `pkgs/prism.nix` was not setting `subPackages`, so `buildGoModule` compiled every `cmd/*` entrypoint in the shared Go module — including `cmd/iris/`. This caused a Home Manager file-collision when both `prism` and `iris` packages were merged into the user profile:

```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  `/nix/store/.../prism-0.1.0/bin/iris` and
  `/nix/store/.../iris-0.1.0-d3/bin/iris`
```

## Fix

Added `subPackages = [ "." ]` to `pkgs/prism.nix`. The prism entrypoint lives at the module root (`main.go`), so `"."` is the correct value. This mirrors the pattern already used in `pkgs/iris.nix` (`subPackages = [ "cmd/iris" ]`).

After the fix:
- `nix build .#prism` → `result/bin/` contains only `prism`
- `nix build .#iris` → `result/bin/` contains only `iris`
- `nh os build` succeeds
- `nix flake check` passes
- `go test ./...` passes

## Refs

Refs #1633