### PR TITLE
fix(sidecar,review): inactivity watchdog + monitor-side force-terminate for stuck review agents (#1709)

### DIFF
--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -103,3 +103,9 @@ func BuildLoopLimitFooterForTest(cycles int, prNumber string) string {
 func CurrentCycleProducedVerdictsForTest(groupData map[string]db.GroupMemberResult) bool {
 	return currentCycleProducedVerdicts(groupData)
 }
+
+// ForceTerminateStuckMembersForTest is an exported wrapper around
+// forceTerminateStuckMembers for use in external test packages (#1709).
+func ForceTerminateStuckMembersForTest(d *db.DB, agentSessions []string, perAgentTimeout time.Duration) {
+	forceTerminateStuckMembers(d, agentSessions, perAgentTimeout)
+}

--- a/modules/programs/prism/prism/internal/review/force_terminate_test.go
+++ b/modules/programs/prism/prism/internal/review/force_terminate_test.go
@@ -1,0 +1,136 @@
+package review_test
+
+// force_terminate_test.go — coverage for forceTerminateStuckMembers (#1709).
+//
+// When the monitor's outer safety timeout fires, any review-agent row still
+// in a non-terminal state must be force-transitioned to "error" so that
+// GroupCompleted returns true on subsequent calls and a future
+// `prism review` for the same parent can run instead of being refused with
+// "round N already in progress".
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// TestForceTerminateStuckMembers_TransitionsActiveRows verifies the core
+// invariant: an active row is rewritten to "error" by the sweep.
+func TestForceTerminateStuckMembers_TransitionsActiveRows(t *testing.T) {
+	d := openTestDB(t)
+	stuck := "prism-test@invoker-force-terminate~review-1-review-goal"
+	if err := d.UpsertStatus(stuck, "testrepo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	review.ForceTerminateStuckMembersForTest(d, []string{stuck}, 10*time.Minute)
+
+	status, err := d.CurrentStatus(stuck)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("session row disappeared after sweep")
+	}
+	if status.State != "error" {
+		t.Errorf("state after sweep: got %q, want %q", status.State, "error")
+	}
+}
+
+// TestForceTerminateStuckMembers_LeavesTerminalRowsAlone verifies the sweep
+// is state-idempotent: rows already in a terminal state must not be
+// overwritten. Without this guard the sweep could clobber a real `finished`
+// verdict if it raced a slow GroupCompleted reload.
+func TestForceTerminateStuckMembers_LeavesTerminalRowsAlone(t *testing.T) {
+	d := openTestDB(t)
+	terminalStates := []string{"finished", "error", "interrupted", "deleted"}
+	sessions := make([]string, 0, len(terminalStates))
+	for _, state := range terminalStates {
+		sess := "prism-test@invoker-force-terminate-terminal~review-1-review-" + state
+		if err := d.UpsertStatus(sess, "testrepo", "/wt", state, nil, nil); err != nil {
+			t.Fatalf("seed %q: %v", sess, err)
+		}
+		sessions = append(sessions, sess)
+	}
+
+	review.ForceTerminateStuckMembersForTest(d, sessions, 10*time.Minute)
+
+	for i, sess := range sessions {
+		status, err := d.CurrentStatus(sess)
+		if err != nil {
+			t.Fatalf("CurrentStatus(%q): %v", sess, err)
+		}
+		if status == nil {
+			t.Fatalf("session %q disappeared", sess)
+		}
+		if status.State != terminalStates[i] {
+			t.Errorf("session %q state: got %q, want %q (sweep clobbered terminal state)",
+				sess, status.State, terminalStates[i])
+		}
+	}
+}
+
+// TestForceTerminateStuckMembers_SkipsMissingRows verifies that a non-existent
+// session name in the input list is silently skipped rather than causing the
+// sweep to fail. Missing rows correspond to agents whose `prism cleanup` ran
+// concurrently with the monitor's safety timeout.
+func TestForceTerminateStuckMembers_SkipsMissingRows(t *testing.T) {
+	d := openTestDB(t)
+	live := "prism-test@invoker-force-terminate-mixed~review-1-review-goal"
+	if err := d.UpsertStatus(live, "testrepo", "/wt", "active", nil, nil); err != nil {
+		t.Fatalf("seed live: %v", err)
+	}
+
+	// Mix of missing (never seeded), empty, and live sessions.
+	review.ForceTerminateStuckMembersForTest(d,
+		[]string{"", "prism-test@invoker-does-not-exist", live},
+		10*time.Minute)
+
+	status, err := d.CurrentStatus(live)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil || status.State != "error" {
+		gotState := "<nil>"
+		if status != nil {
+			gotState = status.State
+		}
+		t.Errorf("live session state after mixed-input sweep: got %q, want error", gotState)
+	}
+}
+
+// TestForceTerminateStuckMembers_LeavesEndedRowsAlone verifies that rows with
+// ended_at set (closed by `prism cleanup` or `prism reset`) are skipped. Such
+// rows already count as terminal for GroupCompleted's ended_at arm, so a
+// state rewrite would be wasted work and could mask the true terminal cause
+// from forensic inspection.
+func TestForceTerminateStuckMembers_LeavesEndedRowsAlone(t *testing.T) {
+	d := openTestDB(t)
+	ended := "prism-test@invoker-force-terminate-ended~review-1-review-goal"
+	// Seed in a non-terminal state then SetEnded to simulate `prism cleanup`'s
+	// state="interrupted" + ended_at write.
+	if err := d.UpsertStatus(ended, "testrepo", "/wt", "interrupted", nil, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := d.SetEnded(ended); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	review.ForceTerminateStuckMembersForTest(d, []string{ended}, 10*time.Minute)
+
+	status, err := d.CurrentStatus(ended)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("session row disappeared")
+	}
+	if status.State != "interrupted" {
+		t.Errorf("state after sweep on ended row: got %q, want %q (sweep clobbered an ended-row's state)",
+			status.State, "interrupted")
+	}
+	if status.EndedAt == nil {
+		t.Error("ended_at was cleared by sweep — must be preserved")
+	}
+}

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -116,9 +116,11 @@ func MonitorFunc(opts MonitorOpts) error {
 	}
 
 	// Poll loop: check GroupCompleted every pollInterval.
+	timedOut := false
 	for {
 		if !deadline.IsZero() && time.Now().After(deadline) {
 			fmt.Fprintf(os.Stderr, "[prism monitor-review] timeout reached for group %s — delivering partial results\n", opts.GroupID)
+			timedOut = true
 			break
 		}
 
@@ -131,6 +133,18 @@ func MonitorFunc(opts MonitorOpts) error {
 		}
 
 		time.Sleep(pollInterval)
+	}
+
+	// If the outer safety timeout fired, force-terminate any remaining
+	// non-terminal members (#1709). Without this, agent rows stay in
+	// `active` indefinitely, GroupCompleted keeps returning false on the
+	// next call, and a subsequent `prism review` for the same parent
+	// refuses with "round N already in progress". The per-session sidecar
+	// inactivity watchdog should normally cover this case, but the monitor
+	// adds a belt-and-braces sweep for sessions whose sidecar died,
+	// crashed, or was misconfigured with ActivityTimeout=0.
+	if timedOut {
+		forceTerminateStuckMembers(d, opts.AgentSessions, opts.Timeout)
 	}
 
 	// Aggregate results.
@@ -217,6 +231,48 @@ func MonitorFunc(opts MonitorOpts) error {
 
 	fmt.Fprintf(os.Stderr, "[prism monitor-review] results delivered to %s\n", opts.WorkerSession)
 	return nil
+}
+
+// forceTerminateStuckMembers walks the given session names and transitions any
+// row still in a non-terminal state to `error` so the monitor's safety-timeout
+// path leaves the review group genuinely terminal (#1709).
+//
+// Without this sweep, a row stuck at state="active" past the safety deadline
+// keeps GroupCompleted returning false, blocks ActiveReviewGroupForParent
+// from clearing, and forces the worker into manual `prism cleanup` recovery.
+// The per-session sidecar inactivity watchdog should normally rescue these
+// rows long before the monitor's outer timeout fires; this is the belt-and-
+// braces fallback for the case where the sidecar itself is unreachable
+// (crashed, killed without cleanup, etc.).
+//
+// All failures are logged but non-fatal: a stuck DB row is recoverable via
+// `prism cleanup`, but a hard error here would also block the partial
+// review-results delivery the monitor has already promised the worker.
+func forceTerminateStuckMembers(d *db.DB, agentSessions []string, perAgentTimeout time.Duration) {
+	for _, sess := range agentSessions {
+		if sess == "" {
+			continue
+		}
+		status, err := d.CurrentStatus(sess)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: CurrentStatus(%s) during force-terminate sweep: %v\n", sess, err)
+			continue
+		}
+		if status == nil {
+			continue
+		}
+		if status.EndedAt != nil {
+			continue
+		}
+		if isTerminalAgentState(status.State) {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "[prism monitor-review] force-terminating stuck member %s (state=%q, per-agent timeout=%v)\n",
+			sess, status.State, perAgentTimeout)
+		if err := d.UpsertStatus(sess, status.Repo, status.Worktree, "error", nil, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: UpsertStatus(%s, error): %v\n", sess, err)
+		}
+	}
 }
 
 // buildMonitorResults constructs AgentResult entries from GroupResults data,

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2078,6 +2078,13 @@ func reviewProfilesFileMissingOneSlot() *config.ProfilesFile {
 // review-agent slots, and that no progress lines are emitted (i.e. no agent
 // spawn was attempted). This is the all-or-nothing AC from #1224.
 func TestRun_RequireSlot_MissingSlot_AbortsAllSpawns(t *testing.T) {
+	// Redirect sidecar state dir so any sidecar pid/log files created by
+	// review.Run's host-mode spawn path land in a tempdir, not the real
+	// $HOME/.local/state/prism/run/ (#1709 follow-up — defence in depth
+	// against test-isolation breaches that surfaced via cross-package
+	// timing changes after #1690 landed on main).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
 	dbPath := filepath.Join(t.TempDir(), "prism.db")
 
 	pf := reviewProfilesFileMissingOneSlot()
@@ -2125,6 +2132,14 @@ func TestRun_RequireSlot_MissingSlot_AbortsAllSpawns(t *testing.T) {
 // the active profile. In host mode with no real agent, SpawnSession will
 // fail for other reasons — but the RequireSlot gate must not be the cause.
 func TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort(t *testing.T) {
+	// Redirect sidecar state dir so any sidecar pid/log files created by
+	// review.Run's host-mode spawn path land in a tempdir, not the real
+	// $HOME/.local/state/prism/run/. Without this, the pid files leak to
+	// host state and TestNotifyInvestigatorCompletion_NoHostBusLeak in the
+	// sidecar package observes them disappear when this test cleans up,
+	// flaking under parallel `go test ./...` scheduling (#1709 follow-up).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
 	dbPath := filepath.Join(t.TempDir(), "prism.db")
 
 	pf := reviewProfilesFileWithAllSlots()
@@ -2154,6 +2169,11 @@ func TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort(t *testing.T) {
 // review.RunAsync also aborts the fan-out when the active profile is missing
 // a review slot (#1224 — both sync and async paths are gated).
 func TestRunAsync_RequireSlot_MissingSlot_AbortsAllSpawns(t *testing.T) {
+	// Redirect sidecar state dir so any sidecar pid/log files created by
+	// review.RunAsync's host-mode spawn path land in a tempdir, not the
+	// real $HOME/.local/state/prism/run/ (#1709 follow-up).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
 	dbPath := filepath.Join(t.TempDir(), "prism.db")
 	d, err := db.Open(dbPath)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -16,6 +16,11 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Reset the inactivity watchdog (#1709): any inbound event counts as
+	// activity. The watchdog only fires after cfg.ActivityTimeout of
+	// continuous silence (no-op when disabled).
+	s.touchActivity()
+
 	// Delegate harness-specific event type extraction to the harness adapter.
 	// Some harnesses send all events as plain `data:` lines with no `event:` field;
 	// the real event type is embedded in the JSON `type` field of the payload.

--- a/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
@@ -26,8 +26,14 @@ import (
 // Returns the sidecar and the testClock so callers can drive the timer
 // manually. Named to avoid colliding with newReviewAgentSidecar in
 // sidecar_test.go (different signature, different purpose).
+//
+// Host-state isolation: redirects $XDG_STATE_HOME to a tempdir so any
+// path lookup performed by the sidecar (e.g. notifyParentWorker on
+// watchdog fire) cannot reach the real prism state directory (#1709,
+// issue #1608 defence in depth).
 func newReviewAgentSidecarWithActivityTimeout(t *testing.T, sockPath string, activityTimeout time.Duration) (*Sidecar, *testClock) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{

--- a/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
@@ -1,0 +1,291 @@
+package sidecar
+
+// inactivity_watchdog_test.go — coverage for the per-session inactivity
+// watchdog added by #1709 to rescue review agents that complete substantive
+// work but never emit state_change{finished}.
+//
+// The watchdog is a Sidecar-side timer that resets on every inbound frame
+// (handlePipeFrame or HandleEvent). When it fires (after Config.ActivityTimeout
+// of total silence), the session is force-transitioned to StateError with note
+// "inactivity timeout" so the review-group monitor's GroupCompleted check
+// returns true and the worker is freed.
+
+import (
+	"testing"
+	"time"
+
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// newReviewAgentSidecarWithActivityTimeout builds a Sidecar with
+// AgentRole="review-goal" and an explicit ActivityTimeout so the inactivity-
+// watchdog path is exercisable in unit tests without real wall-clock waits.
+// Returns the sidecar and the testClock so callers can drive the timer
+// manually. Named to avoid colliding with newReviewAgentSidecar in
+// sidecar_test.go (different signature, different purpose).
+func newReviewAgentSidecarWithActivityTimeout(t *testing.T, sockPath string, activityTimeout time.Duration) (*Sidecar, *testClock) {
+	t.Helper()
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@main~review-1-review-goal",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "review-goal",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		PipeReconnectTimeout:  200 * time.Millisecond,
+		ActivityTimeout:       activityTimeout,
+		IsolationMode:         config.IsolationMode("host"),
+		Harness:               pih.New("", "", ""),
+	}
+	return New(cfg), clk
+}
+
+// TestReviewAgent_DefaultActivityTimeout verifies that New() defaults
+// ActivityTimeout to DefaultReviewAgentInactivityTimeout for review-agent
+// roles (AC: the rescue path is opt-in via role, not by explicit caller).
+func TestReviewAgent_DefaultActivityTimeout(t *testing.T) {
+	d := openTestDB(t)
+	for _, role := range []string{
+		"review-goal", "review-code", "review-context",
+		"review-qa", "review-security",
+	} {
+		t.Run(role, func(t *testing.T) {
+			sc := New(Config{
+				SessionName: "testrepo@main~review-1-" + role,
+				Repo:        "testrepo",
+				DB:          d,
+				AgentRole:   role,
+				HarnessName: "pi",
+				Harness:     pih.New("", "", ""),
+			})
+			if sc.cfg.ActivityTimeout != DefaultReviewAgentInactivityTimeout {
+				t.Errorf("review agent role %q: ActivityTimeout = %v, want %v",
+					role, sc.cfg.ActivityTimeout, DefaultReviewAgentInactivityTimeout)
+			}
+		})
+	}
+}
+
+// TestNonReviewAgent_NoDefaultActivityTimeout verifies that workers and
+// coordinators are NOT given a default inactivity timeout. These sessions
+// may sit idle awaiting human or peer input for long periods; the watchdog
+// is review-agent-only.
+func TestNonReviewAgent_NoDefaultActivityTimeout(t *testing.T) {
+	d := openTestDB(t)
+	for _, role := range []string{"worker", "coordinator", "", "investigate"} {
+		t.Run("role="+role, func(t *testing.T) {
+			sc := New(Config{
+				SessionName: "testrepo@main",
+				Repo:        "testrepo",
+				DB:          d,
+				AgentRole:   role,
+				HarnessName: "pi",
+				Harness:     pih.New("", "", ""),
+			})
+			if sc.cfg.ActivityTimeout != 0 {
+				t.Errorf("non-review role %q: ActivityTimeout = %v, want 0",
+					role, sc.cfg.ActivityTimeout)
+			}
+		})
+	}
+}
+
+// TestExplicitActivityTimeout_PreservedForAnyRole verifies that an explicit
+// non-zero ActivityTimeout is preserved in New() for any role, so operators
+// who want a workers-wide watchdog can opt into one without touching the
+// review-agent default.
+func TestExplicitActivityTimeout_PreservedForAnyRole(t *testing.T) {
+	d := openTestDB(t)
+	for _, role := range []string{"worker", "coordinator", "review-goal", ""} {
+		t.Run("role="+role, func(t *testing.T) {
+			explicit := 42 * time.Minute
+			sc := New(Config{
+				SessionName:     "testrepo@main",
+				Repo:            "testrepo",
+				DB:              d,
+				AgentRole:       role,
+				HarnessName:     "pi",
+				Harness:         pih.New("", "", ""),
+				ActivityTimeout: explicit,
+			})
+			if sc.cfg.ActivityTimeout != explicit {
+				t.Errorf("explicit ActivityTimeout for role %q: got %v, want %v",
+					role, sc.cfg.ActivityTimeout, explicit)
+			}
+		})
+	}
+}
+
+// TestInactivityWatchdog_FiresAfterTurnEndWithNoStateChange reproduces the
+// exact stall described in issue #1709: a review agent receives turn_start,
+// streams an assistant message, sends turn_end, then never emits
+// state_change{finished} (because the LLM stopReason was not "stop"). The
+// session must be force-transitioned to StateError so GroupCompleted returns
+// true and the review monitor can deliver.
+func TestInactivityWatchdog_FiresAfterTurnEndWithNoStateChange(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newReviewAgentSidecarWithActivityTimeout(t, sockPath, 30*time.Second)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive the agent through a normal turn that ends without
+	// state_change{finished} — the stall pattern.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "I checked the build and tests; all green."})
+	sendJSON(t, conn, map[string]any{"type": "turn_end"})
+
+	// The state should be active after turn_start. Wait for it to land in the
+	// DB so the assertion is not racing the inbound-frame handler.
+	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second); got != string(agent.StateActive) {
+		t.Fatalf("state after turn_start: got %q, want %q", got, agent.StateActive)
+	}
+
+	// The watchdog is re-armed on every inbound frame, so the latest timer
+	// registered is the live one (older timers have been Stop()ed). Wait
+	// until the post-turn_end re-arm has happened, then fire that timer.
+	// Timer registration order so far:
+	//   #1 armed by the post-handshake touchActivity()
+	//   #2 armed by turn_start's touchActivity()
+	//   #3 armed by msg_assistant's touchActivity()
+	//   #4 armed by turn_end's touchActivity()  ← the one we want
+	timer := clk.WaitForTimerCount(4, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no activity watchdog timer was registered after turn_end")
+	}
+	// Fire the watchdog — simulates the full ActivityTimeout of silence
+	// post-turn_end.
+	timer.Fire()
+
+	// The session must reach StateError; GroupCompleted will then return true.
+	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateError), 2*time.Second); got != string(agent.StateError) {
+		t.Fatalf("state after inactivity timeout: got %q, want %q", got, agent.StateError)
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// TestInactivityWatchdog_ResetByInboundFrame verifies that any inbound frame
+// resets the watchdog. Without this property the watchdog would falsely fire
+// on agents doing legitimate long-running tool calls that punctuate the
+// silence with tool_call/tool_result frames.
+func TestInactivityWatchdog_ResetByInboundFrame(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newReviewAgentSidecarWithActivityTimeout(t, sockPath, 30*time.Second)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+
+	// First watchdog timer (armed after handshake or first frame).
+	t1 := clk.WaitForTimerCount(1, 5*time.Second)
+	if t1 == nil {
+		t.Fatal("no watchdog timer after first inbound frame")
+	}
+
+	// Send another frame. The handler must Stop() t1 and arm a new timer.
+	sendJSON(t, conn, map[string]any{"type": "tool_call", "toolName": "bash"})
+	if !t1.WaitStopped(5 * time.Second) {
+		t.Fatal("watchdog timer was not stopped by a subsequent inbound frame")
+	}
+	// A new timer must now exist.
+	t2 := clk.WaitForTimerCount(2, 5*time.Second)
+	if t2 == nil {
+		t.Fatal("no new watchdog timer was registered after the reset frame")
+	}
+	if t2 == t1 {
+		t.Fatal("expected a fresh watchdog timer after reset, got the same instance")
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// TestInactivityWatchdog_DisabledForWorker verifies that a worker session
+// (ActivityTimeout=0) never registers a watchdog timer. This is the
+// safety property protecting non-review sessions from accidental
+// force-termination when they sit waiting on a human prompt or a slow
+// review-complete delivery.
+func TestInactivityWatchdog_DisabledForWorker(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive frames; no watchdog timer should be registered (only finished-
+	// debounce-style timers, which require state_change{finished}).
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "tool_call", "toolName": "bash"})
+	sendJSON(t, conn, map[string]any{"type": "turn_end"})
+
+	// Give the sidecar a moment to process the frames.
+	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second); got != string(agent.StateActive) {
+		t.Fatalf("worker state after turn_start: got %q, want active", got)
+	}
+	if n := clk.TimerCount(); n != 0 {
+		// We expect ZERO timers because there is no state_change{finished}
+		// (which would arm the 2s finished-debounce) AND ActivityTimeout=0
+		// (so touchActivity is a no-op).
+		t.Errorf("worker registered %d timer(s); want 0 with ActivityTimeout=0", n)
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// TestInactivityWatchdog_NoOpWhenAlreadyTerminal verifies the watchdog is
+// state-idempotent: if the session has already reached a terminal state via
+// a normal path (state_change{finished} → debounce → StateFinished), firing
+// the watchdog must not overwrite that state.
+func TestInactivityWatchdog_NoOpWhenAlreadyTerminal(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newReviewAgentSidecarWithActivityTimeout(t, sockPath, 30*time.Second)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	// Timer registration order:
+	//   #1 activity watchdog (armed post-handshake by touchActivity)
+	//   #2 activity watchdog (armed by turn_start's touchActivity, replacing #1)
+	//   #3 activity watchdog (armed by state_change's touchActivity, replacing #2)
+	//   #4 finished debounce (armed by handleSessionFinished after state_change)
+	finishedDebounce := clk.WaitForTimerCount(4, 5*time.Second)
+	if finishedDebounce == nil {
+		t.Fatal("no finished-debounce timer registered")
+	}
+	finishedDebounce.Fire()
+	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateFinished), 2*time.Second); got != string(agent.StateFinished) {
+		t.Fatalf("state after finished debounce: got %q, want finished", got)
+	}
+
+	// Now fire the live activity watchdog (timer #3) — must be a no-op
+	// because the session is already terminal. Timer #3 was Stop()ed but
+	// testTimer.Fire still invokes the closure when called directly; we
+	// instead drive the closure on a *non-stopped* clone path by re-arming
+	// touchActivity. Simpler: trigger handleActivityTimeout directly with the
+	// timeout argument and assert state is unchanged. The closure obeys the
+	// same terminal-state guard regardless of which timer instance armed it.
+	sc.handleActivityTimeout(sc.cfg.ActivityTimeout)
+
+	// State must remain finished.
+	if got := getState(t, sc.cfg.DB, sc.cfg.SessionName); got != string(agent.StateFinished) {
+		t.Errorf("state after watchdog fire on terminal session: got %q, want finished (watchdog must be no-op when terminal)", got)
+	}
+
+	conn.Close()
+	_ = wait()
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -91,6 +91,25 @@ const ReconnectRecoveryDelay = 60 * time.Second
 // would see a spurious "finished" notification.
 const ErrorResumeDebounce = 5 * time.Second
 
+// DefaultReviewAgentInactivityTimeout is the default per-session inactivity
+// watchdog window for review-agent sessions (#1709). When no inbound frame
+// arrives from the PI extension (turn_start, turn_end, msg_assistant,
+// state_change, tool_call, tool_result, etc.) for this duration, the sidecar
+// force-transitions the session to StateError with a "inactivity timeout"
+// note so the review group can complete and a follow-up `prism review` can
+// proceed.
+//
+// Set to 15 minutes by default: long enough to comfortably accommodate any
+// tool call a review agent legitimately runs (build, vet, `go test ./...`,
+// `nix build`), short enough to keep the recovery window inside the review
+// monitor's 20-minute safety timeout (2× per-agent timeout of 10m).
+//
+// Only applied to sessions whose AgentRole is a known review-agent role; for
+// all other sessions Config.ActivityTimeout remains 0 (disabled). Workers and
+// coordinators have legitimate long-idle windows (waiting on a coordinator
+// reply, waiting on a human prompt) and must not be force-transitioned.
+const DefaultReviewAgentInactivityTimeout = 15 * time.Minute
+
 // Clock abstracts time and timer operations for testing.
 type Clock interface {
 	Now() time.Time
@@ -217,6 +236,15 @@ type Config struct {
 	// to pipeDisconnectTimeout (30s) when zero. Set to a small value in tests
 	// to avoid real wall-clock waits on the reconnect path.
 	PipeReconnectTimeout time.Duration
+	// ActivityTimeout is the duration of inbound-frame silence after which the
+	// sidecar force-transitions the session to StateError with note="inactivity
+	// timeout" (#1709). The watchdog is reset on every inbound frame received
+	// from the PI extension or SSE harness. Zero disables the watchdog
+	// (default for workers, coordinators, and other non-review sessions). For
+	// review-agent sessions, New() defaults this to
+	// DefaultReviewAgentInactivityTimeout when zero. Set to a small value in
+	// tests to exercise the timeout path deterministically.
+	ActivityTimeout time.Duration
 	// HarnessBinaryPath is the path to the harness binary used by
 	// runStartupStdio for TransportStdioPipe harnesses. The binary is launched
 	// inside a bwrap sandbox (when bwrap is available); the sidecar reads its
@@ -405,6 +433,15 @@ type Sidecar struct {
 	//
 	// Protected by s.mu.
 	reviewingInFlight bool
+
+	// activityTimer is the per-session inactivity watchdog (#1709). It is
+	// (re-)armed by touchActivity() on every inbound frame from the PI
+	// extension (handlePipeFrame) or the SSE harness (HandleEvent). If it
+	// fires — i.e. cfg.ActivityTimeout has elapsed with no inbound frame — the
+	// session is force-transitioned to StateError with note="inactivity
+	// timeout". nil when the watchdog is disabled (cfg.ActivityTimeout == 0).
+	// Protected by s.mu.
+	activityTimer Timer
 }
 
 // New creates a Sidecar with the given configuration.
@@ -439,6 +476,16 @@ func New(cfg Config) *Sidecar {
 	// empty (#555).
 	if cfg.AgentRole != "" {
 		s.rootAgent = cfg.AgentRole
+	}
+	// Default the inactivity watchdog for review-agent sessions (#1709). The
+	// watchdog is opt-in for every other role: workers, coordinators, and
+	// investigate agents may legitimately sit idle awaiting human or peer
+	// input, so force-transitioning them on a silence window would corrupt
+	// normal flow. Review agents, by contrast, have no human-in-the-loop
+	// branch and a stuck review-agent row blocks the whole review group's
+	// completion path — hence the default rescue here.
+	if s.cfg.ActivityTimeout == 0 && reviewAgentAllowlist[cfg.AgentRole] {
+		s.cfg.ActivityTimeout = DefaultReviewAgentInactivityTimeout
 	}
 	return s
 }
@@ -926,6 +973,7 @@ func (s *Sidecar) Shutdown() {
 
 	s.cancelIdleTimer()
 	s.cancelRecoveryTimer()
+	s.cancelActivityTimer()
 
 	if s.lastState != agent.StateFinished &&
 		s.lastState != agent.StateDeleted &&
@@ -1759,6 +1807,11 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			s.mu.Lock()
 			if !s.shuttingDown {
 				s.writeStateChange(agent.StateActive)
+				// Arm the inactivity watchdog once the session is active
+				// (#1709). Subsequent inbound frames reset the timer via
+				// touchActivity(); if the very first inbound frame never
+				// arrives the watchdog still fires after the full window.
+				s.touchActivity()
 			}
 			if s.cfg.OnReady != nil && !s.shuttingDown {
 				go s.cfg.OnReady()
@@ -1864,6 +1917,11 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Reset the inactivity watchdog (#1709): any inbound frame counts as
+	// activity, so the watchdog only fires after a full silence window.
+	// No-op when cfg.ActivityTimeout is zero (disabled for non-review roles).
+	s.touchActivity()
 
 	switch frame.Type {
 	case "state_change":

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -24,6 +25,93 @@ func (s *Sidecar) cancelRecoveryTimer() {
 		s.recoveryTimer.Stop()
 		s.recoveryTimer = nil
 	}
+}
+
+// cancelActivityTimer cancels the inactivity watchdog (#1709). Must be called
+// with s.mu held.
+func (s *Sidecar) cancelActivityTimer() {
+	if s.activityTimer != nil {
+		s.activityTimer.Stop()
+		s.activityTimer = nil
+	}
+}
+
+// touchActivity resets the inactivity watchdog (#1709). Called on every
+// inbound frame from the PI extension (handlePipeFrame) and the SSE harness
+// (HandleEvent) so that any sign of life from the agent restarts the
+// countdown. A no-op when cfg.ActivityTimeout is zero (watchdog disabled)
+// or when the session has already been shut down. Must be called with s.mu
+// held.
+//
+// When the timer fires (no inbound frame for the full window), the closure
+// invokes handleActivityTimeout, which force-transitions the session to
+// StateError with note="inactivity timeout". The transition is
+// state-idempotent: it is a no-op if the session has already reached a
+// terminal state through a normal path.
+func (s *Sidecar) touchActivity() {
+	if s.cfg.ActivityTimeout <= 0 {
+		return
+	}
+	if s.shuttingDown {
+		return
+	}
+	if s.activityTimer != nil {
+		s.activityTimer.Stop()
+		s.activityTimer = nil
+	}
+	timeout := s.cfg.ActivityTimeout
+	s.activityTimer = s.cfg.Clock.AfterFunc(timeout, func() {
+		s.handleActivityTimeout(timeout)
+	})
+}
+
+// handleActivityTimeout is the inactivity-watchdog fire callback (#1709). It
+// runs on the Clock's timer goroutine without s.mu held. Acquires s.mu,
+// checks that the session is still in a non-terminal state, writes a
+// state_change{error} event with note="inactivity timeout", and notifies the
+// parent worker via the existing review-agent startup-failure delivery path
+// so a stalled review agent surfaces a real signal to its worker rather than
+// hanging silently.
+func (s *Sidecar) handleActivityTimeout(timeout interface{}) {
+	s.mu.Lock()
+	s.activityTimer = nil
+
+	if s.shuttingDown {
+		s.mu.Unlock()
+		return
+	}
+
+	// Re-check current state under the lock. If the session has already
+	// reached a terminal state via a normal path (state_change{finished},
+	// session_shutdown, etc.), the watchdog is a no-op.
+	current := s.currentDBState()
+	if current == agent.StateFinished || current == agent.StateError ||
+		current == agent.StateInterrupted {
+		s.logger().Printf("sidecar: inactivity watchdog fired but session already terminal (state=%s) — no-op", current)
+		s.mu.Unlock()
+		return
+	}
+
+	s.logger().Printf("sidecar: inactivity watchdog fired after %v — transition -> error (cause=inactivity_timeout)", timeout)
+	s.cancelIdleTimer()
+	s.cancelRecoveryTimer()
+	s.upsertState(agent.StateError, nil, nil)
+	s.writeStateChange(agent.StateError)
+	s.writeEvent("state_change", map[string]string{
+		"state": string(agent.StateError),
+		"note":  fmt.Sprintf("inactivity timeout after %v", timeout),
+	}, nil)
+	s.lastState = agent.StateError
+	s.lastErrorAt = s.cfg.Clock.Now()
+	s.mu.Unlock()
+
+	// Notify the parent worker on the same channel used for startup
+	// failures so review agents that stall mid-turn surface a real signal
+	// rather than disappearing into the GroupCompleted timeout. The helper
+	// no-ops for non-review-agent session names, so workers and
+	// coordinators that opt into ActivityTimeout do not generate spurious
+	// parent notifications.
+	go s.notifyParentWorkerOnStartupFailure(fmt.Errorf("inactivity timeout: no inbound frame for %v", timeout))
 }
 
 func (s *Sidecar) currentDBState() agent.AgentState {


### PR DESCRIPTION
## Summary

Fixes the recurring infrastructure bug where review agents complete substantive work but never emit their final verdict — leaving them stuck in `active` state, blocking subsequent `prism review` calls on the same PR with "round N already in progress" and forcing coordinator-side manual `prism cleanup`.

## Diagnosis (posted on the issue before code changes — AC #1)

Full analysis in [issue comment](https://github.com/prismatic-koi/nixos-config/issues/1709#issuecomment-4465453081). Short version:

- **Hypothesis 4 is the root cause** (pi-extension `state_change` emission gap). The PI extension only emits `state_change{finished}` when `stopReason === "stop"`. Any other stopReason (`toolUse`, `length`, `error`, `undefined`) returns signal `"none"` and the sidecar waits indefinitely for a state transition that never arrives.
- **Hypothesis 1** (LLM-side stall) is the upstream trigger (LLM hits length cap, network hiccup mid-tool, etc.).
- **Hypotheses 2 and 3 don't fit**: the pipe-reconnect timeout (30 s) covers (2), and there is no group-level subscriber callback to wedge for (3) — the "monitor" is a 5 s `db.GroupCompleted` poll with no shared writer.

Symptoms match exactly: last assistant message is conversational, build/test output is complete, multiple agents on the same group stall together (correlated upstream stall, not group-level state).

## What changed

Two-layered fix — root-cause rescue plus belt-and-braces fallback.

### 1. Sidecar per-session inactivity watchdog (`internal/sidecar/`)

- New `Config.ActivityTimeout`. Defaults to `DefaultReviewAgentInactivityTimeout` (15 min) for review-agent roles via `New()`; 0 (disabled) for workers / coordinators / investigate agents — they may legitimately sit idle awaiting human input and must not be force-transitioned.
- `touchActivity()` resets the timer on every inbound frame from both transports:
  - PI socket-pipe path (`handlePipeFrame`)
  - SSE path (`HandleEvent`)
- On fire, force-transition to `StateError` with note `"inactivity timeout"`, notify the parent worker via the existing review-agent startup-failure delivery channel.
- State-idempotent: no-op when the session has already reached a terminal state through a normal path (finished-debounce, session_shutdown, state_change{error}).
- Documented and configurable via `Config.ActivityTimeout` (AC: "If timeout escalation path added, it's documented and configurable").

### 2. Monitor-side force-terminate sweep (`internal/review/monitor.go`)

When `monitor-review`'s outer safety timeout fires (default 20 min = 2× per-agent), walk the agent sessions and force-terminate any row still in a non-terminal state. Without this, a stuck row keeps `GroupCompleted` returning false on the next call and blocks future `prism review` invocations even though the monitor has already given up.

The per-session watchdog should normally cover this case; this is the fallback for the case where the sidecar itself is unreachable (crashed, killed, etc.). State-idempotent: leaves terminal rows and ended-row rows alone.

## Coverage

All tests passing under `-race -count=20`:

- `TestReviewAgent_DefaultActivityTimeout` — opt-in by role for all 5 review-agent names
- `TestNonReviewAgent_NoDefaultActivityTimeout` — worker/coordinator/empty/investigate untouched
- `TestExplicitActivityTimeout_PreservedForAnyRole` — caller override honoured for any role
- `TestInactivityWatchdog_FiresAfterTurnEndWithNoStateChange` — **reproduces #1709 exactly**: turn_start → msg_assistant → turn_end with no state_change{finished}, watchdog fires, session transitions to error, GroupCompleted unblocked
- `TestInactivityWatchdog_ResetByInboundFrame` — long-running tool calls (any inbound frame) safely reset the timer
- `TestInactivityWatchdog_DisabledForWorker` — zero spurious timers for non-review roles
- `TestInactivityWatchdog_NoOpWhenAlreadyTerminal` — normal finished-debounce path wins; watchdog does not clobber
- `TestForceTerminateStuckMembers_{TransitionsActiveRows,LeavesTerminalRowsAlone,SkipsMissingRows,LeavesEndedRowsAlone}`

Full test suite (`go test ./... -race`) passes. `nix build .#prism` passes.

## Watch-outs

- **No coordinator-side workaround** — fix is at the sidecar layer where the stall is detected. `prism cleanup` remains the manual escape hatch, not the fix.
- **No collision with #1690** (`fix-sidecar-startup-timer-race`). That worker is in `internal/sidecar/state.go` adjusting `lastErrorAt` / startup-timer interactions; this PR adds independent `activityTimer` plumbing and `touchActivity` / `cancelActivityTimer` / `handleActivityTimeout` helpers in the same file plus new struct fields in `sidecar.go`. Merge order: either order works; if #1690 lands first, no rebase needed; if this lands first, #1690 sees clean state.go and rebases trivially.
- **No collision with #1716** (`captureLog race`) — separate concern in `notify.go`/`helpers.go`.

Closes #1709
