### PR TITLE
feat(iris): traverse review-group children in iris cleanup (#1699)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/cleanup.go
+++ b/modules/programs/prism/prism/cmd/iris/cleanup.go
@@ -79,21 +79,23 @@ func init() {
 func runCleanup(sessionName string) error {
 	p := iris.ResolvePaths()
 
-	// Step 0 (issue #1674): kill the running pi child via the daemon before
-	// archiving. Skipped explicitly with --skip-kill or implicitly when the
-	// daemon socket is not reachable (the kill is a best-effort prelude to
-	// the DB-only cleanup steps below; a dead daemon already means no live
-	// pi child to kill).
-	killSummary := "skipped (--skip-kill)"
-	if !cleanupSkipKill {
-		killSummary = killSessionViaDaemon(p.Sock, sessionName)
-	}
-
 	database, err := iris.OpenDB(p.DB)
 	if err != nil {
 		return fmt.Errorf("iris cleanup: open db: %w", err)
 	}
 	defer database.Close()
+
+	// KillFn (issue #1699): the cleanup library invokes this once per
+	// session being cleaned up (parent + each review-group child) BEFORE
+	// the archive step, so kill-then-archive (#1692) holds at every
+	// recursion level. --skip-kill propagates by leaving KillFn nil.
+	var killFn func(string) string
+	if !cleanupSkipKill {
+		sockPath := p.Sock
+		killFn = func(name string) string {
+			return killSessionViaDaemon(sockPath, name)
+		}
+	}
 
 	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
 		Database:       database,
@@ -102,30 +104,60 @@ func runCleanup(sessionName string) error {
 		ArchiveRoot:    p.ArchiveRoot,
 		PIAgentDir:     cleanupPIAgentDir,
 		RemoveWorktree: cleanupRemoveWorktree,
+		KillFn:         killFn,
 	}, sessionName)
 	if err != nil {
 		return fmt.Errorf("iris cleanup: %w", err)
 	}
 
-	fmt.Printf("iris cleanup: %s\n", sessionName)
-	fmt.Printf("  kill:           %s\n", killSummary)
-	if res.ArchivePath != "" {
-		fmt.Printf("  archive:        %s\n", res.ArchivePath)
-	} else {
-		fmt.Printf("  archive:        (skipped — no pi JSONL found)\n")
-	}
-	fmt.Printf("  run dir:        removed=%v\n", res.RunDirRemoved)
-	fmt.Printf("  log file:       removed=%v\n", res.LogFileRemoved)
-	fmt.Printf("  session row:    ended=%v\n", res.SessionRowRemoved)
-	fmt.Printf("  worktree:       removed=%v\n", res.WorktreeRemoved)
-	fmt.Printf("  branch:         removed=%v\n", res.BranchRemoved)
-	if len(res.Errors) > 0 {
-		fmt.Println("  errors:")
-		for _, e := range res.Errors {
-			fmt.Printf("    - %v\n", e)
+	printCleanupResult(os.Stdout, res, cleanupSkipKill)
+	return nil
+}
+
+// printCleanupResult renders a single cleanup result (parent + recursive
+// children, if any) to out. Pulled out as a free function so it can be
+// reused by future bulk-cleanup paths and unit-tested without going
+// through the cobra command.
+func printCleanupResult(out io.Writer, res *iris.CleanupResult, skipKill bool) {
+	fmt.Fprintf(out, "iris cleanup: %s\n", res.SessionName)
+	printCleanupBody(out, res, skipKill, "  ")
+	if len(res.Children) > 0 {
+		fmt.Fprintf(out, "  children:       %d cleaned up\n", len(res.Children))
+		for _, child := range res.Children {
+			fmt.Fprintf(out, "    - %s\n", child.SessionName)
+			printCleanupBody(out, child, skipKill, "        ")
 		}
 	}
-	return nil
+}
+
+// printCleanupBody renders the per-session lines (kill, archive, run dir,
+// etc.) at the given indent. Used for both the parent and each child.
+func printCleanupBody(out io.Writer, res *iris.CleanupResult, skipKill bool, indent string) {
+	kill := res.KillSummary
+	if kill == "" {
+		if skipKill {
+			kill = "skipped (--skip-kill)"
+		} else {
+			kill = "skipped (no KillFn)"
+		}
+	}
+	fmt.Fprintf(out, "%skill:           %s\n", indent, kill)
+	if res.ArchivePath != "" {
+		fmt.Fprintf(out, "%sarchive:        %s\n", indent, res.ArchivePath)
+	} else {
+		fmt.Fprintf(out, "%sarchive:        (skipped — no pi JSONL found)\n", indent)
+	}
+	fmt.Fprintf(out, "%srun dir:        removed=%v\n", indent, res.RunDirRemoved)
+	fmt.Fprintf(out, "%slog file:       removed=%v\n", indent, res.LogFileRemoved)
+	fmt.Fprintf(out, "%ssession row:    ended=%v\n", indent, res.SessionRowRemoved)
+	fmt.Fprintf(out, "%sworktree:       removed=%v\n", indent, res.WorktreeRemoved)
+	fmt.Fprintf(out, "%sbranch:         removed=%v\n", indent, res.BranchRemoved)
+	if len(res.Errors) > 0 {
+		fmt.Fprintf(out, "%serrors:\n", indent)
+		for _, e := range res.Errors {
+			fmt.Fprintf(out, "%s  - %v\n", indent, e)
+		}
+	}
 }
 
 // killSessionViaDaemon dials the iris daemon socket and sends a session_kill

--- a/modules/programs/prism/prism/cmd/iris/cleanup_review_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/cleanup_review_integration_test.go
@@ -1,0 +1,288 @@
+package main
+
+// cleanup_review_integration_test.go — end-to-end integration test for
+// the issue #1699 review-group recursion in `iris cleanup`.
+//
+// Flow:
+//
+//   1. Spawn a parent session (via the iristest harness).
+//   2. Run `iris review <pr>` against the in-process ClientSocket so the
+//      daemon registers a session_groups row and spawns 5 fake review
+//      children.
+//   3. Transition each child to a terminal state (no real pi child
+//      involved — the fake SpawnSession just seeds agent_status).
+//   4. Invoke runCleanup against the same iristest-isolated DB and
+//      assert that the parent AND all 5 children are cleaned up:
+//        - sessions row marked ended for every session
+//        - run dirs removed
+//        - kill callback (here a no-op via --skip-kill) NOT invoked
+//          (we exercise the no-daemon path because the daemon-side
+//          kill is covered by the supervisor tests already)
+//   5. Sanity: a follow-up `iris cleanup` on an already-cleaned parent
+//      reports the children as already-cleaned-up stubs without error.
+//
+// The test uses the iristest isolation harness so the iris DB,
+// XDG_STATE_HOME, and HOME are redirected to a t.TempDir.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// TestCleanup_ReviewGroupChildren_Integration is the headline #1699
+// end-to-end test: spawn a parent, run `iris review` to spawn 5
+// children, let them complete, run `iris cleanup` on the parent, and
+// assert that all 6 sessions (parent + 5 children) are cleaned up.
+func TestCleanup_ReviewGroupChildren_Integration(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	const prNumber = "1699"
+	parent := iristest.SessionName("cleanup-review-parent")
+
+	// Seed the parent's agent_status row so the review-spawn handler
+	// passes its "parent must be active" guard.
+	if err := iso.DB.UpsertStatusWithAgent(parent, "iris-parity", iso.Root, "active", nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpsertStatusWithAgent(parent): %v", err)
+	}
+	// Also seed a sessions row for the parent so iris cleanup can resolve
+	// it (the standalone CleanupSession needs MostRecentSessionForName).
+	if err := insertSessionForCleanup(iso, parent, "iris-test-cleanup-review-parent"); err != nil {
+		t.Fatalf("insertSessionForCleanup(parent): %v", err)
+	}
+
+	// Active-sessions snapshot for the review-spawn handler's parent guard.
+	var (
+		activeMu       sync.Mutex
+		activeSessions = []iris.SessionSnapshot{{
+			Name:       parent,
+			InstanceID: uuid.NewString(),
+			State:      "active",
+			Role:       "worker",
+			Worktree:   iso.Root,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		}}
+	)
+	getActive := func() []iris.SessionSnapshot {
+		activeMu.Lock()
+		defer activeMu.Unlock()
+		out := make([]iris.SessionSnapshot, len(activeSessions))
+		copy(out, activeSessions)
+		return out
+	}
+
+	// Fake SpawnSession: seeds the agent_status row (the handler then
+	// stamps the group_id), AND inserts a sessions row so cleanup can
+	// resolve it.
+	var (
+		spawnMu       sync.Mutex
+		spawnedAgents = make(map[string]string) // role → session_name
+	)
+	spawnSession := func(_ context.Context, sessionName, worktree, role string) (*iris.Supervisor, error) {
+		if err := iso.DB.UpsertStatusWithAgent(sessionName, "iris-parity", worktree, "active", nil, nil, &role, nil); err != nil {
+			return nil, fmt.Errorf("seed agent_status for %s: %w", role, err)
+		}
+		if err := insertSessionForCleanup(iso, sessionName, "iris-test-child-"+role); err != nil {
+			return nil, fmt.Errorf("seed sessions row for %s: %w", role, err)
+		}
+		spawnMu.Lock()
+		spawnedAgents[role] = sessionName
+		spawnMu.Unlock()
+		activeMu.Lock()
+		activeSessions = append(activeSessions, iris.SessionSnapshot{
+			Name:       sessionName,
+			InstanceID: uuid.NewString(),
+			State:      "active",
+			Role:       role,
+			Worktree:   worktree,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		})
+		activeMu.Unlock()
+		return makeFakeSupervisor(sessionName, worktree, role), nil
+	}
+
+	handler := iris.NewReviewSpawnHandler(iris.ReviewSpawnDeps{
+		Database:       iso.DB,
+		SpawnSession:   spawnSession,
+		DeliverPrompt:  func(context.Context, string, string, string, []string) error { return nil },
+		ParentWorktree: func(string) (string, error) { return iso.Root, nil },
+		PollInterval:   25 * time.Millisecond,
+	})
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          iso.Paths.Sock,
+		Database:          iso.DB,
+		GetActiveSessions: getActive,
+		DeliverPrompt:     func(context.Context, string, string, string, []string) error { return nil },
+		SpawnReviewGroup:  handler,
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cs.Serve(ctx)
+
+	// Drive `iris review` via the testable core.
+	reviewOpts := reviewRunOpts{
+		PRNumber:        prNumber,
+		Timeout:         5 * time.Second,
+		SockPath:        iso.Paths.Sock,
+		Parent:          parent,
+		Worktree:        iso.Root,
+		PRVerifier:      func(string) error { return nil },
+		PreflightRunner: noopPreflightRunner,
+		Out:             io.Discard,
+	}
+	runCtx, runCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer runCancel()
+	if err := runReviewAt(runCtx, reviewOpts); err != nil {
+		t.Fatalf("runReviewAt: %v", err)
+	}
+
+	// Assert all 5 canonical agents got spawned.
+	spawnMu.Lock()
+	gotAgents := make(map[string]string, len(spawnedAgents))
+	for k, v := range spawnedAgents {
+		gotAgents[k] = v
+	}
+	spawnMu.Unlock()
+	if len(gotAgents) != len(iris.ReviewAgentNames) {
+		t.Fatalf("spawned %d agents, want %d (got: %v)", len(gotAgents), len(iris.ReviewAgentNames), gotAgents)
+	}
+
+	// Transition each agent to "finished" — the cleanup recursion does
+	// not require terminal state, but a real iris cleanup would only
+	// happen after the round is done, so we mirror that here.
+	for _, role := range iris.ReviewAgentNames {
+		sess := gotAgents[role]
+		r := role
+		if err := iso.DB.UpsertStatusWithAgent(sess, "iris-parity", iso.Root, "finished", nil, nil, &r, nil); err != nil {
+			t.Fatalf("transition %s: %v", sess, err)
+		}
+	}
+
+	// Now exercise the cleanup recursion. We invoke iris.CleanupSession
+	// directly with KillFn=nil to emulate `iris cleanup --skip-kill`
+	// (the daemon-side kill is not in scope for this integration test —
+	// see internal/iris/supervisor_kill_test.go for that coverage).
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		// KillFn nil → emulates --skip-kill end-to-end.
+	}, parent)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	if res.SessionName != parent {
+		t.Errorf("res.SessionName = %q, want %q", res.SessionName, parent)
+	}
+	if !res.SessionRowRemoved {
+		t.Errorf("parent SessionRowRemoved=false, want true (errors=%v)", res.Errors)
+	}
+	if len(res.Children) != len(iris.ReviewAgentNames) {
+		t.Fatalf("len(res.Children) = %d, want %d (children=%+v)", len(res.Children), len(iris.ReviewAgentNames), res.Children)
+	}
+
+	// Assert each child appears with SessionRowRemoved=true. Build a
+	// set of expected child names so the order doesn't matter here.
+	expected := make(map[string]bool, len(gotAgents))
+	for _, name := range gotAgents {
+		expected[name] = true
+	}
+	for _, child := range res.Children {
+		if !expected[child.SessionName] {
+			t.Errorf("unexpected child in result: %q", child.SessionName)
+		}
+		if !child.SessionRowRemoved {
+			t.Errorf("child %q SessionRowRemoved=false, want true (errors=%v)", child.SessionName, child.Errors)
+		}
+	}
+
+	// Confirm every sessions row is now ended.
+	for _, name := range append([]string{parent}, valuesOf(gotAgents)...) {
+		s, err := iso.DB.MostRecentSessionForName(name)
+		if err != nil {
+			t.Fatalf("MostRecentSessionForName(%q): %v", name, err)
+		}
+		if s == nil {
+			t.Errorf("sessions row missing for %q after cleanup", name)
+			continue
+		}
+		if s.EndState == nil {
+			t.Errorf("EndState nil for %q after cleanup, want non-nil", name)
+		}
+	}
+
+	// Sanity: render via printCleanupResult and assert every child name
+	// appears in the printed output (AC: "CLI output reports
+	// cleaned-up children by name").
+	var buf bytes.Buffer
+	printCleanupResult(&buf, res, true /* skipKill */)
+	out := buf.String()
+	if !strings.Contains(out, "children:") {
+		t.Errorf("printCleanupResult output missing 'children:' section; got:\n%s", out)
+	}
+	for _, name := range gotAgents {
+		if !strings.Contains(out, name) {
+			t.Errorf("printCleanupResult output missing child name %q; got:\n%s", name, out)
+		}
+	}
+
+	// Sanity: a follow-up cleanup of the same parent should not error
+	// (idempotent). The parent's sessions row is already ended, but
+	// MostRecentSessionForName still returns the row, so cleanup is a
+	// no-op for the session-state step and a "stub" cleanup for each
+	// child (since their sessions rows are ended too, not deleted).
+	_, err = iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, parent)
+	if err != nil {
+		t.Errorf("second CleanupSession returned error %v, want nil (cleanup must be idempotent)", err)
+	}
+}
+
+// valuesOf returns the values of a string→string map as a slice. The
+// order is map-iteration order; callers that need a deterministic order
+// must sort the result.
+func valuesOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for _, v := range m {
+		out = append(out, v)
+	}
+	return out
+}
+
+// insertSessionForCleanup seeds a sessions row that iris.CleanupSession
+// can resolve via MostRecentSessionForName. The harness/worktree fields
+// are deliberately empty: the cleanup path tolerates worktree-less
+// sessions (archive is skipped, run dir is the only artefact).
+func insertSessionForCleanup(iso *iristest.Isolated, sessionName, instanceID string) error {
+	role := "worker"
+	return iso.DB.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Worktree:    "",
+		Harness:     "pi",
+		AgentRole:   &role,
+		StartedAt:   time.Now(),
+	})
+}

--- a/modules/programs/prism/prism/internal/iris/cleanup.go
+++ b/modules/programs/prism/prism/internal/iris/cleanup.go
@@ -46,6 +46,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
@@ -77,10 +78,39 @@ type CleanupConfig struct {
 	// the worktree is left intact (callers handling worktree removal
 	// themselves should set this false).
 	RemoveWorktree bool
+	// KillFn, when non-nil, is invoked once per session being cleaned up
+	// (parent and each recursive child) BEFORE the archive step. It is the
+	// hook by which the CLI talks to the iris daemon's session_kill
+	// endpoint so a live pi child is terminated before its DB row is
+	// archived (kill-then-archive per #1692). The returned string is a
+	// short human-readable summary suitable for printing (e.g. "killed
+	// (state=finished)", "skipped (daemon not running ...)") and is
+	// recorded on the per-session result. A nil KillFn means "skip the
+	// kill step" — used by tests and by `iris cleanup --skip-kill`.
+	KillFn func(sessionName string) string
+
+	// depth is the internal recursion depth used to bound the
+	// parent → review-children traversal at 2 (parent → review children →
+	// no further nesting). Callers MUST NOT set this — it is incremented
+	// internally when CleanupSession recurses into review-group children.
+	// A child encountered at depth >= maxCleanupDepth-1 that itself has a
+	// session_groups row is skipped with a warning rather than recursed
+	// into. See #1699.
+	depth int
 }
+
+// maxCleanupDepth bounds the recursion in CleanupSession. The intended
+// shape is parent (depth 0) → review children (depth 1) → no further
+// nesting. A child encountered at depth 1 with its own session_groups
+// row triggers a warn-and-skip.
+const maxCleanupDepth = 2
 
 // CleanupResult records which cleanup steps succeeded.
 type CleanupResult struct {
+	// SessionName is the session this result describes. Set on every
+	// result (parent and each child) so callers can attribute errors and
+	// summary lines to a specific session.
+	SessionName string
 	// ArchivePath is the destination of the archived session JSONL when
 	// archive succeeded ("" otherwise). The full path is
 	// <ArchiveRoot>/<session>/<instance_id>/raw/session.jsonl.
@@ -100,6 +130,17 @@ type CleanupResult struct {
 	WorktreeRemoved bool
 	// BranchRemoved is true when the git branch was removed.
 	BranchRemoved bool
+	// KillSummary is the one-line summary returned by KillFn for this
+	// session, or "" when KillFn was nil (kill step skipped). Recorded
+	// for both the parent and each child so the CLI can render a
+	// per-session kill line.
+	KillSummary string
+	// Children holds the per-child CleanupResult for each review-group
+	// child cleaned up as part of this session's teardown. Empty for
+	// sessions with no review-group children (the common, non-review
+	// case). The slice is ordered by child session_name ascending for a
+	// deterministic CLI rendering.
+	Children []*CleanupResult
 	// Errors collects non-fatal errors from individual steps. A nil/empty
 	// slice means every step that ran succeeded.
 	Errors []error
@@ -130,7 +171,27 @@ func CleanupSession(ctx context.Context, cfg CleanupConfig, sessionName string) 
 		return nil, fmt.Errorf("iris cleanup: session %q not found", sessionName)
 	}
 
-	res := &CleanupResult{}
+	res := &CleanupResult{SessionName: sessionName}
+
+	// Step 1 (issue #1699): recurse into review-group children BEFORE this
+	// session's own archive / row-removal / run-dir steps. Children are
+	// cleaned up via their own CleanupSession invocation so each one gets
+	// the kill-then-archive treatment (#1692 + #1697). Recursion is bounded
+	// at maxCleanupDepth — a child encountered at depth 1 that itself has a
+	// session_groups row triggers a warn-and-skip rather than a third
+	// level.
+	//
+	// Errors here are non-fatal: if session_groups is unreadable, cleanup
+	// falls back to parent-only with a warning (per the AC).
+	res.Children = cleanupReviewGroupChildren(ctx, cfg, sessionName, res)
+
+	// Step 1b (issue #1699): kill the running pi child for this session
+	// via the injected KillFn. Runs BEFORE archive so the kill-then-archive
+	// invariant from #1692 is preserved at every recursion level (parent
+	// and each child).
+	if cfg.KillFn != nil {
+		res.KillSummary = cfg.KillFn(sessionName)
+	}
 
 	// Step 2: archive the pi JSONL. Delegates to the shared helper used by
 	// the standalone `iris archive` subcommand (#1697) so cleanup-archived
@@ -224,6 +285,105 @@ func scanForJSONL(cwdDir, sessionID string) string {
 		}
 	}
 	return ""
+}
+
+// cleanupReviewGroupChildren is the issue #1699 recursion step. It looks
+// up every review-group child of parentSession via
+// session_groups.parent_session → agent_status.group_id, and recursively
+// cleans each child up via CleanupSession with depth+1.
+//
+// Recursion bound: when cfg.depth is already >= maxCleanupDepth-1, a child
+// that itself has a session_groups row triggers a warn-and-skip rather
+// than a deeper recursion. This caps the traversal at parent → review
+// children (no further nesting). The cap is deliberately conservative;
+// nothing in iris's current shape spawns review-of-review groups, and a
+// child unexpectedly carrying its own group is treated as an anomaly to
+// surface rather than to silently recurse into.
+//
+// Errors are non-fatal: a failed session_groups lookup logs a warning and
+// returns an empty children slice (parent-only fallback per the AC). A
+// child whose CleanupSession returns an error has the error appended to
+// the parent's Errors slice; the surviving children are still processed.
+//
+// The returned slice is ordered by child session_name ascending so the
+// CLI output is deterministic regardless of map / iteration order in the
+// underlying DB query.
+func cleanupReviewGroupChildren(ctx context.Context, cfg CleanupConfig, parentSession string, parentRes *CleanupResult) []*CleanupResult {
+	members, err := cfg.Database.GroupMembersForParent(parentSession)
+	if err != nil {
+		// session_groups unreadable — fall back to parent-only with a
+		// warning (per the AC). Do NOT propagate the error: the parent
+		// cleanup should still proceed.
+		log.Printf("[iris] cleanup: review-group lookup for parent %q failed: %v — falling back to parent-only cleanup", parentSession, err)
+		parentRes.Errors = append(parentRes.Errors, fmt.Errorf("review-group lookup: %w", err))
+		return nil
+	}
+	if len(members) == 0 {
+		return nil
+	}
+
+	// Sort by session_name for deterministic CLI output (the DB query has
+	// no inherent ordering for GroupMembersForParent).
+	names := make([]string, 0, len(members))
+	for _, m := range members {
+		names = append(names, m.SessionName)
+	}
+	sort.Strings(names)
+
+	out := make([]*CleanupResult, 0, len(names))
+	for _, childName := range names {
+		// Recursion-depth guard: at depth >= maxCleanupDepth-1 (i.e. when
+		// THIS call is already at the child layer), refuse to recurse
+		// further into a grandchild that carries its own group. Log a
+		// warning so the anomaly surfaces in operator output.
+		if cfg.depth >= maxCleanupDepth-1 {
+			hasGroup, hgErr := cfg.Database.HasReviewGroup(childName)
+			if hgErr != nil {
+				log.Printf("[iris] cleanup: depth-guard HasReviewGroup(%q) failed: %v — proceeding without grandchild recursion", childName, hgErr)
+			} else if hasGroup {
+				log.Printf("[iris] cleanup: WARNING: child %q (depth=%d) has its own review group — skipping deeper recursion (maxCleanupDepth=%d)", childName, cfg.depth+1, maxCleanupDepth)
+				parentRes.Errors = append(parentRes.Errors, fmt.Errorf("child %q has its own review group; skipped deeper recursion", childName))
+				continue
+			}
+		}
+
+		// Skip children whose sessions row is missing entirely (already
+		// cleaned up by an earlier pass, or never inserted). Without this
+		// guard the recursive call would return a "session not found"
+		// error and pollute the parent's Errors slice with noise for what
+		// is the expected "already-cleaned-up child → skip gracefully" AC.
+		childSess, lookupErr := cfg.Database.MostRecentSessionForName(childName)
+		if lookupErr != nil {
+			log.Printf("[iris] cleanup: child %q lookup failed: %v — skipping", childName, lookupErr)
+			parentRes.Errors = append(parentRes.Errors, fmt.Errorf("child %q lookup: %w", childName, lookupErr))
+			continue
+		}
+		if childSess == nil {
+			// No sessions row — the child has already been cleaned up
+			// (DB row removed) or was registered in agent_status only.
+			// Surface a stub result for visibility and continue.
+			log.Printf("[iris] cleanup: child %q has no sessions row — already cleaned up; skipping", childName)
+			out = append(out, &CleanupResult{
+				SessionName: childName,
+				KillSummary: "skipped (already cleaned up)",
+			})
+			continue
+		}
+
+		childCfg := cfg
+		childCfg.depth = cfg.depth + 1
+		childRes, cErr := CleanupSession(ctx, childCfg, childName)
+		if cErr != nil {
+			log.Printf("[iris] cleanup: child %q: %v", childName, cErr)
+			parentRes.Errors = append(parentRes.Errors, fmt.Errorf("child %q: %w", childName, cErr))
+			// Even on a top-level error, record a stub so the CLI
+			// reports which child was attempted.
+			out = append(out, &CleanupResult{SessionName: childName, Errors: []error{cErr}})
+			continue
+		}
+		out = append(out, childRes)
+	}
+	return out
 }
 
 // removeWorktreeAndBranch removes the worktree directory and (when present)

--- a/modules/programs/prism/prism/internal/iris/cleanup_review_group_test.go
+++ b/modules/programs/prism/prism/internal/iris/cleanup_review_group_test.go
@@ -1,0 +1,429 @@
+package iris_test
+
+// cleanup_review_group_test.go — tests for the issue #1699 recursion in
+// internal/iris/cleanup.go::CleanupSession.
+//
+// What is covered here:
+//
+//   - Review-group child traversal: a parent that owns a session_groups
+//     row has all its review-children cleaned up in the same pass.
+//   - Output: each child appears in CleanupResult.Children, ordered by
+//     session_name ascending.
+//   - Kill-then-archive: KillFn fires once per session (parent + each
+//     child) BEFORE the archive step, matching #1692.
+//   - Non-review sessions: no children → no behaviour change (no extra
+//     KillFn invocations, empty Children slice).
+//   - Already-cleaned-up child: a member with no sessions row is skipped
+//     gracefully (stub result, no error propagated).
+//   - Recursion bound at 2: a grandchild that itself has a session_groups
+//     row triggers a warn-and-skip and surfaces in the parent's Errors.
+//   - --skip-kill semantics: when KillFn is nil, no kill is attempted at
+//     any recursion level.
+//   - session_groups unreadable → fallback to parent-only with the error
+//     captured in the parent's Errors slice. (Not directly testable
+//     without a DB-level fault injection; covered indirectly via the
+//     code path that handles GroupMembersForParent returning an empty
+//     slice for an unknown parent.)
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// seedSession inserts a sessions row and an agent_status row for the
+// named session. The agent_status row is required so SetGroupID can link
+// the session into a session_groups row.
+func seedSession(t *testing.T, d *db.DB, sessionName, instanceID string) {
+	t.Helper()
+	role := "worker"
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Worktree:    "",
+		Harness:     "pi",
+		AgentRole:   &role,
+		StartedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession(%q): %v", sessionName, err)
+	}
+	if err := d.EnsureStatusRow(sessionName, "test-repo", ""); err != nil {
+		t.Fatalf("EnsureStatusRow(%q): %v", sessionName, err)
+	}
+}
+
+// TestCleanup_TraversesReviewGroupChildren is the headline #1699 test:
+// a parent session with a review group is cleaned up, and every child
+// in the group is cleaned up too. The kill callback fires once per
+// session (parent + each child).
+func TestCleanup_TraversesReviewGroupChildren(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	parent := iristest.SessionName("parent")
+	seedSession(t, iso.DB, parent, "iris-test-parent-001")
+
+	// Register a review group and seed 5 children linked to it.
+	groupID, err := iso.DB.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	children := []string{
+		iristest.SessionName("parent~review-1-review-code"),
+		iristest.SessionName("parent~review-1-review-context"),
+		iristest.SessionName("parent~review-1-review-goal"),
+		iristest.SessionName("parent~review-1-review-qa"),
+		iristest.SessionName("parent~review-1-review-security"),
+	}
+	for i, child := range children {
+		seedSession(t, iso.DB, child, "iris-test-child-00"+string(rune('1'+i)))
+		if err := iso.DB.SetGroupID(child, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", child, err)
+		}
+	}
+
+	// Record every KillFn invocation so we can assert kill-then-archive
+	// fired for every session in the cleanup tree.
+	var killMu sync.Mutex
+	var killed []string
+	killFn := func(name string) string {
+		killMu.Lock()
+		defer killMu.Unlock()
+		killed = append(killed, name)
+		return "killed (state=finished)"
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		KillFn:      killFn,
+	}, parent)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	// Parent fields.
+	if res.SessionName != parent {
+		t.Errorf("res.SessionName = %q, want %q", res.SessionName, parent)
+	}
+	if res.KillSummary == "" {
+		t.Errorf("res.KillSummary empty for parent — KillFn should have fired")
+	}
+	if !res.SessionRowRemoved {
+		t.Errorf("parent SessionRowRemoved=false, want true (errors=%v)", res.Errors)
+	}
+
+	// Children: every member of the group must appear, ordered by
+	// session_name ascending.
+	if got, want := len(res.Children), len(children); got != want {
+		t.Fatalf("len(res.Children) = %d, want %d (children=%+v)", got, want, res.Children)
+	}
+	wantNames := append([]string(nil), children...)
+	sort.Strings(wantNames)
+	for i, child := range res.Children {
+		if child.SessionName != wantNames[i] {
+			t.Errorf("Children[%d].SessionName = %q, want %q", i, child.SessionName, wantNames[i])
+		}
+		if child.KillSummary == "" {
+			t.Errorf("Children[%d].KillSummary empty for %q — KillFn must fire per-child", i, child.SessionName)
+		}
+		if !child.SessionRowRemoved {
+			t.Errorf("Children[%d] (%q): SessionRowRemoved=false, want true", i, child.SessionName)
+		}
+	}
+
+	// KillFn must have fired exactly once per session (parent + 5
+	// children = 6 total).
+	killMu.Lock()
+	defer killMu.Unlock()
+	if got, want := len(killed), 1+len(children); got != want {
+		t.Errorf("KillFn invocations = %d, want %d (got=%v)", got, want, killed)
+	}
+
+	// Parent sessions row should be marked ended.
+	sess, err := iso.DB.MostRecentSessionForName(parent)
+	if err != nil {
+		t.Fatalf("MostRecentSessionForName(parent): %v", err)
+	}
+	if sess.EndState == nil {
+		t.Errorf("parent EndState is nil after cleanup, want non-nil")
+	}
+	// Each child sessions row should also be marked ended.
+	for _, name := range children {
+		s, err := iso.DB.MostRecentSessionForName(name)
+		if err != nil {
+			t.Fatalf("MostRecentSessionForName(%q): %v", name, err)
+		}
+		if s == nil {
+			t.Errorf("child %q sessions row is missing after cleanup", name)
+			continue
+		}
+		if s.EndState == nil {
+			t.Errorf("child %q EndState is nil after cleanup, want non-nil", name)
+		}
+	}
+}
+
+// TestCleanup_NonReviewSession_NoChildren asserts that a session without
+// any review-group children is cleaned up exactly as before (empty
+// Children, KillFn invoked once for the parent only).
+func TestCleanup_NonReviewSession_NoChildren(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	parent := iristest.SessionName("lone-parent")
+	seedSession(t, iso.DB, parent, "iris-test-lone-001")
+
+	var killed []string
+	killFn := func(name string) string {
+		killed = append(killed, name)
+		return "killed (state=finished)"
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		KillFn:      killFn,
+	}, parent)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	if len(res.Children) != 0 {
+		t.Errorf("len(res.Children) = %d, want 0 (non-review session)", len(res.Children))
+	}
+	if len(killed) != 1 || killed[0] != parent {
+		t.Errorf("KillFn invocations = %v, want [%q] (only the parent)", killed, parent)
+	}
+	if !res.SessionRowRemoved {
+		t.Errorf("SessionRowRemoved=false, want true (errors=%v)", res.Errors)
+	}
+}
+
+// TestCleanup_AlreadyCleanedChild_SkipsGracefully covers the AC: a
+// child registered in agent_status but with no sessions row (already
+// cleaned up by an earlier pass) is skipped without erroring out.
+func TestCleanup_AlreadyCleanedChild_SkipsGracefully(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	parent := iristest.SessionName("parent-partly-cleaned")
+	seedSession(t, iso.DB, parent, "iris-test-partly-001")
+
+	groupID, err := iso.DB.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Live child — has both an agent_status row and a sessions row.
+	liveChild := iristest.SessionName("parent-partly-cleaned~review-1-review-code")
+	seedSession(t, iso.DB, liveChild, "iris-test-partly-002")
+	if err := iso.DB.SetGroupID(liveChild, groupID); err != nil {
+		t.Fatalf("SetGroupID(live): %v", err)
+	}
+
+	// Already-cleaned child — agent_status row only (no sessions row).
+	staleChild := iristest.SessionName("parent-partly-cleaned~review-1-review-goal")
+	if err := iso.DB.EnsureStatusRow(staleChild, "test-repo", ""); err != nil {
+		t.Fatalf("EnsureStatusRow(stale): %v", err)
+	}
+	if err := iso.DB.SetGroupID(staleChild, groupID); err != nil {
+		t.Fatalf("SetGroupID(stale): %v", err)
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, parent)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	if got, want := len(res.Children), 2; got != want {
+		t.Fatalf("len(res.Children) = %d, want %d (children=%+v)", got, want, res.Children)
+	}
+
+	// Find each child's result by name.
+	byName := make(map[string]*iris.CleanupResult, len(res.Children))
+	for _, c := range res.Children {
+		byName[c.SessionName] = c
+	}
+	live, ok := byName[liveChild]
+	if !ok {
+		t.Fatalf("live child %q missing from Children", liveChild)
+	}
+	if !live.SessionRowRemoved {
+		t.Errorf("live child SessionRowRemoved=false, want true (errors=%v)", live.Errors)
+	}
+	stale, ok := byName[staleChild]
+	if !ok {
+		t.Fatalf("stale child %q missing from Children", staleChild)
+	}
+	// The stale child should surface as a stub result (KillSummary set
+	// to "skipped (already cleaned up)") with no propagated error.
+	if stale.KillSummary == "" {
+		t.Errorf("stale child KillSummary is empty, want a skip-summary")
+	}
+	// Parent's Errors slice should NOT contain a child-not-found error.
+	for _, e := range res.Errors {
+		if e == nil {
+			continue
+		}
+		if msg := e.Error(); contains(msg, "not found") {
+			t.Errorf("parent Errors should not surface 'not found' for stale child; got %v", e)
+		}
+	}
+}
+
+// TestCleanup_DepthCap_WarnAndSkipGrandchildGroup asserts that when a
+// review-child unexpectedly carries its own session_groups row AND that
+// inner group has members, the cleanup recursion does NOT descend into
+// those grandchildren. The child IS still cleaned up; only its
+// grandchildren are skipped. A warning is surfaced via the child's
+// Errors slice (the depth-cap check fires inside the child's recursive
+// CleanupSession call, when it enumerates its OWN children).
+//
+// Topology built by this test:
+//
+//	parent (depth 0)
+//	  └─ child   (depth 1) — member of parent's group
+//	       └─ grandchild (depth 2) — member of child's group; itself
+//	                           registered as parent of an inner empty
+//	                           session_groups row, which is what the
+//	                           depth-cap HasReviewGroup() check picks
+//	                           up to fire the warn-and-skip.
+func TestCleanup_DepthCap_WarnAndSkipGrandchildGroup(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	parent := iristest.SessionName("grand-parent")
+	seedSession(t, iso.DB, parent, "iris-test-gp-001")
+	parentGroupID, err := iso.DB.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup(parent): %v", err)
+	}
+
+	child := iristest.SessionName("grand-parent~review-1-review-code")
+	seedSession(t, iso.DB, child, "iris-test-gp-002")
+	if err := iso.DB.SetGroupID(child, parentGroupID); err != nil {
+		t.Fatalf("SetGroupID(child): %v", err)
+	}
+	childGroupID, err := iso.DB.RegisterGroup(child)
+	if err != nil {
+		t.Fatalf("RegisterGroup(child): %v", err)
+	}
+
+	// Grandchild: a session row + agent_status row linked to child's
+	// group. The grandchild ALSO has its own (empty) registered group so
+	// the depth-cap HasReviewGroup() check returns true and triggers
+	// warn-and-skip.
+	grandchild := iristest.SessionName("grand-parent~review-1-review-code~review-1-review-code")
+	seedSession(t, iso.DB, grandchild, "iris-test-gp-003")
+	if err := iso.DB.SetGroupID(grandchild, childGroupID); err != nil {
+		t.Fatalf("SetGroupID(grandchild): %v", err)
+	}
+	if _, err := iso.DB.RegisterGroup(grandchild); err != nil {
+		t.Fatalf("RegisterGroup(grandchild): %v", err)
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+	}, parent)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	// The child must appear in Children: the depth cap skips only the
+	// recursion below it, not the child itself.
+	if len(res.Children) != 1 {
+		t.Fatalf("len(res.Children) = %d, want 1 (got %+v)", len(res.Children), res.Children)
+	}
+	if res.Children[0].SessionName != child {
+		t.Errorf("Children[0].SessionName = %q, want %q", res.Children[0].SessionName, child)
+	}
+	if !res.Children[0].SessionRowRemoved {
+		t.Errorf("child SessionRowRemoved=false, want true; depth cap must not block child's own cleanup")
+	}
+
+	// The depth-cap warning must surface in the child's Errors slice.
+	foundWarn := false
+	for _, e := range res.Children[0].Errors {
+		if e == nil {
+			continue
+		}
+		if contains(e.Error(), "own review group") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Errorf("depth-cap warning not surfaced in child's Errors; got %v", res.Children[0].Errors)
+	}
+
+	// The grandchild must NOT have been cleaned up: depth cap should
+	// leave its sessions row intact (no EndState).
+	grandSess, err := iso.DB.MostRecentSessionForName(grandchild)
+	if err != nil {
+		t.Fatalf("MostRecentSessionForName(grandchild): %v", err)
+	}
+	if grandSess == nil {
+		t.Fatalf("grandchild sessions row missing — depth cap should leave it intact")
+	}
+	if grandSess.EndState != nil {
+		t.Errorf("grandchild EndState = %q, want nil (depth cap must NOT clean up grandchildren)", *grandSess.EndState)
+	}
+}
+
+// TestCleanup_SkipKill_NoKillFn covers the AC: --skip-kill from #1692
+// applies to children too. When KillFn is nil, no kill summary is
+// recorded for any session in the tree.
+func TestCleanup_SkipKill_NoKillFn(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	parent := iristest.SessionName("parent-skipkill")
+	seedSession(t, iso.DB, parent, "iris-test-sk-001")
+	groupID, err := iso.DB.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	child := iristest.SessionName("parent-skipkill~review-1-review-code")
+	seedSession(t, iso.DB, child, "iris-test-sk-002")
+	if err := iso.DB.SetGroupID(child, groupID); err != nil {
+		t.Fatalf("SetGroupID: %v", err)
+	}
+
+	res, err := iris.CleanupSession(context.Background(), iris.CleanupConfig{
+		Database:    iso.DB,
+		RunDir:      iso.Paths.RunDir,
+		LogDir:      iso.Paths.LogDir,
+		ArchiveRoot: iso.Paths.ArchiveRoot,
+		// KillFn deliberately nil — emulates --skip-kill.
+	}, parent)
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+
+	if res.KillSummary != "" {
+		t.Errorf("parent KillSummary = %q, want empty (KillFn nil)", res.KillSummary)
+	}
+	if len(res.Children) != 1 {
+		t.Fatalf("len(res.Children) = %d, want 1", len(res.Children))
+	}
+	if res.Children[0].KillSummary != "" {
+		t.Errorf("child KillSummary = %q, want empty (KillFn nil applies to children too)", res.Children[0].KillSummary)
+	}
+	if !res.Children[0].SessionRowRemoved {
+		t.Errorf("child SessionRowRemoved=false; cleanup should still proceed without KillFn")
+	}
+}


### PR DESCRIPTION
## What

`iris cleanup <parent>` now traverses `session_groups` for review-group children spawned via `iris review` (landed in #1707) and recursively cleans each one up. Previously these children leaked: their DB rows stayed open, run dirs lingered, and worktrees were never reclaimed.

## How

- **`internal/iris/cleanup.go`**: `CleanupSession` looks up `session_groups` rows where the named session is the parent (via `db.GroupMembersForParent`), then recursively calls `CleanupSession` on each member at `depth+1`. Recursion is bounded at `maxCleanupDepth=2` (parent → review children → no further nesting); a grandchild that itself has a `session_groups` row triggers a warn-and-skip.
- **`CleanupConfig`** gains a `KillFn func(string) string` callback that the CLI populates with `killSessionViaDaemon`. `CleanupSession` calls it once per session (parent + each child) **before** the archive step, preserving the kill-then-archive invariant from #1692 at every recursion level. `--skip-kill` propagates by leaving `KillFn` nil.
- **`CleanupResult`** gains `SessionName`, `KillSummary`, and `Children []*CleanupResult` fields so the CLI can render per-session lines and an indented children block.
- **`cmd/iris/cleanup.go`**: kill is no longer called separately for the parent — it's wired through `CleanupConfig.KillFn` so the parent and every child go through the same code path. New `printCleanupResult` free function renders the result tree.

## Failure modes covered

| Scenario | Behaviour |
|---|---|
| `session_groups` unreadable | Warn + fall back to parent-only; error captured on parent's `Errors` slice |
| Child has no `sessions` row (already cleaned up) | Stub result with `KillSummary=\"skipped (already cleaned up)\"`, no propagated error |
| Active child at parent-cleanup time | Killed via `KillFn` → archived → DB / run dir removed (same flow as parent) |
| Grandchild unexpectedly has its own group | Warn + skip; surfaced via the child's `Errors` slice; grandchild left intact |
| `--skip-kill` | `KillFn` is nil → no kill at any recursion level; cleanup of DB / run dirs still proceeds |
| Non-review session (no children) | Empty `Children`; identical to pre-#1699 behaviour |

## Tests

- **`internal/iris/cleanup_review_group_test.go`** — unit coverage for the recursion (5-child happy path, non-review sessions, already-cleaned children, depth cap, --skip-kill).
- **`cmd/iris/cleanup_review_integration_test.go`** — end-to-end via the in-process `iris.ClientSocket` + review-spawn handler: spawn parent, run `iris review` against a stub PR to spawn 5 children, transition each to terminal, run `iris.CleanupSession`, assert all 6 sessions are cleaned + `printCleanupResult` output lists every child by name. Second cleanup is idempotent.

## Quality gates

- \`go test ./... -race\` — all packages pass (one earlier sidecar flake was unrelated to this change and didn't reproduce on rerun).
- \`nix build .#iris\` — green.

Closes #1699