### PR TITLE
iris(tui): bubbletea conversation renderer (#1767)

### DIFF
--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -34,6 +34,7 @@ import (
 const (
 	leftPaneRatio   = 0.35 // fraction of total width for the session list
 	bottomBarHeight = 3    // prompt box height in lines
+	statusBarHeight = 1    // status-line strip between events and prompt (#1767)
 	minLeftWidth    = 28
 	minRightWidth   = 20
 )
@@ -93,6 +94,38 @@ var (
 	stylePromptBox = lipgloss.NewStyle().
 			Border(lipgloss.NormalBorder()).
 			BorderForeground(lipgloss.Color(colBlue))
+
+	// styleToolCall renders the one-line tool-call "card" rows. Blue +
+	// bold makes the row visually distinct from surrounding assistant
+	// prose (styleNormal) and from indented tool_result summaries
+	// (styleDim) without using the red treatment reserved for errors.
+	// Issue #1767's renderer table requires tool_call rows be visibly
+	// distinct as one-line cards — child PR 4 replaces this with
+	// multi-line cards; the styling continues to apply to the first row.
+	styleToolCall = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colBlue)).
+			Bold(true)
+
+	// styleErrorProminent renders extension_error blocks. Bold red on
+	// the dark background is the most attention-grabbing combination
+	// available in the existing palette — extension errors are
+	// fatal-class (#1757) so the design doc renderer table calls them
+	// out as a "prominent error block". Distinct from styleError (red
+	// foreground only, no bold) so an extension_error block is visually
+	// louder than a routine permission_denied row.
+	styleErrorProminent = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(colRed)).
+				Bold(true)
+
+	// styleStatusLine renders the bottom status-line strip (#1767) with
+	// a contrasting background bar so the strip reads as a structural
+	// divider between the event pane and the prompt rather than as
+	// another line of conversation content. Foreground stays on the
+	// foreground palette so the metadata (session · state · model ·
+	// cost) is fully legible.
+	styleStatusLine = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colForeground)).
+			Background(lipgloss.Color(colBg1))
 )
 
 // --- Model ---
@@ -111,6 +144,20 @@ type sessionItem struct {
 	snap                 iris.SessionSnapshot
 	lastEventAt          time.Time
 	lastAssistantPreview string
+	// lastModel is the most recently observed model identifier on a
+	// msg_assistant event for this session — sourced from
+	// payload.MsgAssistant.Model ("providerID/modelID"). Used by the
+	// status-line strip (issue #1767) so the focused session shows its
+	// active model without re-querying the DB. Empty string when no
+	// msg_assistant event with a populated Model field has been seen.
+	lastModel string
+	// cumulativeCost is the running sum of payload.MsgAssistant.Cost
+	// values observed for this session since the TUI subscribed.
+	// Displayed by the status-line strip as the focused session's
+	// running cost; zero when no Cost-bearing event has been seen.
+	// Per-session (not per-turn) because the user wants to see total
+	// spend at a glance — per-turn cost is available in checkin output.
+	cumulativeCost float64
 }
 
 // focusArea identifies the currently focused interactive region. Tab
@@ -143,6 +190,14 @@ const (
 // Model is the top-level bubbletea model for the iris TUI.
 type Model struct {
 	client *DaemonClient
+
+	// renderer is the per-event-type dispatch table used by
+	// handleDaemonFrame to render session_event payloads into
+	// NarrativeLines (issue #1767). Constructed once in NewModel; the
+	// dispatch site does not switch on event type directly so child
+	// PR 3 (streaming) and child PR 4 (tool-call cards) can plug into
+	// this table without re-touching the model.
+	renderer *eventRenderer
 
 	// Terminal dimensions.
 	width  int
@@ -204,6 +259,7 @@ type Model struct {
 func NewModel(client *DaemonClient) Model {
 	return Model{
 		client:          client,
+		renderer:        newEventRenderer(),
 		seenRowIDs:      make(map[int64]bool),
 		toolCallByMsgID: make(map[string]int),
 	}
@@ -335,9 +391,40 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 		if m.seenRowIDs[e.RowID] {
 			return m, nil
 		}
-		m.seenRowIDs[e.RowID] = true
 
-		lines := narrative.RenderEvent(e.RowID, e.EventType, e.Payload)
+		// Capture model + accumulated cost for the status-line strip
+		// (issue #1767) AFTER the dedupe check — we want
+		// snapshot-replay overlapping with a live frame to keep the
+		// sidebar timestamp ticking (above) but to NOT double-count
+		// cost or thrash lastModel. The previous block keeps the
+		// sidebar's "most recent activity" honest; this block treats
+		// model/cost as content that only updates on truly novel rows.
+		if e.EventType == "msg_assistant" {
+			if model, cost := extractAssistantModelCost(e.Payload); model != "" || cost > 0 {
+				for i, si := range m.sessions {
+					if si.snap.Name == e.SessionName {
+						if model != "" {
+							m.sessions[i].lastModel = model
+						}
+						m.sessions[i].cumulativeCost += cost
+						break
+					}
+				}
+			}
+		}
+
+		lines := m.renderer.dispatch(e.RowID, e.EventType, e.Payload)
+		if len(lines) == 0 {
+			// Suppressed (session_status, turn_start/end) or a handler
+			// declined to render. Do NOT mark the row_id as seen —
+			// future renderer extensions (e.g. tool-call cards in
+			// child PR 4) may decide to render an event type that is
+			// currently suppressed, and the dedupe map must not
+			// preempt them on replay. Suppression has no per-event
+			// side effect beyond "do not append a line".
+			return m, nil
+		}
+		m.seenRowIDs[e.RowID] = true
 		for _, line := range lines {
 			// For tool_result: find the matching tool_call and pair it.
 			if e.EventType == "tool_result" && line.MessageID != "" {
@@ -665,9 +752,16 @@ func (m Model) View() string {
 	rightPane := m.viewRightPane(rightW)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+	// Status-line strip between the event pane and the prompt (issue
+	// #1767). Spans the full terminal width — the sidebar takes the
+	// left edge but the status line is per-program (focused-session
+	// metadata), not per-pane. Placed above the prompt because the
+	// design doc's ASCII layout puts it there: prompt is the bottom
+	// affordance, status sits between events and prompt.
+	status := m.viewStatusLine(m.width)
 	prompt := m.viewPrompt(m.width)
 
-	return lipgloss.JoinVertical(lipgloss.Left, body, prompt)
+	return lipgloss.JoinVertical(lipgloss.Left, body, status, prompt)
 }
 
 // focusedBorderStyle returns a border style tinted with the primary accent
@@ -721,7 +815,12 @@ func (m Model) paneWidths() (int, int) {
 }
 
 func (m Model) leftPaneHeight() int {
-	h := m.height - bottomBarHeight - 2 // minus prompt box and borders
+	// Subtract the prompt box (bottomBarHeight, includes borders) AND the
+	// status-line strip (statusBarHeight, single line, no border)
+	// introduced in #1767. The -2 still accounts for the side-pane border
+	// rows. Capped at >= 1 so a tiny terminal still renders something
+	// rather than crashing on a zero-height pane.
+	h := m.height - bottomBarHeight - statusBarHeight - 2
 	if h < 1 {
 		h = 1
 	}
@@ -848,29 +947,114 @@ func (m Model) viewRightPane(width int) string {
 	return m.focusedBorderStyle(focusEvents).Width(innerW).Height(paneH).Render(content)
 }
 
-// styleEventLine applies colour to a NarrativeLine.
+// styleEventLine applies colour to a NarrativeLine, with per-event-type
+// visual treatments per the design-doc renderer table (issue #1767):
+//
+//   - state_change            — dim single line (was green; design doc
+//     calls for "Dim status line" so the pane reads as conversation
+//     content first, state-changes second).
+//   - msg_assistant + _body   — normal-foreground rich text.
+//   - msg_user + _body        — blue (operator input visually
+//     distinguished from assistant output).
+//   - tool_call               — styleToolCall: blue foreground, bold.
+//     Visually distinct from surrounding assistant text so the
+//     one-line card stands out as a tool invocation, not prose.
+//   - tool_result             — dim with the leading-indent prefix from
+//     the renderer ("    ↳ result: …") so it reads as a continuation
+//     of its parent tool_call.
+//   - extension_error + _body — prominent red-on-red block. Both lines
+//     carry the same treatment so the header + message read as one
+//     emergency unit. styleErrorProminent uses bold to break out of
+//     the surrounding muted palette — extension errors are fatal-class
+//     (#1757) and should not be possible to miss.
+//   - permission_ask / permission_denied / error — red foreground
+//     (pre-existing behaviour preserved).
+//   - unknown types           — dim fallback (also pre-existing).
 func styleEventLine(line narrative.NarrativeLine, width int) string {
 	text := truncate(line.Text, width)
 	switch line.EventType {
-	case "state_change":
-		return styleGreen.Render(padRight(text, width))
-	case "msg_assistant", "msg_assistant_body":
+	case evTypeStateChange:
+		return styleDim.Render(padRight(text, width))
+	case evTypeMsgAssistant, evTypeMsgAssistant + "_body":
 		return styleNormal.Render(padRight(text, width))
-	case "msg_user", "msg_user_body":
+	case evTypeMsgUser, evTypeMsgUser + "_body":
 		return styleBlue.Render(padRight(text, width))
-	case "tool_call":
+	case evTypeToolCall:
+		return styleToolCall.Render(padRight(text, width))
+	case evTypeToolResult:
 		return styleDim.Render(padRight(text, width))
-	case "tool_result":
-		return styleDim.Render(padRight(text, width))
-	case "permission_ask":
+	case evTypeExtensionError, evTypeExtensionErrorBody:
+		return styleErrorProminent.Render(padRight(text, width))
+	case evTypePermissionAsk:
 		return styleError.Render(padRight(text, width))
-	case "permission_denied":
+	case evTypePermDenied:
 		return styleError.Render(padRight(text, width))
 	case "error":
 		return styleError.Render(padRight(text, width))
 	default:
 		return styleDim.Render(padRight(text, width))
 	}
+}
+
+// viewStatusLine renders the bottom status-line strip (#1767). Shows
+// the focused session's state, model, and cumulative cost when
+// available. When the focused session has no captured model (no
+// msg_assistant with a Model field yet) and no cost, the strip
+// degrades to just the session name + state — deliberately not
+// rendering the literal string "<nil>" or "$0.00" placeholders, which
+// were both review-time gotchas on previous TUI work. The strip is one
+// row tall (statusBarHeight) with no border, separated from the panes
+// above by the panes' own border and from the prompt below by the
+// prompt's border.
+func (m Model) viewStatusLine(width int) string {
+	if width < 1 {
+		return ""
+	}
+	// Find the focused session. We key off m.subscribedTo because the
+	// status line follows the conversation pane's subject, not the
+	// cursor (which can transiently differ during session switching).
+	// When nothing is subscribed (empty list, pre-snapshot), render a
+	// dim placeholder so the layout doesn't collapse.
+	if m.subscribedTo == "" {
+		return styleDim.Render(padRight("  no session selected", width))
+	}
+	var focused *sessionItem
+	for i := range m.sessions {
+		if m.sessions[i].snap.Name == m.subscribedTo {
+			focused = &m.sessions[i]
+			break
+		}
+	}
+	if focused == nil {
+		return styleDim.Render(padRight("  "+m.subscribedTo, width))
+	}
+
+	// Compose: "<name> · <state> · <model> · $<cost>". Each segment is
+	// included only when it has a value, so the strip degrades from the
+	// full four-segment form (active session, msg_assistant flowed) down
+	// to two segments (session name + state) for newly-spawned sessions
+	// that haven't produced any msg_assistant yet.
+	parts := []string{focused.snap.Name}
+	if s := focused.snap.State; s != "" {
+		parts = append(parts, s)
+	}
+	if model := focused.lastModel; model != "" {
+		parts = append(parts, model)
+	}
+	if cost := focused.cumulativeCost; cost > 0 {
+		// 4 decimal places when the cost is sub-cent so a $0.0001
+		// turn doesn't collapse to "$0.00"; 2 decimals otherwise so
+		// the common case reads as "$1.23".
+		var costStr string
+		if cost < 0.01 {
+			costStr = fmt.Sprintf("$%.4f", cost)
+		} else {
+			costStr = fmt.Sprintf("$%.2f", cost)
+		}
+		parts = append(parts, costStr)
+	}
+	line := "  " + strings.Join(parts, " · ")
+	return styleStatusLine.Render(padRight(truncate(line, width), width))
 }
 
 // viewPrompt renders the bottom prompt input.

--- a/modules/programs/prism/prism/internal/iris/tui/renderer.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer.go
@@ -1,0 +1,420 @@
+package tui
+
+// renderer.go — visitor-style event renderer for the iris TUI's
+// conversation pane (issue #1767, child 2 of the bubbletea-native iris
+// TUI design — docs/iris-tui-design.md).
+//
+// # Why a visitor / dispatch table
+//
+// Before this file the right-pane renderer was a single call to
+// narrative.RenderEvent followed by inline per-event-type styling in
+// styleEventLine(). Every new event type required touching both the
+// rendering and the styling site, and there was no clean seam for
+// child PR 3 (streaming msg_assistant deltas) or child PR 4 (rich
+// tool-call cards) to plug into.
+//
+// The eventRenderer wraps a map[string]eventHandler keyed on the
+// agent_events.type column value. dispatch() looks up the handler and
+// falls back to a debug-visible default for unknown types — unknown
+// types never panic the TUI; they render as a single muted "[HH:MM:SS]
+// <type>" line so an operator can see something arrived without
+// crashing the renderer. session_status is mapped to a no-op handler
+// per the design doc renderer table ("Suppressed in conversation;
+// visible only in sidebar's per-session row").
+//
+// # Why we still use narrative.NarrativeLine as the slot type
+//
+// The Model already stores rendered events as []narrative.NarrativeLine
+// — RowID for de-dupe, MessageID for tool_call ↔ tool_result pairing,
+// EventType for downstream styling. Keeping that slot type means the
+// dispatcher can replace narrative.RenderEvent in handleDaemonFrame
+// without disturbing the dedupe/pairing logic. Per-handler functions
+// in this file are free to produce richer output (multi-line blocks
+// for extension_error, prominent visual rows for tool_call) while
+// still flowing through the same buffer.
+//
+// # Streaming readiness (child PR 3)
+//
+// renderMsgAssistant currently produces a complete two-line block
+// (header + body) on every msg_assistant arrival — child 2 is
+// explicitly "no streaming yet, render complete rows when they
+// arrive". Child PR 3 will swap this handler for a streaming-aware
+// variant that coalesces deltas by MessageID; the rest of the
+// pipeline (dispatch, styling, the model buffer) does not change.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris/narrative"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+// Event type constants used by the dispatcher. Mirrored from the
+// agent_events.type values written by writeObservationEvent in
+// internal/iris/harness_socket.go and the visual-mapping table in
+// docs/iris-tui-design.md. Defined here (rather than imported from
+// internal/iris) because there is no canonical home for these strings
+// in the iris package today; this file is the single point of truth
+// for "which event types does the TUI's conversation pane know about".
+const (
+	evTypeMsgAssistant   = "msg_assistant"
+	evTypeMsgUser        = "msg_user"
+	evTypeToolCall       = "tool_call"
+	evTypeToolResult     = "tool_result"
+	evTypeStateChange    = "state_change"
+	evTypeExtensionError = "extension_error"
+	evTypeSessionStatus  = "session_status"
+	evTypePermissionAsk  = "permission_ask"
+	evTypePermDenied     = "permission_denied"
+	evTypeThinking       = "thinking"
+	evTypeTurnStart      = "turn_start"
+	evTypeTurnEnd        = "turn_end"
+
+	// evTypeExtensionErrorBody is a synthetic EventType label attached to
+	// the second line of an extension_error block (the error-message
+	// body). The visual styler uses this label to render the body with
+	// the same prominent red treatment as the header line. Mirrors the
+	// narrative package's "_body" suffix convention for msg_assistant /
+	// msg_user multi-line events.
+	evTypeExtensionErrorBody = "extension_error_body"
+)
+
+// eventHandler is the per-event-type rendering function signature. A
+// handler receives the agent_events row ID and the verbatim payload
+// JSON, and returns zero or more NarrativeLines. Returning nil is
+// explicit "suppress this event from the conversation pane" — used by
+// session_status and the turn_start/turn_end framing events.
+type eventHandler func(rowID int64, payloadJSON string) []narrative.NarrativeLine
+
+// eventFallback is the signature for the unknown-event-type renderer.
+// It receives the eventType as an explicit argument (handlers only
+// know about their own type) so the fallback can include it in the
+// rendered line.
+type eventFallback func(rowID int64, eventType, payloadJSON string) []narrative.NarrativeLine
+
+// eventRenderer is the visitor dispatch table. Lookup is by event-type
+// string; misses fall through to fallback (which produces a
+// debug-visible line so unknown types never silently disappear).
+type eventRenderer struct {
+	handlers map[string]eventHandler
+	fallback eventFallback
+}
+
+// newEventRenderer builds the default dispatch table for the
+// conversation pane. The handler set is fixed at construction time —
+// child PR 3 (streaming) and child PR 4 (tool-call cards) can either
+// swap a specific handler or wrap the renderer; this file keeps the
+// dispatch site free of inline per-type logic.
+func newEventRenderer() *eventRenderer {
+	r := &eventRenderer{handlers: map[string]eventHandler{}}
+	r.handlers[evTypeMsgAssistant] = renderMsgAssistant
+	r.handlers[evTypeMsgUser] = renderMsgUser
+	r.handlers[evTypeToolCall] = renderToolCall
+	r.handlers[evTypeToolResult] = renderToolResult
+	r.handlers[evTypeStateChange] = renderStateChange
+	r.handlers[evTypeExtensionError] = renderExtensionError
+	r.handlers[evTypePermissionAsk] = renderPermissionAsk
+	r.handlers[evTypePermDenied] = renderPermissionDenied
+	r.handlers[evTypeThinking] = renderThinking
+	// Suppressed: session_status (sidebar only — design doc renderer
+	// table), turn_start / turn_end (implicit visual separators, no
+	// dedicated row).
+	r.handlers[evTypeSessionStatus] = renderSuppressed
+	r.handlers[evTypeTurnStart] = renderSuppressed
+	r.handlers[evTypeTurnEnd] = renderSuppressed
+	r.fallback = renderFallback
+	return r
+}
+
+// dispatch routes one event triple to the appropriate handler. Unknown
+// event types go through the fallback. Returns nil for suppressed
+// events so the caller treats them as no-ops (no buffer growth, no
+// dedupe entry).
+func (r *eventRenderer) dispatch(rowID int64, eventType, payloadJSON string) []narrative.NarrativeLine {
+	if h, ok := r.handlers[eventType]; ok {
+		return h(rowID, payloadJSON)
+	}
+	return r.fallback(rowID, eventType, payloadJSON)
+}
+
+// ts returns the current wall-clock "HH:MM:SS" string. Centralised so
+// every handler uses the same format and a future change (e.g. honour
+// agent_events.created_at when the daemon exposes it on the wire) lands
+// in one place. Mirrors narrative.RenderEvent's time.Now() convention —
+// the daemon frame does not currently expose created_at, and the TUI
+// has nothing to do with the value other than render it, so wall-clock
+// at arrival is the most useful display.
+func ts() string {
+	return time.Now().Format("15:04:05")
+}
+
+// renderMsgAssistant renders a complete assistant turn as a two-line
+// block: a header carrying "[HH:MM:SS] assistant  [agent · model]" and
+// a body carrying the message text. No streaming/coalescing — child
+// PR 3 (#1768) handles deltas.
+//
+// On payload parse failure we still render *something* (the raw JSON
+// as the body) so the user can see the event arrived; silent drop on
+// parse failure has cost us bug-hunts before (cf. #1764).
+func renderMsgAssistant(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.MsgAssistant
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		p.Text = payloadJSON
+	}
+	text := p.Text
+	if text == "" {
+		text = "(no text)"
+	}
+	label := narrative.TurnLabel(p.Agent, p.Model)
+	var header string
+	if label != "" {
+		header = fmt.Sprintf("[%s] assistant  [%s]", ts(), label)
+	} else {
+		header = fmt.Sprintf("[%s] assistant", ts())
+	}
+	return []narrative.NarrativeLine{
+		{Text: header, EventType: evTypeMsgAssistant, RowID: rowID, MessageID: p.MessageID},
+		{Text: text, EventType: evTypeMsgAssistant + "_body", RowID: rowID},
+	}
+}
+
+// renderMsgUser mirrors renderMsgAssistant for the user turn. Kept here
+// (rather than delegated to the narrative package) so the visitor is
+// the single source of truth for what the conversation pane renders.
+func renderMsgUser(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.MsgUser
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		p.Text = payloadJSON
+	}
+	text := p.Text
+	if text == "" {
+		text = "(no text)"
+	}
+	label := narrative.TurnLabel(p.Agent, p.Model)
+	var header string
+	if label != "" {
+		header = fmt.Sprintf("[%s] ▶ user  [%s]", ts(), label)
+	} else {
+		header = fmt.Sprintf("[%s] ▶ user", ts())
+	}
+	return []narrative.NarrativeLine{
+		{Text: header, EventType: evTypeMsgUser, RowID: rowID, MessageID: p.MessageID},
+		{Text: text, EventType: evTypeMsgUser + "_body", RowID: rowID},
+	}
+}
+
+// renderToolCall produces a one-line "card" of the form
+//
+//	→ <tool>: <key-arg>
+//
+// using narrative.ToolKeyArg to extract the primary argument (command
+// for bash, file path for read/edit/write, pattern for grep, etc.).
+// The leading "→" plus indent makes a tool-call visually distinct from
+// surrounding assistant text on a single row — the design doc renderer
+// table's "one-line card" requirement. Multi-line/rich tool-call cards
+// (with args, result preview, expand/collapse) are child PR 4's scope.
+func renderToolCall(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.ToolCall
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return []narrative.NarrativeLine{
+			{
+				Text:      fmt.Sprintf("[%s] → tool_call (parse error)", ts()),
+				EventType: evTypeToolCall,
+				RowID:     rowID,
+			},
+		}
+	}
+	keyArg := narrative.ToolKeyArg(p.Tool, p.Args)
+	var text string
+	if keyArg != "" {
+		text = fmt.Sprintf("  → %s: %s", p.Tool, keyArg)
+	} else {
+		text = fmt.Sprintf("  → %s", p.Tool)
+	}
+	return []narrative.NarrativeLine{
+		{Text: text, EventType: evTypeToolCall, RowID: rowID, MessageID: p.MessageID},
+	}
+}
+
+// renderToolResult renders the indented one-line summary that follows a
+// tool_call. The model layer pairs this line with its matching
+// tool_call (by MessageID) so the rendered conversation reads as
+//
+//	→ bash: echo hello ✓ hello
+//
+// rather than as two unrelated rows. When no matching tool_call has
+// been seen yet (replay race, frame ordering), the result line is
+// emitted standalone with a leading indent so the visual still reads
+// as "this is a result, not a top-level statement".
+func renderToolResult(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.ToolResult
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return nil
+	}
+	summary := narrative.ToolResultSummary(p.Tool, p.Result)
+	return []narrative.NarrativeLine{
+		{
+			Text:      fmt.Sprintf("    ↳ result: %s", summary),
+			EventType: evTypeToolResult,
+			RowID:     rowID,
+			MessageID: p.MessageID,
+		},
+	}
+}
+
+// renderStateChange renders a single dim line of the form
+//
+//	[HH:MM:SS] ● <state>
+//
+// matching the design-doc renderer table's "Dim status line: ● <state>
+// with timestamp" description. Styling is applied by styleEventLine
+// based on the EventType label.
+func renderStateChange(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.StateChange
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		p.State = payloadJSON
+	}
+	state := p.State
+	if state == "" {
+		state = "(unknown)"
+	}
+	return []narrative.NarrativeLine{
+		{Text: fmt.Sprintf("[%s] ● %s", ts(), state), EventType: evTypeStateChange, RowID: rowID},
+	}
+}
+
+// renderExtensionError renders the "prominent block" required by the
+// design-doc renderer table — two lines, both styled red+bold:
+//
+//	[HH:MM:SS] ⛔ extension error: <event> at <extensionPath>
+//	  <error message>
+//
+// Two lines (rather than one) because extension errors are fatal-class
+// (issue #1757): the supervisor terminates the session and writes a
+// session_end row with reason="extension_error". The operator needs the
+// error message immediately visible without scrolling/expanding, and
+// the path/event-name context to triage. styleEventLine maps both the
+// header and the "_body" suffix label to the same prominent red
+// rendering so the block reads as a single unit.
+//
+// The payload shape mirrors iris.ExtensionErrorFrame:
+//
+//	{"extensionPath": "...", "event": "...", "error": "..."}
+//
+// Persistence path: writeObservationEvent in harness_socket.go falls
+// through to writing the raw RPC frame when the type does not match
+// one of the known cases (line 436). If a future PR threads
+// extension_error through that path, this handler renders it; until
+// then this is a forward-compatible no-op in production but is
+// exercised by tests.
+func renderExtensionError(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	// Decode opportunistically — fall back to a generic header that
+	// still flags this as an extension error if parsing fails.
+	var frame struct {
+		ExtensionPath string `json:"extensionPath"`
+		Event         string `json:"event"`
+		Error         string `json:"error"`
+	}
+	_ = json.Unmarshal([]byte(payloadJSON), &frame)
+
+	var header string
+	switch {
+	case frame.Event != "" && frame.ExtensionPath != "":
+		header = fmt.Sprintf("[%s] ⛔ extension error: %s at %s",
+			ts(), frame.Event, frame.ExtensionPath)
+	case frame.Event != "":
+		header = fmt.Sprintf("[%s] ⛔ extension error: %s", ts(), frame.Event)
+	default:
+		header = fmt.Sprintf("[%s] ⛔ extension error", ts())
+	}
+
+	body := strings.TrimSpace(frame.Error)
+	if body == "" {
+		// Fall back to the raw payload so the operator can at least
+		// see something if the frame's shape changes upstream.
+		body = strings.TrimSpace(payloadJSON)
+		if body == "" {
+			body = "(no error message)"
+		}
+	}
+
+	return []narrative.NarrativeLine{
+		{Text: header, EventType: evTypeExtensionError, RowID: rowID},
+		{Text: "  " + body, EventType: evTypeExtensionErrorBody, RowID: rowID},
+	}
+}
+
+// renderPermissionAsk preserves the pre-#1767 rendering of permission
+// asks so the conversation pane keeps working for sessions that hit
+// the permission flow. Not in the design-doc renderer table's
+// must-have list — covered here for behavioural parity with the
+// narrative package's checkin output.
+func renderPermissionAsk(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.PermissionAsk
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return []narrative.NarrativeLine{
+			{Text: fmt.Sprintf("[%s] ⚠ permission ask", ts()), EventType: evTypePermissionAsk, RowID: rowID},
+		}
+	}
+	tool := string(p.Tool)
+	if tool == "" {
+		tool = "unknown"
+	}
+	return []narrative.NarrativeLine{
+		{Text: fmt.Sprintf("[%s] ⚠ permission: %s", ts(), tool),
+			EventType: evTypePermissionAsk, RowID: rowID, MessageID: p.MessageID},
+	}
+}
+
+// renderPermissionDenied mirrors renderPermissionAsk for the denial
+// counterpart.
+func renderPermissionDenied(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p payload.PermissionDenied
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return []narrative.NarrativeLine{
+			{Text: fmt.Sprintf("[%s] ✗ permission denied", ts()), EventType: evTypePermDenied, RowID: rowID},
+		}
+	}
+	tool := p.Tool
+	if tool == "" {
+		tool = "unknown"
+	}
+	return []narrative.NarrativeLine{
+		{Text: fmt.Sprintf("[%s] ✗ permission denied: %s", ts(), tool),
+			EventType: evTypePermDenied, RowID: rowID, MessageID: p.MessageID},
+	}
+}
+
+// renderThinking renders the collapsed "· thinking…" placeholder.
+func renderThinking(rowID int64, _ string) []narrative.NarrativeLine {
+	return []narrative.NarrativeLine{
+		{Text: fmt.Sprintf("[%s] · thinking…", ts()), EventType: evTypeThinking, RowID: rowID},
+	}
+}
+
+// renderSuppressed is the handler used by event types the design-doc
+// renderer table marks as "Suppressed in conversation" (session_status)
+// or "implicit visual separator" (turn_start, turn_end). Returns nil
+// so the caller does NOT enter the line into the buffer or the
+// dedupe map — replays of these events are also no-ops.
+func renderSuppressed(_ int64, _ string) []narrative.NarrativeLine {
+	return nil
+}
+
+// renderFallback handles unknown event types. Per the AC: "An
+// unrecognised event type does not panic the renderer; the row is
+// skipped (or rendered as a debug-visible fallback, worker's call)."
+// We choose debug-visible so an operator running with the TUI open
+// when a new event type lands sees that *something* arrived; silent
+// skip would hide the bug-hunting clue that pre-#1764 cost us a week.
+//
+// Note: this is a closure-friendly 3-arg signature (eventType is
+// captured), distinct from the per-type eventHandler signature.
+func renderFallback(rowID int64, eventType, _ string) []narrative.NarrativeLine {
+	return []narrative.NarrativeLine{
+		{Text: fmt.Sprintf("[%s] %s", ts(), eventType), EventType: eventType, RowID: rowID},
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/tui/renderer_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer_test.go
@@ -1,0 +1,434 @@
+package tui_test
+
+// renderer_test.go — tests for the bubbletea conversation-pane renderer
+// introduced in issue #1767 (child 2 of the iris-tui-design tracker
+// #1765). The tests drive the public Model + DaemonFrame path so they
+// also exercise dispatch wiring inside handleDaemonFrame, not just the
+// per-type renderer in isolation.
+//
+// Coverage map (one happy-path test per design-doc renderer-table row):
+//
+//	msg_assistant   → TestRenderer_MsgAssistant
+//	tool_call       → TestRenderer_ToolCallOneLineCard
+//	tool_result     → TestRenderer_ToolResultIndentedSummary
+//	state_change    → TestRenderer_StateChangeDimLine
+//	extension_error → TestRenderer_ExtensionErrorProminentBlock
+//	session_status  → TestRenderer_SessionStatusSuppressed (edge-case AC)
+//	unknown type    → TestRenderer_UnknownEventDoesNotPanic
+//
+// Plus tests for the status-line strip:
+//
+//	TestStatusLine_PopulatedFromMsgAssistant
+//	TestStatusLine_DegradesWithoutModelOrCost
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+// deliverEvent helper: pushes a session_event DaemonFrame through the
+// model and returns the new Model state. Tests use it to keep the
+// per-test boilerplate down to one line per event.
+func deliverEvent(t *testing.T, m tui.Model, sessionName, eventType string, rowID int64, payload any) tui.Model {
+	t.Helper()
+	pb, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	m2, _ := m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: sessionName,
+			RowID:       rowID,
+			EventType:   eventType,
+			Payload:     string(pb),
+		},
+	})
+	return m2.(tui.Model)
+}
+
+// modelWithOneSession returns a connected model subscribed to a single
+// session with the given name. Test code uses this so it can immediately
+// deliver session_events without rebuilding the snapshot fixture.
+func modelWithOneSession(t *testing.T, name string) tui.Model {
+	t.Helper()
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: name, InstanceID: "iid-" + name, State: "active", Role: "worker", Worktree: "/repo/" + name},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	return m2.(tui.Model)
+}
+
+// ---------------------------------------------------------------------------
+// Per-event-type happy-path tests
+// ---------------------------------------------------------------------------
+
+// TestRenderer_MsgAssistant asserts msg_assistant renders as a rich-text
+// block in the conversation pane: a header (with "assistant" label and
+// the agent/model context) and a body line carrying the message text.
+func TestRenderer_MsgAssistant(t *testing.T) {
+	m := modelWithOneSession(t, "msg-test")
+	m = deliverEvent(t, m, "msg-test", "msg_assistant", 1, map[string]any{
+		"messageId": "msg-001",
+		"text":      "Booted iris and synced state.",
+		"agent":     "worker",
+		"model":     "anthropic/claude-sonnet-4",
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "assistant") {
+		t.Errorf("msg_assistant header label not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	if !strings.Contains(view, "Booted iris and synced state.") {
+		t.Errorf("msg_assistant body not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	// The agent/model label should appear in the header so the operator
+	// can see who is speaking. Pre-existing checkin-narrative format
+	// uses "agent · model" inside brackets.
+	if !strings.Contains(view, "worker") || !strings.Contains(view, "claude-sonnet-4") {
+		t.Errorf("msg_assistant agent/model label not in header; excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// TestRenderer_ToolCallOneLineCard asserts tool_call renders as a
+// single visual row containing the tool name and its primary argument
+// (the design doc's "one-line card"). The row must be distinguishable
+// from surrounding assistant text — we check for the leading "→"
+// marker that prefixes every tool_call card.
+func TestRenderer_ToolCallOneLineCard(t *testing.T) {
+	m := modelWithOneSession(t, "tc-test")
+	m = deliverEvent(t, m, "tc-test", "tool_call", 1, map[string]any{
+		"tool":      "bash",
+		"args":      `{"command":"go test ./..."}`,
+		"messageId": "msg-tc-001",
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "bash") {
+		t.Errorf("tool_call tool name not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	if !strings.Contains(view, "go test ./...") {
+		t.Errorf("tool_call command argument not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	if !strings.Contains(view, "→") {
+		t.Errorf("tool_call card marker '→' not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	// One-row check: the rendered "→ bash: …" payload should appear on
+	// exactly one line in the events pane. We split on '\n' and count
+	// lines mentioning "→ bash" — anything other than 1 means the card
+	// has spilled across rows.
+	cardLines := 0
+	for _, l := range strings.Split(view, "\n") {
+		if strings.Contains(l, "→") && strings.Contains(l, "bash") {
+			cardLines++
+		}
+	}
+	if cardLines != 1 {
+		t.Errorf("expected exactly one '→ bash' card row; got %d. view excerpt:\n%s",
+			cardLines, excerpt(view, 800))
+	}
+}
+
+// TestRenderer_ToolResultIndentedSummary asserts that a tool_result
+// renders as an indented summary beneath its matching tool_call. The
+// model layer pairs tool_result into the tool_call line (existing
+// behaviour preserved post-refactor) so we look for the result
+// summary text co-located with the tool name.
+func TestRenderer_ToolResultIndentedSummary(t *testing.T) {
+	m := modelWithOneSession(t, "tr-test")
+	m = deliverEvent(t, m, "tr-test", "tool_call", 1, map[string]any{
+		"tool":      "bash",
+		"args":      `{"command":"echo hi"}`,
+		"messageId": "msg-tr-001",
+	})
+	m = deliverEvent(t, m, "tr-test", "tool_result", 2, map[string]any{
+		"tool":      "bash",
+		"result":    "hi",
+		"messageId": "msg-tr-001",
+	})
+
+	view := m.View()
+	// The result summary must be present somewhere in the pane …
+	if !strings.Contains(view, "hi") {
+		t.Errorf("tool_result summary not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	// … and co-located with its parent tool_call row, not on a
+	// separate top-level line — we check by finding the line carrying
+	// "bash" and verifying the result text is on the same line.
+	for _, l := range strings.Split(view, "\n") {
+		if strings.Contains(l, "→") && strings.Contains(l, "bash") {
+			if !strings.Contains(l, "hi") {
+				t.Errorf("tool_result summary not paired into tool_call line; row:\n%q", l)
+			}
+			return
+		}
+	}
+	t.Errorf("no tool_call row found at all; view excerpt:\n%s", excerpt(view, 600))
+}
+
+// TestRenderer_StateChangeDimLine asserts that state_change events
+// render as a single dim line carrying the state name and the "●"
+// marker from the design-doc renderer table.
+func TestRenderer_StateChangeDimLine(t *testing.T) {
+	m := modelWithOneSession(t, "sc-test")
+	m = deliverEvent(t, m, "sc-test", "state_change", 1, map[string]any{
+		"state": "waiting",
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "waiting") {
+		t.Errorf("state_change state not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+	if !strings.Contains(view, "●") {
+		t.Errorf("state_change marker '●' not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// TestRenderer_ExtensionErrorProminentBlock asserts that an
+// extension_error event renders as a prominent block — the design-doc
+// renderer table calls these out specifically because they are
+// fatal-class (issue #1757). The block must show the extension path,
+// the failing event name, and the error message, so the operator can
+// triage without digging into logs.
+func TestRenderer_ExtensionErrorProminentBlock(t *testing.T) {
+	m := modelWithOneSession(t, "ee-test")
+	m = deliverEvent(t, m, "ee-test", "extension_error", 1, map[string]any{
+		"extensionPath": "/some/path/prism.ts",
+		"event":         "tool.execute.before",
+		"error":         "TypeError: undefined is not a function",
+	})
+
+	view := m.View()
+	for _, want := range []string{
+		"extension error",
+		"tool.execute.before",
+		"/some/path/prism.ts",
+		"TypeError: undefined is not a function",
+	} {
+		if !strings.Contains(view, want) {
+			t.Errorf("extension_error block missing %q; excerpt:\n%s", want, excerpt(view, 800))
+		}
+	}
+	// "Prominent" / "block" requirement: the block must occupy at
+	// least two visual lines (header + body) so the error message is
+	// readable without scrolling. We can't introspect ANSI styling
+	// from a black-box test, but we can verify the body text appears
+	// on a different line from the header.
+	var headerLine, bodyLine string
+	for _, l := range strings.Split(view, "\n") {
+		if strings.Contains(l, "extension error") {
+			headerLine = l
+		}
+		if strings.Contains(l, "TypeError: undefined is not a function") {
+			bodyLine = l
+		}
+	}
+	if headerLine == "" || bodyLine == "" {
+		t.Fatalf("expected both header and body lines; got header=%q body=%q",
+			headerLine, bodyLine)
+	}
+	if headerLine == bodyLine {
+		t.Errorf("extension_error block should span >=2 rows; got single line:\n%q", headerLine)
+	}
+}
+
+// TestRenderer_SessionStatusSuppressed asserts that a session_status
+// event does NOT contribute any row to the conversation pane. The
+// design doc renderer table explicitly suppresses these — they belong
+// to the sidebar's per-session state column. We verify by delivering a
+// session_status frame and confirming the right pane's "waiting for
+// events…" placeholder is still displayed (no event lines were added).
+func TestRenderer_SessionStatusSuppressed(t *testing.T) {
+	m := modelWithOneSession(t, "ss-test")
+	m = deliverEvent(t, m, "ss-test", "session_status", 1, map[string]any{
+		"session_id": "pi-some-ulid",
+		"phase":      "active",
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "waiting for events") {
+		t.Errorf("expected 'waiting for events…' placeholder (session_status should be suppressed); "+
+			"excerpt:\n%s", excerpt(view, 600))
+	}
+	// The literal payload-id string must not appear anywhere in the
+	// rendered output — if it does, the suppression failed.
+	if strings.Contains(view, "pi-some-ulid") {
+		t.Errorf("session_status payload leaked into rendered view; excerpt:\n%s", excerpt(view, 600))
+	}
+
+	// Follow up with a real msg_assistant — that should render, while
+	// the earlier session_status remains absent. This confirms the
+	// suppression is event-type-specific, not a blanket drop.
+	m = deliverEvent(t, m, "ss-test", "msg_assistant", 2, map[string]any{
+		"text": "I'm here.",
+	})
+	view = m.View()
+	if !strings.Contains(view, "I'm here.") {
+		t.Errorf("subsequent msg_assistant after session_status not rendered; excerpt:\n%s",
+			excerpt(view, 600))
+	}
+}
+
+// TestRenderer_UnknownEventDoesNotPanic covers the edge-case AC: an
+// unknown event type must not panic the renderer; we accept either
+// "skipped" or "rendered as debug-visible" — this test asserts the
+// no-panic invariant and that the model continues to accept further
+// events afterwards.
+func TestRenderer_UnknownEventDoesNotPanic(t *testing.T) {
+	m := modelWithOneSession(t, "unk-test")
+
+	// Recover from any panic so the test failure mode is "FAIL with
+	// readable message", not "process aborted".
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("renderer panicked on unknown event type: %v", r)
+		}
+	}()
+
+	m = deliverEvent(t, m, "unk-test", "future_event_xyz", 1, map[string]any{
+		"some": "field",
+	})
+	// Deliver a known event afterwards to confirm the model is still
+	// healthy and accepting frames.
+	m = deliverEvent(t, m, "unk-test", "msg_assistant", 2, map[string]any{
+		"text": "after unknown",
+	})
+	view := m.View()
+	if !strings.Contains(view, "after unknown") {
+		t.Errorf("post-unknown-event msg_assistant did not render; excerpt:\n%s",
+			excerpt(view, 600))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Status-line strip tests
+// ---------------------------------------------------------------------------
+
+// TestStatusLine_PopulatedFromMsgAssistant asserts the bottom strip
+// shows the focused session's name, state, model and cost once a
+// msg_assistant event with model/cost metadata has arrived.
+func TestStatusLine_PopulatedFromMsgAssistant(t *testing.T) {
+	m := modelWithOneSession(t, "status-pop")
+
+	// Baseline: with no msg_assistant yet, the strip should not
+	// contain a cost figure (no model/cost captured).
+	v := m.View()
+	if strings.Contains(v, "$") {
+		// Defensive — if the strip ever starts rendering a placeholder
+		// cost we want to fail loudly so the test gets updated.
+		t.Errorf("baseline status line should not contain '$' (no msg_assistant yet); "+
+			"excerpt:\n%s", excerpt(v, 600))
+	}
+
+	// Deliver a msg_assistant with model + cost.
+	m = deliverEvent(t, m, "status-pop", "msg_assistant", 1, map[string]any{
+		"text":  "ok",
+		"model": "anthropic/claude-sonnet-4",
+		"cost":  0.05,
+	})
+
+	v = m.View()
+	if !strings.Contains(v, "status-pop") {
+		t.Errorf("status line missing session name; excerpt:\n%s", excerpt(v, 600))
+	}
+	if !strings.Contains(v, "active") {
+		t.Errorf("status line missing session state; excerpt:\n%s", excerpt(v, 600))
+	}
+	if !strings.Contains(v, "claude-sonnet-4") {
+		t.Errorf("status line missing model; excerpt:\n%s", excerpt(v, 600))
+	}
+	if !strings.Contains(v, "$0.05") {
+		t.Errorf("status line missing cost; excerpt:\n%s", excerpt(v, 600))
+	}
+
+	// Deliver a second msg_assistant — cost should accumulate.
+	m = deliverEvent(t, m, "status-pop", "msg_assistant", 2, map[string]any{
+		"text":  "more",
+		"model": "anthropic/claude-sonnet-4",
+		"cost":  0.10,
+	})
+	v = m.View()
+	if !strings.Contains(v, "$0.15") {
+		t.Errorf("status line cost did not accumulate; expected $0.15; excerpt:\n%s",
+			excerpt(v, 600))
+	}
+}
+
+// TestStatusLine_DegradesWithoutModelOrCost asserts the strip
+// gracefully degrades when no model/cost is available: it must NOT
+// render the literal string "<nil>", "$0.00", or any other placeholder
+// the operator would misread as live data. The AC says "When model/cost
+// is absent, the strip degrades gracefully (no panic, no empty
+// placeholder text rendered as a literal '<nil>')".
+func TestStatusLine_DegradesWithoutModelOrCost(t *testing.T) {
+	m := modelWithOneSession(t, "degrade")
+
+	// No msg_assistant delivered → no model, no cost.
+	v := m.View()
+
+	// Must not crash, must contain the session name (degraded form).
+	if !strings.Contains(v, "degrade") {
+		t.Errorf("degraded status line missing session name; excerpt:\n%s", excerpt(v, 600))
+	}
+	if !strings.Contains(v, "active") {
+		t.Errorf("degraded status line missing session state; excerpt:\n%s", excerpt(v, 600))
+	}
+	// Critically: must not contain the failure-mode placeholders.
+	for _, bad := range []string{"<nil>", "$0.00", "$NaN", "model: "} {
+		if strings.Contains(v, bad) {
+			t.Errorf("degraded status line contains forbidden placeholder %q; excerpt:\n%s",
+				bad, excerpt(v, 600))
+		}
+	}
+
+	// Deliver a msg_assistant with neither model nor cost — strip
+	// should still not render any cost / model placeholders.
+	m = deliverEvent(t, m, "degrade", "msg_assistant", 1, map[string]any{
+		"text": "no metadata",
+	})
+	v = m.View()
+	for _, bad := range []string{"<nil>", "$0.00", "$NaN"} {
+		if strings.Contains(v, bad) {
+			t.Errorf("post-bare-msg_assistant strip contains %q; excerpt:\n%s",
+				bad, excerpt(v, 600))
+		}
+	}
+}
+
+// TestStatusLine_NoSubscribedSession asserts that with no subscribed
+// session (e.g. empty session list, pre-snapshot) the strip renders a
+// "no session selected" placeholder rather than blanking the bottom
+// row.
+func TestStatusLine_NoSubscribedSession(t *testing.T) {
+	client := tui.NewDaemonClient("/dev/null")
+	m := tui.NewModel(client)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.ConnectedMsg{})
+	m = m2.(tui.Model)
+
+	// Empty snapshot — no subscription.
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type:     iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{},
+	}
+	m2, _ = m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	v := m.View()
+	if !strings.Contains(v, "no session selected") {
+		t.Errorf("status line should show 'no session selected' placeholder when nothing subscribed; "+
+			"excerpt:\n%s", excerpt(v, 600))
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/tui/sidebar.go
+++ b/modules/programs/prism/prism/internal/iris/tui/sidebar.go
@@ -116,6 +116,19 @@ func extractAssistantPreview(payloadJSON string) string {
 	return ""
 }
 
+// extractAssistantModelCost parses a msg_assistant payload and returns
+// (model, cost). Both are zero-valued when the payload doesn't parse or
+// doesn't include them; callers use those to mean "do not update". Used
+// by handleDaemonFrame to keep the status-line strip (#1767) populated
+// without re-decoding the payload in the renderer.
+func extractAssistantModelCost(payloadJSON string) (string, float64) {
+	var p payload.MsgAssistant
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return "", 0
+	}
+	return p.Model, p.Cost
+}
+
 // previewIndentWidth is the visible column width of previewIndent. Hard
 // coded because previewIndent contains a multi-byte rune ("↳") and
 // len(previewIndent) returns the byte count, not the display width.


### PR DESCRIPTION
Child 2 of the iris-tui-design tracker (#1765). Implements the right-pane
event-to-visual renderer per the design doc renderer table.

## What changed

### Visitor-style dispatch (`internal/iris/tui/renderer.go`)

A new `eventRenderer` holds a per-event-type dispatch table. Each handler
takes `(rowID, payloadJSON)` and returns `[]narrative.NarrativeLine`.
Unknown event types fall through to a debug-visible fallback so the
renderer never panics on a new event vocabulary.

Handlers cover the design-doc renderer table:

| Event type | Visual |
|---|---|
| `msg_assistant` | Two-line block: timestamped header + body. |
| `tool_call`     | One-line card: `→ <tool>: <key-arg>`, blue+bold. |
| `tool_result`   | Indented summary, paired into its parent `tool_call` line. |
| `state_change`  | Dim single line with `●` marker. |
| `extension_error` | Two-line prominent block, red+bold (fatal-class, #1757). |
| `session_status` | **Suppressed** — sidebar only, per design doc. |
| `turn_start` / `turn_end` | Suppressed (implicit visual separator). |
| unknown | Debug-visible fallback line. |

The dispatch site in `handleDaemonFrame` is now a single
`m.renderer.dispatch(...)` call — no inlined per-event-type logic. Child
PR 3 (streaming, #1768) and child PR 4 (tool-call cards) can swap a
specific handler without re-touching `model.go`.

### Status-line bottom strip

Adds a one-row strip between the event pane and the prompt showing the
focused session's `name · state · model · cumulative cost`. Model + cost
are sourced from `payload.MsgAssistant.{Model,Cost}` on observed
`msg_assistant` events (cost accumulates, model is the latest non-empty
value). The strip degrades gracefully when either field is absent — no
`<nil>` placeholders, no `\$0.00` literal.

### Tests (`internal/iris/tui/renderer_test.go`)

One happy-path test per design-doc renderer-table row:
- `TestRenderer_MsgAssistant`
- `TestRenderer_ToolCallOneLineCard`
- `TestRenderer_ToolResultIndentedSummary`
- `TestRenderer_StateChangeDimLine`
- `TestRenderer_ExtensionErrorProminentBlock`

Plus the edge cases:
- `TestRenderer_SessionStatusSuppressed` — payload is not leaked into the
  conversation pane, follow-up msg_assistant still renders.
- `TestRenderer_UnknownEventDoesNotPanic` — model accepts further events
  after an unknown one.

And the status-line strip:
- `TestStatusLine_PopulatedFromMsgAssistant` — cost accumulates across
  multiple events.
- `TestStatusLine_DegradesWithoutModelOrCost` — no `<nil>`, no `\$0.00`.
- `TestStatusLine_NoSubscribedSession` — placeholder when no
  subscription is active.

All pre-existing TUI tests continue to pass.

## Out of scope

- **Streaming** (`msg_assistant` deltas) — child 3, #1768.
- **Multi-line tool-call cards** (args, result preview, expand/collapse)
  — child 4.
- Persisting `extension_error` to `agent_events` — handler is wired and
  tested; the supervisor's RPC path doesn't currently write these rows,
  so this renderer is forward-compatible until a future PR threads
  extension_error frames through `writeObservationEvent`.

## Pre-PR self-check

```
go build ./...                                       # ok
go test ./internal/iris/tui/... -race                # ok
go test ./... -race                                  # ok (all packages green)
nix build .#prism                                    # ok
```

Refs #1765
Closes #1767