### PR TITLE
feat(iris): D-8 — bubbletea TUI for session list + event stream + prompt delivery (#1639)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -2,6 +2,7 @@
 //
 // D-3 adds: spawn, harness-socket dispatch, tool override registration.
 // D-6 adds: client IPC socket (iris.sock), session fan-out, subscribe/replay.
+// D-8 adds: bubbletea TUI (iris tui) — session list + live event stream + prompt delivery.
 // See docs/daemon-mode-design.md §3 and §4 for the architecture.
 //
 // Usage:
@@ -10,6 +11,7 @@
 //	iris version                                — same, as a subcommand
 //	iris daemon                                 — start the full daemon (client socket + sessions)
 //	iris spawn --worktree <path> [--role <role>] — spawn a pi session (no client socket)
+//	iris tui [--socket <path>]                  — open the bubbletea TUI
 package main
 
 import (
@@ -33,7 +35,7 @@ import (
 //
 // This intentionally does NOT reuse the prism version string or any
 // prism-internal ldflags variable — iris has its own identity.
-const irisVersion = "0.1.0-d6"
+const irisVersion = "0.1.0-d8"
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
@@ -66,6 +68,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(spawnCmd)
 	rootCmd.AddCommand(daemonCmd)
+	rootCmd.AddCommand(tuiCmd)
 	spawnCmd.Flags().StringVar(&spawnWorktree, "worktree", "", "Absolute path to the git worktree (required)")
 	spawnCmd.Flags().StringVar(&spawnRole, "role", "worker", "Agent role (worker, coordinator, etc.)")
 	spawnCmd.Flags().StringVar(&spawnExtension, "extension", "", "Path to the prism.ts extension file (overrides config)")

--- a/modules/programs/prism/prism/cmd/iris/tui.go
+++ b/modules/programs/prism/prism/cmd/iris/tui.go
@@ -1,0 +1,69 @@
+package main
+
+// tui.go — `iris tui` subcommand.
+//
+// Opens a bubbletea TUI that connects to ~/.local/state/iris/iris.sock and
+// provides a real-time session list + event stream + prompt input.
+//
+// The TUI reads NO state from the DB directly; every piece of state comes via
+// the iris daemon socket (§4 of daemon-mode-design.md).
+//
+// Usage:
+//
+//	iris tui                         — connect to the default socket path
+//	iris tui --socket /path/to.sock  — connect to a custom socket path
+//	iris tui --help                  — show usage
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+var (
+	tuiSocketPath string
+)
+
+// tuiCmd is the `iris tui` subcommand.
+var tuiCmd = &cobra.Command{
+	Use:   "tui",
+	Short: "Open the iris TUI (session list + live event stream + prompt delivery)",
+	Long: `iris tui opens a full-screen bubbletea TUI that connects to the iris daemon
+at ~/.local/state/iris/iris.sock (or --socket <path> to override).
+
+The TUI shows:
+  - Left pane:   live session list (name, state, role).
+  - Right pane:  streaming event log for the selected session in the same
+                 narrative format as 'prism checkin'.
+  - Bottom bar:  prompt input; press Enter to deliver to the selected session.
+
+Navigation:
+  ↑/↓ or k/j    move between sessions
+  PgUp/PgDn      scroll the event pane
+  Enter          send the typed prompt to the selected session
+  q or Ctrl+C    quit
+
+The daemon must be running ('iris daemon') before opening the TUI.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sockPath := tuiSocketPath
+		if sockPath == "" {
+			p := iris.ResolvePaths()
+			sockPath = p.Sock
+		}
+
+		fmt.Fprintf(os.Stderr, "iris tui: connecting to %s\n", sockPath)
+
+		if err := tui.Run(sockPath); err != nil {
+			return fmt.Errorf("iris tui: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	tuiCmd.Flags().StringVar(&tuiSocketPath, "socket", "", "Path to the iris daemon socket (default: ~/.local/state/iris/iris.sock)")
+}

--- a/modules/programs/prism/prism/internal/iris/tui/client.go
+++ b/modules/programs/prism/prism/internal/iris/tui/client.go
@@ -1,0 +1,236 @@
+package tui
+
+// client.go — daemon socket client for the iris TUI.
+//
+// DaemonClient manages a persistent connection to the iris daemon at
+// ~/.local/state/iris/iris.sock. It sends request frames and delivers
+// incoming frames to a bubbletea Program via Send(). It is the only
+// component in this package that touches the network — all state access
+// goes through the daemon socket, never the DB directly.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// DaemonFrame is a bubbletea message carrying a decoded frame from the daemon.
+type DaemonFrame struct {
+	// Raw is the decoded frame. The caller switches on RawType to decide
+	// how to interpret it.
+	RawType string
+	// Snapshot is populated when RawType == DaemonFrameSessionsSnapshot.
+	Snapshot *iris.DaemonSessionsSnapshotFrame
+	// Event is populated when RawType == DaemonFrameSessionEvent.
+	Event *iris.DaemonSessionEventFrame
+	// State is populated when RawType == DaemonFrameSessionState.
+	State *iris.DaemonSessionStateFrame
+	// Error is populated when RawType == DaemonFrameError.
+	Error *iris.DaemonErrorFrame
+}
+
+// ConnectedMsg is sent to the bubbletea program when the client connects.
+type ConnectedMsg struct{}
+
+// DisconnectedMsg is sent when the connection is lost.
+type DisconnectedMsg struct {
+	Err error
+}
+
+// DaemonClient is the socket client. It is safe to send frames from any
+// goroutine via the Send* methods.
+type DaemonClient struct {
+	sockPath string
+	program  *tea.Program
+	// sink is an optional message sink for testing without a real tea.Program.
+	sink func(tea.Msg)
+
+	mu      sync.Mutex
+	conn    net.Conn
+	writer  *bufio.Writer
+	writeMu sync.Mutex
+}
+
+// NewDaemonClient creates a DaemonClient. Connect must be called to establish
+// the connection.
+func NewDaemonClient(sockPath string) *DaemonClient {
+	return &DaemonClient{sockPath: sockPath}
+}
+
+// SetProgram wires the bubbletea program for message delivery. Must be called
+// before Connect.
+func (c *DaemonClient) SetProgram(p *tea.Program) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.program = p
+}
+
+// SetSink wires a plain message sink function for testing. When set, messages
+// are delivered to the sink instead of a tea.Program. This allows integration
+// tests to drive the client without starting a terminal program.
+func (c *DaemonClient) SetSink(fn func(tea.Msg)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sink = fn
+}
+
+// Connect dials the daemon socket and starts the read loop. Call in a goroutine.
+func (c *DaemonClient) Connect() {
+	for {
+		conn, err := net.Dial("unix", c.sockPath)
+		if err != nil {
+			c.send(DisconnectedMsg{Err: fmt.Errorf("dial %q: %w", c.sockPath, err)})
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		c.mu.Lock()
+		c.conn = conn
+		c.writer = bufio.NewWriter(conn)
+		c.mu.Unlock()
+
+		// Request the initial sessions list immediately on connect so the
+		// UI can populate before the user interacts. This is done before
+		// sending ConnectedMsg so the model sees the list on its first update.
+		_ = c.sendSessionsListLocked()
+		c.send(ConnectedMsg{})
+		c.readLoop(conn)
+
+		c.mu.Lock()
+		c.conn = nil
+		c.writer = nil
+		c.mu.Unlock()
+		c.send(DisconnectedMsg{Err: fmt.Errorf("connection closed")})
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// readLoop reads frames from the connection and delivers them to the program.
+func (c *DaemonClient) readLoop(conn net.Conn) {
+	r := bufio.NewReaderSize(conn, 4*1024*1024)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+		var generic struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(line, &generic); err != nil {
+			continue
+		}
+		msg := DaemonFrame{RawType: generic.Type}
+		switch generic.Type {
+		case iris.DaemonFrameSessionsSnapshot:
+			var f iris.DaemonSessionsSnapshotFrame
+			if err := json.Unmarshal(line, &f); err == nil {
+				msg.Snapshot = &f
+			}
+		case iris.DaemonFrameSessionEvent:
+			var f iris.DaemonSessionEventFrame
+			if err := json.Unmarshal(line, &f); err == nil {
+				msg.Event = &f
+			}
+		case iris.DaemonFrameSessionState:
+			var f iris.DaemonSessionStateFrame
+			if err := json.Unmarshal(line, &f); err == nil {
+				msg.State = &f
+			}
+		case iris.DaemonFrameError:
+			var f iris.DaemonErrorFrame
+			if err := json.Unmarshal(line, &f); err == nil {
+				msg.Error = &f
+			}
+		// pong and session_spawned are handled silently.
+		}
+		c.send(msg)
+	}
+}
+
+// send delivers a message to the bubbletea program or sink (if wired).
+func (c *DaemonClient) send(msg tea.Msg) {
+	c.mu.Lock()
+	p := c.program
+	s := c.sink
+	c.mu.Unlock()
+	if p != nil {
+		p.Send(msg)
+	}
+	if s != nil {
+		s(msg)
+	}
+}
+
+// writeFrame serialises v as a JSON line and sends it on the current
+// connection. Returns an error if the connection is not open.
+func (c *DaemonClient) writeFrame(v any) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	c.mu.Lock()
+	w := c.writer
+	c.mu.Unlock()
+
+	if w == nil {
+		return fmt.Errorf("not connected")
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// SendSessionsList requests a sessions snapshot from the daemon.
+func (c *DaemonClient) SendSessionsList() error {
+	return c.writeFrame(iris.ClientSessionsListFrame{
+		Type: iris.ClientFrameSessionsList,
+	})
+}
+
+// sendSessionsListLocked is identical to SendSessionsList but is safe to call
+// from within Connect() where c.writer has just been set. It uses the
+// write-frame path directly without acquiring c.mu.
+func (c *DaemonClient) sendSessionsListLocked() error {
+	return c.writeFrame(iris.ClientSessionsListFrame{
+		Type: iris.ClientFrameSessionsList,
+	})
+}
+
+// SendSessionSubscribe subscribes to a session's event stream.
+// sinceEventID = 0 means no replay.
+func (c *DaemonClient) SendSessionSubscribe(name string, sinceEventID int64) error {
+	return c.writeFrame(iris.ClientSessionSubscribeFrame{
+		Type:         iris.ClientFrameSessionSubscribe,
+		Name:         name,
+		SinceEventID: sinceEventID,
+	})
+}
+
+// SendSessionUnsubscribe cancels a subscription.
+func (c *DaemonClient) SendSessionUnsubscribe(name string) error {
+	return c.writeFrame(iris.ClientSessionUnsubscribeFrame{
+		Type: iris.ClientFrameSessionUnsubscribe,
+		Name: name,
+	})
+}
+
+// SendPromptDeliver delivers a prompt to the named session.
+func (c *DaemonClient) SendPromptDeliver(name, text string) error {
+	return c.writeFrame(iris.ClientPromptDeliverFrame{
+		Type: iris.ClientFramePromptDeliver,
+		Name: name,
+		Text: text,
+	})
+}

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -1,0 +1,730 @@
+package tui
+
+// model.go — bubbletea Model for the iris TUI.
+//
+// Layout (terminal full-screen):
+//
+//	┌─────────────────────────────────────────────────────────────┐
+//	│  left pane (session list)  │  right pane (event stream)    │
+//	│  name  state  role  time   │  narrative lines …            │
+//	│  …                         │                               │
+//	├─────────────────────────────┴───────────────────────────────┤
+//	│  prompt: _                                                  │
+//	└─────────────────────────────────────────────────────────────┘
+//
+// The TUI is a single bubbletea model (Model). All daemon I/O goes through
+// the DaemonClient, which delivers messages via Program.Send(). The TUI
+// reads NO state from the DB — every piece of state comes via the daemon socket.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// --- Layout constants ---
+
+const (
+	leftPaneRatio  = 0.35  // fraction of total width for the session list
+	bottomBarHeight = 3     // prompt box height in lines
+	minLeftWidth   = 28
+	minRightWidth  = 20
+)
+
+// --- Colour scheme (gruvbox-dark inspired, same as prism dashboard) ---
+
+const (
+	colPrimary    = "#d79921" // yellow
+	colSecondary  = "#928374" // grey
+	colGreen      = "#98971a"
+	colBlue       = "#458588"
+	colRed        = "#cc241d"
+	colForeground = "#ebdbb2"
+	colBg0        = "#282828"
+	colBg1        = "#3c3836"
+	colBg2        = "#504945"
+)
+
+// --- Styles ---
+
+var (
+	styleBorder = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(lipgloss.Color(colSecondary))
+
+	styleHeader = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colPrimary)).
+			Bold(true)
+
+	styleSelected = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colBg0)).
+			Background(lipgloss.Color(colPrimary)).
+			Bold(true)
+
+	styleNormal = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colForeground))
+
+	styleDim = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colSecondary))
+
+	styleError = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colRed))
+
+	styleGreen = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colGreen))
+
+	styleBlue = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colBlue))
+
+	stylePromptBox = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(lipgloss.Color(colBlue))
+)
+
+// --- Model ---
+
+// sessionItem holds one session row in the left pane.
+type sessionItem struct {
+	snap iris.SessionSnapshot
+}
+
+// Model is the top-level bubbletea model for the iris TUI.
+type Model struct {
+	client *DaemonClient
+
+	// Terminal dimensions.
+	width  int
+	height int
+
+	// Connection state.
+	connected    bool
+	connectError string
+	reconnecting bool
+
+	// Session list (left pane).
+	sessions []sessionItem
+	cursor   int // selected row index
+
+	// Subscribed session name (may differ from sessions[cursor].snap.Name
+	// transiently during session switching).
+	subscribedTo string
+
+	// Event stream (right pane): rendered narrative lines, newest at bottom.
+	eventLines []NarrativeLine
+	// seenRowIDs deduplicates replayed vs live events.
+	seenRowIDs map[int64]bool
+	// toolCallByMsgID indexes the line slice position for open tool_call lines
+	// so that arriving tool_result frames can append the result inline.
+	toolCallByMsgID map[string]int
+
+	// eventScroll is the number of lines scrolled up from the bottom (0 = live).
+	eventScroll int
+
+	// Prompt input (bottom).
+	promptRunes  []rune
+	promptCursor int // rune insert position
+}
+
+// NewModel creates the iris TUI model.
+func NewModel(client *DaemonClient) Model {
+	return Model{
+		client:          client,
+		seenRowIDs:      make(map[int64]bool),
+		toolCallByMsgID: make(map[string]int),
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// --- Update ---
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case ConnectedMsg:
+		m.connected = true
+		m.reconnecting = false
+		m.connectError = ""
+		// The DaemonClient sends sessions_list immediately on connect;
+		// no need to dispatch a redundant Cmd here.
+		return m, nil
+
+	case DisconnectedMsg:
+		m.connected = false
+		if msg.Err != nil {
+			m.connectError = msg.Err.Error()
+		}
+		m.reconnecting = true
+		return m, nil
+
+	case DaemonFrame:
+		return m.handleDaemonFrame(msg)
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
+	switch msg.RawType {
+
+	case iris.DaemonFrameSessionsSnapshot:
+		if msg.Snapshot == nil {
+			return m, nil
+		}
+		prevSelected := ""
+		if m.cursor < len(m.sessions) {
+			prevSelected = m.sessions[m.cursor].snap.Name
+		}
+		m.sessions = make([]sessionItem, len(msg.Snapshot.Sessions))
+		for i, s := range msg.Snapshot.Sessions {
+			m.sessions[i] = sessionItem{snap: s}
+		}
+		// Restore cursor position if the previously selected session is still present.
+		m.cursor = 0
+		for i, si := range m.sessions {
+			if si.snap.Name == prevSelected {
+				m.cursor = i
+				break
+			}
+		}
+		// Subscribe to the newly selected session if not already subscribed.
+		if len(m.sessions) > 0 {
+			name := m.sessions[m.cursor].snap.Name
+			if name != m.subscribedTo {
+				m.subscribedTo = name
+				m.resetEventPane()
+				return m, func() tea.Msg {
+					_ = m.client.SendSessionSubscribe(name, 0)
+					return nil
+				}
+			}
+		}
+
+	case iris.DaemonFrameSessionEvent:
+		if msg.Event == nil {
+			return m, nil
+		}
+		e := msg.Event
+		if m.seenRowIDs[e.RowID] {
+			return m, nil
+		}
+		m.seenRowIDs[e.RowID] = true
+
+		lines := RenderEvent(e.RowID, e.EventType, e.Payload)
+		for _, line := range lines {
+			// For tool_result: find the matching tool_call and pair it.
+			if e.EventType == "tool_result" && line.MessageID != "" {
+				if idx, ok := m.toolCallByMsgID[line.MessageID]; ok {
+					// Append result text to the tool_call line instead of
+					// adding a separate line.
+					if idx < len(m.eventLines) {
+						existing := m.eventLines[idx]
+						existing.IsPaired = true
+						existing.ResultText = line.Text
+						existing.Text = existing.Text + " " + line.Text
+						m.eventLines[idx] = existing
+					}
+					continue
+				}
+			}
+			pos := len(m.eventLines)
+			m.eventLines = append(m.eventLines, line)
+			// Index tool_call lines for later tool_result pairing.
+			if e.EventType == "tool_call" && line.MessageID != "" {
+				m.toolCallByMsgID[line.MessageID] = pos
+			}
+		}
+		// Snap to bottom if the user is not scrolled up.
+		if m.eventScroll == 0 {
+			// (view already renders from bottom; nothing extra needed)
+		}
+
+	case iris.DaemonFrameSessionState:
+		if msg.State == nil {
+			return m, nil
+		}
+		// Update the in-memory session list state.
+		for i, si := range m.sessions {
+			if si.snap.Name == msg.State.SessionName {
+				m.sessions[i].snap.State = msg.State.State
+				break
+			}
+		}
+
+	case iris.DaemonFrameError:
+		if msg.Error != nil {
+			// Show error as a narrative line in the event pane.
+			m.eventLines = append(m.eventLines, NarrativeLine{
+				Text:      fmt.Sprintf("⚠ daemon error: %s", msg.Error.Message),
+				EventType: "error",
+			})
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "q":
+		return m, tea.Quit
+
+	case "up", "ctrl+p", "k":
+		if m.cursor > 0 {
+			m.cursor--
+			return m, m.switchToSelected()
+		}
+
+	case "down", "ctrl+n", "j":
+		if m.cursor < len(m.sessions)-1 {
+			m.cursor++
+			return m, m.switchToSelected()
+		}
+
+	case "pgup":
+		m.eventScroll += (m.rightPaneHeight() - 2)
+		return m, nil
+
+	case "pgdown":
+		m.eventScroll -= (m.rightPaneHeight() - 2)
+		if m.eventScroll < 0 {
+			m.eventScroll = 0
+		}
+		return m, nil
+
+	case "enter":
+		if len(m.promptRunes) > 0 && m.subscribedTo != "" {
+			text := string(m.promptRunes)
+			m.promptRunes = nil
+			m.promptCursor = 0
+			return m, func() tea.Msg {
+				_ = m.client.SendPromptDeliver(m.subscribedTo, text)
+				return nil
+			}
+		}
+
+	case "backspace", "ctrl+h":
+		if m.promptCursor > 0 {
+			m.promptRunes = append(m.promptRunes[:m.promptCursor-1], m.promptRunes[m.promptCursor:]...)
+			m.promptCursor--
+		}
+
+	case "left", "ctrl+b":
+		if m.promptCursor > 0 {
+			m.promptCursor--
+		}
+
+	case "right", "ctrl+f":
+		if m.promptCursor < len(m.promptRunes) {
+			m.promptCursor++
+		}
+
+	case "home", "ctrl+a":
+		m.promptCursor = 0
+
+	case "end", "ctrl+e":
+		m.promptCursor = len(m.promptRunes)
+
+	case "delete", "ctrl+d":
+		if m.promptCursor < len(m.promptRunes) {
+			m.promptRunes = append(m.promptRunes[:m.promptCursor], m.promptRunes[m.promptCursor+1:]...)
+		}
+
+	default:
+		if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+			ins := []rune(msg.String())
+			newRunes := make([]rune, len(m.promptRunes)+len(ins))
+			copy(newRunes, m.promptRunes[:m.promptCursor])
+			copy(newRunes[m.promptCursor:], ins)
+			copy(newRunes[m.promptCursor+len(ins):], m.promptRunes[m.promptCursor:])
+			m.promptRunes = newRunes
+			m.promptCursor += len(ins)
+		}
+	}
+
+	return m, nil
+}
+
+// switchToSelected unsubscribes from the previous session and subscribes to
+// the newly selected one, clearing the event pane.
+func (m *Model) switchToSelected() tea.Cmd {
+	if m.cursor >= len(m.sessions) {
+		return nil
+	}
+	newName := m.sessions[m.cursor].snap.Name
+	if newName == m.subscribedTo {
+		return nil
+	}
+	prev := m.subscribedTo
+	m.subscribedTo = newName
+	m.resetEventPane()
+
+	return func() tea.Msg {
+		if prev != "" {
+			_ = m.client.SendSessionUnsubscribe(prev)
+		}
+		_ = m.client.SendSessionSubscribe(newName, 0)
+		return nil
+	}
+}
+
+// resetEventPane clears the event buffer and associated indexes.
+func (m *Model) resetEventPane() {
+	m.eventLines = nil
+	m.seenRowIDs = make(map[int64]bool)
+	m.toolCallByMsgID = make(map[string]int)
+	m.eventScroll = 0
+}
+
+// --- View ---
+
+func (m Model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+
+	// Disconnected overlay.
+	if !m.connected {
+		return m.viewDisconnected()
+	}
+
+	leftW, rightW := m.paneWidths()
+
+	leftPane := m.viewLeftPane(leftW)
+	rightPane := m.viewRightPane(rightW)
+
+	body := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+	prompt := m.viewPrompt(m.width)
+
+	return lipgloss.JoinVertical(lipgloss.Left, body, prompt)
+}
+
+func (m Model) viewDisconnected() string {
+	var sb strings.Builder
+	sb.WriteString("\n\n")
+	sb.WriteString(styleError.Render("  ✗ iris daemon not connected"))
+	sb.WriteString("\n\n")
+	if m.connectError != "" {
+		sb.WriteString(styleDim.Render("  " + m.connectError))
+		sb.WriteString("\n")
+	}
+	if m.reconnecting {
+		sb.WriteString(styleDim.Render("  Reconnecting…"))
+	}
+	sb.WriteString("\n\n")
+	sb.WriteString(styleDim.Render("  Make sure the daemon is running:  iris daemon"))
+	sb.WriteString("\n")
+	sb.WriteString(styleDim.Render("  Press q or ctrl+c to quit."))
+	return sb.String()
+}
+
+func (m Model) paneWidths() (int, int) {
+	leftW := int(float64(m.width) * leftPaneRatio)
+	if leftW < minLeftWidth {
+		leftW = minLeftWidth
+	}
+	rightW := m.width - leftW
+	if rightW < minRightWidth {
+		rightW = minRightWidth
+		leftW = m.width - rightW
+	}
+	return leftW, rightW
+}
+
+func (m Model) leftPaneHeight() int {
+	h := m.height - bottomBarHeight - 2 // minus prompt box and borders
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m Model) rightPaneHeight() int {
+	return m.leftPaneHeight()
+}
+
+// viewLeftPane renders the session list.
+func (m Model) viewLeftPane(width int) string {
+	innerW := width - 2 // border left+right
+	paneH := m.leftPaneHeight()
+
+	var rows []string
+
+	// Header.
+	header := styleHeader.Render(padRight("Sessions", innerW))
+	rows = append(rows, header)
+	rows = append(rows, styleDim.Render(strings.Repeat("─", innerW)))
+
+	if len(m.sessions) == 0 {
+		rows = append(rows, "")
+		rows = append(rows, styleDim.Render(padRight("  no sessions", innerW)))
+		rows = append(rows, "")
+		rows = append(rows, styleDim.Render(padRight("  iris spawn --worktree <path>", innerW)))
+	} else {
+		// Column widths.
+		nameW := innerW - 14 // leave room for state + role
+		if nameW < 8 {
+			nameW = 8
+		}
+		for i, si := range m.sessions {
+			name := truncate(si.snap.Name, nameW)
+			state := stateLabel(si.snap.State)
+			role := truncate(si.snap.Role, 6)
+
+			line := fmt.Sprintf(" %-*s %-8s %-6s", nameW, name, state, role)
+			line = padRight(line, innerW)
+
+			if i == m.cursor {
+				rows = append(rows, styleSelected.Render(line))
+			} else {
+				rows = append(rows, styleNormal.Render(line))
+			}
+		}
+	}
+
+	// Pad to full height.
+	for len(rows) < paneH {
+		rows = append(rows, "")
+	}
+	rows = rows[:paneH]
+
+	content := strings.Join(rows, "\n")
+	return styleBorder.Width(innerW).Height(paneH).Render(content)
+}
+
+// viewRightPane renders the event stream for the subscribed session.
+func (m Model) viewRightPane(width int) string {
+	innerW := width - 2
+	paneH := m.rightPaneHeight()
+
+	var rows []string
+
+	// Header.
+	title := "Events"
+	if m.subscribedTo != "" {
+		title = "Events: " + m.subscribedTo
+	}
+	rows = append(rows, styleHeader.Render(padRight(truncate(title, innerW), innerW)))
+	rows = append(rows, styleDim.Render(strings.Repeat("─", innerW)))
+
+	contentH := paneH - 2 // minus header and separator
+	if contentH < 1 {
+		contentH = 1
+	}
+
+	if len(m.eventLines) == 0 {
+		rows = append(rows, "")
+		if m.subscribedTo != "" {
+			rows = append(rows, styleDim.Render(padRight("  waiting for events…", innerW)))
+		} else {
+			rows = append(rows, styleDim.Render(padRight("  select a session to stream events", innerW)))
+		}
+	} else {
+		// Render from the bottom up, respecting scroll offset.
+		total := len(m.eventLines)
+		end := total - m.eventScroll
+		if end < 0 {
+			end = 0
+		}
+		if end > total {
+			end = total
+		}
+		start := end - contentH
+		if start < 0 {
+			start = 0
+		}
+		for _, line := range m.eventLines[start:end] {
+			rendered := styleEventLine(line, innerW)
+			rows = append(rows, rendered)
+		}
+	}
+
+	// Scroll indicator.
+	if m.eventScroll > 0 {
+		rows = append(rows, styleDim.Render(
+			padRight(fmt.Sprintf("  ↑ %d lines above (PgDn to scroll down)", m.eventScroll), innerW),
+		))
+	}
+
+	// Pad to full height.
+	for len(rows) < paneH {
+		rows = append(rows, "")
+	}
+	rows = rows[:paneH]
+
+	content := strings.Join(rows, "\n")
+	return styleBorder.Width(innerW).Height(paneH).Render(content)
+}
+
+// styleEventLine applies colour to a NarrativeLine.
+func styleEventLine(line NarrativeLine, width int) string {
+	text := truncate(line.Text, width)
+	switch line.EventType {
+	case "state_change":
+		return styleGreen.Render(padRight(text, width))
+	case "msg_assistant", "msg_assistant_body":
+		return styleNormal.Render(padRight(text, width))
+	case "msg_user", "msg_user_body":
+		return styleBlue.Render(padRight(text, width))
+	case "tool_call":
+		return styleDim.Render(padRight(text, width))
+	case "tool_result":
+		return styleDim.Render(padRight(text, width))
+	case "permission_ask":
+		return styleError.Render(padRight(text, width))
+	case "permission_denied":
+		return styleError.Render(padRight(text, width))
+	case "error":
+		return styleError.Render(padRight(text, width))
+	default:
+		return styleDim.Render(padRight(text, width))
+	}
+}
+
+// viewPrompt renders the bottom prompt input.
+func (m Model) viewPrompt(width int) string {
+	innerW := width - 2
+	if innerW < 1 {
+		innerW = 1
+	}
+
+	var label string
+	if m.subscribedTo != "" {
+		label = fmt.Sprintf("prompt → %s: ", m.subscribedTo)
+	} else {
+		label = "prompt: "
+	}
+
+	labelStyle := styleHeader
+	labelRendered := labelStyle.Render(label)
+
+	// Cursor rendering.
+	before := string(m.promptRunes[:m.promptCursor])
+	after := string(m.promptRunes[m.promptCursor:])
+	var caretStr string
+	if len(after) > 0 {
+		caretRunes := []rune(after)
+		caretStr = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colBg0)).
+			Background(lipgloss.Color(colPrimary)).
+			Render(string(caretRunes[0]))
+		after = string(caretRunes[1:])
+	} else {
+		caretStr = styleDim.Render("█")
+	}
+
+	inputLine := labelRendered + before + caretStr + after
+
+	help := styleDim.Render("  ↑/↓ select session  enter send  pgup/pgdn scroll events  q quit")
+
+	return stylePromptBox.Width(innerW).Render(inputLine + "\n" + help)
+}
+
+// --- Utilities ---
+
+// padRight pads or truncates s to exactly w display columns.
+func padRight(s string, w int) string {
+	cols := displayWidth(s)
+	if cols >= w {
+		return s
+	}
+	return s + strings.Repeat(" ", w-cols)
+}
+
+// truncate truncates s to at most w display columns, appending "…" if needed.
+func truncate(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	cols := displayWidth(s)
+	if cols <= w {
+		return s
+	}
+	// Trim runes until we fit.
+	runes := []rune(s)
+	result := runes
+	for displayWidth(string(result)) > w-1 && len(result) > 0 {
+		result = result[:len(result)-1]
+	}
+	return string(result) + "…"
+}
+
+// displayWidth returns the display column width of s (approximated as rune count
+// for ASCII-heavy content; full unicode width would require a heavier dependency).
+func displayWidth(s string) int {
+	return utf8.RuneCountInString(s)
+}
+
+// stateLabel returns a short coloured state label.
+func stateLabel(state string) string {
+	switch state {
+	case "active":
+		return styleGreen.Render("active  ")
+	case "spawning":
+		return styleBlue.Render("spawning")
+	case "finished":
+		return styleDim.Render("finished")
+	case "error":
+		return styleError.Render("error   ")
+	default:
+		return styleDim.Render(padRight(state, 8))
+	}
+}
+
+// formatRelTime returns a short relative-time string (≤ 8 chars).
+func formatRelTime(s string) string {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t)
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+// Run starts the bubbletea program and connects the daemon client.
+// It blocks until the user quits.
+func Run(sockPath string) error {
+	client := NewDaemonClient(sockPath)
+	m := NewModel(client)
+
+	opts := []tea.ProgramOption{
+		tea.WithAltScreen(),
+	}
+	p := tea.NewProgram(m, opts...)
+	client.SetProgram(p)
+
+	// Connect asynchronously so the TUI can render the disconnected state
+	// immediately while the dial is in progress.
+	go client.Connect()
+
+	_, err := p.Run()
+	return err
+}

--- a/modules/programs/prism/prism/internal/iris/tui/narrative.go
+++ b/modules/programs/prism/prism/internal/iris/tui/narrative.go
@@ -1,0 +1,378 @@
+package tui
+
+// narrative.go — narrative event renderer for the TUI right pane.
+//
+// renderEventLine converts a DaemonSessionEventFrame into a human-readable
+// one-line string in the same narrative format as `prism checkin`.
+//
+// The rendering is intentionally flat (one frame → one or two display lines)
+// because the right pane buffers a scrollable list of rendered lines rather
+// than a structured model. The pairing of tool_call + tool_result is done by
+// matching on payload MessageIDs across the line buffer.
+//
+// Event types handled:
+//
+//	msg_user       — ▶ user  [agent · model]\n<text>
+//	msg_assistant  — [HH:MM:SS] assistant  [agent · model]\n<text>
+//	tool_call      — → <tool>: <key-arg>
+//	tool_result    — (inline: appended to matching tool_call line)
+//	state_change   — ● <state>
+//	permission_ask — ⚠ permission: <tool>
+//	permission_denied — ✗ permission denied: <tool>
+//	thinking       — (collapsed: "· thinking")
+//	turn_start     — (collapsed)
+//	turn_end       — (collapsed)
+//	<other>        — [HH:MM:SS] <type>
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+// NarrativeLine is a rendered line in the event pane.
+type NarrativeLine struct {
+	// Text is the display string.
+	Text string
+	// EventType is the source event type (used for styling).
+	EventType string
+	// RowID is the source event's DB row ID (for deduplication).
+	RowID int64
+	// MessageID links tool_call ↔ tool_result for pairing.
+	MessageID string
+	// IsPaired is set to true on a tool_call line once its result arrives.
+	IsPaired bool
+	// ResultText is the one-liner result, appended when tool_result arrives.
+	ResultText string
+}
+
+// RenderEvent converts a daemon session_event frame into one or more
+// NarrativeLines. It never returns nil but may return an empty slice for
+// noisy events that are intentionally collapsed (thinking, turn_start, etc).
+func RenderEvent(rowID int64, eventType, payloadJSON string) []NarrativeLine {
+	ts := time.Now().Format("15:04:05") // best-effort timestamp; daemon has authoritative time
+
+	switch eventType {
+	case "msg_user":
+		var p payload.MsgUser
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			p.Text = payloadJSON
+		}
+		text := p.Text
+		if text == "" {
+			text = "(no text)"
+		}
+		label := turnLabel(p.Agent, p.Model)
+		var header string
+		if label != "" {
+			header = fmt.Sprintf("[%s] ▶ user  [%s]", ts, label)
+		} else {
+			header = fmt.Sprintf("[%s] ▶ user", ts)
+		}
+		return []NarrativeLine{
+			{Text: header, EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+			{Text: text, EventType: eventType + "_body", RowID: rowID},
+		}
+
+	case "msg_assistant":
+		var p payload.MsgAssistant
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			p.Text = payloadJSON
+		}
+		text := p.Text
+		if text == "" {
+			text = "(no text)"
+		}
+		label := turnLabel(p.Agent, p.Model)
+		var header string
+		if label != "" {
+			header = fmt.Sprintf("[%s] assistant  [%s]", ts, label)
+		} else {
+			header = fmt.Sprintf("[%s] assistant", ts)
+		}
+		return []NarrativeLine{
+			{Text: header, EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+			{Text: text, EventType: eventType + "_body", RowID: rowID},
+		}
+
+	case "tool_call":
+		var p payload.ToolCall
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			return []NarrativeLine{
+				{Text: fmt.Sprintf("[%s] → tool_call (parse error)", ts), EventType: eventType, RowID: rowID},
+			}
+		}
+		keyArg := toolKeyArg(p.Tool, p.Args)
+		var text string
+		if keyArg != "" {
+			text = fmt.Sprintf("  → %s: %s", p.Tool, keyArg)
+		} else {
+			text = fmt.Sprintf("  → %s", p.Tool)
+		}
+		return []NarrativeLine{
+			{Text: text, EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+		}
+
+	case "tool_result":
+		// Tool results are matched against existing tool_call lines by the
+		// TUI model (appendToolResult). We still return a line in case there
+		// is no matching call (orphaned result).
+		var p payload.ToolResult
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			return nil
+		}
+		summary := toolResultSummary(p.Tool, p.Result)
+		return []NarrativeLine{
+			{Text: fmt.Sprintf("    ↳ result: %s", summary), EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+		}
+
+	case "state_change":
+		var p payload.StateChange
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			p.State = payloadJSON
+		}
+		state := p.State
+		if state == "" {
+			state = "(unknown)"
+		}
+		return []NarrativeLine{
+			{Text: fmt.Sprintf("[%s] ● %s", ts, state), EventType: eventType, RowID: rowID},
+		}
+
+	case "permission_ask":
+		var p payload.PermissionAsk
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			return []NarrativeLine{
+				{Text: fmt.Sprintf("[%s] ⚠ permission ask", ts), EventType: eventType, RowID: rowID},
+			}
+		}
+		tool := string(p.Tool)
+		if tool == "" {
+			tool = "unknown"
+		}
+		return []NarrativeLine{
+			{Text: fmt.Sprintf("[%s] ⚠ permission: %s", ts, tool), EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+		}
+
+	case "permission_denied":
+		var p payload.PermissionDenied
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			return []NarrativeLine{
+				{Text: fmt.Sprintf("[%s] ✗ permission denied", ts), EventType: eventType, RowID: rowID},
+			}
+		}
+		tool := p.Tool
+		if tool == "" {
+			tool = "unknown"
+		}
+		return []NarrativeLine{
+			{Text: fmt.Sprintf("[%s] ✗ permission denied: %s", ts, tool), EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+		}
+
+	case "thinking":
+		// Collapse thinking events into a single indicator line.
+		return []NarrativeLine{
+			{Text: fmt.Sprintf("[%s] · thinking…", ts), EventType: eventType, RowID: rowID},
+		}
+
+	case "turn_start", "turn_end":
+		// Intentionally collapsed — noisy heartbeat events.
+		return nil
+
+	default:
+		// Show unknown events so the user can see daemon activity.
+		return []NarrativeLine{
+			{Text: fmt.Sprintf("[%s] %s", ts, eventType), EventType: eventType, RowID: rowID},
+		}
+	}
+}
+
+// --- helpers (adapted from cmd/checkin_tools.go without DB dependency) ---
+
+// turnLabel builds the "[agent · model]" label for a turn header.
+func turnLabel(agent, model string) string {
+	if agent == "" && model == "" {
+		return ""
+	}
+	if agent == "" {
+		return model
+	}
+	if model == "" {
+		return agent
+	}
+	return agent + " · " + model
+}
+
+// toolKeyArg extracts the primary display argument for a tool one-liner.
+func toolKeyArg(tool, args string) string {
+	switch tool {
+	case "bash", "Bash":
+		cmd := extractBashCommand(args)
+		if len([]rune(cmd)) > 80 {
+			return string([]rune(cmd)[:80]) + "..."
+		}
+		return cmd
+
+	case "read", "Read":
+		return extractStringField(args, "filePath", "path", "file_path")
+
+	case "edit", "Edit":
+		return extractStringField(args, "filePath", "path", "file_path")
+
+	case "write", "Write":
+		return extractStringField(args, "filePath", "path", "file_path")
+
+	case "task", "Task":
+		desc := extractStringField(args, "description", "desc", "prompt")
+		if len([]rune(desc)) > 80 {
+			return string([]rune(desc)[:80]) + "..."
+		}
+		return desc
+
+	case "glob", "Glob":
+		return extractStringField(args, "pattern", "glob")
+
+	case "grep", "Grep":
+		return extractStringField(args, "pattern", "regex", "query")
+
+	default:
+		if len([]rune(args)) > 80 {
+			return string([]rune(args)[:80]) + "..."
+		}
+		return args
+	}
+}
+
+// toolResultSummary produces a one-line result summary.
+func toolResultSummary(tool, result string) string {
+	switch tool {
+	case "bash", "Bash":
+		if result == "" {
+			return "✓"
+		}
+		lower := strings.ToLower(result)
+		isErr := strings.Contains(lower, "error:") ||
+			strings.Contains(lower, "command not found") ||
+			strings.Contains(lower, "exit status") ||
+			strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "no such file")
+		line := firstMeaningfulLine(result)
+		if isErr {
+			if len([]rune(line)) > 60 {
+				return "✗ " + string([]rune(line)[:60]) + "..."
+			}
+			return "✗ " + line
+		}
+		if len([]rune(line)) > 60 {
+			return string([]rune(line)[:60]) + "..."
+		}
+		return line
+
+	case "read", "Read":
+		if result == "" {
+			return "✓ (0 lines)"
+		}
+		n := strings.Count(result, "\n") + 1
+		if strings.HasSuffix(result, "\n") && n > 1 {
+			n--
+		}
+		return fmt.Sprintf("✓ (%d lines)", n)
+
+	case "edit", "Edit", "write", "Write":
+		if isErrorResult(result) {
+			return "✗"
+		}
+		return "✓"
+
+	case "glob", "Glob", "grep", "Grep":
+		if result == "" {
+			return "no matches"
+		}
+		count := 0
+		for _, line := range strings.Split(result, "\n") {
+			if strings.TrimSpace(line) != "" {
+				count++
+			}
+		}
+		if count == 0 {
+			return "no matches"
+		}
+		if count == 1 {
+			return "1 match"
+		}
+		return fmt.Sprintf("%d matches", count)
+
+	default:
+		if result == "" {
+			return "✓"
+		}
+		line := firstMeaningfulLine(result)
+		if len([]rune(line)) > 60 {
+			return string([]rune(line)[:60]) + "..."
+		}
+		return line
+	}
+}
+
+func isErrorResult(result string) bool {
+	if strings.Contains(result, "✗") {
+		return true
+	}
+	lower := strings.ToLower(result)
+	return strings.HasPrefix(lower, "error") ||
+		strings.Contains(lower, "\nerror") ||
+		strings.Contains(lower, "failed:") ||
+		strings.Contains(lower, "failed\n") ||
+		strings.HasSuffix(lower, "failed")
+}
+
+func firstMeaningfulLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	return s
+}
+
+func extractBashCommand(args string) string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(args), &obj); err == nil {
+		for _, key := range []string{"command", "cmd"} {
+			if raw, ok := obj[key]; ok {
+				var s string
+				if err := json.Unmarshal(raw, &s); err == nil {
+					return s
+				}
+			}
+		}
+	}
+	var s string
+	if err := json.Unmarshal([]byte(args), &s); err == nil {
+		return s
+	}
+	return args
+}
+
+func extractStringField(args string, keys ...string) string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(args), &obj); err != nil {
+		var s string
+		if err2 := json.Unmarshal([]byte(args), &s); err2 == nil {
+			return s
+		}
+		return args
+	}
+	for _, key := range keys {
+		if raw, ok := obj[key]; ok {
+			var s string
+			if err := json.Unmarshal(raw, &s); err == nil {
+				return s
+			}
+		}
+	}
+	return args
+}

--- a/modules/programs/prism/prism/internal/iris/tui/tui_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/tui_test.go
@@ -1,0 +1,632 @@
+package tui_test
+
+// tui_test.go — integration tests for the iris TUI package.
+//
+// Key invariant asserted here: the tui package consumes state exclusively via
+// the daemon socket (DaemonClient + frame types from internal/iris). It must
+// never import internal/db directly. This is verified by:
+//
+//  1. A compile-time audit (TestNoDBImport) that walks the package's import
+//     graph and fails if "internal/db" appears in any tui source file.
+//  2. Socket-mock tests that drive a real DaemonClient against a fake TCP
+//     server and verify the correct frames are sent/received.
+//  3. Model-level unit tests that drive the bubbletea Model.Update() loop
+//     directly without starting a terminal program.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"go/parser"
+	"go/token"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+// ---------------------------------------------------------------------------
+// TestNoDBImport — compile-time audit: the tui package must not import internal/db
+// ---------------------------------------------------------------------------
+
+// TestNoDBImport parses every .go file in the tui package directory and asserts
+// that none of them import "github.com/prismatic-koi/prism/internal/db" (or any
+// path that would bring in DB state).
+//
+// This test enforces the AC: "The TUI reads NO state from the DB directly —
+// every piece of state comes via the daemon socket."
+func TestNoDBImport(t *testing.T) {
+	// The test binary runs from the package directory when run with `go test ./...`.
+	// We resolve the tui package directory relative to this file.
+	pkg, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, pkg, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parse dir %q: %v", pkg, err)
+	}
+
+	for _, astPkg := range pkgs {
+		for fileName, f := range astPkg.Files {
+			for _, imp := range f.Imports {
+				path := strings.Trim(imp.Path.Value, `"`)
+				if path == "github.com/prismatic-koi/prism/internal/db" {
+					t.Errorf("file %s imports internal/db — TUI must not read DB directly; use daemon socket frames only", filepath.Base(fileName))
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// newConnectedModel returns a Model that has received a WindowSizeMsg and
+// ConnectedMsg, putting it in the normal connected state for unit tests.
+func newConnectedModel() tui.Model {
+	client := tui.NewDaemonClient("/dev/null")
+	m := tui.NewModel(client)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.ConnectedMsg{})
+	return m2.(tui.Model)
+}
+
+// ---------------------------------------------------------------------------
+// TestTUIRendersSessionList — model correctly processes sessions_snapshot
+// ---------------------------------------------------------------------------
+
+func TestTUIRendersSessionList(t *testing.T) {
+	m := newConnectedModel()
+
+	sessions := []iris.SessionSnapshot{
+		{Name: "nixos-config@main", InstanceID: "iid-1", State: "active", Role: "worker", StartedAt: time.Now().Format(time.RFC3339)},
+		{Name: "nixos-config@feat", InstanceID: "iid-2", State: "spawning", Role: "coordinator", StartedAt: time.Now().Format(time.RFC3339)},
+	}
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type:     iris.DaemonFrameSessionsSnapshot,
+		Sessions: sessions,
+	}
+	m2, _ := m.Update(tui.DaemonFrame{
+		RawType:  iris.DaemonFrameSessionsSnapshot,
+		Snapshot: &snap,
+	})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "nixos-config@main") {
+		t.Errorf("view does not contain first session name; view excerpt:\n%s", excerpt(view, 500))
+	}
+	if !strings.Contains(view, "nixos-config@feat") {
+		t.Errorf("view does not contain second session name; view excerpt:\n%s", excerpt(view, 500))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTUIEmptySessionList — empty session list shows correct empty state
+// ---------------------------------------------------------------------------
+
+func TestTUIEmptySessionList(t *testing.T) {
+	m := newConnectedModel()
+
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type:     iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "no sessions") {
+		t.Errorf("empty state not shown; view excerpt:\n%s", excerpt(view, 300))
+	}
+	if !strings.Contains(view, "iris spawn") {
+		t.Errorf("spawn hint not shown in empty state; view excerpt:\n%s", excerpt(view, 300))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTUIEventStream — session_event frames render in the right pane
+// ---------------------------------------------------------------------------
+
+func TestTUIEventStream(t *testing.T) {
+	m := newConnectedModel()
+
+	sessionName := "iris@main"
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: sessionName, InstanceID: "iid-x", State: "active", Role: "worker"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	// Deliver a state_change event.
+	scPayload, _ := json.Marshal(map[string]string{"state": "active"})
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: sessionName,
+			RowID:       1,
+			EventType:   "state_change",
+			Payload:     string(scPayload),
+		},
+	})
+	m = m2.(tui.Model)
+
+	// Deliver a msg_assistant event.
+	maPayload, _ := json.Marshal(map[string]string{
+		"messageId": "msg-001",
+		"text":      "Hello from iris!",
+		"agent":     "coordinator",
+	})
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: sessionName,
+			RowID:       2,
+			EventType:   "msg_assistant",
+			Payload:     string(maPayload),
+		},
+	})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "active") {
+		t.Errorf("state_change 'active' not rendered; view excerpt:\n%s", excerpt(view, 500))
+	}
+	if !strings.Contains(view, "Hello from iris!") {
+		t.Errorf("assistant message text not rendered; view excerpt:\n%s", excerpt(view, 500))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestToolCallResultPairing — tool_result is paired inline with tool_call
+// ---------------------------------------------------------------------------
+
+func TestToolCallResultPairing(t *testing.T) {
+	m := newConnectedModel()
+
+	sessionName := "iris@test"
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: sessionName, InstanceID: "iid-y", State: "active", Role: "worker"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	// Send tool_call.
+	tcPayload, _ := json.Marshal(map[string]string{
+		"tool":      "bash",
+		"args":      `{"command":"echo hello"}`,
+		"messageId": "msg-tc-001",
+	})
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: sessionName,
+			RowID:       10,
+			EventType:   "tool_call",
+			Payload:     string(tcPayload),
+		},
+	})
+	m = m2.(tui.Model)
+
+	// Send tool_result.
+	trPayload, _ := json.Marshal(map[string]string{
+		"tool":      "bash",
+		"result":    "hello",
+		"messageId": "msg-tc-001",
+	})
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: sessionName,
+			RowID:       11,
+			EventType:   "tool_result",
+			Payload:     string(trPayload),
+		},
+	})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "bash") {
+		t.Errorf("bash tool call not shown; view excerpt:\n%s", excerpt(view, 500))
+	}
+	if !strings.Contains(view, "hello") {
+		t.Errorf("tool result 'hello' not shown in view; view excerpt:\n%s", excerpt(view, 500))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestSessionSwitchUnsubscribes — switching sessions sends correct frames via socket
+// ---------------------------------------------------------------------------
+
+// TestSessionSwitchUnsubscribes uses a fake daemon socket to verify that
+// navigating between sessions sends session_unsubscribe for the old session
+// and session_subscribe for the new one.
+//
+// This test drives the DaemonClient directly without using tea.NewProgram,
+// so it does not require a TTY.
+func TestSessionSwitchUnsubscribes(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "iris-test.sock")
+
+	received := make(chan map[string]any, 128)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go fakeDaemon(ctx, ln, received)
+
+	client := tui.NewDaemonClient(sockPath)
+	// Use a message sink instead of a real tea.Program.
+	msgs := make(chan tea.Msg, 128)
+	client.SetSink(func(msg tea.Msg) { msgs <- msg })
+	go client.Connect()
+
+	// Wait for the initial ConnectedMsg.
+	waitForMsg[tui.ConnectedMsg](t, ctx, msgs, 5*time.Second)
+
+	// The client should have sent sessions_list on connect.
+	waitFor(t, ctx, received, "sessions_list", 3*time.Second)
+
+	// Push a sessions_snapshot with two sessions.
+	sessions := []iris.SessionSnapshot{
+		{Name: "session-A", InstanceID: "iid-a", State: "active", Role: "worker"},
+		{Name: "session-B", InstanceID: "iid-b", State: "active", Role: "worker"},
+	}
+	snap := iris.DaemonSessionsSnapshotFrame{Type: iris.DaemonFrameSessionsSnapshot, Sessions: sessions}
+	// Deliver the snapshot as a DaemonFrame message to simulate what the TUI model would receive.
+	_ = snap // used below indirectly
+
+	// Build a model and drive it manually.
+	m := tui.NewModel(client)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.ConnectedMsg{})
+	m = m2.(tui.Model)
+	var cmd tea.Cmd
+	m2, cmd = m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+	// Execute the cmd to subscribe to session-A.
+	if cmd != nil {
+		cmd()
+	}
+
+	// The model should have subscribed to session-A (first).
+	waitFor(t, ctx, received, "session_subscribe", 3*time.Second)
+
+	// Press down to select session-B — drive the model.
+	m2, cmd = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = m2.(tui.Model)
+	// Execute the command (it sends unsubscribe + subscribe via the client).
+	if cmd != nil {
+		cmd()
+	}
+
+	// Expect session_unsubscribe for A, then session_subscribe for B.
+	unsub := waitFor(t, ctx, received, "session_unsubscribe", 3*time.Second)
+	if unsub["name"] != "session-A" {
+		t.Errorf("unsubscribe name = %v, want session-A", unsub["name"])
+	}
+	sub := waitFor(t, ctx, received, "session_subscribe", 3*time.Second)
+	if sub["name"] != "session-B" {
+		t.Errorf("subscribe name = %v, want session-B", sub["name"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPromptDeliver — enter sends prompt_deliver via socket
+// ---------------------------------------------------------------------------
+
+func TestPromptDeliver(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "iris-prompt.sock")
+
+	received := make(chan map[string]any, 128)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go fakeDaemon(ctx, ln, received)
+
+	client := tui.NewDaemonClient(sockPath)
+	msgs := make(chan tea.Msg, 128)
+	client.SetSink(func(msg tea.Msg) { msgs <- msg })
+	go client.Connect()
+
+	waitForMsg[tui.ConnectedMsg](t, ctx, msgs, 5*time.Second)
+	waitFor(t, ctx, received, "sessions_list", 3*time.Second)
+
+	sessions := []iris.SessionSnapshot{
+		{Name: "prompt-session", InstanceID: "iid-p", State: "active", Role: "worker"},
+	}
+	snap := iris.DaemonSessionsSnapshotFrame{Type: iris.DaemonFrameSessionsSnapshot, Sessions: sessions}
+
+	m := tui.NewModel(client)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.ConnectedMsg{})
+	m = m2.(tui.Model)
+	var cmd tea.Cmd
+	m2, cmd = m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+	if cmd != nil {
+		cmd()
+	}
+
+	waitFor(t, ctx, received, "session_subscribe", 3*time.Second)
+
+	// Type "hello iris" into the prompt.
+	for _, r := range "hello iris" {
+		m2, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = m2.(tui.Model)
+	}
+	// Press enter.
+	m2, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m2.(tui.Model)
+	if cmd != nil {
+		cmd()
+	}
+
+	deliver := waitFor(t, ctx, received, "prompt_deliver", 3*time.Second)
+	if deliver["name"] != "prompt-session" {
+		t.Errorf("prompt_deliver name = %v, want prompt-session", deliver["name"])
+	}
+	if deliver["text"] != "hello iris" {
+		t.Errorf("prompt_deliver text = %v, want 'hello iris'", deliver["text"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestDisconnectedState — disconnected state renders correctly
+// ---------------------------------------------------------------------------
+
+func TestDisconnectedState(t *testing.T) {
+	client := tui.NewDaemonClient("/nonexistent/iris.sock")
+	m := tui.NewModel(client)
+
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = m2.(tui.Model)
+
+	// Simulate disconnected message (no prior ConnectedMsg).
+	m2, _ = m.Update(tui.DisconnectedMsg{Err: nil})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "not connected") {
+		t.Errorf("disconnected state not shown; view excerpt:\n%s", excerpt(view, 300))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNarrativeRenderEvent — unit tests for the narrative renderer
+// ---------------------------------------------------------------------------
+
+func TestNarrativeRenderEvent(t *testing.T) {
+	t.Run("state_change", func(t *testing.T) {
+		p, _ := json.Marshal(map[string]string{"state": "active"})
+		lines := tui.RenderEvent(1, "state_change", string(p))
+		if len(lines) == 0 {
+			t.Fatal("no lines rendered for state_change")
+		}
+		if !strings.Contains(lines[0].Text, "active") {
+			t.Errorf("state not in text: %q", lines[0].Text)
+		}
+		if !strings.Contains(lines[0].Text, "●") {
+			t.Errorf("state marker not in text: %q", lines[0].Text)
+		}
+	})
+
+	t.Run("msg_assistant", func(t *testing.T) {
+		p, _ := json.Marshal(map[string]string{
+			"messageId": "mid-1",
+			"text":      "I'll help with that.",
+			"agent":     "worker",
+		})
+		lines := tui.RenderEvent(2, "msg_assistant", string(p))
+		if len(lines) < 2 {
+			t.Fatalf("expected 2 lines for msg_assistant, got %d", len(lines))
+		}
+		if !strings.Contains(lines[0].Text, "assistant") {
+			t.Errorf("assistant header not in line 0: %q", lines[0].Text)
+		}
+		if !strings.Contains(lines[1].Text, "I'll help with that.") {
+			t.Errorf("message text not in line 1: %q", lines[1].Text)
+		}
+	})
+
+	t.Run("msg_user", func(t *testing.T) {
+		p, _ := json.Marshal(map[string]string{
+			"messageId": "mid-2",
+			"text":      "Please fix the bug.",
+		})
+		lines := tui.RenderEvent(3, "msg_user", string(p))
+		if len(lines) < 2 {
+			t.Fatalf("expected 2 lines for msg_user, got %d", len(lines))
+		}
+		if !strings.Contains(lines[0].Text, "▶ user") {
+			t.Errorf("user marker not in header: %q", lines[0].Text)
+		}
+		if !strings.Contains(lines[1].Text, "Please fix the bug.") {
+			t.Errorf("user text not in body: %q", lines[1].Text)
+		}
+	})
+
+	t.Run("tool_call_bash", func(t *testing.T) {
+		p, _ := json.Marshal(map[string]string{
+			"tool":      "bash",
+			"args":      `{"command":"go test ./..."}`,
+			"messageId": "mid-3",
+		})
+		lines := tui.RenderEvent(4, "tool_call", string(p))
+		if len(lines) == 0 {
+			t.Fatal("no lines for tool_call")
+		}
+		if !strings.Contains(lines[0].Text, "bash") {
+			t.Errorf("tool name not in line: %q", lines[0].Text)
+		}
+		if !strings.Contains(lines[0].Text, "go test ./...") {
+			t.Errorf("command not in line: %q", lines[0].Text)
+		}
+	})
+
+	t.Run("permission_ask", func(t *testing.T) {
+		p, _ := json.Marshal(map[string]any{
+			"tool":      "bash",
+			"messageId": "mid-4",
+		})
+		lines := tui.RenderEvent(5, "permission_ask", string(p))
+		if len(lines) == 0 {
+			t.Fatal("no lines for permission_ask")
+		}
+		if !strings.Contains(lines[0].Text, "⚠") {
+			t.Errorf("warning symbol not in text: %q", lines[0].Text)
+		}
+	})
+
+	t.Run("turn_start_collapsed", func(t *testing.T) {
+		lines := tui.RenderEvent(6, "turn_start", `{}`)
+		if len(lines) != 0 {
+			t.Errorf("turn_start should be collapsed, got %d lines", len(lines))
+		}
+	})
+
+	t.Run("turn_end_collapsed", func(t *testing.T) {
+		lines := tui.RenderEvent(7, "turn_end", `{}`)
+		if len(lines) != 0 {
+			t.Errorf("turn_end should be collapsed, got %d lines", len(lines))
+		}
+	})
+
+	t.Run("unknown_event", func(t *testing.T) {
+		lines := tui.RenderEvent(8, "future_event_type", `{}`)
+		if len(lines) == 0 {
+			t.Fatal("unknown event should produce at least one line")
+		}
+		if !strings.Contains(lines[0].Text, "future_event_type") {
+			t.Errorf("event type not in text: %q", lines[0].Text)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// fakeDaemon accepts connections and forwards all received frames to the
+// received channel. It responds to pings with pongs.
+func fakeDaemon(ctx context.Context, ln net.Listener, received chan map[string]any) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go func(conn net.Conn) {
+			defer conn.Close()
+			r := bufio.NewReader(conn)
+			w := bufio.NewWriter(conn)
+			for {
+				conn.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
+				line, err := r.ReadBytes('\n')
+				if err != nil {
+					return
+				}
+				var m map[string]any
+				if err := json.Unmarshal(line, &m); err != nil {
+					continue
+				}
+				select {
+				case received <- m:
+				default:
+				}
+				if m["type"] == "ping" {
+					pong, _ := json.Marshal(map[string]string{"type": "pong"})
+					pong = append(pong, '\n')
+					w.Write(pong) //nolint:errcheck
+					w.Flush()    //nolint:errcheck
+				}
+			}
+		}(conn)
+	}
+}
+
+// waitFor drains the received channel until a frame with the given type arrives
+// or the deadline expires.
+func waitFor(t *testing.T, ctx context.Context, ch chan map[string]any, frameType string, d time.Duration) map[string]any {
+	t.Helper()
+	deadline := time.NewTimer(d)
+	defer deadline.Stop()
+	for {
+		select {
+		case m := <-ch:
+			if m["type"] == frameType {
+				return m
+			}
+		case <-deadline.C:
+			t.Fatalf("timeout waiting for frame type %q", frameType)
+			return nil
+		case <-ctx.Done():
+			t.Fatalf("context done waiting for frame type %q", frameType)
+			return nil
+		}
+	}
+}
+
+// waitForMsg waits for a specific bubbletea message type on the msgs channel.
+func waitForMsg[T any](t *testing.T, ctx context.Context, msgs chan tea.Msg, d time.Duration) T {
+	t.Helper()
+	deadline := time.NewTimer(d)
+	defer deadline.Stop()
+	for {
+		select {
+		case msg := <-msgs:
+			if v, ok := msg.(T); ok {
+				return v
+			}
+		case <-deadline.C:
+			var zero T
+			t.Fatalf("timeout waiting for message type %T", zero)
+			return zero
+		case <-ctx.Done():
+			var zero T
+			t.Fatalf("context done waiting for message type %T", zero)
+			return zero
+		}
+	}
+}
+
+// excerpt returns the first n bytes of s, for test error output.
+func excerpt(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/pkgs/iris.nix
+++ b/pkgs/iris.nix
@@ -14,7 +14,7 @@
 
 buildGoModule {
   pname = "iris";
-  version = "0.1.0-d4";
+  version = "0.1.0-d8";
 
   src = ../modules/programs/prism/prism;
 


### PR DESCRIPTION
## Summary

Implements D-8 of the iris daemon-mode rollout: a bubbletea TUI that connects to the D-6 client IPC socket and provides a real-time session list, live event stream, and prompt delivery.

## What's new

### `internal/iris/tui/` (new package)

- **`client.go`** — `DaemonClient`: manages a persistent connection to `~/.local/state/iris/iris.sock`. Auto-reconnects with 2s backoff. Delivers `DaemonFrame`, `ConnectedMsg`, `DisconnectedMsg` to the bubbletea program. On connect, immediately sends `sessions_list`. Provides `SetSink` for test isolation without a real `tea.Program`.
- **`model.go`** — `Model`: full bubbletea Model implementing the three-pane layout. Left pane = session list (name, state, role); right pane = event stream; bottom = prompt input. Reads NO state from DB.
- **`narrative.go`** — `RenderEvent`: converts `session_event` frames into `NarrativeLine` slices using the same narrative format as `prism checkin` (state_change ●, msg_assistant, msg_user ▶, tool_call one-liners, permission_ask/denied, thinking, unknown-event passthrough). Tool results are paired inline with their tool_call.
- **`tui_test.go`** — integration and unit tests including:
  - `TestNoDBImport`: AST-level assertion that the `tui` package has zero `internal/db` imports.
  - Session list rendering, empty state, event stream, tool_call/result pairing.
  - Socket-mock tests for session-switch lifecycle (unsubscribe + subscribe) and prompt delivery.
  - Disconnected state rendering.
  - Narrative event renderer unit tests.

### `cmd/iris/tui.go` (new file)

`iris tui` subcommand with `--socket` flag; full `--help` docs.

### `cmd/iris/main.go`

- Register `tuiCmd`.
- Bump version from `0.1.0-d6` to `0.1.0-d8`.

### `pkgs/iris.nix`

- Bump version to `0.1.0-d8`.

## Acceptance criteria checklist

- [x] `iris tui` opens a bubbletea program connecting to `~/.local/state/iris/iris.sock`
- [x] On startup, sends `sessions_list` and renders the session list (name, state, role)
- [x] Arrow keys navigate; selecting a session triggers `session_subscribe` + right-pane stream
- [x] Event stream renders in narrative format matching `prism checkin`
- [x] Prompt input sends `prompt_deliver` on Enter
- [x] Disconnected state shown with reconnect indicator
- [x] Session switch: previous subscription cancelled (`session_unsubscribe`) before new subscribe
- [x] Empty session list shows `no sessions` + `iris spawn` instruction
- [x] TUI reads NO state from DB (asserted by `TestNoDBImport`)
- [x] `iris tui --help` documents the subcommand and flags
- [x] `go test ./...` passes; `nix build .#iris` succeeds
- [x] PR body includes `Refs #1625`, `Closes #1639`, references `#1637/#1648` (D-6)

## Quality gates

```
go build ./...   ✓
go test ./...    ✓  (all new tests pass; one pre-existing flaky race in internal/sidecar not related to this PR)
nix build .#iris ✓
```

Refs #1625, Closes #1639, see also D-6: #1637/#1648