### PR TITLE
feat(iris): `iris investigate` read-only investigator-spawn subcommand

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/investigate.go
+++ b/modules/programs/prism/prism/cmd/iris/investigate.go
@@ -1,0 +1,450 @@
+package main
+
+// investigate.go — `iris investigate` subcommand.
+//
+// `iris investigate` is the daemon-routed analogue of `prism investigate`
+// (cmd/investigate.go). It spawns a read-only investigator session and
+// returns the session name to stdout. The investigator is a child of the
+// calling iris session: its terminal-state notifications flow back via
+// the existing NotifyParent path (issue #1700, wired in main.go's
+// makeNotifyParent and the supervisor's setState callback) so the
+// coordinator sees an "Agent <name> has finished its current task" prompt
+// once the investigation reaches a clean terminal state — the same
+// exactly-once contract `iris escalate` and `iris spawn` inherit.
+//
+// Surface:
+//
+//	iris investigate --prompt "<question>"
+//	iris investigate --prompt-file <path>
+//	iris investigate --prompt -                    # stdin
+//	iris investigate --name <slug> --prompt "..."  # explicit session-name slug
+//
+// --name constraints match prism's investigate (`[a-z0-9-]`, max 40 chars,
+// no leading/trailing dash). Validation is shared with prism via
+// internal/investigate.ValidateName.
+//
+// Behaviour summary (acceptance criteria for #1720):
+//
+//   - --prompt <text> | --prompt-file <path> | --prompt -
+//   - Returns within ~2 seconds with the session name on stdout.
+//   - The investigator's role is set to "investigate". This drives:
+//       * tool_dispatcher gates `write`/`edit` with a clear "read-only" error;
+//       * bash_permission.CheckBashPermission denies the investigator
+//         deny list (prism spawn/review/merge, gh issue create/edit/..., ...).
+//   - Daemon down            → canonical "systemctl --user start iris" hint.
+//   - Caller not in an iris session → "not a registered iris session" error.
+//   - Invalid --name slug    → exits before any wire activity with a clear error.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
+)
+
+// investigateDialTimeout bounds how long `iris investigate` will wait when
+// dialling the daemon socket. Same budget as `iris spawn`.
+const investigateDialTimeout = 2 * time.Second
+
+// investigateWriteTimeout bounds the write of the session_spawn frame.
+const investigateWriteTimeout = 5 * time.Second
+
+// investigateAckWindow is how long we wait after sending session_spawn to
+// see the daemon's session_spawned (or error) frame. The daemon's spawn work
+// (process fork + harness socket bind) typically completes well under a
+// second; a 30 s ceiling matches `iris spawn`.
+const investigateAckWindow = 30 * time.Second
+
+// investigateCmd is the `iris investigate` subcommand.
+var investigateCmd = &cobra.Command{
+	Use:   "investigate",
+	Short: "Spawn a read-only investigator session and return immediately",
+	Long: `iris investigate dials the iris daemon's client IPC socket and asks it
+to spawn a read-only investigator session as a child of the calling iris
+session. The session is named <calling-session>~investigate-<slug>, where
+the slug is derived from the prompt or supplied via --name.
+
+The investigator role is read-only:
+
+  - The 'write' and 'edit' tools fail with a clear "investigator is
+    read-only" message at the iris tool-dispatch layer.
+  - The 'bash' tool's permission gate denies state-mutating invocations:
+    prism spawn / review / merge, iris spawn / review / merge,
+    gh issue create / edit / close / comment, gh pr create / edit /
+    merge / close / review / comment, and git push / commit / add /
+    rebase / reset.
+  - Read-only operations (rg, grep, find, cat, git log, git show, gh
+    issue view / pr view / pr diff, etc.) are all permitted.
+
+The investigator does not self-terminate. Each turn's output is delivered
+back to the calling session via the existing parent-notification path
+(issue #1700 / #1727) when the turn reaches a clean terminal state. The
+coordinator runs 'iris cleanup' once the investigation is done.
+
+Three input variants are accepted (mirrors 'iris prompt'):
+
+  --prompt <text>          inline prompt text
+  --prompt-file <path>     read the prompt body from a file
+  --prompt -               read the prompt body from stdin
+
+--prompt and --prompt-file are mutually exclusive. For file/stdin input a
+single trailing newline is stripped.
+
+The --name flag overrides the auto-derived slug:
+
+    iris investigate --name my-analysis --prompt "..."
+
+results in a session named <caller>~investigate-my-analysis. Validation
+rules for --name:
+
+  - Only lowercase alphanumerics and dashes ([a-z0-9-]) are allowed.
+  - Must not start or end with a dash.
+  - Maximum 40 characters.
+
+When --name is omitted, the slug is derived automatically from the prompt
+text using the same rules as 'prism investigate' (lowercased, punctuation
+stripped, max 30 chars, trimmed at the last word boundary).
+
+The calling session is identified via $IRIS_SESSION_NAME, set by the iris
+supervisor for every pi child. Outside an iris-managed session, pass --from
+explicitly.`,
+	Args:          cobra.NoArgs,
+	RunE:          runInvestigateCmd,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	investigateCmd.Flags().String(
+		"prompt", "",
+		"Text to send to the investigator. Use --prompt-file for complex strings or to avoid shell-escaping issues. Use '-' to read from stdin.",
+	)
+	investigateCmd.Flags().String(
+		"prompt-file", "",
+		"Path to a file containing the prompt text. Mutually exclusive with --prompt.",
+	)
+	investigateCmd.Flags().String(
+		"name", "",
+		"Human-readable slug for the session name (only [a-z0-9-], max 40 chars, no leading/trailing dash). Resulting session name is <caller>~investigate-<name>.",
+	)
+	investigateCmd.Flags().String(
+		"from", "",
+		"Calling session name (defaults to $IRIS_SESSION_NAME). Useful for scripts that spawn investigators on behalf of a known session.",
+	)
+	investigateCmd.Flags().String(
+		"socket", "",
+		"Path to the iris daemon client socket (default: ~/.local/state/iris/iris.sock)",
+	)
+	investigateCmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	rootCmd.AddCommand(investigateCmd)
+}
+
+// runInvestigateCmd is the cobra entry point. It resolves the input, the
+// calling session name, and the slug; validates them; then defers to
+// runInvestigateAt for the wire path.
+func runInvestigateCmd(cmd *cobra.Command, args []string) error {
+	promptText, err := resolveInvestigatePromptInput(cmd)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(promptText) == "" {
+		return errors.New(
+			"a prompt is required — supply one of:\n" +
+				"  --prompt <text>\n" +
+				"  --prompt - (read from stdin)\n" +
+				"  --prompt-file <path>",
+		)
+	}
+
+	suppliedName, _ := cmd.Flags().GetString("name")
+	suppliedName = strings.TrimSpace(suppliedName)
+	if suppliedName != "" {
+		if err := investigatepkg.ValidateName(suppliedName); err != nil {
+			// Re-shape the prism-flavoured error message under the iris
+			// prefix so the CLI surface is consistent.
+			return errors.New(strings.Replace(err.Error(), "prism investigate:", "iris investigate:", 1))
+		}
+	}
+
+	fromFlag, _ := cmd.Flags().GetString("from")
+	from := fromFlag
+	if from == "" {
+		from = os.Getenv("IRIS_SESSION_NAME")
+	}
+	if from == "" {
+		return errors.New(
+			"iris investigate: could not determine calling session\n" +
+				"hint: run from inside an iris-managed pi session (where $IRIS_SESSION_NAME is set),\n" +
+				"or pass --from <session-name> explicitly",
+		)
+	}
+
+	sockPath := resolveSocketPath(cmd)
+	return runInvestigateAt(cmd.Context(), sockPath, from, suppliedName, promptText, os.Stdout)
+}
+
+// runInvestigateAt is the testable core of `iris investigate`. sockPath is
+// passed explicitly so integration tests can point it at a t.TempDir()
+// socket. Returns nil on success and prints the new session name to out.
+func runInvestigateAt(ctx context.Context, sockPath, from, suppliedName, promptText string, out io.Writer) error {
+	if from == "" {
+		return errors.New("iris investigate: from is required")
+	}
+	if promptText == "" {
+		return errors.New("iris investigate: prompt is required")
+	}
+
+	// Resolve the slug + session name BEFORE dialling so an invalid
+	// --name fails fast without ever touching the daemon.
+	slug := suppliedName
+	if slug == "" {
+		slug = investigateSlug(promptText)
+	}
+	sessionName := from + "~investigate-" + slug
+
+	// Resolve the calling session's worktree via a sessions_snapshot. The
+	// investigator must run against the same worktree as the caller so
+	// that read-only inspection sees the same HEAD the coordinator is on.
+	// The lookup also doubles as a "calling session is registered" gate:
+	// when the daemon returns no matching session, we exit before spawn
+	// with a clear "not a registered iris session" error (per AC).
+	worktree, role, err := resolveCallerWorktree(ctx, sockPath, from)
+	if err != nil {
+		return err
+	}
+	// Defence-in-depth: do not allow an investigator to spawn from inside
+	// another investigator session. The issue's Out-of-scope clause is
+	// explicit about no nesting.
+	if role == "investigate" {
+		return fmt.Errorf("iris investigate: calling session %q is itself an investigator; investigators may not spawn further investigators", from)
+	}
+
+	conn, err := dialDaemonForInvestigate(ctx, sockPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := sendInvestigateSpawnFrame(conn, sessionName, worktree, from); err != nil {
+		return err
+	}
+
+	ack, err := readInvestigateAck(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, ack.Name)
+	return nil
+}
+
+// resolveInvestigatePromptInput reads the prompt body from --prompt,
+// --prompt-file, or stdin (when --prompt is "-"). Mirrors resolveIrisPromptInput
+// in prompt.go byte-for-byte so the two CLIs share the same conventions.
+func resolveInvestigatePromptInput(cmd *cobra.Command) (string, error) {
+	promptFile, _ := cmd.Flags().GetString("prompt-file")
+	promptText, _ := cmd.Flags().GetString("prompt")
+
+	if promptFile != "" {
+		data, err := os.ReadFile(promptFile)
+		if err != nil {
+			return "", fmt.Errorf("read prompt file %q: %w", promptFile, err)
+		}
+		return strings.TrimSuffix(string(data), "\n"), nil
+	}
+
+	if promptText == "-" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("read prompt from stdin: %w", err)
+		}
+		return strings.TrimSuffix(string(data), "\n"), nil
+	}
+
+	return promptText, nil
+}
+
+// resolveCallerWorktree fetches a sessions_snapshot from the daemon and
+// returns the worktree and role of the named session. It also acts as the
+// "registered iris session" check (AC: caller must be a registered iris
+// session). Errors are shaped for direct CLI display.
+func resolveCallerWorktree(ctx context.Context, sockPath, from string) (worktree, role string, err error) {
+	snap, ferr := fetchSessionsSnapshot(ctx, sockPath)
+	if ferr != nil {
+		return "", "", ferr
+	}
+	for _, s := range snap.Sessions {
+		if s.Name == from {
+			return s.Worktree, s.Role, nil
+		}
+	}
+	return "", "", fmt.Errorf(
+		"iris investigate: not a registered iris session: %q (run `iris sessions list` to verify)",
+		from,
+	)
+}
+
+// dialDaemonForInvestigate dials the daemon client socket. Same canonical
+// "daemon not running" wording as `iris spawn` / `iris prompt`.
+func dialDaemonForInvestigate(ctx context.Context, sockPath string) (net.Conn, error) {
+	if _, err := os.Stat(sockPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf(
+				"iris daemon not running: socket %s does not exist; start it with `systemctl --user start iris`",
+				sockPath,
+			)
+		}
+		return nil, fmt.Errorf("iris investigate: stat socket %s: %w", sockPath, err)
+	}
+	d := net.Dialer{Timeout: investigateDialTimeout}
+	conn, err := d.DialContext(ctx, "unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"iris daemon not running (could not dial %s: %v); start it with `systemctl --user start iris`",
+			sockPath, err,
+		)
+	}
+	return conn, nil
+}
+
+// sendInvestigateSpawnFrame marshals and writes a session_spawn frame that
+// asks the daemon to spawn an investigator session with a pre-computed
+// session name, worktree borrowed from the caller, role="investigate",
+// and parent=from (so the existing NotifyParent path delivers terminal
+// notifications back to the caller).
+func sendInvestigateSpawnFrame(conn net.Conn, sessionName, worktree, from string) error {
+	frame := iris.ClientSessionSpawnFrame{
+		Type:        iris.ClientFrameSessionSpawn,
+		Worktree:    worktree,
+		Role:        "investigate",
+		Parent:      from,
+		SessionName: sessionName,
+	}
+	data, err := json.Marshal(frame)
+	if err != nil {
+		return fmt.Errorf("iris investigate: marshal session_spawn: %w", err)
+	}
+	data = append(data, '\n')
+	_ = conn.SetWriteDeadline(time.Now().Add(investigateWriteTimeout))
+	if _, err := conn.Write(data); err != nil {
+		return fmt.Errorf("iris investigate: lost connection to daemon during send: %w", err)
+	}
+	return nil
+}
+
+// readInvestigateAck reads frames from the daemon until it sees either a
+// session_spawned or an error frame. Mirrors readSpawnAck but typed to the
+// investigate wire path so the error messages mention "iris investigate".
+func readInvestigateAck(ctx context.Context, conn net.Conn) (*iris.DaemonSessionSpawnedFrame, error) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.SetReadDeadline(time.Now())
+		case <-done:
+		}
+	}()
+
+	_ = conn.SetReadDeadline(time.Now().Add(investigateAckWindow))
+	r := bufio.NewReaderSize(conn, 1<<20)
+
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() {
+				return nil, fmt.Errorf("iris investigate: timed out after %s waiting for session_spawned ack", investigateAckWindow)
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, errors.New("iris investigate: daemon closed connection before sending session_spawned ack (daemon may have died mid-spawn)")
+			}
+			return nil, fmt.Errorf("iris investigate: read ack: %w", err)
+		}
+
+		var head struct {
+			Type        string `json:"type"`
+			RequestType string `json:"request_type"`
+			Message     string `json:"message"`
+		}
+		if err := json.Unmarshal(line, &head); err != nil {
+			fmt.Fprintf(os.Stderr, "[iris] warning: ignoring malformed frame from daemon: %v\n", err)
+			continue
+		}
+		switch head.Type {
+		case iris.DaemonFrameSessionSpawned:
+			var frame iris.DaemonSessionSpawnedFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				return nil, fmt.Errorf("iris investigate: parse session_spawned: %w", err)
+			}
+			return &frame, nil
+		case iris.DaemonFrameError:
+			if head.RequestType == "" || head.RequestType == iris.ClientFrameSessionSpawn {
+				return nil, fmt.Errorf("iris investigate: daemon rejected spawn: %s", head.Message)
+			}
+			fmt.Fprintf(os.Stderr, "[iris] note: unrelated error frame (request_type=%q): %s\n", head.RequestType, head.Message)
+		default:
+			// Unknown frame on this connection — skip and keep reading.
+		}
+	}
+}
+
+// investigateSlug derives a short kebab-case slug from the prompt text.
+// Identical rules to prism's cmd/investigate.go::investigateSlug:
+// lowercase, strip punctuation, replace spaces/underscores with "-",
+// truncate to ≤30 chars at a word boundary, trim trailing "-".
+//
+// Kept as a literal copy (not a shared package import) because the prism
+// CLI helper lives in package cmd; an iris-side dependency on package cmd
+// would pull all of the prism subcommand machinery into the iris binary.
+// The shared validation helper (ValidateName for --name) is small enough
+// to live in its own package (internal/investigate); the slug derivation
+// is a single function and stays here.
+func investigateSlug(prompt string) string {
+	s := strings.ToLower(prompt)
+	s = strings.Map(func(r rune) rune {
+		if r == '_' || unicode.IsSpace(r) {
+			return '-'
+		}
+		return r
+	}, s)
+	var b strings.Builder
+	for _, r := range s {
+		if r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	s = b.String()
+	multiDash := regexp.MustCompile(`-{2,}`)
+	s = multiDash.ReplaceAllString(s, "-")
+	s = strings.TrimLeft(s, "-")
+	if len(s) > 30 {
+		cap := s[:30]
+		if idx := strings.LastIndex(cap, "-"); idx >= 0 {
+			s = s[:idx]
+		} else {
+			s = cap
+		}
+	}
+	s = strings.TrimRight(s, "-")
+	if s == "" {
+		return "query"
+	}
+	return s
+}

--- a/modules/programs/prism/prism/cmd/iris/investigate_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/investigate_integration_test.go
@@ -1,0 +1,353 @@
+package main
+
+// investigate_integration_test.go — end-to-end test of `iris investigate`
+// against a real iris.ClientSocket.
+//
+// The test stands up an in-process ClientSocket whose SpawnSession
+// callback is a recorder, then invokes runInvestigateAt() with the socket
+// path. This proves the wire path used by `iris investigate`:
+//
+//   CLI                 →  sessions_list (resolve caller worktree + role)
+//   CLI                 →  session_spawn frame on iris.sock
+//   daemon ClientSocket →  invokes spawnFn(name, worktree, role="investigate", parent=<from>, ...)
+//   daemon              →  session_spawned frame back to CLI
+//   CLI                 →  prints sessionName to stdout
+//
+// is wired correctly end-to-end. We do not start a real pi child here —
+// the spawnFn returns a fake *iris.Supervisor whose SessionRecord has
+// the fields needed to fill out the ack frame. The full investigator
+// behaviour (read-only enforcement) is covered by the unit tests on
+// internal/iris/bash_permission.go and the tool_dispatcher read-only
+// gates.
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
+)
+
+// TestInvestigate_EndToEndAgainstRealClientSocket exercises the full wire
+// path against a real ClientSocket. It asserts:
+//
+//   - The CLI forwards the caller's worktree (resolved via sessions_list)
+//     and the calling session name as the spawn frame's Parent.
+//   - The CLI passes role="investigate" and the pre-computed session name
+//     (<caller>~investigate-<slug>) to the daemon.
+//   - The CLI prints the new session name on stdout.
+//   - The spawned session appears in the daemon's active-sessions list
+//     with role="investigate" and the expected `~investigate-` suffix.
+func TestInvestigate_EndToEndAgainstRealClientSocket(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	const callerName = "iris-coordinator@invest-e2e"
+	const callerWorktree = "/abs/path/to/caller-worktree"
+
+	// Active-sessions snapshot the daemon hands to clients.  Initially
+	// contains just the caller so resolveCallerWorktree succeeds.
+	var (
+		activeMu       sync.Mutex
+		activeSessions = []iris.SessionSnapshot{{
+			Name:       callerName,
+			InstanceID: uuid.NewString(),
+			State:      "active",
+			Role:       "coordinator",
+			Worktree:   callerWorktree,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		}}
+	)
+	getActive := func() []iris.SessionSnapshot {
+		activeMu.Lock()
+		defer activeMu.Unlock()
+		out := make([]iris.SessionSnapshot, len(activeSessions))
+		copy(out, activeSessions)
+		return out
+	}
+
+	// Record what spawnFn sees.
+	var (
+		recMu       sync.Mutex
+		gotName     string
+		gotWorktree string
+		gotRole     string
+		gotParent   string
+		spawnCalls  int
+	)
+	spawnFn := func(_ context.Context, sessionName, worktree, role, parent string, _ map[string]any) (*iris.Supervisor, error) {
+		recMu.Lock()
+		gotName = sessionName
+		gotWorktree = worktree
+		gotRole = role
+		gotParent = parent
+		spawnCalls++
+		recMu.Unlock()
+		// Add the new session to the active set so the post-spawn
+		// `iris sessions list` AC is observable.
+		activeMu.Lock()
+		activeSessions = append(activeSessions, iris.SessionSnapshot{
+			Name:       sessionName,
+			InstanceID: uuid.NewString(),
+			State:      "active",
+			Role:       role,
+			Worktree:   worktree,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		})
+		activeMu.Unlock()
+		return iris.NewFakeSupervisorForTest(sessionName, worktree, role), nil
+	}
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          iso.Paths.Sock,
+		Database:          iso.DB,
+		GetActiveSessions: getActive,
+		SpawnSession:      spawnFn,
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+	t.Cleanup(srvCancel)
+	go cs.Serve(srvCtx)
+
+	// Drive the investigate CLI core.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	const prompt = "trace the call chain for SSH auth"
+	if err := runInvestigateAt(ctx, iso.Paths.Sock, callerName, "", prompt, &out); err != nil {
+		t.Fatalf("runInvestigateAt: %v", err)
+	}
+
+	// Asserts on what spawnFn observed.
+	recMu.Lock()
+	defer recMu.Unlock()
+	if spawnCalls != 1 {
+		t.Errorf("spawnFn calls = %d, want 1", spawnCalls)
+	}
+	const wantSlug = "trace-the-call-chain-for-ssh"
+	wantName := callerName + "~investigate-" + wantSlug
+	if gotName != wantName {
+		t.Errorf("spawnFn session name = %q, want %q", gotName, wantName)
+	}
+	if gotWorktree != callerWorktree {
+		t.Errorf("spawnFn worktree = %q, want %q (caller worktree borrowed)", gotWorktree, callerWorktree)
+	}
+	if gotRole != "investigate" {
+		t.Errorf("spawnFn role = %q, want %q", gotRole, "investigate")
+	}
+	if gotParent != callerName {
+		t.Errorf("spawnFn parent = %q, want %q (caller session forwarded for terminal-state notification)", gotParent, callerName)
+	}
+
+	// Stdout must contain the new session name (AC: "Returns within ~2
+	// seconds with the session name on stdout").
+	if !strings.Contains(out.String(), wantName) {
+		t.Errorf("stdout = %q, want it to contain %q", out.String(), wantName)
+	}
+
+	// AC: "An integration test spawns an investigator, sends a prompt,
+	// asserts the session appears in `iris sessions list` with the
+	// expected role/name." We check the in-memory snapshot directly
+	// (which `iris sessions list` reads via getActive).
+	activeMu.Lock()
+	defer activeMu.Unlock()
+	found := false
+	for _, s := range activeSessions {
+		if s.Name == wantName {
+			found = true
+			if s.Role != "investigate" {
+				t.Errorf("active session %q role = %q, want %q", s.Name, s.Role, "investigate")
+			}
+			if !strings.Contains(s.Name, "~investigate-") {
+				t.Errorf("active session %q name does not contain ~investigate-", s.Name)
+			}
+		}
+	}
+	if !found {
+		names := make([]string, 0, len(activeSessions))
+		for _, s := range activeSessions {
+			names = append(names, s.Name)
+		}
+		t.Errorf("spawned investigator %q not found in active sessions; got %v", wantName, names)
+	}
+}
+
+// TestInvestigate_NameOverrideSucceeds asserts that --name overrides the
+// auto-derived slug and the resulting session name uses it verbatim.
+func TestInvestigate_NameOverrideSucceeds(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	const callerName = "iris-coordinator@invest-name"
+	const callerWorktree = "/abs/path/to/caller"
+
+	var (
+		activeMu       sync.Mutex
+		activeSessions = []iris.SessionSnapshot{{
+			Name: callerName, InstanceID: uuid.NewString(),
+			State: "active", Role: "coordinator", Worktree: callerWorktree,
+			StartedAt: time.Now().UTC().Format(time.RFC3339),
+		}}
+	)
+	var gotName string
+	spawnFn := func(_ context.Context, sessionName, worktree, role, _parent string, _ map[string]any) (*iris.Supervisor, error) {
+		gotName = sessionName
+		activeMu.Lock()
+		activeSessions = append(activeSessions, iris.SessionSnapshot{
+			Name: sessionName, InstanceID: uuid.NewString(),
+			State: "active", Role: role, Worktree: worktree,
+			StartedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+		activeMu.Unlock()
+		return iris.NewFakeSupervisorForTest(sessionName, worktree, role), nil
+	}
+
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: iso.Paths.Sock,
+		Database: iso.DB,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			activeMu.Lock()
+			defer activeMu.Unlock()
+			out := make([]iris.SessionSnapshot, len(activeSessions))
+			copy(out, activeSessions)
+			return out
+		},
+		SpawnSession: spawnFn,
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+	t.Cleanup(srvCancel)
+	go cs.Serve(srvCtx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var out bytes.Buffer
+	if err := runInvestigateAt(ctx, iso.Paths.Sock, callerName, "my-analysis", "irrelevant prompt body", &out); err != nil {
+		t.Fatalf("runInvestigateAt: %v", err)
+	}
+	wantName := callerName + "~investigate-my-analysis"
+	if gotName != wantName {
+		t.Errorf("session name = %q, want %q (--name override)", gotName, wantName)
+	}
+}
+
+// TestInvestigate_CallerNotRegistered asserts that when $IRIS_SESSION_NAME
+// names a session the daemon does not know about, the CLI exits before
+// spawning with a clear error.
+func TestInvestigate_CallerNotRegistered(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+
+	// Empty active-session set: any caller name will fail the registered-
+	// session lookup.
+	var spawnCalls int
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          iso.Paths.Sock,
+		Database:          iso.DB,
+		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
+		SpawnSession: func(_ context.Context, _name, _w, _r, _p string, _ map[string]any) (*iris.Supervisor, error) {
+			spawnCalls++
+			return nil, nil
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+	t.Cleanup(srvCancel)
+	go cs.Serve(srvCtx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var out bytes.Buffer
+	err := runInvestigateAt(ctx, iso.Paths.Sock, "iris-coordinator@nope", "", "prompt body", &out)
+	if err == nil {
+		t.Fatalf("runInvestigateAt: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a registered iris session") {
+		t.Errorf("error = %v, want substring 'not a registered iris session'", err)
+	}
+	if spawnCalls != 0 {
+		t.Errorf("spawnFn was called %d times; expected 0 (CLI must fail before sending session_spawn)", spawnCalls)
+	}
+}
+
+// TestInvestigate_DaemonDown asserts that when the daemon socket does not
+// exist, the CLI emits the canonical `systemctl --user start iris` hint
+// and exits non-zero. The socket path must NOT exist (we don't Listen).
+func TestInvestigate_DaemonDown(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	// Do not create the socket; runInvestigateAt's dial must fail with
+	// the canonical error.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var out bytes.Buffer
+	err := runInvestigateAt(ctx, iso.Paths.Sock, "iris-coordinator@nope", "", "prompt body", &out)
+	if err == nil {
+		t.Fatalf("runInvestigateAt: want daemon-down error, got nil")
+	}
+	if !strings.Contains(err.Error(), "iris daemon not running") {
+		t.Errorf("error = %v, want substring 'iris daemon not running'", err)
+	}
+	if !strings.Contains(err.Error(), "systemctl --user start iris") {
+		t.Errorf("error = %v, want canonical hint 'systemctl --user start iris'", err)
+	}
+}
+
+// TestInvestigate_RejectsNestedInvestigator asserts that a calling session
+// whose role is "investigate" cannot spawn a further investigator. This
+// matches the issue's Out-of-scope clause "Investigator that can spawn
+// further investigators. No nesting."
+func TestInvestigate_RejectsNestedInvestigator(t *testing.T) {
+	iso := iristest.NewIsolated(t)
+	const callerName = "iris-coordinator@root~investigate-existing"
+	const callerWorktree = "/abs/path/to/worktree"
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: iso.Paths.Sock,
+		Database: iso.DB,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return []iris.SessionSnapshot{{
+				Name: callerName, InstanceID: uuid.NewString(),
+				State: "active", Role: "investigate", Worktree: callerWorktree,
+				StartedAt: time.Now().UTC().Format(time.RFC3339),
+			}}
+		},
+		SpawnSession: func(_ context.Context, _name, _w, _r, _p string, _ map[string]any) (*iris.Supervisor, error) {
+			t.Fatalf("spawnFn must not be called for a nested-investigator spawn")
+			return nil, nil
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+	t.Cleanup(srvCancel)
+	go cs.Serve(srvCtx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var out bytes.Buffer
+	err := runInvestigateAt(ctx, iso.Paths.Sock, callerName, "", "any prompt", &out)
+	if err == nil {
+		t.Fatalf("runInvestigateAt: want nested-investigator error, got nil")
+	}
+	if !strings.Contains(err.Error(), "investigators may not spawn further investigators") {
+		t.Errorf("error = %v, want substring 'investigators may not spawn further investigators'", err)
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/investigate_test.go
+++ b/modules/programs/prism/prism/cmd/iris/investigate_test.go
@@ -1,0 +1,153 @@
+package main
+
+// investigate_test.go — unit tests for the slug-derivation and name-validation
+// helpers used by `iris investigate`. The wire-path is covered in
+// investigate_integration_test.go against an in-process ClientSocket.
+//
+// Slug behaviour MUST match prism's investigate slug rules byte-for-byte so a
+// coordinator can switch between `prism investigate` and `iris investigate`
+// without learning two slug conventions. The test cases below mirror
+// cmd/investigate_test.go::TestInvestigateSlug.
+
+import (
+	"strings"
+	"testing"
+
+	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
+)
+
+func TestIrisInvestigateSlug(t *testing.T) {
+	tests := []struct {
+		prompt string
+		want   string
+	}{
+		{
+			// Word-boundary truncation: matches prism behaviour.
+			prompt: "trace the call chain for SSH auth",
+			want:   "trace-the-call-chain-for-ssh",
+		},
+		{
+			prompt: "What is happening?",
+			want:   "what-is-happening",
+		},
+		{
+			prompt: "  leading and trailing spaces  ",
+			want:   "leading-and-trailing-spaces",
+		},
+		{
+			prompt: "underscores_in_prompt",
+			want:   "underscores-in-prompt",
+		},
+		{
+			prompt: "UPPERCASE WORDS",
+			want:   "uppercase-words",
+		},
+		{
+			prompt: "!!! punctuation only !!!",
+			want:   "punctuation-only",
+		},
+		{
+			prompt: "a very long prompt that goes well beyond the thirty character limit set for slugs",
+			want:   "a-very-long-prompt-that-goes",
+		},
+		{
+			prompt: "",
+			want:   "query",
+		},
+		{
+			prompt: "???",
+			want:   "query",
+		},
+		{
+			prompt: "multiple   spaces   between",
+			want:   "multiple-spaces-between",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.prompt, func(t *testing.T) {
+			got := investigateSlug(tc.prompt)
+			if got != tc.want {
+				t.Errorf("investigateSlug(%q) = %q, want %q", tc.prompt, got, tc.want)
+			}
+			if len(got) > 30 {
+				t.Errorf("investigateSlug(%q) length %d exceeds 30", tc.prompt, len(got))
+			}
+		})
+	}
+}
+
+// TestIrisInvestigateSlugWordBoundary specifically exercises the
+// word-boundary truncation: a prompt that produces a normalised string of
+// exactly 30+ chars with no dash must fall back to the hard cut.
+func TestIrisInvestigateSlugWordBoundary(t *testing.T) {
+	prompt := "abcdefghijklmnopqrstuvwxyzabcde"
+	got := investigateSlug(prompt)
+	if got != "abcdefghijklmnopqrstuvwxyzabcd" {
+		t.Errorf("no-dash fallback: got %q, want %q", got, "abcdefghijklmnopqrstuvwxyzabcd")
+	}
+
+	prompt2 := "hello world foo" + strings.Repeat("x", 20)
+	got2 := investigateSlug(prompt2)
+	if got2 != "hello-world" {
+		t.Errorf("word-boundary: got %q, want %q", got2, "hello-world")
+	}
+}
+
+// TestIrisInvestigateValidateName asserts that the iris CLI uses the same
+// validation helper as prism so the constraint surface is identical.
+func TestIrisInvestigateValidateName(t *testing.T) {
+	valid := []string{
+		"foo",
+		"foo-bar",
+		"my-analysis",
+		"abc123",
+		"a",
+		strings.Repeat("a", 40),
+	}
+	for _, name := range valid {
+		if err := investigatepkg.ValidateName(name); err != nil {
+			t.Errorf("ValidateName(%q) unexpected error: %v", name, err)
+		}
+	}
+
+	invalid := []struct {
+		name        string
+		mustContain string
+	}{
+		{strings.Repeat("a", 41), "maximum is 40"},
+		{"-leading", "start or end with a dash"},
+		{"trailing-", "start or end with a dash"},
+		{"UPPER", "disallowed characters"},
+		{"has spaces", "disallowed characters"},
+		{"under_score", "disallowed characters"},
+		{"foo@bar", "disallowed characters"},
+	}
+	for _, tc := range invalid {
+		err := investigatepkg.ValidateName(tc.name)
+		if err == nil {
+			t.Errorf("ValidateName(%q) expected error, got nil", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.mustContain) {
+			t.Errorf("ValidateName(%q): error %q does not contain %q", tc.name, err.Error(), tc.mustContain)
+		}
+	}
+}
+
+// TestIrisInvestigateSessionNameShape asserts that a session built from
+// the slug satisfies the sidecar's investigateAgentInvokerSession pattern
+// (<invoker>~investigate-<slug>) so the existing notify path can derive
+// the caller correctly.
+func TestIrisInvestigateSessionNameShape(t *testing.T) {
+	invoker := "iris-coordinator@main"
+	slug := investigateSlug("trace the call chain for SSH auth")
+	sessionName := invoker + "~investigate-" + slug
+
+	if !strings.HasPrefix(sessionName, invoker+"~investigate-") {
+		t.Errorf("session name %q does not start with %q", sessionName, invoker+"~investigate-")
+	}
+	if !strings.Contains(sessionName, "~investigate") {
+		t.Errorf("session name %q must contain ~investigate marker", sessionName)
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -329,7 +329,11 @@ func runDaemon() error {
 	// spawnFn is called by the client socket when a session_spawn frame arrives.
 	// It must be defined after clientSock so it can capture clientSock and wire
 	// the harness publisher (D-6 fan-out: harness events → client subscribers).
-	spawnFn := func(spawnCtx context.Context, worktree, role, parent string, configOverrides map[string]any) (*iris.Supervisor, error) {
+	//
+	// sessionName, when non-empty, fixes the new session's logical name
+	// (overriding GenerateSessionName). Used by `iris investigate` so the
+	// session name carries the `<parent>~investigate-<slug>` convention.
+	spawnFn := func(spawnCtx context.Context, sessionName, worktree, role, parent string, configOverrides map[string]any) (*iris.Supervisor, error) {
 		extPath := cfg.PIExtensionPath
 		// Derive the bare repo root from the worktree for 4-PAT GITHUB_TOKEN
 		// selection in the bash sandbox (D-5).
@@ -341,8 +345,12 @@ func runDaemon() error {
 		if resolvedRole == "" {
 			resolvedRole = "worker"
 		}
+		resolvedName := sessionName
+		if resolvedName == "" {
+			resolvedName = iris.GenerateSessionName(worktree, resolvedRole)
+		}
 		superCfg := iris.SupervisorConfig{
-			SessionName:      iris.GenerateSessionName(worktree, resolvedRole),
+			SessionName:      resolvedName,
 			Worktree:         worktree,
 			Role:             resolvedRole,
 			BareRoot:         bareRoot,

--- a/modules/programs/prism/prism/cmd/iris/pr_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/pr_integration_test.go
@@ -157,7 +157,7 @@ func newPRTestEnv(t *testing.T) *prTestEnv {
 			}
 			return out
 		},
-		SpawnSession: func(ctx context.Context, worktree, role, _parent string, _ map[string]any) (*iris.Supervisor, error) {
+		SpawnSession: func(ctx context.Context, _sessionName, worktree, role, _parent string, _ map[string]any) (*iris.Supervisor, error) {
 			mu.Lock()
 			*spawnCalls++
 			*spawnArgs = append(*spawnArgs, spawnCall{worktree: worktree, role: role})

--- a/modules/programs/prism/prism/cmd/iris/spawn_integration_test.go
+++ b/modules/programs/prism/prism/cmd/iris/spawn_integration_test.go
@@ -75,7 +75,7 @@ func TestSpawn_EndToEndAgainstRealClientSocket(t *testing.T) {
 		GetActiveSessions: func() []iris.SessionSnapshot {
 			return nil
 		},
-		SpawnSession: func(ctx context.Context, worktree, role, _parent string, _ map[string]any) (*iris.Supervisor, error) {
+		SpawnSession: func(ctx context.Context, _sessionName, worktree, role, _parent string, _ map[string]any) (*iris.Supervisor, error) {
 			recMu.Lock()
 			gotWtree = worktree
 			gotRole = role
@@ -178,7 +178,7 @@ func TestSpawn_ForwardsIRISSessionNameAsParent(t *testing.T) {
 		SockPath:          sockPath,
 		Database:          database,
 		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
-		SpawnSession: func(ctx context.Context, worktree, role, parent string, _ map[string]any) (*iris.Supervisor, error) {
+		SpawnSession: func(ctx context.Context, _sessionName, worktree, role, parent string, _ map[string]any) (*iris.Supervisor, error) {
 			recMu.Lock()
 			gotParent = parent
 			recMu.Unlock()
@@ -252,7 +252,7 @@ func TestSpawn_EmptyIRISSessionNameYieldsEmptyParent(t *testing.T) {
 		SockPath:          sockPath,
 		Database:          database,
 		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
-		SpawnSession: func(ctx context.Context, worktree, role, parent string, _ map[string]any) (*iris.Supervisor, error) {
+		SpawnSession: func(ctx context.Context, _sessionName, worktree, role, parent string, _ map[string]any) (*iris.Supervisor, error) {
 			recMu.Lock()
 			gotParent = parent
 			called = true

--- a/modules/programs/prism/prism/internal/iris/bash_permission.go
+++ b/modules/programs/prism/prism/internal/iris/bash_permission.go
@@ -51,17 +51,30 @@ import (
 //
 // The policy is:
 //
-//	role=coordinator → command containing a real `prism merge` invocation is allowed.
-//	role!=coordinator (worker, review-*, "" etc.) → `prism merge` is denied.
-//	any role         → all other bash commands are allowed.
+//	role=coordinator    → command containing a real `prism merge` invocation is allowed.
+//	role!=coordinator   → `prism merge` is denied.
+//	role=investigate    → mutation commands (gh mutate, prism spawn/review/merge,
+//	                      git push/commit/add/rebase/reset, iris spawn/review/merge)
+//	                      are denied. Other commands are allowed.
+//	any role            → all other bash commands are allowed.
 //
-// Detection of `prism merge` is intentionally simple: the command string
-// is searched for the token sequence "prism" followed (after whitespace)
-// by "merge". The check is whitespace-tolerant but does not attempt to
-// strip quoted regions. False positives on benign strings like
+// Detection of restricted invocations is intentionally simple: the command
+// string is tokenised on whitespace and matched against fixed binary +
+// subcommand pairs. The check is whitespace-tolerant but does not attempt
+// to strip quoted regions. False positives on benign strings like
 // `echo "prism merge"` are accepted as the safe-by-default behaviour —
 // the test surface exercised by D-10 uses unambiguous invocations.
 func CheckBashPermission(role, command string) (bool, string) {
+	// Investigator deny-list. Mirrors the prism investigator agent's deny
+	// list (modules/programs/prism/agents/investigate.md). The investigator
+	// is read-only: it must not spawn or steer other agents, mutate GitHub,
+	// or mutate git history.
+	if role == "investigate" {
+		if denied, name := mentionsInvestigatorDenied(command); denied {
+			return false, "iris: bash permission denied: investigator is read-only and may not run `" + name + "` (see modules/programs/prism/agents/investigate.md for the full deny list)"
+		}
+		return true, ""
+	}
 	if !mentionsPrismMerge(command) {
 		return true, ""
 	}
@@ -75,9 +88,89 @@ func CheckBashPermission(role, command string) (bool, string) {
 // invocation. Tokenises on whitespace; matches when consecutive non-empty
 // tokens are exactly "prism" and "merge".
 func mentionsPrismMerge(command string) bool {
+	return mentionsCommandPair(command, "prism", "merge")
+}
+
+// investigatorDeniedPairs is the canonical investigator bash deny list.
+// It mirrors `modules/programs/prism/agents/investigate.md` byte-for-byte:
+// no GitHub mutations, no agent spawning, no merge enqueueing, no git
+// history mutation. The list is intentionally restricted to invocations
+// that change state — read-only operations (rg, grep, git log, gh issue
+// view, etc.) are all allowed.
+var investigatorDeniedPairs = [][2]string{
+	// GitHub mutations.
+	{"gh", "issue"},      // gh issue create/edit/close/comment
+	{"gh", "pr"},         // gh pr create/edit/merge/close/review/comment
+	// Note: gh issue view / gh pr view are read-only but share the
+	// `gh issue` / `gh pr` prefix. We refine the match below so that
+	// only mutating subcommands trip the deny list.
+
+	// Prism agent control.
+	{"prism", "spawn"},
+	{"prism", "review"},
+	{"prism", "merge"},
+	{"prism", "merges"},
+
+	// Iris agent control — mirrors the prism list for the iris world so
+	// an investigator cannot spawn iris workers either.
+	{"iris", "spawn"},
+	{"iris", "review"},
+	{"iris", "merge"},
+	{"iris", "merges"},
+	{"iris", "investigate"},
+
+	// Git history mutation. `git push` is the only blanket-denied verb;
+	// the rest are matched on the exact subcommand.
+	{"git", "push"},
+	{"git", "commit"},
+	{"git", "add"},
+	{"git", "rebase"},
+	{"git", "reset"},
+}
+
+// investigatorReadOnlyGhSubcommands lists the read-only `gh issue` /
+// `gh pr` subcommands that ARE allowed even though their `gh issue` /
+// `gh pr` prefix matches the deny list above. Mirrors the
+// "Allowed actions" section of investigate.md.
+var investigatorReadOnlyGhSubcommands = map[string]bool{
+	"view": true,
+	"list": true,
+	"diff": true,
+}
+
+// mentionsInvestigatorDenied reports whether command invokes any item in
+// the investigator deny list. Returns (true, "<binary> <subcommand>") on
+// a match, (false, "") otherwise. The match is exact on two consecutive
+// non-empty whitespace-separated tokens.
+//
+// `gh issue` / `gh pr` are refined: a third token of `view`, `list`, or
+// `diff` flips the match back to allowed (these are read-only).
+func mentionsInvestigatorDenied(command string) (bool, string) {
 	fields := strings.Fields(command)
 	for i := 0; i+1 < len(fields); i++ {
-		if fields[i] == "prism" && fields[i+1] == "merge" {
+		for _, pair := range investigatorDeniedPairs {
+			if fields[i] != pair[0] || fields[i+1] != pair[1] {
+				continue
+			}
+			// Refinement for `gh issue` / `gh pr`: allow read-only
+			// subcommands.
+			if pair[0] == "gh" && (pair[1] == "issue" || pair[1] == "pr") && i+2 < len(fields) {
+				if investigatorReadOnlyGhSubcommands[fields[i+2]] {
+					continue
+				}
+			}
+			return true, pair[0] + " " + pair[1]
+		}
+	}
+	return false, ""
+}
+
+// mentionsCommandPair reports whether command contains the two-token
+// sequence (a, b) as consecutive non-empty whitespace-separated tokens.
+func mentionsCommandPair(command, a, b string) bool {
+	fields := strings.Fields(command)
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == a && fields[i+1] == b {
 			return true
 		}
 	}

--- a/modules/programs/prism/prism/internal/iris/bash_permission_investigator_test.go
+++ b/modules/programs/prism/prism/internal/iris/bash_permission_investigator_test.go
@@ -1,0 +1,136 @@
+package iris
+
+// bash_permission_investigator_test.go — unit tests for the investigator
+// branch of CheckBashPermission. The investigator deny list mirrors
+// modules/programs/prism/agents/investigate.md verbatim; this test pins
+// the canonical examples from that file so a future drift in either side
+// is caught immediately.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckBashPermission_Investigator_DeniesMutations(t *testing.T) {
+	denied := []struct {
+		cmd     string
+		mention string
+	}{
+		// Prism agent control — investigator may not spawn or steer agents.
+		{"prism spawn --worktree /tmp/foo", "prism spawn"},
+		{"prism review 1234", "prism review"},
+		{"prism merge 1234", "prism merge"},
+		{"prism merges", "prism merges"},
+
+		// Iris agent control — same restriction on the iris side.
+		{"iris spawn --worktree /tmp/foo --role worker", "iris spawn"},
+		{"iris review 1234", "iris review"},
+		{"iris merge 1234", "iris merge"},
+		{"iris merges", "iris merges"},
+		{"iris investigate --prompt foo", "iris investigate"},
+
+		// GitHub mutations (issue/pr without a read-only subcommand).
+		{"gh issue create --title foo", "gh issue"},
+		{"gh issue edit 1 --title bar", "gh issue"},
+		{"gh issue close 1", "gh issue"},
+		{"gh issue comment 1 --body foo", "gh issue"},
+		{"gh pr create --title foo", "gh pr"},
+		{"gh pr edit 1 --title bar", "gh pr"},
+		{"gh pr merge 1 --squash", "gh pr"},
+		{"gh pr close 1", "gh pr"},
+		{"gh pr review 1 --approve", "gh pr"},
+		{"gh pr comment 1 --body foo", "gh pr"},
+
+		// Git history mutation.
+		{"git push origin main", "git push"},
+		{"git commit -m foo", "git commit"},
+		{"git add .", "git add"},
+		{"git rebase -i HEAD~3", "git rebase"},
+		{"git reset --hard HEAD~1", "git reset"},
+	}
+	for _, tc := range denied {
+		tc := tc
+		t.Run(tc.cmd, func(t *testing.T) {
+			allowed, reason := CheckBashPermission("investigate", tc.cmd)
+			if allowed {
+				t.Fatalf("CheckBashPermission(investigate, %q) = allowed; expected denied", tc.cmd)
+			}
+			if !strings.Contains(reason, "read-only") {
+				t.Errorf("reason = %q, want it to mention 'read-only'", reason)
+			}
+			if !strings.Contains(reason, tc.mention) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tc.mention)
+			}
+		})
+	}
+}
+
+func TestCheckBashPermission_Investigator_AllowsReadOnly(t *testing.T) {
+	allowed := []string{
+		// Standard read-only utilities.
+		"rg foo .",
+		"grep -rn foo .",
+		"find . -name '*.go'",
+		"ls -la",
+		"cat /etc/hostname",
+		"head -n 20 README.md",
+		"wc -l file.go",
+		"diff a.txt b.txt",
+
+		// Read-only git.
+		"git log --oneline -10",
+		"git diff HEAD",
+		"git show HEAD",
+		"git status",
+		"git blame file.go",
+
+		// Read-only GitHub (refinement: gh issue/pr view/list/diff).
+		"gh issue view 1",
+		"gh issue list",
+		"gh pr view 1",
+		"gh pr list",
+		"gh pr diff 1",
+
+		// Read-only prism introspection.
+		"prism checkin nixos-config@main",
+		"prism logs nixos-config@main",
+		"prism sessions list",
+	}
+	for _, cmd := range allowed {
+		cmd := cmd
+		t.Run(cmd, func(t *testing.T) {
+			ok, reason := CheckBashPermission("investigate", cmd)
+			if !ok {
+				t.Errorf("CheckBashPermission(investigate, %q) = denied (reason=%q); expected allowed", cmd, reason)
+			}
+		})
+	}
+}
+
+// TestCheckBashPermission_NonInvestigatorRolesUnaffected asserts that the
+// investigator deny list does NOT apply to worker / coordinator sessions.
+// Workers can git push / git commit; coordinators can prism merge. The
+// investigator branch must be role-keyed strictly to "investigate".
+func TestCheckBashPermission_NonInvestigatorRolesUnaffected(t *testing.T) {
+	cases := []struct {
+		role, cmd string
+		want      bool
+	}{
+		{"worker", "git push origin foo", true},
+		{"worker", "git commit -m foo", true},
+		{"worker", "gh pr create --title foo", true},
+		{"coordinator", "git push origin main", true},
+		{"coordinator", "prism merge 1234", true},
+		// worker still denied prism merge (existing D-10 behaviour).
+		{"worker", "prism merge 1234", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.role+":"+tc.cmd, func(t *testing.T) {
+			got, _ := CheckBashPermission(tc.role, tc.cmd)
+			if got != tc.want {
+				t.Errorf("CheckBashPermission(%q, %q) = %v, want %v", tc.role, tc.cmd, got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -57,6 +57,7 @@ type ClientSessionUnsubscribeFrame struct {
 //	{"type": "session_spawn", "worktree": "/abs/path", "role": "worker"}
 //	{"type": "session_spawn", "worktree": "...", "role": "coordinator", "config_overrides": {...}}
 //	{"type": "session_spawn", "worktree": "...", "role": "worker", "parent": "nixos-config@main"}
+//	{"type": "session_spawn", "worktree": "...", "role": "investigate", "parent": "...", "session_name": "<parent>~investigate-<slug>"}
 //
 // Parent, when non-empty, names the session that is invoking `iris spawn`.
 // The daemon records it on the new session's row (sessions.parent_session)
@@ -64,11 +65,20 @@ type ClientSessionUnsubscribeFrame struct {
 // "Agent <name> has finished" prompt back to the parent. Empty means "no
 // parent" (top-level spawn from a non-iris shell): no notification will be
 // delivered when the child terminates.
+//
+// SessionName, when non-empty, fixes the new session's logical name instead
+// of letting the daemon derive one via GenerateSessionName(worktree, role).
+// This is used by `iris investigate` and `iris review`, which both need a
+// caller-controlled `<parent>~<kind>-<slug>` shape so downstream code can
+// pattern-match on the name (e.g. notify.go's investigateAgentInvokerSession).
+// The daemon validates that an explicit name is not currently in use by an
+// active session before spawning.
 type ClientSessionSpawnFrame struct {
 	Type            string         `json:"type"` // "session_spawn"
 	Worktree        string         `json:"worktree"`
 	Role            string         `json:"role"`
 	Parent          string         `json:"parent,omitempty"`
+	SessionName     string         `json:"session_name,omitempty"`
 	ConfigOverrides map[string]any `json:"config_overrides,omitempty"`
 }
 

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -97,7 +97,10 @@ type ClientSocket struct {
 	// spawnSession spawns a new session. Set by the daemon at construction.
 	// parent is the spawning session's logical name (from the session_spawn
 	// frame's Parent field; empty for top-level spawns). See #1700.
-	spawnSession func(ctx context.Context, worktree, role, parent string, configOverrides map[string]any) (*Supervisor, error)
+	// sessionName, when non-empty, fixes the new session's logical name
+	// (overriding the daemon's GenerateSessionName default). Used by
+	// `iris investigate` to enforce the `<parent>~investigate-<slug>` shape.
+	spawnSession func(ctx context.Context, sessionName, worktree, role, parent string, configOverrides map[string]any) (*Supervisor, error)
 	// deliverPrompt delivers a prompt to a named session. Set by the daemon.
 	deliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
 	// killSession terminates a named session. Returns the terminal state
@@ -162,8 +165,11 @@ type ClientSocketConfig struct {
 	// SpawnSession spawns a new session and returns the supervisor.
 	// parent is the spawning session's logical name (issue #1700, forwarded
 	// from the session_spawn frame's Parent field). Empty for top-level
-	// spawns invoked from outside an iris session.
-	SpawnSession func(ctx context.Context, worktree, role, parent string, configOverrides map[string]any) (*Supervisor, error)
+	// spawns invoked from outside an iris session. sessionName, when
+	// non-empty, fixes the new session's logical name (overriding the
+	// daemon's GenerateSessionName default); used by `iris investigate`
+	// to enforce the `<parent>~investigate-<slug>` shape.
+	SpawnSession func(ctx context.Context, sessionName, worktree, role, parent string, configOverrides map[string]any) (*Supervisor, error)
 	// DeliverPrompt delivers a prompt to a named session.
 	DeliverPrompt func(ctx context.Context, name, text, deliverAs string, images []string) error
 	// KillSession terminates a named session. Returns the terminal state
@@ -265,7 +271,7 @@ func (cs *ClientSocket) SockPath() string { return cs.sockPath }
 // by the daemon when it needs to capture a reference to the ClientSocket
 // inside the spawn function (circular dependency: spawnFn needs clientSock,
 // clientSock needs spawnFn). Call before Serve().
-func (cs *ClientSocket) SetSpawnSession(fn func(ctx context.Context, worktree, role, parent string, configOverrides map[string]any) (*Supervisor, error)) {
+func (cs *ClientSocket) SetSpawnSession(fn func(ctx context.Context, sessionName, worktree, role, parent string, configOverrides map[string]any) (*Supervisor, error)) {
 	cs.spawnSession = fn
 }
 
@@ -657,7 +663,18 @@ func (cs *ClientSocket) handleSessionSpawn(ctx context.Context, w *jsonlWriter, 
 		role = "worker"
 	}
 
-	sup, err := cs.spawnSession(ctx, frame.Worktree, role, frame.Parent, frame.ConfigOverrides)
+	// If the caller supplied an explicit session name, reject if a session
+	// with that name is already active. This is the equivalent of prism's
+	// `session already exists` guard at SpawnSession's tmux check; we run
+	// it at the daemon boundary so the CLI returns a clear error instead
+	// of a low-level conflict from the supervisor map.
+	if frame.SessionName != "" && cs.sessionExists(frame.SessionName) {
+		sendError(w, ClientFrameSessionSpawn,
+			fmt.Sprintf("session %q is already active", frame.SessionName))
+		return
+	}
+
+	sup, err := cs.spawnSession(ctx, frame.SessionName, frame.Worktree, role, frame.Parent, frame.ConfigOverrides)
 	if err != nil {
 		sendError(w, ClientFrameSessionSpawn, fmt.Sprintf("spawn failed: %v", err))
 		return

--- a/modules/programs/prism/prism/internal/iris/tool_dispatcher.go
+++ b/modules/programs/prism/prism/internal/iris/tool_dispatcher.go
@@ -384,6 +384,15 @@ func (d *toolDispatcher) runRead(ctx context.Context, frame ToolExecFrame) toolR
 
 // runEdit executes the edit tool in a sandboxed subprocess (worktree RW).
 func (d *toolDispatcher) runEdit(ctx context.Context, frame ToolExecFrame) toolResult {
+	// Investigator read-only gate: edit must fail for investigate sessions
+	// with a clear "read-only" message before any path validation runs.
+	// Mirrors the worktree-RO mount prism uses (cmd/investigate.go's
+	// WorktreeReadOnly: true), enforced at the tool-dispatch layer because
+	// iris does not use a container per session.
+	if d.role == "investigate" {
+		return toolResult{Success: false, IsError: true, Output: "iris: investigator is read-only — `edit` is not available in investigate sessions"}
+	}
+
 	filePath := stringArg(frame.Args, "file_path")
 	if filePath == "" {
 		filePath = stringArg(frame.Args, "path")
@@ -449,6 +458,12 @@ func (d *toolDispatcher) runEdit(ctx context.Context, frame ToolExecFrame) toolR
 
 // runWrite executes the write tool in a sandboxed subprocess (worktree RW).
 func (d *toolDispatcher) runWrite(ctx context.Context, frame ToolExecFrame) toolResult {
+	// Investigator read-only gate: write must fail for investigate sessions
+	// with a clear "read-only" message before any path validation runs.
+	if d.role == "investigate" {
+		return toolResult{Success: false, IsError: true, Output: "iris: investigator is read-only — `write` is not available in investigate sessions"}
+	}
+
 	filePath := stringArg(frame.Args, "file_path")
 	if filePath == "" {
 		filePath = stringArg(frame.Args, "path")

--- a/modules/programs/prism/prism/internal/iris/tool_dispatcher_investigator_test.go
+++ b/modules/programs/prism/prism/internal/iris/tool_dispatcher_investigator_test.go
@@ -1,0 +1,107 @@
+package iris
+
+// tool_dispatcher_investigator_test.go — unit tests for the read-only
+// gates on `write` and `edit` when role == "investigate".
+//
+// The investigator must NEVER reach the sandbox subprocess for these
+// tools: the gate runs before path validation so it produces a clear
+// "investigator is read-only" output regardless of args.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunWrite_InvestigatorRoleIsReadOnly(t *testing.T) {
+	d := &toolDispatcher{role: "investigate"}
+	got := d.runWrite(context.Background(), ToolExecFrame{
+		Name: "write",
+		Args: map[string]any{
+			"file_path": "/some/path",
+			"content":   "anything",
+		},
+	})
+	if got.Success {
+		t.Fatalf("runWrite(investigate): success = true, want false")
+	}
+	if !got.IsError {
+		t.Errorf("runWrite(investigate): is_error = false, want true")
+	}
+	if !strings.Contains(got.Output, "investigator is read-only") {
+		t.Errorf("output = %q, want 'investigator is read-only'", got.Output)
+	}
+	if !strings.Contains(got.Output, "write") {
+		t.Errorf("output = %q, want it to mention the blocked tool 'write'", got.Output)
+	}
+}
+
+func TestRunEdit_InvestigatorRoleIsReadOnly(t *testing.T) {
+	d := &toolDispatcher{role: "investigate"}
+	got := d.runEdit(context.Background(), ToolExecFrame{
+		Name: "edit",
+		Args: map[string]any{
+			"file_path":  "/some/path",
+			"old_string": "foo",
+			"new_string": "bar",
+		},
+	})
+	if got.Success {
+		t.Fatalf("runEdit(investigate): success = true, want false")
+	}
+	if !got.IsError {
+		t.Errorf("runEdit(investigate): is_error = false, want true")
+	}
+	if !strings.Contains(got.Output, "investigator is read-only") {
+		t.Errorf("output = %q, want 'investigator is read-only'", got.Output)
+	}
+	if !strings.Contains(got.Output, "edit") {
+		t.Errorf("output = %q, want it to mention the blocked tool 'edit'", got.Output)
+	}
+}
+
+// TestRunWrite_NonInvestigatorRolePassesGate asserts that the read-only
+// gate is strictly role-keyed. A worker session that sends a write with
+// a missing file_path arg trips the next layer's "missing 'file_path'"
+// error — which is the contract we want: the gate is invisible for
+// non-investigator roles.
+func TestRunWrite_NonInvestigatorRolePassesGate(t *testing.T) {
+	d := &toolDispatcher{role: "worker"}
+	got := d.runWrite(context.Background(), ToolExecFrame{
+		Name: "write",
+		Args: map[string]any{
+			// Intentionally no file_path: tests that we hit the next
+			// validation layer, not the read-only gate.
+			"content": "anything",
+		},
+	})
+	if got.Success {
+		t.Fatalf("runWrite(worker, no file_path): success = true, want false")
+	}
+	if strings.Contains(got.Output, "investigator is read-only") {
+		t.Errorf("output = %q; non-investigator role must NOT trip the read-only gate", got.Output)
+	}
+	if !strings.Contains(got.Output, "file_path") {
+		t.Errorf("output = %q, want next-layer 'missing file_path' error", got.Output)
+	}
+}
+
+func TestRunEdit_NonInvestigatorRolePassesGate(t *testing.T) {
+	d := &toolDispatcher{role: "worker"}
+	got := d.runEdit(context.Background(), ToolExecFrame{
+		Name: "edit",
+		Args: map[string]any{
+			"old_string": "foo",
+			"new_string": "bar",
+		},
+	})
+	if got.Success {
+		t.Fatalf("runEdit(worker, no file_path): success = true, want false")
+	}
+	if strings.Contains(got.Output, "investigator is read-only") {
+		t.Errorf("output = %q; non-investigator role must NOT trip the read-only gate", got.Output)
+	}
+	if !strings.Contains(got.Output, "file_path") {
+		t.Errorf("output = %q, want next-layer 'missing file_path' error", got.Output)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `iris investigate` — the iris analogue of `prism investigate`. Coordinators
get the same read-only research subcommand they already use against prism three
times today, this time daemon-routed and matching the iris CLI conventions.

## Surface

```
iris investigate --prompt "<question>"
iris investigate --prompt-file <path>
iris investigate --prompt -                    # stdin
iris investigate --name <slug> --prompt "..."  # explicit slug
```

`--name` constraints (`[a-z0-9-]`, max 40 chars, no leading/trailing dash) are
shared with prism via `internal/investigate.ValidateName`. Slug derivation is a
literal copy of prism's rules so the two CLIs are interchangeable.

The new session is named `<caller>~investigate-<slug>` and shows up in
`iris sessions list` with `role=investigate`. The calling session is taken
from `$IRIS_SESSION_NAME` (#1706); `--from <session>` overrides for scripts.

## Read-only enforcement (tool-dispatch layer)

Per the issue's guidance ("Read-only enforcement at iris tool-dispatch layer
per D-7 CredentialBroker pattern"):

- `internal/iris/tool_dispatcher.go`: `runWrite` and `runEdit` short-circuit
  with a clear `iris: investigator is read-only — \`write\` is not available
  in investigate sessions` message when `role == "investigate"`, before any
  path validation runs. This is the iris analogue of prism's
  `WorktreeReadOnly` bind-mount (iris does not use a container per session).
- `internal/iris/bash_permission.go`: `CheckBashPermission` now denies the
  investigator deny list when `role == "investigate"`. The list mirrors
  `modules/programs/prism/agents/investigate.md` verbatim:
    * `prism / iris spawn|review|merge|merges`, `iris investigate`
    * `gh issue|pr create|edit|merge|close|review|comment` (with
      `view|list|diff` refined to remain allowed — read-only paths)
    * `git push|commit|add|rebase|reset`
  Non-investigator roles are unaffected (the existing D-10 `prism merge`
  worker/coordinator gate is preserved verbatim).

## Daemon plumbing

- `ClientSessionSpawnFrame` gains an optional `session_name` field so the
  caller can fix the new session's logical name (the
  `<parent>~investigate-<slug>` shape that downstream code pattern-matches
  on, mirroring prism's `~investigate` marker). The daemon validates the
  name is not already active before spawning.
- `cmd/iris/main.go::spawnFn` signature extended with the explicit name;
  existing `SpawnSession` test signatures migrated.

## Per-turn output delivery

Per the watch-out ("#1727 — notifyParentWorker is now live. Investigator
output delivery uses the same path. Inherits exactly-once contract
automatically"): the investigator session sets `parent = $IRIS_SESSION_NAME`
on the spawn frame, which the supervisor stores on `sessions.parent_session`.
The existing `NotifyParent` callback wired in `cmd/iris/main.go` delivers a
body-bearing prompt to the calling session on terminal state via
`deliverFn` (the same path as `iris prompt`).

## Coverage

- `cmd/iris/investigate_test.go` — slug derivation parity with prism
  (mirrors `cmd/investigate_test.go` byte-for-byte) and `--name` validation.
- `cmd/iris/investigate_integration_test.go` — end-to-end against a real
  `iris.ClientSocket`:
    * spawn frame contents (name, worktree borrowed from caller, role,
      parent forwarded)
    * stdout prints the new session name
    * post-spawn session appears in the active set with
      `role=investigate` and the `~investigate-` marker
    * `--name` override
    * caller-not-registered refusal — fails before any spawn frame
    * daemon-down emits the canonical `systemctl --user start iris` hint
    * no nested investigators (Out-of-scope clause of the issue)
- `internal/iris/bash_permission_investigator_test.go` — pins the
  investigator deny list and proves non-investigator roles are unaffected.
- `internal/iris/tool_dispatcher_investigator_test.go` — proves `runWrite`
  and `runEdit` short-circuit for `role=investigate` while passing through
  to normal validation for other roles.

## Quality gates

- \`cd modules/programs/prism/prism && go build ./... && go test ./... -race\` ✓
- \`nix build .#iris\` from repo root ✓
- \`./result/bin/iris investigate --help\` ✓ (subcommand and help surface)
- \`./result/bin/iris --help\` ✓ (investigate listed)

## Out of scope (matches the issue body)

- Network-restricted investigation mode — prism's investigators have full
  network access; iris matches.
- Nested investigators — the integration test asserts a caller with
  `role=investigate` is rejected before any spawn.
- Long-running investigators with checkpointing — same lifetime semantics
  as workers (\`iris cleanup\` ends them).

Closes #1720