### PR TITLE
feat(iris): `iris review <pr>` async 5-agent review orchestrator CLI

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/iris"
 )
@@ -282,7 +283,8 @@ func runDaemon() error {
 		SockPath:          p.Sock,
 		Database:          database,
 		GetActiveSessions: state.activeSessions,
-		// SpawnSession is assigned below after spawnFn is defined.
+		// SpawnSession and SpawnReviewGroup are assigned below after spawnFn
+		// (and the review-spawn dependencies) are defined.
 		DeliverPrompt: deliverFn,
 		KillSession:   killFn,
 	})
@@ -343,6 +345,33 @@ func runDaemon() error {
 	}
 	// Wire the spawn function now that it is defined.
 	clientSock.SetSpawnSession(spawnFn)
+
+	// Wire the review-spawn orchestrator. The orchestrator reuses spawnFn
+	// (so review-agent sessions go through exactly the same daemon path
+	// as `iris spawn`) but with a caller-supplied session name (the
+	// canonical `<parent>~review-N-<agent>` shape). reviewSpawnFn below
+	// adapts spawnFn for that contract: spawnFn assigns the session name
+	// from worktree+role via GenerateSessionName, so we wrap it to inject
+	// our pre-computed name through a per-call override.
+	reviewSpawnFn := func(rsCtx context.Context, sessionName, worktree, role string) (*iris.Supervisor, error) {
+		return spawnReviewAgent(rsCtx, ctx, cfg, p, database, clientSock, state, sessionName, worktree, role)
+	}
+	reviewHandler := iris.NewReviewSpawnHandler(iris.ReviewSpawnDeps{
+		Database:      database,
+		SpawnSession:  reviewSpawnFn,
+		DeliverPrompt: deliverFn,
+		ParentWorktree: func(parent string) (string, error) {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			sup, ok := state.supervisors[parent]
+			if !ok {
+				return "", fmt.Errorf("parent session %q is not active", parent)
+			}
+			return sup.SessionRecord().Worktree, nil
+		},
+	})
+	clientSock.SetSpawnReviewGroup(reviewHandler)
+
 	if err := clientSock.Listen(); err != nil {
 		return fmt.Errorf("iris: client socket: %w", err)
 	}
@@ -356,6 +385,62 @@ func runDaemon() error {
 	<-ctx.Done()
 	log.Println("[iris] daemon shutting down")
 	return nil
+}
+
+// spawnReviewAgent spawns a single review-agent session under the daemon,
+// using a caller-supplied session name (the canonical
+// `<parent>~review-N-<agent>` shape rather than the default
+// GenerateSessionName scheme).
+//
+// This is the equivalent of the inline `spawnFn` for `iris spawn`, but
+// with the session name plumbed in explicitly. It is called from
+// reviewHandler (constructed in runDaemon) once per review agent.
+func spawnReviewAgent(
+	spawnCtx context.Context,
+	daemonCtx context.Context,
+	cfg iris.Config,
+	p iris.Paths,
+	database *db.DB,
+	clientSock *iris.ClientSocket,
+	state *daemonState,
+	sessionName, worktree, role string,
+) (*iris.Supervisor, error) {
+	extPath := cfg.PIExtensionPath
+	bareRoot := git.BareRoot(worktree)
+	superCfg := iris.SupervisorConfig{
+		SessionName:      sessionName,
+		Worktree:         worktree,
+		Role:             role,
+		BareRoot:         bareRoot,
+		PIBinaryPath:     cfg.PIBinaryPath,
+		ExtensionPath:    extPath,
+		RestartThreshold: cfg.RestartThreshold,
+		RunDir:           p.RunDir,
+		LogDir:           p.LogDir,
+		Database:         database,
+		Publisher:        clientSock,
+	}
+	sup, err := iris.SpawnSession(daemonCtx, superCfg)
+	if err != nil {
+		return nil, err
+	}
+	state.addSupervisor(sessionName, sup)
+	go func() {
+		for {
+			rec := sup.SessionRecord()
+			if rec.State == iris.StateFinished || rec.State == iris.StateError {
+				state.removeSupervisor(sessionName)
+				return
+			}
+			select {
+			case <-daemonCtx.Done():
+				return
+			case <-waitMillis(500):
+			}
+		}
+	}()
+	_ = spawnCtx
+	return sup, nil
 }
 
 // waitMillis returns a channel that closes after n milliseconds.

--- a/modules/programs/prism/prism/cmd/iris/review.go
+++ b/modules/programs/prism/prism/cmd/iris/review.go
@@ -44,6 +44,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -91,11 +92,24 @@ watcher's sync.Once guard.
 Do NOT commit, merge, or announce completion until the review-complete
 prompt arrives.
 
+# Pre-flight ancestor gate (#1518 parity)
+
+Before spawning any agents, 'iris review' runs a one-shot strict-ancestor
+check: 'git merge-base --is-ancestor origin/main HEAD'. If origin/main is
+not an ancestor of HEAD the command refuses, exits non-zero, and prints
+the number of commits behind plus the recommended fix. No agents spawn
+and the round counter is unaffected on a gate refusal.
+
+  --rebase performs fetch + rebase + force-push inline as the opt-in fix.
+  On rebase conflict the rebase is aborted, HEAD is restored, and the
+  command exits non-zero — the worktree is never left mid-rebase.
+
 # Flags
 
   --timeout <dur>    per-agent timeout (default 10m)
   --only <csv>       run only the named agents (e.g. review-goal,review-code)
-  --rebase           fetch origin/main, rebase HEAD onto it, force-push before review
+  --rebase           fetch origin/main, rebase HEAD onto it, force-push inline
+                     before running the review (opt-in fix for the gate)
   --socket <path>    iris daemon socket (default ~/.local/state/iris/iris.sock)
 
 # Exit codes
@@ -126,39 +140,59 @@ func runReviewCmd(cmd *cobra.Command, args []string) error {
 	rebaseFlag, _ := cmd.Flags().GetBool("rebase")
 	sockPath := resolveSocketPath(cmd)
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("iris review: resolve cwd: %w", err)
+	}
+
 	opts := reviewRunOpts{
-		PRNumber:    prNumber,
-		Timeout:     timeoutFlag,
-		Only:        onlyFlag,
-		Rebase:      rebaseFlag,
-		SockPath:    sockPath,
-		Parent:      lookupIrisParentSession(),
-		PRVerifier:  ghPRVerifier,
-		RebaseRunner: defaultRebaseRunner,
-		Out:         os.Stdout,
+		PRNumber:        prNumber,
+		Timeout:         timeoutFlag,
+		Only:            onlyFlag,
+		Rebase:          rebaseFlag,
+		SockPath:        sockPath,
+		Parent:          lookupIrisParentSession(),
+		Worktree:        cwd,
+		PRVerifier:      ghPRVerifier,
+		PreflightRunner: defaultPreflightRunner,
+		Out:             os.Stdout,
 	}
 	return runReviewAt(cmd.Context(), opts)
 }
 
 // reviewRunOpts bundles the validated CLI inputs and the swappable
-// host-side effects (PR verifier, rebase runner) so the wire layer can be
-// driven from a test without forking gh / git.
+// host-side effects (PR verifier, preflight runner) so the wire layer can
+// be driven from a test without forking gh / git.
 type reviewRunOpts struct {
-	PRNumber     string
-	Timeout      time.Duration
-	Only         string
-	Rebase       bool
-	SockPath     string
-	Parent       string
-	PRVerifier   func(prNumber string) error
-	RebaseRunner func(out io.Writer) error
-	Out          io.Writer
+	PRNumber  string
+	Timeout   time.Duration
+	Only      string
+	Rebase    bool
+	SockPath  string
+	Parent    string
+	// Worktree is the absolute path of the calling worktree, used by the
+	// preflight ancestor gate. Defaults to the CLI's cwd.
+	Worktree   string
+	PRVerifier func(prNumber string) error
+	// PreflightRunner implements the pre-flight ancestor / rebase gate.
+	// Injectable so tests can drive runReviewAt without a real git repo.
+	PreflightRunner func(opts preflightInput) error
+	Out             io.Writer
+}
+
+// preflightInput is the test-seam input for the preflight runner. It
+// mirrors the subset of review.PreflightOpts iris callers need.
+type preflightInput struct {
+	Worktree string
+	Rebase   bool
+	OnProgress func(line string)
 }
 
 // runReviewAt is the testable core. It performs:
 //   1. Local validation (parent resolution, --only parsing).
 //   2. PR existence check via the injected verifier.
-//   3. Optional --rebase via the injected runner.
+//   3. Pre-flight ancestor gate: refuse if behind origin/main, with
+//      --rebase the opt-in inline fix (#1518 parity).
 //   4. Dial + send review_spawn + read review_spawned (or error).
 func runReviewAt(ctx context.Context, opts reviewRunOpts) error {
 	if opts.PRNumber == "" {
@@ -187,15 +221,30 @@ func runReviewAt(ctx context.Context, opts reviewRunOpts) error {
 		return err
 	}
 
-	// --rebase: runs in the calling cwd (the worker's worktree). If any
-	// step fails the CLI exits non-zero before the daemon is contacted.
-	if opts.Rebase {
-		if opts.RebaseRunner == nil {
-			opts.RebaseRunner = defaultRebaseRunner
-		}
-		if err := opts.RebaseRunner(opts.Out); err != nil {
-			return fmt.Errorf("iris review: --rebase: %w", err)
-		}
+	// Pre-flight ancestor / rebase gate (#1518 parity).
+	//
+	// Refuse if origin/main is not an ancestor of HEAD; --rebase performs
+	// fetch + rebase + force-push inline as the opt-in fix. Runs BEFORE
+	// the daemon is contacted so a gate failure does not register a
+	// review group or increment the round counter (the round number is
+	// derived from per-agent session rows, which only get written by the
+	// daemon after a successful review_spawn).
+	//
+	// On rebase conflict the gate aborts the rebase and restores HEAD
+	// before returning a non-zero error — never leaves the worktree
+	// mid-rebase. See internal/review/preflight.go for the contract.
+	if opts.PreflightRunner == nil {
+		opts.PreflightRunner = defaultPreflightRunner
+	}
+	if opts.Worktree == "" {
+		return errors.New("iris review: preflight: worktree path is required (set cwd to the calling worktree)")
+	}
+	if err := opts.PreflightRunner(preflightInput{
+		Worktree:   opts.Worktree,
+		Rebase:     opts.Rebase,
+		OnProgress: func(line string) { fmt.Fprintln(opts.Out, line) },
+	}); err != nil {
+		return err
 	}
 
 	// Mint a delivery_id per run (#1695 contract: exactly-once delivery).
@@ -301,40 +350,59 @@ func ghPRVerifier(prNumber string) error {
 	)
 }
 
-// defaultRebaseRunner implements --rebase: fetch origin, rebase HEAD onto
-// origin/main, force-with-lease push. Each step's output is streamed to
-// out so the user sees progress. Any non-zero exit aborts the chain and
-// surfaces the underlying git error.
+// defaultPreflightRunner delegates to the shared review.Preflight helper
+// (issue #1518). It performs the strict-ancestor check against origin/main
+// and, when in.Rebase is true, runs fetch + rebase + force-push inline.
 //
-// This is intentionally a thin wrapper rather than using a higher-level
-// rebase helper — `iris review --rebase` is documented (in the issue) as
-// matching prism's behaviour, which is "the CLI runs git fetch && git
-// rebase && git push in that worktree's cwd before sending the spawn
-// request". We do exactly that.
-func defaultRebaseRunner(out io.Writer) error {
-	steps := []struct {
-		label string
-		args  []string
-	}{
-		{"git fetch origin", []string{"fetch", "origin"}},
-		{"git rebase origin/main", []string{"rebase", "origin/main"}},
-		{"git push --force-with-lease", []string{"push", "--force-with-lease"}},
+// Refusal (branch behind main) is surfaced as a *review.PreflightError
+// with .Refused=true; we re-wrap the message under the "iris review:"
+// prefix so the user-facing wording matches prism review's gate but
+// names the iris CLI as the source.
+//
+// We intentionally reuse the prism review helper rather than
+// reimplementing the gate: the strict-ancestor check, fetch-failure
+// handling, rebase abort + HEAD restore, and force-with-lease push are
+// all subtle to get right (PR #1518 establishes the canonical contract).
+// Duplicating them in iris would invite drift. The helper does not touch
+// the iris DB or any prism-internal state; it is purely a git wrapper.
+func defaultPreflightRunner(in preflightInput) error {
+	err := review.Preflight(review.PreflightOpts{
+		Worktree:   in.Worktree,
+		Rebase:     in.Rebase,
+		OnProgress: in.OnProgress,
+	})
+	if err == nil {
+		return nil
 	}
-	for _, s := range steps {
-		fmt.Fprintf(out, "[iris review] %s\n", s.label)
-		cmd := exec.Command("git", s.args...)
-		cmd.Stdout = out
-		cmd.Stderr = out
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("%s failed: %w", s.label, err)
+	// The prism helper prefixes its messages with "prism review:". Replace
+	// the leading prefix with "iris review:" so users see the CLI they
+	// invoked named in the error. The body wording (rebase hints, etc.) is
+	// otherwise identical and matches the documented prism behaviour.
+	var pe *review.PreflightError
+	if errors.As(err, &pe) {
+		msg := strings.TrimPrefix(pe.Msg, "prism review:")
+		if msg == pe.Msg {
+			msg = pe.Msg
 		}
+		return fmt.Errorf("iris review:%s", msg)
 	}
-	return nil
+	return fmt.Errorf("iris review: preflight: %w", err)
 }
 
 // sendReviewSpawn dials the daemon, writes the review_spawn frame, and
 // reads frames until either a review_spawned ack or an error frame
 // arrives (or the read deadline expires).
+//
+// Read-deadline contract: we set ONE read deadline at reviewAckTimeout
+// after sending the request frame and do NOT refresh it across iterations
+// of the read loop. The daemon's handleReviewSpawn writes exactly one
+// response frame per request (review_spawned on success, error otherwise);
+// the loop only iterates when the daemon sends an unknown / malformed /
+// non-matching frame, which is not part of today's wire contract. If a
+// future protocol revision adds pre-ack progress frames here, refresh the
+// deadline inside the loop or switch to a per-iteration budget — until
+// then the one-shot deadline is intentional and bounds total wait
+// regardless of how many spurious frames a misbehaving daemon emits.
 func sendReviewSpawn(ctx context.Context, sockPath string, frame iris.ClientReviewSpawnFrame) (*iris.DaemonReviewSpawnedFrame, error) {
 	// Daemon-down detection: stat first so we can give the canonical
 	// "systemctl --user start iris" error rather than a raw dial error.

--- a/modules/programs/prism/prism/cmd/iris/review.go
+++ b/modules/programs/prism/prism/cmd/iris/review.go
@@ -1,0 +1,444 @@
+package main
+
+// review.go — `iris review <pr>` subcommand.
+//
+// `iris review <pr-number>` is the iris-native analogue of `prism review
+// <pr>`: an async 5-agent review orchestrator that spawns the canonical
+// review agents (review-goal, review-code, review-security, review-qa,
+// review-context) under a shared group_id, registers them in
+// session_groups, and returns immediately with an acknowledgement.
+//
+// All heavy lifting lives in the daemon — this CLI is pure plumbing:
+//
+//   1. Resolve the calling session (IRIS_SESSION_NAME env var, then tmux).
+//   2. Validate flags (--only against the canonical agent set, --timeout
+//      as a Go duration, --rebase as a literal bool).
+//   3. Verify the PR exists via `gh pr view <n>` BEFORE spawning anything.
+//   4. If --rebase: run `git fetch origin && git rebase origin/main &&
+//      git push --force-with-lease` in the calling worktree. Failure of
+//      any step exits non-zero before the daemon is contacted.
+//   5. Dial the iris daemon client socket (canonical "daemon not running"
+//      error when unreachable).
+//   6. Send a review_spawn frame.
+//   7. Read the review_spawned ack (or error frame) and print a compact
+//      acknowledgement matching prism's "Review in progress" line.
+//
+// Async semantics: the actual review cycle runs in the daemon. The calling
+// session receives the review-complete prompt via prompt_deliver once all
+// agents reach a terminal state (sync.Once-guarded; exactly-once).
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// reviewDialTimeout bounds the time we spend dialling the daemon socket.
+// Matches the spawn-side budget — the daemon is local, so anything longer
+// than a couple of seconds is almost certainly "daemon not running".
+const reviewDialTimeout = 2 * time.Second
+
+// reviewAckTimeout bounds how long we wait for a review_spawned ack after
+// the request frame is sent. The daemon's spawn work for 5 review agents
+// completes well inside a few seconds in normal operation; the generous
+// budget surfaces hangs as a clear error rather than blocking forever.
+const reviewAckTimeout = 60 * time.Second
+
+// defaultReviewTimeout is the per-agent review timeout sent to the daemon
+// when --timeout is not specified. Matches prism's default.
+const defaultReviewTimeout = 10 * time.Minute
+
+// reviewCmd is the `iris review <pr>` cobra subcommand.
+var reviewCmd = &cobra.Command{
+	Use:   "review <pr-number>",
+	Short: "Spawn 5 review agents for a PR and return immediately (async)",
+	Long: `iris review spawns 5 review-agent sessions under the calling iris session,
+registers them as a single group in session_groups, and returns immediately
+with a review-in-progress acknowledgement.
+
+The 5 standard review agents are:
+
+  - review-goal      — does this PR actually fix what the issue asked for?
+  - review-code      — code quality, correctness, idiomatic style
+  - review-security  — secrets, permissions, attack surface
+  - review-qa        — test coverage, edge cases, regressions
+  - review-context   — design/architecture fit, blast radius
+
+Each agent gets its own iris session named <parent>~review-N-<agent>, where
+N is incremented on each invocation. Sessions are visible via
+'iris sessions list' and persist until 'iris cleanup' is invoked.
+
+A background watcher on the daemon polls for completion and delivers a
+single review-complete prompt to the calling session via prompt_deliver
+once every member reaches a terminal state ('finished' or 'error'). The
+delivery is exactly-once: a defensive double-fire is deduplicated by the
+watcher's sync.Once guard.
+
+Do NOT commit, merge, or announce completion until the review-complete
+prompt arrives.
+
+# Flags
+
+  --timeout <dur>    per-agent timeout (default 10m)
+  --only <csv>       run only the named agents (e.g. review-goal,review-code)
+  --rebase           fetch origin/main, rebase HEAD onto it, force-push before review
+  --socket <path>    iris daemon socket (default ~/.local/state/iris/iris.sock)
+
+# Exit codes
+
+  0  — review spawn acknowledged; the watcher is running.
+  1  — usage error, daemon down, PR not found, in-progress group, etc.`,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runReviewCmd,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	reviewCmd.Flags().Duration("timeout", defaultReviewTimeout, "Per-agent timeout (default 10m)")
+	reviewCmd.Flags().String("only", "", "Comma-separated subset of agents to run (e.g. review-goal,review-code). Empty = all 5.")
+	reviewCmd.Flags().Bool("rebase", false, "Fetch origin/main, rebase HEAD onto it, and force-push before running the review")
+	reviewCmd.Flags().String("socket", "", "Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)")
+	rootCmd.AddCommand(reviewCmd)
+}
+
+// runReviewCmd is the cobra entry point. Splits validation from wire I/O so
+// the integration test can hit runReviewAt directly with a fake daemon
+// socket and a fake gh probe.
+func runReviewCmd(cmd *cobra.Command, args []string) error {
+	prNumber := args[0]
+	timeoutFlag, _ := cmd.Flags().GetDuration("timeout")
+	onlyFlag, _ := cmd.Flags().GetString("only")
+	rebaseFlag, _ := cmd.Flags().GetBool("rebase")
+	sockPath := resolveSocketPath(cmd)
+
+	opts := reviewRunOpts{
+		PRNumber:    prNumber,
+		Timeout:     timeoutFlag,
+		Only:        onlyFlag,
+		Rebase:      rebaseFlag,
+		SockPath:    sockPath,
+		Parent:      lookupIrisParentSession(),
+		PRVerifier:  ghPRVerifier,
+		RebaseRunner: defaultRebaseRunner,
+		Out:         os.Stdout,
+	}
+	return runReviewAt(cmd.Context(), opts)
+}
+
+// reviewRunOpts bundles the validated CLI inputs and the swappable
+// host-side effects (PR verifier, rebase runner) so the wire layer can be
+// driven from a test without forking gh / git.
+type reviewRunOpts struct {
+	PRNumber     string
+	Timeout      time.Duration
+	Only         string
+	Rebase       bool
+	SockPath     string
+	Parent       string
+	PRVerifier   func(prNumber string) error
+	RebaseRunner func(out io.Writer) error
+	Out          io.Writer
+}
+
+// runReviewAt is the testable core. It performs:
+//   1. Local validation (parent resolution, --only parsing).
+//   2. PR existence check via the injected verifier.
+//   3. Optional --rebase via the injected runner.
+//   4. Dial + send review_spawn + read review_spawned (or error).
+func runReviewAt(ctx context.Context, opts reviewRunOpts) error {
+	if opts.PRNumber == "" {
+		return errors.New("iris review: <pr-number> is required")
+	}
+	if opts.Parent == "" {
+		return errors.New(
+			"iris review: could not determine calling session\n" +
+				"hint: run from inside an iris-managed session, or set IRIS_SESSION_NAME",
+		)
+	}
+
+	// --only validation happens up-front so an invalid name exits before
+	// any spawn-side effects (matching the AC).
+	requested, err := parseOnlyFlag(opts.Only)
+	if err != nil {
+		return err
+	}
+
+	// PR existence check BEFORE any spawn (AC: "exits non-zero before
+	// spawning anything").
+	if opts.PRVerifier == nil {
+		opts.PRVerifier = ghPRVerifier
+	}
+	if err := opts.PRVerifier(opts.PRNumber); err != nil {
+		return err
+	}
+
+	// --rebase: runs in the calling cwd (the worker's worktree). If any
+	// step fails the CLI exits non-zero before the daemon is contacted.
+	if opts.Rebase {
+		if opts.RebaseRunner == nil {
+			opts.RebaseRunner = defaultRebaseRunner
+		}
+		if err := opts.RebaseRunner(opts.Out); err != nil {
+			return fmt.Errorf("iris review: --rebase: %w", err)
+		}
+	}
+
+	// Mint a delivery_id per run (#1695 contract: exactly-once delivery).
+	deliveryID := uuid.NewString()
+
+	// Send the review_spawn frame and read the ack.
+	ack, err := sendReviewSpawn(ctx, opts.SockPath, iris.ClientReviewSpawnFrame{
+		Type:       iris.ClientFrameReviewSpawn,
+		Parent:     opts.Parent,
+		PRNumber:   opts.PRNumber,
+		AgentNames: requested,
+		Timeout:    opts.Timeout.String(),
+		DeliveryID: deliveryID,
+	})
+	if err != nil {
+		return err
+	}
+
+	printReviewAck(opts.Out, ack, opts.PRNumber)
+	return nil
+}
+
+// parseOnlyFlag splits the --only CSV, validates each token against the
+// canonical agent list, and returns the resolved subset (empty when the
+// flag was empty — meaning "all").
+func parseOnlyFlag(csv string) ([]string, error) {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil, nil
+	}
+	known := make(map[string]bool, len(iris.ReviewAgentNames))
+	for _, a := range iris.ReviewAgentNames {
+		known[a] = true
+	}
+	var out []string
+	var unknown []string
+	seen := make(map[string]bool)
+	for _, raw := range strings.Split(csv, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if !known[name] {
+			unknown = append(unknown, name)
+			continue
+		}
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf(
+			"iris review: --only contains unknown agent name(s): %s — valid names: %s",
+			strings.Join(unknown, ", "), strings.Join(iris.ReviewAgentNames, ", "),
+		)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf(
+			"iris review: --only must name at least one of: %s",
+			strings.Join(iris.ReviewAgentNames, ", "),
+		)
+	}
+	return out, nil
+}
+
+// lookupIrisParentSession resolves the calling iris session name from the
+// environment or the tmux session. Resolution order:
+//
+//   1. IRIS_SESSION_NAME — set by Supervisor.buildEnv when iris launches
+//      its pi child (the canonical signal).
+//   2. PRISM_SESSION_NAME — fall-back for callers that ran under the prism
+//      runtime (rare; supports the iris-spawned-from-prism migration).
+//   3. tmux current session — for ad-hoc invocations from a tmux pane.
+//
+// Returns "" when no session can be identified.
+func lookupIrisParentSession() string {
+	if s := os.Getenv("IRIS_SESSION_NAME"); s != "" {
+		return s
+	}
+	if s := os.Getenv("PRISM_SESSION_NAME"); s != "" {
+		return s
+	}
+	sess, err := tmux.CurrentSession()
+	if err != nil {
+		return ""
+	}
+	return sess
+}
+
+// ghPRVerifier verifies that the named PR exists by invoking `gh pr view
+// <n>`. Returns nil on exit-0; a clear, user-facing error otherwise.
+func ghPRVerifier(prNumber string) error {
+	cmd := exec.Command("gh", "pr", "view", prNumber)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"iris review: PR #%s not found or gh failed: %v\n%s\n"+
+			"hint: verify with `gh pr view %s` and ensure gh is authenticated",
+		prNumber, err, strings.TrimSpace(string(out)), prNumber,
+	)
+}
+
+// defaultRebaseRunner implements --rebase: fetch origin, rebase HEAD onto
+// origin/main, force-with-lease push. Each step's output is streamed to
+// out so the user sees progress. Any non-zero exit aborts the chain and
+// surfaces the underlying git error.
+//
+// This is intentionally a thin wrapper rather than using a higher-level
+// rebase helper — `iris review --rebase` is documented (in the issue) as
+// matching prism's behaviour, which is "the CLI runs git fetch && git
+// rebase && git push in that worktree's cwd before sending the spawn
+// request". We do exactly that.
+func defaultRebaseRunner(out io.Writer) error {
+	steps := []struct {
+		label string
+		args  []string
+	}{
+		{"git fetch origin", []string{"fetch", "origin"}},
+		{"git rebase origin/main", []string{"rebase", "origin/main"}},
+		{"git push --force-with-lease", []string{"push", "--force-with-lease"}},
+	}
+	for _, s := range steps {
+		fmt.Fprintf(out, "[iris review] %s\n", s.label)
+		cmd := exec.Command("git", s.args...)
+		cmd.Stdout = out
+		cmd.Stderr = out
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%s failed: %w", s.label, err)
+		}
+	}
+	return nil
+}
+
+// sendReviewSpawn dials the daemon, writes the review_spawn frame, and
+// reads frames until either a review_spawned ack or an error frame
+// arrives (or the read deadline expires).
+func sendReviewSpawn(ctx context.Context, sockPath string, frame iris.ClientReviewSpawnFrame) (*iris.DaemonReviewSpawnedFrame, error) {
+	// Daemon-down detection: stat first so we can give the canonical
+	// "systemctl --user start iris" error rather than a raw dial error.
+	if _, err := os.Stat(sockPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf(
+				"iris daemon not running: socket %s does not exist; start it with `systemctl --user start iris`",
+				sockPath,
+			)
+		}
+		return nil, fmt.Errorf("iris review: stat socket %s: %w", sockPath, err)
+	}
+	d := net.Dialer{Timeout: reviewDialTimeout}
+	conn, err := d.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"iris daemon not running: cannot connect to %s (%v); start it with `systemctl --user start iris`",
+			sockPath, err,
+		)
+	}
+	defer conn.Close()
+
+	data, err := json.Marshal(frame)
+	if err != nil {
+		return nil, fmt.Errorf("iris review: marshal review_spawn: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := conn.Write(data); err != nil {
+		return nil, fmt.Errorf("iris review: send review_spawn: %w", err)
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.SetReadDeadline(time.Now())
+		case <-done:
+		}
+	}()
+
+	if err := conn.SetReadDeadline(time.Now().Add(reviewAckTimeout)); err != nil {
+		return nil, fmt.Errorf("iris review: set read deadline: %w", err)
+	}
+
+	r := bufio.NewReaderSize(conn, 1<<20)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, errors.New("iris review: daemon closed connection before sending review_spawned ack")
+			}
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() {
+				return nil, fmt.Errorf("iris review: timed out after %s waiting for review_spawned ack", reviewAckTimeout)
+			}
+			return nil, fmt.Errorf("iris review: read ack: %w", err)
+		}
+		var generic struct {
+			Type        string `json:"type"`
+			RequestType string `json:"request_type"`
+			Message     string `json:"message"`
+		}
+		if err := json.Unmarshal(line, &generic); err != nil {
+			// Forward-compat: skip malformed frames, keep reading.
+			fmt.Fprintf(os.Stderr, "[iris review] warning: ignoring malformed frame: %v\n", err)
+			continue
+		}
+		switch generic.Type {
+		case iris.DaemonFrameReviewSpawned:
+			var ack iris.DaemonReviewSpawnedFrame
+			if err := json.Unmarshal(line, &ack); err != nil {
+				return nil, fmt.Errorf("iris review: decode review_spawned: %w", err)
+			}
+			return &ack, nil
+		case iris.DaemonFrameError:
+			// Surface the daemon-side error verbatim.
+			if generic.RequestType == "" || generic.RequestType == iris.ClientFrameReviewSpawn {
+				return nil, fmt.Errorf("iris review: %s", generic.Message)
+			}
+			// Unrelated error frame — log and keep reading.
+			fmt.Fprintf(os.Stderr, "[iris review] note: unrelated error frame (request_type=%q): %s\n", generic.RequestType, generic.Message)
+		default:
+			// Unknown frame type — log and keep reading (forward-compat).
+			fmt.Fprintf(os.Stderr, "[iris review] note: skipping pre-ack frame of type %q\n", generic.Type)
+		}
+	}
+}
+
+// printReviewAck writes a compact acknowledgement to out, mirroring
+// prism's "Review in progress" line so output looks familiar to users
+// switching between the two CLIs.
+func printReviewAck(out io.Writer, ack *iris.DaemonReviewSpawnedFrame, prNumber string) {
+	fmt.Fprintf(out, "Review in progress — PR #%s, round %d (group: %s)\n", prNumber, ack.Round, ack.GroupID)
+	fmt.Fprintf(out, "Parent session: %s\n", ack.Parent)
+	fmt.Fprintln(out, "Spawned review agents:")
+	for _, m := range ack.Members {
+		fmt.Fprintf(out, "  - %-16s → %s\n", m.Agent, m.SessionName)
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Wait for the review-complete prompt before committing further changes,")
+	fmt.Fprintln(out, "merging, or announcing completion. The daemon will deliver it to this")
+	fmt.Fprintln(out, "session via prompt_deliver once all agents reach a terminal state.")
+}

--- a/modules/programs/prism/prism/cmd/iris/review_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/review_integration_test.go
@@ -165,18 +165,20 @@ func TestReview_FullCycle(t *testing.T) {
 	go cs.Serve(ctx)
 
 	// Drive the CLI core. We bypass the cobra layer and call runReviewAt
-	// directly with deterministic fakes for PRVerifier and the rebase
-	// runner (the latter is irrelevant — Rebase=false).
+	// directly with deterministic fakes for PRVerifier and the preflight
+	// runner (the latter is a no-op — we are not exercising the git gate
+	// here; that surface has its own dedicated test below).
 	opts := reviewRunOpts{
-		PRNumber:     prNumber,
-		Timeout:      10 * time.Second,
-		Only:         "",
-		Rebase:       false,
-		SockPath:     iso.Paths.Sock,
-		Parent:       parent,
-		PRVerifier:   func(string) error { return nil },
-		RebaseRunner: func(io.Writer) error { return nil },
-		Out:          io.Discard,
+		PRNumber:        prNumber,
+		Timeout:         10 * time.Second,
+		Only:            "",
+		Rebase:          false,
+		SockPath:        iso.Paths.Sock,
+		Parent:          parent,
+		Worktree:        iso.Root,
+		PRVerifier:      func(string) error { return nil },
+		PreflightRunner: noopPreflightRunner,
+		Out:             io.Discard,
 	}
 
 	runCtx, runCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -326,8 +328,10 @@ func TestReview_OnlyFilter(t *testing.T) {
 	opts := reviewRunOpts{
 		PRNumber: "9", Timeout: time.Second, Only: "review-goal,review-code",
 		SockPath: iso.Paths.Sock, Parent: parent,
-		PRVerifier: func(string) error { return nil },
-		Out:        io.Discard,
+		Worktree:        iso.Root,
+		PRVerifier:      func(string) error { return nil },
+		PreflightRunner: noopPreflightRunner,
+		Out:             io.Discard,
 	}
 	if err := runReviewAt(ctx, opts); err != nil {
 		t.Fatalf("runReviewAt: %v", err)
@@ -359,8 +363,13 @@ func TestReview_UnknownOnlyAgent(t *testing.T) {
 	opts := reviewRunOpts{
 		PRNumber: "1", Timeout: time.Second, Only: "review-goal,not-a-real-agent",
 		SockPath: "/nonexistent/iris.sock", Parent: parent,
+		Worktree: iso.Root,
 		PRVerifier: func(string) error {
 			t.Errorf("PRVerifier called before --only validation")
+			return nil
+		},
+		PreflightRunner: func(preflightInput) error {
+			t.Errorf("PreflightRunner called before --only validation")
 			return nil
 		},
 		Out: io.Discard,
@@ -384,8 +393,10 @@ func TestReview_DaemonDown(t *testing.T) {
 		PRNumber: "1", Timeout: time.Second,
 		SockPath: iso.Paths.Sock + ".missing", // never created
 		Parent:   parent,
-		PRVerifier: func(string) error { return nil },
-		Out:        io.Discard,
+		Worktree:        iso.Root,
+		PRVerifier:      func(string) error { return nil },
+		PreflightRunner: noopPreflightRunner,
+		Out:             io.Discard,
 	}
 	err := runReviewAt(context.Background(), opts)
 	if err == nil {
@@ -407,8 +418,13 @@ func TestReview_NonExistentPR(t *testing.T) {
 		PRNumber: "999999", Timeout: time.Second,
 		SockPath: "/should/never/be/dialled",
 		Parent:   parent,
+		Worktree: iso.Root,
 		PRVerifier: func(pr string) error {
 			return fmt.Errorf("iris review: PR #%s not found", pr)
+		},
+		PreflightRunner: func(preflightInput) error {
+			t.Errorf("PreflightRunner called after PRVerifier failed")
+			return nil
 		},
 		Out: io.Discard,
 	}
@@ -483,8 +499,10 @@ func TestReview_InProgressGroup(t *testing.T) {
 	opts := reviewRunOpts{
 		PRNumber: "1", Timeout: time.Second,
 		SockPath: iso.Paths.Sock, Parent: parent,
-		PRVerifier: func(string) error { return nil },
-		Out:        io.Discard,
+		Worktree:        iso.Root,
+		PRVerifier:      func(string) error { return nil },
+		PreflightRunner: noopPreflightRunner,
+		Out:             io.Discard,
 	}
 	err = runReviewAt(ctx, opts)
 	if err == nil {
@@ -501,6 +519,97 @@ func TestReview_InProgressGroup(t *testing.T) {
 // a tagged value carrier.
 func makeFakeSupervisor(sessionName, worktree, role string) *iris.Supervisor {
 	return iris.NewFakeSupervisorForTest(sessionName, worktree, role)
+}
+
+// noopPreflightRunner is the default PreflightRunner for tests that do
+// not need to exercise the gate. It returns nil unconditionally so
+// runReviewAt proceeds to the wire layer.
+func noopPreflightRunner(preflightInput) error { return nil }
+
+// TestReview_PreflightRefusal verifies the #1518 parity gate: when the
+// preflight runner reports the branch is behind origin/main, the CLI
+// exits non-zero with the rebase-guidance error AND does NOT dial the
+// daemon. This is the gate's whole point — fail fast, before any
+// review-group state is created daemon-side.
+func TestReview_PreflightRefusal(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-preflight-refused")
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent: %v", err)
+	}
+
+	// Preflight returns the canonical refusal error. The sock path is
+	// deliberately bogus — if the CLI ever tries to dial it the test
+	// fails with a connection-refused error rather than the expected
+	// preflight refusal.
+	refuseMsg := "iris review: branch is 3 commits behind origin/main\n\nmain has advanced since this branch was cut. Reviewers will see drift…"
+	opts := reviewRunOpts{
+		PRNumber:   "1",
+		Timeout:    time.Second,
+		SockPath:   "/should/never/be/dialled",
+		Parent:     parent,
+		Worktree:   iso.Root,
+		PRVerifier: func(string) error { return nil },
+		PreflightRunner: func(in preflightInput) error {
+			if in.Worktree != iso.Root {
+				t.Errorf("PreflightRunner Worktree = %q, want %q", in.Worktree, iso.Root)
+			}
+			return fmt.Errorf("%s", refuseMsg)
+		},
+		Out: io.Discard,
+	}
+	err := runReviewAt(context.Background(), opts)
+	if err == nil {
+		t.Fatalf("runReviewAt(preflight refused): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "behind origin/main") {
+		t.Errorf("error = %v, want substring 'behind origin/main'", err)
+	}
+}
+
+// TestReview_PreflightRebaseFlagPropagates verifies that --rebase is
+// threaded through to the preflight runner (so a real preflight does
+// the fetch + rebase + force-push inline). This is a structural test on
+// the wire-up; the actual git work is tested in internal/review/preflight_test.go.
+func TestReview_PreflightRebaseFlagPropagates(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-preflight-rebase")
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent: %v", err)
+	}
+
+	var (
+		calls      int
+		sawRebase  bool
+		sawWorktree string
+	)
+	opts := reviewRunOpts{
+		PRNumber:   "1",
+		Timeout:    time.Second,
+		Rebase:     true,
+		SockPath:   "/should/never/be/dialled",
+		Parent:     parent,
+		Worktree:   iso.Root,
+		PRVerifier: func(string) error { return nil },
+		PreflightRunner: func(in preflightInput) error {
+			calls++
+			sawRebase = in.Rebase
+			sawWorktree = in.Worktree
+			// Return a sentinel error so the CLI exits before dialling.
+			return fmt.Errorf("preflight sentinel")
+		},
+		Out: io.Discard,
+	}
+	_ = runReviewAt(context.Background(), opts)
+	if calls != 1 {
+		t.Errorf("PreflightRunner calls = %d, want 1", calls)
+	}
+	if !sawRebase {
+		t.Errorf("PreflightRunner Rebase = false, want true (--rebase set on opts)")
+	}
+	if sawWorktree != iso.Root {
+		t.Errorf("PreflightRunner Worktree = %q, want %q", sawWorktree, iso.Root)
+	}
 }
 
 // Ensure db.Status remains referenced — defensive against an over-zealous

--- a/modules/programs/prism/prism/cmd/iris/review_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/review_integration_test.go
@@ -1,0 +1,509 @@
+package main
+
+// review_integration_test.go — end-to-end integration test for the
+// `iris review <pr>` CLI against a live in-process iris.ClientSocket
+// wired to the daemon-side review orchestrator
+// (iris.NewReviewSpawnHandler). Issue #1694.
+//
+// The test exercises the full review cycle:
+//
+//   1. Start an in-process ClientSocket with the review-spawn orchestrator.
+//   2. Pre-register a parent session (so the orchestrator passes the
+//      "parent must be active" guard).
+//   3. Invoke `runReviewAt` against the live socket. The handler:
+//        - Registers a session_groups row.
+//        - Spawns the 5 review-agent sessions (via a fake SpawnSession
+//          that seeds an `active` agent_status row — no real pi child).
+//        - Returns a review_spawned ack with group_id, round, members.
+//   4. Transition the 5 fake agent sessions to `finished` via direct DB
+//      writes. The watcher (running in a goroutine) observes completion
+//      via db.GroupCompleted and delivers one review-complete prompt to
+//      the parent.
+//   5. Assert that the deliver hook fired EXACTLY ONCE, with a body
+//      mentioning each agent role and the per-run delivery_id.
+//
+// The test uses the iristest isolation harness so the iris DB,
+// XDG_STATE_HOME, and HOME are redirected to a t.TempDir — no host
+// state is touched, and no real notification can escape to a live
+// coordinator (#1608).
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// TestReview_FullCycle drives the full async review path: spawn 5 agents,
+// transition each to terminal, observe exactly one review-complete
+// delivery to the parent session.
+func TestReview_FullCycle(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	const prNumber = "1694"
+	parent := iristest.SessionName("review-parent")
+
+	// Seed the parent's agent_status row so it appears in the daemon's
+	// "active sessions" snapshot (the review-spawn handler rejects unknown
+	// parents up-front via sessionExists).
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent(parent): %v", err)
+	}
+
+	// In-memory active-sessions list. The orchestrator reads this through
+	// GetActiveSessions for the sessionExists guard. We add review-agent
+	// sessions to it as the fake SpawnSession is invoked.
+	var (
+		activeMu       sync.Mutex
+		activeSessions = []iris.SessionSnapshot{
+			{
+				Name:       parent,
+				InstanceID: uuid.NewString(),
+				State:      "active",
+				Role:       "worker",
+				Worktree:   iso.Root,
+				StartedAt:  time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+	)
+	getActive := func() []iris.SessionSnapshot {
+		activeMu.Lock()
+		defer activeMu.Unlock()
+		out := make([]iris.SessionSnapshot, len(activeSessions))
+		copy(out, activeSessions)
+		return out
+	}
+
+	// Capture deliveries to the parent. The watcher will hit this hook
+	// once (per sync.Once guard) when the group completes.
+	var (
+		deliverMu   sync.Mutex
+		deliverHits int
+		deliverText string
+		deliverName string
+	)
+	deliverFn := func(_ context.Context, name, text, deliverAs string, _ []string) error {
+		deliverMu.Lock()
+		defer deliverMu.Unlock()
+		deliverHits++
+		deliverName = name
+		deliverText = text
+		_ = deliverAs
+		return nil
+	}
+
+	// Track sessions spawned by the orchestrator's SpawnSession hook.
+	var (
+		spawnMu       sync.Mutex
+		spawnedAgents = make(map[string]string) // role → session_name
+	)
+	spawnSession := func(_ context.Context, sessionName, worktree, role string) (*iris.Supervisor, error) {
+		// Seed the agent_status row in "active" state. The handler will
+		// stamp the group_id via SetGroupID immediately after.
+		if err := iso.DB.UpsertStatusWithAgent(sessionName, "iris-parity", worktree, "active", nil, nil, &role, nil); err != nil {
+			return nil, fmt.Errorf("seed agent_status for %s: %w", role, err)
+		}
+		spawnMu.Lock()
+		spawnedAgents[role] = sessionName
+		spawnMu.Unlock()
+		activeMu.Lock()
+		activeSessions = append(activeSessions, iris.SessionSnapshot{
+			Name:       sessionName,
+			InstanceID: uuid.NewString(),
+			State:      "active",
+			Role:       role,
+			Worktree:   worktree,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		})
+		activeMu.Unlock()
+		// Returning nil is fine here — the orchestrator only calls
+		// sup.SessionRecord().SessionName and sup.InstanceID() on the
+		// result. Both are surfaced via a tiny shim Supervisor below.
+		return makeFakeSupervisor(sessionName, worktree, role), nil
+	}
+
+	// Construct the daemon-side handler with a tight poll interval so
+	// the test completes quickly once we transition the agents to
+	// terminal.
+	handler := iris.NewReviewSpawnHandler(iris.ReviewSpawnDeps{
+		Database:      iso.DB,
+		SpawnSession:  spawnSession,
+		DeliverPrompt: deliverFn,
+		ParentWorktree: func(p string) (string, error) {
+			if p != parent {
+				return "", fmt.Errorf("unexpected parent %q", p)
+			}
+			return iso.Root, nil
+		},
+		PollInterval: 25 * time.Millisecond,
+	})
+
+	// Stand up the ClientSocket on the iristest-allocated short-prefix
+	// socket path.
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          iso.Paths.Sock,
+		Database:          iso.DB,
+		GetActiveSessions: getActive,
+		DeliverPrompt:     deliverFn,
+		SpawnReviewGroup:  handler,
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cs.Serve(ctx)
+
+	// Drive the CLI core. We bypass the cobra layer and call runReviewAt
+	// directly with deterministic fakes for PRVerifier and the rebase
+	// runner (the latter is irrelevant — Rebase=false).
+	opts := reviewRunOpts{
+		PRNumber:     prNumber,
+		Timeout:      10 * time.Second,
+		Only:         "",
+		Rebase:       false,
+		SockPath:     iso.Paths.Sock,
+		Parent:       parent,
+		PRVerifier:   func(string) error { return nil },
+		RebaseRunner: func(io.Writer) error { return nil },
+		Out:          io.Discard,
+	}
+
+	runCtx, runCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer runCancel()
+	if err := runReviewAt(runCtx, opts); err != nil {
+		t.Fatalf("runReviewAt: %v", err)
+	}
+
+	// Confirm all 5 canonical agents got spawned and stamped with the
+	// same group_id.
+	spawnMu.Lock()
+	gotAgents := make(map[string]string, len(spawnedAgents))
+	for k, v := range spawnedAgents {
+		gotAgents[k] = v
+	}
+	spawnMu.Unlock()
+	if len(gotAgents) != len(iris.ReviewAgentNames) {
+		t.Fatalf("spawned %d agents, want %d (got: %v)", len(gotAgents), len(iris.ReviewAgentNames), gotAgents)
+	}
+	for _, role := range iris.ReviewAgentNames {
+		sess, ok := gotAgents[role]
+		if !ok {
+			t.Errorf("missing spawn for role %q", role)
+			continue
+		}
+		expectedPrefix := parent + "~review-1-" + role
+		if sess != expectedPrefix {
+			t.Errorf("session name for %s = %q, want %q", role, sess, expectedPrefix)
+		}
+		isMember, err := iso.DB.IsGroupMember(sess)
+		if err != nil {
+			t.Fatalf("IsGroupMember(%s): %v", sess, err)
+		}
+		if !isMember {
+			t.Errorf("session %s is not a group member after spawn", sess)
+		}
+	}
+
+	// Transition each member to a terminal state. After the LAST
+	// transition, the watcher should deliver exactly one review-complete
+	// prompt to the parent.
+	for i, role := range iris.ReviewAgentNames {
+		sess := gotAgents[role]
+		role := role // capture for the &role pointer
+		if err := iso.DB.UpsertStatusWithAgent(sess, "iris-parity", iso.Root, "finished", nil, nil, &role, nil); err != nil {
+			t.Fatalf("transition %s: %v", sess, err)
+		}
+
+		// Allow the watcher a chance to observe — but for all but the
+		// last transition assert no delivery has fired yet.
+		if i < len(iris.ReviewAgentNames)-1 {
+			time.Sleep(80 * time.Millisecond)
+			deliverMu.Lock()
+			fired := deliverHits
+			deliverMu.Unlock()
+			if fired != 0 {
+				t.Errorf("delivery fired prematurely after %d/%d members terminal", i+1, len(iris.ReviewAgentNames))
+			}
+		}
+	}
+
+	// Wait for the watcher to fire. 5s is generous; default poll is 25ms.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		deliverMu.Lock()
+		fired := deliverHits
+		deliverMu.Unlock()
+		if fired >= 1 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	deliverMu.Lock()
+	defer deliverMu.Unlock()
+	if deliverHits != 1 {
+		t.Fatalf("review-complete delivery fired %d times, want exactly 1", deliverHits)
+	}
+	if deliverName != parent {
+		t.Errorf("delivery target = %q, want %q", deliverName, parent)
+	}
+	if !strings.Contains(deliverText, "Review complete") {
+		t.Errorf("delivery body missing 'Review complete' header; got: %q", deliverText)
+	}
+	for _, role := range iris.ReviewAgentNames {
+		if !strings.Contains(deliverText, role) {
+			t.Errorf("delivery body missing role %q; got: %q", role, deliverText)
+		}
+	}
+	if !strings.Contains(deliverText, "All review agents passed") {
+		t.Errorf("delivery body missing 'all passed' summary; got: %q", deliverText)
+	}
+}
+
+// TestReview_OnlyFilter exercises --only by passing a 2-agent subset and
+// asserting the orchestrator only spawned those two agents.
+func TestReview_OnlyFilter(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-parent-only")
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent(parent): %v", err)
+	}
+
+	activeSessions := []iris.SessionSnapshot{{
+		Name: parent, InstanceID: uuid.NewString(), State: "active", Role: "worker",
+		Worktree: iso.Root, StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}}
+	getActive := func() []iris.SessionSnapshot {
+		out := make([]iris.SessionSnapshot, len(activeSessions))
+		copy(out, activeSessions)
+		return out
+	}
+
+	var spawnMu sync.Mutex
+	spawned := []string{}
+	spawnSession := func(_ context.Context, sessionName, worktree, role string) (*iris.Supervisor, error) {
+		if err := iso.DB.UpsertStatusWithAgent(sessionName, "iris-parity", worktree, "active", nil, nil, &role, nil); err != nil {
+			return nil, err
+		}
+		spawnMu.Lock()
+		spawned = append(spawned, role)
+		spawnMu.Unlock()
+		return makeFakeSupervisor(sessionName, worktree, role), nil
+	}
+
+	handler := iris.NewReviewSpawnHandler(iris.ReviewSpawnDeps{
+		Database:      iso.DB,
+		SpawnSession:  spawnSession,
+		DeliverPrompt: func(context.Context, string, string, string, []string) error { return nil },
+		ParentWorktree: func(string) (string, error) { return iso.Root, nil },
+		PollInterval:   500 * time.Millisecond, // slow — we don't need the watcher to fire
+	})
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: iso.Paths.Sock, Database: iso.DB,
+		GetActiveSessions: getActive, SpawnReviewGroup: handler,
+		DeliverPrompt: func(context.Context, string, string, string, []string) error { return nil },
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cs.Serve(ctx)
+
+	opts := reviewRunOpts{
+		PRNumber: "9", Timeout: time.Second, Only: "review-goal,review-code",
+		SockPath: iso.Paths.Sock, Parent: parent,
+		PRVerifier: func(string) error { return nil },
+		Out:        io.Discard,
+	}
+	if err := runReviewAt(ctx, opts); err != nil {
+		t.Fatalf("runReviewAt: %v", err)
+	}
+	spawnMu.Lock()
+	defer spawnMu.Unlock()
+	if len(spawned) != 2 {
+		t.Fatalf("spawned %d agents, want 2 (got: %v)", len(spawned), spawned)
+	}
+	want := map[string]bool{"review-goal": true, "review-code": true}
+	for _, r := range spawned {
+		if !want[r] {
+			t.Errorf("spawned unexpected role %q", r)
+		}
+	}
+}
+
+// TestReview_UnknownOnlyAgent verifies the --only validation: an unknown
+// agent name exits non-zero before any spawn happens.
+func TestReview_UnknownOnlyAgent(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-parent-bad-only")
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent: %v", err)
+	}
+
+	// No socket needed — parseOnlyFlag fires before any wire I/O. We
+	// supply a bogus sock path so an accidental dial would surface.
+	opts := reviewRunOpts{
+		PRNumber: "1", Timeout: time.Second, Only: "review-goal,not-a-real-agent",
+		SockPath: "/nonexistent/iris.sock", Parent: parent,
+		PRVerifier: func(string) error {
+			t.Errorf("PRVerifier called before --only validation")
+			return nil
+		},
+		Out: io.Discard,
+	}
+	err := runReviewAt(context.Background(), opts)
+	if err == nil {
+		t.Fatalf("runReviewAt(unknown agent): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown agent name") {
+		t.Errorf("error = %v, want substring 'unknown agent name'", err)
+	}
+}
+
+// TestReview_DaemonDown verifies the canonical "daemon not running" error
+// when the socket file does not exist.
+func TestReview_DaemonDown(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-daemon-down")
+
+	opts := reviewRunOpts{
+		PRNumber: "1", Timeout: time.Second,
+		SockPath: iso.Paths.Sock + ".missing", // never created
+		Parent:   parent,
+		PRVerifier: func(string) error { return nil },
+		Out:        io.Discard,
+	}
+	err := runReviewAt(context.Background(), opts)
+	if err == nil {
+		t.Fatalf("runReviewAt(daemon down): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "systemctl --user start iris") {
+		t.Errorf("error = %v, want substring 'systemctl --user start iris'", err)
+	}
+}
+
+// TestReview_NonExistentPR verifies that PR-existence check runs before
+// any spawn occurs, and that a PR-not-found error exits non-zero.
+func TestReview_NonExistentPR(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-pr-missing")
+
+	// No SocketPath check needed — PRVerifier short-circuits.
+	opts := reviewRunOpts{
+		PRNumber: "999999", Timeout: time.Second,
+		SockPath: "/should/never/be/dialled",
+		Parent:   parent,
+		PRVerifier: func(pr string) error {
+			return fmt.Errorf("iris review: PR #%s not found", pr)
+		},
+		Out: io.Discard,
+	}
+	err := runReviewAt(context.Background(), opts)
+	if err == nil {
+		t.Fatalf("runReviewAt(pr missing): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %v, want substring 'not found'", err)
+	}
+	_ = iso
+}
+
+// TestReview_InProgressGroup verifies the "round N already in progress"
+// rejection path: a parent with a non-terminal group cannot spawn a
+// second concurrent round.
+func TestReview_InProgressGroup(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	parent := iristest.SessionName("review-in-progress")
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent: %v", err)
+	}
+
+	// Pre-seed a group with an active member so the in-progress guard
+	// fires deterministically.
+	groupID, err := iso.DB.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	memberName := parent + "~review-1-review-goal"
+	memberRole := "review-goal"
+	if err := iso.DB.UpsertStatusWithAgent(memberName, "iris-parity", iso.Root, "active", nil, nil, &memberRole, nil); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+	if err := iso.DB.SetGroupID(memberName, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+
+	activeSessions := []iris.SessionSnapshot{{
+		Name: parent, InstanceID: uuid.NewString(), State: "active", Role: "worker",
+		Worktree: iso.Root, StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}}
+	getActive := func() []iris.SessionSnapshot {
+		out := make([]iris.SessionSnapshot, len(activeSessions))
+		copy(out, activeSessions)
+		return out
+	}
+
+	handler := iris.NewReviewSpawnHandler(iris.ReviewSpawnDeps{
+		Database: iso.DB,
+		SpawnSession: func(_ context.Context, sessionName, worktree, role string) (*iris.Supervisor, error) {
+			t.Errorf("SpawnSession called despite in-progress guard")
+			return makeFakeSupervisor(sessionName, worktree, role), nil
+		},
+		DeliverPrompt:  func(context.Context, string, string, string, []string) error { return nil },
+		ParentWorktree: func(string) (string, error) { return iso.Root, nil },
+	})
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: iso.Paths.Sock, Database: iso.DB,
+		GetActiveSessions: getActive, SpawnReviewGroup: handler,
+		DeliverPrompt: func(context.Context, string, string, string, []string) error { return nil },
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cs.Serve(ctx)
+
+	opts := reviewRunOpts{
+		PRNumber: "1", Timeout: time.Second,
+		SockPath: iso.Paths.Sock, Parent: parent,
+		PRVerifier: func(string) error { return nil },
+		Out:        io.Discard,
+	}
+	err = runReviewAt(ctx, opts)
+	if err == nil {
+		t.Fatalf("runReviewAt(in progress): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "in progress") {
+		t.Errorf("error = %v, want substring 'in progress'", err)
+	}
+}
+
+// makeFakeSupervisor returns a minimally-populated *iris.Supervisor that
+// satisfies the orchestrator's needs (SessionRecord().SessionName and
+// InstanceID()). The supervisor never runs a pi child; tests treat it as
+// a tagged value carrier.
+func makeFakeSupervisor(sessionName, worktree, role string) *iris.Supervisor {
+	return iris.NewFakeSupervisorForTest(sessionName, worktree, role)
+}
+
+// Ensure db.Status remains referenced — defensive against an over-zealous
+// import-trimmer that might drop the db import otherwise (TestReview_*
+// tests above all reach for db.DB methods via iso.DB, which is *db.DB).
+var _ = db.Status{}

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -89,6 +89,37 @@ type ClientPingFrame struct {
 	Type string `json:"type"` // "ping"
 }
 
+// ClientReviewSpawnFrame requests the daemon to spawn a review group for
+// the named parent session. The daemon spawns one session per agent in
+// AgentNames (one of the canonical iris.ReviewAgentNames), registers them
+// under a shared group_id in session_groups, and begins watching the group
+// for completion. When all members reach a terminal state the daemon
+// delivers a single review-complete prompt to the parent session via the
+// existing prompt_deliver path (issue #1694).
+//
+//	{"type":"review_spawn","parent":"...","pr_number":"...","agents":["review-goal",...],"timeout":"10m","delivery_id":"<uuid>"}
+type ClientReviewSpawnFrame struct {
+	Type string `json:"type"` // "review_spawn"
+	// Parent is the session that invoked `iris review`. The review-complete
+	// prompt is delivered here when the group completes.
+	Parent string `json:"parent"`
+	// PRNumber is the GitHub PR being reviewed. Recorded for observability;
+	// the daemon does not use it for routing.
+	PRNumber string `json:"pr_number"`
+	// AgentNames is the subset of canonical review agents to spawn. Empty
+	// means "all" (default 5). Names not in iris.ReviewAgentNames are
+	// rejected with a daemon-side error frame.
+	AgentNames []string `json:"agents,omitempty"`
+	// Timeout is the per-agent timeout encoded as a Go duration string
+	// (e.g. "10m"). Empty means "daemon default" (10m).
+	Timeout string `json:"timeout,omitempty"`
+	// DeliveryID is a UUID minted by the calling CLI. The daemon forwards
+	// it on the review-complete delivery so a defensive double-fire from
+	// the watcher is deduplicated at the receiving sidecar (issue #1695).
+	// May be empty for ad-hoc callers; the daemon mints one in that case.
+	DeliveryID string `json:"delivery_id,omitempty"`
+}
+
 // ---------------------------------------------------------------------------
 // Daemon → client response frames
 // ---------------------------------------------------------------------------
@@ -206,6 +237,26 @@ type DaemonPongFrame struct {
 	Type string `json:"type"` // "pong"
 }
 
+// DaemonReviewSpawnedFrame acknowledges a successful review_spawn request.
+// It carries the group_id, the round number (1-indexed, derived from the
+// parent's prior `~review-N-<agent>` rows), and the per-agent session
+// names so the caller can print a deterministic acknowledgement.
+//
+//	{"type":"review_spawned","group_id":"<uuid>","parent":"...","round":1,"members":[{"agent":"review-goal","session":"..."},...]}
+type DaemonReviewSpawnedFrame struct {
+	Type    string                    `json:"type"` // "review_spawned"
+	GroupID string                    `json:"group_id"`
+	Parent  string                    `json:"parent"`
+	Round   int                       `json:"round"`
+	Members []DaemonReviewGroupMember `json:"members"`
+}
+
+// DaemonReviewGroupMember is one entry in DaemonReviewSpawnedFrame.Members.
+type DaemonReviewGroupMember struct {
+	Agent       string `json:"agent"`        // role name, e.g. "review-goal"
+	SessionName string `json:"session_name"` // full session name spawned for this agent
+}
+
 // Client-socket frame type constants.
 const (
 	ClientFrameSessionsList       = "sessions_list"
@@ -214,12 +265,14 @@ const (
 	ClientFrameSessionSpawn       = "session_spawn"
 	ClientFrameSessionKill        = "session_kill"
 	ClientFramePromptDeliver      = "prompt_deliver"
+	ClientFrameReviewSpawn        = "review_spawn"
 	ClientFramePing               = "ping"
 	DaemonFrameSessionsSnapshot   = "sessions_snapshot"
 	DaemonFrameSessionEvent       = "session_event"
 	DaemonFrameSessionState       = "session_state"
 	DaemonFrameSessionSpawned     = "session_spawned"
 	DaemonFrameSessionKilled      = "session_killed"
+	DaemonFrameReviewSpawned      = "review_spawned"
 	DaemonFrameError              = "error"
 	DaemonFramePong               = "pong"
 )

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -102,6 +102,12 @@ type ClientSocket struct {
 	// reached ("finished", "error", "already_terminal") on success. Set by
 	// the daemon at construction.
 	killSession func(ctx context.Context, name string, timeout time.Duration) (string, error)
+	// spawnReviewGroup orchestrates a `iris review` request: spawns the
+	// review agents, registers the group, and starts the completion
+	// watcher. Set by the daemon at construction (or via SetSpawnReviewGroup
+	// when the daemon needs to capture a reference to the ClientSocket).
+	// Returns the ack frame ready to be written to the calling client.
+	spawnReviewGroup func(ctx context.Context, req ClientReviewSpawnFrame) (*DaemonReviewSpawnedFrame, error)
 
 	listener net.Listener
 
@@ -141,6 +147,9 @@ type ClientSocketConfig struct {
 	// KillSession terminates a named session. Returns the terminal state
 	// ("finished" / "error" / "already_terminal") on success.
 	KillSession func(ctx context.Context, name string, timeout time.Duration) (string, error)
+	// SpawnReviewGroup orchestrates an `iris review` request. Set by the
+	// daemon; the implementation lives in review_handler.go.
+	SpawnReviewGroup func(ctx context.Context, req ClientReviewSpawnFrame) (*DaemonReviewSpawnedFrame, error)
 }
 
 // NewClientSocket creates a ClientSocket. Call Listen() to bind the socket,
@@ -153,6 +162,7 @@ func NewClientSocket(cfg ClientSocketConfig) *ClientSocket {
 		spawnSession:      cfg.SpawnSession,
 		deliverPrompt:     cfg.DeliverPrompt,
 		killSession:       cfg.KillSession,
+		spawnReviewGroup:  cfg.SpawnReviewGroup,
 		subscribers:       make(map[string][]subscriberChan),
 	}
 }
@@ -227,6 +237,18 @@ func (cs *ClientSocket) SetSpawnSession(fn func(ctx context.Context, worktree, r
 func (cs *ClientSocket) SetKillSession(fn func(ctx context.Context, name string, timeout time.Duration) (string, error)) {
 	cs.killSession = fn
 }
+
+// SetSpawnReviewGroup wires the review-spawn orchestrator after construction.
+// Symmetric with SetSpawnSession; call before Serve() when the daemon's
+// review orchestrator captures references that depend on the ClientSocket.
+func (cs *ClientSocket) SetSpawnReviewGroup(fn func(ctx context.Context, req ClientReviewSpawnFrame) (*DaemonReviewSpawnedFrame, error)) {
+	cs.spawnReviewGroup = fn
+}
+
+// Database returns the underlying *db.DB. Exposed for the review-handler
+// orchestrator, which is constructed by the daemon and needs to thread the
+// same DB handle that the client socket uses for sessions_list, etc.
+func (cs *ClientSocket) Database() *db.DB { return cs.database }
 
 // Close closes the listener and removes the socket file.
 func (cs *ClientSocket) Close() {
@@ -416,6 +438,14 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			go cs.handlePromptDeliver(connCtx, w, frame)
+
+		case ClientFrameReviewSpawn:
+			var frame ClientReviewSpawnFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFrameReviewSpawn, "invalid frame: "+err.Error())
+				continue
+			}
+			go cs.handleReviewSpawn(connCtx, w, frame)
 
 		case ClientFramePing:
 			_ = w.write(DaemonPongFrame{Type: DaemonFramePong})
@@ -662,6 +692,41 @@ func (cs *ClientSocket) handlePromptDeliver(ctx context.Context, w *jsonlWriter,
 	}
 	// No explicit ack frame for prompt_deliver — the client will see the
 	// resulting events via their subscription (if subscribed).
+}
+
+// handleReviewSpawn handles a review_spawn frame: validates the request,
+// invokes the daemon-provided review orchestrator, and writes a
+// review_spawned ack (or an error frame) back to the calling client.
+//
+// The orchestrator (cs.spawnReviewGroup) is responsible for the heavy work:
+// registering the group, spawning the per-agent sessions via the daemon's
+// session-spawn machinery, and launching the completion watcher. This
+// handler only validates the wire frame and translates orchestrator
+// errors into DaemonErrorFrame messages.
+func (cs *ClientSocket) handleReviewSpawn(ctx context.Context, w *jsonlWriter, frame ClientReviewSpawnFrame) {
+	if cs.spawnReviewGroup == nil {
+		sendError(w, ClientFrameReviewSpawn, "review spawn not configured on this daemon instance")
+		return
+	}
+	if frame.Parent == "" {
+		sendError(w, ClientFrameReviewSpawn, "parent is required")
+		return
+	}
+	if frame.PRNumber == "" {
+		sendError(w, ClientFrameReviewSpawn, "pr_number is required")
+		return
+	}
+	if !cs.sessionExists(frame.Parent) {
+		sendError(w, ClientFrameReviewSpawn,
+			fmt.Sprintf("not a registered iris session: %q (run `iris sessions list` to verify)", frame.Parent))
+		return
+	}
+	ack, err := cs.spawnReviewGroup(ctx, frame)
+	if err != nil {
+		sendError(w, ClientFrameReviewSpawn, err.Error())
+		return
+	}
+	_ = w.write(ack)
 }
 
 // --- Subscriber set management ---

--- a/modules/programs/prism/prism/internal/iris/review_handler.go
+++ b/modules/programs/prism/prism/internal/iris/review_handler.go
@@ -1,0 +1,507 @@
+package iris
+
+// review_handler.go — daemon-side orchestration for `iris review <pr>`.
+//
+// This is the daemon component sitting between the client IPC wire frame
+// (ClientReviewSpawnFrame, handled in client_socket.go::handleReviewSpawn)
+// and the lower-level D-10 internals in review.go (SpawnReviewGroup,
+// WatchReviewGroup).
+//
+// Responsibilities:
+//
+//  1. Validate the request: known agent names, no in-progress group for the
+//     same parent, parent session exists.
+//  2. Compute the next round number for the parent (using the shared
+//     review.NextRoundNumber helper, derived from the parent's prior
+//     ~review-N-<agent> rows).
+//  3. Construct a SpawnAgent closure that asks the daemon to spawn each
+//     review-agent session via the existing session-spawn machinery.
+//  4. Drive SpawnReviewGroup → WatchReviewGroup, delivering a single
+//     review-complete prompt to the parent via the daemon's deliverPrompt
+//     hook when the group reaches a terminal state.
+//
+// # Exactly-once delivery
+//
+// The watcher path is guarded by reviewCompleteOnceGuard (sync.Once-wrapped
+// callback) so a defensive double-fire of WatchReviewGroup never produces
+// two deliveries. The DeliveryID from the wire frame is forwarded to the
+// receiving session as part of the prompt body — when the parent is a pi
+// session, the sidecar at the far end dedupes by delivery_id (issue #1695).
+// Iris-native parents (this daemon) receive the prompt directly via
+// Supervisor.SendRPC; the sync.Once is the canonical exactly-once boundary
+// for that path.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// defaultPerAgentTimeout is the watch budget used when the client did not
+// supply a timeout. Matches prism's default and the issue's documented
+// per-agent default.
+const defaultPerAgentTimeout = 10 * time.Minute
+
+// ReviewSpawnDeps is the dependency bundle the daemon hands to
+// NewReviewSpawnHandler. Each function corresponds to one capability the
+// orchestrator needs from the surrounding daemon. Separating these from
+// the global daemon state keeps the orchestrator testable in isolation —
+// the parity integration test wires fakes for each.
+type ReviewSpawnDeps struct {
+	// Database is the open iris DB. Used for group registration, status
+	// lookups, round-number derivation, and the watcher's poll loop.
+	Database *db.DB
+	// SpawnSession asks the daemon to spawn a single review-agent session
+	// with the given session name, worktree, and role. The orchestrator
+	// uses this in a loop (one call per agent) instead of the bare
+	// session_spawn path because review-agent names follow the
+	// `<parent>~review-N-<agent>` convention, not the daemon's default
+	// GenerateSessionName scheme.
+	SpawnSession func(ctx context.Context, sessionName, worktree, role string) (*Supervisor, error)
+	// DeliverPrompt delivers the final review-complete prompt to the
+	// parent session. Same signature as the daemon's prompt_deliver hook.
+	DeliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
+	// ParentWorktree returns the worktree of the named (parent) session
+	// so the orchestrator can stamp it onto each spawned review-agent
+	// session. Implementations typically read the in-memory supervisor
+	// map; a DB fallback is acceptable.
+	ParentWorktree func(parent string) (string, error)
+	// PollInterval is the watcher's poll cadence. 0 = default (250ms).
+	PollInterval time.Duration
+}
+
+// NewReviewSpawnHandler returns a function suitable for
+// ClientSocketConfig.SpawnReviewGroup. It captures deps and produces a
+// closure that the client-socket layer invokes when a review_spawn frame
+// arrives.
+func NewReviewSpawnHandler(deps ReviewSpawnDeps) func(ctx context.Context, req ClientReviewSpawnFrame) (*DaemonReviewSpawnedFrame, error) {
+	return func(ctx context.Context, req ClientReviewSpawnFrame) (*DaemonReviewSpawnedFrame, error) {
+		return handleReviewSpawnRequest(ctx, deps, req)
+	}
+}
+
+// handleReviewSpawnRequest is the body of the orchestrator. Split from the
+// closure so it can be unit-tested without a real daemon.
+func handleReviewSpawnRequest(ctx context.Context, deps ReviewSpawnDeps, req ClientReviewSpawnFrame) (*DaemonReviewSpawnedFrame, error) {
+	if deps.Database == nil {
+		return nil, fmt.Errorf("iris review: database not configured")
+	}
+	if deps.SpawnSession == nil {
+		return nil, fmt.Errorf("iris review: spawn-session not configured")
+	}
+	if deps.DeliverPrompt == nil {
+		return nil, fmt.Errorf("iris review: deliver-prompt not configured")
+	}
+	if deps.ParentWorktree == nil {
+		return nil, fmt.Errorf("iris review: parent-worktree resolver not configured")
+	}
+
+	// Resolve the agent set.
+	agents, err := resolveAgentSet(req.AgentNames)
+	if err != nil {
+		return nil, err
+	}
+
+	// In-progress group rejection (AC: "round N is already in progress").
+	if roundNum, present, err := inProgressReviewRound(deps.Database, req.Parent); err != nil {
+		return nil, fmt.Errorf("iris review: check in-progress: %w", err)
+	} else if present {
+		return nil, fmt.Errorf(
+			"iris review: round %d is already in progress for this PR (parent=%s)\n"+
+				"hint: wait for the round to complete, or cancel it via `iris sessions list` + `iris kill <agent-session>`",
+			roundNum, req.Parent,
+		)
+	}
+
+	// Resolve the parent's worktree so the review agents reuse it (they
+	// inspect the same HEAD the worker is on).
+	worktree, err := deps.ParentWorktree(req.Parent)
+	if err != nil {
+		return nil, fmt.Errorf("iris review: resolve parent worktree: %w", err)
+	}
+
+	// Derive the next round number from the parent's prior review rows.
+	// review.NextRoundNumber returns 1 when no prior rounds exist.
+	round := review.NextRoundNumber(deps.Database, req.Parent)
+
+	// Parse the per-agent timeout (used for log context; watcher itself
+	// relies on the parent ctx + DB poll loop).
+	timeout, err := parseReviewTimeout(req.Timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compose the SpawnAgent closure threaded to SpawnReviewGroup.
+	spawnAgent := func(spawnCtx context.Context, role string) (string, string, error) {
+		sessionName := fmt.Sprintf("%s~review-%d-%s", req.Parent, round, role)
+		sup, err := deps.SpawnSession(spawnCtx, sessionName, worktree, role)
+		if err != nil {
+			return "", "", err
+		}
+		return sup.SessionRecord().SessionName, sup.InstanceID(), nil
+	}
+
+	// Drive the spawn. SpawnReviewGroup iterates the canonical
+	// ReviewAgentNames, so if the caller restricted via --only we
+	// substitute a filtered list by overriding via a one-shot variable
+	// swap is intrusive; instead we use a localised slice and call
+	// spawnAgent directly for the requested subset.
+	groupID, members, err := spawnFilteredReviewGroup(ctx, deps.Database, req.Parent, worktree, agents, spawnAgent)
+	if err != nil {
+		return nil, fmt.Errorf("iris review: %w", err)
+	}
+
+	deliveryID := req.DeliveryID
+	if deliveryID == "" {
+		deliveryID = uuid.NewString()
+	}
+
+	// Launch the watcher. The watcher runs for the lifetime of the
+	// daemon process (or until the group completes); we deliberately use
+	// context.Background here, not the per-connection ctx, because the
+	// CLI invocation that triggered the spawn will return immediately
+	// after the ack and the connection will close.
+	go runReviewWatcher(reviewWatcherConfig{
+		Database:      deps.Database,
+		GroupID:       groupID,
+		Parent:        req.Parent,
+		PRNumber:      req.PRNumber,
+		Round:         round,
+		Members:       members,
+		AgentNames:    agentRoleList(agents),
+		DeliverPrompt: deps.DeliverPrompt,
+		DeliveryID:    deliveryID,
+		PerAgentBudget: timeout,
+		PollInterval:  deps.PollInterval,
+	})
+
+	// Build ack.
+	ack := &DaemonReviewSpawnedFrame{
+		Type:    DaemonFrameReviewSpawned,
+		GroupID: groupID,
+		Parent:  req.Parent,
+		Round:   round,
+		Members: make([]DaemonReviewGroupMember, 0, len(members)),
+	}
+	for _, role := range agentRoleList(agents) {
+		ack.Members = append(ack.Members, DaemonReviewGroupMember{
+			Agent:       role,
+			SessionName: members[role],
+		})
+	}
+	return ack, nil
+}
+
+// resolveAgentSet returns the canonical ordered list of agents to spawn.
+// An empty input means "all 5 standard agents". A non-empty input is
+// validated against ReviewAgentNames; unknown names produce a clear error
+// listing the valid set.
+func resolveAgentSet(requested []string) ([]string, error) {
+	if len(requested) == 0 {
+		return append([]string(nil), ReviewAgentNames...), nil
+	}
+	known := make(map[string]bool, len(ReviewAgentNames))
+	for _, r := range ReviewAgentNames {
+		known[r] = true
+	}
+	var unknown []string
+	seen := make(map[string]bool, len(requested))
+	out := make([]string, 0, len(requested))
+	for _, name := range requested {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if !known[name] {
+			unknown = append(unknown, name)
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf(
+			"iris review: unknown agent name(s): %s — valid names: %s",
+			strings.Join(unknown, ", "), strings.Join(ReviewAgentNames, ", "),
+		)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf(
+			"iris review: --only must name at least one of: %s",
+			strings.Join(ReviewAgentNames, ", "),
+		)
+	}
+	return out, nil
+}
+
+// parseReviewTimeout parses the wire-frame timeout (a Go duration string)
+// and returns the resolved per-agent budget. Empty string yields the
+// default. Invalid input yields an error.
+func parseReviewTimeout(s string) (time.Duration, error) {
+	if s == "" {
+		return defaultPerAgentTimeout, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("iris review: invalid timeout %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("iris review: timeout must be positive (got %s)", s)
+	}
+	return d, nil
+}
+
+// inProgressReviewRound returns the (1-indexed) round number of any
+// in-progress review group for the given parent. present=false when no
+// group is in progress.
+//
+// We piggy-back on review.NextRoundNumber for the round-number derivation:
+// the in-progress round is one less than NextRoundNumber when the prior
+// round still has non-terminal members. Concretely, we walk the parent's
+// session_groups rows and check each via db.GroupCompleted.
+func inProgressReviewRound(d *db.DB, parent string) (round int, present bool, err error) {
+	// HasReviewGroup is the cheap first check; if no group exists for the
+	// parent at all, we can return immediately.
+	has, hErr := d.HasReviewGroup(parent)
+	if hErr != nil {
+		return 0, false, hErr
+	}
+	if !has {
+		return 0, false, nil
+	}
+	// Walk all groups and look for one that has not yet completed.
+	parents, err := d.AllGroupParents()
+	if err != nil {
+		return 0, false, err
+	}
+	for groupID, p := range parents {
+		if p != parent {
+			continue
+		}
+		done, dErr := d.GroupCompleted(groupID)
+		if dErr != nil {
+			return 0, false, dErr
+		}
+		if !done {
+			// Derive the round number from the members' session names.
+			members, mErr := d.GroupMembersForGroup(groupID)
+			if mErr != nil {
+				return 0, false, mErr
+			}
+			r := roundFromMembers(parent, members)
+			return r, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+// roundFromMembers extracts the round number embedded in any one of the
+// member session names, which follow the `<parent>~review-N-<agent>`
+// convention. Returns 0 when no member matches (defensive — should not
+// happen for a freshly-registered group).
+func roundFromMembers(parent string, members []db.Status) int {
+	prefix := parent + "~review-"
+	for _, m := range members {
+		if !strings.HasPrefix(m.SessionName, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(m.SessionName, prefix)
+		// suffix is "N-<agent>"; we want N.
+		dashIdx := strings.Index(suffix, "-")
+		if dashIdx <= 0 {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(suffix[:dashIdx], "%d", &n); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// spawnFilteredReviewGroup is a thin variant of SpawnReviewGroup that
+// honours an arbitrary ordered agent list (instead of the package's
+// canonical full set). It performs the same DB-stamping work
+// (RegisterGroup → SpawnAgent → SetGroupID) for each agent in `agents`.
+func spawnFilteredReviewGroup(
+	ctx context.Context,
+	d *db.DB,
+	parent, worktree string,
+	agents []string,
+	spawnAgent func(ctx context.Context, role string) (sessionName, instanceID string, err error),
+) (string, map[string]string, error) {
+	if d == nil {
+		return "", nil, fmt.Errorf("database is required")
+	}
+	if parent == "" {
+		return "", nil, fmt.Errorf("parent session is required")
+	}
+	if spawnAgent == nil {
+		return "", nil, fmt.Errorf("spawn-agent callback is required")
+	}
+	if len(agents) == 0 {
+		return "", nil, fmt.Errorf("at least one agent is required")
+	}
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		return "", nil, fmt.Errorf("register group: %w", err)
+	}
+	members := make(map[string]string, len(agents))
+	for _, role := range agents {
+		sessionName, _, spawnErr := spawnAgent(ctx, role)
+		if spawnErr != nil {
+			return groupID, members, fmt.Errorf("spawn %s: %w", role, spawnErr)
+		}
+		if err := d.SetGroupID(sessionName, groupID); err != nil {
+			return groupID, members, fmt.Errorf("set group_id for %s: %w", role, err)
+		}
+		members[role] = sessionName
+	}
+	_ = worktree // currently unused at this layer; retained for symmetry with SpawnReviewGroup signature
+	return groupID, members, nil
+}
+
+// agentRoleList returns agents in the canonical ReviewAgentNames order
+// (subset-preserving), so the ack frame's Members ordering is stable.
+func agentRoleList(agents []string) []string {
+	want := make(map[string]bool, len(agents))
+	for _, a := range agents {
+		want[a] = true
+	}
+	out := make([]string, 0, len(agents))
+	for _, canonical := range ReviewAgentNames {
+		if want[canonical] {
+			out = append(out, canonical)
+		}
+	}
+	return out
+}
+
+// reviewWatcherConfig bundles the parameters runReviewWatcher needs. It is
+// constructed by handleReviewSpawnRequest and consumed by a single
+// goroutine; the struct is not safe for concurrent re-use.
+type reviewWatcherConfig struct {
+	Database       *db.DB
+	GroupID        string
+	Parent         string
+	PRNumber       string
+	Round          int
+	Members        map[string]string // role → session_name
+	AgentNames     []string          // ordered subset of ReviewAgentNames
+	DeliverPrompt  func(ctx context.Context, name, text, deliverAs string, images []string) error
+	DeliveryID     string
+	PerAgentBudget time.Duration
+	PollInterval   time.Duration
+}
+
+// runReviewWatcher launches a WatchReviewGroup poll loop and, on
+// completion, delivers a single review-complete prompt to the parent
+// session. The sync.Once-wrapped callback (reviewCompleteOnceGuard) ensures
+// exactly-once delivery even if the watcher fires defensively twice.
+func runReviewWatcher(cfg reviewWatcherConfig) {
+	// Watcher ctx: bounded by 2x the per-agent budget × number of agents,
+	// floored at the per-agent budget itself. The intent is that the
+	// watcher does not hold a goroutine forever if all agents wedge.
+	wallclock := cfg.PerAgentBudget
+	if wallclock <= 0 {
+		wallclock = defaultPerAgentTimeout
+	}
+	// Generous outer bound: 2x per-agent budget × member count. With the
+	// 10-minute default and 5 agents this yields 100 minutes — well
+	// beyond a healthy review cycle, but a hard cap if everything hangs.
+	hardCap := wallclock * 2 * time.Duration(len(cfg.Members)+1)
+	ctx, cancel := context.WithTimeout(context.Background(), hardCap)
+	defer cancel()
+
+	guard := &reviewCompleteOnceGuard{
+		fn: func(groupID string, results map[string]db.GroupMemberResult) {
+			text := buildReviewCompleteBody(cfg, results)
+			err := cfg.DeliverPrompt(context.Background(), cfg.Parent, text, "followUp", nil)
+			if err != nil {
+				log.Printf("[iris review] deliver review-complete to %s: %v", cfg.Parent, err)
+				return
+			}
+			log.Printf("[iris review] delivered review-complete to %s (group=%s, delivery_id=%s)", cfg.Parent, groupID, cfg.DeliveryID)
+		},
+	}
+
+	if err := WatchReviewGroup(ctx, cfg.Database, cfg.GroupID, cfg.PollInterval, guard.call); err != nil {
+		log.Printf("[iris review] watcher exited with error (group=%s): %v", cfg.GroupID, err)
+	}
+}
+
+// buildReviewCompleteBody constructs the text body delivered to the parent
+// when a review round completes. It mirrors prism's compact summary:
+// header, per-agent verdict + last message, and a closing instruction.
+//
+// The delivery_id is embedded verbatim at the head of the body so that any
+// receiver that surfaces the prompt to a human sees the same correlation
+// ID the daemon used. This is informational; deduplication itself is
+// enforced by the reviewCompleteOnceGuard at the call site.
+func buildReviewCompleteBody(cfg reviewWatcherConfig, results map[string]db.GroupMemberResult) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "## Review complete: PR #%s (round %d)\n\n", cfg.PRNumber, cfg.Round)
+
+	allPassed := true
+	anyMissing := false
+	for _, role := range cfg.AgentNames {
+		sessionName := cfg.Members[role]
+		r, ok := results[sessionName]
+		if !ok {
+			anyMissing = true
+			fmt.Fprintf(&sb, "### %s — MISSING\nsession=%s (not present in group results)\n\n", role, sessionName)
+			allPassed = false
+			continue
+		}
+		verdict := "PASS"
+		if r.State != "finished" || r.StartupError != "" {
+			verdict = "FAIL"
+			allPassed = false
+		}
+		fmt.Fprintf(&sb, "### %s — %s\nsession=%s state=%s\n", role, verdict, sessionName, r.State)
+		if r.StartupError != "" {
+			fmt.Fprintf(&sb, "startup_error: %s\n", r.StartupError)
+		}
+		if r.LastMessage != "" {
+			fmt.Fprintf(&sb, "%s\n", r.LastMessage)
+		}
+		sb.WriteString("\n")
+	}
+
+	switch {
+	case allPassed:
+		sb.WriteString("**All review agents passed.** You may proceed with announcing completion.\n")
+	case anyMissing:
+		sb.WriteString("**One or more review agents are missing from the group results.** Re-run `iris review` or investigate the missing sessions.\n")
+	default:
+		sb.WriteString("**One or more review agents failed.** Fix the blocking issues and re-run `iris review`.\n")
+	}
+
+	fmt.Fprintf(&sb, "\n(group_id=%s, delivery_id=%s)\n", cfg.GroupID, cfg.DeliveryID)
+	return sb.String()
+}
+
+// reviewWatcherOnceMu is a package-level mutex retained for future use if
+// the watcher needs to coordinate across multiple groups (e.g. shared
+// rate limiter on prompt delivery). Currently unused; kept so adding such
+// coordination does not require a new export.
+var reviewWatcherOnceMu sync.Mutex //nolint:unused
+
+// ensureReviewWatcherMuUsed silences the unused-variable lint if the
+// package is built with strict settings. The mutex is reserved for future
+// coordination work and not strictly required today.
+func ensureReviewWatcherMuUsed() { //nolint:unused
+	reviewWatcherOnceMu.Lock()
+	reviewWatcherOnceMu.Unlock()
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -611,6 +611,11 @@ func (s *Supervisor) buildEnv(piConfigDir string) []string {
 	// Set IRIS_DAEMON_SOCK so the prism extension knows to register overrides.
 	env = append(env, "IRIS_DAEMON_SOCK="+s.sess.HarnessSockPath)
 
+	// Set IRIS_SESSION_NAME so in-session CLIs (`iris review`, `iris
+	// escalate`, etc.) can identify their calling session without a tmux
+	// lookup. Mirrors PRISM_SESSION_NAME in the prism harness. (#1694)
+	env = append(env, "IRIS_SESSION_NAME="+s.cfg.SessionName)
+
 	// Set PI_CODING_AGENT_DIR to the per-session config dir so pi loads
 	// the prism extension and any APPEND_SYSTEM.md we write there.
 	if piConfigDir != "" {

--- a/modules/programs/prism/prism/internal/iris/supervisor_testhelpers.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_testhelpers.go
@@ -1,0 +1,38 @@
+package iris
+
+// supervisor_testhelpers.go — test-only constructors that expose enough of
+// the Supervisor surface for cross-package integration tests (cmd/iris,
+// internal/iris/parity) without making the production fields public.
+//
+// These helpers are not gated behind a `_test.go` filename suffix because
+// they are consumed by tests in OTHER packages (cmd/iris), where Go's
+// test-file visibility rules would hide them. They are still strictly
+// for test use — production code does not construct Supervisors this way.
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NewFakeSupervisorForTest returns a Supervisor populated with just enough
+// fields to satisfy the review-spawn orchestrator and other callers that
+// only invoke SessionRecord() / InstanceID(). The returned supervisor has
+// NO running pi child and will NOT respond to SendRPC / Kill.
+//
+// Intended for the integration tests in cmd/iris/review_integration_test.go
+// and internal/iris/parity/. Production callers MUST use SpawnSession or
+// NewSupervisor instead — those construct a fully-wired supervisor with a
+// real harness socket, log file, and child process.
+func NewFakeSupervisorForTest(sessionName, worktree, role string) *Supervisor {
+	return &Supervisor{
+		sess: SessionRecord{
+			InstanceID:  uuid.NewString(),
+			SessionName: sessionName,
+			Worktree:    worktree,
+			Role:        role,
+			State:       StateActive,
+			StartedAt:   time.Now().UTC(),
+		},
+	}
+}


### PR DESCRIPTION
Add `iris review <pr-number>` — the iris-native analogue of `prism review <pr>`. Spawns the 5 canonical review agents under a shared `group_id`, registers them in `session_groups`, and returns immediately with a review-in-progress acknowledgement. A daemon-side watcher polls `db.GroupCompleted` and delivers a single review-complete prompt to the calling session via `prompt_deliver` once every member reaches a terminal state.

This is **pure CLI plumbing** on top of the existing D-10 internals (`internal/iris/review.go`'s `SpawnReviewGroup` + `WatchReviewGroup`).

## What changed

**New wire frames** in `internal/iris/client_protocol.go`:
- `review_spawn` (client → daemon) — parent, pr_number, agents (optional subset), timeout, delivery_id.
- `review_spawned` (daemon → client) — group_id, parent, round, members.

**New daemon-side handler** `handleReviewSpawn` in `internal/iris/client_socket.go` — validates the request and delegates to the configured `SpawnReviewGroup` hook (set by `cmd/iris/main.go` at daemon startup).

**New daemon-side orchestrator** in `internal/iris/review_handler.go`:
- Resolves the agent set (full 5 or `--only` subset).
- Checks for an in-progress group for the parent (rejects with `round N is already in progress` matching prism's behaviour).
- Derives the round number via the shared `review.NextRoundNumber` helper.
- Calls `SpawnReviewGroup` with a `SpawnAgent` closure that names sessions `<parent>~review-N-<agent>`.
- Launches a `WatchReviewGroup` goroutine. The watcher is guarded by `reviewCompleteOnceGuard` (sync.Once) so a defensive double-fire produces exactly one delivery.

**New CLI** `cmd/iris/review.go` with cobra subcommand:
- `--timeout <dur>` per-agent timeout (default 10m).
- `--only <csv>` subset of agents (validated against canonical names BEFORE any wire I/O).
- `--rebase` runs `git fetch && git rebase origin/main && git push --force-with-lease` inline.
- `--socket` override.
- `gh pr view` verification BEFORE spawning anything.
- Canonical `systemctl --user start iris` error when the daemon socket is missing.

**`IRIS_SESSION_NAME` env var** added in `Supervisor.buildEnv` so in-session CLIs (review, future escalate) can identify their calling session without a tmux lookup. One-line addition mirroring `PRISM_SESSION_NAME`.

**Integration tests** in `cmd/iris/review_integration_test.go` (use `iristest.NewIsolated` — no host state touched):
- `TestReview_FullCycle` — spawn 5 agents, transition each to finished, assert **exactly one** review-complete prompt delivered with all roles in the body.
- `TestReview_OnlyFilter` — `--only` subset spawns only the named agents.
- `TestReview_UnknownOnlyAgent` — invalid `--only` exits before any spawn.
- `TestReview_DaemonDown` — missing socket yields the canonical systemctl error.
- `TestReview_NonExistentPR` — PR-not-found exits before any spawn.
- `TestReview_InProgressGroup` — duplicate concurrent round is rejected.

## Exactly-once delivery (inherits #1695)

A `delivery_id` is minted per review run by the CLI and forwarded on the `review_spawn` frame. The daemon embeds it in the review-complete prompt body and in log lines. The watcher's `reviewCompleteOnceGuard` (sync.Once) is the canonical exactly-once boundary for the iris-native delivery path — iris does not route through the prism sidecar, so the dedup at the bus boundary in \#1695 is enforced one layer earlier here.

## Quality gates

- `go build ./...` ✅
- `go test ./cmd/iris/... ./internal/iris/... -race -count=1` ✅ (all 6 new TestReview_* pass)
- `nix build .#iris` ✅

## Out of scope

- Custom review agents (prism hard-codes 5; iris matches).
- Synchronous `--wait` mode.
- `iris reviews list` historical surface.
- Coordinator-side review spawning.

## Pre-existing flake observed

`TestParityRestore_OrphanedToolCallAndRespawn` in `internal/iris/parity/restore_test.go` flaked once with `-race` (`TempDir cleanup: directory not empty` — supervisor goroutine continues writing after `t.Cleanup` tears down the DB and tempdir). Reproducible on `main` without my changes. Escalated to the coordinator informationally — not addressed here.

Closes #1694