### PR TITLE
iris: Restart=always on systemd user unit

### DIFF
--- a/modules/programs/iris/default.nix
+++ b/modules/programs/iris/default.nix
@@ -87,11 +87,14 @@ in
               "daemon"
             ];
             RunAtLoad = true;
-            # Restart on crash but not on clean exit — `iris daemon` exiting 0
-            # is an explicit shutdown request and should not loop.
-            KeepAlive = {
-              SuccessfulExit = false;
-            };
+            # KeepAlive = true: launchd analogue of Restart=always.
+            # Always restart the daemon, regardless of exit code. Clean exit 0
+            # from SIGTERM, internal os.Exit(0), or any other graceful path
+            # still triggers a restart — the daemon should be up whenever the
+            # user is logged in. The "keep it down" verbs are
+            # `launchctl unload` / `launchctl bootout` / `launchctl stop`,
+            # not a clean exit.
+            KeepAlive = true;
             # Intentionally no EnvironmentVariables block. See the comment at
             # the top of this file for why `IRIS_DAEMON_SOCK` is *not* set here.
             # launchd has no journal — capture stdout/stderr to per-user logs.

--- a/modules/programs/iris/default.nix
+++ b/modules/programs/iris/default.nix
@@ -60,7 +60,11 @@ in
           Service = {
             Type = "simple";
             ExecStart = "${pkgs.iris}/bin/iris daemon";
-            Restart = "on-failure";
+            # Always restart — iris is an always-up user daemon, so even a
+            # clean SIGTERM exit (e.g. `systemctl --user kill iris`) should
+            # bring it back. `systemctl --user stop iris` remains the explicit
+            # "keep it down" verb and is unaffected.
+            Restart = "always";
             RestartSec = 5;
             # Intentionally no Environment= block. See the comment at the top
             # of this file for why `IRIS_DAEMON_SOCK` is *not* set here.


### PR DESCRIPTION
Flip the iris service from `Restart=on-failure` / `KeepAlive.SuccessfulExit = false` to `Restart=always` / `KeepAlive = true` on Linux and Darwin respectively.

`on-failure` does not restart on clean SIGTERM-then-exit-0, so `systemctl --user kill iris` (default signal: SIGTERM, which the daemon traps and exits 0 from) leaves the daemon down. iris is an always-up user daemon; `always` is the correct semantic. `systemctl --user stop iris` (and `launchctl unload` / `launchctl bootout` / `launchctl stop` on Darwin) remain the explicit "keep it down" verbs under either policy.

**Darwin had the same bug.** The original PR rationale (and issue #1666's "Fix" section) claimed `KeepAlive = { SuccessfulExit = false; }` was already the launchd analogue of `Restart=always`. That was wrong — per `launchd.plist(5)`, `SuccessfulExit = false` restarts only on non-zero exit, i.e. the analogue of `Restart=on-failure`. Caught by review-context on round 1. Darwin is now flipped to `KeepAlive = true`, which is the genuine launchd analogue of `Restart=always`. Both platforms now have identical always-up semantics, and issue #1666 has been edited to reflect the corrected understanding.

## AC status

- [x] [functional] `modules/programs/iris/default.nix` sets `Restart = "always"` on the iris systemd unit (was `"on-failure"`).
- [x] [functional] Darwin launchd agent: `KeepAlive` changed from `{ SuccessfulExit = false; }` to `true`. The pre-existing `SuccessfulExit = false` was the launchd analogue of `Restart=on-failure` (per `launchd.plist(5)`), not `Restart=always` — so Darwin had the same kill-leaves-daemon-down bug as Linux. This flip brings the two platforms back in sync.
- [ ] [functional] On a Linux host with iris enabled, after `nh switch` and `systemctl --user kill iris`, `systemctl --user is-active iris` returns `active` within 10 seconds. **[pending user verification]** — requires a host with iris enabled; coordinator will exercise on navi after merge.
- [x] [functional] `nixfmt .` passes on the changed `.nix` file.
- [x] [functional] The PR body includes `Closes #1666`.

Closes #1666
