### PR TITLE
iris: fix supervisor-goroutine-outlives-test-cleanup race (#1705)

### DIFF
--- a/modules/programs/prism/prism/internal/iris/iristest/iristest.go
+++ b/modules/programs/prism/prism/internal/iris/iristest/iristest.go
@@ -33,11 +33,13 @@
 package iristest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/iris"
@@ -219,6 +221,82 @@ func checkUnderShort(t *testing.T, name, path, short string) {
 	if !strings.HasPrefix(path, short) {
 		t.Fatalf("iristest: isolation broken: %s=%q does not start with short tempdir %q", name, path, short)
 	}
+}
+
+// RunRestoreForTest is the test-only wrapper around iris.RunRestore that
+// guarantees the supervisor goroutines spawned by restore do not outlive
+// the test — fixing the lifecycle race tracked in issue #1705.
+//
+// # The race
+//
+// iris.RunRestore spawns one supervisor goroutine per active session via
+// `go sup.Start(ctx)` and returns immediately. Those goroutines keep
+// writing to the DB and the per-session run directory until either ctx is
+// cancelled or the (fake) pi child's circuit breaker opens. Under -race,
+// any of these scenarios is enough to fail the test:
+//
+//   - The supervisor's setState writes an event row after t.Cleanup has
+//     closed the DB → "sql: database is closed".
+//   - The supervisor writes a per-session log entry under the tempdir
+//     after t.Cleanup has begun removing it → "unlinkat .../001:
+//     directory not empty".
+//
+// # The fix
+//
+// RunRestoreForTest registers a t.Cleanup that:
+//  1. Cancels the supervisor context (so Start returns at the next select).
+//  2. Waits on <-sup.Done() for every supervisor in the result.
+//
+// # Cleanup-ordering invariant (load-bearing)
+//
+// t.Cleanup callbacks run in LIFO order. The cleanups registered by
+// NewIsolated (DB close, tempdir removal, short-prefix removal) and by
+// t.TempDir() are all registered before RunRestoreForTest is called from
+// the test body, so the cleanup registered here runs FIRST — which is
+// exactly what we need: the supervisor goroutines must be fully drained
+// before the DB closes and before tempdirs are removed.
+//
+// Calling this helper before NewIsolated (or before any t.TempDir() the
+// supervisor writes into) would invert the ordering and re-introduce the
+// race. Do not do that.
+//
+// # Why a helper, not a fix on iris.RunRestore
+//
+// Production callers (the iris daemon) own the supervisor lifecycle for
+// the lifetime of the process — they intentionally let those goroutines
+// run until the daemon's signal context fires. Forcing a synchronous
+// shutdown inside RunRestore would either deadlock the daemon or require
+// reworking the daemon's main loop. Keeping the wait in the test helper
+// targets the actual failure mode (test teardown) without changing
+// production semantics.
+func RunRestoreForTest(t *testing.T, cfg iris.RestoreConfig) (*iris.RestoreResult, error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	result, err := iris.RunRestore(ctx, cfg)
+	// Register cleanup AFTER calling RunRestore so the result.Supervisors
+	// slice is fully populated by the time the cleanup closure captures it.
+	var sups []*iris.Supervisor
+	if result != nil {
+		sups = result.Supervisors
+	}
+	t.Cleanup(func() {
+		cancel()
+		for _, sup := range sups {
+			if sup == nil {
+				continue
+			}
+			select {
+			case <-sup.Done():
+			case <-time.After(10 * time.Second):
+				// A wedged supervisor is a real bug — surface it loudly so
+				// it cannot hide as a flake. We use t.Errorf rather than
+				// t.Fatalf because we're inside a cleanup and want every
+				// supervisor reported, not just the first.
+				t.Errorf("iristest: RunRestoreForTest: supervisor %s did not shut down within 10s after ctx cancel", sup.InstanceID())
+			}
+		}
+	})
+	return result, err
 }
 
 // sanitiseForSessionName replaces characters that are awkward in iris

--- a/modules/programs/prism/prism/internal/iris/parity/restore_test.go
+++ b/modules/programs/prism/prism/internal/iris/parity/restore_test.go
@@ -28,7 +28,6 @@ package parity_test
 //     checking the spawned harness socket exists.
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -127,10 +126,11 @@ func TestParityRestore_OrphanedToolCallAndRespawn(t *testing.T) {
 		t.Fatalf("write fake-pi: %v", err)
 	}
 
-	// 5. Run RunRestore as if the daemon just restarted.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	result, err := iris.RunRestore(ctx, iris.RestoreConfig{
+	// 5. Run RunRestore as if the daemon just restarted. Use the iristest
+	// helper so the spawned supervisor goroutine is cancelled and drained
+	// before t.Cleanup tears down iso.DB and iso.Root — fixing the
+	// supervisor-outlives-cleanup race tracked in issue #1705.
+	result, err := iristest.RunRestoreForTest(t, iris.RestoreConfig{
 		Database:   iso.DB,
 		RunDir:     iso.Paths.RunDir,
 		PIAgentDir: iso.PIAgentDir,

--- a/modules/programs/prism/prism/internal/iris/restore.go
+++ b/modules/programs/prism/prism/internal/iris/restore.go
@@ -69,6 +69,18 @@ type RestoreResult struct {
 	// SessionsSkipped is the number of active sessions that could not be restored
 	// (missing JSONL, missing worktree, etc.).
 	SessionsSkipped int
+	// Supervisors is the list of supervisor instances that RunRestore started
+	// goroutines for (one per SessionsRestored increment). Callers that own
+	// the supervisor lifecycle — the daemon's process loop, or tests that
+	// must wait for shutdown before tearing down tempdirs / closing the DB —
+	// should cancel the supervisor context and then wait on <-sup.Done() for
+	// each entry to guarantee no late writes against torn-down state.
+	//
+	// This was added to fix issue #1705: supervisor goroutines spawned by
+	// RunRestore outlived test t.Cleanup, racing against tempdir removal and
+	// DB close under -race. Tests should use iristest.RunRestoreForTest which
+	// wires up the shutdown wait automatically.
+	Supervisors []*Supervisor
 }
 
 // RunRestore executes the daemon-restart restore sequence. It is called once
@@ -132,10 +144,13 @@ func RunRestore(ctx context.Context, cfg RestoreConfig) (*RestoreResult, error) 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			restored := restoreActiveSession(ctx, cfg, sess)
+			sup, restored := restoreActiveSession(ctx, cfg, sess)
 			mu.Lock()
 			if restored {
 				result.SessionsRestored++
+				if sup != nil {
+					result.Supervisors = append(result.Supervisors, sup)
+				}
 			} else {
 				result.SessionsSkipped++
 			}
@@ -182,8 +197,11 @@ func detectAndWriteOrphans(database *db.DB, pub EventPublisher, instanceID, sess
 }
 
 // restoreActiveSession attempts to re-spawn a single active session. Returns
-// true if a Supervisor was started, false otherwise.
-func restoreActiveSession(ctx context.Context, cfg RestoreConfig, sess db.IrisSessionRow) bool {
+// the started Supervisor and true when a Supervisor was started, or (nil,
+// false) otherwise. The returned supervisor is owned by the caller — its
+// goroutine runs asynchronously and the caller is responsible for waiting
+// on <-sup.Done() before tearing down any shared state (tempdir, DB).
+func restoreActiveSession(ctx context.Context, cfg RestoreConfig, sess db.IrisSessionRow) (*Supervisor, bool) {
 	// Check whether the worktree still exists.
 	if _, err := os.Stat(sess.Worktree); os.IsNotExist(err) {
 		log.Printf("[iris] restore: worktree %q for session %s no longer exists — marking error",
@@ -191,7 +209,7 @@ func restoreActiveSession(ctx context.Context, cfg RestoreConfig, sess db.IrisSe
 		if merr := markSessionErrorWithReason(cfg.Database, sess.InstanceID, "worktree missing"); merr != nil {
 			log.Printf("[iris] restore: failed to mark session %s error: %v", sess.InstanceID, merr)
 		}
-		return false
+		return nil, false
 	}
 
 	// Locate the pi JSONL session file.
@@ -202,7 +220,7 @@ func restoreActiveSession(ctx context.Context, cfg RestoreConfig, sess db.IrisSe
 		if merr := markSessionErrorWithReason(cfg.Database, sess.InstanceID, "session file missing"); merr != nil {
 			log.Printf("[iris] restore: failed to mark session %s error: %v", sess.InstanceID, merr)
 		}
-		return false
+		return nil, false
 	}
 
 	log.Printf("[iris] restore: re-spawning session %s (%s) with JSONL %q",
@@ -228,11 +246,11 @@ func restoreActiveSession(ctx context.Context, cfg RestoreConfig, sess db.IrisSe
 		if merr := markSessionErrorWithReason(cfg.Database, sess.InstanceID, "supervisor creation failed"); merr != nil {
 			log.Printf("[iris] restore: failed to mark session %s error: %v", sess.InstanceID, merr)
 		}
-		return false
+		return nil, false
 	}
 
 	go sup.Start(ctx)
-	return true
+	return sup, true
 }
 
 // findPiSessionJSONL locates the pi JSONL session file for the given session

--- a/modules/programs/prism/prism/internal/iris/restore_integration_test.go
+++ b/modules/programs/prism/prism/internal/iris/restore_integration_test.go
@@ -20,7 +20,6 @@ package iris_test
 // The test is Linux-only (uses /bin/sh) but otherwise self-contained.
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
 )
 
 // TestRestoreIntegration_EndToEnd exercises the full restore path:
@@ -103,9 +103,6 @@ func TestRestoreIntegration_EndToEnd(t *testing.T) {
 		t.Fatalf("WriteFile fake-pi: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	cfg := iris.RestoreConfig{
 		Database:   database,
 		RunDir:     runDir,
@@ -117,7 +114,10 @@ func TestRestoreIntegration_EndToEnd(t *testing.T) {
 		},
 	}
 
-	result, err := iris.RunRestore(ctx, cfg)
+	// Use the iristest helper so the spawned supervisor goroutines are
+	// cancelled and drained before t.Cleanup tears down runDir, tmp, and
+	// the DB (issue #1705).
+	result, err := iristest.RunRestoreForTest(t, cfg)
 	if err != nil {
 		t.Fatalf("RunRestore: %v", err)
 	}
@@ -233,9 +233,6 @@ func TestRestoreIntegration_MultipleActiveSessions(t *testing.T) {
 		t.Fatalf("WriteFile fake-pi: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	cfg := iris.RestoreConfig{
 		Database:   database,
 		RunDir:     runDir,
@@ -247,7 +244,10 @@ func TestRestoreIntegration_MultipleActiveSessions(t *testing.T) {
 		},
 	}
 
-	result, err := iris.RunRestore(ctx, cfg)
+	// Use the iristest helper so all spawned supervisor goroutines are
+	// cancelled and drained before t.Cleanup tears down runDir, tmp, and
+	// the DB (issue #1705).
+	result, err := iristest.RunRestoreForTest(t, cfg)
 	if err != nil {
 		t.Fatalf("RunRestore: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/iris/restore_test.go
+++ b/modules/programs/prism/prism/internal/iris/restore_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
 )
 
 // --- Helpers ---
@@ -557,7 +558,10 @@ func TestRestoreSession_WithJSONL(t *testing.T) {
 		},
 	}
 
-	result, err := iris.RunRestore(context.Background(), cfg)
+	// Use iristest.RunRestoreForTest so the spawned supervisor goroutine is
+	// cancelled and drained before the t.TempDir / database t.Cleanup run —
+	// fixing the supervisor-outlives-cleanup race tracked in issue #1705.
+	result, err := iristest.RunRestoreForTest(t, cfg)
 	if err != nil {
 		t.Fatalf("RunRestore: %v", err)
 	}
@@ -622,7 +626,10 @@ func TestRestoreSession_Concurrent(t *testing.T) {
 		},
 	}
 
-	result, err := iris.RunRestore(context.Background(), cfg)
+	// Same reasoning as TestRestoreSession_WithJSONL: use the iristest
+	// helper so every supervisor goroutine is drained before tempdir/DB
+	// teardown (issue #1705).
+	result, err := iristest.RunRestoreForTest(t, cfg)
 	if err != nil {
 		t.Fatalf("RunRestore: %v", err)
 	}


### PR DESCRIPTION
## Summary

Three restore-class tests intermittently failed under `-race` because `iris.RunRestore` spawns supervisor goroutines that keep writing to the per-test tempdir and DB after the test body returns. `t.Cleanup` then races against those late writes, surfacing as:

- `unlinkat .../001: directory not empty`
- `sql: database is closed`

Affected tests:
- `TestParityRestore_OrphanedToolCallAndRespawn` (`internal/iris/parity/restore_test.go`)
- `TestRestoreSession_WithJSONL` (`internal/iris/restore_test.go`)
- `TestRestoreSession_Concurrent` (`internal/iris/restore_test.go`)

This was a P1 — PR #1712 hit the second test on incidental CI runs.

## Fix

1. **Thread spawned supervisors out of `RunRestore`.** Added `RestoreResult.Supervisors []*Supervisor` so callers can observe (and wait on) what was started. `restoreActiveSession` now returns `(*Supervisor, bool)`.
2. **New test helper `iristest.RunRestoreForTest`.** Wraps `iris.RunRestore`, registers a `t.Cleanup` that cancels the supervisor ctx and waits on `<-sup.Done()` for every started supervisor. The cleanup is registered **after** `iris.RunRestore` so it captures the populated slice, and **runs before** the DB-close / tempdir-remove cleanups in LIFO order — exactly the ordering invariant called out in the issue. Documented prominently.
3. **All five restore-class tests** (the three flaky ones plus the two `TestRestoreIntegration_*` end-to-end tests with the same shape) now use the helper.

Production semantics unchanged: the iris daemon still owns supervisor lifecycle for the process lifetime; only test scaffolding waits synchronously on `Done()`.

## Verification

- `go test ./internal/iris/ ./internal/iris/parity/ -race -count=20 -run 'TestRestoreSession|TestParityRestore'` — **20-of-20 clean**, no "directory not empty" or "sql: database is closed" lines in output.
- `go test ./... -race -count=1` — full module suite passes.
- `nix build .#iris` — succeeds.

## Watch-outs addressed

- No new mutex; reuses the existing `Supervisor.done` channel and `Supervisor.InstanceID()` accessor.
- No `time.Sleep` workaround; the wait blocks on `<-sup.Done()` with a 10s safety deadline that `t.Errorf`s rather than hiding wedged supervisors.
- The shared scaffold (`iristest.RunRestoreForTest`) means future restore-style tests inherit the lifecycle discipline by default.

Closes #1705