### PR TITLE
iris feedback: friction-log subcommand (#1721)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/feedback.go
+++ b/modules/programs/prism/prism/cmd/iris/feedback.go
@@ -1,0 +1,369 @@
+package main
+
+// iris feedback — friction log analogue of `prism feedback` (issue #1721).
+//
+// Records short notes about iris CLI rough edges to a local JSONL store at
+// $XDG_STATE_HOME/iris/feedback.jsonl, with optional upstream POST when
+// IRIS_FEEDBACK_ENDPOINT is set.
+//
+// Surface (mirrors prism feedback byte-for-byte except for the binary
+// name and the env var):
+//
+//	iris feedback "<text>"           # record one note
+//	iris feedback -                   # read note from stdin
+//	iris feedback list                # list local notes (human-readable)
+//	iris feedback list --json         # JSON array of all notes
+//	iris feedback list --days N       # only entries newer than N days
+//	iris feedback prune --days N --yes  # drop entries older than N days
+//
+// The store is local-first: a missing or failing upstream endpoint never
+// loses the local record. Upstream HTTP status (when configured) is
+// surfaced in the success message so the operator can see what happened.
+//
+// The Entry struct from internal/feedback is reused as-is so that a future
+// tool can merge prism + iris feedback stores without schema gymnastics
+// (per the watch-out on #1721). That means the JSON key `prism_version`
+// is retained even when populated from the iris binary's git SHA — the
+// field is a "tool version" slot, not a strict prism-only identifier.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/archive"
+	"github.com/prismatic-koi/prism/internal/feedback"
+)
+
+// IRISFeedbackEndpointEnv is the environment variable that, when non-empty,
+// causes `iris feedback` to POST each newly-recorded entry to the named URL
+// after writing it locally. A failure to POST does not affect the local
+// record (the local copy is the source of truth).
+const IRISFeedbackEndpointEnv = "IRIS_FEEDBACK_ENDPOINT"
+
+// irisFeedbackUpstreamTimeout caps how long a single upstream POST can run
+// before we give up and report the timeout in the success message. The
+// local record is already on disk before the POST is attempted.
+const irisFeedbackUpstreamTimeout = 30 * time.Second
+
+// irisFeedbackUpstreamClient is the HTTP client used for the upstream POST.
+// Overridable from tests via the package-level variable so test servers
+// can intercept requests without monkey-patching net/http.
+var irisFeedbackUpstreamClient = &http.Client{Timeout: irisFeedbackUpstreamTimeout}
+
+// irisFeedbackStorePathFn lets tests inject a writable store path. When nil
+// (production) the path is resolved from $XDG_STATE_HOME via
+// irisFeedbackDefaultPath. The injection point exists because the nix-build
+// sandbox has HOME=/homeless-shelter; tests set XDG_STATE_HOME to a
+// t.TempDir() and the production code path picks that up automatically.
+var irisFeedbackStorePathFn = func() (string, error) { return irisFeedbackDefaultPath() }
+
+// irisFeedbackDefaultPath returns the canonical iris feedback.jsonl path,
+// honouring $XDG_STATE_HOME first and falling back to
+// $HOME/.local/state/iris/feedback.jsonl.
+//
+// This is a deliberate near-duplicate of feedback.DefaultPath() — the only
+// difference is the "iris" namespace directory instead of "prism". Reusing
+// the prism path would conflate the two stores; the issue explicitly calls
+// for separate stores at $XDG_STATE_HOME/iris/feedback.jsonl.
+func irisFeedbackDefaultPath() (string, error) {
+	if state := os.Getenv("XDG_STATE_HOME"); state != "" {
+		return filepath.Join(state, "iris", "feedback.jsonl"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("iris feedback: cannot resolve store path — neither XDG_STATE_HOME nor HOME is set")
+	}
+	return filepath.Join(home, ".local", "state", "iris", "feedback.jsonl"), nil
+}
+
+// resolveIrisFeedbackStore returns a Store rooted at the configured path.
+func resolveIrisFeedbackStore() (*feedback.Store, error) {
+	path, err := irisFeedbackStorePathFn()
+	if err != nil {
+		return nil, err
+	}
+	return feedback.NewStore(path), nil
+}
+
+var feedbackCmd = &cobra.Command{
+	Use:   "feedback [text|-]",
+	Short: "Record a short note about iris CLI friction (local JSONL log)",
+	Long: `Record a short note about iris CLI friction.
+
+Each entry is appended as one JSON object per line to
+$XDG_STATE_HOME/iris/feedback.jsonl. The store is local-first: a missing
+or failing upstream endpoint never loses the local record.
+
+  iris feedback "the --tier flag rejects 'enterprise' but the docs list it"
+  echo "feedback from a script" | iris feedback -
+
+When IRIS_FEEDBACK_ENDPOINT is set, the entry is also POSTed upstream
+after being written locally. The HTTP status is reported in the success
+message.
+
+Subcommands:
+  iris feedback list               human-readable list of local entries
+  iris feedback list --json        JSON array of all entries
+  iris feedback list --days N      only entries within the last N days
+  iris feedback prune --days N --yes
+                                   drop entries older than N days
+`,
+	Args:         cobra.MaximumNArgs(1),
+	RunE:         runIrisFeedbackRecord,
+	SilenceUsage: true,
+}
+
+var feedbackListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List recorded iris feedback entries",
+	Args:         cobra.NoArgs,
+	RunE:         runIrisFeedbackList,
+	SilenceUsage: true,
+}
+
+var feedbackPruneCmd = &cobra.Command{
+	Use:          "prune --days N --yes",
+	Short:        "Remove iris feedback entries older than N days (requires --yes)",
+	Args:         cobra.NoArgs,
+	RunE:         runIrisFeedbackPrune,
+	SilenceUsage: true,
+}
+
+func init() {
+	feedbackListCmd.Flags().Bool("json", false, "Emit the JSONL contents as a JSON array")
+	feedbackListCmd.Flags().Int("days", 0, "Only show entries within the last N days (0 = no filter)")
+
+	feedbackPruneCmd.Flags().Int("days", 0, "Remove entries older than N days (required, must be > 0)")
+	feedbackPruneCmd.Flags().Bool("yes", false, "Confirm the prune. Without --yes, prune errors instead of prompting (principle 1)")
+
+	feedbackCmd.AddCommand(feedbackListCmd)
+	feedbackCmd.AddCommand(feedbackPruneCmd)
+	rootCmd.AddCommand(feedbackCmd)
+}
+
+// runIrisFeedbackRecord handles `iris feedback "<text>"` and `iris feedback -`.
+func runIrisFeedbackRecord(cmd *cobra.Command, args []string) error {
+	text, err := readIrisFeedbackText(args, os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	entry := buildIrisFeedbackEntry(text, time.Now().UTC())
+
+	store, err := resolveIrisFeedbackStore()
+	if err != nil {
+		return err
+	}
+	if err := store.Append(entry); err != nil {
+		return err
+	}
+
+	endpoint := resolveIrisFeedbackEndpoint()
+	if endpoint == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "feedback recorded locally (%s)\n", store.Path)
+		return nil
+	}
+	status, postErr := postIrisFeedbackUpstream(endpoint, entry)
+	if postErr != nil {
+		// Local record is unaffected; surface the upstream failure but exit 0.
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"feedback recorded locally (%s); upstream POST failed: %v\n",
+			store.Path, postErr)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"feedback recorded locally and sent upstream (status: %d)\n", status)
+	return nil
+}
+
+// readIrisFeedbackText resolves the feedback text from either the positional
+// argument or stdin (when the argument is "-"). Returns an error when no
+// argument is supplied — the AC requires a non-zero exit with usage in
+// that case.
+func readIrisFeedbackText(args []string, stdin io.Reader) (string, error) {
+	if len(args) == 0 {
+		return "", errors.New(
+			"a feedback text is required — supply one of:\n" +
+				"  iris feedback \"<text>\"\n" +
+				"  iris feedback - (read from stdin)",
+		)
+	}
+	arg := args[0]
+	if arg != "-" {
+		s := strings.TrimSpace(arg)
+		if s == "" {
+			return "", errors.New("feedback text is empty")
+		}
+		return s, nil
+	}
+	// Stdin path. Refuse if stdin is a terminal so the user gets a clear
+	// error rather than a hung command.
+	if f, ok := stdin.(*os.File); ok {
+		info, statErr := f.Stat()
+		if statErr == nil && (info.Mode()&os.ModeCharDevice) != 0 {
+			return "", errors.New(
+				"iris feedback -: stdin is a terminal; pipe text or use iris feedback \"<text>\"",
+			)
+		}
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return "", errors.New("iris feedback -: stdin produced no text")
+	}
+	return s, nil
+}
+
+// buildIrisFeedbackEntry assembles an Entry from the recording context.
+// The Session field is auto-populated from IRIS_SESSION_NAME (set by the
+// iris supervisor's buildEnv for every pi child — issue #1704/#1706); it
+// remains empty when invoked from a non-iris shell.
+//
+// The PrismVersion field is reused as the "tool version" slot per the
+// #1721 watch-out (keep field names byte-for-byte with cmd/feedback.go so
+// future tooling can merge stores) — for iris-originated entries it
+// carries the iris binary's VCS revision.
+func buildIrisFeedbackEntry(text string, now time.Time) feedback.Entry {
+	e := feedback.Entry{
+		Timestamp:    now.Format(time.RFC3339),
+		Text:         text,
+		Session:      os.Getenv("IRIS_SESSION_NAME"),
+		PrismVersion: archive.PrismGitSHA(),
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		e.CWD = cwd
+	}
+	return e
+}
+
+// postIrisFeedbackUpstream POSTs a single entry to endpoint as JSON. Returns
+// the HTTP status code on success. A non-2xx response is treated as an
+// error so the caller can surface it (the local record is already saved).
+func postIrisFeedbackUpstream(endpoint string, e feedback.Entry) (int, error) {
+	body, err := json.Marshal(e)
+	if err != nil {
+		return 0, fmt.Errorf("marshal entry: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), irisFeedbackUpstreamTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := irisFeedbackUpstreamClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	// Drain so the connection can be reused.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 400 {
+		return resp.StatusCode, fmt.Errorf("upstream returned HTTP %d", resp.StatusCode)
+	}
+	return resp.StatusCode, nil
+}
+
+// resolveIrisFeedbackEndpoint returns the configured upstream URL from the
+// IRIS_FEEDBACK_ENDPOINT environment variable. Unlike prism, iris has no
+// config-file equivalent for this slot — env var only. Returns "" when
+// unset.
+func resolveIrisFeedbackEndpoint() string {
+	return strings.TrimSpace(os.Getenv(IRISFeedbackEndpointEnv))
+}
+
+// runIrisFeedbackList implements `iris feedback list [--json] [--days N]`.
+//
+// Human-readable output is newest-first; --json emits the same set as a
+// JSON array (also newest-first). An empty store prints nothing in
+// human mode and `[]` in JSON mode.
+func runIrisFeedbackList(cmd *cobra.Command, _ []string) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	days, _ := cmd.Flags().GetInt("days")
+	if days < 0 {
+		return fmt.Errorf("--days must be a non-negative integer")
+	}
+
+	store, err := resolveIrisFeedbackStore()
+	if err != nil {
+		return err
+	}
+	entries, err := store.List()
+	if err != nil {
+		return err
+	}
+	if days > 0 {
+		cutoff := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+		entries = feedback.FilterSince(entries, cutoff)
+	}
+
+	// Newest-first ordering (AC). Store.List() returns append order
+	// (oldest-first); reverse in place.
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+
+	w := cmd.OutOrStdout()
+	if jsonOut {
+		// AC: --json emits a JSON array. Use a non-nil slice so the empty
+		// case marshals to [] rather than null.
+		if entries == nil {
+			entries = []feedback.Entry{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+	for _, e := range entries {
+		fmt.Fprintf(w, "%s  %s\n", e.Timestamp, e.Text)
+	}
+	return nil
+}
+
+// runIrisFeedbackPrune implements `iris feedback prune --days N --yes`.
+//
+// Per principle 1 (no implicit confirmations), --yes is mandatory. Without
+// it we error out instead of prompting; the operator has to opt in
+// explicitly.
+func runIrisFeedbackPrune(cmd *cobra.Command, _ []string) error {
+	days, _ := cmd.Flags().GetInt("days")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if days <= 0 {
+		return fmt.Errorf("--days must be a positive integer (e.g. --days 30)")
+	}
+	if !yes {
+		return fmt.Errorf(
+			"iris feedback prune requires --yes to confirm (principle 1: no implicit confirmations)\n" +
+				"    re-run with --yes to drop entries older than the cutoff",
+		)
+	}
+
+	store, err := resolveIrisFeedbackStore()
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+	kept, removed, err := store.Prune(cutoff)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"feedback pruned: removed %d entries older than %s; kept %d (%s)\n",
+		removed, cutoff.Format(time.RFC3339), kept, store.Path)
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/iris/feedback_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/feedback_integration_test.go
@@ -1,0 +1,342 @@
+package main
+
+// feedback_integration_test.go — integration coverage for the `iris feedback`
+// record / list / prune cycle (issue #1721).
+//
+// The test drives the cobra commands directly (no subprocess) but exercises
+// the full code path: argument parsing, store creation, JSONL append, list
+// + filter + JSON encoding, and prune with --yes. The on-disk feedback.jsonl
+// is asserted between steps so a regression in any of the three verbs is
+// caught.
+//
+// Isolation: the test sets XDG_STATE_HOME to a t.TempDir() so the
+// production resolveIrisFeedbackStore path is exercised end-to-end without
+// touching the developer's real ~/.local/state. This also keeps the test
+// happy in the nix sandbox where HOME=/homeless-shelter.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/prismatic-koi/prism/internal/feedback"
+)
+
+// withIsolatedFeedback redirects $XDG_STATE_HOME to a tempdir and the
+// in-process feedback-record helpers to read it. Returns the resolved
+// feedback.jsonl path.
+func withIsolatedFeedback(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	// Make sure no inherited endpoint sends test data anywhere.
+	t.Setenv(IRISFeedbackEndpointEnv, "")
+	return filepath.Join(dir, "iris", "feedback.jsonl")
+}
+
+// readEntries decodes the on-disk JSONL file and returns the entries in
+// append order (oldest first). It is the test's source of truth for
+// asserting record / prune outcomes — the CLI's list output is a separate
+// signal we also check.
+func readEntries(t *testing.T, path string) []feedback.Entry {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out []feedback.Entry
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e feedback.Entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// runFeedbackCmd is a thin helper that invokes the cobra command with the
+// given args and a fresh stdout buffer. It returns the captured stdout and
+// any execution error.
+//
+// We re-resolve the command by name on rootCmd so each call gets the same
+// surface the user sees, not a cached reference. Cobra retains parsed flag
+// values across Execute() calls in the same process, so we reset flag
+// state on the feedback subtree before each run — otherwise --json or
+// --days from one call leaks into the next.
+func runFeedbackCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	resetFeedbackFlags()
+	rootCmd.SetArgs(append([]string{"feedback"}, args...))
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	err := rootCmd.Execute()
+	return out.String(), err
+}
+
+// resetFeedbackFlags clears any flag values that previous Execute() calls
+// stored on the feedback subcommands. cobra/pflag does not reset values
+// between invocations, so a test that ran `list --json` would leave
+// --json=true visible to subsequent `list` calls in the same test binary.
+func resetFeedbackFlags() {
+	// pflag has no public per-flag reset hook; visit each flag and restore
+	// its declared default. The subcommands carry the only flags relevant
+	// to these tests (--json, --days, --yes).
+	for _, c := range []*cobra.Command{feedbackListCmd, feedbackPruneCmd} {
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+}
+
+// TestIrisFeedback_RecordListPruneCycle is the canonical AC test: record 3
+// entries, list them, prune the oldest, assert state. It also asserts
+// IRIS_SESSION_NAME auto-population and the human-readable list ordering
+// (newest first).
+func TestIrisFeedback_RecordListPruneCycle(t *testing.T) {
+	path := withIsolatedFeedback(t)
+	t.Setenv("IRIS_SESSION_NAME", "iris-test@worker-1")
+
+	// Inject a store-path resolver so the cobra commands route to the
+	// isolated path. (XDG_STATE_HOME is also set above; the override is
+	// belt-and-braces — explicit beats implicit when tests run in parallel
+	// with future state-mutating code.)
+	origPathFn := irisFeedbackStorePathFn
+	irisFeedbackStorePathFn = func() (string, error) { return path, nil }
+	t.Cleanup(func() { irisFeedbackStorePathFn = origPathFn })
+
+	// Record 3 entries. We can't easily backdate via the CLI so we write
+	// the older two directly into the store and use the CLI for the third
+	// — proving that the on-disk format the CLI produces is read back
+	// identically by list/prune.
+	now := time.Now().UTC()
+	old := feedback.Entry{
+		Timestamp:    now.Add(-30 * 24 * time.Hour).Format(time.RFC3339),
+		Text:         "oldest entry, will be pruned",
+		Session:      "iris-test@past",
+		PrismVersion: "test-sha",
+	}
+	mid := feedback.Entry{
+		Timestamp:    now.Add(-5 * 24 * time.Hour).Format(time.RFC3339),
+		Text:         "middle entry, recent enough to keep",
+		Session:      "iris-test@past",
+		PrismVersion: "test-sha",
+	}
+	if err := feedback.NewStore(path).Append(old); err != nil {
+		t.Fatalf("seed old entry: %v", err)
+	}
+	if err := feedback.NewStore(path).Append(mid); err != nil {
+		t.Fatalf("seed mid entry: %v", err)
+	}
+
+	// Record the newest entry via the CLI — exercises the full
+	// runIrisFeedbackRecord path including IRIS_SESSION_NAME pickup.
+	out, err := runFeedbackCmd(t, "fresh entry from the CLI")
+	if err != nil {
+		t.Fatalf("record via CLI: %v", err)
+	}
+	if !strings.Contains(out, "feedback recorded locally") {
+		t.Fatalf("record success message missing: %q", out)
+	}
+	if !strings.Contains(out, path) {
+		t.Fatalf("record message should mention store path %q; got %q", path, out)
+	}
+
+	entries := readEntries(t, path)
+	if len(entries) != 3 {
+		t.Fatalf("want 3 on-disk entries after record, got %d: %+v", len(entries), entries)
+	}
+	if entries[2].Text != "fresh entry from the CLI" {
+		t.Fatalf("newest entry text wrong: %+v", entries[2])
+	}
+	if entries[2].Session != "iris-test@worker-1" {
+		t.Fatalf("IRIS_SESSION_NAME not picked up: session=%q", entries[2].Session)
+	}
+
+	// list (human) — should print newest first; assert the order of Text
+	// substrings in the captured output.
+	out, err = runFeedbackCmd(t, "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	freshIdx := strings.Index(out, "fresh entry from the CLI")
+	midIdx := strings.Index(out, "middle entry")
+	oldIdx := strings.Index(out, "oldest entry")
+	if freshIdx < 0 || midIdx < 0 || oldIdx < 0 {
+		t.Fatalf("list missing one of the entries: %q", out)
+	}
+	if !(freshIdx < midIdx && midIdx < oldIdx) {
+		t.Fatalf("list should be newest-first; got order fresh=%d mid=%d old=%d in %q",
+			freshIdx, midIdx, oldIdx, out)
+	}
+
+	// list --json --days 10 — should drop the 30-day-old entry and emit
+	// a JSON array of exactly two.
+	out, err = runFeedbackCmd(t, "list", "--json", "--days", "10")
+	if err != nil {
+		t.Fatalf("list --json --days: %v", err)
+	}
+	var jsonOut []feedback.Entry
+	if err := json.Unmarshal([]byte(out), &jsonOut); err != nil {
+		t.Fatalf("list --json output not a JSON array: %v\noutput=%q", err, out)
+	}
+	if len(jsonOut) != 2 {
+		t.Fatalf("list --json --days 10: want 2 entries, got %d: %+v", len(jsonOut), jsonOut)
+	}
+
+	// prune without --yes must error and leave the file untouched.
+	out, err = runFeedbackCmd(t, "prune", "--days", "10")
+	if err == nil {
+		t.Fatalf("prune without --yes should error, got success: %q", out)
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("prune error should mention --yes; got %v", err)
+	}
+	if got := len(readEntries(t, path)); got != 3 {
+		t.Fatalf("prune without --yes mutated the store: want 3 entries, got %d", got)
+	}
+
+	// prune --days 10 --yes drops the 30-day-old entry only.
+	out, err = runFeedbackCmd(t, "prune", "--days", "10", "--yes")
+	if err != nil {
+		t.Fatalf("prune --yes: %v", err)
+	}
+	if !strings.Contains(out, "removed 1") || !strings.Contains(out, "kept 2") {
+		t.Fatalf("prune summary unexpected: %q", out)
+	}
+	remaining := readEntries(t, path)
+	if len(remaining) != 2 {
+		t.Fatalf("after prune want 2 entries, got %d: %+v", len(remaining), remaining)
+	}
+	for _, e := range remaining {
+		if strings.Contains(e.Text, "oldest") {
+			t.Fatalf("oldest entry survived prune: %+v", e)
+		}
+	}
+}
+
+// TestIrisFeedback_FirstInvocationCreatesStore exercises the AC that the
+// store is created on demand when it does not yet exist.
+func TestIrisFeedback_FirstInvocationCreatesStore(t *testing.T) {
+	path := withIsolatedFeedback(t)
+	origPathFn := irisFeedbackStorePathFn
+	irisFeedbackStorePathFn = func() (string, error) { return path, nil }
+	t.Cleanup(func() { irisFeedbackStorePathFn = origPathFn })
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("precondition: feedback.jsonl should not exist, stat err=%v", err)
+	}
+	// list on an empty store must succeed and print nothing (human mode).
+	out, err := runFeedbackCmd(t, "list")
+	if err != nil {
+		t.Fatalf("list on empty store: %v", err)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("list on empty store should be empty; got %q", out)
+	}
+
+	// list --json on an empty store must emit `[]` (not `null`).
+	out, err = runFeedbackCmd(t, "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json on empty store: %v", err)
+	}
+	if strings.TrimSpace(out) != "[]" {
+		t.Fatalf("list --json on empty store should be []; got %q", out)
+	}
+
+	// First record creates the file (and parent dir).
+	if _, err := runFeedbackCmd(t, "first note"); err != nil {
+		t.Fatalf("record on fresh store: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("feedback.jsonl should now exist: %v", err)
+	}
+}
+
+// TestIrisFeedback_UpstreamPostLocalFirst proves the local-first contract:
+// when IRIS_FEEDBACK_ENDPOINT points at an upstream that fails, the local
+// record still lands and the command exits 0 with a message that mentions
+// the upstream failure.
+func TestIrisFeedback_UpstreamPostLocalFirst(t *testing.T) {
+	path := withIsolatedFeedback(t)
+	origPathFn := irisFeedbackStorePathFn
+	irisFeedbackStorePathFn = func() (string, error) { return path, nil }
+	t.Cleanup(func() { irisFeedbackStorePathFn = origPathFn })
+
+	// Two upstream variants: a 500 (POST reached server, server rejected)
+	// and a happy 202 (POST accepted). Both must leave the local record on
+	// disk; the success message differs.
+	t.Run("upstream-500-local-still-written", func(t *testing.T) {
+		var calls int32
+		var mu sync.Mutex
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv(IRISFeedbackEndpointEnv, srv.URL)
+
+		// Clear file between sub-tests so the assertion isolates this call.
+		_ = os.Remove(path)
+
+		out, err := runFeedbackCmd(t, "upstream 500 case")
+		if err != nil {
+			t.Fatalf("record: %v", err)
+		}
+		if !strings.Contains(out, "feedback recorded locally") {
+			t.Fatalf("want local-record success message, got %q", out)
+		}
+		if !strings.Contains(out, "upstream POST failed") {
+			t.Fatalf("want upstream-failure annotation, got %q", out)
+		}
+		entries := readEntries(t, path)
+		if len(entries) != 1 || entries[0].Text != "upstream 500 case" {
+			t.Fatalf("local record missing after upstream failure: %+v", entries)
+		}
+		mu.Lock()
+		got := calls
+		mu.Unlock()
+		if got != 1 {
+			t.Fatalf("upstream should have been POSTed exactly once, got %d", got)
+		}
+	})
+
+	t.Run("upstream-202-status-surfaced", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv(IRISFeedbackEndpointEnv, srv.URL)
+
+		_ = os.Remove(path)
+
+		out, err := runFeedbackCmd(t, "happy upstream")
+		if err != nil {
+			t.Fatalf("record: %v", err)
+		}
+		if !strings.Contains(out, "status: 202") {
+			t.Fatalf("want upstream-status annotation, got %q", out)
+		}
+		entries := readEntries(t, path)
+		if len(entries) != 1 {
+			t.Fatalf("want 1 local entry, got %d", len(entries))
+		}
+	})
+}

--- a/modules/programs/prism/prism/docs/daemon-mode-design.md
+++ b/modules/programs/prism/prism/docs/daemon-mode-design.md
@@ -675,7 +675,7 @@ grep -r IRIS_ modules/programs/prism/prism/cmd/iris/ \
               modules/programs/prism/prism/internal/iris/
 ```
 
-Only three `IRIS_*` env vars should appear:
+Only four `IRIS_*` env vars should appear:
 
 - `IRIS_DAEMON_SOCK` — set by the supervisor on the **pi child process**
   (`internal/iris/supervisor.go::buildEnv`) so the prism extension running
@@ -692,6 +692,16 @@ Only three `IRIS_*` env vars should appear:
 - `IRIS_PARITY_TEST_MODE` — the parity-test harness guard
   (`internal/iris/iristest/iristest.go:54`,
   `internal/iris/parity/parity_isolation_test.go`). Test-only.
+- `IRIS_FEEDBACK_ENDPOINT` — host-side opt-in upstream POST target for
+  `iris feedback` (`cmd/iris/feedback.go`, issue #1721). Read directly via
+  `os.Getenv` from the user's interactive shell when `iris feedback`
+  records an entry; if set, the entry is POSTed to the named URL after the
+  local-first JSONL write succeeds. This is **not** a daemon-proxy path:
+  the supervisor never sets it on the pi child, the credential broker
+  never forwards it into any tool sandbox (invariant 2's allowlist is
+  closed), and a sandboxed subprocess cannot use it to call back into the
+  daemon. It is a configuration knob for the operator's own shell, in the
+  same shape as `PRISM_FEEDBACK_ENDPOINT` for prism.
 
 There is no `IRIS_HOST_API`, no `IRIS_CLI_PROXY`, and no analogue of prism's
 host-API socket path that a sandboxed subprocess could use to call back into


### PR DESCRIPTION
Adds `iris feedback` — the friction-log subcommand, analogue of `prism feedback`. Records short notes about iris CLI rough edges to a local JSONL store at `\$XDG_STATE_HOME/iris/feedback.jsonl`, with optional upstream POST when `IRIS_FEEDBACK_ENDPOINT` is set.

## Surface

```
iris feedback "<text>"               # record one note
iris feedback -                       # read note from stdin
iris feedback list                    # human-readable list (newest first)
iris feedback list --json             # JSON array of all entries
iris feedback list --days N           # entries within the last N days
iris feedback prune --days N --yes    # drop entries older than N days
```

`iris --help` lists `feedback`; each subcommand has its own `--help`.

## Design notes

- **Storage schema reuses `internal/feedback`** — `feedback.Entry` and `feedback.Store` are reused as-is so the on-disk shape is byte-for-byte compatible with `prism feedback` (per the #1721 watch-out about future tooling that may merge the two stores). That means the JSON key `prism_version` is retained even when populated by iris — the slot is treated as a generic "tool version" field.
- **Path namespace divergence is deliberate** — `\$XDG_STATE_HOME/iris/feedback.jsonl` instead of `prism/`. Separate stores by design; only the entry schema is shared.
- **`IRIS_SESSION_NAME` auto-population** — read directly via `os.Getenv` (set by `supervisor.buildEnv` per #1704/#1706). Empty when invoked outside an iris-managed session.
- **Local-first contract** — upstream POST failures never lose the local record; the success message surfaces the HTTP status (or the failure reason) so the operator can see what happened.
- **`--yes` is mandatory for prune** — principle 1 (no implicit confirmations); without it, prune errors instead of prompting.

## Tests

`modules/programs/prism/prism/cmd/iris/feedback_integration_test.go` covers:

1. **Record + list + prune cycle (AC)** — seeds two backdated entries (30d / 5d old), records a third via the CLI (asserting `IRIS_SESSION_NAME` pickup), lists them (asserting newest-first ordering), filters via `--days 10` in JSON mode, asserts `prune` without `--yes` errors and leaves the store untouched, then prunes the 30d-old entry and asserts on-disk state.
2. **First-invocation creates the store** — `list` and `list --json` on an empty/missing store succeed and emit `` / `[]` respectively; first record creates parent dir + file.
3. **Local-first contract under upstream errors** — `httptest.Server` returning 500 still results in a local record + an "upstream POST failed" annotation in the success message; a 202 surfaces the status code in the success message.

All tests run under `-race`.

## Quality gates

- \`go build ./...\` — clean
- \`go test ./... -race\` — all packages green
- \`nix build .#iris\` — succeeds

Closes #1721