### PR TITLE
feat(iris): iris sessions list / iris sessions status CLI subcommands

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/iris/list_sessions.go
@@ -1,0 +1,228 @@
+package main
+
+// list_sessions.go — `iris sessions list` implementation.
+//
+// Renders the sessions_snapshot from the iris daemon as either a human-readable
+// table or a JSON array (--json). The JSON shape is the stable contract for
+// scripting and parity tests (#1669):
+//
+//	[
+//	  {
+//	    "id": "<full uuid>",
+//	    "state": "active",
+//	    "role": "coordinator",
+//	    "worktree": "/full/path/to/worktree",
+//	    "harness_session_id": "/home/ben/.pi/agent/.../uuid.jsonl",
+//	    "created_at": "2026-05-16T10:05:48Z",   // RFC3339
+//	    "uptime_seconds": 201
+//	  },
+//	  ...
+//	]
+//
+// Empty list renders as `[]` in JSON and as just the header row in the table.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// sessionListJSONRow is the stable JSON shape for `iris sessions list --json`.
+// Field names and types are AC-fixed: renames and removals are breaking
+// changes. Adding fields is fine.
+type sessionListJSONRow struct {
+	ID               string `json:"id"`
+	State            string `json:"state"`
+	Role             string `json:"role"`
+	Worktree         string `json:"worktree"`
+	HarnessSessionID string `json:"harness_session_id"`
+	CreatedAt        string `json:"created_at"`     // RFC3339
+	UptimeSeconds    int64  `json:"uptime_seconds"` // wall-clock since created_at
+	// Name is informational — useful for cross-referencing with the TUI
+	// and `iris spawn` output. Not in the AC's minimum field set but
+	// stable nonetheless.
+	Name string `json:"name"`
+}
+
+// Lipgloss colours: mirror the iris TUI palette so the CLI feels at home
+// with the TUI. Hard-coded here (rather than imported) because the TUI's
+// colour constants are package-private to internal/iris/tui.
+const (
+	cliColPrimary   = "#d79921" // yellow
+	cliColSecondary = "#928374" // grey
+)
+
+// runSessionsList is the cobra RunE for `iris sessions list`.
+func runSessionsList(cmd *cobra.Command, _ []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	sockPath := resolveSocketPath(cmd)
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	defer cancel()
+
+	snap, err := fetchSessionsSnapshot(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+
+	if jsonMode {
+		return renderSessionsListJSON(cmd.OutOrStdout(), snap.Sessions, time.Now())
+	}
+	return renderSessionsListTable(cmd.OutOrStdout(), snap.Sessions, time.Now())
+}
+
+// renderSessionsListJSON writes the stable JSON-array form of the snapshot to w.
+// `sessions` may be nil/empty — the output is then `[]`.
+//
+// `now` is parameterised so tests can pin uptime_seconds to a deterministic
+// value. Production callers pass time.Now().
+func renderSessionsListJSON(w io.Writer, sessions []iris.SessionSnapshot, now time.Time) error {
+	rows := make([]sessionListJSONRow, 0, len(sessions))
+	for _, s := range sessions {
+		var uptime int64
+		if t, err := time.Parse(time.RFC3339, s.StartedAt); err == nil {
+			d := now.Sub(t)
+			if d < 0 {
+				d = 0
+			}
+			uptime = int64(d.Seconds())
+		}
+		rows = append(rows, sessionListJSONRow{
+			ID:               s.InstanceID,
+			State:            s.State,
+			Role:             s.Role,
+			Worktree:         s.Worktree,
+			HarnessSessionID: s.HarnessSessionID,
+			CreatedAt:        s.StartedAt,
+			UptimeSeconds:    uptime,
+			Name:             s.Name,
+		})
+	}
+	// Marshal indented for readability — humans pipe `--json` into `jq`
+	// often enough that pretty-printing pays for itself, and parsers don't
+	// care.
+	data, err := json.MarshalIndent(rows, "", "  ")
+	if err != nil {
+		return fmt.Errorf("iris sessions list --json: marshal: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, string(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// renderSessionsListTable writes the human-readable table to w.
+//
+// Column widths are fixed so the output is grep-able. The SESSION column
+// shows a 12-char truncation of the UUID (mirrors git short-hash convention,
+// per the spec). WORKTREE shows the basename — the full path is in --json.
+func renderSessionsListTable(w io.Writer, sessions []iris.SessionSnapshot, now time.Time) error {
+	const (
+		wSession  = 12
+		wState    = 10
+		wRole     = 12
+		wWorktree = 24
+		wUptime   = 10
+	)
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(cliColSecondary))
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s",
+		wSession, "SESSION",
+		wState, "STATE",
+		wRole, "ROLE",
+		wWorktree, "WORKTREE",
+		wUptime, "UPTIME",
+	)
+	if _, err := fmt.Fprintln(w, styleHeader.Render(header)); err != nil {
+		return err
+	}
+
+	if len(sessions) == 0 {
+		// AC: empty list → header only, no body, no "no sessions" message.
+		return nil
+	}
+
+	stateStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(cliColPrimary))
+	for _, s := range sessions {
+		shortID := s.InstanceID
+		if len(shortID) > wSession {
+			shortID = shortID[:wSession]
+		}
+		state := truncateForColumn(s.State, wState)
+		role := truncateForColumn(s.Role, wRole)
+		worktreeBase := filepath.Base(s.Worktree)
+		if worktreeBase == "." || worktreeBase == "/" {
+			// Defensive: don't render an opaque "." for unusual paths.
+			worktreeBase = s.Worktree
+		}
+		worktree := truncateForColumn(worktreeBase, wWorktree)
+		uptime := formatUptime(s.StartedAt, now)
+
+		_, err := fmt.Fprintf(w, "%-*s  %s  %-*s  %-*s  %-*s\n",
+			wSession, shortID,
+			stateStyle.Render(fmt.Sprintf("%-*s", wState, state)),
+			wRole, role,
+			wWorktree, worktree,
+			wUptime, uptime,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// truncateForColumn truncates s to maxLen runes, appending "…" if it had to
+// drop characters. Returns the literal s when already short enough.
+func truncateForColumn(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen < 2 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-1] + "…"
+}
+
+// formatUptime renders the wall-clock duration since startedAt as a compact
+// string (`3m21s`, `1h04m`, `42s`). Returns "—" when startedAt is unparseable
+// or in the future.
+func formatUptime(startedAt string, now time.Time) string {
+	if startedAt == "" {
+		return "—"
+	}
+	t, err := time.Parse(time.RFC3339, startedAt)
+	if err != nil {
+		return "—"
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		return "—"
+	}
+	if d < time.Second {
+		return "<1s"
+	}
+	hours := int(d.Hours())
+	mins := int(d.Minutes()) % 60
+	secs := int(d.Seconds()) % 60
+	switch {
+	case hours > 0:
+		return fmt.Sprintf("%dh%02dm", hours, mins)
+	case mins > 0:
+		return fmt.Sprintf("%dm%02ds", mins, secs)
+	default:
+		return fmt.Sprintf("%ds", secs)
+	}
+}
+

--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -12,6 +12,8 @@
 //	iris daemon                                 — start the full daemon (client socket + sessions)
 //	iris spawn --worktree <path> [--role <role>] — spawn a pi session (no client socket)
 //	iris tui [--socket <path>]                  — open the bubbletea TUI
+//	iris sessions list [--json]                 — list daemon-tracked sessions (human or JSON)
+//	iris sessions status [--json]               — print session counts by state
 package main
 
 import (
@@ -268,12 +270,13 @@ func (ds *daemonState) activeSessions() []iris.SessionSnapshot {
 	for _, sup := range ds.supervisors {
 		rec := sup.SessionRecord()
 		out = append(out, iris.SessionSnapshot{
-			Name:       rec.SessionName,
-			InstanceID: rec.InstanceID,
-			State:      string(rec.State),
-			Role:       rec.Role,
-			Worktree:   rec.Worktree,
-			StartedAt:  rec.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+			Name:             rec.SessionName,
+			InstanceID:       rec.InstanceID,
+			State:            string(rec.State),
+			Role:             rec.Role,
+			Worktree:         rec.Worktree,
+			StartedAt:        rec.StartedAt.UTC().Format(time.RFC3339),
+			HarnessSessionID: rec.PiSessionPath,
 		})
 	}
 	return out

--- a/modules/programs/prism/prism/cmd/iris/sessions.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions.go
@@ -1,0 +1,221 @@
+package main
+
+// sessions.go — `iris sessions` subcommand group.
+//
+// Canonical commands:
+//
+//	iris sessions list           active session table (human-readable)
+//	iris sessions list --json    JSON array of session-status objects
+//	iris sessions status         single-line state counts
+//	iris sessions status --json  JSON object keyed by state with integer counts
+//
+// Both commands dial the iris daemon client socket (~/.local/state/iris/iris.sock
+// by default; override with --socket) and read the existing sessions_snapshot
+// frame (D-6). Neither command reads iris.db directly — the daemon is the
+// single source of truth for live session state.
+//
+// Out of scope for this command group (see #1669):
+//   - --all (no cross-repo model in iris)
+//   - --tmux-format on status (#1672)
+//   - sessions watch (use the TUI)
+//   - backward-compat aliases (iris is new; no legacy surface)
+//   - state/role/since filter flags
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// sessionsCmd is the parent of `iris sessions list` and `iris sessions status`.
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "Query and inspect iris daemon-tracked sessions",
+	Long: `Subcommand group for querying the iris daemon's session list.
+
+Both 'list' and 'status' dial the iris daemon client socket and read the
+existing sessions_snapshot frame — they do not read the iris DB directly.
+
+The daemon must be running ('iris daemon') for these commands to work; if it
+is not, they exit non-zero with a clear "is the iris daemon running?" error.`,
+}
+
+// sessionsListCmd implements `iris sessions list`.
+var sessionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List daemon-tracked sessions",
+	Long: `Print a table of sessions the iris daemon is currently tracking.
+
+Columns: SESSION (12-char UUID prefix), STATE, ROLE, WORKTREE (basename), UPTIME.
+The full UUID and full worktree path are available via --json.
+
+When no sessions are present, only the header row is printed (exit 0). This
+keeps the output trivially grep-able.`,
+	RunE: runSessionsList,
+	// Errors here are operational (daemon down, lost connection) — not
+	// usage errors — so suppress cobra's usage dump on failure. main.go
+	// already prints the error message to stderr; SilenceErrors stops cobra
+	// from also printing it (avoiding duplicate output).
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+// sessionsStatusCmd implements `iris sessions status`.
+var sessionsStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print iris session counts by state",
+	Long: `Print a one-line summary of daemon-tracked sessions grouped by state.
+
+Without flags: a single human-readable line, e.g.
+    active: 2  waiting: 0  finished: 1  error: 0
+
+With --json: a JSON object keyed by state with integer values, e.g.
+    {"active":2,"waiting":0,"idle":0,"finished":1,"error":0}`,
+	RunE:          runSessionsStatus,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	sessionsListCmd.Flags().Bool("json", false, "Emit a JSON array of session objects instead of the human-readable table")
+	sessionsListCmd.Flags().String("socket", "", "Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)")
+
+	sessionsStatusCmd.Flags().Bool("json", false, "Emit a JSON object keyed by state with integer counts")
+	sessionsStatusCmd.Flags().String("socket", "", "Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)")
+
+	sessionsCmd.AddCommand(sessionsListCmd)
+	sessionsCmd.AddCommand(sessionsStatusCmd)
+	rootCmd.AddCommand(sessionsCmd)
+}
+
+// daemonDialTimeout caps the time we spend trying to connect to the daemon
+// socket. The daemon is local so a healthy dial completes in microseconds; a
+// multi-second hang almost certainly means the daemon is not running and the
+// socket file is a stale leftover, or the daemon is wedged. Either way the
+// CLI should fail fast with a clear error rather than block indefinitely.
+const daemonDialTimeout = 2 * time.Second
+
+// daemonReadTimeout caps the time we wait for the sessions_snapshot response.
+// The daemon answers from in-memory state, so a healthy round trip is sub-ms.
+// A multi-second wait indicates the daemon is wedged or the connection has
+// dropped silently — fail fast with a clear error.
+const daemonReadTimeout = 5 * time.Second
+
+// resolveSocketPath returns --socket if set, otherwise the canonical iris
+// daemon socket path.
+func resolveSocketPath(cmd *cobra.Command) string {
+	if sock, _ := cmd.Flags().GetString("socket"); sock != "" {
+		return sock
+	}
+	return iris.ResolvePaths().Sock
+}
+
+// fetchSessionsSnapshot dials the iris daemon, sends a sessions_list frame,
+// and returns the decoded sessions_snapshot.
+//
+// Error categories (all wrapped with a fixed prefix for predictable grepping):
+//
+//   - "iris daemon not running" — socket file missing or connection refused.
+//     The user should run `systemctl --user start iris` (or the equivalent
+//     on Darwin).
+//   - "iris daemon: lost connection to daemon" — the dial succeeded but the
+//     read returned EOF / unexpected EOF / connection reset before a complete
+//     frame arrived.
+//   - "iris daemon: malformed response" — a line arrived but did not parse as
+//     a sessions_snapshot frame. Defensive: should not happen against a
+//     healthy daemon.
+//   - "iris daemon: unexpected error response: <msg>" — the daemon sent an
+//     error frame in response to sessions_list.
+func fetchSessionsSnapshot(ctx context.Context, sockPath string) (*iris.DaemonSessionsSnapshotFrame, error) {
+	// Phase 1: dial. We distinguish "socket not present" from "daemon
+	// refused us" so the operator sees the most useful error.
+	if _, err := os.Stat(sockPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("iris daemon not running: socket %s does not exist; start it with `systemctl --user start iris` (or `launchctl kickstart -k gui/$UID/iris` on Darwin)", sockPath)
+		}
+		// Other stat errors (permission etc.) are unusual but should
+		// surface verbatim.
+		return nil, fmt.Errorf("iris daemon: stat socket %s: %w", sockPath, err)
+	}
+
+	dialer := net.Dialer{Timeout: daemonDialTimeout}
+	conn, err := dialer.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		// At this point the socket file exists but the dial failed. Common
+		// causes: ECONNREFUSED (stale socket; daemon crashed without
+		// unlinking), ENOTSOCK (regular file at that path — someone created
+		// it manually), or permission denied. All map to the same operator
+		// remedy: start the daemon.
+		return nil, fmt.Errorf("iris daemon not running: cannot connect to %s (%v); start it with `systemctl --user start iris` (or `launchctl kickstart -k gui/$UID/iris` on Darwin)", sockPath, err)
+	}
+	defer conn.Close()
+
+	// Phase 2: send sessions_list.
+	req := iris.ClientSessionsListFrame{Type: iris.ClientFrameSessionsList}
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		// Marshalling a fixed struct cannot fail in practice; keep a
+		// defensive error path so misuse doesn't panic.
+		return nil, fmt.Errorf("iris daemon: marshal request: %w", err)
+	}
+	reqBytes = append(reqBytes, '\n')
+
+	_ = conn.SetWriteDeadline(time.Now().Add(daemonReadTimeout))
+	if _, err := conn.Write(reqBytes); err != nil {
+		return nil, fmt.Errorf("iris daemon: lost connection to daemon during request: %w", err)
+	}
+
+	// Phase 3: read frames until we get a sessions_snapshot. The daemon
+	// may send unrelated frames (none in normal flow, but be defensive).
+	_ = conn.SetReadDeadline(time.Now().Add(daemonReadTimeout))
+	r := bufio.NewReaderSize(conn, 4*1024*1024)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, fmt.Errorf("iris daemon: lost connection to daemon before response: %w", err)
+			}
+			// Includes net.Error timeouts.
+			return nil, fmt.Errorf("iris daemon: lost connection to daemon: %w", err)
+		}
+		// Decode the type discriminator first so we can route a stray
+		// error frame distinctly from a malformed payload.
+		var head struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(line, &head); err != nil {
+			return nil, fmt.Errorf("iris daemon: malformed response from daemon: %w", err)
+		}
+		switch head.Type {
+		case iris.DaemonFrameSessionsSnapshot:
+			var snap iris.DaemonSessionsSnapshotFrame
+			if err := json.Unmarshal(line, &snap); err != nil {
+				return nil, fmt.Errorf("iris daemon: malformed response from daemon: %w", err)
+			}
+			return &snap, nil
+		case iris.DaemonFrameError:
+			var ef iris.DaemonErrorFrame
+			if err := json.Unmarshal(line, &ef); err != nil {
+				return nil, fmt.Errorf("iris daemon: malformed response from daemon: %w", err)
+			}
+			return nil, fmt.Errorf("iris daemon: unexpected error response: %s", ef.Message)
+		default:
+			// Unknown frame: ignore and keep reading. The protocol comment
+			// in client_protocol.go states both sides must tolerate unknown
+			// types. Reset the read deadline so a flood of unknowns can't
+			// be used to slow us down past the original budget — we just
+			// extend per-frame.
+			continue
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/sessions_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions_integration_test.go
@@ -1,0 +1,257 @@
+package main
+
+// sessions_integration_test.go — integration tests for `iris sessions list`
+// and `iris sessions status` that exercise the real client-socket round-trip.
+//
+// These tests stand up an in-process iris.ClientSocket (the daemon's IPC
+// surface) backed by a synthetic session list, then drive fetchSessionsSnapshot
+// against it. The DB on disk is left empty so we exercise the AC:
+//
+//	"the command works correctly when the DB is not readable by the invoking
+//	 process but the client socket is."
+//
+// The negative case (daemon not running) is covered separately by pointing the
+// CLI at a non-existent socket path and asserting the documented error string.
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// startTestClientSocket starts an iris.ClientSocket on a tempdir socket path,
+// backed by `sessions`. Returns the socket path. The socket and its goroutines
+// are torn down on test cleanup.
+//
+// We open a throwaway DB at <tempdir>/iris.db purely to satisfy the
+// ClientSocketConfig contract — no rows are written. The DB is closed on
+// cleanup.
+func startTestClientSocket(t *testing.T, sessions []iris.SessionSnapshot) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	// Unix socket sun_path is 108 bytes; t.TempDir() under a long test
+	// name can blow that. Use a short MkdirTemp prefix for the socket
+	// itself and keep the throwaway DB in the regular tempdir.
+	shortPrefix := t.TempDir() // already short on most systems; if not, MkdirTemp would be needed.
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+	dbPath := filepath.Join(tmp, "iris.db")
+
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go cs.Serve(ctx)
+
+	return sockPath
+}
+
+// TestFetchSessionsSnapshot_RealSocket verifies the CLI's dial+request+parse
+// path against a real iris.ClientSocket carrying two synthetic sessions.
+// This is the positive integration test for the AC:
+//
+//	"queries the daemon over the client socket — does NOT read iris.db
+//	 directly."
+func TestFetchSessionsSnapshot_RealSocket(t *testing.T) {
+	sessions := []iris.SessionSnapshot{
+		{
+			Name:             "iris-test@coordinator",
+			InstanceID:       "abcd1234-0000-1111-2222-333333333333",
+			State:            "active",
+			Role:             "coordinator",
+			Worktree:         "/tmp/iris-test/.bare/main",
+			StartedAt:        time.Now().UTC().Add(-3 * time.Minute).Format(time.RFC3339),
+			HarnessSessionID: "/tmp/iris-test/.pi/agent/sessions/coord.jsonl",
+		},
+		{
+			Name:             "iris-test@worker",
+			InstanceID:       "feed1234-0000-1111-2222-444444444444",
+			State:            "waiting",
+			Role:             "worker",
+			Worktree:         "/tmp/iris-test/feature-x",
+			StartedAt:        time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339),
+			HarnessSessionID: "/tmp/iris-test/.pi/agent/sessions/worker.jsonl",
+		},
+	}
+	sockPath := startTestClientSocket(t, sessions)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	snap, err := fetchSessionsSnapshot(ctx, sockPath)
+	if err != nil {
+		t.Fatalf("fetchSessionsSnapshot: %v", err)
+	}
+	if len(snap.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(snap.Sessions))
+	}
+
+	// Build a name → snapshot map for order-independent assertions.
+	byName := map[string]iris.SessionSnapshot{}
+	for _, s := range snap.Sessions {
+		byName[s.Name] = s
+	}
+	coord, ok := byName["iris-test@coordinator"]
+	if !ok {
+		t.Fatalf("coordinator session missing from snapshot: %+v", snap.Sessions)
+	}
+	if coord.Role != "coordinator" || coord.State != "active" {
+		t.Errorf("coordinator snapshot mismatch: %+v", coord)
+	}
+	if coord.HarnessSessionID == "" {
+		t.Errorf("coordinator HarnessSessionID is empty: %+v", coord)
+	}
+}
+
+// TestFetchSessionsSnapshot_DaemonNotRunning verifies the documented error
+// when the socket file does not exist, per the AC:
+//
+//	"daemon not running → non-zero exit with a clear error pointing at
+//	 systemctl --user start iris, NOT a connection-refused stack trace."
+func TestFetchSessionsSnapshot_DaemonNotRunning(t *testing.T) {
+	// Point at a path inside a tempdir that we never create.
+	sockPath := filepath.Join(t.TempDir(), "definitely-not-here.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := fetchSessionsSnapshot(ctx, sockPath)
+	if err == nil {
+		t.Fatal("expected error when daemon not running, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "iris daemon not running") {
+		t.Errorf("error message must announce daemon-not-running condition: %q", msg)
+	}
+	if !strings.Contains(msg, "systemctl --user start iris") {
+		t.Errorf("error message must point at `systemctl --user start iris`: %q", msg)
+	}
+}
+
+// TestFetchSessionsSnapshot_StaleSocketRefused verifies that a socket file
+// existing without a listener (the daemon crashed without unlinking) maps
+// to the same "daemon not running" remedy. Implementation: bind a unix
+// socket then close the listener; the file lingers but connections refuse.
+func TestFetchSessionsSnapshot_StaleSocketRefused(t *testing.T) {
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "stale.sock")
+
+	// Create a stale socket file via os.Create — the stat check passes but
+	// the dial will hit ECONNREFUSED since nothing is listening.
+	f, err := os.Create(sockPath)
+	if err != nil {
+		t.Fatalf("create stale socket file: %v", err)
+	}
+	_ = f.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err = fetchSessionsSnapshot(ctx, sockPath)
+	if err == nil {
+		t.Fatal("expected error against stale socket, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "systemctl --user start iris") {
+		t.Errorf("stale socket error should still point at the start command: %q", msg)
+	}
+}
+
+// TestFetchSessionsSnapshot_MalformedResponse exercises the "malformed
+// response" branch. We stand up a unix-socket listener that responds with a
+// not-JSON line. The CLI must surface "malformed response" rather than hang.
+func TestFetchSessionsSnapshot_MalformedResponse(t *testing.T) {
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "bad.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Drain the client's sessions_list request before replying so the
+		// CLI doesn't see a write error before its read. A single line is
+		// enough; we don't validate the content.
+		buf := make([]byte, 4096)
+		_, _ = conn.Read(buf)
+		// Send a non-JSON line and close.
+		_, _ = conn.Write([]byte("this is not json\n"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err = fetchSessionsSnapshot(ctx, sockPath)
+	if err == nil {
+		t.Fatal("expected malformed-response error, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed response") {
+		t.Errorf("expected 'malformed response' in error, got %q", err.Error())
+	}
+}
+
+// TestFetchSessionsSnapshot_ConnectionDropMidResponse exercises the
+// "lost connection" branch. The server accepts the dial, then closes the
+// connection without writing any reply. The CLI must report "lost
+// connection" rather than hang.
+func TestFetchSessionsSnapshot_ConnectionDropMidResponse(t *testing.T) {
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "drop.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Drain the request, then close without writing a reply.
+		buf := make([]byte, 4096)
+		_, _ = conn.Read(buf)
+		_ = conn.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err = fetchSessionsSnapshot(ctx, sockPath)
+	if err == nil {
+		t.Fatal("expected lost-connection error, got nil")
+	}
+	if !strings.Contains(err.Error(), "lost connection") {
+		t.Errorf("expected 'lost connection' in error, got %q", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/sessions_status.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions_status.go
@@ -1,0 +1,129 @@
+package main
+
+// sessions_status.go — `iris sessions status` implementation.
+//
+// Prints state counts derived from the iris daemon's sessions_snapshot.
+// Without --json: one human-readable line padded across the canonical state
+// set (visual stability across invocations matters for shell aliases that
+// align several lines side by side).
+// With --json: a single JSON object keyed by state with integer counts.
+//
+// The canonical state set we report on is:
+//
+//	active, waiting, idle, finished, error
+//
+// Sessions whose `state` field doesn't match any canonical name are bucketed
+// into `idle` (defensive — should not happen in normal operation; matches
+// prism's behaviour). The `spawning` iris-internal state (pre-handshake)
+// is also folded into `active` for the human form because from an operator's
+// perspective "the session is starting up" is closer to active than to idle —
+// the JSON form preserves it as its own key only if a session is actually in
+// that state at the time of the snapshot.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// sessionStateCounts holds the per-state count totals. Keys correspond to the
+// canonical state names. New states added to iris will surface here without
+// code changes: any state we don't explicitly recognise lands in `other`,
+// which is rendered only when non-zero. The five canonical buckets are
+// always emitted so the JSON shape is stable.
+type sessionStateCounts struct {
+	Active   int `json:"active"`
+	Waiting  int `json:"waiting"`
+	Idle     int `json:"idle"`
+	Finished int `json:"finished"`
+	Error    int `json:"error"`
+	// Spawning is iris-specific (pre-handshake). Emitted only when >0 so
+	// scripts that key off the canonical five aren't surprised by an
+	// extra always-zero field; bucketed into Active in the human form.
+	Spawning int `json:"spawning,omitempty"`
+}
+
+// runSessionsStatus is the cobra RunE for `iris sessions status`.
+func runSessionsStatus(cmd *cobra.Command, _ []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	sockPath := resolveSocketPath(cmd)
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	defer cancel()
+
+	snap, err := fetchSessionsSnapshot(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+
+	counts := countStates(snap.Sessions)
+	if jsonMode {
+		return renderStatusJSON(cmd.OutOrStdout(), counts)
+	}
+	return renderStatusLine(cmd.OutOrStdout(), counts)
+}
+
+// countStates buckets each session into one of the canonical state counters.
+// Unknown states fall into Idle so the line form remains useful — operators
+// can spot the anomaly via the JSON shape if curious.
+func countStates(sessions []iris.SessionSnapshot) sessionStateCounts {
+	var c sessionStateCounts
+	for _, s := range sessions {
+		switch s.State {
+		case "active":
+			c.Active++
+		case "waiting":
+			c.Waiting++
+		case "idle":
+			c.Idle++
+		case "finished":
+			c.Finished++
+		case "error":
+			c.Error++
+		case "spawning":
+			c.Spawning++
+		default:
+			// Unknown — fold into idle for the human line so the total
+			// session count is still visible. The JSON form preserves
+			// the canonical keys and silently drops this session from
+			// the per-state view; this is the same defensive bucket
+			// prism uses.
+			c.Idle++
+		}
+	}
+	return c
+}
+
+// renderStatusJSON writes a single JSON object with integer state counts.
+func renderStatusJSON(w io.Writer, c sessionStateCounts) error {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("iris sessions status --json: marshal: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, string(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// renderStatusLine writes a single padded line of `state: count` pairs in the
+// canonical order. The canonical set always appears even when zero so the
+// columnar alignment is stable across invocations.
+func renderStatusLine(w io.Writer, c sessionStateCounts) error {
+	// Spawning is folded into the active bucket for the human line —
+	// operators care about "is a session in flight" more than the
+	// micro-distinction between spawning and active.
+	active := c.Active + c.Spawning
+	line := fmt.Sprintf("active: %d  waiting: %d  idle: %d  finished: %d  error: %d",
+		active, c.Waiting, c.Idle, c.Finished, c.Error)
+	if _, err := fmt.Fprintln(w, line); err != nil {
+		return err
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/iris/sessions_test.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions_test.go
@@ -1,0 +1,329 @@
+package main
+
+// sessions_test.go — unit tests for the rendering layer of
+// `iris sessions list` and `iris sessions status`.
+//
+// These tests exercise the pure rendering functions (renderSessionsListTable,
+// renderSessionsListJSON, renderStatusLine, renderStatusJSON, countStates,
+// formatUptime, truncateForColumn) against synthetic SessionSnapshot inputs.
+//
+// Integration coverage (real daemon socket + real network round-trip) lives in
+// sessions_integration_test.go.
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// fixedNow returns a deterministic "now" so uptime renders are stable across
+// test runs. The fixed value is well after the test fixtures' StartedAt
+// values so uptime is always positive.
+func fixedNow(t *testing.T) time.Time {
+	t.Helper()
+	n, err := time.Parse(time.RFC3339, "2026-05-16T10:10:00Z")
+	if err != nil {
+		t.Fatalf("parse fixed now: %v", err)
+	}
+	return n
+}
+
+// fixtureSessions returns two synthetic SessionSnapshot rows, one coordinator
+// in "active" and one worker in "waiting". Both have RFC3339 StartedAt
+// stamps that produce stable uptimes against fixedNow().
+func fixtureSessions() []iris.SessionSnapshot {
+	return []iris.SessionSnapshot{
+		{
+			Name:             "iris-test@main",
+			InstanceID:       "11111111-2222-3333-4444-555555555555",
+			State:            "active",
+			Role:             "coordinator",
+			Worktree:         "/home/user/code/iris-test/.bare/main",
+			StartedAt:        "2026-05-16T10:00:00Z", // 10 minutes before fixedNow
+			HarnessSessionID: "/home/user/.pi/agent/sessions/aaaaaaaa.jsonl",
+		},
+		{
+			Name:             "iris-test@feature-x",
+			InstanceID:       "66666666-7777-8888-9999-aaaaaaaaaaaa",
+			State:            "waiting",
+			Role:             "worker",
+			Worktree:         "/home/user/code/iris-test/feature-x",
+			StartedAt:        "2026-05-16T10:09:30Z", // 30 seconds before
+			HarnessSessionID: "/home/user/.pi/agent/sessions/bbbbbbbb.jsonl",
+		},
+	}
+}
+
+// TestRenderSessionsListTable_Empty asserts the empty-list AC: header only,
+// no body, no "no sessions" message.
+func TestRenderSessionsListTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderSessionsListTable(&buf, nil, fixedNow(t)); err != nil {
+		t.Fatalf("renderSessionsListTable: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly one line (header), got %d:\n%s", len(lines), out)
+	}
+	for _, header := range []string{"SESSION", "STATE", "ROLE", "WORKTREE", "UPTIME"} {
+		if !strings.Contains(lines[0], header) {
+			t.Errorf("header missing %q: %q", header, lines[0])
+		}
+	}
+	if strings.Contains(out, "no sessions") {
+		t.Errorf("output must not contain a 'no sessions' message:\n%s", out)
+	}
+}
+
+// TestRenderSessionsListTable_Populated asserts the populated table shows
+// the truncated 12-char UUID, the worktree basename (not the full path),
+// and a non-empty uptime.
+func TestRenderSessionsListTable_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderSessionsListTable(&buf, fixtureSessions(), fixedNow(t)); err != nil {
+		t.Fatalf("renderSessionsListTable: %v", err)
+	}
+	out := buf.String()
+
+	// 12-char UUID prefix for each session, no full UUID.
+	if !strings.Contains(out, "11111111-222") {
+		t.Errorf("expected 12-char UUID prefix for first session:\n%s", out)
+	}
+	if strings.Contains(out, "11111111-2222-3333-4444-555555555555") {
+		t.Errorf("full UUID must not appear in human-readable table:\n%s", out)
+	}
+
+	// Worktree basename, not full path.
+	if !strings.Contains(out, "feature-x") {
+		t.Errorf("expected worktree basename 'feature-x':\n%s", out)
+	}
+	if strings.Contains(out, "/home/user/code/iris-test/feature-x") {
+		t.Errorf("full worktree path must not appear in human-readable table:\n%s", out)
+	}
+
+	// State and role columns rendered for both rows.
+	if !strings.Contains(out, "active") || !strings.Contains(out, "waiting") {
+		t.Errorf("expected both states present:\n%s", out)
+	}
+	if !strings.Contains(out, "coordinator") || !strings.Contains(out, "worker") {
+		t.Errorf("expected both roles present:\n%s", out)
+	}
+
+	// Uptime: coordinator started 10m ago → "10m00s"; worker 30s ago → "30s".
+	if !strings.Contains(out, "10m00s") {
+		t.Errorf("expected coordinator uptime '10m00s':\n%s", out)
+	}
+	if !strings.Contains(out, "30s") {
+		t.Errorf("expected worker uptime '30s':\n%s", out)
+	}
+}
+
+// TestRenderSessionsListJSON_Empty asserts the empty list emits `[]` not `null`.
+func TestRenderSessionsListJSON_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderSessionsListJSON(&buf, nil, fixedNow(t)); err != nil {
+		t.Fatalf("renderSessionsListJSON: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != "[]" {
+		t.Errorf("expected `[]` for empty list, got %q", got)
+	}
+}
+
+// TestRenderSessionsListJSON_Schema asserts the AC-fixed field set is present
+// with the expected types, and full identifiers (UUID, full worktree path)
+// are preserved.
+func TestRenderSessionsListJSON_Schema(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderSessionsListJSON(&buf, fixtureSessions(), fixedNow(t)); err != nil {
+		t.Fatalf("renderSessionsListJSON: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// AC field set: id, state, role, worktree, harness_session_id,
+	// created_at, uptime_seconds. Name is informational but stable.
+	requiredKeys := []string{
+		"id", "state", "role", "worktree",
+		"harness_session_id", "created_at", "uptime_seconds",
+	}
+	for i, row := range rows {
+		for _, k := range requiredKeys {
+			if _, ok := row[k]; !ok {
+				t.Errorf("row %d missing required key %q: %v", i, k, row)
+			}
+		}
+		// uptime_seconds must decode as a number.
+		if _, ok := row["uptime_seconds"].(float64); !ok {
+			t.Errorf("row %d uptime_seconds is not a number: %v", i, row["uptime_seconds"])
+		}
+	}
+
+	// First row: full UUID, full worktree path preserved verbatim.
+	if rows[0]["id"] != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("row 0 id: got %v, want full UUID", rows[0]["id"])
+	}
+	if rows[0]["worktree"] != "/home/user/code/iris-test/.bare/main" {
+		t.Errorf("row 0 worktree: got %v, want full path", rows[0]["worktree"])
+	}
+	// Uptime in seconds: 10 minutes = 600.
+	if v, _ := rows[0]["uptime_seconds"].(float64); v != 600 {
+		t.Errorf("row 0 uptime_seconds: got %v, want 600", v)
+	}
+	if v, _ := rows[1]["uptime_seconds"].(float64); v != 30 {
+		t.Errorf("row 1 uptime_seconds: got %v, want 30", v)
+	}
+	// created_at preserved as RFC3339 input.
+	if rows[0]["created_at"] != "2026-05-16T10:00:00Z" {
+		t.Errorf("row 0 created_at: got %v, want RFC3339 stamp", rows[0]["created_at"])
+	}
+}
+
+// TestCountStates exercises the state-bucketing logic, including the unknown
+// state (folded into idle) and spawning (its own bucket in JSON, folded into
+// active in the human line).
+func TestCountStates(t *testing.T) {
+	in := []iris.SessionSnapshot{
+		{State: "active"},
+		{State: "active"},
+		{State: "waiting"},
+		{State: "finished"},
+		{State: "error"},
+		{State: "spawning"},
+		{State: "idle"},
+		{State: "totally-made-up"}, // unknown → idle bucket
+	}
+	c := countStates(in)
+	if c.Active != 2 {
+		t.Errorf("Active = %d, want 2", c.Active)
+	}
+	if c.Waiting != 1 {
+		t.Errorf("Waiting = %d, want 1", c.Waiting)
+	}
+	if c.Finished != 1 {
+		t.Errorf("Finished = %d, want 1", c.Finished)
+	}
+	if c.Error != 1 {
+		t.Errorf("Error = %d, want 1", c.Error)
+	}
+	if c.Spawning != 1 {
+		t.Errorf("Spawning = %d, want 1", c.Spawning)
+	}
+	if c.Idle != 2 {
+		// one explicit "idle" + one unknown bucketed into idle
+		t.Errorf("Idle = %d, want 2 (explicit + unknown bucket)", c.Idle)
+	}
+}
+
+// TestRenderStatusLine asserts the canonical-set always-present padded form.
+func TestRenderStatusLine(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusLine(&buf, sessionStateCounts{Active: 2, Finished: 1}); err != nil {
+		t.Fatalf("renderStatusLine: %v", err)
+	}
+	out := strings.TrimSpace(buf.String())
+	want := "active: 2  waiting: 0  idle: 0  finished: 1  error: 0"
+	if out != want {
+		t.Errorf("status line mismatch:\n got: %q\nwant: %q", out, want)
+	}
+}
+
+// TestRenderStatusLine_FoldsSpawningIntoActive asserts the human line groups
+// spawning sessions with active (operator perspective: "in flight").
+func TestRenderStatusLine_FoldsSpawningIntoActive(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusLine(&buf, sessionStateCounts{Active: 1, Spawning: 2}); err != nil {
+		t.Fatalf("renderStatusLine: %v", err)
+	}
+	if !strings.Contains(buf.String(), "active: 3") {
+		t.Errorf("expected 'active: 3' (1 active + 2 spawning folded in), got %q", buf.String())
+	}
+}
+
+// TestRenderStatusJSON asserts the JSON keys and types match the AC.
+func TestRenderStatusJSON(t *testing.T) {
+	var buf bytes.Buffer
+	c := sessionStateCounts{Active: 2, Waiting: 1, Finished: 3, Error: 1}
+	if err := renderStatusJSON(&buf, c); err != nil {
+		t.Fatalf("renderStatusJSON: %v", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, buf.String())
+	}
+
+	// Canonical keys are always present.
+	for _, k := range []string{"active", "waiting", "idle", "finished", "error"} {
+		v, ok := obj[k]
+		if !ok {
+			t.Errorf("missing canonical key %q in JSON: %s", k, buf.String())
+			continue
+		}
+		if _, ok := v.(float64); !ok {
+			t.Errorf("value for %q is not a number: %T %v", k, v, v)
+		}
+	}
+	if v, _ := obj["active"].(float64); v != 2 {
+		t.Errorf("active = %v, want 2", v)
+	}
+	if v, _ := obj["finished"].(float64); v != 3 {
+		t.Errorf("finished = %v, want 3", v)
+	}
+}
+
+// TestFormatUptime spot-checks the duration formatter at the boundaries.
+func TestFormatUptime(t *testing.T) {
+	now := fixedNow(t)
+	cases := []struct {
+		started string
+		want    string
+	}{
+		{"", "—"},
+		{"not-a-date", "—"},
+		{"2030-01-01T00:00:00Z", "—"}, // future
+		{"2026-05-16T10:09:59.5Z", "<1s"},
+		{"2026-05-16T10:09:30Z", "30s"},
+		{"2026-05-16T10:00:00Z", "10m00s"},
+		{"2026-05-16T08:30:00Z", "1h40m"},
+	}
+	for _, tc := range cases {
+		got := formatUptime(tc.started, now)
+		if got != tc.want {
+			t.Errorf("formatUptime(%q): got %q, want %q", tc.started, got, tc.want)
+		}
+	}
+}
+
+// TestTruncateForColumn covers the three branches: short string, exact, and
+// over-long string with the ellipsis tail.
+func TestTruncateForColumn(t *testing.T) {
+	cases := []struct {
+		in     string
+		max    int
+		want   string
+	}{
+		{"abc", 5, "abc"},
+		{"abcde", 5, "abcde"},
+		{"abcdef", 5, "abcd…"},
+		{"abcdef", 1, "a"},
+		{"abc", 0, ""},
+	}
+	for _, tc := range cases {
+		got := truncateForColumn(tc.in, tc.max)
+		if got != tc.want {
+			t.Errorf("truncateForColumn(%q, %d): got %q, want %q", tc.in, tc.max, got, tc.want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -103,7 +103,8 @@ type DaemonSessionsSnapshotFrame struct {
 }
 
 // SessionSnapshot is a single session entry in a sessions_snapshot frame.
-// Fields are a subset of the iris SessionRecord, sufficient for the TUI.
+// Fields are a subset of the iris SessionRecord, sufficient for the TUI and
+// for the `iris sessions list` / `iris sessions status` CLI commands.
 type SessionSnapshot struct {
 	// Name is the logical session name (e.g. "nixos-config@my-branch").
 	Name string `json:"name"`
@@ -117,6 +118,11 @@ type SessionSnapshot struct {
 	Worktree string `json:"worktree"`
 	// StartedAt is the RFC3339 timestamp when this session was created.
 	StartedAt string `json:"started_at"`
+	// HarnessSessionID is the harness-side session identifier — for the pi
+	// harness this is the full path to the pi JSONL session file (a stable
+	// identifier suitable for cross-referencing pi-side logs). May be empty
+	// before the harness handshake has completed.
+	HarnessSessionID string `json:"harness_session_id,omitempty"`
 }
 
 // DaemonSessionEventFrame wraps a raw event payload from the subscribed


### PR DESCRIPTION
Adds an `iris sessions` subcommand group with `list` and `status` children, modelled on prism's canonical shape:

```
iris sessions list             human-readable table
iris sessions list --json      stable JSON array
iris sessions status           one-line state counts
iris sessions status --json    JSON object keyed by state
```

Both commands **dial the iris daemon client socket** — the existing `sessions_snapshot` frame (D-6). Neither reads `iris.db` directly. The daemon is the single source of truth for live session state.

## Error handling

| Condition | Behaviour |
| --- | --- |
| Socket file missing | non-zero exit, "iris daemon not running" with pointer to `systemctl --user start iris` (or `launchctl kickstart` on Darwin) |
| Dial refused / stale socket | same as above |
| Connection drops mid-response | non-zero exit, "lost connection to daemon" |
| Malformed reply | non-zero exit, "malformed response from daemon" |

## Stable JSON contract

```json
{
  "id": "<full uuid>",
  "state": "active",
  "role": "coordinator",
  "worktree": "/full/path",
  "harness_session_id": "/home/.../uuid.jsonl",
  "created_at": "2026-05-16T10:05:48Z",
  "uptime_seconds": 201,
  "name": "iris-test@main"
}
```

Empty list emits `[]` (never `null`). Human table prints only the header row when empty, exit 0.

## Wire frame change

`iris.SessionSnapshot` is extended additively with `HarnessSessionID` (populated from the supervisor's `PiSessionPath`). `StartedAt` now uses canonical `time.RFC3339` formatting (previously a tolerant equivalent layout) — no consumers parse the field so this is non-breaking. No new wire frame was introduced, per the issue's central constraint.

## Tests

- `sessions_test.go` — rendering for both human and JSON paths, `countStates` bucketing, `formatUptime` / `truncateForColumn` boundaries.
- `sessions_integration_test.go` — real `iris.ClientSocket` round-trip (positive), plus four negative paths: daemon-not-running, stale-socket-refused, malformed-response, connection-drop-mid-response.

## Quality gates

- `go build ./...` ✓
- `go test ./... -race` ✓
- `nix build .#iris` ✓
- `nix build .#prism --override runChecks=true` (homeless-shelter gate) ✓
- `iris --help` lists the new `sessions` subcommand ✓

Closes #1669