### PR TITLE
iris: systemd user service + launchd user agent for auto-start

### DIFF
--- a/modules/programs/iris/default.nix
+++ b/modules/programs/iris/default.nix
@@ -9,15 +9,31 @@ let
   username = config.nx.username;
   homeDir = config.home-manager.users.${username}.home.homeDirectory;
 
-  # Canonical per-user socket path. Aligned with the default that the iris Go
-  # binary resolves in `internal/iris/paths.go` (`$XDG_STATE_HOME/iris/iris.sock`,
-  # which on a default home defaults to `~/.local/state/iris/iris.sock`). The
-  # env var is therefore redundant rather than required — see issue #1663.
+  # NOTE on the daemon's socket path and IRIS_DAEMON_SOCK
+  # ---------------------------------------------------------------------------
+  # An earlier revision of this module set `IRIS_DAEMON_SOCK` in the daemon's
+  # service environment, mirroring the wording of issue #1663. That was wrong.
   #
-  # macOS does not export `XDG_RUNTIME_DIR`, so we use the same XDG_STATE_HOME
-  # path on both platforms to keep the contract uniform. Clients dial
-  # `IRIS_DAEMON_SOCK` and get the same answer regardless of OS.
-  irisDaemonSock = "${homeDir}/.local/state/iris/iris.sock";
+  # In the iris codebase, `IRIS_DAEMON_SOCK` is **not** the daemon's bind
+  # address: the daemon resolves its bind path purely from XDG_STATE_HOME via
+  # `internal/iris/paths.go::ResolvePaths()`, and all in-tree clients
+  # (`cmd/iris/{main,tui,stats}.go`) use the same `ResolvePaths().Sock` —
+  # never `os.Getenv("IRIS_DAEMON_SOCK")`. The env var is reserved for a
+  # different role: the daemon sets it on each pi child it spawns, pointing
+  # at that child's per-session **harness** socket. The prism extension reads
+  # it as a trigger to register iris tool overrides and to dial the harness
+  # socket. See `internal/iris/supervisor.go` (writer) and
+  # `modules/programs/prism/pi/extensions/prism.ts` (reader), and
+  # `docs/daemon-mode-design.md` §3.4 for the explicit contract.
+  #
+  # If we exported `IRIS_DAEMON_SOCK=<daemon client socket>` in the daemon's
+  # service environment, and that value ever escaped into a user login shell
+  # (e.g. via `systemctl --user import-environment` on Linux, or any pi
+  # process inheriting it from launchd on Darwin), the prism extension would
+  # dial the daemon's client socket as if it were a harness socket — wrong
+  # protocol, wrong endpoint. The conservative fix is to leave the env var
+  # unset on the daemon side and rely on the binary's XDG-derived default.
+  # Clients do the same; the contract is path-based, not env-var-based.
 in
 {
   options = {
@@ -46,12 +62,8 @@ in
             ExecStart = "${pkgs.iris}/bin/iris daemon";
             Restart = "on-failure";
             RestartSec = 5;
-            # Export the canonical socket path so anything the daemon spawns
-            # (and any login shell that inherits this env via `systemctl --user
-            # show-environment`) agrees with the daemon's bind path.
-            Environment = [
-              "IRIS_DAEMON_SOCK=${irisDaemonSock}"
-            ];
+            # Intentionally no Environment= block. See the comment at the top
+            # of this file for why `IRIS_DAEMON_SOCK` is *not* set here.
           };
 
           Install = {
@@ -76,9 +88,8 @@ in
             KeepAlive = {
               SuccessfulExit = false;
             };
-            EnvironmentVariables = {
-              IRIS_DAEMON_SOCK = irisDaemonSock;
-            };
+            # Intentionally no EnvironmentVariables block. See the comment at
+            # the top of this file for why `IRIS_DAEMON_SOCK` is *not* set here.
             # launchd has no journal — capture stdout/stderr to per-user logs.
             StandardOutPath = "${homeDir}/Library/Logs/iris/stdout.log";
             StandardErrorPath = "${homeDir}/Library/Logs/iris/stderr.log";

--- a/modules/programs/iris/default.nix
+++ b/modules/programs/iris/default.nix
@@ -6,6 +6,18 @@
 }:
 let
   cfg = config.nx.programs.iris;
+  username = config.nx.username;
+  homeDir = config.home-manager.users.${username}.home.homeDirectory;
+
+  # Canonical per-user socket path. Aligned with the default that the iris Go
+  # binary resolves in `internal/iris/paths.go` (`$XDG_STATE_HOME/iris/iris.sock`,
+  # which on a default home defaults to `~/.local/state/iris/iris.sock`). The
+  # env var is therefore redundant rather than required — see issue #1663.
+  #
+  # macOS does not export `XDG_RUNTIME_DIR`, so we use the same XDG_STATE_HOME
+  # path on both platforms to keep the contract uniform. Clients dial
+  # `IRIS_DAEMON_SOCK` and get the same answer regardless of OS.
+  irisDaemonSock = "${homeDir}/.local/state/iris/iris.sock";
 in
 {
   options = {
@@ -17,8 +29,62 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users.${config.nx.username} = {
-      home.packages = [ pkgs.iris ];
-    };
+    home-manager.users.${username} = lib.mkMerge [
+      {
+        home.packages = [ pkgs.iris ];
+      }
+
+      # ── Linux: systemd user service ─────────────────────────────────────────
+      (lib.mkIf pkgs.stdenv.isLinux {
+        systemd.user.services.iris = {
+          Unit = {
+            Description = "iris daemon — daemon-supervised pi RPC + per-tool sandboxing";
+          };
+
+          Service = {
+            Type = "simple";
+            ExecStart = "${pkgs.iris}/bin/iris daemon";
+            Restart = "on-failure";
+            RestartSec = 5;
+            # Export the canonical socket path so anything the daemon spawns
+            # (and any login shell that inherits this env via `systemctl --user
+            # show-environment`) agrees with the daemon's bind path.
+            Environment = [
+              "IRIS_DAEMON_SOCK=${irisDaemonSock}"
+            ];
+          };
+
+          Install = {
+            WantedBy = [ "default.target" ];
+          };
+        };
+      })
+
+      # ── Darwin: launchd user agent ──────────────────────────────────────────
+      (lib.mkIf pkgs.stdenv.isDarwin {
+        launchd.agents.iris = {
+          enable = true;
+          config = {
+            Label = "local.iris.daemon";
+            ProgramArguments = [
+              "${pkgs.iris}/bin/iris"
+              "daemon"
+            ];
+            RunAtLoad = true;
+            # Restart on crash but not on clean exit — `iris daemon` exiting 0
+            # is an explicit shutdown request and should not loop.
+            KeepAlive = {
+              SuccessfulExit = false;
+            };
+            EnvironmentVariables = {
+              IRIS_DAEMON_SOCK = irisDaemonSock;
+            };
+            # launchd has no journal — capture stdout/stderr to per-user logs.
+            StandardOutPath = "${homeDir}/Library/Logs/iris/stdout.log";
+            StandardErrorPath = "${homeDir}/Library/Logs/iris/stderr.log";
+          };
+        };
+      })
+    ];
   };
 }


### PR DESCRIPTION
## Summary

Extends `modules/programs/iris/default.nix` so that enabling `nx.programs.iris.enable = true` on a host also installs a user-level service that auto-starts the iris daemon on login and restarts it on crash. Enables the post-D-10 battle-testing window without manual `iris daemon &` invocations on every reboot.

### Linux — systemd user service

- `ExecStart = ${pkgs.iris}/bin/iris daemon`
- `WantedBy = default.target` (starts on user login)
- `Restart = on-failure`, `RestartSec = 5`
- Journal logging (no explicit redirection — `journalctl --user -u iris`)
- `Description = iris daemon — daemon-supervised pi RPC + per-tool sandboxing`
- No `BindsTo` / `Requires` — daemon is self-contained
- **No `Environment=` block** — see "Note on `IRIS_DAEMON_SOCK`" below

### Darwin — launchd user agent

- `Label = local.iris.daemon`
- `ProgramArguments = [ iris, daemon ]`
- `RunAtLoad = true`
- `KeepAlive.SuccessfulExit = false` (restart on crash; clean `exit 0` is treated as an explicit shutdown)
- `StandardOutPath = ~/Library/Logs/iris/stdout.log`
- `StandardErrorPath = ~/Library/Logs/iris/stderr.log`
- **No `EnvironmentVariables` block** — see "Note on `IRIS_DAEMON_SOCK`" below

### Note on `IRIS_DAEMON_SOCK` (deviation from issue text)

Issue #1663 calls for setting `IRIS_DAEMON_SOCK` in the daemon's service environment, on the assumption that it names the daemon's bind socket. **This assumption is wrong with respect to the actual iris codebase**, as surfaced by round-1 review-context. In the iris codebase:

- The daemon resolves its bind path from `XDG_STATE_HOME` via `internal/iris/paths.go::ResolvePaths()`. It does not read `IRIS_DAEMON_SOCK`.
- All in-tree clients (`cmd/iris/main.go`, `cmd/iris/tui.go`, `cmd/iris/stats.go`) dial the same `ResolvePaths().Sock` — never `os.Getenv("IRIS_DAEMON_SOCK")`.
- The single Go writer of `IRIS_DAEMON_SOCK` is `internal/iris/supervisor.go:378`, which sets it on **pi child processes** the daemon spawns, pointing at that session's per-session **harness** socket (a different protocol).
- The single TS reader is `modules/programs/prism/pi/extensions/prism.ts:1999`, which uses it as a trigger to register iris tool overrides and dial the harness socket.
- `docs/daemon-mode-design.md` §3.4 makes this contract explicit: *"users opt out of iris control by ensuring `IRIS_DAEMON_SOCK` is not set in their environment."*

If the daemon's service environment exported `IRIS_DAEMON_SOCK=~/.local/state/iris/iris.sock` and that value escaped into a user login shell (e.g. via `systemctl --user import-environment` on Linux, or any pi process inheriting it from launchd on Darwin), the prism extension would dial the daemon's client socket as if it were a harness socket — wrong protocol, wrong endpoint. So we leave the env var unset on the daemon side and rely on the path-based default; the rationale is captured in a top-of-file comment for future readers. The "On both platforms, `IRIS_DAEMON_SOCK`… matches the documented per-user socket path" AC in #1663 is therefore not literally satisfied, and the user/coordinator may wish to amend the issue text to reflect the correct contract.

This change is consistent with the spawn-prompt clarification: *"If the iris binary already encodes a default socket path in Go, align the unit-file env var with that default so the env var is redundant rather than required."* The binary does encode the default; the env var is redundant; we omit it.

## Generated Linux unit (sanity check)

```
[Install]
WantedBy=default.target

[Service]
ExecStart=/nix/store/…-iris-0.1.0-d8/bin/iris daemon
Restart=on-failure
RestartSec=5
Type=simple

[Unit]
Description=iris daemon — daemon-supervised pi RPC + per-tool sandboxing
```

## Acceptance Criteria

Cross-platform live-host verification is the user's job at PR-review time (per the issue's verification approach). What this worker has verified is marked `[built]`; runtime checks remain `[pending user verification]`.

- [x] [built] When `nx.programs.iris.enable = true` is set on a Linux host, `nh switch` installs a `systemd.user.services.iris` unit definition. *(Built `.#nixosConfigurations.navi.config.system.build.toplevel` locally — `iris.service.drv` builds and the rendered unit file matches the spec.)*
- [ ] [pending user verification] On the Linux host, after `nh switch`, `systemctl --user is-active iris` returns `active`.
- [ ] [pending user verification] On the Linux host, after a reboot, `systemctl --user is-active iris` returns `active` without manual intervention.
- [ ] [pending user verification] On the Linux host, killing the daemon process results in the unit restarting within 10 seconds; `is-active` returns `active` again.
- [ ] [pending user verification] On the Linux host, `journalctl --user -u iris` returns the daemon's stdout/stderr output.
- [x] [built] When `nx.programs.iris.enable = true` is set on a Darwin host, `nh switch` installs a launchd user agent. *(Validated by type-checking the Darwin branch via a synthetic `home-manager.lib.homeManagerConfiguration` eval on `aarch64-darwin` — the rendered plist contains `Label=local.iris.daemon`, `RunAtLoad=true`, `KeepAlive.SuccessfulExit=false`, and the log paths.)*
- [ ] [pending user verification] On the Darwin host, after reboot + user login, `launchctl list local.iris.daemon` shows the daemon running.
- [ ] [pending user verification] On the Darwin host, killing the daemon results in launchd restarting it within 10 seconds.
- [ ] ~~[functional] On both platforms, the `IRIS_DAEMON_SOCK` environment variable in the daemon's process environment matches the documented per-user socket path.~~ **Intentionally not satisfied** — see "Note on `IRIS_DAEMON_SOCK`" above. The daemon and clients agree on the path via the XDG-derived default in `internal/iris/paths.go`; the env var is reserved for the per-session harness-socket role and must not leak into a user login shell.
- [ ] [pending user verification] Applying `nh switch` twice in a row with no changes is idempotent and does not restart the daemon. *(Home Manager hashes unit content; no manual intervention required from this module.)*
- [ ] [pending user verification] Applying `nh switch` with a changed unit definition restarts the daemon; sessions restore cleanly via D-9.
- [x] [edge-case, built] When `nx.programs.iris.enable = false`, neither the systemd unit nor the launchd agent is installed. *(Whole module body is under `lib.mkIf cfg.enable`; no traces leak.)*
- [x] [built] Unit / agent definitions live in `modules/programs/iris/default.nix`. No changes to `modules/programs/prism/`.
- [x] [built] `nixfmt .` passes on the changed file.
- [x] [built] PR body includes `Closes #1663`. No reference to #1625.

## Notes for the user / coordinator

- iris is already enabled on `navi` (`machines/navi/configuration.nix:35`). The next `nh switch` on navi will pick the unit up — no machine-config change needed.
- The Darwin host (`m4mac`) does not currently set `nx.programs.iris.enable = true`. Verifying the Darwin ACs requires the user to flip that flag on m4mac as part of testing.
- Round 1 review found a semantic misuse of `IRIS_DAEMON_SOCK` (verdict: 4 PASS, 1 FAIL on review-context); round 2 drops the env-var entirely and documents the rationale in-source. See the "Note on `IRIS_DAEMON_SOCK`" section above for the full reasoning.

Closes #1663
