### PR TITLE
pi/sidecar/iris: mid-tool heartbeat to keep watchdog alive on long bash tools

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -61,6 +61,9 @@ import {
   // Assistant-message text extraction (issue #1764)
   extractAssistantText,
   isAssistantTextDeltaEvent,
+  // Mid-tool heartbeat (issue #1761)
+  startToolHeartbeat,
+  TOOL_HEARTBEAT_INTERVAL_MS,
 } from "./prism.ts"
 import prismExtension from "./prism.ts"
 
@@ -3642,5 +3645,225 @@ describe("#1764: pi 0.72.1 wire-frame coverage matrix", () => {
       0,
       matrix[6].desc,
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #1761: mid-tool heartbeat
+// ---------------------------------------------------------------------------
+//
+// The PI extension emits a `tool_progress` frame on a fixed cadence while a
+// tool execution is in flight so that long-running bash invocations (e.g.
+// `nix build`, `go test -count=20`) don't silence the wire long enough to
+// trip the sidecar's per-session inactivity watchdog (#1728).
+//
+// These tests exercise startToolHeartbeat in isolation: they supply a fake
+// scheduler and a recording writer so the behaviour can be asserted without
+// real wall-clock waits.
+
+interface RecordingWriter extends FrameWriter {
+  frames: Array<Record<string, unknown>>
+  closed: boolean
+}
+
+function makeRecordingWriter(): RecordingWriter {
+  const frames: Array<Record<string, unknown>> = []
+  let closed = false
+  return {
+    frames,
+    get closed() {
+      return closed
+    },
+    write(frame) {
+      if (closed) return
+      // Deep-clone the frame so accidental mutation by the SUT doesn't
+      // invalidate the recorded sequence.
+      frames.push(JSON.parse(JSON.stringify(frame)))
+    },
+    close() {
+      closed = true
+    },
+  }
+}
+
+interface FakeScheduler {
+  setInterval: (cb: () => void, ms: number) => unknown
+  clearInterval: (handle: unknown) => void
+  tick: () => void
+  intervalMs: number
+  cleared: boolean
+  unrefCount: number
+}
+
+function makeFakeScheduler(): FakeScheduler {
+  let callback: (() => void) | null = null
+  let intervalMs = 0
+  let cleared = false
+  let unrefCount = 0
+  // A token object that exposes .unref so the SUT's duck-typed unref call
+  // can be observed (mirrors Node's Timeout shape closely enough for our
+  // purposes).
+  const handle = {
+    unref() {
+      unrefCount++
+    },
+  }
+  return {
+    setInterval(cb, ms) {
+      callback = cb
+      intervalMs = ms
+      return handle
+    },
+    clearInterval(h) {
+      if (h !== handle) {
+        throw new Error("fake clearInterval called with unknown handle")
+      }
+      cleared = true
+      callback = null
+    },
+    tick() {
+      if (callback) callback()
+    },
+    get intervalMs() {
+      return intervalMs
+    },
+    get cleared() {
+      return cleared
+    },
+    get unrefCount() {
+      return unrefCount
+    },
+  }
+}
+
+describe("#1761: startToolHeartbeat — basic cadence", () => {
+  it("emits a tool_progress frame on each tick with id and name", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(
+      writer,
+      "tool-call-abc",
+      "bash",
+      30_000,
+      sched,
+    )
+
+    // No frame emitted before any tick — fast tools that finish before the
+    // first cadence boundary cost nothing on the wire (edge-case AC).
+    assert.equal(writer.frames.length, 0, "no frame before first tick")
+    assert.equal(sched.intervalMs, 30_000)
+
+    sched.tick()
+    assert.equal(writer.frames.length, 1)
+    assert.deepEqual(writer.frames[0], {
+      type: "tool_progress",
+      id: "tool-call-abc",
+      name: "bash",
+    })
+
+    sched.tick()
+    sched.tick()
+    assert.equal(writer.frames.length, 3, "one frame per tick")
+
+    cancel()
+    assert.ok(sched.cleared, "cancel must clear the interval")
+  })
+
+  it("idempotent cancel — calling twice is a no-op the second time", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(writer, "id", "bash", 1000, sched)
+    cancel()
+    // Second invocation must not throw or call clearInterval again. The
+    // fake scheduler would throw on a second clear with the same handle
+    // because handle ownership is one-shot.
+    cancel()
+    assert.ok(sched.cleared)
+  })
+
+  it("post-cancel ticks are inert (no further frames)", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(writer, "id", "bash", 1000, sched)
+    sched.tick()
+    cancel()
+    // After cancel, the fake's callback is nulled; tick() is a no-op.
+    sched.tick()
+    sched.tick()
+    assert.equal(writer.frames.length, 1)
+  })
+
+  it("unrefs the timer handle so it doesn't pin the event loop", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(writer, "id", "bash", 1000, sched)
+    assert.equal(sched.unrefCount, 1, "handle.unref must be called once")
+    cancel()
+  })
+})
+
+describe("#1761: startToolHeartbeat — disabled paths", () => {
+  it("returns a noop cancel when intervalMs is 0 (disabled)", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(writer, "id", "bash", 0, sched)
+    // No interval scheduled — interval ms stays at the fake's default 0.
+    assert.equal(sched.intervalMs, 0)
+    // Calling the cancel must not throw and must not clear (nothing armed).
+    cancel()
+    assert.equal(sched.cleared, false)
+    assert.equal(writer.frames.length, 0)
+  })
+
+  it("returns a noop cancel when intervalMs is negative (disabled)", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(writer, "id", "bash", -1, sched)
+    cancel()
+    assert.equal(sched.cleared, false)
+    assert.equal(writer.frames.length, 0)
+  })
+
+  it("returns a noop cancel when writer is null (handshake incomplete)", () => {
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(null, "id", "bash", 1000, sched)
+    cancel()
+    assert.equal(sched.cleared, false)
+  })
+})
+
+describe("#1761: startToolHeartbeat — closed writer", () => {
+  it("a tick after writer.close() does not throw and produces no frame", () => {
+    const writer = makeRecordingWriter()
+    const sched = makeFakeScheduler()
+    const cancel = startToolHeartbeat(writer, "id", "bash", 1000, sched)
+    writer.close()
+    // The FrameWriter contract is "silently drop post-close writes". The
+    // tick must therefore be safe even if cancel() lost the race with
+    // socket teardown.
+    sched.tick()
+    sched.tick()
+    assert.equal(writer.frames.length, 0)
+    cancel()
+  })
+})
+
+describe("#1761: TOOL_HEARTBEAT_INTERVAL_MS — env override", () => {
+  it("default cadence is 30 seconds (well below the 15-minute watchdog window)", () => {
+    // Snapshot the export at module-load time. The override is evaluated
+    // once at module init, so we only assert the default-or-override
+    // invariant here: the value is a positive finite number under 15
+    // minutes (the inactivity watchdog window).
+    assert.ok(Number.isFinite(TOOL_HEARTBEAT_INTERVAL_MS))
+    // Sanity: must be strictly less than the 15-minute watchdog window to
+    // leave headroom for clock skew, scheduler jitter, and the socket
+    // round-trip from PI to the sidecar.
+    if (process.env.PRISM_TOOL_HEARTBEAT_INTERVAL_MS === undefined) {
+      assert.equal(
+        TOOL_HEARTBEAT_INTERVAL_MS,
+        30_000,
+        "default cadence must be 30s",
+      )
+    }
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -709,6 +709,107 @@ export const TRUNCATION_SENTINEL = "…[truncated]"
 /** Harness identifier sent in the `hello` frame. */
 export const HARNESS_NAME = "pi"
 
+// ---------------------------------------------------------------------------
+// Mid-tool heartbeat (#1761)
+// ---------------------------------------------------------------------------
+//
+// Long-running tool calls (e.g. `nix build .#prism`, `go test -count=20`) can
+// exceed the sidecar's per-session inactivity watchdog window (#1728, default
+// 15 min for review agents) when the call produces no intermediate frames on
+// the wire. The sidecar interprets the silence as a stuck agent and force-
+// transitions the session to `error`.
+//
+// Fix shape (a) from #1761: while a tool execution is in flight, emit a
+// lightweight `tool_progress` frame on a fixed cadence. The sidecar's
+// `touchActivity` runs on every inbound frame and resets the watchdog, so
+// this drops in with no sidecar-side timer logic. The sidecar has an
+// explicit case for the frame that resets activity *without* writing it to
+// `agent_events`, so the heartbeat is invisible to downstream consumers
+// (narrative, checkin, TUI) and never looks like a duplicate turn or tool
+// call.
+//
+// Cadence: 30s by default, comfortably below the 15-minute watchdog window.
+// The first heartbeat fires after one full cadence has elapsed — fast tools
+// (completing in < TOOL_HEARTBEAT_INTERVAL_MS) never emit one.
+//
+// Genuine-stuck rescue path is preserved: if PI itself is hung (event loop
+// blocked, process wedged), no heartbeats are emitted and the watchdog still
+// fires within its configured window. The heartbeat only proves "PI's event
+// loop is alive and a tool is in flight" — not "the tool is making progress".
+// That weaker guarantee is sufficient: the existing watchdog target is
+// session-level liveness, not per-tool progress.
+//
+// PRISM_TOOL_HEARTBEAT_INTERVAL_MS overrides the cadence for testing
+// (small values make the timer test loop fast). Values <= 0 disable the
+// heartbeat entirely.
+export const TOOL_HEARTBEAT_INTERVAL_MS: number = (() => {
+  const override = process.env.PRISM_TOOL_HEARTBEAT_INTERVAL_MS
+  if (override !== undefined) {
+    const parsed = Number(override)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+  return 30_000
+})()
+
+/**
+ * Start a periodic heartbeat for an in-flight tool call. Returns a
+ * cancellation function the caller must invoke when the tool ends or the
+ * connection drops.
+ *
+ * The heartbeat is a no-op (returns a noop cancel) when:
+ *   - intervalMs <= 0 (disabled),
+ *   - the writer is unavailable (handshake not complete).
+ *
+ * The first frame fires after `intervalMs` has elapsed — a tool that
+ * completes before then emits nothing.
+ *
+ * Exported for unit testing.
+ */
+export function startToolHeartbeat(
+  writer: FrameWriter | null,
+  toolCallId: string,
+  toolName: string,
+  intervalMs: number = TOOL_HEARTBEAT_INTERVAL_MS,
+  scheduler: {
+    setInterval: (cb: () => void, ms: number) => unknown
+    clearInterval: (handle: unknown) => void
+  } = {
+    setInterval: (cb, ms) => setInterval(cb, ms),
+    clearInterval: (h) => clearInterval(h as ReturnType<typeof setInterval>),
+  },
+): () => void {
+  if (intervalMs <= 0 || writer === null) {
+    return () => {}
+  }
+  // Refresh the unref so the heartbeat interval doesn't pin the Node event
+  // loop open (it's a best-effort liveness ping, not a load-bearing timer).
+  const handle = scheduler.setInterval(() => {
+    // The writer may have been closed between scheduling and firing. The
+    // FrameWriter.write contract already silently drops post-close writes,
+    // but check anyway to skip the JSON.stringify cost.
+    writer.write({
+      type: "tool_progress",
+      id: toolCallId,
+      name: toolName,
+    })
+  }, intervalMs)
+  // Node's setInterval returns a Timeout with .unref(); duck-type to keep
+  // this helper environment-agnostic (the unit-test scheduler returns a
+  // plain object).
+  const maybeUnref = (handle as { unref?: () => void }).unref
+  if (typeof maybeUnref === "function") {
+    maybeUnref.call(handle)
+  }
+  let cancelled = false
+  return () => {
+    if (cancelled) return
+    cancelled = true
+    scheduler.clearInterval(handle)
+  }
+}
+
 /**
  * The message injected as a steer after the agent runs `git push`.
  * Exported so unit tests can assert against the canonical text.
@@ -1889,6 +1990,22 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // ExtensionContext, so we capture one whenever a turn-active hook fires.
   let lastCtx: ExtensionContext | null = null
 
+  // Mid-tool heartbeat cancellation handles, keyed by toolCallId (#1761).
+  // tool_execution_start populates the map; tool_execution_end clears the
+  // matching entry. The map (not a single handle) defends against PI
+  // executing tools concurrently — each gets its own ticker.
+  const toolHeartbeats = new Map<string, () => void>()
+  const cancelAllToolHeartbeats = (): void => {
+    for (const cancel of toolHeartbeats.values()) {
+      try {
+        cancel()
+      } catch (err) {
+        console.error("[prism-extension] cancel tool heartbeat failed:", err)
+      }
+    }
+    toolHeartbeats.clear()
+  }
+
   // ── First-connect retry state ─────────────────────────────────────────
   //
   // firstConnect starts true and is set to false only after a successful
@@ -1998,6 +2115,11 @@ export default function prismExtension(pi: ExtensionAPI): void {
       socket = null
       writer = null
       handshakeComplete = false
+      // Cancel any in-flight tool heartbeats so they don't keep ticking
+      // against a torn-down writer (#1761). The writer's own post-close
+      // guard would silently drop the writes, but cancelling here releases
+      // the timer handles too.
+      cancelAllToolHeartbeats()
       // Per wire spec §7.6: if the sidecar dies, PI continues running
       // standalone. We don't try to reconnect here; the sidecar's reconnect
       // loop re-accepts on session_start.
@@ -2443,6 +2565,14 @@ export default function prismExtension(pi: ExtensionAPI): void {
     if (truncated) frame.truncated = true
     writer.write(frame)
 
+    // Arm the mid-tool heartbeat (#1761). The first frame fires only after
+    // TOOL_HEARTBEAT_INTERVAL_MS has elapsed, so fast tools cost nothing.
+    // Cancellation is keyed by tool-call id so concurrent tools don't
+    // interfere with one another.
+    if (id !== "" && !toolHeartbeats.has(id)) {
+      toolHeartbeats.set(id, startToolHeartbeat(writer, id, name))
+    }
+
     // ── Behavioural guards ────────────────────────────────────────────────
     // Guards are suppressed inside review-agent sessions.
     if (!isReviewSession) {
@@ -2496,11 +2626,20 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
   pi.on("tool_execution_end", async (event, ctx) => {
     lastCtx = ctx
-    if (!writer || !handshakeComplete) return
     const id =
       typeof (event as { toolCallId?: unknown }).toolCallId === "string"
         ? (event as { toolCallId: string }).toolCallId
         : ""
+    // Cancel the heartbeat for this tool call (#1761). Always run, even if
+    // the writer was torn down in between — the map entry must not leak.
+    if (id !== "") {
+      const cancel = toolHeartbeats.get(id)
+      if (cancel) {
+        cancel()
+        toolHeartbeats.delete(id)
+      }
+    }
+    if (!writer || !handshakeComplete) return
     const isError =
       (event as { isError?: unknown }).isError === true
     const result = (event as { result?: unknown }).result
@@ -2680,6 +2819,9 @@ export default function prismExtension(pi: ExtensionAPI): void {
       clearTimeout(pendingRetryTimer)
       pendingRetryTimer = null
     }
+    // Cancel any in-flight tool heartbeats on shutdown (#1761) so the
+    // timers don't fire after the writer is closed.
+    cancelAllToolHeartbeats()
     if (writer) {
       writer.close()
     }

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -596,6 +596,35 @@ suffix ` (host)` is appended after the branch label and before any PR/cycle
 info. This surfaces unsandboxed sessions visually so users can tell them
 apart from sandboxed ones at a glance.
 
+### 5.12 `tool_progress`
+
+```json
+{"type":"tool_progress","id":"call_abc123","name":"bash"}
+```
+
+Mid-tool heartbeat. The extension emits this frame on a fixed cadence
+(default 30s, configurable via `PRISM_TOOL_HEARTBEAT_INTERVAL_MS`) while a
+tool execution is in flight, so that long-running invocations such as
+`nix build .#prism` or `go test -count=20` don't silence the wire long
+enough to trip the sidecar's per-session inactivity watchdog (#1728).
+
+- `id` (string, required) — the `tool_call.id` of the in-flight call.
+- `name` (string, required) — the tool name (e.g. `"bash"`). Informational
+  only; the sidecar does not branch on it.
+
+The first heartbeat fires only after the configured cadence has elapsed,
+so fast tools (completing in < cadence) never produce a `tool_progress`
+frame on the wire.
+
+**Sidecar behaviour:** `tool_progress` resets the inactivity watchdog
+via the standard inbound-frame `touchActivity` path, but is **not**
+written to `agent_events`. Downstream consumers (narrative renderer,
+checkin, TUI) therefore never see the frame — it is purely a liveness
+signal between the extension and the sidecar. See `handlePipeFrame`'s
+explicit `tool_progress` case for the no-op-on-events contract.
+
+Introduced in #1761.
+
 ## 6. Frame catalogue — sidecar → extension
 
 Frames sent by the sidecar to the extension. These represent **prism

--- a/modules/programs/prism/prism/internal/iris/harness_socket.go
+++ b/modules/programs/prism/prism/internal/iris/harness_socket.go
@@ -405,6 +405,17 @@ func (h *HarnessSocketServer) handleConn(ctx context.Context, conn net.Conn) err
 			// Observation frame — write to DB for logging.
 			h.writeObservationEvent("tool_result", line)
 
+		case "tool_progress":
+			// Mid-tool heartbeat (#1761). PI emits this on a fixed cadence
+			// while a tool call is in flight so long-running shells don't
+			// silence the wire long enough to trip downstream inactivity
+			// timers. Deliberately not written to agent_events: it would
+			// otherwise surface in narrative output (default branch of
+			// narrative.RenderRow) as a duplicate artefact. The receipt of
+			// the frame is itself the activity signal — no further work
+			// needed here.
+			continue
+
 		case "state_change":
 			// State transition from the extension (e.g. waiting, active,
 			// finished, interrupted). Write the agent_events row FIRST per

--- a/modules/programs/prism/prism/internal/iris/harness_tool_progress_test.go
+++ b/modules/programs/prism/prism/internal/iris/harness_tool_progress_test.go
@@ -1,0 +1,117 @@
+package iris_test
+
+// harness_tool_progress_test.go — iris-side coverage for the #1761
+// mid-tool heartbeat. The iris HarnessSocketServer must treat
+// `tool_progress` as an inbound liveness frame: read it off the wire
+// without crashing AND without writing it to agent_events (the narrative
+// renderer's default branch would otherwise surface it as a stream of
+// "tool_progress" lines between tool_call and tool_result).
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+)
+
+// TestToolProgress_NotWrittenToEvents drives a tool_progress observation
+// frame at iris's harness socket and confirms it is not persisted to
+// agent_events. Control frames (state_change) are sent before and after
+// so the test has a robust before/after signal — without those, the
+// negative assertion would be racing the server goroutine's drain.
+func TestToolProgress_NotWrittenToEvents(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	const instanceID = "test-tool-progress-001"
+	const sessionName = "test@tool-progress"
+	insertTestSessionRow(t, database, instanceID, sessionName, tmp)
+
+	sockPath := filepath.Join(tmp, "harness.sock")
+	sess := &iris.SessionRecord{
+		InstanceID:      instanceID,
+		SessionName:     sessionName,
+		Worktree:        tmp,
+		Role:            "worker",
+		HarnessSockPath: sockPath,
+	}
+	srv, err := iris.NewHarnessSocketServer(sess, database)
+	if err != nil {
+		t.Fatalf("NewHarnessSocketServer: %v", err)
+	}
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go func() { _ = srv.AcceptOne(ctx) }()
+
+	conn, r := dialHarness(t, sockPath)
+	doHandshake(t, conn, r)
+
+	// Bracket the heartbeats with state_change frames as before/after
+	// markers — they are guaranteed to be persisted (state_change is a
+	// well-known observation type), so we can wait for the "after" marker
+	// to know the server has drained.
+	sendFrame(t, conn, map[string]any{"type": "state_change", "state": "active"})
+	for i := 0; i < 5; i++ {
+		sendFrame(t, conn, map[string]any{
+			"type": "tool_progress",
+			"id":   "call-1",
+			"name": "bash",
+		})
+	}
+	sendFrame(t, conn, map[string]any{"type": "state_change", "state": "waiting"})
+
+	// Wait until both state_change events are visible in the DB — that
+	// guarantees the tool_progress frames in between have also been
+	// processed by the dispatch loop.
+	deadline := time.Now().Add(2 * time.Second)
+	var activeSeen, waitingSeen bool
+	for time.Now().Before(deadline) {
+		all, err := database.AllSessionEvents(sessionName)
+		if err != nil {
+			t.Fatalf("AllSessionEvents: %v", err)
+		}
+		activeSeen = false
+		waitingSeen = false
+		for _, e := range all {
+			if e.Type == "state_change" {
+				// Crude but sufficient: payload contains "active" / "waiting".
+				if strings.Contains(string(e.Payload), "active") && !activeSeen {
+					activeSeen = true
+				} else if strings.Contains(string(e.Payload), "waiting") {
+					waitingSeen = true
+				}
+			}
+		}
+		if activeSeen && waitingSeen {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !activeSeen || !waitingSeen {
+		t.Fatalf("control state_change events not flushed (active=%v, waiting=%v) — test setup is broken", activeSeen, waitingSeen)
+	}
+
+	// Now assert no tool_progress rows landed in agent_events.
+	all, err := database.AllSessionEvents(sessionName)
+	if err != nil {
+		t.Fatalf("AllSessionEvents: %v", err)
+	}
+	for _, e := range all {
+		if e.Type == "tool_progress" {
+			t.Errorf("tool_progress frame leaked into agent_events (event=%+v) — must be invisible to downstream consumers per #1761", e)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
@@ -295,3 +295,197 @@ func TestInactivityWatchdog_NoOpWhenAlreadyTerminal(t *testing.T) {
 	conn.Close()
 	_ = wait()
 }
+
+// ── #1761: mid-tool heartbeat ───────────────────────────────────────────────
+//
+// The PI extension emits a `tool_progress` frame on a fixed cadence while a
+// tool execution is in flight so that long-running bash invocations (e.g.
+// `nix build`, `go test -count=20`) don't silence the wire long enough to
+// trip the per-session inactivity watchdog.
+//
+// Sidecar-side contract:
+//
+//   - tool_progress is treated as an inbound frame: it resets the watchdog
+//     via touchActivity (same path as every other frame).
+//   - tool_progress is NOT written to agent_events: it must remain invisible
+//     to downstream consumers (narrative renderer, checkin, TUI). The
+//     renderer's default branch would otherwise print "tool_progress" lines
+//     between every tool_call/tool_result pair.
+//   - The genuine-stuck rescue path is preserved: if no tool_progress (or
+//     other frame) arrives, the watchdog still fires within the configured
+//     window. This is implicitly true given the watchdog has no per-frame
+//     branch, but the test asserts it explicitly so future refactors can't
+//     accidentally regress it.
+
+// TestToolProgressHeartbeat_ResetsWatchdog drives the exact pathology from
+// issue #1761: a review agent runs a long bash tool with no other frames
+// emitted, but the extension sends a tool_progress heartbeat. The watchdog
+// must be reset (not fire) for each heartbeat that arrives within the
+// timeout window.
+func TestToolProgressHeartbeat_ResetsWatchdog(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newReviewAgentSidecarWithActivityTimeout(t, sockPath, 30*time.Second)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Open a turn and start a tool call — the "before the long sleep"
+	// situation the extension sees just before kicking off `nix build`.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{
+		"type": "tool_call",
+		"id":   "call-1",
+		"name": "bash",
+		"args": map[string]any{"command": "nix build .#prism"},
+	})
+
+	// Timer registration order so far:
+	//   #1 armed by post-handshake touchActivity
+	//   #2 armed by turn_start touchActivity (replaces #1)
+	//   #3 armed by tool_call touchActivity  (replaces #2)
+	t3 := clk.WaitForTimerCount(3, 5*time.Second)
+	if t3 == nil {
+		t.Fatal("no watchdog timer after tool_call")
+	}
+
+	// Heartbeat #1 — must Stop t3 and arm t4.
+	sendJSON(t, conn, map[string]any{
+		"type": "tool_progress",
+		"id":   "call-1",
+		"name": "bash",
+	})
+	if !t3.WaitStopped(5 * time.Second) {
+		t.Fatal("tool_progress did not reset the watchdog (t3 not stopped)")
+	}
+	t4 := clk.WaitForTimerCount(4, 5*time.Second)
+	if t4 == nil || t4 == t3 {
+		t.Fatal("no fresh watchdog timer after tool_progress")
+	}
+
+	// Heartbeat #2 — must reset again.
+	sendJSON(t, conn, map[string]any{
+		"type": "tool_progress",
+		"id":   "call-1",
+		"name": "bash",
+	})
+	if !t4.WaitStopped(5 * time.Second) {
+		t.Fatal("second tool_progress did not reset the watchdog (t4 not stopped)")
+	}
+	t5 := clk.WaitForTimerCount(5, 5*time.Second)
+	if t5 == nil || t5 == t4 {
+		t.Fatal("no fresh watchdog timer after second tool_progress")
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// TestToolProgressHeartbeat_NotWrittenToEvents verifies tool_progress is
+// excluded from agent_events. The narrative renderer's default branch would
+// otherwise print one "tool_progress" line per heartbeat, polluting checkin
+// output and the TUI feed with internal liveness noise.
+func TestToolProgressHeartbeat_NotWrittenToEvents(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, _ := newReviewAgentSidecarWithActivityTimeout(t, sockPath, 30*time.Second)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Send a tool_call (must persist) bracketed by several tool_progress
+	// heartbeats (must NOT persist), then a tool_result (must persist).
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{
+		"type": "tool_call",
+		"id":   "call-1",
+		"name": "bash",
+		"args": map[string]any{"command": "nix build .#prism"},
+	})
+	for i := 0; i < 5; i++ {
+		sendJSON(t, conn, map[string]any{
+			"type": "tool_progress",
+			"id":   "call-1",
+			"name": "bash",
+		})
+	}
+	sendJSON(t, conn, map[string]any{
+		"type":    "tool_result",
+		"id":      "call-1",
+		"success": true,
+		"output":  "ok",
+	})
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	var (
+		sawToolCall   bool
+		sawToolResult bool
+	)
+	for _, ev := range events {
+		if ev.Type == "tool_progress" {
+			t.Errorf("tool_progress frame leaked into agent_events (event=%+v) — must be invisible to downstream consumers", ev)
+		}
+		if ev.Type == "tool_call" {
+			sawToolCall = true
+		}
+		if ev.Type == "tool_result" {
+			sawToolResult = true
+		}
+	}
+	if !sawToolCall {
+		t.Error("tool_call event missing from agent_events (control)")
+	}
+	if !sawToolResult {
+		t.Error("tool_result event missing from agent_events (control)")
+	}
+}
+
+// TestToolProgressHeartbeat_GenuineStuckStillFires verifies the rescue path
+// is preserved: if the agent stops emitting heartbeats (PI hung, event loop
+// blocked, etc.), the watchdog still force-transitions the session to error
+// within the configured window. This is the property that makes #1728's
+// rescue logic load-bearing — the heartbeat must not be load-bearing in the
+// opposite direction (preventing fire when truly stuck).
+func TestToolProgressHeartbeat_GenuineStuckStillFires(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc, clk := newReviewAgentSidecarWithActivityTimeout(t, sockPath, 30*time.Second)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive into a long tool call with a couple of heartbeats — simulates
+	// a tool running normally for a while.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{
+		"type": "tool_call",
+		"id":   "call-1",
+		"name": "bash",
+		"args": map[string]any{"command": "nix build .#prism"},
+	})
+	sendJSON(t, conn, map[string]any{"type": "tool_progress", "id": "call-1", "name": "bash"})
+	sendJSON(t, conn, map[string]any{"type": "tool_progress", "id": "call-1", "name": "bash"})
+
+	// State is now active. Timer registration:
+	//   #1 post-handshake, #2 turn_start, #3 tool_call,
+	//   #4 first tool_progress, #5 second tool_progress.
+	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second); got != string(agent.StateActive) {
+		t.Fatalf("state after tool_call: got %q, want active", got)
+	}
+	live := clk.WaitForTimerCount(5, 5*time.Second)
+	if live == nil {
+		t.Fatal("no watchdog timer after two heartbeats")
+	}
+	// Now the agent stops emitting heartbeats entirely (PI hung). Fire the
+	// live watchdog — the rescue path must fire.
+	live.Fire()
+
+	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateError), 2*time.Second); got != string(agent.StateError) {
+		t.Fatalf("state after watchdog fire on heartbeat silence: got %q, want %q — rescue path regressed", got, agent.StateError)
+	}
+
+	conn.Close()
+	_ = wait()
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2164,6 +2164,21 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 		// the existing agent_events payload format (P2.WIRE §8.1).
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
 
+	case "tool_progress":
+		// Mid-tool heartbeat (#1761). The PI extension emits this frame on
+		// a fixed cadence while a tool call is in flight so that long-running
+		// bash invocations (e.g. `nix build`, `go test -count=20`) don't
+		// silence the wire long enough to trip the inactivity watchdog added
+		// in #1728.
+		//
+		// touchActivity (called at the top of handlePipeFrame) already
+		// resets the watchdog — the heartbeat needs no further action here.
+		// Deliberately do NOT writeEvent: the narrative renderer's default
+		// case prints unknown event types, and we don't want the heartbeat
+		// to surface as a duplicate tool call / extra turn / visible artefact
+		// in `prism checkin`, the TUI, or any downstream consumer.
+		s.logger().Printf("sidecar: tool_progress heartbeat received (activity reset)")
+
 	case "session_status":
 		// Extract the PI session ID from the frame and record it in the DB so
 		// that prism cleanup can locate the correct session directory for


### PR DESCRIPTION
Closes #1761.

## Problem

review-qa's inactivity watchdog (#1728) fires on PRs whose diff size pushes
slow-tool calls (\`nix build .#prism\`, \`go test -count=20\`) past the
15-minute per-session window. PI emits no wire frames between
\`tool_call\` and \`tool_result\` for a single long bash invocation — the
sidecar sees silence and concludes the agent is stuck.

Empirical reproducer: PR #1756 (the #1709 reopen fix). Two consecutive
\`prism review 1756\` rounds both failed with \`review-qa: ERROR —
inactivity timeout: no inbound frame for 15m0s\` while the other four
reviewers passed cleanly on the same PR. The single long bash call
(\`nix build\` + \`go test -count=20\`) was running ~12 minutes between
adjacent inbound frames, exceeding the 15-minute watchdog window.

## Fix

This implements **fix shape (a)** from the issue: a PI mid-tool heartbeat
frame. The PI extension emits a \`tool_progress\` frame on a fixed cadence
(default 30s, overridable via \`PRISM_TOOL_HEARTBEAT_INTERVAL_MS\`) while a
tool execution is in flight. The sidecar's existing \`touchActivity\` path
resets the watchdog on every inbound frame, so the heartbeat is enough to
keep the session alive on legitimate slow tools — no sidecar timer or
threshold logic.

Most general fix — benefits every slow-tool agent, not just review-qa.

## Wire-side contract

- **Fast-tool guarantee.** Tools that finish before the first cadence
  boundary never emit a heartbeat (setInterval first-fire-after-delay
  semantics). No behaviour change for the common case.
- **Invisible to downstream consumers.** The frame is NOT written to
  \`agent_events\` on either the sidecar or iris path — both have explicit
  cases that reset activity and drop the frame. Narrative output, checkin,
  and the TUI feed stay clean (no duplicate tool calls / extra turns / visible
  artefacts).
- **Genuine-stuck rescue path preserved.** If PI's event loop is hung (no
  heartbeats emitted), the watchdog still fires within the configured
  window. \`TestToolProgressHeartbeat_GenuineStuckStillFires\` asserts this
  explicitly.
- **Cheap and self-contained.** The timer is unref'd so it doesn't pin the
  Node event loop; it's cancelled on \`tool_execution_end\`, socket close,
  and \`session_shutdown\`. Keyed by tool-call id so concurrent tools don't
  interfere.

## Tests

- **TypeScript (\`prism.test.ts\`):** \`startToolHeartbeat\` unit tests
  — cadence, disabled paths (intervalMs ≤ 0, null writer), post-close
  safety, idempotent cancel, unref invariant.
- **Go (\`internal/sidecar\`):** \`tool_progress\` resets the watchdog
  timer; \`tool_progress\` is not persisted to \`agent_events\`; the rescue
  path still fires when heartbeats stop.
- **Go (\`internal/iris\`):** \`tool_progress\` is not persisted to
  \`agent_events\` on the iris harness-socket path either.

All three layers covered to defend against regressions in any of them.

## Docs

\`pi-wire-protocol.md §5.12\` documents the new frame and its
no-op-on-events contract.

## Self-check

- \`go test ./... -race\` ✅ (all packages pass)
- \`nix build .#prism\` ✅
- \`tsx prism.test.ts\` ✅ (73 suites, all pass — was 69 before)