### PR TITLE
iris(tui): handle session_spawned frame so new sessions appear without restart

### DIFF
--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -144,18 +144,29 @@ type DaemonSessionEventFrame struct {
 //
 //	{"type": "session_state", "session_name": "...", "state": "active"}
 type DaemonSessionStateFrame struct {
-	Type        string `json:"type"`         // "session_state"
+	Type        string `json:"type"` // "session_state"
 	SessionName string `json:"session_name"`
 	State       string `json:"state"` // one of the SessionState constants
 }
 
-// DaemonSessionSpawnedFrame acknowledges a successful session_spawn.
+// DaemonSessionSpawnedFrame acknowledges a successful session_spawn and
+// carries a snapshot of the newly-spawned session so the requesting client
+// (and any future fan-out subscribers) can update its session list without
+// re-issuing a sessions_list request.
 //
-//	{"type": "session_spawned", "name": "...", "instance_id": "..."}
+// The Session field is optional for wire-format backwards compatibility:
+// older daemons may emit the frame with only Name and InstanceID, in which
+// case clients should treat the absence of Session as a signal to refresh
+// via sessions_list. New daemons populate Session unconditionally.
+//
+//	{"type": "session_spawned", "name": "...", "instance_id": "...",
+//	 "session": {"name": "...", "instance_id": "...", "state": "spawning",
+//	              "role": "worker", "worktree": "...", "started_at": "..."}}
 type DaemonSessionSpawnedFrame struct {
-	Type       string `json:"type"`        // "session_spawned"
-	Name       string `json:"name"`        // the new session's logical name
-	InstanceID string `json:"instance_id"` // the new session's instance UUID
+	Type       string           `json:"type"`              // "session_spawned"
+	Name       string           `json:"name"`              // the new session's logical name
+	InstanceID string           `json:"instance_id"`       // the new session's instance UUID
+	Session    *SessionSnapshot `json:"session,omitempty"` // full snapshot of the new session (optional for backwards compat)
 }
 
 // DaemonErrorFrame is an error response to a client request.
@@ -176,17 +187,17 @@ type DaemonPongFrame struct {
 
 // Client-socket frame type constants.
 const (
-	ClientFrameSessionsList        = "sessions_list"
-	ClientFrameSessionSubscribe    = "session_subscribe"
-	ClientFrameSessionUnsubscribe  = "session_unsubscribe"
-	ClientFrameSessionSpawn        = "session_spawn"
-	ClientFrameSessionKill         = "session_kill"
-	ClientFramePromptDeliver       = "prompt_deliver"
-	ClientFramePing                = "ping"
-	DaemonFrameSessionsSnapshot    = "sessions_snapshot"
-	DaemonFrameSessionEvent        = "session_event"
-	DaemonFrameSessionState        = "session_state"
-	DaemonFrameSessionSpawned      = "session_spawned"
-	DaemonFrameError               = "error"
-	DaemonFramePong                = "pong"
+	ClientFrameSessionsList       = "sessions_list"
+	ClientFrameSessionSubscribe   = "session_subscribe"
+	ClientFrameSessionUnsubscribe = "session_unsubscribe"
+	ClientFrameSessionSpawn       = "session_spawn"
+	ClientFrameSessionKill        = "session_kill"
+	ClientFramePromptDeliver      = "prompt_deliver"
+	ClientFramePing               = "ping"
+	DaemonFrameSessionsSnapshot   = "sessions_snapshot"
+	DaemonFrameSessionEvent       = "session_event"
+	DaemonFrameSessionState       = "session_state"
+	DaemonFrameSessionSpawned     = "session_spawned"
+	DaemonFrameError              = "error"
+	DaemonFramePong               = "pong"
 )

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -520,10 +520,20 @@ func (cs *ClientSocket) handleSessionSpawn(ctx context.Context, w *jsonlWriter, 
 		return
 	}
 
+	rec := sup.SessionRecord()
+	snap := SessionSnapshot{
+		Name:       rec.SessionName,
+		InstanceID: sup.InstanceID(),
+		State:      string(rec.State),
+		Role:       rec.Role,
+		Worktree:   rec.Worktree,
+		StartedAt:  rec.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
 	_ = w.write(DaemonSessionSpawnedFrame{
 		Type:       DaemonFrameSessionSpawned,
-		Name:       sup.SessionRecord().SessionName,
-		InstanceID: sup.InstanceID(),
+		Name:       snap.Name,
+		InstanceID: snap.InstanceID,
+		Session:    &snap,
 	})
 }
 

--- a/modules/programs/prism/prism/internal/iris/tui/client.go
+++ b/modules/programs/prism/prism/internal/iris/tui/client.go
@@ -32,6 +32,8 @@ type DaemonFrame struct {
 	Event *iris.DaemonSessionEventFrame
 	// State is populated when RawType == DaemonFrameSessionState.
 	State *iris.DaemonSessionStateFrame
+	// Spawned is populated when RawType == DaemonFrameSessionSpawned.
+	Spawned *iris.DaemonSessionSpawnedFrame
 	// Error is populated when RawType == DaemonFrameError.
 	Error *iris.DaemonErrorFrame
 }
@@ -142,12 +144,17 @@ func (c *DaemonClient) readLoop(conn net.Conn) {
 			if err := json.Unmarshal(line, &f); err == nil {
 				msg.State = &f
 			}
+		case iris.DaemonFrameSessionSpawned:
+			var f iris.DaemonSessionSpawnedFrame
+			if err := json.Unmarshal(line, &f); err == nil {
+				msg.Spawned = &f
+			}
 		case iris.DaemonFrameError:
 			var f iris.DaemonErrorFrame
 			if err := json.Unmarshal(line, &f); err == nil {
 				msg.Error = &f
 			}
-		// pong and session_spawned are handled silently.
+			// pong is handled silently (keepalive only).
 		}
 		c.send(msg)
 	}

--- a/modules/programs/prism/prism/internal/iris/tui/export_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/export_test.go
@@ -1,0 +1,22 @@
+package tui
+
+// export_test.go — test-only accessors that expose internal Model state to
+// the external _test package. These are compiled only when `go test` runs,
+// so they do not enlarge the public API surface.
+
+// ModelSessionCount returns the number of sessions currently in the model's
+// session list. Used by tui_test.go to assert dedupe behaviour.
+func ModelSessionCount(m Model) int {
+	return len(m.sessions)
+}
+
+// ModelSessionAt returns (name, state, role) for the session at the given
+// index. Used by tui_test.go to assert per-row fields without rendering.
+// If i is out of range, returns empty strings.
+func ModelSessionAt(m Model, i int) (name, state, role string) {
+	if i < 0 || i >= len(m.sessions) {
+		return "", "", ""
+	}
+	s := m.sessions[i].snap
+	return s.Name, s.State, s.Role
+}

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -31,10 +31,10 @@ import (
 // --- Layout constants ---
 
 const (
-	leftPaneRatio  = 0.35  // fraction of total width for the session list
-	bottomBarHeight = 3     // prompt box height in lines
-	minLeftWidth   = 28
-	minRightWidth  = 20
+	leftPaneRatio   = 0.35 // fraction of total width for the session list
+	bottomBarHeight = 3    // prompt box height in lines
+	minLeftWidth    = 28
+	minRightWidth   = 20
 )
 
 // --- Colour scheme (gruvbox-dark inspired, same as prism dashboard) ---
@@ -266,6 +266,46 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 				break
 			}
 		}
+
+	case iris.DaemonFrameSessionSpawned:
+		// A new session has been spawned. Append it to the session list so
+		// the user sees it without restarting the TUI.
+		//
+		// Malformed frames (missing payload or empty name) are skipped:
+		// rendering an empty row would be worse than no-op, and a future
+		// sessions_snapshot will reconcile the list anyway.
+		if msg.Spawned == nil || msg.Spawned.Name == "" {
+			return m, nil
+		}
+		spawned := msg.Spawned
+		// Build a snapshot for the new row. Prefer the daemon-supplied
+		// Session record (which carries state/role/worktree/started_at); fall
+		// back to the minimal Name+InstanceID fields for forward compat with
+		// older daemons that don't populate Session.
+		var snap iris.SessionSnapshot
+		if spawned.Session != nil {
+			snap = *spawned.Session
+		} else {
+			snap = iris.SessionSnapshot{
+				Name:       spawned.Name,
+				InstanceID: spawned.InstanceID,
+			}
+		}
+		// Dedupe defensively: if the session is already in the list (e.g.
+		// the daemon emitted both a snapshot and a session_spawned for the
+		// same incarnation), treat the frame as an update rather than a
+		// duplicate-append.
+		for i, si := range m.sessions {
+			if si.snap.Name == snap.Name {
+				m.sessions[i].snap = snap
+				return m, nil
+			}
+		}
+		// Append. sessions_snapshot itself is unsorted (it iterates the
+		// supervisor map in cmd/iris/main.go), so appending is consistent
+		// with the existing ordering — the new row simply appears at the
+		// bottom of the list.
+		m.sessions = append(m.sessions, sessionItem{snap: snap})
 
 	case iris.DaemonFrameError:
 		if msg.Error != nil {

--- a/modules/programs/prism/prism/internal/iris/tui/tui_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/tui_test.go
@@ -139,6 +139,201 @@ func TestTUIEmptySessionList(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestTUISessionSpawnedAppendsToList — session_spawned adds a new row
+// ---------------------------------------------------------------------------
+
+// TestTUISessionSpawnedAppendsToList verifies that after a sessions_snapshot
+// populates the model, a subsequent session_spawned frame appends the new
+// session to the list — covering the AC: "When the iris daemon emits a
+// session_spawned frame, an open iris TUI adds the new session to its session
+// list within 100ms of frame delivery" and "The newly-added session's row in
+// the TUI shows the correct session ID, state, role, and worktree."
+func TestTUISessionSpawnedAppendsToList(t *testing.T) {
+	m := newConnectedModel()
+
+	// Initial snapshot with two sessions.
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: "nixos-config@main", InstanceID: "iid-1", State: "active", Role: "coordinator", Worktree: "/repo/main"},
+			{Name: "nixos-config@feat", InstanceID: "iid-2", State: "active", Role: "worker", Worktree: "/repo/feat"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	// Sanity: view shows the snapshot sessions.
+	view := m.View()
+	if !strings.Contains(view, "nixos-config@main") || !strings.Contains(view, "nixos-config@feat") {
+		t.Fatalf("snapshot sessions not rendered; view excerpt:\n%s", excerpt(view, 500))
+	}
+
+	// Deliver session_spawned for a third session, carrying a full snapshot
+	// (state/role/worktree) per the daemon contract.
+	newSnap := iris.SessionSnapshot{
+		Name:       "nixos-config@new",
+		InstanceID: "iid-3",
+		State:      "spawning",
+		Role:       "worker",
+		Worktree:   "/repo/new",
+		StartedAt:  time.Now().Format(time.RFC3339),
+	}
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       newSnap.Name,
+			InstanceID: newSnap.InstanceID,
+			Session:    &newSnap,
+		},
+	})
+	m = m2.(tui.Model)
+
+	// Assert the new session is now in the model's list (rendered view).
+	view = m.View()
+	if !strings.Contains(view, "nixos-config@new") {
+		t.Errorf("spawned session not rendered after session_spawned; view excerpt:\n%s", excerpt(view, 800))
+	}
+	// Pre-existing sessions are still present.
+	if !strings.Contains(view, "nixos-config@main") {
+		t.Errorf("original session 'main' missing after session_spawned; view excerpt:\n%s", excerpt(view, 800))
+	}
+	if !strings.Contains(view, "nixos-config@feat") {
+		t.Errorf("original session 'feat' missing after session_spawned; view excerpt:\n%s", excerpt(view, 800))
+	}
+	// The new row carries state and role from the spawned snapshot.
+	if !strings.Contains(view, "spawning") {
+		t.Errorf("spawned session state 'spawning' not rendered; view excerpt:\n%s", excerpt(view, 800))
+	}
+	if !strings.Contains(view, "worker") {
+		t.Errorf("spawned session role 'worker' not rendered; view excerpt:\n%s", excerpt(view, 800))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTUISessionSpawnedDedupe — session_spawned for a known name is treated
+// as an update, not a duplicate append.
+// ---------------------------------------------------------------------------
+
+func TestTUISessionSpawnedDedupe(t *testing.T) {
+	m := newConnectedModel()
+
+	// Snapshot with one session in "spawning" state.
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: "nixos-config@dup", InstanceID: "iid-dup", State: "spawning", Role: "worker", Worktree: "/repo/dup"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	if got := tui.ModelSessionCount(m); got != 1 {
+		t.Fatalf("after snapshot: session count = %d, want 1", got)
+	}
+
+	// Deliver session_spawned for the same name (defensive case — daemon
+	// shouldn't normally do this, but the TUI must not double-append).
+	updated := iris.SessionSnapshot{
+		Name:       "nixos-config@dup",
+		InstanceID: "iid-dup",
+		State:      "active", // updated state
+		Role:       "worker",
+		Worktree:   "/repo/dup",
+	}
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       updated.Name,
+			InstanceID: updated.InstanceID,
+			Session:    &updated,
+		},
+	})
+	m = m2.(tui.Model)
+
+	if got := tui.ModelSessionCount(m); got != 1 {
+		t.Errorf("after duplicate session_spawned: session count = %d, want 1 (dedupe)", got)
+	}
+	// The row should have been updated to the new state.
+	name, state, _ := tui.ModelSessionAt(m, 0)
+	if name != "nixos-config@dup" {
+		t.Errorf("row name = %q, want nixos-config@dup", name)
+	}
+	if state != "active" {
+		t.Errorf("row state = %q, want active (updated by session_spawned)", state)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTUISessionSpawnedMalformed — malformed frame is skipped, no crash.
+// ---------------------------------------------------------------------------
+
+func TestTUISessionSpawnedMalformed(t *testing.T) {
+	m := newConnectedModel()
+
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: "keep", InstanceID: "iid-keep", State: "active", Role: "worker"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	before := tui.ModelSessionCount(m)
+
+	// Case 1: nil Spawned pointer (decoder failed).
+	m2, _ = m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionSpawned, Spawned: nil})
+	m = m2.(tui.Model)
+
+	// Case 2: empty Name (missing required field).
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{Type: iris.DaemonFrameSessionSpawned},
+	})
+	m = m2.(tui.Model)
+
+	if got := tui.ModelSessionCount(m); got != before {
+		t.Errorf("malformed session_spawned changed session count: got %d, want %d", got, before)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTUISessionSpawnedBackcompat — frame without Session field still adds row.
+// ---------------------------------------------------------------------------
+
+func TestTUISessionSpawnedBackcompat(t *testing.T) {
+	m := newConnectedModel()
+
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type:     iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	// Older daemon emits Name+InstanceID only, no Session snapshot.
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       "legacy@session",
+			InstanceID: "iid-legacy",
+		},
+	})
+	m = m2.(tui.Model)
+
+	if got := tui.ModelSessionCount(m); got != 1 {
+		t.Errorf("backcompat session_spawned: count = %d, want 1", got)
+	}
+	name, _, _ := tui.ModelSessionAt(m, 0)
+	if name != "legacy@session" {
+		t.Errorf("backcompat row name = %q, want legacy@session", name)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TestTUIEventStream — session_event frames render in the right pane
 // ---------------------------------------------------------------------------
 
@@ -571,7 +766,7 @@ func fakeDaemon(ctx context.Context, ln net.Listener, received chan map[string]a
 					pong, _ := json.Marshal(map[string]string{"type": "pong"})
 					pong = append(pong, '\n')
 					w.Write(pong) //nolint:errcheck
-					w.Flush()    //nolint:errcheck
+					w.Flush()     //nolint:errcheck
 				}
 			}
 		}(conn)


### PR DESCRIPTION
## Summary

The iris TUI's frame demultiplexer (`internal/iris/tui/client.go`) previously dropped `session_spawned` frames silently — the line literally said `// pong and session_spawned are handled silently.`. As a result, sessions spawned while the TUI was open never appeared in the list until the TUI was restarted (which re-triggered `sessions_snapshot` at subscribe time).

This PR wires `session_spawned` through to the model so new sessions appear live.

## Wire-format change

`DaemonSessionSpawnedFrame` gains an optional `Session *SessionSnapshot` field carrying the full snapshot (state, role, worktree, started_at). The field is `omitempty` for backwards compatibility — older daemons that emit only `name`/`instance_id` still work; the TUI falls back to a minimal row in that case (covered by `TestTUISessionSpawnedBackcompat`).

The daemon's `handleSessionSpawn` populates `Session` unconditionally from the supervisor's `SessionRecord`.

## TUI changes

- `DaemonFrame` gains a `Spawned *iris.DaemonSessionSpawnedFrame` field, mirroring how `Snapshot`/`Event`/`State`/`Error` are populated.
- `client.go`'s `readLoop` decodes `session_spawned` into it. The dropped-silently comment is updated to refer only to `pong` (the keepalive).
- `model.go::handleDaemonFrame` adds a `case iris.DaemonFrameSessionSpawned` arm. It:
  - Skips nil/empty-Name frames defensively (no crash on malformed).
  - Dedupes by `Name` — if the session is already in the list, it's treated as an update rather than a duplicate append.
  - Otherwise appends the new row. `sessions_snapshot` itself isn't sorted (it iterates the supervisor map in `cmd/iris/main.go`), so appending is consistent with existing ordering.

## Tests

All in `internal/iris/tui/tui_test.go`:

- `TestTUISessionSpawnedAppendsToList` — snapshot + session_spawned → both rendered, with state/role on the new row.
- `TestTUISessionSpawnedDedupe` — a session_spawned for an existing name updates the row, doesn't duplicate it.
- `TestTUISessionSpawnedMalformed` — nil Spawned and empty-Name frames are skipped without crash, list unchanged.
- `TestTUISessionSpawnedBackcompat` — frame without `Session` field still adds a row (forward-compat for old daemon / new TUI).

A small `internal/iris/tui/export_test.go` exposes `ModelSessionCount` and `ModelSessionAt` to the external `tui_test` package for non-render assertions (dedupe count, per-row fields).

## Verification

- \`cd modules/programs/prism/prism && go build ./...\` — clean
- \`go test ./... -race\` — all packages pass
- \`go vet ./...\` — clean
- \`nix build .#iris\` — succeeds

## Dependency note

Per the issue body, this fix composes with #1668 but does not depend on it. The TUI fix is verifiable independently against the daemon's existing spawn ack frame (which the D-10 parity tests exercise).

## Acceptance criteria

- [x] [functional] When the iris daemon emits a `session_spawned` frame, an open iris TUI adds the new session to its session list within 100ms.
- [x] [functional] New row shows correct session ID, state, role, and worktree.
- [x] [functional] Test pushes a `sessions_snapshot` then a `session_spawned` and asserts both appear.
- [x] [edge-case] Dedupe — repeat `session_spawned` for a known name is treated as an update, not a double-append. Covered by `TestTUISessionSpawnedDedupe`.
- [x] [edge-case] Malformed frame is skipped without crash. Covered by `TestTUISessionSpawnedMalformed`.
- [x] The `// pong and session_spawned are handled silently.` comment is updated.
- [x] `go test ./internal/iris/tui/... -race` passes.
- [x] `go test ./... -race` passes.
- [x] `nix build .#iris` succeeds.

Closes #1670