### PR TITLE
navi: double swap from 20 GiB to 40 GiB

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -230,7 +230,7 @@
   swapDevices = [
     {
       device = "/persist/swapfile";
-      size = 16384; # 16 GiB
+      size = 36864; # 36 GiB
     }
   ];
 


### PR DESCRIPTION
## Motivation

The prism system on `navi` recently OOM-crashed. Grow the `/persist/swapfile`
so the machine has substantially more headroom under memory pressure — the
user's framing was "we have about 20 GiB currently, can we double that?".

## Change

`machines/navi/configuration.nix`: bump the `/persist/swapfile` size from
`16384` (16 GiB) to `36864` (36 GiB). The inline comment is updated from
`# 16 GiB` to `# 36 GiB` to match.

## Total swap before / after (live system)

|         | Partition (live) | Swapfile | Total |
|---------|------------------|----------|-------|
| Before  | 4 GiB            | 16 GiB   | 20 GiB |
| After   | 4 GiB            | 36 GiB   | **40 GiB** |

Verified on the running machine:

```
$ swapon --show
NAME              TYPE      SIZE  USED PRIO
/persist/swapfile file       16G   61M   -1
/dev/nvme0n1p3    partition   4G 28.7M   -1

$ free -h
Swap:           19Gi        89Mi        19Gi
```

### Note on the disko / live partition divergence

`machines/navi/disko.nix` declares `size = "16G"` for the swap partition,
but disko does not repartition a live disk — the partition was never
actually grown from its original 4 GiB. So the *declared* layout and the
*live* layout disagree on that one number; the live layout is what matters
for OOM headroom.

This PR sidesteps the divergence entirely: all extra swap capacity goes
into the swapfile on `/persist`, which is exactly what this PR does. The
partition stays at its live size of 4 GiB regardless.

## What is *not* changed

- **`machines/navi/disko.nix`** — the swap partition (declared `16G`,
  actually 4 GiB on disk) is the `resumeDevice` and lives on a live disk.
  Repartitioning is out of scope; all extra capacity goes into the swapfile.
- **`services.earlyoom`** — settings left untouched.
- No other modules or machines.

## Safety

`/persist` has ~445 GiB free, so a 36 GiB swapfile is comfortable.

## Verification

- `nixfmt machines/navi/configuration.nix` produces no diff.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel`
  succeeds locally.

The swapfile is recreated by the `mkswap-persist-swapfile.service` systemd
unit on activation, so the new size takes effect on the next `nh switch` /
activation.
