### PR TITLE
fix(sidecar): drain in-flight notify goroutines in captureLog tests

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -180,9 +180,9 @@ func (s *Sidecar) handleServerConnected() {
 		s.logger().Printf("sidecar: transition -> finished (cause=recovery_timer)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
-		go s.notifyCoordinator()
 		finalText := s.lastInvestigatorText
-		go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
+		s.goNotify(s.notifyCoordinator)
+		s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateFinished, finalText) })
 	})
 }
 
@@ -271,7 +271,7 @@ func (s *Sidecar) handleSessionFinished() {
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
 			finalText := s.lastInvestigatorText
-			go s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText)
+			s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText) })
 			return
 		}
 
@@ -302,9 +302,9 @@ func (s *Sidecar) handleSessionFinished() {
 		s.logger().Printf("sidecar: transition -> finished (cause=finished_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
-		go s.notifyCoordinator()
 		finalText := s.lastInvestigatorText
-		go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
+		s.goNotify(s.notifyCoordinator)
+		s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateFinished, finalText) })
 	})
 }
 
@@ -344,7 +344,7 @@ func (s *Sidecar) handleSessionIdle() {
 			s.upsertState(agent.StateInterrupted, nil, nil)
 			s.writeStateChange(agent.StateInterrupted)
 			finalText := s.lastInvestigatorText
-			go s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText)
+			s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText) })
 			return
 		}
 
@@ -376,9 +376,9 @@ func (s *Sidecar) handleSessionIdle() {
 		s.logger().Printf("sidecar: transition -> finished (cause=idle_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
-		go s.notifyCoordinator()
 		finalText := s.lastInvestigatorText
-		go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
+		s.goNotify(s.notifyCoordinator)
+		s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateFinished, finalText) })
 	})
 }
 
@@ -537,7 +537,7 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		s.upsertState(agent.StateInterrupted, nil, nil)
 		s.writeStateChange(agent.StateInterrupted)
 		finalText := s.lastInvestigatorText
-		go s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText)
+		s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateInterrupted, finalText) })
 	} else {
 		s.cancelIdleTimer()
 		s.cancelRecoveryTimer()
@@ -550,7 +550,7 @@ func (s *Sidecar) handleSessionError(evt harness.HarnessEvent) {
 		s.writeStateChange(agent.StateError)
 		s.writeEvent("error", map[string]string{"name": errorName}, nil)
 		finalText := s.lastInvestigatorText
-		go s.notifyInvestigatorCompletion(agent.StateError, finalText)
+		s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateError, finalText) })
 	}
 }
 
@@ -842,9 +842,9 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 				s.logger().Printf("sidecar: transition -> finished (cause=root_agent_idle_debounce)")
 				s.upsertState(agent.StateFinished, nil, nil)
 				s.writeStateChange(agent.StateFinished)
-				go s.notifyCoordinator()
 				finalText := s.lastInvestigatorText
-				go s.notifyInvestigatorCompletion(agent.StateFinished, finalText)
+				s.goNotify(s.notifyCoordinator)
+				s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateFinished, finalText) })
 			})
 		}
 

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -355,3 +355,35 @@ func buildNotifyPromptBody(text string, status *db.Status) map[string]any {
 
 	return body
 }
+
+// goNotify launches fn on a new goroutine while tracking it in s.notifyWG.
+// All call sites that previously used `go s.notify*` should use this helper
+// instead so that tests can drain in-flight notify goroutines via
+// WaitNotifies before reading test-observable state (logs, DB rows). The
+// fire-and-forget production semantics are preserved — callers do not
+// observe completion.
+//
+// This is the canonical site of the fix for the test-race class that
+// includes #1713 (testTimer.Fire vs state-machine write) and #1716
+// (captureLog strings.Builder Write/Read race). See those issues for the
+// race-class context.
+func (s *Sidecar) goNotify(fn func()) {
+	s.notifyWG.Add(1)
+	go func() {
+		defer s.notifyWG.Done()
+		fn()
+	}()
+}
+
+// WaitNotifies blocks until every goroutine launched via goNotify has
+// returned. It is safe to call from any goroutine and is a no-op when no
+// notify goroutines are in flight.
+//
+// Intended use is in tests that exercise sidecar event handling and read
+// log output afterwards: call WaitNotifies between the synchronous event
+// dispatch (HandleEvent / testTimer.Fire) and the log-read (captureLog's
+// getLogs()) so that any notify goroutine writing to the captured logger
+// has completed before the test inspects the buffer.
+func (s *Sidecar) WaitNotifies() {
+	s.notifyWG.Wait()
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -256,6 +256,16 @@ type Sidecar struct {
 	cfg     Config
 	harness harness.Harness // agent runtime adapter; injected via Config.Harness
 
+	// notifyWG tracks every goroutine spawned via goNotify — the family of
+	// finish/error notifications (notifyCoordinator,
+	// notifyInvestigatorCompletion, notifyParentWorkerOnStartupFailure) that
+	// are dispatched from synchronous state-transition paths but write to
+	// s.cfg.Logger and other test-observable state asynchronously. Production
+	// code does not call Wait; the wg exists so tests can drain in-flight
+	// notifies via WaitNotifies() before reading captureLog output. See
+	// issues #1713 and #1716 for the race class this closes.
+	notifyWG sync.WaitGroup
+
 	mu              sync.Mutex
 	lastState       agent.AgentState
 	idleTimer       Timer
@@ -2087,7 +2097,7 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)
 		s.lastState = agent.StateFinished
-		go s.notifyCoordinator()
+		s.goNotify(s.notifyCoordinator)
 		return true
 
 	default:

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7647,10 +7647,22 @@ func TestSessionError_MessageAbortedError_PathUnchanged(t *testing.T) {
 // Because each sidecar owns its logger, parallel test runs can never
 // contaminate each other's buffers, and background goroutines spawned by the
 // sidecar write to the same isolated buffer for the lifetime of that sidecar.
+//
+// The returned read function calls sc.WaitNotifies() before reading the
+// buffer so that any in-flight notify goroutines launched from a synchronous
+// transition path (HandleEvent / testTimer.Fire) have committed their log
+// writes before the test inspects the buffer. This closes the race class
+// reported in #1713 and #1716 — production notify goroutines outliving the
+// test entrypoint and racing the test's buf.String() read. Without this,
+// the strings.Builder Write/String pair is observable under -race and the
+// test flakes intermittently.
 func captureLog(sc *Sidecar) func() string {
 	var buf strings.Builder
 	sc.cfg.Logger = log.New(&buf, "", 0)
-	return func() string { return buf.String() }
+	return func() string {
+		sc.WaitNotifies()
+		return buf.String()
+	}
 }
 
 // TestTransitionCause_IdleDebounce verifies that transitioning to finished via

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -195,7 +195,7 @@ func (s *Sidecar) writeStartupErrorImpl(startupErr error, asyncNotify bool) {
 	// Normal finish notifications for review agents remain suppressed in
 	// notifyCoordinator — this is an exception only for the startup-failure path.
 	if asyncNotify {
-		go s.notifyParentWorkerOnStartupFailure(startupErr)
+		s.goNotify(func() { s.notifyParentWorkerOnStartupFailure(startupErr) })
 	} else {
 		s.notifyParentWorkerOnStartupFailure(startupErr)
 	}


### PR DESCRIPTION
Closes #1713
Closes #1716

## Summary

Both #1713 and #1716 are the same race-class family as #1657, #1690, and #1715:
production goroutines spawned from sidecar synchronous transition paths
outlive the test's assertion, then write to test-observable state. This PR
fixes both with one targeted change to the notify dispatch layer.

## Race

- `TestTransitionCause_IdleDebounce` and `TestTransitionCause_RecoveryTimer` (#1713) — reproducible immediately on `origin/main` under `-race`.
- `TestTransitionCause_RootAgentIdleDebounce` (#1716) — ~1/200 under `-race`.

In all three, the writer goroutine is one of `go s.notifyCoordinator()` /
`go s.notifyInvestigatorCompletion(...)` spawned from a `testTimer.Fire()` or
`HandleEvent` callback. That goroutine calls `s.logger().Printf(...)` via
`isCoordinatorSession` (helpers.go:142, 144) and the notifier's own status
logs (notify.go:202-304). `captureLog` backs the per-sidecar logger with a
`strings.Builder`, which is not safe for concurrent Write/Read. The test's
`getLogs()` call races the in-flight notify goroutine.

Race report excerpt for `TestTransitionCause_IdleDebounce` on the pre-fix branch:

```
WARNING: DATA RACE
Read at … by goroutine 21:
  strings.(*Builder).String()
  sidecar.captureLog.func1()  sidecar_test.go:7653
  sidecar.TestTransitionCause_IdleDebounce()  sidecar_test.go:7671

Previous write at … by goroutine 25:
  strings.(*Builder).Write()
  log.(*Logger).Printf()
  sidecar.isCoordinatorSession()  helpers.go:142
  sidecar.(*Sidecar).notifyCoordinator()  notify.go:202
  sidecar.(*Sidecar).handleSessionIdle.func1.gowrap3()  events.go:379
```

Per-issue diagnoses were posted on #1713 and #1716 before any code changes.

## Fix — Option B (minimal)

Single `sync.WaitGroup` on `Sidecar` that tracks every notify goroutine:

- new field `Sidecar.notifyWG`
- new helper `Sidecar.goNotify(fn)` — `Add(1)` / `defer Done()`
- new method `Sidecar.WaitNotifies()` — `Wait()`
- every `go s.notify*` call site converted to `s.goNotify(...)`. Production
  semantics unchanged: still fire-and-forget, callers do not observe
  completion.
- `captureLog`'s returned read function now calls `sc.WaitNotifies()` before
  reading the builder. Every existing test that uses `captureLog` is
  transparently safe; no per-test changes needed.

Option A (mutex-wrap the captureLog buffer) was rejected: it hides the
symptom but leaves the door open for future tests to read other state that
the notify goroutine still mutates (DB rows, etc.). Option B addresses the
root cause: tests can deterministically drain in-flight notifies.

## Audit — every test-observable notify call site converted

| Site | Before | After |
|---|---|---|
| events.go:183 | `go s.notifyCoordinator()` (recovery_timer) | `s.goNotify(s.notifyCoordinator)` |
| events.go:185 | `go s.notifyInvestigatorCompletion(...)` | `s.goNotify(func() { ... })` |
| events.go:274 | `go s.notifyInvestigatorCompletion(...)` (interrupted_by_denial) | `s.goNotify(func() { ... })` |
| events.go:305 | `go s.notifyCoordinator()` (finished_debounce) | `s.goNotify(s.notifyCoordinator)` |
| events.go:307 | `go s.notifyInvestigatorCompletion(...)` | `s.goNotify(func() { ... })` |
| events.go:347 | `go s.notifyInvestigatorCompletion(...)` (interrupted_by_denial) | `s.goNotify(func() { ... })` |
| events.go:379 | `go s.notifyCoordinator()` (idle_debounce) | `s.goNotify(s.notifyCoordinator)` |
| events.go:381 | `go s.notifyInvestigatorCompletion(...)` | `s.goNotify(func() { ... })` |
| events.go:540 | `go s.notifyInvestigatorCompletion(...)` (session.error MessageAbortedError) | `s.goNotify(func() { ... })` |
| events.go:553 | `go s.notifyInvestigatorCompletion(...)` (session.error other) | `s.goNotify(func() { ... })` |
| events.go:845 | `go s.notifyCoordinator()` (root_agent_idle_debounce) | `s.goNotify(s.notifyCoordinator)` |
| events.go:847 | `go s.notifyInvestigatorCompletion(...)` | `s.goNotify(func() { ... })` |
| sidecar.go:2090 | `go s.notifyCoordinator()` (pi clean shutdown) | `s.goNotify(s.notifyCoordinator)` |
| state.go:198 | `go s.notifyParentWorkerOnStartupFailure(...)` (writeStartupError async path) | `s.goNotify(func() { ... })` |

The synchronous variants in `writeStartupErrorImpl` (the #1690 canonical-pattern
fix) and `sidecar.go:779` (bwrap timeout path) are unchanged — those run inline,
so they do not need wg tracking.

The other `go func()`s in `sidecar.go` (lines 527, 673, 698, 732, 1104, 1542,
1575) are all in `Run()` / startup goroutines that tests calling `HandleEvent`
or `Fire()` do not invoke, so they are not test-observable through `captureLog`.

## Verification

| Command | Result |
|---|---|
| `go test ./internal/sidecar/ -race -count=20 -run 'TestTransitionCause_IdleDebounce\|TestTransitionCause_RecoveryTimer'` | 20/20 PASS |
| `go test ./internal/sidecar/ -race -count=200 -run TestTransitionCause_RootAgentIdleDebounce` | 200/200 PASS |
| `go test ./internal/sidecar/... -race -count=20 -timeout 1500s` | 20/20 PASS (~14m) |
| `go test ./... -race -timeout 600s` | all packages PASS |
| `nix build .#prism` | OK |
| `nix build .#prism.override { runChecks = true; }` | OK |

## Refs

- #1657 — `TestSocketPipe_SessionStatus_PopulatesHarnessSessionID` (write-ordering pattern, canonical for this race class)
- #1690 — `TestStartupConnectTimeout_EmitsTimingMarker` (introduced the sync-variant pattern on `writeStartupError`)
- #1715 — `iris supervisor goroutine outlives test cleanup` (sibling race in `internal/iris/parity`)