### PR TITLE
iris: extend #1715 cleanup discipline to client/harness socket scaffold

### DIFF
--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -137,6 +137,16 @@ type ClientSocket struct {
 	// The mutex guards both the map and the slices inside it.
 	subMu       sync.Mutex
 	subscribers map[string][]subscriberChan
+
+	// wg tracks every goroutine the ClientSocket spawns: Serve, each
+	// per-connection handleConn, each runSubscription, and the per-frame
+	// handlers (handleSessionSpawn / handleSessionKill / handlePromptDeliver
+	// / handleReviewSpawn / handleEscalationDeliver). Wait() blocks until
+	// all of them return and is the canonical drain point for test cleanup
+	// (issue #1705) — callers that own the DB or tempdir must Wait before
+	// closing those resources, otherwise late writes from runSubscription
+	// or a frame handler race against teardown.
+	wg sync.WaitGroup
 }
 
 // subscriberChan wraps a channel together with a unique ID so that
@@ -244,7 +254,14 @@ func (cs *ClientSocket) Listen() error {
 // Serve accepts client connections in a loop until ctx is cancelled. Each
 // accepted connection is handled in its own goroutine. Serve is intended to
 // be called in its own goroutine.
+//
+// Serve itself, every spawned handleConn, and every goroutine those handlers
+// spawn (runSubscription, handle*Frame) are tracked in cs.wg so test
+// scaffolding can Wait() for all of them to drain before tearing down the
+// DB / tempdir (issue #1705).
 func (cs *ClientSocket) Serve(ctx context.Context) {
+	cs.wg.Add(1)
+	defer cs.wg.Done()
 	for {
 		conn, err := cs.listener.Accept()
 		if err != nil {
@@ -260,8 +277,29 @@ func (cs *ClientSocket) Serve(ctx context.Context) {
 			}
 			continue
 		}
-		go cs.handleConn(ctx, conn)
+		cs.wg.Add(1)
+		go func(conn net.Conn) {
+			defer cs.wg.Done()
+			cs.handleConn(ctx, conn)
+		}(conn)
 	}
+}
+
+// Wait blocks until every goroutine spawned by this ClientSocket has
+// returned: the Serve accept loop, every per-connection handleConn, every
+// runSubscription, and every per-frame handler. It is the canonical drain
+// point for test cleanup (issue #1705) — callers that own the DB or the
+// tempdir backing the iris paths must Wait before closing those resources.
+//
+// Wait does NOT cancel anything itself. Callers must first cancel the
+// context passed to Serve and Close() the listener so the goroutines
+// actually exit; Wait only blocks until they do.
+//
+// Production callers in the iris daemon do not need to call Wait — the
+// daemon's process lifetime owns these goroutines and they exit when the
+// daemon does. Wait exists for test scaffolding.
+func (cs *ClientSocket) Wait() {
+	cs.wg.Wait()
 }
 
 // SockPath returns the filesystem path of the client IPC socket.
@@ -432,18 +470,22 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 			activeSubs[frame.Name] = subEntry{id: subID, cancel: subCancel}
 			subMu.Unlock()
 
-			go cs.runSubscription(subCtx, w, frame, subID, func() {
-				// Called by the subscription goroutine when done (client
-				// disconnect or ctx cancel). Remove from the local map and
-				// the global subscriber set.
-				subMu.Lock()
-				if e, ok := activeSubs[frame.Name]; ok && e.id == subID {
-					delete(activeSubs, frame.Name)
-				}
-				subMu.Unlock()
-				cs.removeSubscriber(frame.Name, subID)
-				subCancel()
-			})
+			cs.wg.Add(1)
+			go func() {
+				defer cs.wg.Done()
+				cs.runSubscription(subCtx, w, frame, subID, func() {
+					// Called by the subscription goroutine when done (client
+					// disconnect or ctx cancel). Remove from the local map and
+					// the global subscriber set.
+					subMu.Lock()
+					if e, ok := activeSubs[frame.Name]; ok && e.id == subID {
+						delete(activeSubs, frame.Name)
+					}
+					subMu.Unlock()
+					cs.removeSubscriber(frame.Name, subID)
+					subCancel()
+				})
+			}()
 
 		case ClientFrameSessionUnsubscribe:
 			var frame ClientSessionUnsubscribeFrame
@@ -465,7 +507,11 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				sendError(w, ClientFrameSessionSpawn, "invalid frame: "+err.Error())
 				continue
 			}
-			go cs.handleSessionSpawn(connCtx, w, frame)
+			cs.wg.Add(1)
+			go func(frame ClientSessionSpawnFrame) {
+				defer cs.wg.Done()
+				cs.handleSessionSpawn(connCtx, w, frame)
+			}(frame)
 
 		case ClientFrameSessionKill:
 			var frame ClientSessionKillFrame
@@ -473,7 +519,11 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				sendError(w, ClientFrameSessionKill, "invalid frame: "+err.Error())
 				continue
 			}
-			go cs.handleSessionKill(connCtx, w, frame)
+			cs.wg.Add(1)
+			go func(frame ClientSessionKillFrame) {
+				defer cs.wg.Done()
+				cs.handleSessionKill(connCtx, w, frame)
+			}(frame)
 
 		case ClientFramePromptDeliver:
 			var frame ClientPromptDeliverFrame
@@ -481,7 +531,11 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				sendError(w, ClientFramePromptDeliver, "invalid frame: "+err.Error())
 				continue
 			}
-			go cs.handlePromptDeliver(connCtx, w, frame)
+			cs.wg.Add(1)
+			go func(frame ClientPromptDeliverFrame) {
+				defer cs.wg.Done()
+				cs.handlePromptDeliver(connCtx, w, frame)
+			}(frame)
 
 		case ClientFrameReviewSpawn:
 			var frame ClientReviewSpawnFrame
@@ -489,7 +543,11 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				sendError(w, ClientFrameReviewSpawn, "invalid frame: "+err.Error())
 				continue
 			}
-			go cs.handleReviewSpawn(connCtx, w, frame)
+			cs.wg.Add(1)
+			go func(frame ClientReviewSpawnFrame) {
+				defer cs.wg.Done()
+				cs.handleReviewSpawn(connCtx, w, frame)
+			}(frame)
 
 		case ClientFrameEscalationDeliver:
 			var frame ClientEscalationDeliverFrame
@@ -497,7 +555,11 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 				sendError(w, ClientFrameEscalationDeliver, "invalid frame: "+err.Error())
 				continue
 			}
-			go cs.handleEscalationDeliver(connCtx, w, frame)
+			cs.wg.Add(1)
+			go func(frame ClientEscalationDeliverFrame) {
+				defer cs.wg.Done()
+				cs.handleEscalationDeliver(connCtx, w, frame)
+			}(frame)
 
 		case ClientFramePing:
 			_ = w.write(DaemonPongFrame{Type: DaemonFramePong})

--- a/modules/programs/prism/prism/internal/iris/client_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/iristest"
 )
 
 // ---------------------------------------------------------------------------
@@ -222,6 +223,22 @@ func TestClientFrameRoundTrip(t *testing.T) {
 
 // newTestClientSocket creates a ClientSocket backed by a test DB with an in-memory
 // session list. Returns the socket and a publish function.
+//
+// Cleanup ordering (load-bearing, per issue #1705): t.Cleanup runs in LIFO
+// order. The cleanups below are registered in this order:
+//
+//  1. database.Close   — runs LAST among these.
+//  2. cs.Close         — closes the listener so Accept errors out.
+//  3. cancel           — cancels the Serve context so handleConn /
+//                        runSubscription / handle*Frame goroutines exit.
+//  4. cs.Wait drain    — runs FIRST: blocks until every spawned
+//                        ClientSocket goroutine returns, so no late
+//                        write races against Close / database.Close /
+//                        tempdir removal.
+//
+// t.TempDir()'s implicit cleanup is registered before any of ours, so it
+// runs last — after the drain has guaranteed no goroutine is still
+// writing to the tempdir.
 func newTestClientSocket(t *testing.T, sessions []iris.SessionSnapshot) (*iris.ClientSocket, func(iris.EventPublication)) {
 	t.Helper()
 	tmp := t.TempDir()
@@ -249,8 +266,35 @@ func newTestClientSocket(t *testing.T, sessions []iris.SessionSnapshot) (*iris.C
 	t.Cleanup(cancel)
 	go cs.Serve(ctx)
 
+	// Drain in-flight ClientSocket goroutines before any earlier cleanup
+	// closes the DB or removes the tempdir (issue #1705). Registered LAST
+	// so LIFO order runs it FIRST.
+	t.Cleanup(func() {
+		cancel()
+		cs.Close()
+		waitClientSocketOrFail(t, cs)
+	})
+
 	return cs, func(pub iris.EventPublication) {
 		cs.Publish(pub)
+	}
+}
+
+// waitClientSocketOrFail bounds the cs.Wait() call so a wedged goroutine
+// cannot hang the test process. The bound is generous — a healthy drain
+// completes in milliseconds. A wedge is a real bug and we surface it
+// loudly via t.Errorf so it cannot hide as a flake.
+func waitClientSocketOrFail(t *testing.T, cs *iris.ClientSocket) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		cs.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Errorf("newTestClientSocket: ClientSocket did not drain within 10s after cancel+Close — wedged goroutine")
 	}
 }
 
@@ -855,63 +899,21 @@ func TestClientSocketSockPath(t *testing.T) {
 // review-goal identified as broken: SetPublisher wired through the
 // SupervisorConfig.Publisher field and called in NewSupervisor.
 func TestHarnessToClientFanOut(t *testing.T) {
-	tmp := t.TempDir()
-	dbPath := filepath.Join(tmp, "iris.db")
-	database, err := iris.OpenDB(dbPath)
-	if err != nil {
-		t.Fatalf("OpenDB: %v", err)
-	}
-	defer database.Close()
-
-	sessionName := "harness-fanout@test"
-
-	// --- Set up the ClientSocket ---
-	sockPath := filepath.Join(tmp, "iris.sock")
-	cs := iris.NewClientSocket(iris.ClientSocketConfig{
-		SockPath: sockPath,
-		Database: database,
-		GetActiveSessions: func() []iris.SessionSnapshot {
-			return []iris.SessionSnapshot{
-				{Name: sessionName, InstanceID: "iid-hf", State: "active", Role: "worker"},
-			}
-		},
+	// Use iristest.NewSocketScaffold so every goroutine the ClientSocket
+	// or HarnessSocketServer spawns (Serve, handleConn, runSubscription,
+	// dispatchToolExec, etc.) is drained before the per-test DB and
+	// tempdir are torn down. See issue #1705 and PR #1715 — the same
+	// cleanup-ordering race that affected the restore tests affects this
+	// fanout test under a different scaffold; the helper extends the
+	// supervisor-Done discipline to the client/harness-socket pair.
+	scaffold := iristest.NewSocketScaffold(t, iristest.SocketScaffoldOptions{
+		SessionName: "harness-fanout@test",
+		InstanceID:  "iid-hf",
+		Role:        "worker",
 	})
-	if err := cs.Listen(); err != nil {
-		t.Fatalf("ClientSocket.Listen: %v", err)
-	}
-	defer cs.Close()
-
-	csCtx, csCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer csCancel()
-	go cs.Serve(csCtx)
-
-	// Insert sessions row so FK on agent_events.instance_id is satisfied.
-	insertTestSessionRow(t, database, "iid-hf", sessionName, tmp)
-
-	// --- Set up the HarnessSocketServer with the ClientSocket as publisher ---
-	harnessSockPath := filepath.Join(tmp, "harness.sock")
-	sess := &iris.SessionRecord{
-		InstanceID:      "iid-hf",
-		SessionName:     sessionName,
-		Worktree:        tmp,
-		Role:            "worker",
-		HarnessSockPath: harnessSockPath,
-	}
-	harness, err := iris.NewHarnessSocketServer(sess, database)
-	if err != nil {
-		t.Fatalf("NewHarnessSocketServer: %v", err)
-	}
-	// KEY: wire the client socket as the harness publisher.
-	harness.SetPublisher(cs)
-
-	if err := harness.Listen(); err != nil {
-		t.Fatalf("HarnessSocketServer.Listen: %v", err)
-	}
-	defer harness.Close()
-
-	harnessCtx, harnessCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer harnessCancel()
-	go func() { _ = harness.AcceptOne(harnessCtx) }()
+	sessionName := scaffold.SessionName
+	sockPath := scaffold.ClientSocket.SockPath()
+	harnessSockPath := scaffold.HarnessSocketServer.SockPath()
 
 	// --- Connect a client to the ClientSocket and subscribe ---
 	clientConn, clientReader := dialClientSocket(t, sockPath)
@@ -977,14 +979,6 @@ func TestHarnessToClientFanOut(t *testing.T) {
 // This is a unit test of the SupervisorConfig.Publisher → SetPublisher path
 // without actually spawning a pi child.
 func TestSupervisorPublisherConfig(t *testing.T) {
-	tmp := t.TempDir()
-	dbPath := filepath.Join(tmp, "iris.db")
-	database, err := iris.OpenDB(dbPath)
-	if err != nil {
-		t.Fatalf("OpenDB: %v", err)
-	}
-	defer database.Close()
-
 	// A minimal EventPublisher implementation that records publications.
 	type testPublisher struct {
 		mu   sync.Mutex
@@ -997,37 +991,18 @@ func TestSupervisorPublisherConfig(t *testing.T) {
 		tp.pubs = append(tp.pubs, pub)
 	})
 
-	sessionName := "sup-publisher@test"
-
-	// Set up a HarnessSocketServer with the publisher wired via SupervisorConfig.Publisher.
-	// (We don't spawn a real supervisor — we test the harness server directly to
-	// validate the wiring path that NewSupervisor follows.)
-
-	// Insert sessions row so FK on agent_events.instance_id is satisfied.
-	insertTestSessionRow(t, database, "iid-sp", sessionName, tmp)
-
-	harnessSockPath := filepath.Join(tmp, "harness.sock")
-	sess := &iris.SessionRecord{
-		InstanceID:      "iid-sp",
-		SessionName:     sessionName,
-		Worktree:        tmp,
-		Role:            "worker",
-		HarnessSockPath: harnessSockPath,
-	}
-	harness, err := iris.NewHarnessSocketServer(sess, database)
-	if err != nil {
-		t.Fatalf("NewHarnessSocketServer: %v", err)
-	}
-	// This is the same call that NewSupervisor makes when cfg.Publisher != nil.
-	harness.SetPublisher(publishFn)
-	if err := harness.Listen(); err != nil {
-		t.Fatalf("Listen: %v", err)
-	}
-	defer harness.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	go func() { _ = harness.AcceptOne(ctx) }()
+	// Use iristest.NewSocketScaffold to inherit the #1705 cleanup
+	// discipline (drain in-flight goroutines before DB / tempdir
+	// teardown). The scaffold's default publisher is the ClientSocket;
+	// here we override it with the test's recording publishFn to exercise
+	// the SupervisorConfig.Publisher → SetPublisher path.
+	scaffold := iristest.NewSocketScaffold(t, iristest.SocketScaffoldOptions{
+		SessionName: "sup-publisher@test",
+		InstanceID:  "iid-sp",
+		Role:        "worker",
+		Publisher:   publishFn,
+	})
+	harnessSockPath := scaffold.HarnessSocketServer.SockPath()
 
 	// Connect as the extension, do handshake, send a tool_exec.
 	hConn, hReader := dialHarness(t, harnessSockPath)

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -80,6 +80,18 @@ type HarnessSocketServer struct {
 	// frame arrives — used by the supervisor to detect clean exits.
 	sessionShutdownReceived bool
 	shutdownMu              sync.Mutex
+
+	// wg tracks goroutines spawned by this server that may write to the DB
+	// or the session run directory: every `go h.dispatchToolExec(...)` and
+	// the AcceptOne accept loop register an Add(1) before they start and a
+	// Done() before they return. Wait() blocks until all of them complete
+	// and is the canonical drain point for test cleanup ordering
+	// (issue #1705) — callers that own shared state (tempdir, DB) must
+	// invoke Wait before tearing that state down, otherwise a late write
+	// from dispatchToolExec → writeEvent races against tempdir removal and
+	// DB close, surfacing as 'unlinkat ... directory not empty' or
+	// 'sql: database is closed'.
+	wg sync.WaitGroup
 }
 
 // SockPath returns the path of the harness socket.
@@ -158,6 +170,14 @@ func (h *HarnessSocketServer) Listen() error {
 // socket. The listener is only closed (and the socket file removed) by an
 // explicit call to Close().
 func (h *HarnessSocketServer) AcceptOne(ctx context.Context) error {
+	// Track this call in the WaitGroup so test scaffolding can Wait() for
+	// the AcceptOne → handleConn path to finish before tearing down the
+	// per-session tempdir / DB (issue #1705). Production callers Wait()
+	// implicitly via the daemon's normal shutdown sequence; the WaitGroup
+	// is otherwise free of cost.
+	h.wg.Add(1)
+	defer h.wg.Done()
+
 	// Ensure any prior deadline is cleared before we start waiting.
 	if dl, ok := h.listener.(interface{ SetDeadline(time.Time) error }); ok {
 		_ = dl.SetDeadline(time.Time{})
@@ -190,6 +210,24 @@ func (h *HarnessSocketServer) AcceptOne(ctx context.Context) error {
 		}
 		return h.handleConn(ctx, res.conn)
 	}
+}
+
+// Wait blocks until every goroutine spawned by this HarnessSocketServer
+// has returned: the AcceptOne / handleConn loop and every in-flight
+// dispatchToolExec. It is the canonical drain point for test cleanup
+// (issue #1705) — callers that own the per-session tempdir or the DB
+// must Wait() before closing those resources, otherwise a late write
+// from a dispatch goroutine races against teardown.
+//
+// Wait does NOT cancel anything itself. Callers must first cancel the
+// context passed to AcceptOne (and any other context driving dispatch)
+// so the goroutines actually exit; Wait only blocks until they do.
+//
+// Production callers in the iris daemon do not need to call Wait — the
+// daemon's process lifetime owns these goroutines and they exit when
+// the daemon does. Wait exists for test scaffolding.
+func (h *HarnessSocketServer) Wait() {
+	h.wg.Wait()
 }
 
 // Close closes the listener and removes the socket file.
@@ -303,7 +341,14 @@ func (h *HarnessSocketServer) handleConn(ctx context.Context, conn net.Conn) err
 				log.Printf("[iris] harness: bad tool_exec frame: %v", err)
 				continue
 			}
-			go h.dispatchToolExec(ctx, w, frame)
+			// Track the dispatch in h.wg so Wait() drains in-flight tool
+			// executions before test cleanup tears down the tempdir / DB
+			// (issue #1705).
+			h.wg.Add(1)
+			go func(frame ToolExecFrame) {
+				defer h.wg.Done()
+				h.dispatchToolExec(ctx, w, frame)
+			}(frame)
 
 		case FrameTypeToolAbort:
 			var frame ToolAbortFrame

--- a/modules/programs/prism/prism/internal/iris/harness_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket_test.go
@@ -121,6 +121,22 @@ func doHandshake(t *testing.T, conn net.Conn, r *bufio.Reader) map[string]any {
 // startServer starts a HarnessSocketServer in a background goroutine and
 // returns it. A sessions row is inserted so FK constraints on agent_events
 // are satisfied when events are written with instance_id set.
+//
+// Cleanup ordering (load-bearing, per issue #1705): t.Cleanup runs in LIFO
+// order. The cleanups below are registered in this order:
+//
+//  1. database.Close   — runs LAST among these.
+//  2. srv.Close        — closes the listener so AcceptOne errors out.
+//  3. cancel           — cancels the AcceptOne context so any in-flight
+//                        dispatchToolExec subprocess is signalled to abort.
+//  4. srv.Wait drain   — runs FIRST: blocks until every dispatchToolExec
+//                        goroutine and the AcceptOne goroutine return, so
+//                        no late write races against Close /
+//                        database.Close / tempdir removal.
+//
+// t.TempDir()'s implicit cleanup is registered before any of ours, so it
+// runs last — after the drain has guaranteed no goroutine is still
+// writing to the tempdir.
 func startServer(t *testing.T) *iris.HarnessSocketServer {
 	t.Helper()
 	tmp := t.TempDir()
@@ -155,7 +171,35 @@ func startServer(t *testing.T) *iris.HarnessSocketServer {
 	t.Cleanup(cancel)
 	go func() { _ = srv.AcceptOne(ctx) }()
 
+	// Drain in-flight HarnessSocketServer goroutines (AcceptOne /
+	// dispatchToolExec) before any earlier cleanup closes the DB or
+	// removes the tempdir (issue #1705). Registered LAST so LIFO order
+	// runs it FIRST.
+	t.Cleanup(func() {
+		cancel()
+		srv.Close()
+		waitHarnessSocketOrFail(t, srv)
+	})
+
 	return srv
+}
+
+// waitHarnessSocketOrFail bounds the srv.Wait() call so a wedged dispatch
+// (e.g. a hung bash subprocess) cannot hang the test process. A healthy
+// drain completes in milliseconds; the 10s bound is generous. A wedge is
+// a real bug surfaced loudly via t.Errorf, never hidden as a flake.
+func waitHarnessSocketOrFail(t *testing.T, srv *iris.HarnessSocketServer) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		srv.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Errorf("startServer: HarnessSocketServer did not drain within 10s after cancel+Close — wedged goroutine")
+	}
 }
 
 // TestHandshake verifies hello/hello_ack round-trip.

--- a/modules/programs/prism/prism/internal/iris/iristest/sockets.go
+++ b/modules/programs/prism/prism/internal/iris/iristest/sockets.go
@@ -1,0 +1,266 @@
+package iristest
+
+// sockets.go — test-scaffold helpers for tests that wire a ClientSocket
+// and/or a HarnessSocketServer against a per-test DB and tempdir.
+//
+// # The race these helpers fix (issue #1705)
+//
+// PR #1715 fixed the supervisor-goroutine-outlives-cleanup race for the
+// restore tests by exposing iris.RunRestore's supervisor list and adding
+// RunRestoreForTest, which Wait()s on every spawned supervisor before
+// t.Cleanup tears the per-test tempdir / DB down.
+//
+// The same race class affects every test that wires a ClientSocket or a
+// HarnessSocketServer directly: those servers spawn goroutines —
+// HarnessSocketServer.dispatchToolExec, ClientSocket.handleConn,
+// ClientSocket.runSubscription, every per-frame handler — and those
+// goroutines write to the DB and to the per-session run directory. A test
+// that returns before those goroutines finish leaves them racing against
+// t.Cleanup's `database.Close()` and tempdir removal, surfacing as
+// 'unlinkat .../001: directory not empty' or 'sql: database is closed'
+// (see #1705 reopen comment, PR #1728 CI flake on TestHarnessToClientFanOut).
+//
+// # The discipline
+//
+// Both HarnessSocketServer and ClientSocket now expose a Wait() method
+// (added in this change) that blocks until every goroutine the server
+// has spawned has returned. The helpers below register a t.Cleanup that:
+//
+//  1. Cancels the per-server context (so context-driven select arms fire).
+//  2. Closes the listener (so Accept returns; new dials fail fast).
+//  3. Calls Wait() to drain in-flight goroutines.
+//
+// t.Cleanup runs in LIFO order, so a cleanup registered by these helpers
+// AFTER the test obtains its DB / tempdir runs FIRST during teardown —
+// exactly the ordering we need: drain goroutines first, then close DB,
+// then remove tempdir.
+//
+// # No new synchronisation primitives
+//
+// The helpers reuse the WaitGroup-based Wait() methods on the servers.
+// No new mutex, no atomic, no time.Sleep workaround.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// drainTimeout bounds the Wait() call in the cleanup. A wedged goroutine
+// is a real bug; we surface it via t.Errorf rather than blocking the test
+// process indefinitely.
+const drainTimeout = 10 * time.Second
+
+// SocketScaffold bundles a ClientSocket and a HarnessSocketServer wired
+// against a shared DB and tempdir, with cleanup that drains all spawned
+// goroutines before the DB / tempdir are torn down.
+//
+// Use this for tests that exercise the full client-socket + harness-socket
+// fan-out path (e.g. TestHarnessToClientFanOut) or any test that wires
+// both servers together.
+type SocketScaffold struct {
+	// Tmp is the per-test t.TempDir() owned by the scaffold.
+	Tmp string
+	// DB is the open iris DB at $Tmp/iris.db.
+	DB *db.DB
+	// ClientSocket is the user-facing IPC socket; Listen and Serve have
+	// already been called. SockPath is at $Tmp/iris.sock.
+	ClientSocket *iris.ClientSocket
+	// HarnessSocketServer is the per-session harness listener; Listen
+	// has been called and AcceptOne is running in a background goroutine.
+	HarnessSocketServer *iris.HarnessSocketServer
+	// SessionName is the in-memory session record's logical name.
+	SessionName string
+	// InstanceID is the in-memory session record's instance UUID.
+	InstanceID string
+}
+
+// SocketScaffoldOptions is the input to NewSocketScaffold. Both
+// SessionName and InstanceID default to deterministic values when empty.
+type SocketScaffoldOptions struct {
+	// SessionName is the iris session name to register in the sessions row
+	// and on the HarnessSocketServer. Default: "iris-test@fanout".
+	SessionName string
+	// InstanceID is the session instance UUID. Default: "iid-test".
+	InstanceID string
+	// Role is the agent role on the harness session record. Default:
+	// "worker".
+	Role string
+	// GetActiveSessions overrides the ClientSocket's session list
+	// getter. Default: a single-element list containing a SessionSnapshot
+	// derived from SessionName / InstanceID / Role.
+	GetActiveSessions func() []iris.SessionSnapshot
+	// Publisher overrides the harness publisher. When non-nil, the helper
+	// wires this publisher onto the HarnessSocketServer instead of the
+	// scaffold's ClientSocket. When nil, the ClientSocket itself is wired
+	// as the publisher (this is the common case — it matches the
+	// harness→publisher→client fan-out the daemon configures in
+	// production).
+	Publisher iris.EventPublisher
+	// NoPublisher, when true, suppresses publisher wiring entirely. Used
+	// by tests that want to verify the no-publisher branch of
+	// HarnessSocketServer.publishEvent.
+	NoPublisher bool
+}
+
+// NewSocketScaffold creates a SocketScaffold for a test. It:
+//
+//  1. Creates a per-test tempdir and opens an iris DB inside it.
+//  2. Inserts a sessions row so agent_events writes satisfy the FK.
+//  3. Constructs a ClientSocket on $Tmp/iris.sock, calls Listen and
+//     launches Serve in a goroutine under a scaffold-owned context.
+//  4. Constructs a HarnessSocketServer on $Tmp/harness.sock, calls Listen,
+//     wires the ClientSocket as the harness publisher (unless opts
+//     override), and launches AcceptOne in a goroutine under a separate
+//     scaffold-owned context.
+//  5. Registers t.Cleanup hooks that cancel both contexts, close the
+//     listeners, Wait() for in-flight goroutines, then close the DB.
+//
+// Cleanup-ordering invariant (load-bearing): the helper registers its
+// drain cleanup AFTER t.TempDir() and the DB-close cleanup, so LIFO
+// ordering runs the drain FIRST, then the DB close, then the tempdir
+// removal. Any reordering re-introduces the #1705 race.
+func NewSocketScaffold(t *testing.T, opts SocketScaffoldOptions) *SocketScaffold {
+	t.Helper()
+
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("iristest: OpenDB(%q): %v", dbPath, err)
+	}
+	// DB close is registered BEFORE the drain cleanup below so LIFO
+	// ordering runs the drain first, then this close.
+	t.Cleanup(func() { _ = database.Close() })
+
+	sessionName := opts.SessionName
+	if sessionName == "" {
+		sessionName = "iris-test@fanout"
+	}
+	instanceID := opts.InstanceID
+	if instanceID == "" {
+		instanceID = "iid-test"
+	}
+	role := opts.Role
+	if role == "" {
+		role = "worker"
+	}
+
+	// FK on agent_events.instance_id requires the sessions row to exist
+	// before any harness event is written.
+	if err := database.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Worktree:    tmp,
+		Harness:     "pi",
+		StartedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("iristest: InsertSession: %v", err)
+	}
+
+	getActiveSessions := opts.GetActiveSessions
+	if getActiveSessions == nil {
+		snap := iris.SessionSnapshot{
+			Name:       sessionName,
+			InstanceID: instanceID,
+			State:      "active",
+			Role:       role,
+		}
+		getActiveSessions = func() []iris.SessionSnapshot {
+			return []iris.SessionSnapshot{snap}
+		}
+	}
+
+	clientSockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath:          clientSockPath,
+		Database:          database,
+		GetActiveSessions: getActiveSessions,
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("iristest: ClientSocket.Listen: %v", err)
+	}
+
+	harnessSockPath := filepath.Join(tmp, "harness.sock")
+	sess := &iris.SessionRecord{
+		InstanceID:      instanceID,
+		SessionName:     sessionName,
+		Worktree:        tmp,
+		Role:            role,
+		HarnessSockPath: harnessSockPath,
+	}
+	harness, err := iris.NewHarnessSocketServer(sess, database)
+	if err != nil {
+		t.Fatalf("iristest: NewHarnessSocketServer: %v", err)
+	}
+
+	if !opts.NoPublisher {
+		if opts.Publisher != nil {
+			harness.SetPublisher(opts.Publisher)
+		} else {
+			harness.SetPublisher(cs)
+		}
+	}
+	if err := harness.Listen(); err != nil {
+		t.Fatalf("iristest: HarnessSocketServer.Listen: %v", err)
+	}
+
+	// Background contexts for Serve and AcceptOne. We own the cancellers
+	// so the cleanup can stop both servers deterministically.
+	csCtx, csCancel := context.WithCancel(context.Background())
+	go cs.Serve(csCtx)
+
+	harnessCtx, harnessCancel := context.WithCancel(context.Background())
+	go func() { _ = harness.AcceptOne(harnessCtx) }()
+
+	// Drain cleanup. Registered LAST among the cleanups this helper owns,
+	// so LIFO ordering runs it FIRST during teardown: cancel contexts,
+	// close listeners, Wait() for goroutines. Only after Wait() returns
+	// is the DB closed (registered above) and the tempdir removed
+	// (registered by t.TempDir before any of this helper's cleanups).
+	t.Cleanup(func() {
+		// Cancel contexts so context-driven select arms fire.
+		harnessCancel()
+		csCancel()
+		// Close listeners so Accept returns and pending dials fail fast.
+		harness.Close()
+		cs.Close()
+		// Drain in-flight goroutines. A bounded wait protects against
+		// a wedged goroutine hanging the test process indefinitely; a
+		// real wedge is a bug and is surfaced via t.Errorf.
+		waitOrFail(t, "HarnessSocketServer", harness.Wait)
+		waitOrFail(t, "ClientSocket", cs.Wait)
+	})
+
+	return &SocketScaffold{
+		Tmp:                 tmp,
+		DB:                  database,
+		ClientSocket:        cs,
+		HarnessSocketServer: harness,
+		SessionName:         sessionName,
+		InstanceID:          instanceID,
+	}
+}
+
+// waitOrFail runs wait() in a goroutine and either returns when it
+// completes or surfaces a t.Errorf when drainTimeout elapses. The bound
+// is high enough that a non-wedged goroutine drains comfortably; a
+// wedge indicates a real bug, not a flake, and the error is loud so it
+// cannot hide.
+func waitOrFail(t *testing.T, label string, wait func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(drainTimeout):
+		t.Errorf("iristest: %s did not drain within %v after cancel+close \u2014 wedged goroutine", label, drainTimeout)
+	}
+}


### PR DESCRIPTION
PR #1715 fixed the supervisor-goroutine-outlives-cleanup race for the restore
tests by exposing `iris.RunRestore`'s supervisor list and adding
`iristest.RunRestoreForTest`, which `Wait()`s on every spawned supervisor
before `t.Cleanup` tears the per-test tempdir / DB down.

The same race class still affects `TestHarnessToClientFanOut` and any other
test that wires a `ClientSocket` and/or a `HarnessSocketServer` directly:
those servers spawn goroutines — `HarnessSocketServer.dispatchToolExec`,
`ClientSocket.handleConn`, `ClientSocket.runSubscription`, the per-frame
handlers — that write to the DB and the per-session run directory. A test
that returns before those goroutines finish leaves them racing against
`t.Cleanup`'s `database.Close()` and tempdir removal, surfacing as
`unlinkat .../001: directory not empty` (the symptom on PR #1728's CI flake,
documented in the reopen comment on this issue).

This PR extends the #1715 discipline to that scaffold.

## Changes

- **`HarnessSocketServer` and `ClientSocket` each gain a `Wait()` method.**
  Both servers now track every goroutine they spawn in an internal
  `sync.WaitGroup`. `AcceptOne` / `dispatchToolExec` on the harness side, and
  `Serve` / `handleConn` / `runSubscription` / every per-frame handler on the
  client side, each `Add(1)` before they start and `Done()` before they
  return. `Wait()` blocks until every spawned goroutine has returned. It does
  not cancel anything itself — it is purely a drain barrier. Production
  callers (the iris daemon) do not need to call `Wait` because the daemon's
  process lifetime owns these goroutines.

- **New helper `iristest.NewSocketScaffold`** in
  `internal/iris/iristest/sockets.go`. The canonical test-scaffold helper for
  tests that exercise the client/harness fan-out path. It opens a DB, builds
  both servers, wires them together (ClientSocket as the harness publisher
  by default; overridable via `Publisher` / `NoPublisher` options), launches
  `Serve` and `AcceptOne` under scaffold-owned contexts, and registers a
  `t.Cleanup` that cancels both contexts, closes the listeners, and calls
  `Wait()` on both servers (bounded by 10s so a wedged goroutine surfaces
  loudly as `t.Errorf`, never as a flake). The drain cleanup is registered
  after `t.TempDir()` and the DB-close cleanup, so LIFO ordering runs the
  drain FIRST during teardown, then the DB close, then the tempdir removal —
  exactly the ordering invariant #1705 calls out.

- **`TestHarnessToClientFanOut` and `TestSupervisorPublisherConfig`** are
  refactored to use `NewSocketScaffold`. The latter passes a custom
  `Publisher` to keep exercising the `SupervisorConfig.Publisher → SetPublisher`
  path.

- **The in-package helpers `newTestClientSocket` (client_socket_test.go) and
  `startServer` (harness_socket_test.go) are updated** with the same
  drain-on-cleanup pattern using `cs.Wait()` / `srv.Wait()` directly, so every
  existing test that uses those helpers inherits the discipline automatically
  — no opt-in required.

## Watch-outs addressed

- **#1715 patterns** — same `sync.WaitGroup` / Wait-on-Done shape; bounded
  waits surface wedges via `t.Errorf` rather than hiding them.
- **#1729 captureLog drain pattern** — same idea: drain in-flight goroutines
  before tearing down shared state, registered as a `t.Cleanup` that runs
  before the DB / tempdir cleanups in LIFO order.
- **Test isolation per #1608** — `NewSocketScaffold` uses `t.TempDir()` and
  does not touch host paths; session names are stable strings, not slugs
  derived from the test name, and no DB / sockets escape the tempdir.
- **No new mutex/atomic** — reuses `sync.WaitGroup`, the same primitive #1715
  already established.
- **No `time.Sleep` workaround** — the drain is a deterministic Wait on
  WaitGroup completion; the `time.After(10s)` is only a wedge-detection
  fallback, never a normal-path delay.

## Verification

From `modules/programs/prism/prism/`:

```bash
# Per-issue AC: 20/20 stability
go test ./internal/iris/ -race -run TestHarnessToClientFanOut -count=20
# → ok (20/20 PASS)

# Issue AC: extended to TestSupervisorPublisherConfig which now shares the scaffold
go test ./internal/iris/ -race \
  -run 'TestHarnessToClientFanOut|TestSupervisorPublisherConfig' -count=20
# → ok (40/40 PASS combined)

# Build + lint
go build ./...
go vet ./internal/iris/...
```

From repo root:

```bash
nix build .#iris
# → succeeds
```

## Pre-existing flakes (not introduced by this PR, escalated separately)

The full module suite under `-race -count=N` exposes several pre-existing
flakes unrelated to the cleanup-race class:

- `TestSupervisorKill_SIGKILLEscalation_NotifiesParentOnce` and
  `TestSupervisorKill_EscalatesToSIGKILL` — the pi child sometimes exits
  cleanly before SIGTERM fires under CPU contention, surfacing
  `terminal state = finished, want error`. Reproduces on `main` at the same
  rate with no changes from this PR applied.
- `TestFanOut` (the 3-client subscribe test, distinct from the
  `TestHarnessToClient` fanout target of this PR) — flakes when paired with
  bwrap-running tests because the 50ms `time.Sleep` after `sendClientFrame`
  is insufficient for subscription registration under CPU pressure. Also
  reproduces on `main`.
- `TestToolAbort` / `TestBashAbortReturnsAborted` — intermittent under
  full-suite `-race -count=1` (same shape on `main`).

All escalated to the coordinator informationally; none are in scope for this
PR. The target AC `TestHarnessToClientFanOut` 20/20 under `-race -count=20` is
met.

Closes #1705
