### PR TITLE
fix(iris/tui): auto-subscribe on session_spawned when list was empty

### DIFF
--- a/modules/programs/prism/prism/internal/iris/tui/export_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/export_test.go
@@ -20,3 +20,17 @@ func ModelSessionAt(m Model, i int) (name, state, role string) {
 	s := m.sessions[i].snap
 	return s.Name, s.State, s.Role
 }
+
+// ModelSubscribedTo returns the session name the model is currently
+// subscribed to (the gate that prompt-send is conditioned on). Used by
+// tui_test.go to assert the auto-subscribe behaviour on session_spawned
+// when the list transitions from empty to non-empty.
+func ModelSubscribedTo(m Model) string {
+	return m.subscribedTo
+}
+
+// ModelCursor returns the cursor index. Used by tui_test.go to assert
+// cursor invariants after navigation / auto-subscribe.
+func ModelCursor(m Model) int {
+	return m.cursor
+}

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -338,7 +338,26 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 		// supervisor map in cmd/iris/main.go), so appending is consistent
 		// with the existing ordering — the new row simply appears at the
 		// bottom of the list.
+		wasEmpty := len(m.sessions) == 0
 		m.sessions = append(m.sessions, sessionItem{snap: snap})
+		// Auto-subscribe when the list transitions from empty to non-empty
+		// and there is no existing subscription. This mirrors the
+		// sessions_snapshot auto-subscribe path so a session spawned while
+		// the TUI is open with an empty list becomes immediately usable
+		// (prompt send is gated on subscribedTo != ""). We deliberately do
+		// NOT switch subscription when the list was already non-empty —
+		// that would steal focus from a session the user is actively
+		// watching whenever a sibling spawns.
+		if wasEmpty && m.subscribedTo == "" {
+			m.cursor = 0
+			name := snap.Name
+			m.subscribedTo = name
+			m.resetEventPane()
+			return m, func() tea.Msg {
+				_ = m.client.SendSessionSubscribe(name, 0)
+				return nil
+			}
+		}
 
 	case iris.DaemonFrameError:
 		if msg.Error != nil {

--- a/modules/programs/prism/prism/internal/iris/tui/tui_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/tui_test.go
@@ -341,6 +341,136 @@ func TestTUISessionSpawnedBackcompat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestTUISessionSpawnedAutoSubscribeFromEmpty — session_spawned auto-subscribes
+// when the list transitions from empty to non-empty (issue #1736).
+// ---------------------------------------------------------------------------
+
+// TestTUISessionSpawnedAutoSubscribeFromEmpty covers the core AC: with an
+// empty list and no current subscription, a session_spawned frame must set
+// subscribedTo to the spawned session so prompt-send becomes functional.
+func TestTUISessionSpawnedAutoSubscribeFromEmpty(t *testing.T) {
+	m := newConnectedModel()
+
+	// Empty snapshot — the case where the user opens iris tui before any
+	// session exists.
+	emptySnap := iris.DaemonSessionsSnapshotFrame{
+		Type:     iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &emptySnap})
+	m = m2.(tui.Model)
+
+	if sub := tui.ModelSubscribedTo(m); sub != "" {
+		t.Fatalf("precondition: subscribedTo = %q, want empty", sub)
+	}
+
+	// Now spawn a session out-of-band.
+	newSnap := iris.SessionSnapshot{
+		Name:       "nixos-config@spawned",
+		InstanceID: "iid-new",
+		State:      "spawning",
+		Role:       "worker",
+		Worktree:   "/repo/new",
+	}
+	m2, cmd := m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       newSnap.Name,
+			InstanceID: newSnap.InstanceID,
+			Session:    &newSnap,
+		},
+	})
+	m = m2.(tui.Model)
+
+	if sub := tui.ModelSubscribedTo(m); sub != "nixos-config@spawned" {
+		t.Errorf("subscribedTo = %q after session_spawned from empty list, want %q", sub, "nixos-config@spawned")
+	}
+	if c := tui.ModelCursor(m); c != 0 {
+		t.Errorf("cursor = %d, want 0 (only row)", c)
+	}
+	// The model should have returned a command to actually send the
+	// SUBSCRIBE frame (mirroring sessions_snapshot auto-subscribe).
+	if cmd == nil {
+		t.Errorf("expected non-nil tea.Cmd to dispatch SUBSCRIBE; got nil")
+	}
+}
+
+// TestTUISessionSpawnedDoesNotStealSubscription covers the edge-case AC:
+// when the user is already subscribed to a session, a later session_spawned
+// must NOT steal the subscription / cursor.
+func TestTUISessionSpawnedDoesNotStealSubscription(t *testing.T) {
+	m := newConnectedModel()
+
+	// Snapshot with one session — auto-subscribe should pick it.
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: "first", InstanceID: "iid-1", State: "active", Role: "worker"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	if sub := tui.ModelSubscribedTo(m); sub != "first" {
+		t.Fatalf("precondition: subscribedTo = %q, want %q", sub, "first")
+	}
+
+	// A second session spawns. We must NOT switch to it.
+	newSnap := iris.SessionSnapshot{
+		Name: "second", InstanceID: "iid-2", State: "spawning", Role: "worker",
+	}
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       newSnap.Name,
+			InstanceID: newSnap.InstanceID,
+			Session:    &newSnap,
+		},
+	})
+	m = m2.(tui.Model)
+
+	if sub := tui.ModelSubscribedTo(m); sub != "first" {
+		t.Errorf("subscribedTo = %q after sibling spawn, want %q (must not steal)", sub, "first")
+	}
+	if c := tui.ModelCursor(m); c != 0 {
+		t.Errorf("cursor = %d after sibling spawn, want 0 (must not move)", c)
+	}
+	if got := tui.ModelSessionCount(m); got != 2 {
+		t.Errorf("session count = %d, want 2 (new row appended)", got)
+	}
+}
+
+// TestTUISessionSpawnedBackcompatAutoSubscribe — even when the daemon
+// emits a legacy frame (no Session payload) into an empty list, the TUI
+// auto-subscribes using the Name field.
+func TestTUISessionSpawnedBackcompatAutoSubscribe(t *testing.T) {
+	m := newConnectedModel()
+
+	emptySnap := iris.DaemonSessionsSnapshotFrame{
+		Type:     iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &emptySnap})
+	m = m2.(tui.Model)
+
+	m2, _ = m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionSpawned,
+		Spawned: &iris.DaemonSessionSpawnedFrame{
+			Type:       iris.DaemonFrameSessionSpawned,
+			Name:       "legacy@only",
+			InstanceID: "iid-legacy",
+		},
+	})
+	m = m2.(tui.Model)
+
+	if sub := tui.ModelSubscribedTo(m); sub != "legacy@only" {
+		t.Errorf("subscribedTo = %q, want %q", sub, "legacy@only")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TestTUIEventStream — session_event frames render in the right pane
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1736.

## Problem

The iris TUI auto-subscribes to the highlighted session on `sessions_snapshot` (TUI startup), but the `session_spawned` handler added in #1673 only appended the new session to the list — it never set `subscribedTo`. Prompt-send is gated on `subscribedTo != ""` (model.go line 385), so a session spawned out-of-band while the TUI was open with an empty list left the cursor positioned correctly and the prompt field accepting input, but **enter silently no-op'd**.

## Fix

In `handleDaemonFrame` for `session_spawned`: remember whether the list was empty before appending. If it was empty AND `subscribedTo == ""`, pin the cursor to row 0 and auto-subscribe to the new session, mirroring the `sessions_snapshot` path.

## Edge cases preserved

- **Existing subscription preserved when a sibling spawns** — we gate on the empty→non-empty transition, so a worker spawning a peer while the user is watching another session does not steal focus. Covered by `TestTUISessionSpawnedDoesNotStealSubscription`.
- **Explicit cursor-navigation unchanged** — `up`/`down` lives in `handleKey` (untouched), so the existing `switchToSelected()` path still drives subscription on cursor moves.
- **Legacy daemon frames** (no `Session` payload, just `Name`/`InstanceID`) also auto-subscribe — covered by `TestTUISessionSpawnedBackcompatAutoSubscribe`.

## Tests

New tests in `internal/iris/tui/tui_test.go`:

- `TestTUISessionSpawnedAutoSubscribeFromEmpty` — core AC: empty list → session_spawned → `subscribedTo` is the spawned session, tea.Cmd dispatched.
- `TestTUISessionSpawnedDoesNotStealSubscription` — sibling-spawn doesn't move cursor or change subscription.
- `TestTUISessionSpawnedBackcompatAutoSubscribe` — legacy frame path auto-subscribes via `Name` field.

Two test-only accessors added in `export_test.go` (`ModelSubscribedTo`, `ModelCursor`) so assertions don't scrape rendered output.

## Verification

```
go test ./internal/iris/... -race   # all green
nix build .#iris                    # ok
```