### PR TITLE
fix(iris): drop 'iris-<role>@' prefix; session name is now <repo>/<branch>

### DIFF
--- a/modules/programs/prism/prism/cmd/iris/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/iris/list_sessions.go
@@ -122,11 +122,16 @@ func renderSessionsListJSON(w io.Writer, sessions []iris.SessionSnapshot, now ti
 // renderSessionsListTable writes the human-readable table to w.
 //
 // Column widths are fixed so the output is grep-able. The SESSION column
-// shows a 12-char truncation of the UUID (mirrors git short-hash convention,
-// per the spec). WORKTREE shows the basename — the full path is in --json.
+// shows the logical session name (e.g. `hass-config/main`) — this is the
+// disambiguating identifier across worktrees and the value users pass to
+// `iris prompt`, `iris kill`, etc. The instance UUID remains available in
+// the --json output (`id` field). WORKTREE shows the worktree basename;
+// the full path is in --json. See issue #1738 for the SESSION-column
+// rationale: the previous UUID-prefix display was opaque and gave users
+// no way to map a row back to a worktree at a glance.
 func renderSessionsListTable(w io.Writer, sessions []iris.SessionSnapshot, now time.Time) error {
 	const (
-		wSession  = 12
+		wSession  = 32
 		wState    = 10
 		wRole     = 12
 		wWorktree = 24
@@ -152,10 +157,7 @@ func renderSessionsListTable(w io.Writer, sessions []iris.SessionSnapshot, now t
 
 	stateStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(cliColPrimary))
 	for _, s := range sessions {
-		shortID := s.InstanceID
-		if len(shortID) > wSession {
-			shortID = shortID[:wSession]
-		}
+		name := truncateForColumn(s.Name, wSession)
 		state := truncateForColumn(s.State, wState)
 		role := truncateForColumn(s.Role, wRole)
 		worktreeBase := filepath.Base(s.Worktree)
@@ -167,7 +169,7 @@ func renderSessionsListTable(w io.Writer, sessions []iris.SessionSnapshot, now t
 		uptime := formatUptime(s.StartedAt, now)
 
 		_, err := fmt.Fprintf(w, "%-*s  %s  %-*s  %-*s  %-*s\n",
-			wSession, shortID,
+			wSession, name,
 			stateStyle.Render(fmt.Sprintf("%-*s", wState, state)),
 			wRole, role,
 			wWorktree, worktree,

--- a/modules/programs/prism/prism/cmd/iris/main.go
+++ b/modules/programs/prism/prism/cmd/iris/main.go
@@ -163,20 +163,59 @@ var daemonCmd = &cobra.Command{
 
 // daemonState holds the in-memory runtime state of the iris daemon.
 type daemonState struct {
-	mu          sync.Mutex
-	supervisors map[string]*iris.Supervisor // session name → supervisor
+	mu sync.Mutex
+	// supervisors is the live session-name → supervisor map. Only
+	// fully-spawned sessions appear here.
+	supervisors map[string]*iris.Supervisor
+	// reservedNames is the set of session names whose spawn is in flight.
+	// It is consulted alongside `supervisors` when enforcing
+	// session-name uniqueness so that two concurrent spawns targeting
+	// the same name cannot both pass the check before either calls
+	// addSupervisor. See reserveSupervisorName and issue #1738.
+	reservedNames map[string]struct{}
 }
 
 func (ds *daemonState) addSupervisor(name string, sup *iris.Supervisor) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 	ds.supervisors[name] = sup
+	// Spawn completed — release the reservation slot so this name behaves
+	// like any other live session for subsequent uniqueness checks.
+	delete(ds.reservedNames, name)
+}
+
+// reserveSupervisorName atomically checks that name is not already in use
+// (neither live nor reserved by an in-flight spawn) and, if free, marks
+// it as reserved. Returns true on success; the caller must subsequently
+// either call addSupervisor (on spawn success) or removeSupervisor (on
+// spawn failure), both of which release the reservation. Returns false
+// when the name collides — the caller should surface that as an error
+// to the client rather than proceeding.
+//
+// This is the race-free check-and-set used by the daemon spawn path to
+// prevent two concurrent spawns from silently overwriting the same
+// supervisor-map entry — see issue #1738.
+func (ds *daemonState) reserveSupervisorName(name string) bool {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	if _, exists := ds.supervisors[name]; exists {
+		return false
+	}
+	if _, reserved := ds.reservedNames[name]; reserved {
+		return false
+	}
+	ds.reservedNames[name] = struct{}{}
+	return true
 }
 
 func (ds *daemonState) removeSupervisor(name string) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 	delete(ds.supervisors, name)
+	// Also drop any in-flight reservation: the only caller that uses
+	// removeSupervisor as a spawn-failure rollback (spawnFn) needs the
+	// name freed so the user can retry.
+	delete(ds.reservedNames, name)
 }
 
 func (ds *daemonState) activeSessions() []iris.SessionSnapshot {
@@ -228,7 +267,8 @@ func runDaemon() error {
 	defer cancel()
 
 	state := &daemonState{
-		supervisors: make(map[string]*iris.Supervisor),
+		supervisors:   make(map[string]*iris.Supervisor),
+		reservedNames: make(map[string]struct{}),
 	}
 
 	// deliverFn is called by the client socket when a prompt_deliver frame arrives.
@@ -347,7 +387,22 @@ func runDaemon() error {
 		}
 		resolvedName := sessionName
 		if resolvedName == "" {
-			resolvedName = iris.GenerateSessionName(worktree, resolvedRole)
+			resolvedName = iris.GenerateSessionName(worktree)
+		}
+		// Uniqueness: reject the spawn if a session with this logical name
+		// is already active. The same guard runs at the client-socket
+		// boundary when the client supplies an explicit session name
+		// (handleSessionSpawn), but the daemon-derived path (empty
+		// sessionName → GenerateSessionName) needs its own check so the
+		// supervisor map cannot be silently overwritten — see issue #1738.
+		//
+		// We intentionally reject rather than uniquify (e.g.
+		// `repo/branch-2`): a clear error gives the user an actionable
+		// signal (`iris cleanup` the stale one, or pick a different
+		// worktree) rather than quietly producing a second session that
+		// the user will struggle to associate with the right worktree.
+		if !state.reserveSupervisorName(resolvedName) {
+			return nil, fmt.Errorf("session %q is already active (same worktree+repo would overwrite it)", resolvedName)
 		}
 		superCfg := iris.SupervisorConfig{
 			SessionName:      resolvedName,
@@ -372,6 +427,9 @@ func runDaemon() error {
 		}
 		sup, err := iris.SpawnSession(ctx, superCfg)
 		if err != nil {
+			// Spawn failed — release the reservation so the name can be
+			// retried after the user fixes the underlying problem.
+			state.removeSupervisor(resolvedName)
 			return nil, err
 		}
 		state.addSupervisor(superCfg.SessionName, sup)
@@ -402,7 +460,7 @@ func runDaemon() error {
 	// as `iris spawn`) but with a caller-supplied session name (the
 	// canonical `<parent>~review-N-<agent>` shape). reviewSpawnFn below
 	// adapts spawnFn for that contract: spawnFn assigns the session name
-	// from worktree+role via GenerateSessionName, so we wrap it to inject
+	// from worktree via GenerateSessionName, so we wrap it to inject
 	// our pre-computed name through a per-call override.
 	reviewSpawnFn := func(rsCtx context.Context, sessionName, worktree, role string) (*iris.Supervisor, error) {
 		return spawnReviewAgent(rsCtx, ctx, cfg, p, database, clientSock, state, sessionName, worktree, role)
@@ -471,8 +529,15 @@ func spawnReviewAgent(
 		Database:         database,
 		Publisher:        clientSock,
 	}
+	// Reserve the session name before spawning so a concurrent spawn for
+	// the same review-agent name cannot silently overwrite the supervisor
+	// map. Same rationale as the spawnFn check; see issue #1738.
+	if !state.reserveSupervisorName(sessionName) {
+		return nil, fmt.Errorf("session %q is already active (review-agent name collision)", sessionName)
+	}
 	sup, err := iris.SpawnSession(daemonCtx, superCfg)
 	if err != nil {
+		state.removeSupervisor(sessionName)
 		return nil, err
 	}
 	state.addSupervisor(sessionName, sup)

--- a/modules/programs/prism/prism/cmd/iris/main_reservation_test.go
+++ b/modules/programs/prism/prism/cmd/iris/main_reservation_test.go
@@ -1,0 +1,132 @@
+package main
+
+// main_reservation_test.go — unit tests for daemonState.reserveSupervisorName.
+//
+// The reservation slot exists because the daemon's spawn path is
+// non-atomic: GenerateSessionName / addSupervisor are separated by
+// SpawnSession which can take seconds. Two concurrent spawns targeting
+// the same session name would, without reservation, both pass the
+// "is name free?" check and the second would silently overwrite the
+// supervisor-map entry of the first — the exact failure mode reported
+// in issue #1738.
+//
+// These tests pin down the contract:
+//
+//   - reserveSupervisorName returns true exactly once for a given name
+//     while either a reservation OR a live supervisor for that name exists.
+//   - addSupervisor consumes the reservation (so the same name is then
+//     blocked by the live entry, not the placeholder).
+//   - removeSupervisor releases both the live entry and the reservation
+//     so the name can be retried after a failed spawn.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+func newTestDaemonState() *daemonState {
+	return &daemonState{
+		supervisors:   make(map[string]*iris.Supervisor),
+		reservedNames: make(map[string]struct{}),
+	}
+}
+
+// TestReserveSupervisorName_RejectsDuplicateReservation is the core
+// race-free check the spawn path relies on: a second concurrent spawn
+// for the same name (where neither has called addSupervisor yet) must
+// fail the reservation check rather than silently passing.
+func TestReserveSupervisorName_RejectsDuplicateReservation(t *testing.T) {
+	ds := newTestDaemonState()
+	if !ds.reserveSupervisorName("repo/main") {
+		t.Fatal("first reservation: expected true, got false")
+	}
+	if ds.reserveSupervisorName("repo/main") {
+		t.Error("second reservation for same name: expected false, got true")
+	}
+	// A different name is unaffected.
+	if !ds.reserveSupervisorName("repo/other") {
+		t.Error("reservation for different name: expected true, got false")
+	}
+}
+
+// TestReserveSupervisorName_RejectsLiveSupervisor verifies that once a
+// supervisor is registered for a name, reserveSupervisorName for that
+// name returns false — i.e. the live entry blocks new reservations the
+// same way an in-flight one does.
+func TestReserveSupervisorName_RejectsLiveSupervisor(t *testing.T) {
+	ds := newTestDaemonState()
+	// Live supervisor is registered directly (skipping the reservation
+	// step) — equivalent to the test having seeded a fake live session.
+	ds.supervisors["repo/main"] = nil
+	if ds.reserveSupervisorName("repo/main") {
+		t.Error("reservation for already-live name: expected false, got true")
+	}
+}
+
+// TestAddSupervisor_ClearsReservation asserts the lifecycle: a successful
+// spawn (reserve → addSupervisor) drops the placeholder. Subsequent
+// reservation requests for the same name are blocked by the live entry,
+// not by a stale reservation row.
+func TestAddSupervisor_ClearsReservation(t *testing.T) {
+	ds := newTestDaemonState()
+	if !ds.reserveSupervisorName("repo/main") {
+		t.Fatal("reserve: expected true")
+	}
+	// addSupervisor with a nil supervisor — we don't need a real one
+	// for this test; the map mechanics are what we're asserting.
+	ds.addSupervisor("repo/main", nil)
+	if _, stillReserved := ds.reservedNames["repo/main"]; stillReserved {
+		t.Error("addSupervisor did not drop the reservation row")
+	}
+	if _, live := ds.supervisors["repo/main"]; !live {
+		t.Error("addSupervisor did not register the live entry")
+	}
+}
+
+// TestRemoveSupervisor_ReleasesReservation asserts the failure-rollback
+// path: when SpawnSession returns an error, spawnFn calls
+// removeSupervisor to free the name so the user can retry.
+func TestRemoveSupervisor_ReleasesReservation(t *testing.T) {
+	ds := newTestDaemonState()
+	if !ds.reserveSupervisorName("repo/main") {
+		t.Fatal("reserve: expected true")
+	}
+	// Spawn failed before addSupervisor — only the reservation exists.
+	ds.removeSupervisor("repo/main")
+	if _, stillReserved := ds.reservedNames["repo/main"]; stillReserved {
+		t.Error("removeSupervisor did not drop the reservation row")
+	}
+	// And the name is reservable again.
+	if !ds.reserveSupervisorName("repo/main") {
+		t.Error("name still blocked after removeSupervisor; expected to be free")
+	}
+}
+
+// TestReserveSupervisorName_Concurrent stresses the lock: with N
+// goroutines all trying to reserve the same name, exactly one must
+// succeed. This is the property that makes the daemon spawn path
+// race-free for issue #1738.
+func TestReserveSupervisorName_Concurrent(t *testing.T) {
+	ds := newTestDaemonState()
+	const N = 64
+	var wg sync.WaitGroup
+	wg.Add(N)
+	var mu sync.Mutex
+	successCount := 0
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			if ds.reserveSupervisorName("repo/main") {
+				mu.Lock()
+				successCount++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if successCount != 1 {
+		t.Errorf("expected exactly 1 successful reservation under contention, got %d", successCount)
+	}
+}

--- a/modules/programs/prism/prism/cmd/iris/sessions.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions.go
@@ -55,8 +55,9 @@ var sessionsListCmd = &cobra.Command{
 	Short: "List daemon-tracked sessions",
 	Long: `Print a table of sessions the iris daemon is currently tracking.
 
-Columns: SESSION (12-char UUID prefix), STATE, ROLE, WORKTREE (basename), UPTIME.
-The full UUID and full worktree path are available via --json.
+Columns: SESSION (logical name, e.g. <repo>/<branch>), STATE, ROLE,
+WORKTREE (basename), UPTIME. The instance UUID and full worktree path
+are available via --json.
 
 When no sessions are present, only the header row is printed (exit 0). This
 keeps the output trivially grep-able.`,

--- a/modules/programs/prism/prism/cmd/iris/sessions_test.go
+++ b/modules/programs/prism/prism/cmd/iris/sessions_test.go
@@ -37,9 +37,10 @@ func fixedNow(t *testing.T) time.Time {
 // in "active" and one worker in "waiting". Both have RFC3339 StartedAt
 // stamps that produce stable uptimes against fixedNow().
 func fixtureSessions() []iris.SessionSnapshot {
+	// New session-name format per issue #1738: <repo>/<branch>.
 	return []iris.SessionSnapshot{
 		{
-			Name:             "iris-test@main",
+			Name:             "iris-test/main",
 			InstanceID:       "11111111-2222-3333-4444-555555555555",
 			State:            "active",
 			Role:             "coordinator",
@@ -48,7 +49,7 @@ func fixtureSessions() []iris.SessionSnapshot {
 			HarnessSessionID: "/home/user/.pi/agent/sessions/aaaaaaaa.jsonl",
 		},
 		{
-			Name:             "iris-test@feature-x",
+			Name:             "iris-test/feature-x",
 			InstanceID:       "66666666-7777-8888-9999-aaaaaaaaaaaa",
 			State:            "waiting",
 			Role:             "worker",
@@ -82,8 +83,8 @@ func TestRenderSessionsListTable_Empty(t *testing.T) {
 }
 
 // TestRenderSessionsListTable_Populated asserts the populated table shows
-// the truncated 12-char UUID, the worktree basename (not the full path),
-// and a non-empty uptime.
+// the logical session name (issue #1738 — was 12-char UUID prefix), the
+// worktree basename (not the full path), and a non-empty uptime.
 func TestRenderSessionsListTable_Populated(t *testing.T) {
 	var buf bytes.Buffer
 	if err := renderSessionsListTable(&buf, fixtureSessions(), fixedNow(t)); err != nil {
@@ -91,12 +92,20 @@ func TestRenderSessionsListTable_Populated(t *testing.T) {
 	}
 	out := buf.String()
 
-	// 12-char UUID prefix for each session, no full UUID.
-	if !strings.Contains(out, "11111111-222") {
-		t.Errorf("expected 12-char UUID prefix for first session:\n%s", out)
+	// SESSION column now shows the logical name (issue #1738) so that two
+	// sessions with the same WORKTREE basename in different repos are
+	// visually distinguishable. The instance UUID stays available via --json.
+	if !strings.Contains(out, "iris-test/main") {
+		t.Errorf("expected logical name 'iris-test/main' in SESSION column:\n%s", out)
+	}
+	if !strings.Contains(out, "iris-test/feature-x") {
+		t.Errorf("expected logical name 'iris-test/feature-x' in SESSION column:\n%s", out)
 	}
 	if strings.Contains(out, "11111111-2222-3333-4444-555555555555") {
 		t.Errorf("full UUID must not appear in human-readable table:\n%s", out)
+	}
+	if strings.Contains(out, "11111111-222") {
+		t.Errorf("UUID prefix must no longer appear in human-readable table (use --json for instance id):\n%s", out)
 	}
 
 	// Worktree basename, not full path.

--- a/modules/programs/prism/prism/cmd/iris/spawn_test.go
+++ b/modules/programs/prism/prism/cmd/iris/spawn_test.go
@@ -94,8 +94,9 @@ func (m *mockDaemon) serve(t *testing.T) {
 	switch m.reply {
 	case replySuccess:
 		writeMockFrame(conn, iris.DaemonSessionSpawnedFrame{
-			Type:       iris.DaemonFrameSessionSpawned,
-			Name:       "iris-worker@" + filepath.Base(frame.Worktree),
+			Type: iris.DaemonFrameSessionSpawned,
+			// New <repo>/<branch> format per issue #1738.
+			Name:       "test-repo/" + filepath.Base(frame.Worktree),
 			InstanceID: "fake-instance-uuid-0000",
 		})
 	case replyError:
@@ -111,8 +112,9 @@ func (m *mockDaemon) serve(t *testing.T) {
 	case replyUnknown:
 		writeMockFrame(conn, map[string]any{"type": "some_future_frame", "data": 42})
 		writeMockFrame(conn, iris.DaemonSessionSpawnedFrame{
-			Type:       iris.DaemonFrameSessionSpawned,
-			Name:       "iris-worker@" + filepath.Base(frame.Worktree),
+			Type: iris.DaemonFrameSessionSpawned,
+			// New <repo>/<branch> format per issue #1738.
+			Name:       "test-repo/" + filepath.Base(frame.Worktree),
 			InstanceID: "fake-instance-uuid-0001",
 		})
 	}

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -67,7 +67,7 @@ type ClientSessionUnsubscribeFrame struct {
 // delivered when the child terminates.
 //
 // SessionName, when non-empty, fixes the new session's logical name instead
-// of letting the daemon derive one via GenerateSessionName(worktree, role).
+// of letting the daemon derive one via GenerateSessionName(worktree).
 // This is used by `iris investigate` and `iris review`, which both need a
 // caller-controlled `<parent>~<kind>-<slug>` shape so downstream code can
 // pattern-match on the name (e.g. notify.go's investigateAgentInvokerSession).

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -1188,19 +1188,57 @@ func PiSessionPathFromSessionID(piAgentDir, encodedCwd, sessionID string) (strin
 	return "", fmt.Errorf("iris: pi session %q not found under %q", sessionID, sessionsDir)
 }
 
-// GenerateSessionName generates a default session name from a worktree path
-// and role. The format is "iris-<role>@<basename>" where basename is the
-// last path component of the worktree. This is used by the daemon when a
-// client sends a session_spawn frame without specifying a session name.
+// GenerateSessionName generates a default session name from a worktree path.
+// The format is "<repo>/<branch>" where:
+//
+//   - <branch> is the final path component of the worktree (in the standard
+//     bare+worktree layout, the worktree directory is named after the branch);
+//   - <repo>   is the parent directory's name (the repo's bare/worktree
+//     container).
+//
+// This is used by the daemon when a client sends a session_spawn frame
+// without specifying a session name. Including the repo in the default
+// name prevents collisions across repos that share a branch name
+// (e.g. `main` in `nixos-config` and `main` in `hass-config`) — see
+// issue #1738.
+//
+// The role parameter is intentionally not part of the name: role is
+// already a separate field on SessionSnapshot and surfaced in its own
+// column. The historical "iris-<role>@" prefix was a tmux-coexistence
+// holdover from when iris and prism shared a tmux server; iris no longer
+// runs under tmux, so the prefix has been dropped.
+//
+// Slash in the returned name: callers that derive filesystem paths from
+// the session name must decide how to handle the embedded '/'. iris
+// currently makes two choices:
+//
+//   - Per-session log files (Paths.SessionLogPath) sanitise '/' to '_'
+//     so the log file is flat (`<repo>_<branch>.log`).
+//   - The archive layout accepts the slash as a real subdirectory, so
+//     archives are naturally grouped by repo on disk
+//     (`<archive-root>/<repo>/<branch>/<instance>/raw/session.jsonl`).
 //
 // Examples:
 //
-//	GenerateSessionName("/home/user/code/my-project", "worker")
-//	  → "iris-worker@my-project"
-func GenerateSessionName(worktree, role string) string {
-	base := filepath.Base(worktree)
-	if base == "" || base == "." || base == "/" {
-		base = "session"
+//	GenerateSessionName("/home/user/code/my-project/main")
+//	  → "my-project/main"
+//	GenerateSessionName("/home/user/code/hass-config/test")
+//	  → "hass-config/test"
+//	GenerateSessionName("/foo")
+//	  → "session/foo"   (no parent directory; safe fallback)
+func GenerateSessionName(worktree string) string {
+	abs, err := filepath.Abs(worktree)
+	if err != nil || abs == "" {
+		abs = worktree
 	}
-	return fmt.Sprintf("iris-%s@%s", role, base)
+	branch := filepath.Base(abs)
+	if branch == "" || branch == "." || branch == "/" {
+		branch = "default"
+	}
+	parent := filepath.Dir(abs)
+	repo := filepath.Base(parent)
+	if repo == "" || repo == "." || repo == "/" {
+		repo = "session"
+	}
+	return fmt.Sprintf("%s/%s", repo, branch)
 }

--- a/modules/programs/prism/prism/internal/iris/supervisor_session_name_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_session_name_test.go
@@ -1,0 +1,129 @@
+package iris
+
+// supervisor_session_name_test.go — unit tests for GenerateSessionName.
+//
+// These tests pin down the new <repo>/<branch> session-name convention
+// introduced in issue #1738. The previous "iris-<role>@<basename>" shape
+// was a tmux-coexistence holdover that dropped repo context and so
+// collided across repos sharing a branch name (e.g. `main` in
+// `nixos-config` vs. `main` in `hass-config`). The new shape always
+// carries the repo so two spawns on the same branch in different repos
+// produce two distinct session names.
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateSessionName_RepoSlashBranch(t *testing.T) {
+	cases := []struct {
+		worktree string
+		want     string
+	}{
+		// Canonical bare+worktree layout: parent dir = repo, leaf = branch.
+		{"/home/user/code/my-project/main", "my-project/main"},
+		{"/home/user/code/hass-config/test", "hass-config/test"},
+		{"/home/user/code/nixos-config/feature-x", "nixos-config/feature-x"},
+		// Trailing slash should not change the split.
+		{"/home/user/code/hass-config/main/", "hass-config/main"},
+		// Two repos sharing a branch name produce distinct session names —
+		// this is the regression the issue is fixing.
+		{"/x/repo-a/main", "repo-a/main"},
+		{"/x/repo-b/main", "repo-b/main"},
+	}
+	for _, tc := range cases {
+		got := GenerateSessionName(tc.worktree)
+		if got != tc.want {
+			t.Errorf("GenerateSessionName(%q) = %q, want %q", tc.worktree, got, tc.want)
+		}
+	}
+}
+
+// TestGenerateSessionName_NoCrossRepoCollision is the explicit AC check:
+// two worktrees on the same branch in different repos must produce
+// distinct session names (the symptom that motivated #1738).
+func TestGenerateSessionName_NoCrossRepoCollision(t *testing.T) {
+	a := GenerateSessionName("/home/x/repo-a/main")
+	b := GenerateSessionName("/home/x/repo-b/main")
+	if a == b {
+		t.Fatalf("expected distinct session names for different repos sharing a branch; both = %q", a)
+	}
+	if a != "repo-a/main" {
+		t.Errorf("a = %q, want %q", a, "repo-a/main")
+	}
+	if b != "repo-b/main" {
+		t.Errorf("b = %q, want %q", b, "repo-b/main")
+	}
+}
+
+// TestGenerateSessionName_NoIrisPrefix verifies the historical
+// "iris-<role>@" prefix has been removed (tmux-coexistence holdover).
+func TestGenerateSessionName_NoIrisPrefix(t *testing.T) {
+	got := GenerateSessionName("/home/user/code/my-project/main")
+	if got == "" {
+		t.Fatal("got empty session name")
+	}
+	for _, badSubstr := range []string{"iris-", "@", "worker", "coordinator"} {
+		if containsSubstring(got, badSubstr) {
+			t.Errorf("session name %q must not contain %q (drop tmux-coexistence prefix and role)", got, badSubstr)
+		}
+	}
+}
+
+// TestGenerateSessionName_SinglePathComponent exercises the AC edge case:
+// a one-component path like `/foo` must not panic and must produce a
+// graceful fallback.
+func TestGenerateSessionName_SinglePathComponent(t *testing.T) {
+	got := GenerateSessionName("/foo")
+	// With only one component, the parent is "/" — the fallback maps that
+	// to "session" so the returned name is still well-formed.
+	want := "session/foo"
+	if got != want {
+		t.Errorf("GenerateSessionName(\"/foo\") = %q, want %q", got, want)
+	}
+}
+
+// TestGenerateSessionName_EmptyAndDotPaths covers degenerate inputs.
+// They must not panic and must produce a non-empty, slash-shaped name.
+func TestGenerateSessionName_EmptyAndDotPaths(t *testing.T) {
+	cases := []string{"", ".", "/"}
+	for _, in := range cases {
+		got := GenerateSessionName(in)
+		if got == "" {
+			t.Errorf("GenerateSessionName(%q) returned empty string", in)
+		}
+		if !containsSubstring(got, "/") {
+			t.Errorf("GenerateSessionName(%q) = %q, want a name containing '/'", in, got)
+		}
+	}
+}
+
+// TestGenerateSessionName_RelativePath verifies relative paths are
+// resolved against the cwd before splitting. The exact repo name will
+// depend on the cwd, but the result must end with "/<basename>" and
+// contain no panic.
+func TestGenerateSessionName_RelativePath(t *testing.T) {
+	got := GenerateSessionName("some-branch")
+	// We don't assert the repo half (it's cwd-dependent), but we do
+	// assert the branch half is preserved and the shape is repo/branch.
+	if got == "" {
+		t.Fatal("got empty session name for relative path")
+	}
+	if filepath.Base(got) != "some-branch" {
+		t.Errorf("GenerateSessionName(\"some-branch\") = %q, want a name ending in /some-branch", got)
+	}
+}
+
+// containsSubstring is a tiny strings.Contains shim local to this file
+// so the test does not pull in the `strings` import for one call.
+func containsSubstring(s, substr string) bool {
+	if substr == "" {
+		return true
+	}
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Battle-testing surfaced that `iris.GenerateSessionName` produced
`iris-<role>@<basename>` which (1) dropped repo context, (2) carried a
tmux-coexistence-era prefix that is dead weight now that iris does not
run under tmux, and (3) silently overwrote the daemon's supervisor map
on collision. Two spawns on the same branch in different repos
produced `iris-worker@main` twice and one session disappeared from
`iris sessions list` without a signal.

This PR renames the default to `<repo>/<branch>`, drops the role
parameter, and adds a race-free daemon-side uniqueness check so
collisions produce a clear error instead of silently losing a session.

## Changes

- `internal/iris/supervisor.go::GenerateSessionName(worktree)` — new
  signature (role dropped); new format `<repo>/<branch>` with graceful
  fallbacks (`/foo` → `session/foo`, empty/dot → `session/default`).
- `cmd/iris/main.go::daemonState.reserveSupervisorName` — race-free
  check-and-set used by both `spawnFn` and `spawnReviewAgent` before
  `iris.SpawnSession`. Rolled back on spawn failure via
  `removeSupervisor` so the name can be retried.
- `cmd/iris/list_sessions.go` — `iris sessions list` SESSION column
  now shows the logical session name (was a 12-char UUID prefix). The
  instance UUID stays available in `--json` (`id` field).
- New unit tests:
  - `internal/iris/supervisor_session_name_test.go`: AC checks
    including the no-cross-repo-collision invariant and edge cases.
  - `cmd/iris/main_reservation_test.go`: lifecycle + concurrent
    contention assertion (exactly one of N goroutines wins).

## Key decisions

### 1. Daemon-side uniqueness check: REJECT (not uniquify)

When two spawns target the same logical name, the daemon now returns
a clear error: `session "<name>" is already active (same worktree+repo
would overwrite it)`. The alternative was to uniquify with a numeric
suffix (e.g. `hass-config/main-2`); I picked reject because:

- A clear error is actionable — the user runs `iris cleanup` on the
  stale one or picks a different worktree.
- Silent uniquification would produce a second session the user
  cannot easily map back to a worktree, repeating the same
  observability gap that caused the original bug.
- The codebase already had this guard for explicit session names
  (`handleSessionSpawn`); generalising it to the daemon-derived path
  is more consistent than splitting policy by code path.

The race-free version uses a `reservedNames` set so two concurrent
spawns can't both pass the "is it free?" check before either calls
`addSupervisor`. `TestReserveSupervisorName_Concurrent` pins this
down with 64 goroutines.

### 2. WORKTREE column: stays as branch-only

The SESSION column now carries the `<repo>/<branch>` disambiguator,
which means WORKTREE doesn't need to grow. Keeping WORKTREE as the
basename keeps the table narrow and grep-able. Full path remains
available via `--json`.

### 3. Slash in session names — split policy per consumer

`hass-config/main` contains a `/`. Two distinct policies:

- **Per-session log files** (`Paths.SessionLogPath`): **flat** —
  `sanitiseSessionFileName` already replaces `/` with `_`, so logs
  land at `~/.local/state/iris/logs/hass-config_main.log`. Flat
  filenames are easier to `ls` and `grep`, and no behaviour change
  is needed (the function already handled this case for safety).
- **Archive layout** (`internal/iris/archive.go`): **subdir**.
  Archives go to `<archive-root>/<repo>/<branch>/<instance>/raw/…`,
  naturally grouping per-repo. Archive paths are not globbed by
  external tooling.

Both choices documented in the package-level doc comment on
`GenerateSessionName` so the question is not re-litigated.

## Out of scope

- Existing session rows in the iris DB keep their old name format
  (\`iris-worker@…\`). No DB migration: only new spawns use the new
  shape, matching the policy in the issue's Watch-outs section.
- Test fixtures that hardcode `iris-worker@…` / `iris-test@…` are not
  renamed — they continue to work as opaque unique-on-host strings
  and are owned by concurrent PRs (#1705 iristest, #1724 harness
  socket test).
- TUI picker SESSION column (`switch_tui.go`) was not touched — owned
  by concurrent #1736 / #1737.
- `internal/iris/client_socket.go::resolveEscalationTarget` audited
  per the watch-out: it filters by `Role == "coordinator"`, not by
  any session-name prefix, so the change is safe.
- D-9 restore path audited: it reads `sess.SessionName` verbatim from
  the DB and never parses the format, so existing-row names continue
  to work.

## Verification

- `go build ./...` from `modules/programs/prism/prism/` — clean
- `go test ./internal/iris/... ./cmd/iris/... -count=1` — all pass
- `nix build .#prism` — clean
- New unit tests:
  - `TestGenerateSessionName_NoCrossRepoCollision` — the regression
    check (`/x/repo-a/main` and `/x/repo-b/main` produce distinct
    names).
  - `TestGenerateSessionName_SinglePathComponent` — AC edge case
    (`/foo` → `session/foo`, no panic).
  - `TestReserveSupervisorName_Concurrent` — exactly one of 64
    goroutines wins the reservation race.

Closes #1738