### PR TITLE
sidecar: fix flaky harness-pipe timeout state-write race (#1760)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -660,6 +660,36 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		}
 	}
 
+	// FK guard (#1760). Any subsequent writeEvent call sets agent_events.instance_id
+	// to s.cfg.InstanceID, which is a foreign key into sessions(instance_id). In
+	// production the parent row is inserted by the tmux-session-start handler
+	// (cmd/event.go) or by session.SpawnSession before the sidecar runs, but the
+	// sidecar may also be started in contexts where that didn't happen — sidecar
+	// unit tests, ad-hoc bring-up, or any future caller that mints an instance_id
+	// inline above. InsertSession uses INSERT OR IGNORE so the call is a no-op
+	// when the row already exists; this guarantees that downstream event writes
+	// never fail with FOREIGN KEY constraint failed (787).
+	if s.cfg.InstanceID != "" && s.cfg.DB != nil {
+		harnessName := s.cfg.HarnessName
+		if harnessName == "" {
+			harnessName = "pi"
+		}
+		sess := db.Session{
+			InstanceID:  s.cfg.InstanceID,
+			SessionName: s.cfg.SessionName,
+			Repo:        s.cfg.Repo,
+			Worktree:    s.cfg.Worktree,
+			Harness:     harnessName,
+		}
+		if s.cfg.AgentRole != "" {
+			role := s.cfg.AgentRole
+			sess.AgentRole = &role
+		}
+		if err := s.cfg.DB.InsertSession(sess); err != nil {
+			s.logger().Printf("sidecar: warning: InsertSession for instance %s failed (FK-guard): %v", s.cfg.InstanceID, err)
+		}
+	}
+
 	// B.3 Stage 2: Start the merge-queue watcher for coordinator sessions.
 	// This is transport-agnostic and must run for ALL transport shapes so that
 	// PI coordinator sessions receive merge-queue notifications exactly like
@@ -1552,6 +1582,21 @@ const piWireProtocolVersion = 2
 // connection drop before marking the session as error. See P2.WIRE §7.2.
 const pipeDisconnectTimeout = 30 * time.Second
 
+// acceptOutcome enumerates the reasons an Accept attempt in
+// runStartupSocketPipe returned without a live connection. It is required
+// (instead of a plain bool) so that the caller can distinguish a startup
+// timeout from a concurrent ctx cancellation — the timeout path must record
+// state=error in the DB even if ctx happens to be cancelled in the same
+// scheduling tick (#1760).
+type acceptOutcome int
+
+const (
+	acceptConnected   acceptOutcome = iota // got a connection
+	acceptTimedOut                          // timer fired before connect or ctx cancel
+	acceptCtxCanceled                       // ctx cancelled (and timer had not yet fired)
+	acceptListenerErr                       // listener.Accept returned an error
+)
+
 // runStartupSocketPipe binds the per-session Unix socket (Linux) or TCP
 // listener (Darwin), accepts the PI extension's connection, performs the
 // P2.WIRE hello/hello_ack handshake, then enters the bidirectional frame loop.
@@ -1657,29 +1702,45 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 	defer closePipeListener()
 
 	// acceptWithTimeout waits up to the given duration for a new connection.
-	// Returns (conn, true) on success or (nil, false) on timeout/ctx cancel.
+	// Returns the connection and an outcome value identifying which select
+	// case fired. The outcome is required (not just a bool) because the caller
+	// must perform a state=error write on timeout even when ctx is concurrently
+	// cancelled — collapsing timeout and ctx-cancel into a single "!ok" branch
+	// caused issue #1760, where the select picked ctx.Done() under contended
+	// scheduling and the state write was short-circuited.
 	type acceptResult struct {
 		conn net.Conn
 		err  error
 	}
-	acceptWithTimeout := func(timeout time.Duration) (net.Conn, bool) {
+	acceptWithTimeout := func(timeout time.Duration) (net.Conn, acceptOutcome) {
 		ch := make(chan acceptResult, 1)
 		go func() {
 			c, e := ln.Accept()
 			ch <- acceptResult{c, e}
 		}()
+		deadline := time.Now().Add(timeout)
 		timer := time.NewTimer(timeout)
 		defer timer.Stop()
 		select {
-		case <-ctx.Done():
-			return nil, false
 		case <-timer.C:
-			return nil, false
+			return nil, acceptTimedOut
+		case <-ctx.Done():
+			// Prefer the timeout outcome whenever the wall-clock deadline has
+			// already passed, regardless of which channel happened to be ready
+			// first. The original implementation reported ctx-cancel here and
+			// the caller then skipped the state=error write, producing the
+			// #1760 flake: under contended scheduling the deadline can elapse
+			// well before the timer goroutine actually delivers to timer.C,
+			// so a strict "is timer.C ready?" check is not reliable.
+			if !time.Now().Before(deadline) {
+				return nil, acceptTimedOut
+			}
+			return nil, acceptCtxCanceled
 		case ar := <-ch:
 			if ar.err != nil {
-				return nil, false
+				return nil, acceptListenerErr
 			}
-			return ar.conn, true
+			return ar.conn, acceptConnected
 		}
 	}
 
@@ -1728,35 +1789,38 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 
 	for {
 		// --- Wait for the extension to connect ----------------------------
-		conn, ok := acceptWithTimeout(acceptTimeout)
-		if !ok {
-			s.mu.Lock()
-			if ctx.Err() != nil {
-				// Context cancelled (SIGTERM path) — Shutdown() handles state.
-				s.mu.Unlock()
-			} else {
-				// Timeout waiting for (re)connection.
+		conn, outcome := acceptWithTimeout(acceptTimeout)
+		if outcome != acceptConnected {
+			switch outcome {
+			case acceptTimedOut, acceptListenerErr:
+				// Timeout waiting for (re)connection (or listener error, which
+				// the writer goroutine also treats as a hard failure). We must
+				// record the error state in the DB BEFORE consulting ctx —
+				// under contended scheduling the timer fire and an external
+				// ctx cancel can land in the same window, and skipping the
+				// write because ctx happens to be cancelled produces the
+				// flake described in #1760 (state stays "idle" forever).
+				s.mu.Lock()
 				s.flushPipeAccum()
 				s.upsertState(agent.StateError, nil, nil)
 				s.writeEvent("state_change", map[string]string{"state": string(agent.StateError), "note": "reconnect timeout"}, nil)
 				s.lastState = agent.StateError
+				s.harnessPipeOutCh = nil
 				s.mu.Unlock()
 				err := fmt.Errorf("sidecar: runStartupSocketPipe: timed out waiting for extension to (re)connect (timeout=%s)", acceptTimeout)
 				s.logger().Printf("%v", err)
-				// Drain and stop the writer goroutine.
+				close(outCh)
+				<-writerDone
+				return err
+			case acceptCtxCanceled:
+				// Context cancelled (SIGTERM path) — Shutdown() handles state.
 				s.mu.Lock()
 				s.harnessPipeOutCh = nil
 				s.mu.Unlock()
 				close(outCh)
 				<-writerDone
-				return err
+				return ctx.Err()
 			}
-			s.mu.Lock()
-			s.harnessPipeOutCh = nil
-			s.mu.Unlock()
-			close(outCh)
-			<-writerDone
-			return ctx.Err()
 		}
 
 		s.logger().Printf("sidecar: runStartupSocketPipe: extension connected from %s", conn.RemoteAddr())

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_hostapi_bind_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_hostapi_bind_test.go
@@ -292,10 +292,13 @@ func TestHostAPI_SurvivesHarnessPipeHandshakeFailure_NeverConnects(t *testing.T)
 	// host-API socket.
 
 	// Poll until the DB shows error state (written by runStartupSocketPipe
-	// timeout path). This replaces a fixed sleep-then-assert — the state write
-	// can land any time after the timeout fires, so a poll-loop is required to
-	// avoid a race under contended scheduling (issue #1595).
-	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 2*time.Second); st != "error" {
+	// timeout path). The state write happens after the 200ms startup timeout
+	// fires; under contended scheduling (race detector + Nix sandbox CI) the
+	// scheduling latency between timer fire and DB commit can run into the
+	// hundreds of ms, so a 5s ceiling is used instead of the original 2s
+	// (#1760). The poll exits as soon as the state lands, so a generous
+	// ceiling is essentially free on healthy runs.
+	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 5*time.Second); st != "error" {
 		t.Errorf("DB state after harness-pipe timeout = %q, want error", st)
 	}
 
@@ -370,7 +373,9 @@ func TestHostAPI_SurvivesHarnessPipeHandshakeFailure_MalformedHello(t *testing.T
 	// Poll until the DB shows error state — the error write from
 	// runStartupSocketPipe can land any time after the malformed hello is
 	// rejected, so polling avoids a sleep-then-assert race (issue #1595).
-	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 2*time.Second); st != "error" {
+	// 5s ceiling chosen to absorb scheduler contention on race-detector
+	// CI runs (#1760).
+	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 5*time.Second); st != "error" {
 		t.Errorf("DB state after malformed hello = %q, want error", st)
 	}
 
@@ -409,9 +414,10 @@ func TestHostAPI_HarnessPipeFailureRecordsErrorState(t *testing.T) {
 	// Wait for harness-pipe socket, then poll until the DB shows error state.
 	// A fixed sleep-then-assert races the timeout handler's DB write under
 	// contended scheduling (e.g. the Nix sandbox runner); a poll-loop with a
-	// 2s ceiling is robust without materially slowing healthy runs (issue #1595).
+	// 5s ceiling is robust without materially slowing healthy runs
+	// (issues #1595, #1760).
 	waitForHostAPISock(t, hostAPISockPath)
-	if s := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 2*time.Second); s != "error" {
+	if s := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 5*time.Second); s != "error" {
 		t.Errorf("DB state after harness-pipe timeout = %q, want error", s)
 	}
 
@@ -636,8 +642,8 @@ func TestHostAPI_NoGoroutineLeak(t *testing.T) {
 	// has fired and its handler has committed the state write. Only then do we
 	// check that the host-API is still serving. Using a poll-loop instead of a
 	// fixed sleep avoids a sleep-then-assert race under contended scheduling
-	// (e.g. the Nix sandbox runner) (issue #1595).
-	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 2*time.Second); st != "error" {
+	// (e.g. the Nix sandbox runner) (issues #1595, #1760).
+	if st := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, "error", 5*time.Second); st != "error" {
 		t.Errorf("DB state after harness-pipe timeout = %q, want error", st)
 	}
 


### PR DESCRIPTION
Fixes the flake in `TestHostAPI_SurvivesHarnessPipeHandshakeFailure_NeverConnects`
described in #1760, and addresses the deeper race in `runStartupSocketPipe`'s
timeout path plus the FK constraint log line on the same failing run.

## What was broken

The harness-pipe startup timeout in `runStartupSocketPipe` collapsed two
distinct outcomes (timer fire / ctx cancel) into a single \`!ok\` boolean,
then checked \`ctx.Err()\` to decide whether to write \`state=error\`. Under
contended scheduling (\`-race\` on Linux CI) the timer fire and the test's
deferred ctx cancel can land in overlapping scheduling ticks; the legacy
code intermittently saw \`ctx.Err() != nil\` and skipped the state write,
leaving DB state as \"idle\" and tripping the test's assertion.

The failing CI run also showed \`FOREIGN KEY constraint failed (787)\` on a
\`state_change\` event insert. The sidecar mints/loads an \`instance_id\` and
writes it as \`agent_events.instance_id\` (FK → \`sessions.instance_id\`),
but the parent \`sessions\` row was only inserted by external callers
(\`tmux-session-start\`, \`SpawnSession\`) — never by the sidecar itself.

## What changed

**Production code (\`internal/sidecar/sidecar.go\`):**

1. \`acceptWithTimeout\` now returns \`(net.Conn, acceptOutcome)\` instead of
   \`(net.Conn, bool)\`. The four outcomes (connected / timed-out /
   ctx-canceled / listener-error) let the caller route each path
   correctly. The \`ctx.Done()\` case uses a wall-clock deadline check so
   that a timer fire which happens to lose Go's pseudo-random select
   race is still routed to \`acceptTimedOut\`.

2. The caller's switch on \`outcome\` performs the \`state=error\` write on
   the timeout path **without** consulting \`ctx.Err()\`. ctx cancellation
   no longer short-circuits the state write.

3. FK guard: after the existing instance_id mint/load block, the sidecar
   now calls \`InsertSession\` (INSERT OR IGNORE) for its current
   \`InstanceID\`. Production callers that already insert the row see a
   no-op; test contexts and ad-hoc bring-up paths get the row inserted
   inline, so downstream \`writeEvent\` calls never fail FK.

**Tests (\`internal/sidecar/sidecar_hostapi_bind_test.go\`):**

All four \`waitForState\` callsites in this file have their ceiling bumped
from 2s → 5s. The poll exits as soon as the state lands, so the generous
ceiling is essentially free on healthy runs and absorbs scheduler-induced
delays on race-detector CI.

## Verification

| Check | Result |
|---|---|
| \`go test ./internal/sidecar/... -race -count=100 -p 1\` (AC #2) | 100/100 PASS |
| \`go test ./internal/sidecar/... -race -count=100\` default parallelism (AC #2) | 100/100 PASS |
| \`go test ./...\` | PASS |
| \`nix build .#prism\` | PASS |
| \`nix build prism with runChecks=true\` (homeless-shelter sandbox) | PASS |

## AC tick

- [x] [functional] The \`state=error\` write in \`runStartupSocketPipe\`'s
      timeout path is robust to concurrent ctx cancellation — the
      outcome-based switch performs the write before/instead of any
      ctx.Err() check.
- [x] [functional] \`TestHostAPI_SurvivesHarnessPipeHandshakeFailure_NeverConnects\`
      passes 100/100 with both \`-race -count=100 -p 1\` and
      \`-race -count=100\` (default parallelism).
- [x] [edge-case] The \`FOREIGN KEY constraint failed\` log line is no
      longer present — the parent \`sessions\` row is inserted
      synchronously by the sidecar before any event write attempt.
- [x] [functional] Sibling tests using \`waitForState\` audited — all four
      callsites in this file have ceilings bumped from 2s to 5s.

Closes #1760