### PR TITLE
iris cmd tests: isolate from host tmux server (#1733)

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/merges_test.go
+++ b/modules/programs/prism/prism/cmd/iris/merges_test.go
@@ -517,8 +517,12 @@ func TestIrisMergesList_InvalidSession(t *testing.T) {
 	t.Setenv("IRIS_SESSION_NAME", "")
 	t.Setenv("PRISM_SESSION_NAME", "")
 	// Defensively clear tmux env so lookupIrisParentSession doesn't pick up
-	// the host tmux session inside CI.
+	// the host tmux session inside CI. Clearing $TMUX alone is insufficient
+	// — `tmux display-message` still walks its socket directory and finds a
+	// running server (#1733) — so we also redirect tmux.TmuxBin to a
+	// non-existent path via isolateHostTmux.
 	t.Setenv("TMUX", "")
+	isolateHostTmux(t)
 
 	_, listCmd, _ := newMergesTestCmds(t)
 	var buf bytes.Buffer

--- a/modules/programs/prism/prism/cmd/iris/tmux_isolation_test.go
+++ b/modules/programs/prism/prism/cmd/iris/tmux_isolation_test.go
@@ -1,0 +1,44 @@
+package main
+
+// tmux_isolation_test.go — test scaffolding for isolating iris CLI tests
+// from any tmux server running on the developer host.
+//
+// Background (issue #1733). Several iris CLI tests clear
+// $IRIS_SESSION_NAME and $PRISM_SESSION_NAME expecting
+// lookupIrisParentSession() to return "" (the "cannot determine calling
+// session" path). That helper has a third fallback — tmux.CurrentSession()
+// — which shells out to `tmux display-message -p "#{session_name}"`. On a
+// developer host with a running tmux server, that command succeeds even
+// when $TMUX is unset (tmux walks its socket directory and picks up the
+// default server), so the test inherits a host session name instead of the
+// empty string it expected. The test passes in CI because GH runners have
+// no tmux server up.
+//
+// isolateHostTmux redirects tmux.TmuxBin to a non-existent path for the
+// duration of the test. tmux.CurrentSession() then fails with an exec
+// error and lookupIrisParentSession() returns "" as the test expects.
+//
+// Production code is unaffected — TmuxBin is a package-level variable
+// reset by t.Cleanup, and the redirect lives entirely in test scaffolding.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// isolateHostTmux points tmux.TmuxBin at a non-existent binary so any
+// fallback to tmux.CurrentSession() during the test fails with an exec
+// error rather than picking up a real tmux server running on the
+// developer's host. Restored on t.Cleanup.
+//
+// Use from any iris CLI test that clears $IRIS_SESSION_NAME and
+// $PRISM_SESSION_NAME and relies on the env-empty path through
+// lookupIrisParentSession().
+func isolateHostTmux(t *testing.T) {
+	t.Helper()
+	orig := tmux.TmuxBin
+	tmux.TmuxBin = filepath.Join(t.TempDir(), "no-such-tmux-binary")
+	t.Cleanup(func() { tmux.TmuxBin = orig })
+}


### PR DESCRIPTION
## Summary

Fixes a host-state leak in `cmd/iris/` tests. `TestIrisMergesList_InvalidSession`
clears `$IRIS_SESSION_NAME`, `$PRISM_SESSION_NAME`, and `$TMUX` expecting
`lookupIrisParentSession()` to return `""` (the "cannot determine calling
session" path). That helper has a third fallback — `tmux.CurrentSession()`
— which shells out to `tmux display-message -p "#{session_name}"`. On a
developer host with a running tmux server, that command succeeds even when
`$TMUX` is unset (tmux walks its socket directory and picks up the default
server), so the test inherits a host session name and fails with
`session "placeholder" not found` instead of the expected
`cannot determine calling session`. CI passes because GH runners have no
tmux server up.

## Fix

Pure test scaffolding. New `cmd/iris/tmux_isolation_test.go` exposes an
`isolateHostTmux(t)` helper that points `tmux.TmuxBin` at a non-existent
path for the duration of the test (restored on `t.Cleanup`). Any fallback
to `tmux.CurrentSession()` then fails with an exec error and
`lookupIrisParentSession()` returns `""` as the test expects.

`TestIrisMergesList_InvalidSession` now calls `isolateHostTmux(t)`
alongside the existing env clears. The `$TMUX` clear is kept as
defence-in-depth so the test does not _need_ to fork-and-exec a missing
binary on hosts that have no tmux running at all.

Production `tmux.CurrentSession()` and the `lookupIrisParentSession()`
tmux fallback are unchanged.

## Audit

Searched `cmd/iris/` for tests that clear both `IRIS_SESSION_NAME` and
`PRISM_SESSION_NAME`:

| Test | Reaches tmux fallback? |
| --- | --- |
| `TestIrisMergesList_InvalidSession` (merges_test.go:511) | **Yes** — calls `runMergesList` → `resolveIrisMergesCaller` → `lookupIrisParentSession` |
| `TestRunSpawnAt_NoParentSessionWhenEnvUnset` (spawn_integration_test.go:280) | No — `cmd/iris/spawn.go` uses `os.Getenv("IRIS_SESSION_NAME")` directly with no tmux fallback |

Only the merges test needed fixing.

## Verification

Reproducer (with one tmux session running on the host):

\`\`\`bash
tmux new-session -d -s placeholder
cd modules/programs/prism/prism
go test ./cmd/iris/ -race -run TestIrisMergesList_InvalidSession -count=1
\`\`\`

- Before: \`FAIL — error says "session \"placeholder\" not found"\`
- After: \`ok  github.com/prismatic-koi/prism/cmd/iris\`

Full gates:

- \`go build ./...\` — clean
- \`go test ./cmd/iris/... -race -count=1\` — pass (with a host tmux server running)
- \`go test ./... -race -count=1\` — all packages pass
- \`nix build .#iris\` — succeeds

Closes #1733