### PR TITLE
feat(iris): emit and handle agent_status.state="waiting" end-to-end (#1701)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -18,6 +18,7 @@ import {
   attachJsonlReader,
   coerceToolOutput,
   dispatchInboundFrame,
+  isIrisMode,
   parseEndpoint,
   redactLine,
   shouldActivate,
@@ -65,11 +66,11 @@ import prismExtension from "./prism.ts"
 // ---------------------------------------------------------------------------
 
 describe("shouldActivate", () => {
-  it("returns false when PRISM_SESSION_NAME is missing", () => {
+  it("returns false when neither PRISM_SESSION_NAME nor IRIS_DAEMON_SOCK is set", () => {
     assert.equal(shouldActivate({}), false)
   })
 
-  it("returns false when PRISM_SESSION_NAME is empty", () => {
+  it("returns false when PRISM_SESSION_NAME is empty and IRIS_DAEMON_SOCK is absent", () => {
     assert.equal(shouldActivate({ PRISM_SESSION_NAME: "" }), false)
   })
 
@@ -77,6 +78,48 @@ describe("shouldActivate", () => {
     assert.equal(
       shouldActivate({ PRISM_SESSION_NAME: "nixos-config@main" }),
       true,
+    )
+  })
+
+  // Issue #1701: the extension must also activate under iris so the
+  // state_change="waiting" emission path (turn_end paused) can fire.
+  it("returns true when IRIS_DAEMON_SOCK is set (iris mode)", () => {
+    assert.equal(
+      shouldActivate({ IRIS_DAEMON_SOCK: "/run/user/1000/iris/foo/harness.sock" }),
+      true,
+    )
+  })
+
+  it("returns false when IRIS_DAEMON_SOCK is set but empty", () => {
+    assert.equal(shouldActivate({ IRIS_DAEMON_SOCK: "" }), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isIrisMode (iris-mode flag for turn_end paused emission)
+// ---------------------------------------------------------------------------
+
+describe("isIrisMode", () => {
+  it("returns false when IRIS_DAEMON_SOCK is absent", () => {
+    assert.equal(isIrisMode({}), false)
+  })
+
+  it("returns false when IRIS_DAEMON_SOCK is empty", () => {
+    assert.equal(isIrisMode({ IRIS_DAEMON_SOCK: "" }), false)
+  })
+
+  it("returns true when IRIS_DAEMON_SOCK is set", () => {
+    assert.equal(
+      isIrisMode({ IRIS_DAEMON_SOCK: "/tmp/iris/abc/harness.sock" }),
+      true,
+    )
+  })
+
+  it("does NOT activate iris-mode when only PRISM_SESSION_NAME is set", () => {
+    // prism-mode session: must not switch turn_end paused to "waiting".
+    assert.equal(
+      isIrisMode({ PRISM_SESSION_NAME: "nixos-config@main" }),
+      false,
     )
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1330,15 +1330,36 @@ export function resolveTurnEndSignal(
 
 /**
  * Returns true when the extension should activate (i.e., we are running
- * under prism). The sole signal is the presence of PRISM_SESSION_NAME in the
- * environment — prism's agent-pane launcher always sets this before exec'ing
- * PI inside the sandbox.
+ * under prism OR under iris). prism's agent-pane launcher sets
+ * PRISM_SESSION_NAME before exec'ing PI inside the sandbox; iris's
+ * supervisor sets IRIS_DAEMON_SOCK before exec'ing PI in --mode rpc. Either
+ * signal activates the extension so the wire-protocol producer (state_change,
+ * tool_call observations, session_status, etc.) runs in both code paths
+ * (issue #1701).
  *
  * Exposed as a function (not a captured boolean) so tests can manipulate
  * process.env between calls.
  */
 export function shouldActivate(env: NodeJS.ProcessEnv = process.env): boolean {
-  return typeof env.PRISM_SESSION_NAME === "string" && env.PRISM_SESSION_NAME.length > 0
+  if (typeof env.PRISM_SESSION_NAME === "string" && env.PRISM_SESSION_NAME.length > 0) {
+    return true
+  }
+  if (typeof env.IRIS_DAEMON_SOCK === "string" && env.IRIS_DAEMON_SOCK.length > 0) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Returns true when the extension is running under iris (the iris daemon
+ * has spawned this pi child). Used to switch the turn_end paused-emission
+ * from state_change="finished" (prism semantics: turn over, sidecar may go
+ * idle) to state_change="waiting" (iris semantics: pi is paused awaiting
+ * the next user prompt and must be visible to coordinators as such, per
+ * issue #1701).
+ */
+export function isIrisMode(env: NodeJS.ProcessEnv = process.env): boolean {
+  return typeof env.IRIS_DAEMON_SOCK === "string" && env.IRIS_DAEMON_SOCK.length > 0
 }
 
 // ---------------------------------------------------------------------------
@@ -1687,10 +1708,23 @@ export default function prismExtension(pi: ExtensionAPI): void {
     return
   }
 
-  const endpointEnv = process.env.PRISM_HARNESS_PIPE
+  // Endpoint derivation (issue #1701):
+  //   - prism path: PRISM_HARNESS_PIPE points at the sidecar's listener.
+  //   - iris path:  IRIS_DAEMON_SOCK is the per-session harness socket
+  //                 (always a Unix domain socket). Synthesise a unix://
+  //                 endpoint so the same connect/handshake code path runs.
+  // PRISM_HARNESS_PIPE takes precedence so an explicit override during
+  // debugging works in either mode.
+  let endpointEnv = process.env.PRISM_HARNESS_PIPE
+  if (!endpointEnv) {
+    const irisSock = process.env.IRIS_DAEMON_SOCK
+    if (irisSock && irisSock.length > 0) {
+      endpointEnv = "unix://" + irisSock
+    }
+  }
   if (!endpointEnv) {
     console.error(
-      "[prism-extension] PRISM_SESSION_NAME is set but PRISM_HARNESS_PIPE is not — extension is a no-op",
+      "[prism-extension] neither PRISM_HARNESS_PIPE nor IRIS_DAEMON_SOCK is set — extension is a no-op",
     )
     return
   }
@@ -1702,6 +1736,12 @@ export default function prismExtension(pi: ExtensionAPI): void {
     console.error("[prism-extension] parseEndpoint failed:", err)
     return
   }
+
+  // Iris-mode flag captured once at activation. Drives the turn_end
+  // paused-emission switch (state_change "waiting" vs "finished") and any
+  // future iris-only branches. Same string contract as the iris daemon
+  // (modules/programs/prism/prism/internal/iris/session.go: StateWaiting).
+  const irisMode = isIrisMode()
 
   // ── Behavioural guard state ───────────────────────────────────────────
   //
@@ -2235,7 +2275,20 @@ export default function prismExtension(pi: ExtensionAPI): void {
           hasPending,
           pendingReviewCall,
         )
-        if (signal === "interrupted") {
+        if (irisMode) {
+          // Iris semantics (issue #1701): pi is paused for the next user
+          // prompt, not "finished". Both stopReason=stop and stopReason=
+          // aborted leave pi alive and waiting on the harness socket — the
+          // session is persistent, so the canonical state is "waiting".
+          // The iris harness handler maps state_change="waiting" →
+          // StateWaiting and fires PublishState so subscribers (TUI, `iris
+          // sessions list`, `iris prompt`'s guard) see the transition
+          // within ~100 ms. A signal of "none" still suppresses emission
+          // (toolUse, error, length — the turn is not really paused).
+          if (signal === "interrupted" || signal === "finished") {
+            writer.write({ type: "state_change", state: "waiting" })
+          }
+        } else if (signal === "interrupted") {
           writer.write({ type: "state_change", state: "interrupted" })
         } else if (signal === "finished") {
           writer.write({ type: "state_change", state: "finished" })

--- a/modules/programs/prism/prism/internal/db/iris.go
+++ b/modules/programs/prism/prism/internal/db/iris.go
@@ -21,12 +21,19 @@ type IrisSessionRow struct {
 }
 
 // IrisSessionsToRestore returns all sessions in the iris DB that were in
-// "spawning" or "active" state when the daemon died (i.e. sessions that have
-// an iris_state of "spawning" or "active"). These are the candidates for
-// orphan detection and re-spawn.
+// "spawning", "active", or "waiting" state when the daemon died (i.e. sessions
+// that have a non-terminal iris_state). These are the candidates for orphan
+// detection and re-spawn.
 //
 // The harness column is used to restrict to iris-managed sessions (harness='pi').
 // Sessions with end_state IS NOT NULL (finished/error) are excluded.
+//
+// Sessions in "waiting" state (paused for user input at crash time, issue
+// #1701) are restored via the same path as "active": pi is re-spawned with
+// the previous JSONL session file. Restored sessions transition through
+// StateSpawning → StateActive on re-handshake; if pi is still paused for
+// input, the extension will emit state_change="waiting" again on the next
+// pause and the session converges back to waiting.
 func (d *DB) IrisSessionsToRestore() ([]IrisSessionRow, error) {
 	const q = `
 SELECT instance_id, session_name, COALESCE(worktree, ''), COALESCE(agent_role, ''),
@@ -34,7 +41,7 @@ SELECT instance_id, session_name, COALESCE(worktree, ''), COALESCE(agent_role, '
   FROM sessions
  WHERE harness = 'pi'
    AND end_state IS NULL
-   AND iris_state IN ('spawning', 'active')
+   AND iris_state IN ('spawning', 'active', 'waiting')
  ORDER BY started_at ASC`
 	rows, err := d.conn.Query(q)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -67,6 +67,15 @@ type HarnessSocketServer struct {
 	// under the supervisor's lock (issue #1682). Nil in harness-only tests.
 	sessionStatusHandler func(sessionID string)
 
+	// stateChangeHandler is invoked when a state_change frame arrives from
+	// the extension, immediately after the agent_events row is written.
+	// Wired by the Supervisor so it can drive the in-memory session state
+	// machine, update sessions.iris_state, and notify subscribers via
+	// PublishState. Per PR #1657 the event row is written *before* the
+	// status row — callers must preserve that ordering (issue #1701). Nil
+	// in harness-only tests; in that case the frame is logged only.
+	stateChangeHandler func(state string)
+
 	// sessionShutdownReceived is set to true when the session_shutdown
 	// frame arrives — used by the supervisor to detect clean exits.
 	sessionShutdownReceived bool
@@ -105,6 +114,18 @@ func (h *HarnessSocketServer) SetPublisher(p EventPublisher) {
 func (h *HarnessSocketServer) SetSessionStatusHandler(fn func(sessionID string)) {
 	h.mu.Lock()
 	h.sessionStatusHandler = fn
+	h.mu.Unlock()
+}
+
+// SetStateChangeHandler wires a callback invoked when a state_change frame
+// arrives from the extension. The callback runs synchronously after the
+// agent_events row is written (PR #1657 ordering: event row first, then
+// the status row inside the supervisor's setState). The callback is
+// expected to drive setState under the supervisor's lock so PublishState
+// fires for every transition (issue #1701).
+func (h *HarnessSocketServer) SetStateChangeHandler(fn func(state string)) {
+	h.mu.Lock()
+	h.stateChangeHandler = fn
 	h.mu.Unlock()
 }
 
@@ -338,6 +359,32 @@ func (h *HarnessSocketServer) handleConn(ctx context.Context, conn net.Conn) err
 		case "tool_result":
 			// Observation frame — write to DB for logging.
 			h.writeObservationEvent("tool_result", line)
+
+		case "state_change":
+			// State transition from the extension (e.g. waiting, active,
+			// finished, interrupted). Write the agent_events row FIRST per
+			// PR #1657 ordering, then dispatch to the supervisor so the
+			// sessions.iris_state row, the in-memory SessionRecord, and the
+			// PublishState fan-out all happen under the supervisor's lock
+			// (issue #1701).
+			h.writeObservationEvent("state_change", line)
+			var stateFrame struct {
+				State string `json:"state"`
+			}
+			if err := json.Unmarshal(line, &stateFrame); err != nil || stateFrame.State == "" {
+				if err != nil {
+					log.Printf("[iris] harness: bad state_change frame: %v", err)
+				} else {
+					log.Printf("[iris] harness: state_change frame missing state field")
+				}
+				continue
+			}
+			h.mu.Lock()
+			handler := h.stateChangeHandler
+			h.mu.Unlock()
+			if handler != nil {
+				handler(stateFrame.State)
+			}
 
 		default:
 			// Unknown or other observation frames — write to DB generically.

--- a/modules/programs/prism/prism/internal/iris/harness_state_change_test.go
+++ b/modules/programs/prism/prism/internal/iris/harness_state_change_test.go
@@ -1,0 +1,187 @@
+package iris_test
+
+// harness_state_change_test.go — tests for the state_change frame handler
+// added in issue #1701. Validates:
+//
+//   - state_change="waiting" → handler called with "waiting"
+//   - state_change="active"  → handler called with "active"
+//   - state_change="finished"/"interrupted" → handler called (supervisor
+//     decides whether to act); event row written in all cases
+//   - agent_events row written BEFORE the handler runs (PR #1657 ordering)
+//   - malformed state_change frames (missing state field, bad JSON) are
+//     ignored without crashing the handler
+//   - handler is optional (nil) — frame is still recorded as an event
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// startServerWithStateHandler starts a harness server, wires a recording
+// state-change handler, and returns both.
+func startServerWithStateHandler(t *testing.T) (*iris.HarnessSocketServer, *stateChangeRecorder) {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	const instanceID = "test-state-instance-001"
+	insertTestSessionRow(t, database, instanceID, "test@state-change", tmp)
+
+	sockPath := filepath.Join(tmp, "harness.sock")
+	sess := &iris.SessionRecord{
+		InstanceID:      instanceID,
+		SessionName:     "test@state-change",
+		Worktree:        tmp,
+		Role:            "worker",
+		HarnessSockPath: sockPath,
+	}
+	srv, err := iris.NewHarnessSocketServer(sess, database)
+	if err != nil {
+		t.Fatalf("NewHarnessSocketServer: %v", err)
+	}
+
+	rec := &stateChangeRecorder{}
+	srv.SetStateChangeHandler(rec.record)
+
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { srv.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	go func() { _ = srv.AcceptOne(ctx) }()
+
+	return srv, rec
+}
+
+type stateChangeRecorder struct {
+	mu     sync.Mutex
+	states []string
+}
+
+func (r *stateChangeRecorder) record(state string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states = append(r.states, state)
+}
+
+func (r *stateChangeRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.states))
+	copy(out, r.states)
+	return out
+}
+
+func (r *stateChangeRecorder) waitForLen(t *testing.T, n int, timeout time.Duration) []string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		got := r.snapshot()
+		if len(got) >= n {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return r.snapshot()
+}
+
+// TestStateChange_Waiting verifies that a state_change waiting frame is
+// dispatched to the handler. This is the production trigger for the iris
+// prompt waiting-state guard (#1689) — the entire AC chain in #1701 hinges
+// on the handler firing.
+func TestStateChange_Waiting(t *testing.T) {
+	srv, rec := startServerWithStateHandler(t)
+	conn, r := dialHarness(t, srv.SockPath())
+	doHandshake(t, conn, r)
+
+	sendFrame(t, conn, map[string]any{
+		"type":  "state_change",
+		"state": "waiting",
+	})
+
+	got := rec.waitForLen(t, 1, 2*time.Second)
+	if len(got) != 1 || got[0] != "waiting" {
+		t.Fatalf("expected handler called with 'waiting' once, got %v", got)
+	}
+}
+
+// TestStateChange_Active verifies that a state_change active frame is
+// dispatched. This is the transition out of waiting when a prompt arrives
+// (turn_start → before_agent_start → state_change:active).
+func TestStateChange_Active(t *testing.T) {
+	srv, rec := startServerWithStateHandler(t)
+	conn, r := dialHarness(t, srv.SockPath())
+	doHandshake(t, conn, r)
+
+	sendFrame(t, conn, map[string]any{
+		"type":  "state_change",
+		"state": "active",
+	})
+
+	got := rec.waitForLen(t, 1, 2*time.Second)
+	if len(got) != 1 || got[0] != "active" {
+		t.Fatalf("expected handler called with 'active' once, got %v", got)
+	}
+}
+
+// TestStateChange_WaitingThenActive verifies the full cycle: a session goes
+// into waiting (paused for input) and back to active when a turn starts.
+func TestStateChange_WaitingThenActive(t *testing.T) {
+	srv, rec := startServerWithStateHandler(t)
+	conn, r := dialHarness(t, srv.SockPath())
+	doHandshake(t, conn, r)
+
+	sendFrame(t, conn, map[string]any{"type": "state_change", "state": "waiting"})
+	sendFrame(t, conn, map[string]any{"type": "state_change", "state": "active"})
+
+	got := rec.waitForLen(t, 2, 2*time.Second)
+	if len(got) != 2 || got[0] != "waiting" || got[1] != "active" {
+		t.Fatalf("expected [waiting active], got %v", got)
+	}
+}
+
+// TestStateChange_MissingStateField verifies that malformed frames are
+// rejected without dispatching to the handler. The frame should still be
+// recorded as an observation event (writeObservationEvent runs first).
+func TestStateChange_MissingStateField(t *testing.T) {
+	srv, rec := startServerWithStateHandler(t)
+	conn, r := dialHarness(t, srv.SockPath())
+	doHandshake(t, conn, r)
+
+	// state_change frame with missing state field — handler must NOT be called.
+	sendFrame(t, conn, map[string]any{"type": "state_change"})
+	// Follow with a well-formed frame so we have a wait condition.
+	sendFrame(t, conn, map[string]any{"type": "state_change", "state": "waiting"})
+
+	got := rec.waitForLen(t, 1, 2*time.Second)
+	if len(got) != 1 || got[0] != "waiting" {
+		t.Fatalf("expected handler called only once with 'waiting' (malformed frame ignored), got %v", got)
+	}
+}
+
+// TestStateChange_NoHandler verifies that the server does not crash when
+// no state-change handler is wired. Frames are still written to the events
+// stream via writeObservationEvent.
+func TestStateChange_NoHandler(t *testing.T) {
+	srv := startServer(t) // no SetStateChangeHandler
+	conn, r := dialHarness(t, srv.SockPath())
+	doHandshake(t, conn, r)
+
+	sendFrame(t, conn, map[string]any{"type": "state_change", "state": "waiting"})
+	// Allow the server goroutine to process the frame.
+	time.Sleep(100 * time.Millisecond)
+
+	// If we got here without a panic, the test passes.
+}

--- a/modules/programs/prism/prism/internal/iris/restore.go
+++ b/modules/programs/prism/prism/internal/iris/restore.go
@@ -109,12 +109,16 @@ func RunRestore(ctx context.Context, cfg RestoreConfig) (*RestoreResult, error) 
 		result.SpawningMarkError++
 	}
 
-	// Step 2: Restore active sessions concurrently.
+	// Step 2: Restore active and waiting sessions concurrently. "waiting" is
+	// treated the same as "active" for restore purposes (issue #1701): pi is
+	// re-spawned with the previous JSONL session file, and the extension's
+	// next state_change frame (whether "waiting" or "active") re-asserts the
+	// correct state on the restored supervisor.
 	var wg sync.WaitGroup
 	var mu sync.Mutex // guards result counters
 
 	for _, sess := range sessions {
-		if sess.IrisState != string(StateActive) {
+		if sess.IrisState != string(StateActive) && sess.IrisState != string(StateWaiting) {
 			continue
 		}
 		sess := sess // capture for goroutine
@@ -355,7 +359,7 @@ func newRestoreSupervisor(cfg SupervisorConfig, sess db.IrisSessionRow) (*Superv
 	}
 	sessionLog := newSessionLogger(logFile, cfg.SessionName)
 
-	return &Supervisor{
+	sup := &Supervisor{
 		cfg:            cfg,
 		sess:           record,
 		harness:        harness,
@@ -363,5 +367,13 @@ func newRestoreSupervisor(cfg SupervisorConfig, sess db.IrisSessionRow) (*Superv
 		sessionLog:     sessionLog,
 		sessionLogFile: logFile,
 		done:           make(chan struct{}),
-	}, nil
+	}
+	// Wire harness → supervisor callbacks so restored sessions get the same
+	// in-memory updates as freshly-spawned ones. Without this, a restored
+	// session's pi child could deliver session_status or state_change frames
+	// that update the DB but leave the in-memory SessionRecord stale
+	// (issues #1682 and #1701).
+	harness.SetSessionStatusHandler(sup.handleSessionStatus)
+	harness.SetStateChangeHandler(sup.handleStateChange)
+	return sup, nil
 }

--- a/modules/programs/prism/prism/internal/iris/session.go
+++ b/modules/programs/prism/prism/internal/iris/session.go
@@ -18,6 +18,15 @@ const (
 	// handshake has completed.
 	StateActive SessionState = "active"
 
+	// StateWaiting means the pi child has paused for user input — typically
+	// when an assistant turn has finished and the next user message has not
+	// arrived. Emitted by the pi extension as a state_change frame on the
+	// harness socket and surfaced so coordinators (e.g. `iris prompt`'s
+	// waiting-state guard, #1689) can distinguish an idle-but-attentive
+	// session from one that is still working. Use the literal lowercase
+	// string "waiting" — matches prism's agent.StateWaiting; do not drift.
+	StateWaiting SessionState = "waiting"
+
 	// StateFinished means the session ended cleanly (session_shutdown frame
 	// received and pi exited with code 0).
 	StateFinished SessionState = "finished"

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -247,7 +247,58 @@ func NewSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 	// stay empty for the entire lifetime of every live session even though
 	// the DB row is correct.
 	harness.SetSessionStatusHandler(sup.handleSessionStatus)
+	// Wire the state_change handler so the harness socket can drive the
+	// in-memory session state machine when the extension emits a
+	// state_change frame (issue #1701). The handler runs *after* the
+	// agent_events row has been written by writeObservationEvent, preserving
+	// the PR #1657 event-row-before-status-row ordering.
+	harness.SetStateChangeHandler(sup.handleStateChange)
 	return sup, nil
+}
+
+// handleStateChange is the callback the HarnessSocketServer invokes when a
+// state_change frame arrives from the extension. It maps the wire state
+// string to a SessionState and drives setState under the supervisor's lock
+// (PR #1687 pattern). Unknown wire states are logged and ignored — the
+// extension is forward-compatible per the wire spec.
+//
+// Issue #1701: this is the production path that lands a session in
+// StateWaiting. Without it the iris prompt waiting-state guard (#1689) is
+// unreachable.
+func (s *Supervisor) handleStateChange(state string) {
+	// Terminal states are owned by the supervisor lifecycle (clean exit,
+	// non-zero exit, kill). Don't let the extension drive us out of a
+	// terminal state — once finished/error, the supervisor goroutine has
+	// already returned or is about to, and re-asserting active/waiting here
+	// would publish a misleading transition.
+	s.mu.Lock()
+	current := s.state
+	killing := s.killReason != ""
+	s.mu.Unlock()
+	if current == StateFinished || current == StateError || killing {
+		s.logf("supervisor: ignoring state_change=%q while terminal/killing (current=%s)", state, current)
+		return
+	}
+
+	var next SessionState
+	switch state {
+	case "waiting":
+		next = StateWaiting
+	case "active":
+		next = StateActive
+	default:
+		// Other wire states (finished, interrupted, etc.) are not driven
+		// through this path — terminal transitions are owned by the
+		// supervisor loop. Log and ignore so future wire-protocol additions
+		// are forward-compatible.
+		s.logf("supervisor: state_change=%q ignored (not driven from harness)", state)
+		return
+	}
+
+	if current == next {
+		return
+	}
+	s.setState(next)
 }
 
 // handleSessionStatus is the callback the HarnessSocketServer invokes when

--- a/modules/programs/prism/prism/internal/iris/supervisor_state_change_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_state_change_test.go
@@ -1,0 +1,220 @@
+package iris
+
+// supervisor_state_change_test.go — tests for the supervisor's
+// handleStateChange callback wired in issue #1701. Validates:
+//
+//   - handleStateChange("waiting") drives setState(StateWaiting) and
+//     publishes a PublishState("waiting") event.
+//   - handleStateChange("active") drives setState(StateActive) (idempotent
+//     when already active).
+//   - Transitions across waiting↔active fire PublishState each time.
+//   - Unknown wire states are ignored (forward-compatible).
+//   - handleStateChange is a no-op when the supervisor is in a terminal
+//     state (the extension should never drive us out of finished/error).
+//
+// The full end-to-end (extension → harness socket → supervisor → DB +
+// PublishState) is covered by harness_state_change_test.go and the higher-
+// level integration tests; these unit tests pin the supervisor-side
+// semantics so future refactors of setState do not silently drop the
+// waiting transition.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+func newStateChangeSupervisor(t *testing.T) (*Supervisor, *statePublisherSpy, *db.DB) {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	spy := &statePublisherSpy{}
+	runDir, err := os.MkdirTemp("", "iris-sc-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+
+	cfg := SupervisorConfig{
+		SessionName: "iris-test@state-change",
+		Worktree:    tmp,
+		Role:        "worker",
+		RunDir:      runDir,
+		LogDir:      filepath.Join(tmp, "logs"),
+		Database:    database,
+		Publisher:   spy,
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(sup.closeSessionLogFile)
+	return sup, spy, database
+}
+
+// waitForPublications polls the spy until it has at least n events or the
+// deadline expires. Returns the snapshot.
+func waitForPublications(t *testing.T, spy *statePublisherSpy, n int, timeout time.Duration) []stateEvent {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		got := spy.snapshot()
+		if len(got) >= n {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return spy.snapshot()
+}
+
+// TestHandleStateChange_Waiting verifies the canonical issue #1701 path: an
+// extension state_change="waiting" frame results in StateWaiting being set
+// and PublishState being called.
+func TestHandleStateChange_Waiting(t *testing.T) {
+	sup, spy, database := newStateChangeSupervisor(t)
+
+	// The supervisor starts in StateSpawning. A state_change before active
+	// is unusual but should still produce the transition — sandbox time so
+	// far as the wire spec is concerned (no ordering assumed).
+	sup.handleStateChange("waiting")
+
+	if got := sup.State(); got != StateWaiting {
+		t.Fatalf("State() = %q, want %q", got, StateWaiting)
+	}
+
+	got := waitForPublications(t, spy, 1, time.Second)
+	if len(got) != 1 || got[0].State != string(StateWaiting) {
+		t.Fatalf("expected PublishState(\"waiting\") once, got %v", got)
+	}
+
+	// sessions.iris_state in the DB should also be "waiting".
+	sessions, err := database.IrisSessionsToRestore()
+	if err != nil {
+		t.Fatalf("IrisSessionsToRestore: %v", err)
+	}
+	var gotState string
+	for _, s := range sessions {
+		if s.InstanceID == sup.InstanceID() {
+			gotState = s.IrisState
+			break
+		}
+	}
+	if gotState != string(StateWaiting) {
+		t.Errorf("DB iris_state = %q, want %q", gotState, StateWaiting)
+	}
+}
+
+// TestHandleStateChange_WaitingThenActive verifies the round-trip: paused →
+// next prompt arrives → active. Each transition must call PublishState.
+func TestHandleStateChange_WaitingThenActive(t *testing.T) {
+	sup, spy, _ := newStateChangeSupervisor(t)
+
+	sup.handleStateChange("waiting")
+	sup.handleStateChange("active")
+
+	if got := sup.State(); got != StateActive {
+		t.Fatalf("State() = %q, want %q", got, StateActive)
+	}
+
+	got := waitForPublications(t, spy, 2, time.Second)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 publications, got %d: %v", len(got), got)
+	}
+	if got[0].State != string(StateWaiting) {
+		t.Errorf("first publication = %q, want %q", got[0].State, StateWaiting)
+	}
+	if got[1].State != string(StateActive) {
+		t.Errorf("second publication = %q, want %q", got[1].State, StateActive)
+	}
+}
+
+// TestHandleStateChange_IdempotentWaiting verifies that a repeated
+// state_change="waiting" frame does not produce a duplicate PublishState
+// (avoids spamming subscribers when pi re-emits at every paused turn).
+func TestHandleStateChange_IdempotentWaiting(t *testing.T) {
+	sup, spy, _ := newStateChangeSupervisor(t)
+
+	sup.handleStateChange("waiting")
+	sup.handleStateChange("waiting") // repeat
+	sup.handleStateChange("waiting") // repeat
+
+	got := waitForPublications(t, spy, 1, time.Second)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 publication for repeated waiting, got %d: %v", len(got), got)
+	}
+}
+
+// TestHandleStateChange_UnknownStateIgnored verifies forward compatibility:
+// unknown wire-state strings (future extensions) are logged and ignored
+// rather than crashing or mis-typing the in-memory state.
+func TestHandleStateChange_UnknownStateIgnored(t *testing.T) {
+	sup, spy, _ := newStateChangeSupervisor(t)
+	pre := sup.State()
+
+	sup.handleStateChange("compacting") // not driven through this path
+	sup.handleStateChange("totally_made_up_state")
+
+	if got := sup.State(); got != pre {
+		t.Errorf("State() changed to %q after unknown wire states, want %q (unchanged)", got, pre)
+	}
+	got := spy.snapshot()
+	if len(got) != 0 {
+		t.Errorf("expected zero publications for unknown states, got %v", got)
+	}
+}
+
+// TestHandleStateChange_FinishedIsNotDriven verifies that the terminal
+// "finished" wire state from the extension is NOT propagated to setState
+// via handleStateChange — terminal transitions are owned by the supervisor
+// loop (clean exit, restart-exhaustion, kill). This guards against the
+// extension racing the supervisor and double-firing session_end events.
+func TestHandleStateChange_FinishedIsNotDriven(t *testing.T) {
+	sup, spy, _ := newStateChangeSupervisor(t)
+	pre := sup.State()
+
+	sup.handleStateChange("finished")
+	sup.handleStateChange("interrupted")
+
+	if got := sup.State(); got != pre {
+		t.Errorf("State() = %q, want %q (terminal wire states must not change state)", got, pre)
+	}
+	if got := spy.snapshot(); len(got) != 0 {
+		t.Errorf("expected zero publications, got %v", got)
+	}
+}
+
+// TestHandleStateChange_TerminalSupervisorIgnores verifies that once the
+// supervisor has entered a terminal state, the harness handler cannot drive
+// it back to active/waiting. The pi child should be gone, but a late frame
+// in flight must not corrupt the terminal record.
+func TestHandleStateChange_TerminalSupervisorIgnores(t *testing.T) {
+	sup, spy, _ := newStateChangeSupervisor(t)
+
+	// Drive to terminal.
+	sup.setState(StateFinished)
+	// Reset the spy so we only count post-terminal events.
+	spy.mu.Lock()
+	spy.states = nil
+	spy.mu.Unlock()
+
+	// Late state_change frames must be ignored.
+	sup.handleStateChange("waiting")
+	sup.handleStateChange("active")
+
+	if got := sup.State(); got != StateFinished {
+		t.Errorf("State() = %q, want %q (terminal must be sticky)", got, StateFinished)
+	}
+	if got := spy.snapshot(); len(got) != 0 {
+		t.Errorf("expected zero post-terminal publications, got %v", got)
+	}
+}
+

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -83,6 +83,13 @@ var (
 	styleBlue = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colBlue))
 
+	// styleYellow highlights sessions in `waiting` state — paused for the
+	// next user prompt. Distinct from `active` (green) and `finished`
+	// (dim) so operators can spot attention-needed sessions at a glance.
+	styleYellow = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colPrimary)).
+			Bold(true)
+
 	stylePromptBox = lipgloss.NewStyle().
 			Border(lipgloss.NormalBorder()).
 			BorderForeground(lipgloss.Color(colBlue))
@@ -742,6 +749,8 @@ func stateLabel(state string) string {
 	switch state {
 	case "active":
 		return styleGreen.Render("active  ")
+	case "waiting":
+		return styleYellow.Render("waiting ")
 	case "spawning":
 		return styleBlue.Render("spawning")
 	case "finished":


### PR DESCRIPTION
## Summary

Wires the production path that lands an iris session in `waiting` state so the iris prompt waiting-state guard (#1689) is reachable, the TUI shows paused sessions distinctively, and `iris sessions status --tmux-format` counts them correctly.

Before this change there was **no** production code path that produced `agent_status.state = "waiting"`. The guard, snapshot fields, and CLI counter were all forward-compatible but unreachable — a coordinator could send a prompt to a session whose pi was genuinely paused for input and silently corrupt the input field. The guard's literal-`"waiting"` string never fired because no production code transitioned a session into that state.

## Pieces (in dependency order)

### 1. pi-extension (`pi/extensions/prism.ts`)

- `shouldActivate()` now returns true when either `PRISM_SESSION_NAME` (prism) OR `IRIS_DAEMON_SOCK` (iris) is set. Both code paths share the same wire-protocol producer.
- Endpoint derivation falls back to `unix://$IRIS_DAEMON_SOCK` when `PRISM_HARNESS_PIPE` is unset, so the same connect + handshake pipeline serves both modes.
- New `isIrisMode()` helper captures the iris-vs-prism branch at activation; `turn_end` paused-emission switches from `state_change="finished"` (prism semantics: turn over, sidecar may go idle) to `state_change="waiting"` (iris semantics: pi is alive and paused awaiting the next user prompt).
- State string is the literal lowercase `"waiting"` — matches prism's `agent.StateWaiting`; no drift.

### 2. iris harness socket (`internal/iris/harness_socket.go`)

- `handleConn` now dispatches `state_change` frames. Per PR #1657 ordering the `agent_events` row is written FIRST via `writeObservationEvent`, then the new `stateChangeHandler` is invoked with the parsed `state` string.
- Malformed frames (missing `state` field, bad JSON) are logged and ignored without crashing the dispatch loop.
- New `SetStateChangeHandler` mirrors the existing `SetSessionStatusHandler` pattern.

### 3. iris supervisor (`internal/iris/supervisor.go`)

- New `handleStateChange(state string)` callback wired in both `NewSupervisor` and `newRestoreSupervisor`. Maps wire states (`"waiting"`, `"active"`) to `SessionState` under `s.mu` and calls `setState` so `PublishState` fires for every transition (PR #1687 lock pattern, PR #1688 broadcast).
- Terminal supervisor states (`finished`, `error`) and in-flight kills are sticky — the extension cannot drive us out of them. A late state_change frame in flight when a kill commits cannot corrupt the terminal record.
- Unknown wire states (`compacting`, future additions) are logged and ignored — forward-compatible per the wire spec.

### 4. D-9 restore path (`internal/db/iris.go` + `internal/iris/restore.go`)

- `IrisSessionsToRestore` now selects `iris_state IN ('spawning', 'active', 'waiting')`. Sessions that were paused for input at crash time get restored via the same re-spawn path as active ones; the extension's next state_change re-asserts the correct state on the restored supervisor.

### 5. TUI styling (`internal/iris/tui/model.go`)

- New `styleYellow` (bold yellow, matches `colPrimary`) for the `waiting` state label in the session list. Distinct from `active` (green) and `finished` (dim).

## Tests

- **`harness_state_change_test.go`** (new): end-to-end harness-socket dispatch (dial → handshake → send state_change → handler called with correct state). Covers waiting, active, round-trip, malformed-frame ignored, nil-handler no-crash.
- **`supervisor_state_change_test.go`** (new): unit-level supervisor semantics (handleStateChange → setState → PublishState + DB iris_state row). Covers waiting, round-trip publication, idempotent repeat, unknown-state forward compat, terminal-sticky guard.
- **`prism.test.ts`**: `shouldActivate` and `isIrisMode` tests cover the new env-fallback (IRIS_DAEMON_SOCK activates the extension).

## Quality gates

- `go test ./... -race` — passes (all 28 packages).
- `nix build .#iris` — passes.
- `nix build .#prism` — passes (no regression in the prism path).

## Watch-outs covered

- Both prism AND iris share `pi/extensions/prism.ts`; `isIrisMode` switches `turn_end` emission only in iris mode, so prism's existing `finished`/`interrupted` wire is unchanged.
- Exact same state string as prism (`"waiting"`, lowercase) — see the `StateWaiting` const doc in `session.go`.
- PR #1687 supervisor lock pattern preserved (`setState` holds `s.mu`).
- PR #1657 write ordering preserved (agent_events row via `writeObservationEvent` BEFORE the supervisor's iris_state row in `setState`).

Closes #1701