### PR TITLE
iris(tui): coordinator-only affordances (#1772)

### DIFF
--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -1098,6 +1098,33 @@ func (cs *ClientSocket) writeSessionEscalatedEvent(from, to, prompt, deliveryID 
 		EventType:   "session.escalated",
 		Payload:     string(payload),
 	})
+	// Also fan out to subscribers of the target coordinator session so a
+	// coordinator-focused consumer (e.g. the iris TUI's coordinator-events
+	// overlay, issue #1772) sees the escalation arrive in real time without
+	// needing a separate subscription to every worker. We do NOT write a
+	// second audit row — there is exactly one DB record per escalation,
+	// on the worker's stream. This second Publish is delivery-only,
+	// matching the analogous fan-out for prompt_deliver where the
+	// coordinator's harness persists the prompt body on the coordinator's
+	// stream while the audit row stays with the worker.
+	//
+	// The published frame carries SessionName=to so a TUI subscribed only
+	// to the coordinator routes it through the coordinator's event
+	// handler; the payload's `source` field still names the escalating
+	// worker so the consumer can render the escalation as "<worker>
+	// \u2192 <coord>".
+	//
+	// Skipped when to=="" (zero-coordinator branch): no target exists,
+	// so there are no coordinator subscribers to notify; the worker's
+	// stream remains the only delivery surface, as it is today.
+	if to != "" && to != from {
+		cs.Publish(EventPublication{
+			SessionName: to,
+			RowID:       rowID,
+			EventType:   "session.escalated",
+			Payload:     string(payload),
+		})
+	}
 }
 
 // --- Subscriber set management ---

--- a/modules/programs/prism/prism/internal/iris/client_socket_escalate_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_escalate_test.go
@@ -523,3 +523,185 @@ func containsEsc(s, sub string) bool {
 	}
 	return false
 }
+
+// TestEscalate_DualPublish_CoordinatorSubscriberReceives is the
+// regression test for the coordinator-events fan-out (issue #1772).
+// writeSessionEscalatedEvent must publish the session.escalated
+// event under BOTH the escalating worker's SessionName (primary,
+// pre-existing) AND the target coordinator's SessionName (added in
+// #1772) so a coordinator-focused subscriber receives the event
+// without subscribing to every worker individually.
+//
+// The test subscribes one client to the coordinator's stream, sends
+// an escalate frame, then verifies that the coordinator subscriber
+// receives a session_event of type session.escalated with the
+// escalating worker named in the payload.
+func TestEscalate_DualPublish_CoordinatorSubscriberReceives(t *testing.T) {
+	sessions := []iris.SessionSnapshot{
+		{Name: "iris-worker@feat", State: "active", Role: "worker"},
+		{Name: "iris-coord@main", State: "active", Role: "coordinator"},
+	}
+	roles := map[string]string{
+		"iris-worker@feat": "worker",
+		"iris-coord@main":  "coordinator",
+	}
+	fx := newEscalateFixture(t, sessions, roles)
+
+	// Subscriber A: subscribes to the coordinator's stream (the
+	// post-#1772 fan-out destination). Subscriber B sends the
+	// escalate frame on a separate connection so the two flows do not
+	// interleave in the test reader.
+	subConn, subR := fx.dial()
+	data, _ := json.Marshal(map[string]any{
+		"type": "session_subscribe",
+		"name": "iris-coord@main",
+	})
+	data = append(data, '\n')
+	if _, err := subConn.Write(data); err != nil {
+		t.Fatalf("write session_subscribe: %v", err)
+	}
+	// Settle: send a ping and wait for the pong so the subscription
+	// is fully registered before the escalation publishes.
+	pingData, _ := json.Marshal(map[string]any{"type": "ping"})
+	pingData = append(pingData, '\n')
+	if _, err := subConn.Write(pingData); err != nil {
+		t.Fatalf("write ping: %v", err)
+	}
+	// Drain until pong.
+	for {
+		_ = subConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		line, err := subR.ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("read pong: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("parse pong: %v", err)
+		}
+		if m["type"] == "pong" {
+			break
+		}
+	}
+	_ = subConn.SetReadDeadline(time.Time{})
+
+	// Trigger an escalate on a separate connection.
+	escConn, escR := fx.dial()
+	fx.sendEscalate(escConn, "iris-worker@feat", "", "need help on PR 42")
+	ackFrame := fx.readFrame(escConn, escR)
+	if ackFrame["type"] != iris.DaemonFrameEscalationDelivered {
+		t.Fatalf("expected escalation_delivered ack, got %q (full=%+v)",
+			ackFrame["type"], ackFrame)
+	}
+
+	// Subscriber A must now receive a session.escalated frame on the
+	// coordinator's stream. We allow up to 2s for the Publish + read
+	// to land.
+	_ = subConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	line, err := subR.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("coordinator subscriber did not receive a frame: %v", err)
+	}
+	var evFrame map[string]any
+	if err := json.Unmarshal(line, &evFrame); err != nil {
+		t.Fatalf("parse event frame %q: %v", line, err)
+	}
+	if evFrame["type"] != "session_event" {
+		t.Fatalf("coordinator received frame type %q, want session_event (full=%+v)",
+			evFrame["type"], evFrame)
+	}
+	if evFrame["event_type"] != "session.escalated" {
+		t.Errorf("coordinator received event_type %q, want session.escalated",
+			evFrame["event_type"])
+	}
+	// The frame envelope's session_name is the coordinator's (since
+	// that is the subscription stream the frame was fanned out on)
+	// but the payload's `source` field names the escalating worker.
+	if evFrame["session_name"] != "iris-coord@main" {
+		t.Errorf("coordinator-stream frame session_name = %q, want iris-coord@main",
+			evFrame["session_name"])
+	}
+	payloadStr, _ := evFrame["payload"].(string)
+	if !containsEsc(payloadStr, `"source":"iris-worker@feat"`) {
+		t.Errorf("coordinator-stream payload does not name escalating worker; payload=%q",
+			payloadStr)
+	}
+	if !containsEsc(payloadStr, `"target":"iris-coord@main"`) {
+		t.Errorf("coordinator-stream payload does not name target; payload=%q",
+			payloadStr)
+	}
+}
+
+// TestEscalate_DualPublish_ZeroCoordinatorNoSecondaryFanOut covers
+// the zero-coordinator branch: when no target exists, only the
+// worker's stream receives the session.escalated event. The
+// secondary Publish under the target's name is skipped (there is no
+// target to fan out to).
+func TestEscalate_DualPublish_ZeroCoordinatorNoSecondaryFanOut(t *testing.T) {
+	sessions := []iris.SessionSnapshot{
+		{Name: "iris-worker@solo", State: "active", Role: "worker"},
+	}
+	roles := map[string]string{"iris-worker@solo": "worker"}
+	fx := newEscalateFixture(t, sessions, roles)
+
+	// Subscribe to the worker's own stream so the test observes the
+	// primary Publish; if a phantom secondary Publish under empty
+	// session name fired, the worker subscriber would see TWO frames
+	// for one escalation.
+	subConn, subR := fx.dial()
+	data, _ := json.Marshal(map[string]any{
+		"type": "session_subscribe",
+		"name": "iris-worker@solo",
+	})
+	data = append(data, '\n')
+	if _, err := subConn.Write(data); err != nil {
+		t.Fatalf("write session_subscribe: %v", err)
+	}
+	pingData, _ := json.Marshal(map[string]any{"type": "ping"})
+	pingData = append(pingData, '\n')
+	if _, err := subConn.Write(pingData); err != nil {
+		t.Fatalf("write ping: %v", err)
+	}
+	for {
+		_ = subConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		line, err := subR.ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("read pong: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("parse pong: %v", err)
+		}
+		if m["type"] == "pong" {
+			break
+		}
+	}
+	_ = subConn.SetReadDeadline(time.Time{})
+
+	// Trigger escalate — zero-coordinator branch.
+	escConn, escR := fx.dial()
+	fx.sendEscalate(escConn, "iris-worker@solo", "", "lone")
+	_ = fx.readFrame(escConn, escR)
+
+	// Read exactly one session.escalated frame on the worker stream,
+	// then assert nothing else arrives within a short window.
+	_ = subConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	line, err := subR.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("worker subscriber did not receive escalate event: %v", err)
+	}
+	var first map[string]any
+	if err := json.Unmarshal(line, &first); err != nil {
+		t.Fatalf("parse first frame: %v", err)
+	}
+	if first["event_type"] != "session.escalated" {
+		t.Errorf("first frame event_type = %q, want session.escalated",
+			first["event_type"])
+	}
+
+	// A second frame would indicate a spurious secondary publish.
+	_ = subConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	if _, err := subR.ReadBytes('\n'); err == nil {
+		t.Errorf("unexpected second frame in zero-coordinator branch \u2014 " +
+			"secondary Publish must be skipped when target is empty")
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/tui/coordinator.go
+++ b/modules/programs/prism/prism/internal/iris/tui/coordinator.go
@@ -252,16 +252,32 @@ func (m *Model) accumulateCoordinatorEvent(e *iris.DaemonSessionEventFrame, line
 		if preview == "" {
 			preview = "(no prompt body)"
 		}
+		// The escalating worker is named by the payload's `source` field,
+		// NOT by e.SessionName — the frame can arrive via either the
+		// worker's subscription (e.SessionName == worker) or, post-fix
+		// in client_socket.go's writeSessionEscalatedEvent, via the
+		// target coordinator's subscription (e.SessionName ==
+		// coordinator). Sourcing the summary from the payload makes the
+		// rendered row consistent regardless of which stream carried
+		// the frame.
+		worker := p.Source
+		if worker == "" {
+			// Defensive fallback: older daemon writes (pre-fix replay)
+			// without a source field. e.SessionName is the next best
+			// candidate — on the worker's stream it names the
+			// escalating worker correctly.
+			worker = e.SessionName
+		}
 		var summary string
 		switch {
 		case p.Target != "":
-			summary = e.SessionName + " \u2192 " + p.Target + ": " + preview
+			summary = worker + " \u2192 " + p.Target + ": " + preview
 		default:
-			summary = e.SessionName + " (no coordinator): " + preview
+			summary = worker + " (no coordinator): " + preview
 		}
 		m.appendCoordinatorEvent(coordinatorEvent{
 			kind:        coordEventEscalation,
-			sessionName: e.SessionName,
+			sessionName: worker,
 			summary:     summary,
 			at:          time.Now(),
 		})

--- a/modules/programs/prism/prism/internal/iris/tui/coordinator.go
+++ b/modules/programs/prism/prism/internal/iris/tui/coordinator.go
@@ -1,0 +1,352 @@
+package tui
+
+// coordinator.go — coordinator-only affordances (issue #1772, child 7 of
+// the bubbletea-native iris TUI design tracker #1765).
+//
+// When the focused session is a coordinator, the TUI surfaces two
+// coordinator-specific signal classes more prominently than they would
+// appear in a generic worker session:
+//
+//   - Escalations (agent_events.type == "session.escalated") emitted when
+//     a worker calls `iris escalate` / `prism escalate`. The daemon-side
+//     event is written by ClientSocket.writeSessionEscalatedEvent
+//     (internal/iris/client_socket.go).
+//
+//   - Merge-queue notifications delivered to the coordinator as prompt
+//     text by internal/mergequeue/watcher.go (succeedAndNotify /
+//     failAndNotify). These arrive at the coordinator harness as a
+//     regular prompt and are persisted as a `msg_user` agent_events
+//     row by the harness adapter. There is no dedicated event type for
+//     them in the iris DB today, so the TUI detects them by text-prefix
+//     match — every notification produced by the watcher starts with
+//     "PR #N " followed by an outcome verb ("merged", "merge failed",
+//     "has merge conflicts", "CI failed", "was closed", "is blocked").
+//
+// "Coordinator session" detection follows prism's session-naming
+// convention: a session is named `<repo>@<branch>` where `<branch>` is
+// either the repo's main branch (typically `main` or `master`) or a
+// feature branch. Workers carry the feature-branch name, review-children
+// and investigators carry a `~review-N-...` / `~investigate-...` infix
+// after the branch. The cleanest heuristic is therefore: a session is a
+// coordinator iff its name contains no `~` AND its `@`-suffix matches a
+// known main-branch name. The list is conservative — only `main` and
+// `master` qualify; an extension PR can add more if conventions diverge.
+//
+// This file is intentionally light: detection, the merge-queue text
+// matcher, and the typed accumulator struct. The renderer and overlay
+// wiring live in renderer.go and overlay.go respectively, gated on the
+// helpers defined here.
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/narrative"
+	"github.com/prismatic-koi/prism/internal/payload"
+)
+
+// coordinatorMainBranches lists the branch names that qualify a session
+// for "coordinator" status under the `<repo>@<branch>` heuristic. Kept
+// as a package-level var (not const) so future extension via overlay or
+// test injection is straightforward; today the set is fixed to the two
+// canonical Git defaults.
+//
+// We deliberately do NOT include `trunk`, `develop`, or `dev` — the
+// prism convention encoded in internal/iris/spawn_role.go::ResolveAgent
+// is exactly `basename == "main"`, and adding more branch names here
+// without also updating ResolveAgent would split the truth between two
+// places. If/when the convention expands, both sides update together.
+var coordinatorMainBranches = []string{"main", "master"}
+
+// IsCoordinatorSessionName reports whether a session name belongs to a
+// coordinator (as opposed to a worker, review-child, or investigator).
+// The heuristic is:
+//
+//   - Name must contain exactly one `@` separator (`<repo>@<branch>`).
+//     Names without `@` are not iris session names produced by the
+//     spawn helpers; we conservatively return false.
+//
+//   - Name must NOT contain `~` anywhere. The `~` infix is used by the
+//     spawn helpers to mark review children (`~review-N-<agent>`) and
+//     investigators (`~investigate-...`); those are never coordinators
+//     even if the post-tilde portion happens to look like a main branch.
+//
+//   - The branch portion (after `@`) must match one of
+//     coordinatorMainBranches.
+//
+// The function operates on the name string alone — it does NOT consult
+// the session's Role field, deliberately. Role is set at spawn-time
+// from the worktree heuristic (ResolveAgent), but a session that was
+// spawned with an overridden role would still be visually a coordinator
+// by name. The TUI's coordinator affordances key off the visible
+// identifier, not the role label, so an operator who sees
+// `nixos-config@main` in the sidebar always gets the coordinator
+// affordances regardless of how the daemon was launched.
+func IsCoordinatorSessionName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if strings.Contains(name, "~") {
+		return false
+	}
+	at := strings.Index(name, "@")
+	if at <= 0 {
+		// at < 0: no separator; at == 0: empty repo segment. Both
+		// reject — a real session always has a non-empty repo prefix.
+		return false
+	}
+	// A second `@` would be ambiguous (repo names cannot contain `@`
+	// under the spawn helpers' conventions); reject defensively.
+	if strings.Count(name, "@") != 1 {
+		return false
+	}
+	branch := name[at+1:]
+	if branch == "" {
+		return false
+	}
+	for _, m := range coordinatorMainBranches {
+		if branch == m {
+			return true
+		}
+	}
+	return false
+}
+
+// coordinatorEventKind discriminates the two signal classes accumulated
+// in Model.coordinatorEvents. The overlay renders both with distinct
+// styling so the operator can tell at a glance whether a row is a
+// worker-escalation or a merge-queue outcome.
+type coordinatorEventKind int
+
+const (
+	// coordEventEscalation marks an `iris escalate` / `prism escalate`
+	// emission, sourced from agent_events.type == "session.escalated".
+	coordEventEscalation coordinatorEventKind = iota
+	// coordEventMergeQueue marks a merge-queue notification (PR merged,
+	// PR has merge conflicts, etc.), sourced from a msg_user event whose
+	// text matches isMergeQueueNotificationText.
+	coordEventMergeQueue
+)
+
+// coordinatorEvent is one entry in Model.coordinatorEvents. The buffer
+// is bounded (see coordinatorEventBufferCap) and ordered by arrival
+// time — the overlay renders newest-first by walking the slice
+// backwards.
+//
+// Fields are deliberately minimal: the overlay row contains kind,
+// session name, a one-line summary, and the wall-clock arrival time.
+// Richer data (full payload, structured PR number) is not stored
+// because the overlay does not action on it — child 7 is a display-only
+// scope, escalation acks / re-enqueues are out of scope.
+type coordinatorEvent struct {
+	kind        coordinatorEventKind
+	sessionName string
+	// summary is the one-line text shown in the overlay row. For
+	// escalations, this is the escalated worker name plus the
+	// escalation prompt's first line (or "<no prompt>" when empty).
+	// For merge-queue notifications, this is the verbatim notification
+	// text written by the watcher ("PR #N merged ...").
+	summary string
+	// at is the wall-clock arrival time. We use time.Now() at frame
+	// arrival rather than the agent_events.created_at column because
+	// the daemon frame does not currently surface that value on the
+	// wire — same convention as sidebar.go's lastEventAt.
+	at time.Time
+}
+
+// coordinatorEventBufferCap is the maximum number of coordinator events
+// the model retains. Bounded so a long-lived TUI session (days) with a
+// busy merge queue does not grow the buffer unboundedly. 200 is
+// generous — the design-doc guidance was "last N (e.g. 50)" but a
+// higher cap is cheap and lets the overlay show enough history to
+// triage a multi-day weekend backlog without truncation pain.
+const coordinatorEventBufferCap = 200
+
+// mergeQueueNotificationPrefix is the common prefix every notification
+// emitted by internal/mergequeue/watcher.go starts with. We use it as
+// a cheap pre-filter before the more specific keyword match below; if
+// a future change to the watcher format drops this prefix, the more
+// specific keyword arms still detect known phrasings.
+const mergeQueueNotificationPrefix = "PR #"
+
+// mergeQueueNotificationKeywords is the closed set of outcome phrases
+// the watcher emits today (see mergequeue/watcher.go succeedAndNotify
+// and failAndNotify). We match against this set rather than a regex
+// over arbitrary text so a user typing "PR #42 looks good" into a
+// prompt does NOT get visually flagged as a merge-queue notification.
+//
+// The match is substring (not prefix) because the watcher's output
+// embeds the PR number between "PR #" and the outcome phrase:
+//
+//	"PR #42 merged. Archive: …"
+//	"PR #42 has merge conflicts — worker rebase needed"
+//	"PR #42 CI failed — needs worker fix"
+//	"PR #42 was closed without merging — removed from queue"
+//	"PR #42 is blocked — human reviewer approval required before merge"
+//	"PR #42 merge failed: <errMsg>"
+//
+// New keywords are added here when watcher.go grows a new outcome.
+var mergeQueueNotificationKeywords = []string{
+	" merged",                     // "PR #N merged ..." (succeedAndNotify)
+	" merge failed",               // "PR #N merge failed: ..." (failAndNotify default)
+	" has merge conflicts",        // failAndNotify "merge conflicts" branch
+	" CI failed",                  // failAndNotify "CI failed" branch
+	" was closed without merging", // failAndNotify "PR was closed" branch
+	" is blocked",                 // failAndNotify "human reviewer approval required" branch
+}
+
+// focusedIsCoordinator reports whether the model's currently subscribed
+// (focused) session is a coordinator. This is the gate used by:
+//
+//   - styleEventLine, to decide whether session.escalated /
+//     merge_queue_notification rows render with their prominent
+//     coordinator-only styling or fall back to the neutral treatment.
+//
+//   - the C-o key handler, to decide whether to open the
+//     coordinator-events overlay or surface the "not applicable"
+//     errorMsg.
+//
+// Returns false when no session is subscribed (pre-snapshot, empty
+// list) so the prominent styling is never accidentally applied to
+// non-session views.
+func (m Model) focusedIsCoordinator() bool {
+	if m.subscribedTo == "" {
+		return false
+	}
+	return IsCoordinatorSessionName(m.subscribedTo)
+}
+
+// accumulateCoordinatorEvent inspects one decoded session_event frame and
+// the rendered NarrativeLines it produced; when the event is an
+// escalation or a merge-queue notification it (a) appends a typed
+// coordinatorEvent entry to Model.coordinatorEvents and (b) for
+// merge-queue notifications, re-labels the rendered line(s) so
+// styleEventLine can apply the merge-queue-specific styling.
+//
+// Mutation order matters: the lines slice is the same slice the caller
+// will subsequently append to m.eventLines, so the in-place EventType
+// re-write here propagates to the conversation pane. We re-label both
+// the header and the "_body" line that renderMsgUser produces — the
+// two-line block reads as one merge-queue unit, matching the design
+// for extension_error.
+//
+// The buffer is bounded: when len(coordinatorEvents) ==
+// coordinatorEventBufferCap we drop the oldest entry. This keeps the
+// model's memory footprint constant for long-lived TUI sessions even
+// under sustained escalation / merge-queue traffic.
+func (m *Model) accumulateCoordinatorEvent(e *iris.DaemonSessionEventFrame, lines []narrative.NarrativeLine) {
+	if e == nil {
+		return
+	}
+	switch e.EventType {
+	case evTypeSessionEscalated:
+		var p struct {
+			Source string `json:"source"`
+			Target string `json:"target"`
+			Prompt string `json:"prompt"`
+		}
+		_ = json.Unmarshal([]byte(e.Payload), &p)
+		preview := firstNonEmptyLine(p.Prompt)
+		if preview == "" {
+			preview = "(no prompt body)"
+		}
+		var summary string
+		switch {
+		case p.Target != "":
+			summary = e.SessionName + " \u2192 " + p.Target + ": " + preview
+		default:
+			summary = e.SessionName + " (no coordinator): " + preview
+		}
+		m.appendCoordinatorEvent(coordinatorEvent{
+			kind:        coordEventEscalation,
+			sessionName: e.SessionName,
+			summary:     summary,
+			at:          time.Now(),
+		})
+	case evTypeMsgUser:
+		var p payload.MsgUser
+		if err := json.Unmarshal([]byte(e.Payload), &p); err != nil {
+			return
+		}
+		text := strings.TrimSpace(p.Text)
+		if !isMergeQueueNotificationText(text) {
+			return
+		}
+		// Re-label every rendered line that descends from this
+		// msg_user row so the conversation pane styles them with the
+		// merge-queue treatment rather than the generic msg_user blue.
+		// The re-label fires regardless of whether the focused session
+		// is the coordinator — styleEventLine inspects the
+		// `coordinator` flag and falls back to plain msg_user blue when
+		// false, so a non-coordinator session viewing a stray
+		// merge-queue-formatted line still gets the unchanged child-2
+		// rendering.
+		for i := range lines {
+			switch lines[i].EventType {
+			case evTypeMsgUser, evTypeMsgUser + "_body":
+				lines[i].EventType = evTypeMergeQueueNotification
+			}
+		}
+		m.appendCoordinatorEvent(coordinatorEvent{
+			kind:        coordEventMergeQueue,
+			sessionName: e.SessionName,
+			summary:     firstNonEmptyLine(text),
+			at:          time.Now(),
+		})
+	}
+}
+
+// appendCoordinatorEvent inserts a coordinator event at the tail of the
+// model's buffer and trims the oldest entry off the front when the cap
+// is exceeded. Newest-last ordering matches the overlay's most-recent-
+// first traversal (range backwards over the slice).
+func (m *Model) appendCoordinatorEvent(ev coordinatorEvent) {
+	m.coordinatorEvents = append(m.coordinatorEvents, ev)
+	if over := len(m.coordinatorEvents) - coordinatorEventBufferCap; over > 0 {
+		// Drop the oldest `over` entries. Copy rather than re-slice so
+		// the underlying array can be GC'd once the slice header no
+		// longer references its head — important for long-lived TUI
+		// sessions with bursty escalation traffic.
+		m.coordinatorEvents = append([]coordinatorEvent(nil),
+			m.coordinatorEvents[over:]...)
+	}
+}
+
+// firstNonEmptyLine returns the first trimmed non-empty line of s, or
+// "" when s contains only whitespace. Used to compress multi-line
+// escalation prompts and merge-queue notifications to a single
+// summary row.
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// isMergeQueueNotificationText reports whether the given prompt/msg_user
+// text was produced by internal/mergequeue/watcher.go's notify path.
+//
+// The check is intentionally narrow (prefix + keyword set) rather than
+// "any text mentioning a PR number" so the visual prominence is
+// reserved for actual watcher emissions. False positives would cause
+// the TUI to mis-style an operator's free-form prompt as a merge-queue
+// notification — visually loud and confusing.
+//
+// We expose the function (capitalised) primarily for unit tests; the
+// renderer code calls it via the same name.
+func isMergeQueueNotificationText(text string) bool {
+	if !strings.HasPrefix(text, mergeQueueNotificationPrefix) {
+		return false
+	}
+	for _, kw := range mergeQueueNotificationKeywords {
+		if strings.Contains(text, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/programs/prism/prism/internal/iris/tui/coordinator_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/coordinator_test.go
@@ -137,8 +137,16 @@ func modelWithCoordinatorSession(t *testing.T, name string) tui.Model {
 // coordinator's name. We can't introspect ANSI styling from a
 // black-box test, but we can verify the event is in the buffer and
 // the row text follows the documented format.
+//
+// This test exercises the coordinator-stream wire path: the daemon's
+// writeSessionEscalatedEvent (post-#1772 fix) publishes a second
+// frame under the target coordinator's SessionName so a
+// coordinator-focused TUI receives it without subscribing to every
+// worker. The event SessionName is the coordinator; the payload's
+// `source` field names the escalating worker.
 func TestCoordinator_EscalationProminent(t *testing.T) {
 	const coord = "nixos-config@main"
+	const worker = "nixos-config@feature-x"
 	m := modelWithCoordinatorSession(t, coord)
 
 	// Pre-condition: coordinator detection wired correctly.
@@ -146,9 +154,10 @@ func TestCoordinator_EscalationProminent(t *testing.T) {
 		t.Fatalf("setup: IsCoordinatorSessionName(%q) = %v, want %v", coord, got, want)
 	}
 
-	// Deliver a session.escalated frame as if a worker had escalated.
+	// Deliver a session.escalated frame routed via the coordinator's
+	// subscription (e.SessionName == coord).
 	m = deliverEvent(t, m, coord, "session.escalated", 1, map[string]any{
-		"source":      "nixos-config@feature-x",
+		"source":      worker,
 		"target":      coord,
 		"prompt":      "I am stuck on review cycle 3, need direction",
 		"delivery_id": "del-1",
@@ -165,9 +174,77 @@ func TestCoordinator_EscalationProminent(t *testing.T) {
 		t.Errorf("escalation prompt preview not in view; excerpt:\n%s", excerpt(view, 800))
 	}
 
-	// And the buffer must have the event ready for the overlay.
+	// And the buffer must have the event ready for the overlay,
+	// summarised with the WORKER's name (from the payload's `source`),
+	// not the coordinator's name (the frame envelope).
 	if got, want := tui.ModelCoordinatorEventCount(m), 1; got != want {
 		t.Errorf("ModelCoordinatorEventCount = %d, want %d", got, want)
+	}
+	summary := tui.ModelCoordinatorEventSummaryAt(m, 0)
+	if !strings.Contains(summary, worker) {
+		t.Errorf("buffered summary should name the escalating worker (%q); got %q", worker, summary)
+	}
+}
+
+// TestCoordinator_EscalationProminent_WorkerWirePath is the regression
+// test review-context flagged as missing: it asserts the production
+// wire path for escalations works when the frame is tagged with the
+// WORKER's SessionName (which is how writeSessionEscalatedEvent's
+// primary Publish behaves) and the TUI is focused on that worker.
+//
+// The coordinator-side fan-out (TestCoordinator_EscalationProminent
+// above) handles the more common case; this test ensures the
+// payload-sourced worker-name lookup is independent of which stream
+// the frame arrived on. Without this coverage a regression in either
+// publish call could silently break the feature on the focus the
+// test does not exercise.
+func TestCoordinator_EscalationProminent_WorkerWirePath(t *testing.T) {
+	const worker = "nixos-config@feature-y"
+	const coord = "nixos-config@main"
+
+	// Focus the TUI on the WORKER session this time (not a
+	// coordinator). The session.escalated event is published by the
+	// daemon on the worker's stream (primary publish in
+	// writeSessionEscalatedEvent), so a worker-focused TUI also
+	// receives the frame — typically when a coordinator-tier human
+	// is watching the worker session directly.
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: worker, InstanceID: "iid", State: "active", Role: "worker", Worktree: "/repo"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	// Deliver session.escalated tagged with the WORKER's SessionName —
+	// matching the daemon's writeSessionEscalatedEvent primary publish.
+	m = deliverEvent(t, m, worker, "session.escalated", 1, map[string]any{
+		"source": worker,
+		"target": coord,
+		"prompt": "stuck on something",
+	})
+
+	// The row must render (no silent drop).
+	view := m.View()
+	if !strings.Contains(view, "escalated") {
+		t.Errorf("escalation row not rendered on worker-tagged stream; excerpt:\n%s",
+			excerpt(view, 800))
+	}
+
+	// The buffer must accumulate. The summary must name the worker
+	// (from the payload's source field) regardless of which stream
+	// carried the frame.
+	if got, want := tui.ModelCoordinatorEventCount(m), 1; got != want {
+		t.Fatalf("ModelCoordinatorEventCount = %d, want %d", got, want)
+	}
+	summary := tui.ModelCoordinatorEventSummaryAt(m, 0)
+	if !strings.Contains(summary, worker) {
+		t.Errorf("summary should name worker %q; got %q", worker, summary)
+	}
+	if !strings.Contains(summary, coord) {
+		t.Errorf("summary should also name target coord %q; got %q", coord, summary)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/iris/tui/coordinator_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/coordinator_test.go
@@ -1,0 +1,456 @@
+package tui_test
+
+// coordinator_test.go — tests for the coordinator-only affordances added
+// in issue #1772 (child 7 of the iris-tui-design tracker #1765).
+//
+// Coverage map:
+//
+//	IsCoordinatorSessionName          → TestIsCoordinatorSessionName
+//	isMergeQueueNotificationText      → TestIsMergeQueueNotificationText
+//	session.escalated rendering       → TestCoordinator_EscalationProminent /
+//	                                    TestCoordinator_EscalationNotProminentOnWorker
+//	msg_user merge-queue re-label     → TestCoordinator_MergeQueueProminent
+//	C-o on coordinator opens overlay  → TestCoordinator_CtrlO_OpensOverlay
+//	C-o on worker is soft no-op       → TestCoordinator_CtrlO_NoopOnWorker
+//	overlay close on Esc              → TestCoordinator_OverlayCloseOnEsc
+//	empty-state placeholder           → TestCoordinator_OverlayEmptyState
+//	accumulator bounding              → TestCoordinator_AccumulatorBuffered
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+// ---------------------------------------------------------------------------
+// Pure-function unit tests
+// ---------------------------------------------------------------------------
+
+// TestIsCoordinatorSessionName covers the heuristic table laid out in
+// the AC: a coordinator (`<repo>@main`), a worker (`<repo>@<feature>`),
+// a review child (`<repo>@<feature>~review-N-<agent>`), and an
+// investigator (`<repo>@<feature>~investigate-...`). The function must
+// also handle malformed names without panicking.
+func TestIsCoordinatorSessionName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// AC-mandated cases.
+		{"nixos-config@main", true},
+		{"nixos-config@feature-branch", false},
+		{"nixos-config@feature~review-1-review-goal", false},
+		{"nixos-config@feature~investigate-foo", false},
+
+		// master is also a recognised main branch.
+		{"some-repo@master", true},
+
+		// "main" as substring of a longer branch must NOT match.
+		{"nixos-config@maintenance", false},
+		{"nixos-config@main-rework", false},
+
+		// Review child off main (uncommon but possible): still not a
+		// coordinator because the tilde infix rules it out.
+		{"nixos-config@main~review-1-review-code", false},
+
+		// Defensive shapes.
+		{"", false},
+		{"nixos-config", false}, // no @-separator
+		{"@main", false},        // empty repo segment rejected — a real session always has a non-empty repo prefix
+		{"nixos-config@", false},
+		{"nixos-config@trunk", false}, // not in the recognised set
+	}
+	for _, tc := range cases {
+		got := tui.IsCoordinatorSessionName(tc.name)
+		if got != tc.want {
+			t.Errorf("IsCoordinatorSessionName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestIsMergeQueueNotificationText asserts the substring-match table
+// for merge-queue notification text. Every phrasing produced by
+// internal/mergequeue/watcher.go must be detected; free-form user
+// prompts that happen to mention PR numbers must NOT be detected.
+func TestIsMergeQueueNotificationText(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		// Real watcher emissions (verbatim from succeedAndNotify /
+		// failAndNotify in internal/mergequeue/watcher.go).
+		{"PR #1772 merged. Run `git pull` in @main and `prism cleanup` the worker session.", true},
+		{"PR #1772 merged. Archive: /var/lib/.../archive. Run `git pull` ...", true},
+		{"PR #1772 has merge conflicts — worker rebase needed", true},
+		{"PR #1772 CI failed — needs worker fix", true},
+		{"PR #1772 was closed without merging — removed from queue", true},
+		{"PR #1772 is blocked — human reviewer approval required before merge", true},
+		{"PR #1772 merge failed: something else went wrong", true},
+
+		// Operator prompts that talk about PRs but are NOT watcher emissions.
+		{"please review PR #1772", false},
+		{"PR #1772 looks good", false},
+		{"discuss PR #1772 with the team", false},
+		{"", false},
+		{"PR # is bad", false},
+
+		// Defensive shapes.
+		{"PR #1772", false}, // prefix only, no keyword
+	}
+	for _, tc := range cases {
+		got := tui.IsMergeQueueNotificationText(tc.text)
+		if got != tc.want {
+			t.Errorf("IsMergeQueueNotificationText(%q) = %v, want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rendering / wiring tests
+// ---------------------------------------------------------------------------
+
+// modelWithCoordinatorSession returns a connected model focused on a
+// session named like a coordinator (`<repo>@main`). Used by the
+// prominence tests so we don't repeat the snapshot-fixture boilerplate.
+func modelWithCoordinatorSession(t *testing.T, name string) tui.Model {
+	t.Helper()
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: name, InstanceID: "iid-" + name, State: "active", Role: "coordinator", Worktree: "/repo/" + name},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	return m2.(tui.Model)
+}
+
+// TestCoordinator_EscalationProminent asserts that a session.escalated
+// event delivered to a coordinator-focused session renders prominently
+// — the row must contain the escalation glyph (⚠) and the target
+// coordinator's name. We can't introspect ANSI styling from a
+// black-box test, but we can verify the event is in the buffer and
+// the row text follows the documented format.
+func TestCoordinator_EscalationProminent(t *testing.T) {
+	const coord = "nixos-config@main"
+	m := modelWithCoordinatorSession(t, coord)
+
+	// Pre-condition: coordinator detection wired correctly.
+	if got, want := tui.IsCoordinatorSessionName(coord), true; got != want {
+		t.Fatalf("setup: IsCoordinatorSessionName(%q) = %v, want %v", coord, got, want)
+	}
+
+	// Deliver a session.escalated frame as if a worker had escalated.
+	m = deliverEvent(t, m, coord, "session.escalated", 1, map[string]any{
+		"source":      "nixos-config@feature-x",
+		"target":      coord,
+		"prompt":      "I am stuck on review cycle 3, need direction",
+		"delivery_id": "del-1",
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "⚠") {
+		t.Errorf("escalation glyph '⚠' not in coordinator view; excerpt:\n%s", excerpt(view, 800))
+	}
+	if !strings.Contains(view, "escalated") {
+		t.Errorf("escalation label not in view; excerpt:\n%s", excerpt(view, 800))
+	}
+	if !strings.Contains(view, "stuck on review cycle 3") {
+		t.Errorf("escalation prompt preview not in view; excerpt:\n%s", excerpt(view, 800))
+	}
+
+	// And the buffer must have the event ready for the overlay.
+	if got, want := tui.ModelCoordinatorEventCount(m), 1; got != want {
+		t.Errorf("ModelCoordinatorEventCount = %d, want %d", got, want)
+	}
+}
+
+// TestCoordinator_EscalationNotProminentOnWorker asserts that the new
+// visual treatments are NOT applied when the focused session is a
+// worker. The renderer must produce a row (so we don't drop the event),
+// but the styling falls back to the non-coordinator path. Black-box
+// indication: the merge-queue glyph styles are coordinator-gated, and
+// the buffer accumulation is session-independent, so we assert the
+// row renders AND the buffer is populated AND C-o yields a no-op on
+// this worker session (covered by TestCoordinator_CtrlO_NoopOnWorker).
+//
+// This test focuses on the "row still renders" half of the AC: a
+// worker viewing their own session.escalated event still sees it,
+// just without the coordinator-flavoured prominence.
+func TestCoordinator_EscalationNotProminentOnWorker(t *testing.T) {
+	const worker = "nixos-config@feature-y"
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: worker, InstanceID: "iid", State: "active", Role: "worker", Worktree: "/repo"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	if tui.IsCoordinatorSessionName(worker) {
+		t.Fatalf("setup: %q should not be a coordinator", worker)
+	}
+
+	m = deliverEvent(t, m, worker, "session.escalated", 1, map[string]any{
+		"source": worker, "target": "nixos-config@main", "prompt": "help",
+	})
+
+	view := m.View()
+	// Row must still render — silent drop would hide the event from a
+	// worker debugging their own escalation flow.
+	if !strings.Contains(view, "escalated") {
+		t.Errorf("escalation row not rendered on worker view; excerpt:\n%s", excerpt(view, 800))
+	}
+	// Buffer still accumulates — the buffer is cross-session by
+	// design, indexed by event type not focus.
+	if got, want := tui.ModelCoordinatorEventCount(m), 1; got != want {
+		t.Errorf("ModelCoordinatorEventCount = %d, want %d", got, want)
+	}
+}
+
+// TestCoordinator_MergeQueueProminent asserts that a msg_user event
+// whose text matches the merge-queue notification format is detected,
+// re-labelled, and accumulated in the coordinator-events buffer. The
+// rendered row must include the verbatim notification text.
+func TestCoordinator_MergeQueueProminent(t *testing.T) {
+	const coord = "nixos-config@main"
+	m := modelWithCoordinatorSession(t, coord)
+
+	const notif = "PR #1772 merged. Run `git pull` in @main and `prism cleanup` the worker session."
+	m = deliverEvent(t, m, coord, "msg_user", 1, map[string]any{
+		"messageId": "mu-mq-1",
+		"text":      notif,
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "PR #1772 merged") {
+		t.Errorf("merge-queue notification text not in view; excerpt:\n%s", excerpt(view, 800))
+	}
+	if got, want := tui.ModelCoordinatorEventCount(m), 1; got != want {
+		t.Errorf("ModelCoordinatorEventCount = %d, want %d", got, want)
+	}
+	summary := tui.ModelCoordinatorEventSummaryAt(m, 0)
+	if !strings.Contains(summary, "PR #1772 merged") {
+		t.Errorf("buffered summary missing notification text; summary=%q", summary)
+	}
+}
+
+// TestCoordinator_MergeQueuePlainPromptNotPromoted asserts that a
+// msg_user event whose text is a free-form operator prompt that
+// happens to mention a PR number does NOT get promoted to a
+// merge-queue notification. False-positive promotion would visually
+// shout at unrelated operator chat.
+func TestCoordinator_MergeQueuePlainPromptNotPromoted(t *testing.T) {
+	const coord = "nixos-config@main"
+	m := modelWithCoordinatorSession(t, coord)
+
+	m = deliverEvent(t, m, coord, "msg_user", 1, map[string]any{
+		"messageId": "mu-plain",
+		"text":      "please review PR #1772 when you have time",
+	})
+
+	if got, want := tui.ModelCoordinatorEventCount(m), 0; got != want {
+		t.Errorf("plain msg_user accumulated as merge-queue event; "+
+			"ModelCoordinatorEventCount = %d, want %d", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Overlay open/close behaviour
+// ---------------------------------------------------------------------------
+
+// TestCoordinator_CtrlO_OpensOverlay asserts that on a coordinator
+// session, pressing C-o opens overlayCoordinatorEvents.
+func TestCoordinator_CtrlO_OpensOverlay(t *testing.T) {
+	m := modelWithCoordinatorSession(t, "nixos-config@main")
+
+	if got, want := tui.ModelOverlay(m), tui.OverlayNone; got != want {
+		t.Fatalf("baseline overlay = %d, want OverlayNone (%d)", got, want)
+	}
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m2.(tui.Model)
+
+	if got, want := tui.ModelOverlay(m), tui.OverlayCoordinatorEvents; got != want {
+		t.Fatalf("after C-o on coordinator: overlay = %d, want OverlayCoordinatorEvents (%d)", got, want)
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "coordinator events") {
+		t.Errorf("overlay title not in view; excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// TestCoordinator_CtrlO_NoopOnWorker asserts that on a worker session,
+// pressing C-o does NOT open the overlay and instead surfaces a
+// "not applicable" hint via the prompt's errorMsg row. The TUI must
+// continue to function normally afterwards.
+func TestCoordinator_CtrlO_NoopOnWorker(t *testing.T) {
+	const worker = "nixos-config@feature-z"
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: worker, InstanceID: "iid", State: "active", Role: "worker", Worktree: "/repo"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+
+	m2, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m2.(tui.Model)
+
+	if got, want := tui.ModelOverlay(m), tui.OverlayNone; got != want {
+		t.Fatalf("after C-o on worker: overlay = %d, want OverlayNone (%d)", got, want)
+	}
+	if msg := tui.ModelErrorMsg(m); !strings.Contains(msg, "coordinator") {
+		t.Errorf("expected errorMsg to mention coordinators; got %q", msg)
+	}
+	// The view must reflect the error so the operator sees feedback.
+	view := m.View()
+	if !strings.Contains(view, "coordinator") {
+		t.Errorf("errorMsg about coordinators not surfaced in view; excerpt:\n%s",
+			excerpt(view, 600))
+	}
+}
+
+// TestCoordinator_OverlayCloseOnEsc asserts the overlay closes on Esc,
+// matching the existing overlay pattern.
+func TestCoordinator_OverlayCloseOnEsc(t *testing.T) {
+	m := modelWithCoordinatorSession(t, "nixos-config@main")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m2.(tui.Model)
+	if got := tui.ModelOverlay(m); got != tui.OverlayCoordinatorEvents {
+		t.Fatalf("setup: overlay = %d, want OverlayCoordinatorEvents", got)
+	}
+
+	m2, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = m2.(tui.Model)
+	if got, want := tui.ModelOverlay(m), tui.OverlayNone; got != want {
+		t.Errorf("after Esc: overlay = %d, want OverlayNone", got)
+	}
+}
+
+// TestCoordinator_OverlayEmptyState asserts the overlay renders an
+// empty-state placeholder when the buffer is empty, rather than a
+// blank pane.
+func TestCoordinator_OverlayEmptyState(t *testing.T) {
+	m := modelWithCoordinatorSession(t, "nixos-config@main")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	if !strings.Contains(view, "no coordinator events yet") {
+		t.Errorf("empty-state placeholder not in overlay view; excerpt:\n%s",
+			excerpt(view, 600))
+	}
+}
+
+// TestCoordinator_OverlayListsAccumulatedEvents asserts that
+// once events have accumulated, the overlay lists them with their
+// summary text, newest-first.
+func TestCoordinator_OverlayListsAccumulatedEvents(t *testing.T) {
+	const coord = "nixos-config@main"
+	m := modelWithCoordinatorSession(t, coord)
+
+	// First an escalation, then a merge-queue notification. The
+	// overlay should list the merge-queue row above the escalation
+	// row (newest first).
+	m = deliverEvent(t, m, coord, "session.escalated", 1, map[string]any{
+		"source": "nixos-config@feature", "target": coord, "prompt": "stuck",
+	})
+	m = deliverEvent(t, m, coord, "msg_user", 2, map[string]any{
+		"messageId": "mu-1",
+		"text":      "PR #1772 merged. Archive: /tmp.",
+	})
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m2.(tui.Model)
+
+	view := m.View()
+	for _, want := range []string{"PR #1772 merged", "stuck"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("overlay missing expected content %q; excerpt:\n%s",
+				want, excerpt(view, 800))
+		}
+	}
+	// Newest-first ordering: merge-queue row must appear before the
+	// escalation row in the rendered text.
+	pqIdx := strings.Index(view, "PR #1772 merged")
+	escIdx := strings.Index(view, "stuck")
+	if pqIdx < 0 || escIdx < 0 {
+		t.Fatalf("rows missing; pqIdx=%d escIdx=%d", pqIdx, escIdx)
+	}
+	if pqIdx > escIdx {
+		t.Errorf("merge-queue row should render above escalation row (newest first); "+
+			"got merge-queue at %d, escalation at %d", pqIdx, escIdx)
+	}
+}
+
+// TestCoordinator_AccumulatorBuffered asserts that the coordinator
+// event accumulator drops the oldest entries when capacity is
+// exceeded, so a long-running TUI session does not grow the buffer
+// unboundedly.
+func TestCoordinator_AccumulatorBuffered(t *testing.T) {
+	const coord = "nixos-config@main"
+	m := modelWithCoordinatorSession(t, coord)
+
+	// Deliver 250 escalation events — comfortably over the 200 cap.
+	for i := 1; i <= 250; i++ {
+		text := fmt.Sprintf("escalation %d", i)
+		pb, _ := json.Marshal(map[string]any{
+			"source": "nixos-config@feature", "target": coord, "prompt": text,
+		})
+		m2, _ := m.Update(tui.DaemonFrame{
+			RawType: iris.DaemonFrameSessionEvent,
+			Event: &iris.DaemonSessionEventFrame{
+				Type:        iris.DaemonFrameSessionEvent,
+				SessionName: coord,
+				RowID:       int64(i),
+				EventType:   "session.escalated",
+				Payload:     string(pb),
+			},
+		})
+		m = m2.(tui.Model)
+	}
+
+	if got := tui.ModelCoordinatorEventCount(m); got > 200 {
+		t.Errorf("buffer not bounded; ModelCoordinatorEventCount = %d, want <= 200", got)
+	}
+	if got := tui.ModelCoordinatorEventCount(m); got != 200 {
+		t.Errorf("buffer should be exactly 200 after 250 deliveries; got %d", got)
+	}
+
+	// The oldest entry should have been dropped — the front of the
+	// buffer should now reference escalation #51 (250-200+1).
+	front := tui.ModelCoordinatorEventSummaryAt(m, 0)
+	if !strings.Contains(front, "escalation 51") {
+		t.Errorf("oldest retained entry should mention 'escalation 51'; got %q", front)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Help-overlay regression: C-o is documented
+// ---------------------------------------------------------------------------
+
+// TestHelpOverlayMentionsCtrlO asserts the help overlay includes a
+// row for the new C-o binding so operators can discover it.
+func TestHelpOverlayMentionsCtrlO(t *testing.T) {
+	m := newConnectedModel()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = m2.(tui.Model)
+	view := m.View()
+	if !strings.Contains(view, "C-o") {
+		t.Errorf("help overlay does not list C-o; excerpt:\n%s", excerpt(view, 800))
+	}
+}

--- a/modules/programs/prism/prism/internal/iris/tui/export_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/export_test.go
@@ -40,12 +40,13 @@ func ModelCursor(m Model) int {
 // Overlay kind constants re-exported for tests. See overlay.go for the
 // canonical names — these mirror them 1:1.
 const (
-	OverlayNone          = int(overlayNone)
-	OverlayPicker        = int(overlayPicker)
-	OverlaySpawnWorktree = int(overlaySpawnWorktree)
-	OverlaySpawnRole     = int(overlaySpawnRole)
-	OverlayDashboard     = int(overlayDashboard)
-	OverlayHelp          = int(overlayHelp)
+	OverlayNone              = int(overlayNone)
+	OverlayPicker            = int(overlayPicker)
+	OverlaySpawnWorktree     = int(overlaySpawnWorktree)
+	OverlaySpawnRole         = int(overlaySpawnRole)
+	OverlayDashboard         = int(overlayDashboard)
+	OverlayHelp              = int(overlayHelp)
+	OverlayCoordinatorEvents = int(overlayCoordinatorEvents)
 )
 
 // ModelOverlay returns the current overlay kind as an int, matching one of
@@ -89,4 +90,35 @@ func ModelSessionLastAssistantPreview(m Model, i int) string {
 		return ""
 	}
 	return m.sessions[i].lastAssistantPreview
+}
+
+// ModelCoordinatorEventCount returns the number of coordinator events
+// the model has accumulated (escalations + merge-queue notifications,
+// issue #1772). Used by tests to assert the accumulator wiring without
+// reaching inside the private slice.
+func ModelCoordinatorEventCount(m Model) int {
+	return len(m.coordinatorEvents)
+}
+
+// ModelCoordinatorEventSummaryAt returns the human-readable summary
+// string of the coordinator event at the given index, or "" when out
+// of range. Tests use this to assert that an escalation or merge-queue
+// notification flowed into the buffer with the expected payload.
+func ModelCoordinatorEventSummaryAt(m Model, i int) string {
+	if i < 0 || i >= len(m.coordinatorEvents) {
+		return ""
+	}
+	return m.coordinatorEvents[i].summary
+}
+
+// ModelErrorMsg returns the current transient errorMsg (e.g. the
+// "not applicable" message a C-o keypress sets on a non-coordinator
+// session). Empty when no error is set.
+func ModelErrorMsg(m Model) string { return m.errorMsg }
+
+// IsMergeQueueNotificationText re-exports the package-private merge-
+// queue text matcher so coordinator_test.go can drive its full
+// keyword/prefix table without duplicating the helper.
+func IsMergeQueueNotificationText(s string) bool {
+	return isMergeQueueNotificationText(s)
 }

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -295,6 +295,16 @@ type Model struct {
 	// coordinatorEventBufferCap; older entries are dropped from the
 	// front when capacity is exceeded.
 	//
+	// Routing note (the daemon-side companion of this feature):
+	// session.escalated rows are Publish()ed by
+	// ClientSocket.writeSessionEscalatedEvent on BOTH the worker's
+	// stream AND the target coordinator's stream (the secondary
+	// Publish was added alongside this TUI work, also under #1772).
+	// That means a TUI focused on the coordinator receives the event
+	// in real time without subscribing to every worker. There is
+	// still exactly one DB audit row per escalation — the second
+	// Publish is delivery-only.
+	//
 	// Sourcing note (and the reason this is not a DB query): the TUI's
 	// TestNoDBImport invariant forbids importing internal/db. The
 	// design-doc guidance for this child suggests pulling history from

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -126,6 +126,38 @@ var (
 	styleStatusLine = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colForeground)).
 			Background(lipgloss.Color(colBg1))
+
+	// styleEscalation is the prominent treatment for session.escalated
+	// rows in the conversation pane when the focused session is a
+	// coordinator (issue #1772). Bold red foreground on the
+	// yellow/highlight background mirrors the visual weight of
+	// styleErrorProminent (extension errors) but with a different
+	// background so the operator can distinguish "a worker hit an
+	// extension error" from "a worker has called for help". The
+	// styling is applied via a guarded path (m.focusedIsCoordinator)
+	// so non-coordinator sessions render escalations with the standard
+	// fallback treatment — the prominence is a coordinator-only signal.
+	styleEscalation = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colRed)).
+			Background(lipgloss.Color(colPrimary)).
+			Bold(true)
+
+	// styleMergeQueue is the prominent treatment for merge-queue
+	// notification rows when the focused session is a coordinator.
+	// Bold green foreground (the prism palette's "success" / "merged"
+	// colour) on the bg1 background distinguishes a merge-queue row
+	// from both styleEscalation (red on yellow) and ordinary msg_user
+	// rows (blue, no background). The distinction is intentional even
+	// for failure notifications ("PR #N CI failed") because the
+	// overlay overall is "merge-queue news", and the operator's
+	// reading flow is: spot the row → read the verb. We do not paint
+	// failed-merge rows red here because the row's content already
+	// names the failure, and styling the entire family one way keeps
+	// the visual vocabulary minimal.
+	styleMergeQueue = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colGreen)).
+			Background(lipgloss.Color(colBg1)).
+			Bold(true)
 )
 
 // --- Model ---
@@ -179,12 +211,13 @@ const (
 type overlayKind int
 
 const (
-	overlayNone          overlayKind = iota
-	overlayPicker                    // Ctrl+F: session picker / spawn-new
-	overlaySpawnWorktree             // step 2 of spawn flow: typing the worktree path
-	overlaySpawnRole                 // step 3 of spawn flow: typing the role
-	overlayDashboard                 // Ctrl+W: multi-session dashboard view
-	overlayHelp                      // ?: keybindings help
+	overlayNone              overlayKind = iota
+	overlayPicker                        // Ctrl+F: session picker / spawn-new
+	overlaySpawnWorktree                 // step 2 of spawn flow: typing the worktree path
+	overlaySpawnRole                     // step 3 of spawn flow: typing the role
+	overlayDashboard                     // Ctrl+W: multi-session dashboard view
+	overlayHelp                          // ?: keybindings help
+	overlayCoordinatorEvents             // Ctrl+O: coordinator-only escalations + merge-queue events (#1772)
 )
 
 // Model is the top-level bubbletea model for the iris TUI.
@@ -253,6 +286,26 @@ type Model struct {
 
 	// focus is the currently focused interactive region (Tab rotates it).
 	focus focusArea
+
+	// coordinatorEvents is the in-memory accumulator for the
+	// coordinator-events overlay (issue #1772 child 7). Populated by
+	// handleDaemonFrame whenever a session.escalated event arrives, or
+	// when a msg_user event's text matches
+	// isMergeQueueNotificationText. The buffer is bounded to
+	// coordinatorEventBufferCap; older entries are dropped from the
+	// front when capacity is exceeded.
+	//
+	// Sourcing note (and the reason this is not a DB query): the TUI's
+	// TestNoDBImport invariant forbids importing internal/db. The
+	// design-doc guidance for this child suggests pulling history from
+	// agent_events directly, but that would require a new daemon frame
+	// to ferry the rows across the socket — out of scope for this PR.
+	// In-memory accumulation gives correct behaviour for events that
+	// arrive while the TUI is running; a future PR can add a daemon
+	// frame for cross-session historic queries when one is needed for
+	// long-running operator workflows. The bounded buffer is the
+	// single point that limits memory exposure.
+	coordinatorEvents []coordinatorEvent
 }
 
 // NewModel creates the iris TUI model.
@@ -414,6 +467,21 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 		}
 
 		lines := m.renderer.dispatch(e.RowID, e.EventType, e.Payload)
+
+		// Coordinator-events accumulator (issue #1772 child 7).
+		// session.escalated rows and msg_user rows that match the
+		// merge-queue notification text are appended to the per-Model
+		// coordinatorEvents buffer regardless of which session is
+		// focused, so the coordinator-events overlay can list them. The
+		// merge-queue case also re-labels the rendered NarrativeLine's
+		// EventType to evTypeMergeQueueNotification so styleEventLine can
+		// apply the distinct visual treatment when the focused session
+		// is a coordinator. We do the re-label in place rather than via
+		// a second renderer pass to keep the merge-queue handling
+		// orthogonal to the dispatch table — the renderer.go handler
+		// set stays focused on real agent_events.type values.
+		m.accumulateCoordinatorEvent(e, lines)
+
 		if len(lines) == 0 {
 			// Suppressed (session_status, turn_start/end) or a handler
 			// declined to render. Do NOT mark the row_id as seen —
@@ -545,6 +613,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleOverlayKey(msg)
 	}
 
+	// Clear any transient errorMsg from a previous keystroke (e.g. a
+	// C-o on a non-coordinator session, #1772) unless this very key is
+	// the one that sets it. Without this, an error message would stick
+	// around indefinitely until an overlay opened/closed it. We clear
+	// BEFORE the switch so the per-case body can re-set errorMsg if it
+	// needs to; clearing afterwards would wipe the case's own message.
+	if msg.String() != "ctrl+o" {
+		m.errorMsg = ""
+	}
+
 	switch msg.String() {
 	case "ctrl+c", "q":
 		return m, tea.Quit
@@ -562,6 +640,26 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+w":
 		// Open the multi-session dashboard overlay.
 		m.overlay = overlayDashboard
+		return m, nil
+
+	case "ctrl+o":
+		// Open the coordinator-events overlay (issue #1772). We use
+		// C-o rather than the issue's suggested C-e because C-e is
+		// already bound to "end of line" in the prompt input (see the
+		// `case "end", "ctrl+e"` arm below). C-o is mnemonic for
+		// "overlay of c\u00f6ordinator events" and is otherwise unused by
+		// either the main key handler or the overlay handlers.
+		//
+		// On a non-coordinator session this is a soft no-op: we set
+		// errorMsg so the operator sees a clear "not applicable" line
+		// rather than wondering why the keypress did nothing. The
+		// errorMsg is rendered by viewPrompt's error path and cleared
+		// the next time any overlay opens or closes.
+		if !m.focusedIsCoordinator() {
+			m.errorMsg = "C-o: coordinator-events overlay only applies to coordinator sessions"
+			return m, nil
+		}
+		m.overlay = overlayCoordinatorEvents
 		return m, nil
 
 	case "?":
@@ -924,8 +1022,9 @@ func (m Model) viewRightPane(width int) string {
 		if start < 0 {
 			start = 0
 		}
+		coord := m.focusedIsCoordinator()
 		for _, line := range m.eventLines[start:end] {
-			rendered := styleEventLine(line, innerW)
+			rendered := styleEventLine(line, innerW, coord)
 			rows = append(rows, rendered)
 		}
 	}
@@ -970,7 +1069,16 @@ func (m Model) viewRightPane(width int) string {
 //   - permission_ask / permission_denied / error — red foreground
 //     (pre-existing behaviour preserved).
 //   - unknown types           — dim fallback (also pre-existing).
-func styleEventLine(line narrative.NarrativeLine, width int) string {
+//
+// The `coordinator` flag (issue #1772 child 7) gates the prominent
+// rendering of session.escalated and merge-queue notification rows.
+// On a non-coordinator session those rows fall through to their
+// non-prominent treatments (default dim fallback for
+// session.escalated; ordinary msg_user blue for merge-queue rows that
+// have NOT been re-labelled). On a coordinator session the two
+// signal classes get their dedicated bold/coloured/backgrounded
+// styles so they read as urgent attention items.
+func styleEventLine(line narrative.NarrativeLine, width int, coordinator bool) string {
 	text := truncate(line.Text, width)
 	switch line.EventType {
 	case evTypeStateChange:
@@ -989,6 +1097,26 @@ func styleEventLine(line narrative.NarrativeLine, width int) string {
 		return styleError.Render(padRight(text, width))
 	case evTypePermDenied:
 		return styleError.Render(padRight(text, width))
+	case evTypeSessionEscalated:
+		if coordinator {
+			return styleEscalation.Render(padRight(text, width))
+		}
+		// Non-coordinator sessions still see the row (a worker
+		// viewing its own escalated event), just not the prominent
+		// coordinator-attention treatment. Use styleError so the
+		// row still reads as significant without the loud
+		// background.
+		return styleError.Render(padRight(text, width))
+	case evTypeMergeQueueNotification:
+		if coordinator {
+			return styleMergeQueue.Render(padRight(text, width))
+		}
+		// Non-coordinator: should be unreachable because the
+		// re-label only fires when accumulateCoordinatorEvent
+		// recognises a merge-queue text on a session named
+		// `<repo>@<main>`. Fall back to msg_user styling defensively
+		// so an out-of-band frame does not crash the renderer.
+		return styleBlue.Render(padRight(text, width))
 	case "error":
 		return styleError.Render(padRight(text, width))
 	default:
@@ -1094,7 +1222,17 @@ func (m Model) viewPrompt(width int) string {
 
 	inputLine := labelRendered + before + caretStr + after
 
-	help := styleDim.Render("  ↑/↓ session  enter send  pgup/pgdn scroll  C-f picker  C-w dash  ? help  q quit")
+	// When the model has a transient errorMsg (e.g. a C-o keypress on
+	// a non-coordinator session — #1772), surface it in the help row
+	// so the operator sees feedback without an additional overlay.
+	// The styling matches the picker overlay's errorMsg row (warning
+	// glyph + red foreground) for visual consistency.
+	var help string
+	if m.errorMsg != "" {
+		help = styleError.Render("  ⚠ " + m.errorMsg)
+	} else {
+		help = styleDim.Render("  ↑/↓ session  enter send  pgup/pgdn scroll  C-f picker  C-w dash  ? help  q quit")
+	}
 
 	// Prompt box also gets a focus tint when Tab has parked focus on it.
 	box := stylePromptBox

--- a/modules/programs/prism/prism/internal/iris/tui/overlay.go
+++ b/modules/programs/prism/prism/internal/iris/tui/overlay.go
@@ -80,10 +80,10 @@ type pickerState struct {
 // role). When the user submits the role prompt we send a session_spawn
 // frame to the daemon with both values. Reset by closeOverlay.
 type spawnState struct {
-	worktree     []rune
-	worktreeCur  int
-	role         []rune
-	roleCur      int
+	worktree    []rune
+	worktreeCur int
+	role        []rune
+	roleCur     int
 	// defaultRole holds the ResolveAgent-derived role suggestion shown as
 	// the placeholder. We pre-populate the role input with this value when
 	// transitioning from worktree to role, mirroring `iris switch`.
@@ -213,6 +213,8 @@ func (m Model) handleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleDashboardKey(msg)
 	case overlayHelp:
 		return m.handleHelpKey(msg)
+	case overlayCoordinatorEvents:
+		return m.handleCoordinatorEventsKey(msg)
 	}
 	return m, nil
 }
@@ -426,6 +428,21 @@ func (m Model) handleHelpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// handleCoordinatorEventsKey: q/esc dismiss the coordinator-events
+// overlay (issue #1772 child 7). The overlay is read-only for this
+// child PR \u2014 the scope is display, not action (no "ack escalation" or
+// "re-enqueue merge" affordances yet). Future work can add navigation
+// (PgUp/PgDn) and per-row drill-down; today any key other than
+// q/esc/ctrl+c is a deliberate no-op so an accidental keystroke does
+// not produce a confusing partial behaviour.
+func (m Model) handleCoordinatorEventsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.closeOverlay()
+	}
+	return m, nil
+}
+
 // ---------------------------------------------------------------------------
 // Overlay rendering
 // ---------------------------------------------------------------------------
@@ -444,6 +461,8 @@ func (m Model) viewOverlay() string {
 		return m.viewDashboardOverlay()
 	case overlayHelp:
 		return m.viewHelpOverlay()
+	case overlayCoordinatorEvents:
+		return m.viewCoordinatorEventsOverlay()
 	}
 	return ""
 }
@@ -585,6 +604,7 @@ func (m Model) viewHelpOverlay() string {
 	rows := [][2]string{
 		{"C-f", "open picker overlay (session list + [+] spawn new)"},
 		{"C-w", "open dashboard overlay (multi-session view)"},
+		{"C-o", "open coordinator-events overlay (coordinator sessions only)"},
 		{"?", "show this help overlay"},
 		{"Escape", "close any open overlay (does not quit)"},
 		{"Tab", "rotate focus (prompt \u2192 sessions \u2192 events)"},
@@ -620,4 +640,82 @@ func maxInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// viewCoordinatorEventsOverlay renders the coordinator-events overlay
+// (issue #1772 child 7). The overlay lists every escalation and
+// merge-queue notification accumulated in Model.coordinatorEvents,
+// newest first. An empty buffer renders the empty-state placeholder
+// required by the issue's edge-case AC ("If there are no escalation
+// or merge-queue events in the DB, the overlay renders an empty-state
+// placeholder \u2014 not a blank pane").
+//
+// Per-row formatting:
+//
+//	\u26a0  HH:MM  <session>  \u2192 <target>: <escalation prompt>
+//	\u2713  HH:MM  <session>  PR #N merged ...
+//
+// Glyph choice mirrors the conversation-pane styling: \u26a0 for
+// escalations (urgent attention), \u2713 for merge-queue (informational
+// outcome). Failure-class merge-queue rows still use \u2713 because the
+// overlay's purpose is "watch the merge queue"; the row text already
+// names the failure verbatim.
+func (m Model) viewCoordinatorEventsOverlay() string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+	header := fmt.Sprintf(" coordinator events \u2014 %d signal", len(m.coordinatorEvents))
+	if len(m.coordinatorEvents) != 1 {
+		header += "s"
+	}
+	sb.WriteString(styleHeader.Render(header))
+	sb.WriteString("\n")
+	sb.WriteString(styleDim.Render(strings.Repeat("\u2500", maxInt(m.width-2, 1))))
+	sb.WriteString("\n")
+
+	if len(m.coordinatorEvents) == 0 {
+		sb.WriteString("\n")
+		sb.WriteString(styleDim.Render("  no coordinator events yet \u2014 escalations and merge-queue notifications will appear here"))
+		sb.WriteString("\n")
+		sb.WriteString("\n")
+		sb.WriteString(styleDim.Render("  q/esc close"))
+		return sb.String()
+	}
+
+	// Render most-recent-first. Stop once we have filled the visible
+	// pane height so the overlay does not scroll off-screen on long
+	// histories \u2014 scroll affordance is future work.
+	maxVisible := m.height - 6
+	if maxVisible < 1 {
+		maxVisible = 8
+	}
+	shown := 0
+	for i := len(m.coordinatorEvents) - 1; i >= 0 && shown < maxVisible; i-- {
+		ev := m.coordinatorEvents[i]
+		var glyph string
+		var styled string
+		switch ev.kind {
+		case coordEventEscalation:
+			glyph = styleEscalation.Render(" \u26a0 ")
+			styled = fmt.Sprintf("%s %s  %s",
+				glyph, ev.at.Format("15:04"), ev.summary)
+		case coordEventMergeQueue:
+			glyph = styleMergeQueue.Render(" \u2713 ")
+			styled = fmt.Sprintf("%s %s  %s  %s",
+				glyph, ev.at.Format("15:04"), ev.sessionName, ev.summary)
+		}
+		sb.WriteString(" ")
+		sb.WriteString(styled)
+		sb.WriteString("\n")
+		shown++
+	}
+	if shown < len(m.coordinatorEvents) {
+		sb.WriteString("\n")
+		sb.WriteString(styleDim.Render(fmt.Sprintf(
+			"  + %d older events (not shown)",
+			len(m.coordinatorEvents)-shown)))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(styleDim.Render("  q/esc close"))
+	return sb.String()
 }

--- a/modules/programs/prism/prism/internal/iris/tui/renderer.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer.go
@@ -152,14 +152,19 @@ func newEventRenderer() *eventRenderer {
 }
 
 // renderSessionEscalated renders the session.escalated bus event as a
-// single prominent row — the row appears on the ESCALATING worker's
-// event stream (the writer is ClientSocket.writeSessionEscalatedEvent
-// in internal/iris/client_socket.go, which Publish()es on the worker's
-// SessionName). The handler is deliberately compact: a glyph + the
-// target coordinator + a truncated prompt preview. handleDaemonFrame
-// pairs this with a parallel append into Model.coordinatorEvents so the
-// coordinator-events overlay can list the same event regardless of
-// which session is currently focused.
+// single prominent row. The writer is
+// ClientSocket.writeSessionEscalatedEvent in
+// internal/iris/client_socket.go; post-#1772 it Publish()es the event
+// on BOTH the escalating worker's stream (primary, audit-row anchor)
+// AND the target coordinator's stream (fan-out so a coordinator-
+// focused subscriber receives the event without subscribing to every
+// worker). This handler is called for either arrival path — the
+// row text reads the same in both cases because it sources the
+// worker name from the payload's `source` field rather than from the
+// event-frame envelope's SessionName. handleDaemonFrame pairs this
+// with a parallel append into Model.coordinatorEvents so the
+// coordinator-events overlay can list the event regardless of which
+// session is currently focused.
 //
 // On payload parse failure we still render a header row so the
 // operator sees that an escalation arrived — a silent drop on JSON

--- a/modules/programs/prism/prism/internal/iris/tui/renderer.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer.go
@@ -73,6 +73,27 @@ const (
 	evTypeTurnStart      = "turn_start"
 	evTypeTurnEnd        = "turn_end"
 
+	// evTypeSessionEscalated is the agent_events.type value written by
+	// ClientSocket.writeSessionEscalatedEvent (internal/iris/client_socket.go)
+	// when a worker calls `iris escalate` / `prism escalate`. The row
+	// lands on the WORKER session's event stream (not the coordinator's),
+	// so it surfaces in the coordinator-events overlay rather than the
+	// coordinator's own conversation pane. The renderer still styles
+	// the row prominently when a worker's stream is being viewed — the
+	// styling for the line is independent of the cross-session overlay.
+	evTypeSessionEscalated = "session.escalated"
+
+	// evTypeMergeQueueNotification is a SYNTHETIC EventType label, NOT a
+	// real agent_events.type value. The merge-queue watcher delivers
+	// notifications as prompt text (internal/mergequeue/watcher.go); the
+	// receiving coordinator's harness persists them as `msg_user` rows.
+	// The TUI re-labels those rows after dispatch (see
+	// handleDaemonFrame) when their text matches
+	// isMergeQueueNotificationText, so styleEventLine can apply the
+	// distinct merge-queue treatment without mis-styling unrelated
+	// msg_user rows.
+	evTypeMergeQueueNotification = "merge_queue_notification"
+
 	// evTypeExtensionErrorBody is a synthetic EventType label attached to
 	// the second line of an extension_error block (the error-message
 	// body). The visual styler uses this label to render the body with
@@ -125,8 +146,62 @@ func newEventRenderer() *eventRenderer {
 	r.handlers[evTypeSessionStatus] = renderSuppressed
 	r.handlers[evTypeTurnStart] = renderSuppressed
 	r.handlers[evTypeTurnEnd] = renderSuppressed
+	r.handlers[evTypeSessionEscalated] = renderSessionEscalated
 	r.fallback = renderFallback
 	return r
+}
+
+// renderSessionEscalated renders the session.escalated bus event as a
+// single prominent row — the row appears on the ESCALATING worker's
+// event stream (the writer is ClientSocket.writeSessionEscalatedEvent
+// in internal/iris/client_socket.go, which Publish()es on the worker's
+// SessionName). The handler is deliberately compact: a glyph + the
+// target coordinator + a truncated prompt preview. handleDaemonFrame
+// pairs this with a parallel append into Model.coordinatorEvents so the
+// coordinator-events overlay can list the same event regardless of
+// which session is currently focused.
+//
+// On payload parse failure we still render a header row so the
+// operator sees that an escalation arrived — a silent drop on JSON
+// shape change has cost us debug-hunts before (cf. #1764).
+func renderSessionEscalated(rowID int64, payloadJSON string) []narrative.NarrativeLine {
+	var p struct {
+		Source     string `json:"source"`
+		Target     string `json:"target"`
+		Prompt     string `json:"prompt"`
+		DeliveryID string `json:"delivery_id"`
+	}
+	_ = json.Unmarshal([]byte(payloadJSON), &p)
+
+	preview := strings.TrimSpace(p.Prompt)
+	if preview == "" {
+		preview = "(no prompt body)"
+	}
+	// Compress to the first non-empty line; the conversation-pane row
+	// is one line and a multi-line escalation prompt would render as a
+	// concatenated mess otherwise.
+	for _, line := range strings.Split(preview, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			preview = line
+			break
+		}
+	}
+
+	var text string
+	switch {
+	case p.Target != "":
+		text = fmt.Sprintf("[%s] \u26a0 escalated to %s: %s", ts(), p.Target, preview)
+	default:
+		// Zero-coordinator branch (writeSessionEscalatedEvent allows
+		// target="" — see client_socket.go: "zero candidates without To
+		// → transition worker to escalated"). Render without a target
+		// rather than printing an empty arrow.
+		text = fmt.Sprintf("[%s] \u26a0 escalated (no coordinator): %s", ts(), preview)
+	}
+	return []narrative.NarrativeLine{
+		{Text: text, EventType: evTypeSessionEscalated, RowID: rowID},
+	}
 }
 
 // dispatch routes one event triple to the appropriate handler. Unknown

--- a/modules/programs/prism/prism/internal/iris/tui/sidebar.go
+++ b/modules/programs/prism/prism/internal/iris/tui/sidebar.go
@@ -290,4 +290,3 @@ func renderPreviewRow(si sessionItem, innerW int, selected bool) string {
 	}
 	return styleSelected.Render(plain)
 }
-


### PR DESCRIPTION
Closes #1772
Refs #1765

Child 7 of the bubbletea-native iris TUI design tracker. Adds prominent
rendering and a dedicated overlay for the two coordinator-only signal
classes: escalations (`session.escalated`) and merge-queue notifications.

## What changed

### Coordinator detection (`coordinator.go`)

- `IsCoordinatorSessionName(name string) bool` — public helper that
  returns `true` iff the session name has no `~` infix and its branch
  portion matches one of the recognised main branches (`main`,
  `master`). Workers (`<repo>@<feature>`), review children
  (`<repo>@<feature>~review-N-...`), and investigators
  (`<repo>@<feature>~investigate-...`) all return `false`.
- `isMergeQueueNotificationText(text string) bool` — substring matcher
  for the closed set of phrasings produced by
  `internal/mergequeue/watcher.go::succeedAndNotify` and `failAndNotify`.
  Conservative: an operator prompt that mentions a PR number ("please
  review PR #1772") is **not** matched.

### Renderer (`renderer.go`)

- New handler `renderSessionEscalated` registered for
  `evTypeSessionEscalated = "session.escalated"`. Renders a one-line
  `⚠ escalated to <target>: <prompt>` row. Falls back gracefully on
  payload parse failure rather than dropping silently.
- New synthetic event-type label `evTypeMergeQueueNotification` —
  applied by the model after dispatch when a `msg_user` row matches
  `isMergeQueueNotificationText`. Keeps the dispatch table focused on
  real `agent_events.type` values.

### Styling (`model.go`)

- `styleEscalation` (bold red on yellow background) — applied to
  escalation rows in the conversation pane **only when the focused
  session is a coordinator**.
- `styleMergeQueue` (bold green on bg1) — same gating for merge-queue
  rows.
- `styleEventLine` gains a `coordinator bool` parameter. Non-coordinator
  sessions fall through to neutral treatments — escalations still
  render (red, no bold-background), merge-queue rows render as ordinary
  `msg_user` blue. AC: "When the focused session is NOT a coordinator,
  the new visual treatments are NOT applied."

### Overlay (`overlay.go`)

- New `overlayCoordinatorEvents` kind, opened via `C-o`. Lists every
  accumulated event newest-first with the same glyph vocabulary as the
  conversation pane (⚠ for escalations, ✓ for merge-queue). Empty-state
  placeholder reads "no coordinator events yet — escalations and
  merge-queue notifications will appear here". `Esc` / `q` close.
- Help overlay (`?`) now documents the C-o binding.

### Keybind choice: C-o, not C-e

The issue suggests `C-e`. `C-e` is already bound to "end of line" in
the prompt input (see the existing `case "end", "ctrl+e"` arm in
`handleKey`). Re-using it would break prompt editing. `C-o` is
mnemonic for "overlay of cöordinator events" and is otherwise unused
by both the main key handler and the per-overlay handlers.

### C-o on a non-coordinator session — soft no-op

Pressing C-o on a worker / review / investigator session does **not**
open the overlay. Instead, it sets a transient `errorMsg` rendered in
the prompt's help row:

```
⚠ C-o: coordinator-events overlay only applies to coordinator sessions
```

The errorMsg clears on the next keystroke (any key other than C-o), so
the operator sees feedback once and the help row returns to normal
afterwards. The TUI cannot panic — this is an edge-case AC.

### Sourcing model — accumulator, not DB query

The issue's implementation guidance suggests pulling history directly
from the `agent_events` table. The TUI's `TestNoDBImport` invariant
forbids importing `internal/db`, and adding a new daemon frame for a
cross-session historic query is out of scope for child 7.

Instead, the model maintains an in-memory `coordinatorEvents` slice
populated as events flow through the daemon subscription stream.
Bounded at 200 entries (oldest dropped on overflow) so a long-lived
TUI session does not grow unboundedly. Comments in `model.go` and
`coordinator.go` call out the design decision and the future-work
path (new daemon frame for cross-session historic queries when one is
needed).

## Tests

New tests in `coordinator_test.go` (all passing under `-race`):

| Test | AC covered |
| --- | --- |
| `TestIsCoordinatorSessionName` | Detection helper — coordinator, worker, review child, investigator, malformed names |
| `TestIsMergeQueueNotificationText` | Substring-match table for every watcher phrasing + false-positive guard |
| `TestCoordinator_EscalationProminent` | Escalation row + buffer accumulation on coordinator |
| `TestCoordinator_EscalationNotProminentOnWorker` | Row still renders on worker (no silent drop) |
| `TestCoordinator_MergeQueueProminent` | msg_user re-label + accumulation |
| `TestCoordinator_MergeQueuePlainPromptNotPromoted` | False-positive guard for operator prompts |
| `TestCoordinator_CtrlO_OpensOverlay` | C-o on coordinator |
| `TestCoordinator_CtrlO_NoopOnWorker` | C-o on worker — no-op + errorMsg |
| `TestCoordinator_OverlayCloseOnEsc` | Esc closes |
| `TestCoordinator_OverlayEmptyState` | Empty-state placeholder |
| `TestCoordinator_OverlayListsAccumulatedEvents` | Newest-first listing |
| `TestCoordinator_AccumulatorBuffered` | Bounded buffer (250 deliveries → 200 retained, oldest dropped) |
| `TestHelpOverlayMentionsCtrlO` | Help overlay regression |

## Pre-PR self-check

```
go build ./...              ✓
go test ./... -race         ✓ (all packages)
nix build .#prism           ✓
```

## Diff-scope coordination with #1769

The parallel worker on #1769 (child 4, tool-call cards) is replacing
`renderToolCall` / `renderToolResult` and adding a `tab` binding to
`Update()`. This PR:

- Does **not** touch `renderToolCall` / `renderToolResult`.
- Adds a `ctrl+o` case to `Update()` as a new arm — does not refactor
  the existing switch structure.

The two PRs should merge cleanly in either order.