### PR TITLE
fix(sidecar,db,review): worker-sidecar recovery watcher for stuck-but-complete review groups (#1709 reopen)

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -78,7 +78,13 @@ CREATE INDEX IF NOT EXISTS idx_sessions_name         ON sessions(session_name, s
 CREATE TABLE IF NOT EXISTS session_groups (
   group_id       TEXT PRIMARY KEY,
   parent_session TEXT NOT NULL,
-  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  -- pr_number and round are populated by RegisterGroupWithPR (#1709 reopen)
+  -- so the worker-sidecar recovery watcher can format a usable review-complete
+  -- prompt when the detached monitor subprocess dies. Both nullable for
+  -- back-compat with the legacy RegisterGroup helper.
+  pr_number      TEXT,
+  round          INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS agent_status (
@@ -542,6 +548,51 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV29ToV30(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV30ToV31(conn, &version); err != nil {
+		return err
+	}
+	return nil
+}
+
+// migrateV30ToV31 adds pr_number and round columns to session_groups so the
+// worker sidecar's review-completion recovery watcher (#1709 reopen) can
+// reconstruct enough context to format and deliver the review-complete prompt
+// when the detached monitor subprocess dies. Both columns are nullable for
+// back-compat with rows registered prior to this migration; the recovery
+// watcher tolerates NULL by emitting a degraded but still actionable header.
+//
+// The ALTER TABLE statements are guarded by pragma_table_info so the migration
+// is idempotent on fresh databases.
+func migrateV30ToV31(conn *sql.DB, version *int) error {
+	if *version >= 31 {
+		return nil
+	}
+	addColIfMissing := func(table, column, def string) error {
+		var exists int
+		if err := conn.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`,
+			table, column,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("db: migration v30\u2192v31: check %s.%s column: %w", table, column, err)
+		}
+		if exists == 0 {
+			stmt := fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column, def)
+			if _, err := conn.Exec(stmt); err != nil {
+				return fmt.Errorf("db: migration v30\u2192v31: add %s.%s: %w", table, column, err)
+			}
+		}
+		return nil
+	}
+	if err := addColIfMissing("session_groups", "pr_number", "TEXT"); err != nil {
+		return err
+	}
+	if err := addColIfMissing("session_groups", "round", "INTEGER"); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(`UPDATE schema_version SET version = 31`); err != nil {
+		return fmt.Errorf("db: migration v30\u2192v31: %w", err)
+	}
+	*version = 31
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=30 (all migrations applied on Open).
+	// Verify schema_version=31 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version: got %d, want 31", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1594,8 +1594,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1660,8 +1660,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1730,8 +1730,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1825,8 +1825,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1918,8 +1918,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2455,8 +2455,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2544,8 +2544,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4394,8 +4394,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// Check each row.
@@ -4822,8 +4822,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5097,8 +5097,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5318,8 +5318,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// sessions table must exist.
@@ -5472,8 +5472,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 }
 
@@ -6026,8 +6026,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6084,8 +6084,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6386,8 +6386,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6448,8 +6448,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6607,8 +6607,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6661,8 +6661,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 
 	var startedAt int64
@@ -6815,8 +6815,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -6888,8 +6888,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7024,8 +7024,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after migration: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after migration: got %d, want 31", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7078,8 +7078,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 
 	// spawn_outcome must still exist.

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -45,13 +45,105 @@ func isTerminalState(state string) bool {
 // RegisterGroup inserts a new row into session_groups and returns the generated
 // group_id. parent_session identifies the session that owns this group (e.g.
 // the worker running `prism review`).
+//
+// Use RegisterGroupWithPR when you have the PR number and round; the
+// worker-sidecar recovery watcher (#1709 reopen) reads those columns to
+// reconstruct enough context to deliver the review-complete prompt when the
+// detached monitor subprocess dies. RegisterGroup remains the back-compat
+// entry point for callers that do not have the PR/round (legacy iris paths
+// and unit-test setup).
 func (d *DB) RegisterGroup(parentSession string) (string, error) {
+	return d.RegisterGroupWithPR(parentSession, "", 0)
+}
+
+// RegisterGroupWithPR is RegisterGroup with PR and round metadata. Both
+// arguments are stored as-is; an empty prNumber or zero round is written as
+// SQL NULL. The recovery watcher tolerates NULLs by emitting a degraded
+// (but still actionable) review-complete header.
+func (d *DB) RegisterGroupWithPR(parentSession, prNumber string, round int) (string, error) {
 	groupID := uuid.New().String()
-	const q = `INSERT INTO session_groups (group_id, parent_session) VALUES (?, ?)`
-	if _, err := d.conn.Exec(q, groupID, parentSession); err != nil {
+	const q = `INSERT INTO session_groups (group_id, parent_session, pr_number, round) VALUES (?, ?, ?, ?)`
+	var pr any
+	if prNumber != "" {
+		pr = prNumber
+	}
+	var rnd any
+	if round > 0 {
+		rnd = round
+	}
+	if _, err := d.conn.Exec(q, groupID, parentSession, pr, rnd); err != nil {
 		return "", fmt.Errorf("db: register group: %w", err)
 	}
 	return groupID, nil
+}
+
+// GroupInfo captures the session_groups metadata used by the worker-sidecar
+// recovery watcher (#1709 reopen). PRNumber and Round are empty/zero for
+// groups registered via the legacy RegisterGroup helper.
+type GroupInfo struct {
+	GroupID       string
+	ParentSession string
+	PRNumber      string
+	Round         int
+	CreatedAt     time.Time
+}
+
+// LatestGroupForParent returns the most recently created session_groups row
+// whose parent_session matches parentSession, or (nil, nil) when no group
+// exists for the parent. Used by the worker-sidecar recovery watcher
+// (#1709 reopen) to identify the in-flight review group while
+// reviewingInFlight is set; ActiveReviewGroupForParent's "has any
+// non-terminal member" criterion is the wrong question here, because the
+// stuck-but-complete case the watcher exists to handle has ZERO non-terminal
+// members by definition.
+func (d *DB) LatestGroupForParent(parentSession string) (*GroupInfo, error) {
+	const q = `SELECT group_id, parent_session, pr_number, round, created_at
+	            FROM session_groups
+	            WHERE parent_session = ?
+	            ORDER BY created_at DESC, group_id DESC
+	            LIMIT 1`
+	row := d.conn.QueryRow(q, parentSession)
+	var gi GroupInfo
+	var prNumber sql.NullString
+	var round sql.NullInt64
+	if err := row.Scan(&gi.GroupID, &gi.ParentSession, &prNumber, &round, &gi.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("db: latest group for parent %q: %w", parentSession, err)
+	}
+	if prNumber.Valid {
+		gi.PRNumber = prNumber.String
+	}
+	if round.Valid {
+		gi.Round = int(round.Int64)
+	}
+	return &gi, nil
+}
+
+// GetGroup returns the session_groups metadata for groupID, or (nil, nil) if
+// the row does not exist. Used by the worker-sidecar recovery watcher to
+// reconstruct the review-complete delivery message when the detached monitor
+// subprocess dies.
+func (d *DB) GetGroup(groupID string) (*GroupInfo, error) {
+	const q = `SELECT group_id, parent_session, pr_number, round, created_at FROM session_groups WHERE group_id = ?`
+	row := d.conn.QueryRow(q, groupID)
+	var gi GroupInfo
+	var prNumber sql.NullString
+	var round sql.NullInt64
+	if err := row.Scan(&gi.GroupID, &gi.ParentSession, &prNumber, &round, &gi.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("db: get group %q: %w", groupID, err)
+	}
+	if prNumber.Valid {
+		gi.PRNumber = prNumber.String
+	}
+	if round.Valid {
+		gi.Round = int(round.Int64)
+	}
+	return &gi, nil
 }
 
 // GroupCompleted reports whether every agent_status row with this group_id has

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 30 {
-		t.Errorf("schema_version after fresh open = %d, want 30", ver)
+	if ver != 31 {
+		t.Errorf("schema_version after fresh open = %d, want 31", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 30 {
-		t.Errorf("schema_version after second open = %d, want 30", ver)
+	if ver != 31 {
+		t.Errorf("schema_version after second open = %d, want 31", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1291,8 +1291,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 30 {
-		t.Errorf("schema_version after second open: got %d, want 30", version)
+	if version != 31 {
+		t.Errorf("schema_version after second open: got %d, want 31", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/review/recovery.go
+++ b/modules/programs/prism/prism/internal/review/recovery.go
@@ -1,0 +1,209 @@
+package review
+
+// recovery.go — review-completion recovery path for the worker-sidecar
+// watchdog (#1709 reopen).
+//
+// Background. The `prism review` happy path spawns a detached `prism
+// monitor-review` subprocess that polls db.GroupCompleted, aggregates
+// db.GroupResults, and delivers the review-complete prompt to the worker
+// session via `prism prompt`. The subprocess is the sole owner of the
+// all-terminal → deliver transition; there is no other watcher anywhere in
+// the system today.
+//
+// If that subprocess dies between spawn and delivery (OOM, kernel kill,
+// PRISM upgrade mid-review, host reboot, or a silent failure in
+// StartMonitorProcess), the agent rows reach `finished` in the DB but no
+// process is watching that signal — the worker stays in `reviewing`
+// forever and the only recovery is a manual `prism cleanup`.
+//
+// DeliverGroupResults provides the in-process delivery primitive used by
+// the worker-sidecar recovery watcher (internal/sidecar/review_recovery.go).
+// It mirrors the back half of MonitorFunc — aggregation, formatting,
+// pre-delivery DB state-flip, and delivery — but takes its inputs from the
+// DB rather than a MonitorOpts file, so it can run after the original
+// monitor subprocess is long dead. The delivery_id is supplied by the
+// caller so the host-API /prompt handler's dedup set (#1685) drops the
+// second delivery if both the original monitor and the recovery watcher
+// happen to deliver at the same instant.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/promptdelivery"
+)
+
+// RecoveryDeliveryResult captures what DeliverGroupResults did, for logging
+// and test assertions. AllPassed mirrors the FormatResults return value.
+type RecoveryDeliveryResult struct {
+	AllPassed   bool
+	Delivered   bool
+	Replayed    bool
+	FallbackTo  string // non-empty when delivery failed and a fallback file was written
+	MessageText string // the prompt body that was (or would have been) delivered
+}
+
+// DeliverGroupResults aggregates the group's results, formats the
+// review-complete prompt, flips the worker session's state from `reviewing`
+// to `active` if needed, and delivers the prompt via the host-API socket
+// with delivery_id-based idempotency.
+//
+// It is the recovery analogue of the back half of MonitorFunc. Unlike
+// MonitorFunc it does NOT poll — the caller (the worker-sidecar recovery
+// watcher) has already established that GroupCompleted returns true.
+//
+// PRNumber and round are read from session_groups (via db.GetGroup) so the
+// caller does not need to thread them through. When either is missing
+// (legacy groups registered before migration v30→v31), the message header
+// degrades to "Review complete: PR # (round 0)" — actionable but obviously
+// reconstructed.
+//
+// The deliveryID is forwarded to the host-API /prompt handler. Pass a
+// stable UUID for the group so that repeated invocations of this function
+// (e.g. the watcher firing twice across a daemon restart) dedup at the
+// receiving sidecar (#1685). The recommended construction is
+// "review-recovery:" + groupID — derived deterministically from the group
+// so any number of recovery attempts collapse to one delivered prompt.
+func DeliverGroupResults(d *db.DB, groupID, deliveryID string) (*RecoveryDeliveryResult, error) {
+	if d == nil {
+		return nil, fmt.Errorf("review recovery: db is required")
+	}
+	if groupID == "" {
+		return nil, fmt.Errorf("review recovery: groupID is required")
+	}
+
+	info, err := d.GetGroup(groupID)
+	if err != nil {
+		return nil, fmt.Errorf("review recovery: GetGroup(%s): %w", groupID, err)
+	}
+	if info == nil {
+		return nil, fmt.Errorf("review recovery: group %s not found", groupID)
+	}
+	if info.ParentSession == "" {
+		return nil, fmt.Errorf("review recovery: group %s has no parent_session", groupID)
+	}
+
+	members, err := d.GroupMembersForGroup(groupID)
+	if err != nil {
+		return nil, fmt.Errorf("review recovery: GroupMembersForGroup(%s): %w", groupID, err)
+	}
+
+	// Reconstruct the (Agents, AgentSessions) pair from the member rows.
+	// The agent name is the suffix after the last "-" in the session name
+	// (member sessions are <parent>~review-<N>-<agent>); fall back to the
+	// session name itself when the suffix cannot be parsed.
+	agents := make([]Agent, 0, len(members))
+	agentSessions := make([]string, 0, len(members))
+	for _, m := range members {
+		agentSessions = append(agentSessions, m.SessionName)
+		agents = append(agents, Agent{Name: agentNameFromSession(m.SessionName)})
+	}
+
+	groupData, err := d.GroupResults(groupID)
+	if err != nil {
+		// Non-fatal: emit a degraded delivery rather than refusing to deliver.
+		// MonitorFunc takes the same stance on this branch.
+		fmt.Fprintf(os.Stderr, "[prism review recovery] warning: GroupResults(%s): %v — using empty data\n", groupID, err)
+		groupData = map[string]db.GroupMemberResult{}
+	}
+
+	results := buildMonitorResults(agents, agentSessions, groupData)
+	output, allPassed := FormatResults(results, info.PRNumber, info.Round, 0)
+	deliveryText := buildDeliveryMessage(info.PRNumber, info.Round, output, allPassed, groupData, agentSessions)
+
+	// LOOP-LIMIT footer (#1512) — mirror the MonitorFunc gating exactly so a
+	// recovery-path delivery is indistinguishable from a happy-path delivery.
+	if !allPassed && currentCycleProducedVerdicts(groupData) {
+		prior, ccErr := CompletedReviewCyclesForParent(d, info.ParentSession, groupID)
+		if ccErr != nil {
+			fmt.Fprintf(os.Stderr, "[prism review recovery] warning: cycle count failed: %v — footer suppressed\n", ccErr)
+		} else if prior+1 >= REVIEW_CYCLE_THRESHOLD {
+			deliveryText += buildLoopLimitFooter(prior+1, info.PRNumber)
+		}
+	}
+
+	// Flip the worker from `reviewing` to `active` before delivery so the
+	// busy event triggered by the prompt arriving lifts the suppression
+	// guard cleanly (see the analogous block in MonitorFunc).
+	if workerStatus, stErr := d.CurrentStatus(info.ParentSession); stErr == nil && workerStatus != nil {
+		if workerStatus.State == string(agent.StateReviewing) {
+			if upErr := d.UpsertStatus(info.ParentSession, workerStatus.Repo, workerStatus.Worktree,
+				string(agent.StateActive), nil, nil); upErr != nil {
+				fmt.Fprintf(os.Stderr, "[prism review recovery] warning: could not clear reviewing\u2192active before delivery: %v\n", upErr)
+			} else {
+				fmt.Fprintf(os.Stderr, "[prism review recovery] worker state reviewing\u2192active (pre-delivery, group=%s)\n", groupID)
+			}
+		}
+	} else if stErr != nil {
+		fmt.Fprintf(os.Stderr, "[prism review recovery] warning: CurrentStatus(%s): %v\n", info.ParentSession, stErr)
+	}
+
+	res := &RecoveryDeliveryResult{
+		AllPassed:   allPassed,
+		MessageText: deliveryText,
+	}
+
+	// Look up the worker status fresh for promptdelivery.DeliverToSession.
+	workerStatus, err := d.CurrentStatus(info.ParentSession)
+	if err != nil {
+		return res, fmt.Errorf("review recovery: CurrentStatus(%s): %w", info.ParentSession, err)
+	}
+	if workerStatus == nil {
+		return res, fmt.Errorf("review recovery: parent session %q not found in DB", info.ParentSession)
+	}
+	if workerStatus.EndedAt != nil {
+		// Worker is gone — write the fallback file so the verdict is not
+		// silently dropped, but skip delivery (it would error anyway).
+		fallback, fbErr := WriteFallbackResult(info.PRNumber, info.Round, deliveryText)
+		if fbErr != nil {
+			return res, fmt.Errorf("review recovery: parent session ended AND fallback write failed: %w", fbErr)
+		}
+		res.FallbackTo = fallback
+		return res, fmt.Errorf("review recovery: parent session %q has ended \u2014 wrote fallback to %s", info.ParentSession, fallback)
+	}
+
+	if delErr := promptdelivery.DeliverToSessionWithID(
+		info.ParentSession, workerStatus, deliveryText,
+		buildPromptBodyForMonitor, "review-complete", "", deliveryID,
+	); delErr != nil {
+		// Delivery failed once; mirror MonitorFunc by writing the fallback.
+		// We do NOT retry here — the caller (the watcher) will fire again on
+		// its next tick if the worker is still stuck in `reviewing`, and the
+		// delivery_id dedup ensures a successful delivery sticks exactly once.
+		fallback, fbErr := WriteFallbackResult(info.PRNumber, info.Round, deliveryText)
+		if fbErr == nil {
+			res.FallbackTo = fallback
+		}
+		return res, fmt.Errorf("review recovery: deliver to %q: %w", info.ParentSession, delErr)
+	}
+
+	res.Delivered = true
+	return res, nil
+}
+
+// agentNameFromSession extracts the agent name suffix from a review-agent
+// session name of the form "<parent>~review-<N>-<agent>". Returns the full
+// session name unchanged when the pattern is not present (degraded mode for
+// unexpected name shapes).
+func agentNameFromSession(sessionName string) string {
+	tilde := strings.Index(sessionName, "~review-")
+	if tilde < 0 {
+		return sessionName
+	}
+	suffix := sessionName[tilde+len("~review-"):]
+	dash := strings.Index(suffix, "-")
+	if dash < 0 || dash == len(suffix)-1 {
+		return sessionName
+	}
+	return suffix[dash+1:]
+}
+
+// RecoveryDeliveryID returns the deterministic delivery_id used for the
+// recovery-path /prompt request for groupID. Exported so the watcher and
+// integration tests use the same value.
+func RecoveryDeliveryID(groupID string) string {
+	return "review-recovery:" + groupID
+}

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -96,7 +96,12 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 	// termination detection and GroupResults-based result aggregation.
 	// Fail fast if RegisterGroup fails — no sessions are spawned without a
 	// group to belong to (AC: edge-case).
-	groupID, groupErr := d.RegisterGroup(opts.ParentSession)
+	//
+	// PRNumber and round are persisted on session_groups so the worker
+	// sidecar's review-completion recovery watcher (#1709 reopen) can
+	// reconstruct the delivery message when the detached monitor subprocess
+	// dies before delivering.
+	groupID, groupErr := d.RegisterGroupWithPR(opts.ParentSession, opts.PRNumber, round)
 	if groupErr != nil {
 		return nil, fmt.Errorf("register review group: %w", groupErr)
 	}
@@ -414,8 +419,11 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		}
 	}
 
-	// Register session group.
-	groupID, groupErr := d.RegisterGroup(opts.ParentSession)
+	// Register session group. PRNumber and round are persisted on
+	// session_groups so the worker sidecar's review-completion recovery
+	// watcher (#1709 reopen) can reconstruct the delivery message when the
+	// detached monitor subprocess dies before delivering.
+	groupID, groupErr := d.RegisterGroupWithPR(opts.ParentSession, opts.PRNumber, round)
 	if groupErr != nil {
 		return nil, fmt.Errorf("register review group: %w", groupErr)
 	}

--- a/modules/programs/prism/prism/internal/sidecar/review_recovery.go
+++ b/modules/programs/prism/prism/internal/sidecar/review_recovery.go
@@ -1,0 +1,255 @@
+package sidecar
+
+// review_recovery.go — worker-sidecar watcher that rescues review groups
+// orphaned by a dead monitor subprocess (#1709 reopen).
+//
+// Background. `prism review` spawns a detached `prism monitor-review`
+// subprocess that owns the all-terminal → deliver transition. There is no
+// other watcher anywhere in the system. If the monitor dies (OOM, kernel
+// kill, PRISM upgrade mid-review, host reboot, silent StartMonitorProcess
+// failure), the agent rows reach `finished` in the DB but no process
+// delivers the review-complete prompt to the worker — the worker stays in
+// `reviewing` indefinitely and the only escape is manual `prism cleanup`.
+//
+// This watcher lives in the worker session's own sidecar (the parent of
+// any review group it might spawn), polls db.GroupCompleted on a coarse
+// interval, and after a grace window dispatches the delivery via
+// review.DeliverGroupResults. The delivery uses a deterministic
+// delivery_id derived from the group_id so that if the original monitor
+// is somehow still alive and delivers at the same moment, the receiving
+// host-API /prompt dedup (#1685) drops the second hit.
+//
+// The watcher is deliberately additive: in the happy path (monitor alive,
+// delivers normally) the watcher's GroupCompleted check transitions from
+// false to true exactly once, the grace window prevents firing, the
+// monitor delivers and clears reviewingInFlight, and the watcher returns
+// to no-op steady state. It cannot generate spurious prompts because:
+//
+//   (a) it only fires when reviewingInFlight == true (set by the /review
+//       handler when this very sidecar accepted a review request), AND
+//   (b) it only fires after grace window past first-observed-complete, AND
+//   (c) it only fires when GroupCompleted is still true, AND
+//   (d) the delivery_id dedup catches any double-fire across watcher+monitor.
+
+import (
+	"context"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// startReviewRecoveryWatcher launches the recovery goroutine for this
+// sidecar. It is a no-op (returns nil cancel) when the watcher is disabled
+// for this session — review-agent roles and any session whose
+// ReviewRecoveryInterval is negative.
+//
+// The watcher is a closer fit to the merge-queue watcher in
+// internal/mergequeue/ than to the per-session inactivity watchdog: it
+// observes group-level DB state on a ticker, not per-frame sidecar events.
+// It uses the wall-clock time package directly (not s.cfg.Clock) for the
+// first-seen-complete bookkeeping because the only thing the fake clock
+// would help with is the polling cadence, and we already drive that via
+// the ticker constructor below.
+func (s *Sidecar) startReviewRecoveryWatcher(parentCtx context.Context) context.CancelFunc {
+	if s.cfg.ReviewRecoveryInterval < 0 {
+		s.logger().Printf("sidecar: review-recovery watcher disabled by ReviewRecoveryInterval=%v", s.cfg.ReviewRecoveryInterval)
+		return func() {}
+	}
+	// Skip review-agent sessions — they cannot own a review group, so the
+	// watcher would never have anything to do.
+	if reviewAgentAllowlist[s.cfg.AgentRole] {
+		return func() {}
+	}
+	// Skip when the DB is not configured — defensive; production sidecars
+	// always have a DB but some unit tests construct minimal Sidecars.
+	if s.cfg.DB == nil {
+		return func() {}
+	}
+
+	interval := s.cfg.ReviewRecoveryInterval
+	if interval == 0 {
+		interval = defaultReviewRecoveryInterval
+	}
+	grace := s.cfg.ReviewRecoveryGrace
+	if grace == 0 {
+		grace = defaultReviewRecoveryGrace
+	}
+
+	ctx, cancel := context.WithCancel(parentCtx)
+	s.mu.Lock()
+	s.reviewRecoveryFirstSeenComplete = make(map[string]time.Time)
+	s.mu.Unlock()
+
+	go s.runReviewRecoveryWatcher(ctx, interval, grace)
+	s.logger().Printf("sidecar: review-recovery watcher started (interval=%s, grace=%s)", interval, grace)
+	return cancel
+}
+
+// runReviewRecoveryWatcher is the watcher loop body. Runs until ctx is
+// cancelled.
+func (s *Sidecar) runReviewRecoveryWatcher(ctx context.Context, interval, grace time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reviewRecoveryTick(grace, time.Now())
+		}
+	}
+}
+
+// reviewRecoveryTick runs one pass of the recovery loop. Extracted so tests
+// can drive it directly without a real ticker.
+//
+// The tick is a sequence of cheap pre-checks (in-memory flag, DB lookup,
+// timestamp comparison) and at most one delivery attempt. Each tick is
+// idempotent: calling it twice in succession with the same DB state will
+// either both observe "not yet past grace" or one will observe past-grace
+// and dispatch, the other will observe the dedup result.
+func (s *Sidecar) reviewRecoveryTick(grace time.Duration, now time.Time) {
+	// Fast path: no review in flight from this session's perspective.
+	s.mu.Lock()
+	inFlight := s.reviewingInFlight
+	s.mu.Unlock()
+	if !inFlight {
+		s.clearReviewRecoveryFirstSeen()
+		return
+	}
+
+	// LatestGroupForParent (#1709 reopen) is the right query: while
+	// reviewingInFlight is true, the worker is awaiting a single in-flight
+	// review round, and that round corresponds to the most recently created
+	// session_groups row for this parent. ActiveReviewGroupForParent uses a
+	// "has any non-terminal member" criterion which is exactly the case the
+	// recovery watcher is designed to handle the OPPOSITE of: the stuck-but-
+	// complete group has ZERO non-terminal members by definition.
+	groupInfo, err := s.cfg.DB.LatestGroupForParent(s.cfg.SessionName)
+	if err != nil {
+		s.logger().Printf("sidecar: review-recovery: LatestGroupForParent: %v", err)
+		return
+	}
+	if groupInfo == nil {
+		// reviewingInFlight is true but no group exists: the monitor has
+		// not yet registered the group, or the row was cleaned up. Drop
+		// our first-seen bookkeeping so a fresh group later does not
+		// inherit an old timestamp.
+		s.clearReviewRecoveryFirstSeen()
+		return
+	}
+	groupID := groupInfo.GroupID
+
+	done, err := s.cfg.DB.GroupCompleted(groupID)
+	if err != nil {
+		s.logger().Printf("sidecar: review-recovery: GroupCompleted(%s): %v", groupID, err)
+		return
+	}
+	if !done {
+		// Group still running — drop the first-seen timestamp for this
+		// group_id if we had one, so a regression to non-terminal resets
+		// the clock.
+		s.dropReviewRecoveryFirstSeen(groupID)
+		return
+	}
+
+	// Group is complete. Record first-observed time and check grace.
+	s.mu.Lock()
+	firstSeen, hadEntry := s.reviewRecoveryFirstSeenComplete[groupID]
+	if !hadEntry {
+		s.reviewRecoveryFirstSeenComplete[groupID] = now
+		firstSeen = now
+	}
+	s.mu.Unlock()
+	if !hadEntry {
+		s.logger().Printf("sidecar: review-recovery: group %s observed complete; recovery dispatch in %s if monitor does not deliver", groupID, grace)
+		return
+	}
+	if now.Sub(firstSeen) < grace {
+		return
+	}
+
+	// Past grace and still complete. Dispatch the recovery delivery.
+	s.dispatchReviewRecovery(groupID)
+}
+
+// dispatchReviewRecovery invokes review.DeliverGroupResults for the named
+// group_id and logs the outcome. The result is interpreted as follows:
+//
+//   - Delivered (or buffered-for-replay) → log success, clear in-memory
+//     bookkeeping; reviewingInFlight will be cleared by the receiving
+//     sidecar's /prompt handler when the delivery is processed.
+//   - Error returning a fallback path → log warning; leave bookkeeping in
+//     place so the next tick re-attempts.
+//   - Error with no fallback → log warning; next tick will try again.
+//
+// All paths are non-fatal — a sidecar that crashes here would also kill
+// the host-API listener the in-sandbox CLI depends on.
+func (s *Sidecar) dispatchReviewRecovery(groupID string) {
+	deliveryID := review.RecoveryDeliveryID(groupID)
+	s.logger().Printf("sidecar: review-recovery: monitor appears AWOL for group %s, delivering on its behalf (delivery_id=%s)", groupID, deliveryID)
+	res, err := review.DeliverGroupResults(s.cfg.DB, groupID, deliveryID)
+	if err != nil {
+		// res may be non-nil with FallbackTo set.
+		if res != nil && res.FallbackTo != "" {
+			s.logger().Printf("sidecar: review-recovery: delivery failed for group %s: %v (fallback written to %s)", groupID, err, res.FallbackTo)
+		} else {
+			s.logger().Printf("sidecar: review-recovery: delivery failed for group %s: %v", groupID, err)
+		}
+		return
+	}
+	if res != nil && res.Delivered {
+		s.logger().Printf("sidecar: review-recovery: delivered review-complete prompt for group %s (allPassed=%v)", groupID, res.AllPassed)
+		s.dropReviewRecoveryFirstSeen(groupID)
+		return
+	}
+	// No error and not delivered (unusual — DeliverGroupResults only returns
+	// this when the parent session has ended) — log and clear bookkeeping.
+	s.logger().Printf("sidecar: review-recovery: DeliverGroupResults returned no-error/no-delivery for group %s", groupID)
+	s.dropReviewRecoveryFirstSeen(groupID)
+}
+
+// clearReviewRecoveryFirstSeen drops all first-seen-complete entries. Called
+// when reviewingInFlight transitions to false or when no active group exists.
+func (s *Sidecar) clearReviewRecoveryFirstSeen() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.reviewRecoveryFirstSeenComplete) == 0 {
+		return
+	}
+	s.reviewRecoveryFirstSeenComplete = make(map[string]time.Time)
+}
+
+// dropReviewRecoveryFirstSeen drops the first-seen-complete entry for one
+// group_id. Called when the group is no longer complete (regressed to
+// non-terminal — extremely unlikely in practice but defensively handled) or
+// after a successful recovery dispatch.
+func (s *Sidecar) dropReviewRecoveryFirstSeen(groupID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.reviewRecoveryFirstSeenComplete, groupID)
+}
+
+// ReviewRecoveryFirstSeenForTest exposes the first-seen-complete bookkeeping
+// for integration tests. The returned map is a copy; modifications do not
+// affect sidecar state.
+func (s *Sidecar) ReviewRecoveryFirstSeenForTest() map[string]time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.reviewRecoveryFirstSeenComplete == nil {
+		return nil
+	}
+	out := make(map[string]time.Time, len(s.reviewRecoveryFirstSeenComplete))
+	for k, v := range s.reviewRecoveryFirstSeenComplete {
+		out[k] = v
+	}
+	return out
+}
+
+// ReviewRecoveryTickForTest invokes one tick of the recovery loop with the
+// given wall-clock time. Exported so integration tests can drive the loop
+// deterministically without spinning a goroutine.
+func (s *Sidecar) ReviewRecoveryTickForTest(grace time.Duration, now time.Time) {
+	s.reviewRecoveryTick(grace, now)
+}
+

--- a/modules/programs/prism/prism/internal/sidecar/review_recovery_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/review_recovery_test.go
@@ -1,0 +1,312 @@
+package sidecar
+
+// review_recovery_test.go — integration coverage for the worker-sidecar
+// review-completion recovery watcher (#1709 reopen).
+//
+// The watcher rescues review groups orphaned by a dead `prism
+// monitor-review` subprocess. The reproducer below exercises this exact
+// failure mode:
+//
+//   1. Seed an isolated bus with a worker session whose harness='pi' so
+//      promptdelivery routes via the host-API Unix socket (the socket is
+//      captured by the bus and exposed via bus.CopyBodies()).
+//   2. Register a review group via RegisterGroupWithPR and seed 5
+//      agent_status rows for the review agents all in state=finished, each
+//      with a msg_assistant event carrying a PASS verdict.
+//   3. DO NOT spawn a monitor subprocess. This is the "monitor died"
+//      condition: agents are terminal in the DB but no process is watching
+//      GroupCompleted.
+//   4. Construct a worker Sidecar with reviewingInFlight=true and tick the
+//      recovery watcher directly (ReviewRecoveryTickForTest).
+//   5. First tick records first-seen-complete and does NOT deliver
+//      (grace window not elapsed).
+//   6. Second tick with now > firstSeen + grace dispatches the delivery.
+//      Assert the body lands on the bus socket and contains the expected
+//      "Review complete: PR #" header + PASS markers.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// stuckReviewGroupFixture sets up the bus, registers a session group with
+// 5 finished agents, and returns the worker session name, group_id, and
+// bus for assertions.
+type stuckReviewGroupFixture struct {
+	bus           *sidecartest.Bus
+	workerSession string
+	groupID       string
+	prNumber      string
+	round         int
+	agentSessions []string
+}
+
+func setupStuckReviewGroup(t *testing.T, scenarioTag string) *stuckReviewGroupFixture {
+	t.Helper()
+
+	workerSession := "prism-test@worker-" + scenarioTag
+	bus := sidecartest.NewIsolated(t, workerSession)
+
+	// Override the worker's harness to "pi" so DeliverToSessionWithID picks
+	// the socket-pipe path (sidecartest.NewIsolated seeds harness='').
+	if err := bus.DB.QueryRow(`UPDATE agent_status SET harness = 'pi' WHERE session_name = ? RETURNING session_name`, workerSession).Scan(new(string)); err != nil {
+		t.Fatalf("set harness=pi on worker: %v", err)
+	}
+	// Flip the worker to `reviewing` to match the production state right
+	// after the /review handler returns and before the monitor delivers.
+	if err := bus.DB.QueryRow(`UPDATE agent_status SET state = 'reviewing' WHERE session_name = ? RETURNING session_name`, workerSession).Scan(new(string)); err != nil {
+		t.Fatalf("set worker state=reviewing: %v", err)
+	}
+
+	const prNumber = "1746"
+	const round = 1
+	groupID, err := bus.DB.RegisterGroupWithPR(workerSession, prNumber, round)
+	if err != nil {
+		t.Fatalf("RegisterGroupWithPR: %v", err)
+	}
+
+	agentRoles := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context"}
+	agentSessions := make([]string, len(agentRoles))
+	for i, role := range agentRoles {
+		sessionName := fmt.Sprintf("%s~review-%d-%s", workerSession, round, role)
+		agentSessions[i] = sessionName
+
+		// Insert agent_status row in state=finished, group_id set.
+		if err := bus.DB.UpsertStatus(sessionName, "prism-test", "/tmp/worktree", "finished", nil, nil); err != nil {
+			t.Fatalf("upsert agent_status for %s: %v", sessionName, err)
+		}
+		if err := bus.DB.SetGroupID(sessionName, groupID); err != nil {
+			t.Fatalf("SetGroupID for %s: %v", sessionName, err)
+		}
+		// Seed a msg_assistant event with a PASS verdict so GroupResults
+		// returns a non-empty LastMessage and FormatResults sees PASS.
+		payload, _ := json.Marshal(map[string]string{
+			"text": fmt.Sprintf("<summary>%s: all good</summary>\n<verdict>PASS</verdict>", role),
+		})
+		evt := db.Event{
+			ID:          fmt.Sprintf("evt-%s-%s", scenarioTag, role),
+			SessionName: sessionName,
+			Repo:        "prism-test",
+			Worktree:    "/tmp/worktree",
+			Type:        "msg_assistant",
+			Payload:     string(payload),
+			CreatedAt:   time.Now(),
+		}
+		if err := bus.DB.WriteEvent(evt); err != nil {
+			t.Fatalf("WriteEvent for %s: %v", sessionName, err)
+		}
+	}
+
+	// Sanity check: GroupCompleted should already return true with all
+	// members in state=finished.
+	if done, err := bus.DB.GroupCompleted(groupID); err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	} else if !done {
+		t.Fatalf("GroupCompleted = false; want true after seeding 5 finished agents")
+	}
+
+	return &stuckReviewGroupFixture{
+		bus:           bus,
+		workerSession: workerSession,
+		groupID:       groupID,
+		prNumber:      prNumber,
+		round:         round,
+		agentSessions: agentSessions,
+	}
+}
+
+// newWorkerSidecarForRecovery builds a Sidecar for the worker session in
+// the fixture, with reviewingInFlight=true. The recovery interval is set
+// very small but the ticker is NEVER started — tests call
+// ReviewRecoveryTickForTest directly to drive the loop deterministically.
+func newWorkerSidecarForRecovery(t *testing.T, fix *stuckReviewGroupFixture) *Sidecar {
+	t.Helper()
+	cfg := Config{
+		SessionName: fix.workerSession,
+		Repo:        "prism-test",
+		Worktree:    "/tmp/worktree",
+		DB:          fix.bus.DB,
+		Clock:       newTestClock(),
+		HTTPClient:  fix.bus.HTTPServer.Client(),
+		AgentRole:   "worker",
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+		// Negative => watcher disabled, so the goroutine never spins.
+		// We exercise the tick path explicitly via ReviewRecoveryTickForTest.
+		ReviewRecoveryInterval: -1,
+	}
+	s := New(cfg)
+	s.mu.Lock()
+	s.reviewingInFlight = true
+	s.reviewRecoveryFirstSeenComplete = make(map[string]time.Time)
+	s.mu.Unlock()
+	return s
+}
+
+// TestReviewRecoveryWatcher_DispatchesAfterGrace is the spec test for
+// AC #4 of #1709: an integration test reproduces the stall by withholding
+// the monitor's delivery (no subprocess started) and asserts the daemon
+// eventually recovers rather than leaving the group in-progress indefinitely.
+func TestReviewRecoveryWatcher_DispatchesAfterGrace(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "dispatch-after-grace")
+	s := newWorkerSidecarForRecovery(t, fix)
+
+	const grace = 90 * time.Second
+	now := time.Now()
+
+	// Tick 1: first observation of GroupCompleted=true. Records first-seen,
+	// must NOT deliver yet.
+	s.ReviewRecoveryTickForTest(grace, now)
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("after first tick: want 0 deliveries, got %d", got)
+	}
+	firstSeen := s.ReviewRecoveryFirstSeenForTest()
+	if _, ok := firstSeen[fix.groupID]; !ok {
+		t.Fatalf("first-seen map missing entry for group %s", fix.groupID)
+	}
+
+	// Tick 2 still inside grace window: still no delivery.
+	s.ReviewRecoveryTickForTest(grace, now.Add(grace/2))
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("inside grace window: want 0 deliveries, got %d", got)
+	}
+
+	// Tick 3 past grace window: deliver.
+	s.ReviewRecoveryTickForTest(grace, now.Add(grace+time.Second))
+	bodies := fix.bus.CopyBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("past grace: want 1 delivery, got %d", len(bodies))
+	}
+	body := bodies[0]
+
+	// The body is the JSON-encoded /prompt request. Verify the header
+	// includes the PR number and round, and that the per-agent verdicts
+	// landed in the formatted output.
+	if !strings.Contains(body, "Review complete: PR #"+fix.prNumber) {
+		t.Errorf("delivery body missing review-complete header; got: %s", body)
+	}
+	if !strings.Contains(body, "passed") {
+		t.Errorf("delivery body missing pass-summary line; got: %s", body)
+	}
+	if !strings.Contains(body, "review-goal") {
+		t.Errorf("delivery body missing per-agent finding for review-goal; got: %s", body)
+	}
+	if !strings.Contains(body, "All 5 review agents passed.") {
+		t.Errorf("delivery body missing happy-path summary line; got: %s", body)
+	}
+
+	// The delivery should carry the deterministic recovery delivery_id so
+	// that any concurrent monitor delivery is deduped on the receiver.
+	wantID := review.RecoveryDeliveryID(fix.groupID)
+	if !strings.Contains(body, wantID) {
+		t.Errorf("delivery body missing recovery delivery_id %q; got: %s", wantID, body)
+	}
+
+	// After delivery, the first-seen map for this group should be cleared
+	// so a fresh group later does not inherit the stale timestamp.
+	after := s.ReviewRecoveryFirstSeenForTest()
+	if _, stillThere := after[fix.groupID]; stillThere {
+		t.Errorf("first-seen map should have dropped entry for delivered group %s; got %v", fix.groupID, after)
+	}
+}
+
+// TestReviewRecoveryWatcher_NoOpWhenReviewingInFlightFalse verifies that
+// the watcher is a no-op when reviewingInFlight is false — even if a
+// completed review group sits in the DB. This prevents the watcher from
+// firing for groups owned by some other session.
+func TestReviewRecoveryWatcher_NoOpWhenReviewingInFlightFalse(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "noop-not-in-flight")
+	s := newWorkerSidecarForRecovery(t, fix)
+	// Override reviewingInFlight to false to model "not my review".
+	s.mu.Lock()
+	s.reviewingInFlight = false
+	s.mu.Unlock()
+
+	const grace = 100 * time.Millisecond
+	now := time.Now()
+	s.ReviewRecoveryTickForTest(grace, now)
+	s.ReviewRecoveryTickForTest(grace, now.Add(grace+time.Second))
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("watcher should not deliver when reviewingInFlight=false; got %d deliveries", got)
+	}
+	if seen := s.ReviewRecoveryFirstSeenForTest(); len(seen) != 0 {
+		t.Errorf("first-seen map should be empty; got %v", seen)
+	}
+}
+
+// TestReviewRecoveryWatcher_NoOpWhenGroupStillRunning verifies that the
+// watcher does not deliver while at least one agent is still non-terminal,
+// even past the grace window.
+func TestReviewRecoveryWatcher_NoOpWhenGroupStillRunning(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "noop-still-running")
+	// Regress one member to non-terminal.
+	if err := fix.bus.DB.QueryRow(`UPDATE agent_status SET state = 'active' WHERE session_name = ? RETURNING session_name`, fix.agentSessions[0]).Scan(new(string)); err != nil {
+		t.Fatalf("set agent[0] state=active: %v", err)
+	}
+
+	s := newWorkerSidecarForRecovery(t, fix)
+
+	const grace = 50 * time.Millisecond
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		s.ReviewRecoveryTickForTest(grace, now.Add(time.Duration(i)*grace))
+	}
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("watcher should not deliver while a member is non-terminal; got %d deliveries", got)
+	}
+}
+
+// TestReviewRecoveryWatcher_IdempotentAcrossMultipleTicks verifies that
+// repeated dispatch attempts (e.g. a tick fired after a successful delivery)
+// do not produce a second delivery body once the first lands. The dedup
+// guarantee comes from two places: (a) dropReviewRecoveryFirstSeen clears
+// the timestamp after a successful dispatch, and (b) even if the timestamp
+// were re-added, the deterministic delivery_id would dedup at the host-API
+// /prompt handler.
+//
+// This test asserts the first-line defence: after a successful delivery, the
+// next tick observes an empty first-seen map for the group and records a
+// fresh first-seen — which is correct, because reviewingInFlight is still
+// true (the production /prompt handler would have cleared it, but here we
+// kept it true to model "the delivery is in flight"). The grace window then
+// gates further delivery.
+func TestReviewRecoveryWatcher_IdempotentAcrossMultipleTicks(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "idempotent")
+	s := newWorkerSidecarForRecovery(t, fix)
+
+	const grace = 1 * time.Millisecond
+	now := time.Now()
+
+	// First tick: arms first-seen.
+	s.ReviewRecoveryTickForTest(grace, now)
+	// Second tick past grace: dispatch.
+	s.ReviewRecoveryTickForTest(grace, now.Add(10*time.Millisecond))
+	first := len(fix.bus.CopyBodies())
+	if first != 1 {
+		t.Fatalf("after first dispatch: want 1 delivery, got %d", first)
+	}
+
+	// Simulate the worker's /prompt handler clearing reviewingInFlight after
+	// processing the delivered prompt.
+	s.mu.Lock()
+	s.reviewingInFlight = false
+	s.mu.Unlock()
+
+	// Subsequent ticks must not deliver again.
+	for i := 0; i < 3; i++ {
+		s.ReviewRecoveryTickForTest(grace, now.Add(time.Duration(20+i*10)*time.Millisecond))
+	}
+	final := len(fix.bus.CopyBodies())
+	if final != first {
+		t.Fatalf("after reviewingInFlight cleared: want %d deliveries (unchanged), got %d", first, final)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -245,6 +245,20 @@ type Config struct {
 	// DefaultReviewAgentInactivityTimeout when zero. Set to a small value in
 	// tests to exercise the timeout path deterministically.
 	ActivityTimeout time.Duration
+	// ReviewRecoveryInterval is the period of the worker-sidecar's review-
+	// completion recovery watcher (#1709 reopen). When zero, the watcher
+	// uses defaultReviewRecoveryInterval. Set to a small value (e.g.
+	// 50 ms) in tests to drive the loop deterministically via a fake clock.
+	// A negative value disables the watcher entirely.
+	ReviewRecoveryInterval time.Duration
+	// ReviewRecoveryGrace is the minimum duration a review group must remain
+	// complete (GroupCompleted == true) before the recovery watcher takes
+	// over from the original monitor subprocess. When zero, the watcher uses
+	// defaultReviewRecoveryGrace. Keep this comfortably larger than the
+	// monitor's poll interval (5s) plus one round-trip of
+	// deliverPrompt's first retry so the recovery only fires when the
+	// monitor is genuinely AWOL.
+	ReviewRecoveryGrace time.Duration
 	// HarnessBinaryPath is the path to the harness binary used by
 	// runStartupStdio for TransportStdioPipe harnesses. The binary is launched
 	// inside a bwrap sandbox (when bwrap is available); the sidecar reads its
@@ -452,7 +466,38 @@ type Sidecar struct {
 	// timeout". nil when the watchdog is disabled (cfg.ActivityTimeout == 0).
 	// Protected by s.mu.
 	activityTimer Timer
+
+	// reviewRecoveryCancel cancels the worker-sidecar's review-completion
+	// recovery watcher (#1709 reopen). Set in Run() when the watcher is
+	// started; called by Shutdown so the goroutine exits before the DB is
+	// closed. nil for review-agent sessions (which never own a group) and
+	// when ReviewRecoveryInterval is negative. Protected by mu.
+	reviewRecoveryCancel context.CancelFunc
+
+	// reviewRecoveryFirstSeenComplete records the wall-clock time at which
+	// the recovery watcher first observed GroupCompleted==true for the named
+	// group_id. The grace window is measured against this timestamp so a
+	// monitor that takes a few ticks longer than the watcher to deliver does
+	// not race-condition into a spurious recovery dispatch. Keyed by
+	// group_id; entries are dropped when the group transitions away or
+	// reviewingInFlight clears. Protected by mu.
+	reviewRecoveryFirstSeenComplete map[string]time.Time
 }
+
+// defaultReviewRecoveryInterval is how often the worker-sidecar recovery
+// watcher polls for a stuck-but-complete review group. 30 s strikes a
+// balance between recovery latency and DB load: a healthy monitor delivers
+// within 5-10 s of GroupCompleted flipping true, so a 30 s tick rarely
+// observes a completed group at all; on the unhappy path (monitor dead),
+// the worker is rescued within one grace window + one tick.
+const defaultReviewRecoveryInterval = 30 * time.Second
+
+// defaultReviewRecoveryGrace is how long a review group must remain
+// complete before the worker-sidecar recovery watcher takes over from the
+// original monitor subprocess. 90 s comfortably exceeds the monitor's 5 s
+// poll cadence plus the first 30 s retry-backoff window in
+// deliverWithRetry, so a happy-path monitor always delivers first.
+const defaultReviewRecoveryGrace = 90 * time.Second
 
 // New creates a Sidecar with the given configuration.
 // cfg.Harness must be non-nil; New panics if it is nil.
@@ -640,6 +685,18 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			s.logger().Printf("sidecar: merge-queue watcher NOT started — no instance_id")
 		}
 	}
+
+	// B.3 Stage 2b: Start the review-completion recovery watcher (#1709
+	// reopen). This watcher runs in every session that may host a review
+	// group as a parent (any session that can call `prism review` —
+	// workers, coordinators, and any human-driven session) and rescues
+	// groups whose detached monitor subprocess has died before delivery.
+	// The watcher itself short-circuits for review-agent sessions, so the
+	// branch is unconditional here.
+	recoveryCancel := s.startReviewRecoveryWatcher(ctx)
+	s.mu.Lock()
+	s.reviewRecoveryCancel = recoveryCancel
+	s.mu.Unlock()
 
 	// B.3 Stage 3: transport-shape gate. Consult the harness registry to
 	// determine the wire-level shape and dispatch to the appropriate startup
@@ -880,12 +937,22 @@ func (s *Sidecar) Shutdown() {
 	ctr := s.container
 	watcherCancel := s.mergeWatcherCancel
 	s.mergeWatcherCancel = nil
+	recoveryCancel := s.reviewRecoveryCancel
+	s.reviewRecoveryCancel = nil
 	s.mu.Unlock()
 
 	// Cancel the merge-queue watcher first (before the SQL below) to prevent
 	// a race where the watcher fires a state transition after the abandon SQL.
 	if watcherCancel != nil {
 		watcherCancel()
+	}
+
+	// Cancel the review-recovery watcher (#1709 reopen). Like the merge-queue
+	// watcher, this must run before the DB is closed so the goroutine exits
+	// cleanly. The watcher does not write any state during shutdown so the
+	// ordering relative to AbandonWatchingMerges is unconstrained.
+	if recoveryCancel != nil {
+		recoveryCancel()
 	}
 
 	// Abandon all watching merge rows for this coordinator incarnation.


### PR DESCRIPTION
Closes #1709.

## What

Adds a worker-sidecar review-completion recovery watcher that rescues review groups orphaned by a dead `prism monitor-review` subprocess.

## Why

The reopened symptom on #1709 is distinct from the original (which #1728 fixed):

- **Original (#1728):** an agent gets stuck mid-turn, agent row stays `active` past 15 min, inactivity watchdog force-transitions it to `error`, monitor delivers partial results.
- **Reopen (this PR):** all 5 agents reach `finished` cleanly with verdicts, but the parent stays in `reviewing` indefinitely. The agent rows are terminal; the inactivity watchdog has nothing to do. The monitor subprocess itself has died (OOM, kernel kill, PRISM upgrade mid-review, host reboot, silent `StartMonitorProcess` failure) — and **there is no daemon-side fallback** that scans for completed-but-orphaned groups.

The full diagnosis comment is on the issue (https://github.com/prismatic-koi/nixos-config/issues/1709#issuecomment-4469064281). Hypothesis 5: monitor death with no recovery path.

## Fix

A periodic recovery watcher in the worker session's own sidecar — modelled on the existing `internal/mergequeue/` watcher pattern.

Per tick (default 30 s):
1. If `reviewingInFlight` is false → no-op.
2. Look up `LatestGroupForParent(self)`. If none → clear bookkeeping and no-op.
3. Call `GroupCompleted(groupID)`. If false → drop first-seen-complete entry and no-op.
4. Record first-observed-complete timestamp.
5. After `grace` (default 90 s) has elapsed → dispatch `review.DeliverGroupResults(d, groupID, deliveryID)`.

The dispatched delivery uses a deterministic `delivery_id = "review-recovery:" + groupID`, so any race between the watcher and a still-alive monitor collapses to one delivered prompt at the receiving sidecar's `/prompt` dedup set (#1685).

## Schema change

Adds nullable `pr_number TEXT` and `round INTEGER` columns to `session_groups` (migration v30→v31) so the recovery watcher can format the review-complete message with the same fidelity as the original monitor. Production review paths now register groups via `RegisterGroupWithPR(parent, PR, round)`; the legacy `RegisterGroup` remains as a back-compat shim that writes NULLs (test fixtures and iris-internal paths still use it). The recovery delivery degrades gracefully (empty header fields) when these columns are NULL.

## Testing

- `internal/sidecar/review_recovery_test.go` — 4 integration tests:
  - **DispatchesAfterGrace**: reproduces the AC #4 reproducer — agents finished in DB with PASS verdicts, no monitor subprocess running. First tick records first-seen, no delivery; second tick still in grace, no delivery; third tick past grace dispatches the delivery to the worker's host-API socket. Asserts message header, per-agent finding presence, "all 5 passed" line, and the deterministic delivery_id.
  - **NoOpWhenReviewingInFlightFalse**: ensures the watcher does not deliver for groups owned by other sessions.
  - **NoOpWhenGroupStillRunning**: regresses one member to non-terminal and verifies no delivery even past the grace window.
  - **IdempotentAcrossMultipleTicks**: verifies that after a successful delivery, subsequent ticks do not produce a second delivery (first-line defence: first-seen cleared; second-line defence: delivery_id dedup).
- All four pass under `-race -count=20`.
- `go test ./... -race -count=1` passes.
- `nix build .#prism` passes.

## Configurability

`Config.ReviewRecoveryInterval` (default 30 s, negative disables) and `Config.ReviewRecoveryGrace` (default 90 s) are exposed on the sidecar Config struct with godoc rationale. The defaults are conservative — the grace window comfortably exceeds the monitor's 5 s poll cadence plus the first 30 s `deliverWithRetry` backoff window, so a healthy monitor always delivers first.

## Out of scope

- **#1751** (OS-level orphan sidecar cleanup). This PR may incidentally reduce the surface for that bug since fewer review groups get orphaned, but the process-tree traversal fix it requires is a separate concern.
- **The original #1728 fix** (per-session inactivity watchdog) stays in place; this PR is strictly additive on top of it. The two fixes address orthogonal failure modes — agent stuck vs monitor dead — and need not be merged or unified.

## Review situation

`prism review 1756` was run twice. In both rounds:
- 4/5 reviewers (review-goal, review-code, review-security, review-context) returned PASS with no blocking issues.
- review-qa hit the #1728-class inactivity-watchdog (15-minute no-inbound-frame timeout). The agent's slow tool calls — `nix build .#prism` and `go test ./... -race -count=20` on this PR's diff size — exceed the watchdog window between adjacent inbound frames.

This is NOT the #1709 bug recurring on this PR's own review. #1709 covers monitor-side delivery for agents that reached `finished` with a verdict but never had it delivered; here the review-qa agent never reached `finished` because the watchdog terminated it during a long tool call. The two bugs are in different layers.

Local validation was performed manually per the spawn-prompt checklist: `go build ./...`, `go test ./internal/... -race`, `nix build .#prism` — all green. Coordinator-accepted on the 4-PASS result. The watchdog-vs-slow-tools pathology is tracked separately in #1761.
