### PR TITLE
iris: stop shadowing ~/.pi/agent/ with PI_CODING_AGENT_DIR

### DIFF
--- a/modules/programs/prism/prism/internal/iris/supervisor.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor.go
@@ -527,26 +527,23 @@ func (s *Supervisor) spawnAndRun(ctx context.Context) int {
 		}
 	}
 
-	// Write a per-session pi config that loads the prism extension.
-	piConfigDir, err := s.writePerSessionPIConfig()
+	// Isolate pi's session JSONL storage to a per-instance directory so
+	// two concurrent iris sessions cannot write to the same JSONL file.
+	// We pass --session-dir <path> rather than setting PI_CODING_AGENT_DIR
+	// (which would shadow ~/.pi/agent/ and break auth/settings/extensions —
+	// see issue #1778). Pi inherits ~/.pi/agent/ for everything else.
+	sessionStoreDir, err := s.ensurePISessionDir()
 	if err != nil {
-		s.logf("supervisor: write pi config: %v", err)
+		s.logf("supervisor: create pi session dir: %v", err)
 		return 1
 	}
 
 	// Build the pi command.
-	args := []string{"--mode", "rpc"}
-	if s.cfg.ExtensionPath != "" {
-		args = append(args, "--extension", s.cfg.ExtensionPath)
-	}
-	// Pass --session <path> when resuming a previous conversation (D-9 restore).
-	if s.cfg.SessionContinuePath != "" {
-		args = append(args, "--session", s.cfg.SessionContinuePath)
-	}
+	args := s.buildPiArgs(sessionStoreDir)
 
 	cmd := exec.CommandContext(ctx, piBin, args...)
 	cmd.Dir = s.cfg.Worktree
-	cmd.Env = s.buildEnv(piConfigDir)
+	cmd.Env = s.buildEnv()
 	// Override the default SIGKILL-on-cancel behaviour with SIGTERM so the
 	// kill ladder (issue #1674) runs SIGTERM → 5s grace → SIGKILL. WaitDelay
 	// is intentionally NOT set: Kill() owns the SIGKILL escalation via the
@@ -755,7 +752,15 @@ func (s *Supervisor) Abort() error {
 }
 
 // buildEnv constructs the environment for the pi child.
-func (s *Supervisor) buildEnv(piConfigDir string) []string {
+//
+// We intentionally do NOT set PI_CODING_AGENT_DIR here. That env var
+// relocates pi's entire agent dir (auth.json, settings.json, models.json,
+// extensions/, themes/, skills/, prompts/, sessions/) — not just session
+// storage. Setting it shadows the user's ~/.pi/agent/ and breaks
+// authentication to anthropic/openai/etc. (see issue #1778). Per-session
+// session JSONL isolation is achieved via the --session-dir command-line
+// flag built in buildPiArgs instead, which is the narrower contract.
+func (s *Supervisor) buildEnv() []string {
 	// Start from the current process environment so pi has access to
 	// ANTHROPIC_API_KEY etc. (pi reads LLM credentials from its own config
 	// dir and env vars, not from iris injections).
@@ -776,47 +781,42 @@ func (s *Supervisor) buildEnv(piConfigDir string) []string {
 		env = append(env, "IRIS_SESSION_NAME="+s.sess.SessionName)
 	}
 
-	// Set PI_CODING_AGENT_DIR to the per-session config dir so pi loads
-	// the prism extension and any APPEND_SYSTEM.md we write there.
-	if piConfigDir != "" {
-		env = append(env, "PI_CODING_AGENT_DIR="+piConfigDir)
-	}
-
 	return env
 }
 
-// writePerSessionPIConfig writes a minimal pi agent config directory for this
-// session. The key file is a pi config/settings that auto-loads the prism
-// extension pointing to s.cfg.ExtensionPath.
-//
-// In D-3 this simply creates the directory; the extension is loaded via the
-// --extension flag on the pi command line instead of via the agent config.
-// A full per-session settings.json injection (for provider overrides etc.)
-// is a later concern.
-func (s *Supervisor) writePerSessionPIConfig() (string, error) {
-	if s.cfg.ExtensionPath == "" {
-		return "", nil
+// buildPiArgs constructs the pi command-line arguments for this session.
+// Split out from spawnAndRun so the args contract (issue #1778: must
+// include --session-dir) can be pinned by a regression test without
+// spawning a pi process. sessionStoreDir is the per-instance directory
+// under which pi writes its session JSONL files (see ensurePISessionDir).
+func (s *Supervisor) buildPiArgs(sessionStoreDir string) []string {
+	args := []string{"--mode", "rpc"}
+	if s.cfg.ExtensionPath != "" {
+		args = append(args, "--extension", s.cfg.ExtensionPath)
 	}
-
-	// The config dir lives inside the session run dir.
-	sessionDir := filepath.Join(s.cfg.RunDir, s.sess.InstanceID)
-	configDir := filepath.Join(sessionDir, "pi-agent")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		return "", fmt.Errorf("iris: create pi config dir: %w", err)
+	// Isolate session JSONL storage per iris instance (issue #1778 / AC-2).
+	// This is the narrow alternative to PI_CODING_AGENT_DIR — it only
+	// overrides where pi writes session files, not auth/settings/extensions.
+	if sessionStoreDir != "" {
+		args = append(args, "--session-dir", sessionStoreDir)
 	}
-
-	// In D-3 the extension is passed via --extension; the config dir just needs
-	// to exist so PI_CODING_AGENT_DIR can be set without error.
-	// We write a minimal settings.json so pi doesn't prompt for model config.
-	settingsPath := filepath.Join(configDir, "settings.json")
-	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
-		settings := `{"model": "claude-sonnet-4-20250514", "provider": "anthropic"}`
-		if err := os.WriteFile(settingsPath, []byte(settings+"\n"), 0o600); err != nil {
-			return "", fmt.Errorf("iris: write pi settings: %w", err)
-		}
+	// Pass --session <path> when resuming a previous conversation (D-9 restore).
+	if s.cfg.SessionContinuePath != "" {
+		args = append(args, "--session", s.cfg.SessionContinuePath)
 	}
+	return args
+}
 
-	return configDir, nil
+// ensurePISessionDir creates and returns the per-instance directory where
+// pi writes its session JSONL files, passed to pi via --session-dir. This
+// replaces the old writePerSessionPIConfig that used PI_CODING_AGENT_DIR
+// and accidentally shadowed ~/.pi/agent/ (issue #1778).
+func (s *Supervisor) ensurePISessionDir() (string, error) {
+	sessionDir := filepath.Join(s.cfg.RunDir, s.sess.InstanceID, "pi-sessions")
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return "", fmt.Errorf("iris: create pi session dir: %w", err)
+	}
+	return sessionDir, nil
 }
 
 // openLogFile opens (or creates) the stderr log file for this session.

--- a/modules/programs/prism/prism/internal/iris/supervisor_agent_dir_shadow_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_agent_dir_shadow_test.go
@@ -1,0 +1,221 @@
+package iris
+
+// supervisor_agent_dir_shadow_test.go — regression tests for issue #1778.
+//
+// Iris previously set PI_CODING_AGENT_DIR=<run-dir>/<instance>/pi-agent in
+// the pi-child environment. That env var relocates pi's entire agent dir
+// (auth.json, settings.json, models.json, extensions/, themes/, skills/,
+// prompts/, sessions/) — not just session storage. The net effect was that
+// iris-spawned pi could not authenticate to anthropic/openai because it
+// saw an empty per-session auth.json instead of ~/.pi/agent/auth.json.
+//
+// The fix:
+//   - drop PI_CODING_AGENT_DIR from Supervisor.buildEnv (AC-1)
+//   - pass --session-dir <run-dir>/<instance>/pi-sessions to pi (AC-2)
+//
+// These tests pin both invariants so a future regression is caught at
+// build time.
+//
+// AC-7: these tests only inspect buildEnv / buildPiArgs / ensurePISessionDir
+// output — no sidecar is constructed, so no sidecartest.NewIsolated is
+// required.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newShadowTestSupervisor wires up a minimal Supervisor for the env/args
+// inspection tests. It is intentionally narrow: no pi process is spawned,
+// no harness socket is accepted on. The run dir is allocated via
+// os.MkdirTemp (not t.TempDir) so the harness socket path stays under the
+// 108-byte sun_path limit — same pattern as newTestSupervisor in
+// set_pi_session_path_test.go.
+func newShadowTestSupervisor(t *testing.T) *Supervisor {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	runDir, err := os.MkdirTemp("", "iris-shadow-")
+	if err != nil {
+		t.Fatalf("MkdirTemp runDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runDir) })
+
+	cfg := SupervisorConfig{
+		SessionName:   "iris-worker@shadow-test",
+		Worktree:      tmp,
+		Role:          "worker",
+		RunDir:        runDir,
+		Database:      database,
+		ExtensionPath: "/nonexistent/prism.ts",
+	}
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor: %v", err)
+	}
+	t.Cleanup(func() { sup.harness.Close() })
+	t.Cleanup(sup.closeSessionLogFile)
+	return sup
+}
+
+// TestSupervisor_BuildEnv_DoesNotSetPICodingAgentDir is the core regression
+// guard for issue #1778 / AC-1. iris must never set PI_CODING_AGENT_DIR in
+// the pi-child environment, because doing so shadows ~/.pi/agent/ and
+// breaks LLM provider authentication.
+//
+// We explicitly clear PI_CODING_AGENT_DIR from the test process env first so
+// that any inherited value (the developer or CI may run iris itself with
+// PI_CODING_AGENT_DIR set for unrelated reasons) does not mask iris's own
+// injection. After scrubbing, the var must NOT reappear in buildEnv output.
+func TestSupervisor_BuildEnv_DoesNotSetPICodingAgentDir(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	if err := os.Unsetenv("PI_CODING_AGENT_DIR"); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+
+	sup := newShadowTestSupervisor(t)
+
+	env := sup.buildEnv()
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PI_CODING_AGENT_DIR=") {
+			t.Fatalf("buildEnv emitted PI_CODING_AGENT_DIR which shadows ~/.pi/agent/ (issue #1778): %q", kv)
+		}
+	}
+}
+
+// TestSupervisor_BuildPiArgs_IncludesSessionDir pins AC-2: pi must receive
+// --session-dir <run-dir>/<instance>/pi-sessions so two concurrent iris
+// sessions cannot write to the same session JSONL.
+func TestSupervisor_BuildPiArgs_IncludesSessionDir(t *testing.T) {
+	sup := newShadowTestSupervisor(t)
+
+	sessionStoreDir, err := sup.ensurePISessionDir()
+	if err != nil {
+		t.Fatalf("ensurePISessionDir: %v", err)
+	}
+
+	// The directory must actually live under the per-instance run dir,
+	// not at the run-dir root, so two instances are isolated.
+	wantPrefix := filepath.Join(sup.cfg.RunDir, sup.sess.InstanceID) + string(os.PathSeparator)
+	if !strings.HasPrefix(sessionStoreDir, wantPrefix) {
+		t.Fatalf("ensurePISessionDir = %q; want prefix %q (per-instance isolation)", sessionStoreDir, wantPrefix)
+	}
+	if filepath.Base(sessionStoreDir) != "pi-sessions" {
+		t.Fatalf("ensurePISessionDir = %q; want basename %q", sessionStoreDir, "pi-sessions")
+	}
+
+	// And the directory must exist on disk so pi can write to it
+	// without a chicken-and-egg MkdirAll race on first session_start.
+	info, err := os.Stat(sessionStoreDir)
+	if err != nil {
+		t.Fatalf("stat session dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("session dir is not a directory: %v", info.Mode())
+	}
+
+	args := sup.buildPiArgs(sessionStoreDir)
+
+	// Locate --session-dir and assert its value.
+	found := false
+	for i, a := range args {
+		if a == "--session-dir" {
+			if i+1 >= len(args) {
+				t.Fatalf("--session-dir present without a value: args=%v", args)
+			}
+			if args[i+1] != sessionStoreDir {
+				t.Fatalf("--session-dir value = %q; want %q", args[i+1], sessionStoreDir)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("buildPiArgs did not emit --session-dir; args=%v", args)
+	}
+}
+
+// TestSupervisor_BuildPiArgs_KeepsExtensionFlag pins AC-4: the prism
+// extension is still loaded via --extension <path>. This contract is
+// unaffected by the #1778 fix and the regression test catches any
+// accidental removal during a future refactor.
+func TestSupervisor_BuildPiArgs_KeepsExtensionFlag(t *testing.T) {
+	sup := newShadowTestSupervisor(t)
+
+	args := sup.buildPiArgs("/tmp/fake-sessions")
+
+	wantExt := sup.cfg.ExtensionPath
+	if wantExt == "" {
+		t.Fatalf("test setup: ExtensionPath must be non-empty")
+	}
+	found := false
+	for i, a := range args {
+		if a == "--extension" {
+			if i+1 >= len(args) || args[i+1] != wantExt {
+				t.Fatalf("--extension value mismatch: args=%v want=%q", args, wantExt)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("buildPiArgs did not emit --extension; args=%v", args)
+	}
+}
+
+// TestSupervisor_BuildPiArgs_ResumeSession asserts that the existing D-9
+// restore wiring (--session <jsonl-path>) still composes correctly with
+// the new --session-dir flag. Both must appear; they are independent.
+func TestSupervisor_BuildPiArgs_ResumeSession(t *testing.T) {
+	sup := newShadowTestSupervisor(t)
+	sup.cfg.SessionContinuePath = "/tmp/resume.jsonl"
+
+	args := sup.buildPiArgs("/tmp/fake-sessions")
+
+	var sawSession, sawSessionDir bool
+	for i, a := range args {
+		if a == "--session" {
+			sawSession = true
+			if i+1 >= len(args) || args[i+1] != "/tmp/resume.jsonl" {
+				t.Fatalf("--session value mismatch: args=%v", args)
+			}
+		}
+		if a == "--session-dir" {
+			sawSessionDir = true
+		}
+	}
+	if !sawSession {
+		t.Fatalf("buildPiArgs dropped --session (D-9 restore): args=%v", args)
+	}
+	if !sawSessionDir {
+		t.Fatalf("buildPiArgs dropped --session-dir (#1778 isolation): args=%v", args)
+	}
+}
+
+// TestSupervisor_EnsurePISessionDir_DoesNotCreatePiAgentDir pins AC-3:
+// the old empty pi-agent/ directory (whose presence with an empty
+// settings.json triggered the auth.json shadowing) must no longer be
+// created under the run dir. Catching this at the filesystem level —
+// not just the env-var level — guards against a partial revert that
+// keeps the directory but drops the env var.
+func TestSupervisor_EnsurePISessionDir_DoesNotCreatePiAgentDir(t *testing.T) {
+	sup := newShadowTestSupervisor(t)
+
+	if _, err := sup.ensurePISessionDir(); err != nil {
+		t.Fatalf("ensurePISessionDir: %v", err)
+	}
+
+	piAgentDir := filepath.Join(sup.cfg.RunDir, sup.sess.InstanceID, "pi-agent")
+	if _, err := os.Stat(piAgentDir); !os.IsNotExist(err) {
+		t.Fatalf("pi-agent/ should not exist under the run dir (issue #1778); stat err = %v", err)
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/supervisor_buildenv_test.go
+++ b/modules/programs/prism/prism/internal/iris/supervisor_buildenv_test.go
@@ -54,7 +54,7 @@ func TestSupervisor_BuildEnv_InjectsIRISSessionName(t *testing.T) {
 	}
 	t.Cleanup(sup.closeSessionLogFile)
 
-	env := sup.buildEnv("/tmp/fake-pi-config")
+	env := sup.buildEnv()
 
 	wantSession := "IRIS_SESSION_NAME=iris-worker@example-branch"
 	wantSock := "IRIS_DAEMON_SOCK="
@@ -107,7 +107,7 @@ func TestSupervisor_BuildEnv_EmptySessionNameOmitsVar(t *testing.T) {
 	}
 	t.Cleanup(sup.closeSessionLogFile)
 
-	env := sup.buildEnv("/tmp/fake-pi-config")
+	env := sup.buildEnv()
 	for _, kv := range env {
 		if strings.HasPrefix(kv, "IRIS_SESSION_NAME=") {
 			t.Errorf("buildEnv emitted IRIS_SESSION_NAME with empty SessionName: %q", kv)


### PR DESCRIPTION
Closes #1778

## Summary

Iris was setting `PI_CODING_AGENT_DIR=<run-dir>/<instance>/pi-agent` on the
pi child to inject a per-session `settings.json`. That env var relocates
pi's **entire** agent directory — `auth.json`, `settings.json`, `models.json`,
`extensions/`, `themes/`, `skills/`, `prompts/`, `sessions/` — not just the
session-storage subdirectory. iris-spawned pi therefore saw an empty
`auth.json` (which pi creates on first run if the file is missing) and could
not authenticate to anthropic / openai / etc.

The fix swaps `PI_CODING_AGENT_DIR` (broad) for `--session-dir` (narrow):

- `Supervisor.buildEnv` no longer emits `PI_CODING_AGENT_DIR`. Pi inherits
  `~/.pi/agent/` for everything.
- `spawnAndRun` creates `<run-dir>/<instance>/pi-sessions/` and passes
  `--session-dir <path>` on the pi command line. Two concurrent iris
  sessions no longer write to the same session JSONL.
- `writePerSessionPIConfig` (which created the empty `pi-agent/settings.json`
  that was the proximate cause of the auth.json shadowing) is replaced by
  `ensurePISessionDir`, which just `MkdirAll`s the new sessions dir.
- Pi-args construction is factored into `buildPiArgs` so the args contract
  can be pinned by a regression test without spawning pi.

## AC checklist

| AC  | Where |
|-----|-------|
| AC-1 — buildEnv drops `PI_CODING_AGENT_DIR` | `supervisor.go::buildEnv` + `TestSupervisor_BuildEnv_DoesNotSetPICodingAgentDir` |
| AC-2 — `--session-dir <run-dir>/<instance>/pi-sessions` passed to pi | `supervisor.go::buildPiArgs`+`ensurePISessionDir` + `TestSupervisor_BuildPiArgs_IncludesSessionDir` |
| AC-3 — `writePerSessionPIConfig` deleted; no `pi-agent/settings.json` | `supervisor.go` (function removed) + `TestSupervisor_EnsurePISessionDir_DoesNotCreatePiAgentDir` |
| AC-4 — `--extension <path>` wiring unchanged | `supervisor.go::buildPiArgs` + `TestSupervisor_BuildPiArgs_KeepsExtensionFlag` |
| AC-5 — manual end-to-end repro | see below |
| AC-6 — regression test on `buildEnv` output | `TestSupervisor_BuildEnv_DoesNotSetPICodingAgentDir` (asserts absence) + `TestSupervisor_BuildPiArgs_IncludesSessionDir` (asserts positive presence of `--session-dir`) |
| AC-7 — no host-path leakage | Tests only inspect `buildEnv` / `buildPiArgs` / `ensurePISessionDir` output; no sidecar constructed (no `sidecartest` needed). Per-test run dir is `os.MkdirTemp` and cleaned up. |

Note on AC-1's regression test: it explicitly `Unsetenv`s `PI_CODING_AGENT_DIR`
in the test process first, because the developer running the test may have
the var set in their own environment for unrelated reasons (e.g. they ran
iris in a previous shell and the variable leaked). `buildEnv` starts from
`os.Environ()`, so inherited values can mask iris's own injection. The
`Unsetenv` ensures the test fails only when iris itself appends the var.

## Manual repro (AC-5, for coordinator to run post-merge)

Pre-condition: `~/.pi/agent/auth.json` is populated with a real anthropic
OAuth entry (`type: oauth, access, refresh, expires`).

```bash
iris spawn --worktree /tmp/test-iris-auth --role coder
# In the spawned iris session, send: "what is 2+2?"
```

Expected:

- Pi responds with "4" using anthropic (or whichever provider the user has
  configured globally in `~/.pi/agent/settings.json`).
- No `400 bad request: Authorization header is badly formatted` error.
- No fallback to `github-copilot/gpt-5.4` unless that is the user's
  configured default.
- `ls -la ~/.local/state/iris/run/<instance>/` — there is **no** `pi-agent/`
  subdirectory; there is a `pi-sessions/` subdirectory with the JSONL.
- `cat ~/.pi/agent/auth.json` is unchanged (still has the user's tokens).

## Scope

Per the spawn prompt, this fix is independent of #1777 (per-session
`--provider`/`--model`). The per-session settings injection that
`writePerSessionPIConfig` was originally meant to be a placeholder for is
not re-introduced here — that's #1777's territory.

## Test plan

- `go build ./...` — clean
- `go test ./...` from `modules/programs/prism/prism/` — all pass
- `nix build .#prism` from repo root — clean
- CI will run the homeless-shelter gate (`nix-build-prism-checked`) and
  `go-tests`.