### PR TITLE
iris: write config.json with pi_extension_path

### DIFF
--- a/modules/programs/iris/default.nix
+++ b/modules/programs/iris/default.nix
@@ -9,6 +9,29 @@ let
   username = config.nx.username;
   homeDir = config.home-manager.users.${username}.home.homeDirectory;
 
+  # Resolve the absolute store path to the prism PI extension file
+  # (prism.ts). The supervisor passes this path verbatim to
+  # `pi --extension <path>`; if it is empty, `--extension` is silently
+  # omitted and every pi child runs as vanilla pi with no iris awareness
+  # (see issue #1752 for the diagnosis).
+  #
+  # Source-sharing: the canonical `prism.ts` lives at
+  # `../prism/pi/extensions/prism.ts`. Both this module and
+  # `modules/programs/prism/pi.nix` reference that same file — there is no
+  # duplicate copy of the extension source. We rebuild the trivial
+  # single-file derivation here (rather than reading
+  # `config.nx.programs.prism.piExtensionDir`) so that iris does not
+  # silently break when prism is disabled on a host.
+  prismExtensionDir = pkgs.runCommand "prism-pi-extension" { } ''
+    mkdir -p $out
+    cp ${../prism/pi/extensions/prism.ts} $out/prism.ts
+  '';
+  prismExtensionPath = "${prismExtensionDir}/prism.ts";
+
+  irisConfig = {
+    pi_extension_path = prismExtensionPath;
+  };
+
   # NOTE on the daemon's socket path and IRIS_DAEMON_SOCK
   # ---------------------------------------------------------------------------
   # An earlier revision of this module set `IRIS_DAEMON_SOCK` in the daemon's
@@ -48,6 +71,12 @@ in
     home-manager.users.${username} = lib.mkMerge [
       {
         home.packages = [ pkgs.iris ];
+
+        # Write ~/.config/iris/config.json so the iris daemon knows where
+        # the prism PI extension lives. Without this, `PIExtensionPath`
+        # defaults to "" and the supervisor omits `--extension` from every
+        # pi child — see issue #1752.
+        xdg.configFile."iris/config.json".text = builtins.toJSON irisConfig;
       }
 
       # ── Linux: systemd user service ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the silent breakage of every iris session on hosts that enable `nx.programs.iris`. The module previously enabled the daemon but never wrote `~/.config/iris/config.json`, so `PIExtensionPath` defaulted to `""` and the supervisor omitted `--extension <prism.ts>` from every pi child. Pi ran as vanilla pi with no iris awareness — harness sockets stayed LISTEN-only forever, no events reached the iris DB, and `iris checkin` reported `(no assistant turns yet)` indefinitely.

## Change

`modules/programs/iris/default.nix`:

- Add a small `prismExtensionDir` derivation that wraps the canonical `../prism/pi/extensions/prism.ts` source — the same file `modules/programs/prism/pi.nix` references. Single canonical source, no duplicate copy.
- Build the derivation locally (rather than reading `config.nx.programs.prism.piExtensionDir`) so iris keeps working when prism is disabled on a host.
- Write `~/.config/iris/config.json` via `xdg.configFile` containing `{"pi_extension_path": "<store-path>/prism.ts"}`.
- The new `xdg.configFile` entry sits inside `lib.mkIf cfg.enable`, so disabling the iris module produces no config file.

The long `IRIS_DAEMON_SOCK` comment block is preserved verbatim — this PR is about the config file, not env vars.

## Verification

- `nixfmt modules/programs/iris/default.nix` — no diff.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — succeeds.
- Inspected the resulting store output:
  ```
  $ cat /nix/store/...-hm_irisconfig.json
  {"pi_extension_path":"/nix/store/...-prism-pi-extension/prism.ts"}
  $ ls /nix/store/...-prism-pi-extension/
  prism.ts
  ```

The end-to-end edge-case AC (nh switch → restart iris → spawn → `iris checkin` shows session_start) requires switching to the new generation on this host and will be exercised post-merge.

Closes #1752