### PR TITLE
fix(iris): eliminate subscribe-vs-publish race in TestFanOut and siblings

### DIFF
--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -470,21 +470,37 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 			activeSubs[frame.Name] = subEntry{id: subID, cancel: subCancel}
 			subMu.Unlock()
 
+			onDone := func() {
+				// Called by the subscription goroutine when done (client
+				// disconnect or ctx cancel). Remove from the local map and
+				// the global subscriber set.
+				subMu.Lock()
+				if e, ok := activeSubs[frame.Name]; ok && e.id == subID {
+					delete(activeSubs, frame.Name)
+				}
+				subMu.Unlock()
+				cs.removeSubscriber(frame.Name, subID)
+				subCancel()
+			}
+
+			// Register the live subscriber synchronously, before reading the
+			// next frame on this connection. This is what makes the
+			// session_subscribe → next-frame ordering on the wire a true
+			// happens-before relationship for Publish: any frame the client
+			// sends after observing a response to a subsequent request (e.g.
+			// ping/pong) is guaranteed to see the subscriber registered. If
+			// setupSubscription fails (session not found, etc.) it has
+			// already sent the error frame; we run onDone to clear the
+			// local activeSubs entry and continue.
+			subState, ok := cs.setupSubscription(w, frame, subID)
+			if !ok {
+				onDone()
+				continue
+			}
 			cs.wg.Add(1)
 			go func() {
 				defer cs.wg.Done()
-				cs.runSubscription(subCtx, w, frame, subID, func() {
-					// Called by the subscription goroutine when done (client
-					// disconnect or ctx cancel). Remove from the local map and
-					// the global subscriber set.
-					subMu.Lock()
-					if e, ok := activeSubs[frame.Name]; ok && e.id == subID {
-						delete(activeSubs, frame.Name)
-					}
-					subMu.Unlock()
-					cs.removeSubscriber(frame.Name, subID)
-					subCancel()
-				})
+				cs.runSubscription(subCtx, w, frame, subState, onDone)
 			}()
 
 		case ClientFrameSessionUnsubscribe:
@@ -588,41 +604,43 @@ func (cs *ClientSocket) handleSessionsList(w *jsonlWriter) {
 	})
 }
 
-// runSubscription manages a single subscription for one session on one client
-// connection. It:
+// subscriptionState carries the result of setupSubscription into the
+// runSubscription goroutine. It captures the snapshot rowid (for replay
+// deduplication) and the live channel (registered in the subscriber set).
+type subscriptionState struct {
+	ch            chan subscriberMessage
+	snapshotRowID int64
+}
+
+// setupSubscription performs the synchronous portion of subscribing a client
+// to a session: verifying the session exists, snapshotting the max rowid for
+// replay deduplication, and registering the live channel in the subscriber
+// set. It runs on the connection's reader goroutine so that by the time it
+// returns, any subsequent frame the client sends (and any response the
+// client observes from this socket) is guaranteed to see the subscriber
+// registered. This is what eliminates the subscribe-then-publish race that
+// plagued tests using a fixed time.Sleep as their readiness barrier.
 //
-//  1. Checks that the session exists (sends error if not; keeps connection open).
-//  2. Snapshots the current max rowid for replay deduplication.
-//  3. Registers a live channel in the subscriber set.
-//  4. Replays events since_event_id from the DB (if requested).
-//  5. Drains the live channel, writing session_event frames to the client.
-//
-// onDone is called when the goroutine exits (whether by ctx cancel, write
-// error, or channel overflow).
-func (cs *ClientSocket) runSubscription(
-	ctx context.Context,
+// Returns ok=false if the session does not exist; an error frame has
+// already been written to the client.
+func (cs *ClientSocket) setupSubscription(
 	w *jsonlWriter,
 	frame ClientSessionSubscribeFrame,
 	subID string,
-	onDone func(),
-) {
-	defer onDone()
-
+) (subscriptionState, bool) {
 	sessionName := frame.Name
 
-	// Step 1: Verify the session exists. A "not found" still registers the
-	// subscription for sessions that may start later, but per the AC the
-	// requirement is to return an error and keep the connection open.
-	// We check the in-memory supervisor map via getActiveSessions.
+	// Verify the session exists. A "not found" still keeps the connection
+	// open, per the documented contract for session_subscribe.
 	if !cs.sessionExists(sessionName) {
 		sendError(w, ClientFrameSessionSubscribe,
 			fmt.Sprintf("session %q not found", sessionName))
-		return
+		return subscriptionState{}, false
 	}
 
-	// Step 2: Snapshot the current max rowid before registering the live
-	// channel. This is the key to avoiding the replay-vs-live race described
-	// in the file-level comment and §4.3 of the design doc.
+	// Snapshot the current max rowid before registering the live channel.
+	// This is the key to avoiding the replay-vs-live race described in the
+	// file-level comment and §4.3 of the design doc.
 	//
 	// Timeline:
 	//   T0: snapshotRowID = MAX(rowid) = N
@@ -639,11 +657,36 @@ func (cs *ClientSocket) runSubscription(
 		snapshotRowID = 0
 	}
 
-	// Step 3: Register the live channel.
+	// Register the live channel. After this returns, Publish() for this
+	// session will see the subscriber.
 	ch := make(chan subscriberMessage, subscriberChanSize)
 	cs.addSubscriber(sessionName, subscriberChan{id: subID, ch: ch})
 
-	// Step 4: Replay from DB if since_event_id was given.
+	return subscriptionState{ch: ch, snapshotRowID: snapshotRowID}, true
+}
+
+// runSubscription handles the asynchronous portion of a subscription: the
+// optional since_event_id replay from the DB, followed by the long-running
+// drain of the live channel. setupSubscription must have been called
+// successfully before this goroutine starts; the live channel and snapshot
+// rowid are passed in via subscriptionState.
+//
+// onDone is called when the goroutine exits (whether by ctx cancel, write
+// error, or channel overflow).
+func (cs *ClientSocket) runSubscription(
+	ctx context.Context,
+	w *jsonlWriter,
+	frame ClientSessionSubscribeFrame,
+	state subscriptionState,
+	onDone func(),
+) {
+	defer onDone()
+
+	sessionName := frame.Name
+	ch := state.ch
+	snapshotRowID := state.snapshotRowID
+
+	// Replay from DB if since_event_id was given.
 	if frame.SinceEventID > 0 {
 		events, err := cs.database.QuerySessionEventsSinceRowID(sessionName, frame.SinceEventID)
 		if err != nil {
@@ -668,7 +711,7 @@ func (cs *ClientSocket) runSubscription(
 		}
 	}
 
-	// Step 5: Drain the live channel, skipping duplicates from the replay range.
+	// Drain the live channel, skipping duplicates from the replay range.
 	for {
 		select {
 		case <-ctx.Done():
@@ -971,10 +1014,10 @@ func (cs *ClientSocket) handleEscalationDeliver(ctx context.Context, w *jsonlWri
 //
 //   - ("<name>", nil)        — explicit --to or single auto-discovered coord.
 //   - ("", nil)              — zero coordinators (the caller should still
-//                              transition to escalated and ack with delivered=false).
+//     transition to escalated and ack with delivered=false).
 //   - ("", err)              — multiple candidates without --to, or --to
-//                              names a session that is not a coordinator,
-//                              or --to names a session that does not exist.
+//     names a session that is not a coordinator,
+//     or --to names a session that does not exist.
 func (cs *ClientSocket) resolveEscalationTarget(from, explicitTo string) (string, error) {
 	if explicitTo != "" {
 		if explicitTo == from {

--- a/modules/programs/prism/prism/internal/iris/client_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_test.go
@@ -344,6 +344,38 @@ func readClientFrame(t *testing.T, r *bufio.Reader) map[string]any {
 	return m
 }
 
+// subscribeAndWait sends a session_subscribe frame for the given session and
+// then sends a ping, draining frames until the matching pong arrives. This
+// is a deterministic readiness barrier: the client socket's handleConn reads
+// frames sequentially, so by the time the ping has been processed and the
+// pong observed, the session_subscribe frame has been parsed and the
+// subscription goroutine has been spawned. In practice the subscription
+// goroutine's setup (sessionExists + MaxSessionEventRowID + addSubscriber)
+// completes within the same scheduler quantum as the ping/pong round-trip,
+// giving a far stronger ordering than a fixed time.Sleep under CPU
+// contention. Any session_event frames that arrive interleaved with the
+// pong (e.g. from since_event_id replay) would be unexpected at this point
+// in the protocol; the helper does not tolerate them and will fail the
+// test, which is the right behaviour for subscribe-without-replay flows.
+func subscribeAndWait(t *testing.T, conn net.Conn, r *bufio.Reader, sessionName string) {
+	t.Helper()
+	sendClientFrame(t, conn, map[string]any{
+		"type": "session_subscribe",
+		"name": sessionName,
+	})
+	sendClientFrame(t, conn, map[string]any{"type": "ping"})
+	for {
+		frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+		if !ok {
+			t.Fatalf("subscribeAndWait(%q): pong not received within 5s", sessionName)
+		}
+		if frame["type"] == "pong" {
+			return
+		}
+		t.Fatalf("subscribeAndWait(%q): unexpected frame before pong: %v", sessionName, frame)
+	}
+}
+
 // readClientFrameWithTimeout reads a frame, failing if none arrives within d.
 func readClientFrameWithTimeout(t *testing.T, conn net.Conn, r *bufio.Reader, d time.Duration) (map[string]any, bool) {
 	t.Helper()
@@ -450,14 +482,8 @@ func TestFanOut(t *testing.T) {
 	for i := range clients {
 		conn, r := dialClientSocket(t, cs.SockPath())
 		clients[i] = clientConn{conn, r}
-		sendClientFrame(t, conn, map[string]any{
-			"type": "session_subscribe",
-			"name": sessionName,
-		})
+		subscribeAndWait(t, conn, r, sessionName)
 	}
-
-	// Allow subscriptions to be registered (goroutines need a moment to start).
-	time.Sleep(50 * time.Millisecond)
 
 	// Publish an event.
 	publish(iris.EventPublication{
@@ -499,21 +525,22 @@ func TestDisconnectedSubscriberRemoved(t *testing.T) {
 	}
 	cs, publish := newTestClientSocket(t, sessions)
 
-	// Subscribe client A (rA not used since A disconnects before receiving events).
-	connA, _ := dialClientSocket(t, cs.SockPath())
-	sendClientFrame(t, connA, map[string]any{"type": "session_subscribe", "name": sessionName})
+	// Subscribe client A. We need a reader for the ping/pong barrier even
+	// though A disconnects before receiving any session events.
+	connA, rA := dialClientSocket(t, cs.SockPath())
+	subscribeAndWait(t, connA, rA, sessionName)
 
 	// Subscribe client B.
 	connB, rB := dialClientSocket(t, cs.SockPath())
-	sendClientFrame(t, connB, map[string]any{"type": "session_subscribe", "name": sessionName})
-
-	// Allow subscriptions to register.
-	time.Sleep(50 * time.Millisecond)
+	subscribeAndWait(t, connB, rB, sessionName)
 
 	// Disconnect client A.
 	connA.Close()
 
-	// Brief delay to let the server detect the disconnect.
+	// Brief delay to let the server detect the disconnect. This is a
+	// best-effort wait — the test still passes if the disconnect hasn't
+	// been observed by the server, because Publish drops on full channels
+	// rather than blocking. The sleep just keeps the log noise down.
 	time.Sleep(50 * time.Millisecond)
 
 	// Publish — client B must still receive.
@@ -633,8 +660,8 @@ func TestSinceEventIDReplay(t *testing.T) {
 	conn, r := dialClientSocket(t, sockPath)
 
 	sendClientFrame(t, conn, map[string]any{
-		"type":          "session_subscribe",
-		"name":          sessionName,
+		"type":           "session_subscribe",
+		"name":           sessionName,
 		"since_event_id": sinceRowID,
 	})
 
@@ -680,13 +707,25 @@ func TestSessionUnsubscribe(t *testing.T) {
 
 	conn, r := dialClientSocket(t, cs.SockPath())
 
-	// Subscribe.
-	sendClientFrame(t, conn, map[string]any{"type": "session_subscribe", "name": sessionName})
-	time.Sleep(50 * time.Millisecond)
-
-	// Unsubscribe.
+	// Subscribe, then immediately unsubscribe. Both pairs use a ping/pong
+	// barrier to ensure the server has processed the frame before we move
+	// on — for subscribe this guarantees the subscriber is registered
+	// (so a missed publish would be a real bug, not a race), and for
+	// unsubscribe it guarantees the subscriber has been removed before
+	// Publish runs (so any frame the client receives would be a real bug).
+	subscribeAndWait(t, conn, r, sessionName)
 	sendClientFrame(t, conn, map[string]any{"type": "session_unsubscribe", "name": sessionName})
-	time.Sleep(50 * time.Millisecond)
+	sendClientFrame(t, conn, map[string]any{"type": "ping"})
+	for {
+		frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+		if !ok {
+			t.Fatal("unsubscribe: pong not received within 5s")
+		}
+		if frame["type"] == "pong" {
+			break
+		}
+		t.Fatalf("unsubscribe: unexpected frame before pong: %v", frame)
+	}
 
 	// Publish — the client should NOT receive this.
 	publish(iris.EventPublication{
@@ -816,8 +855,8 @@ func TestStaleSocketRemoved(t *testing.T) {
 	}
 
 	cs := iris.NewClientSocket(iris.ClientSocketConfig{
-		SockPath: sockPath,
-		Database: database,
+		SockPath:          sockPath,
+		Database:          database,
 		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
 	})
 	// This should succeed even though a file exists at sockPath.
@@ -867,8 +906,8 @@ func TestClientSocketSockPath(t *testing.T) {
 
 	sockPath := filepath.Join(tmp, "iris.sock")
 	cs := iris.NewClientSocket(iris.ClientSocketConfig{
-		SockPath: sockPath,
-		Database: database,
+		SockPath:          sockPath,
+		Database:          database,
 		GetActiveSessions: func() []iris.SessionSnapshot { return nil },
 	})
 	if err := cs.Listen(); err != nil {
@@ -917,12 +956,7 @@ func TestHarnessToClientFanOut(t *testing.T) {
 
 	// --- Connect a client to the ClientSocket and subscribe ---
 	clientConn, clientReader := dialClientSocket(t, sockPath)
-	sendClientFrame(t, clientConn, map[string]any{
-		"type": "session_subscribe",
-		"name": sessionName,
-	})
-	// Allow the subscription goroutine to register.
-	time.Sleep(50 * time.Millisecond)
+	subscribeAndWait(t, clientConn, clientReader, sessionName)
 
 	// --- Simulate a harness event by connecting as the pi extension and sending a tool_exec ---
 	hConn, hReader := dialHarness(t, harnessSockPath)


### PR DESCRIPTION
Closes #1742.

## Summary

`TestFanOut` in `internal/iris/client_socket_test.go` flaked under `-race` CPU contention because it used `time.Sleep(50ms)` as the only barrier between sending `session_subscribe` and calling `Publish`. The server's `runSubscription` goroutine could be scheduled later than 50ms under load, so `Publish` iterated an empty subscriber set and the test missed the broadcast.

## Fix

The fix has two parts:

1. **Production code** (`client_socket.go`): split `runSubscription` into a synchronous `setupSubscription` (session-exists check + max-rowid snapshot + `addSubscriber`) and an asynchronous drain loop. The synchronous portion runs on `handleConn`'s reader goroutine before the next frame is read, which means after the server has processed `session_subscribe` the subscriber is guaranteed to be in the live set.

2. **Tests** (`client_socket_test.go`): replace `time.Sleep` with a `subscribeAndWait` helper that sends `session_subscribe` followed by `ping` and reads until `pong` arrives. Since handleConn reads frames sequentially and the live subscriber is now registered synchronously, the pong arrival is a true happens-before barrier for `Publish` — Option B from the issue body, no new wire frames.

The helper is applied to all four tests with the same subscribe-then-publish shape:

- `TestFanOut` (the named flake)
- `TestDisconnectedSubscriberRemoved`
- `TestSessionUnsubscribe` (also given a ping/pong barrier after the unsubscribe frame for symmetry)
- `TestHarnessToClientFanOut`

## time.Sleep audit (per AC #6)

Searched `internal/iris/**/*_test.go` for all `time.Sleep` patterns. Classified each by shape:

| File | Line | Pattern | Same-shape as #1742? | Action |
|------|------|---------|----------------------|--------|
| `client_socket_test.go` | 416 | subscribe-then-publish | **yes** | fixed (TestFanOut) |
| `client_socket_test.go` | 467, 473 | subscribe-then-publish + post-disconnect drain | **yes** (subscribe), no (drain) | fixed (subscribe portion); post-disconnect drain kept as best-effort wait, doc-commented |
| `client_socket_test.go` | 641, 645 | subscribe-then-publish + unsubscribe-then-publish | **yes** | fixed (both pairs use ping/pong) |
| `client_socket_test.go` | 923 | subscribe-then-publish (via harness) | **yes** | fixed |
| `client_socket_test.go` | 1054 | "let publishEvent goroutine complete" before reading slice | different shape (no subscribe protocol) | left as-is — `TestSupervisorPublisherConfig` polls a goroutine writing to a slice; would need a different sync primitive |
| `client_socket_test.go` | 267 | dial retry loop | different shape | left as-is |
| `client_socket_escalate_test.go` | 130, 500 | dial retry / poll for hook fire | different shape | left as-is |
| `harness_socket_test.go` | 315, 436, 539, 69, 368 | wait-for-subprocess-start, wait-for-DB-flush, dial retry | different shape | left as-is — owned by in-flight worker #1724 |
| `harness_state_change_test.go`, `parity/*_test.go`, `restore_*_test.go`, `session_kill_*_test.go`, `set_pi_session_path_test.go`, `supervisor_*_test.go` | various | mostly poll loops with explicit deadlines, or subprocess-start waits | different shape | left as-is |
| `bash_sandbox_linux_test.go` | 119, 134, 200 | subprocess timing | different shape | left as-is |

The only tests with the same subscribe-vs-publish shape as #1742 are the four in `client_socket_test.go` listed above. All four are now fixed.

### Pre-existing flakes surfaced during AC verification

While running `go test ./internal/iris/ -race -count=20` (AC #3), two unrelated tests flaked on `main` independently of any change in this PR:

- `TestSupervisorKill_EscalatesToSIGKILL` (`supervisor_kill_test.go`)
- `TestToolAbort` (`harness_socket_test.go:300`)

Both reproduce with my changes stashed. Escalated informationally to the coordinator; **not fixed in this PR**. The `TestToolAbort` failure is the same `time.Sleep`-as-synchronisation antipattern (50ms to "let the subprocess start" before sending `tool_abort`) but on a different protocol surface (harness, not client-socket). `harness_socket_test.go` is owned by in-flight worker #1724; flagging here so they (or a follow-up) can pick it up.

## Verification

- `go test ./internal/iris/ -race -count=50 -timeout 600s -run "TestFanOut|TestHarnessToClientFanOut"` — **50/50 PASS**
- `go test ./internal/iris/ -race -count=20 -timeout 1800s -skip "TestSupervisorKill_EscalatesToSIGKILL|TestToolAbort"` — **PASS** (both skips are pre-existing main flakes; see note above)
- `go test ./... -race` — **PASS** for all packages
- `nix build .#prism` — **PASS**
- `gofmt`, `go vet ./...` — clean

## Concurrency notes (per spawn prompt)

- **#1705** (`iristest/`): no overlap — I did not extend `iristest` helpers; the new `subscribeAndWait` is a local test helper in `client_socket_test.go` alongside the existing `dialClientSocket` / `sendClientFrame` helpers.
- **#1724, #1737, #1738, #1739**: no overlap with `client_socket.go` or `client_socket_test.go`.
