### PR TITLE
feat(iris): `iris reviews` historical review-group listing (#1722)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/reviews.go
+++ b/modules/programs/prism/prism/cmd/iris/reviews.go
@@ -1,0 +1,580 @@
+package main
+
+// reviews.go — `iris reviews` historical review-group listing (#1722).
+//
+// This is the iris analogue of `prism reviews`. It exposes the historical
+// review-group ledger so coordinators and workers can revisit past review
+// activity without dropping into raw SQL or grepping session names.
+//
+// Distinct from `iris review <pr>`, which spawns a NEW review round. This
+// surface only reads the session_groups table and its members.
+//
+// Subcommands:
+//
+//   iris reviews                    list recent review groups, newest first
+//   iris reviews --days N           filter to groups created in the last N days
+//   iris reviews --json             emit a JSON array
+//   iris reviews show <group_id>    list one group's members + outcomes
+//   iris reviews show <group_id> --json   JSON object for the group
+//
+// Data source: reads iris.db directly via internal/db (the same read-only
+// carve-out as `iris checkin` — #1676). The daemon does not need to be
+// running for this surface to work; SQLite's WAL mode lets us share the
+// database with the daemon when it is.
+//
+// Empty / missing-group behaviour:
+//
+//   - `iris reviews` with zero rows prints "no reviews recorded" and exits 0.
+//   - `iris reviews show <id>` with an unknown id exits non-zero with a
+//     clear "no such group" error.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// reviewsCmd is the parent cobra command. Plain `iris reviews` runs
+// runReviewsList (the same RunE as `iris reviews list`-style would, but
+// we keep the surface flat to match the issue spec: `iris reviews` is the
+// list verb, and `iris reviews show <group>` is the only subcommand).
+var reviewsCmd = &cobra.Command{
+	Use:   "reviews",
+	Short: "List historical review groups recorded in the iris database",
+	Long: `List historical review groups recorded in the iris database.
+
+Each row shows: PR number (inferred from the parent session's branch when
+possible), parent (worker) session, round number, group state
+(in-progress / completed / empty), member count, age, and the per-agent
+session names.
+
+This subcommand is read-only. It reads the iris database directly and
+does not require the iris daemon to be running. Use 'iris reviews show
+<group_id>' to inspect one group's members in detail.
+
+Empty ledger → "no reviews recorded" (exit 0). Missing group_id in
+'iris reviews show' → "no such review group" (exit non-zero).`,
+	Args:          cobra.NoArgs,
+	RunE:          runReviewsList,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+// reviewsShowCmd implements `iris reviews show <group_id>`.
+var reviewsShowCmd = &cobra.Command{
+	Use:   "show <group_id>",
+	Short: "Show one review group's members with state and timing",
+	Long: `Show one review group's members with terminal state and timing.
+
+Each row of the output corresponds to one agent_status row in the group,
+with columns: session name, role (root agent name), state, started-at
+(last_seen for active rows; ended_at for terminal rows), and duration.
+
+Use --json to emit a JSON object suitable for scripting. An unknown
+<group_id> exits non-zero with a clear "no such review group" error.`,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runReviewsShow,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	reviewsCmd.Flags().Bool("json", false, "Emit a JSON array of review-group entries instead of the human-readable table")
+	reviewsCmd.Flags().Int("days", 0, "Only show groups created within the last N days (0 = no filter)")
+	reviewsCmd.Flags().Int("limit", 0, "Limit the number of rows returned (0 = all)")
+
+	reviewsShowCmd.Flags().Bool("json", false, "Emit a JSON object instead of the human-readable table")
+
+	reviewsCmd.AddCommand(reviewsShowCmd)
+	rootCmd.AddCommand(reviewsCmd)
+}
+
+// reviewSessionPattern matches per-agent review session names of the form
+// "<parent>~review-<N>-<agent>". Used to recover the round number N from
+// any one member.
+var reviewSessionPattern = regexp.MustCompile(`^(.+)~review-(\d+)-(.+)$`)
+
+// reviewParentBranchPattern extracts the branch component from a parent
+// session name "<repo>@<branch>". Used as a heuristic for surfacing the
+// PR number when the branch happens to be of the form "pr-<N>".
+var reviewParentBranchPattern = regexp.MustCompile(`@(.+)$`)
+
+// reviewsOpenDB opens the iris DB for read. Mirrors openIrisDBForRead in
+// checkin.go — we wrap the missing-file failure mode in an actionable
+// "iris database not found" message rather than the raw modernc.org
+// error. Defined separately from openIrisDBForRead so the error prefix
+// is correctly "iris reviews:" and the caller can be tested in isolation.
+func reviewsOpenDB(dbPath string) (*db.DB, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("iris database not found at %s; has the iris daemon ever run? (start it with `systemctl --user start iris` on Linux, or `launchctl kickstart -k gui/$UID/local.iris.daemon` on Darwin)", dbPath)
+		}
+		return nil, fmt.Errorf("cannot read iris database at %s: %w", dbPath, err)
+	}
+	d, err := iris.OpenDB(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open iris database at %s: %w", dbPath, err)
+	}
+	return d, nil
+}
+
+// resolveReviewsDBPath returns the path used by `iris reviews`. testDBPath
+// (from db.go) wins so tests can redirect via SetTestDBPath; otherwise we
+// defer to iris.ResolvePaths().DB. Sharing the test hook with the `iris
+// db` family keeps the test surface consistent.
+func resolveReviewsDBPath() string {
+	if testDBPath != "" {
+		return testDBPath
+	}
+	return iris.ResolvePaths().DB
+}
+
+func runReviewsList(cmd *cobra.Command, _ []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	days, _ := cmd.Flags().GetInt("days")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	if days < 0 {
+		return fmt.Errorf("iris reviews: --days must be ≥ 0, got %d", days)
+	}
+	if limit < 0 {
+		return fmt.Errorf("iris reviews: --limit must be ≥ 0, got %d", limit)
+	}
+
+	dbPath := resolveReviewsDBPath()
+	d, err := reviewsOpenDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("iris reviews: %w", err)
+	}
+	defer d.Close()
+
+	// Fetch all groups (limit is applied client-side after the --days filter
+	// so the two flags compose predictably: "limit N after filtering to the
+	// last D days" rather than "limit before filtering").
+	groups, err := d.ReviewGroupsList(0)
+	if err != nil {
+		return fmt.Errorf("iris reviews: %w", err)
+	}
+
+	if days > 0 {
+		cutoff := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+		filtered := groups[:0]
+		for _, g := range groups {
+			if g.CreatedAt.After(cutoff) {
+				filtered = append(filtered, g)
+			}
+		}
+		groups = filtered
+	}
+	if limit > 0 && len(groups) > limit {
+		groups = groups[:limit]
+	}
+
+	out := cmd.OutOrStdout()
+	if jsonMode {
+		return renderReviewsListJSON(out, groups)
+	}
+	return renderReviewsList(out, groups)
+}
+
+func runReviewsShow(cmd *cobra.Command, args []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	groupID := strings.TrimSpace(args[0])
+	if groupID == "" {
+		return fmt.Errorf("iris reviews show: empty <group_id> argument")
+	}
+
+	dbPath := resolveReviewsDBPath()
+	d, err := reviewsOpenDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("iris reviews show: %w", err)
+	}
+	defer d.Close()
+
+	// Resolve the group: pull all groups and find the one with this id.
+	// This is the simplest way to surface a clear "no such group" error
+	// without adding a single-row lookup helper to internal/db (which
+	// would risk overlap with #1699's work on the same package). The list
+	// query is cheap — session_groups is small.
+	allGroups, err := d.ReviewGroupsList(0)
+	if err != nil {
+		return fmt.Errorf("iris reviews show: %w", err)
+	}
+	var summary *db.ReviewGroupSummary
+	for i := range allGroups {
+		if allGroups[i].GroupID == groupID {
+			summary = &allGroups[i]
+			break
+		}
+	}
+	if summary == nil {
+		return fmt.Errorf("iris reviews show: no such review group %q", groupID)
+	}
+
+	members, err := d.GroupMembersForGroup(groupID)
+	if err != nil {
+		return fmt.Errorf("iris reviews show: members: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	if jsonMode {
+		return renderReviewsShowJSON(out, *summary, members)
+	}
+	return renderReviewsShow(out, *summary, members)
+}
+
+// reviewsJSONRow is the snake_case JSON shape for one review-group row.
+// Defined explicitly so the JSON contract is decoupled from
+// db.ReviewGroupSummary's field naming. Mirrors `prism reviews list`'s
+// JSON shape so scripts can be shared between the two surfaces.
+type reviewsJSONRow struct {
+	GroupID       string   `json:"group_id"`
+	PR            *int     `json:"pr"`
+	ParentSession string   `json:"parent_session"`
+	AgentSessions []string `json:"agent_sessions"`
+	AgentStates   []string `json:"agent_states"`
+	GroupState    string   `json:"group_state"`
+	MemberCount   int      `json:"member_count"`
+	StartedAt     string   `json:"started_at"` // RFC3339, UTC
+	Round         *int     `json:"round"`
+}
+
+// reviewsShowJSON is the snake_case shape returned by `iris reviews show
+// --json`. Contains the same group-level fields as reviewsJSONRow plus a
+// members[] array with per-agent timing.
+type reviewsShowJSON struct {
+	GroupID       string                 `json:"group_id"`
+	PR            *int                   `json:"pr"`
+	ParentSession string                 `json:"parent_session"`
+	GroupState    string                 `json:"group_state"`
+	StartedAt     string                 `json:"started_at"`
+	Round         *int                   `json:"round"`
+	Members       []reviewsShowJSONMember `json:"members"`
+}
+
+type reviewsShowJSONMember struct {
+	SessionName string  `json:"session_name"`
+	Role        string  `json:"role"` // root_agent_name; empty when unrecorded
+	State       string  `json:"state"`
+	LastSeen    string  `json:"last_seen"` // RFC3339, UTC
+	EndedAt     *string `json:"ended_at"`  // RFC3339 / UTC, or null when still running
+	DurationMs  *int64  `json:"duration_ms"` // ended_at − last_seen-on-creation; null when active
+}
+
+func renderReviewsListJSON(out io.Writer, groups []db.ReviewGroupSummary) error {
+	rows := make([]reviewsJSONRow, 0, len(groups))
+	for _, g := range groups {
+		row := reviewsJSONRow{
+			GroupID:       g.GroupID,
+			ParentSession: g.ParentSession,
+			AgentSessions: append([]string(nil), g.Members...),
+			AgentStates:   append([]string(nil), g.AgentStates...),
+			GroupState:    g.GroupState,
+			MemberCount:   len(g.Members),
+			StartedAt:     g.CreatedAt.UTC().Format(time.RFC3339),
+		}
+		if pr := inferPRFromGroup(g); pr > 0 {
+			row.PR = &pr
+		}
+		if round := inferRoundFromGroup(g); round > 0 {
+			row.Round = &round
+		}
+		rows = append(rows, row)
+	}
+	enc := json.NewEncoder(out)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(rows)
+}
+
+func renderReviewsShowJSON(out io.Writer, g db.ReviewGroupSummary, members []db.Status) error {
+	body := reviewsShowJSON{
+		GroupID:       g.GroupID,
+		ParentSession: g.ParentSession,
+		GroupState:    g.GroupState,
+		StartedAt:     g.CreatedAt.UTC().Format(time.RFC3339),
+		Members:       make([]reviewsShowJSONMember, 0, len(members)),
+	}
+	if pr := inferPRFromGroup(g); pr > 0 {
+		body.PR = &pr
+	}
+	if round := inferRoundFromGroup(g); round > 0 {
+		body.Round = &round
+	}
+	for _, m := range members {
+		role := ""
+		if m.RootAgentName != nil {
+			role = *m.RootAgentName
+		}
+		entry := reviewsShowJSONMember{
+			SessionName: m.SessionName,
+			Role:        role,
+			State:       m.State,
+			LastSeen:    m.LastSeen.UTC().Format(time.RFC3339),
+		}
+		if m.EndedAt != nil {
+			endedStr := m.EndedAt.UTC().Format(time.RFC3339)
+			entry.EndedAt = &endedStr
+			// Duration: ended − started_at. The session group's created_at
+			// (g.CreatedAt) is the closest proxy for "this agent started"
+			// since the agent_status row doesn't carry a started_at. We
+			// fall back to the member's last_seen when ended_at is older
+			// than the group (which would yield a negative duration).
+			if !m.EndedAt.Before(g.CreatedAt) {
+				dur := m.EndedAt.Sub(g.CreatedAt).Milliseconds()
+				entry.DurationMs = &dur
+			}
+		}
+		body.Members = append(body.Members, entry)
+	}
+	enc := json.NewEncoder(out)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(body)
+}
+
+// renderReviewsList renders the human-readable table for `iris reviews`.
+// Column layout matches `prism reviews list` (PR / ROUND / STATE / PARENT
+// / N / AGE / AGENTS) so the two surfaces are visually consistent.
+func renderReviewsList(out io.Writer, groups []db.ReviewGroupSummary) error {
+	if len(groups) == 0 {
+		fmt.Fprintln(out, "no reviews recorded")
+		return nil
+	}
+
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(cliColSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(cliColSecondary))
+
+	const (
+		wPR     = 6
+		wRound  = 5
+		wState  = 12
+		wParent = 30
+		wAgents = 4
+		wAge    = 8
+	)
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
+		wPR, "PR",
+		wRound, "ROUND",
+		wState, "STATE",
+		wParent, "PARENT",
+		wAgents, "N",
+		wAge, "AGE",
+		"AGENTS",
+	)
+	fmt.Fprintln(out, styleHeader.Render(header))
+	fmt.Fprintln(out, styleDim.Render(strings.Repeat("─", len(header)+5)))
+
+	now := time.Now()
+	for _, g := range groups {
+		prStr := "—"
+		if pr := inferPRFromGroup(g); pr > 0 {
+			prStr = fmt.Sprintf("#%d", pr)
+		}
+		roundStr := "—"
+		if r := inferRoundFromGroup(g); r > 0 {
+			roundStr = fmt.Sprintf("%d", r)
+		}
+		parent := truncateForColumn(g.ParentSession, wParent)
+		ageStr := formatAgeFromTime(g.CreatedAt, now)
+		agents := truncateForColumn(strings.Join(g.Members, ","), 80)
+		state := reviewGroupStateStyle(g.GroupState).Render(fmt.Sprintf("%-*s", wState, truncateForColumn(g.GroupState, wState)))
+		fmt.Fprintf(out, "%-*s  %-*s  %s  %-*s  %-*d  %-*s  %s\n",
+			wPR, prStr,
+			wRound, roundStr,
+			state,
+			wParent, parent,
+			wAgents, len(g.Members),
+			wAge, ageStr,
+			agents,
+		)
+	}
+	return nil
+}
+
+// renderReviewsShow renders the human-readable table for `iris reviews
+// show <group_id>`. Header line states the group's metadata; the table
+// below lists each member with role, state, started/ended timestamps,
+// and duration.
+func renderReviewsShow(out io.Writer, g db.ReviewGroupSummary, members []db.Status) error {
+	styleHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(cliColSecondary))
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(cliColSecondary))
+
+	prStr := "—"
+	if pr := inferPRFromGroup(g); pr > 0 {
+		prStr = fmt.Sprintf("#%d", pr)
+	}
+	roundStr := "—"
+	if r := inferRoundFromGroup(g); r > 0 {
+		roundStr = fmt.Sprintf("%d", r)
+	}
+
+	fmt.Fprintf(out, "Group:   %s\n", g.GroupID)
+	fmt.Fprintf(out, "PR:      %s\n", prStr)
+	fmt.Fprintf(out, "Round:   %s\n", roundStr)
+	fmt.Fprintf(out, "Parent:  %s\n", g.ParentSession)
+	fmt.Fprintf(out, "State:   %s\n", g.GroupState)
+	fmt.Fprintf(out, "Started: %s\n", g.CreatedAt.UTC().Format(time.RFC3339))
+	fmt.Fprintln(out)
+
+	if len(members) == 0 {
+		fmt.Fprintln(out, "(no members)")
+		return nil
+	}
+
+	// Session names of the form "<repo>@<branch>~review-<N>-<agent>" are
+	// commonly 50–70 chars long. We size the column to fit the worst case
+	// without truncation — a wide column is fine for `show`, which is a
+	// detail view, even if it pushes other columns off-screen on narrow
+	// terminals.
+	const (
+		wSession = 72
+		wRole    = 18
+		wState   = 12
+		wDur     = 10
+	)
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %s",
+		wSession, "SESSION",
+		wRole, "ROLE",
+		wState, "STATE",
+		wDur, "DURATION",
+		"ENDED",
+	)
+	fmt.Fprintln(out, styleHeader.Render(header))
+	fmt.Fprintln(out, styleDim.Render(strings.Repeat("─", len(header)+5)))
+
+	for _, m := range members {
+		role := "—"
+		if m.RootAgentName != nil && *m.RootAgentName != "" {
+			role = *m.RootAgentName
+		}
+		dur := "—"
+		endedStr := "—"
+		if m.EndedAt != nil {
+			endedStr = m.EndedAt.UTC().Format(time.RFC3339)
+			if !m.EndedAt.Before(g.CreatedAt) {
+				dur = formatDuration(m.EndedAt.Sub(g.CreatedAt))
+			}
+		}
+		state := reviewGroupStateStyle(m.State).Render(fmt.Sprintf("%-*s", wState, truncateForColumn(m.State, wState)))
+		fmt.Fprintf(out, "%-*s  %-*s  %s  %-*s  %s\n",
+			wSession, truncateForColumn(m.SessionName, wSession),
+			wRole, truncateForColumn(role, wRole),
+			state,
+			wDur, dur,
+			endedStr,
+		)
+	}
+	return nil
+}
+
+// reviewGroupStateStyle returns the lipgloss style for a review-group or
+// per-agent state. Mirrors `prism reviews list`'s palette: yellow for in
+// progress, green for completed/finished, grey for empty / deleted /
+// interrupted, default for everything else.
+func reviewGroupStateStyle(state string) lipgloss.Style {
+	switch state {
+	case "in-progress", "active":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("33"))
+	case "completed", "finished":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("32"))
+	case "empty", "deleted", "interrupted":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(cliColSecondary))
+	case "error":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	default:
+		return lipgloss.NewStyle()
+	}
+}
+
+// inferPRFromGroup returns the PR number for a review group when it is
+// derivable from the parent session's branch component (e.g.
+// "repo@pr-123"). Returns 0 when no PR number can be inferred.
+func inferPRFromGroup(g db.ReviewGroupSummary) int {
+	m := reviewParentBranchPattern.FindStringSubmatch(g.ParentSession)
+	if len(m) != 2 {
+		return 0
+	}
+	branch := m[1]
+	for _, prefix := range []string{"pr-", "pr"} {
+		if strings.HasPrefix(branch, prefix) {
+			rest := strings.TrimPrefix(branch, prefix)
+			if n, err := strconv.Atoi(rest); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// inferRoundFromGroup returns the review round number derived from any
+// one member's session name (`<parent>~review-<N>-<agent>`). All members
+// share the same round, so the first parsed value wins.
+func inferRoundFromGroup(g db.ReviewGroupSummary) int {
+	for _, name := range g.Members {
+		m := reviewSessionPattern.FindStringSubmatch(name)
+		if len(m) == 4 {
+			if n, err := strconv.Atoi(m[2]); err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// formatAgeFromTime renders the wall-clock duration since t as a compact
+// string (`3m`, `1h`, `2d`). Matches the AGE column of `prism reviews
+// list` for visual consistency. Returns "—" for unset / future times.
+func formatAgeFromTime(t, now time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		return "—"
+	}
+	return formatDuration(d)
+}
+
+// formatDuration is the shared compact-duration formatter used by the
+// AGE and DURATION columns. Three buckets:
+//
+//	< 1 minute   →  "Xs"
+//	< 1 hour     →  "Xm"
+//	< 1 day      →  "XhYm"
+//	≥ 1 day      →  "XdYh"
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return "<1s"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	if hours == 0 {
+		return fmt.Sprintf("%dd", days)
+	}
+	return fmt.Sprintf("%dd%dh", days, hours)
+}

--- a/modules/programs/prism/prism/cmd/iris/reviews_test.go
+++ b/modules/programs/prism/prism/cmd/iris/reviews_test.go
@@ -1,0 +1,556 @@
+package main
+
+// reviews_test.go — unit + integration tests for `iris reviews` and
+// `iris reviews show` (#1722).
+//
+// All tests run under iristest.NewIsolated so HOME / XDG_STATE_HOME are
+// redirected to a per-test tempdir. No host state is touched and no
+// notification can escape to a live coordinator (#1608).
+//
+// Seeding strategy:
+//
+//   We exercise the read surface directly against iristest's iso.DB,
+//   inserting session_groups rows via RegisterGroup and agent_status
+//   rows via UpsertStatusWithRootAgent + SetGroupID. This is the same
+//   shape that iris's review orchestrator would write — but it avoids
+//   spinning up the full daemon-side review handler (which has its own
+//   integration test, TestReview_FullCycle in review_integration_test.go).
+//
+// The CLI is driven through the global rootCmd via runReviewsCommand,
+// the reviews-package analogue of db_test.go::runCommand. Flag state on
+// reviewsCmd / reviewsShowCmd is reset between invocations so cobra/pflag
+// does not leak values across test functions.
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// runReviewsCommand drives the global rootCmd with the given args and
+// returns captured stdout + the cobra error. Resets reviewsCmd flags
+// before and after so test order does not matter.
+func runReviewsCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	resetReviewsFlags()
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stdout)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+		rootCmd.SetIn(nil)
+		resetReviewsFlags()
+	})
+	err := rootCmd.ExecuteContext(context.Background())
+	return stdout.String(), err
+}
+
+func resetReviewsFlags() {
+	visit := func(c *cobra.Command) {
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+	visit(reviewsCmd)
+	for _, sub := range reviewsCmd.Commands() {
+		visit(sub)
+	}
+}
+
+// seedReviewGroup registers a fresh session_groups row with parentSession
+// as the parent and seeds memberRoles as agent_status rows joined to that
+// group. The members are upserted in `state` (e.g. "active" or "finished")
+// so the group's rolled-up state matches what the test wants to assert.
+//
+// Returns (groupID, memberSessionNames).
+func seedReviewGroup(t *testing.T, iso *iristest.Isolated, parentSession string, memberRoles []string, state string) (string, []string) {
+	t.Helper()
+	groupID, err := iso.DB.RegisterGroup(parentSession)
+	if err != nil {
+		t.Fatalf("RegisterGroup(%s): %v", parentSession, err)
+	}
+	members := make([]string, 0, len(memberRoles))
+	for _, role := range memberRoles {
+		role := role
+		sess := parentSession + "~review-1-" + role
+		if err := iso.DB.UpsertStatusWithRootAgent(sess, "iris-test", iso.Root, state, nil, nil, &role, nil); err != nil {
+			t.Fatalf("UpsertStatusWithRootAgent(%s): %v", sess, err)
+		}
+		if err := iso.DB.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID(%s, %s): %v", sess, groupID, err)
+		}
+		members = append(members, sess)
+	}
+	return groupID, members
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris reviews (list)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReviewsList_Empty asserts that `iris reviews` against a fresh DB
+// (no session_groups rows) prints the "no reviews recorded" sentinel and
+// exits 0.
+func TestReviewsList_Empty(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	out, err := runReviewsCommand(t, "reviews")
+	if err != nil {
+		t.Fatalf("iris reviews: %v", err)
+	}
+	if !strings.Contains(out, "no reviews recorded") {
+		t.Errorf("expected 'no reviews recorded', got:\n%s", out)
+	}
+}
+
+// TestReviewsList_ShowsRecentGroups seeds two groups (one in-progress,
+// one completed) and asserts both appear in the list output with the
+// correct rolled-up state.
+func TestReviewsList_ShowsRecentGroups(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parentA := iristest.SessionName("worker-a")
+	parentB := iristest.SessionName("worker-b")
+	_, _ = seedReviewGroup(t, iso, parentA, []string{"review-goal", "review-code"}, "active")
+	groupB, _ := seedReviewGroup(t, iso, parentB, []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}, "finished")
+
+	out, err := runReviewsCommand(t, "reviews")
+	if err != nil {
+		t.Fatalf("iris reviews: %v", err)
+	}
+	// Both parents should appear (truncated column may strip the prefix
+	// but the branch suffix uniquely identifies each row).
+	for _, want := range []string{"worker-a", "worker-b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in list output:\n%s", want, out)
+		}
+	}
+	// The completed group should be tagged as such.
+	if !strings.Contains(out, "completed") {
+		t.Errorf("expected 'completed' state tag for group %s in:\n%s", groupB, out)
+	}
+	if !strings.Contains(out, "in-progress") {
+		t.Errorf("expected 'in-progress' state tag in:\n%s", out)
+	}
+}
+
+// TestReviewsList_JSON asserts that `--json` emits a parseable JSON array
+// whose entries carry the expected fields.
+func TestReviewsList_JSON(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parent := iristest.SessionName("worker-json")
+	groupID, members := seedReviewGroup(t, iso, parent, []string{"review-goal", "review-code"}, "finished")
+
+	out, err := runReviewsCommand(t, "reviews", "--json")
+	if err != nil {
+		t.Fatalf("iris reviews --json: %v", err)
+	}
+
+	var rows []reviewsJSONRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("expected JSON array, got: %s\nerr: %v", out, err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %s", len(rows), out)
+	}
+	row := rows[0]
+	if row.GroupID != groupID {
+		t.Errorf("GroupID = %q, want %q", row.GroupID, groupID)
+	}
+	if row.ParentSession != parent {
+		t.Errorf("ParentSession = %q, want %q", row.ParentSession, parent)
+	}
+	if row.GroupState != "completed" {
+		t.Errorf("GroupState = %q, want 'completed'", row.GroupState)
+	}
+	if row.MemberCount != len(members) {
+		t.Errorf("MemberCount = %d, want %d", row.MemberCount, len(members))
+	}
+	if len(row.AgentSessions) != len(members) {
+		t.Errorf("AgentSessions = %v, want %d entries", row.AgentSessions, len(members))
+	}
+	if row.Round == nil || *row.Round != 1 {
+		t.Errorf("Round = %v, want 1 (from session-name suffix)", row.Round)
+	}
+	if row.StartedAt == "" {
+		t.Errorf("StartedAt is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, row.StartedAt); err != nil {
+		t.Errorf("StartedAt = %q is not RFC3339: %v", row.StartedAt, err)
+	}
+}
+
+// TestReviewsList_DaysFilter asserts that `--days N` filters out groups
+// older than N days. We achieve a deterministic "old" group by
+// back-dating session_groups.created_at via a direct UPDATE — the only
+// way to drive the filter without sleeping in tests.
+func TestReviewsList_DaysFilter(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parentRecent := iristest.SessionName("worker-recent")
+	parentOld := iristest.SessionName("worker-old")
+	_, _ = seedReviewGroup(t, iso, parentRecent, []string{"review-goal"}, "active")
+	oldGroupID, _ := seedReviewGroup(t, iso, parentOld, []string{"review-goal"}, "finished")
+
+	// Back-date the "old" group to 10 days ago. The *db.DB type does not
+	// expose Exec (intentionally — write surfaces are routed through
+	// helpers), so we open a sibling sqlite handle for this one-line
+	// fixture write. This is a test-only hack scoped to the iris reviews
+	// suite; production code never touches session_groups.created_at.
+	backdateCreatedAt(t, iso.Paths.DB, oldGroupID, time.Now().Add(-10*24*time.Hour))
+
+	// With --days 7 the old group is filtered out, the recent one stays.
+	out, err := runReviewsCommand(t, "reviews", "--days", "7")
+	if err != nil {
+		t.Fatalf("iris reviews --days 7: %v", err)
+	}
+	if !strings.Contains(out, "worker-recent") {
+		t.Errorf("expected 'worker-recent' in --days 7 output:\n%s", out)
+	}
+	if strings.Contains(out, "worker-old") {
+		t.Errorf("'worker-old' should be filtered out at --days 7:\n%s", out)
+	}
+
+	// With no filter both should appear.
+	outAll, err := runReviewsCommand(t, "reviews")
+	if err != nil {
+		t.Fatalf("iris reviews (no filter): %v", err)
+	}
+	if !strings.Contains(outAll, "worker-recent") || !strings.Contains(outAll, "worker-old") {
+		t.Errorf("expected both groups in unfiltered output:\n%s", outAll)
+	}
+}
+
+// TestReviewsList_NegativeDaysRejected asserts that --days < 0 is a
+// usage error (non-zero exit, descriptive message).
+func TestReviewsList_NegativeDaysRejected(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runReviewsCommand(t, "reviews", "--days", "-1")
+	if err == nil {
+		t.Fatalf("expected error for --days -1")
+	}
+	if !strings.Contains(err.Error(), "--days") {
+		t.Errorf("error should mention --days, got: %v", err)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iris reviews show <group_id>
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReviewsShow_ListsMembers seeds a group with the canonical 5 review
+// agents and asserts `iris reviews show <id>` prints each member's
+// session name and role.
+func TestReviewsShow_ListsMembers(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parent := iristest.SessionName("worker-show")
+	roles := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	groupID, members := seedReviewGroup(t, iso, parent, roles, "finished")
+
+	out, err := runReviewsCommand(t, "reviews", "show", groupID)
+	if err != nil {
+		t.Fatalf("iris reviews show: %v\n%s", err, out)
+	}
+
+	// Group header fields.
+	if !strings.Contains(out, groupID) {
+		t.Errorf("output missing group_id %q:\n%s", groupID, out)
+	}
+	if !strings.Contains(out, parent) {
+		t.Errorf("output missing parent session %q:\n%s", parent, out)
+	}
+	if !strings.Contains(out, "completed") {
+		t.Errorf("output missing 'completed' state:\n%s", out)
+	}
+
+	// Each member's session name and role should appear.
+	for i, role := range roles {
+		if !strings.Contains(out, members[i]) {
+			t.Errorf("output missing member %q:\n%s", members[i], out)
+		}
+		if !strings.Contains(out, role) {
+			t.Errorf("output missing role %q:\n%s", role, out)
+		}
+	}
+}
+
+// TestReviewsShow_JSON asserts that --json emits a JSON object with a
+// members array carrying state + role per member.
+func TestReviewsShow_JSON(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parent := iristest.SessionName("worker-show-json")
+	roles := []string{"review-goal", "review-code"}
+	groupID, _ := seedReviewGroup(t, iso, parent, roles, "finished")
+
+	out, err := runReviewsCommand(t, "reviews", "show", groupID, "--json")
+	if err != nil {
+		t.Fatalf("iris reviews show --json: %v\n%s", err, out)
+	}
+
+	var body reviewsShowJSON
+	if err := json.Unmarshal([]byte(out), &body); err != nil {
+		t.Fatalf("expected JSON object, got: %s\nerr: %v", out, err)
+	}
+	if body.GroupID != groupID {
+		t.Errorf("GroupID = %q, want %q", body.GroupID, groupID)
+	}
+	if body.ParentSession != parent {
+		t.Errorf("ParentSession = %q, want %q", body.ParentSession, parent)
+	}
+	if body.GroupState != "completed" {
+		t.Errorf("GroupState = %q, want 'completed'", body.GroupState)
+	}
+	if len(body.Members) != len(roles) {
+		t.Fatalf("Members = %d, want %d", len(body.Members), len(roles))
+	}
+	gotRoles := map[string]bool{}
+	for _, m := range body.Members {
+		gotRoles[m.Role] = true
+		if m.State != "finished" {
+			t.Errorf("member %s state = %q, want 'finished'", m.SessionName, m.State)
+		}
+		if m.LastSeen == "" {
+			t.Errorf("member %s has empty LastSeen", m.SessionName)
+		}
+	}
+	for _, want := range roles {
+		if !gotRoles[want] {
+			t.Errorf("expected role %q in JSON members, got: %+v", want, body.Members)
+		}
+	}
+}
+
+// TestReviewsShow_NoSuchGroup asserts that an unknown group_id exits
+// non-zero with a clear "no such review group" message.
+func TestReviewsShow_NoSuchGroup(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	_, err := runReviewsCommand(t, "reviews", "show", "deadbeef-not-a-group")
+	if err == nil {
+		t.Fatalf("expected error for missing group")
+	}
+	if !strings.Contains(err.Error(), "no such review group") {
+		t.Errorf("error should mention 'no such review group', got: %v", err)
+	}
+}
+
+// TestReviewsShow_EmptyGroup asserts that a group registered with no
+// members renders cleanly (header + "(no members)" sentinel) rather
+// than erroring.
+func TestReviewsShow_EmptyGroup(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parent := iristest.SessionName("worker-empty")
+	groupID, err := iso.DB.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	out, err := runReviewsCommand(t, "reviews", "show", groupID)
+	if err != nil {
+		t.Fatalf("iris reviews show (empty): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "(no members)") {
+		t.Errorf("expected '(no members)' sentinel, got:\n%s", out)
+	}
+	if !strings.Contains(out, groupID) {
+		t.Errorf("output missing group_id %q:\n%s", groupID, out)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: full review-cycle → list → show round-trip.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReviews_FullCycle_ListShow is the post-#1707 integration test
+// required by issue #1722's ACs: drive the review-spawn write path
+// against the DB, then exercise `iris reviews` to list it and `iris
+// reviews show <group>` to inspect its members. We register the group
+// and members directly (the equivalent of what the daemon-side
+// orchestrator writes) rather than spinning up the live ClientSocket —
+// that path has its own dedicated test (TestReview_FullCycle).
+func TestReviews_FullCycle_ListShow(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	withIsolatedDB(t, iso)
+
+	parent := iristest.SessionName("review-parent-integration")
+	roles := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	groupID, members := seedReviewGroup(t, iso, parent, roles, "finished")
+
+	// Step 1: `iris reviews` lists the group.
+	listOut, err := runReviewsCommand(t, "reviews")
+	if err != nil {
+		t.Fatalf("iris reviews: %v", err)
+	}
+	if !strings.Contains(listOut, parent) {
+		t.Errorf("list output missing parent %q:\n%s", parent, listOut)
+	}
+	if !strings.Contains(listOut, "completed") {
+		t.Errorf("list output missing 'completed' state:\n%s", listOut)
+	}
+
+	// Step 2: `iris reviews --json` returns the group_id.
+	jsonOut, err := runReviewsCommand(t, "reviews", "--json")
+	if err != nil {
+		t.Fatalf("iris reviews --json: %v", err)
+	}
+	var rows []reviewsJSONRow
+	if err := json.Unmarshal([]byte(jsonOut), &rows); err != nil {
+		t.Fatalf("expected JSON array: %v\n%s", err, jsonOut)
+	}
+	found := false
+	for _, r := range rows {
+		if r.GroupID == groupID {
+			found = true
+			if r.MemberCount != len(roles) {
+				t.Errorf("member_count = %d, want %d", r.MemberCount, len(roles))
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("group_id %q not found in --json output: %s", groupID, jsonOut)
+	}
+
+	// Step 3: `iris reviews show <group_id>` lists all 5 members.
+	showOut, err := runReviewsCommand(t, "reviews", "show", groupID)
+	if err != nil {
+		t.Fatalf("iris reviews show: %v\n%s", err, showOut)
+	}
+	for i, role := range roles {
+		if !strings.Contains(showOut, members[i]) {
+			t.Errorf("show output missing member %q:\n%s", members[i], showOut)
+		}
+		if !strings.Contains(showOut, role) {
+			t.Errorf("show output missing role %q:\n%s", role, showOut)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper-function unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestInferPRFromGroup covers the parent-branch heuristic for PR
+// extraction. The list / show surfaces both rely on this so a wrong
+// guess for one ripples to the other.
+func TestInferPRFromGroup(t *testing.T) {
+	cases := []struct {
+		parent string
+		want   int
+	}{
+		{"repo@pr-123", 123},
+		{"repo@pr456", 456},
+		{"repo@main", 0},
+		{"repo@feature-x", 0},
+		{"no-at-symbol", 0},
+		{"repo@pr-", 0},
+		{"repo@pr-0", 0},
+	}
+	for _, tc := range cases {
+		g := makeSummary(tc.parent, nil)
+		if got := inferPRFromGroup(g); got != tc.want {
+			t.Errorf("inferPRFromGroup(%q) = %d, want %d", tc.parent, got, tc.want)
+		}
+	}
+}
+
+// TestInferRoundFromGroup covers the per-member round-number parse.
+func TestInferRoundFromGroup(t *testing.T) {
+	cases := []struct {
+		members []string
+		want    int
+	}{
+		{[]string{"repo@main~review-1-review-goal"}, 1},
+		{[]string{"repo@main~review-3-review-code", "repo@main~review-3-review-qa"}, 3},
+		{[]string{"repo@main~not-a-review-session"}, 0},
+		{nil, 0},
+	}
+	for _, tc := range cases {
+		g := makeSummary("repo@main", tc.members)
+		if got := inferRoundFromGroup(g); got != tc.want {
+			t.Errorf("inferRoundFromGroup(%v) = %d, want %d", tc.members, got, tc.want)
+		}
+	}
+}
+
+// TestFormatDuration covers the human-readable duration buckets.
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{500 * time.Millisecond, "<1s"},
+		{3 * time.Second, "3s"},
+		{45 * time.Second, "45s"},
+		{2 * time.Minute, "2m"},
+		{59 * time.Minute, "59m"},
+		{1 * time.Hour, "1h"},
+		{1*time.Hour + 30*time.Minute, "1h30m"},
+		{25 * time.Hour, "1d1h"},
+		{48 * time.Hour, "2d"},
+	}
+	for _, tc := range cases {
+		if got := formatDuration(tc.in); got != tc.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// backdateCreatedAt rewrites session_groups.created_at for the given
+// group_id by opening a sibling read-write handle on the iris DB file.
+//
+// internal/db deliberately doesn't expose an Exec method, so to set up
+// the --days-filter fixture we open a one-shot sqlite handle, run the
+// UPDATE, and close immediately. WAL mode (set by iris.OpenDB on the
+// iso.DB handle) lets the two handles coexist.
+func backdateCreatedAt(t *testing.T, dbPath, groupID string, when time.Time) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("backdateCreatedAt: open: %v", err)
+	}
+	defer conn.Close()
+	// The session_groups.created_at column is stored as the SQLite
+	// CURRENT_TIMESTAMP textual form ("YYYY-MM-DD HH:MM:SS"). Use the
+	// same shape so the column scans back into time.Time on read.
+	ts := when.UTC().Format("2006-01-02 15:04:05")
+	if _, err := conn.Exec(`UPDATE session_groups SET created_at = ? WHERE group_id = ?`, ts, groupID); err != nil {
+		t.Fatalf("backdateCreatedAt: exec: %v", err)
+	}
+}
+
+// makeSummary is a tiny helper for the inference-function tests so we
+// don't allocate a full DB just to test pure string parsing.
+func makeSummary(parent string, members []string) db.ReviewGroupSummary {
+	return db.ReviewGroupSummary{ParentSession: parent, Members: members}
+}


### PR DESCRIPTION
Adds `iris reviews` — the iris analogue of `prism reviews`. Historical
review-group listing surface, distinct from `iris review <pr>` (which
spawns a new round).

## Surface

```
iris reviews                       # list recent groups, newest first
iris reviews --days N              # filter to last N days
iris reviews --json                # JSON array
iris reviews --limit N             # cap row count
iris reviews show <group_id>       # list members with state + timing
iris reviews show <group_id> --json
```

Column layout (`PR / ROUND / STATE / PARENT / N / AGE / AGENTS`) mirrors
`prism reviews list` so the two surfaces are visually consistent.

## Implementation

- New `cmd/iris/reviews.go` — cobra subcommand + JSON renderer.
- New `cmd/iris/reviews_test.go` — 13 tests covering list / show / JSON /
  --days filter / empty / no-such-group / round-trip integration test.
- Reuses existing `internal/db` helpers: `ReviewGroupsList` and
  `GroupMembersForGroup` (already added in #1500 for the prism surface).
  No internal/db churn — avoids overlap with the in-flight #1699 work.
- Read-only carve-out per #1676 — opens iris.db directly via
  `iris.OpenDB`. No daemon required. SQLite WAL lets us coexist with the
  running daemon.

## Acceptance criteria

- [x] `iris reviews` lists groups with PR / parent / member count /
      started / state.
- [x] `iris reviews --days N` filters.
- [x] `iris reviews --json` emits JSON array (`reviewsJSONRow` shape).
- [x] `iris reviews show <group_id>` lists members with role + state +
      timing.
- [x] Missing group → exit non-zero with `no such review group` error.
- [x] Empty ledger → `no reviews recorded` (exit 0).
- [x] `iris reviews --help` and `iris reviews show --help` documented.
- [x] Subcommand visible in `iris --help`.
- [x] Integration test `TestReviews_FullCycle_ListShow` exercises the
      list + show round-trip post-#1707 (seeds the group via the same
      DB writes the daemon-side orchestrator performs, then drives both
      CLI verbs).
- [x] `go test ./... -race` passes (one unrelated flake in
      `internal/iris/TestToolAbort` — escalated, passes in isolation,
      unrelated to this branch).
- [x] `nix build .#iris` succeeds.

## Test plan

```bash
cd modules/programs/prism/prism
go build ./...
go test ./cmd/iris/ -race -count=1   # 13 new tests
go test ./internal/db/ -race -count=1
nix build .#iris
./result/bin/iris reviews --help
./result/bin/iris --help | grep reviews
```

Closes #1722