### PR TITLE
fix(prism): doom-loop detector keys on full argv (#1683)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -28,6 +28,7 @@ import {
   type InboundDispatchAPI,
   // Behavioural guards
   similarityKey,
+  tokenizeBashCommand,
   processDoomLoop,
   isGitPush,
   EXCLUDED_BASH_BASES,
@@ -722,7 +723,7 @@ describe("similarityKey — excluded tools", () => {
   })
 })
 
-describe("similarityKey — bash subcommand-driven CLIs", () => {
+describe("similarityKey — bash full-argv keying (#1683)", () => {
   it("gh issue view with different numbers produces different keys", () => {
     const keys = [1, 2, 3, 4, 5].map((n) =>
       similarityKey("bash", { command: `gh issue view ${n}` }),
@@ -730,16 +731,151 @@ describe("similarityKey — bash subcommand-driven CLIs", () => {
     assert.equal(new Set(keys).size, 5)
   })
 
-  it("git log with different flags produces the same key", () => {
+  it("git log with different flag values produces different keys (#1683)", () => {
+    // Post-#1683: flags are part of the key. `git log -1` and `git log -3`
+    // are different argv, so they hash differently. This intentionally
+    // overrides the pre-fix collapsing heuristic — doom-loop detection is
+    // about exact argv repetition, not semantic equivalence.
     const a = similarityKey("bash", { command: "git log -1" })
     const b = similarityKey("bash", { command: "git log -3" })
-    assert.equal(a, b)
+    assert.notEqual(a, b)
   })
 
   it("go test and go build produce different keys", () => {
     const a = similarityKey("bash", { command: "go test ./..." })
     const b = similarityKey("bash", { command: "go build ./..." })
     assert.notEqual(a, b)
+  })
+})
+
+// Issue #1683: doom-loop detector false positives on different-argv bash calls.
+// The detector used to key on `base + firstPositional`, collapsing
+// `prism checkin <s> --last 50`, `--last 100`, `--verbose`, etc. to the same
+// key and tripping the 5-in-a-row counter on legitimate iterative diagnosis.
+// The fix includes the full normalised argv in the key.
+describe("similarityKey — #1683 false-positive cases", () => {
+  it("5 prism-checkin calls with different --last/--types/--verbose flags produce 5 distinct keys", () => {
+    const session = "nixos-config@iris-tui-session-spawned"
+    const cmds = [
+      `prism checkin ${session} --types audit --last 50`,
+      `prism checkin ${session} --last 40 --verbose`,
+      `prism checkin ${session} --last 40 --verbose --types audit`,
+      `prism checkin ${session} --last 60 --verbose`,
+      `prism checkin ${session} --last 100`,
+    ]
+    const keys = cmds.map((command) => similarityKey("bash", { command }))
+    assert.equal(new Set(keys).size, 5)
+  })
+
+  it("5 prism-checkin calls with different first positional (session) produce 5 distinct keys", () => {
+    const cmds = [
+      "prism checkin nixos-config@worker-a --last 50",
+      "prism checkin nixos-config@worker-b --last 50",
+      "prism checkin nixos-config@worker-c --last 50",
+      "prism checkin nixos-config@worker-d --last 50",
+      "prism checkin nixos-config@worker-e --last 50",
+    ]
+    const keys = cmds.map((command) => similarityKey("bash", { command }))
+    assert.equal(new Set(keys).size, 5)
+  })
+
+  it("alternating prism-checkin between two sessions produces 2 distinct keys", () => {
+    const cmds = [
+      "prism checkin nixos-config@worker-a",
+      "prism checkin nixos-config@worker-b",
+      "prism checkin nixos-config@worker-a",
+      "prism checkin nixos-config@worker-b",
+      "prism checkin nixos-config@worker-a",
+    ]
+    const keys = cmds.map((command) => similarityKey("bash", { command }))
+    assert.equal(new Set(keys).size, 2)
+  })
+})
+
+describe("similarityKey — #1683 true-positive cases", () => {
+  it("5 identical prism-checkin commands produce 1 key", () => {
+    const cmd = "prism checkin nixos-config@worker-a --last 50"
+    const keys = [1, 2, 3, 4, 5].map(() => similarityKey("bash", { command: cmd }))
+    assert.equal(new Set(keys).size, 1)
+  })
+
+  it("5 identical non-bash commands still produce 1 key (edit on the same file)", () => {
+    const keys = [1, 2, 3, 4, 5].map(() =>
+      similarityKey("edit", { filePath: "/foo.go", newString: "x" }),
+    )
+    assert.equal(new Set(keys).size, 1)
+  })
+})
+
+describe("similarityKey — #1683 whitespace and quoting normalisation", () => {
+  it("double-quoted and single-quoted -c arg produce the same key", () => {
+    const a = similarityKey("bash", { command: `bash -c "ls -la"` })
+    const b = similarityKey("bash", { command: `bash -c 'ls -la'` })
+    assert.equal(a, b)
+  })
+
+  it("runs of internal whitespace are collapsed", () => {
+    const a = similarityKey("bash", { command: "go   test     ./..." })
+    const b = similarityKey("bash", { command: "go test ./..." })
+    assert.equal(a, b)
+  })
+
+  it("leading/trailing whitespace does not change the key", () => {
+    const a = similarityKey("bash", { command: "  go test ./...  " })
+    const b = similarityKey("bash", { command: "go test ./..." })
+    assert.equal(a, b)
+  })
+
+  it("tabs and spaces are equivalent token separators", () => {
+    const a = similarityKey("bash", { command: "go\ttest\t./..." })
+    const b = similarityKey("bash", { command: "go test ./..." })
+    assert.equal(a, b)
+  })
+})
+
+// Direct unit tests for the tokeniser helper.
+describe("tokenizeBashCommand", () => {
+  it("splits on whitespace", () => {
+    assert.deepEqual(tokenizeBashCommand("a b c"), ["a", "b", "c"])
+  })
+
+  it("collapses runs of whitespace", () => {
+    assert.deepEqual(tokenizeBashCommand("a   b \t c"), ["a", "b", "c"])
+  })
+
+  it("trims leading/trailing whitespace", () => {
+    assert.deepEqual(tokenizeBashCommand("  a b  "), ["a", "b"])
+  })
+
+  it("keeps a double-quoted region with whitespace as one token, stripping the quotes", () => {
+    assert.deepEqual(tokenizeBashCommand(`bash -c "ls -la"`), ["bash", "-c", "ls -la"])
+  })
+
+  it("keeps a single-quoted region with whitespace as one token, stripping the quotes", () => {
+    assert.deepEqual(tokenizeBashCommand(`bash -c 'ls -la'`), ["bash", "-c", "ls -la"])
+  })
+
+  it("double- and single-quoted forms of the same content tokenise identically", () => {
+    assert.deepEqual(
+      tokenizeBashCommand(`bash -c "ls -la"`),
+      tokenizeBashCommand(`bash -c 'ls -la'`),
+    )
+  })
+
+  it("concatenates adjacent quoted and unquoted segments into a single token", () => {
+    assert.deepEqual(tokenizeBashCommand(`foo"bar baz"qux`), ["foobar bazqux"])
+  })
+
+  it("returns an empty array for empty/whitespace-only input", () => {
+    assert.deepEqual(tokenizeBashCommand(""), [])
+    assert.deepEqual(tokenizeBashCommand("   \t  "), [])
+  })
+
+  it("tolerates an unmatched trailing quote (does not throw, consumes remainder)", () => {
+    // The opening quote starts a token; everything after is part of that
+    // token (with the quote char itself dropped). The result is deliberate:
+    // a total function, never an exception, for arbitrary agent input.
+    assert.deepEqual(tokenizeBashCommand(`a "b c`), ["a", "b c"])
   })
 })
 
@@ -751,17 +887,16 @@ describe("similarityKey — bash cd-prefix stripping", () => {
 
   it("strips a single 'cd /path &&' prefix (gh command)", () => {
     const key = similarityKey("bash", { command: "cd /foo && gh pr create --title foo" })
-    // gh is a subcommand CLI; positionals are pr, create, foo (--title is a flag, foo is its value
-    // but the algorithm doesn't parse flag arity — foo appears as a positional).
-    assert.equal(key, "bash:gh pr create foo")
+    // Post-#1683: full argv is included in the key.
+    assert.equal(key, "bash:gh pr create --title foo")
     // Crucially, it must NOT be bash:cd.
     assert.notEqual(key, "bash:cd")
   })
 
   it("strips a single 'cd /path &&' prefix (nix command)", () => {
     const key = similarityKey("bash", { command: "cd /foo/bar && nix eval .#foo" })
-    // nix is not in SUBCOMMAND_CLIS, so base=nix, firstPos=eval.
-    assert.equal(key, "bash:nix eval")
+    // Post-#1683: full argv is included in the key.
+    assert.equal(key, "bash:nix eval .#foo")
     // Crucially, it must NOT be bash:cd.
     assert.notEqual(key, "bash:cd")
   })
@@ -773,9 +908,11 @@ describe("similarityKey — bash cd-prefix stripping", () => {
 
   it("does NOT strip a bare 'cd /foo' (no following command)", () => {
     const key = similarityKey("bash", { command: "cd /foo" })
-    // Bare cd is not stripped; base=cd, firstPos=/foo.
+    // Bare cd is not stripped; base=cd, positional=/foo.
     // The key contains 'cd' as the base command, confirming the bare cd is treated as-is.
     assert.ok(key !== null && key.startsWith("bash:cd"), `expected key starting with bash:cd, got ${key}`)
+    // Post-#1683: positional is also in the key.
+    assert.equal(key, "bash:cd /foo")
   })
 
   it("strips 'cd /path;' (semicolon separator) prefix", () => {

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -122,6 +122,69 @@ export const EXCLUDED_BASH_BASES = new Set([
 ])
 
 /**
+ * Quote-aware tokeniser for a bash command string.
+ *
+ * Splits the input on whitespace, but treats matched single-quoted (`'...'`)
+ * and double-quoted (`"..."`) regions as part of a single token. The quote
+ * characters themselves are stripped from the resulting token. Adjacent
+ * quoted and unquoted segments concatenate (e.g. `foo"bar baz"` → one token
+ * `foobar baz`).
+ *
+ * This is intentionally simple — it does not handle backslash escapes,
+ * `$'...'` ANSI-C quoting, or `$"..."` localised quoting. The goal is
+ * normalisation for doom-loop similarity, not a full POSIX shell parser:
+ * for that purpose, treating `bash -c "ls -la"` and `bash -c 'ls -la'` as
+ * the same token sequence is the desired and sufficient outcome (#1683).
+ *
+ * Unmatched trailing quotes are tolerated: the rest of the string is
+ * consumed as a single token with the opening quote stripped, which keeps
+ * the function total (never throws) for arbitrary input.
+ *
+ * Exported for unit testing.
+ */
+export function tokenizeBashCommand(cmd: string): string[] {
+  const tokens: string[] = []
+  let current = ""
+  let inToken = false
+  let quote: '"' | "'" | null = null
+
+  const flush = () => {
+    if (inToken) {
+      tokens.push(current)
+      current = ""
+      inToken = false
+    }
+  }
+
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]
+    if (quote !== null) {
+      if (ch === quote) {
+        // Closing quote — drop it, stay in the same token.
+        quote = null
+      } else {
+        current += ch
+      }
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      // Opening quote — start (or continue) a token, drop the quote char.
+      quote = ch
+      inToken = true
+      continue
+    }
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      flush()
+      continue
+    }
+    current += ch
+    inToken = true
+  }
+  flush()
+  return tokens
+}
+
+/**
  * Compute a normalised similarity key for a tool call.
  * Returns null for excluded tools (no detection).
  *
@@ -144,8 +207,14 @@ export function similarityKey(tool: string, args: unknown): string | null {
       // `git push origin` rather than `cd`. Bare `cd /foo` (no following
       // command) is NOT stripped — it remains `bash:cd` as a legitimate op.
       const stripped = cmd.trim().replace(/^(cd\s+\S+\s*(?:&&|;)\s*)+/, "")
-      const tokens = stripped.split(/\s+/)
-      const meaningful = tokens.filter((t) => t.length > 0)
+
+      // Quote-aware tokenisation. Splits on whitespace outside matched single
+      // or double quotes, then strips the surrounding quote characters from
+      // each token. This normalises whitespace and quoting so that
+      // `bash -c "ls -la"` and `bash -c 'ls -la'` produce the same token
+      // sequence (`bash`, `-c`, `ls -la`) — see #1683.
+      const meaningful = tokenizeBashCommand(stripped)
+
       let baseIdx = 0
       while (baseIdx < meaningful.length && meaningful[baseIdx].startsWith("-")) {
         baseIdx++
@@ -156,26 +225,15 @@ export function similarityKey(tool: string, args: unknown): string | null {
         return null
       }
 
-      const SUBCOMMAND_CLIS = new Set(["gh", "git", "kubectl", "helm", "docker", "podman"])
-      if (SUBCOMMAND_CLIS.has(base)) {
-        const positionals: string[] = []
-        for (let i = baseIdx + 1; i < meaningful.length; i++) {
-          if (!meaningful[i].startsWith("-")) {
-            positionals.push(meaningful[i])
-          }
-        }
-        const parts = [base, ...positionals.slice(0, 3)]
-        return `bash:${parts.join(" ")}`.trimEnd()
-      }
-
-      let firstPos = ""
-      for (let i = baseIdx + 1; i < meaningful.length; i++) {
-        if (!meaningful[i].startsWith("-")) {
-          firstPos = meaningful[i]
-          break
-        }
-      }
-      return `bash:${base} ${firstPos}`.trimEnd()
+      // Identity key is the full normalised argv (base + every following
+      // token, preserving order). Including flags and trailing positionals
+      // ensures different invocations of the same base command (e.g.
+      // `prism checkin <s> --last 50` vs `--last 100`) produce different
+      // keys — the previous "base + firstPositional" formula collapsed
+      // legitimate diagnostic refinement into a doom-loop false positive
+      // (#1683).
+      const parts = meaningful.slice(baseIdx)
+      return `bash:${parts.join(" ")}`.trimEnd()
     }
 
     case "edit":


### PR DESCRIPTION
Closes #1683.

## Summary

The pi extension's `similarityKey()` for bash was keying on
`base + firstPositional` only, dropping every flag and trailing
positional. Five sequential

    prism checkin <s> --last 50
    prism checkin <s> --last 100
    prism checkin <s> --verbose
    prism checkin <s> --types audit
    prism checkin <s> --last 25

all collapsed to the same key `bash:prism checkin` and tripped the
doom-loop banner despite each call having different argv. Per AC #1,
the diagnosis comment confirming **hypothesis 2** is posted on the
issue.

## Fix

- Include the full normalised argv in the bash key:
  `bash:<base> <token1> <token2> …` — flags and positionals alike.
- Add a quote-aware `tokenizeBashCommand()` helper so
  `bash -c "ls -la"` and `bash -c 'ls -la'` produce the same
  token sequence. Whitespace runs are collapsed; tabs and spaces are
  equivalent.
- The pre-existing cd-prefix stripping, `EXCLUDED_BASH_BASES` check,
  and `baseIdx` flag-skipping behaviour are unchanged.
- The previous `SUBCOMMAND_CLIS` first-3-positionals heuristic is
  retired — under the new spec, exact argv match is the only collapse
  criterion. `git log -1` and `git log -3` now hash differently
  (the previous test asserting they were equal is updated; the new
  rule is the principle the issue body asks for).
- **Banner text is byte-for-byte unchanged.** This fix is about
  *when* the banner fires, not *what* it says.

## Tests

`prism.test.ts` gains direct coverage of:

- The exact #1683 reproducer: 5 prism-checkin calls with different
  `--last`/`--types`/`--verbose` produce 5 distinct keys.
- Different first positional (different session names) → different
  keys; alternating sessions never trips the banner.
- 5 identical-argv bash calls still produce one key → banner fires.
- 5 identical `edit` calls on the same file still produce one key
  → general detection unaffected.
- Quote normalisation: `bash -c "ls -la"` ≡ `bash -c 'ls -la'`.
- Whitespace normalisation: runs of spaces, tabs, leading/trailing
  whitespace.
- Direct tokeniser tests, including unmatched-quote tolerance.

The previously-narrow `git log` collapse test is updated; the
`gh pr create --title foo` and `nix eval .#foo` cd-prefix tests
are updated to reflect the new key format.

## Verification

- `tsx --test --test-force-exit prism.test.ts` — **266 / 266 pass**.
- `go test ./... -race` (prism module) — pass.
- `nix build .#prism` — pass.
- Manual reproducer (script that walks the exact 5 commands from the
  issue body through `processDoomLoop`): detector does **not**
  fire; 5 identical-argv calls still **do** fire.

## Concurrency check

#1685 worker (`fix-prism-escalate-duplicate`) was working in
`internal/sidecar/` (Go). This PR touches only
`modules/programs/prism/pi/extensions/prism.{ts,test.ts}`. No
file-level overlap; no shared structs.

## Out of scope

- No whitelisting of specific commands.
- No role-specific behaviour.
- No suppression mechanism.
- The pre-existing test-runner hang at end of `tsx --test prism.test.ts`
  (open sockets from #1554 retry tests; works around via
  `--test-force-exit`) is unrelated to this change.