### PR TITLE
prism: traverse review/investigator sidecars in cleanup (#1751)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -225,6 +225,11 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 		}
 		_ = tmux.KillSession(m.session)
 		prismSession.KillSidecar(m.session)
+		// Orphan-sidecar safety net (issue #1751): SIGTERM any sidecar
+		// processes still alive for review-group or investigator-group
+		// children of this worker. Runs before the DB-backed cleanup so
+		// processes whose DB rows were already purged are still caught.
+		killOrphanReviewSidecars(m.session)
 		if d, err := openDB(); err == nil {
 			// Stop and remove child review-agent containers BEFORE removing their
 			// DB rows — so a failed stop still has a record to retry against.
@@ -590,6 +595,11 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 	printLine("killing session %s\n", session)
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
+	// Orphan-sidecar safety net (issue #1751): SIGTERM any sidecar
+	// processes still alive for review-group or investigator-group
+	// children of this worker. Done before DB cleanup so processes
+	// whose DB rows have already been purged are still caught.
+	killOrphanReviewSidecars(session)
 	// session_killed reflects the post-condition (tmux session is gone),
 	// which is true whether the session was alive or already-dead before this
 	// call. KillSession's error is intentionally ignored above (it returns
@@ -772,6 +782,11 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 	result.SessionKilled = true
 	_ = tmux.KillSession(session)
 	prismSession.KillSidecar(session)
+	// Orphan-sidecar safety net (issue #1751): SIGTERM any sidecar
+	// processes still alive for review-group or investigator-group
+	// children of this session. Done before DB cleanup so processes
+	// whose DB rows have already been purged are still caught.
+	killOrphanReviewSidecars(session)
 	var archiveCollisionWarning string
 	if d, err := openDB(); err == nil {
 		// Stop and remove child review-agent containers BEFORE removing their

--- a/modules/programs/prism/prism/cmd/cleanup_orphan_sidecars.go
+++ b/modules/programs/prism/prism/cmd/cleanup_orphan_sidecars.go
@@ -1,0 +1,215 @@
+package cmd
+
+// cleanup_orphan_sidecars.go — find and SIGTERM orphan review-group and
+// investigator-group sidecar processes that outlived their DB rows.
+//
+// Background (issue #1751): when a worker session is cleaned up after its PR
+// is merged, `prism cleanup --yes --session <worker>` clears the worker's
+// own state and runs review.CleanupReviewSessionsForParent which cleans up
+// DB rows for known review children. However, sidecar processes spawned
+// for review-group children (`<worker>~review-N-<role>`) and investigator
+// children (`<worker>~investigate-<slug>`) are not always reachable through
+// the DB by the time cleanup runs — their DB rows may have been ended /
+// purged earlier, or they may have been spawned without a DB row at all.
+// The OS-level sidecar processes then leak: each holds bwrap mounts, a
+// port allocation, and resident memory.
+//
+// The traversal here is the cleanup-side safety net. It is intentionally
+// process-tree based rather than DB-based so it works regardless of DB
+// state, regardless of whether the worker's worktree still exists, and
+// regardless of when in the cleanup sequence it runs.
+//
+// Linux-only: it walks /proc. On other platforms it is a no-op (NixOS is
+// the supported deployment target and prism CI runs on Linux). macOS dev
+// boxes still call this; it returns silently rather than erroring.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+
+	prismSession "github.com/prismatic-koi/prism/internal/session"
+)
+
+// killOrphanReviewSidecars enumerates running prism sidecar processes whose
+// `--session` argv argument has the prefix "<parentSession>~" and an infix
+// of "~review-" or "~investigate-" after that prefix, then sends SIGTERM
+// to each. The corresponding sidecar PID file is also removed on a best-
+// effort basis so a subsequent KillSidecar call does not stumble over it.
+//
+// The function is tolerant of races: processes that exit between
+// enumeration and signal are silently ignored (ESRCH). It is also
+// idempotent — calling it twice in a row simply finds zero matching
+// processes the second time.
+//
+// On non-Linux platforms this is a no-op (returns immediately). The
+// project's deployment target is NixOS; macOS-side cleanup of leaked
+// sidecars is out of scope.
+//
+// The parentSession argument must not be empty — callers should guard
+// against that (it would otherwise match every sidecar process whose
+// session name starts with "~", which is meaningless).
+func killOrphanReviewSidecars(parentSession string) {
+	if parentSession == "" {
+		return
+	}
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	pids, err := findOrphanReviewSidecarPIDs(parentSession, "/proc")
+	if err != nil {
+		// /proc is missing or unreadable — non-fatal; we just can't
+		// do the traversal. Log to stderr so the caller has a
+		// breadcrumb but do not return an error.
+		fmt.Fprintf(os.Stderr, "[prism] warning: killOrphanReviewSidecars: enumerate /proc: %v\n", err)
+		return
+	}
+
+	for _, match := range pids {
+		// SIGTERM first — graceful shutdown gives the sidecar a chance to
+		// clean up its socket and PID file. ESRCH is benign (process
+		// already exited between enumeration and signal).
+		if err := syscall.Kill(match.pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+			fmt.Fprintf(os.Stderr, "[prism] warning: killOrphanReviewSidecars: kill pid %d (session %q): %v\n",
+				match.pid, match.session, err)
+			continue
+		}
+		// Best-effort PID file removal so a later KillSidecar() doesn't
+		// trip over a stale PID file pointing at a now-dead process.
+		// SidecarPIDPath is pure (just path construction) so it is safe
+		// to call even after the process is gone.
+		removeSidecarPIDFile(match.session)
+	}
+}
+
+// sidecarMatch records the PID and session name of a sidecar that
+// killOrphanReviewSidecars determined belongs to a review or
+// investigator child of the parent.
+type sidecarMatch struct {
+	pid     int
+	session string
+}
+
+// findOrphanReviewSidecarPIDs walks procRoot (typically "/proc") looking
+// for prism sidecar processes whose --session argv arg matches the parent
+// session's review or investigator children. It is exported as a
+// lower-case helper for testing — tests can populate a fake /proc tree in
+// a t.TempDir() and pass that path.
+//
+// Matching criteria (all must hold):
+//
+//  1. /proc/<pid>/cmdline is readable.
+//  2. The cmdline contains both "sidecar" and "--session" tokens — the
+//     same invariant session.KillSidecar uses to recognise prism
+//     sidecars. We do not require the binary basename to be "prism"
+//     because `go test` re-invokes the test binary as a stub sidecar
+//     (see killsidecar_test.go::startStubProcess) and its argv[0] is
+//     "*.test", not "prism".
+//  3. The --session flag's value has the prefix "<parentSession>~".
+//  4. The suffix after that prefix begins with "review-" or
+//     "investigate-". This intentionally excludes the parent itself
+//     (whose --session value is exactly parentSession with no "~")
+//     and any unrelated sub-session shape we have not yet introduced.
+func findOrphanReviewSidecarPIDs(parentSession, procRoot string) ([]sidecarMatch, error) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return nil, err
+	}
+	prefix := parentSession + "~"
+	var matches []sidecarMatch
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// /proc contains many non-numeric entries (self, sys, etc.).
+		// Skip anything that isn't a PID.
+		pid, err := strconv.Atoi(name)
+		if err != nil {
+			continue
+		}
+		cmdlineBytes, err := os.ReadFile(filepath.Join(procRoot, name, "cmdline"))
+		if err != nil {
+			// Process exited between ReadDir and ReadFile, or we
+			// can't read it (permissions). Skip silently — this is
+			// the common race when /proc churns.
+			continue
+		}
+		// /proc/<pid>/cmdline uses NUL byte separators between argv
+		// entries and ends with a trailing NUL. Splitting on "\x00"
+		// recovers the argv slice; a final empty element from the
+		// trailing NUL is harmless to leave in.
+		argv := strings.Split(string(cmdlineBytes), "\x00")
+		if !isPrismSidecarCmdline(argv) {
+			continue
+		}
+		sessionArg := sessionArgFromCmdline(argv)
+		if sessionArg == "" {
+			continue
+		}
+		if !strings.HasPrefix(sessionArg, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(sessionArg, prefix)
+		if !strings.HasPrefix(suffix, "review-") && !strings.HasPrefix(suffix, "investigate-") {
+			continue
+		}
+		matches = append(matches, sidecarMatch{pid: pid, session: sessionArg})
+	}
+	return matches, nil
+}
+
+// isPrismSidecarCmdline reports whether argv looks like a prism sidecar
+// invocation: it must contain both a "sidecar" token and a "--session"
+// flag (in either "--session foo" or "--session=foo" form). This matches
+// the invariant in session.KillSidecar so the two recognisers stay in
+// lockstep.
+func isPrismSidecarCmdline(argv []string) bool {
+	hasSidecar := false
+	hasSession := false
+	for _, a := range argv {
+		if a == "sidecar" {
+			hasSidecar = true
+		}
+		if a == "--session" || strings.HasPrefix(a, "--session=") {
+			hasSession = true
+		}
+	}
+	return hasSidecar && hasSession
+}
+
+// sessionArgFromCmdline returns the value of the --session flag in argv,
+// supporting both "--session foo" (two argv slots) and "--session=foo"
+// (single argv slot). Returns "" when --session is absent or the
+// argument is malformed (e.g. trailing --session with no value).
+func sessionArgFromCmdline(argv []string) string {
+	for i, a := range argv {
+		if a == "--session" {
+			if i+1 < len(argv) {
+				return argv[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(a, "--session=") {
+			return strings.TrimPrefix(a, "--session=")
+		}
+	}
+	return ""
+}
+
+// removeSidecarPIDFile removes the PID file for sessionName best-effort.
+// Used after we have SIGTERMed a process we discovered via /proc — the
+// PID file (if any) is now stale and would only mislead a later
+// KillSidecar call.
+func removeSidecarPIDFile(sessionName string) {
+	pidPath, err := prismSession.SidecarPIDPath(sessionName)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(pidPath)
+}

--- a/modules/programs/prism/prism/cmd/cleanup_orphan_sidecars_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_orphan_sidecars_test.go
@@ -1,0 +1,418 @@
+package cmd
+
+// Tests for killOrphanReviewSidecars (issue #1751).
+//
+// The traversal walks /proc looking at each running process's argv via
+// /proc/<pid>/cmdline, matches `--session <parent>~review-…` (or
+// `~investigate-…`), and SIGTERMs the survivors. These tests cover:
+//
+//   - findOrphanReviewSidecarPIDs against a fake /proc tree on disk: pure
+//     unit tests for the argv-parsing and prefix-matching logic. No real
+//     processes are spawned for these.
+//   - killOrphanReviewSidecars end-to-end on /proc with real stub processes
+//     (re-invocations of the test binary via PRISM_CMD_TEST_STUB=1) that
+//     present cmdlines like a real sidecar. Verifies the SIGTERM actually
+//     terminates the processes and that unrelated stubs (different parent,
+//     non-review children, non-sidecar processes) are not touched.
+//
+// The stub-spawning approach is the same one used by killsidecar_test.go
+// (see startStubProcess and TestMain) so we re-use its infrastructure.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startStubProcessNamed re-invokes the current test binary with
+// PRISM_CMD_TEST_STUB=1 and the given session name on the argv, so the
+// stub's /proc/<pid>/cmdline contains both "sidecar" and "--session <name>"
+// — the invariants killOrphanReviewSidecars checks for.
+//
+// Returns the PID and a cleanup func; tests should register the cleanup
+// with t.Cleanup so leaked stubs do not survive a failed assertion.
+func startStubProcessNamed(t *testing.T, sessionName string) (pid int, cleanup func()) {
+	t.Helper()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(self, "sidecar", "--session", sessionName)
+	cmd.Env = append(os.Environ(), "PRISM_CMD_TEST_STUB=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start stub process %q: %v", sessionName, err)
+	}
+
+	return cmd.Process.Pid, func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+}
+
+// writeFakeProcEntry creates procRoot/<pid>/cmdline with the given argv as
+// NUL-separated bytes plus a trailing NUL — mirroring the real kernel-
+// supplied layout of /proc/<pid>/cmdline.
+//
+// procRoot is a t.TempDir(); each test populates its own fake tree so
+// these unit tests can run on any platform and need no /proc access.
+func writeFakeProcEntry(t *testing.T, procRoot string, pid int, argv []string) {
+	t.Helper()
+	dir := filepath.Join(procRoot, strconv.Itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir fake /proc entry: %v", err)
+	}
+	var buf []byte
+	for _, a := range argv {
+		buf = append(buf, []byte(a)...)
+		buf = append(buf, 0)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cmdline"), buf, 0o644); err != nil {
+		t.Fatalf("write fake cmdline: %v", err)
+	}
+}
+
+// TestFindOrphanReviewSidecarPIDs_MatchesAllReviewCycles covers the
+// "multiple review cycles" AC: a parent with both ~review-1-… and
+// ~review-2-… children should produce matches for both.
+func TestFindOrphanReviewSidecarPIDs_MatchesAllReviewCycles(t *testing.T) {
+	procRoot := t.TempDir()
+	parent := "myrepo@feature"
+
+	// Two review cycles, five agents each — typical real-world pattern.
+	cycles := [][]string{
+		{
+			parent + "~review-1-review-goal",
+			parent + "~review-1-review-code",
+			parent + "~review-1-review-security",
+			parent + "~review-1-review-qa",
+			parent + "~review-1-review-context",
+		},
+		{
+			parent + "~review-2-review-goal",
+			parent + "~review-2-review-code",
+		},
+	}
+
+	pid := 10000
+	wantSessions := map[string]bool{}
+	for _, cycle := range cycles {
+		for _, s := range cycle {
+			writeFakeProcEntry(t, procRoot, pid, []string{"prism", "sidecar", "--session", s, "--port", "14000"})
+			wantSessions[s] = true
+			pid++
+		}
+	}
+
+	// Add an unrelated sidecar (different parent) — must NOT match.
+	writeFakeProcEntry(t, procRoot, pid, []string{"prism", "sidecar", "--session", "other-repo@branch~review-1-review-goal"})
+	pid++
+	// Add a non-sidecar process (no "sidecar" token) — must NOT match.
+	writeFakeProcEntry(t, procRoot, pid, []string{"/usr/bin/sleep", "60"})
+	pid++
+	// Add a non-PID directory under /proc (mimics e.g. /proc/sys).
+	if err := os.MkdirAll(filepath.Join(procRoot, "sys"), 0o755); err != nil {
+		t.Fatalf("mkdir non-PID: %v", err)
+	}
+
+	matches, err := findOrphanReviewSidecarPIDs(parent, procRoot)
+	if err != nil {
+		t.Fatalf("findOrphanReviewSidecarPIDs: %v", err)
+	}
+
+	gotSessions := map[string]bool{}
+	for _, m := range matches {
+		gotSessions[m.session] = true
+	}
+
+	for s := range wantSessions {
+		if !gotSessions[s] {
+			t.Errorf("missing match for session %q", s)
+		}
+	}
+	for s := range gotSessions {
+		if !wantSessions[s] {
+			t.Errorf("unexpected match for session %q", s)
+		}
+	}
+}
+
+// TestFindOrphanReviewSidecarPIDs_MatchesInvestigatorChildren covers the
+// "~investigate-" infix AC alongside the "~review-" one.
+func TestFindOrphanReviewSidecarPIDs_MatchesInvestigatorChildren(t *testing.T) {
+	procRoot := t.TempDir()
+	parent := "myrepo@feature"
+
+	writeFakeProcEntry(t, procRoot, 11001, []string{"prism", "sidecar", "--session", parent + "~investigate-some-slug"})
+	writeFakeProcEntry(t, procRoot, 11002, []string{"prism", "sidecar", "--session", parent + "~investigate-another-slug"})
+	// Parent itself — must NOT match (no "~" suffix).
+	writeFakeProcEntry(t, procRoot, 11003, []string{"prism", "sidecar", "--session", parent})
+
+	matches, err := findOrphanReviewSidecarPIDs(parent, procRoot)
+	if err != nil {
+		t.Fatalf("findOrphanReviewSidecarPIDs: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("got %d matches, want 2: %+v", len(matches), matches)
+	}
+}
+
+// TestFindOrphanReviewSidecarPIDs_DoesNotMatchOtherParent verifies the
+// "non-review sessions unchanged" AC — an unrelated parent's review
+// children are not matched.
+func TestFindOrphanReviewSidecarPIDs_DoesNotMatchOtherParent(t *testing.T) {
+	procRoot := t.TempDir()
+
+	// We're cleaning up "myrepo@feature" but a sibling worker exists
+	// with its own review children. Those must NOT be matched.
+	writeFakeProcEntry(t, procRoot, 12001, []string{"prism", "sidecar", "--session", "myrepo@feature~review-1-review-goal"})
+	writeFakeProcEntry(t, procRoot, 12002, []string{"prism", "sidecar", "--session", "myrepo@other-branch~review-1-review-goal"})
+	writeFakeProcEntry(t, procRoot, 12003, []string{"prism", "sidecar", "--session", "other-repo@feature~review-1-review-goal"})
+
+	matches, err := findOrphanReviewSidecarPIDs("myrepo@feature", procRoot)
+	if err != nil {
+		t.Fatalf("findOrphanReviewSidecarPIDs: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want exactly 1 (for myrepo@feature only): %+v", len(matches), matches)
+	}
+	if matches[0].session != "myrepo@feature~review-1-review-goal" {
+		t.Errorf("matched wrong session: %q", matches[0].session)
+	}
+}
+
+// TestFindOrphanReviewSidecarPIDs_EqualsArgForm verifies the --session=foo
+// (single argv slot) variant parses correctly. The prism sidecar invokes
+// it as "--session <name>" today, but tolerating both forms keeps the
+// matcher robust if that changes.
+func TestFindOrphanReviewSidecarPIDs_EqualsArgForm(t *testing.T) {
+	procRoot := t.TempDir()
+	parent := "myrepo@feature"
+
+	writeFakeProcEntry(t, procRoot, 13001, []string{"prism", "sidecar", "--session=" + parent + "~review-1-review-goal"})
+
+	matches, err := findOrphanReviewSidecarPIDs(parent, procRoot)
+	if err != nil {
+		t.Fatalf("findOrphanReviewSidecarPIDs: %v", err)
+	}
+	if len(matches) != 1 || matches[0].session != parent+"~review-1-review-goal" {
+		t.Fatalf("expected one --session=… match, got %+v", matches)
+	}
+}
+
+// TestFindOrphanReviewSidecarPIDs_EmptyParent guards the "do not match
+// every sidecar starting with ~" failure mode. Passing an empty parent
+// would otherwise match every prism sidecar on the host.
+func TestFindOrphanReviewSidecarPIDs_EmptyParent(t *testing.T) {
+	// killOrphanReviewSidecars short-circuits on empty parent. The
+	// underlying findOrphanReviewSidecarPIDs is permissive — the empty-
+	// guard is at the public wrapper layer. Exercise the wrapper to
+	// confirm it does nothing.
+	if runtime.GOOS != "linux" {
+		t.Skip("killOrphanReviewSidecars is a no-op on non-Linux")
+	}
+	// Spawn a real review-shaped stub. If the empty guard were missing,
+	// the wrapper would walk /proc and SIGTERM this stub. We assert it
+	// survives.
+	pid, cleanup := startStubProcessNamed(t, "myrepo@feature~review-1-review-goal")
+	t.Cleanup(cleanup)
+	// Give the kernel a beat to populate /proc/<pid>/cmdline.
+	time.Sleep(30 * time.Millisecond)
+
+	killOrphanReviewSidecars("")
+
+	if !processExists(pid) {
+		t.Fatalf("stub pid %d was killed despite empty parent — empty-guard regression", pid)
+	}
+}
+
+// TestKillOrphanReviewSidecars_EndToEnd is the integration test required
+// by AC: spawn fake ~review-1-… and ~review-2-… sidecars, call
+// killOrphanReviewSidecars, assert all are dead and unrelated stubs are
+// untouched.
+func TestKillOrphanReviewSidecars_EndToEnd(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("killOrphanReviewSidecars walks /proc — Linux only")
+	}
+
+	parent := "myrepo@feature"
+
+	// Spawn five review-shape stubs (two cycles + investigator).
+	reviewSessions := []string{
+		parent + "~review-1-review-goal",
+		parent + "~review-1-review-code",
+		parent + "~review-2-review-goal",
+		parent + "~review-2-review-code",
+		parent + "~investigate-some-slug",
+	}
+	reviewPIDs := make([]int, 0, len(reviewSessions))
+	for _, s := range reviewSessions {
+		pid, cleanup := startStubProcessNamed(t, s)
+		t.Cleanup(cleanup)
+		reviewPIDs = append(reviewPIDs, pid)
+	}
+
+	// Spawn two unrelated stubs that must survive: an unrelated parent's
+	// review child, and the parent itself.
+	unrelatedSessions := []string{
+		"other-repo@feature~review-1-review-goal",
+		parent, // the parent sidecar itself
+	}
+	unrelatedPIDs := make([]int, 0, len(unrelatedSessions))
+	for _, s := range unrelatedSessions {
+		pid, cleanup := startStubProcessNamed(t, s)
+		t.Cleanup(cleanup)
+		unrelatedPIDs = append(unrelatedPIDs, pid)
+	}
+
+	// Give the kernel time to populate /proc/<pid>/cmdline for every stub.
+	time.Sleep(50 * time.Millisecond)
+	for i, pid := range reviewPIDs {
+		if !cmdlineContainsSession(pid, reviewSessions[i]) {
+			t.Skipf("kernel did not populate /proc/%d/cmdline with %q yet — test environment too slow", pid, reviewSessions[i])
+		}
+	}
+
+	killOrphanReviewSidecars(parent)
+
+	// All review/investigator PIDs should be dead within a short timeout
+	// (SIGTERM → process exit → /proc entry gone).
+	deadline := time.Now().Add(3 * time.Second)
+	for i, pid := range reviewPIDs {
+		for time.Now().Before(deadline) && processExists(pid) {
+			time.Sleep(20 * time.Millisecond)
+		}
+		if processExists(pid) {
+			t.Errorf("review stub pid %d (%q) still alive after killOrphanReviewSidecars",
+				pid, reviewSessions[i])
+		}
+	}
+
+	// All unrelated PIDs must still be alive.
+	for i, pid := range unrelatedPIDs {
+		if !processExists(pid) {
+			t.Errorf("unrelated stub pid %d (%q) was killed by killOrphanReviewSidecars — must not match",
+				pid, unrelatedSessions[i])
+		}
+	}
+}
+
+// TestKillOrphanReviewSidecars_AlreadyExited covers the edge-case AC: a
+// review sidecar that has already exited produces no error log and no
+// panic. We exercise this by calling the function against a parent for
+// which no live processes exist — the loop body never runs and the
+// function returns cleanly. The "no spurious error log" portion is
+// covered by the lack of test output checks; a panic or non-nil error
+// would fail the test.
+func TestKillOrphanReviewSidecars_AlreadyExited(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("killOrphanReviewSidecars walks /proc — Linux only")
+	}
+	// Use a parent name that no live process matches.
+	killOrphanReviewSidecars("nonexistent@parent-with-no-children")
+}
+
+// TestKillOrphanReviewSidecars_RepeatIsIdempotent confirms calling the
+// wrapper twice in a row is harmless: the first call kills the stubs,
+// the second call finds no live processes (because they're gone) and
+// returns silently with no error log. This covers the "already exited
+// — no spurious error log" edge-case AC at the wrapper layer.
+func TestKillOrphanReviewSidecars_RepeatIsIdempotent(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("killOrphanReviewSidecars walks /proc — Linux only")
+	}
+
+	parent := "myrepo@idempotent-feature"
+	sessionName := parent + "~review-1-review-goal"
+
+	pid, cleanup := startStubProcessNamed(t, sessionName)
+	t.Cleanup(cleanup)
+	time.Sleep(30 * time.Millisecond)
+
+	killOrphanReviewSidecars(parent)
+
+	// Wait for the stub to die.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && processExists(pid) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if processExists(pid) {
+		t.Fatalf("stub pid %d still alive after first killOrphanReviewSidecars", pid)
+	}
+
+	// Second call — must not panic, must not produce an error. Cannot
+	// directly assert "no stderr output" without capturing it, but a
+	// regression to a panic would fail this test.
+	killOrphanReviewSidecars(parent)
+}
+
+// cmdlineContainsSession returns true when /proc/<pid>/cmdline contains
+// the given session name. Used to wait out kernel cmdline-publication
+// latency in TestKillOrphanReviewSidecars_EndToEnd.
+func cmdlineContainsSession(pid int, session string) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return false
+	}
+	for _, arg := range strings.Split(string(data), "\x00") {
+		if arg == session {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSessionArgFromCmdline_SpaceForm verifies the --session foo form.
+func TestSessionArgFromCmdline_SpaceForm(t *testing.T) {
+	got := sessionArgFromCmdline([]string{"prism", "sidecar", "--session", "x", "--port", "1"})
+	if got != "x" {
+		t.Errorf("got %q, want %q", got, "x")
+	}
+}
+
+// TestSessionArgFromCmdline_EqualsForm verifies the --session=foo form.
+func TestSessionArgFromCmdline_EqualsForm(t *testing.T) {
+	got := sessionArgFromCmdline([]string{"prism", "sidecar", "--session=x", "--port", "1"})
+	if got != "x" {
+		t.Errorf("got %q, want %q", got, "x")
+	}
+}
+
+// TestSessionArgFromCmdline_TrailingFlag handles the malformed case
+// where --session appears with no value.
+func TestSessionArgFromCmdline_TrailingFlag(t *testing.T) {
+	got := sessionArgFromCmdline([]string{"prism", "sidecar", "--session"})
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// TestIsPrismSidecarCmdline rejects argvs that don't include both the
+// "sidecar" and "--session" tokens. Mirrors the invariant in
+// session.KillSidecar so the two recognisers stay in sync.
+func TestIsPrismSidecarCmdline(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		{"sidecar+session", []string{"prism", "sidecar", "--session", "x"}, true},
+		{"missing sidecar", []string{"prism", "--session", "x"}, false},
+		{"missing session", []string{"prism", "sidecar"}, false},
+		{"unrelated process", []string{"/usr/bin/sleep", "60"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isPrismSidecarCmdline(c.argv); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When `prism cleanup --yes --session <worker>` runs after a worker's PR
is merged, the existing `review.CleanupReviewSessionsForParent` only
cleans up review children that still have DB rows. Sidecar processes
whose DB rows have been purged (or were never persisted for some
reason) survive as orphans, each holding bwrap mounts, a port
allocation, and resident memory. We saw 12+ such orphans on one host
contributing to OOM pressure (per the issue).

Implements **fix shape A** from #1751: cleanup-side traversal. Walks
`/proc`, parses each running process's argv from `/proc/<pid>/cmdline`,
and SIGTERMs every sidecar whose `--session` value matches
`<worker>~review-*` or `<worker>~investigate-*`.

Traversal properties:
- Independent of DB state — works even when DB rows were already purged
- Independent of worktree existence — works even after the worktree is
  torn down
- Runs in all three cleanup paths (interactive `doCleanup`,
  `headlessCleanupWithJSON`, `headlessCloseSessionWithJSON`)
- Tolerant of races: ESRCH is swallowed silently if a process exits
  between enumeration and signal
- Linux-only (NixOS deployment target); macOS dev boxes call this and
  it returns silently
- Empty parent name is rejected up-front to avoid matching every
  sidecar with a `~` infix

The traversal does **not** use `pkill -f` (per issue guidance —
argv search is fragile). It parses each argv slot for the `--session`
flag's value and prefix-matches against `<worker>~`, then requires a
`review-` or `investigate-` token after that prefix. Both
`--session foo` and `--session=foo` argv forms are supported.

## Acceptance criteria

- [x] [functional] After `prism cleanup --yes --session <worker>`
  returns, `pgrep -af 'prism sidecar.*~review-'` shows zero processes
  matching that worker's review children. Same for `~investigate-`.
  Covered by `TestKillOrphanReviewSidecars_EndToEnd`.
- [x] [functional] If the worker had multiple review cycles, all are
  cleaned up — not just the latest. Covered by
  `TestFindOrphanReviewSidecarPIDs_MatchesAllReviewCycles` and the
  end-to-end test (two cycles + investigator).
- [x] [edge-case] If a review sidecar has already exited, the cleanup
  is a no-op for that child (no spurious error log). Covered by
  `TestKillOrphanReviewSidecars_AlreadyExited` and
  `TestKillOrphanReviewSidecars_RepeatIsIdempotent`. The Kill loop
  swallows `ESRCH` silently.
- [x] [edge-case] If a review sidecar is mid-startup (process alive,
  port not yet bound), SIGTERM terminates it cleanly. The traversal
  relies only on cmdline contents, which the kernel publishes before
  the sidecar binds its port — covered implicitly by the end-to-end
  test's stub processes (they never bind any port).
- [x] [functional] Existing `prism cleanup` behaviour for non-review
  sessions is unchanged — only the new traversal is added. Empty
  parent guarded; non-matching parents skipped; existing DB-backed
  `review.CleanupReviewSessionsForParent` call is preserved
  unchanged. Covered by
  `TestFindOrphanReviewSidecarPIDs_DoesNotMatchOtherParent` and
  `TestFindOrphanReviewSidecarPIDs_EmptyParent`.
- [x] [functional] Test in `cmd/cleanup_orphan_sidecars_test.go`
  covers the traversal end-to-end with fake parent + stub
  `~review-1-…` sidecars.
- [x] [functional] `go test ./... -race` passes;
  `nix build .#prism` succeeds (both verified locally).

## Files

- `modules/programs/prism/prism/cmd/cleanup_orphan_sidecars.go` —
  new file. Public `killOrphanReviewSidecars(parent)` wrapper plus
  pure helpers for argv parsing (testable without /proc).
- `modules/programs/prism/prism/cmd/cleanup_orphan_sidecars_test.go` —
  new file. Unit tests over a fake `/proc` tree in `t.TempDir()` plus
  an integration test that spawns real stub processes via the
  existing `PRISM_CMD_TEST_STUB` mechanism in `killsidecar_test.go`.
- `modules/programs/prism/prism/cmd/cleanup.go` — call
  `killOrphanReviewSidecars(session)` from all three cleanup paths
  immediately after `KillSidecar(session)` on the worker itself, so
  the orphan-traversal runs whether or not the DB is reachable.

Closes #1751