### PR TITLE
feat(iris): `iris prompt <session>` CLI for delivering a prompt (#1677)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -15,6 +15,7 @@
 //	iris tui [--socket <path>]                  — open the bubbletea TUI
 //	iris sessions list [--json]                 — list daemon-tracked sessions (human or JSON)
 //	iris sessions status [--json]               — print session counts by state
+//	iris prompt <session> --prompt <text>       — deliver a prompt to a running session
 package main
 
 import (
@@ -70,8 +71,8 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	// spawnCmd is registered in cmd/iris/spawn.go's init() so the spawn
-	// subcommand and its flags live together in one file.
+	// spawnCmd, sessionsCmd and promptCmd are registered in their own files'
+	// init() functions so each subcommand and its flags live together.
 	rootCmd.AddCommand(daemonCmd)
 	rootCmd.AddCommand(tuiCmd)
 }

--- a/modules/programs/prism/prism/cmd/iris/prompt.go
+++ b/modules/programs/prism/prism/cmd/iris/prompt.go
@@ -1,0 +1,397 @@
+package main
+
+// prompt.go — `iris prompt` subcommand.
+//
+// `iris prompt <session>` dials the iris daemon's client IPC socket and asks
+// it to forward a prompt to the named running session. It is the analogue of
+// `prism prompt <session>` for the daemon-mode world (issue #1677).
+//
+// The wire frame `prompt_deliver` is defined in
+// internal/iris/client_protocol.go and handled by the daemon's ClientSocket
+// (see internal/iris/client_socket.go::handlePromptDeliver). This file is
+// pure CLI plumbing on top of that frame:
+//
+//	1. Resolve the prompt body from --prompt / --prompt-file / --prompt -
+//	   (stdin), mirroring prism's conventions in cmd/prompt_input.go.
+//	2. Dial the daemon client socket. If unreachable, emit the canonical
+//	   "daemon not running" error (same wording used by `iris spawn`).
+//	3. Fetch a sessions_snapshot to validate that the target session exists
+//	   and is NOT in `waiting` state. The waiting-state guard mirrors
+//	   prism's: a waiting session is paused for direct user input, and a
+//	   programmatic prompt corrupts the input field.
+//	4. Send the prompt_deliver frame.
+//	5. Read for a brief window. The daemon's protocol does NOT emit an
+//	   explicit ack on success — handlePromptDeliver only writes a frame
+//	   on FAILURE (an error frame). Treat read-timeout / EOF-with-no-error
+//	   as success.
+//
+// # Behaviour summary (acceptance criteria for #1677)
+//
+//   - --prompt <text> | --prompt-file <path> | --prompt -  (mutually exclusive
+//     --prompt vs --prompt-file; `--prompt -` reads stdin)
+//   - Trailing single newline stripped from file/stdin input.
+//   - Daemon down → "iris daemon not running … systemctl --user start iris".
+//   - No such session → clear error, no stack trace.
+//   - Session in waiting state → refuse, exit non-zero with the documented
+//     "switch and respond directly" message.
+//   - Mid-send connection drop → "lost connection to daemon", no hang.
+//   - On success: prints "prompt delivered to <session>" and exits 0.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// promptDialTimeout bounds how long `iris prompt` will wait when dialling
+// the daemon socket. Matches the spawn-side budget — the daemon is local,
+// a healthy dial completes in microseconds, and a multi-second hang almost
+// certainly means the daemon is not running.
+const promptDialTimeout = 2 * time.Second
+
+// promptWriteTimeout bounds the write of the prompt_deliver frame.
+const promptWriteTimeout = 5 * time.Second
+
+// promptAckWindow is how long we wait after sending prompt_deliver to see
+// whether the daemon returns an error frame. The current daemon protocol
+// has NO success ack for prompt_deliver — only an error frame on failure
+// (see internal/iris/client_socket.go::handlePromptDeliver). We therefore
+// wait briefly: any error frame must arrive within this window or we treat
+// the delivery as successful. The daemon's deliverFn is synchronous w.r.t.
+// the SendRPC call, so a real failure surfaces well within this budget.
+//
+// This is deliberately short. A longer window would slow down every
+// successful invocation. If a future protocol revision adds an explicit
+// ack frame, callers should switch to read-until-ack rather than a fixed
+// window — see the comment in readPromptAck for the path.
+const promptAckWindow = 1500 * time.Millisecond
+
+// promptCmd is the `iris prompt` subcommand. It dials the daemon client
+// socket and asks the daemon to forward the prompt to the named session.
+var promptCmd = &cobra.Command{
+	Use:   "prompt <session>",
+	Short: "Send a prompt to a running iris session via the daemon",
+	Long: `iris prompt dials the iris daemon's client IPC socket and asks it to
+deliver a prompt to the named session.
+
+The daemon must already be running. If it is not, this command exits
+non-zero with a clear error pointing at 'systemctl --user start iris'.
+
+Three input variants are accepted:
+
+  --prompt <text>          inline prompt text
+  --prompt-file <path>     read the prompt body from a file
+  --prompt -               read the prompt body from stdin
+
+--prompt and --prompt-file are mutually exclusive. For file/stdin input a
+single trailing newline is stripped (matches prism's behaviour).
+
+Note: a literal "-" cannot be sent as a prompt via --prompt because it is
+reserved as the stdin sentinel. Use --prompt-file for that case.
+
+# Waiting-state guard
+
+If the target session is in 'waiting' state — meaning the agent has paused
+for direct user input — this command refuses to send. Injecting a
+programmatic prompt would corrupt the input field. Switch to the session
+in the TUI (C-f or C-w) and respond directly instead.`,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runPromptCmd,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	promptCmd.Flags().String(
+		"prompt", "",
+		"Text to send to the agent. Use --prompt-file for complex strings or to avoid shell-escaping issues. Use '-' to read from stdin.",
+	)
+	promptCmd.Flags().String(
+		"prompt-file", "",
+		"Path to a file containing the prompt text. Mutually exclusive with --prompt.",
+	)
+	promptCmd.Flags().String(
+		"socket", "",
+		"Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)",
+	)
+	promptCmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	rootCmd.AddCommand(promptCmd)
+}
+
+// runPromptCmd is the cobra entry point. It resolves the input, then defers
+// to runPromptAt for the wire path so that integration tests can drive the
+// flow against an in-process ClientSocket.
+func runPromptCmd(cmd *cobra.Command, args []string) error {
+	sessionName := args[0]
+
+	promptText, err := resolveIrisPromptInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	sockPath := resolveSocketPath(cmd)
+
+	return runPromptAt(cmd.Context(), sockPath, sessionName, promptText, os.Stdin, os.Stdout)
+}
+
+// runPromptAt is the testable core of `iris prompt`. sockPath is passed
+// explicitly so integration tests can point it at a t.TempDir() socket.
+// stdin is currently unused but is passed in to mirror runSpawnAt's shape
+// and to keep the door open for future ReadAll-from-stdin paths.
+func runPromptAt(ctx context.Context, sockPath, sessionName, promptText string, _ io.Reader, out io.Writer) error {
+	if sessionName == "" {
+		return errors.New("iris prompt: <session> is required")
+	}
+	if promptText == "" {
+		return errors.New(
+			"a prompt is required — supply one of:\n" +
+				"  --prompt <text>\n" +
+				"  --prompt - (read from stdin)\n" +
+				"  --prompt-file <path>",
+		)
+	}
+
+	// Phase 1: validate target session via sessions_snapshot.
+	// This reuses the existing daemon surface — no new request frame needed.
+	// It also exercises the "daemon not running" error path before we
+	// commit to opening a second connection for prompt_deliver.
+	if err := assertSessionAcceptsPrompt(ctx, sockPath, sessionName); err != nil {
+		return err
+	}
+
+	// Phase 2: send the prompt_deliver frame on a fresh connection.
+	conn, err := dialDaemonForPrompt(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := sendPromptDeliverFrame(conn, sessionName, promptText); err != nil {
+		return err
+	}
+
+	// Phase 3: brief read window for an error frame. No news is good news.
+	if err := readPromptAck(ctx, conn); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "prompt delivered to %s\n", sessionName)
+	return nil
+}
+
+// resolveIrisPromptInput reads the prompt body from --prompt, --prompt-file,
+// or stdin (when --prompt is "-"). It mirrors the behaviour of prism's
+// resolvePromptWithSource in cmd/prompt_input.go:
+//
+//   - --prompt-file <path>  → file contents, single trailing newline stripped
+//   - --prompt -            → stdin contents, single trailing newline stripped
+//   - --prompt <text>       → text verbatim
+//
+// Cobra enforces the mutual exclusion of --prompt vs --prompt-file before
+// RunE is called, so no manual check is needed here.
+func resolveIrisPromptInput(cmd *cobra.Command) (string, error) {
+	promptFile, _ := cmd.Flags().GetString("prompt-file")
+	promptText, _ := cmd.Flags().GetString("prompt")
+
+	if promptFile != "" {
+		data, err := os.ReadFile(promptFile)
+		if err != nil {
+			return "", fmt.Errorf("read prompt file %q: %w", promptFile, err)
+		}
+		return strings.TrimSuffix(string(data), "\n"), nil
+	}
+
+	if promptText == "-" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("read prompt from stdin: %w", err)
+		}
+		return strings.TrimSuffix(string(data), "\n"), nil
+	}
+
+	return promptText, nil
+}
+
+// assertSessionAcceptsPrompt fetches a sessions_snapshot from the daemon,
+// looks up sessionName, and returns:
+//
+//   - nil                    — session exists and is NOT in waiting state.
+//   - "daemon not running"   — the snapshot fetch failed because the daemon
+//                              is not reachable (fetchSessionsSnapshot wraps
+//                              this with the canonical wording).
+//   - "no such session"      — the snapshot returned but did not contain
+//                              sessionName.
+//   - waiting-state refusal  — the named session exists with state=="waiting".
+func assertSessionAcceptsPrompt(ctx context.Context, sockPath, sessionName string) error {
+	snap, err := fetchSessionsSnapshot(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+	for _, s := range snap.Sessions {
+		if s.Name != sessionName {
+			continue
+		}
+		if s.State == "waiting" {
+			// Mirror prism's documented message verbatim (minus the
+			// `prism checkin` hint, which has no iris equivalent yet —
+			// the C-f / C-w tmux switch hint applies in both worlds).
+			return fmt.Errorf(
+				"session %q is waiting for user input\n\n"+
+					"The agent has paused and is expecting a direct response from the user.\n"+
+					"Please switch to that session and respond there, or escalate to the user\n"+
+					"so they can address it directly.\n\n"+
+					"  (C-f or C-w)       — switch to the session in tmux",
+				sessionName,
+			)
+		}
+		return nil
+	}
+	// Build a short list of known names for a helpful error.
+	names := make([]string, 0, len(snap.Sessions))
+	for _, s := range snap.Sessions {
+		names = append(names, s.Name)
+	}
+	if len(names) == 0 {
+		return fmt.Errorf(
+			"iris prompt: no such session %q — no active sessions reported by daemon (run `iris sessions list` to verify)",
+			sessionName,
+		)
+	}
+	return fmt.Errorf(
+		"iris prompt: no such session %q — active sessions: %s",
+		sessionName, strings.Join(names, ", "),
+	)
+}
+
+// dialDaemonForPrompt dials the daemon client socket for the prompt_deliver
+// frame. It uses the same canonical "daemon not running" wording as
+// `iris spawn`. We re-dial (rather than reusing the connection used for
+// sessions_list) to keep the two phases independent: the sessions_snapshot
+// fetch can use its own short read window, and the prompt_deliver write
+// path doesn't need to share state with it.
+func dialDaemonForPrompt(ctx context.Context, sockPath string) (net.Conn, error) {
+	d := net.Dialer{Timeout: promptDialTimeout}
+	conn, err := d.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"iris daemon not running (could not dial %s: %v); start it with: systemctl --user start iris",
+			sockPath, err,
+		)
+	}
+	return conn, nil
+}
+
+// sendPromptDeliverFrame marshals and writes a ClientPromptDeliverFrame to
+// the daemon connection. The frame format is the D-6 wire protocol
+// (internal/iris/client_protocol.go); this function MUST NOT add fields not
+// defined there.
+func sendPromptDeliverFrame(conn net.Conn, sessionName, promptText string) error {
+	frame := iris.ClientPromptDeliverFrame{
+		Type: iris.ClientFramePromptDeliver,
+		Name: sessionName,
+		Text: promptText,
+	}
+	data, err := json.Marshal(frame)
+	if err != nil {
+		return fmt.Errorf("iris prompt: marshal prompt_deliver: %w", err)
+	}
+	data = append(data, '\n')
+	_ = conn.SetWriteDeadline(time.Now().Add(promptWriteTimeout))
+	if _, err := conn.Write(data); err != nil {
+		return fmt.Errorf("iris prompt: lost connection to daemon during send: %w", err)
+	}
+	return nil
+}
+
+// readPromptAck waits up to promptAckWindow for an error frame from the
+// daemon. The current protocol does NOT emit a success ack — handlePromptDeliver
+// only writes a frame on failure (an error frame with request_type ==
+// "prompt_deliver"). We therefore wait briefly and treat:
+//
+//   - error frame received        → return the daemon-side error.
+//   - read deadline / timeout     → success (no error means delivered).
+//   - EOF before deadline         → if context is still live, "lost
+//                                   connection to daemon". The daemon
+//                                   closes the connection if we close
+//                                   first; we don't, so EOF here means
+//                                   the daemon went away mid-window.
+//   - context cancelled           → return ctx.Err().
+//
+// If a future protocol revision adds an explicit prompt_delivered ack
+// frame, swap the timeout branch for a hard-fail and accept the new frame
+// type here.
+func readPromptAck(ctx context.Context, conn net.Conn) error {
+	// Honour context cancellation by tripping the read deadline.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.SetReadDeadline(time.Now())
+		case <-done:
+		}
+	}()
+
+	_ = conn.SetReadDeadline(time.Now().Add(promptAckWindow))
+	r := bufio.NewReaderSize(conn, 1<<20)
+
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() {
+				// Timeout with no error frame → delivery succeeded.
+				return nil
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return errors.New("iris prompt: lost connection to daemon before ack")
+			}
+			return fmt.Errorf("iris prompt: read ack: %w", err)
+		}
+
+		var generic struct {
+			Type        string `json:"type"`
+			RequestType string `json:"request_type"`
+			Message     string `json:"message"`
+		}
+		if err := json.Unmarshal(line, &generic); err != nil {
+			// Malformed frame — keep reading; the daemon may follow up
+			// with a real error. Don't treat as fatal.
+			fmt.Fprintf(os.Stderr, "[iris] warning: ignoring malformed frame from daemon: %v\n", err)
+			continue
+		}
+		switch generic.Type {
+		case iris.DaemonFrameError:
+			// Only treat error frames whose request_type matches as fatal;
+			// stray errors from other in-flight requests on the same
+			// connection shouldn't surface here (we use a fresh conn) but
+			// being explicit avoids surprises.
+			if generic.RequestType == "" || generic.RequestType == iris.ClientFramePromptDeliver {
+				if strings.Contains(generic.Message, "not found") ||
+					strings.Contains(generic.Message, "no such session") {
+					return fmt.Errorf("iris prompt: no such session: %s", generic.Message)
+				}
+				return fmt.Errorf("iris prompt: daemon rejected prompt: %s", generic.Message)
+			}
+			// Unrelated error frame — log and keep waiting.
+			fmt.Fprintf(os.Stderr, "[iris] note: unrelated error frame (request_type=%q): %s\n", generic.RequestType, generic.Message)
+		default:
+			// Any other frame type is unexpected on this connection (we
+			// did not subscribe). Skip and keep reading until timeout.
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/prompt_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/prompt_integration_test.go
@@ -1,0 +1,332 @@
+package main
+
+// prompt_integration_test.go — integration tests for `iris prompt` against a
+// real iris.ClientSocket (issue #1677).
+//
+// Each test stands up an in-process ClientSocket whose GetActiveSessions and
+// DeliverPrompt hooks are stubs we can observe, then drives runPromptAt
+// against the live socket path. This proves the wire path used by
+// `iris prompt`:
+//
+//	CLI                 →  sessions_list  + prompt_deliver  frames on iris.sock
+//	daemon ClientSocket →  sessions_snapshot back, then invokes DeliverPrompt
+//
+// is wired correctly end-to-end. We do not run a real pi child — DeliverPrompt
+// is a recorder.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// startPromptTestSocket starts an iris.ClientSocket on a tempdir socket path
+// backed by `sessions` for sessions_list responses and `deliver` for
+// prompt_deliver dispatch. Returns the socket path. The socket and its
+// goroutines are torn down on test cleanup.
+func startPromptTestSocket(
+	t *testing.T,
+	sessions []iris.SessionSnapshot,
+	deliver func(ctx context.Context, name, text, deliverAs string, images []string) error,
+) string {
+	t.Helper()
+
+	// Per-session Unix sockets must fit under the 108-byte sun_path limit.
+	// t.TempDir() can blow that under long test names — anchor under a short
+	// MkdirTemp prefix (same pattern used by spawn_integration_test.go).
+	shortPrefix, err := os.MkdirTemp("", "iris-prompt-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+
+	dbPath := filepath.Join(shortPrefix, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+		DeliverPrompt: deliver,
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go cs.Serve(ctx)
+
+	return sockPath
+}
+
+// TestPrompt_HappyPath drives the full wire path:
+// sessions_list → snapshot returns target session in active state →
+// prompt_deliver → DeliverPrompt hook receives the body → CLI prints
+// confirmation.
+func TestPrompt_HappyPath(t *testing.T) {
+	const targetName = "iris-test@active"
+	const promptBody = "please proceed with the next step"
+
+	sessions := []iris.SessionSnapshot{
+		{
+			Name:       targetName,
+			InstanceID: "abcd1234-0000-1111-2222-333333333333",
+			State:      "active",
+			Role:       "worker",
+			Worktree:   "/tmp/iris-test/feature",
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+
+	var (
+		mu          sync.Mutex
+		gotName     string
+		gotText     string
+		gotDeliver  string
+		deliverHits int
+	)
+	deliver := func(_ context.Context, name, text, deliverAs string, _ []string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotName = name
+		gotText = text
+		gotDeliver = deliverAs
+		deliverHits++
+		return nil
+	}
+
+	sockPath := startPromptTestSocket(t, sessions, deliver)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	if err := runPromptAt(ctx, sockPath, targetName, promptBody, nil, &out); err != nil {
+		t.Fatalf("runPromptAt: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if deliverHits != 1 {
+		t.Errorf("DeliverPrompt called %d times, want 1", deliverHits)
+	}
+	if gotName != targetName {
+		t.Errorf("DeliverPrompt name = %q, want %q", gotName, targetName)
+	}
+	if gotText != promptBody {
+		t.Errorf("DeliverPrompt text = %q, want %q", gotText, promptBody)
+	}
+	// We don't send deliver_as from the CLI yet; the daemon-side handler
+	// receives the empty string and substitutes "prompt" inside the
+	// supervisor RPC. The hook here sees the raw frame value.
+	if gotDeliver != "" {
+		t.Errorf("DeliverPrompt deliver_as = %q, want \"\"", gotDeliver)
+	}
+
+	stdout := out.String()
+	if !strings.Contains(stdout, "prompt delivered to "+targetName) {
+		t.Errorf("expected confirmation in stdout; got %q", stdout)
+	}
+}
+
+// TestPrompt_WaitingStateGuard asserts that a session in waiting state is
+// refused: the CLI exits non-zero with the documented message and the
+// DeliverPrompt hook is NEVER invoked (no prompt_deliver frame sent).
+func TestPrompt_WaitingStateGuard(t *testing.T) {
+	const targetName = "iris-test@paused"
+
+	sessions := []iris.SessionSnapshot{
+		{
+			Name:       targetName,
+			InstanceID: "deadbeef-0000-1111-2222-333333333333",
+			State:      "waiting",
+			Role:       "worker",
+			Worktree:   "/tmp/iris-test/paused",
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+
+	var deliverHits int
+	deliver := func(_ context.Context, _, _, _ string, _ []string) error {
+		deliverHits++
+		return nil
+	}
+
+	sockPath := startPromptTestSocket(t, sessions, deliver)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	err := runPromptAt(ctx, sockPath, targetName, "do the thing", nil, &out)
+	if err == nil {
+		t.Fatalf("runPromptAt: want error for waiting state, got nil (stdout=%q)", out.String())
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "waiting for user input") {
+		t.Errorf("error missing 'waiting for user input' wording: %q", msg)
+	}
+	if !strings.Contains(msg, targetName) {
+		t.Errorf("error missing session name %q: %q", targetName, msg)
+	}
+	if deliverHits != 0 {
+		t.Errorf("DeliverPrompt invoked %d times despite waiting-state guard; want 0", deliverHits)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no stdout on refusal; got %q", out.String())
+	}
+}
+
+// TestPrompt_NoSuchSession asserts that an unknown session name produces a
+// clean "no such session" error referencing the requested name, without
+// invoking DeliverPrompt.
+func TestPrompt_NoSuchSession(t *testing.T) {
+	sessions := []iris.SessionSnapshot{
+		{
+			Name:       "iris-test@other",
+			InstanceID: "11111111-0000-1111-2222-333333333333",
+			State:      "active",
+			Role:       "worker",
+			Worktree:   "/tmp/iris-test/other",
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	var deliverHits int
+	deliver := func(_ context.Context, _, _, _ string, _ []string) error {
+		deliverHits++
+		return nil
+	}
+	sockPath := startPromptTestSocket(t, sessions, deliver)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	err := runPromptAt(ctx, sockPath, "iris-test@does-not-exist", "hi", nil, &out)
+	if err == nil {
+		t.Fatalf("runPromptAt: want error for unknown session, got nil")
+	}
+	if !strings.Contains(err.Error(), "no such session") {
+		t.Errorf("error missing 'no such session' wording: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "iris-test@does-not-exist") {
+		t.Errorf("error missing requested name: %q", err.Error())
+	}
+	if deliverHits != 0 {
+		t.Errorf("DeliverPrompt invoked %d times on unknown-session path; want 0", deliverHits)
+	}
+}
+
+// TestPrompt_DaemonNotRunning points the CLI at a non-existent socket and
+// asserts the documented "daemon not running" wording.
+func TestPrompt_DaemonNotRunning(t *testing.T) {
+	shortPrefix, err := os.MkdirTemp("", "iris-prompt-no-daemon-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+
+	// Path does not exist — fetchSessionsSnapshot will surface the canonical
+	// "daemon not running" error before we ever try to dial for prompt_deliver.
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	err = runPromptAt(ctx, sockPath, "iris-test@anything", "hi", nil, &out)
+	if err == nil {
+		t.Fatalf("runPromptAt: want daemon-not-running error, got nil")
+	}
+	if !strings.Contains(err.Error(), "daemon not running") {
+		t.Errorf("error missing 'daemon not running' wording: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "systemctl --user start iris") {
+		t.Errorf("error missing 'systemctl --user start iris' hint: %q", err.Error())
+	}
+}
+
+// TestPrompt_EmptyPrompt asserts the CLI refuses an empty prompt body with
+// the documented multi-line "supply one of …" error.
+func TestPrompt_EmptyPrompt(t *testing.T) {
+	// We don't need a daemon for this — the empty-prompt check runs before
+	// any wire activity. Use a never-listened-on path.
+	shortPrefix, err := os.MkdirTemp("", "iris-prompt-empty-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = runPromptAt(ctx, sockPath, "iris-test@whatever", "", nil, nil)
+	if err == nil {
+		t.Fatalf("runPromptAt: want error for empty prompt, got nil")
+	}
+	if !strings.Contains(err.Error(), "a prompt is required") {
+		t.Errorf("error missing 'a prompt is required' wording: %q", err.Error())
+	}
+}
+
+// TestPrompt_DeliverError asserts that an error returned from DeliverPrompt
+// is surfaced as the CLI error (the daemon emits an error frame and the
+// readPromptAck path translates it). The session is in active state so the
+// guard does not refuse.
+func TestPrompt_DeliverError(t *testing.T) {
+	const targetName = "iris-test@broken"
+
+	sessions := []iris.SessionSnapshot{
+		{
+			Name:       targetName,
+			InstanceID: "22222222-0000-1111-2222-333333333333",
+			State:      "active",
+			Role:       "worker",
+			Worktree:   "/tmp/iris-test/broken",
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	deliver := func(_ context.Context, _, _, _ string, _ []string) error {
+		return errSentinelDeliverFailed
+	}
+
+	sockPath := startPromptTestSocket(t, sessions, deliver)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	err := runPromptAt(ctx, sockPath, targetName, "hi", nil, &out)
+	if err == nil {
+		t.Fatalf("runPromptAt: want delivery error, got nil")
+	}
+	if !strings.Contains(err.Error(), "synthetic-deliver-failure") {
+		t.Errorf("error missing daemon-side reason: %q", err.Error())
+	}
+}
+
+// errSentinelDeliverFailed is a sentinel error used by TestPrompt_DeliverError
+// to assert the CLI surfaces the daemon-side failure message verbatim.
+var errSentinelDeliverFailed = sentinelErr("synthetic-deliver-failure")
+
+type sentinelErr string
+
+func (e sentinelErr) Error() string { return string(e) }

--- a/modules/programs/prism/prism/cmd/iris/prompt_test.go
+++ b/modules/programs/prism/prism/cmd/iris/prompt_test.go
@@ -1,0 +1,195 @@
+package main
+
+// prompt_test.go — unit tests for `iris prompt` flag parsing and the
+// resolveIrisPromptInput helper. Wire-level integration is covered in
+// prompt_integration_test.go.
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// withFakeStdin replaces os.Stdin with a pipe whose read end is preloaded
+// with `body`. It restores the original stdin on test cleanup.
+func withFakeStdin(t *testing.T, body string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	if _, err := io.WriteString(w, body); err != nil {
+		_ = r.Close()
+		_ = w.Close()
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		_ = r.Close()
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+	})
+}
+
+// newPromptCmdForTest builds a fresh cobra.Command with the same flag set as
+// promptCmd, so each test gets a clean flag state without depending on
+// process-global state.
+func newPromptCmdForTest() *cobra.Command {
+	c := &cobra.Command{
+		Use:  "prompt <session>",
+		Args: cobra.ExactArgs(1),
+		// No RunE — the tests inspect flags/resolveIrisPromptInput directly.
+	}
+	c.Flags().String("prompt", "", "")
+	c.Flags().String("prompt-file", "", "")
+	c.Flags().String("socket", "", "")
+	c.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	return c
+}
+
+func TestResolveIrisPromptInput_InlinePrompt(t *testing.T) {
+	cmd := newPromptCmdForTest()
+	if err := cmd.ParseFlags([]string{"--prompt", "hello world"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := resolveIrisPromptInput(cmd)
+	if err != nil {
+		t.Fatalf("resolveIrisPromptInput: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("got %q, want %q", got, "hello world")
+	}
+}
+
+func TestResolveIrisPromptInput_PromptFile_TrimsSingleTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.txt")
+	// One trailing newline — should be stripped to match prism's behaviour.
+	if err := os.WriteFile(path, []byte("multi\nline body\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newPromptCmdForTest()
+	if err := cmd.ParseFlags([]string{"--prompt-file", path}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := resolveIrisPromptInput(cmd)
+	if err != nil {
+		t.Fatalf("resolveIrisPromptInput: %v", err)
+	}
+	const want = "multi\nline body"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveIrisPromptInput_PromptFile_PreservesInternalAndExtraTrailingNewlines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.txt")
+	// Two trailing newlines — only ONE is stripped (matches prism: a single
+	// editor-inserted trailing newline is removed; deliberate blank lines
+	// at the end of a body are preserved).
+	if err := os.WriteFile(path, []byte("body\n\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := newPromptCmdForTest()
+	if err := cmd.ParseFlags([]string{"--prompt-file", path}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := resolveIrisPromptInput(cmd)
+	if err != nil {
+		t.Fatalf("resolveIrisPromptInput: %v", err)
+	}
+	if got != "body\n" {
+		t.Errorf("got %q, want %q", got, "body\n")
+	}
+}
+
+func TestResolveIrisPromptInput_PromptFile_NotFound(t *testing.T) {
+	cmd := newPromptCmdForTest()
+	if err := cmd.ParseFlags([]string{"--prompt-file", "/no/such/file/iris-prompt-test"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, err := resolveIrisPromptInput(cmd)
+	if err == nil {
+		t.Fatalf("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "read prompt file") {
+		t.Errorf("error missing 'read prompt file' wording: %q", err.Error())
+	}
+}
+
+func TestResolveIrisPromptInput_Stdin(t *testing.T) {
+	withFakeStdin(t, "from stdin\n")
+	cmd := newPromptCmdForTest()
+	if err := cmd.ParseFlags([]string{"--prompt", "-"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := resolveIrisPromptInput(cmd)
+	if err != nil {
+		t.Fatalf("resolveIrisPromptInput: %v", err)
+	}
+	if got != "from stdin" {
+		t.Errorf("got %q, want %q", got, "from stdin")
+	}
+}
+
+func TestResolveIrisPromptInput_NoFlags_ReturnsEmpty(t *testing.T) {
+	cmd := newPromptCmdForTest()
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := resolveIrisPromptInput(cmd)
+	if err != nil {
+		t.Fatalf("resolveIrisPromptInput: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// TestPromptCmd_MutualExclusion confirms that cobra enforces the mutual
+// exclusion of --prompt and --prompt-file. We build a synthetic root that
+// hosts an exact-copy `prompt` subcommand (same MarkFlagsMutuallyExclusive
+// call) so we can drive Execute() without booting the real rootCmd's
+// daemon startup path.
+func TestPromptCmd_MutualExclusion(t *testing.T) {
+	root := &cobra.Command{Use: "iris", SilenceUsage: true, SilenceErrors: true}
+	sub := &cobra.Command{
+		Use:           "prompt <session>",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          func(*cobra.Command, []string) error { return nil },
+	}
+	sub.Flags().String("prompt", "", "")
+	sub.Flags().String("prompt-file", "", "")
+	sub.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	root.AddCommand(sub)
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetOut(&stderr)
+	root.SetArgs([]string{"prompt", "some-session", "--prompt", "x", "--prompt-file", "/tmp/y"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected mutual-exclusion error, got nil (stderr=%q)", stderr.String())
+	}
+	// Cobra's actual wording is: "if any flags in the group [prompt prompt-file]
+	// are set none of the others can be". We accept either that or the
+	// shorthand "exclusive" wording in case cobra revises the phrasing.
+	low := strings.ToLower(err.Error())
+	if !strings.Contains(low, "exclusive") &&
+		!(strings.Contains(low, "prompt-file") && strings.Contains(low, "none of the others")) {
+		t.Errorf("error did not mention mutual exclusion: %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Adds `iris prompt <session>` — the daemon-mode analogue of `prism prompt <session>`. Closes the gap where the only way to inject a prompt into a running iris session was through the TUI, which is unsuitable for scripted use.

The wire frame `prompt_deliver` and its daemon-side handler already exist (D-6, `internal/iris/client_socket.go::handlePromptDeliver`); this PR is pure CLI plumbing on top.

## Behaviour

Three input variants — mirror prism's CLI shape:

```
iris prompt <session> --prompt <text>
iris prompt <session> --prompt-file <path>
iris prompt <session> --prompt -            # read body from stdin
```

- `--prompt` and `--prompt-file` are mutually exclusive (enforced by cobra).
- File / stdin input strip a single trailing newline (matches prism).
- A literal `-` cannot be sent as a prompt via `--prompt` — `-` is the reserved stdin sentinel. Use `--prompt-file` for that.

## Waiting-state guard

Before sending, the CLI fetches a `sessions_snapshot` and:

- If the session's `state == "waiting"` — refuses with prism's documented wording (the agent has paused for direct user input; switch in tmux and respond directly). No `prompt_deliver` frame is sent.
- If the session is not in the snapshot — clear "no such session" error citing the active session names.
- If the daemon socket cannot be reached — the canonical `iris daemon not running … systemctl --user start iris` wording (same as `iris spawn` and `iris sessions list`).

iris does not currently set a `waiting` state on its own (no production code path produces it today), but the guard is wired against the literal string `"waiting"` per the issue spec — forward-compatible with any future iris waiting-state implementation, and exercised end-to-end by `TestPrompt_WaitingStateGuard`.

## Success / failure handling

The daemon's `prompt_deliver` protocol does **not** emit an explicit success ack — `handlePromptDeliver` only writes a frame on **failure** (an `error` frame). The CLI therefore waits a brief 1.5s window for an error frame after sending; a clean read-timeout or silent EOF-after-timeout = success. EOF before the window expires surfaces "lost connection to daemon" rather than hanging.

On success: `prompt delivered to <session>` and exit 0.

## Acceptance criteria

All ACs from #1677 covered:

- [x] `--prompt`, `--prompt-file`, `--prompt -` (stdin) input variants
- [x] `--prompt` / `--prompt-file` mutually exclusive
- [x] Success → confirmation, exit 0
- [x] Daemon down → canonical `systemctl --user start iris` error
- [x] No such session → clear error, no stack trace
- [x] Waiting state → refusal message, no `prompt_deliver` frame sent
- [x] Mid-send connection drop → "lost connection to daemon", no hang
- [x] `iris --help` lists `prompt`; `iris prompt --help` documents flags, stdin convention, waiting-state guard
- [x] Integration tests for happy path and waiting-state guard (also no-such-session, daemon-not-running, empty prompt, delivery error)
- [x] `go test ./... -race` passes
- [x] `nix build .#iris` succeeds

## Tests

- `prompt_test.go` — unit tests for flag parsing and `resolveIrisPromptInput`: inline `--prompt`, `--prompt-file` (single-newline-trim semantics + extra newline preservation + missing-file error), `--prompt -` stdin, empty-flags case, and cobra-enforced mutual exclusion.
- `prompt_integration_test.go` — end-to-end against a real `iris.ClientSocket` with stub `GetActiveSessions` / `DeliverPrompt` hooks: happy path (hook invoked once with correct name/text, CLI prints confirmation), waiting-state guard (no hook invocation, refusal message), no-such-session, daemon-not-running, empty-prompt refusal, daemon-side delivery error surfaces verbatim.

## Quality gates

Run locally:

```
cd modules/programs/prism/prism
go build ./...                 # clean
go test ./... -race -count=1   # all packages pass

# from repo root
nix build .#iris               # clean; ./result/bin/iris prompt --help
                               # shows documented help; daemon-not-running
                               # path surfaces canonical error
```

Closes #1677