### PR TITLE
feat(iris): `iris archive <session>` standalone archive subcommand (#1697)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/archive.go
+++ b/modules/programs/prism/prism/cmd/iris/archive.go
@@ -1,0 +1,195 @@
+// archive.go — `iris archive <session>` standalone archive subcommand (#1697).
+//
+// Standalone archive operation, separate from cleanup. Copies the pi JSONL
+// session file into the iris archive tree at the documented path:
+//
+//	~/code/archives/iris/<session>/<instance_id>/raw/session.jsonl
+//
+// Differences from `iris cleanup`:
+//
+//   - The session keeps running. No session_kill, no DB end_state mutation,
+//     no run dir / log file / worktree removal.
+//   - No daemon dependency. The DB read + file copy work whether or not the
+//     iris daemon is running. (Same carve-out as `iris checkin` — read-only
+//     DB queries do not need to route through the daemon socket.)
+//   - Idempotent. Running it twice on a still-running session re-copies the
+//     latest JSONL snapshot to the same archive path.
+//
+// The archive copy itself reuses the same internal helper that
+// CleanupSession invokes (internal/iris/archive.go::archiveSessionJSONL) so
+// cleanup-archived and standalone-archived sessions produce identical
+// output paths and content.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+var (
+	archiveInstanceID string
+	archivePIAgentDir string
+	archiveAllJSON    bool
+)
+
+var archiveCmd = &cobra.Command{
+	Use:   "archive <session>",
+	Short: "Archive an iris session's pi JSONL (session keeps running)",
+	Long: `Copy the pi JSONL session file for the named iris session into the
+iris archive tree, leaving the session running.
+
+This is the standalone archive verb — it is intentionally narrower than
+'iris cleanup', which also marks the session row ended and removes the
+per-session run directory, log file, and (optionally) worktree. Use
+'iris archive' when you want a snapshot of the session JSONL while the
+session continues to run; use 'iris cleanup' when you want to tear the
+session down.
+
+Lookup:
+
+  iris archive <session-name>            most-recent incarnation of <session-name>
+  iris archive --instance-id <uuid>      explicit instance_id lookup
+
+Output path (matches cleanup):
+
+  ~/code/archives/iris/<session>/<instance_id>/raw/session.jsonl
+
+When the session has no pi JSONL on disk yet (pi crashed before writing
+or never started), the command exits 0 with an informative message and
+does not create an empty archive directory.
+
+This subcommand reads iris.db directly and copies a file. It does not
+require the iris daemon to be running.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runArchive,
+	// SilenceUsage so a user-facing failure (missing session, copy error)
+	// does not dump the cobra usage block over the actual error message.
+	SilenceUsage:  true,
+	SilenceErrors: false,
+}
+
+func init() {
+	archiveCmd.Flags().StringVar(&archiveInstanceID, "instance-id", "", "Look up the session by full instance_id (UUID) instead of session name")
+	archiveCmd.Flags().StringVar(&archivePIAgentDir, "pi-agent-dir", "", "Override the pi agent dir (default: ~/.pi/agent/)")
+	archiveCmd.Flags().BoolVar(&archiveAllJSON, "all-json", false, "Emit a JSON object with the full archive result instead of the human-readable summary")
+	rootCmd.AddCommand(archiveCmd)
+}
+
+// archiveJSONOutput is the stable JSON shape emitted by `iris archive
+// --all-json`. Field names use snake_case to match the rest of the iris
+// JSON surface (sessions list, checkin --json). Adding fields is fine;
+// renames and removals are breaking changes.
+type archiveJSONOutput struct {
+	SessionName      string  `json:"session_name"`
+	InstanceID       string  `json:"instance_id"`
+	HarnessSessionID *string `json:"harness_session_id,omitempty"`
+	Worktree         string  `json:"worktree,omitempty"`
+	// ArchivePath is the destination session.jsonl path on success. Null
+	// when Skipped=true (no JSONL to copy).
+	ArchivePath *string `json:"archive_path"`
+	// Skipped is true when the source JSONL did not exist. The command
+	// still exits 0 in this case — Skipped is the documented "empty JSONL"
+	// outcome from the spec.
+	Skipped    bool   `json:"skipped"`
+	SkipReason string `json:"skip_reason,omitempty"`
+}
+
+// runArchive is the cobra RunE for `iris archive <session>`.
+//
+// Flow:
+//
+//  1. Validate flag/arg combinations. Either a positional session-name or
+//     --instance-id must be supplied; passing both is a usage error so the
+//     intent is unambiguous.
+//  2. Open iris.db for read/write (the archive copy itself doesn't write
+//     the DB, but iris.OpenDB returns a writable handle and the archive
+//     adapter may want to write metadata in the future).
+//  3. Resolve the sessions row via name or instance-id.
+//  4. Call iris.ArchiveSessionRow to perform the copy.
+//  5. Print a human-readable summary or JSON, per --all-json.
+func runArchive(cmd *cobra.Command, args []string) error {
+	switch {
+	case archiveInstanceID != "" && len(args) > 0:
+		return fmt.Errorf("iris archive: pass either <session> or --instance-id, not both")
+	case archiveInstanceID == "" && len(args) == 0:
+		return fmt.Errorf("iris archive: requires a <session> argument or --instance-id <uuid>")
+	}
+
+	p := iris.ResolvePaths()
+	database, err := iris.OpenDB(p.DB)
+	if err != nil {
+		return fmt.Errorf("iris archive: open db: %w", err)
+	}
+	defer database.Close()
+
+	cfg := iris.ArchiveConfig{
+		Database:    database,
+		ArchiveRoot: p.ArchiveRoot,
+		PIAgentDir:  archivePIAgentDir,
+	}
+
+	ctx := context.Background()
+	var (
+		res  *iris.ArchiveResult
+		aerr error
+	)
+	if archiveInstanceID != "" {
+		res, aerr = iris.ArchiveSessionByInstanceID(ctx, cfg, archiveInstanceID)
+	} else {
+		res, aerr = iris.ArchiveSession(ctx, cfg, args[0])
+	}
+	if aerr != nil {
+		return aerr
+	}
+
+	if archiveAllJSON {
+		return emitArchiveJSON(cmd, res)
+	}
+	return emitArchiveHuman(cmd, res)
+}
+
+// emitArchiveHuman writes the human-readable summary form to cmd.OutOrStdout.
+// Layout mirrors `iris cleanup`'s indented summary so users moving between
+// the two commands see the same shape.
+func emitArchiveHuman(cmd *cobra.Command, res *iris.ArchiveResult) error {
+	w := cmd.OutOrStdout()
+	sess := res.Session
+	fmt.Fprintf(w, "iris archive: %s\n", sess.SessionName)
+	fmt.Fprintf(w, "  instance:       %s\n", sess.InstanceID)
+	if res.Skipped {
+		fmt.Fprintf(w, "  archive:        (skipped — %s)\n", res.SkipReason)
+		return nil
+	}
+	fmt.Fprintf(w, "  archive:        %s\n", res.ArchivePath)
+	return nil
+}
+
+// emitArchiveJSON writes the --all-json form to cmd.OutOrStdout. Always
+// emits a single JSON object (never an array) so consumers can json.Unmarshal
+// without a wrapper type.
+func emitArchiveJSON(cmd *cobra.Command, res *iris.ArchiveResult) error {
+	out := archiveJSONOutput{
+		SessionName:      res.Session.SessionName,
+		InstanceID:       res.Session.InstanceID,
+		HarnessSessionID: res.Session.HarnessSessionID,
+		Worktree:         res.Session.Worktree,
+		Skipped:          res.Skipped,
+		SkipReason:       res.SkipReason,
+	}
+	if res.ArchivePath != "" {
+		ap := res.ArchivePath
+		out.ArchivePath = &ap
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("iris archive --all-json: marshal: %w", err)
+	}
+	_, werr := fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return werr
+}

--- a/modules/programs/prism/prism/cmd/iris/archive_test.go
+++ b/modules/programs/prism/prism/cmd/iris/archive_test.go
@@ -1,0 +1,300 @@
+package main
+
+// archive_test.go — unit + integration tests for `iris archive` (#1697).
+//
+// These tests exercise:
+//
+//   - The cobra command's flag parsing (--instance-id, --all-json, mutually
+//     exclusive arg vs --instance-id).
+//   - The human and JSON output shapes via emitArchiveHuman / emitArchiveJSON.
+//   - End-to-end invocation against an isolated DB through cobra's
+//     SetArgs/Execute API so the wiring matches what a real CLI invocation
+//     does.
+//
+// All tests use iristest.NewIsolated, which redirects HOME and XDG_STATE_HOME
+// to a per-test tempdir so the homeless-shelter sandbox in CI stays happy.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	piharness "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// seedArchivableSession inserts a sessions row, writes the matching pi
+// JSONL to disk under iso.PIAgentDir, and returns the names the caller
+// needs for assertions.
+func seedArchivableSession(t *testing.T, iso *iristest.Isolated, suffix string) (sessionName, instanceID string) {
+	t.Helper()
+	sessionName = iristest.SessionName(suffix)
+	instanceID = "iris-test-cmd-archive-" + suffix
+	hsid := "pi-" + suffix + "-ULID"
+	worktree := filepath.Join(iso.Root, "wt-"+suffix)
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	role := "worker"
+	hsidPtr := hsid
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:       instanceID,
+		SessionName:      sessionName,
+		Worktree:         worktree,
+		Harness:          "pi",
+		AgentRole:        &role,
+		HarnessSessionID: &hsidPtr,
+		StartedAt:        time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	encoded := piharness.EncodePiCWD(worktree)
+	sessionsDir := filepath.Join(iso.PIAgentDir, "sessions", encoded)
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+	body := []byte(`{"type":"session_init","session_id":"` + hsid + `"}` + "\n")
+	if err := os.WriteFile(filepath.Join(sessionsDir, "20260101T000000Z_"+hsid+".jsonl"), body, 0o644); err != nil {
+		t.Fatalf("write pi jsonl: %v", err)
+	}
+	return sessionName, instanceID
+}
+
+// runCmd executes a fresh cobra Command tree with the given args and
+// captures stdout. We rebuild the tree per test instead of mutating the
+// package-level archiveCmd so the package-level flag globals are reset
+// cleanly between invocations.
+func runCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	// Reset package-level flag globals before each run. Cobra writes flag
+	// values into these on Execute and they would otherwise leak between
+	// tests sharing the package-level archiveCmd.
+	archiveInstanceID = ""
+	archivePIAgentDir = ""
+	archiveAllJSON = false
+
+	root := &cobra.Command{Use: "iris-test-root"}
+	// Build a fresh archiveCmd that mirrors the production registration.
+	c := &cobra.Command{
+		Use:           archiveCmd.Use,
+		RunE:          runArchive,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	c.Flags().StringVar(&archiveInstanceID, "instance-id", "", "")
+	c.Flags().StringVar(&archivePIAgentDir, "pi-agent-dir", "", "")
+	c.Flags().BoolVar(&archiveAllJSON, "all-json", false, "")
+	root.AddCommand(c)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"archive"}, args...))
+	err := root.ExecuteContext(context.Background())
+	return buf.String(), err
+}
+
+// TestArchiveCmd_Human asserts the human-readable summary form prints the
+// session name and the documented archive path.
+func TestArchiveCmd_Human(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID := seedArchivableSession(t, iso, "human")
+
+	out, err := runCmd(t, sessionName, "--pi-agent-dir", iso.PIAgentDir)
+	if err != nil {
+		t.Fatalf("runCmd: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, sessionName) {
+		t.Errorf("output missing session name %q:\n%s", sessionName, out)
+	}
+	wantPath := filepath.Join(iso.Paths.ArchiveRoot, sessionName, instanceID, "raw", "session.jsonl")
+	if !strings.Contains(out, wantPath) {
+		t.Errorf("output missing archive path %q:\n%s", wantPath, out)
+	}
+}
+
+// TestArchiveCmd_AllJSON asserts the JSON form parses, has the expected
+// fields, and points at the documented archive path.
+func TestArchiveCmd_AllJSON(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID := seedArchivableSession(t, iso, "json")
+
+	out, err := runCmd(t, sessionName, "--pi-agent-dir", iso.PIAgentDir, "--all-json")
+	if err != nil {
+		t.Fatalf("runCmd: %v\n%s", err, out)
+	}
+	var got archiveJSONOutput
+	if jerr := json.Unmarshal([]byte(out), &got); jerr != nil {
+		t.Fatalf("parse JSON: %v\n%s", jerr, out)
+	}
+	if got.SessionName != sessionName {
+		t.Errorf("SessionName = %q, want %q", got.SessionName, sessionName)
+	}
+	if got.InstanceID != instanceID {
+		t.Errorf("InstanceID = %q, want %q", got.InstanceID, instanceID)
+	}
+	if got.Skipped {
+		t.Errorf("Skipped = true on happy path: %q", got.SkipReason)
+	}
+	wantPath := filepath.Join(iso.Paths.ArchiveRoot, sessionName, instanceID, "raw", "session.jsonl")
+	if got.ArchivePath == nil || *got.ArchivePath != wantPath {
+		t.Errorf("ArchivePath = %v, want %q", got.ArchivePath, wantPath)
+	}
+}
+
+// TestArchiveCmd_InstanceID asserts the --instance-id lookup variant works
+// when no positional argument is given.
+func TestArchiveCmd_InstanceID(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID := seedArchivableSession(t, iso, "id")
+
+	out, err := runCmd(t, "--instance-id", instanceID, "--pi-agent-dir", iso.PIAgentDir, "--all-json")
+	if err != nil {
+		t.Fatalf("runCmd: %v\n%s", err, out)
+	}
+	var got archiveJSONOutput
+	if jerr := json.Unmarshal([]byte(out), &got); jerr != nil {
+		t.Fatalf("parse JSON: %v\n%s", jerr, out)
+	}
+	if got.SessionName != sessionName {
+		t.Errorf("SessionName = %q, want %q", got.SessionName, sessionName)
+	}
+	if got.InstanceID != instanceID {
+		t.Errorf("InstanceID = %q, want %q", got.InstanceID, instanceID)
+	}
+}
+
+// TestArchiveCmd_NoArgsNoFlag asserts that calling `iris archive` with no
+// session and no --instance-id is a usage error.
+func TestArchiveCmd_NoArgsNoFlag(t *testing.T) {
+	iristest.NewIsolated(t)
+	_, err := runCmd(t)
+	if err == nil {
+		t.Fatalf("expected error when called with no args and no --instance-id, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires") {
+		t.Errorf("error %q does not mention \"requires\"", err)
+	}
+}
+
+// TestArchiveCmd_BothArgAndInstanceID asserts that supplying both a
+// positional session and --instance-id is a usage error (intent is
+// ambiguous).
+func TestArchiveCmd_BothArgAndInstanceID(t *testing.T) {
+	iristest.NewIsolated(t)
+	_, err := runCmd(t, "some-name", "--instance-id", "some-uuid")
+	if err == nil {
+		t.Fatalf("expected error when called with both positional and --instance-id, got nil")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error %q does not mention \"not both\"", err)
+	}
+}
+
+// TestArchiveCmd_EmptyJSONLExitsZero asserts that a session with no pi
+// JSONL on disk exits 0 with an informative "(skipped — ...)" message and
+// does NOT create an empty archive directory tree. This is the spec's
+// "Empty JSONL → exit 0 with informative message, no empty archive" AC.
+func TestArchiveCmd_EmptyJSONLExitsZero(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	sessionName := iristest.SessionName("cmd-empty")
+	worktree := filepath.Join(iso.Root, "wt-cmd-empty")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	hsid := "pi-cmd-empty-ULID"
+	role := "worker"
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:       "iris-test-cmd-empty",
+		SessionName:      sessionName,
+		Worktree:         worktree,
+		Harness:          "pi",
+		AgentRole:        &role,
+		HarnessSessionID: &hsid,
+		StartedAt:        time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	out, err := runCmd(t, sessionName, "--pi-agent-dir", iso.PIAgentDir)
+	if err != nil {
+		t.Fatalf("runCmd (empty jsonl) returned err: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "skipped") {
+		t.Errorf("output should mention \"skipped\":\n%s", out)
+	}
+	wantNoDir := filepath.Join(iso.Paths.ArchiveRoot, sessionName)
+	if _, statErr := os.Stat(wantNoDir); !os.IsNotExist(statErr) {
+		t.Errorf("archive dir %q should not exist on empty-JSONL skip (stat err=%v)", wantNoDir, statErr)
+	}
+}
+
+// TestArchiveCmd_DaemonDownStillWorks documents the "daemon-down but
+// session in DB → still works" AC. The cobra command never dials the
+// daemon socket — it reads the DB and copies a file. We assert that by
+// running the command without any daemon process and without ever passing
+// a socket path.
+func TestArchiveCmd_DaemonDownStillWorks(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, _ := seedArchivableSession(t, iso, "no-daemon")
+
+	// Sanity: the iris client socket path under iso must NOT exist; this
+	// test would be vacuous if a stray daemon were running there.
+	if _, err := os.Stat(iso.Paths.Sock); !os.IsNotExist(err) {
+		t.Fatalf("precondition: iris.sock %q must not exist (err=%v)", iso.Paths.Sock, err)
+	}
+
+	out, err := runCmd(t, sessionName, "--pi-agent-dir", iso.PIAgentDir)
+	if err != nil {
+		t.Fatalf("runCmd (daemon down): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "session.jsonl") {
+		t.Errorf("output missing session.jsonl path:\n%s", out)
+	}
+}
+
+// TestArchiveCmd_SessionNotFound asserts a missing session name surfaces a
+// non-zero exit (returned error) rather than silently exiting 0.
+func TestArchiveCmd_SessionNotFound(t *testing.T) {
+	iristest.NewIsolated(t)
+	_, err := runCmd(t, iristest.SessionName("nope-not-real"))
+	if err == nil {
+		t.Fatalf("expected error for missing session, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error %q does not mention \"not found\"", err)
+	}
+}
+
+// TestArchiveCmd_SessionStaysRunning asserts the cobra path does not mark
+// the session ended — same contract as TestArchiveSession_SessionRowUntouched
+// but exercised through the user-facing entry point. Belt-and-braces guard
+// against a future refactor that wires cleanup-style mutation into the
+// archive command.
+func TestArchiveCmd_SessionStaysRunning(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID := seedArchivableSession(t, iso, "running")
+
+	if _, err := runCmd(t, sessionName, "--pi-agent-dir", iso.PIAgentDir); err != nil {
+		t.Fatalf("runCmd: %v", err)
+	}
+	got, err := iso.DB.SessionByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("session row vanished after archive")
+	}
+	if got.EndedAt != nil || got.EndState != nil {
+		t.Errorf("session row mutated by archive: ended_at=%v end_state=%v", got.EndedAt, got.EndState)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/archive.go
+++ b/modules/programs/prism/prism/internal/iris/archive.go
@@ -1,0 +1,221 @@
+package iris
+
+// archive.go — standalone iris session archive operation (#1697).
+//
+// ArchiveSession is the standalone analogue of the archive step inside
+// CleanupSession. It copies the pi JSONL file for a session into the iris
+// archive tree and returns the destination path — without touching the
+// sessions row, the run directory, the per-session log file, or the
+// worktree. The session can keep running afterwards.
+//
+// This is a deliberately narrower contract than CleanupSession:
+//
+//   - Cleanup is a teardown verb. It marks the row ended, removes run
+//     artefacts, and (optionally) deletes the worktree. It is a one-shot
+//     destructive operation.
+//   - Archive is a copy verb. It snapshots the pi JSONL into the archive
+//     tree at the documented path. It is non-destructive and may be re-run
+//     while the session is still active.
+//
+// The two share the same path layout
+// (<ArchiveRoot>/<session>/<instance_id>/raw/session.jsonl) and the same
+// archive-writing helper (archiveSessionJSONL) so a session that is later
+// cleaned up will overwrite/match the path produced by an earlier
+// standalone archive — no parallel layouts to keep in sync.
+//
+// Daemon dependency: none. ArchiveSession reads iris.db directly and
+// performs a file copy. It works whether or not the iris daemon is running.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+	piharness "github.com/prismatic-koi/prism/internal/harness/pi"
+)
+
+// ArchiveConfig holds the parameters needed to run a standalone archive
+// for a single session. It is a strict subset of CleanupConfig — the
+// fields that drive cleanup-only behaviour (run dir removal, worktree
+// removal) are deliberately absent.
+type ArchiveConfig struct {
+	// Database is the open iris DB.
+	Database *db.DB
+	// ArchiveRoot is the root of the iris archive tree
+	// (e.g. ~/code/archives/iris/). Session JSONL files are copied to
+	// <ArchiveRoot>/<session>/<instance_id>/raw/session.jsonl.
+	ArchiveRoot string
+	// PIAgentDir is the base directory where pi stores session files
+	// (default: ~/.pi/agent/). When empty, defaults to ~/.pi/agent/.
+	PIAgentDir string
+}
+
+// ArchiveResult records the outcome of a single ArchiveSession call.
+type ArchiveResult struct {
+	// Session is the resolved sessions row.
+	Session *db.Session
+	// ArchivePath is the destination of the archived session JSONL when
+	// the archive step actually wrote a file. Empty when the source JSONL
+	// did not exist (pi never wrote one) — see Skipped/SkipReason.
+	ArchivePath string
+	// Skipped is true when the archive step was a no-op because there was
+	// nothing to archive (no harness session id on the row, or no JSONL on
+	// disk). Skipped + nil error is the documented "empty JSONL → exit 0
+	// with informative message" case from the spec.
+	Skipped bool
+	// SkipReason is a short human-readable explanation when Skipped=true.
+	SkipReason string
+}
+
+// ArchiveSession copies the pi JSONL file for sessionName into the archive
+// tree at the documented path and returns an ArchiveResult describing the
+// outcome.
+//
+// Behaviour:
+//
+//   - The session row is resolved by session_name (most-recent incarnation,
+//     matching the cleanup path). For instance-id lookups, callers should
+//     resolve themselves and use ArchiveSessionRow.
+//   - The session row is NOT modified. ArchiveSession is read-only against
+//     the DB; the session keeps running after the call returns.
+//   - When the source JSONL does not exist (pi never wrote one, or the
+//     session was constructed without a worktree), ArchiveSession returns a
+//     result with Skipped=true and a non-empty SkipReason. This is not an
+//     error — callers should surface the reason to the user and exit 0.
+//   - On success, ArchivePath points at
+//     <ArchiveRoot>/<sessionName>/<instance_id>/raw/session.jsonl.
+func ArchiveSession(ctx context.Context, cfg ArchiveConfig, sessionName string) (*ArchiveResult, error) {
+	if cfg.Database == nil {
+		return nil, errors.New("iris archive: Database is required")
+	}
+	if cfg.ArchiveRoot == "" {
+		return nil, errors.New("iris archive: ArchiveRoot is required")
+	}
+	if sessionName == "" {
+		return nil, errors.New("iris archive: session name is required")
+	}
+
+	sess, err := cfg.Database.MostRecentSessionForName(sessionName)
+	if err != nil {
+		return nil, fmt.Errorf("iris archive: lookup session %q: %w", sessionName, err)
+	}
+	if sess == nil {
+		return nil, fmt.Errorf("iris archive: session %q not found", sessionName)
+	}
+	return ArchiveSessionRow(ctx, cfg, sess)
+}
+
+// ArchiveSessionByInstanceID is the instance-id lookup variant of
+// ArchiveSession. The argument must be the full 36-char UUID. Returns the
+// same error shape as ArchiveSession when the row is not found.
+func ArchiveSessionByInstanceID(ctx context.Context, cfg ArchiveConfig, instanceID string) (*ArchiveResult, error) {
+	if cfg.Database == nil {
+		return nil, errors.New("iris archive: Database is required")
+	}
+	if cfg.ArchiveRoot == "" {
+		return nil, errors.New("iris archive: ArchiveRoot is required")
+	}
+	if instanceID == "" {
+		return nil, errors.New("iris archive: instance id is required")
+	}
+
+	sess, err := cfg.Database.SessionByInstanceID(instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("iris archive: lookup session by instance %q: %w", instanceID, err)
+	}
+	if sess == nil {
+		return nil, fmt.Errorf("iris archive: instance %q not found", instanceID)
+	}
+	return ArchiveSessionRow(ctx, cfg, sess)
+}
+
+// ArchiveSessionRow runs the archive copy for a pre-resolved sessions row.
+// It is exported so callers that have already done their own lookup (e.g.
+// CleanupSession or a future bulk-archive pass) can reuse the copy logic
+// without paying for a second DB query. See ArchiveSession for behaviour.
+func ArchiveSessionRow(ctx context.Context, cfg ArchiveConfig, sess *db.Session) (*ArchiveResult, error) {
+	res := &ArchiveResult{Session: sess}
+
+	path, skipReason, err := archiveSessionJSONL(ctx, cfg, sess)
+	if err != nil {
+		return res, fmt.Errorf("iris archive: %w", err)
+	}
+	if path == "" {
+		res.Skipped = true
+		res.SkipReason = skipReason
+		return res, nil
+	}
+	res.ArchivePath = path
+	return res, nil
+}
+
+// archiveSessionJSONL is the shared archive-writing helper used by both
+// ArchiveSession (standalone) and CleanupSession (teardown). It locates
+// the pi JSONL file for the session and copies it to
+// <ArchiveRoot>/<session>/<instance_id>/raw/session.jsonl.
+//
+// Returns:
+//
+//   - (path, "", nil) on success — path is the destination session.jsonl.
+//   - ("", reason, nil) when there is nothing to archive — reason is a
+//     short human-readable explanation suitable for printing to the user.
+//   - ("", "", err) on a real failure (mkdir / copy / adapter error).
+//
+// No archive directory is created when there is nothing to archive — the
+// destination tree is touched only after a source file is located.
+func archiveSessionJSONL(ctx context.Context, cfg ArchiveConfig, sess *db.Session) (string, string, error) {
+	if sess.HarnessSessionID == nil || *sess.HarnessSessionID == "" || sess.Worktree == "" {
+		// No harness session to archive (pi never started, or session was
+		// constructed without a worktree). Treat as a documented no-op.
+		return "", "no harness session id or worktree on sessions row", nil
+	}
+
+	piAgentDir := cfg.PIAgentDir
+	if piAgentDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("resolve home: %w", err)
+		}
+		piAgentDir = filepath.Join(home, ".pi", "agent")
+	}
+
+	// Use the shared pi archive adapter so the source-path encoding stays
+	// in lock-step with the rest of the codebase. Locate the JSONL file
+	// ourselves so the test-friendly PIAgentDir override is honoured.
+	adapter := piharness.NewArchiveAdapter()
+	encodedCWD := piharness.EncodePiCWD(sess.Worktree)
+	cwdDir := filepath.Join(piAgentDir, "sessions", encodedCWD)
+	srcPath := scanForJSONL(cwdDir, *sess.HarnessSessionID)
+	if srcPath == "" {
+		// Nothing on disk — pi never wrote a JSONL file. Documented no-op:
+		// must not create the archive directory tree.
+		return "", fmt.Sprintf("no pi JSONL on disk under %s", cwdDir), nil
+	}
+
+	rawDir := filepath.Join(cfg.ArchiveRoot, sess.SessionName, sess.InstanceID, "raw")
+	if err := os.MkdirAll(rawDir, 0o700); err != nil {
+		return "", "", fmt.Errorf("mkdir archive raw dir: %w", err)
+	}
+	p := harnessarchive.SourceParams{
+		SessionName:      sess.SessionName,
+		InstanceID:       sess.InstanceID,
+		HarnessSessionID: *sess.HarnessSessionID,
+		IsolationMode:    "host",
+		Worktree:         sess.Worktree,
+	}
+	if err := adapter.Archive(ctx, srcPath, rawDir, p); err != nil {
+		return "", "", fmt.Errorf("archive: %w", err)
+	}
+	dst := filepath.Join(rawDir, "session.jsonl")
+	if _, err := os.Stat(dst); err != nil {
+		// Adapter ran but the destination is missing — surface as an error
+		// so callers know the archive step did not produce the documented
+		// file.
+		return "", "", fmt.Errorf("archive produced no session.jsonl at %q: %w", dst, err)
+	}
+	return dst, "", nil
+}

--- a/modules/programs/prism/prism/internal/iris/archive_test.go
+++ b/modules/programs/prism/prism/internal/iris/archive_test.go
@@ -1,0 +1,289 @@
+package iris_test
+
+// archive_test.go — unit tests for the standalone iris.ArchiveSession path
+// (#1697).
+//
+// These tests exercise the archive verb in isolation from cleanup so the
+// "no row mutation, no run-dir touch, session keeps running" contract is
+// asserted directly. Cleanup-archive parity (same path layout, same file
+// contents) is covered by internal/iris/parity/archive_test.go and the
+// regression check at the bottom of this file.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	piharness "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// seedSessionWithJSONL inserts a sessions row and writes a pi JSONL file
+// under iso.PIAgentDir at the encoded-cwd path. Returns (sessionName,
+// instanceID, harnessSessionID, jsonlBytes) for the test to assert on.
+func seedSessionWithJSONL(t *testing.T, iso *iristest.Isolated, nameSuffix string) (string, string, string, []byte) {
+	t.Helper()
+	sessionName := iristest.SessionName(nameSuffix)
+	worktree := filepath.Join(iso.Root, "wt-"+nameSuffix)
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	instanceID := "iris-test-archive-" + nameSuffix
+	hsid := "pi-" + nameSuffix + "-ULID"
+	role := "worker"
+	hsidPtr := hsid
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:       instanceID,
+		SessionName:      sessionName,
+		Worktree:         worktree,
+		Harness:          "pi",
+		AgentRole:        &role,
+		HarnessSessionID: &hsidPtr,
+		StartedAt:        time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	encoded := piharness.EncodePiCWD(worktree)
+	sessionsDir := filepath.Join(iso.PIAgentDir, "sessions", encoded)
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+	body := []byte(`{"type":"session_init","session_id":"` + hsid + `"}` + "\n" +
+		`{"type":"msg_assistant","content":"hi from archive test"}` + "\n")
+	piJSONL := filepath.Join(sessionsDir, "20260101T000000Z_"+hsid+".jsonl")
+	if err := os.WriteFile(piJSONL, body, 0o644); err != nil {
+		t.Fatalf("write pi jsonl: %v", err)
+	}
+	return sessionName, instanceID, hsid, body
+}
+
+// TestArchiveSession_HappyPath asserts the standalone archive verb copies
+// the pi JSONL to the documented path and returns a non-skipped result.
+func TestArchiveSession_HappyPath(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID, _, body := seedSessionWithJSONL(t, iso, "happy")
+
+	res, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}, sessionName)
+	if err != nil {
+		t.Fatalf("ArchiveSession: %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("ArchiveSession: unexpected Skipped=true (reason=%q)", res.SkipReason)
+	}
+	want := filepath.Join(iso.Paths.ArchiveRoot, sessionName, instanceID, "raw", "session.jsonl")
+	if res.ArchivePath != want {
+		t.Errorf("ArchivePath = %q, want %q", res.ArchivePath, want)
+	}
+	if got, err := os.ReadFile(want); err != nil {
+		t.Fatalf("read archive: %v", err)
+	} else if string(got) != string(body) {
+		t.Errorf("archive content mismatch:\n got: %q\nwant: %q", got, body)
+	}
+}
+
+// TestArchiveSession_SessionRowUntouched asserts the standalone archive
+// verb does NOT mark the session ended (the key contract distinguishing it
+// from CleanupSession). This is the "session stays running" AC.
+func TestArchiveSession_SessionRowUntouched(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID, _, _ := seedSessionWithJSONL(t, iso, "untouched")
+
+	if _, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}, sessionName); err != nil {
+		t.Fatalf("ArchiveSession: %v", err)
+	}
+
+	got, err := iso.DB.SessionByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("session row %q vanished after archive", instanceID)
+	}
+	if got.EndedAt != nil {
+		t.Errorf("standalone archive set EndedAt=%v; want nil (session must keep running)", got.EndedAt)
+	}
+	if got.EndState != nil {
+		t.Errorf("standalone archive set EndState=%v; want nil", *got.EndState)
+	}
+}
+
+// TestArchiveSession_EmptyJSONL asserts that a session with no pi JSONL on
+// disk produces Skipped=true (no error, no archive directory created). This
+// is the "Empty JSONL → exit 0 with informative message, no empty archive"
+// AC from the spec.
+func TestArchiveSession_EmptyJSONL(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	sessionName := iristest.SessionName("empty-jsonl")
+	worktree := filepath.Join(iso.Root, "wt-empty")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	hsid := "pi-empty-ULID"
+	role := "worker"
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:       "iris-test-archive-empty",
+		SessionName:      sessionName,
+		Worktree:         worktree,
+		Harness:          "pi",
+		AgentRole:        &role,
+		HarnessSessionID: &hsid,
+		StartedAt:        time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	res, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}, sessionName)
+	if err != nil {
+		t.Fatalf("ArchiveSession (empty jsonl): %v", err)
+	}
+	if !res.Skipped {
+		t.Errorf("Skipped = false; want true on empty JSONL")
+	}
+	if res.SkipReason == "" {
+		t.Errorf("SkipReason = empty; want a non-empty informative message")
+	}
+	if res.ArchivePath != "" {
+		t.Errorf("ArchivePath = %q; want \"\" on skip", res.ArchivePath)
+	}
+	// "no empty archive" — the destination directory must NOT have been
+	// created when there was nothing to copy.
+	wantNoDir := filepath.Join(iso.Paths.ArchiveRoot, sessionName)
+	if _, statErr := os.Stat(wantNoDir); !os.IsNotExist(statErr) {
+		t.Errorf("archive dir %q should not exist on empty-JSONL skip (err=%v)", wantNoDir, statErr)
+	}
+}
+
+// TestArchiveSession_ByInstanceID asserts the --instance-id lookup variant
+// resolves to the same outcome as the by-name variant.
+func TestArchiveSession_ByInstanceID(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID, _, _ := seedSessionWithJSONL(t, iso, "by-instance")
+
+	res, err := iris.ArchiveSessionByInstanceID(context.Background(), iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}, instanceID)
+	if err != nil {
+		t.Fatalf("ArchiveSessionByInstanceID: %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("Skipped=true on happy by-instance path: %q", res.SkipReason)
+	}
+	want := filepath.Join(iso.Paths.ArchiveRoot, sessionName, instanceID, "raw", "session.jsonl")
+	if res.ArchivePath != want {
+		t.Errorf("ArchivePath = %q, want %q", res.ArchivePath, want)
+	}
+}
+
+// TestArchiveSession_NotFound asserts a non-existent session returns a
+// clear error rather than a result with Skipped=true.
+func TestArchiveSession_NotFound(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	_, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}, iristest.SessionName("does-not-exist"))
+	if err == nil {
+		t.Fatalf("ArchiveSession on missing session: got nil error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error %q does not mention \"not found\"", err)
+	}
+}
+
+// TestArchiveSession_ConfigValidation asserts missing required fields are
+// rejected with a clear error.
+func TestArchiveSession_ConfigValidation(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	if _, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, "x"); err == nil || !strings.Contains(err.Error(), "Database is required") {
+		t.Errorf("missing Database: got %v, want \"Database is required\"", err)
+	}
+	if _, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		Database: iso.DB,
+	}, "x"); err == nil || !strings.Contains(err.Error(), "ArchiveRoot is required") {
+		t.Errorf("missing ArchiveRoot: got %v, want \"ArchiveRoot is required\"", err)
+	}
+	if _, err := iris.ArchiveSession(context.Background(), iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, ""); err == nil || !strings.Contains(err.Error(), "session name is required") {
+		t.Errorf("empty session name: got %v, want \"session name is required\"", err)
+	}
+}
+
+// TestArchiveSession_Idempotent asserts that running archive twice on the
+// same session writes the same destination both times (a snapshot verb,
+// not an append-only one) and does not error on the second invocation.
+func TestArchiveSession_Idempotent(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, _, _, _ := seedSessionWithJSONL(t, iso, "idempotent")
+	cfg := iris.ArchiveConfig{
+		Database:    iso.DB,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}
+	r1, err := iris.ArchiveSession(context.Background(), cfg, sessionName)
+	if err != nil {
+		t.Fatalf("first ArchiveSession: %v", err)
+	}
+	r2, err := iris.ArchiveSession(context.Background(), cfg, sessionName)
+	if err != nil {
+		t.Fatalf("second ArchiveSession: %v", err)
+	}
+	if r1.ArchivePath != r2.ArchivePath {
+		t.Errorf("idempotent archive: paths differ: %q vs %q", r1.ArchivePath, r2.ArchivePath)
+	}
+	if r1.Skipped || r2.Skipped {
+		t.Errorf("idempotent archive: unexpected Skipped (r1=%v, r2=%v)", r1.Skipped, r2.Skipped)
+	}
+}
+
+// TestCleanupArchive_PathParity asserts the regression invariant from the
+// spec: CleanupSession's archive step still writes to the same path that
+// ArchiveSession produces. This guards against the refactor accidentally
+// diverging the two code paths.
+func TestCleanupArchive_PathParity(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	sessionName, instanceID, _, _ := seedSessionWithJSONL(t, iso, "parity")
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		PIAgentDir:  iso.PIAgentDir,
+	}, sessionName)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+	want := filepath.Join(iso.Paths.ArchiveRoot, sessionName, instanceID, "raw", "session.jsonl")
+	if res.ArchivePath != want {
+		t.Errorf("CleanupSession.ArchivePath = %q, want %q", res.ArchivePath, want)
+	}
+	if _, statErr := os.Stat(want); statErr != nil {
+		t.Fatalf("cleanup archive missing at %q: %v", want, statErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/cleanup.go
+++ b/modules/programs/prism/prism/internal/iris/cleanup.go
@@ -49,8 +49,6 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
-	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
-	piharness "github.com/prismatic-koi/prism/internal/harness/pi"
 )
 
 // CleanupConfig holds the parameters needed to run cleanup for a single
@@ -134,8 +132,14 @@ func CleanupSession(ctx context.Context, cfg CleanupConfig, sessionName string) 
 
 	res := &CleanupResult{}
 
-	// Step 2: archive the pi JSONL.
-	archivePath, archErr := archivePiJSONL(ctx, cfg, sess)
+	// Step 2: archive the pi JSONL. Delegates to the shared helper used by
+	// the standalone `iris archive` subcommand (#1697) so cleanup-archived
+	// and standalone-archived sessions land at the same path.
+	archivePath, _, archErr := archiveSessionJSONL(ctx, ArchiveConfig{
+		Database:    cfg.Database,
+		ArchiveRoot: cfg.ArchiveRoot,
+		PIAgentDir:  cfg.PIAgentDir,
+	}, sess)
 	if archErr != nil {
 		log.Printf("[iris] cleanup: archive %q: %v", sessionName, archErr)
 		res.Errors = append(res.Errors, fmt.Errorf("archive: %w", archErr))
@@ -200,62 +204,6 @@ func CleanupSession(ctx context.Context, cfg CleanupConfig, sessionName string) 
 	}
 
 	return res, nil
-}
-
-// archivePiJSONL locates the pi JSONL file for the session and copies it to
-// <ArchiveRoot>/<session>/<instance_id>/raw/session.jsonl. Returns the
-// destination path on success, "" when there was nothing to archive.
-func archivePiJSONL(ctx context.Context, cfg CleanupConfig, sess *db.Session) (string, error) {
-	if sess.HarnessSessionID == nil || *sess.HarnessSessionID == "" || sess.Worktree == "" {
-		// No harness session to archive (pi never started, or session was
-		// constructed without a worktree). Treat as a no-op — not an error.
-		return "", nil
-	}
-
-	piAgentDir := cfg.PIAgentDir
-	if piAgentDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolve home: %w", err)
-		}
-		piAgentDir = filepath.Join(home, ".pi", "agent")
-	}
-
-	// Use the shared pi archive adapter so the source-path encoding stays
-	// in lock-step with the rest of the codebase (single source of truth).
-	// Locate the JSONL file ourselves (the adapter's SourcePath resolves ~
-	// via os.UserHomeDir() — we honour the test-friendly PIAgentDir override
-	// by scanning the encoded-cwd dir directly).
-	adapter := piharness.NewArchiveAdapter()
-	encodedCWD := piharness.EncodePiCWD(sess.Worktree)
-	cwdDir := filepath.Join(piAgentDir, "sessions", encodedCWD)
-	srcPath := scanForJSONL(cwdDir, *sess.HarnessSessionID)
-	if srcPath == "" {
-		// Nothing on disk — pi never wrote a JSONL file. Not an error.
-		return "", nil
-	}
-
-	rawDir := filepath.Join(cfg.ArchiveRoot, sess.SessionName, sess.InstanceID, "raw")
-	if err := os.MkdirAll(rawDir, 0o700); err != nil {
-		return "", fmt.Errorf("mkdir archive raw dir: %w", err)
-	}
-	p := harnessarchive.SourceParams{
-		SessionName:      sess.SessionName,
-		InstanceID:       sess.InstanceID,
-		HarnessSessionID: *sess.HarnessSessionID,
-		IsolationMode:    "host",
-		Worktree:         sess.Worktree,
-	}
-	if err := adapter.Archive(ctx, srcPath, rawDir, p); err != nil {
-		return "", fmt.Errorf("archive: %w", err)
-	}
-	dst := filepath.Join(rawDir, "session.jsonl")
-	if _, err := os.Stat(dst); err != nil {
-		// Adapter ran but the destination is missing — surface as an error so
-		// callers know the archive step did not produce the documented file.
-		return "", fmt.Errorf("archive produced no session.jsonl at %q: %w", dst, err)
-	}
-	return dst, nil
 }
 
 // scanForJSONL scans cwdDir for a file matching "*_<sessionID>.jsonl" and


### PR DESCRIPTION
Adds a standalone archive verb to the iris CLI that copies the pi JSONL
session file into the iris archive tree at the documented path without
tearing the session down.

## What

- `iris archive <session>` — looks up the most-recent incarnation of the
  named session and copies its pi JSONL to
  `~/code/archives/iris/<session>/<instance_id>/raw/session.jsonl`.
- `iris archive --instance-id <uuid>` — explicit instance-id lookup
  variant.
- `iris archive ... --all-json` — emits a JSON object describing the
  outcome (session_name, instance_id, archive_path, skipped,
  skip_reason).
- `iris archive ... --pi-agent-dir <path>` — test/override hook,
  matching `iris cleanup`.

## Why this is separate from `iris cleanup`

`iris cleanup` is a teardown verb — it marks the session row ended,
removes the per-session run dir / log file, and (optionally) deletes
the worktree. `iris archive` is a non-destructive snapshot verb: the
session keeps running, and the command is idempotent.

## Refactor

`archivePiJSONL` in `internal/iris/cleanup.go` is extracted into a new
`internal/iris/archive.go` with three public entry points:

- `ArchiveSession(ctx, cfg, sessionName)` — by-name lookup
- `ArchiveSessionByInstanceID(ctx, cfg, instanceID)` — by-uuid lookup
- `ArchiveSessionRow(ctx, cfg, sess)` — pre-resolved row

…all delegating to an internal `archiveSessionJSONL` helper. The
existing `CleanupSession` now calls that helper directly so cleanup-
and standalone-archive paths share one source of truth for the copy
logic and the destination path layout. A regression test
(`TestCleanupArchive_PathParity`) pins this.

## ACs

- [x] `iris archive <session>` copies pi JSONL to archive path,
      session row stays untouched
      (`TestArchiveSession_SessionRowUntouched`,
      `TestArchiveCmd_SessionStaysRunning`)
- [x] `--instance-id <id>` lookup variant
      (`TestArchiveSession_ByInstanceID`,
      `TestArchiveCmd_InstanceID`)
- [x] `--all-json` JSON output (`TestArchiveCmd_AllJSON`)
- [x] Empty JSONL → exit 0 with informative message, no empty archive
      (`TestArchiveSession_EmptyJSONL`,
      `TestArchiveCmd_EmptyJSONLExitsZero`)
- [x] Daemon-down but session in DB → still works
      (`TestArchiveCmd_DaemonDownStillWorks`)
- [x] Same path layout as cleanup-archived sessions
      (`TestCleanupArchive_PathParity`)
- [x] Cleanup integration unchanged — existing tests still pass
      (`internal/iris/cleanup_logfile_test.go`,
      `internal/iris/parity/archive_test.go`,
      `internal/iris/parity/cleanup_test.go`)
- [x] `go test ./... -race` clean
- [x] `nix build .#iris` clean

Closes #1697