### PR TITLE
feat(iris): per-session log files and `iris logs <session>` CLI

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/cleanup.go
+++ b/modules/programs/prism/prism/cmd/iris/cleanup.go
@@ -62,6 +62,7 @@ func runCleanup(sessionName string) error {
 	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
 		Database:       database,
 		RunDir:         p.RunDir,
+		LogDir:         p.LogDir,
 		ArchiveRoot:    p.ArchiveRoot,
 		PIAgentDir:     cleanupPIAgentDir,
 		RemoveWorktree: cleanupRemoveWorktree,
@@ -77,6 +78,7 @@ func runCleanup(sessionName string) error {
 		fmt.Printf("  archive:        (skipped — no pi JSONL found)\n")
 	}
 	fmt.Printf("  run dir:        removed=%v\n", res.RunDirRemoved)
+	fmt.Printf("  log file:       removed=%v\n", res.LogFileRemoved)
 	fmt.Printf("  session row:    ended=%v\n", res.SessionRowRemoved)
 	fmt.Printf("  worktree:       removed=%v\n", res.WorktreeRemoved)
 	fmt.Printf("  branch:         removed=%v\n", res.BranchRemoved)

--- a/modules/programs/prism/prism/cmd/iris/logs.go
+++ b/modules/programs/prism/prism/cmd/iris/logs.go
@@ -1,0 +1,522 @@
+package main
+
+// logs.go — `iris logs <session>` subcommand (issue #1675).
+//
+// The daemon writes a per-session log file at
+// ~/.local/state/iris/logs/<session>.log capturing the supervisor's
+// session-scoped log lines (spawn, state transitions, RPC events, restart
+// decisions). `iris logs <session>` reads that file and writes to stdout.
+//
+// Flags:
+//
+//	--tail N        write only the last N lines (after-the-fact, like `tail -n N`)
+//	--follow, -f    stream new lines as they arrive (like `tail -f`)
+//
+// When --follow is set, iris dials the daemon client socket and subscribes to
+// session_state frames for the named session. When the session transitions to
+// a terminal state ("finished" or "error"), a 5-second grace timer starts;
+// any trailing log lines are emitted, then the command exits 0. The grace
+// matches prism's behaviour so trailing supervisor lines (final state write,
+// archive notice) reach the user.
+//
+// Reading the log file is a pure file operation — `iris logs` works even
+// when the daemon is dead, provided the file exists on disk. This is
+// intentional: diagnostics must work when the daemon is wedged. Terminal-
+// state detection requires the daemon (the daemon is the source of truth for
+// session lifecycle) — when the daemon is not running and --follow is set,
+// the command streams the file and exits when the file stops growing for the
+// grace window.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// logsFollowGraceForTest is the time to keep streaming after the session
+// reaches a terminal state (finished or error). Matches prism's
+// `prism logs --follow` behaviour. Five seconds is enough to capture
+// trailing supervisor lines (final state writes, archive notices, restart-
+// decision logs) without making the CLI feel sluggish to exit.
+//
+// Declared as a var (not const) so the unit tests in logs_test.go can
+// shorten it to keep the suite fast. Production code never mutates it.
+var logsFollowGraceForTest = 5 * time.Second
+
+// logsIdleGraceForTest is how long --follow waits for new lines when the
+// daemon is not reachable and we therefore cannot subscribe to
+// session_state. The command exits when no new bytes have arrived for this
+// duration. Chosen to be conservative — if a session is genuinely idle for
+// 30s, the user can re-invoke; the alternative (waiting forever) would hang
+// scripts.
+//
+// Var rather than const for the same reason as logsFollowGraceForTest.
+var logsIdleGraceForTest = 30 * time.Second
+
+// logsPollInterval is the sleep between read attempts on the log file in
+// --follow mode. Short enough to feel live, long enough that a slow disk
+// doesn't dominate.
+const logsPollInterval = 200 * time.Millisecond
+
+// subscribeProbeTimeout is how long subscribeTerminalState waits for a
+// first daemon frame before assuming the subscription is live. The daemon
+// emits an error frame immediately for unknown sessions — a timeout means
+// "subscription accepted, no events yet". 300ms is well above the loopback
+// round-trip and well below any user-visible latency.
+const subscribeProbeTimeout = 300 * time.Millisecond
+
+var (
+	logsTail   int
+	logsFollow bool
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs <session>",
+	Short: "Print or stream the daemon's per-session log file",
+	Long: `Print the iris daemon's per-session log file for <session>.
+
+The daemon writes one log file per session at ~/.local/state/iris/logs/<session>.log
+capturing supervisor lifecycle lines (spawn, state transitions, RPC observation,
+restart-policy decisions). This command reads that file.
+
+Flags:
+
+  --tail N        Print only the last N lines.
+  --follow, -f    Stream new lines as they arrive. Exits ~5 seconds after the
+                  session reaches a terminal state ("finished" or "error"),
+                  so trailing supervisor lines are captured. When the daemon
+                  is not reachable, --follow falls back to a 30-second idle
+                  timeout (no new bytes → exit).
+
+When no log file exists for the named session (e.g. the session just started
+and the supervisor has not yet written a line), the command exits 0 with no
+output rather than erroring — an empty log is not an error.
+
+Diagnostics-first: reading the log is a pure file operation. The command
+works even when the iris daemon is dead, provided the file exists on disk.
+Terminal-state detection in --follow mode requires the daemon (the daemon is
+the source of truth for session lifecycle); without it, --follow uses the
+idle-timeout fallback.`,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runLogs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	logsCmd.Flags().IntVar(&logsTail, "tail", 0, "Print only the last N lines (0 = print all)")
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Stream new lines as they arrive; exits ~5s after session reaches terminal state")
+	rootCmd.AddCommand(logsCmd)
+}
+
+// runLogs is the cobra RunE for `iris logs <session>`.
+func runLogs(cmd *cobra.Command, args []string) error {
+	sessionName := args[0]
+	if sessionName == "" {
+		return errors.New("iris logs: session name is required")
+	}
+
+	p := iris.ResolvePaths()
+	logPath := p.SessionLogPath(sessionName)
+
+	// AC: when the daemon is not running but the log file exists, the
+	// command still works. We therefore do NOT require the daemon to be
+	// reachable for the bare or --tail invocation.
+	//
+	// AC: when no log file exists, exit 0 with empty output (not an error).
+	// We rely on the daemon writing the file as soon as the supervisor logs
+	// its first line; until then, "session exists but has no log yet" is
+	// indistinguishable from "session does not exist" at the file-system
+	// level. The full session-existence check would require a DB or
+	// daemon round-trip — out of scope here per the AC.
+	//
+	// Confirming session existence (and emitting a clear "no such session"
+	// message when missing) is best-effort via the daemon when --follow is
+	// requested: a follower without a daemon round-trip cannot know when to
+	// exit, so we dial the daemon and surface "no such session" if it
+	// answers negatively.
+
+	if !logsFollow {
+		return runLogsOneShot(cmd.OutOrStdout(), logPath)
+	}
+	return runLogsFollow(cmd.Context(), cmd.OutOrStdout(), p, sessionName, logPath)
+}
+
+// runLogsOneShot reads the entire log file (or the last --tail N lines) and
+// writes to w. Missing-file is not an error.
+func runLogsOneShot(w io.Writer, logPath string) error {
+	f, err := os.Open(logPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// AC: no log file → exit 0 with empty output.
+			return nil
+		}
+		return fmt.Errorf("iris logs: open %q: %w", logPath, err)
+	}
+	defer f.Close()
+
+	if logsTail > 0 {
+		return writeLastNLines(w, f, logsTail)
+	}
+	if _, err := io.Copy(w, f); err != nil {
+		return fmt.Errorf("iris logs: read %q: %w", logPath, err)
+	}
+	return nil
+}
+
+// writeLastNLines reads from r and writes the last n lines to w. It scans
+// the full input — the per-session log is bounded by session lifetime, so
+// a streaming scan is acceptable. A ring-buffer keeps memory at O(n).
+func writeLastNLines(w io.Writer, r io.Reader, n int) error {
+	if n <= 0 {
+		return nil
+	}
+	ring := make([]string, 0, n)
+	scanner := bufio.NewScanner(r)
+	// Allow long lines — supervisor RPC payloads can contain large JSON.
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		if len(ring) < n {
+			ring = append(ring, scanner.Text())
+			continue
+		}
+		// Shift left by one and append. For modest n this is fine;
+		// production tail counts are <= a few thousand.
+		copy(ring, ring[1:])
+		ring[n-1] = scanner.Text()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("iris logs: scan: %w", err)
+	}
+	for _, line := range ring {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runLogsFollow streams the log file, exiting ~5s after the session reaches a
+// terminal state. It:
+//
+//  1. Opens the log file (tolerating not-yet-present — polls until it shows up).
+//  2. Optionally seeks to the end if --tail was not given (matching `tail -f`
+//     default; if --tail N was given, prints the last N lines first then
+//     streams the tail).
+//  3. Dials the daemon client socket and subscribes to session_state for the
+//     named session. On terminal-state, starts a 5s grace timer; exits when
+//     the timer fires.
+//  4. Falls back to an idle timeout if the daemon is not reachable.
+func runLogsFollow(ctx context.Context, w io.Writer, p iris.Paths, sessionName, logPath string) error {
+	// Subscribe to session_state in a goroutine. The result is delivered via
+	// a terminalCh that closes when the daemon reports a terminal state, or
+	// is left nil when the daemon is not reachable (idle-timeout fallback).
+	terminalCh := make(chan struct{})
+	subErr := subscribeTerminalState(ctx, p.Sock, sessionName, terminalCh)
+	if subErr != nil {
+		// Daemon unreachable or session not found. The latter is an explicit
+		// "no such session" surface; the former falls back to the idle
+		// timeout. We can distinguish via the error message.
+		if isSessionNotFound(subErr) {
+			return fmt.Errorf("iris logs: %w", subErr)
+		}
+		// Daemon unreachable. Set terminalCh to nil so the streamer uses
+		// the idle-timeout fallback.
+		terminalCh = nil
+	}
+
+	// Print the last --tail N lines first if requested (matches prism behaviour).
+	startOffset := int64(0)
+	if logsTail > 0 {
+		f, err := os.Open(logPath)
+		if err == nil {
+			_ = writeLastNLines(w, f, logsTail)
+			off, _ := f.Seek(0, io.SeekEnd)
+			startOffset = off
+			f.Close()
+		} else if errors.Is(err, os.ErrNotExist) {
+			// File not present yet — fall through; streamLog will poll
+			// for it and start from offset 0.
+		} else {
+			return fmt.Errorf("iris logs: open %q: %w", logPath, err)
+		}
+	} else {
+		// Default --follow with no --tail: start from end of current file
+		// to mimic `tail -f` (don't dump the whole history). Issue #1675
+		// is silent on this choice; matching `tail -f` is the least
+		// surprising option.
+		if st, err := os.Stat(logPath); err == nil {
+			startOffset = st.Size()
+		}
+	}
+
+	return streamLog(ctx, w, logPath, startOffset, terminalCh)
+}
+
+// streamLog tails the file at logPath starting from startOffset and writes
+// new bytes to w. It returns when either:
+//
+//   - terminalCh closes, then logsFollowGrace elapses (the daemon-driven exit
+//     path), or
+//   - no new bytes have arrived for logsIdleGrace (the daemon-unreachable
+//     fallback; terminalCh is nil), or
+//   - ctx is cancelled.
+//
+// Re-opens the file on rotation. Bounded poll interval keeps CPU near zero.
+func streamLog(ctx context.Context, w io.Writer, logPath string, startOffset int64, terminalCh <-chan struct{}) error {
+	var (
+		f         *os.File
+		offset    = startOffset
+		lastBytes = time.Now()
+		// graceDeadline is non-zero only after terminalCh has closed.
+		graceDeadline time.Time
+	)
+	closeFile := func() {
+		if f != nil {
+			f.Close()
+			f = nil
+		}
+	}
+	defer closeFile()
+
+	ticker := time.NewTicker(logsPollInterval)
+	defer ticker.Stop()
+
+	// Drain initial available bytes immediately (don't wait for the first tick).
+	for {
+		// Open the file lazily — it may not exist yet (no log lines written).
+		if f == nil {
+			ff, err := os.Open(logPath)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("iris logs: open %q: %w", logPath, err)
+				}
+				// File not present — keep waiting.
+			} else {
+				f = ff
+				if _, err := f.Seek(offset, io.SeekStart); err != nil {
+					closeFile()
+					return fmt.Errorf("iris logs: seek %q: %w", logPath, err)
+				}
+			}
+		}
+
+		// Read whatever is available.
+		if f != nil {
+			n, err := io.Copy(w, f)
+			if err != nil {
+				closeFile()
+				return fmt.Errorf("iris logs: read %q: %w", logPath, err)
+			}
+			if n > 0 {
+				offset += n
+				lastBytes = time.Now()
+			}
+		}
+
+		// Decide whether to exit.
+		if terminalCh != nil {
+			select {
+			case <-terminalCh:
+				if graceDeadline.IsZero() {
+					graceDeadline = time.Now().Add(logsFollowGraceForTest)
+				}
+			default:
+			}
+			if !graceDeadline.IsZero() && time.Now().After(graceDeadline) {
+				return nil
+			}
+		} else {
+			// Idle-timeout fallback when the daemon is unreachable.
+			if time.Since(lastBytes) > logsIdleGraceForTest {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// isSessionNotFound reports whether err is the daemon's "session not found"
+// error response. The daemon's session_subscribe handler emits an error
+// frame with message containing "not found" when the session is unknown.
+func isSessionNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "not found")
+}
+
+// subscribeTerminalState dials the daemon and subscribes to session_state
+// frames for the named session. When a terminal-state frame ("finished" or
+// "error") arrives, terminalCh is closed. The goroutine exits when the
+// daemon connection drops, ctx is cancelled, or a terminal state is seen.
+//
+// Returns nil when the subscription is successfully established (the
+// goroutine is running). Returns a non-nil error when:
+//
+//   - the daemon socket is not present or refuses the connection
+//     (the caller falls back to the idle-timeout path), or
+//   - the daemon answers session_subscribe with an error frame
+//     (e.g. "session not found"; the caller surfaces this verbatim).
+func subscribeTerminalState(ctx context.Context, sockPath, sessionName string, terminalCh chan<- struct{}) error {
+	// Phase 1: dial.
+	if _, err := os.Stat(sockPath); err != nil {
+		return fmt.Errorf("daemon not running: %w", err)
+	}
+	dialer := net.Dialer{Timeout: daemonDialTimeout}
+	conn, err := dialer.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("dial daemon: %w", err)
+	}
+
+	// Phase 2: send session_subscribe.
+	req := iris.ClientSessionSubscribeFrame{
+		Type: iris.ClientFrameSessionSubscribe,
+		Name: sessionName,
+	}
+	reqBytes, _ := json.Marshal(req)
+	reqBytes = append(reqBytes, '\n')
+	_ = conn.SetWriteDeadline(time.Now().Add(daemonReadTimeout))
+	if _, err := conn.Write(reqBytes); err != nil {
+		conn.Close()
+		return fmt.Errorf("write session_subscribe: %w", err)
+	}
+	// Clear the write deadline; reads below have their own per-frame deadline.
+	_ = conn.SetWriteDeadline(time.Time{})
+
+	// Phase 3: poll the connection for a short window so we can detect
+	// "session not found" synchronously (the daemon emits an error frame
+	// immediately for unknown sessions). If the deadline expires without a
+	// frame, the subscription is live (the daemon only sends frames when
+	// events arrive). We then spawn the long-running goroutine and return
+	// nil.
+	r := bufio.NewReaderSize(conn, 1*1024*1024)
+	_ = conn.SetReadDeadline(time.Now().Add(subscribeProbeTimeout))
+	first, readErr := r.ReadBytes('\n')
+	_ = conn.SetReadDeadline(time.Time{})
+
+	var (
+		sawFirst bool
+		firstFrame []byte = first
+	)
+	if readErr == nil {
+		sawFirst = true
+	} else {
+		// A net.Error timeout means no frame arrived in the probe window —
+		// that's the expected "subscription is live" case. Any other error
+		// (EOF, connection reset, etc.) is a real failure.
+		ne, ok := readErr.(net.Error)
+		if !ok || !ne.Timeout() {
+			conn.Close()
+			return fmt.Errorf("read first frame: %w", readErr)
+		}
+	}
+
+	if sawFirst {
+		var head struct {
+			Type        string `json:"type"`
+			Message     string `json:"message"`
+			RequestType string `json:"request_type"`
+		}
+		if err := json.Unmarshal(firstFrame, &head); err != nil {
+			conn.Close()
+			return fmt.Errorf("malformed daemon response: %w", err)
+		}
+		if head.Type == iris.DaemonFrameError {
+			conn.Close()
+			// "session not found" or similar — surface verbatim.
+			return errors.New(head.Message)
+		}
+		// A state frame arriving as the first frame is possible if there's
+		// a race between subscribe and a transition; handle it now.
+		if head.Type == iris.DaemonFrameSessionState {
+			var sf iris.DaemonSessionStateFrame
+			if err := json.Unmarshal(firstFrame, &sf); err == nil && isTerminalState(sf.State) {
+				close(terminalCh)
+				conn.Close()
+				return nil
+			}
+		}
+		// Otherwise: an event frame arrived. Subscription is live; fall
+		// through to the goroutine which will continue draining.
+	}
+
+	// Subscription is live. Drain the remaining frames in a goroutine.
+	go func() {
+		defer conn.Close()
+		// Close terminalCh exactly once.
+		closed := false
+		closeOnce := func() {
+			if !closed {
+				close(terminalCh)
+				closed = true
+			}
+		}
+		// On any unexpected exit (connection drop, EOF), we do NOT close
+		// terminalCh — the streamer should keep tailing until ctx is
+		// cancelled or the idle timeout fires. This mirrors the prism
+		// behaviour where a dead daemon does not immediately terminate
+		// the follower.
+		defer func() {
+			// If ctx was cancelled, propagate by closing terminalCh so the
+			// streamer exits promptly. ctx.Err() is non-nil only after Done.
+			if ctx.Err() != nil {
+				closeOnce()
+			}
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			line, err := r.ReadBytes('\n')
+			if err != nil {
+				return
+			}
+			var h struct {
+				Type string `json:"type"`
+			}
+			if err := json.Unmarshal(line, &h); err != nil {
+				continue
+			}
+			if h.Type != iris.DaemonFrameSessionState {
+				continue
+			}
+			var sf iris.DaemonSessionStateFrame
+			if err := json.Unmarshal(line, &sf); err != nil {
+				continue
+			}
+			if isTerminalState(sf.State) {
+				closeOnce()
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// isTerminalState returns true for state names that represent a session
+// reaching the end of its lifetime ("finished" or "error"). The string set
+// mirrors the SessionState constants in internal/iris.
+func isTerminalState(state string) bool {
+	return state == "finished" || state == "error"
+}

--- a/modules/programs/prism/prism/cmd/iris/logs_test.go
+++ b/modules/programs/prism/prism/cmd/iris/logs_test.go
@@ -1,0 +1,329 @@
+package main
+
+// logs_test.go — unit tests for `iris logs <session>` (issue #1675).
+//
+// Covers:
+//   - one-shot read: full log, --tail N
+//   - missing log file → exit 0 with empty output
+//   - --follow: streams new bytes, exits after terminal-state grace
+//   - --follow: idle-timeout fallback when the daemon is unreachable
+//   - subscribeTerminalState: detects "session not found" vs. "daemon down"
+//
+// Integration with the supervisor's per-session log writer is covered by
+// internal/iris/supervisor_logfile_test.go.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// TestRunLogsOneShot_FullFile exercises the bare `iris logs <session>` path:
+// the entire log file is copied to stdout, byte-for-byte.
+func TestRunLogsOneShot_FullFile(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "test.log")
+	content := "line one\nline two\nline three\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Reset flag globals between tests — Cobra leaves them set across runs.
+	logsTail = 0
+	logsFollow = false
+
+	var buf bytes.Buffer
+	if err := runLogsOneShot(&buf, logPath); err != nil {
+		t.Fatalf("runLogsOneShot: %v", err)
+	}
+	if buf.String() != content {
+		t.Fatalf("output mismatch:\n got:  %q\n want: %q", buf.String(), content)
+	}
+}
+
+// TestRunLogsOneShot_TailN exercises --tail N: only the last N lines are
+// printed, in order.
+func TestRunLogsOneShot_TailN(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "test.log")
+	content := "a\nb\nc\nd\ne\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	logsTail = 3
+	logsFollow = false
+	t.Cleanup(func() { logsTail = 0 })
+
+	var buf bytes.Buffer
+	if err := runLogsOneShot(&buf, logPath); err != nil {
+		t.Fatalf("runLogsOneShot: %v", err)
+	}
+	want := "c\nd\ne\n"
+	if buf.String() != want {
+		t.Fatalf("tail output mismatch:\n got:  %q\n want: %q", buf.String(), want)
+	}
+}
+
+// TestRunLogsOneShot_TailLargerThanFile asserts --tail N > file-lines returns
+// the entire file rather than padding or erroring.
+func TestRunLogsOneShot_TailLargerThanFile(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "test.log")
+	content := "x\ny\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	logsTail = 100
+	logsFollow = false
+	t.Cleanup(func() { logsTail = 0 })
+
+	var buf bytes.Buffer
+	if err := runLogsOneShot(&buf, logPath); err != nil {
+		t.Fatalf("runLogsOneShot: %v", err)
+	}
+	if buf.String() != content {
+		t.Fatalf("output mismatch:\n got:  %q\n want: %q", buf.String(), content)
+	}
+}
+
+// TestRunLogsOneShot_MissingFile asserts that a missing log file yields
+// exit 0 with no output — the AC: "no log file yet → exit 0 with empty
+// output (not error)".
+func TestRunLogsOneShot_MissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "does-not-exist.log")
+
+	logsTail = 0
+	logsFollow = false
+
+	var buf bytes.Buffer
+	if err := runLogsOneShot(&buf, logPath); err != nil {
+		t.Fatalf("runLogsOneShot: expected nil error for missing file, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected empty output for missing file, got %q", buf.String())
+	}
+}
+
+// TestStreamLog_TailFollow_TerminalGrace asserts that streamLog reads new
+// bytes appended after start, then exits within the grace window after
+// terminalCh closes.
+func TestStreamLog_TailFollow_TerminalGrace(t *testing.T) {
+	// Short-circuit constants for the test so the suite stays fast.
+	oldGrace := logsFollowGraceForTest
+	logsFollowGraceForTest = 150 * time.Millisecond
+	t.Cleanup(func() { logsFollowGraceForTest = oldGrace })
+
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "tail.log")
+	if err := os.WriteFile(logPath, []byte("initial\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	terminalCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		// Start at offset 0 so the test can see "initial\n" plus any appended lines.
+		done <- streamLog(ctx, &buf, logPath, 0, terminalCh)
+	}()
+
+	// Append a second line after a brief delay so the poller picks it up.
+	time.Sleep(50 * time.Millisecond)
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open append: %v", err)
+	}
+	if _, err := f.WriteString("appended\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	f.Close()
+
+	// Allow the poller to read the appended line.
+	time.Sleep(2 * logsPollInterval)
+
+	// Signal terminal state. streamLog should exit within grace.
+	close(terminalCh)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamLog returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamLog did not exit within timeout after terminalCh closed")
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "initial") || !strings.Contains(got, "appended") {
+		t.Fatalf("expected to see both 'initial' and 'appended' in output, got %q", got)
+	}
+}
+
+// TestStreamLog_IdleTimeout asserts that with terminalCh == nil (daemon
+// unreachable), streamLog exits after logsIdleGraceForTest of no new bytes.
+func TestStreamLog_IdleTimeout(t *testing.T) {
+	oldIdle := logsIdleGraceForTest
+	logsIdleGraceForTest = 200 * time.Millisecond
+	t.Cleanup(func() { logsIdleGraceForTest = oldIdle })
+
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "idle.log")
+	if err := os.WriteFile(logPath, []byte("hello\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var buf bytes.Buffer
+	start := time.Now()
+	if err := streamLog(ctx, &buf, logPath, 0, nil); err != nil {
+		t.Fatalf("streamLog: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("streamLog returned too quickly: %v (expected >= idle grace)", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("streamLog took too long: %v", elapsed)
+	}
+	if !strings.Contains(buf.String(), "hello") {
+		t.Fatalf("expected initial content, got %q", buf.String())
+	}
+}
+
+// TestSubscribeTerminalState_SessionNotFound starts an in-process daemon
+// client socket with no sessions, then asserts that subscribeTerminalState
+// returns a "not found" error (not a daemon-unreachable error).
+func TestSubscribeTerminalState_SessionNotFound(t *testing.T) {
+	sockPath := startEmptyDaemonSocket(t)
+	terminalCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := subscribeTerminalState(ctx, sockPath, "nonexistent@branch", terminalCh)
+	if err == nil {
+		t.Fatal("expected error for nonexistent session, got nil")
+	}
+	if !isSessionNotFound(err) {
+		t.Fatalf("expected session-not-found error, got: %v", err)
+	}
+}
+
+// TestSubscribeTerminalState_DaemonDown asserts that a non-existent socket
+// path returns a non-not-found error (the streamer's fallback path).
+func TestSubscribeTerminalState_DaemonDown(t *testing.T) {
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "missing.sock")
+
+	terminalCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := subscribeTerminalState(ctx, sockPath, "any@branch", terminalCh)
+	if err == nil {
+		t.Fatal("expected error for missing daemon socket, got nil")
+	}
+	if isSessionNotFound(err) {
+		t.Fatalf("expected daemon-down error, got session-not-found: %v", err)
+	}
+}
+
+// TestSubscribeTerminalState_TerminalCloses starts an in-process daemon,
+// subscribes, then publishes a "finished" state. terminalCh must close.
+func TestSubscribeTerminalState_TerminalCloses(t *testing.T) {
+	sessions := []iris.SessionSnapshot{{Name: "x@branch", InstanceID: "00000000-0000-0000-0000-000000000001", State: "active"}}
+	cs, sockPath := startDaemonSocketWithSessions(t, sessions)
+
+	terminalCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := subscribeTerminalState(ctx, sockPath, "x@branch", terminalCh); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	// Give the daemon's runSubscription goroutine a moment to register
+	// the live channel before we publish.
+	time.Sleep(50 * time.Millisecond)
+	cs.PublishState("x@branch", "finished")
+
+	select {
+	case <-terminalCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminalCh did not close after publishing 'finished' state")
+	}
+}
+
+// --- Helpers ---
+
+// startEmptyDaemonSocket starts an iris.ClientSocket bound to a tempdir
+// socket path, with no active sessions. The socket is torn down on cleanup.
+func startEmptyDaemonSocket(t *testing.T) string {
+	t.Helper()
+	_, sockPath := startDaemonSocketWithSessions(t, nil)
+	return sockPath
+}
+
+// startDaemonSocketWithSessions starts an iris.ClientSocket bound to a
+// tempdir socket path, returning the socket and its path. The provided
+// sessions list is served via the GetActiveSessions callback.
+func startDaemonSocketWithSessions(t *testing.T, sessions []iris.SessionSnapshot) (*iris.ClientSocket, string) {
+	t.Helper()
+
+	// Short prefix to stay under the 108-byte sun_path limit.
+	shortPrefix, err := os.MkdirTemp("", "iris-logs-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	t.Cleanup(serveCancel)
+	go cs.Serve(serveCtx)
+
+	// Spin until the socket file exists.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return cs, sockPath
+}
+

--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -126,6 +126,7 @@ func startup() error {
 			ExtensionPath:    extensionPath,
 			RestartThreshold: cfg.RestartThreshold,
 			RunDir:           p.RunDir,
+			LogDir:           p.LogDir,
 			Database:         db,
 		},
 	}
@@ -283,6 +284,7 @@ func runDaemon() error {
 			ExtensionPath:    extPath,
 			RestartThreshold: cfg.RestartThreshold,
 			RunDir:           p.RunDir,
+			LogDir:           p.LogDir,
 			Database:         database,
 			// Wire the client socket as the harness publisher so that every
 			// harness event is fanned out to all subscribed clients in real time.

--- a/modules/programs/prism/prism/internal/iris/cleanup.go
+++ b/modules/programs/prism/prism/internal/iris/cleanup.go
@@ -61,6 +61,11 @@ type CleanupConfig struct {
 	// RunDir is the iris run directory (e.g. ~/.local/state/iris/run/).
 	// Per-session subdirs under this path are removed.
 	RunDir string
+	// LogDir is the iris per-session log directory (e.g.
+	// ~/.local/state/iris/logs/). When non-empty, cleanup removes the
+	// per-session log file at <LogDir>/<session>.log. Empty disables the
+	// log-removal step (used by tests that don't exercise the log path).
+	LogDir string
 	// ArchiveRoot is the root of the iris archive tree
 	// (e.g. ~/code/archives/iris/). Session JSONL files are copied to
 	// <ArchiveRoot>/<session>/<instance_id>/raw/session.jsonl.
@@ -88,6 +93,10 @@ type CleanupResult struct {
 	SessionRowRemoved bool
 	// RunDirRemoved is true when <RunDir>/<instance_id>/ was removed.
 	RunDirRemoved bool
+	// LogFileRemoved is true when the per-session log file at
+	// <LogDir>/<session>.log was removed (or was already absent). Always
+	// true on the success path when LogDir is non-empty.
+	LogFileRemoved bool
 	// WorktreeRemoved is true when the worktree was removed
 	// (RemoveWorktree=true and removal succeeded).
 	WorktreeRemoved bool
@@ -162,6 +171,21 @@ func CleanupSession(ctx context.Context, cfg CleanupConfig, sessionName string) 
 	} else {
 		log.Printf("[iris] cleanup: stat run dir %q: %v", sessionRunDir, err)
 		res.Errors = append(res.Errors, fmt.Errorf("stat run dir: %w", err))
+	}
+
+	// Step 4b: remove the per-session log file.
+	if cfg.LogDir != "" {
+		logPath := (Paths{LogDir: cfg.LogDir}).SessionLogPath(sess.SessionName)
+		if err := os.Remove(logPath); err != nil {
+			if os.IsNotExist(err) {
+				res.LogFileRemoved = true
+			} else {
+				log.Printf("[iris] cleanup: remove log file %q: %v", logPath, err)
+				res.Errors = append(res.Errors, fmt.Errorf("remove log file: %w", err))
+			}
+		} else {
+			res.LogFileRemoved = true
+		}
 	}
 
 	// Step 5: remove the worktree and branch when requested and safe.

--- a/modules/programs/prism/prism/internal/iris/cleanup_logfile_test.go
+++ b/modules/programs/prism/prism/internal/iris/cleanup_logfile_test.go
@@ -1,0 +1,133 @@
+package iris_test
+
+// cleanup_logfile_test.go — tests that iris.CleanupSession removes the
+// per-session log file at <LogDir>/<session>.log (issue #1675).
+//
+// Other cleanup-step coverage lives in internal/iris/parity/cleanup_test.go;
+// this file is narrowly scoped to the log-file removal step so it can be
+// asserted without standing up a full git+pi layout.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// TestCleanup_RemovesPerSessionLogFile asserts that CleanupSession removes
+// the per-session log file when LogDir is configured.
+func TestCleanup_RemovesPerSessionLogFile(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	sessionName := iristest.SessionName("logfile-cleanup")
+	instanceID := "iris-test-logfile-cleanup-001"
+	role := "worker"
+
+	// Seed a session row so CleanupSession resolves it.
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Worktree:    "", // worktree-less is fine: cleanup tolerates it.
+		Harness:     "pi",
+		AgentRole:   &role,
+		StartedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	// Create a per-session log file at the canonical location.
+	logPath := iso.Paths.SessionLogPath(sessionName)
+	if err := os.MkdirAll(iso.Paths.LogDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll LogDir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("some log content\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile log: %v", err)
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, sessionName)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	if !res.LogFileRemoved {
+		t.Errorf("LogFileRemoved=false, want true (errors=%v)", res.Errors)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Errorf("log file %q still exists after cleanup (err=%v)", logPath, err)
+	}
+}
+
+// TestCleanup_MissingLogFileIsNotAnError asserts that cleaning up a session
+// with no log file (e.g. one that crashed before writing) still succeeds and
+// reports LogFileRemoved=true (treating absent-on-cleanup as the success
+// path).
+func TestCleanup_MissingLogFileIsNotAnError(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	sessionName := iristest.SessionName("logfile-cleanup-missing")
+	instanceID := "iris-test-logfile-cleanup-002"
+	role := "worker"
+
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Worktree:    "",
+		Harness:     "pi",
+		AgentRole:   &role,
+		StartedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	logPath := iso.Paths.SessionLogPath(sessionName)
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: log file %q must not exist", logPath)
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, sessionName)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+	if !res.LogFileRemoved {
+		t.Errorf("LogFileRemoved=false on missing log; want true (errors=%v)", res.Errors)
+	}
+	// Sanity: errors slice should not mention the log file at all.
+	for _, e := range res.Errors {
+		if filepath.Dir(logPath) != "" && e != nil {
+			// We don't want a "no such file or directory" error here.
+			if errMentionsPath(e.Error(), logPath) {
+				t.Errorf("unexpected error mentioning log path: %v", e)
+			}
+		}
+	}
+}
+
+// errMentionsPath is a cheap substring check used to confirm we did not
+// surface a not-exist error in the cleanup result for the missing log.
+func errMentionsPath(msg, path string) bool {
+	return len(msg) >= len(path) && contains(msg, path)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -75,6 +75,16 @@ type EventPublication struct {
 	Payload     string
 }
 
+// subscriberMessage is the wrapper type carried on per-subscriber channels.
+// Exactly one of Event or State is populated. State carries a session-state
+// transition ("spawning" -> "active" -> "finished"|"error"); Event carries a
+// session_event from the harness. Splitting these in a union avoids the cost
+// of a separate channel per subscriber.
+type subscriberMessage struct {
+	Event *EventPublication
+	State string // "" when this message is an event
+}
+
 // ClientSocket is the user-facing IPC socket. It binds to the iris.sock path
 // and manages per-client connection goroutines and the per-session subscriber
 // map for fan-out.
@@ -101,7 +111,7 @@ type ClientSocket struct {
 // unsubscribe can remove the correct entry from the slice.
 type subscriberChan struct {
 	id string
-	ch chan EventPublication
+	ch chan subscriberMessage
 }
 
 // PublisherFunc is an adapter that allows a plain function to be used as an
@@ -222,14 +232,41 @@ func (cs *ClientSocket) Publish(pub EventPublication) {
 	copy(chans, cs.subscribers[pub.SessionName])
 	cs.subMu.Unlock()
 
+	event := pub // copy so the pointer below is stable for this iteration
+	msg := subscriberMessage{Event: &event}
 	for _, sc := range chans {
 		select {
-		case sc.ch <- pub:
+		case sc.ch <- msg:
 		default:
 			// The subscriber channel is full. We drop the event for this
 			// subscriber; the subscriber goroutine will detect the next
 			// failure and close the connection.
 			log.Printf("[iris] client socket: subscriber %s for session %q channel full, dropping event", sc.id, pub.SessionName)
+		}
+	}
+}
+
+// PublishState broadcasts a session_state transition to all clients
+// subscribed to the named session. Implements stateNotifier so the supervisor
+// can deliver state changes without coupling to the ClientSocket concrete
+// type. State is one of the SessionState string values ("spawning",
+// "active", "finished", "error").
+func (cs *ClientSocket) PublishState(sessionName, state string) {
+	cs.subMu.Lock()
+	chans := make([]subscriberChan, len(cs.subscribers[sessionName]))
+	copy(chans, cs.subscribers[sessionName])
+	cs.subMu.Unlock()
+
+	msg := subscriberMessage{State: state}
+	for _, sc := range chans {
+		select {
+		case sc.ch <- msg:
+		default:
+			// Channel full — the slow subscriber will be cleaned up on its
+			// next event. Dropping a state transition is acceptable here:
+			// the caller (e.g. `iris logs --follow`) can fall back to
+			// sessions_list to recover. Log so this is observable.
+			log.Printf("[iris] client socket: subscriber %s for session %q channel full, dropping state %q", sc.id, sessionName, state)
 		}
 	}
 }
@@ -444,7 +481,7 @@ func (cs *ClientSocket) runSubscription(
 	}
 
 	// Step 3: Register the live channel.
-	ch := make(chan EventPublication, subscriberChanSize)
+	ch := make(chan subscriberMessage, subscriberChanSize)
 	cs.addSubscriber(sessionName, subscriberChan{id: subID, ch: ch})
 
 	// Step 4: Replay from DB if since_event_id was given.
@@ -477,10 +514,25 @@ func (cs *ClientSocket) runSubscription(
 		select {
 		case <-ctx.Done():
 			return
-		case pub, ok := <-ch:
+		case msg, ok := <-ch:
 			if !ok {
 				return // Channel closed.
 			}
+			if msg.State != "" {
+				stateFrame := DaemonSessionStateFrame{
+					Type:        DaemonFrameSessionState,
+					SessionName: sessionName,
+					State:       msg.State,
+				}
+				if err := w.write(stateFrame); err != nil {
+					return // Client disconnected.
+				}
+				continue
+			}
+			if msg.Event == nil {
+				continue
+			}
+			pub := *msg.Event
 			// Skip events that were already sent during the DB replay.
 			if frame.SinceEventID > 0 && pub.RowID <= snapshotRowID {
 				continue

--- a/modules/programs/prism/prism/internal/iris/paths.go
+++ b/modules/programs/prism/prism/internal/iris/paths.go
@@ -23,12 +23,39 @@ type Paths struct {
 	Sock string
 	// RunDir is ~/.local/state/iris/run/ (reserved; not used in D-2)
 	RunDir string
-	// LogDir is ~/.local/state/iris/logs/ (reserved; not used in D-2)
+	// LogDir is ~/.local/state/iris/logs/. The daemon writes one log file
+	// per session at <LogDir>/<session-name>.log. See SessionLogPath.
 	LogDir string
 	// ConfigFile is ~/.config/iris/config.json
 	ConfigFile string
 	// ArchiveRoot is ~/code/archives/iris/ (reserved; not used in D-2)
 	ArchiveRoot string
+}
+
+// SessionLogPath returns the per-session log file path for the given session
+// name. The path is <LogDir>/<sanitised-name>.log. Session names already use
+// the form "<repo>@<branch>" — both halves are filesystem-safe except for
+// path separators which we replace with '_'. The sanitisation is intentionally
+// permissive: callers that pass a malicious name only see their own log file.
+func (p Paths) SessionLogPath(sessionName string) string {
+	return filepath.Join(p.LogDir, sanitiseSessionFileName(sessionName)+".log")
+}
+
+// sanitiseSessionFileName replaces path separators in a session name so the
+// result is safe to use as a filename. Other characters are left as-is —
+// session names are user-controlled but iris itself is single-user, so the
+// only risk is a user accidentally embedding a '/'.
+func sanitiseSessionFileName(name string) string {
+	out := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c == '/' || c == '\\' || c == 0 {
+			out = append(out, '_')
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
 }
 
 // ResolvePaths resolves the iris path layout from environment variables,

--- a/modules/programs/prism/prism/internal/iris/restore.go
+++ b/modules/programs/prism/prism/internal/iris/restore.go
@@ -350,10 +350,18 @@ func newRestoreSupervisor(cfg SupervisorConfig, sess db.IrisSessionRow) (*Superv
 	}
 
 
+	logFile, logErr := openSessionLogFile(cfg.LogDir, cfg.SessionName)
+	if logErr != nil {
+		log.Printf("[iris] restore: open per-session log: %v (continuing without per-session log)", logErr)
+	}
+	sessionLog := newSessionLogger(logFile, cfg.SessionName)
+
 	return &Supervisor{
-		cfg:     cfg,
-		sess:    record,
-		harness: harness,
-		state:   StateSpawning,
+		cfg:            cfg,
+		sess:           record,
+		harness:        harness,
+		state:          StateSpawning,
+		sessionLog:     sessionLog,
+		sessionLogFile: logFile,
 	}, nil
 }

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -55,6 +55,14 @@ type SupervisorConfig struct {
 	ShutdownTimeout time.Duration
 	// RunDir is the iris run directory (e.g. ~/.local/state/iris/run/).
 	RunDir string
+	// LogDir is the iris per-session log directory (e.g.
+	// ~/.local/state/iris/logs/). When non-empty, the supervisor opens a
+	// per-session log file at <LogDir>/<session-name>.log and tees its
+	// session-scoped log lines into it. The file is opened with O_APPEND
+	// so restart and re-spawn append rather than truncate. Empty disables
+	// per-session logging — in that case session log lines only go to the
+	// global logger (stderr / journal).
+	LogDir string
 	// Database is the open iris DB (used for event writes).
 	Database *db.DB
 	// Publisher is the optional EventPublisher wired to the harness socket so
@@ -81,8 +89,64 @@ type Supervisor struct {
 	// stdinPipe is the write end of pi's stdin (for sending RPC commands).
 	stdinPipe io.WriteCloser
 
+	// sessionLog is the per-session logger that writes to both the global
+	// log destination (stderr / journal) and the per-session log file under
+	// LogDir. Always non-nil after construction; falls back to the stderr-
+	// only global logger when LogDir is empty or the file cannot be opened.
+	sessionLog *log.Logger
+	// sessionLogFile is the per-session log file. May be nil when LogDir is
+	// empty or the file could not be opened. Closed by Start() on terminal
+	// state.
+	sessionLogFile *os.File
+
 	mu    sync.Mutex
 	state SessionState
+}
+
+// stateNotifier is implemented by publishers that want to receive
+// state-transition notifications. The supervisor calls PublishState on every
+// transition so subscribed clients can drive UI updates (e.g. the TUI session
+// table, or `iris logs --follow` exiting after terminal state).
+//
+// EventPublisher implementations may optionally satisfy this interface; the
+// supervisor checks for it at the call site rather than embedding it in the
+// EventPublisher interface so existing test publishers that only implement
+// Publish continue to compile.
+type stateNotifier interface {
+	PublishState(sessionName, state string)
+}
+
+// openSessionLogFile opens (creating if needed) the per-session log file under
+// logDir for the given session name. Returns (nil, nil) when logDir is empty
+// — callers must tolerate a nil file. Errors are returned for logging by the
+// caller but never made fatal: missing per-session logs do not block spawn.
+func openSessionLogFile(logDir, sessionName string) (*os.File, error) {
+	if logDir == "" || sessionName == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir log dir %q: %w", logDir, err)
+	}
+	path := (Paths{LogDir: logDir}).SessionLogPath(sessionName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open session log %q: %w", path, err)
+	}
+	return f, nil
+}
+
+// newSessionLogger constructs a *log.Logger that writes to both the global
+// stderr destination and the given per-session file. When f is nil, the
+// returned logger writes only to stderr (matching the global log package).
+// The prefix is "[iris:<session>] " so per-session files self-identify even
+// after grepping across multiple logs.
+func newSessionLogger(f *os.File, sessionName string) *log.Logger {
+	prefix := fmt.Sprintf("[iris:%s] ", sessionName)
+	flags := log.LstdFlags | log.Lmicroseconds
+	if f == nil {
+		return log.New(os.Stderr, prefix, flags)
+	}
+	return log.New(io.MultiWriter(os.Stderr, f), prefix, flags)
 }
 
 // NewSupervisor creates a Supervisor for the given config and begins the
@@ -142,11 +206,19 @@ func NewSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 		log.Printf("[iris] supervisor: failed to set initial iris_state: %v", err)
 	}
 
+	logFile, logErr := openSessionLogFile(cfg.LogDir, cfg.SessionName)
+	if logErr != nil {
+		log.Printf("[iris] supervisor: open per-session log: %v (continuing without per-session log)", logErr)
+	}
+	sessionLog := newSessionLogger(logFile, cfg.SessionName)
+
 	sup := &Supervisor{
-		cfg:     cfg,
-		sess:    sess,
-		harness: harness,
-		state:   StateSpawning,
+		cfg:            cfg,
+		sess:           sess,
+		harness:        harness,
+		state:          StateSpawning,
+		sessionLog:     sessionLog,
+		sessionLogFile: logFile,
 	}
 	// Wire the session_status handler so the harness socket can update the
 	// in-memory SessionRecord.PiSessionPath as soon as pi delivers its
@@ -244,10 +316,35 @@ func (s *Supervisor) SetPublisher(p EventPublisher) {
 	s.harness.SetPublisher(p)
 }
 
+// logf writes a log line via the per-session logger (stderr + per-session
+// file). All supervisor lines should use this rather than the global log
+// package so per-session log files capture them.
+func (s *Supervisor) logf(format string, args ...any) {
+	if s.sessionLog != nil {
+		s.sessionLog.Printf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
+}
+
+// closeSessionLogFile closes the per-session log file if open. Safe to call
+// multiple times.
+func (s *Supervisor) closeSessionLogFile() {
+	if s.sessionLogFile != nil {
+		_ = s.sessionLogFile.Close()
+		s.sessionLogFile = nil
+	}
+}
+
 // Start spawns the pi child and runs the supervisor loop. It blocks until the
 // session reaches a terminal state (finished or error) or ctx is cancelled.
 // Start is intended to be called in its own goroutine.
 func (s *Supervisor) Start(ctx context.Context) {
+	// Ensure the per-session log file is closed when Start returns. The
+	// supervisor's lifetime is the goroutine that runs Start, so this is the
+	// correct close site.
+	defer s.closeSessionLogFile()
+
 	for {
 		exitCode := s.spawnAndRun(ctx)
 
@@ -262,7 +359,7 @@ func (s *Supervisor) Start(ctx context.Context) {
 
 		if exitCode == 0 {
 			if !cleanExit {
-				log.Printf("[iris] supervisor: session %s: pi exited 0 without session_shutdown (anomaly)", s.sess.InstanceID)
+				s.logf("supervisor: session %s: pi exited 0 without session_shutdown (anomaly)", s.sess.InstanceID)
 			}
 			s.setState(StateFinished)
 			return
@@ -271,13 +368,13 @@ func (s *Supervisor) Start(ctx context.Context) {
 		// Non-zero exit.
 		s.sess.RestartCount++
 		if s.sess.RestartCount >= s.cfg.RestartThreshold {
-			log.Printf("[iris] supervisor: session %s: circuit breaker opened after %d failures", s.sess.InstanceID, s.sess.RestartCount)
+			s.logf("supervisor: session %s: circuit breaker opened after %d failures", s.sess.InstanceID, s.sess.RestartCount)
 			s.setState(StateError)
 			return
 		}
 
 		backoff := RestartBackoff(s.sess.RestartCount)
-		log.Printf("[iris] supervisor: session %s: pi exited non-zero (attempt %d/%d), restarting in %v",
+		s.logf("supervisor: session %s: pi exited non-zero (attempt %d/%d), restarting in %v",
 			s.sess.InstanceID, s.sess.RestartCount, s.cfg.RestartThreshold-1, backoff)
 		s.setState(StateError)
 
@@ -301,7 +398,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 		var err error
 		piBin, err = exec.LookPath("pi")
 		if err != nil {
-			log.Printf("[iris] supervisor: pi not found on PATH: %v", err)
+			s.logf("supervisor: pi not found on PATH: %v", err)
 			return 1
 		}
 	}
@@ -309,7 +406,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 	// Write a per-session pi config that loads the prism extension.
 	piConfigDir, err := s.writePerSessionPIConfig()
 	if err != nil {
-		log.Printf("[iris] supervisor: write pi config: %v", err)
+		s.logf("supervisor: write pi config: %v", err)
 		return 1
 	}
 
@@ -330,12 +427,12 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 	// Wire stdin/stdout pipes.
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
-		log.Printf("[iris] supervisor: stdin pipe: %v", err)
+		s.logf("supervisor: stdin pipe: %v", err)
 		return 1
 	}
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Printf("[iris] supervisor: stdout pipe: %v", err)
+		s.logf("supervisor: stdout pipe: %v", err)
 		stdinPipe.Close()
 		return 1
 	}
@@ -348,7 +445,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 	}
 
 	if err := cmd.Start(); err != nil {
-		log.Printf("[iris] supervisor: start pi: %v", err)
+		s.logf("supervisor: start pi: %v", err)
 		return 1
 	}
 
@@ -356,7 +453,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 	s.stdinPipe = stdinPipe
 	s.mu.Unlock()
 
-	log.Printf("[iris] supervisor: spawned pi pid=%d (session %s)", cmd.Process.Pid, s.sess.InstanceID)
+	s.logf("supervisor: spawned pi pid=%d (session %s)", cmd.Process.Pid, s.sess.InstanceID)
 	s.setState(StateActive)
 
 	// Run the harness socket acceptor in a goroutine.
@@ -364,7 +461,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 	defer harnessCancel()
 	go func() {
 		if err := s.harness.AcceptOne(harnessCtx); err != nil && harnessCtx.Err() == nil {
-			log.Printf("[iris] supervisor: harness accept error (session %s): %v", s.sess.InstanceID, err)
+			s.logf("supervisor: harness accept error (session %s): %v", s.sess.InstanceID, err)
 		}
 	}()
 
@@ -412,15 +509,15 @@ func (s *Supervisor) handleRPCEvent(line []byte) {
 
 	var generic GenericFrame
 	if err := json.Unmarshal(line, &generic); err != nil {
-		log.Printf("[iris] supervisor: RPC parse error: %v", err)
+		s.logf("supervisor: RPC parse error: %v", err)
 		return
 	}
 
 	switch generic.Type {
 	case "agent_start":
-		log.Printf("[iris] supervisor: session %s: agent_start", s.sess.InstanceID)
+		s.logf("supervisor: session %s: agent_start", s.sess.InstanceID)
 	case "agent_end":
-		log.Printf("[iris] supervisor: session %s: agent_end", s.sess.InstanceID)
+		s.logf("supervisor: session %s: agent_end", s.sess.InstanceID)
 	case "response":
 		// Command acknowledgement — log at debug level (suppressed for now).
 	}
@@ -507,7 +604,7 @@ func (s *Supervisor) openLogFile() *os.File {
 	logPath := filepath.Join(logDir, "pi-stderr.log")
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		log.Printf("[iris] supervisor: open log file %q: %v (stderr will be discarded)", logPath, err)
+		s.logf("supervisor: open log file %q: %v (stderr will be discarded)", logPath, err)
 		return nil
 	}
 	return f
@@ -520,20 +617,33 @@ func (s *Supervisor) setState(newState SessionState) {
 	s.sess.State = newState
 	s.mu.Unlock()
 
+	// Log the transition into the per-session log so `iris logs <session>`
+	// captures lifecycle events even when no harness traffic is in flight.
+	s.logf("supervisor: session %s state=%s", s.sess.InstanceID, newState)
+
 	// Always write iris_state to the DB so the restore path can read it.
 	if err := s.cfg.Database.IrisUpdateSessionState(s.sess.InstanceID, string(newState)); err != nil {
-		log.Printf("[iris] supervisor: update iris_state: %v", err)
+		s.logf("supervisor: update iris_state: %v", err)
 	}
 
 	// Update the sessions DB row end state for terminal states.
 	switch newState {
 	case StateFinished:
 		if err := s.cfg.Database.UpdateSessionEnded(s.sess.InstanceID, "finished"); err != nil {
-			log.Printf("[iris] supervisor: update session ended: %v", err)
+			s.logf("supervisor: update session ended: %v", err)
 		}
 	case StateError:
 		if err := s.cfg.Database.UpdateSessionEnded(s.sess.InstanceID, "error"); err != nil {
-			log.Printf("[iris] supervisor: update session ended: %v", err)
+			s.logf("supervisor: update session ended: %v", err)
+		}
+	}
+
+	// Notify subscribers of state transitions via the EventPublisher when it
+	// implements stateNotifier (the production ClientSocket does; test
+	// publishers that only implement Publish are unaffected).
+	if s.cfg.Publisher != nil {
+		if n, ok := s.cfg.Publisher.(stateNotifier); ok {
+			n.PublishState(s.sess.SessionName, string(newState))
 		}
 	}
 }

--- a/modules/programs/prism/prism/internal/iris/supervisor_logfile_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_logfile_test.go
@@ -1,0 +1,137 @@
+package iris
+
+// supervisor_logfile_test.go — tests for the per-session log file writer
+// (issue #1675).
+//
+// Covers:
+//   - openSessionLogFile creates the parent directory and opens with append.
+//   - openSessionLogFile is a no-op when logDir is empty.
+//   - newSessionLogger writes through to the per-session file when provided
+//     and tees to stderr (we verify the file half here; stderr is exercised
+//     transitively by every test that calls log.Printf).
+//   - Re-opening for the same session appends rather than truncates.
+//   - sanitiseSessionFileName replaces path separators.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenSessionLogFile_CreatesDirAndFile(t *testing.T) {
+	tmp := t.TempDir()
+	logDir := filepath.Join(tmp, "logs")
+	// Parent doesn't exist yet — openSessionLogFile must MkdirAll it.
+
+	f, err := openSessionLogFile(logDir, "iris-test@branch")
+	if err != nil {
+		t.Fatalf("openSessionLogFile: %v", err)
+	}
+	if f == nil {
+		t.Fatal("expected non-nil file, got nil")
+	}
+	defer f.Close()
+
+	want := filepath.Join(logDir, "iris-test@branch.log")
+	if f.Name() != want {
+		t.Fatalf("file path mismatch:\n got:  %q\n want: %q", f.Name(), want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("stat %q: %v", want, err)
+	}
+}
+
+func TestOpenSessionLogFile_EmptyDirIsNoop(t *testing.T) {
+	f, err := openSessionLogFile("", "any@branch")
+	if err != nil {
+		t.Fatalf("openSessionLogFile: %v", err)
+	}
+	if f != nil {
+		t.Fatalf("expected nil file when logDir is empty, got %v", f.Name())
+	}
+}
+
+func TestOpenSessionLogFile_AppendsOnReopen(t *testing.T) {
+	tmp := t.TempDir()
+
+	f1, err := openSessionLogFile(tmp, "x@y")
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if _, err := f1.WriteString("first\n"); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	f1.Close()
+
+	f2, err := openSessionLogFile(tmp, "x@y")
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	if _, err := f2.WriteString("second\n"); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	f2.Close()
+
+	got, err := os.ReadFile(filepath.Join(tmp, "x@y.log"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	want := "first\nsecond\n"
+	if string(got) != want {
+		t.Fatalf("file content mismatch:\n got:  %q\n want: %q", got, want)
+	}
+}
+
+func TestNewSessionLogger_WritesToFile(t *testing.T) {
+	tmp := t.TempDir()
+	f, err := openSessionLogFile(tmp, "x@y")
+	if err != nil {
+		t.Fatalf("openSessionLogFile: %v", err)
+	}
+	defer f.Close()
+
+	logger := newSessionLogger(f, "x@y")
+	logger.Print("hello world")
+
+	// Flush by syncing the file.
+	_ = f.Sync()
+
+	got, err := os.ReadFile(filepath.Join(tmp, "x@y.log"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(got), "hello world") {
+		t.Fatalf("expected 'hello world' in log file, got %q", string(got))
+	}
+	// Prefix should self-identify the session for cross-log grep.
+	if !strings.Contains(string(got), "[iris:x@y]") {
+		t.Fatalf("expected [iris:x@y] prefix in log file, got %q", string(got))
+	}
+}
+
+func TestSanitiseSessionFileName_ReplacesSeparators(t *testing.T) {
+	cases := map[string]string{
+		"plain@branch":      "plain@branch",
+		"a/b":               "a_b",
+		"with\\backslash":   "with_backslash",
+		"nul\x00byte":       "nul_byte",
+		"normal-name_only.": "normal-name_only.",
+	}
+	for in, want := range cases {
+		got := sanitiseSessionFileName(in)
+		if got != want {
+			t.Errorf("sanitiseSessionFileName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPathsSessionLogPath_UsesSanitiser(t *testing.T) {
+	p := Paths{LogDir: "/log"}
+	if got := p.SessionLogPath("a@b"); got != "/log/a@b.log" {
+		t.Errorf("plain: got %q want /log/a@b.log", got)
+	}
+	if got := p.SessionLogPath("evil/../path"); got != "/log/evil_.._path.log" {
+		t.Errorf("traversal: got %q", got)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor_state_publish_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_state_publish_test.go
@@ -1,0 +1,233 @@
+package iris
+
+// supervisor_state_publish_test.go — asserts that the supervisor calls
+// PublishState on its EventPublisher (when that publisher implements
+// stateNotifier) at every state transition. This is the wire `iris logs
+// --follow` relies on for prompt terminal-state detection (issue #1675).
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// statePublisherSpy records every PublishState call. It also implements
+// EventPublisher.Publish as a no-op so it can be used wherever the harness
+// expects an EventPublisher.
+type statePublisherSpy struct {
+	mu     sync.Mutex
+	states []stateEvent
+}
+
+type stateEvent struct {
+	Name  string
+	State string
+}
+
+func (sp *statePublisherSpy) Publish(_ EventPublication) {}
+
+func (sp *statePublisherSpy) PublishState(name, state string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.states = append(sp.states, stateEvent{Name: name, State: state})
+}
+
+func (sp *statePublisherSpy) snapshot() []stateEvent {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	out := make([]stateEvent, len(sp.states))
+	copy(out, sp.states)
+	return out
+}
+
+// TestSupervisorSetState_PublishesState constructs a Supervisor without
+// invoking Start, then calls setState manually and asserts the spy received
+// the matching PublishState invocations. This is a unit-level check; the
+// integration path (full daemon + ClientSocket.PublishState) is covered by
+// the logs CLI tests.
+func TestSupervisorSetState_PublishesState(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	spy := &statePublisherSpy{}
+
+	// Short prefix to stay under the 108-byte sun_path limit (t.TempDir()
+	// with a long test name easily overruns).
+	runDir, err := os.MkdirTemp("", "iris-sst-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+
+	cfg := SupervisorConfig{
+		SessionName: "iris-test@state-publish",
+		Worktree:    tmp,
+		Role:        "worker",
+		RunDir:      runDir,
+		LogDir:      filepath.Join(tmp, "logs"),
+		Database:    database,
+		Publisher:   spy,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(sup.closeSessionLogFile)
+
+	sup.setState(StateActive)
+	sup.setState(StateFinished)
+
+	// Give the publisher a moment in case it ever becomes async.
+	time.Sleep(20 * time.Millisecond)
+
+	got := spy.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 state publications, got %d: %+v", len(got), got)
+	}
+	if got[0] != (stateEvent{Name: "iris-test@state-publish", State: string(StateActive)}) {
+		t.Errorf("first: got %+v", got[0])
+	}
+	if got[1] != (stateEvent{Name: "iris-test@state-publish", State: string(StateFinished)}) {
+		t.Errorf("second: got %+v", got[1])
+	}
+}
+
+// TestSupervisorSetState_PlainEventPublisherIsNotNotified asserts that a
+// publisher which only implements Publish (no PublishState) is not invoked
+// for state transitions — the supervisor must type-assert defensively so
+// existing test fixtures keep compiling.
+func TestSupervisorSetState_PlainEventPublisherIsNotNotified(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	// PublisherFunc satisfies EventPublisher but NOT stateNotifier.
+	called := 0
+	pub := PublisherFunc(func(_ EventPublication) { called++ })
+
+	runDir, err := os.MkdirTemp("", "iris-sst-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+
+	cfg := SupervisorConfig{
+		SessionName: "iris-test@plain-publisher",
+		Worktree:    tmp,
+		Role:        "worker",
+		RunDir:      runDir,
+		LogDir:      filepath.Join(tmp, "logs"),
+		Database:    database,
+		Publisher:   pub,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(sup.closeSessionLogFile)
+
+	sup.setState(StateActive)
+	sup.setState(StateFinished)
+
+	if called != 0 {
+		t.Errorf("plain EventPublisher.Publish should not be called for state transitions, called=%d", called)
+	}
+}
+
+// TestSupervisorWritesPerSessionLog asserts that constructing a supervisor
+// with a LogDir results in supervisor.logf writing to the per-session file.
+// This is the bridge `iris logs <session>` depends on.
+func TestSupervisorWritesPerSessionLog(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	logDir := filepath.Join(tmp, "logs")
+	runDir, err := os.MkdirTemp("", "iris-sst-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+	cfg := SupervisorConfig{
+		SessionName: "iris-test@logfile",
+		Worktree:    tmp,
+		Role:        "worker",
+		RunDir:      runDir,
+		LogDir:      logDir,
+		Database:    database,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(sup.closeSessionLogFile)
+
+	sup.logf("hello %s", "world")
+
+	// Sync via Close-and-reopen would be invasive; the underlying logger
+	// writes synchronously. Read the file directly.
+	logPath := filepath.Join(logDir, "iris-test@logfile.log")
+	data, err := readFileWithRetry(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !containsBytes(data, []byte("hello world")) {
+		t.Fatalf("log file does not contain 'hello world': %q", string(data))
+	}
+	if !containsBytes(data, []byte("[iris:iris-test@logfile]")) {
+		t.Fatalf("log file does not contain session prefix: %q", string(data))
+	}
+}
+
+func containsBytes(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		ok := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// readFileWithRetry retries a few times in case the test process has not yet
+// flushed buffered writes to the log file. log.Logger writes are synchronous
+// via the underlying *os.File, so this rarely needs to retry — but the
+// helper guards against rare scheduler-driven flakes on slow CI.
+func readFileWithRetry(path string) ([]byte, error) {
+	var (
+		data []byte
+		err  error
+	)
+	for i := 0; i < 10; i++ {
+		data, err = os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			return data, nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return data, err
+}


### PR DESCRIPTION
Implements `iris logs <session>` — the iris analogue of `prism logs <session>`. Two parts: the daemon now writes per-session log files; a new CLI reads them.

Closes #1675

## What's new

**Daemon side.** The Supervisor now opens a per-session log file at `~/.local/state/iris/logs/<session>.log` and tees its session-scoped log lines into both the global stderr/journal destination and that file. The file is opened with `O_APPEND` so restarts and re-spawns extend rather than truncate. State transitions (`spawning` → `active` → `finished`/`error`) are logged in the per-session file and also published to subscribed clients via a new `ClientSocket.PublishState` method on a new `session_state` frame path through the existing fan-out channel.

**CLI side.** `cmd/iris/logs.go`:

  - bare `iris logs <session>` — full log to stdout
  - `--tail N` — last N lines (ring-buffer scan, O(N) memory)
  - `--follow` / `-f` — stream new bytes; exits ~5 s after the daemon reports a terminal state. When the daemon is unreachable, falls back to a 30 s idle timeout (no new bytes → exit) so scripts cannot hang indefinitely.

**Cleanup.** `iris cleanup <session>` now removes the per-session log file as part of its teardown sequence. Missing-on-cleanup is treated as success.

## ACs covered

- [x] Daemon writes per-session log files at `~/.local/state/iris/logs/<session>.log` capturing supervisor lines.
- [x] `iris logs <session>` reads that file and writes to stdout.
- [x] `--tail N` writes only the last N lines.
- [x] `--follow`/`-f` streams new lines and exits ~5 s after the session reaches a terminal state (`finished` or `error`).
- [x] No log file yet → exit 0 with empty output (not an error).
- [x] Daemon not running but log file exists → still works (pure file read).
- [x] Session not found in `--follow` → clear error from the daemon's subscribe response.
- [x] `iris cleanup <session>` removes the per-session log file.
- [x] Subcommand appears in `iris --help` and `iris logs --help` documents the flags and grace behaviour.
- [x] `go test ./... -race` passes locally.
- [x] `nix build .#iris` succeeds locally.

## Implementation notes

- The supervisor's session-tagged `log.Printf` lines were converted to a new `s.logf` helper backed by `log.New(io.MultiWriter(os.Stderr, sessionLogFile), …)`. The global stderr destination is preserved so the daemon's bootstrap/error visibility is unchanged — only session-scoped lines now also land in the per-session file.
- Terminal-state detection in `--follow` uses the same client-socket subscription path the TUI uses (`session_subscribe` + listen for `session_state` frames), per #1668's "all client surfaces go through the daemon" principle. Reading the log file itself stays purely local.
- `EventPublisher` was not modified. A new `stateNotifier` interface (`PublishState(name, state string)`) is type-asserted at the supervisor call site, so existing publisher fixtures that only implement `Publish` continue to compile without change.
- `subscriberMessage` is a small wrapper carried on per-subscriber channels; it holds either an event or a state. Splitting these in a union avoids the cost of a second channel per subscriber.

## Tests

- `cmd/iris/logs_test.go` — one-shot full read, `--tail N`, missing-file → exit 0, follow + grace, idle-timeout fallback, "session not found" surfaced, terminal-state detection over a real in-process daemon socket.
- `internal/iris/supervisor_logfile_test.go` — file creation, empty-LogDir no-op, append-on-reopen, sanitiser for path separators, `SessionLogPath` derivation.
- `internal/iris/supervisor_state_publish_test.go` — `setState` invokes `PublishState`; plain `EventPublisher` (no `stateNotifier`) is not invoked; `s.logf` writes through to the per-session file.
- `internal/iris/cleanup_logfile_test.go` — cleanup removes the file; missing file at cleanup time is success, not an error.

Full `go test ./... -race` is green.