### PR TITLE
fix(iris): populate SessionRecord.PiSessionPath from session_status handler

### DIFF
--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -120,8 +120,14 @@ type SessionSnapshot struct {
 	StartedAt string `json:"started_at"`
 	// HarnessSessionID is the harness-side session identifier — for the pi
 	// harness this is the full path to the pi JSONL session file (a stable
-	// identifier suitable for cross-referencing pi-side logs). May be empty
-	// before the harness handshake has completed.
+	// identifier suitable for cross-referencing pi-side logs). Populated
+	// within milliseconds of session start, once the pi child emits its
+	// first session_status frame (handled by the iris harness socket and
+	// mirrored into the in-memory SessionRecord under the supervisor's
+	// lock). The transient window between session_start and that first
+	// frame is the only time this field is empty for a live session;
+	// restored sessions have it populated from the DB before any client
+	// can observe them.
 	HarnessSessionID string `json:"harness_session_id,omitempty"`
 }
 

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -61,6 +61,12 @@ type HarnessSocketServer struct {
 	// Nil when no client socket is configured (e.g. in harness-only tests).
 	publisher EventPublisher
 
+	// sessionStatusHandler is invoked when a session_status frame delivers a
+	// non-empty session_id, immediately after the DB write. Wired by the
+	// Supervisor so it can update its in-memory SessionRecord.PiSessionPath
+	// under the supervisor's lock (issue #1682). Nil in harness-only tests.
+	sessionStatusHandler func(sessionID string)
+
 	// sessionShutdownReceived is set to true when the session_shutdown
 	// frame arrives — used by the supervisor to detect clean exits.
 	sessionShutdownReceived bool
@@ -89,6 +95,16 @@ func NewHarnessSocketServer(sess *SessionRecord, database *db.DB) (*HarnessSocke
 func (h *HarnessSocketServer) SetPublisher(p EventPublisher) {
 	h.mu.Lock()
 	h.publisher = p
+	h.mu.Unlock()
+}
+
+// SetSessionStatusHandler wires a callback invoked when the session_status
+// frame arrives with a non-empty session_id. The callback runs synchronously
+// after the DB write so the in-memory SessionRecord and the DB row stay in
+// lock-step. Wired by the Supervisor; nil in harness-only tests.
+func (h *HarnessSocketServer) SetSessionStatusHandler(fn func(sessionID string)) {
+	h.mu.Lock()
+	h.sessionStatusHandler = fn
 	h.mu.Unlock()
 }
 
@@ -287,13 +303,28 @@ func (h *HarnessSocketServer) handleConn(ctx context.Context, conn net.Conn) err
 		case "session_status":
 			// Extract session_id (pi's JSONL session UUID) and persist it in
 			// sessions.harness_session_id so the D-9 restore path can locate
-			// the JSONL file at daemon restart.
+			// the JSONL file at daemon restart. After the DB write, invoke
+			// the session-status handler (wired by the Supervisor) so the
+			// in-memory SessionRecord.PiSessionPath is updated too — without
+			// this, daemonState.activeSessions() would report an empty
+			// harness_session_id for every live session (issue #1682).
 			var statusFrame map[string]any
 			if err := json.Unmarshal(line, &statusFrame); err == nil {
 				if sessionID, ok := statusFrame["session_id"].(string); ok && sessionID != "" {
 					if err := h.database.IrisUpdateHarnessSessionID(h.sess.InstanceID, sessionID); err != nil {
 						log.Printf("[iris] harness: failed to persist session_id %q for instance %s: %v",
 							sessionID, h.sess.InstanceID, err)
+					}
+					// Ordering invariant (PR #1657): the agent_events row for
+					// session_status is written by writeObservationEvent below;
+					// the DB harness_session_id row is set above. The in-memory
+					// mutation here mirrors the DB write — same ordering, same
+					// place.
+					h.mu.Lock()
+					handler := h.sessionStatusHandler
+					h.mu.Unlock()
+					if handler != nil {
+						handler(sessionID)
 					}
 				}
 			}

--- a/modules/programs/prism/prism/internal/iris/set_pi_session_path_test.go
+++ b/modules/programs/prism/prism/internal/iris/set_pi_session_path_test.go
@@ -1,0 +1,244 @@
+package iris
+
+// set_pi_session_path_test.go -- tests for Supervisor.SetPiSessionPath and the
+// session_status -> in-memory-record wiring (issue #1682).
+//
+// The bug fixed by this code path: SessionRecord.PiSessionPath was only ever
+// populated by the D-9 restore path, so live sessions emitted an empty
+// harness_session_id field in sessions_snapshot frames and `iris sessions
+// list --json` output. The DB was correct (via IrisUpdateHarnessSessionID),
+// but the in-memory record read by daemonState.activeSessions() was stale.
+//
+// These tests cover:
+//   - The setter mutates the in-memory record (unit AC).
+//   - Concurrent setter + SessionRecord() reads are race-free (security AC).
+//   - The harness session_status handler triggers the setter end-to-end
+//     (integration AC).
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestSupervisor builds a Supervisor with the harness server listening
+// but no pi child spawned. Suitable for exercising SetPiSessionPath and the
+// session_status handler in isolation. Returns the Supervisor and its
+// auto-generated instance ID.
+func newTestSupervisor(t *testing.T, sessionName string) (*Supervisor, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	// Use a short run dir to stay under the Unix socket path limit
+	// (sun_path is 108 bytes). The default per-test tempdir under
+	// /tmp/<TestName>/NNN/ can already eat 60+ bytes which, plus the
+	// UUID (36) plus "/harness.sock" (13), busts the limit.
+	runDir, err := os.MkdirTemp("", "iris-set-pi-")
+	if err != nil {
+		t.Fatalf("MkdirTemp runDir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(runDir) })
+
+	cfg := SupervisorConfig{
+		SessionName:      sessionName,
+		Worktree:         tmp,
+		Role:             "worker",
+		PIBinaryPath:     "/bin/true",
+		RestartThreshold: 1,
+		RunDir:           runDir,
+		Database:         database,
+		// PIAgentDir points at a tmp dir so resolvePiSessionPath falls
+		// back to the bare UUID when no JSONL file is on disk -- which
+		// is exactly the behaviour we want to assert in these tests
+		// (path resolution proper is covered by the restore tests, which
+		// share the underlying findPiSessionJSONL logic).
+		PIAgentDir: filepath.Join(tmp, "pi-agent"),
+	}
+
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(func() { sup.harness.Close() })
+
+	return sup, sup.sess.InstanceID
+}
+
+// TestSupervisor_SetPiSessionPath_Mutates verifies the basic invariant: a
+// call to SetPiSessionPath updates the in-memory SessionRecord such that the
+// next SessionRecord() observes the new value.
+func TestSupervisor_SetPiSessionPath_Mutates(t *testing.T) {
+	sup, instanceID := newTestSupervisor(t, "test@set-pi-session-path")
+
+	const wantPath = "/home/ben/.pi/agent/sessions/--tmp-foo--/123_uuid.jsonl"
+	sup.SetPiSessionPath(instanceID, wantPath)
+
+	got := sup.SessionRecord().PiSessionPath
+	if got != wantPath {
+		t.Errorf("SessionRecord().PiSessionPath after SetPiSessionPath = %q; want %q",
+			got, wantPath)
+	}
+}
+
+// TestSupervisor_SetPiSessionPath_IgnoresWrongInstanceID is a defensive check:
+// the setter is scoped to this supervisor's session, so a call with a
+// different instanceID must be a no-op.
+func TestSupervisor_SetPiSessionPath_IgnoresWrongInstanceID(t *testing.T) {
+	sup, _ := newTestSupervisor(t, "test@wrong-id")
+
+	sup.SetPiSessionPath("not-this-session", "/some/other/path.jsonl")
+	if got := sup.SessionRecord().PiSessionPath; got != "" {
+		t.Errorf("SessionRecord().PiSessionPath after wrong-id setter call = %q; want empty",
+			got)
+	}
+}
+
+// TestSupervisor_SetPiSessionPath_Concurrent exercises the security AC: a
+// setter goroutine and a reader goroutine (mirroring activeSessions()) must
+// not race under -race. The test runs a bounded number of iterations and
+// asserts every observed value is one of the values that has been set.
+func TestSupervisor_SetPiSessionPath_Concurrent(t *testing.T) {
+	sup, instanceID := newTestSupervisor(t, "test@race")
+
+	const iters = 2000
+	paths := []string{
+		"/p/a.jsonl",
+		"/p/b.jsonl",
+		"/p/c.jsonl",
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var observedBad atomic.Int64
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			sup.SetPiSessionPath(instanceID, paths[i%len(paths)])
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		valid := map[string]bool{"": true}
+		for _, p := range paths {
+			valid[p] = true
+		}
+		for i := 0; i < iters; i++ {
+			rec := sup.SessionRecord()
+			if !valid[rec.PiSessionPath] {
+				observedBad.Add(1)
+			}
+		}
+	}()
+	wg.Wait()
+
+	if n := observedBad.Load(); n > 0 {
+		t.Errorf("reader observed %d unexpected PiSessionPath values -- either a torn read or a non-atomic update", n)
+	}
+}
+
+// TestSupervisor_SessionStatus_PopulatesInMemoryRecord is the integration AC:
+// driving a session_status frame through the harness socket must cause the
+// in-memory SessionRecord.PiSessionPath to be populated immediately after
+// the DB write, with no other prerequisites (no subscriber connected, no
+// state transition).
+//
+// The test stands up a real HarnessSocketServer wired to a Supervisor (so
+// the SetSessionStatusHandler callback from NewSupervisor is in effect),
+// completes the harness handshake, sends a session_status frame, and polls
+// the in-memory record until it's populated.
+func TestSupervisor_SessionStatus_PopulatesInMemoryRecord(t *testing.T) {
+	const sessionUUID = "pi-ses-test-1682"
+	sup, instanceID := newTestSupervisor(t, "test@session-status-1682")
+
+	// NewSupervisor already called harness.Listen(); just start accepting.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { _ = sup.harness.AcceptOne(ctx) }()
+
+	// Dial and complete the handshake.
+	conn, err := net.DialTimeout("unix", sup.harness.sockPath, time.Second)
+	if err != nil {
+		t.Fatalf("dial harness: %v", err)
+	}
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	hello := map[string]any{
+		"type":             "hello",
+		"protocol_version": ProtocolVersion,
+		"harness":          "pi",
+		"harness_version":  "test",
+	}
+	if err := writeJSONLFrame(conn, hello); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+	if _, err := r.ReadBytes('\n'); err != nil {
+		t.Fatalf("read hello_ack: %v", err)
+	}
+
+	// Send session_status with a session_id.
+	if err := writeJSONLFrame(conn, map[string]any{
+		"type":       "session_status",
+		"session_id": sessionUUID,
+	}); err != nil {
+		t.Fatalf("write session_status: %v", err)
+	}
+
+	// Poll the in-memory record for the populated PiSessionPath.
+	deadline := time.Now().Add(2 * time.Second)
+	var got string
+	for time.Now().Before(deadline) {
+		got = sup.SessionRecord().PiSessionPath
+		if got != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got == "" {
+		t.Fatal("SessionRecord().PiSessionPath remained empty after session_status -- in-memory wiring is broken")
+	}
+	if got != sessionUUID {
+		// If we ever resolve to a real path it should at least contain
+		// the UUID. With no JSONL on disk the fallback is the UUID.
+		t.Logf("PiSessionPath = %q (UUID-fallback expected for this test fixture)", got)
+	}
+
+	// And the DB row must also have the UUID -- keep the assertion here so
+	// we catch any future refactor that drops the DB write.
+	var dbHSID string
+	row := sup.cfg.Database.QueryRow(
+		`SELECT COALESCE(harness_session_id, '') FROM sessions WHERE instance_id = ?`,
+		instanceID,
+	)
+	if err := row.Scan(&dbHSID); err != nil {
+		t.Fatalf("query sessions.harness_session_id: %v", err)
+	}
+	if dbHSID != sessionUUID {
+		t.Errorf("DB harness_session_id = %q; want %q", dbHSID, sessionUUID)
+	}
+}
+
+// writeJSONLFrame writes a single JSON line frame on conn.
+func writeJSONLFrame(conn net.Conn, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = conn.Write(data)
+	return err
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/db"
+	piharness "github.com/prismatic-koi/prism/internal/harness/pi"
 )
 
 // SupervisorConfig holds the spawn parameters for one pi session.
@@ -141,19 +142,99 @@ func NewSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 		log.Printf("[iris] supervisor: failed to set initial iris_state: %v", err)
 	}
 
-	return &Supervisor{
+	sup := &Supervisor{
 		cfg:     cfg,
 		sess:    sess,
 		harness: harness,
 		state:   StateSpawning,
-	}, nil
+	}
+	// Wire the session_status handler so the harness socket can update the
+	// in-memory SessionRecord.PiSessionPath as soon as pi delivers its
+	// session UUID (issue #1682). Without this, the in-memory record would
+	// stay empty for the entire lifetime of every live session even though
+	// the DB row is correct.
+	harness.SetSessionStatusHandler(sup.handleSessionStatus)
+	return sup, nil
 }
 
-// InstanceID returns the session instance ID.
+// handleSessionStatus is the callback the HarnessSocketServer invokes when
+// a session_status frame delivers pi's session UUID. It resolves the JSONL
+// file path the same way the D-9 restore path does and stores it on the
+// in-memory SessionRecord under the supervisor's lock.
+//
+// If the JSONL file cannot be located (a transient condition at the moment
+// session_status arrives — pi may not yet have flushed the first chunk),
+// the UUID itself is stored as the path. This keeps harness_session_id
+// non-empty for the live-session AC; the next daemon-restart restore will
+// upgrade it to a full path via findPiSessionJSONL.
+func (s *Supervisor) handleSessionStatus(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	path := s.resolvePiSessionPath(sessionID)
+	s.SetPiSessionPath(s.sess.InstanceID, path)
+}
+
+// resolvePiSessionPath finds the pi JSONL file for the given session UUID by
+// scanning the per-cwd pi sessions directory. Mirrors findPiSessionJSONL
+// (used by the restore path) so live and restored sessions converge on the
+// same path format.
+func (s *Supervisor) resolvePiSessionPath(sessionID string) string {
+	piAgentDir := s.cfg.PIAgentDir
+	if piAgentDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			// Cannot resolve — fall back to the bare UUID so clients still
+			// see a non-empty harness_session_id.
+			return sessionID
+		}
+		piAgentDir = filepath.Join(home, ".pi", "agent")
+	}
+	encodedCWD := piharness.EncodePiCWD(s.sess.Worktree)
+	cwdDir := filepath.Join(piAgentDir, "sessions", encodedCWD)
+	entries, err := os.ReadDir(cwdDir)
+	if err != nil {
+		return sessionID
+	}
+	suffix := "_" + sessionID + ".jsonl"
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), suffix) {
+			return filepath.Join(cwdDir, e.Name())
+		}
+	}
+	return sessionID
+}
+
+// InstanceID returns the session instance ID. The instance ID is immutable
+// after NewSupervisor returns so this is safe without holding the lock.
 func (s *Supervisor) InstanceID() string { return s.sess.InstanceID }
 
-// SessionRecord returns a copy of the session record.
-func (s *Supervisor) SessionRecord() SessionRecord { return s.sess }
+// SessionRecord returns a copy of the session record under the supervisor's
+// lock so callers see a consistent snapshot of fields that may be mutated
+// concurrently (State, PiSessionPath, RestartCount).
+func (s *Supervisor) SessionRecord() SessionRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sess
+}
+
+// SetPiSessionPath updates the in-memory SessionRecord's PiSessionPath field
+// under the supervisor's lock. Called by the harness socket session_status
+// handler immediately after the DB write so that daemonState.activeSessions()
+// (which reads from the in-memory record, not the DB) reports the correct
+// harness_session_id for live sessions.
+//
+// The instanceID argument is checked against this supervisor's instance ID;
+// a mismatch is a no-op (defensive — the caller should already be scoped
+// to this supervisor's session).
+func (s *Supervisor) SetPiSessionPath(instanceID, path string) {
+	if instanceID != s.sess.InstanceID {
+		return
+	}
+	s.mu.Lock()
+	s.sess.PiSessionPath = path
+	s.mu.Unlock()
+}
 
 // SetPublisher wires an EventPublisher to this supervisor's harness socket.
 // It may be called at any time after NewSupervisor returns and before or


### PR DESCRIPTION
## Summary

Fixes the bug where `iris.SessionRecord.PiSessionPath` was only ever populated by the D-9 restore path. Live (non-restored) sessions emitted an empty `harness_session_id` in `sessions_snapshot` frames and `iris sessions list --json` output, because the in-memory record that `daemonState.activeSessions()` reads was never updated. The DB was always correct (via `IrisUpdateHarnessSessionID`), but the in-memory side lagged forever.

## Change

- **`Supervisor.SetPiSessionPath(instanceID, path)`** — thread-safe setter on the supervisor, mutating `s.sess.PiSessionPath` under the existing `s.mu` lock. Defensive instance-ID check so a mismatched caller is a no-op.
- **`Supervisor.SessionRecord()`** — now lock-protected. `activeSessions()` and friends previously read `s.sess` without locking, which would have been flagged by `-race` against the new concurrent setter.
- **`HarnessSocketServer.SetSessionStatusHandler(fn)`** — new wiring point so the harness socket can call back into the supervisor without holding a back-pointer. `NewSupervisor` installs `sup.handleSessionStatus` as the handler.
- **`handleSessionStatus`** — resolves the JSONL path the same way the D-9 restore path does (`piharness.EncodePiCWD` + directory scan), falling back to the bare UUID if the file isn't on disk yet. Then calls `SetPiSessionPath`.
- **`harness_socket.go::session_status`** — invokes the handler immediately after the `IrisUpdateHarnessSessionID` DB write, preserving the PR #1657 ordering invariant (DB write → observation event write).
- **Doc comment** — `SessionSnapshot.HarnessSessionID` no longer hedges with "may be empty before the harness handshake has completed"; the transient window is now millisecond-scale.

## Tests

All in `internal/iris/set_pi_session_path_test.go`:

- `TestSupervisor_SetPiSessionPath_Mutates` — basic in-memory mutation.
- `TestSupervisor_SetPiSessionPath_IgnoresWrongInstanceID` — defensive setter behaviour.
- `TestSupervisor_SetPiSessionPath_Concurrent` — concurrent setter + `SessionRecord()` reads under `-race` (security AC). Runs 2000 iterations on each goroutine.
- `TestSupervisor_SessionStatus_PopulatesInMemoryRecord` — end-to-end through the harness socket: handshake, send `session_status`, observe in-memory `PiSessionPath` populated and DB `harness_session_id` set.

## Quality gates

- ` go build ./...` ✅
- `go test ./... -race` ✅
- `nix build .#iris` ✅

## Scope

Intentionally **not** included (per issue out-of-scope section):

- Refactoring `activeSessions()` to read from the DB instead of the in-memory record.
- Auditing other `SessionRecord` fields for the same staleness pattern.
- Back-filling `PiSessionPath` for sessions created before this fix (restore handles this on next daemon restart).

Closes #1682