### PR TITLE
feat(iris): `iris sessions status --tmux-format` + tmux status-right segment

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/sessions.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions.go
@@ -16,7 +16,6 @@ package main
 //
 // Out of scope for this command group (see #1669):
 //   - --all (no cross-repo model in iris)
-//   - --tmux-format on status (#1672)
 //   - sessions watch (use the TUI)
 //   - backward-compat aliases (iris is new; no legacy surface)
 //   - state/role/since filter flags
@@ -80,7 +79,17 @@ Without flags: a single human-readable line, e.g.
     active: 2  waiting: 0  finished: 1  error: 0
 
 With --json: a JSON object keyed by state with integer values, e.g.
-    {"active":2,"waiting":0,"idle":0,"finished":1,"error":0}`,
+    {"active":2,"waiting":0,"idle":0,"finished":1,"error":0}
+
+With --tmux-format: a tmux #[fg=...] colour-formatted segment suitable for
+embedding in tmux's status-right. Combine with --waiting to restrict the
+segment to just the waiting count (matching the prism segment shape).
+
+When the iris daemon is not running, --tmux-format and --waiting --tmux-format
+exit 0 with an empty string — tmux re-runs status-right continuously, so an
+error message there would be permanently visible in the status bar.
+
+--json and --tmux-format are mutually exclusive.`,
 	RunE:          runSessionsStatus,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -90,7 +99,9 @@ func init() {
 	sessionsListCmd.Flags().Bool("json", false, "Emit a JSON array of session objects instead of the human-readable table")
 	sessionsListCmd.Flags().String("socket", "", "Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)")
 
-	sessionsStatusCmd.Flags().Bool("json", false, "Emit a JSON object keyed by state with integer counts")
+	sessionsStatusCmd.Flags().Bool("json", false, "Emit a JSON object keyed by state with integer counts (mutually exclusive with --tmux-format)")
+	sessionsStatusCmd.Flags().Bool("tmux-format", false, "Emit a tmux #[fg=...] colour-formatted segment suitable for status-right; exits 0 with empty output when the daemon is unreachable")
+	sessionsStatusCmd.Flags().Bool("waiting", false, "Restrict output to the waiting-session count (with --tmux-format, emits the prism-compatible waiting segment)")
 	sessionsStatusCmd.Flags().String("socket", "", "Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)")
 
 	sessionsCmd.AddCommand(sessionsListCmd)

--- a/modules/programs/prism/prism/cmd/iris/sessions_status.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions_status.go
@@ -7,6 +7,19 @@ package main
 // set (visual stability across invocations matters for shell aliases that
 // align several lines side by side).
 // With --json: a single JSON object keyed by state with integer counts.
+// With --tmux-format: a tmux #[fg=...] colour-formatted segment (mirrors
+// `prism sessions status --tmux-format` byte-for-byte via the shared
+// internal/tmuxstatus package). Adding --waiting restricts the segment to
+// just the waiting-count pip — this is the form embedded in the tmux
+// status-right alongside the prism segment during the iris coexistence
+// window (#1672).
+//
+// Tmux status-right runs the command continuously. A non-empty error string
+// would therefore be permanently visible in the status bar — so when
+// --tmux-format is set and the daemon is unreachable, the command exits 0
+// with an empty string. The error path is preserved for the non-tmux modes
+// (operators running the command interactively still want to know the
+// daemon is down).
 //
 // The canonical state set we report on is:
 //
@@ -29,7 +42,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/tmuxstatus"
 )
 
 // sessionStateCounts holds the per-state count totals. Keys correspond to the
@@ -52,19 +67,43 @@ type sessionStateCounts struct {
 // runSessionsStatus is the cobra RunE for `iris sessions status`.
 func runSessionsStatus(cmd *cobra.Command, _ []string) error {
 	jsonMode, _ := cmd.Flags().GetBool("json")
-	sockPath := resolveSocketPath(cmd)
+	tmuxFormat, _ := cmd.Flags().GetBool("tmux-format")
+	waitingOnly, _ := cmd.Flags().GetBool("waiting")
 
+	// Mutual exclusion is checked before any I/O so the error message is
+	// the same whether or not the daemon is reachable. Mirrors the
+	// equivalent guard in prism's status command.
+	if jsonMode && tmuxFormat {
+		return fmt.Errorf("iris sessions status: --json and --tmux-format are mutually exclusive")
+	}
+
+	sockPath := resolveSocketPath(cmd)
 	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 	defer cancel()
 
 	snap, err := fetchSessionsSnapshot(ctx, sockPath)
 	if err != nil {
+		// Graceful-degradation path for tmux status-right: an error string
+		// would otherwise be permanently visible in the status bar. Exit 0
+		// with no output and let the segment vanish until the daemon
+		// returns. Operators running `iris sessions status` interactively
+		// (no --tmux-format) still get the actionable error.
+		if tmuxFormat {
+			return nil
+		}
 		return err
 	}
 
 	counts := countStates(snap.Sessions)
+
+	if tmuxFormat {
+		return renderStatusTmux(cmd.OutOrStdout(), counts, waitingOnly)
+	}
 	if jsonMode {
 		return renderStatusJSON(cmd.OutOrStdout(), counts)
+	}
+	if waitingOnly {
+		return renderStatusWaitingPlain(cmd.OutOrStdout(), counts)
 	}
 	return renderStatusLine(cmd.OutOrStdout(), counts)
 }
@@ -126,4 +165,65 @@ func renderStatusLine(w io.Writer, c sessionStateCounts) error {
 		return err
 	}
 	return nil
+}
+
+// renderStatusWaitingPlain writes just the waiting count (no formatting),
+// matching `prism sessions status --waiting`. One line, integer, newline.
+func renderStatusWaitingPlain(w io.Writer, c sessionStateCounts) error {
+	if _, err := fmt.Fprintln(w, c.Waiting); err != nil {
+		return err
+	}
+	return nil
+}
+
+// renderStatusTmux writes the tmux-format segment via the shared
+// internal/tmuxstatus package. waitingOnly switches between the
+// --waiting --tmux-format and --tmux-format renderers; both return an
+// empty string when there's nothing to display, which is the desired
+// status-right behaviour.
+//
+// Spawning is folded into Active here to match the human-line semantics:
+// the status bar's "active" pip should include sessions still coming up,
+// because the operator-visible distinction is "is something in flight" vs
+// "is something waiting on me".
+func renderStatusTmux(w io.Writer, c sessionStateCounts, waitingOnly bool) error {
+	tc := tmuxstatus.Counts{
+		Active:   c.Active + c.Spawning,
+		Waiting:  c.Waiting,
+		Idle:     c.Idle,
+		Finished: c.Finished,
+		Error:    c.Error,
+	}
+	cols := tmuxStatusColors()
+	var s string
+	if waitingOnly {
+		s = tmuxstatus.FormatWaiting(tc, cols)
+	} else {
+		s = tmuxstatus.Format(tc, cols)
+	}
+	if s == "" {
+		return nil
+	}
+	if _, err := fmt.Fprint(w, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+// tmuxStatusColors loads the shared prism colour palette via internal/config
+// so the iris status-right segment matches the prism segment exactly. The
+// config loader returns gruvbox-dark defaults when no config file is
+// present, so this works in `go test`, `go build`, and Nix-built binaries
+// alike. Loaded per-call (rather than at init time) so the iris CLI does
+// not pay the JSON-decode cost on commands that don't need colours; the
+// tmux-format command is the only caller.
+func tmuxStatusColors() tmuxstatus.Colors {
+	cfg := config.Load()
+	return tmuxstatus.Colors{
+		Yellow:  cfg.ColorYellow,
+		Purple:  cfg.ColorPurple,
+		Green:   cfg.ColorGreen,
+		Red:     cfg.ColorRed,
+		Primary: cfg.ColorPrimary,
+	}
 }

--- a/modules/programs/prism/prism/cmd/iris/sessions_test.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions_test.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -303,6 +304,177 @@ func TestFormatUptime(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("formatUptime(%q): got %q, want %q", tc.started, got, tc.want)
 		}
+	}
+}
+
+// TestRenderStatusWaitingPlain asserts `--waiting` (no --tmux-format) prints
+// the integer waiting count followed by a newline. Mirrors `prism sessions
+// status --waiting`.
+func TestRenderStatusWaitingPlain(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusWaitingPlain(&buf, sessionStateCounts{Waiting: 3, Active: 7}); err != nil {
+		t.Fatalf("renderStatusWaitingPlain: %v", err)
+	}
+	if got := buf.String(); got != "3\n" {
+		t.Errorf("got %q, want %q", got, "3\n")
+	}
+}
+
+// TestRenderStatusTmux_WaitingZeroIsEmpty asserts the AC: zero-waiting under
+// --waiting --tmux-format produces no output (so the tmux status segment
+// vanishes when nothing is waiting).
+func TestRenderStatusTmux_WaitingZeroIsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusTmux(&buf, sessionStateCounts{Active: 5, Finished: 2}, true); err != nil {
+		t.Fatalf("renderStatusTmux: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for zero waiting, got %q", buf.String())
+	}
+}
+
+// TestRenderStatusTmux_WaitingNonZero asserts the --waiting --tmux-format
+// output contains a tmux #[fg=...] colour escape and the waiting count.
+// Exact byte-shape is locked down in the shared tmuxstatus package's tests;
+// here we just confirm the wiring (counts + colour palette) is plumbed
+// through.
+func TestRenderStatusTmux_WaitingNonZero(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusTmux(&buf, sessionStateCounts{Waiting: 4}, true); err != nil {
+		t.Fatalf("renderStatusTmux: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "4 waiting") {
+		t.Errorf("expected '4 waiting' in output: %q", out)
+	}
+	if !strings.Contains(out, "#[fg=") {
+		t.Errorf("expected a tmux #[fg=...] colour escape in output: %q", out)
+	}
+	if !strings.HasSuffix(out, "| ") {
+		t.Errorf("expected trailing '| ' separator: %q", out)
+	}
+}
+
+// TestRenderStatusTmux_FullEmptyWhenNothingActionable asserts the full
+// (non-waiting) tmux-format renderer also collapses to empty when there's
+// nothing worth showing in the status bar (only idle, or no sessions).
+func TestRenderStatusTmux_FullEmptyWhenNothingActionable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusTmux(&buf, sessionStateCounts{Idle: 3}, false); err != nil {
+		t.Fatalf("renderStatusTmux: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for idle-only counts, got %q", buf.String())
+	}
+}
+
+// TestRenderStatusTmux_FullFoldsSpawningIntoActive asserts that the full
+// tmux segment surfaces spawning sessions under the active pip — operator
+// perspective: a session coming up is "in flight".
+func TestRenderStatusTmux_FullFoldsSpawningIntoActive(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderStatusTmux(&buf, sessionStateCounts{Active: 1, Spawning: 2}, false); err != nil {
+		t.Fatalf("renderStatusTmux: %v", err)
+	}
+	if !strings.Contains(buf.String(), "3 active") {
+		t.Errorf("expected '3 active' (1 active + 2 spawning), got %q", buf.String())
+	}
+}
+
+// TestSessionsStatusCmd_JSONAndTmuxFormatMutuallyExclusive asserts the AC:
+// passing both flags errors before any I/O happens (the error must surface
+// even if the daemon is unreachable, so it must be a flag-parse-time check).
+func TestSessionsStatusCmd_JSONAndTmuxFormatMutuallyExclusive(t *testing.T) {
+	// Snapshot and restore the flag values around the test so we don't leak
+	// state into other tests sharing the package-level cobra command.
+	jsonOrig := sessionsStatusCmd.Flag("json").Value.String()
+	tmuxOrig := sessionsStatusCmd.Flag("tmux-format").Value.String()
+	defer func() {
+		_ = sessionsStatusCmd.Flags().Set("json", jsonOrig)
+		_ = sessionsStatusCmd.Flags().Set("tmux-format", tmuxOrig)
+	}()
+
+	if err := sessionsStatusCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+	if err := sessionsStatusCmd.Flags().Set("tmux-format", "true"); err != nil {
+		t.Fatalf("set --tmux-format: %v", err)
+	}
+
+	err := runSessionsStatus(sessionsStatusCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --json and --tmux-format both set, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' in error, got: %v", err)
+	}
+}
+
+// TestSessionsStatusCmd_TmuxFormat_DaemonDownIsSilent asserts the
+// graceful-degradation AC: when the daemon is unreachable AND --tmux-format
+// is set, the command exits 0 with empty output (so the tmux status bar
+// does not display a connection-refused error).
+//
+// The non-tmux variant still surfaces the error (operators running the
+// command interactively want to know the daemon is down).
+func TestSessionsStatusCmd_TmuxFormat_DaemonDownIsSilent(t *testing.T) {
+	// Point at a guaranteed-non-existent socket path so fetchSessionsSnapshot
+	// fails fast with a clear "daemon not running" error.
+	bogusSock := t.TempDir() + "/no-such-iris.sock"
+
+	// Snapshot & restore flag state.
+	sockOrig := sessionsStatusCmd.Flag("socket").Value.String()
+	tmuxOrig := sessionsStatusCmd.Flag("tmux-format").Value.String()
+	waitOrig := sessionsStatusCmd.Flag("waiting").Value.String()
+	defer func() {
+		_ = sessionsStatusCmd.Flags().Set("socket", sockOrig)
+		_ = sessionsStatusCmd.Flags().Set("tmux-format", tmuxOrig)
+		_ = sessionsStatusCmd.Flags().Set("waiting", waitOrig)
+		sessionsStatusCmd.SetContext(nil)
+	}()
+	// cobra populates cmd.Context() during Execute(); when we invoke RunE
+	// directly we have to set it ourselves or the context.WithTimeout call
+	// in runSessionsStatus panics on a nil parent.
+	sessionsStatusCmd.SetContext(context.Background())
+	if err := sessionsStatusCmd.Flags().Set("socket", bogusSock); err != nil {
+		t.Fatalf("set --socket: %v", err)
+	}
+
+	// 1. --tmux-format alone: must exit 0 with empty output.
+	if err := sessionsStatusCmd.Flags().Set("tmux-format", "true"); err != nil {
+		t.Fatalf("set --tmux-format: %v", err)
+	}
+	var out bytes.Buffer
+	sessionsStatusCmd.SetOut(&out)
+	if err := runSessionsStatus(sessionsStatusCmd, nil); err != nil {
+		t.Fatalf("--tmux-format with daemon down: expected nil error, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("--tmux-format with daemon down: expected empty output, got %q", out.String())
+	}
+
+	// 2. --waiting --tmux-format: same graceful-degradation behaviour.
+	if err := sessionsStatusCmd.Flags().Set("waiting", "true"); err != nil {
+		t.Fatalf("set --waiting: %v", err)
+	}
+	out.Reset()
+	if err := runSessionsStatus(sessionsStatusCmd, nil); err != nil {
+		t.Fatalf("--waiting --tmux-format with daemon down: expected nil error, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("--waiting --tmux-format with daemon down: expected empty output, got %q", out.String())
+	}
+
+	// 3. Without --tmux-format the error must still surface (interactive use).
+	if err := sessionsStatusCmd.Flags().Set("tmux-format", "false"); err != nil {
+		t.Fatalf("unset --tmux-format: %v", err)
+	}
+	if err := sessionsStatusCmd.Flags().Set("waiting", "false"); err != nil {
+		t.Fatalf("unset --waiting: %v", err)
+	}
+	out.Reset()
+	if err := runSessionsStatus(sessionsStatusCmd, nil); err == nil {
+		t.Errorf("plain mode with daemon down: expected error, got nil (output=%q)", out.String())
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/status.go
+++ b/modules/programs/prism/prism/cmd/status.go
@@ -14,7 +14,23 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/tmuxstatus"
 )
+
+// statusColors returns the tmuxstatus.Colors palette derived from the loaded
+// prism theme (cmd/colors.go). Wrapped in a helper so the iris CLI and the
+// prism CLI can share the formatter implementation without sharing the
+// cmd-package theme globals — iris loads the same internal/config and builds
+// its own equivalent struct.
+func statusColors() tmuxstatus.Colors {
+	return tmuxstatus.Colors{
+		Yellow:  ColorYellow,
+		Purple:  ColorPurple,
+		Green:   ColorGreen,
+		Red:     ColorRed,
+		Primary: ColorPrimary,
+	}
+}
 
 var statusCmd = &cobra.Command{
 	Use:    "status",
@@ -90,11 +106,18 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return renderStatusJSON(nActive, nWaiting, nIdle, nFinished, nError)
 	}
 
+	counts := tmuxstatus.Counts{
+		Active: nActive, Waiting: nWaiting, Idle: nIdle,
+		Finished: nFinished, Error: nError,
+	}
+
 	if waitingOnly {
 		if tmuxFormat {
 			// Emit a tmux-formatted colour string, or nothing if count is zero.
-			if nWaiting > 0 {
-				fmt.Printf("#[fg=%s]%d waiting #[fg=%s]| ", ColorYellow, nWaiting, ColorPrimary)
+			// The shared tmuxstatus.FormatWaiting helper guarantees the iris
+			// segment renders byte-identically to this one.
+			if s := tmuxstatus.FormatWaiting(counts, statusColors()); s != "" {
+				fmt.Print(s)
 			}
 		} else {
 			fmt.Println(nWaiting)
@@ -111,21 +134,8 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	// here, otherwise error sessions silently disappear from the status
 	// bar. Render in red so they're visually distinct from idle.
 	if tmuxFormat {
-		var parts []string
-		if nWaiting > 0 {
-			parts = append(parts, fmt.Sprintf("#[fg=%s]%d waiting", ColorYellow, nWaiting))
-		}
-		if nActive > 0 {
-			parts = append(parts, fmt.Sprintf("#[fg=%s]%d active", ColorPurple, nActive))
-		}
-		if nFinished > 0 {
-			parts = append(parts, fmt.Sprintf("#[fg=%s]%d done", ColorGreen, nFinished))
-		}
-		if nError > 0 {
-			parts = append(parts, fmt.Sprintf("#[fg=%s]%d error", ColorRed, nError))
-		}
-		if len(parts) > 0 {
-			fmt.Printf("%s #[fg=%s]| ", strings.Join(parts, " "), ColorPrimary)
+		if s := tmuxstatus.Format(counts, statusColors()); s != "" {
+			fmt.Print(s)
 		}
 	} else {
 		var parts []string

--- a/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus.go
+++ b/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus.go
@@ -1,0 +1,101 @@
+// Package tmuxstatus formats agent-session state counts for embedding in a
+// tmux status-right segment.
+//
+// This is the shared rendering layer used by both `prism sessions status
+// --tmux-format` and `iris sessions status --tmux-format`. Keeping the two
+// callers locked to a single implementation is the entire point: the user
+// runs prism and iris side-by-side during the coexistence window (#1672),
+// and visual divergence between the two segments would be immediately
+// noticeable in the status bar.
+//
+// The output uses tmux #[fg=...] colour escapes — these are interpreted by
+// tmux when the string is substituted into status-right; they are *not*
+// terminal escape sequences. A consumer that prints the output anywhere
+// other than tmux will see literal "#[fg=#xxxxxx]" text.
+//
+// All formatters return "" when there is nothing to render. This is the
+// graceful-degradation contract relied on by tmux's continuous status-right
+// invocation: an empty string disappears from the status bar; a non-empty
+// string with a trailing "| " separator integrates with the rest of the
+// status segments.
+package tmuxstatus
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Counts is the per-state session-count input to the formatters.
+//
+// The five fields here are the canonical state set rendered in the status
+// bar. Other states (e.g. iris's transient "spawning") must be folded into
+// one of these by the caller before rendering — keeping the formatter agnostic
+// of upstream state taxonomies means iris and prism can evolve their state
+// machines independently without dragging the formatter along.
+type Counts struct {
+	Active   int
+	Waiting  int
+	Idle     int
+	Finished int
+	Error    int
+}
+
+// Colors holds the four foreground colours referenced by the formatter, plus
+// the trailing-separator colour used to close out the segment.
+//
+// The fields are tmux-format colour values (typically "#rrggbb" hex strings,
+// but any tmux-accepted colour name works). They come from the prism config
+// (loaded via internal/config) so a single ~/.config/prism/config.json drives
+// both prism and iris segments — the user theming the prism segment also
+// themes the iris segment.
+type Colors struct {
+	Yellow  string // waiting count
+	Purple  string // active count
+	Green   string // finished count
+	Red     string // error count
+	Primary string // trailing "| " separator
+}
+
+// FormatWaiting renders the --waiting --tmux-format segment: a single
+// "<n> waiting" pip in Yellow followed by the Primary-coloured "| "
+// separator. Returns "" when c.Waiting <= 0 so the segment disappears
+// entirely from the status bar (the AC's "no waiting → empty string" path).
+//
+// The trailing space after "| " is intentional — it separates this segment
+// from whatever follows in status-right (the prism segment, the hostname,
+// etc.).
+func FormatWaiting(c Counts, col Colors) string {
+	if c.Waiting <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("#[fg=%s]%d waiting #[fg=%s]| ", col.Yellow, c.Waiting, col.Primary)
+}
+
+// Format renders the full multi-state segment: a Yellow waiting pip, a
+// Purple active pip, a Green finished pip, and a Red error pip — each
+// included only when its count is non-zero, in that fixed order, separated
+// by a single space, with a trailing Primary-coloured "| " separator.
+//
+// Returns "" when no pip would render (all four counts are zero), so the
+// segment again vanishes from the status bar rather than emitting a
+// dangling separator. Idle is intentionally omitted: idle sessions are the
+// non-event baseline and don't earn a status-bar pip.
+func Format(c Counts, col Colors) string {
+	var parts []string
+	if c.Waiting > 0 {
+		parts = append(parts, fmt.Sprintf("#[fg=%s]%d waiting", col.Yellow, c.Waiting))
+	}
+	if c.Active > 0 {
+		parts = append(parts, fmt.Sprintf("#[fg=%s]%d active", col.Purple, c.Active))
+	}
+	if c.Finished > 0 {
+		parts = append(parts, fmt.Sprintf("#[fg=%s]%d done", col.Green, c.Finished))
+	}
+	if c.Error > 0 {
+		parts = append(parts, fmt.Sprintf("#[fg=%s]%d error", col.Red, c.Error))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s #[fg=%s]| ", strings.Join(parts, " "), col.Primary)
+}

--- a/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus_test.go
+++ b/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus_test.go
@@ -1,0 +1,98 @@
+package tmuxstatus
+
+import (
+	"strings"
+	"testing"
+)
+
+// testColors returns a fixed palette so output expectations are stable across
+// CI hosts (defaults from internal/config could drift; the tests don't care
+// about specific shades, only about which colour-slot is wired to which pip).
+func testColors() Colors {
+	return Colors{
+		Yellow:  "#yellow",
+		Purple:  "#purple",
+		Green:   "#green",
+		Red:     "#red",
+		Primary: "#primary",
+	}
+}
+
+// TestFormatWaiting_ZeroIsEmpty asserts the AC: zero-waiting → empty string.
+// The status bar must not render a stray separator when there's nothing to say.
+func TestFormatWaiting_ZeroIsEmpty(t *testing.T) {
+	if got := FormatWaiting(Counts{}, testColors()); got != "" {
+		t.Errorf("FormatWaiting(0) = %q, want empty string", got)
+	}
+	// A non-zero non-Waiting field must not flip the result to non-empty:
+	// --waiting is strict, only the Waiting bucket counts.
+	if got := FormatWaiting(Counts{Active: 5, Finished: 3, Error: 1}, testColors()); got != "" {
+		t.Errorf("FormatWaiting(active+finished+error, no waiting) = %q, want empty", got)
+	}
+}
+
+// TestFormatWaiting_NonZero asserts the byte-for-byte segment shape so the
+// iris and prism status bar segments stay visually identical.
+func TestFormatWaiting_NonZero(t *testing.T) {
+	got := FormatWaiting(Counts{Waiting: 2}, testColors())
+	want := "#[fg=#yellow]2 waiting #[fg=#primary]| "
+	if got != want {
+		t.Errorf("FormatWaiting:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestFormat_AllZeroIsEmpty asserts the all-zero (or only-idle) case yields
+// an empty string. Idle is the non-event baseline and never earns a pip.
+func TestFormat_AllZeroIsEmpty(t *testing.T) {
+	if got := Format(Counts{}, testColors()); got != "" {
+		t.Errorf("Format(zero) = %q, want empty", got)
+	}
+	if got := Format(Counts{Idle: 7}, testColors()); got != "" {
+		t.Errorf("Format(only idle) = %q, want empty", got)
+	}
+}
+
+// TestFormat_OrderAndColours asserts the canonical ordering — waiting,
+// active, finished, error — and the colour slot each pip occupies. The
+// trailing "| " separator must be Primary-coloured and present when at least
+// one pip rendered.
+func TestFormat_OrderAndColours(t *testing.T) {
+	got := Format(Counts{Active: 1, Waiting: 2, Finished: 3, Error: 4}, testColors())
+
+	// Order matters: waiting must come before active before finished before error.
+	wantSubsInOrder := []string{
+		"#[fg=#yellow]2 waiting",
+		"#[fg=#purple]1 active",
+		"#[fg=#green]3 done",
+		"#[fg=#red]4 error",
+		"#[fg=#primary]| ",
+	}
+	prev := -1
+	for _, s := range wantSubsInOrder {
+		idx := strings.Index(got, s)
+		if idx < 0 {
+			t.Errorf("Format output missing %q:\n  full: %q", s, got)
+			continue
+		}
+		if idx <= prev {
+			t.Errorf("Format output has %q out of order (idx %d <= prev %d):\n  full: %q",
+				s, idx, prev, got)
+		}
+		prev = idx
+	}
+}
+
+// TestFormat_OmitsZeroPips asserts pips with zero count are dropped, not
+// rendered as "0 waiting". Otherwise the status bar would always show every
+// label regardless of whether anything is happening.
+func TestFormat_OmitsZeroPips(t *testing.T) {
+	got := Format(Counts{Waiting: 1}, testColors())
+	if !strings.Contains(got, "1 waiting") {
+		t.Errorf("Format must include the present pip: %q", got)
+	}
+	for _, banned := range []string{"0 active", "0 done", "0 error", "0 waiting"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("Format must not render zero-count pip %q: %q", banned, got)
+		}
+	}
+}

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -10,13 +10,17 @@ let
   isDarwin = pkgs.stdenv.isDarwin;
   prismPkg = pkgs.callPackage ../../../pkgs/prism.nix { };
   prism = "${prismPkg}/bin/prism";
-  # iris binary path, used by the prefix+i context-switcher popup binding
-  # (issue #1671). The iris module's `pkgs.iris` is enabled per-host via
-  # nx.programs.iris.enable, but the tmux binding is wired unconditionally:
-  # hosts that do not enable iris simply get a popup that fails fast with
-  # "iris daemon not running" (or "command not found" if the binary is
-  # missing). That is acceptable for the coexistence window — the binding
-  # is opt-in via the prism prefix, so it never fires unless the user asks.
+  # iris binary path. Two consumers share this path:
+  #   - the prefix+i context-switcher popup binding (issue #1671); and
+  #   - the tmux status-right iris segment (issue #1672), which calls
+  #     `iris sessions status --waiting --tmux-format` alongside the prism
+  #     equivalent during the iris coexistence window.
+  # The iris module's `nx.programs.iris.enable` gates whether the daemon
+  # runs, but both tmux integrations are wired unconditionally: hosts that
+  # do not enable iris see an empty status-right segment (the command
+  # gracefully degrades when the daemon socket is absent) and a popup
+  # binding that fails fast if pressed. Acceptable for the coexistence
+  # window — neither costs anything visible until the user opts in.
   irisPkg = pkgs.callPackage ../../../pkgs/iris.nix { };
   iris = "${irisPkg}/bin/iris";
 
@@ -131,7 +135,12 @@ in
               set -g status-left-length 30
               set -g status-left " [#{session_name}] "
               # set -g status-right "#{?window_bigger,[#{window_offset_x}#,#{window_offset_y}] ,}#{=21:pane_title} "
-              set -g status-right "#(${prism} sessions status --waiting --tmux-format)#h "
+              # status-right composition (#1672): prism segment first, then the
+              # iris segment, then the hostname. Both segments emit empty
+              # strings when their respective daemons are down or have nothing
+              # waiting, so the visible bar collapses cleanly to just `#h `
+              # in the steady state.
+              set -g status-right "#(${prism} sessions status --waiting --tmux-format)#(${iris} sessions status --waiting --tmux-format)#h "
               set -g status-style 'bg=${bg1} fg=${secondary}'
               set -g message-style 'bg=${primary} fg=${bg1}'
               set -g mode-style 'bg=${bg3} fg=${foreground}'


### PR DESCRIPTION
Closes #1672

Adds the iris analogue of `prism sessions status --waiting --tmux-format`
and wires it into the tmux `status-right` alongside the prism segment for
the iris coexistence window.

## What changed

### `internal/tmuxstatus/` — new shared package
Extracted the tmux-format renderer from prism's `cmd/status.go` into a
dependency-free internal package. Both prism and iris call it, so the two
status-bar segments are guaranteed to render byte-identically — visual
divergence during the coexistence window would be immediately noticeable.

prism's `cmd/status.go` now delegates to the package; output is
unchanged (locked down by the existing `status_json_test.go` suite).

### `iris sessions status` — new flags
- `--tmux-format` emits the multi-state colour segment.
- `--waiting --tmux-format` emits only the waiting-count pip — this is
  the form embedded in tmux `status-right`.
- `--json` and `--tmux-format` are mutually exclusive (errored at
  flag-parse time, before any I/O, so the message surfaces even when the
  daemon is unreachable).
- **Graceful degradation:** when the daemon is unreachable,
  `--tmux-format` (with or without `--waiting`) exits 0 with empty
  output. tmux re-runs `status-right` continuously, so a
  connection-refused error string would be permanently visible in the
  status bar. The non-tmux modes still surface the error for interactive
  use.

Iris uses the same `internal/config` colour palette as prism, so a
single `~/.config/prism/config.json` themes both segments consistently.

Spawning sessions fold into the `active` pip (matches the human-line
semantics: "is a session in flight" — a session coming up qualifies).

### `tmux.nix` — status-right wiring
```
status-right "#(${prism} sessions status --waiting --tmux-format)#(${iris} sessions status --waiting --tmux-format)#h "
```
prism segment first, iris segment, then `#h`. Both collapse to empty
when their respective daemons are down or have nothing waiting, so the
steady-state bar is just `#h`.

## Acceptance criteria

- [x] `iris sessions status --tmux-format` prints colour-formatted state counts.
- [x] `iris sessions status --waiting --tmux-format` prints only the waiting-count pip, format-identical to prism.
- [x] Daemon-down → exit 0 with empty output (no error string in the status bar).
- [x] Zero waiting → empty string.
- [x] Non-zero waiting → coloured segment with count.
- [x] `--tmux-format` + `--json` → clear error, exit non-zero.
- [x] `status-right` contains both prism and iris segments.
- [x] `go test ./... -race` passes.
- [x] `nix build .#iris` succeeds.
- [x] `nixosConfigurations.navi.config.system.build.toplevel` builds (manual `nh switch` validation deferred to local — sandbox can't sudo).

## Verified locally

```
$ ./result/bin/iris sessions status --tmux-format --socket /tmp/no-such.sock
(exit=0, empty output)

$ ./result/bin/iris sessions status --waiting --tmux-format --socket /tmp/no-such.sock
(exit=0, empty output)

$ ./result/bin/iris sessions status --json --tmux-format
iris sessions status: --json and --tmux-format are mutually exclusive
(exit=1)

$ nix eval --raw .#nixosConfigurations.navi.config.home-manager.users.ben.programs.tmux.extraConfig | grep status-right
set -g status-right "#(/nix/store/.../prism sessions status --waiting --tmux-format)#(/nix/store/.../iris sessions status --waiting --tmux-format)#h "
```

## Tests

- `internal/tmuxstatus`: zero/non-zero × waiting/full × pip ordering.
- `cmd/iris`: four flag combinations, mutual-exclusion guard, daemon-down graceful-degradation for both `--tmux-format` and `--waiting --tmux-format`, non-tmux error-surfacing.