### PR TITLE
fix(review): isolate tmux in TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort (#1732)

### DIFF
--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2140,6 +2140,20 @@ func TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort(t *testing.T) {
 	// flaking under parallel `go test ./...` scheduling (#1709 follow-up).
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
+	// Redirect tmux.TmuxBin to a no-op shell-script stub so review.Run's
+	// host-mode spawn loop does not create real tmux sessions on the user's
+	// default tmux server. Without this, SpawnSession's tmux-new-session
+	// call lands on the live tmux server and the post-readiness-gate
+	// cleanup (`tmux.KillSession`, best-effort) can leak the 5 review-agent
+	// sessions under parallel `go test ./...` scheduling — picked up by the
+	// cmd/-package TestMain leak guard as `nixos-config@require-slot-ok~
+	// review-1-review-{role}` (#1732, regression introduced by #1728).
+	//
+	// Uses spawnSpyTmuxBin from spawn_prompt_file_test.go — the canonical
+	// tmux-isolation pattern in this package. Must NOT call t.Parallel:
+	// the helper rewrites the package-global tmux.TmuxBin.
+	_ = spawnSpyTmuxBin(t)
+
 	dbPath := filepath.Join(t.TempDir(), "prism.db")
 
 	pf := reviewProfilesFileWithAllSlots()


### PR DESCRIPTION
## Summary

P1 fix. PR #1728 introduced a tmux-session leak that catches in the cmd/-package leak guard, blocking every PR built on current main. This PR fixes the one leaking test.

## Root cause

`TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort` (added by #1728 in `internal/review/review_test.go`) drives `review.Run` with `IsolationMode:"host"` and all five review-agent slots present. The `RequireSlot` gate does not fire — Run proceeds into the spawn loop and `session.SpawnSession` (LayoutAgentOnly + host) creates a real tmux session for each of the 5 review agents on the user's default tmux server before the 1 s readiness gate trips.

The post-gate cleanup (`tmux.KillSession`) is best-effort and ignored on error, so under parallel `go test ./...` scheduling the sessions outlive the test and the cmd/-package `TestMain` leak guard catches them in the same run:

```
[LEAK GUARD] cmd test suite created 5 new live tmux session(s):
  - nixos-config@require-slot-ok~review-1-review-code
  - nixos-config@require-slot-ok~review-1-review-context
  - nixos-config@require-slot-ok~review-1-review-goal
  - nixos-config@require-slot-ok~review-1-review-qa
  - nixos-config@require-slot-ok~review-1-review-security
```

The sibling test `TestRun_RequireSlot_MissingSlot_AbortsAllSpawns` does NOT leak — its profile is missing a slot so `RequireSlot` aborts before any `SpawnSession` call.

## Fix

Install `spawnSpyTmuxBin(t)` — the canonical tmux-isolation pattern already in use elsewhere in this package (`spawn_prompt_file_test.go`) — on the leaking test. This redirects `tmux.TmuxBin` to a no-op shell-script stub for the duration of the test. No real tmux session is ever created.

Leak guard remains active and unmodified (no changes to `cmd/killsidecar_test.go`).

## Verification

- `tmux ls` before and after `go test ./internal/review/ -run TestRun_RequireSlot -race -count=20`: same count.
- `go test ./cmd/... -race -count=1` (with a placeholder tmux session up to enable the leak-guard's tmux-server probe): no leak reported.
- `go test ./... -race -count=1`: clean (pre-existing failure in `TestIrisMergesList_InvalidSession` reproduces on main without my changes — escalated separately, out of scope).
- `nix build .#prism`: ok.
- `nix build .#prism.override { runChecks = true; }`: ok (homeless-shelter sandbox checked variant).

Closes #1732