### PR TITLE
iris: surface extension_error frames in supervisor RPC handler (#1757)

### DIFF
--- a/modules/programs/prism/prism/internal/iris/protocol.go
+++ b/modules/programs/prism/prism/internal/iris/protocol.go
@@ -107,6 +107,21 @@ type GenericFrame struct {
 	Type string `json:"type"`
 }
 
+// ExtensionErrorFrame is emitted by pi on its stdout RPC channel when an
+// extension handler throws. The supervisor treats this as a non-retriable
+// fatal error: the extension is fundamentally broken and the same fault
+// will fire on every restart until the underlying bug is fixed (issue
+// #1757).
+//
+//	{type: "extension_error", extensionPath: <path>, event: <handler>,
+//	 error: <message>}
+type ExtensionErrorFrame struct {
+	Type          string `json:"type"` // "extension_error"
+	ExtensionPath string `json:"extensionPath"`
+	Event         string `json:"event"`
+	Error         string `json:"error"`
+}
+
 // ProtocolVersion is the wire protocol version iris speaks. Must match the
 // extension's PROTOCOL_VERSION constant (currently 2, bumped in #1434).
 const ProtocolVersion = 2

--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -657,6 +657,78 @@ func (s *Supervisor) handleRPCEvent(line []byte) {
 		s.logf("supervisor: session %s: agent_end", s.sess.InstanceID)
 	case "response":
 		// Command acknowledgement — log at debug level (suppressed for now).
+	case "extension_error":
+		// Issue #1757: pi's prism extension threw inside a handler
+		// (commonly session_start). This is a fatal, non-retriable failure:
+		// the same fault will fire on every restart until the extension bug
+		// is fixed. Surface it loudly in the daemon log and drive the
+		// session to StateError so subscribers and the circuit breaker see
+		// the terminal outcome.
+		s.handleExtensionError(line)
+	default:
+		// Hot-path: keep formatting cheap. Pi can emit many RPC frames per
+		// second during an active turn. Log the parsed type plus the raw
+		// line, truncated so a runaway frame cannot blow the log out.
+		s.logf("supervisor: session %s: unknown RPC type=%q raw=%s",
+			s.sess.InstanceID, generic.Type, truncateForLog(line, rpcLogMaxBytes))
+	}
+}
+
+// rpcLogMaxBytes caps the raw-frame payload included in the default-arm
+// log line. Roughly 1 KiB — enough to identify the frame in a future
+// debug session without flooding the journal if pi ever emits a megabyte
+// blob.
+const rpcLogMaxBytes = 1024
+
+// truncateForLog returns line as a string, truncated to at most max bytes
+// with a trailing ellipsis when truncation occurs. Allocates at most one
+// new string; no JSON re-encoding (the line is already a JSON-line frame
+// from pi's stdout).
+func truncateForLog(line []byte, max int) string {
+	if len(line) <= max {
+		return string(line)
+	}
+	return string(line[:max]) + "...(truncated)"
+}
+
+// handleExtensionError handles the extension_error RPC frame: logs at
+// error level with the extension path, event name, and error message;
+// transitions the supervisor to StateError with reason "extension_error";
+// and cancels the per-session context so pi exits cleanly. Restart is
+// suppressed by the killReason guard in setState (issue #1757).
+func (s *Supervisor) handleExtensionError(line []byte) {
+	var frame ExtensionErrorFrame
+	if err := json.Unmarshal(line, &frame); err != nil {
+		// Fall back to a generic error log if the frame is malformed —
+		// we still want the diagnostic surfaced, just with less detail.
+		s.logf("supervisor: session %s: ERROR extension_error (unparsable frame): %v raw=%s",
+			s.sess.InstanceID, err, truncateForLog(line, rpcLogMaxBytes))
+	} else {
+		s.logf("supervisor: session %s: ERROR extension_error event=%q extensionPath=%q error=%q",
+			s.sess.InstanceID, frame.Event, frame.ExtensionPath, frame.Error)
+	}
+
+	// Set killReason BEFORE setState so the session_end event carries the
+	// correct termination reason, and the setState guard suppresses the
+	// loop's StateFinished override that fires when ctx is cancelled below.
+	s.mu.Lock()
+	// Don't overwrite a prior kill reason — if the operator already
+	// initiated a Kill, that reason takes precedence.
+	if s.killReason == "" {
+		s.killReason = "extension_error"
+	}
+	cancel := s.cancel
+	s.mu.Unlock()
+
+	s.setState(StateError)
+
+	// Tear down pi the same way Kill does: cancel the per-session context.
+	// spawnAndRun configures cmd.Cancel to send SIGTERM, so this triggers a
+	// graceful shutdown attempt. The Start loop's ctx.Err() branch then
+	// runs setState(StateFinished), which the killReason guard suppresses
+	// (see setState).
+	if cancel != nil {
+		cancel()
 	}
 }
 
@@ -782,7 +854,11 @@ func (s *Supervisor) setState(newState SessionState) {
 	if s.killReason != "" && newState == StateFinished && s.state != StateFinished {
 		// Re-map to StateError when SIGKILL was already needed; otherwise
 		// leave the SIGTERM-clean path to set StateFinished explicitly.
-		if s.killReason == "killed_sigkill" || s.killReason == "killed_no_process" {
+		// Issue #1757: extension_error is also a terminal-StateError reason
+		// — we set StateError directly from handleExtensionError and then
+		// cancel ctx to tear pi down. The loop's ctx.Err() branch must NOT
+		// override that with StateFinished.
+		if s.killReason == "killed_sigkill" || s.killReason == "killed_no_process" || s.killReason == "extension_error" {
 			s.mu.Unlock()
 			return
 		}

--- a/modules/programs/prism/prism/internal/iris/supervisor_extension_error_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_extension_error_test.go
@@ -1,0 +1,316 @@
+package iris
+
+// supervisor_extension_error_test.go — tests for handleRPCEvent's
+// extension_error case and default (unknown-type) arm (issue #1757).
+//
+// Background. The supervisor reads pi's stdout RPC channel line-by-line
+// and dispatches on the `type` field. Before #1757 the switch handled
+// only agent_start / agent_end / response, and dropped every other frame
+// silently. Fatal extension failures (the prism extension throwing in
+// session_start) were invisible in the daemon log, even though pi emitted
+// the diagnostic on the right channel.
+//
+// Coverage:
+//
+//   - An extension_error frame transitions the supervisor to StateError,
+//     captures "extension_error" as the kill reason, and writes the error
+//     message + extension path + event name into the per-session log.
+//   - An extension_error frame does NOT trigger a restart (the failure is
+//     non-retriable; the same fault will fire on every spawn until the
+//     underlying extension bug is fixed).
+//   - An unknown RPC type leaves the supervisor in StateActive and logs
+//     the raw frame (truncated form is fine) plus the type field.
+//   - Known types (agent_start, agent_end, response) continue to log /
+//     no-op as before — no regression from the new switch arms.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// newExtensionErrorSupervisor returns a Supervisor wired with a per-session
+// log file we can read back, plus the path to that log file. The supervisor
+// has NO running pi child — these tests call handleRPCEvent directly, the
+// same pattern as supervisor_state_change_test.go's handleStateChange tests.
+func newExtensionErrorSupervisor(t *testing.T) (sup *Supervisor, logPath string, database *db.DB) {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	runDir, err := os.MkdirTemp("", "iris-extn-err-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+
+	logDir := filepath.Join(tmp, "logs")
+	sessionName := "iris-test@extension-error"
+
+	cfg := SupervisorConfig{
+		SessionName: sessionName,
+		Worktree:    tmp,
+		Role:        "worker",
+		RunDir:      runDir,
+		LogDir:      logDir,
+		Database:    database,
+	}
+	sup, err = NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(sup.closeSessionLogFile)
+
+	logPath = filepath.Join(logDir, sanitiseSessionFileName(sessionName)+".log")
+	return sup, logPath, database
+}
+
+// readLog reads the per-session log file. Returns "" when the file does
+// not exist yet (helpful when assertions run before any logf call has
+// fired).
+func readLog(t *testing.T, logPath string) string {
+	t.Helper()
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("ReadFile %q: %v", logPath, err)
+	}
+	return string(b)
+}
+
+// TestHandleRPCEvent_ExtensionError_TransitionsToStateError pins the issue
+// #1757 acceptance criteria: an extension_error frame must drive the
+// supervisor to StateError with the error message, extension path, and
+// event name in the daemon log.
+func TestHandleRPCEvent_ExtensionError_TransitionsToStateError(t *testing.T) {
+	sup, logPath, database := newExtensionErrorSupervisor(t)
+
+	const extPath = "/nix/store/abc-prism-extension/prism.ts"
+	const eventName = "session_start"
+	// Embedded double quotes in the error message exercise the JSON-line
+	// decode — marshal via encoding/json rather than string concat so the
+	// wire frame is valid even when the error text contains " or \.
+	const errMsg = "[iris-extension] fatal: canonical built-in \"read\" was not overridden"
+
+	frameMap := map[string]any{
+		"type":          "extension_error",
+		"extensionPath": extPath,
+		"event":         eventName,
+		"error":         errMsg,
+	}
+	frameBytes, err := json.Marshal(frameMap)
+	if err != nil {
+		t.Fatalf("marshal frame: %v", err)
+	}
+	frame := append(frameBytes, '\n')
+
+	sup.handleRPCEvent(frame)
+
+	if got := sup.State(); got != StateError {
+		t.Fatalf("State() = %q, want %q after extension_error", got, StateError)
+	}
+
+	logContent := readLog(t, logPath)
+	// Substring assertions — the log line uses %q which JSON-escapes inner
+	// quotes, so we look for the unique anchor tokens from the original
+	// message rather than the exact string.
+	for _, want := range []string{eventName, extPath, "extension_error",
+		"[iris-extension] fatal:", "was not overridden"} {
+		if !strings.Contains(logContent, want) {
+			t.Errorf("log missing %q\nfull log:\n%s", want, logContent)
+		}
+	}
+
+	// session_end event should be present with reason="extension_error" so
+	// downstream consumers (journal, narrative CLI, parent-notify) see the
+	// non-retriable terminal cause.
+	assertSessionEndReason(t, database, sup.sess.SessionName, "extension_error")
+}
+
+// TestHandleRPCEvent_ExtensionError_NoRestart pins the watch-out: an
+// extension_error frame is a non-retriable failure. The supervisor must
+// not loop back into spawning. We verify this by driving Start() against
+// a sleep-like binary, injecting an extension_error frame into
+// handleRPCEvent, and asserting the Start goroutine exits in StateError
+// without re-spawning.
+func TestHandleRPCEvent_ExtensionError_NoRestart(t *testing.T) {
+	// Use a sleep wrapper as the "pi" binary so spawnAndRun reaches
+	// StateActive and the per-session ctx is wired up (handleExtensionError
+	// needs s.cancel to terminate the child).
+	script := writeShellScript(t, "exec sleep 60\n", "")
+	sup, database := killTestSupervisor(t, script)
+
+	preRestart := sup.sess.RestartCount
+
+	// Inject the extension_error frame directly — same path the stdout
+	// reader goroutine would take when pi emits one.
+	frame := []byte(`{"type":"extension_error","extensionPath":"/x/prism.ts","event":"session_start","error":"boom"}` + "\n")
+	sup.handleRPCEvent(frame)
+
+	// Wait for Start to converge on StateError. Bounded so a regression
+	// (e.g. restart loop) fails the test rather than hanging.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		st := sup.State()
+		if st == StateError {
+			break
+		}
+		if st == StateSpawning {
+			t.Fatalf("supervisor re-entered StateSpawning after extension_error \u2014 must not restart")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := sup.State(); got != StateError {
+		t.Fatalf("State() = %q, want %q (did Start return?)", got, StateError)
+	}
+
+	// RestartCount must not have advanced \u2014 the loop should have exited
+	// via the ctx.Err() branch (suppressed by killReason guard), not via
+	// the non-zero-exit restart path that bumps RestartCount.
+	if sup.sess.RestartCount != preRestart {
+		t.Errorf("RestartCount = %d, want %d (extension_error must not trigger restart)",
+			sup.sess.RestartCount, preRestart)
+	}
+
+	// Exactly one session_end event with the extension_error reason. A
+	// duplicate would indicate the ctx.Err() branch's StateFinished
+	// override leaked past the killReason guard.
+	if got := countSessionEndEvents(t, database, sup.sess.SessionName); got != 1 {
+		t.Errorf("session_end event count = %d, want 1", got)
+	}
+	assertSessionEndReason(t, database, sup.sess.SessionName, "extension_error")
+}
+
+// TestHandleRPCEvent_UnknownType_LoggedButHarmless pins the default arm:
+// an unrecognised RPC type must be logged (so future pi RPC additions are
+// visible) and must not transition the supervisor or panic.
+func TestHandleRPCEvent_UnknownType_LoggedButHarmless(t *testing.T) {
+	sup, logPath, _ := newExtensionErrorSupervisor(t)
+
+	// Drive to StateActive so the test can assert "unknown type does not
+	// flip state". setState() emits a log line on the transition; we
+	// snapshot the log AFTER that so the unknown-type assertion isn't
+	// confused by setState's own line.
+	sup.setState(StateActive)
+	preLog := readLog(t, logPath)
+
+	frame := []byte(`{"type":"some_future_event","data":42}` + "\n")
+	sup.handleRPCEvent(frame)
+
+	if got := sup.State(); got != StateActive {
+		t.Errorf("State() = %q, want %q (unknown RPC type must not change state)", got, StateActive)
+	}
+
+	logContent := readLog(t, logPath)
+	if logContent == preLog {
+		t.Fatal("default arm produced no log output \u2014 unknown types must be surfaced")
+	}
+	// New content only.
+	newContent := logContent[len(preLog):]
+	for _, want := range []string{"some_future_event", "unknown RPC type"} {
+		if !strings.Contains(newContent, want) {
+			t.Errorf("new log content missing %q\nnew content:\n%s", want, newContent)
+		}
+	}
+	// The raw frame body should appear (the truncation helper preserves
+	// short frames intact).
+	if !strings.Contains(newContent, `"data":42`) {
+		t.Errorf("raw frame body missing from log; got:\n%s", newContent)
+	}
+}
+
+// TestHandleRPCEvent_UnknownType_TruncatesHugeRawFrame guards the
+// hot-path watch-out: a runaway frame must not blow the log file out.
+// The default arm caps the raw payload at rpcLogMaxBytes.
+func TestHandleRPCEvent_UnknownType_TruncatesHugeRawFrame(t *testing.T) {
+	sup, logPath, _ := newExtensionErrorSupervisor(t)
+	sup.setState(StateActive)
+	preLog := readLog(t, logPath)
+
+	// 100 KiB of junk inside a "data" field. This is well past
+	// rpcLogMaxBytes (~1 KiB).
+	huge := strings.Repeat("A", 100*1024)
+	frame := []byte(`{"type":"future_huge","data":"` + huge + `"}` + "\n")
+	sup.handleRPCEvent(frame)
+
+	logContent := readLog(t, logPath)
+	newContent := logContent[len(preLog):]
+
+	// The new log content must be vastly smaller than the raw frame \u2014
+	// truncation is doing its job.
+	if len(newContent) > 4*1024 {
+		t.Errorf("default-arm log line is %d bytes for a 100 KiB frame \u2014 truncation regression",
+			len(newContent))
+	}
+	if !strings.Contains(newContent, "...(truncated)") {
+		t.Errorf("expected truncation marker in log output, got:\n%s", newContent)
+	}
+	// Type must still be present so the line remains useful.
+	if !strings.Contains(newContent, "future_huge") {
+		t.Errorf("type missing from truncated log output, got:\n%s", newContent)
+	}
+}
+
+// TestHandleRPCEvent_KnownTypes_NoRegression confirms the three pre-#1757
+// known types continue to behave as before \u2014 agent_start / agent_end
+// log a lifecycle line and response is intentionally silent.
+func TestHandleRPCEvent_KnownTypes_NoRegression(t *testing.T) {
+	sup, logPath, _ := newExtensionErrorSupervisor(t)
+	sup.setState(StateActive)
+	preLog := readLog(t, logPath)
+
+	sup.handleRPCEvent([]byte(`{"type":"agent_start"}` + "\n"))
+	sup.handleRPCEvent([]byte(`{"type":"agent_end"}` + "\n"))
+	sup.handleRPCEvent([]byte(`{"type":"response","id":"x","ok":true}` + "\n"))
+
+	if got := sup.State(); got != StateActive {
+		t.Errorf("State() = %q, want %q (known types must not change state)", got, StateActive)
+	}
+
+	logContent := readLog(t, logPath)
+	newContent := logContent[len(preLog):]
+	for _, want := range []string{"agent_start", "agent_end"} {
+		if !strings.Contains(newContent, want) {
+			t.Errorf("expected %q in log after known-type frame; got:\n%s", want, newContent)
+		}
+	}
+	// `response` is intentionally suppressed at debug level. The log must
+	// not include "unknown RPC type" for it \u2014 that would mean the
+	// default arm picked it up by mistake.
+	if strings.Contains(newContent, "unknown RPC type") {
+		t.Errorf("known types must not hit the default arm; got:\n%s", newContent)
+	}
+}
+
+// TestHandleRPCEvent_MalformedExtensionError pins the defensive path:
+// a malformed extension_error frame still surfaces a diagnostic and still
+// drives the session to StateError. The raw line is captured so the
+// operator can reconstruct what pi sent.
+func TestHandleRPCEvent_MalformedExtensionError(t *testing.T) {
+	sup, logPath, _ := newExtensionErrorSupervisor(t)
+
+	// Valid JSON for the type-dispatch decode, but the body fields don't
+	// decode into ExtensionErrorFrame as strings (event is an int).
+	frame := []byte(`{"type":"extension_error","event":42,"extensionPath":["arr"],"error":null}` + "\n")
+	sup.handleRPCEvent(frame)
+
+	if got := sup.State(); got != StateError {
+		t.Fatalf("State() = %q, want %q even on malformed extension_error", got, StateError)
+	}
+	logContent := readLog(t, logPath)
+	if !strings.Contains(logContent, "extension_error") {
+		t.Errorf("malformed extension_error still must log; got:\n%s", logContent)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor_kill_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_kill_test.go
@@ -365,7 +365,7 @@ func countSessionEndEvents(t *testing.T, database *db.DB, sessionName string) in
 func TestSupervisorKill_ReasonStrings(t *testing.T) {
 	// If these strings change, downstream tooling (cleanup output, narrative
 	// CLI, future iris kill --reason) must be updated in lockstep.
-	want := []string{"killed_sigterm", "killed_sigkill", "clean_exit", "error", "killed_no_process"}
+	want := []string{"killed_sigterm", "killed_sigkill", "clean_exit", "error", "killed_no_process", "extension_error"}
 	for _, s := range want {
 		if !strings.Contains(s, "_") && s != "error" {
 			t.Errorf("expected snake_case kill reason, got %q", s)


### PR DESCRIPTION
## Summary

Adds two arms to `internal/iris/supervisor.go::handleRPCEvent` so the supervisor stops silently dropping pi RPC frames it doesn't recognise:

1. `case "extension_error":` — logs at error level with extension path, event name, and error message; flips the supervisor to `StateError` with reason `"extension_error"`; cancels the per-session context so pi exits cleanly via the existing SIGTERM-on-ctx-cancel wiring. Restart is suppressed by extending the `killReason` guard in `setState` so the loop's `ctx.Err()` branch does not override the `StateError` transition with `StateFinished`.

2. `default:` — logs the parsed type plus the raw frame at info level, truncated at 1 KiB so a runaway pi frame cannot blow the journal out. Future RPC additions are visible without code changes.

`extension_error` is treated as non-retriable: the same fault will fire on every restart until the underlying extension bug is fixed, so it goes through the same `StateError`-with-reason machinery the SIGKILL path uses rather than the restart-backoff path.

## Background

Before this change, fatal extension failures (the prism extension throwing in `session_start`) were invisible in `journalctl --user -u iris`. The frames existed and pi emitted them on the right channel; the supervisor's `handleRPCEvent` switch just had no arm for them. That directly caused a >2-hour debug session for the `read`-override bug now tracked in companion issue #1758.

## Files

- `internal/iris/protocol.go` — adds `ExtensionErrorFrame` struct.
- `internal/iris/supervisor.go`:
  - `handleRPCEvent`: new `extension_error` and `default` arms.
  - new `handleExtensionError` helper.
  - new `truncateForLog` helper + `rpcLogMaxBytes` constant.
  - `setState`: extends the `killReason` guard to suppress the loop's `StateFinished` override for `"extension_error"` (alongside `"killed_sigkill"` / `"killed_no_process"`).
- `internal/iris/supervisor_kill_test.go` — extends the canonical-reason smoke test to include `"extension_error"`.
- `internal/iris/supervisor_extension_error_test.go` — new test file:
  - `TestHandleRPCEvent_ExtensionError_TransitionsToStateError` — pins state, log content, and `session_end` reason.
  - `TestHandleRPCEvent_ExtensionError_NoRestart` — drives `Start()` against a sleep wrapper, injects the frame, asserts converge on `StateError` without re-entering `StateSpawning` and without bumping `RestartCount`. A duplicate `session_end` event would signal a guard regression.
  - `TestHandleRPCEvent_UnknownType_LoggedButHarmless` — default-arm logs the unknown type and raw frame, state unchanged.
  - `TestHandleRPCEvent_UnknownType_TruncatesHugeRawFrame` — 100 KiB frame produces ≤4 KiB log line with truncation marker (hot-path watch-out).
  - `TestHandleRPCEvent_KnownTypes_NoRegression` — `agent_start` / `agent_end` / `response` still behave as before.
  - `TestHandleRPCEvent_MalformedExtensionError` — malformed frame still surfaces a diagnostic and still drives `StateError`.

## Verification

- `go build ./...` — clean.
- `go test ./internal/iris/... -race` — passes.
- `go test ./internal/iris/ -run TestHandleRPCEvent -race -count=20` — stable.
- `go test ./...` — full suite green.
- `nix build .#prism` — succeeds.

Closes #1757