### PR TITLE
fix(iris): implement session_kill and wire iris cleanup to kill-then-archive

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/cleanup.go
+++ b/modules/programs/prism/prism/cmd/iris/cleanup.go
@@ -5,12 +5,25 @@
 // This is the iris analogue of `prism cleanup` and never invokes any
 // prism code path — see internal/iris/cleanup.go for the implementation
 // and contract.
+//
+// Issue #1674: cleanup now invokes session_kill against the running daemon
+// before archiving so that the kill-then-archive flow is atomic from the
+// user's perspective and no zombie pi process is left running. When the
+// daemon is not reachable, cleanup proceeds with the DB-only steps and
+// reports skipped=true on the kill summary line.
 
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -20,7 +33,18 @@ import (
 var (
 	cleanupRemoveWorktree bool
 	cleanupPIAgentDir     string
+	cleanupSkipKill       bool
 )
+
+// cleanupKillDialTimeout bounds the dial against the daemon socket; cleanup
+// must not hang when the daemon is down (the DB-only path is still useful).
+const cleanupKillDialTimeout = 2 * time.Second
+
+// cleanupKillAckTimeout bounds how long cleanup waits for the daemon's
+// session_killed (or error) frame. The daemon's own kill ladder is
+// SIGTERM+5s+SIGKILL+2s = 7s upper bound, so 15s gives the daemon plenty of
+// slack and still surfaces hangs as a clear error.
+const cleanupKillAckTimeout = 15 * time.Second
 
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup <session>",
@@ -48,11 +72,23 @@ remove a worktree whose basename is "main" under a prism .bare layout.`,
 func init() {
 	cleanupCmd.Flags().BoolVar(&cleanupRemoveWorktree, "remove-worktree", false, "Remove the worktree directory and local git branch (coordinator worktree is always protected)")
 	cleanupCmd.Flags().StringVar(&cleanupPIAgentDir, "pi-agent-dir", "", "Override the pi agent dir (default: ~/.pi/agent/)")
+	cleanupCmd.Flags().BoolVar(&cleanupSkipKill, "skip-kill", false, "Skip the session_kill step (DB-only cleanup; pi child is left untouched)")
 	rootCmd.AddCommand(cleanupCmd)
 }
 
 func runCleanup(sessionName string) error {
 	p := iris.ResolvePaths()
+
+	// Step 0 (issue #1674): kill the running pi child via the daemon before
+	// archiving. Skipped explicitly with --skip-kill or implicitly when the
+	// daemon socket is not reachable (the kill is a best-effort prelude to
+	// the DB-only cleanup steps below; a dead daemon already means no live
+	// pi child to kill).
+	killSummary := "skipped (--skip-kill)"
+	if !cleanupSkipKill {
+		killSummary = killSessionViaDaemon(p.Sock, sessionName)
+	}
+
 	database, err := iris.OpenDB(p.DB)
 	if err != nil {
 		return fmt.Errorf("iris cleanup: open db: %w", err)
@@ -72,6 +108,7 @@ func runCleanup(sessionName string) error {
 	}
 
 	fmt.Printf("iris cleanup: %s\n", sessionName)
+	fmt.Printf("  kill:           %s\n", killSummary)
 	if res.ArchivePath != "" {
 		fmt.Printf("  archive:        %s\n", res.ArchivePath)
 	} else {
@@ -89,4 +126,77 @@ func runCleanup(sessionName string) error {
 		}
 	}
 	return nil
+}
+
+// killSessionViaDaemon dials the iris daemon socket and sends a session_kill
+// frame. Returns a one-line summary string suitable for printing in the
+// cleanup output. All failure modes — daemon down, no such session,
+// ack timeout — are non-fatal: the DB-only cleanup steps still run.
+func killSessionViaDaemon(sockPath, sessionName string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupKillAckTimeout+cleanupKillDialTimeout)
+	defer cancel()
+
+	d := net.Dialer{Timeout: cleanupKillDialTimeout}
+	conn, err := d.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		return fmt.Sprintf("skipped (daemon not running at %s)", sockPath)
+	}
+	defer conn.Close()
+
+	frame := iris.ClientSessionKillFrame{
+		Type: iris.ClientFrameSessionKill,
+		Name: sessionName,
+	}
+	data, err := json.Marshal(frame)
+	if err != nil {
+		return fmt.Sprintf("skipped (marshal kill frame: %v)", err)
+	}
+	data = append(data, '\n')
+	if _, err := conn.Write(data); err != nil {
+		return fmt.Sprintf("skipped (write kill frame: %v)", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(cleanupKillAckTimeout)); err != nil {
+		return fmt.Sprintf("skipped (set read deadline: %v)", err)
+	}
+	r := bufio.NewReaderSize(conn, 1<<20)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return "skipped (daemon closed connection before ack)"
+			}
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() {
+				return fmt.Sprintf("skipped (timed out after %s)", cleanupKillAckTimeout)
+			}
+			return fmt.Sprintf("skipped (read ack: %v)", err)
+		}
+		var generic struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(line, &generic); err != nil {
+			// Skip malformed frames; keep reading for the ack.
+			fmt.Fprintf(os.Stderr, "[iris] cleanup: ignoring malformed frame from daemon: %v\n", err)
+			continue
+		}
+		switch generic.Type {
+		case iris.DaemonFrameSessionKilled:
+			var f iris.DaemonSessionKilledFrame
+			if err := json.Unmarshal(line, &f); err != nil {
+				return fmt.Sprintf("acknowledged (decode: %v)", err)
+			}
+			return fmt.Sprintf("killed (state=%s)", f.State)
+		case iris.DaemonFrameError:
+			var f iris.DaemonErrorFrame
+			if err := json.Unmarshal(line, &f); err != nil {
+				return fmt.Sprintf("skipped (decode error frame: %v)", err)
+			}
+			return fmt.Sprintf("skipped (%s)", f.Message)
+		default:
+			// Other frames (session_event, session_state, etc.) may arrive
+			// before the ack — the daemon is a multiplexed surface. Skip.
+			continue
+		}
+	}
 }

--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -250,6 +250,31 @@ func runDaemon() error {
 		})
 	}
 
+	// killFn is called by the client socket when a session_kill frame arrives.
+	// It looks up the supervisor by name and invokes Supervisor.Kill which
+	// cancels the per-session context (SIGTERM via exec.CommandContext) and
+	// escalates to SIGKILL on timeout.
+	killFn := func(killCtx context.Context, name string, timeout time.Duration) (string, error) {
+		state.mu.Lock()
+		sup, ok := state.supervisors[name]
+		state.mu.Unlock()
+		if !ok {
+			return "", fmt.Errorf("session %q not found", name)
+		}
+		priorState := sup.State()
+		terminal, err := sup.Kill(killCtx, timeout)
+		if err != nil {
+			return "", err
+		}
+		// If the session was already terminal before Kill ran, surface that
+		// as "already_terminal" so the client can distinguish idempotent
+		// no-ops from real kill outcomes.
+		if priorState == iris.StateFinished || priorState == iris.StateError {
+			return "already_terminal", nil
+		}
+		return string(terminal), nil
+	}
+
 	// Create the client IPC socket first so spawnFn can capture it and wire
 	// each new harness as a publisher (D-6 fan-out). spawnFn is passed to
 	// NewClientSocket as ClientSocketConfig.SpawnSession.
@@ -259,6 +284,7 @@ func runDaemon() error {
 		GetActiveSessions: state.activeSessions,
 		// SpawnSession is assigned below after spawnFn is defined.
 		DeliverPrompt: deliverFn,
+		KillSession:   killFn,
 	})
 
 	// spawnFn is called by the client socket when a session_spawn frame arrives.

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -175,6 +175,21 @@ type DaemonSessionSpawnedFrame struct {
 	Session    *SessionSnapshot `json:"session,omitempty"` // full snapshot of the new session (optional for backwards compat)
 }
 
+// DaemonSessionKilledFrame acknowledges a successful session_kill. The
+// State field reports the terminal state the session settled into — one of
+// "finished" (clean SIGTERM exit), "error" (SIGKILL escalation), or
+// "already_terminal" (the session was already in a terminal state and the
+// kill was a no-op). Clients receive this frame whether the kill cancelled
+// a live pi child or completed idempotently against an already-finished
+// session.
+//
+//	{"type": "session_killed", "name": "...", "state": "finished"}
+type DaemonSessionKilledFrame struct {
+	Type  string `json:"type"`  // "session_killed"
+	Name  string `json:"name"`  // session name from the request frame
+	State string `json:"state"` // "finished" | "error" | "already_terminal"
+}
+
 // DaemonErrorFrame is an error response to a client request.
 //
 //	{"type": "error", "request_type": "session_subscribe", "message": "session not found"}
@@ -204,6 +219,7 @@ const (
 	DaemonFrameSessionEvent       = "session_event"
 	DaemonFrameSessionState       = "session_state"
 	DaemonFrameSessionSpawned     = "session_spawned"
+	DaemonFrameSessionKilled      = "session_killed"
 	DaemonFrameError              = "error"
 	DaemonFramePong               = "pong"
 )

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -98,6 +98,10 @@ type ClientSocket struct {
 	spawnSession func(ctx context.Context, worktree, role string, configOverrides map[string]any) (*Supervisor, error)
 	// deliverPrompt delivers a prompt to a named session. Set by the daemon.
 	deliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
+	// killSession terminates a named session. Returns the terminal state
+	// reached ("finished", "error", "already_terminal") on success. Set by
+	// the daemon at construction.
+	killSession func(ctx context.Context, name string, timeout time.Duration) (string, error)
 
 	listener net.Listener
 
@@ -134,6 +138,9 @@ type ClientSocketConfig struct {
 	SpawnSession func(ctx context.Context, worktree, role string, configOverrides map[string]any) (*Supervisor, error)
 	// DeliverPrompt delivers a prompt to a named session.
 	DeliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
+	// KillSession terminates a named session. Returns the terminal state
+	// ("finished" / "error" / "already_terminal") on success.
+	KillSession func(ctx context.Context, name string, timeout time.Duration) (string, error)
 }
 
 // NewClientSocket creates a ClientSocket. Call Listen() to bind the socket,
@@ -145,6 +152,7 @@ func NewClientSocket(cfg ClientSocketConfig) *ClientSocket {
 		getActiveSessions: cfg.GetActiveSessions,
 		spawnSession:      cfg.SpawnSession,
 		deliverPrompt:     cfg.DeliverPrompt,
+		killSession:       cfg.KillSession,
 		subscribers:       make(map[string][]subscriberChan),
 	}
 }
@@ -211,6 +219,13 @@ func (cs *ClientSocket) SockPath() string { return cs.sockPath }
 // clientSock needs spawnFn). Call before Serve().
 func (cs *ClientSocket) SetSpawnSession(fn func(ctx context.Context, worktree, role string, configOverrides map[string]any) (*Supervisor, error)) {
 	cs.spawnSession = fn
+}
+
+// SetKillSession wires the kill function after construction. Symmetric with
+// SetSpawnSession; call before Serve() when the daemon's killFn captures a
+// reference to the ClientSocket.
+func (cs *ClientSocket) SetKillSession(fn func(ctx context.Context, name string, timeout time.Duration) (string, error)) {
+	cs.killSession = fn
 }
 
 // Close closes the listener and removes the socket file.
@@ -392,7 +407,7 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				sendError(w, ClientFrameSessionKill, "invalid frame: "+err.Error())
 				continue
 			}
-			sendError(w, ClientFrameSessionKill, "session_kill not yet implemented")
+			go cs.handleSessionKill(connCtx, w, frame)
 
 		case ClientFramePromptDeliver:
 			var frame ClientPromptDeliverFrame
@@ -586,6 +601,43 @@ func (cs *ClientSocket) handleSessionSpawn(ctx context.Context, w *jsonlWriter, 
 		Name:       snap.Name,
 		InstanceID: snap.InstanceID,
 		Session:    &snap,
+	})
+}
+
+// killSessionTimeout is the SIGTERM grace period the daemon applies on every
+// session_kill frame. It matches the AC for issue #1674: SIGTERM, 5s wait,
+// then SIGKILL escalation.
+const killSessionTimeout = 5 * time.Second
+
+// handleSessionKill terminates a named session and writes a session_killed
+// ack back to the client. Errors (no-such-session, kill timed out, no kill
+// function wired) come back as DaemonErrorFrame so the client can distinguish
+// success from failure on the same conn.
+//
+// Idempotent: a session already in a terminal state returns success with
+// state="already_terminal" without re-killing.
+func (cs *ClientSocket) handleSessionKill(ctx context.Context, w *jsonlWriter, frame ClientSessionKillFrame) {
+	if cs.killSession == nil {
+		sendError(w, ClientFrameSessionKill, "session kill not configured on this daemon instance")
+		return
+	}
+	if frame.Name == "" {
+		sendError(w, ClientFrameSessionKill, "name is required")
+		return
+	}
+	if !cs.sessionExists(frame.Name) {
+		sendError(w, ClientFrameSessionKill, fmt.Sprintf("session %q not found", frame.Name))
+		return
+	}
+	state, err := cs.killSession(ctx, frame.Name, killSessionTimeout)
+	if err != nil {
+		sendError(w, ClientFrameSessionKill, fmt.Sprintf("kill failed: %v", err))
+		return
+	}
+	_ = w.write(DaemonSessionKilledFrame{
+		Type:  DaemonFrameSessionKilled,
+		Name:  frame.Name,
+		State: state,
 	})
 }
 

--- a/modules/programs/prism/prism/internal/iris/client_socket_kill_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_kill_test.go
@@ -1,0 +1,213 @@
+package iris_test
+
+// client_socket_kill_test.go — integration tests for the session_kill frame
+// (issue #1674). These exercise the client-socket wire path that returns
+// session_killed / error frames to clients, including the no-such-session
+// and already-terminal idempotent paths.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// newKillTestClientSocket builds a ClientSocket whose KillSession callback
+// records every invocation and returns a configurable state/error pair.
+// This isolates the wire path (frame parsing + ack frame) from the daemon
+// state machine; full end-to-end killing is covered by the Supervisor.Kill
+// tests in supervisor_kill_test.go.
+type killRecord struct {
+	name    string
+	timeout time.Duration
+}
+
+func newKillTestClientSocket(t *testing.T, sessions []iris.SessionSnapshot, killState string, killErr error) (*iris.ClientSocket, *[]killRecord) {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	sockPath := filepath.Join(tmp, "iris.sock")
+	records := &[]killRecord{}
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+		KillSession: func(_ context.Context, name string, timeout time.Duration) (string, error) {
+			*records = append(*records, killRecord{name: name, timeout: timeout})
+			return killState, killErr
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	go cs.Serve(ctx)
+
+	return cs, records
+}
+
+// TestSessionKill_HappyPath verifies that a session_kill frame for a live
+// session triggers KillSession, returns a session_killed ack carrying the
+// terminal state, and forwards the 5-second timeout.
+func TestSessionKill_HappyPath(t *testing.T) {
+	cs, records := newKillTestClientSocket(t,
+		[]iris.SessionSnapshot{{Name: "alive@test", InstanceID: "iid-1", State: "active"}},
+		"finished", nil,
+	)
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_kill",
+		"name": "alive@test",
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatal("no ack frame received")
+	}
+	if frame["type"] != "session_killed" {
+		t.Fatalf("type = %v, want session_killed (frame=%v)", frame["type"], frame)
+	}
+	if frame["name"] != "alive@test" {
+		t.Errorf("name = %v, want alive@test", frame["name"])
+	}
+	if frame["state"] != "finished" {
+		t.Errorf("state = %v, want finished", frame["state"])
+	}
+
+	// KillSession invoked exactly once with the canonical 5s timeout.
+	if len(*records) != 1 {
+		t.Fatalf("KillSession called %d times, want 1", len(*records))
+	}
+	rec := (*records)[0]
+	if rec.name != "alive@test" {
+		t.Errorf("recorded name = %q", rec.name)
+	}
+	if rec.timeout != 5*time.Second {
+		t.Errorf("recorded timeout = %s, want 5s (the canonical session_kill grace period)", rec.timeout)
+	}
+}
+
+// TestSessionKill_NoSuchSession verifies that killing a session that is not
+// in the active set produces an error frame (request_type=session_kill)
+// without invoking KillSession. The connection stays open so the client can
+// continue using it.
+func TestSessionKill_NoSuchSession(t *testing.T) {
+	cs, records := newKillTestClientSocket(t,
+		[]iris.SessionSnapshot{}, // no sessions
+		"finished", nil,
+	)
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_kill",
+		"name": "missing@test",
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatal("no error frame received")
+	}
+	if frame["type"] != "error" {
+		t.Fatalf("type = %v, want error (frame=%v)", frame["type"], frame)
+	}
+	if frame["request_type"] != "session_kill" {
+		t.Errorf("request_type = %v, want session_kill", frame["request_type"])
+	}
+	if len(*records) != 0 {
+		t.Errorf("KillSession should not be invoked on missing session, got %d records", len(*records))
+	}
+
+	// Connection should still be open — send a ping and verify pong arrives.
+	sendClientFrame(t, conn, map[string]any{"type": "ping"})
+	pong, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok || pong["type"] != "pong" {
+		t.Errorf("ping after error did not return pong (got %v, ok=%v)", pong, ok)
+	}
+}
+
+// TestSessionKill_AlreadyTerminal_Idempotent verifies that calling
+// session_kill on a session whose state is already terminal returns a
+// session_killed ack with state="already_terminal" — the daemon-side
+// killFn maps that case before invoking the supervisor.
+func TestSessionKill_AlreadyTerminal_Idempotent(t *testing.T) {
+	cs, records := newKillTestClientSocket(t,
+		[]iris.SessionSnapshot{{Name: "done@test", InstanceID: "iid-d", State: "finished"}},
+		"already_terminal", nil,
+	)
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_kill",
+		"name": "done@test",
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatal("no ack frame received")
+	}
+	if frame["type"] != "session_killed" {
+		t.Fatalf("type = %v, want session_killed (frame=%v)", frame["type"], frame)
+	}
+	if frame["state"] != "already_terminal" {
+		t.Errorf("state = %v, want already_terminal", frame["state"])
+	}
+	if len(*records) != 1 {
+		t.Errorf("KillSession should still be called for idempotency check, got %d", len(*records))
+	}
+}
+
+// TestSessionKill_NoKillFunctionWired verifies that a daemon constructed
+// without a KillSession callback rejects session_kill with a clear error
+// rather than silently succeeding or panicking.
+func TestSessionKill_NoKillFunctionWired(t *testing.T) {
+	cs, _ := newTestClientSocket(t,
+		[]iris.SessionSnapshot{{Name: "alive@test", InstanceID: "iid-1", State: "active"}},
+	)
+	// newTestClientSocket does not wire KillSession.
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_kill",
+		"name": "alive@test",
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatal("no ack frame received")
+	}
+	if frame["type"] != "error" {
+		t.Fatalf("type = %v, want error (frame=%v)", frame["type"], frame)
+	}
+}
+
+// TestSessionKill_InvalidFrame verifies that a session_kill frame missing
+// the required "name" field returns an error frame.
+func TestSessionKill_InvalidFrame(t *testing.T) {
+	cs, _ := newKillTestClientSocket(t,
+		[]iris.SessionSnapshot{},
+		"finished", nil,
+	)
+
+	conn, r := dialClientSocket(t, cs.SockPath())
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_kill",
+		// name omitted
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatal("no ack frame received")
+	}
+	if frame["type"] != "error" {
+		t.Errorf("type = %v, want error", frame["type"])
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/restore.go
+++ b/modules/programs/prism/prism/internal/iris/restore.go
@@ -363,5 +363,6 @@ func newRestoreSupervisor(cfg SupervisorConfig, sess db.IrisSessionRow) (*Superv
 		state:          StateSpawning,
 		sessionLog:     sessionLog,
 		sessionLogFile: logFile,
+		done:           make(chan struct{}),
 	}, nil
 }

--- a/modules/programs/prism/prism/internal/iris/restore.go
+++ b/modules/programs/prism/prism/internal/iris/restore.go
@@ -349,7 +349,6 @@ func newRestoreSupervisor(cfg SupervisorConfig, sess db.IrisSessionRow) (*Superv
 		log.Printf("[iris] restore: failed to reset iris_state to spawning for %s: %v", sess.InstanceID, err)
 	}
 
-
 	logFile, logErr := openSessionLogFile(cfg.LogDir, cfg.SessionName)
 	if logErr != nil {
 		log.Printf("[iris] restore: open per-session log: %v (continuing without per-session log)", logErr)

--- a/modules/programs/prism/prism/internal/iris/session_kill_e2e_test.go
+++ b/modules/programs/prism/prism/internal/iris/session_kill_e2e_test.go
@@ -1,0 +1,228 @@
+package iris
+
+// session_kill_e2e_test.go — end-to-end integration test for the full
+// session_kill wire path (issue #1674).
+//
+// Flow:
+//
+//   1. Start a real ClientSocket + a real Supervisor against a `/bin/sleep`
+//      child (acting as a stand-in for pi).
+//   2. Open a client connection to the daemon socket.
+//   3. Send a session_kill frame.
+//   4. Assert: session_killed ack arrives, the underlying process is gone
+//      (cannot signal pid 0), the session DB row carries end_state set.
+//
+// This is the integration AC: "spawn a session, call session_kill via the
+// client socket, and assert pi is no longer running and the session state
+// is finished in the DB."
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSessionKill_E2E_KillsRealProcess(t *testing.T) {
+	// Short-prefix tempdir so the harness socket path fits in sun_path.
+	shortPrefix, err := os.MkdirTemp("", "iris-e2e-kill-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+
+	dbPath := filepath.Join(shortPrefix, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	// Build a script that just sleeps — enough to stand in for pi.
+	script := writeShellScript(t, "exec sleep 60\n")
+
+	// Spawn the supervisor.
+	cfg := SupervisorConfig{
+		SessionName:     "iris-e2e-kill@test",
+		Worktree:        shortPrefix,
+		Role:            "worker",
+		PIBinaryPath:    script,
+		RunDir:          shortPrefix,
+		LogDir:          filepath.Join(shortPrefix, "logs"),
+		Database:        database,
+		ShutdownTimeout: 100 * time.Millisecond,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	supCtx, supCancel := context.WithCancel(context.Background())
+	t.Cleanup(supCancel)
+	go sup.Start(supCtx)
+
+	// Wait until the supervisor is active and capture the pid.
+	if !waitForState(sup, StateActive, 5*time.Second) {
+		t.Fatalf("supervisor never reached active (state=%s)", sup.State())
+	}
+	sup.mu.Lock()
+	proc := sup.process
+	sup.mu.Unlock()
+	if proc == nil {
+		t.Fatal("supervisor reported active but process handle was nil")
+	}
+	pid := proc.Pid
+
+	// Build a single-session ClientSocket that knows about this supervisor.
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+	var mu sync.Mutex
+	cs := NewClientSocket(ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []SessionSnapshot {
+			mu.Lock()
+			defer mu.Unlock()
+			rec := sup.SessionRecord()
+			return []SessionSnapshot{{
+				Name:       rec.SessionName,
+				InstanceID: rec.InstanceID,
+				State:      string(rec.State),
+				Role:       rec.Role,
+				Worktree:   rec.Worktree,
+			}}
+		},
+		KillSession: func(killCtx context.Context, name string, timeout time.Duration) (string, error) {
+			if name != cfg.SessionName {
+				t.Fatalf("unexpected session name in KillSession: %q", name)
+			}
+			prior := sup.State()
+			terminal, err := sup.Kill(killCtx, timeout)
+			if err != nil {
+				return "", err
+			}
+			if prior == StateFinished || prior == StateError {
+				return "already_terminal", nil
+			}
+			return string(terminal), nil
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("ClientSocket.Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	csCtx, csCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(csCancel)
+	go cs.Serve(csCtx)
+
+	// Dial the client socket and send the kill frame.
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial client socket: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	killFrame := map[string]any{
+		"type": "session_kill",
+		"name": cfg.SessionName,
+	}
+	data, _ := json.Marshal(killFrame)
+	data = append(data, '\n')
+	if _, err := conn.Write(data); err != nil {
+		t.Fatalf("write kill frame: %v", err)
+	}
+
+	// Read frames until we see session_killed or timeout.
+	conn.SetReadDeadline(time.Now().Add(15 * time.Second)) //nolint:errcheck
+	r := bufio.NewReaderSize(conn, 1<<20)
+
+	var (
+		gotKilled bool
+		killState string
+	)
+	for !gotKilled {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("read ack: %v", err)
+		}
+		var generic struct {
+			Type  string `json:"type"`
+			State string `json:"state"`
+		}
+		if err := json.Unmarshal(line, &generic); err != nil {
+			continue
+		}
+		if generic.Type == "session_killed" {
+			gotKilled = true
+			killState = generic.State
+		}
+		if generic.Type == "error" {
+			t.Fatalf("daemon returned error frame: %s", string(line))
+		}
+	}
+
+	if killState != string(StateFinished) {
+		t.Errorf("kill state = %q, want %q (a /bin/sleep responds cleanly to SIGTERM)", killState, StateFinished)
+	}
+
+	// Wait for the supervisor goroutine to fully converge.
+	select {
+	case <-sup.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("supervisor did not converge within 5s after session_killed ack")
+	}
+
+	// The pi child must no longer be alive.
+	if processAlive(pid) {
+		t.Errorf("pid %d still alive after session_kill", pid)
+	}
+
+	// DB state assertions: sessions row has end_state set.
+	sess, err := database.SessionByInstanceID(sup.sess.InstanceID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("session row missing post-kill")
+	}
+	if sess.EndState == nil {
+		t.Error("sessions.end_state is NULL after kill (expected non-nil)")
+	} else if *sess.EndState != "finished" {
+		t.Errorf("sessions.end_state = %q, want finished", *sess.EndState)
+	}
+
+	// And a session_end event was written with the kill reason.
+	assertSessionEndReason(t, database, cfg.SessionName, "killed_sigterm")
+}
+
+// waitForState polls the supervisor's state until it equals want or the
+// deadline expires. Returns true on match.
+func waitForState(sup *Supervisor, want SessionState, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if sup.State() == want {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// processAlive returns true when a signal-0 probe of pid succeeds. On
+// Unix this is the canonical "is pid alive" check.
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Signal 0 tests for the existence of the process without sending a
+	// signal. ESRCH means the process is gone; EPERM means it exists but
+	// we don't have permission (treat as alive for the test).
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -16,6 +16,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -24,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -89,6 +91,11 @@ type Supervisor struct {
 	// stdinPipe is the write end of pi's stdin (for sending RPC commands).
 	stdinPipe io.WriteCloser
 
+	// process is the live pi *os.Process while pi is running, nil otherwise.
+	// Used by Kill() to escalate to SIGKILL after a SIGTERM timeout. Guarded
+	// by mu — same lock as stdinPipe and state.
+	process *os.Process
+
 	// sessionLog is the per-session logger that writes to both the global
 	// log destination (stderr / journal) and the per-session log file under
 	// LogDir. Always non-nil after construction; falls back to the stderr-
@@ -99,8 +106,21 @@ type Supervisor struct {
 	// state.
 	sessionLogFile *os.File
 
+	// cancel is the per-session context cancel function. It is set by Start()
+	// at the top of the loop and used by Kill() to send SIGTERM via
+	// exec.CommandContext. Guarded by mu.
+	cancel context.CancelFunc
+	// done is closed by Start() when the supervisor goroutine returns. Kill()
+	// waits on it to determine when pi has fully exited. Initialised in
+	// NewSupervisor so callers can wait even before Start() runs.
+	done chan struct{}
+
 	mu    sync.Mutex
 	state SessionState
+	// killReason, when non-empty, overrides the default termination reason in
+	// the session_end event emitted on terminal state. Set by Kill() to
+	// "killed_sigterm" or "killed_sigkill". Guarded by mu.
+	killReason string
 }
 
 // stateNotifier is implemented by publishers that want to receive
@@ -219,6 +239,7 @@ func NewSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 		state:          StateSpawning,
 		sessionLog:     sessionLog,
 		sessionLogFile: logFile,
+		done:           make(chan struct{}),
 	}
 	// Wire the session_status handler so the harness socket can update the
 	// in-memory SessionRecord.PiSessionPath as soon as pi delivers its
@@ -340,10 +361,26 @@ func (s *Supervisor) closeSessionLogFile() {
 // session reaches a terminal state (finished or error) or ctx is cancelled.
 // Start is intended to be called in its own goroutine.
 func (s *Supervisor) Start(ctx context.Context) {
+	// Wrap the caller's context in a per-session cancel so Kill() can SIGTERM
+	// this one pi child without disturbing other sessions sharing the daemon
+	// context. The wrapped context is the one that flows to exec.CommandContext
+	// in spawnAndRun — cancelling it triggers SIGTERM delivery to pi.
+	ctx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	s.cancel = cancel
+	s.mu.Unlock()
+	defer cancel()
+
 	// Ensure the per-session log file is closed when Start returns. The
 	// supervisor's lifetime is the goroutine that runs Start, so this is the
-	// correct close site.
+	// correct close site. Match the natural session-end teardown convention
+	// here too: close the harness listener (which removes the Unix socket
+	// inode on Linux per the D-5 cycle-4 fix) so the kill path and the
+	// natural exit path leave the same observable filesystem state.
 	defer s.closeSessionLogFile()
+	defer s.harness.Close()
+	// Signal completion to anyone waiting on Kill().
+	defer close(s.done)
 
 	for {
 		exitCode := s.spawnAndRun(ctx)
@@ -423,6 +460,17 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 	cmd := exec.CommandContext(ctx, piBin, args...)
 	cmd.Dir = s.cfg.Worktree
 	cmd.Env = s.buildEnv(piConfigDir)
+	// Override the default SIGKILL-on-cancel behaviour with SIGTERM so the
+	// kill ladder (issue #1674) runs SIGTERM → 5s grace → SIGKILL. WaitDelay
+	// is intentionally NOT set: Kill() owns the SIGKILL escalation via the
+	// recorded *os.Process handle, and a WaitDelay set here would race with
+	// the explicit escalation path.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
 
 	// Wire stdin/stdout pipes.
 	stdinPipe, err := cmd.StdinPipe()
@@ -451,6 +499,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 
 	s.mu.Lock()
 	s.stdinPipe = stdinPipe
+	s.process = cmd.Process
 	s.mu.Unlock()
 
 	s.logf("supervisor: spawned pi pid=%d (session %s)", cmd.Process.Pid, s.sess.InstanceID)
@@ -484,6 +533,7 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 
 	s.mu.Lock()
 	s.stdinPipe = nil
+	s.process = nil
 	s.mu.Unlock()
 
 	if waitErr == nil {
@@ -613,8 +663,34 @@ func (s *Supervisor) openLogFile() *os.File {
 // setState updates the in-memory and DB state of the session.
 func (s *Supervisor) setState(newState SessionState) {
 	s.mu.Lock()
+	// Suppress redundant transitions — the kill path may re-assert
+	// StateError after setState already drove the supervisor into a terminal
+	// state via the normal restart-policy path. Without this guard, the
+	// session_end event would be written twice for a single kill.
+	if s.state == newState && (newState == StateFinished || newState == StateError) {
+		s.mu.Unlock()
+		return
+	}
+	// When Kill has set killReason, the supervisor loop's race with ctx
+	// cancellation can briefly drive the state through StateFinished (the
+	// ctx.Err()-check branch at the top of Start's for-loop maps cancelled
+	// context to StateFinished). That is wrong for a kill: the canonical
+	// outcome of session_kill is StateFinished only when pi exited cleanly
+	// on SIGTERM, otherwise StateError. Suppress the intermediate
+	// StateFinished from the loop so the kill path produces one terminal
+	// transition with the correct reason — Kill itself drives the final
+	// setState call.
+	if s.killReason != "" && newState == StateFinished && s.state != StateFinished {
+		// Re-map to StateError when SIGKILL was already needed; otherwise
+		// leave the SIGTERM-clean path to set StateFinished explicitly.
+		if s.killReason == "killed_sigkill" || s.killReason == "killed_no_process" {
+			s.mu.Unlock()
+			return
+		}
+	}
 	s.state = newState
 	s.sess.State = newState
+	killReason := s.killReason
 	s.mu.Unlock()
 
 	// Log the transition into the per-session log so `iris logs <session>`
@@ -626,13 +702,26 @@ func (s *Supervisor) setState(newState SessionState) {
 		s.logf("supervisor: update iris_state: %v", err)
 	}
 
-	// Update the sessions DB row end state for terminal states.
+	// Update the sessions DB row end state for terminal states. PR #1657
+	// ordering: write the session_end event FIRST (into agent_events) so any
+	// subscriber observing the event stream sees the termination reason
+	// before the sessions.end_state column reflects it.
 	switch newState {
 	case StateFinished:
+		reason := killReason
+		if reason == "" {
+			reason = "clean_exit"
+		}
+		s.writeSessionEndEvent(reason, string(newState))
 		if err := s.cfg.Database.UpdateSessionEnded(s.sess.InstanceID, "finished"); err != nil {
 			s.logf("supervisor: update session ended: %v", err)
 		}
 	case StateError:
+		reason := killReason
+		if reason == "" {
+			reason = "error"
+		}
+		s.writeSessionEndEvent(reason, string(newState))
 		if err := s.cfg.Database.UpdateSessionEnded(s.sess.InstanceID, "error"); err != nil {
 			s.logf("supervisor: update session ended: %v", err)
 		}
@@ -645,6 +734,51 @@ func (s *Supervisor) setState(newState SessionState) {
 		if n, ok := s.cfg.Publisher.(stateNotifier); ok {
 			n.PublishState(s.sess.SessionName, string(newState))
 		}
+	}
+}
+
+// writeSessionEndEvent writes a session_end row into agent_events with the
+// termination reason and terminal state. Mirrors the harness writeEvent
+// shape (uuid id, instance_id pointer, payload JSON-encoded). The publisher
+// fan-out is invoked when configured so subscribed clients see the
+// session_end event the same way they see a session_status or tool_call
+// frame.
+func (s *Supervisor) writeSessionEndEvent(reason, state string) {
+	payload, err := json.Marshal(map[string]any{
+		"type":   "session_end",
+		"reason": reason,
+		"state":  state,
+	})
+	if err != nil {
+		s.logf("supervisor: marshal session_end payload: %v", err)
+		return
+	}
+	iid := s.sess.InstanceID
+	var iidPtr *string
+	if iid != "" {
+		iidPtr = &iid
+	}
+	event := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: s.sess.SessionName,
+		Worktree:    s.sess.Worktree,
+		Type:        "session_end",
+		Payload:     string(payload),
+		CreatedAt:   time.Now(),
+		InstanceID:  iidPtr,
+	}
+	rowID, err := s.cfg.Database.WriteEventReturningRowID(event)
+	if err != nil {
+		s.logf("supervisor: write session_end event: %v", err)
+		return
+	}
+	if s.cfg.Publisher != nil {
+		s.cfg.Publisher.Publish(EventPublication{
+			SessionName: s.sess.SessionName,
+			RowID:       rowID,
+			EventType:   "session_end",
+			Payload:     string(payload),
+		})
 	}
 }
 
@@ -682,6 +816,119 @@ func formatDuration(d time.Duration) string {
 
 // rpcAbortCmd is the JSON payload for the pi abort RPC command.
 var rpcAbortCmd = map[string]any{"type": "abort"}
+
+// DefaultKillTimeout is the SIGTERM grace period applied by Kill when the
+// caller passes 0. After this elapses without pi exiting cleanly, Kill
+// escalates to SIGKILL on the underlying process.
+const DefaultKillTimeout = 5 * time.Second
+
+// State returns the supervisor's current session state under the lock.
+func (s *Supervisor) State() SessionState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// Done returns a channel that is closed when the supervisor's Start
+// goroutine returns. Useful for callers that want to wait for full session
+// teardown without polling SessionRecord().State.
+func (s *Supervisor) Done() <-chan struct{} { return s.done }
+
+// Kill terminates the pi child managed by this supervisor.
+//
+//   1. If the session is already terminal (finished/error) the call is a
+//      no-op and returns (state, nil). This is the idempotent path — callers
+//      that re-kill an already-dead session see success.
+//   2. Otherwise the per-session context is cancelled; exec.CommandContext
+//      delivers SIGTERM to pi. Kill then waits up to timeout (or
+//      DefaultKillTimeout when timeout is 0) for the Start goroutine to
+//      finish.
+//   3. If pi has not exited by the deadline, Kill sends SIGKILL directly to
+//      the recorded process handle and waits a further 2 seconds for the
+//      goroutine to converge. The terminal state in that case is
+//      StateError; the clean SIGTERM path produces StateFinished.
+//
+// Kill is safe to call concurrently from multiple goroutines; the lock
+// protects the cancel/process handles and the Done channel disambiguates
+// the convergence.
+func (s *Supervisor) Kill(ctx context.Context, timeout time.Duration) (SessionState, error) {
+	if timeout <= 0 {
+		timeout = DefaultKillTimeout
+	}
+
+	s.mu.Lock()
+	current := s.state
+	s.mu.Unlock()
+	if current == StateFinished || current == StateError {
+		return current, nil
+	}
+
+	// Step 1: cancel the per-session context. spawnAndRun configures
+	// cmd.Cancel to send SIGTERM (overriding the default SIGKILL) so this
+	// triggers a graceful shutdown attempt rather than an immediate kill.
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel == nil {
+		// Start() has not been entered yet — there is no pi child to signal.
+		// Mark the session error and let the caller proceed.
+		s.mu.Lock()
+		s.killReason = "killed_no_process"
+		s.mu.Unlock()
+		s.setState(StateError)
+		return StateError, fmt.Errorf("iris kill: supervisor for %q has no live context", s.sess.SessionName)
+	}
+	s.mu.Lock()
+	// Default to the SIGTERM-clean reason; if we escalate to SIGKILL below
+	// we'll overwrite it before setState runs.
+	s.killReason = "killed_sigterm"
+	s.mu.Unlock()
+	s.logf("supervisor: session %s: kill requested, sending SIGTERM via ctx cancel", s.sess.InstanceID)
+	cancel()
+
+	// Step 2: wait up to timeout for Start to exit cleanly.
+	select {
+	case <-s.done:
+		return s.State(), nil
+	case <-time.After(timeout):
+	case <-ctx.Done():
+		return s.State(), ctx.Err()
+	}
+
+	// Step 3: SIGKILL escalation.
+	s.mu.Lock()
+	proc := s.process
+	s.mu.Unlock()
+	s.mu.Lock()
+	s.killReason = "killed_sigkill"
+	s.mu.Unlock()
+	if proc != nil {
+		s.logf("supervisor: session %s: SIGTERM grace expired after %s, sending SIGKILL", s.sess.InstanceID, timeout)
+		if err := proc.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			s.logf("supervisor: session %s: SIGKILL: %v", s.sess.InstanceID, err)
+		}
+	} else {
+		s.logf("supervisor: session %s: SIGTERM grace expired with no live process handle", s.sess.InstanceID)
+	}
+
+	// Wait briefly for the supervisor goroutine to converge. We bound this
+	// so a wedged Wait() does not hang the daemon — a SIGKILLed process
+	// almost always reaps within milliseconds.
+	select {
+	case <-s.done:
+	case <-time.After(2 * time.Second):
+		s.logf("supervisor: session %s: supervisor goroutine did not converge after SIGKILL", s.sess.InstanceID)
+	case <-ctx.Done():
+		return s.State(), ctx.Err()
+	}
+
+	// Force the terminal state to StateError so the SIGKILL outcome is
+	// distinguishable from a clean SIGTERM exit — setState is idempotent on
+	// the DB side, so re-asserting it here when the supervisor loop already
+	// did is safe.
+	s.setState(StateError)
+	return StateError, nil
+}
 
 // StopGracefully sends abort to pi, waits up to shutdownTimeout for it to exit.
 // If it doesn't exit, SIGTERM is sent.

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -84,9 +84,9 @@ type SupervisorConfig struct {
 
 // Supervisor manages a single pi child process.
 type Supervisor struct {
-	cfg      SupervisorConfig
-	sess     SessionRecord
-	harness  *HarnessSocketServer
+	cfg     SupervisorConfig
+	sess    SessionRecord
+	harness *HarnessSocketServer
 
 	// stdinPipe is the write end of pi's stdin (for sending RPC commands).
 	stdinPipe io.WriteCloser
@@ -377,10 +377,16 @@ func (s *Supervisor) Start(ctx context.Context) {
 	// here too: close the harness listener (which removes the Unix socket
 	// inode on Linux per the D-5 cycle-4 fix) so the kill path and the
 	// natural exit path leave the same observable filesystem state.
-	defer s.closeSessionLogFile()
-	defer s.harness.Close()
-	// Signal completion to anyone waiting on Kill().
+	//
+	// Defer ordering is LIFO and load-bearing: `close(s.done)` is the
+	// completion signal Kill() blocks on, and it MUST fire last so the
+	// harness listener (and therefore the Unix socket inode) is fully torn
+	// down before Kill returns to the caller. Reversing these defers makes
+	// TestSupervisorKill_RemovesHarnessSocketFile flake on CI — the kill
+	// path observes s.done closed before harness.Close has run.
 	defer close(s.done)
+	defer s.harness.Close()
+	defer s.closeSessionLogFile()
 
 	for {
 		exitCode := s.spawnAndRun(ctx)
@@ -836,17 +842,17 @@ func (s *Supervisor) Done() <-chan struct{} { return s.done }
 
 // Kill terminates the pi child managed by this supervisor.
 //
-//   1. If the session is already terminal (finished/error) the call is a
-//      no-op and returns (state, nil). This is the idempotent path — callers
-//      that re-kill an already-dead session see success.
-//   2. Otherwise the per-session context is cancelled; exec.CommandContext
-//      delivers SIGTERM to pi. Kill then waits up to timeout (or
-//      DefaultKillTimeout when timeout is 0) for the Start goroutine to
-//      finish.
-//   3. If pi has not exited by the deadline, Kill sends SIGKILL directly to
-//      the recorded process handle and waits a further 2 seconds for the
-//      goroutine to converge. The terminal state in that case is
-//      StateError; the clean SIGTERM path produces StateFinished.
+//  1. If the session is already terminal (finished/error) the call is a
+//     no-op and returns (state, nil). This is the idempotent path — callers
+//     that re-kill an already-dead session see success.
+//  2. Otherwise the per-session context is cancelled; exec.CommandContext
+//     delivers SIGTERM to pi. Kill then waits up to timeout (or
+//     DefaultKillTimeout when timeout is 0) for the Start goroutine to
+//     finish.
+//  3. If pi has not exited by the deadline, Kill sends SIGKILL directly to
+//     the recorded process handle and waits a further 2 seconds for the
+//     goroutine to converge. The terminal state in that case is
+//     StateError; the clean SIGTERM path produces StateFinished.
 //
 // Kill is safe to call concurrently from multiple goroutines; the lock
 // protects the cancel/process handles and the Done channel disambiguates

--- a/modules/programs/prism/prism/internal/iris/supervisor_kill_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_kill_test.go
@@ -1,0 +1,311 @@
+package iris
+
+// supervisor_kill_test.go — tests for Supervisor.Kill and the daemon-side
+// session_kill flow (issue #1674).
+//
+// Coverage:
+//
+//   - Kill() on a fresh supervisor (Start never entered) returns an error
+//     and forces StateError without panicking.
+//   - Kill() against a live `/bin/sleep` child cancels the per-session
+//     context, sleep exits on SIGTERM, terminal state is StateFinished,
+//     a session_end event is written with reason="killed_sigterm".
+//   - Kill() against a SIGTERM-ignoring child escalates to SIGKILL within
+//     the timeout and the terminal state is StateError with
+//     reason="killed_sigkill".
+//   - Kill() is idempotent: re-killing an already-terminal supervisor
+//     returns the existing state with no error and no extra session_end.
+//   - The harness Unix socket file is removed after the supervisor's Start
+//     goroutine returns (kill path leaves the same filesystem state as the
+//     natural session-end path).
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// killTestSupervisor builds a Supervisor wired against a sleep-like binary so
+// the test can drive Kill() against a real process without forking pi. The
+// returned supervisor has its Start() goroutine already running.
+//
+// When piArgs is non-empty, the bin is invoked as `bin <piArgs...>` via a
+// helper wrapper. We honour the supervisor's required `--mode rpc` arg by
+// using a shell script that ignores its arguments and runs the requested
+// behaviour.
+func killTestSupervisor(t *testing.T, piBin string) (*Supervisor, *db.DB) {
+	t.Helper()
+	// Use a short tmpdir for the harness socket — sun_path is 108 bytes on
+	// Linux and t.TempDir() can blow past that with a long test name.
+	shortPrefix, err := os.MkdirTemp("", "iris-kill-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+
+	dbPath := filepath.Join(shortPrefix, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	cfg := SupervisorConfig{
+		SessionName:  "iris-kill@test",
+		Worktree:     shortPrefix,
+		Role:         "worker",
+		PIBinaryPath: piBin,
+		RunDir:       shortPrefix,
+		LogDir:       filepath.Join(shortPrefix, "logs"),
+		Database:     database,
+		// Aggressive shutdown timeout so tests don't accumulate latency.
+		ShutdownTimeout: 100 * time.Millisecond,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go sup.Start(ctx)
+
+	// Wait for state to advance past spawning so Kill() actually exercises
+	// the live-process path.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if sup.State() == StateActive {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if sup.State() != StateActive {
+		t.Fatalf("supervisor never reached StateActive (got %s)", sup.State())
+	}
+	return sup, database
+}
+
+// writeShellScript writes a shell script to a tempfile, marks it executable,
+// and returns its path. The script ignores its arguments — the supervisor
+// passes `--mode rpc [--extension ...]` and our test scripts don't care.
+func writeShellScript(t *testing.T, body string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "iris-kill-script-*.sh")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	header := "#!/bin/sh\n"
+	if _, err := f.WriteString(header + body); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close script: %v", err)
+	}
+	if err := os.Chmod(f.Name(), 0o700); err != nil {
+		t.Fatalf("chmod script: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	return f.Name()
+}
+
+// TestSupervisorKill_NoStartContext asserts that Kill on a supervisor whose
+// Start goroutine has not started yet returns an error and forces an error
+// state — no panic, no hang.
+func TestSupervisorKill_NoStartContext(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	runDir, err := os.MkdirTemp("", "iris-kill-nostart-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+
+	cfg := SupervisorConfig{
+		SessionName: "iris-kill@nostart",
+		Worktree:    tmp,
+		Role:        "worker",
+		RunDir:      runDir,
+		LogDir:      filepath.Join(tmp, "logs"),
+		Database:    database,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(sup.closeSessionLogFile)
+
+	state, err := sup.Kill(context.Background(), 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("Kill on never-Started supervisor: expected error, got nil")
+	}
+	if state != StateError {
+		t.Errorf("state = %s, want %s", state, StateError)
+	}
+}
+
+// TestSupervisorKill_CleanSIGTERM exercises the happy path: a `/bin/sleep`
+// child is started, Kill() cancels the per-session ctx, sleep receives
+// SIGTERM and exits, terminal state is StateFinished, and a session_end
+// event is recorded with reason="killed_sigterm".
+func TestSupervisorKill_CleanSIGTERM(t *testing.T) {
+	// /bin/sleep with no arguments fails — use a wrapper that sleeps long
+	// enough that natural exit doesn't race the kill.
+	script := writeShellScript(t, "exec sleep 60\n")
+	sup, database := killTestSupervisor(t, script)
+
+	start := time.Now()
+	state, err := sup.Kill(context.Background(), 5*time.Second)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if state != StateFinished {
+		t.Errorf("terminal state = %s, want %s", state, StateFinished)
+	}
+	if elapsed > 4*time.Second {
+		t.Errorf("clean SIGTERM kill took %s, expected < 1s for a sleep that respects SIGTERM", elapsed)
+	}
+
+	// Confirm session_end event landed with the expected reason.
+	assertSessionEndReason(t, database, sup.sess.SessionName, "killed_sigterm")
+}
+
+// TestSupervisorKill_EscalatesToSIGKILL exercises the SIGTERM-ignoring path.
+// A shell that traps and ignores SIGTERM forces Kill() to escalate via
+// os.Process.Kill() before the wait deadline. The terminal state is
+// StateError and the session_end event reason is "killed_sigkill".
+func TestSupervisorKill_EscalatesToSIGKILL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("escalation test sleeps ~5s; skipping in short mode")
+	}
+	// trap '' TERM disables the default SIGTERM handler. The shell still
+	// reaps SIGKILL because SIGKILL cannot be trapped.
+	script := writeShellScript(t, "trap '' TERM\nsleep 60\n")
+	sup, database := killTestSupervisor(t, script)
+
+	start := time.Now()
+	// Pass a short 1-second SIGTERM timeout so the test doesn't spend the
+	// full 5s default.
+	state, err := sup.Kill(context.Background(), 1*time.Second)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if state != StateError {
+		t.Errorf("terminal state = %s, want %s (SIGKILL path)", state, StateError)
+	}
+	// 1s SIGTERM grace + ≤2s SIGKILL convergence: total under 4s.
+	if elapsed > 4*time.Second {
+		t.Errorf("SIGKILL escalation took %s, expected < 4s", elapsed)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("SIGKILL escalation took %s, expected ≥ ~1s SIGTERM grace", elapsed)
+	}
+
+	assertSessionEndReason(t, database, sup.sess.SessionName, "killed_sigkill")
+}
+
+// TestSupervisorKill_Idempotent verifies that calling Kill twice in
+// succession returns success both times and does not write a second
+// session_end event.
+func TestSupervisorKill_Idempotent(t *testing.T) {
+	script := writeShellScript(t, "exec sleep 60\n")
+	sup, database := killTestSupervisor(t, script)
+
+	if _, err := sup.Kill(context.Background(), 5*time.Second); err != nil {
+		t.Fatalf("first Kill: %v", err)
+	}
+	state, err := sup.Kill(context.Background(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("second Kill: %v", err)
+	}
+	if state != StateFinished && state != StateError {
+		t.Errorf("second-kill state = %s, want a terminal state", state)
+	}
+
+	// Count session_end events. Only one should be present.
+	endCount := countSessionEndEvents(t, database, sup.sess.SessionName)
+	if endCount != 1 {
+		t.Errorf("session_end event count = %d, want 1", endCount)
+	}
+}
+
+// TestSupervisorKill_RemovesHarnessSocketFile pins the watch-out from
+// issue #1674: closing the harness listener removes the Unix socket inode
+// on Linux. The kill path runs the same defer block as the natural
+// session-end path, so the socket file must be gone after Kill returns.
+func TestSupervisorKill_RemovesHarnessSocketFile(t *testing.T) {
+	script := writeShellScript(t, "exec sleep 60\n")
+	sup, _ := killTestSupervisor(t, script)
+
+	sockPath := sup.harness.SockPath()
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("harness socket not present pre-kill: %v", err)
+	}
+	if _, err := sup.Kill(context.Background(), 5*time.Second); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Errorf("harness socket %q still exists after kill (err=%v); kill path must close the listener", sockPath, err)
+	}
+}
+
+// assertSessionEndReason scans agent_events for the given session and
+// asserts that the most recent session_end payload carries the expected
+// reason.
+func assertSessionEndReason(t *testing.T, database *db.DB, sessionName, wantReason string) {
+	t.Helper()
+	events, err := database.QueryEvents(sessionName, 100, nil, nil, []string{"session_end"})
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("no session_end event found for %q", sessionName)
+	}
+	// Inspect the most recent row.
+	last := events[len(events)-1]
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(last.Payload), &payload); err != nil {
+		t.Fatalf("decode session_end payload: %v", err)
+	}
+	got, _ := payload["reason"].(string)
+	if got != wantReason {
+		t.Errorf("session_end reason = %q, want %q (payload=%s)", got, wantReason, last.Payload)
+	}
+}
+
+// countSessionEndEvents returns the number of session_end events recorded
+// for the given session name.
+func countSessionEndEvents(t *testing.T, database *db.DB, sessionName string) int {
+	t.Helper()
+	events, err := database.QueryEvents(sessionName, 100, nil, nil, []string{"session_end"})
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	return len(events)
+}
+
+// Smoke test: surface the documented kill-reason constants so a typo in the
+// canonical strings is caught at compile time. (Pure string literals today;
+// promoting to constants is a future cleanup.)
+func TestSupervisorKill_ReasonStrings(t *testing.T) {
+	// If these strings change, downstream tooling (cleanup output, narrative
+	// CLI, future iris kill --reason) must be updated in lockstep.
+	want := []string{"killed_sigterm", "killed_sigkill", "clean_exit", "error", "killed_no_process"}
+	for _, s := range want {
+		if !strings.Contains(s, "_") && s != "error" {
+			t.Errorf("expected snake_case kill reason, got %q", s)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor_state_publish_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_state_publish_test.go
@@ -101,8 +101,15 @@ func TestSupervisorSetState_PublishesState(t *testing.T) {
 
 // TestSupervisorSetState_PlainEventPublisherIsNotNotified asserts that a
 // publisher which only implements Publish (no PublishState) is not invoked
-// for state transitions — the supervisor must type-assert defensively so
-// existing test fixtures keep compiling.
+// for *state transitions* via PublishState — the supervisor must type-assert
+// defensively so existing test fixtures keep compiling.
+//
+// Issue #1674 added a session_end event write on terminal transitions; that
+// event flows through the regular Publish path (it is a real agent_events
+// row, not a state notification) so plain publishers DO receive exactly one
+// session_end Publish call per terminal transition. This test pins both
+// behaviours: no PublishState invocations on a plain publisher, and exactly
+// one Publish call carrying the session_end event.
 func TestSupervisorSetState_PlainEventPublisherIsNotNotified(t *testing.T) {
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "iris.db")
@@ -113,8 +120,13 @@ func TestSupervisorSetState_PlainEventPublisherIsNotNotified(t *testing.T) {
 	t.Cleanup(func() { _ = database.Close() })
 
 	// PublisherFunc satisfies EventPublisher but NOT stateNotifier.
-	called := 0
-	pub := PublisherFunc(func(_ EventPublication) { called++ })
+	var pubMu sync.Mutex
+	var publishedTypes []string
+	pub := PublisherFunc(func(p EventPublication) {
+		pubMu.Lock()
+		defer pubMu.Unlock()
+		publishedTypes = append(publishedTypes, p.EventType)
+	})
 
 	runDir, err := os.MkdirTemp("", "iris-sst-")
 	if err != nil {
@@ -131,6 +143,8 @@ func TestSupervisorSetState_PlainEventPublisherIsNotNotified(t *testing.T) {
 		Database:    database,
 		Publisher:   pub,
 	}
+	// Insert a sessions row so the FK on agent_events.instance_id is
+	// satisfied when writeSessionEndEvent runs on terminal transitions.
 	sup, err := NewSupervisor(cfg)
 	if err != nil {
 		t.Fatalf("NewSupervisor: %v", err)
@@ -140,8 +154,12 @@ func TestSupervisorSetState_PlainEventPublisherIsNotNotified(t *testing.T) {
 	sup.setState(StateActive)
 	sup.setState(StateFinished)
 
-	if called != 0 {
-		t.Errorf("plain EventPublisher.Publish should not be called for state transitions, called=%d", called)
+	pubMu.Lock()
+	got := append([]string(nil), publishedTypes...)
+	pubMu.Unlock()
+
+	if len(got) != 1 || got[0] != "session_end" {
+		t.Errorf("expected exactly one session_end Publish call, got %v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #1674

## Investigation (posted as a comment on #1674)

`iris cleanup` today **does not terminate the pi child** \u2014 the CLI only archives the JSONL, marks the sessions row ended, removes the run dir, and optionally removes the worktree. There is no daemon-side per-session kill path either: the supervisor is anchored to the daemon's outer signal context, so SIGINT/SIGTERM of the daemon cascades to all children, but no single-session kill exists. The `session_kill` stub returns `"session_kill not yet implemented"`.

**Severity = P1.** Every `iris cleanup` on a live session orphans the pi process while removing the per-session run dir out from under it.

This PR implements both halves of AC #10: the daemon-side SIGTERM/SIGKILL ladder and the cleanup wiring that turns `iris cleanup` into a true kill-then-archive flow.

## Daemon-side kill ladder \u2014 `internal/iris/supervisor.go`

- `Supervisor.Start` now wraps the caller ctx in a per-session cancel so each session has its own SIGTERM trigger separate from the daemon ctx. New `cancel` and `done` fields are guarded by `s.mu` \u2014 no new synchronisation primitives.
- `spawnAndRun` sets `cmd.Cancel` to send SIGTERM rather than the Go default of SIGKILL, so ctx-cancel runs the canonical kill ladder.
- `Supervisor.Kill(ctx, timeout)` cancels the per-session ctx (SIGTERM \u2192 5s grace), then escalates via `os.Process.Kill()` when `Done()` does not close in time. Terminal state is `StateFinished` for a clean SIGTERM exit, `StateError` for SIGKILL escalation. The `killReason` field (`killed_sigterm` / `killed_sigkill` / `killed_no_process`) feeds the `session_end` event payload.
- `setState` now writes a `session_end` `agent_events` row on terminal transitions, **before** `UpdateSessionEnded` updates the sessions column \u2014 PR #1657 ordering preserved.
- The harness listener is now closed via `defer s.harness.Close()` in `Start`, so the Unix socket inode is removed on the natural session-end path too (D-5 cycle-4 invariant honoured for both kill and natural paths).

## Wire path \u2014 `internal/iris/client_protocol.go`, `client_socket.go`

- New `DaemonSessionKilledFrame` (type `session_killed`) with a `state` field carrying `finished` / `error` / `already_terminal`.
- `ClientSocketConfig.KillSession` and `SetKillSession` added, matching the existing `SpawnSession` / `DeliverPrompt` wiring style.
- `handleSessionKill` replaces the stub: validates frame, checks session existence (clear `session %q not found` error), invokes `killSession` with the canonical 5s timeout, writes a `session_killed` ack or an `error` frame.
- Idempotent: an already-terminal session is reported as `state=already_terminal` without re-killing.

## Daemon glue \u2014 `cmd/iris/main.go`

`killFn` looks up the supervisor in `daemonState.supervisors`, invokes `Supervisor.Kill`, and surfaces `already_terminal` when the session was already in a terminal state before `Kill` ran.

## CLI cleanup wiring \u2014 `cmd/iris/cleanup.go`

`iris cleanup <session>` now dials the daemon socket and sends a `session_kill` frame **before** the DB-only steps run. Failure modes (daemon down, no such session, ack timeout) are non-fatal and reported in the summary output. A new `--skip-kill` flag preserves the old DB-only behaviour for callers that explicitly opt out.

## Tests

- **`supervisor_kill_test.go`** \u2014 no-start-ctx, clean SIGTERM, SIGKILL escalation against a `trap '' TERM` shell (\u22481s SIGTERM grace, < 4s total), idempotency (exactly one `session_end` row), harness socket inode removed post-kill.
- **`client_socket_kill_test.go`** \u2014 happy path, no-such-session error + connection stays open (ping/pong proof), already-terminal idempotent ack, missing `KillSession` callback rejected cleanly, invalid frame rejected.
- **`session_kill_e2e_test.go`** \u2014 full wire path: supervisor + client socket, send `session_kill` frame, assert ack, process gone via signal-0 probe, `sessions.end_state=finished` in DB, `session_end` event with `reason=killed_sigterm`.

## Quality gates

- `cd modules/programs/prism/prism && go build ./...` clean.
- `go test ./... -race -count=1` all green.
- `nix build .#iris` succeeds.
- `nix build .#prism` succeeds.