### PR TITLE
fix(sidecar): suppress finished-debounce on in-memory reviewingInFlight alone (#1652)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -279,11 +279,18 @@ func (s *Sidecar) handleSessionFinished() {
 		// If reviewingInFlight, suppress finished — the worker is awaiting review
 		// results; it will transition to finished naturally after the
 		// review-complete prompt is delivered and the worker resolves the results.
+		//
+		// Note: we rely on the in-memory flag alone (not the DB state) because the
+		// DB state can be overwritten back to active by intermediate state_change
+		// frames while reviewingInFlight is still true (the TOCTOU race fixed by
+		// #1652). The flag has a clear, well-defined clearing path: only
+		// source="review-complete" prompt delivery clears it, so it cannot wedge
+		// the session. See handleSessionIdle for the SSE-path equivalent.
 		currentState := s.currentDBState()
 		if currentState == agent.StateInterrupted || currentState == agent.StateError {
 			return
 		}
-		if s.reviewingInFlight && currentState == agent.StateReviewing {
+		if s.reviewingInFlight {
 			s.logger().Printf("sidecar: finished debounce suppressed (cause=reviewing — awaiting review-complete prompt)")
 			return
 		}
@@ -345,6 +352,14 @@ func (s *Sidecar) handleSessionIdle() {
 		// If reviewingInFlight, suppress finished — the worker is awaiting review
 		// results; it will transition to finished naturally after the
 		// review-complete prompt is delivered and the worker resolves the results.
+		//
+		// Note: unlike handleSessionFinished (the PI socket-pipe path, fixed by
+		// #1652), this SSE path retains the AND with DB state deliberately. The
+		// monitor writes "active" to DB just before delivering the review-complete
+		// prompt via deliverViaHTTP (bypassing the sidecar's /prompt handler).
+		// That pre-delivery write is the signal that review is done; if we
+		// suppressed on reviewingInFlight alone here, the session would wedge
+		// after review-complete delivery on SSE-harness workers (#1384).
 		currentState := s.currentDBState()
 		if currentState == agent.StateInterrupted || currentState == agent.StateError {
 			return

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -2613,5 +2613,183 @@ func TestSocketPipe_SessionStatus_EmptySessionID_NoOp(t *testing.T) {
 	}
 }
 
+// ── #1652 regression tests ────────────────────────────────────────────────
+//
+// These tests guard against the race where the finished-debounce in
+// handleSessionFinished suppresses only when BOTH reviewingInFlight==true AND
+// the DB state is StateReviewing. Intermediate state_change frames can drive
+// the DB back to StateActive while the in-memory flag is still true, causing
+// the AND to fail and the session to prematurely transition to StateFinished.
+//
+// The fix (approach b from issue #1652): rely on the in-memory flag alone.
+
+// TestSocketPipe_StateChange_DoesNotClobberReviewing verifies that a
+// state_change{finished} frame while reviewingInFlight==true does NOT
+// transition the session to finished, even when the DB state has drifted back
+// to active (i.e. the old AND guard would have failed). This is the core
+// regression test for issue #1652.
+//
+// Synchronisation: WaitForTimerCount waits for the debounce timer, then we
+// fire it manually and assert the session stays not-finished.
+func TestSocketPipe_StateChange_DoesNotClobberReviewing(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Bring the session to active.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second); st != string(agent.StateActive) {
+		t.Fatalf("state never reached active after turn_start, got %q", st)
+	}
+
+	// Simulate /review: write reviewing to the DB and set reviewingInFlight.
+	if err := sc.cfg.DB.UpsertStatus(
+		sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree,
+		string(agent.StateReviewing), nil, nil,
+	); err != nil {
+		t.Fatalf("UpsertStatus reviewing: %v", err)
+	}
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+
+	// Simulate DB state drifting back to active (the bug scenario from #1652):
+	// a state_change frame from a prior code path overwrote reviewing with active.
+	// We replicate this directly without going through the protocol.
+	if err := sc.cfg.DB.UpsertStatus(
+		sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree,
+		string(agent.StateActive), nil, nil,
+	); err != nil {
+		t.Fatalf("UpsertStatus active (simulating drift): %v", err)
+	}
+
+	// Confirm DB is now active (not reviewing) — this is the buggy state.
+	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateActive) {
+		t.Fatalf("expected DB to be active (drift simulation), got %q", s)
+	}
+
+	// Send state_change{finished} — this starts the finished debounce.
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	// Wait for the debounce timer to be registered.
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer created after state_change{finished}")
+	}
+
+	// Fire the debounce timer — with the fix the suppression should trigger.
+	timer.Fire()
+
+	// Give the debounce closure time to run.
+	time.Sleep(100 * time.Millisecond)
+
+	// The session must NOT have transitioned to finished (reviewingInFlight is
+	// still true, so the debounce should be suppressed).
+	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if st == string(agent.StateFinished) {
+		t.Errorf("session transitioned to finished while reviewingInFlight=true and DB state=active — #1652 regression")
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestSocketPipe_FailedRetryReview_StateChangeDoesNotFinish reproduces the
+// exact timeline from issue #1652:
+//
+//  1. Worker starts, reaches active.
+//  2. /review is called (1st attempt) — writes reviewing to DB, sets flag.
+//  3. /review subprocess fails — reviewingInFlight stays true (HTTP 500 path).
+//  4. /review is called again (2nd attempt, --rebase) — flag is already true.
+//  5. Worker does fix-cycle work: state_change frames drive DB back to active.
+//  6. Worker emits state_change{finished} — debounce fires — session must NOT
+//     transition to finished.
+//
+// Synchronisation: WaitForTimerCount + manual Fire + sleep.
+func TestSocketPipe_FailedRetryReview_StateChangeDoesNotFinish(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Step 1: worker reaches active.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second); st != string(agent.StateActive) {
+		t.Fatalf("state never reached active after turn_start, got %q", st)
+	}
+
+	// Step 2: first /review attempt — writes reviewing + sets flag.
+	if err := sc.cfg.DB.UpsertStatus(
+		sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree,
+		string(agent.StateReviewing), nil, nil,
+	); err != nil {
+		t.Fatalf("UpsertStatus reviewing (1st attempt): %v", err)
+	}
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+
+	// Step 3: /review subprocess fails. In the real code the HTTP handler
+	// returns 500 and does NOT clear reviewingInFlight (it stays true). The DB
+	// state stays "reviewing" at this point.
+
+	// Step 4: second /review attempt (--rebase). reviewingInFlight is already
+	// true; the handler skips the DB write and re-launches the subprocess.
+	// (Nothing to do here — the flag is already set.)
+
+	// Step 5: worker does fix-cycle work. state_change{active} frames via the
+	// default branch of handlePipeFrame drive DB back to active.
+	// We simulate this directly to avoid relying on internal protocol details.
+	if err := sc.cfg.DB.UpsertStatus(
+		sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree,
+		string(agent.StateActive), nil, nil,
+	); err != nil {
+		t.Fatalf("UpsertStatus active (fix-cycle drift): %v", err)
+	}
+
+	// Confirm DB has drifted back to active while flag is still set.
+	if s := getState(t, sc.cfg.DB, sc.cfg.SessionName); s != string(agent.StateActive) {
+		t.Fatalf("expected DB=active after fix-cycle drift, got %q", s)
+	}
+	sc.mu.Lock()
+	stillInFlight := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if !stillInFlight {
+		t.Fatal("reviewingInFlight should still be true after failed-then-retried /review")
+	}
+
+	// Step 6: worker finishes its fix-cycle turn → state_change{finished}.
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	// Wait for the debounce timer.
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer created after state_change{finished}")
+	}
+
+	// Fire the debounce — with the fix it must be suppressed.
+	timer.Fire()
+	time.Sleep(100 * time.Millisecond)
+
+	// Session must NOT be finished — review is still in flight.
+	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if st == string(agent.StateFinished) {
+		t.Errorf("session prematurely finished during failed-then-retried /review with DB state=active — #1652 regression")
+	}
+
+	// Cleanup: clear the flag and shut down.
+	sc.mu.Lock()
+	sc.reviewingInFlight = false
+	sc.mu.Unlock()
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
 // Ensure db import is used.
 var _ *db.DB


### PR DESCRIPTION
## Summary

Fixes the race where a worker session prematurely transitions to `finished` during a `prism review` cycle.

## Root cause

The suppression in `handleSessionFinished` (events.go) required BOTH:
1. `s.reviewingInFlight == true` (in-memory flag), AND
2. `s.currentDBState() == StateReviewing` (DB read)

This AND is fragile: intermediate `state_change` frames arriving via `handlePipeFrame`'s default branch write `StateActive` to the DB while `reviewingInFlight` is still true. The DB state drifts back to `active`, the AND fails, and the finished-debounce fires — causing the worker session to transition to `finished` while `prism review` is still in flight.

## Fix (approach b from the issue)

In `handleSessionFinished` (PI socket-pipe path), suppress on `reviewingInFlight` alone. The in-memory flag has a single, well-defined clearing path (`source="review-complete"` prompt delivery). It cannot wedge the session because review completion always clears it.

`handleSessionIdle` (SSE/OpenCode path) **retains the AND deliberately**: the monitor writes `active` to the DB just before delivering the review-complete prompt via `deliverViaHTTP` (bypassing `/prompt`, so `reviewingInFlight` is never cleared on that path). That pre-delivery write is the signal that review is done — suppressing on the flag alone would wedge SSE workers after review-complete delivery (existing test coverage for #1384).

## Changes

- `internal/sidecar/events.go`: Change `handleSessionFinished` suppression from `reviewingInFlight && DB==reviewing` to `reviewingInFlight` alone. Update comment explaining the asymmetry with `handleSessionIdle`.
- `internal/sidecar/sidecar_socketpipe_test.go`: Two new regression tests:
  - `TestSocketPipe_StateChange_DoesNotClobberReviewing`: `state_change{finished}` while `reviewingInFlight=true` and `DB=active` does NOT transition to finished.
  - `TestSocketPipe_FailedRetryReview_StateChangeDoesNotFinish`: Exact D-9 timeline from #1652 (failed `/review` → retry → worker emits `state_change` → session stays not-finished).

## Testing

- All existing tests pass including the #1384 SSE-path tests.
- Two new regression tests added for the PI path.
- `go test ./... -race` ✅
- `nix build .#prism` ✅

Closes #1652