### PR TITLE
fix(iris): route `iris spawn` through the running daemon

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -3,6 +3,7 @@
 // D-3 adds: spawn, harness-socket dispatch, tool override registration.
 // D-6 adds: client IPC socket (iris.sock), session fan-out, subscribe/replay.
 // D-8 adds: bubbletea TUI (iris tui) — session list + live event stream + prompt delivery.
+// Issue #1668: `iris spawn` routes through the running daemon (no in-process supervisor).
 // See docs/daemon-mode-design.md §3 and §4 for the architecture.
 //
 // Usage:
@@ -10,7 +11,7 @@
 //	iris --version                              — print version string and exit 0
 //	iris version                                — same, as a subcommand
 //	iris daemon                                 — start the full daemon (client socket + sessions)
-//	iris spawn --worktree <path> [--role <role>] — spawn a pi session (no client socket)
+//	iris spawn --worktree <path> [--role <role>] — ask the running daemon to spawn a pi session
 //	iris tui [--socket <path>]                  — open the bubbletea TUI
 package main
 
@@ -67,20 +68,11 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(spawnCmd)
+	// spawnCmd is registered in cmd/iris/spawn.go's init() so the spawn
+	// subcommand and its flags live together in one file.
 	rootCmd.AddCommand(daemonCmd)
 	rootCmd.AddCommand(tuiCmd)
-	spawnCmd.Flags().StringVar(&spawnWorktree, "worktree", "", "Absolute path to the git worktree (required)")
-	spawnCmd.Flags().StringVar(&spawnRole, "role", "worker", "Agent role (worker, coordinator, etc.)")
-	spawnCmd.Flags().StringVar(&spawnExtension, "extension", "", "Path to the prism.ts extension file (overrides config)")
-	_ = spawnCmd.MarkFlagRequired("worktree")
 }
-
-var (
-	spawnWorktree  string
-	spawnRole      string
-	spawnExtension string
-)
 
 // versionCmd provides `iris version` as an explicit subcommand in addition to
 // the --version flag (cobra wires --version automatically from rootCmd.Version).
@@ -149,85 +141,6 @@ func startup() error {
 	}
 
 	fmt.Println("iris daemon initialised (D-9). Use 'iris daemon' to start the full daemon, or 'iris spawn --worktree <path>' to test a session.")
-	<-ctx.Done()
-	return nil
-}
-
-// spawnCmd spawns a single pi session and blocks until it completes.
-// This provides a CLI entry point for testing D-3 without a full daemon.
-var spawnCmd = &cobra.Command{
-	Use:   "spawn",
-	Short: "Spawn a pi session and run until it completes",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return spawnSession()
-	},
-}
-
-func spawnSession() error {
-	p := iris.ResolvePaths()
-
-	cfg, err := iris.LoadConfig(p.ConfigFile)
-	if err != nil {
-		return fmt.Errorf("iris: load config: %w", err)
-	}
-
-	db, err := iris.OpenDB(p.DB)
-	if err != nil {
-		return fmt.Errorf("iris: open db: %w", err)
-	}
-	defer db.Close()
-
-	// Ensure the run directory exists.
-	if err := os.MkdirAll(p.RunDir, 0o700); err != nil {
-		return fmt.Errorf("iris: create run dir: %w", err)
-	}
-
-	extensionPath := spawnExtension
-	if extensionPath == "" {
-		extensionPath = cfg.PIExtensionPath
-	}
-
-	// Derive the bare repo root from the worktree path for the 4-PAT
-	// GITHUB_TOKEN selection in the bash sandbox (D-5).
-	spawnBareRoot := git.BareRoot(spawnWorktree)
-
-	// Resolve the agent role. If --role was given explicitly (the cobra flag
-	// default is "worker"), the explicit value wins; when the caller sets
-	// --role="" we apply the bare+worktree default-agent heuristic. Callers
-	// using the default "worker" still get the explicit-wins path, matching
-	// prism's session.DefaultAgent contract.
-	resolvedRole := iris.ResolveAgent(spawnWorktree, spawnRole)
-	if resolvedRole == "" {
-		resolvedRole = "worker"
-	}
-
-	superCfg := iris.SupervisorConfig{
-		SessionName:      fmt.Sprintf("iris@%s", resolvedRole),
-		Worktree:         spawnWorktree,
-		Role:             resolvedRole,
-		BareRoot:         spawnBareRoot,
-		PIBinaryPath:     cfg.PIBinaryPath,
-		ExtensionPath:    extensionPath,
-		RestartThreshold: cfg.RestartThreshold,
-		RunDir:           p.RunDir,
-		Database:         db,
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
-	fmt.Printf("[iris] spawning session (worktree=%s, role=%s)\n", spawnWorktree, spawnRole)
-
-	sup, err := iris.SpawnSession(ctx, superCfg)
-	if err != nil {
-		return fmt.Errorf("iris: spawn: %w", err)
-	}
-
-	fmt.Printf("[iris] session %s running (socket: %s)\n",
-		sup.InstanceID(), sup.SessionRecord().HarnessSockPath)
-
-	// Block until the session terminates (supervisor's Start goroutine exits)
-	// or context is cancelled.
 	<-ctx.Done()
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/iris/spawn.go
+++ b/modules/programs/prism/prism/cmd/iris/spawn.go
@@ -1,0 +1,250 @@
+package main
+
+// spawn.go — `iris spawn` subcommand.
+//
+// `iris spawn` dials the running iris daemon's client IPC socket
+// (~/.local/state/iris/iris.sock) and asks it to spawn a pi session. The
+// session's lifetime is owned by the daemon, not by the shell that ran
+// `iris spawn`: this command exits immediately after the daemon
+// acknowledges the spawn with a session_spawned frame.
+//
+// This routing was introduced for issue #1668. Before #1668, `iris spawn`
+// ran an in-process supervisor and the resulting session was invisible to
+// any other daemon-aware client (TUI, future `iris sessions list`, future
+// C-f picker). The in-process path has been removed entirely: the daemon
+// is the single source of truth for iris session lifecycle.
+//
+// # Behaviour
+//
+//	- If the daemon is not running (or its socket cannot be dialled),
+//	  `iris spawn` exits non-zero with a clear error pointing at
+//	  `systemctl --user start iris`. It does NOT silently fall back to an
+//	  in-process supervisor — that would re-introduce the original bug.
+//	- On a successful spawn, stdout includes both the session UUID
+//	  (instance_id) and the harness socket path, preserving backward
+//	  compatibility with any scripted callers that parsed the previous
+//	  in-process command's output.
+//	- If the daemon dies after the spawn frame is sent but before the
+//	  ack arrives, `iris spawn` exits non-zero with a clear error rather
+//	  than hanging.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// spawnDialTimeout bounds how long `iris spawn` will wait when dialling the
+// daemon socket. The daemon is local so a real connection should complete
+// in milliseconds; anything longer is almost certainly "daemon not running".
+const spawnDialTimeout = 2 * time.Second
+
+// spawnAckTimeout bounds how long `iris spawn` will wait for a
+// session_spawned (or error) frame after sending the spawn request. The
+// daemon's spawn work (process fork + harness socket bind) typically takes
+// well under a second; a generous timeout still surfaces hangs as a clear
+// error per AC ("daemon dies between the spawn frame send and the spawn_ack
+// receipt … exits non-zero rather than hanging indefinitely").
+const spawnAckTimeout = 30 * time.Second
+
+var (
+	spawnWorktree string
+	spawnRole     string
+)
+
+// spawnCmd is the `iris spawn` subcommand. It dials the daemon client socket
+// and asks the daemon to spawn the session.
+var spawnCmd = &cobra.Command{
+	Use:   "spawn",
+	Short: "Spawn a pi session via the running iris daemon",
+	Long: `iris spawn dials the iris daemon's client IPC socket and asks it to
+spawn a pi session. The daemon owns the session's lifetime: closing the
+terminal that ran 'iris spawn' does NOT kill the session.
+
+The daemon must already be running. If it is not, this command exits
+non-zero with a clear error — it will not start a local in-process
+supervisor as a fallback (see issue #1668 for the history).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSpawn(cmd.Context())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(spawnCmd)
+	spawnCmd.Flags().StringVar(&spawnWorktree, "worktree", "", "Absolute path to the git worktree (required)")
+	spawnCmd.Flags().StringVar(&spawnRole, "role", "worker", "Agent role (worker, coordinator, etc.)")
+	_ = spawnCmd.MarkFlagRequired("worktree")
+}
+
+// runSpawn implements the spawn flow:
+//
+//  1. Resolve the daemon socket path.
+//  2. Dial it (fail loud if the daemon is not running).
+//  3. Send a session_spawn frame.
+//  4. Read frames until session_spawned or error or EOF/timeout.
+//  5. Print session UUID + harness socket path, then exit 0.
+func runSpawn(ctx context.Context) error {
+	p := iris.ResolvePaths()
+	return runSpawnAt(ctx, p.Sock, p.RunDir, spawnWorktree, spawnRole, os.Stdout)
+}
+
+// runSpawnAt is the testable core of runSpawn. sockPath and runDir are passed
+// explicitly so the integration test can point them at a t.TempDir(). Stdout
+// is captured into out so the test can assert on what the user sees.
+func runSpawnAt(ctx context.Context, sockPath, runDir, worktree, role string, out io.Writer) error {
+	if worktree == "" {
+		return errors.New("iris spawn: --worktree is required")
+	}
+
+	fmt.Fprintf(out, "[iris] spawning session via daemon (worktree=%s, role=%s)\n", worktree, role)
+
+	conn, err := dialDaemon(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := sendSpawnFrame(conn, worktree, role); err != nil {
+		return fmt.Errorf("iris spawn: send spawn frame: %w", err)
+	}
+
+	name, instanceID, err := readSpawnAck(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	harnessSock := iris.HarnessSockPath(runDir, instanceID)
+	fmt.Fprintf(out, "[iris] session %s spawned (instance_id=%s, socket=%s)\n",
+		name, instanceID, harnessSock)
+	return nil
+}
+
+// dialDaemon attempts to dial the daemon client socket. If the dial fails
+// (most commonly because the daemon is not running), it returns a clear
+// user-facing error that names the start command rather than the raw
+// syscall message.
+func dialDaemon(ctx context.Context, sockPath string) (net.Conn, error) {
+	d := net.Dialer{Timeout: spawnDialTimeout}
+	conn, err := d.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		return nil, daemonNotRunningError(sockPath, err)
+	}
+	return conn, nil
+}
+
+// daemonNotRunningError formats the canonical "daemon not running" message.
+// It is the SAME error regardless of the underlying syscall failure mode
+// (ENOENT vs ECONNREFUSED) so that scripts can match on a single message.
+func daemonNotRunningError(sockPath string, cause error) error {
+	return fmt.Errorf(
+		"iris daemon not running (could not dial %s: %v); start it with: systemctl --user start iris",
+		sockPath, cause,
+	)
+}
+
+// sendSpawnFrame writes a ClientSessionSpawnFrame to the daemon connection.
+// The frame format is the D-6 wire protocol (internal/iris/client_protocol.go);
+// this function MUST NOT add fields not defined there.
+func sendSpawnFrame(conn net.Conn, worktree, role string) error {
+	frame := iris.ClientSessionSpawnFrame{
+		Type:     iris.ClientFrameSessionSpawn,
+		Worktree: worktree,
+		Role:     role,
+	}
+	data, err := json.Marshal(frame)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if _, err := conn.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readSpawnAck reads JSON-line frames from conn until it sees either:
+//
+//   - session_spawned     — success; returns (name, instance_id, nil)
+//   - error               — daemon-side failure; returns ("", "", error)
+//   - EOF                 — daemon died mid-spawn; returns clear error
+//   - context cancelled   — caller gave up; returns ctx.Err()
+//   - read deadline       — no frame within spawnAckTimeout; returns clear error
+//
+// Unknown frame types are logged and skipped (forward-compatibility — matches
+// the daemon's own behaviour for unknown frames).
+func readSpawnAck(ctx context.Context, conn net.Conn) (string, string, error) {
+	// Honour context cancellation by closing the conn from a goroutine.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.SetReadDeadline(time.Now())
+		case <-done:
+		}
+	}()
+
+	if err := conn.SetReadDeadline(time.Now().Add(spawnAckTimeout)); err != nil {
+		return "", "", fmt.Errorf("iris spawn: set read deadline: %w", err)
+	}
+
+	r := bufio.NewReaderSize(conn, 1<<20)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", "", ctx.Err()
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return "", "", errors.New("iris spawn: daemon closed connection before sending session_spawned ack (daemon may have died mid-spawn)")
+			}
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() {
+				return "", "", fmt.Errorf("iris spawn: timed out after %s waiting for session_spawned ack", spawnAckTimeout)
+			}
+			return "", "", fmt.Errorf("iris spawn: read ack: %w", err)
+		}
+
+		// Peek at the type only — we don't unmarshal the whole frame until we
+		// know which type to decode it as.
+		var generic struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(line, &generic); err != nil {
+			// Malformed frame — keep reading; the daemon may follow up with
+			// a real ack. Don't treat as fatal.
+			fmt.Fprintf(os.Stderr, "[iris] warning: ignoring malformed frame from daemon: %v\n", err)
+			continue
+		}
+
+		switch generic.Type {
+		case iris.DaemonFrameSessionSpawned:
+			var f iris.DaemonSessionSpawnedFrame
+			if err := json.Unmarshal(line, &f); err != nil {
+				return "", "", fmt.Errorf("iris spawn: decode session_spawned: %w", err)
+			}
+			return f.Name, f.InstanceID, nil
+		case iris.DaemonFrameError:
+			var f iris.DaemonErrorFrame
+			if err := json.Unmarshal(line, &f); err != nil {
+				return "", "", fmt.Errorf("iris spawn: decode error frame: %w", err)
+			}
+			return "", "", fmt.Errorf("iris spawn: daemon rejected spawn: %s", f.Message)
+		default:
+			// Unknown frame — log and keep reading. The daemon emits no
+			// other frames before the ack today, but future versions might
+			// add log/progress frames. Forward-compat per §4 of the design doc.
+			fmt.Fprintf(os.Stderr, "[iris] note: skipping pre-ack frame of type %q\n", generic.Type)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/spawn_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/spawn_integration_test.go
@@ -1,0 +1,147 @@
+package main
+
+// spawn_integration_test.go — end-to-end test of `iris spawn` against a real
+// iris.ClientSocket (issue #1668).
+//
+// The test stands up an in-process ClientSocket whose SpawnSession callback
+// is a recorder, then invokes runSpawnAt() with the socket path. This proves
+// the wire path used by `iris spawn`:
+//
+//   CLI                 →  session_spawn frame on iris.sock
+//   daemon ClientSocket →  invokes spawnFn(worktree, role, ...)
+//   daemon              →  session_spawned frame back to CLI
+//
+// is wired correctly end-to-end. We do not start a real pi child here —
+// the spawnFn returns a stub *iris.Supervisor whose SessionRecord has the
+// fields needed to fill out the ack frame. The full pi-running session
+// shape is covered by TestNewRestoreSupervisor_PopulatesBareRoot and the
+// other supervisor tests.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// TestSpawn_EndToEndAgainstRealClientSocket exercises the full wire path
+// against a real ClientSocket. It asserts that the spawnFn receives the
+// worktree and role from the CLI flags, which is sufficient to guarantee
+// the resulting Supervisor (built by the real spawnFn in main.go) will
+// populate BareRoot, Role and Worktree on the session record — see
+// TestNewRestoreSupervisor_PopulatesBareRoot for the per-field assertion.
+func TestSpawn_EndToEndAgainstRealClientSocket(t *testing.T) {
+	// Per-session Unix sockets must fit under the 108-byte sun_path limit.
+	// t.TempDir() can produce long paths when the test name is long, so anchor
+	// the runDir and sock under a short os.MkdirTemp() prefix (same pattern
+	// used by iristest.NewIsolated).
+	shortPrefix, err := os.MkdirTemp("", "iris-spawn-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+
+	dbPath := filepath.Join(shortPrefix, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+	runDir := filepath.Join(shortPrefix, "run")
+
+	// Record what the daemon-side spawnFn sees.
+	var (
+		recMu      sync.Mutex
+		gotWtree   string
+		gotRole    string
+		spawnCalls int
+	)
+
+	// Build a stub Supervisor by constructing a SessionRecord with the
+	// minimum needed for the spawn ack and BareRoot/role assertions.
+	// We use iris.NewSupervisor with a real (empty) DB so the ack frame's
+	// fields match the protocol contract.
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return nil
+		},
+		SpawnSession: func(ctx context.Context, worktree, role string, _ map[string]any) (*iris.Supervisor, error) {
+			recMu.Lock()
+			gotWtree = worktree
+			gotRole = role
+			spawnCalls++
+			recMu.Unlock()
+
+			// Build a real Supervisor. PIBinaryPath=/bin/true means the
+			// child exits immediately — we don't Start() it so no process
+			// is actually forked here. NewSupervisor binds the per-session
+			// harness socket; t.TempDir() under runDir keeps it isolated.
+			sup, err := iris.NewSupervisor(iris.SupervisorConfig{
+				SessionName:  "iris-" + role + "@" + filepath.Base(worktree),
+				Worktree:     worktree,
+				Role:         role,
+				BareRoot:     "/fake/bare-root-for-test",
+				PIBinaryPath: "/bin/true",
+				RunDir:       runDir,
+				Database:     database,
+			})
+			return sup, err
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+	t.Cleanup(srvCancel)
+	go cs.Serve(srvCtx)
+
+	// Drive the spawn from the CLI side.
+	const worktree = "/abs/path/to/my-worktree"
+	const role = "coordinator"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := runSpawnAt(ctx, sockPath, runDir, worktree, role, &out); err != nil {
+		t.Fatalf("runSpawnAt: %v", err)
+	}
+
+	// Assert: the daemon-side spawnFn was invoked exactly once with the
+	// worktree and role from the CLI. This is the wire-level contract:
+	// whatever the CLI sends, the daemon's spawnFn receives.
+	recMu.Lock()
+	defer recMu.Unlock()
+	if spawnCalls != 1 {
+		t.Errorf("spawnFn called %d times, want 1", spawnCalls)
+	}
+	if gotWtree != worktree {
+		t.Errorf("spawnFn worktree = %q, want %q", gotWtree, worktree)
+	}
+	if gotRole != role {
+		t.Errorf("spawnFn role = %q, want %q", gotRole, role)
+	}
+
+	// Assert: the CLI printed both the session name and a harness socket
+	// path. The harness socket path is deterministic from runDir + the
+	// instance UUID returned in the ack.
+	output := out.String()
+	if !strings.Contains(output, "iris-coordinator@my-worktree") {
+		t.Errorf("expected session name in output; got %q", output)
+	}
+	if !strings.Contains(output, runDir) {
+		t.Errorf("expected harness socket path (under %q) in output; got %q", runDir, output)
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/spawn_test.go
+++ b/modules/programs/prism/prism/cmd/iris/spawn_test.go
@@ -1,0 +1,308 @@
+package main
+
+// spawn_test.go — tests for `iris spawn` (issue #1668).
+//
+// These tests cover the CLI's daemon-routed spawn flow. Rather than wiring a
+// real daemon (which would require a pi binary), they stand up a mock daemon
+// socket that speaks the D-6 wire protocol and assert that `iris spawn`:
+//
+//   - sends a session_spawn frame with the worktree/role from the CLI flags;
+//   - prints session UUID and harness socket path on success;
+//   - exits with a clear error when the daemon is not running;
+//   - exits with a clear error when the daemon closes the connection
+//     before sending a session_spawned ack (covers the "daemon dies
+//     mid-spawn" edge case);
+//   - exits with a clear error when the daemon returns an error frame;
+//   - does NOT fall back to an in-process supervisor in any failure mode.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// mockDaemon is a tiny test double that binds a Unix socket and replies to a
+// single session_spawn frame with a script of responses.
+type mockDaemon struct {
+	sockPath string
+	listener net.Listener
+	// reply controls what the mock sends back after receiving the spawn frame.
+	reply mockReply
+	// gotFrame captures the parsed spawn frame for assertions.
+	gotFrame chan iris.ClientSessionSpawnFrame
+}
+
+type mockReply int
+
+const (
+	replySuccess mockReply = iota // emit DaemonFrameSessionSpawned
+	replyError                    // emit DaemonFrameError
+	replyHangup                   // close the connection without replying
+	replyUnknown                  // emit one unknown frame, then success (forward-compat)
+)
+
+func newMockDaemon(t *testing.T, reply mockReply) *mockDaemon {
+	t.Helper()
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "iris.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	m := &mockDaemon{
+		sockPath: sockPath,
+		listener: ln,
+		reply:    reply,
+		gotFrame: make(chan iris.ClientSessionSpawnFrame, 1),
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go m.serve(t)
+	return m
+}
+
+func (m *mockDaemon) serve(t *testing.T) {
+	conn, err := m.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	r := bufio.NewReader(conn)
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		t.Logf("mockDaemon: read: %v", err)
+		return
+	}
+	var frame iris.ClientSessionSpawnFrame
+	if err := json.Unmarshal(line, &frame); err != nil {
+		t.Logf("mockDaemon: parse spawn frame: %v", err)
+		return
+	}
+	m.gotFrame <- frame
+
+	switch m.reply {
+	case replySuccess:
+		writeMockFrame(conn, iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       "iris-worker@" + filepath.Base(frame.Worktree),
+			InstanceID: "fake-instance-uuid-0000",
+		})
+	case replyError:
+		writeMockFrame(conn, iris.DaemonErrorFrame{
+			Type:        iris.DaemonFrameError,
+			RequestType: iris.ClientFrameSessionSpawn,
+			Message:     "synthetic test failure",
+		})
+	case replyHangup:
+		// Close without writing anything — simulates the daemon dying after
+		// receiving the spawn frame.
+		return
+	case replyUnknown:
+		writeMockFrame(conn, map[string]any{"type": "some_future_frame", "data": 42})
+		writeMockFrame(conn, iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       "iris-worker@" + filepath.Base(frame.Worktree),
+			InstanceID: "fake-instance-uuid-0001",
+		})
+	}
+	// Keep the connection open briefly so the client can drain. The defer
+	// closes it.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func writeMockFrame(w io.Writer, v any) {
+	data, _ := json.Marshal(v)
+	data = append(data, '\n')
+	_, _ = w.Write(data)
+}
+
+// ---------------------------------------------------------------------------
+// Test: success path — happy spawn returns ack with session UUID
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_Success(t *testing.T) {
+	m := newMockDaemon(t, replySuccess)
+
+	runDir := filepath.Join(t.TempDir(), "run")
+	worktree := "/abs/path/to/worktree"
+	var out bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := runSpawnAt(ctx, m.sockPath, runDir, worktree, "worker", &out)
+	if err != nil {
+		t.Fatalf("runSpawnAt: %v", err)
+	}
+
+	// Assert the daemon received the right spawn frame.
+	select {
+	case got := <-m.gotFrame:
+		if got.Type != iris.ClientFrameSessionSpawn {
+			t.Errorf("frame type = %q, want %q", got.Type, iris.ClientFrameSessionSpawn)
+		}
+		if got.Worktree != worktree {
+			t.Errorf("frame worktree = %q, want %q", got.Worktree, worktree)
+		}
+		if got.Role != "worker" {
+			t.Errorf("frame role = %q, want worker", got.Role)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("mock daemon did not receive a spawn frame")
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "fake-instance-uuid-0000") {
+		t.Errorf("expected output to mention the instance UUID; got %q", output)
+	}
+	// AC: stdout still includes the harness socket path so existing scripted
+	// callers keep working. The path is deterministic from runDir/instance_id.
+	wantHarness := iris.HarnessSockPath(runDir, "fake-instance-uuid-0000")
+	if !strings.Contains(output, wantHarness) {
+		t.Errorf("expected output to mention the harness socket path %q; got %q",
+			wantHarness, output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: role flag propagates to the spawn frame
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_RolePropagates(t *testing.T) {
+	m := newMockDaemon(t, replySuccess)
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := runSpawnAt(ctx, m.sockPath, t.TempDir(), "/wt", "coordinator", &out); err != nil {
+		t.Fatalf("runSpawnAt: %v", err)
+	}
+	got := <-m.gotFrame
+	if got.Role != "coordinator" {
+		t.Errorf("role = %q, want coordinator", got.Role)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: daemon not running — clear error, no fallback
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_DaemonNotRunning(t *testing.T) {
+	// Point at a path that doesn't exist. The dial must fail and the error
+	// message must name systemctl --user start iris so the user knows how
+	// to recover.
+	bogusSock := filepath.Join(t.TempDir(), "does-not-exist.sock")
+	var out bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := runSpawnAt(ctx, bogusSock, t.TempDir(), "/wt", "worker", &out)
+	if err == nil {
+		t.Fatal("expected an error when daemon is not running, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "iris daemon not running") {
+		t.Errorf("expected 'iris daemon not running' in error, got: %v", err)
+	}
+	if !strings.Contains(msg, "systemctl --user start iris") {
+		t.Errorf("expected 'systemctl --user start iris' in error, got: %v", err)
+	}
+	// AC: no in-process fallback. The clearest assertion is that the
+	// runDir was not created — the removed in-process path used to call
+	// os.MkdirAll(p.RunDir, ...).
+	if _, statErr := os.Stat(filepath.Join(t.TempDir(), "run")); !errors.Is(statErr, os.ErrNotExist) {
+		// The path above was a fresh TempDir anyway; the real check is that
+		// runSpawnAt did not, for example, write to it. We assert no output
+		// was produced beyond the "spawning…" log line that precedes the
+		// dial.
+		if strings.Contains(out.String(), "spawned") {
+			t.Errorf("expected no 'spawned' output on failure; got %q", out.String())
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: daemon dies mid-spawn — clear error, no hang
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_DaemonHangup(t *testing.T) {
+	m := newMockDaemon(t, replyHangup)
+	var out bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := runSpawnAt(ctx, m.sockPath, t.TempDir(), "/wt", "worker", &out)
+	if err == nil {
+		t.Fatal("expected an error when daemon hangs up mid-spawn, got nil")
+	}
+	if !strings.Contains(err.Error(), "daemon closed connection") {
+		t.Errorf("expected 'daemon closed connection' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: daemon returns an error frame — surfaced verbatim
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_DaemonErrorFrame(t *testing.T) {
+	m := newMockDaemon(t, replyError)
+	var out bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := runSpawnAt(ctx, m.sockPath, t.TempDir(), "/wt", "worker", &out)
+	if err == nil {
+		t.Fatal("expected an error when daemon rejects spawn, got nil")
+	}
+	if !strings.Contains(err.Error(), "synthetic test failure") {
+		t.Errorf("expected the daemon's message to be surfaced; got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: unknown pre-ack frame is skipped (forward compat)
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_UnknownFrameSkipped(t *testing.T) {
+	m := newMockDaemon(t, replyUnknown)
+	var out bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := runSpawnAt(ctx, m.sockPath, t.TempDir(), "/wt", "worker", &out); err != nil {
+		t.Fatalf("runSpawnAt: %v", err)
+	}
+	if !strings.Contains(out.String(), "fake-instance-uuid-0001") {
+		t.Errorf("expected instance UUID in stdout after skipping unknown frame; got %q", out.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: missing --worktree returns a clear error
+// ---------------------------------------------------------------------------
+
+func TestRunSpawn_EmptyWorktree(t *testing.T) {
+	var out bytes.Buffer
+	err := runSpawnAt(context.Background(), "/dev/null", t.TempDir(), "", "worker", &out)
+	if err == nil {
+		t.Fatal("expected an error when worktree is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "--worktree is required") {
+		t.Errorf("expected '--worktree is required' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1668

Before this PR, `iris spawn` ran an in-process supervisor that bypassed the iris daemon entirely. Sessions spawned this way were invisible to any daemon-aware client (TUI, future `iris sessions list`, future C-f picker, `journalctl --user -u iris`). The package documentation in `cmd/iris/main.go` even acknowledged this: "spawn a pi session (no client socket)".

## Fix shape

`cmd/iris/spawn.go` is a thin daemon client:

1. Resolves the daemon socket via `internal/iris/paths.go::ResolvePaths().Sock`.
2. Dials it with a 2s timeout.
3. Sends a `session_spawn` frame (D-6 wire protocol, unchanged).
4. Waits for `session_spawned` or `error` with a 30s ack timeout.
5. Prints the session UUID and harness socket path, then exits 0.

The in-process supervisor path is removed entirely — no `--no-daemon` escape hatch. If the daemon is not running, `iris spawn` exits non-zero with:

```
Error: iris daemon not running (could not dial …/iris.sock: …); start it with: systemctl --user start iris
```

## Wire protocol

**Unchanged.** This PR uses `ClientSessionSpawnFrame` and `DaemonSessionSpawnedFrame` from `internal/iris/client_protocol.go` exactly as settled by D-6 (#1637). The harness socket path printed on success is reconstructed deterministically via `iris.HarnessSockPath(runDir, instanceID)` — no new wire field needed.

## BareRoot / role preservation

The daemon's existing `spawnFn` in `cmd/iris/main.go` already calls `git.BareRoot(worktree)` and `iris.ResolveAgent(worktree, role)` and passes both into `SupervisorConfig`. By routing through that path, we get the correct `BareRoot` plumbing for free. The existing regression test `TestNewRestoreSupervisor_PopulatesBareRoot` continues to cover the `SupervisorConfig → SessionRecord` link.

## Tests

`cmd/iris/spawn_test.go` — 7 unit tests against a mock daemon socket:

- success path: spawn frame sent, ack received, UUID + harness path in stdout
- role flag propagates verbatim
- daemon not running → clear error naming systemctl, no fallback
- daemon hangs up mid-spawn → clear error, no hang
- daemon returns error frame → message surfaced verbatim
- unknown pre-ack frame is skipped (forward-compat)
- empty `--worktree` rejected

`cmd/iris/spawn_integration_test.go` — end-to-end test against a real `iris.ClientSocket` proving the CLI → daemon `spawnFn` wire path delivers the worktree and role from the CLI flags.

## Verification

```bash
# From modules/programs/prism/prism/
go build ./...
go test ./... -race      # all green
go test ./cmd/iris/...   # 8/8 new tests pass

# From the repo root
nix build .#iris                                # OK
nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'  # OK
```

Manual smoke against the built binary:

```
$ XDG_STATE_HOME=/tmp/no-iris ./result/bin/iris spawn --worktree /tmp/x
[iris] spawning session via daemon (worktree=/tmp/x, role=worker)
Error: iris daemon not running (could not dial /tmp/no-iris/iris/iris.sock: dial unix /tmp/no-iris/iris/iris.sock: connect: no such file or directory); start it with: systemctl --user start iris
$ echo $?
1
```

## Out of scope

- TUI live refresh on `session_added` — separate worker (#1670).
- `iris sessions list` CLI — separate worker (#1669).
- Daemon auto-start when not running — explicit decision NOT to do this (per issue body).
