### PR TITLE
feat(iris): `iris pr <number>` CLI for fetching PR + spawning a session

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/pr.go
+++ b/modules/programs/prism/prism/cmd/iris/pr.go
@@ -1,0 +1,511 @@
+package main
+
+// pr.go — `iris pr <number>` subcommand.
+//
+// `iris pr <n>` is the iris analogue of `prism pr <n>` (cmd/pr.go). It fetches
+// the PR's head branch via `gh`, sets up a worktree at <bareRoot>/<branch> in
+// the prism bare+worktree layout, and asks the running iris daemon to spawn a
+// session on it. If `--prompt`, `--prompt-file`, or `--prompt -` is given,
+// the prompt is delivered to the freshly-spawned session after the spawn ack.
+//
+// This is a pure CLI wrapper on top of the daemon-routed spawn introduced in
+// #1680 (iris spawn) and the prompt-delivery wire frame introduced in
+// #1677 (iris prompt). No new daemon-side surface is required:
+//
+//   1. CLI resolves the bare repo root from --repo or the working directory.
+//   2. CLI checks `gh` is on PATH (clearer error than the generic exec one).
+//   3. CLI runs `gh pr view <n>` (via internal/git.PRBranch) to resolve the
+//      PR's head branch.
+//   4. CLI either (a) reuses an existing clean worktree for that branch, or
+//      (b) calls git.CreateWorktree(bareRoot, branch) to make one.
+//      Dirty existing worktrees cause a hard refusal.
+//   5. CLI dials the daemon and sends a session_spawn frame for the worktree
+//      — same code path as `iris spawn`.
+//   6. If a prompt was supplied, CLI sends a follow-up prompt_deliver frame.
+//
+// # Edge-case handling (acceptance criteria for issue #1702)
+//
+//   - No such PR     → `gh pr view` exits non-zero; we surface its stderr.
+//   - Daemon down    → canonical "iris daemon not running … systemctl --user
+//                      start iris" error from dialDaemon (shared with spawn).
+//   - Dirty worktree → "worktree dirty" refusal before any spawn frame.
+//   - gh missing     → "gh CLI not found on PATH" before any network call.
+//
+// # Out of scope
+//
+//   - `--review` shortcut. Compose with `--prompt 'review this PR'`.
+//   - Auto-cleanup on PR merge. Handled by the merge queue elsewhere.
+//   - Smart workspace setup (nix develop etc.). Out of scope per the issue.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/git"
+)
+
+// prRole is the agent role used for sessions spawned by `iris pr`. The role is
+// resolved daemon-side by iris.ResolveAgent — for a PR worktree, the basename
+// is the PR branch (never "main"), so it always resolves to "worker".
+const prRole = "worker"
+
+// prCmd is the `iris pr <number>` cobra subcommand.
+var prCmd = &cobra.Command{
+	Use:   "pr <number>",
+	Short: "Fetch a PR branch and spawn an iris session on it",
+	Long: `iris pr fetches the head branch of the named PR (via 'gh pr view') and
+asks the running iris daemon to spawn a session on a worktree for it.
+
+Behaviour:
+
+  iris pr <n>                       fetch + worktree + spawn (no prompt)
+  iris pr <n> --prompt <text>       deliver <text> after spawn acks
+  iris pr <n> --prompt-file <path>  read prompt from file
+  iris pr <n> --prompt -            read prompt from stdin
+  iris pr <n> --repo <repo>         operate on another repo (name under ~/code
+                                    or an absolute path to a prism bare repo)
+
+A single trailing newline is stripped from --prompt-file and --prompt -
+input (matches prism's convention). --prompt and --prompt-file are mutually
+exclusive.
+
+# Worktree reuse
+
+If a worktree for the PR's head branch already exists under <bareRoot>/<branch>
+it is reused — no duplicate is created. If the current working directory is
+that worktree, the spawn happens in place.
+
+If the existing worktree has uncommitted changes (staged or unstaged),
+the command refuses with a "worktree dirty" error rather than silently
+spawning on dirty state.
+
+# Requirements
+
+The 'gh' CLI must be installed and authenticated. The iris daemon must be
+running (start it with 'systemctl --user start iris'). The target repo must
+use the prism bare+worktree layout (a '.bare' directory at the repo root).`,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runPRCmd,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	prCmd.Flags().String(
+		"repo", "",
+		"Target repo: a folder name under ~/code, or an absolute path to a prism bare repo. Defaults to the current working directory's bare root.",
+	)
+	prCmd.Flags().String(
+		"prompt", "",
+		"Text to deliver to the spawned session. Use '-' to read from stdin. Mutually exclusive with --prompt-file.",
+	)
+	prCmd.Flags().String(
+		"prompt-file", "",
+		"Path to a file containing the prompt text. Mutually exclusive with --prompt.",
+	)
+	prCmd.Flags().String(
+		"socket", "",
+		"Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)",
+	)
+	prCmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	rootCmd.AddCommand(prCmd)
+}
+
+// prOptions is the fully-resolved input to runPRAt: positional and flag values
+// parsed and validated, ready to drive the wire path. Bundling them keeps the
+// function signature small and makes the integration test's call-site readable.
+type prOptions struct {
+	PRNumber  string
+	BareRoot  string
+	Prompt    string
+	HasPrompt bool
+	SockPath  string
+	HomeDir   string // used to expand "~/" in --repo for tests
+	CWD       string // used for in-place detection
+
+	// GHLookPath stubs exec.LookPath("gh") for tests. Defaults to exec.LookPath.
+	GHLookPath func(string) (string, error)
+
+	// ResolveBranch stubs the PR-number → branch resolution for tests. Defaults
+	// to a wrapper around git.PRBranch (which shells out to `gh pr view`). The
+	// integration test substitutes an in-memory stub so it does not need a real
+	// gh CLI or network access.
+	ResolveBranch func(bareRoot, prNumber string) (string, error)
+}
+
+// runPRCmd is the cobra entry point. It marshals flags into prOptions and
+// delegates to runPRAt for the wire path so the integration test can drive
+// the same code against an in-process ClientSocket.
+func runPRCmd(cmd *cobra.Command, args []string) error {
+	prNumber := args[0]
+	if prNumber == "" {
+		return errors.New("iris pr: <number> is required")
+	}
+
+	repoFlag, _ := cmd.Flags().GetString("repo")
+	bareRoot, err := resolvePRBareRoot(repoFlag, "", "")
+	if err != nil {
+		return err
+	}
+
+	promptText, hasPrompt, err := resolvePRPromptInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	cwd, _ := os.Getwd()
+	opts := prOptions{
+		PRNumber:      prNumber,
+		BareRoot:      bareRoot,
+		Prompt:        promptText,
+		HasPrompt:     hasPrompt,
+		SockPath:      resolveSocketPath(cmd),
+		CWD:           cwd,
+		GHLookPath:    exec.LookPath,
+		ResolveBranch: resolvePRBranchVerbose,
+	}
+	return runPRAt(cmd.Context(), opts, os.Stdout)
+}
+
+// resolvePRPromptInput reads --prompt, --prompt-file, or --prompt - (stdin).
+// It is the same surface as resolveIrisPromptInput in prompt.go but also
+// returns a `hasPrompt` discriminator so the caller can distinguish "no
+// prompt requested" from "explicit empty prompt" — the post-spawn delivery
+// is only attempted when hasPrompt is true.
+//
+// A single trailing newline is stripped from file/stdin input (matches
+// prism's prompt_input.go convention).
+//
+// Mutual exclusion of --prompt vs --prompt-file is enforced by cobra before
+// RunE is called.
+func resolvePRPromptInput(cmd *cobra.Command) (text string, hasPrompt bool, err error) {
+	promptFile, _ := cmd.Flags().GetString("prompt-file")
+	promptText, _ := cmd.Flags().GetString("prompt")
+
+	if promptFile != "" {
+		data, readErr := os.ReadFile(promptFile)
+		if readErr != nil {
+			return "", false, fmt.Errorf("read prompt file %q: %w", promptFile, readErr)
+		}
+		return strings.TrimSuffix(string(data), "\n"), true, nil
+	}
+
+	if cmd.Flags().Changed("prompt") {
+		if promptText == "-" {
+			data, readErr := io.ReadAll(os.Stdin)
+			if readErr != nil {
+				return "", false, fmt.Errorf("read prompt from stdin: %w", readErr)
+			}
+			return strings.TrimSuffix(string(data), "\n"), true, nil
+		}
+		return promptText, true, nil
+	}
+
+	return "", false, nil
+}
+
+// resolvePRBareRoot resolves the bare repo root to operate on:
+//
+//   - If repoFlag is non-empty, treat it as a shorthand under ~/code (or
+//     other prism project locations are not honoured here — iris does not
+//     load prism's config.json) or as an absolute path.
+//   - Otherwise, walk up from CWD looking for a .bare entry.
+//
+// homeDirOverride and cwdOverride are test hooks. Both default to the real
+// $HOME / os.Getwd() when empty.
+func resolvePRBareRoot(repoFlag, homeDirOverride, cwdOverride string) (string, error) {
+	home := homeDirOverride
+	if home == "" {
+		home, _ = os.UserHomeDir()
+	}
+
+	if repoFlag != "" {
+		// Expand "~/" if the user typed it.
+		candidate := repoFlag
+		if strings.HasPrefix(candidate, "~/") && home != "" {
+			candidate = filepath.Join(home, candidate[2:])
+		}
+		if filepath.IsAbs(candidate) {
+			if git.IsBareRepo(candidate) {
+				return candidate, nil
+			}
+			return "", fmt.Errorf("iris pr: %s is not a prism bare repo (missing .bare/)", candidate)
+		}
+		// Shorthand: only look under ~/code (iris does not load prism's
+		// ProjectLocations config — keep the lookup table small and
+		// predictable). If the user wants a non-~/code repo, they pass an
+		// absolute path.
+		if home != "" {
+			p := filepath.Join(home, "code", candidate)
+			if git.IsBareRepo(p) {
+				return p, nil
+			}
+		}
+		return "", fmt.Errorf("iris pr: repo %q not found under ~/code (pass an absolute path for repos outside ~/code)", repoFlag)
+	}
+
+	cwd := cwdOverride
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("iris pr: get working directory: %w", err)
+		}
+	}
+	bareRoot := git.BareRoot(cwd)
+	if bareRoot == "" {
+		// Maybe cwd is itself the bare root.
+		if git.IsBareRepo(cwd) {
+			return cwd, nil
+		}
+		return "", fmt.Errorf("iris pr: current directory %s is not inside a prism bare repo; pass --repo <name|path>", cwd)
+	}
+	return bareRoot, nil
+}
+
+// findExistingWorktreeForBranch scans the bare repo's worktree list and
+// returns the path of the worktree currently checked out at branch, or "" if
+// none. We match by SymbolicRef rather than by directory name because a user
+// may have renamed the worktree directory after `git worktree add`.
+func findExistingWorktreeForBranch(bareRoot, branch string) string {
+	for _, wt := range git.Worktrees(bareRoot) {
+		ref, err := git.SymbolicRef(wt)
+		if err != nil {
+			continue
+		}
+		if ref == "refs/heads/"+branch {
+			return wt
+		}
+	}
+	return ""
+}
+
+// runPRAt is the testable core of `iris pr`. It is invoked by both the cobra
+// RunE wrapper and the integration test. opts is fully resolved; out is the
+// stdout writer that captures human-readable progress output.
+//
+// Phases:
+//
+//  1. Verify the gh CLI is available (defensive: gives a clearer error than
+//     the generic "executable file not found in $PATH" from gh-pr-view).
+//  2. Resolve the PR's head branch via gh.
+//  3. Find or create the worktree:
+//     - If a worktree for the branch already exists, reject if dirty.
+//     - Otherwise call git.CreateWorktree.
+//  4. Dial the daemon and send session_spawn (reuse the spawn.go helpers).
+//  5. On ack, if a prompt was supplied, send prompt_deliver on a fresh conn.
+func runPRAt(ctx context.Context, opts prOptions, out io.Writer) error {
+	if opts.PRNumber == "" {
+		return errors.New("iris pr: <number> is required")
+	}
+	if opts.BareRoot == "" {
+		return errors.New("iris pr: bare root not resolved")
+	}
+
+	lookPath := opts.GHLookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	if _, err := lookPath("gh"); err != nil {
+		return fmt.Errorf(
+			"iris pr: 'gh' CLI not found on PATH — install GitHub CLI and run 'gh auth login' first (%w)",
+			err,
+		)
+	}
+
+	// Resolve PR → branch. The default implementation calls git.PRBranch which
+	// shells out to `gh pr view --json headRefName`. Tests inject a stub via
+	// opts.ResolveBranch to avoid needing a real gh CLI / network call.
+	resolveBranch := opts.ResolveBranch
+	if resolveBranch == nil {
+		resolveBranch = resolvePRBranchVerbose
+	}
+	fmt.Fprintf(out, "[iris pr] resolving PR #%s in %s...\n", opts.PRNumber, filepath.Base(opts.BareRoot))
+	branch, err := resolveBranch(opts.BareRoot, opts.PRNumber)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "[iris pr] PR #%s → branch %q\n", opts.PRNumber, branch)
+
+	// Find or create the worktree for that branch.
+	worktree, reused, err := acquireWorktreeForBranch(opts.BareRoot, branch, out)
+	if err != nil {
+		return err
+	}
+	if reused {
+		// AC: when the PR branch matches the CWD's worktree, spawn in-place
+		// (no re-checkout). The "no re-checkout" semantics are automatic
+		// because acquireWorktreeForBranch did not create a new worktree.
+		// We surface the in-place detail only as informational output.
+		if opts.CWD != "" {
+			if cwdMatch, _ := samePath(opts.CWD, worktree); cwdMatch {
+				fmt.Fprintf(out, "[iris pr] current directory matches PR worktree; spawning in place\n")
+			}
+		}
+	}
+
+	// Dial the daemon and send session_spawn. We re-use the existing helpers
+	// from spawn.go (dialDaemon, sendSpawnFrame, readSpawnAck) so the wire
+	// behaviour stays identical to `iris spawn`.
+	conn, err := dialDaemon(ctx, opts.SockPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := sendSpawnFrame(conn, worktree, prRole); err != nil {
+		return fmt.Errorf("iris pr: send spawn frame: %w", err)
+	}
+	sessionName, instanceID, err := readSpawnAck(ctx, conn)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "[iris pr] session %s spawned (instance_id=%s, worktree=%s)\n",
+		sessionName, instanceID, worktree)
+
+	// Optional follow-up: deliver the prompt to the freshly spawned session.
+	if opts.HasPrompt {
+		if err := deliverPRPrompt(ctx, opts.SockPath, sessionName, opts.Prompt); err != nil {
+			// The spawn already succeeded — surface the delivery failure but
+			// don't pretend the session didn't get created.
+			return fmt.Errorf("iris pr: session %s spawned but prompt delivery failed: %w", sessionName, err)
+		}
+		fmt.Fprintf(out, "[iris pr] prompt delivered to %s\n", sessionName)
+	}
+
+	return nil
+}
+
+// resolvePRBranchVerbose wraps git.PRBranch with a more useful error message
+// when gh exits non-zero (the common case being "no such PR"). git.PRBranch
+// only returns a generic "gh pr view: exit status 1" today; we re-run gh
+// directly to surface its stderr to the user.
+func resolvePRBranchVerbose(bareRoot, prNumber string) (string, error) {
+	branch, err := git.PRBranch(bareRoot, prNumber)
+	if err == nil {
+		if branch == "" {
+			return "", fmt.Errorf("iris pr: gh pr view returned an empty branch name for PR #%s", prNumber)
+		}
+		return branch, nil
+	}
+	// Re-run gh to capture stderr for a clearer error.
+	remoteURL, urlErr := runGitCmd(bareRoot, "config", "--get", "remote.origin.url")
+	if urlErr != nil || remoteURL == "" {
+		return "", fmt.Errorf("iris pr: could not resolve PR #%s (%w)", prNumber, err)
+	}
+	cmd := exec.Command("gh", "pr", "view", prNumber,
+		"--repo", strings.TrimSpace(remoteURL),
+		"--json", "headRefName", "--jq", ".headRefName")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if _, runErr := cmd.Output(); runErr != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return "", fmt.Errorf("iris pr: could not resolve PR #%s: %s", prNumber, stderrText)
+		}
+		return "", fmt.Errorf("iris pr: could not resolve PR #%s (%w)", prNumber, runErr)
+	}
+	// gh succeeded on the retry — odd, but return the original error if
+	// branch is still empty.
+	return "", fmt.Errorf("iris pr: could not resolve PR #%s (%w)", prNumber, err)
+}
+
+// runGitCmd shells out to `git -C <bareRoot> <args...>` and returns trimmed
+// stdout. This is used only by resolvePRBranchVerbose to fetch the remote URL
+// when the primary lookup has already failed; the normal happy path goes
+// through internal/git helpers.
+func runGitCmd(bareRoot string, args ...string) (string, error) {
+	// The bare repo lives at <bareRoot>/.bare in the prism layout. Use
+	// --git-dir directly so we don't depend on `git -C` finding it.
+	bareDir := filepath.Join(bareRoot, ".bare")
+	full := append([]string{"--git-dir", bareDir}, args...)
+	out, err := exec.Command("git", full...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// acquireWorktreeForBranch returns a worktree path for the given branch in
+// the bare repo, reusing an existing one if present and clean. Returns
+// (path, reused, err). On a dirty existing worktree it refuses.
+func acquireWorktreeForBranch(bareRoot, branch string, out io.Writer) (string, bool, error) {
+	if existing := findExistingWorktreeForBranch(bareRoot, branch); existing != "" {
+		// Reject if the existing worktree has uncommitted changes — silently
+		// spawning on dirty state would surprise the user.
+		stat, err := git.Stat(existing)
+		if err != nil {
+			return "", false, fmt.Errorf("iris pr: stat existing worktree %s: %w", existing, err)
+		}
+		if stat.Files > 0 {
+			return "", false, fmt.Errorf(
+				"iris pr: existing worktree for branch %q at %s is dirty (%s) — commit, stash, or `git restore` first",
+				branch, existing, stat.String(),
+			)
+		}
+		fmt.Fprintf(out, "[iris pr] reusing existing worktree at %s\n", existing)
+		return existing, true, nil
+	}
+
+	fmt.Fprintf(out, "[iris pr] creating worktree for branch %q...\n", branch)
+	worktree, err := git.CreateWorktree(bareRoot, branch)
+	if err != nil {
+		return "", false, fmt.Errorf("iris pr: create worktree: %w", err)
+	}
+	fmt.Fprintf(out, "[iris pr] worktree at %s\n", worktree)
+	return worktree, false, nil
+}
+
+// samePath compares two paths for filesystem equality after Abs + symlink-aware
+// normalisation. Returns (true, nil) when the paths refer to the same location.
+// Errors fall through as (false, err); callers may treat any error as "not
+// the same path" since the worst case is a redundant message line.
+func samePath(a, b string) (bool, error) {
+	absA, err := filepath.Abs(a)
+	if err != nil {
+		return false, err
+	}
+	absB, err := filepath.Abs(b)
+	if err != nil {
+		return false, err
+	}
+	if absA == absB {
+		return true, nil
+	}
+	realA, _ := filepath.EvalSymlinks(absA)
+	realB, _ := filepath.EvalSymlinks(absB)
+	return realA != "" && realA == realB, nil
+}
+
+// deliverPRPrompt sends a prompt_deliver frame for sessionName/promptText on a
+// fresh connection. It mirrors the shape of `iris prompt`'s send path but uses
+// a slightly tighter ack window because the spawn ack has just told us the
+// session exists and is live — the only reason for an error frame here would
+// be an internal daemon failure.
+func deliverPRPrompt(ctx context.Context, sockPath, sessionName, promptText string) error {
+	conn, err := dialDaemonForPrompt(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := sendPromptDeliverFrame(conn, sessionName, promptText); err != nil {
+		return err
+	}
+
+	// Brief read window matches `iris prompt`: no news (timeout) means
+	// success; an error frame is surfaced; an early EOF is a lost connection.
+	ackCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	return readPromptAck(ackCtx, conn)
+}

--- a/modules/programs/prism/prism/cmd/iris/pr_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/pr_integration_test.go
@@ -1,0 +1,502 @@
+package main
+
+// pr_integration_test.go — end-to-end test of `iris pr <number>` against a
+// real iris.ClientSocket and a real bare git repo on disk (issue #1702).
+//
+// The test stands up:
+//
+//   1. A real bare+worktree git repo (created with `git init --bare` + an
+//      initial commit on main) so git.PRBranch's caller-supplied stub can
+//      return a real branch name and git.CreateWorktree can actually create
+//      a directory.
+//   2. An in-process iris.ClientSocket whose SpawnSession and DeliverPrompt
+//      callbacks are recorders.
+//   3. Both halves are driven by runPRAt — which uses prOptions.ResolveBranch
+//      to stub the `gh pr view` call, and prOptions.GHLookPath to stub the
+//      `gh` PATH check.
+//
+// What this proves:
+//   - The CLI passes the resolved worktree path to the daemon's session_spawn
+//     handler — BareRoot propagation is therefore correct (daemon-side, by
+//     #1680).
+//   - When --prompt is given, prompt_deliver follows the spawn ack with the
+//     same session name returned in the spawn frame.
+//   - Existing-worktree reuse works (second invocation does not create a
+//     duplicate).
+//   - A dirty existing worktree refuses without spawning.
+//   - A daemon-down dial produces the canonical wording.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// prTestEnv bundles the temp dirs, bare repo, and live daemon socket used by
+// the integration tests so each test reads cleanly.
+type prTestEnv struct {
+	bareRoot   string
+	branch     string
+	sockPath   string
+	spawnCalls *int
+	spawnArgs  *[]spawnCall
+	deliver    *[]deliverCall
+	mu         *sync.Mutex
+}
+
+type spawnCall struct {
+	worktree string
+	role     string
+}
+
+type deliverCall struct {
+	name string
+	text string
+}
+
+// newPRTestEnv creates a bare git repo with a single PR-branch commit and
+// stands up an in-process iris.ClientSocket on a tempdir socket. Returns the
+// env handle and the resolved branch name (which the test stub
+// ResolveBranch should return).
+func newPRTestEnv(t *testing.T) *prTestEnv {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH — skipping integration test")
+	}
+
+	// Short prefix so the AF_UNIX path stays under 108 bytes.
+	shortPrefix, err := os.MkdirTemp("", "iris-pr-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortPrefix) })
+
+	bareRoot := filepath.Join(shortPrefix, "myrepo")
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if err := os.MkdirAll(bareRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll bareRoot: %v", err)
+	}
+	if out, err := exec.Command("git", "init", "--bare", "-b", "main", bareDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+
+	// Initial commit on main via an orphan worktree, then remove the worktree.
+	initDir := filepath.Join(shortPrefix, "init-checkout")
+	if out, err := exec.Command("git", "--git-dir", bareDir, "worktree",
+		"add", "--orphan", "-b", "main", initDir).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add orphan: %v\n%s", err, out)
+	}
+	cfg := []string{
+		"-C", initDir,
+		"-c", "user.email=test@test.com",
+		"-c", "user.name=Test",
+		"-c", "commit.gpgsign=false",
+	}
+	if out, err := exec.Command("git", append(cfg,
+		"commit", "--allow-empty", "-m", "init")...).CombinedOutput(); err != nil {
+		t.Fatalf("git commit init: %v\n%s", err, out)
+	}
+
+	// Create the PR's head branch as a local ref so git.CreateWorktree can
+	// check it out without needing a remote. (The shim ResolveBranch stub
+	// will return this branch name as the resolved head.)
+	const branch = "feat/pr-1234"
+	if out, err := exec.Command("git", "--git-dir", bareDir, "branch",
+		branch, "main").CombinedOutput(); err != nil {
+		t.Fatalf("git branch: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "--git-dir", bareDir, "worktree",
+		"remove", "--force", initDir).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree remove init: %v\n%s", err, out)
+	}
+
+	// Stand up the in-process daemon socket.
+	dbPath := filepath.Join(shortPrefix, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	sockPath := filepath.Join(shortPrefix, "iris.sock")
+	runDir := filepath.Join(shortPrefix, "run")
+
+	mu := &sync.Mutex{}
+	spawnCalls := new(int)
+	spawnArgs := new([]spawnCall)
+	deliver := new([]deliverCall)
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			// Return a snapshot containing whatever spawns have happened so
+			// far so that the post-spawn `iris prompt` path (which calls
+			// sessions_list first) can find the freshly spawned session.
+			mu.Lock()
+			defer mu.Unlock()
+			out := make([]iris.SessionSnapshot, 0, *spawnCalls)
+			for _, sc := range *spawnArgs {
+				out = append(out, iris.SessionSnapshot{
+					Name:       "iris-" + sc.role + "@" + filepath.Base(sc.worktree),
+					InstanceID: "test-instance-" + sc.role,
+					State:      "active",
+					Role:       sc.role,
+					Worktree:   sc.worktree,
+					StartedAt:  time.Now().UTC().Format(time.RFC3339),
+				})
+			}
+			return out
+		},
+		SpawnSession: func(ctx context.Context, worktree, role string, _ map[string]any) (*iris.Supervisor, error) {
+			mu.Lock()
+			*spawnCalls++
+			*spawnArgs = append(*spawnArgs, spawnCall{worktree: worktree, role: role})
+			mu.Unlock()
+			// Build a minimal supervisor. PIBinaryPath=/bin/true means the
+			// child would exit immediately, but we never call Start() —
+			// NewSupervisor only binds the per-session harness socket.
+			return iris.NewSupervisor(iris.SupervisorConfig{
+				SessionName:  "iris-" + role + "@" + filepath.Base(worktree),
+				Worktree:     worktree,
+				Role:         role,
+				BareRoot:     bareRoot,
+				PIBinaryPath: "/bin/true",
+				RunDir:       runDir,
+				Database:     database,
+			})
+		},
+		DeliverPrompt: func(_ context.Context, name, text, _ string, _ []string) error {
+			mu.Lock()
+			*deliver = append(*deliver, deliverCall{name: name, text: text})
+			mu.Unlock()
+			return nil
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+	t.Cleanup(srvCancel)
+	go cs.Serve(srvCtx)
+
+	return &prTestEnv{
+		bareRoot:   bareRoot,
+		branch:     branch,
+		sockPath:   sockPath,
+		spawnCalls: spawnCalls,
+		spawnArgs:  spawnArgs,
+		deliver:    deliver,
+		mu:         mu,
+	}
+}
+
+// stubGHFound stubs prOptions.GHLookPath to pretend `gh` is on PATH.
+func stubGHFound(string) (string, error) { return "/usr/bin/gh", nil }
+
+// stubGHMissing stubs prOptions.GHLookPath to pretend `gh` is NOT on PATH.
+func stubGHMissing(string) (string, error) {
+	return "", errors.New(`exec: "gh": executable file not found in $PATH`)
+}
+
+// TestPR_HappyPath_NoPrompt drives the full wire path with no --prompt flag:
+// branch resolves, worktree is created, daemon receives session_spawn with
+// the worktree path, and DeliverPrompt is NEVER invoked.
+func TestPR_HappyPath_NoPrompt(t *testing.T) {
+	env := newPRTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	opts := prOptions{
+		PRNumber:      "1234",
+		BareRoot:      env.bareRoot,
+		SockPath:      env.sockPath,
+		GHLookPath:    stubGHFound,
+		ResolveBranch: func(_, _ string) (string, error) { return env.branch, nil },
+	}
+	if err := runPRAt(ctx, opts, &out); err != nil {
+		t.Fatalf("runPRAt: %v\nstdout: %s", err, out.String())
+	}
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if *env.spawnCalls != 1 {
+		t.Errorf("spawn calls = %d, want 1", *env.spawnCalls)
+	}
+	wantWorktree := filepath.Join(env.bareRoot, env.branch)
+	if got := (*env.spawnArgs)[0].worktree; got != wantWorktree {
+		t.Errorf("spawn worktree = %q, want %q", got, wantWorktree)
+	}
+	if got := (*env.spawnArgs)[0].role; got != "worker" {
+		t.Errorf("spawn role = %q, want %q", got, "worker")
+	}
+	if len(*env.deliver) != 0 {
+		t.Errorf("DeliverPrompt invoked %d times without --prompt; want 0", len(*env.deliver))
+	}
+	// Worktree directory should now exist on disk.
+	if _, err := os.Stat(wantWorktree); err != nil {
+		t.Errorf("expected worktree at %s: %v", wantWorktree, err)
+	}
+	// Output should include the session UUID and worktree path.
+	stdout := out.String()
+	if !strings.Contains(stdout, "spawned") {
+		t.Errorf("expected 'spawned' in stdout, got %q", stdout)
+	}
+	if !strings.Contains(stdout, wantWorktree) {
+		t.Errorf("expected worktree path %q in stdout, got %q", wantWorktree, stdout)
+	}
+}
+
+// TestPR_HappyPath_WithPrompt asserts that --prompt is delivered to the
+// freshly spawned session after the spawn ack.
+func TestPR_HappyPath_WithPrompt(t *testing.T) {
+	env := newPRTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const promptBody = "review this PR"
+	var out bytes.Buffer
+	opts := prOptions{
+		PRNumber:      "1234",
+		BareRoot:      env.bareRoot,
+		SockPath:      env.sockPath,
+		Prompt:        promptBody,
+		HasPrompt:     true,
+		GHLookPath:    stubGHFound,
+		ResolveBranch: func(_, _ string) (string, error) { return env.branch, nil },
+	}
+	if err := runPRAt(ctx, opts, &out); err != nil {
+		t.Fatalf("runPRAt: %v\nstdout: %s", err, out.String())
+	}
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if *env.spawnCalls != 1 {
+		t.Errorf("spawn calls = %d, want 1", *env.spawnCalls)
+	}
+	if len(*env.deliver) != 1 {
+		t.Fatalf("DeliverPrompt invoked %d times, want 1; spawn calls=%d", len(*env.deliver), *env.spawnCalls)
+	}
+	if got := (*env.deliver)[0].text; got != promptBody {
+		t.Errorf("delivered text = %q, want %q", got, promptBody)
+	}
+	wantSessionName := "iris-worker@" + env.branch
+	// Branch name has a slash so basename is the trailing component.
+	wantSessionName = "iris-worker@" + filepath.Base(env.branch)
+	if got := (*env.deliver)[0].name; got != wantSessionName {
+		t.Errorf("delivered name = %q, want %q", got, wantSessionName)
+	}
+	if !strings.Contains(out.String(), "prompt delivered") {
+		t.Errorf("expected 'prompt delivered' in stdout, got %q", out.String())
+	}
+}
+
+// TestPR_WorktreeReuse asserts that a second invocation against the same PR
+// reuses the existing worktree (no duplicate spawn-side worktree path
+// mismatch, no error).
+func TestPR_WorktreeReuse(t *testing.T) {
+	env := newPRTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	opts := prOptions{
+		PRNumber:      "1234",
+		BareRoot:      env.bareRoot,
+		SockPath:      env.sockPath,
+		GHLookPath:    stubGHFound,
+		ResolveBranch: func(_, _ string) (string, error) { return env.branch, nil },
+	}
+	var out1 bytes.Buffer
+	if err := runPRAt(ctx, opts, &out1); err != nil {
+		t.Fatalf("first runPRAt: %v", err)
+	}
+	var out2 bytes.Buffer
+	if err := runPRAt(ctx, opts, &out2); err != nil {
+		t.Fatalf("second runPRAt: %v\nstdout=%s", err, out2.String())
+	}
+	if !strings.Contains(out2.String(), "reusing existing worktree") {
+		t.Errorf("expected reuse message in second-call stdout, got %q", out2.String())
+	}
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if *env.spawnCalls != 2 {
+		t.Errorf("spawn calls = %d, want 2", *env.spawnCalls)
+	}
+	// Both spawns must target the same worktree path.
+	if (*env.spawnArgs)[0].worktree != (*env.spawnArgs)[1].worktree {
+		t.Errorf("spawn worktrees differ: %q vs %q",
+			(*env.spawnArgs)[0].worktree, (*env.spawnArgs)[1].worktree)
+	}
+}
+
+// TestPR_DirtyWorktreeRefused asserts that a dirty existing worktree is
+// refused before any spawn frame is sent.
+func TestPR_DirtyWorktreeRefused(t *testing.T) {
+	env := newPRTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// First call creates the worktree cleanly.
+	opts := prOptions{
+		PRNumber:      "1234",
+		BareRoot:      env.bareRoot,
+		SockPath:      env.sockPath,
+		GHLookPath:    stubGHFound,
+		ResolveBranch: func(_, _ string) (string, error) { return env.branch, nil },
+	}
+	var out1 bytes.Buffer
+	if err := runPRAt(ctx, opts, &out1); err != nil {
+		t.Fatalf("first runPRAt: %v", err)
+	}
+	worktree := filepath.Join(env.bareRoot, env.branch)
+
+	// Dirty the worktree: add a tracked file then modify it after committing.
+	// Easier: just write an untracked file — git diff --numstat HEAD reports
+	// untracked? It does NOT. We need a modification to a tracked file or a
+	// staged add. Use `git add` of a new file to make it appear in
+	// `--cached`.
+	junkPath := filepath.Join(worktree, "junk.txt")
+	if err := os.WriteFile(junkPath, []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write junk.txt: %v", err)
+	}
+	if out, err := exec.Command("git",
+		"-C", worktree,
+		"-c", "user.email=test@test.com",
+		"-c", "user.name=Test",
+		"add", "junk.txt").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+
+	// Reset spawn counter so we can assert that no NEW spawn happened.
+	env.mu.Lock()
+	startSpawns := *env.spawnCalls
+	startDelivers := len(*env.deliver)
+	env.mu.Unlock()
+
+	var out2 bytes.Buffer
+	err := runPRAt(ctx, opts, &out2)
+	if err == nil {
+		t.Fatalf("runPRAt: want dirty-worktree error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dirty") {
+		t.Errorf("error missing 'dirty' wording: %q", err.Error())
+	}
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if *env.spawnCalls != startSpawns {
+		t.Errorf("spawn calls = %d, want unchanged from %d", *env.spawnCalls, startSpawns)
+	}
+	if len(*env.deliver) != startDelivers {
+		t.Errorf("deliver calls = %d, want unchanged from %d", len(*env.deliver), startDelivers)
+	}
+}
+
+// TestPR_GHMissing asserts that a missing `gh` CLI produces the documented
+// error without dialling the daemon.
+func TestPR_GHMissing(t *testing.T) {
+	env := newPRTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	opts := prOptions{
+		PRNumber:      "1234",
+		BareRoot:      env.bareRoot,
+		SockPath:      env.sockPath,
+		GHLookPath:    stubGHMissing,
+		ResolveBranch: func(_, _ string) (string, error) { return env.branch, nil },
+	}
+	var out bytes.Buffer
+	err := runPRAt(ctx, opts, &out)
+	if err == nil {
+		t.Fatalf("runPRAt: want gh-missing error, got nil")
+	}
+	if !strings.Contains(err.Error(), "gh") {
+		t.Errorf("error missing 'gh' wording: %q", err.Error())
+	}
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if *env.spawnCalls != 0 {
+		t.Errorf("spawn calls = %d, want 0 (gh missing should short-circuit)", *env.spawnCalls)
+	}
+}
+
+// TestPR_NoSuchPR asserts that a branch-resolver error (e.g. gh saying the PR
+// doesn't exist) is surfaced cleanly and no worktree is created.
+func TestPR_NoSuchPR(t *testing.T) {
+	env := newPRTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	opts := prOptions{
+		PRNumber:   "9999",
+		BareRoot:   env.bareRoot,
+		SockPath:   env.sockPath,
+		GHLookPath: stubGHFound,
+		ResolveBranch: func(_, _ string) (string, error) {
+			return "", errors.New("iris pr: could not resolve PR #9999: no pull requests found for branch")
+		},
+	}
+	var out bytes.Buffer
+	err := runPRAt(ctx, opts, &out)
+	if err == nil {
+		t.Fatalf("runPRAt: want no-such-PR error, got nil")
+	}
+	if !strings.Contains(err.Error(), "9999") {
+		t.Errorf("error missing PR number: %q", err.Error())
+	}
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	if *env.spawnCalls != 0 {
+		t.Errorf("spawn calls = %d, want 0 (resolver error should short-circuit)", *env.spawnCalls)
+	}
+}
+
+// TestPR_DaemonNotRunning asserts that pointing at a non-existent socket path
+// surfaces the canonical "daemon not running … systemctl --user start iris"
+// wording.
+func TestPR_DaemonNotRunning(t *testing.T) {
+	env := newPRTestEnv(t)
+	// Replace sockPath with a non-existent path so the dial fails.
+	missingSock := filepath.Join(filepath.Dir(env.sockPath), "no-such-iris.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	opts := prOptions{
+		PRNumber:      "1234",
+		BareRoot:      env.bareRoot,
+		SockPath:      missingSock,
+		GHLookPath:    stubGHFound,
+		ResolveBranch: func(_, _ string) (string, error) { return env.branch, nil },
+	}
+	var out bytes.Buffer
+	err := runPRAt(ctx, opts, &out)
+	if err == nil {
+		t.Fatalf("runPRAt: want daemon-not-running error, got nil")
+	}
+	if !strings.Contains(err.Error(), "iris daemon not running") {
+		t.Errorf("error missing 'iris daemon not running' wording: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "systemctl --user start iris") {
+		t.Errorf("error missing systemctl hint: %q", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/pr_test.go
+++ b/modules/programs/prism/prism/cmd/iris/pr_test.go
@@ -1,0 +1,166 @@
+package main
+
+// pr_test.go — unit tests for the small helpers in pr.go that don't need a
+// live socket / git repo. The end-to-end wire path is exercised by
+// pr_integration_test.go.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolvePRBareRoot_RepoFlagAbsolute asserts that an absolute path is
+// accepted when it points at a prism bare repo.
+func TestResolvePRBareRoot_RepoFlagAbsolute(t *testing.T) {
+	tmp := t.TempDir()
+	bareRoot := filepath.Join(tmp, "myrepo")
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	got, err := resolvePRBareRoot(bareRoot, "", "")
+	if err != nil {
+		t.Fatalf("resolvePRBareRoot: %v", err)
+	}
+	if got != bareRoot {
+		t.Errorf("got %q, want %q", got, bareRoot)
+	}
+}
+
+// TestResolvePRBareRoot_RepoFlagShorthand asserts that a shorthand name is
+// resolved under ~/code (with $HOME pointed at a tempdir).
+func TestResolvePRBareRoot_RepoFlagShorthand(t *testing.T) {
+	tmp := t.TempDir()
+	bareRoot := filepath.Join(tmp, "code", "myrepo")
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	got, err := resolvePRBareRoot("myrepo", tmp, "")
+	if err != nil {
+		t.Fatalf("resolvePRBareRoot: %v", err)
+	}
+	if got != bareRoot {
+		t.Errorf("got %q, want %q", got, bareRoot)
+	}
+}
+
+// TestResolvePRBareRoot_RepoFlagTildeExpansion asserts that "~/code/X" expands
+// using the supplied home dir override (test-friendly hook).
+func TestResolvePRBareRoot_RepoFlagTildeExpansion(t *testing.T) {
+	tmp := t.TempDir()
+	bareRoot := filepath.Join(tmp, "code", "myrepo")
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	got, err := resolvePRBareRoot("~/code/myrepo", tmp, "")
+	if err != nil {
+		t.Fatalf("resolvePRBareRoot: %v", err)
+	}
+	if got != bareRoot {
+		t.Errorf("got %q, want %q", got, bareRoot)
+	}
+}
+
+// TestResolvePRBareRoot_AbsoluteNonBareRepoRejected asserts that an absolute
+// path without a .bare/ entry is rejected with a clear error.
+func TestResolvePRBareRoot_AbsoluteNonBareRepoRejected(t *testing.T) {
+	tmp := t.TempDir() // No .bare/ inside.
+	_, err := resolvePRBareRoot(tmp, "", "")
+	if err == nil {
+		t.Fatalf("want error for non-bare repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a prism bare repo") {
+		t.Errorf("error missing 'not a prism bare repo' wording: %q", err.Error())
+	}
+}
+
+// TestResolvePRBareRoot_ShorthandNotFound asserts that a shorthand that does
+// not exist under ~/code returns a helpful error message.
+func TestResolvePRBareRoot_ShorthandNotFound(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := resolvePRBareRoot("does-not-exist", tmp, "")
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found under ~/code") {
+		t.Errorf("error missing '~/code' hint: %q", err.Error())
+	}
+}
+
+// TestResolvePRBareRoot_CWDInsideWorktree asserts that the bare-root walk
+// finds the parent directory when cwd is a worktree inside a bare layout.
+func TestResolvePRBareRoot_CWDInsideWorktree(t *testing.T) {
+	tmp := t.TempDir()
+	bareRoot := filepath.Join(tmp, "myrepo")
+	worktree := filepath.Join(bareRoot, "feature")
+	if err := os.MkdirAll(filepath.Join(bareRoot, ".bare"), 0o755); err != nil {
+		t.Fatalf("MkdirAll .bare: %v", err)
+	}
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktree: %v", err)
+	}
+
+	got, err := resolvePRBareRoot("", "", worktree)
+	if err != nil {
+		t.Fatalf("resolvePRBareRoot: %v", err)
+	}
+	if got != bareRoot {
+		t.Errorf("got %q, want %q", got, bareRoot)
+	}
+}
+
+// TestResolvePRBareRoot_CWDNotInRepo asserts that a cwd outside any prism
+// bare repo produces a clear "pass --repo" hint.
+func TestResolvePRBareRoot_CWDNotInRepo(t *testing.T) {
+	tmp := t.TempDir() // no .bare/ anywhere in this tree
+	_, err := resolvePRBareRoot("", "", tmp)
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--repo") {
+		t.Errorf("error missing '--repo' hint: %q", err.Error())
+	}
+}
+
+// TestSamePath_Identical asserts that two distinct strings resolving to the
+// same absolute path compare equal.
+func TestSamePath_Identical(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "x")
+	if err := os.MkdirAll(a, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Same path, different forms.
+	b := filepath.Join(tmp, "y", "..", "x")
+	same, err := samePath(a, b)
+	if err != nil {
+		t.Fatalf("samePath: %v", err)
+	}
+	if !same {
+		t.Errorf("expected samePath(%q, %q) = true", a, b)
+	}
+}
+
+// TestSamePath_Different asserts that two distinct paths compare unequal.
+func TestSamePath_Different(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "x")
+	b := filepath.Join(tmp, "y")
+	if err := os.MkdirAll(a, 0o755); err != nil {
+		t.Fatalf("MkdirAll a: %v", err)
+	}
+	if err := os.MkdirAll(b, 0o755); err != nil {
+		t.Fatalf("MkdirAll b: %v", err)
+	}
+	same, err := samePath(a, b)
+	if err != nil {
+		t.Fatalf("samePath: %v", err)
+	}
+	if same {
+		t.Errorf("expected samePath(%q, %q) = false", a, b)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `iris pr <number>` — the iris analogue of `prism pr <number>`. Fetches a PR's head branch via `gh pr view`, creates (or reuses) a worktree under the prism bare+worktree layout, and asks the running iris daemon to spawn a session on it. When `--prompt` / `--prompt-file` / `--prompt -` is given, the prompt is delivered to the freshly spawned session after the spawn ack.

This is pure CLI composition over the existing daemon-side frames — no new daemon surface is introduced:

- spawn flow → `session_spawn` (introduced in #1680)
- prompt flow → `prompt_deliver` (introduced in #1677)

## Surface

\`\`\`
iris pr <n>                       # fetch + worktree + spawn (no prompt)
iris pr <n> --prompt <text>       # deliver after spawn acks
iris pr <n> --prompt-file <path>  # read prompt from file
iris pr <n> --prompt -            # read prompt from stdin
iris pr <n> --repo <repo>         # cross-repo PR (name under ~/code or absolute path)
\`\`\`

`--prompt` and `--prompt-file` are mutually exclusive (cobra-enforced). A single trailing newline is stripped from file/stdin input (matches prism's convention).

## Edge cases (per the ACs)

| AC | Coverage |
|---|---|
| No such PR | branch-resolver error surfaced verbatim, no worktree created (`TestPR_NoSuchPR`) |
| Daemon down | canonical `iris daemon not running ... systemctl --user start iris` (`TestPR_DaemonNotRunning`) |
| Dirty worktree | refused before any spawn frame (`TestPR_DirtyWorktreeRefused`) |
| Missing `gh` | short-circuits before dialling the daemon (`TestPR_GHMissing`) |
| Worktree reuse | second call reuses existing worktree, no duplicate (`TestPR_WorktreeReuse`) |
| In-place spawn (cwd matches PR worktree) | informational stdout line; spawn happens in place |
| `--prompt` delivery | `prompt_deliver` follows spawn ack (`TestPR_HappyPath_WithPrompt`) |
| `--repo` cross-repo | accepted as shorthand under \`~/code\` or absolute path (`TestResolvePRBareRoot_*`) |
| BareRoot propagation | daemon-side per #1680; verified by integration test asserting the spawn frame carries the worktree path |
| Help text | `iris pr --help` documents all flags including \`--repo\` |

## Tests

\`\`\`
$ go test ./cmd/iris/ -race -run TestPR -v
=== RUN   TestPR_HappyPath_NoPrompt       --- PASS (0.14s)
=== RUN   TestPR_HappyPath_WithPrompt     --- PASS (1.60s)
=== RUN   TestPR_WorktreeReuse            --- PASS (0.16s)
=== RUN   TestPR_DirtyWorktreeRefused     --- PASS (0.20s)
=== RUN   TestPR_GHMissing                --- PASS (0.10s)
=== RUN   TestPR_NoSuchPR                 --- PASS (0.11s)
=== RUN   TestPR_DaemonNotRunning         --- PASS (0.12s)
\`\`\`

Plus 8 unit tests for the bare-root resolver and \`samePath\` helper. Full \`go test ./... -race\` is green; \`nix build .#iris\` succeeds.

## Notes

- The integration test stubs \`gh\` via \`prOptions.GHLookPath\` and \`prOptions.ResolveBranch\` so it does not require a real \`gh\` CLI or network access. The real CLI path goes through \`internal/git.PRBranch\` (which shells out to \`gh pr view --json headRefName\`); a re-run with stderr capture (\`resolvePRBranchVerbose\`) is used to surface gh's error message when the primary lookup fails.
- The CLI does NOT read prism's \`ProjectLocations\` config — \`--repo\` shorthand resolves only under \`~/code/\`. For repos outside that, pass an absolute path. This keeps iris's repo-lookup surface predictable and avoids pulling in the prism config package.

Closes #1702