### PR TITLE
Add hubble to kubetools module

### DIFF
--- a/modules/programs/kubetools.nix
+++ b/modules/programs/kubetools.nix
@@ -25,6 +25,7 @@ in
         home-manager.users.${username} = {
           home.packages = with pkgs; [
             fluxcd
+            hubble
             krew
             kubectl
             kubelogin


### PR DESCRIPTION
Added the Hubble CLI tool to the list of installed Kubernetes packages within the kubetools module. This change ensures that Hubble is available in the user environment for improved network observability and debugging in Kubernetes clusters.