### PR TITLE
feat(iris): D-7 — credential broker, per-call audit log, iris stats credentials

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/stats.go
+++ b/modules/programs/prism/prism/cmd/iris/stats.go
@@ -1,0 +1,103 @@
+// stats.go — `iris stats ...` subcommands (D-7).
+//
+// `iris stats credentials <session>` prints the credential audit log for a
+// session: for each tool_call event in the session, the credentials that
+// were injected into the subprocess. Names only, never values.
+//
+// The data source is the agent_events table populated by the iris harness
+// socket (internal/iris/harness_socket.go). Each tool_call event payload
+// contains a `credentials_injected` JSON array; this command reads it back.
+//
+// This is an operator-facing diagnostic — wired up here in the iris binary
+// rather than as a prism subcommand so the iris credential model is
+// self-contained.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Iris audit and diagnostic subcommands",
+}
+
+var statsCredentialsCmd = &cobra.Command{
+	Use:   "credentials <session>",
+	Short: "List credentials injected into each tool call of a session",
+	Long: `Print, for each tool_call event recorded against the named session, the
+credentials that were injected into the corresponding tool subprocess.
+
+The output is one line per tool call:
+
+    <created_at>  <tool>  <credentials_injected>
+
+Names are stable identifiers — never values. "[]" means no credentials were
+injected (the normal case for read/edit/write/grep/find/ls). See
+docs/iris-credential-model.md for the full set of names the broker emits.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runStatsCredentials(args[0])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(statsCmd)
+	statsCmd.AddCommand(statsCredentialsCmd)
+}
+
+// runStatsCredentials prints the credential audit log for session.
+func runStatsCredentials(session string) error {
+	p := iris.ResolvePaths()
+	database, err := iris.OpenDB(p.DB)
+	if err != nil {
+		return fmt.Errorf("iris: open db: %w", err)
+	}
+	defer database.Close()
+
+	events, err := database.QueryEvents(session, 0, nil, nil, []string{"tool_call"})
+	if err != nil {
+		return fmt.Errorf("iris: query events: %w", err)
+	}
+
+	if len(events) == 0 {
+		fmt.Printf("no tool_call events for session %q\n", session)
+		return nil
+	}
+
+	for _, e := range events {
+		var payload struct {
+			Name                 string   `json:"name"`
+			CredentialsInjected  []string `json:"credentials_injected"`
+			AgentRole            string   `json:"agent_role"`
+		}
+		// We tolerate malformed/legacy payloads so a single bad event does
+		// not block the whole audit log.
+		_ = json.Unmarshal([]byte(e.Payload), &payload)
+
+		creds := "[]"
+		if len(payload.CredentialsInjected) > 0 {
+			creds = "[" + strings.Join(payload.CredentialsInjected, ",") + "]"
+		}
+
+		role := payload.AgentRole
+		if role == "" {
+			role = "-"
+		}
+
+		fmt.Printf("%s  tool=%s  role=%s  credentials_injected=%s\n",
+			e.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			payload.Name,
+			role,
+			creds,
+		)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/docs/iris-credential-model.md
+++ b/modules/programs/prism/prism/docs/iris-credential-model.md
@@ -1,0 +1,275 @@
+# Iris credential model
+
+**Status:** Implemented in D-7 (#1638) on top of the D-5 (#1636) per-tool bash
+sandbox. Companion to the design doc — see [§7 of the daemon-mode design
+doc](./daemon-mode-design.md#7-per-tool-credential-brokering) for the threat
+model context.
+
+## 1. What this document is
+
+This is the operator-facing reference for which credentials reach which tool
+subprocesses in iris daemon mode. It answers four questions:
+
+1. **The matrix** — for each tool, what credentials are injected and what is
+   omitted.
+2. **The source** — for each credential, where the value comes from on the
+   host and how it is resolved.
+3. **The audit surface** — how to inspect after the fact what each tool call
+   actually had access to.
+4. **The fallback rules** — what happens when a credential is unresolvable
+   (no host token, missing AWS files, unknown role, etc.).
+
+If you only want to look something up, jump to:
+
+- [§2 Credential matrix](#2-credential-matrix-per-tool)
+- [§6 Audit log: `iris stats credentials`](#6-audit-log)
+
+If you are modifying iris and need to change credential plumbing, read all
+six sections plus design-doc §7.
+
+## 2. Credential matrix (per tool)
+
+| Tool | Credentials injected into subprocess | Mounts available |
+|---|---|---|
+| `read`, `edit`, `write`, `grep`, `find`, `ls` | **None.** | Worktree (RO or RW depending on tool), per-session `/tmp`, standard system read-only roots. |
+| `bash` | `GITHUB_TOKEN` (role-scoped, with fallback — see §3.1). `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` always pointed at in-sandbox paths so the AWS CLI's file-based credential chain works (§3.2). | Worktree (RW), per-session `/tmp`, system roots, `~/.cache/nix` (RW), `/nix/var/nix/daemon-socket` (RW), synthesised `~/.gitconfig` (RO), `~/.ssh/{access-key,signing-key,signing-key.pub,allowed_signers,known_hosts}` (RO, conditional), synthesised `~/.ssh/config` (RO), `~/.aws/{config,credentials,sso,cli}` (mixed RO/RW, conditional), `~/.kube/config` (RO, conditional). |
+
+**Tools / extensions not in this matrix:** MCP-bridge tools (Atlassian etc.)
+authenticate via OAuth tokens that the extension manages — iris does not
+mediate them. See design-doc §5 for the extension authentication model.
+
+## 3. Credentials in detail
+
+### 3.1 `GITHUB_TOKEN`
+
+The bash subprocess receives a role-scoped GitHub Personal Access Token (PAT)
+chosen by the **4-PAT architecture** (account × role → token). The selection
+key is `PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE>`, where:
+
+- `<ACCOUNT>` is derived from the bare repo's `origin` remote URL (e.g.
+  `prismatic-koi`, `thankyou-payroll`), upper-cased with `-` → `_`.
+- `<ROLE>` is the session's `agent_role` (e.g. `WORKER`, `COORDINATOR`).
+
+Concretely the broker looks for env vars of the form:
+
+```
+PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR
+PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER
+PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_COORDINATOR
+PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER
+```
+
+**Resolution algorithm:**
+
+1. If the session has a bare repo root and the role is `worker` or
+   `coordinator`, look up `PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE>`. If set and
+   non-empty → use it. Audit name: `GITHUB_TOKEN`.
+2. Otherwise fall back to host `GITHUB_TOKEN`. If set and non-empty → use
+   it. Audit name: `GITHUB_TOKEN(fallback:host)`.
+3. Otherwise neither is set → no `GITHUB_TOKEN` is injected into the bash
+   subprocess. The audit log records the absence (no `GITHUB_TOKEN*` entry
+   in `credentials_injected`). This is **not an error**; some sessions
+   legitimately have no GitHub access.
+
+**Edge cases:**
+
+- **Empty / unknown role.** Treated as the no-role case: the broker skips
+  the role-scoped lookup and goes straight to the host fallback (step 2).
+  Audit name on a hit is `GITHUB_TOKEN(fallback:host)`. No crash.
+- **Empty `BareRoot`.** Same as empty role — the broker cannot derive an
+  account, so it skips step 1.
+- **Role-scoped var set to empty string.** Treated the same as unset.
+
+**Raw `PRISM_GITHUB_TOKEN_*` env vars are NEVER propagated to the subprocess
+verbatim.** Only the resolved `GITHUB_TOKEN` reaches the bash subprocess.
+
+### 3.2 AWS credentials
+
+AWS credentials are **file-mount based, not env-based.** The bash sandbox
+mounts the host's AWS config/credentials files (RO) at the canonical
+in-sandbox paths and points the AWS CLI at them via:
+
+```
+AWS_CONFIG_FILE=~/.aws/config
+AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials
+```
+
+**Resolution algorithm:**
+
+1. The broker always sets `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE`
+   in the env — these are harmless when the underlying files do not exist
+   (the AWS CLI will fall through to other auth sources).
+2. The audit record reflects host file presence. If any of the source paths
+   (`~/.config/aws/readonly-config`, `~/.config/aws/credentials`,
+   `~/.aws/config`, `~/.aws/credentials`) exists, the audit log records
+   `AWS_*` in `credentials_injected`. Otherwise the marker is omitted.
+
+**Edge case: no AWS files anywhere.** The subprocess starts with the env
+vars set but no underlying files; AWS CLI calls will fail with "unable to
+locate credentials" (the normal AWS error). No iris error is raised, and
+the audit log clearly shows `AWS_*` was not in scope.
+
+### 3.3 Non-credential env vars (always present in bash)
+
+The broker also forwards the following non-credential plumbing so bash
+subprocesses behave like a normal shell:
+
+```
+PATH                    (host value, or fallback to nix profiles)
+HOME, USER, LOGNAME     (host value if set)
+LANG, LC_ALL, TERM      (host value if set)
+GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL
+NIX_CONFIG=store = daemon
+```
+
+These are not credentials and never appear in `credentials_injected`.
+
+## 4. What is NEVER injected
+
+The broker is also defined by what it refuses to forward. None of the
+following appear in any bash (or file-tool) subprocess env, regardless of
+host state:
+
+**LLM / provider API keys.** Bash subprocesses must not make LLM calls.
+
+```
+ANTHROPIC_API_KEY
+OPENROUTER_API_KEY
+OPENAI_API_KEY
+GEMINI_API_KEY
+GOOGLE_API_KEY
+GITHUB_COPILOT_TOKEN
+DEEPSEEK_API_KEY
+```
+
+The exhaustive list is exported as `iris.ForbiddenLLMKeyNames()` so tests
+can stay in sync.
+
+**Raw role-scoped tokens.** No `PRISM_GITHUB_TOKEN_*` env var ever appears
+in the subprocess; only the resolved `GITHUB_TOKEN` does (§3.1).
+
+**Pi-process credential paths.** The bash sandbox mount layout deliberately
+omits:
+
+```
+~/.claude
+~/.mcp-auth
+~/.pi/agent/*
+~/.cache/bun
+~/.config/pi/*
+```
+
+These are pi's own credential surface (see design-doc §7.3). In daemon mode
+pi runs unsandboxed and reads them directly; tool subprocesses must not.
+
+## 5. The CredentialBroker type
+
+The credential resolution and audit logic lives in
+`internal/iris/credential_broker.go`:
+
+```go
+type CredentialBroker struct{}
+
+func NewCredentialBroker() *CredentialBroker
+
+type BashResolution struct {
+    Env   []string  // KEY=VAL pairs to inject
+    Names []string  // audit-only names (no values)
+}
+
+func (b *CredentialBroker) ResolveBash(role, bareRoot string) BashResolution
+```
+
+The broker is stateless and safe for concurrent use. Each tool call
+constructs a broker (or reuses one), resolves credentials at dispatch time
+(`harness_socket.go::dispatchToolExec`), and passes the env list into the
+platform-specific bash sandbox builder.
+
+**Why per-call, not per-session.** Resolving every call means a daemon
+restart, a sops re-decrypt, or a `prism` config reload cannot leave stale
+credentials behind — the source of truth is always the current host state.
+The design-doc §7.2 calls this out explicitly: credentials live in the
+host environment / file system, not in the daemon's memory.
+
+## 6. Audit log
+
+Every `tool_call` event written by the harness socket carries two D-7
+fields in its JSON payload:
+
+```json
+{
+  "id": "<tool exec id>",
+  "name": "bash",
+  "args": { ... },
+  "credentials_injected": ["GITHUB_TOKEN", "AWS_*"],
+  "agent_role": "worker"
+}
+```
+
+`credentials_injected` is always an array — `[]` means the call ran with no
+credentials in scope (the normal case for read/edit/write/grep/find/ls).
+
+**Inspecting a session:**
+
+```
+iris stats credentials <session-name>
+```
+
+prints one line per tool call:
+
+```
+2026-05-16T14:22:31+13:00  tool=bash  role=worker  credentials_injected=[GITHUB_TOKEN(fallback:host),AWS_*]
+2026-05-16T14:22:35+13:00  tool=read  role=worker  credentials_injected=[]
+2026-05-16T14:22:36+13:00  tool=bash  role=worker  credentials_injected=[GITHUB_TOKEN]
+```
+
+Names are stable identifiers. The full set the broker emits is:
+
+| Audit name | Meaning |
+|---|---|
+| `GITHUB_TOKEN` | Role-scoped `PRISM_GITHUB_TOKEN_<account>_<role>` was set and used. |
+| `GITHUB_TOKEN(fallback:host)` | Role-scoped was unset; host `GITHUB_TOKEN` was used. |
+| `AWS_*` | At least one of the AWS config/credentials source files was present on the host. |
+
+A `tool_call` event with `credentials_injected: []` and `name: bash` means
+the bash subprocess ran with no `GITHUB_TOKEN` and no AWS credentials — for
+example, a host with neither configured. This is the legitimate no-credentials
+state, not an error.
+
+## 7. Fallback summary (decision table)
+
+| Scenario | `GITHUB_TOKEN` in env | Audit `credentials_injected` |
+|---|---|---|
+| Role-scoped var set | resolved value | `["GITHUB_TOKEN", ...]` |
+| Role-scoped unset, host `GITHUB_TOKEN` set | host value | `["GITHUB_TOKEN(fallback:host)", ...]` |
+| Role empty / unknown, host `GITHUB_TOKEN` set | host value | `["GITHUB_TOKEN(fallback:host)", ...]` |
+| Neither set | not present | `[...]` (GitHub omitted; other creds may still appear) |
+| AWS files present on host | env vars set | `[..., "AWS_*"]` |
+| AWS files absent | env vars still set (harmless) | `[...]` (AWS omitted) |
+
+No row produces an error: missing credentials are an expected operational
+state, and the audit log makes them visible to the operator.
+
+## 8. Where to look in the code
+
+| Concern | File |
+|---|---|
+| Broker type and resolution logic | `internal/iris/credential_broker.go` |
+| Bash subprocess env (thin shim) | `internal/iris/bash_credentials.go` |
+| Per-call audit log write | `internal/iris/harness_socket.go::dispatchToolExec` |
+| Linux mount layout | `internal/iris/bash_sandbox_linux.go::bashToolMountsLinux` |
+| macOS SBPL profile | `internal/iris/bash_sandbox_darwin.go::GenerateBashSBPLProfile` |
+| 4-PAT account derivation | `internal/container/credentials.go::GithubAccountFromBareRoot` |
+| `iris stats credentials` CLI | `cmd/iris/stats.go` |
+| Exhaustive negative tests | `internal/iris/credential_broker*_test.go` |
+
+## 9. Lineage
+
+- **D-5 (#1636)** introduced the bash sandbox and inline credential
+  injection.
+- **D-7 (#1638)** — this document — extracted the inline logic into the
+  `CredentialBroker`, added the audit field, added the `iris stats
+  credentials` subcommand, and pinned the negative tests as ACs.
+- Future work: extend the broker to handle additional tools that need
+  scoped credentials (e.g. a future `gh` tool with a finer-grained GitHub
+  token); document any new audit names here.

--- a/modules/programs/prism/prism/internal/container/credentials.go
+++ b/modules/programs/prism/prism/internal/container/credentials.go
@@ -107,6 +107,14 @@ func (m *Manager) CredentialEnvVars() []string {
 	return m.credentialEnvVars()
 }
 
+// GithubAccountFromBareRoot is the exported version of githubAccountFromBareRoot.
+// Used by the iris credential broker (D-7) to identify which role-scoped
+// PRISM_GITHUB_TOKEN_<account>_<role> env var was the source of the resolved
+// token, so the audit log can distinguish role-scoped from host-fallback hits.
+func GithubAccountFromBareRoot(bareRoot string) string {
+	return githubAccountFromBareRoot(bareRoot)
+}
+
 // GithubTokenForBareRootAndRole returns the role-scoped GitHub token for the
 // given bare repo root and agent role, using the 4-PAT architecture.
 // Returns "" when no matching token is found in the host environment.

--- a/modules/programs/prism/prism/internal/iris/bash_credentials.go
+++ b/modules/programs/prism/prism/internal/iris/bash_credentials.go
@@ -1,92 +1,23 @@
 package iris
 
-// bash_credentials.go — bash-specific credential helper for D-5.
+// bash_credentials.go — thin shim over the D-7 CredentialBroker.
 //
-// The bash subprocess receives a role-scoped GITHUB_TOKEN selected from the
-// 4-PAT architecture (account × role → token), reusing the logic already
-// implemented in internal/container/credentials.go via the exported
-// container.GithubTokenForBareRootAndRole free function.
+// Before D-7, this file owned bash credential resolution directly. D-7 moved
+// the resolution logic into credential_broker.go so credential decisions live
+// in a single place that also produces audit metadata.
 //
-// LLM API keys (ANTHROPIC_API_KEY, OPENROUTER_API_KEY) are explicitly excluded:
-// bash subprocesses must not be able to make LLM calls.
-//
-// AWS environment variables are NOT injected here — the bash subprocess
-// reads the AWS credentials from the mounted ~/.aws/{config,credentials}
-// files directly (the AWS CLI resolves them from the file-based credential
-// chain). AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE are set to point
-// at the in-sandbox canonical paths.
+// The bashEnv free function is preserved as a shim so the platform sandbox
+// builders (bash_sandbox_{linux,darwin}.go) and the existing test suite
+// continue to work unchanged when they only need the env list. New code that
+// also needs the audit names should call CredentialBroker.ResolveBash
+// directly instead — see harness_socket.go for the canonical caller.
 
-import (
-	"os"
-
-	"github.com/prismatic-koi/prism/internal/container"
-)
-
-// bashEnv returns the complete environment variable list for a bash subprocess.
-// It includes:
-//   - PATH, HOME, USER, LOGNAME, LANG, LC_ALL (standard shell env)
-//   - TERM (terminal type for interactive tools)
-//   - GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL
-//     (git identity, forwarded from host so bash commands can commit)
-//   - NIX_CONFIG (point at the nix daemon)
-//   - GITHUB_TOKEN (role-scoped, from 4-PAT architecture via container package)
-//   - AWS_CONFIG_FILE, AWS_SHARED_CREDENTIALS_FILE (point at in-sandbox paths)
+// bashEnv returns the env-var list for a bash subprocess via the default
+// CredentialBroker. It discards the audit names; use ResolveBash directly
+// when those are needed.
 //
-// Explicitly NOT included:
-//   - ANTHROPIC_API_KEY (LLM API key — bash must not make LLM calls)
-//   - OPENROUTER_API_KEY (LLM API key — bash must not make LLM calls)
-//   - Any pi-process-specific credentials (~/.claude, ~/.mcp-auth, etc.)
+// Kept as a free function so the platform sandbox builders can call it
+// without plumbing a broker through every dispatcher field.
 func bashEnv(role, bareRoot string) []string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = os.Getenv("HOME")
-	}
-
-	var env []string
-
-	// Standard shell environment.
-	pathVal := os.Getenv("PATH")
-	if pathVal == "" {
-		pathVal = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
-	}
-	env = append(env, "PATH="+pathVal)
-
-	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL"} {
-		if val := os.Getenv(key); val != "" {
-			env = append(env, key+"="+val)
-		}
-	}
-
-	// Terminal type.
-	if term := os.Getenv("TERM"); term != "" {
-		env = append(env, "TERM="+term)
-	}
-
-	// Git identity — forwarded so bash can run git commit.
-	for _, key := range []string{
-		"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
-		"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
-	} {
-		if val := os.Getenv(key); val != "" {
-			env = append(env, key+"="+val)
-		}
-	}
-
-	// Nix daemon.
-	env = append(env, "NIX_CONFIG=store = daemon")
-
-	// Role-scoped GitHub token — reuses the 4-PAT architecture from the
-	// container package.  LLM API keys are deliberately excluded here.
-	if tok := container.GithubTokenForBareRootAndRole(bareRoot, role); tok != "" {
-		env = append(env, "GITHUB_TOKEN="+tok)
-	}
-
-	// AWS credential file paths — point at the in-sandbox canonical paths.
-	// These match the MountSpec SandboxPaths for ~/.aws/config and
-	// ~/.aws/credentials.  Bwrap uses Dst==Src mounts so the in-sandbox
-	// paths equal the host paths.
-	env = append(env, "AWS_CONFIG_FILE="+home+"/.aws/config")
-	env = append(env, "AWS_SHARED_CREDENTIALS_FILE="+home+"/.aws/credentials")
-
-	return env
+	return NewCredentialBroker().ResolveBash(role, bareRoot).Env
 }

--- a/modules/programs/prism/prism/internal/iris/bash_sandbox_darwin.go
+++ b/modules/programs/prism/prism/internal/iris/bash_sandbox_darwin.go
@@ -71,7 +71,14 @@ func (d *toolDispatcher) runBashInSandbox(ctx context.Context, command string) t
 	//
 	// We construct: env -i VAR=val ... bash -c '<command>'
 	// This produces a clean environment without the host LLM API keys.
-	envPairs := bashEnv(d.role, d.bareRoot)
+	// Use the dispatcher's broker so credential resolution is consistent
+	// with the audit-log decision recorded against the matching tool_call
+	// event (D-7).
+	broker := d.broker
+	if broker == nil {
+		broker = NewCredentialBroker()
+	}
+	envPairs := broker.ResolveBash(d.role, d.bareRoot).Env
 
 	// Build the argv for sandbox-exec.
 	allArgs := []string{"-f", profilePath}

--- a/modules/programs/prism/prism/internal/iris/bash_sandbox_linux.go
+++ b/modules/programs/prism/prism/internal/iris/bash_sandbox_linux.go
@@ -71,8 +71,14 @@ func (d *toolDispatcher) runBashInSandbox(ctx context.Context, command string) t
 	)
 	args = append(args, mountArgs...)
 
-	// Inject env vars via --setenv.
-	for _, kv := range bashEnv(d.role, d.bareRoot) {
+	// Inject env vars via --setenv. Use the dispatcher's broker so credential
+	// resolution is consistent with the audit-log decision recorded against
+	// the matching tool_call event (D-7).
+	broker := d.broker
+	if broker == nil {
+		broker = NewCredentialBroker()
+	}
+	for _, kv := range broker.ResolveBash(d.role, d.bareRoot).Env {
 		k, v, _ := strings.Cut(kv, "=")
 		args = append(args, "--setenv", k, v)
 	}

--- a/modules/programs/prism/prism/internal/iris/credential_broker.go
+++ b/modules/programs/prism/prism/internal/iris/credential_broker.go
@@ -1,0 +1,307 @@
+package iris
+
+// credential_broker.go — D-7 credential-brokering subsystem for iris tool
+// subprocesses.
+//
+// The CredentialBroker is the single point that decides which credentials
+// reach each tool subprocess. It replaces the inline credential resolution
+// that D-5 added to bash_credentials.go: callers obtain credentials by
+// asking the broker, and the broker also reports an audit-only list of
+// credential names that is persisted with the corresponding tool_call event.
+//
+// Design notes:
+//
+//   - The broker is stateless: it reads the host environment and the file
+//     system at the moment of each call. This matches the design-doc
+//     statement that "credentials are resolved per-call" (§7.2) and means
+//     a daemon restart cannot serve stale credentials.
+//
+//   - The broker is the only place that should read from host env vars or
+//     known credential file paths when assembling a tool subprocess. Mount
+//     decisions still live in bash_sandbox_{linux,darwin}.go because they
+//     are platform-specific, but those files now query the broker to learn
+//     which mounts and env vars they should produce.
+//
+//   - Names are stable, machine-readable audit identifiers — never values.
+//     The format is documented in docs/iris-credential-model.md so that
+//     `iris stats credentials` output is greppable and operators can build
+//     dashboards on top of it.
+//
+// Credential matrix (initial — D-7):
+//
+//   read/edit/write/grep/find/ls  → no credentials
+//   bash                          → GITHUB_TOKEN (role-scoped or host fallback),
+//                                   AWS_* (file-mount based, conditional)
+//
+// LLM API keys are explicitly excluded from every tool subprocess. The
+// broker does not even read them.
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// CredentialBroker resolves credentials for tool subprocesses.
+//
+// A single broker can be reused across calls; it holds no mutable state and
+// is safe for concurrent use. Construct one per-daemon with NewCredentialBroker
+// or use a per-call zero value.
+type CredentialBroker struct{}
+
+// NewCredentialBroker returns a broker. There is currently no configurable
+// state, but the constructor exists so future changes can attach cached
+// secret backends, refresh policy, etc. without breaking callers.
+func NewCredentialBroker() *CredentialBroker { return &CredentialBroker{} }
+
+// BashResolution is the result of resolving credentials for a bash tool call.
+type BashResolution struct {
+	// Env is the full environment-variable list to pass to the bash
+	// subprocess (KEY=VAL pairs). It includes both credentials and the
+	// non-credential shell-environment plumbing (PATH, HOME, AWS_CONFIG_FILE,
+	// etc.) — the broker owns the whole bash subprocess env in order to be
+	// the single source of truth for what reaches the subprocess.
+	Env []string
+
+	// Names is the audit list of credentials injected into Env. Names only,
+	// never values. Used for the `credentials_injected` field on the
+	// tool_call event and surfaced via `iris stats credentials`.
+	//
+	// Possible values:
+	//   "GITHUB_TOKEN"                — role-scoped PRISM_GITHUB_TOKEN_* hit.
+	//   "GITHUB_TOKEN(fallback:host)" — role-scoped missing; host GITHUB_TOKEN used.
+	//   "AWS_*"                       — AWS config/credentials files were
+	//                                   present on the host and AWS_CONFIG_FILE
+	//                                   / AWS_SHARED_CREDENTIALS_FILE were set.
+	//
+	// When neither a role-scoped token nor a host GITHUB_TOKEN is available,
+	// "GITHUB_TOKEN" is omitted from Names entirely (the audit log records
+	// the absence by omission).
+	Names []string
+}
+
+// audit-name constants — kept here so the docs and tests reference the same
+// strings the broker emits.
+const (
+	credNameGitHubToken         = "GITHUB_TOKEN"
+	credNameGitHubTokenFallback = "GITHUB_TOKEN(fallback:host)"
+	credNameAWS                 = "AWS_*"
+)
+
+// llmAPIKeyNames is the closed list of LLM/related provider keys that the
+// broker explicitly refuses to forward into any tool subprocess. The list
+// is exhaustive across providers prism has ever supported, plus speculative
+// keys that the threat model wants kept out regardless of consumer status.
+//
+// Exported (via ForbiddenLLMKeyNames) so tests outside this package can
+// assert the same list without copy-pasting.
+var llmAPIKeyNames = []string{
+	"ANTHROPIC_API_KEY",
+	"OPENROUTER_API_KEY",
+	"OPENAI_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GITHUB_COPILOT_TOKEN",
+	"DEEPSEEK_API_KEY",
+}
+
+// ForbiddenLLMKeyNames returns a copy of the forbidden LLM API key list.
+// Use this in tests instead of duplicating the list.
+func ForbiddenLLMKeyNames() []string {
+	out := make([]string, len(llmAPIKeyNames))
+	copy(out, llmAPIKeyNames)
+	return out
+}
+
+// ResolveBash returns the environment and audit names for a bash tool call.
+//
+// role is the session's agent role ("worker", "coordinator", or any other
+// string — empty / unknown roles are treated as "no role" and produce no
+// role-scoped token, falling through to the host GITHUB_TOKEN if present).
+//
+// bareRoot is the bare repo root used to derive the GitHub account; when
+// empty, the broker cannot select a role-scoped token and falls through.
+func (b *CredentialBroker) ResolveBash(role, bareRoot string) BashResolution {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+
+	res := BashResolution{}
+
+	// ── Standard shell environment ─────────────────────────────────────────
+	pathVal := os.Getenv("PATH")
+	if pathVal == "" {
+		pathVal = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+	}
+	res.Env = append(res.Env, "PATH="+pathVal)
+
+	for _, key := range []string{"HOME", "USER", "LOGNAME", "LANG", "LC_ALL"} {
+		if val := os.Getenv(key); val != "" {
+			res.Env = append(res.Env, key+"="+val)
+		}
+	}
+	if term := os.Getenv("TERM"); term != "" {
+		res.Env = append(res.Env, "TERM="+term)
+	}
+
+	// Git identity — forwarded so bash can run git commit.
+	for _, key := range []string{
+		"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+		"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+	} {
+		if val := os.Getenv(key); val != "" {
+			res.Env = append(res.Env, key+"="+val)
+		}
+	}
+
+	// Nix daemon.
+	res.Env = append(res.Env, "NIX_CONFIG=store = daemon")
+
+	// ── GitHub token (4-PAT architecture with host fallback) ──────────────
+	//
+	// We need to distinguish:
+	//   (a) role-scoped PRISM_GITHUB_TOKEN_<account>_<role> present  → "GITHUB_TOKEN"
+	//   (b) role-scoped absent, host GITHUB_TOKEN present            → "GITHUB_TOKEN(fallback:host)"
+	//   (c) neither present                                          → omit entirely
+	//
+	// container.GithubTokenForBareRootAndRole returns the resolved token but
+	// hides which branch was taken. We re-derive the decision here so the
+	// audit log can record it precisely.
+	if tok, source := b.resolveGitHubToken(role, bareRoot); tok != "" {
+		res.Env = append(res.Env, "GITHUB_TOKEN="+tok)
+		switch source {
+		case githubTokenSourceRoleScoped:
+			res.Names = append(res.Names, credNameGitHubToken)
+		case githubTokenSourceHostFallback:
+			res.Names = append(res.Names, credNameGitHubTokenFallback)
+		}
+	}
+
+	// ── AWS credentials (file-mount based) ────────────────────────────────
+	//
+	// AWS env vars are NOT injected. The bash sandbox mounts ~/.aws/config
+	// and ~/.aws/credentials (RO) when they exist on the host, and we point
+	// AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE at the in-sandbox paths
+	// so the AWS CLI resolves credentials from the files.
+	//
+	// We always set the AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE env
+	// vars (they are harmless when the files do not exist), but we only
+	// claim "AWS_*" in the audit list when at least one of the source files
+	// is actually present on the host.
+	res.Env = append(res.Env, "AWS_CONFIG_FILE="+home+"/.aws/config")
+	res.Env = append(res.Env, "AWS_SHARED_CREDENTIALS_FILE="+home+"/.aws/credentials")
+	if awsCredentialsPresent(home) {
+		res.Names = append(res.Names, credNameAWS)
+	}
+
+	// Stable order for audit comparison/grep.
+	sort.Strings(res.Names)
+
+	return res
+}
+
+// githubTokenSource indicates which branch of the 4-PAT lookup was taken.
+type githubTokenSource int
+
+const (
+	githubTokenSourceNone githubTokenSource = iota
+	githubTokenSourceRoleScoped
+	githubTokenSourceHostFallback
+)
+
+// resolveGitHubToken re-derives the 4-PAT decision so the broker can record
+// which branch was taken in the audit log. Logic mirrors
+// container.GithubTokenForBareRootAndRole; the two are kept in sync but
+// cannot share the inner decision because the container helper returns only
+// the resolved token string.
+//
+// Behaviour:
+//   - When bareRoot is empty or the account cannot be derived, no role-scoped
+//     env var is consulted; the function falls through to host GITHUB_TOKEN.
+//   - When role is empty / unknown (not "worker" or "coordinator"), no
+//     role-scoped env var is consulted; falls through to host.
+//   - When the role-scoped var is set but empty, it counts as unset
+//     (`t.Setenv(name, "")` in tests sets the empty string, which we
+//     intentionally treat the same as missing).
+func (b *CredentialBroker) resolveGitHubToken(role, bareRoot string) (string, githubTokenSource) {
+	// Use the container package's free function to get the resolved token
+	// (so the broker and the container path share the same selection logic),
+	// then re-do the decision here to learn which branch was taken.
+	resolved := container.GithubTokenForBareRootAndRole(bareRoot, role)
+	if resolved == "" {
+		return "", githubTokenSourceNone
+	}
+
+	// Was the role-scoped var the source?
+	if name := roleScopedTokenName(role, bareRoot); name != "" {
+		if v := os.Getenv(name); v != "" {
+			return resolved, githubTokenSourceRoleScoped
+		}
+	}
+	// Otherwise the host fallback was the source.
+	return resolved, githubTokenSourceHostFallback
+}
+
+// roleScopedTokenName returns the PRISM_GITHUB_TOKEN_<account>_<role> env-var
+// name for a (role, bareRoot) pair, or "" when no role-scoped name applies.
+// Mirrors the lookup-key construction in container/credentials.go.
+func roleScopedTokenName(role, bareRoot string) string {
+	account := container.GithubAccountFromBareRoot(bareRoot)
+	if account == "" {
+		return ""
+	}
+	roleKey := upperASCII(role)
+	if roleKey != "WORKER" && roleKey != "COORDINATOR" {
+		return ""
+	}
+	accountKey := replaceASCII(upperASCII(account), '-', '_')
+	return "PRISM_GITHUB_TOKEN_" + accountKey + "_" + roleKey
+}
+
+// awsCredentialsPresent reports whether either the canonical config or
+// credentials file is present on the host. We check the sops-managed
+// source paths (used by the bash sandbox mount layout), not the
+// in-sandbox destination paths.
+func awsCredentialsPresent(home string) bool {
+	candidates := []string{
+		filepath.Join(home, ".config", "aws", "readonly-config"),
+		filepath.Join(home, ".config", "aws", "credentials"),
+		filepath.Join(home, ".aws", "config"),
+		filepath.Join(home, ".aws", "credentials"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// upperASCII uppercases ASCII letters without involving locale or
+// allocating in the typical fast-path.
+func upperASCII(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out[i] = c
+	}
+	return string(out)
+}
+
+func replaceASCII(s string, from, to byte) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == from {
+			out[i] = to
+		} else {
+			out[i] = s[i]
+		}
+	}
+	return string(out)
+}

--- a/modules/programs/prism/prism/internal/iris/credential_broker_mount_darwin_test.go
+++ b/modules/programs/prism/prism/internal/iris/credential_broker_mount_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package iris
+
+// credential_broker_mount_darwin_test.go — Darwin-only SBPL audit for the
+// D-7 bash sandbox.  Asserts that the generated SBPL profile never grants
+// access to any pi-process credential path and never references any
+// forbidden LLM API key name.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBashSBPLProfile_ForbiddenPathsExhaustive walks every forbidden
+// pi-process credential path and confirms it is absent from the generated
+// SBPL profile. The profile is built fresh per call so this is a pure
+// generator check — no sandbox-exec invocation required.
+func TestBashSBPLProfile_ForbiddenPathsExhaustive(t *testing.T) {
+	home := t.TempDir()
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	profile := GenerateBashSBPLProfile(home, worktree, tmpDir, "", "", "", false)
+
+	for _, path := range forbiddenPiPaths() {
+		if strings.Contains(profile, path) {
+			t.Errorf("GenerateBashSBPLProfile output references forbidden pi credential path %q\n%s",
+				path, profile)
+		}
+	}
+}
+
+// TestBashSBPLProfile_NoLLMKeyNames asserts that no LLM API key name appears
+// anywhere in the generated SBPL profile (defence in depth — the profile
+// should never mention key names since SBPL only references file paths and
+// mach-port names).
+func TestBashSBPLProfile_NoLLMKeyNames(t *testing.T) {
+	home := t.TempDir()
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	profile := GenerateBashSBPLProfile(home, worktree, tmpDir, "", "", "", false)
+
+	for _, k := range forbiddenEnvKeys() {
+		if strings.Contains(profile, k) {
+			t.Errorf("GenerateBashSBPLProfile output mentions forbidden LLM key %q\n%s",
+				k, profile)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/credential_broker_mount_linux_test.go
+++ b/modules/programs/prism/prism/internal/iris/credential_broker_mount_linux_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package iris
+
+// credential_broker_mount_linux_test.go — Linux-only mount-layout audit for
+// the D-7 bash sandbox. Asserts that bashToolMountsLinux NEVER includes any
+// pi-process credential path or LLM API key env var, regardless of which
+// optional credentials are present on the host.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBashToolMountsLinux_ForbiddenPathsExhaustive walks every forbidden
+// pi-process credential path and confirms it is absent from the bwrap
+// argument list. This is the exhaustive version of the existing
+// TestBashToolMountsLinux_PiCredentialsAbsent test, made explicit per #1638.
+func TestBashToolMountsLinux_ForbiddenPathsExhaustive(t *testing.T) {
+	home := t.TempDir()
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	mounts := bashToolMountsLinux(home, worktree, tmpDir, "", "", "", false)
+	mountStr := strings.Join(mounts, " ")
+
+	for _, path := range forbiddenPiPaths() {
+		if strings.Contains(mountStr, path) {
+			t.Errorf("bashToolMountsLinux contains forbidden pi credential path %q\n  full args: %v",
+				path, mounts)
+		}
+	}
+}
+
+// TestBashToolMountsLinux_NoLLMKeyMounts asserts no forbidden LLM API key
+// name appears as a --setenv arg in the bwrap invocation. This is a
+// belt-and-braces complement to TestBashEnv_NoForbiddenKeys.
+//
+// Note: bashToolMountsLinux does not emit --setenv pairs (those are appended
+// in runBashInSandbox after the mount args), so this test currently only
+// checks that no LLM key appears anywhere in the mount layout (e.g. via a
+// stray bind-mount of a credentials file).
+func TestBashToolMountsLinux_NoLLMKeyMounts(t *testing.T) {
+	home := t.TempDir()
+	worktree := t.TempDir()
+	tmpDir := t.TempDir()
+
+	mounts := bashToolMountsLinux(home, worktree, tmpDir, "", "", "", false)
+	mountStr := strings.Join(mounts, " ")
+
+	for _, k := range forbiddenEnvKeys() {
+		if strings.Contains(mountStr, k) {
+			t.Errorf("bashToolMountsLinux args contain forbidden LLM key name %q\n  full args: %v",
+				k, mounts)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/credential_broker_mount_test.go
+++ b/modules/programs/prism/prism/internal/iris/credential_broker_mount_test.go
@@ -1,0 +1,90 @@
+package iris
+
+// credential_broker_mount_test.go — D-7 mount-layout negative tests.
+//
+// These tests assert that the bash sandbox mount/profile layouts produced by
+// the platform builders do NOT include the pi-process credential paths or
+// any LLM API key environment variables.
+//
+// The exhaustive list of forbidden paths (per #1638 AC):
+//
+//   - ~/.claude
+//   - ~/.mcp-auth
+//   - ~/.pi/agent/*
+//   - ~/.cache/bun
+//   - ~/.config/pi/*
+//
+// Tests are split per platform so they can use the platform-specific
+// builder directly. Cross-platform tests on the generic broker live in
+// credential_broker_test.go.
+
+import (
+	"strings"
+	"testing"
+)
+
+// forbiddenPiPaths lists the substrings that must NEVER appear in the bash
+// sandbox mount layout or SBPL profile.  Exported via this helper so the
+// Linux and Darwin tests stay in lock-step.
+func forbiddenPiPaths() []string {
+	return []string{
+		"/.claude",
+		"/.mcp-auth",
+		"/.pi/agent",
+		"/.cache/bun",
+		"/.config/pi",
+	}
+}
+
+// forbiddenEnvKeys lists the LLM API key env var names that must never
+// appear as bwrap --setenv arguments or in the SBPL profile.
+func forbiddenEnvKeys() []string {
+	return ForbiddenLLMKeyNames()
+}
+
+// TestForbiddenPiPaths_Stable verifies the forbidden-path list matches the
+// AC verbatim. Guards against future drift where someone removes an entry
+// thinking it is redundant.
+func TestForbiddenPiPaths_Stable(t *testing.T) {
+	want := []string{
+		"/.claude",
+		"/.mcp-auth",
+		"/.pi/agent",
+		"/.cache/bun",
+		"/.config/pi",
+	}
+	got := forbiddenPiPaths()
+	if len(got) != len(want) {
+		t.Fatalf("forbidden paths length mismatch: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("forbiddenPiPaths()[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBashEnv_NoForbiddenKeys is the cross-platform belt-and-braces check
+// that ResolveBash().Env contains no forbidden LLM key for any platform.
+func TestBashEnv_NoForbiddenKeys(t *testing.T) {
+	for _, k := range forbiddenEnvKeys() {
+		t.Setenv(k, "should-be-stripped")
+	}
+	// Also set every PRISM_GITHUB_TOKEN_* so we cover the raw-leak case.
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER", "raw")
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR", "raw")
+
+	env := bashEnv("worker", "")
+	joined := strings.Join(env, "\n")
+
+	for _, k := range forbiddenEnvKeys() {
+		if strings.Contains(joined, k+"=") {
+			t.Errorf("bashEnv() contains forbidden key %q; must be stripped", k)
+		}
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PRISM_GITHUB_TOKEN_") {
+			t.Errorf("bashEnv() contains raw PRISM_GITHUB_TOKEN_* var: %q", kv)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/credential_broker_test.go
+++ b/modules/programs/prism/prism/internal/iris/credential_broker_test.go
@@ -1,0 +1,290 @@
+package iris
+
+// credential_broker_test.go — exhaustive negative + edge-case tests for the
+// D-7 CredentialBroker.
+//
+// These tests assert:
+//
+//   - LLM API keys are absent from the bash subprocess environment for every
+//     provider on the forbidden list, even when set on the host.
+//   - PRISM_GITHUB_TOKEN_* raw forms are never leaked into the env; only the
+//     resolved per-call GITHUB_TOKEN is present.
+//   - GitHub-token resolution edge cases: role-scoped hit, host fallback,
+//     neither present, empty/unknown role.
+//   - AWS audit-name presence reflects host file presence.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// clearAllGitHubTokens unsets every GitHub-related env var the broker might
+// consult so each test starts from a known clean slate. Uses t.Setenv so the
+// values are restored after the test.
+func clearAllGitHubTokens(t *testing.T) {
+	t.Helper()
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER", "")
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR", "")
+	t.Setenv("PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER", "")
+	t.Setenv("PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_COORDINATOR", "")
+}
+
+// hasEnvKey reports whether the env list contains KEY=... for the given key.
+func hasEnvKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasName reports whether names contains s.
+func hasName(names []string, s string) bool {
+	for _, n := range names {
+		if n == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ── [security] LLM API keys are never forwarded ─────────────────────────────
+
+// TestCredentialBroker_AllLLMKeysAbsent asserts that NO key on the forbidden
+// LLM API key list ever appears in the bash subprocess env, even when every
+// one of them is set on the host with a non-empty value.
+func TestCredentialBroker_AllLLMKeysAbsent(t *testing.T) {
+	clearAllGitHubTokens(t)
+
+	keys := ForbiddenLLMKeyNames()
+	if len(keys) == 0 {
+		t.Fatal("ForbiddenLLMKeyNames() returned empty list")
+	}
+	for _, k := range keys {
+		t.Setenv(k, "secret-"+k)
+	}
+
+	res := NewCredentialBroker().ResolveBash("worker", "")
+
+	for _, k := range keys {
+		if hasEnvKey(res.Env, k) {
+			t.Errorf("ResolveBash env contains forbidden LLM key %q; must be excluded.\n  env=%v", k, res.Env)
+		}
+		if hasName(res.Names, k) {
+			t.Errorf("ResolveBash names contains forbidden LLM key %q in audit list", k)
+		}
+	}
+}
+
+// TestCredentialBroker_RawPrismTokensNeverLeak asserts that no
+// PRISM_GITHUB_TOKEN_* env var (raw form) is ever propagated into the bash
+// subprocess env. Only the resolved GITHUB_TOKEN should be present.
+func TestCredentialBroker_RawPrismTokensNeverLeak(t *testing.T) {
+	clearAllGitHubTokens(t)
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER", "raw-role-token")
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR", "raw-coord-token")
+	t.Setenv("PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER", "raw-tp-worker")
+
+	res := NewCredentialBroker().ResolveBash("worker", "")
+
+	for _, kv := range res.Env {
+		if strings.HasPrefix(kv, "PRISM_GITHUB_TOKEN_") {
+			t.Errorf("ResolveBash env contains raw PRISM_GITHUB_TOKEN_* var; only the resolved GITHUB_TOKEN must reach the subprocess:\n  kv=%q", kv)
+		}
+	}
+}
+
+// ── [edge-case] GitHub-token resolution ─────────────────────────────────────
+
+// TestCredentialBroker_HostFallback: role-scoped unset → host GITHUB_TOKEN
+// used, audit name reflects fallback.
+func TestCredentialBroker_HostFallback(t *testing.T) {
+	clearAllGitHubTokens(t)
+	t.Setenv("GITHUB_TOKEN", "ghp-host-fallback")
+
+	res := NewCredentialBroker().ResolveBash("worker", "")
+
+	// Env contains GITHUB_TOKEN=ghp-host-fallback.
+	found := ""
+	for _, kv := range res.Env {
+		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			found = kv
+		}
+	}
+	if found != "GITHUB_TOKEN=ghp-host-fallback" {
+		t.Errorf("expected GITHUB_TOKEN=ghp-host-fallback, got %q (env=%v)", found, res.Env)
+	}
+
+	// Audit name reflects fallback. With an empty bareRoot the broker cannot
+	// derive an account so the resolution is necessarily the host fallback.
+	if !hasName(res.Names, "GITHUB_TOKEN(fallback:host)") {
+		t.Errorf("expected 'GITHUB_TOKEN(fallback:host)' in audit names, got %v", res.Names)
+	}
+	if hasName(res.Names, "GITHUB_TOKEN") {
+		t.Errorf("audit names contains both fallback marker and plain GITHUB_TOKEN: %v", res.Names)
+	}
+}
+
+// TestCredentialBroker_NeitherTokenPresent: no role-scoped, no host token →
+// no GITHUB_TOKEN in env, no GITHUB_TOKEN-related name in audit list, no
+// error raised.
+func TestCredentialBroker_NeitherTokenPresent(t *testing.T) {
+	clearAllGitHubTokens(t)
+
+	res := NewCredentialBroker().ResolveBash("worker", "")
+
+	if hasEnvKey(res.Env, "GITHUB_TOKEN") {
+		t.Errorf("expected no GITHUB_TOKEN in env; got %v", res.Env)
+	}
+	for _, n := range res.Names {
+		if strings.HasPrefix(n, "GITHUB_TOKEN") {
+			t.Errorf("expected no GITHUB_TOKEN audit name; got %v", res.Names)
+		}
+	}
+}
+
+// TestCredentialBroker_EmptyRoleNoCrash: empty/unknown role → broker treats
+// it as no-role, does not crash, falls back to host token if present.
+func TestCredentialBroker_EmptyRoleNoCrash(t *testing.T) {
+	clearAllGitHubTokens(t)
+	t.Setenv("GITHUB_TOKEN", "ghp-host-empty-role")
+
+	for _, role := range []string{"", "unknown-role", "REVIEWER"} {
+		res := NewCredentialBroker().ResolveBash(role, "")
+
+		if !hasEnvKey(res.Env, "GITHUB_TOKEN") {
+			t.Errorf("role=%q: expected host GITHUB_TOKEN fallback in env; got %v", role, res.Env)
+		}
+		// Should be the fallback marker, not the role-scoped one — since no
+		// role-scoped lookup applies for empty/unknown roles.
+		if !hasName(res.Names, "GITHUB_TOKEN(fallback:host)") {
+			t.Errorf("role=%q: expected fallback marker in names; got %v", role, res.Names)
+		}
+	}
+}
+
+// TestCredentialBroker_UnknownRoleHostUnset: empty/unknown role with no host
+// token → no GITHUB_TOKEN in env, no GITHUB_TOKEN audit name.
+func TestCredentialBroker_UnknownRoleHostUnset(t *testing.T) {
+	clearAllGitHubTokens(t)
+
+	res := NewCredentialBroker().ResolveBash("", "")
+
+	if hasEnvKey(res.Env, "GITHUB_TOKEN") {
+		t.Errorf("expected no GITHUB_TOKEN; got %v", res.Env)
+	}
+	for _, n := range res.Names {
+		if strings.HasPrefix(n, "GITHUB_TOKEN") {
+			t.Errorf("expected no GITHUB_TOKEN audit name; got %v", res.Names)
+		}
+	}
+}
+
+// ── [edge-case] AWS audit-name reflects host file presence ──────────────────
+
+// TestCredentialBroker_AWSAbsent: when no AWS files exist anywhere the broker
+// looks, the AWS_* audit name is omitted.
+func TestCredentialBroker_AWSAbsent(t *testing.T) {
+	clearAllGitHubTokens(t)
+	// Redirect $HOME to a temp dir with no AWS files so the broker's
+	// awsCredentialsPresent check is guaranteed negative.
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	res := NewCredentialBroker().ResolveBash("worker", "")
+
+	if hasName(res.Names, "AWS_*") {
+		t.Errorf("AWS_* should not be in audit names when no AWS files exist; got %v", res.Names)
+	}
+}
+
+// TestCredentialBroker_AWSPresent: when an AWS file exists in the host
+// $HOME/.aws layout, AWS_* appears in the audit names.
+func TestCredentialBroker_AWSPresent(t *testing.T) {
+	clearAllGitHubTokens(t)
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	// Drop a stub credentials file at the canonical path.
+	awsDir := filepath.Join(tempHome, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatalf("mkdir aws: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(awsDir, "credentials"), []byte("[default]\n"), 0o600); err != nil {
+		t.Fatalf("write aws credentials: %v", err)
+	}
+
+	res := NewCredentialBroker().ResolveBash("worker", "")
+
+	if !hasName(res.Names, "AWS_*") {
+		t.Errorf("AWS_* should be in audit names when AWS credentials present; got %v", res.Names)
+	}
+	// AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE point at the in-sandbox
+	// canonical paths; we always set them regardless of host presence.
+	if !hasEnvKey(res.Env, "AWS_CONFIG_FILE") {
+		t.Errorf("AWS_CONFIG_FILE should be set in env; got %v", res.Env)
+	}
+	if !hasEnvKey(res.Env, "AWS_SHARED_CREDENTIALS_FILE") {
+		t.Errorf("AWS_SHARED_CREDENTIALS_FILE should be set in env; got %v", res.Env)
+	}
+}
+
+// ── [functional] dispatcher CredentialNamesForTool integration ──────────────
+
+// TestDispatcherCredentialNames_FileToolsHaveNone asserts that the dispatcher
+// reports the empty list for every file tool (the file tools must run without
+// any credentials in their subprocess).
+func TestDispatcherCredentialNames_FileToolsHaveNone(t *testing.T) {
+	clearAllGitHubTokens(t)
+	t.Setenv("GITHUB_TOKEN", "ghp-should-not-be-injected-into-file-tools")
+
+	d := &toolDispatcher{
+		role:     "worker",
+		bareRoot: "",
+		broker:   NewCredentialBroker(),
+	}
+
+	for _, tool := range []string{"read", "edit", "write", "grep", "find", "ls"} {
+		names := d.CredentialNamesForTool(tool)
+		if len(names) != 0 {
+			t.Errorf("CredentialNamesForTool(%q) = %v; want empty list", tool, names)
+		}
+	}
+}
+
+// TestDispatcherCredentialNames_BashHasGitHubToken asserts that the bash tool
+// reports the GITHUB_TOKEN audit name when a host token is configured.
+func TestDispatcherCredentialNames_BashHasGitHubToken(t *testing.T) {
+	clearAllGitHubTokens(t)
+	t.Setenv("GITHUB_TOKEN", "ghp-host-for-bash")
+
+	d := &toolDispatcher{
+		role:     "worker",
+		bareRoot: "",
+		broker:   NewCredentialBroker(),
+	}
+	names := d.CredentialNamesForTool("bash")
+	if !hasName(names, "GITHUB_TOKEN(fallback:host)") {
+		t.Errorf("CredentialNamesForTool(bash) = %v; want fallback marker", names)
+	}
+}
+
+// TestDispatcherCredentialNames_NilBrokerSafe asserts that a dispatcher with
+// no broker set falls back to a default broker rather than panicking. This
+// keeps unit tests that construct an ad-hoc toolDispatcher (e.g. the existing
+// TestRunBash_MissingCommand) working without modification.
+func TestDispatcherCredentialNames_NilBrokerSafe(t *testing.T) {
+	clearAllGitHubTokens(t)
+
+	d := &toolDispatcher{role: "worker", bareRoot: "", broker: nil}
+	names := d.CredentialNamesForTool("bash") // should not panic
+	if names == nil {
+		// Empty slice is OK; nil also OK — we only require no panic.
+		_ = names
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -330,15 +330,9 @@ func (h *HarnessSocketServer) dispatchToolExec(ctx context.Context, w *jsonlWrit
 		h.mu.Unlock()
 	}()
 
-	// Write tool_call event to DB (AC: every tool_exec → tool_call event).
-	payloadBytes, _ := json.Marshal(map[string]any{
-		"id":   frame.ID,
-		"name": frame.Name,
-		"args": frame.Args,
-	})
-	h.writeEvent("tool_call", payloadBytes)
-
-	// Execute the tool.
+	// Build the dispatcher first so we can ask the broker which credentials
+	// are about to be injected — that list is recorded on the tool_call event
+	// (D-7 audit logging) before dispatch runs.
 	//
 	// Derive tmpDir from the harness socket path:
 	//   sessionDir = filepath.Dir(sess.HarnessSockPath)
@@ -352,10 +346,33 @@ func (h *HarnessSocketServer) dispatchToolExec(ctx context.Context, w *jsonlWrit
 		tmpDir:     tmpDir,
 		role:       h.sess.Role,
 		bareRoot:   h.sess.BareRoot,
+		broker:     NewCredentialBroker(),
 		writer:     w,
 		abortCh:    abortCh,
 		toolExecID: frame.ID,
 	}
+
+	// D-7: record which credentials are about to be injected. Names only,
+	// never values. nil/empty → no credentials (still a valid audit record).
+	credentialsInjected := dispatcher.CredentialNamesForTool(frame.Name)
+	if credentialsInjected == nil {
+		// Use an empty (non-nil) slice so the JSON field is [], not null —
+		// downstream consumers can distinguish "no credentials injected" from
+		// "field missing on a pre-D-7 event".
+		credentialsInjected = []string{}
+	}
+
+	// Write tool_call event to DB (AC: every tool_exec → tool_call event).
+	payloadBytes, _ := json.Marshal(map[string]any{
+		"id":                   frame.ID,
+		"name":                 frame.Name,
+		"args":                 frame.Args,
+		"credentials_injected": credentialsInjected,
+		"agent_role":           h.sess.Role,
+	})
+	h.writeEvent("tool_call", payloadBytes)
+
+	// Execute the tool.
 	result := dispatcher.dispatch(ctx, frame)
 
 	// Send the result frame.

--- a/modules/programs/prism/prism/internal/iris/harness_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket_test.go
@@ -455,6 +455,117 @@ func TestDBEventWritten(t *testing.T) {
 	if toolResultCount == 0 {
 		t.Error("no tool_result event written to DB")
 	}
+
+	// D-7: every tool_call payload must carry a credentials_injected field
+	// (JSON array of names). For bash the field is non-empty when a host
+	// GITHUB_TOKEN is configured — we don't assert specific names here
+	// (env-dependent), only the field's presence and shape.
+	for _, e := range events {
+		if e.Type != "tool_call" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(e.Payload), &payload); err != nil {
+			t.Fatalf("unmarshal tool_call payload: %v", err)
+		}
+		if _, ok := payload["credentials_injected"]; !ok {
+			t.Errorf("tool_call payload missing credentials_injected field: %s", e.Payload)
+		}
+		if _, ok := payload["credentials_injected"].([]any); !ok {
+			t.Errorf("credentials_injected is not a JSON array: %T (%s)",
+				payload["credentials_injected"], e.Payload)
+		}
+	}
+}
+
+// TestDBEventWritten_CredentialsInjectedShape exercises the harness dispatch
+// path WITHOUT a sandbox so it runs on every platform / sandbox config.
+//
+// We send a tool_exec for an unknown tool name: the dispatcher returns an
+// immediate error toolResult without spawning any subprocess, but the
+// harness still writes a tool_call event for the dispatch attempt. The test
+// asserts that the tool_call payload includes a credentials_injected field
+// (per D-7) and that it is an empty array for non-bash tools.
+func TestDBEventWritten_CredentialsInjectedShape(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	const instanceID = "test-creds-shape"
+	insertTestSessionRow(t, database, instanceID, "test@creds-shape", tmp)
+
+	sockPath := filepath.Join(tmp, "harness.sock")
+	sess := &iris.SessionRecord{
+		InstanceID:      instanceID,
+		SessionName:     "test@creds-shape",
+		Worktree:        tmp,
+		Role:            "worker",
+		HarnessSockPath: sockPath,
+	}
+	srv, err := iris.NewHarnessSocketServer(sess, database)
+	if err != nil {
+		t.Fatalf("NewHarnessSocketServer: %v", err)
+	}
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { _ = srv.AcceptOne(ctx) }()
+
+	conn, r := dialHarness(t, sockPath)
+	doHandshake(t, conn, r)
+
+	sendFrame(t, conn, map[string]any{
+		"type": "tool_exec",
+		"id":   "call-shape-001",
+		"name": "definitely-not-a-real-tool",
+		"args": map[string]any{},
+	})
+
+	for {
+		frame := readFrame(t, r)
+		if frame["type"] == "tool_exec_result" {
+			break
+		}
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	events, err := database.AllSessionEvents("test@creds-shape")
+	if err != nil {
+		t.Fatalf("AllSessionEvents: %v", err)
+	}
+
+	var found bool
+	for _, e := range events {
+		if e.Type != "tool_call" {
+			continue
+		}
+		found = true
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(e.Payload), &payload); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		arr, ok := payload["credentials_injected"].([]any)
+		if !ok {
+			t.Fatalf("credentials_injected missing or not an array: %s", e.Payload)
+		}
+		if len(arr) != 0 {
+			t.Errorf("credentials_injected for unknown tool should be []; got %v", arr)
+		}
+		if payload["agent_role"] != "worker" {
+			t.Errorf("agent_role = %v; want \"worker\"", payload["agent_role"])
+		}
+	}
+	if !found {
+		t.Error("no tool_call event written")
+	}
 }
 
 // TestReadTool verifies the read tool executor.

--- a/modules/programs/prism/prism/internal/iris/restore.go
+++ b/modules/programs/prism/prism/internal/iris/restore.go
@@ -318,6 +318,12 @@ func newRestoreSupervisor(cfg SupervisorConfig, sess db.IrisSessionRow) (*Superv
 		RestartThreshold: cfg.RestartThreshold,
 		StartedAt:        sess.StartedAt,
 		PiSessionPath:    cfg.SessionContinuePath,
+		// BareRoot must be populated here so the D-5/D-7 credential broker can
+		// resolve the role-scoped GITHUB_TOKEN for bash subprocesses run by a
+		// restored session. Without this, restored sessions would always fall
+		// back to host GITHUB_TOKEN — a silent credential downgrade. Mirrors
+		// the spawn and daemon paths in cmd/iris/main.go.
+		BareRoot: cfg.BareRoot,
 	}
 
 	// Create session run directory (may already exist from previous incarnation).

--- a/modules/programs/prism/prism/internal/iris/restore_bareroot_test.go
+++ b/modules/programs/prism/prism/internal/iris/restore_bareroot_test.go
@@ -1,0 +1,77 @@
+package iris
+
+// restore_bareroot_test.go — D-7 regression test: the restore path must
+// populate SessionRecord.BareRoot so the credential broker can resolve the
+// role-scoped GITHUB_TOKEN for bash subprocesses run by a restored session.
+//
+// Without this plumbing, restored sessions would silently downgrade to the
+// host GITHUB_TOKEN fallback every time the daemon restarts — a credential
+// downgrade with no visible symptom until tools start failing on private
+// repos.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestNewRestoreSupervisor_PopulatesBareRoot constructs a restore supervisor
+// directly and asserts that the resulting SessionRecord has BareRoot set
+// from the SupervisorConfig.
+func TestNewRestoreSupervisor_PopulatesBareRoot(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	const wantBareRoot = "/path/to/fake/bare-root"
+
+	cfg := SupervisorConfig{
+		SessionName:      "test@restore-bareroot",
+		Worktree:         tmp,
+		Role:             "worker",
+		BareRoot:         wantBareRoot,
+		PIBinaryPath:     "/bin/true",
+		RestartThreshold: 1,
+		RunDir:           tmp,
+		Database:         database,
+	}
+
+	sess := db.IrisSessionRow{
+		InstanceID:  "test-instance-id",
+		SessionName: "test@restore-bareroot",
+		Worktree:    tmp,
+		Role:        "worker",
+		StartedAt:   time.Now(),
+	}
+
+	// Insert the sessions row so the supervisor's later DB writes do not
+	// violate FK constraints — newRestoreSupervisor itself does not write,
+	// but it calls IrisUpdateSessionState which requires the row to exist.
+	if err := database.InsertSession(db.Session{
+		InstanceID:  sess.InstanceID,
+		SessionName: sess.SessionName,
+		Worktree:    sess.Worktree,
+		Harness:     "pi",
+		StartedAt:   sess.StartedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	sup, err := newRestoreSupervisor(cfg, sess)
+	if err != nil {
+		t.Fatalf("newRestoreSupervisor: %v", err)
+	}
+	defer sup.harness.Close()
+
+	got := sup.SessionRecord().BareRoot
+	if got != wantBareRoot {
+		t.Errorf("SessionRecord.BareRoot = %q; want %q (restore path must propagate BareRoot from SupervisorConfig)",
+			got, wantBareRoot)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/tool_dispatcher.go
+++ b/modules/programs/prism/prism/internal/iris/tool_dispatcher.go
@@ -58,9 +58,33 @@ type toolDispatcher struct {
 	// bareRoot is the bare git repository root, used to derive the GitHub
 	// account for the 4-PAT token selection.
 	bareRoot   string
+	// broker resolves per-call credentials for tool subprocesses (D-7).
+	// May be nil in legacy tests; callers should populate it from the harness.
+	broker     *CredentialBroker
 	writer     *jsonlWriter
 	abortCh    <-chan struct{}
 	toolExecID string
+}
+
+// CredentialNamesForTool returns the audit-only credential names that would
+// be injected into a subprocess for the named tool, given the dispatcher's
+// role and bareRoot. Used by the harness socket server to populate the
+// `credentials_injected` field on tool_call events before dispatch runs.
+//
+// The list mirrors what dispatch() will actually inject; it is computed by
+// asking the broker, not by re-implementing the policy here.
+func (d *toolDispatcher) CredentialNamesForTool(toolName string) []string {
+	broker := d.broker
+	if broker == nil {
+		broker = NewCredentialBroker()
+	}
+	switch toolName {
+	case "bash":
+		return broker.ResolveBash(d.role, d.bareRoot).Names
+	default:
+		// File tools and any unknown tool: no credentials injected.
+		return nil
+	}
 }
 
 // dispatch selects and runs the appropriate tool executor for the frame.


### PR DESCRIPTION
D-7 of the iris daemon-mode rollout. Builds on D-5 (#1636) which landed the
bash sandbox and inline credential injection — this change extracts the
inline logic into a first-class `iris.CredentialBroker`, adds per-call audit
logging, an `iris stats credentials` subcommand, and a documented credential
model.

## What this changes

- **`internal/iris/credential_broker.go`** — new `CredentialBroker` type
  owning credential resolution for tool subprocesses. `ResolveBash` returns
  both the env-var list (what reaches the subprocess) and an audit-only
  name list (what we record against the corresponding `tool_call` event).
- **`internal/iris/bash_credentials.go`** — reduced to a thin shim around
  the broker so existing callers (`bash_sandbox_{linux,darwin}.go`) keep
  working without touching their signatures. The Linux and Darwin sandbox
  builders also now query the dispatcher's broker directly so credential
  resolution stays consistent with the audit-log decision.
- **`internal/iris/harness_socket.go`** — `dispatchToolExec` asks the
  broker which credentials are about to be injected and records the names
  on the `tool_call` event payload (`credentials_injected` JSON array)
  before dispatch runs. Also writes `agent_role` for context.
- **`cmd/iris/stats.go`** — new `iris stats credentials <session>`
  subcommand prints one line per `tool_call` event with the credential
  names that were injected. Names only — never values.
- **`docs/iris-credential-model.md`** — operator-facing reference covering
  the credential matrix per tool, the source of each credential, the
  audit-logging surface, and the fallback decision table.

## Restore-path fix (D-5 watch-out)

The D-5 cycle-4 fix added `BareRoot` population on `SupervisorConfig` in
three places, including `restore.go`. But the corresponding `SessionRecord`
in `newRestoreSupervisor` was never updated — so the harness-socket bash
dispatcher saw an empty `bareRoot` for any restored session and silently
downgraded every GITHUB_TOKEN to the host fallback. Fixed with a
regression test (`TestNewRestoreSupervisor_PopulatesBareRoot`).

## Exhaustive negative tests

- Every key on the forbidden LLM API key list (`ANTHROPIC_API_KEY`,
  `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`,
  `GOOGLE_API_KEY`, `GITHUB_COPILOT_TOKEN`, `DEEPSEEK_API_KEY`) is
  asserted absent from the bash subprocess env even when set on the host.
- No raw `PRISM_GITHUB_TOKEN_*` env var is ever propagated — only the
  resolved `GITHUB_TOKEN`.
- Linux mount layout (`bashToolMountsLinux`) and Darwin SBPL profile
  (`GenerateBashSBPLProfile`) assert no pi-process credential path is ever
  referenced (`~/.claude`, `~/.mcp-auth`, `~/.pi/agent/*`, `~/.cache/bun`,
  `~/.config/pi/*`).
- Edge cases:
  - Role-scoped token unset, host `GITHUB_TOKEN` set → fallback; audit
    name is `GITHUB_TOKEN(fallback:host)`.
  - Neither token present → no `GITHUB_TOKEN` in env, no `GITHUB_TOKEN`
    audit name, no error.
  - Empty / unknown role → treated as no-role; falls through to host
    fallback. No crash.
  - AWS files absent on host → no `AWS_*` audit name; `AWS_CONFIG_FILE`
    and `AWS_SHARED_CREDENTIALS_FILE` still set (harmless) so the env
    shape stays stable.
- Harness-level test confirms the `tool_call` payload contains
  `credentials_injected` as a JSON array end-to-end.

## Quality gates

```
cd modules/programs/prism/prism
go build ./...
go test ./... -race    # all pass

# from repo root
nix build .#iris       # success
nix build --impure --no-link --expr \
  '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
                       # success — homeless-shelter signal preserved
```

Refs #1625
Closes #1638
Refs #1636 (D-5, the structural predecessor)