### PR TITLE
feat(iris): `iris dashboard` multi-session view + tmux keybindings

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/dashboard.go
+++ b/modules/programs/prism/prism/cmd/iris/dashboard.go
@@ -30,11 +30,13 @@ package main
 // canonical shape this command follows.
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -81,9 +83,13 @@ Two surfaces:
                             without any additional plumbing.
 
 The iris daemon must be running ('iris daemon' or 'systemctl --user start
-iris') for the dashboard to populate. When the daemon is unreachable, the
-dashboard renders a clear "iris daemon not connected" overlay with a
-'systemctl --user start iris' hint and remains responsive to q/esc.`,
+iris') for the dashboard to populate. If the daemon is not reachable at
+startup the command exits non-zero with a clear 'systemctl --user start
+iris' hint (matching 'iris sessions list' / 'iris prompt'). If the
+daemon disappears mid-session (e.g. the user restarts iris while the
+dashboard is open) the bubbletea program renders a "daemon not
+connected" overlay and reconnects automatically when the socket
+returns.`,
 	RunE:          runDashboard,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -105,6 +111,10 @@ func runDashboard(cmd *cobra.Command, _ []string) error {
 	sockPath := dashboardSocketPath
 	if sockPath == "" {
 		sockPath = iris.ResolvePaths().Sock
+	}
+
+	if err := dashboardPreflightProbe(cmd.Context(), sockPath); err != nil {
+		return err
 	}
 
 	if dashboardPopup {
@@ -136,6 +146,38 @@ func runDashboard(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	return syscallExecTmuxAttach(dashboard.DashSession)
+}
+
+// dashboardPreflightProbe synchronously verifies the iris daemon is
+// reachable before the cobra RunE hands control to bubbletea. AC #8 of
+// issue #1703 requires that `iris dashboard` exit non-zero with the
+// canonical `systemctl --user start iris` hint when the daemon is not
+// running. The bubbletea program by itself would only surface a
+// DisconnectedMsg into the model (rendering an overlay) and the
+// user-driven quit path returns exit 0 — contradicting the literal AC
+// and diverging from `iris sessions list` / `iris prompt`.
+//
+// We reuse fetchSessionsSnapshot (the same helper backing `iris sessions
+// list`) so the hint shape is locked to a single source of truth across
+// the iris CLI. Probing applies to popup mode too: a daemon-down popup
+// would otherwise render an opaque overlay inside `tmux display-popup
+// -E` with no readable error code for shell callers; a synchronous probe
+// lets the popup close immediately with the error visible on the
+// invoking pane's stderr.
+//
+// The DisconnectedMsg overlay still applies for mid-session reconnects
+// (daemon restarts while the dashboard is open) — the DaemonClient's
+// retry loop keeps running and the overlay narrates the outage. Only the
+// daemon-down-at-startup case maps to exit non-zero.
+//
+// Factored into its own function (rather than inlined into runDashboard)
+// so dashboard_test.go can assert the exit-non-zero + hint-shape
+// contract without driving the cobra command.
+func dashboardPreflightProbe(ctx context.Context, sockPath string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_, err := fetchSessionsSnapshot(probeCtx, sockPath)
+	return err
 }
 
 // runDashboardProgram runs the bubbletea program for the given mode against

--- a/modules/programs/prism/prism/cmd/iris/dashboard.go
+++ b/modules/programs/prism/prism/cmd/iris/dashboard.go
@@ -1,0 +1,206 @@
+package main
+
+// dashboard.go — `iris dashboard` subcommand (issue #1703).
+//
+// The iris analogue of `prism dashboard`. Two surfaces:
+//
+//   iris dashboard               persistent mode (long-lived bubbletea
+//                                program). When invoked outside tmux, the
+//                                process execs `tmux attach-session -t
+//                                iris-dashboard`, creating the session if
+//                                it does not yet exist. When invoked from
+//                                inside tmux, the same recipe applies: the
+//                                tmux binding handles entry, this command
+//                                runs the bubbletea loop directly.
+//
+//   iris dashboard --popup       ephemeral popup mode (one-shot, q/esc
+//                                quits). Spawned by `tmux display-popup
+//                                -E ...` from the C-q binding. The popup
+//                                runs inside the caller's own client.
+//
+//   iris dashboard --caller-session <name>
+//                                marks the calling session as "you are
+//                                here" — a ◆ prefix on the matching row.
+//                                The tmux binding passes
+//                                "$(tmux display-message -p '#S')" so the
+//                                indicator works without any additional
+//                                plumbing.
+//
+// Read /home/ben/code/nixos-config/.../prism/cmd/dashboard.go for the
+// canonical shape this command follows.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/dashboard"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+var (
+	dashboardPopup         bool
+	dashboardCallerSession string
+	dashboardSocketPath    string
+)
+
+var dashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "Live multi-session dashboard for all daemon-known iris sessions",
+	Long: `iris dashboard opens a full-screen bubbletea dashboard showing every
+daemon-known iris session at a glance: state, role, worktree basename,
+uptime, and a recent-activity indicator. It updates live as sessions are
+spawned, transition states, or are cleaned up.
+
+Two surfaces:
+
+  iris dashboard            Persistent mode. When run outside tmux, this
+                            process execs into 'tmux attach-session -t
+                            iris-dashboard', creating the session on first
+                            use. The tmux binding (prefix+I) toggles
+                            between the dashboard session and the previous
+                            client location.
+
+  iris dashboard --popup    Ephemeral popup mode (one-shot, q/esc quits),
+                            spawned by 'tmux display-popup -E ...' via the
+                            C-q binding. The popup runs inside the
+                            caller's own client.
+
+  iris dashboard --caller-session <name>
+                            Marks the named tmux session as "you are here"
+                            with a ◆ prefix on the matching row. The tmux
+                            binding passes the result of 'tmux
+                            display-message -p "#S"' so this works
+                            without any additional plumbing.
+
+The iris daemon must be running ('iris daemon' or 'systemctl --user start
+iris') for the dashboard to populate. When the daemon is unreachable, the
+dashboard renders a clear "iris daemon not connected" overlay with a
+'systemctl --user start iris' hint and remains responsive to q/esc.`,
+	RunE:          runDashboard,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	dashboardCmd.Flags().BoolVar(&dashboardPopup, "popup", false, "Run as ephemeral popup (spawned by C-q keybinding); q/esc closes")
+	dashboardCmd.Flags().StringVar(&dashboardCallerSession, "caller-session", "", "Tmux session name of the invoking client (for 'you are here' indicator)")
+	dashboardCmd.Flags().StringVar(&dashboardSocketPath, "socket", "", "Path to the iris daemon socket (default: ~/.local/state/iris/iris.sock)")
+	rootCmd.AddCommand(dashboardCmd)
+}
+
+// runDashboard is the cobra RunE. It branches on --popup vs persistent;
+// persistent mode further branches on whether we're already inside tmux:
+// if not, exec into `tmux attach-session -t iris-dashboard` so the user
+// ends up attached to the persistent session rather than running a
+// short-lived foreground bubbletea program in their shell.
+func runDashboard(cmd *cobra.Command, _ []string) error {
+	sockPath := dashboardSocketPath
+	if sockPath == "" {
+		sockPath = iris.ResolvePaths().Sock
+	}
+
+	if dashboardPopup {
+		return runDashboardProgram(dashboard.ModePopup, sockPath, dashboardCallerSession)
+	}
+
+	// Persistent mode.
+	inTmux := os.Getenv("TMUX") != ""
+	if inTmux {
+		// If we're already inside the iris-dashboard session, run the
+		// bubbletea program directly. Otherwise the binding (prefix+I)
+		// has done its job and asked us to switch — but a CLI invocation
+		// from any other tmux session reaches here too; ensure the
+		// dashboard session exists, then switch the current client to it.
+		currentSess, _ := tmux.CurrentSession()
+		if currentSess == dashboard.DashSession {
+			return runDashboardProgram(dashboard.ModePersistent, sockPath, dashboardCallerSession)
+		}
+		if err := ensureDashSession(); err != nil {
+			return err
+		}
+		client, _ := tmux.CurrentClient()
+		return tmux.SwitchClient(client, dashboard.DashSession)
+	}
+
+	// Outside tmux: ensure session exists, then exec tmux attach so this
+	// process is replaced by a full tmux client attached to the dashboard.
+	if err := ensureDashSession(); err != nil {
+		return err
+	}
+	return syscallExecTmuxAttach(dashboard.DashSession)
+}
+
+// runDashboardProgram runs the bubbletea program for the given mode against
+// the iris daemon socket at sockPath. callerSession is forwarded to the
+// model for the "you are here" indicator (empty is fine — no indicator is
+// rendered). Blocks until the user quits.
+func runDashboardProgram(mode dashboard.Mode, sockPath, callerSession string) error {
+	client := tui.NewDaemonClient(sockPath)
+	m := dashboard.NewModel(client, mode, callerSession)
+
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	client.SetProgram(p)
+
+	// Connect asynchronously so the dashboard can render the disconnected
+	// overlay immediately while the dial is in progress. Mirrors the iris
+	// TUI's startup sequence. The DaemonClient owns its own retry loop, so
+	// we do not pass a context here — the goroutine exits when the process
+	// exits.
+	go client.Connect()
+
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("iris dashboard: %w", err)
+	}
+	return nil
+}
+
+// ensureDashSession creates the iris-dashboard tmux session if it doesn't
+// exist. The session runs `iris dashboard` (persistent mode) directly — no
+// restart loop. The persistent dashboard exits cleanly on q; tmux will
+// keep the session around with a "[exited]" indicator until the binding
+// re-enters.
+//
+// We use os.Executable to resolve the absolute path of the running iris
+// binary, so the spawned tmux session command works even when the pane
+// shell does not have the Nix store path on PATH (the same trick prism's
+// dashboard.go uses for the same reason).
+func ensureDashSession() error {
+	if tmux.HasSession(dashboard.DashSession) {
+		return nil
+	}
+	self, err := os.Executable()
+	if err != nil {
+		// Fall back to the bare name; if PATH doesn't have iris, tmux
+		// will surface the error inside the new session, which is more
+		// debuggable than failing here silently.
+		self = "iris"
+	}
+	dashCmd := "'" + strings.ReplaceAll(self, "'", "'\\''") + "' dashboard"
+	c := exec.Command(tmux.TmuxBin, "new-session", "-ds", dashboard.DashSession, "-n", "dashboard", dashCmd)
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("iris dashboard: create tmux session: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// syscallExecTmuxAttach replaces the current process with `tmux
+// attach-session -t sess` using syscall.Exec so no parent process remains.
+// Mirrors the prism dashboard's syscallExecTmux helper.
+func syscallExecTmuxAttach(sess string) error {
+	tmuxBin, err := exec.LookPath(tmux.TmuxBin)
+	if err != nil {
+		// LookPath fails when TmuxBin is already an absolute path that
+		// doesn't appear on PATH; try using it directly (the ldflags
+		// injection path on NixOS).
+		tmuxBin = tmux.TmuxBin
+	}
+	return syscall.Exec(tmuxBin, []string{"tmux", "attach-session", "-t", sess}, os.Environ())
+}

--- a/modules/programs/prism/prism/cmd/iris/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/iris/dashboard_test.go
@@ -1,0 +1,56 @@
+package main
+
+// dashboard_test.go — pre-flight probe tests for `iris dashboard`.
+//
+// AC #8 of issue #1703 requires that `iris dashboard` exit non-zero with
+// the canonical `systemctl --user start iris` hint when the daemon is not
+// running. The synchronous pre-flight probe (dashboardPreflightProbe)
+// owns that contract; this test locks the hint shape so future changes
+// can't drift it out of alignment with `iris sessions list` /
+// `iris prompt`.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDashboard_DaemonNotRunning points the pre-flight probe at a
+// non-existent socket path and asserts the canonical error shape:
+//
+//   - non-nil error (mapping to a non-zero CLI exit)
+//   - contains "daemon not running"
+//   - contains "systemctl --user start iris"
+//
+// Mirrors TestPrompt_DaemonNotRunning in prompt_integration_test.go so
+// both surfaces produce byte-aligned operator instructions when iris is
+// down.
+func TestDashboard_DaemonNotRunning(t *testing.T) {
+	dir, err := os.MkdirTemp("", "iris-dashboard-no-daemon-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	// Path deliberately does not exist — fetchSessionsSnapshot stat()s
+	// the path first and surfaces the canonical "socket does not exist"
+	// error before any dial is attempted.
+	sockPath := filepath.Join(dir, "iris.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = dashboardPreflightProbe(ctx, sockPath)
+	if err == nil {
+		t.Fatalf("dashboardPreflightProbe: want daemon-not-running error, got nil")
+	}
+	if !strings.Contains(err.Error(), "daemon not running") {
+		t.Errorf("error missing 'daemon not running' wording: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "systemctl --user start iris") {
+		t.Errorf("error missing 'systemctl --user start iris' hint: %q", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/dashboard/dashboard.go
+++ b/modules/programs/prism/prism/internal/iris/dashboard/dashboard.go
@@ -1,0 +1,662 @@
+// Package dashboard implements the iris live multi-session dashboard TUI
+// (issue #1703).
+//
+// This is the iris analogue of `prism dashboard`. Where `iris tui` is a
+// per-session-focused view (session list + event stream + prompt), the
+// dashboard is the read-only "what's happening across my whole work" view:
+// every daemon-known iris session in one screen, with state, role,
+// worktree, uptime, and a recent-activity indicator.
+//
+// State source:
+//   - sessions_snapshot (initial + periodic refresh) — authoritative list.
+//   - session_spawned (push) — new session appears immediately on the
+//     client that triggered the spawn; cross-client appearance happens
+//     within one refresh tick.
+//   - session_state (push, per subscribed session) — live state colour.
+//   - session_event (push, per subscribed session) — drives the recent
+//     activity column.
+//
+// The dashboard subscribes to every visible session so state and event
+// frames flow without needing an explicit "subscribe to all" frame. Disposal
+// of subscriptions for sessions that drop off the snapshot is handled in
+// reconcileSessions.
+//
+// The dashboard never reads iris.db directly. All state access goes through
+// the daemon socket, mirroring the discipline asserted in the iris TUI's
+// TestNoDBImport.
+package dashboard
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+// DashSession is the canonical persistent dashboard tmux session name.
+// Mirrors prism's DashSession naming (s/prism/iris/) so the keybinding
+// recipe is structurally identical.
+const DashSession = "iris-dashboard"
+
+// refreshInterval is how often the dashboard issues a sessions_list to
+// reconcile against the daemon's authoritative session set. A 1s cadence
+// satisfies the "row disappears within ~1 second" cleanup AC while still
+// being cheap (sessions_snapshot is an in-memory dump).
+const refreshInterval = 1 * time.Second
+
+// Mode distinguishes popup (one-shot, q/esc quits) from persistent (long-lived
+// session running `iris dashboard`). Both share the same Model — the only
+// behavioural difference is what `q`/`esc` does.
+type Mode int
+
+const (
+	// ModePopup is the ephemeral popup mode (spawned by the C-q binding via
+	// `tmux display-popup -E`). q/esc quits the program and the popup
+	// closes.
+	ModePopup Mode = iota
+	// ModePersistent is the long-lived mode that runs inside the
+	// `iris-dashboard` tmux session. q/esc still quits — the tmux binding
+	// recipe handles re-entry — but in practice users leave it open.
+	ModePersistent
+)
+
+// sessionRow is the rendered, in-memory state for a single dashboard row.
+type sessionRow struct {
+	snap         iris.SessionSnapshot
+	lastEventAt  time.Time
+	lastEventTxt string
+	subscribed   bool
+}
+
+// tickMsg is the periodic refresh trigger.
+type tickMsg time.Time
+
+// tick returns a Cmd that fires a tickMsg after refreshInterval.
+func tick() tea.Cmd {
+	return tea.Tick(refreshInterval, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+// Model is the bubbletea model for the iris dashboard.
+//
+// Exported fields are intentionally minimal — the dashboard surface is
+// read-only, so test access is via the export_test.go shims in the same
+// package, not via field exposure.
+type Model struct {
+	client *tui.DaemonClient
+	mode   Mode
+
+	// callerSession is the tmux session name passed via --caller-session.
+	// When non-empty, the row whose Name matches is decorated with a
+	// "you are here" indicator (◆ prefix), matching prism's treatment.
+	callerSession string
+
+	// Connection state.
+	connected    bool
+	connectError string
+	reconnecting bool
+
+	// Terminal dimensions.
+	width  int
+	height int
+
+	// Sessions, keyed by name for O(1) reconcile and update.
+	sessions map[string]*sessionRow
+	// order is the rendered row order, recomputed on every reconcile.
+	order []string
+
+	// Theme, loaded from internal/config so the dashboard tracks the same
+	// palette as the tmuxstatus segment (#1672) — a single source of truth
+	// for "what colour is `active`".
+	theme palette
+}
+
+// palette holds the resolved theme colours used by the dashboard. Loaded once
+// at NewModel time from internal/config so tests can assert against fixed
+// values without needing the config file on disk (config.Load returns
+// gruvbox-dark defaults when no file is present).
+type palette struct {
+	primary    string // separator / accent
+	secondary  string // dim
+	purple     string // active / spawning
+	yellow     string // waiting
+	green      string // finished
+	red        string // error
+	blue       string // role accents
+	foreground string
+	bg0        string
+}
+
+func loadPalette() palette {
+	cfg := config.Load()
+	return palette{
+		primary:    cfg.ColorPrimary,
+		secondary:  cfg.ColorSecondary,
+		purple:     cfg.ColorPurple,
+		yellow:     cfg.ColorYellow,
+		green:      cfg.ColorGreen,
+		red:        cfg.ColorRed,
+		blue:       cfg.ColorBlue,
+		foreground: cfg.ColorForeground,
+		bg0:        cfg.ColorBg0,
+	}
+}
+
+// NewModel constructs a dashboard model. client is the (already-configured)
+// DaemonClient — the caller is responsible for SetProgram/Connect plumbing.
+// mode and callerSession come from the cobra flags.
+func NewModel(client *tui.DaemonClient, mode Mode, callerSession string) Model {
+	return Model{
+		client:        client,
+		mode:          mode,
+		callerSession: callerSession,
+		sessions:      make(map[string]*sessionRow),
+		theme:         loadPalette(),
+	}
+}
+
+// Init starts the periodic refresh tick. The DaemonClient already issues an
+// initial sessions_list on connect, so no startup Cmd is needed beyond the
+// tick.
+func (m Model) Init() tea.Cmd {
+	return tick()
+}
+
+// Update is the bubbletea reducer. Frame handling lives in handleDaemonFrame
+// to keep the switch arm short.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tui.ConnectedMsg:
+		m.connected = true
+		m.reconnecting = false
+		m.connectError = ""
+		return m, nil
+
+	case tui.DisconnectedMsg:
+		m.connected = false
+		if msg.Err != nil {
+			m.connectError = msg.Err.Error()
+		}
+		m.reconnecting = true
+		return m, nil
+
+	case tui.DaemonFrame:
+		return m.handleDaemonFrame(msg)
+
+	case tickMsg:
+		// Periodic refresh: ask the daemon for the authoritative session
+		// list. The handler in handleDaemonFrame will reconcile (additions,
+		// removals, subscription cleanup) when the snapshot arrives.
+		cmd := func() tea.Msg {
+			_ = m.client.SendSessionsList()
+			return nil
+		}
+		return m, tea.Batch(cmd, tick())
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "q", "esc":
+		// Both modes quit on q/esc. In popup mode this closes the popup
+		// frame (display-popup -E). In persistent mode the tmux binding
+		// recipe (D key) re-enters by switching back to the dashboard
+		// session, so a stray q simply exits the bubbletea program — the
+		// session itself remains and can be re-entered.
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleDaemonFrame(msg tui.DaemonFrame) (tea.Model, tea.Cmd) {
+	switch msg.RawType {
+
+	case iris.DaemonFrameSessionsSnapshot:
+		if msg.Snapshot == nil {
+			return m, nil
+		}
+		return m.reconcileSessions(msg.Snapshot.Sessions)
+
+	case iris.DaemonFrameSessionSpawned:
+		if msg.Spawned == nil || msg.Spawned.Name == "" {
+			return m, nil
+		}
+		// session_spawned is broadcast only to the spawning client today,
+		// but handle it eagerly anyway — it lets the originating client
+		// see the new row sub-tick rather than waiting up to refreshInterval.
+		// The next sessions_snapshot will reconcile cross-client.
+		var snap iris.SessionSnapshot
+		if msg.Spawned.Session != nil {
+			snap = *msg.Spawned.Session
+		} else {
+			snap = iris.SessionSnapshot{
+				Name:       msg.Spawned.Name,
+				InstanceID: msg.Spawned.InstanceID,
+			}
+		}
+		return m.applySnapshotAdd(snap)
+
+	case iris.DaemonFrameSessionState:
+		if msg.State == nil {
+			return m, nil
+		}
+		if row, ok := m.sessions[msg.State.SessionName]; ok {
+			row.snap.State = msg.State.State
+		}
+		return m, nil
+
+	case iris.DaemonFrameSessionEvent:
+		if msg.Event == nil {
+			return m, nil
+		}
+		if row, ok := m.sessions[msg.Event.SessionName]; ok {
+			row.lastEventAt = time.Now()
+			row.lastEventTxt = activityLabel(msg.Event.EventType)
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// applySnapshotAdd inserts or updates a single row from a session_spawned
+// frame and (re)subscribes to its event stream so live state/event frames
+// flow. Order is recomputed via sortOrder so the new row appears in the
+// canonical position.
+func (m Model) applySnapshotAdd(snap iris.SessionSnapshot) (tea.Model, tea.Cmd) {
+	if existing, ok := m.sessions[snap.Name]; ok {
+		// Merge: preserve our liveness tracking but take the new snapshot.
+		existing.snap = snap
+		return m, nil
+	}
+	row := &sessionRow{snap: snap}
+	m.sessions[snap.Name] = row
+	m.order = sortOrder(m.sessions)
+	if !row.subscribed {
+		row.subscribed = true
+		name := snap.Name
+		return m, func() tea.Msg {
+			_ = m.client.SendSessionSubscribe(name, 0)
+			return nil
+		}
+	}
+	return m, nil
+}
+
+// reconcileSessions takes an authoritative sessions_snapshot and brings the
+// in-memory map into agreement: adds new rows (subscribing to each so live
+// frames flow), removes rows that are no longer present (unsubscribing), and
+// updates the snapshot fields on rows that persist. Returns a Cmd that
+// dispatches all the subscribe/unsubscribe writes in parallel.
+func (m Model) reconcileSessions(snaps []iris.SessionSnapshot) (tea.Model, tea.Cmd) {
+	seen := make(map[string]bool, len(snaps))
+	var subscribes []string
+	for _, s := range snaps {
+		seen[s.Name] = true
+		if existing, ok := m.sessions[s.Name]; ok {
+			// Preserve liveness tracking; refresh the snapshot fields.
+			existing.snap = s
+			continue
+		}
+		row := &sessionRow{snap: s, subscribed: true}
+		m.sessions[s.Name] = row
+		subscribes = append(subscribes, s.Name)
+	}
+	// Removals: any in-memory row whose name is no longer in the snapshot.
+	var unsubscribes []string
+	for name := range m.sessions {
+		if !seen[name] {
+			unsubscribes = append(unsubscribes, name)
+			delete(m.sessions, name)
+		}
+	}
+	m.order = sortOrder(m.sessions)
+
+	if len(subscribes) == 0 && len(unsubscribes) == 0 {
+		return m, nil
+	}
+	client := m.client
+	cmd := func() tea.Msg {
+		for _, n := range subscribes {
+			_ = client.SendSessionSubscribe(n, 0)
+		}
+		for _, n := range unsubscribes {
+			_ = client.SendSessionUnsubscribe(n)
+		}
+		return nil
+	}
+	return m, cmd
+}
+
+// sortOrder returns a stable ordering for the row keys: by StartedAt
+// descending (newest first), with name as the tiebreaker. Empty StartedAt
+// sorts last (treats unstarted/restored rows as oldest).
+func sortOrder(sessions map[string]*sessionRow) []string {
+	names := make([]string, 0, len(sessions))
+	for n := range sessions {
+		names = append(names, n)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		ri, rj := sessions[names[i]], sessions[names[j]]
+		ti, _ := time.Parse(time.RFC3339, ri.snap.StartedAt)
+		tj, _ := time.Parse(time.RFC3339, rj.snap.StartedAt)
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return names[i] < names[j]
+	})
+	return names
+}
+
+// activityLabel turns an event type into a short activity blurb for the
+// recent-activity column. Mirrors the verb shapes used by the prism
+// dashboard's activity indicator.
+func activityLabel(eventType string) string {
+	switch eventType {
+	case "msg_assistant", "msg_assistant_body":
+		return "assistant turn"
+	case "msg_user", "msg_user_body":
+		return "user prompt"
+	case "tool_call":
+		return "tool call"
+	case "tool_result":
+		return "tool result"
+	case "permission_ask":
+		return "permission ask"
+	case "permission_denied":
+		return "permission denied"
+	case "state_change":
+		return "state change"
+	case "":
+		return ""
+	default:
+		return eventType
+	}
+}
+
+// ── view ───────────────────────────────────────────────────────────────────
+
+// View renders the dashboard. Layout, top to bottom:
+//
+//	header line     "iris dashboard — N sessions"
+//	separator
+//	column headers  "  SESSION  STATE  ROLE  WORKTREE  UPTIME  ACTIVITY"
+//	rows…
+//	footer hint     "q/esc to quit"
+func (m Model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+
+	if !m.connected {
+		return m.viewDisconnected()
+	}
+
+	var sb strings.Builder
+	sb.WriteString(m.viewHeader())
+	sb.WriteString("\n")
+	sb.WriteString(m.styleDim().Render(strings.Repeat("─", max(0, m.width))))
+	sb.WriteString("\n")
+
+	if len(m.order) == 0 {
+		sb.WriteString("\n")
+		sb.WriteString(m.styleDim().Render("  no iris sessions yet — spawn one with `iris spawn --worktree <path>`."))
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString(m.viewColumnHeader())
+		sb.WriteString("\n")
+		for _, name := range m.order {
+			row := m.sessions[name]
+			sb.WriteString(m.viewRow(row))
+			sb.WriteString("\n")
+		}
+	}
+
+	// Footer.
+	sb.WriteString("\n")
+	footer := "q/esc to quit"
+	if m.mode == ModePersistent {
+		footer = "q/esc to quit  (re-enter via prefix+I)"
+	}
+	sb.WriteString(m.styleDim().Render("  " + footer))
+	return sb.String()
+}
+
+// viewDisconnected renders the daemon-down overlay. The hint matches the
+// "iris daemon not running" wording used by `iris sessions list` for
+// consistent operator instructions.
+func (m Model) viewDisconnected() string {
+	var sb strings.Builder
+	sb.WriteString("\n\n")
+	sb.WriteString(m.styleError().Render("  ✗ iris daemon not connected"))
+	sb.WriteString("\n\n")
+	if m.connectError != "" {
+		sb.WriteString(m.styleDim().Render("  " + m.connectError))
+		sb.WriteString("\n")
+	}
+	if m.reconnecting {
+		sb.WriteString(m.styleDim().Render("  Reconnecting…"))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(m.styleDim().Render("  Start the daemon: systemctl --user start iris"))
+	sb.WriteString("\n")
+	sb.WriteString(m.styleDim().Render("  Press q or ctrl+c to quit."))
+	return sb.String()
+}
+
+// viewHeader renders the title bar with the session count.
+func (m Model) viewHeader() string {
+	title := fmt.Sprintf("  iris dashboard — %d session%s", len(m.order), plural(len(m.order)))
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(m.theme.primary)).
+		Bold(true)
+	return style.Render(title)
+}
+
+// Column widths. The dashboard is full-screen and every column is fixed-width
+// so columns line up cleanly across rows (parity with prism's dashboard).
+const (
+	colSessionW  = 36
+	colStateW    = 10
+	colRoleW     = 12
+	colWorktreeW = 24
+	colUptimeW   = 8
+	colActivityW = 28
+)
+
+func (m Model) viewColumnHeader() string {
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(m.theme.foreground)).
+		Bold(true)
+	header := fmt.Sprintf("  %-*s %-*s %-*s %-*s %-*s %-*s",
+		colSessionW, "SESSION",
+		colStateW, "STATE",
+		colRoleW, "ROLE",
+		colWorktreeW, "WORKTREE",
+		colUptimeW, "UPTIME",
+		colActivityW, "ACTIVITY",
+	)
+	return style.Render(header)
+}
+
+// viewRow renders a single dashboard row. Layout:
+//
+//	"<here> SESSION  STATE  ROLE  WORKTREE  UPTIME  ACTIVITY"
+//
+// The "here" prefix is "◆ " when row.snap.Name == m.callerSession (matches
+// prism's "you are here" indicator); otherwise "  " (two spaces) for column
+// alignment.
+func (m Model) viewRow(row *sessionRow) string {
+	here := "  "
+	if m.callerSession != "" && row.snap.Name == m.callerSession {
+		here = lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.yellow)).Bold(true).Render("◆ ")
+	}
+
+	name := truncCols(row.snap.Name, colSessionW)
+	state := stateLabel(row.snap.State)
+	statePadded := padCols(state, colStateW)
+	stateColoured := m.styleForState(row.snap.State).Render(statePadded)
+
+	role := truncCols(row.snap.Role, colRoleW)
+	worktree := truncCols(filepath.Base(row.snap.Worktree), colWorktreeW)
+	uptime := padCols(formatUptime(row.snap.StartedAt), colUptimeW)
+	activity := truncCols(formatActivity(row.lastEventAt, row.lastEventTxt), colActivityW)
+
+	// Assemble: name  state  role  worktree  uptime  activity
+	return fmt.Sprintf("%s%-*s %s %-*s %-*s %s %-*s",
+		here,
+		colSessionW, name,
+		stateColoured,
+		colRoleW, role,
+		colWorktreeW, worktree,
+		uptime,
+		colActivityW, activity,
+	)
+}
+
+// stateLabel returns the human-readable state name. Unknown states fall
+// through unchanged so operators can still see them in the dashboard.
+func stateLabel(state string) string {
+	switch state {
+	case "active":
+		return "active"
+	case "spawning":
+		return "spawning"
+	case "waiting":
+		return "waiting"
+	case "idle":
+		return "idle"
+	case "finished":
+		return "finished"
+	case "error":
+		return "error"
+	case "":
+		return "—"
+	default:
+		return state
+	}
+}
+
+// styleForState returns a lipgloss style with the colour appropriate to the
+// state. The mapping mirrors the tmuxstatus segment colours so the
+// dashboard, the status-right segment, and (later) any other iris surfaces
+// all use one palette per state — when a user themes "active" purple in
+// ~/.config/prism/config.json, every iris surface respects it.
+func (m Model) styleForState(state string) lipgloss.Style {
+	colour := m.theme.secondary
+	switch state {
+	case "active", "spawning":
+		colour = m.theme.purple
+	case "waiting":
+		colour = m.theme.yellow
+	case "finished":
+		colour = m.theme.green
+	case "error":
+		colour = m.theme.red
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colour))
+}
+
+func (m Model) styleDim() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.secondary))
+}
+
+func (m Model) styleError() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.red)).Bold(true)
+}
+
+// formatUptime returns a short uptime string (≤ 7 chars) given an RFC3339
+// timestamp. Empty input → "—".
+func formatUptime(s string) string {
+	if s == "" {
+		return "—"
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "—"
+	}
+	d := time.Since(t)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// formatActivity renders the recent-activity column entry. Empty when no
+// event has been observed for this row yet (avoids implying "0s ago").
+func formatActivity(at time.Time, label string) string {
+	if at.IsZero() || label == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s at %s", label, at.Format("15:04:05"))
+}
+
+// truncCols truncates s to at most w display columns, appending "…" if it
+// had to cut. Display width is approximated as rune count (the dashboard
+// renders ASCII session names, role tags, basenames, and HH:MM:SS — full
+// CJK/grapheme width measurement isn't worth the extra dependency here).
+func truncCols(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= w {
+		return s
+	}
+	if w == 1 {
+		return "…"
+	}
+	runes := []rune(s)
+	return string(runes[:w-1]) + "…"
+}
+
+// padCols pads s on the right with spaces to exactly w display columns.
+// Truncates with truncCols if s is wider.
+func padCols(s string, w int) string {
+	if utf8.RuneCountInString(s) > w {
+		return truncCols(s, w)
+	}
+	return s + strings.Repeat(" ", w-utf8.RuneCountInString(s))
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/modules/programs/prism/prism/internal/iris/dashboard/dashboard_test.go
+++ b/modules/programs/prism/prism/internal/iris/dashboard/dashboard_test.go
@@ -1,0 +1,285 @@
+package dashboard_test
+
+// dashboard_test.go — model-level unit tests for the iris dashboard
+// (issue #1703). These exercise the bubbletea Update() reducer directly
+// without starting a terminal program: the AC asserts that "the dashboard
+// updates live as sessions are spawned, transition states, or are cleaned
+// up", which translates to three Update transitions:
+//
+//   1. session added         (sessions_snapshot adds a row)
+//   2. session removed       (sessions_snapshot reconciles a removal)
+//   3. state changed         (session_state updates the in-memory row)
+//
+// We also assert that session_spawned drives a row appearance directly
+// (the originating-client fast path) and that session_event populates the
+// recent-activity column.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/dashboard"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+// newTestModel returns a Model that has received a WindowSizeMsg and
+// ConnectedMsg so subsequent frames can flow.
+func newTestModel(t *testing.T) dashboard.Model {
+	t.Helper()
+	client := tui.NewDaemonClient("/dev/null") // no real socket — frames driven by tests
+	m := dashboard.NewModel(client, dashboard.ModePopup, "")
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
+	m = m2.(dashboard.Model)
+	m2, _ = m.Update(tui.ConnectedMsg{})
+	return m2.(dashboard.Model)
+}
+
+func snapFrame(snaps ...iris.SessionSnapshot) tui.DaemonFrame {
+	return tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionsSnapshot,
+		Snapshot: &iris.DaemonSessionsSnapshotFrame{
+			Type:     iris.DaemonFrameSessionsSnapshot,
+			Sessions: snaps,
+		},
+	}
+}
+
+// TestSessionAddedViaSnapshot verifies that a sessions_snapshot frame populates
+// the dashboard row map.
+func TestSessionAddedViaSnapshot(t *testing.T) {
+	m := newTestModel(t)
+	if got := dashboard.SessionCount(m); got != 0 {
+		t.Fatalf("initial session count: got %d, want 0", got)
+	}
+
+	snap := iris.SessionSnapshot{
+		Name:       "nixos-config@feat-x",
+		InstanceID: "iid-1",
+		State:      "active",
+		Role:       "worker",
+		Worktree:   "/repo/feat-x",
+		StartedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	m2, _ := m.Update(snapFrame(snap))
+	m = m2.(dashboard.Model)
+
+	if got := dashboard.SessionCount(m); got != 1 {
+		t.Fatalf("after snapshot: session count got %d, want 1", got)
+	}
+	if !dashboard.HasSession(m, "nixos-config@feat-x") {
+		t.Fatalf("session not found in dashboard map")
+	}
+	if got := dashboard.SessionState(m, "nixos-config@feat-x"); got != "active" {
+		t.Fatalf("session state got %q, want %q", got, "active")
+	}
+}
+
+// TestSessionRemovedViaSnapshot verifies that a sessions_snapshot frame which
+// no longer contains a previously-known session removes it from the map. This
+// covers the "row disappears within ~1 second" cleanup AC.
+func TestSessionRemovedViaSnapshot(t *testing.T) {
+	m := newTestModel(t)
+	a := iris.SessionSnapshot{Name: "a", InstanceID: "iid-a", State: "active", Role: "worker"}
+	b := iris.SessionSnapshot{Name: "b", InstanceID: "iid-b", State: "active", Role: "worker"}
+	m2, _ := m.Update(snapFrame(a, b))
+	m = m2.(dashboard.Model)
+	if got := dashboard.SessionCount(m); got != 2 {
+		t.Fatalf("after first snapshot: got %d sessions, want 2", got)
+	}
+
+	// Second snapshot drops "a" — simulates cleanup.
+	m2, _ = m.Update(snapFrame(b))
+	m = m2.(dashboard.Model)
+	if got := dashboard.SessionCount(m); got != 1 {
+		t.Fatalf("after reconcile: got %d sessions, want 1", got)
+	}
+	if dashboard.HasSession(m, "a") {
+		t.Fatalf("session 'a' should have been removed by reconcile")
+	}
+	if !dashboard.HasSession(m, "b") {
+		t.Fatalf("session 'b' should still be present after reconcile")
+	}
+}
+
+// TestStateChangePropagates verifies session_state frames mutate the
+// in-memory row's state field. This is the live-update path used when the
+// daemon publishes state transitions to subscribed clients.
+func TestStateChangePropagates(t *testing.T) {
+	m := newTestModel(t)
+	a := iris.SessionSnapshot{Name: "a", InstanceID: "iid-a", State: "spawning", Role: "worker"}
+	m2, _ := m.Update(snapFrame(a))
+	m = m2.(dashboard.Model)
+	if got := dashboard.SessionState(m, "a"); got != "spawning" {
+		t.Fatalf("initial state got %q, want %q", got, "spawning")
+	}
+
+	state := tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionState,
+		State: &iris.DaemonSessionStateFrame{
+			Type:        iris.DaemonFrameSessionState,
+			SessionName: "a",
+			State:       "active",
+		},
+	}
+	m2, _ = m.Update(state)
+	m = m2.(dashboard.Model)
+
+	if got := dashboard.SessionState(m, "a"); got != "active" {
+		t.Fatalf("after session_state: state got %q, want %q", got, "active")
+	}
+}
+
+// TestSessionSpawnedAppendsRow verifies the originating-client fast path:
+// a session_spawned frame appends a row before the next sessions_snapshot
+// reconcile. This is the same eager-row UX the iris TUI provides via
+// session_spawned (#1670).
+func TestSessionSpawnedAppendsRow(t *testing.T) {
+	m := newTestModel(t)
+	spawned := tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       "fresh@now",
+			InstanceID: "iid-fresh",
+			Session: &iris.SessionSnapshot{
+				Name:       "fresh@now",
+				InstanceID: "iid-fresh",
+				State:      "spawning",
+				Role:       "worker",
+				StartedAt:  time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+	m2, _ := m.Update(spawned)
+	m = m2.(dashboard.Model)
+	if !dashboard.HasSession(m, "fresh@now") {
+		t.Fatalf("session_spawned did not append row")
+	}
+	if got := dashboard.SessionState(m, "fresh@now"); got != "spawning" {
+		t.Fatalf("spawned row state got %q, want %q", got, "spawning")
+	}
+}
+
+// TestSessionEventUpdatesActivityColumn verifies that a session_event frame
+// records the event type and timestamp on the matching row, populating the
+// recent-activity indicator.
+func TestSessionEventUpdatesActivityColumn(t *testing.T) {
+	m := newTestModel(t)
+	a := iris.SessionSnapshot{Name: "a", InstanceID: "iid-a", State: "active", Role: "worker"}
+	m2, _ := m.Update(snapFrame(a))
+	m = m2.(dashboard.Model)
+
+	before := time.Now()
+	event := tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: "a",
+			RowID:       42,
+			EventType:   "tool_call",
+			Payload:     "{}",
+		},
+	}
+	m2, _ = m.Update(event)
+	m = m2.(dashboard.Model)
+
+	label, at := dashboard.SessionLastEvent(m, "a")
+	if label == "" {
+		t.Fatalf("expected a non-empty activity label after session_event")
+	}
+	if !strings.Contains(label, "tool") {
+		t.Fatalf("activity label got %q, want it to mention tool", label)
+	}
+	if at.Before(before) {
+		t.Fatalf("activity timestamp not updated: %v before %v", at, before)
+	}
+}
+
+// TestEmptySessionsView verifies the dashboard renders the empty-state hint
+// (and remains responsive to q) when no sessions are present.
+func TestEmptySessionsView(t *testing.T) {
+	m := newTestModel(t)
+	view := m.View()
+	if !strings.Contains(view, "no iris sessions yet") {
+		t.Fatalf("empty view does not contain empty-state hint; view excerpt:\n%s", excerpt(view, 600))
+	}
+	// q should still cause a Quit Cmd.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Fatalf("q produced no Cmd; expected tea.Quit")
+	}
+	// Cmd is a closure that returns tea.QuitMsg{} when invoked.
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("q Cmd produced %T, want tea.QuitMsg", msg)
+	}
+}
+
+// TestDisconnectedView verifies the daemon-down overlay renders the canonical
+// hint, satisfying the "daemon not running → clear hint" AC.
+func TestDisconnectedView(t *testing.T) {
+	client := tui.NewDaemonClient("/dev/null")
+	m := dashboard.NewModel(client, dashboard.ModePopup, "")
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = m2.(dashboard.Model)
+	// Note: we deliberately did not send ConnectedMsg, so the model is in
+	// the disconnected state.
+	view := m.View()
+	if !strings.Contains(view, "iris daemon not connected") {
+		t.Fatalf("disconnected view missing not-connected line; view excerpt:\n%s", excerpt(view, 400))
+	}
+	if !strings.Contains(view, "systemctl --user start iris") {
+		t.Fatalf("disconnected view missing start-the-daemon hint; view excerpt:\n%s", excerpt(view, 400))
+	}
+}
+
+// TestCallerSessionMarker verifies that the --caller-session row is
+// decorated with the "you are here" diamond.
+func TestCallerSessionMarker(t *testing.T) {
+	client := tui.NewDaemonClient("/dev/null")
+	m := dashboard.NewModel(client, dashboard.ModePopup, "myself@here")
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 40})
+	m = m2.(dashboard.Model)
+	m2, _ = m.Update(tui.ConnectedMsg{})
+	m = m2.(dashboard.Model)
+	a := iris.SessionSnapshot{Name: "myself@here", InstanceID: "iid-1", State: "active", Role: "coordinator"}
+	b := iris.SessionSnapshot{Name: "other@there", InstanceID: "iid-2", State: "active", Role: "worker"}
+	m2, _ = m.Update(snapFrame(a, b))
+	m = m2.(dashboard.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "◆") {
+		t.Fatalf("caller-session view missing the ◆ marker; view excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// TestRenderIncludesSessionAndState verifies the rendered view contains the
+// session name and a colourised state for both rows, exercising the full
+// view path end-to-end.
+func TestRenderIncludesSessionAndState(t *testing.T) {
+	m := newTestModel(t)
+	a := iris.SessionSnapshot{Name: "alpha@one", InstanceID: "iid-a", State: "active", Role: "worker", Worktree: "/p/alpha", StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	b := iris.SessionSnapshot{Name: "beta@two", InstanceID: "iid-b", State: "error", Role: "coordinator", Worktree: "/p/beta", StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	m2, _ := m.Update(snapFrame(a, b))
+	m = m2.(dashboard.Model)
+
+	view := m.View()
+	for _, want := range []string{"alpha@one", "beta@two", "active", "error", "alpha", "beta"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view missing %q; excerpt:\n%s", want, excerpt(view, 800))
+		}
+	}
+}
+
+// excerpt returns up to n bytes of s with newlines preserved, useful for
+// failure messages that need a peek at the rendered View().
+func excerpt(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/modules/programs/prism/prism/internal/iris/dashboard/export_test.go
+++ b/modules/programs/prism/prism/internal/iris/dashboard/export_test.go
@@ -1,0 +1,47 @@
+package dashboard
+
+// export_test.go — test-only accessors that expose internal Model state to
+// the dashboard_test package. Compiled only when `go test` runs, so they
+// do not enlarge the public API surface.
+
+import "time"
+
+// SessionCount returns the number of rows currently tracked by the model.
+func SessionCount(m Model) int {
+	return len(m.sessions)
+}
+
+// HasSession returns true if a row exists for the given name.
+func HasSession(m Model, name string) bool {
+	_, ok := m.sessions[name]
+	return ok
+}
+
+// SessionState returns the in-memory state field for the named row, or
+// "" if no such row exists. Used to assert that session_state frames
+// updated the row.
+func SessionState(m Model, name string) string {
+	r, ok := m.sessions[name]
+	if !ok {
+		return ""
+	}
+	return r.snap.State
+}
+
+// SessionLastEvent returns (label, at) for the named row's most recent
+// observed event. Zero values when no event has been seen.
+func SessionLastEvent(m Model, name string) (string, time.Time) {
+	r, ok := m.sessions[name]
+	if !ok {
+		return "", time.Time{}
+	}
+	return r.lastEventTxt, r.lastEventAt
+}
+
+// Order returns the rendered row order. Useful for asserting that a new
+// session_spawned row appears in the canonical position.
+func Order(m Model) []string {
+	out := make([]string, len(m.order))
+	copy(out, m.order)
+	return out
+}

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -234,6 +234,29 @@ in
               bind-key D run-shell \
                 'if [ "$(${pkgs.tmux}/bin/tmux display-message -p "#S")" = "prism-dashboard" ]; then ${pkgs.tmux}/bin/tmux switch-client -l; else ${pkgs.tmux}/bin/tmux has-session -t prism-dashboard 2>/dev/null || ${pkgs.tmux}/bin/tmux new-session -ds prism-dashboard -n dashboard "${prism} dashboard"; ${pkgs.tmux}/bin/tmux switch-client -t prism-dashboard; fi'
 
+              # --- Iris dashboard keybindings (issue #1703) ---
+              #
+              # C-q: ephemeral iris dashboard popup. Mirrors the prism C-w
+              # popup geometry (80% x 60%, -b single, -E to close on child
+              # exit). Different leader key from C-w so both surfaces remain
+              # usable side by side during the iris coexistence window. The
+              # --caller-session flag receives the current tmux session name
+              # via display-message so the "you are here" ◆ indicator works
+              # without any additional plumbing.
+              bind -n C-q display-popup -E -w 80% -h 60% -b single \
+                "${iris} dashboard --popup --caller-session \"$(${pkgs.tmux}/bin/tmux display-message -p '#S')\""
+
+              # prefix+I: toggle the persistent iris-dashboard session.
+              # Iris uses 'I' (uppercase) here because prism already binds
+              # the uppercase 'D' to its own persistent dashboard and iris
+              # already binds the lowercase 'i' to the context switcher
+              # (#1684). The recipe mirrors the prism D binding: if already
+              # in the iris-dashboard session, switch-client -l returns the
+              # client to its previous location; otherwise ensure the
+              # session exists and switch to it.
+              bind-key I run-shell \
+                'if [ "$(${pkgs.tmux}/bin/tmux display-message -p "#S")" = "iris-dashboard" ]; then ${pkgs.tmux}/bin/tmux switch-client -l; else ${pkgs.tmux}/bin/tmux has-session -t iris-dashboard 2>/dev/null || ${pkgs.tmux}/bin/tmux new-session -ds iris-dashboard -n dashboard "${iris} dashboard"; ${pkgs.tmux}/bin/tmux switch-client -t iris-dashboard; fi'
+
               # toggle to/from term window (C-Space)
               unbind C-Space
               bind -n C-Space run-shell 'idx=$(${pkgs.tmux}/bin/tmux list-windows -F "##I:##W" | grep ":term$" | head -1 | cut -d: -f1); cur=$(${pkgs.tmux}/bin/tmux display-message -p "#{window_name}"); if [ -z "$idx" ]; then ${pkgs.tmux}/bin/tmux new-window -n term; elif [ "$cur" = "term" ]; then ${pkgs.tmux}/bin/tmux select-window -t agent; else ${pkgs.tmux}/bin/tmux select-window -t "$idx"; fi'


### PR DESCRIPTION
Adds the iris analogue of \`prism dashboard\` — a live, read-only multi-session
view that complements the per-session-focused \`iris tui\` (#1655) and the
context-switcher \`iris switch\` (#1684).

## What

### CLI

- \`iris dashboard\` — persistent bubbletea dashboard. Outside tmux, execs into
  \`tmux attach-session -t iris-dashboard\` so the user ends up attached to the
  long-lived session rather than running a foreground program in their shell.
- \`iris dashboard --popup\` — ephemeral popup mode for \`tmux display-popup -E\`.
  q/esc quits cleanly.
- \`iris dashboard --caller-session <name>\` — marks the named tmux session as
  \"you are here\" with a ◆ prefix on the matching row, matching prism's visual
  treatment.

### Rendering

Columns: SESSION, STATE, ROLE, WORKTREE (basename), UPTIME, ACTIVITY. The
state column is coloured via the same palette as the iris tmux status-right
segment (#1672) — both pull from \`internal/config\`, so a single
\`~/.config/prism/config.json\` themes both surfaces.

### Live updates

Reuses \`internal/iris/tui\`'s DaemonClient so the same sessions_snapshot +
session_state + session_event + session_spawned demux drives the live view.
The dashboard subscribes to every visible session so state and event frames
flow without an explicit \"subscribe to all\" frame, and reconciles
subscriptions on every refresh tick. A 1 s periodic \`sessions_list\` reconcile
satisfies the \"row disappears within ~1 second\" cleanup AC.

### Tmux bindings

- \`C-q\` — popup. Different leader key from prism's \`C-w\` so both surfaces
  remain usable side-by-side during the iris coexistence window.
- \`prefix+I\` — toggle the persistent \`iris-dashboard\` session. Uppercase \`I\`
  because prism already binds \`prefix+D\` (its persistent dashboard) and iris
  already binds \`prefix+i\` (lowercase, the \`iris switch\` context-switcher
  from #1684).

## Tests

\`internal/iris/dashboard/dashboard_test.go\` covers:

- session added (sessions_snapshot adds a row)
- session removed (sessions_snapshot reconciles a removal — the cleanup AC)
- state changed (session_state mutates the in-memory row)
- session_spawned fast-path (originating-client eager row append)
- session_event populates the recent-activity column
- empty / disconnected / caller-session views

## Quality gates

- \`go build ./...\` ✓
- \`go test ./... -race\` ✓ (all 27 packages pass; full output in worker log)
- \`go vet ./...\` ✓ (clean)
- \`nix build .#iris\` ✓

Manual verification of the tmux popup/keybinding is post-\`nh switch\` (tmux
popups can't be automated; explicitly called out in the AC).

Closes #1703