### PR TITLE
iris: add db query / schema / tables read-only introspection

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/db.go
+++ b/modules/programs/prism/prism/cmd/iris/db.go
@@ -1,0 +1,129 @@
+package main
+
+// db.go — `iris db` subcommand group.
+//
+// Implements issue #1698. The `iris db` family is the iris analogue of the
+// prism `db` surface (cmd/db.go + cmd/db_query.go + cmd/db_schema.go +
+// cmd/db_tables.go). It provides ad-hoc, read-only introspection over the
+// iris SQLite database (~/.local/state/iris/iris.db by default), so an
+// operator can debug iris session-state problems without dropping into the
+// raw `sqlite3` binary.
+//
+// # Read-only by design
+//
+// Iris adds a defence-in-depth layer over prism's approach: before opening
+// the DB at all, the `iris db query` command runs a keyword-based pre-check
+// (see isWriteStatement in db_query.go) that rejects INSERT / UPDATE /
+// DELETE / DROP / CREATE / ALTER and friends with a clear error. The DB is
+// then opened in SQLite read-only mode (?mode=ro via db.OpenReadOnly),
+// which is itself enough to prevent writes — the pre-check exists so the
+// failure path is unambiguous and the error message points the user at
+// `sqlite3` for legitimate write workflows.
+//
+// # Daemon coexistence
+//
+// SQLite's WAL mode (set by the daemon via db.Open) supports multiple
+// concurrent readers alongside a single writer, so `iris db query` can
+// safely read the DB while the iris daemon has it open for writes. Each
+// subcommand opens its own short-lived read-only connection (via
+// db.OpenReadOnly) and closes it on completion — no shared handle, no
+// long-lived locks.
+//
+// # No daemon socket
+//
+// Unlike `iris sessions list` (which dials the daemon's client socket),
+// the `iris db` family reads the DB file directly. This mirrors the
+// pattern established by `iris checkin` (issue #1676): read-only DB
+// inspection is a debug surface and the all-surfaces-go-through-daemon
+// rule (#1668 / #1669) only applies to mutations and shared mutable
+// state. The user does not need the daemon running to inspect the DB.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// testDBPath overrides resolveDBPath() during tests. Set via SetTestDBPath.
+// Mirrors the same hook in prism's cmd/db.go so test infrastructure can
+// point the CLI at a tempdir-backed DB without relying on env vars alone.
+//
+// Tests should pair calls to SetTestDBPath with a t.Cleanup that restores
+// it to "" — otherwise subsequent tests in the same package see the stale
+// path and exhibit confusing cross-test pollution.
+var testDBPath string
+
+// SetTestDBPath overrides the DB path used by iris db subcommands. Only for
+// use in tests. Call SetTestDBPath("") (or t.Cleanup(...)) to restore the
+// canonical XDG-derived path.
+func SetTestDBPath(p string) { testDBPath = p }
+
+// resolveDBPath returns the iris DB path. testDBPath wins; otherwise we
+// defer to iris.ResolvePaths() — the same single source of truth used by
+// every other iris CLI surface.
+func resolveDBPath() string {
+	if testDBPath != "" {
+		return testDBPath
+	}
+	return iris.ResolvePaths().DB
+}
+
+// dbCmd is the parent cobra command for the read-only iris-db surface.
+// Subcommands are registered in their own files' init() funcs so each
+// command's flags live next to its RunE.
+var dbCmd = &cobra.Command{
+	Use:   "db",
+	Short: "Read-only SQL query and schema introspection over the iris database",
+	Long: `Read-only SQL query and schema introspection over the iris database.
+
+The "iris db" surface exposes the iris SQLite database for ad-hoc forensic
+queries by operators debugging the daemon or session state. Curated views
+(iris sessions list, iris checkin) answer most questions; this surface fills
+the gap when raw SQL is needed.
+
+All subcommands are read-only by design:
+
+  - "iris db query" rejects write statements (INSERT / UPDATE / DELETE /
+    DROP / CREATE / ALTER and friends) before the database is opened, then
+    opens the DB in SQLite read-only mode as a defence-in-depth measure.
+    For legitimate writes, use sqlite3 directly.
+  - "iris db schema" and "iris db tables" read sqlite_master only.
+
+SQLite's WAL mode (set by the daemon) allows these read-only commands to
+run safely while the iris daemon has the DB open for writes. The daemon
+does not need to be stopped — concurrent readers do not interfere with
+the daemon's session updates.
+
+The DB path is resolved from $XDG_STATE_HOME (default
+~/.local/state/iris/iris.db). When the file does not exist (e.g. the iris
+daemon has never run), every subcommand exits non-zero with a clear
+"iris database not found" error pointing at the expected path.`,
+}
+
+func init() {
+	rootCmd.AddCommand(dbCmd)
+}
+
+// ensureDBExists returns an actionable error when the iris DB file does
+// not exist or is otherwise unreadable. Run before db.OpenReadOnly so the
+// operator sees "iris database not found" — pointing at the daemon as the
+// thing that would normally create it — rather than the raw modernc.org
+// "unable to open database file" message.
+//
+// Each `iris db <verb>` caller wraps the error with its own "iris db
+// <verb>:" prefix, so this function returns an unprefixed message.
+func ensureDBExists(dbPath string) error {
+	if dbPath == "" {
+		return fmt.Errorf("iris database path is empty (XDG_STATE_HOME misconfigured?)")
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("iris database not found at %s; has the iris daemon ever run? (start it with `systemctl --user start iris` on Linux, or `launchctl kickstart -k gui/$UID/local.iris.daemon` on Darwin)", dbPath)
+		}
+		return fmt.Errorf("cannot read iris database at %s: %w", dbPath, err)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/iris/db_query.go
+++ b/modules/programs/prism/prism/cmd/iris/db_query.go
@@ -1,0 +1,498 @@
+package main
+
+// db_query.go — `iris db query` subcommand.
+//
+// Mirrors prism's cmd/db_query.go, with one critical iris-specific
+// addition spelled out by issue #1698: a **pre-execution keyword check**
+// that rejects write statements BEFORE the DB is opened. The pre-check is
+// belt-and-braces with SQLite's own read-only mode (which would also
+// reject the write at execution time); together they make the failure
+// surface unambiguous and the error message actionable.
+//
+// # Read-only enforcement layers
+//
+// 1. isWriteStatement() walks the SQL once, skipping comments and string
+//    literals, and rejects the input if the first non-comment keyword is
+//    one of INSERT / UPDATE / DELETE / REPLACE / DROP / CREATE / ALTER /
+//    TRUNCATE / PRAGMA / ATTACH / DETACH / REINDEX / VACUUM / BEGIN /
+//    COMMIT / ROLLBACK / SAVEPOINT / RELEASE. The check returns the
+//    rejected keyword so the error message is specific.
+//
+// 2. The DB is then opened in SQLite read-only mode via db.OpenReadOnly
+//    (?mode=ro). Even if a write keyword somehow slipped past the
+//    pre-check (e.g. a future SQLite verb we don't yet know about),
+//    SQLite would surface the "attempt to write a readonly database"
+//    error at execution time.
+//
+// # No proxy path
+//
+// Unlike prism's db_query.go, iris does not proxy through a host-API
+// socket — iris CLI surfaces read the DB file directly per the carve-out
+// in issue #1676. This keeps the implementation simpler and avoids the
+// "no daemon? no debug" trap.
+//
+// # JSON output parity with prism
+//
+// The JSON wire shape (`{"columns": [...], "rows": [...], "elapsedMs": N}`)
+// and per-cell coercion (int64 → number, float64 → number, string →
+// string, bool → bool, []byte → base64 string, nil → null) match prism's
+// behaviour byte-for-byte. Tests in db_query_test.go assert this.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// dbQueryDefaultTimeout caps a single `iris db query` invocation. 5s is
+// generous for forensic queries against a single-user iris DB; a runaway
+// SELECT is interrupted rather than blocking the CLI indefinitely.
+const dbQueryDefaultTimeout = 5 * time.Second
+
+// dbQueryRowDisplayLimit truncates table-mode output after this many
+// rows. JSON mode is never truncated — `--json` is documented as "all
+// rows" for scripting use.
+const dbQueryRowDisplayLimit = 50
+
+var dbQueryCmd = &cobra.Command{
+	Use:   "query [SQL | -]",
+	Short: "Run a single read-only SQL statement against the iris database",
+	Long: `Run a single read-only SQL statement against the iris database.
+
+The SQL text may be passed as the first positional argument, or read from
+stdin by passing "-". Stdin is convenient for multi-line queries that
+would be awkward to quote on argv:
+
+    iris db query - <<'SQL'
+      SELECT session_name, started_at FROM sessions
+       WHERE harness = 'pi' AND iris_state = 'active'
+       ORDER BY started_at DESC LIMIT 10;
+    SQL
+
+Read-only enforcement is enforced in two layers:
+
+  1. A keyword pre-check rejects INSERT / UPDATE / DELETE / DROP /
+     CREATE / ALTER / REPLACE / TRUNCATE / PRAGMA / ATTACH / DETACH /
+     REINDEX / VACUUM and transaction-control verbs BEFORE the database
+     is opened, with a clear "iris db query is read-only — use sqlite3
+     directly for writes" error.
+  2. The DB is then opened in SQLite read-only mode (?mode=ro) as
+     defence-in-depth.
+
+Multi-statement input (more than one SQL statement separated by ";") is
+rejected at the CLI layer before any SQL runs.
+
+By default output is rendered as an aligned table with a truncation
+notice when there are more than 50 rows. Use --json to emit structured
+JSON of the form {"columns": [...], "rows": [...], "elapsedMs": N};
+--json emits all rows.`,
+	Args:          cobra.MaximumNArgs(1),
+	RunE:          runDBQuery,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	dbQueryCmd.Flags().Bool("json", false, "Emit structured JSON to stdout instead of an aligned table")
+	dbQueryCmd.Flags().Duration("timeout", dbQueryDefaultTimeout, "Statement timeout (Go duration, e.g. 5s, 100ms)")
+	dbCmd.AddCommand(dbQueryCmd)
+}
+
+func runDBQuery(cmd *cobra.Command, args []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	if timeout <= 0 {
+		timeout = dbQueryDefaultTimeout
+	}
+
+	sqlText, err := readDBQuerySQL(args, cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+
+	// Layer 1 of read-only enforcement: keyword pre-check, BEFORE we even
+	// open the DB. The error message is specific (names the rejected
+	// keyword) and points the operator at sqlite3 for legitimate writes.
+	if kw, ok := isWriteStatement(sqlText); ok {
+		return fmt.Errorf("iris db query is read-only — rejected write keyword %q. Use sqlite3 directly for writes (e.g. `sqlite3 %s`).", kw, resolveDBPath())
+	}
+
+	// Single-statement guard. Done at the CLI layer per the AC: "is
+	// rejected at the CLI layer with a clear error before any SQL runs".
+	ok, parseErr := db.IsSingleStatement(sqlText)
+	if parseErr != nil {
+		return fmt.Errorf("iris db query: %w", parseErr)
+	}
+	if !ok {
+		return fmt.Errorf("iris db query: input must contain exactly one SQL statement (use separate invocations for multi-statement queries)")
+	}
+
+	dbPath := resolveDBPath()
+	if err := ensureDBExists(dbPath); err != nil {
+		return fmt.Errorf("iris db query: %w", err)
+	}
+
+	conn, err := db.OpenReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("iris db query: %w", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	res, err := db.RunQuery(ctx, conn, sqlText)
+	if err != nil {
+		// Defence-in-depth (layer 2) error path: even if a write keyword
+		// slipped past isWriteStatement, SQLite returns the "readonly
+		// database" error here and we surface it with the same prefix as
+		// the pre-check failure.
+		if db.IsReadOnlyError(err) {
+			return fmt.Errorf("iris db query is read-only — SQLite rejected the write at execution time. Use sqlite3 directly for writes: %w", err)
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("iris db query: timeout exceeded (%s)", timeout)
+		}
+		// SQLite syntax / runtime error — surface the raw driver
+		// message (no stack trace) per the AC: "the CLI exits non-zero
+		// with the underlying SQLite error message (no stack trace)".
+		return fmt.Errorf("iris db query: %w", err)
+	}
+	res.ElapsedMs = time.Since(start).Milliseconds()
+
+	return renderDBQueryResult(cmd.OutOrStdout(), res, jsonMode)
+}
+
+// readDBQuerySQL resolves the SQL text from argv or stdin.
+//
+//   - One arg, not "-":   the arg itself is the SQL.
+//   - One arg, "-":       read from stdin.
+//   - No args, stdin TTY: refuse with a clear error rather than hang.
+//   - No args, stdin pipe/file: read from stdin (mirrors `sqlite3 < f.sql`).
+func readDBQuerySQL(args []string, stdin io.Reader) (string, error) {
+	if len(args) == 1 && args[0] != "-" {
+		return strings.TrimSpace(args[0]), nil
+	}
+	if len(args) == 1 && args[0] == "-" {
+		return readAllOrErr(stdin)
+	}
+	if f, ok := stdin.(*os.File); ok {
+		fi, statErr := f.Stat()
+		if statErr == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+			return "", fmt.Errorf("iris db query: SQL is required as an argument (or use \"-\" to read from stdin)")
+		}
+	}
+	return readAllOrErr(stdin)
+}
+
+func readAllOrErr(r io.Reader) (string, error) {
+	if r == nil {
+		return "", fmt.Errorf("iris db query: stdin is unavailable")
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("iris db query: read stdin: %w", err)
+	}
+	out := strings.TrimSpace(string(b))
+	if out == "" {
+		return "", fmt.Errorf("iris db query: empty input — pass a SQL statement on argv or via stdin")
+	}
+	return out, nil
+}
+
+// writeKeywords is the set of SQL verbs that mutate state. The pre-check
+// uses an exact match against the first non-comment, non-whitespace
+// token. Anything not in this set falls through to SQLite's read-only
+// handle — which itself rejects writes — so an unknown future verb is
+// caught at layer 2 rather than silently allowed.
+//
+// Sourced from the SQLite "SQL Language" reference plus the standard
+// transaction-control verbs. Kept in upper-case; the lookup is
+// case-insensitive at the call site.
+var writeKeywords = map[string]struct{}{
+	"INSERT":    {},
+	"UPDATE":    {},
+	"DELETE":    {},
+	"REPLACE":   {},
+	"DROP":      {},
+	"CREATE":    {},
+	"ALTER":     {},
+	"TRUNCATE":  {},
+	"PRAGMA":    {}, // some PRAGMAs have side effects; reject the verb wholesale
+	"ATTACH":    {},
+	"DETACH":    {},
+	"REINDEX":   {},
+	"VACUUM":    {},
+	"ANALYZE":   {},
+	"BEGIN":     {},
+	"COMMIT":    {},
+	"END":       {}, // alias for COMMIT
+	"ROLLBACK":  {},
+	"SAVEPOINT": {},
+	"RELEASE":   {},
+}
+
+// isWriteStatement returns (keyword, true) when sqlText's first
+// non-comment, non-whitespace token is one of writeKeywords. Otherwise
+// returns ("", false).
+//
+// The walker handles:
+//
+//   - Leading whitespace.
+//   - Line comments ("-- …" through end of line).
+//   - Block comments ("/* … */", may span newlines).
+//
+// It does NOT need to handle string literals — we only inspect the very
+// first token, and SQL verbs cannot legally be quoted as identifiers and
+// still parse as a statement (a quoted "INSERT" is an identifier in a
+// position where SQLite expects a statement and would fail at parse
+// time). Keeping the walker simple — first non-comment token only — is
+// deliberate.
+func isWriteStatement(sqlText string) (string, bool) {
+	i := 0
+	for i < len(sqlText) {
+		c := sqlText[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v':
+			i++
+		case c == '-' && i+1 < len(sqlText) && sqlText[i+1] == '-':
+			// Line comment — skip through end-of-line or EOF.
+			i += 2
+			for i < len(sqlText) && sqlText[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(sqlText) && sqlText[i+1] == '*':
+			// Block comment — skip through */ or EOF.
+			i += 2
+			for i+1 < len(sqlText) && !(sqlText[i] == '*' && sqlText[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(sqlText) {
+				i += 2 // consume the */
+			} else {
+				// Unterminated block comment — fall through; the SQLite
+				// parser will surface the error.
+				return "", false
+			}
+		default:
+			// First real token: read until non-identifier character, then
+			// uppercase and compare.
+			start := i
+			for i < len(sqlText) && isKeywordChar(sqlText[i]) {
+				i++
+			}
+			token := strings.ToUpper(sqlText[start:i])
+			if _, ok := writeKeywords[token]; ok {
+				return token, true
+			}
+			return "", false
+		}
+	}
+	// Whitespace / comments only — not a write statement (will fail the
+	// IsSingleStatement check downstream).
+	return "", false
+}
+
+// isKeywordChar reports whether c is a character that can appear inside
+// a SQL keyword. Letters, digits, and underscore — the standard
+// identifier-character set, which is a superset of keyword characters.
+func isKeywordChar(c byte) bool {
+	return (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_'
+}
+
+// renderDBQueryResult writes res to w in either JSON or aligned-table
+// mode. JSON mode preserves prism's wire shape byte-for-byte.
+func renderDBQueryResult(w io.Writer, res *db.QueryResult, jsonMode bool) error {
+	if jsonMode {
+		return renderDBQueryJSON(w, res)
+	}
+	return renderDBQueryTable(w, res)
+}
+
+// renderDBQueryJSON emits {"columns": [...], "rows": [...], "elapsedMs": N}.
+//
+// BLOB cells are converted to base64 to match standard JSON encoding
+// conventions; NULL stays as JSON null. The output matches prism's
+// renderDBQueryJSON byte-for-byte (modulo the actual data) so a script
+// consuming both surfaces sees one wire shape.
+func renderDBQueryJSON(w io.Writer, res *db.QueryResult) error {
+	cooked := make([][]any, len(res.Rows))
+	for i, row := range res.Rows {
+		newRow := make([]any, len(row))
+		for j, cell := range row {
+			switch v := cell.(type) {
+			case []byte:
+				newRow[j] = base64.StdEncoding.EncodeToString(v)
+			default:
+				newRow[j] = v
+			}
+		}
+		cooked[i] = newRow
+	}
+	out := struct {
+		Columns   []string `json:"columns"`
+		Rows      [][]any  `json:"rows"`
+		ElapsedMs int64    `json:"elapsedMs"`
+	}{
+		Columns:   res.Columns,
+		Rows:      cooked,
+		ElapsedMs: res.ElapsedMs,
+	}
+	if out.Rows == nil {
+		out.Rows = [][]any{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(out)
+}
+
+// dbQueryNullStyle is the style used to render NULL cells (and the
+// truncation tail) in table mode. Faint per the AC: "NULL values are
+// rendered as the literal string NULL (dimmed in table mode)".
+var dbQueryNullStyle = lipgloss.NewStyle().Faint(true)
+
+// dbQueryHeaderStyle bolds the header row. The fg colour mirrors iris's
+// other CLI tables (see list_sessions.go) so the `iris db` family feels
+// like a member of the iris CLI rather than an alien import.
+var dbQueryHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(cliColSecondary))
+
+// renderDBQueryTable formats res as an aligned text table with a styled
+// header row and a footer showing row count and elapsed time. Long
+// output is truncated after dbQueryRowDisplayLimit rows.
+func renderDBQueryTable(w io.Writer, res *db.QueryResult) error {
+	if len(res.Columns) == 0 {
+		fmt.Fprintf(w, "(no columns) — %d row(s) — %dms\n", len(res.Rows), res.ElapsedMs)
+		return nil
+	}
+
+	formatted := make([][]string, len(res.Rows))
+	truncated := false
+	displayCount := len(res.Rows)
+	if displayCount > dbQueryRowDisplayLimit {
+		displayCount = dbQueryRowDisplayLimit
+		truncated = true
+	}
+	for i := 0; i < displayCount; i++ {
+		row := res.Rows[i]
+		out := make([]string, len(res.Columns))
+		for j := range res.Columns {
+			if j < len(row) {
+				out[j] = formatCellTable(row[j])
+			}
+		}
+		formatted[i] = out
+	}
+
+	widths := make([]int, len(res.Columns))
+	for i, c := range res.Columns {
+		widths[i] = len([]rune(c))
+	}
+	for i := 0; i < displayCount; i++ {
+		row := formatted[i]
+		for j, cell := range row {
+			n := len([]rune(cell))
+			if n > widths[j] {
+				widths[j] = n
+			}
+		}
+	}
+
+	// Header.
+	for i, c := range res.Columns {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprint(w, dbQueryHeaderStyle.Render(padRunes(c, widths[i])))
+	}
+	fmt.Fprintln(w)
+
+	// Body.
+	for i := 0; i < displayCount; i++ {
+		row := formatted[i]
+		for j := 0; j < len(res.Columns); j++ {
+			if j > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			cell := ""
+			if j < len(row) {
+				cell = row[j]
+			}
+			padded := padRunes(cell, widths[j])
+			if cell == "NULL" {
+				fmt.Fprint(w, dbQueryNullStyle.Render(padded))
+			} else {
+				fmt.Fprint(w, padded)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if truncated {
+		more := len(res.Rows) - displayCount
+		fmt.Fprintln(w, dbQueryNullStyle.Render(fmt.Sprintf("... (%d more — pass --json to see all)", more)))
+	}
+
+	footerStyle := lipgloss.NewStyle().Faint(true)
+	fmt.Fprintln(w, footerStyle.Render(fmt.Sprintf("(%d row%s, %dms)", len(res.Rows), pluralS(len(res.Rows)), res.ElapsedMs)))
+	return nil
+}
+
+// formatCellTable converts a raw scanned value to its string form for
+// table output, matching prism's formatCellTable byte-for-byte:
+//
+//   - NULL → "NULL"
+//   - BLOB → "0x<hex>"
+//   - everything else → predictable per-type formatting.
+func formatCellTable(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "NULL"
+	case []byte:
+		return "0x" + hex.EncodeToString(t)
+	case string:
+		return t
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case float64:
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+// padRunes right-pads s with spaces to width n in runes.
+func padRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-len(r))
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/modules/programs/prism/prism/cmd/iris/db_schema.go
+++ b/modules/programs/prism/prism/cmd/iris/db_schema.go
@@ -1,0 +1,130 @@
+package main
+
+// db_schema.go — `iris db schema` subcommand.
+//
+// Mirrors prism's cmd/db_schema.go with one surface tweak called out by
+// issue #1698: iris requires either a <table> argument or the --all flag;
+// it does not default to "print everything" on a bare invocation. This
+// matches the issue's AC wording verbatim:
+//
+//   iris db schema [table]      # show CREATE TABLE for the named table
+//   iris db schema --all        # show schema for every table
+//
+// Either way, output is deterministic: tables before indexes, alpha
+// within each group. Internal sqlite_* objects are excluded by the
+// underlying db.Schema primitive.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var dbSchemaCmd = &cobra.Command{
+	Use:   "schema [table]",
+	Short: "Print CREATE TABLE / CREATE INDEX statements from the iris database",
+	Long: `Print CREATE TABLE / CREATE INDEX statements from the iris database.
+
+Either a <table> argument or --all is required:
+
+  iris db schema sessions     # print the CREATE TABLE for the sessions table
+  iris db schema --all        # print DDL for every user table and index
+
+Output is deterministic: tables before indexes, sorted alphabetically
+within each group. Internal sqlite_* objects (sqlite_master,
+sqlite_sequence, …) are excluded. Auto-generated indexes for PRIMARY
+KEY / UNIQUE constraints — which have no printable DDL in sqlite_master
+— are also excluded.
+
+This subcommand is read-only: it opens the iris DB in SQLite read-only
+mode and only queries sqlite_master. It runs safely alongside the iris
+daemon (SQLite WAL mode supports concurrent readers).
+
+Use --json to emit a JSON object keyed by table/index name with the
+CREATE statement as the value. The default human-readable form prints
+each CREATE statement on its own (with a trailing semicolon, so the
+output is paste-able into sqlite3).`,
+	Args:          cobra.MaximumNArgs(1),
+	RunE:          runDBSchema,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	dbSchemaCmd.Flags().Bool("json", false, "Emit a JSON object keyed by table/index name instead of plain text")
+	dbSchemaCmd.Flags().Bool("all", false, "Print the schema for every user table and index (mutually exclusive with a <table> argument)")
+	dbCmd.AddCommand(dbSchemaCmd)
+}
+
+func runDBSchema(cmd *cobra.Command, args []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	allMode, _ := cmd.Flags().GetBool("all")
+
+	tableFilter := ""
+	if len(args) == 1 {
+		tableFilter = args[0]
+	}
+
+	// Require either an argument or --all. Both is a usage error so the
+	// operator doesn't write `iris db schema sessions --all` and wonder
+	// which one wins.
+	switch {
+	case tableFilter == "" && !allMode:
+		return fmt.Errorf("iris db schema: a <table> argument or --all is required")
+	case tableFilter != "" && allMode:
+		return fmt.Errorf("iris db schema: --all is mutually exclusive with a <table> argument")
+	}
+
+	dbPath := resolveDBPath()
+	if err := ensureDBExists(dbPath); err != nil {
+		return fmt.Errorf("iris db schema: %w", err)
+	}
+
+	conn, err := db.OpenReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("iris db schema: %w", err)
+	}
+	defer conn.Close()
+
+	entries, err := db.Schema(context.Background(), conn, tableFilter)
+	if err != nil {
+		return fmt.Errorf("iris db schema: %w", err)
+	}
+	if tableFilter != "" && len(entries) == 0 {
+		return fmt.Errorf("iris db schema: table %q not found", tableFilter)
+	}
+	return renderDBSchema(cmd.OutOrStdout(), entries, jsonMode)
+}
+
+// renderDBSchema writes entries to w. JSON mode emits an object keyed by
+// the entry name (matches the issue's "for schema, an object keyed by
+// table name"). Text mode prints each CREATE statement followed by a
+// blank line — and adds a trailing semicolon when sqlite_master omits one,
+// so the output pastes cleanly into sqlite3.
+func renderDBSchema(w io.Writer, entries []db.SchemaEntry, jsonMode bool) error {
+	if jsonMode {
+		out := make(map[string]string, len(entries))
+		for _, e := range entries {
+			out[e.Name] = e.SQL
+		}
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		return enc.Encode(out)
+	}
+
+	for _, e := range entries {
+		text := strings.TrimSpace(e.SQL)
+		if !strings.HasSuffix(text, ";") {
+			text += ";"
+		}
+		fmt.Fprintln(w, text)
+		fmt.Fprintln(w)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/iris/db_tables.go
+++ b/modules/programs/prism/prism/cmd/iris/db_tables.go
@@ -1,0 +1,86 @@
+package main
+
+// db_tables.go — `iris db tables` subcommand.
+//
+// Mirrors prism's cmd/db_tables.go. Prints a sorted list of user table
+// names (sqlite_* internal objects are excluded). Used by operators and
+// agents to discover the schema before writing a query.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+var dbTablesCmd = &cobra.Command{
+	Use:   "tables",
+	Short: "Print a sorted list of user table names in the iris database (excludes sqlite_*)",
+	Long: `Print a sorted list of user table names in the iris database.
+
+Internal sqlite_* objects (sqlite_master, sqlite_sequence, etc.) are
+excluded. The list is sorted lexicographically.
+
+This subcommand is read-only: it opens the iris DB in SQLite read-only
+mode and runs a single SELECT against sqlite_master. It is safe to run
+while the iris daemon is operating on the same DB — SQLite's WAL mode
+(set by the daemon) supports concurrent readers without blocking the
+daemon's writes.
+
+Use --json to emit a JSON array of strings (e.g. ["agent_events",
+"sessions"]) suitable for scripting. The default human-readable form
+prints one name per line.`,
+	Args:          cobra.NoArgs,
+	RunE:          runDBTables,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	dbTablesCmd.Flags().Bool("json", false, "Emit a JSON array of strings instead of one name per line")
+	dbCmd.AddCommand(dbTablesCmd)
+}
+
+func runDBTables(cmd *cobra.Command, _ []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	dbPath := resolveDBPath()
+	if err := ensureDBExists(dbPath); err != nil {
+		return fmt.Errorf("iris db tables: %w", err)
+	}
+
+	conn, err := db.OpenReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("iris db tables: %w", err)
+	}
+	defer conn.Close()
+
+	names, err := db.Tables(context.Background(), conn)
+	if err != nil {
+		return fmt.Errorf("iris db tables: %w", err)
+	}
+	return renderDBTables(cmd.OutOrStdout(), names, jsonMode)
+}
+
+// renderDBTables writes the table list to w. JSON mode emits a JSON array
+// of strings (with a non-nil zero-length array when the DB has no user
+// tables, so the output is always a parseable JSON value). Text mode
+// prints one name per line and emits nothing for an empty list.
+func renderDBTables(w io.Writer, names []string, jsonMode bool) error {
+	if jsonMode {
+		if names == nil {
+			names = []string{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		return enc.Encode(names)
+	}
+	for _, n := range names {
+		fmt.Fprintln(w, n)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/iris/db_test.go
+++ b/modules/programs/prism/prism/cmd/iris/db_test.go
@@ -1,0 +1,767 @@
+package main
+
+// db_test.go — unit + integration tests for the `iris db` family
+// (`iris db tables / schema / query`).
+//
+// All tests use iristest.NewIsolated to redirect HOME / XDG_STATE_HOME
+// to a per-test tempdir so the suite is safe in CI's nix sandbox
+// ($HOME=/homeless-shelter) and never touches the developer's real
+// ~/.local/state/iris.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// withIsolatedDB wires the iris-test iso onto the package-level testDBPath
+// hook so RunE-driven cobra invocations see the per-test iris DB. The
+// returned cleanup restores the hook to "" for the next test.
+func withIsolatedDB(t *testing.T, iso *iristest.Isolated) {
+	t.Helper()
+	SetTestDBPath(iso.Paths.DB)
+	t.Cleanup(func() { SetTestDBPath("") })
+}
+
+// seedDBSession inserts a single sessions row so `iris db tables` etc.
+// have real data to render. Returns the inserted session_name.
+func seedDBSession(t *testing.T, iso *iristest.Isolated, suffix string) string {
+	t.Helper()
+	name := iristest.SessionName(suffix)
+	role := "worker"
+	worktree := iso.Root + "/worktree"
+	if err := iso.DB.InsertSession(db.Session{
+		InstanceID:  uuid.NewString(),
+		SessionName: name,
+		AgentRole:   &role,
+		Repo:        "iris-test",
+		Worktree:    worktree,
+		Harness:     "pi",
+		StartedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seedDBSession: insert: %v", err)
+	}
+	return name
+}
+
+// runCommand executes a fresh cobra command tree under a captured stdout
+// buffer. Returns the captured stdout and the cobra error (if any). The
+// global rootCmd is reused — we reset args and reparent stdout per call.
+//
+// Cobra retains *flag* state on the underlying *pflag.FlagSet across
+// Execute() calls (the flag library does not clear values when args are
+// re-parsed). To avoid leakage between test invocations we walk every
+// flag on dbCmd and its registered children and restore each to its
+// default value before invoking the command.
+func runCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	resetCobraFlags(dbCmd)
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stdout)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		// Restore stdin/stdout/stderr and args to defaults so a
+		// subsequent test starts clean.
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+		rootCmd.SetIn(nil)
+		resetCobraFlags(dbCmd)
+	})
+	err := rootCmd.ExecuteContext(context.Background())
+	return stdout.String(), err
+}
+
+// resetCobraFlags walks every flag on c and its subcommands and restores
+// each to its DefValue. Required because cobra/pflag retains the last
+// parsed value across Execute() calls when the same *Command instance
+// is reused (as it is here, via the package-global rootCmd / dbCmd).
+func resetCobraFlags(c *cobra.Command) {
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+	for _, child := range c.Commands() {
+		resetCobraFlags(child)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris db tables
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDBTables_ListsTables asserts that `iris db tables` prints at least
+// the sessions and agent_events tables (created by db.Open() migrations)
+// and excludes sqlite_* internals.
+func TestDBTables_ListsTables(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "tables")
+	if err != nil {
+		t.Fatalf("iris db tables: %v", err)
+	}
+
+	want := []string{"sessions"}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("output missing %q:\n%s", w, out)
+		}
+	}
+	if strings.Contains(out, "sqlite_master") || strings.Contains(out, "sqlite_sequence") {
+		t.Errorf("output should exclude sqlite_* internals:\n%s", out)
+	}
+	// One name per line, sorted.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for i := 1; i < len(lines); i++ {
+		if lines[i] < lines[i-1] {
+			t.Errorf("tables not sorted: %q before %q", lines[i-1], lines[i])
+		}
+	}
+}
+
+// TestDBTables_JSON asserts that `iris db tables --json` emits a JSON
+// array of strings.
+func TestDBTables_JSON(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "tables", "--json")
+	if err != nil {
+		t.Fatalf("iris db tables --json: %v", err)
+	}
+
+	var names []string
+	if err := json.Unmarshal([]byte(out), &names); err != nil {
+		t.Fatalf("expected JSON array, got: %s", out)
+	}
+	if len(names) == 0 {
+		t.Fatalf("expected at least one table in JSON output, got 0")
+	}
+	found := false
+	for _, n := range names {
+		if n == "sessions" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'sessions' in JSON table list: %v", names)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris db schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDBSchema_NamedTable asserts that `iris db schema sessions` prints
+// the CREATE TABLE statement for sessions and nothing else.
+func TestDBSchema_NamedTable(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "schema", "sessions")
+	if err != nil {
+		t.Fatalf("iris db schema sessions: %v", err)
+	}
+	if !strings.Contains(strings.ToUpper(out), "CREATE TABLE") {
+		t.Errorf("expected CREATE TABLE in output:\n%s", out)
+	}
+	if !strings.Contains(out, "sessions") {
+		t.Errorf("expected 'sessions' in output:\n%s", out)
+	}
+	// Should end with semicolon (paste-able into sqlite3).
+	trimmed := strings.TrimSpace(out)
+	if !strings.HasSuffix(trimmed, ";") {
+		t.Errorf("expected trailing semicolon, got:\n%s", out)
+	}
+}
+
+// TestDBSchema_All asserts that `iris db schema --all` prints DDL for
+// multiple tables / indexes.
+func TestDBSchema_All(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "schema", "--all")
+	if err != nil {
+		t.Fatalf("iris db schema --all: %v", err)
+	}
+	// At least two CREATE statements (sessions + agent_events at minimum).
+	upper := strings.ToUpper(out)
+	if got := strings.Count(upper, "CREATE TABLE"); got < 2 {
+		t.Errorf("expected ≥2 CREATE TABLE statements with --all, got %d:\n%s", got, out)
+	}
+}
+
+// TestDBSchema_RequiresArgOrAll asserts that running `iris db schema`
+// with neither a table arg nor --all is a usage error.
+func TestDBSchema_RequiresArgOrAll(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runCommand(t, "db", "schema")
+	if err == nil {
+		t.Fatalf("expected error for bare `iris db schema`, got nil")
+	}
+	if !strings.Contains(err.Error(), "table") && !strings.Contains(err.Error(), "--all") {
+		t.Errorf("expected helpful 'table or --all' error, got: %v", err)
+	}
+}
+
+// TestDBSchema_TableAndAllMutuallyExclusive asserts that passing both a
+// table arg and --all is a usage error.
+func TestDBSchema_TableAndAllMutuallyExclusive(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runCommand(t, "db", "schema", "sessions", "--all")
+	if err == nil {
+		t.Fatalf("expected error for `iris db schema sessions --all`, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' in error, got: %v", err)
+	}
+}
+
+// TestDBSchema_NoSuchTable asserts that an unknown table name returns a
+// clear "not found" error.
+func TestDBSchema_NoSuchTable(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runCommand(t, "db", "schema", "this_table_does_not_exist")
+	if err == nil {
+		t.Fatalf("expected error for unknown table, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+// TestDBSchema_JSON asserts that `--json` emits an object keyed by name.
+func TestDBSchema_JSON(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "schema", "sessions", "--json")
+	if err != nil {
+		t.Fatalf("iris db schema sessions --json: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("expected JSON object, got: %s", out)
+	}
+	ddl, ok := m["sessions"]
+	if !ok {
+		t.Fatalf("expected 'sessions' key in JSON: %v", m)
+	}
+	if !strings.Contains(strings.ToUpper(ddl), "CREATE TABLE") {
+		t.Errorf("expected CREATE TABLE in sessions DDL: %q", ddl)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris db query — happy paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDBQuery_BasicSelect runs a simple SELECT against a seeded sessions
+// row and asserts the human-readable table contains the session name.
+func TestDBQuery_BasicSelect(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+	name := seedDBSession(t, iso, "basic")
+
+	out, err := runCommand(t, "db", "query", "SELECT session_name FROM sessions")
+	if err != nil {
+		t.Fatalf("iris db query: %v", err)
+	}
+	if !strings.Contains(out, name) {
+		t.Errorf("expected session_name %q in output:\n%s", name, out)
+	}
+	if !strings.Contains(out, "1 row") {
+		t.Errorf("expected '1 row' footer in output:\n%s", out)
+	}
+}
+
+// TestDBQuery_JSON asserts the JSON wire shape matches prism's:
+// {"columns": [...], "rows": [...], "elapsedMs": N}.
+func TestDBQuery_JSON(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+	seedDBSession(t, iso, "json-shape")
+
+	out, err := runCommand(t, "db", "query", "--json", "SELECT session_name, repo FROM sessions")
+	if err != nil {
+		t.Fatalf("iris db query --json: %v", err)
+	}
+
+	var got struct {
+		Columns   []string `json:"columns"`
+		Rows      [][]any  `json:"rows"`
+		ElapsedMs int64    `json:"elapsedMs"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected JSON, got %q: %v", out, err)
+	}
+	wantCols := []string{"session_name", "repo"}
+	if fmt.Sprint(got.Columns) != fmt.Sprint(wantCols) {
+		t.Errorf("columns mismatch: got %v want %v", got.Columns, wantCols)
+	}
+	if len(got.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got.Rows))
+	}
+	if got.Rows[0][1] != "iris-test" {
+		t.Errorf("expected repo='iris-test' at rows[0][1], got %v", got.Rows[0][1])
+	}
+}
+
+// TestDBQuery_JSON_EmptyResult asserts that an empty result set serialises
+// as "rows": [] (not null) — matches prism's wire-shape guarantee.
+func TestDBQuery_JSON_EmptyResult(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "query", "--json", "SELECT session_name FROM sessions WHERE 1 = 0")
+	if err != nil {
+		t.Fatalf("iris db query --json: %v", err)
+	}
+	if !strings.Contains(out, `"rows":[]`) {
+		t.Errorf("expected \"rows\":[] in empty-result JSON, got: %s", out)
+	}
+}
+
+// TestDBQuery_JSON_NullCoercion asserts NULL columns serialise as JSON
+// null (matches prism byte-for-byte).
+func TestDBQuery_JSON_NullCoercion(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runCommand(t, "db", "query", "--json", "SELECT NULL AS x")
+	if err != nil {
+		t.Fatalf("iris db query --json: %v", err)
+	}
+	if !strings.Contains(out, `"rows":[[null]]`) {
+		t.Errorf("expected \"rows\":[[null]] in NULL output, got: %s", out)
+	}
+}
+
+// TestDBQuery_Stdin asserts that `iris db query -` reads from stdin.
+func TestDBQuery_Stdin(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+	name := seedDBSession(t, iso, "stdin")
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stdout)
+	rootCmd.SetIn(strings.NewReader("SELECT session_name FROM sessions"))
+	rootCmd.SetArgs([]string{"db", "query", "-"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetIn(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("iris db query -: %v", err)
+	}
+	if !strings.Contains(stdout.String(), name) {
+		t.Errorf("expected %q in stdin-fed output:\n%s", name, stdout.String())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris db query — security: write-keyword rejection BEFORE opening the DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDBQuery_RejectsWriteStatements walks every keyword the AC names
+// explicitly (INSERT / UPDATE / DELETE / DROP / CREATE / ALTER) plus a
+// few extras (REPLACE / PRAGMA / ATTACH / DETACH / BEGIN / COMMIT /
+// ROLLBACK / VACUUM / REINDEX / SAVEPOINT / RELEASE). Each should be
+// rejected non-zero with a "read-only" / write-keyword error.
+//
+// Per the AC, the rejection happens BEFORE the DB is opened. We assert
+// this indirectly by pointing testDBPath at a path that does NOT exist —
+// if the pre-check fired, we never see "iris database not found". If
+// only the open-time check fired, we would.
+func TestDBQuery_RejectsWriteStatements(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	// Deliberately point at a non-existent DB to prove the pre-check
+	// fires BEFORE the DB is opened. (NewIsolated has created a real DB
+	// under iso.Paths.DB, but we override here.)
+	bogusDB := filepath.Join(iso.Root, "definitely-does-not-exist.db")
+	SetTestDBPath(bogusDB)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"insert", "INSERT INTO sessions (session_name) VALUES ('x')"},
+		{"update", "UPDATE sessions SET worktree='y' WHERE session_name='x'"},
+		{"delete", "DELETE FROM sessions WHERE session_name='x'"},
+		{"drop", "DROP TABLE sessions"},
+		{"create", "CREATE TABLE foo (a INT)"},
+		{"alter", "ALTER TABLE sessions ADD COLUMN q TEXT"},
+		{"replace", "REPLACE INTO sessions (session_name) VALUES ('x')"},
+		{"pragma", "PRAGMA journal_mode = DELETE"},
+		{"attach", "ATTACH DATABASE '/tmp/x.db' AS other"},
+		{"detach", "DETACH DATABASE other"},
+		{"begin", "BEGIN TRANSACTION"},
+		{"commit", "COMMIT"},
+		{"rollback", "ROLLBACK"},
+		{"vacuum", "VACUUM"},
+		{"reindex", "REINDEX sessions"},
+		{"savepoint", "SAVEPOINT sp"},
+		{"release", "RELEASE sp"},
+		// Case insensitivity.
+		{"lowercase-insert", "insert into sessions (session_name) values ('x')"},
+		// Leading whitespace.
+		{"leading-ws", "   \n  UPDATE sessions SET worktree='y'"},
+		// Leading block comment.
+		{"block-comment", "/* evil */ DROP TABLE sessions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use the cobra `--` separator so SQL that begins with "--"
+			// (a line comment) is not mis-parsed as a flag.
+			out, err := runCommand(t, "db", "query", "--", tc.sql)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil (out=%s)", tc.sql, out)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "read-only") {
+				t.Errorf("expected 'read-only' in error for %q, got: %v", tc.sql, err)
+			}
+			// Pre-check signal: we should NOT see the "iris database not
+			// found" message, because the rejection happens before the DB
+			// is opened.
+			if strings.Contains(msg, "iris database not found") {
+				t.Errorf("write-rejection should fire BEFORE DB-open; got 'not found' for %q: %v", tc.sql, err)
+			}
+		})
+	}
+
+	// Separate sub-test for the leading-line-comment case. Cobra treats
+	// a positional starting with "--" as a flag, so we feed this case
+	// via stdin instead — the SQL still hits isWriteStatement before
+	// any DB open.
+	t.Run("line-comment", func(t *testing.T) {
+		var stdout bytes.Buffer
+		rootCmd.SetOut(&stdout)
+		rootCmd.SetErr(&stdout)
+		rootCmd.SetIn(strings.NewReader("-- evil\nDELETE FROM sessions"))
+		rootCmd.SetArgs([]string{"db", "query", "-"})
+		t.Cleanup(func() {
+			rootCmd.SetOut(nil)
+			rootCmd.SetErr(nil)
+			rootCmd.SetIn(nil)
+			rootCmd.SetArgs(nil)
+		})
+		err := rootCmd.ExecuteContext(context.Background())
+		if err == nil {
+			t.Fatalf("expected error for line-comment write, got nil")
+		}
+		if !strings.Contains(err.Error(), "read-only") {
+			t.Errorf("expected 'read-only' in error, got: %v", err)
+		}
+	})
+}
+
+// TestDBQuery_AllowsSelect_AfterWriteKeywordCheck is a defensive
+// counter-test: SELECT must not trigger the write-keyword check.
+func TestDBQuery_AllowsSelect_AfterWriteKeywordCheck(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	if _, err := runCommand(t, "db", "query", "SELECT 1"); err != nil {
+		t.Fatalf("plain SELECT was rejected: %v", err)
+	}
+	// Common SELECT forms with comments / WITH must also pass.
+	if _, err := runCommand(t, "db", "query", "--", "-- this is a SELECT\nSELECT 1"); err != nil {
+		t.Fatalf("SELECT with leading line comment was rejected: %v", err)
+	}
+	if _, err := runCommand(t, "db", "query", "/* preface */ SELECT 1"); err != nil {
+		t.Fatalf("SELECT with leading block comment was rejected: %v", err)
+	}
+	if _, err := runCommand(t, "db", "query", "WITH cte AS (SELECT 1) SELECT * FROM cte"); err != nil {
+		t.Fatalf("WITH-style SELECT was rejected: %v", err)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris db query — error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDBQuery_MissingDB asserts that pointing the CLI at a non-existent
+// DB returns a clear "not found" error (the operator should be pointed
+// at the daemon and the expected path).
+func TestDBQuery_MissingDB(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	bogus := filepath.Join(iso.Root, "no-such-db.sqlite")
+	SetTestDBPath(bogus)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	_, err := runCommand(t, "db", "query", "SELECT 1")
+	if err == nil {
+		t.Fatalf("expected error for missing DB, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), bogus) {
+		t.Errorf("expected DB path %q in error, got: %v", bogus, err)
+	}
+}
+
+// TestDBTables_MissingDB and TestDBSchema_MissingDB confirm the same
+// behaviour for the other subcommands.
+func TestDBTables_MissingDB(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	bogus := filepath.Join(iso.Root, "no-such-db.sqlite")
+	SetTestDBPath(bogus)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	_, err := runCommand(t, "db", "tables")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' error for missing DB, got: %v", err)
+	}
+}
+
+func TestDBSchema_MissingDB(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	bogus := filepath.Join(iso.Root, "no-such-db.sqlite")
+	SetTestDBPath(bogus)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	_, err := runCommand(t, "db", "schema", "--all")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' error for missing DB, got: %v", err)
+	}
+}
+
+// TestDBQuery_InvalidSQL asserts that a syntactically invalid SQL
+// statement is rejected with the SQLite error message (no stack trace).
+func TestDBQuery_InvalidSQL(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runCommand(t, "db", "query", "SELECT * FROM not_a_real_table_xxx")
+	if err == nil {
+		t.Fatalf("expected error for invalid SQL, got nil")
+	}
+	msg := err.Error()
+	// SQLite emits "no such table" for unknown table refs — surface it.
+	if !strings.Contains(msg, "no such table") {
+		t.Errorf("expected SQLite 'no such table' error, got: %v", err)
+	}
+	// No goroutine / stack-trace markers.
+	if strings.Contains(msg, "goroutine ") || strings.Contains(msg, ".go:") {
+		t.Errorf("error should not contain a stack trace: %v", err)
+	}
+}
+
+// TestDBQuery_MultiStatement_Rejected asserts that two statements
+// separated by a semicolon are rejected at the CLI layer.
+func TestDBQuery_MultiStatement_Rejected(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runCommand(t, "db", "query", "SELECT 1; SELECT 2")
+	if err == nil {
+		t.Fatalf("expected error for multi-statement input, got nil")
+	}
+	if !strings.Contains(err.Error(), "one SQL statement") {
+		t.Errorf("expected 'one SQL statement' in error, got: %v", err)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Concurrent reader vs. iris daemon writer (WAL coexistence)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDBQuery_ConcurrentWithDaemonWrites simulates the AC's daemon-running
+// scenario: a writer connection (the "daemon") performs N session
+// inserts while a reader (`iris db query` semantics, via db.OpenReadOnly)
+// repeatedly counts rows. Neither side should error; the read connection
+// must NOT block writes (SQLite WAL mode is set by iris.OpenDB).
+func TestDBQuery_ConcurrentWithDaemonWrites(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	// Verify WAL is set — without it, the AC's "does not interfere"
+	// guarantee does not hold. iris.OpenDB sets WAL during migrations.
+	var journalMode string
+	if err := iso.DB.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("query journal_mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		t.Fatalf("expected WAL journal mode, got %q (concurrent-reader AC requires WAL)", journalMode)
+	}
+
+	const writerIters = 30
+	const readerIters = 60
+
+	var wg sync.WaitGroup
+	writerErr := make(chan error, 1)
+	readerErr := make(chan error, 1)
+
+	// Writer: simulates the daemon by inserting sessions through the
+	// existing writable handle (iso.DB).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < writerIters; i++ {
+			role := "worker"
+			if err := iso.DB.InsertSession(db.Session{
+				InstanceID:  uuid.NewString(),
+				SessionName: fmt.Sprintf("%s-%d", iristest.SessionName("concurrent"), i),
+				AgentRole:   &role,
+				Repo:        "iris-test",
+				Worktree:    fmt.Sprintf("%s/wt-%d", iso.Root, i),
+				Harness:     "pi",
+				StartedAt:   time.Now().UTC(),
+			}); err != nil {
+				writerErr <- fmt.Errorf("writer insert %d: %w", i, err)
+				return
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+		writerErr <- nil
+	}()
+
+	// Reader: opens a fresh ?mode=ro handle per iteration, mirroring how
+	// each `iris db query` invocation behaves.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < readerIters; i++ {
+			conn, err := db.OpenReadOnly(iso.Paths.DB)
+			if err != nil {
+				readerErr <- fmt.Errorf("reader open %d: %w", i, err)
+				return
+			}
+			res, err := db.RunQuery(context.Background(), conn, "SELECT COUNT(*) FROM sessions")
+			conn.Close()
+			if err != nil {
+				readerErr <- fmt.Errorf("reader query %d: %w", i, err)
+				return
+			}
+			if len(res.Rows) != 1 || len(res.Rows[0]) != 1 {
+				readerErr <- fmt.Errorf("reader query %d: malformed row shape: %v", i, res.Rows)
+				return
+			}
+			time.Sleep(500 * time.Microsecond)
+		}
+		readerErr <- nil
+	}()
+
+	wg.Wait()
+	if err := <-writerErr; err != nil {
+		t.Fatalf("writer failed: %v", err)
+	}
+	if err := <-readerErr; err != nil {
+		t.Fatalf("reader failed: %v", err)
+	}
+
+	// Final assertion: all inserts landed.
+	var finalCount int64
+	if err := iso.DB.QueryRow("SELECT COUNT(*) FROM sessions").Scan(&finalCount); err != nil {
+		t.Fatalf("final count: %v", err)
+	}
+	if finalCount < writerIters {
+		t.Errorf("expected ≥%d sessions after concurrent test, got %d", writerIters, finalCount)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit-level coverage of the write-keyword check
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIsWriteStatement_Table is a direct unit test of isWriteStatement.
+// It covers the table-driven cases that the higher-level
+// TestDBQuery_RejectsWriteStatements asserts behaviour for, but at the
+// per-function level so a regression in the walker is caught even if the
+// cobra wiring is otherwise broken.
+func TestIsWriteStatement_Table(t *testing.T) {
+	cases := []struct {
+		name    string
+		sql     string
+		wantKw  string
+		wantHit bool
+	}{
+		{"plain insert", "INSERT INTO x VALUES (1)", "INSERT", true},
+		{"lowercase update", "update x set a=1", "UPDATE", true},
+		{"leading ws", "   \n\t DELETE FROM x", "DELETE", true},
+		{"line comment first", "-- explain\nDROP TABLE x", "DROP", true},
+		{"block comment first", "/* hi */ ALTER TABLE x ADD COLUMN q INT", "ALTER", true},
+		{"nested comments not supported but pass through", "/* outer */ CREATE TABLE x (a INT)", "CREATE", true},
+		{"select passes", "SELECT 1", "", false},
+		{"with-cte passes", "WITH cte AS (SELECT 1) SELECT * FROM cte", "", false},
+		{"explain passes", "EXPLAIN SELECT 1", "", false},
+		{"empty input", "", "", false},
+		{"only comments", "-- nothing here", "", false},
+		// Common write verbs.
+		{"replace", "REPLACE INTO x VALUES (1)", "REPLACE", true},
+		{"pragma", "PRAGMA journal_mode", "PRAGMA", true},
+		{"attach", "ATTACH 'x.db' AS y", "ATTACH", true},
+		{"detach", "DETACH y", "DETACH", true},
+		{"begin", "BEGIN", "BEGIN", true},
+		{"commit", "COMMIT", "COMMIT", true},
+		{"end (commit alias)", "END", "END", true},
+		{"rollback", "ROLLBACK", "ROLLBACK", true},
+		{"vacuum", "VACUUM", "VACUUM", true},
+		{"reindex", "REINDEX", "REINDEX", true},
+		{"savepoint", "SAVEPOINT sp", "SAVEPOINT", true},
+		{"release", "RELEASE sp", "RELEASE", true},
+		{"analyze", "ANALYZE", "ANALYZE", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, hit := isWriteStatement(tc.sql)
+			if hit != tc.wantHit {
+				t.Errorf("hit mismatch: got %v want %v (kw=%q)", hit, tc.wantHit, got)
+			}
+			if hit && got != tc.wantKw {
+				t.Errorf("kw mismatch: got %q want %q", got, tc.wantKw)
+			}
+		})
+	}
+}
+
+// TestResolveDBPath_UsesIrisPaths is a small smoke test that the
+// dbPath() default resolution lands under XDG_STATE_HOME. iristest
+// pre-sets that env var so we just call ResolvePaths() and compare.
+func TestResolveDBPath_UsesIrisPaths(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	SetTestDBPath("") // ensure default branch
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	want := iris.ResolvePaths().DB
+	if got := resolveDBPath(); got != want {
+		t.Errorf("resolveDBPath default mismatch: got %q want %q", got, want)
+	}
+	// Defensive: env var should agree.
+	if !strings.HasPrefix(want, os.Getenv("XDG_STATE_HOME")) {
+		t.Errorf("iris DB path %q not under XDG_STATE_HOME=%q", want, os.Getenv("XDG_STATE_HOME"))
+	}
+	_ = iso
+}


### PR DESCRIPTION
Adds the iris analogue of prism's `db` family: ad-hoc, read-only SQL introspection over the iris SQLite database. Mirrors prism's `cmd/db.go` + `cmd/db_query.go` + `cmd/db_schema.go` + `cmd/db_tables.go` file-for-file.

## Surface

```
iris db tables                # list user tables (sqlite_* excluded)
iris db schema <table>        # CREATE TABLE for a named table
iris db schema --all          # DDL for every user table + index
iris db query "<SQL>"         # run a read-only SELECT
iris db query -               # read SQL from stdin
iris db query <SQL> --json    # prism-parity JSON wire shape
```

## Security — defence-in-depth read-only enforcement

Per the issue watch-out, read-only is enforced in **two layers**:

1. **Pre-execution keyword check** (`isWriteStatement`, db_query.go) — rejects `INSERT / UPDATE / DELETE / DROP / CREATE / ALTER / REPLACE / PRAGMA / ATTACH / DETACH / VACUUM / REINDEX / ANALYZE / BEGIN / COMMIT / END / ROLLBACK / SAVEPOINT / RELEASE` **before** the DB is opened, with a clear `iris db query is read-only — rejected write keyword 'X'` error. Tests cover every keyword listed in the AC plus the rest.
2. **SQLite read-only open** (`?mode=ro` via `internal/db.OpenReadOnly`) as defence-in-depth.

The pre-check fires before the DB is opened — the test `TestDBQuery_RejectsWriteStatements` proves this by pointing the CLI at a non-existent DB path and asserting the rejection message does NOT contain `iris database not found`.

## Concurrency with the daemon

SQLite WAL mode (set by the daemon) supports concurrent readers. `TestDBQuery_ConcurrentWithDaemonWrites` runs 30 daemon-style inserts alongside 60 reader iterations (fresh `?mode=ro` handle per iteration, matching the CLI's per-invocation lifecycle) and asserts neither side errors. It first verifies the DB is actually in WAL mode so the test cannot silently pass on a non-WAL DB.

## JSON parity with prism

Wire shape (`{"columns":[...],"rows":[...],"elapsedMs":N}`) and per-cell coercion (`int64`/`float64`/`string`/`bool`/`nil`→`null`/`[]byte`→base64) are identical to `cmd/db_query.go`. Tests assert NULL → JSON `null` and empty result → `"rows":[]` (never `null`).

## Error paths

- **Missing DB** → `iris database not found at <path>; has the iris daemon ever run? (start it with \`systemctl --user start iris\` on Linux, or \`launchctl kickstart -k gui/\$UID/local.iris.daemon\` on Darwin)`
- **Invalid SQL** → underlying SQLite error verbatim (no Go stack trace) — `TestDBQuery_InvalidSQL` asserts no `goroutine ` / `.go:` markers in the message.
- **Multi-statement** → rejected at the CLI via the existing `db.IsSingleStatement` tokenizer.

## Reuse

No new DB plumbing — uses `internal/db.OpenReadOnly`, `Tables`, `Schema`, `RunQuery`, `IsSingleStatement`, and `IsReadOnlyError`. Path resolution delegates to `iris.ResolvePaths()`.

## Quality gates

- `go build ./...` ✓
- `go test ./cmd/iris/ -race` ✓ (all 35+ db tests pass, plus the pre-existing iris-cmd suite is untouched)
- `nix build .#iris` ✓ (verified `./result/bin/iris db --help` lists the new surface)

Closes #1698