### PR TITLE
iris-tui: tool-call cards + pi 0.72.1 payload shape fix (#1769 + #1783)

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin_raw.go
+++ b/modules/programs/prism/prism/cmd/checkin_raw.go
@@ -156,6 +156,27 @@ func renderCheckinEventsRaw(session string, d *db.DB, events []db.Event, verbose
 	return nil
 }
 
+// displayArgs returns a human-readable string for a tool_call's
+// args field. Post-#1783 Args is a json.RawMessage; when it's a
+// JSON string literal we unwrap the quotes (so `"echo hi"` displays
+// as `echo hi`), otherwise we echo the raw JSON. Empty / null
+// inputs degrade to an empty string. Pure-string fallback preserves
+// pre-#1783 forensic output for unrecognised tool shapes.
+func displayArgs(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+	s := string(args)
+	if s == "null" {
+		return ""
+	}
+	var unquoted string
+	if err := json.Unmarshal(args, &unquoted); err == nil {
+		return unquoted
+	}
+	return s
+}
+
 // renderChildEvent prints a single child event using the legacy raw-event style.
 // Used by renderCheckinEventsRaw (--types path) and renderProxiedCheckin.
 // prefix is prepended before the leading spaces (used for subagent indentation).
@@ -167,11 +188,11 @@ func renderChildEvent(eventType, rawPayload string, verbose bool, prefix string)
 			fmt.Printf("%s  → (tool_call parse error)\n", prefix)
 			return
 		}
-		args := p.Args
+		args := displayArgs(p.Args)
 		if !verbose && len(args) > 80 {
 			args = args[:80] + "..."
 		}
-		fmt.Printf("%s  → %s: %s [✓]\n", prefix, p.Tool, args)
+		fmt.Printf("%s  → %s: %s [✓]\n", prefix, p.Name, args)
 
 	case "tool_result":
 		var p payload.ToolResult
@@ -179,7 +200,7 @@ func renderChildEvent(eventType, rawPayload string, verbose bool, prefix string)
 			fmt.Printf("%s  → (tool_result parse error)\n", prefix)
 			return
 		}
-		result := p.Result
+		result := p.Output
 		if !verbose && len(result) > 80 {
 			result = result[:80] + "..."
 		}
@@ -238,7 +259,7 @@ func renderChildEventVerbose(eventType, rawPayload string, prefix string) {
 			fmt.Printf("%s  → (tool_call parse error)\n", prefix)
 			return
 		}
-		fmt.Printf("%s  → %s: %s\n", prefix, p.Tool, p.Args)
+		fmt.Printf("%s  → %s: %s\n", prefix, p.Name, displayArgs(p.Args))
 
 	case "tool_result":
 		var p payload.ToolResult
@@ -246,7 +267,7 @@ func renderChildEventVerbose(eventType, rawPayload string, prefix string) {
 			fmt.Printf("%s  → (tool_result parse error)\n", prefix)
 			return
 		}
-		fmt.Printf("%s  → result: %s\n", prefix, p.Result)
+		fmt.Printf("%s  → result: %s\n", prefix, p.Output)
 
 	case "permission_ask":
 		var p payload.PermissionAsk
@@ -302,26 +323,28 @@ func renderChildEventVerbose(eventType, rawPayload string, prefix string) {
 // Tool results are matched positionally to tool calls of the same tool name
 // within the message. Permission and thinking events are rendered as before.
 func renderChildEventsDefault(children []childEventItem, prefix string) {
-	// Split children into tool_calls, tool_results (by tool name for pairing),
+	// Split children into tool_calls, tool_results (by id for pairing),
 	// and other events (permission_ask, permission_denied, thinking).
 	//
-	// Pairing strategy: maintain a per-tool FIFO queue of results. When we
-	// encounter a tool_call for tool T, dequeue the next result for T (if any).
-	// This handles the common case where results appear in the same order as calls.
+	// Post-#1783 pairing strategy: payload.ToolCall and ToolResult
+	// share an `id` field (the extension's toolCallId). Pair on id.
+	// A tool_result whose id has no matching tool_call (e.g. parent
+	// scrolled out) is rendered as an orphan line beneath the tool
+	// calls, preserving the previous unpaired-result rendering.
 	type toolCallEntry struct {
+		id      string
 		tool    string
 		args    string
 		payload string
 	}
 	type toolResultEntry struct {
-		tool    string
-		result  string
-		payload string
+		id     string
+		result string
 	}
 
-	// Collect tool calls and results in order.
 	var toolCalls []toolCallEntry
-	resultsByTool := make(map[string][]toolResultEntry)
+	resultByID := make(map[string]toolResultEntry)
+	var orphanResults []toolResultEntry
 
 	// Also collect other events in order (permission_ask, permission_denied, thinking)
 	// to be rendered after the tool one-liners.
@@ -336,34 +359,37 @@ func renderChildEventsDefault(children []childEventItem, prefix string) {
 		case "tool_call":
 			var p payload.ToolCall
 			if err := json.Unmarshal([]byte(c.payload), &p); err == nil {
-				toolCalls = append(toolCalls, toolCallEntry{tool: p.Tool, args: p.Args, payload: c.payload})
-				// Pre-index result slot (will be filled when result arrives).
+				toolCalls = append(toolCalls, toolCallEntry{id: p.ID, tool: p.Name, args: string(p.Args), payload: c.payload})
 			} else {
-				toolCalls = append(toolCalls, toolCallEntry{tool: "?", args: "", payload: c.payload})
+				toolCalls = append(toolCalls, toolCallEntry{id: "", tool: "?", args: "", payload: c.payload})
 			}
 		case "tool_result":
 			var p payload.ToolResult
 			if err := json.Unmarshal([]byte(c.payload), &p); err == nil {
-				resultsByTool[p.Tool] = append(resultsByTool[p.Tool], toolResultEntry{tool: p.Tool, result: p.Result, payload: c.payload})
+				entry := toolResultEntry{id: p.ID, result: p.Output}
+				if p.ID != "" {
+					resultByID[p.ID] = entry
+				} else {
+					orphanResults = append(orphanResults, entry)
+				}
 			}
 		default:
 			others = append(others, otherEvent{c.eventType, c.payload})
 		}
 	}
 
-	// Render tool one-liners, consuming results from the per-tool FIFO queue.
-	usedResults := make(map[string]int) // tool → count consumed
+	// Render tool one-liners. Pair each call with its id-matched
+	// result. A call with no matching result renders alone
+	// (in-flight); a result with no matching call appears in the
+	// orphanResults slice below.
+	pairedIDs := make(map[string]bool, len(toolCalls))
 	for _, tc := range toolCalls {
-		// Dequeue the next result for this tool.
-		resultList := resultsByTool[tc.tool]
-		usedIdx := usedResults[tc.tool]
 		var resultSummary string
-		if usedIdx < len(resultList) {
-			resultSummary = toolResultSummary(tc.tool, resultList[usedIdx].result)
-			usedResults[tc.tool] = usedIdx + 1
-		} else {
-			// No result available (still running or not recorded).
-			resultSummary = ""
+		if tc.id != "" {
+			if tr, ok := resultByID[tc.id]; ok {
+				resultSummary = toolResultSummary(tc.tool, tr.result)
+				pairedIDs[tc.id] = true
+			}
 		}
 
 		keyArg := toolKeyArg(tc.tool, tc.args)
@@ -377,6 +403,19 @@ func renderChildEventsDefault(children []childEventItem, prefix string) {
 		default:
 			fmt.Printf("%s  → %s\n", prefix, tc.tool)
 		}
+	}
+
+	// Render orphan results (no matching tool_call observed in this
+	// turn window). Use the generic summariser since we have no
+	// tool-name context.
+	for _, tr := range orphanResults {
+		fmt.Printf("%s  ↳ result (orphan): %s\n", prefix, toolResultSummary("", tr.result))
+	}
+	for id, tr := range resultByID {
+		if pairedIDs[id] {
+			continue
+		}
+		fmt.Printf("%s  ↳ result (orphan): %s\n", prefix, toolResultSummary("", tr.result))
 	}
 
 	// Render other events (permission_ask, permission_denied, thinking).

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -8,6 +8,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -88,14 +89,75 @@ func userPayload(msgID, text string) string {
 	return fmt.Sprintf(`{"messageId":%q,"text":%q}`, msgID, text)
 }
 
-// toolCallPayload returns a minimal tool_call JSON payload.
+// toolCallPayload returns a tool_call JSON payload combining the
+// post-#1783 pi-extension wire shape ({name, id, args}) with a
+// synthetic `messageId` field carrying the same id.
+//
+// Why the synthetic messageId: `internal/db/events.go::QueryEventsByMessageIDs`
+// uses `JSON_EXTRACT(payload, '$.messageId')` to fetch child events
+// (tool_call/tool_result) for an assistant turn. The pi prism
+// extension does NOT emit a parent-message linkage on its
+// tool_call/tool_result frames — the per-call `id` it emits is the
+// toolCallId, NOT the parent assistant messageId. That mismatch is a
+// pre-existing bug separate from #1783's field-rename scope (see
+// coordinator escalation 2026-05-17). For tests we inject the
+// synthetic field so the SQL pushdown can still locate children;
+// production output is unchanged from its pre-#1783 broken state
+// until the secondary-query path is reworked.
+//
+// The args input is loose — it may be:
+//   - empty ("") — emitted as JSON null;
+//   - a JSON value literal (starts with `{`, `[`, `"`, `t`, `f`, `n`,
+//     or a digit / minus) — inlined verbatim so call sites can pass
+//     `{"filePath":"..."}` as-is;
+//   - any other bare string — JSON-string-encoded so it survives as
+//     a string-typed args field (matching the consumer's fallback
+//     parsing in extractBashCommand / extractStringField).
 func toolCallPayload(msgID, tool, args string) string {
-	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"args":%q}`, msgID, tool, args)
+	var argsJSON string
+	switch {
+	case args == "":
+		argsJSON = "null"
+	case isJSONValueLiteral(args):
+		argsJSON = args
+	default:
+		b, _ := json.Marshal(args)
+		argsJSON = string(b)
+	}
+	return fmt.Sprintf(`{"name":%q,"id":%q,"messageId":%q,"args":%s}`, tool, msgID, msgID, argsJSON)
 }
 
-// toolResultPayload returns a minimal tool_result JSON payload.
+// isJSONValueLiteral returns true when s looks like a JSON value
+// literal (object, array, string, bool, null, number). Heuristic only
+// — used by toolCallPayload to decide whether to inline verbatim or
+// JSON-encode as a string. The check is on the first non-whitespace
+// byte; that's enough for the test-fixture use cases.
+func isJSONValueLiteral(s string) bool {
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		switch r {
+		case '{', '[', '"', 't', 'f', 'n', '-':
+			return true
+		}
+		if r >= '0' && r <= '9' {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// toolResultPayload returns a tool_result JSON payload combining the
+// post-#1783 pi-extension wire shape ({id, success, output}) with a
+// synthetic `messageId` field carrying the same id. See
+// toolCallPayload for the rationale on the synthetic field.
+// `tool` is accepted for backward-compat with existing call sites
+// but is no longer part of the wire format; it is silently dropped.
 func toolResultPayload(msgID, tool, result string) string {
-	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"result":%q}`, msgID, tool, result)
+	_ = tool
+	return fmt.Sprintf(`{"id":%q,"messageId":%q,"success":true,"output":%q}`, msgID, msgID, result)
 }
 
 // permAskPayload returns a minimal permission_ask JSON payload.

--- a/modules/programs/prism/prism/cmd/checkin_tools.go
+++ b/modules/programs/prism/prism/cmd/checkin_tools.go
@@ -113,12 +113,21 @@ func toolKeyArg(tool, args string) string {
 		return ""
 
 	default:
-		// Generic: first ~80 chars of raw args.
-		if len([]rune(args)) > 80 {
-			runes := []rune(args)
+		// Post-#1783: payload.ToolCall.Args is a JSON RawMessage,
+		// so a string-typed args arrives here with its JSON quotes
+		// intact (e.g. `"main.go"`). Strip the quoting via
+		// json.Unmarshal so the generic-tool fallback matches the
+		// pre-#1783 behaviour for unrecognised tools.
+		display := args
+		var s string
+		if err := json.Unmarshal([]byte(args), &s); err == nil {
+			display = s
+		}
+		if len([]rune(display)) > 80 {
+			runes := []rune(display)
 			return string(runes[:80]) + "..."
 		}
-		return args
+		return display
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/iris/checkin.go
+++ b/modules/programs/prism/prism/cmd/iris/checkin.go
@@ -428,7 +428,11 @@ type childItem struct {
 func renderChildEvents(w io.Writer, children []childItem, verbose bool) {
 	// First pass: collect tool_result payloads by messageId so we can
 	// fold them into their matching tool_call rendering.
-	resultByMsgID := make(map[string]payload.ToolResult, len(children))
+	// resultByID maps payload.ToolResult.ID → the parsed result.
+	// Post-#1783 the wire field is `id` (not `messageId`); pairing
+	// semantics are unchanged — we still match the tool_call's
+	// equivalent id field.
+	resultByID := make(map[string]payload.ToolResult, len(children))
 	for _, c := range children {
 		if c.eventType != "tool_result" {
 			continue
@@ -437,12 +441,12 @@ func renderChildEvents(w io.Writer, children []childItem, verbose bool) {
 		if err := json.Unmarshal([]byte(c.payload), &tr); err != nil {
 			continue
 		}
-		if tr.MessageID != "" {
-			resultByMsgID[tr.MessageID] = tr
+		if tr.ID != "" {
+			resultByID[tr.ID] = tr
 		}
 	}
 
-	seenResultMsgIDs := make(map[string]bool, len(resultByMsgID))
+	seenResultIDs := make(map[string]bool, len(resultByID))
 
 	for _, c := range children {
 		switch c.eventType {
@@ -453,29 +457,29 @@ func renderChildEvents(w io.Writer, children []childItem, verbose bool) {
 				continue
 			}
 			if verbose {
-				fmt.Fprintf(w, "  → %s\n", tc.Tool)
-				fmt.Fprintf(w, "    args: %s\n", tc.Args)
-				if tr, ok := resultByMsgID[tc.MessageID]; ok {
-					fmt.Fprintf(w, "    result: %s\n", tr.Result)
-					seenResultMsgIDs[tc.MessageID] = true
+				fmt.Fprintf(w, "  → %s\n", tc.Name)
+				fmt.Fprintf(w, "    args: %s\n", string(tc.Args))
+				if tr, ok := resultByID[tc.ID]; ok {
+					fmt.Fprintf(w, "    result: %s\n", tr.Output)
+					seenResultIDs[tc.ID] = true
 				}
 				continue
 			}
-			key := narrative.ToolKeyArg(tc.Tool, tc.Args)
-			if tr, ok := resultByMsgID[tc.MessageID]; ok {
-				summary := narrative.ToolResultSummary(tc.Tool, tr.Result)
+			key := narrative.ToolKeyArg(tc.Name, tc.Args)
+			if tr, ok := resultByID[tc.ID]; ok {
+				summary := narrative.ToolResultSummary(tc.Name, tr.Output)
 				if key != "" {
-					fmt.Fprintf(w, "  → %s: %s %s\n", tc.Tool, key, summary)
+					fmt.Fprintf(w, "  → %s: %s %s\n", tc.Name, key, summary)
 				} else {
-					fmt.Fprintf(w, "  → %s %s\n", tc.Tool, summary)
+					fmt.Fprintf(w, "  → %s %s\n", tc.Name, summary)
 				}
-				seenResultMsgIDs[tc.MessageID] = true
+				seenResultIDs[tc.ID] = true
 			} else {
 				// No result yet (in-flight) — render the call alone.
 				if key != "" {
-					fmt.Fprintf(w, "  → %s: %s\n", tc.Tool, key)
+					fmt.Fprintf(w, "  → %s: %s\n", tc.Name, key)
 				} else {
-					fmt.Fprintf(w, "  → %s\n", tc.Tool)
+					fmt.Fprintf(w, "  → %s\n", tc.Name)
 				}
 			}
 		case "tool_result":
@@ -484,14 +488,16 @@ func renderChildEvents(w io.Writer, children []childItem, verbose bool) {
 			if err := json.Unmarshal([]byte(c.payload), &tr); err != nil {
 				continue
 			}
-			if seenResultMsgIDs[tr.MessageID] {
+			if seenResultIDs[tr.ID] {
 				continue
 			}
 			if verbose {
-				fmt.Fprintf(w, "  ↳ result (orphan): %s\n", tr.Result)
+				fmt.Fprintf(w, "  ↳ result (orphan): %s\n", tr.Output)
 				continue
 			}
-			fmt.Fprintf(w, "  ↳ result (orphan): %s\n", narrative.ToolResultSummary(tr.Tool, tr.Result))
+			// Post-#1783: ToolResult has no tool-name field. Pass
+			// "" so the summariser falls into its generic branch.
+			fmt.Fprintf(w, "  ↳ result (orphan): %s\n", narrative.ToolResultSummary("", tr.Output))
 		case "permission_ask":
 			var pa payload.PermissionAsk
 			if err := json.Unmarshal([]byte(c.payload), &pa); err != nil {

--- a/modules/programs/prism/prism/cmd/iris/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/iris/checkin_test.go
@@ -81,17 +81,30 @@ func seedAssistantTurn(t *testing.T, iso *iristest.Isolated, sessionName, text, 
 		t.Fatalf("seedAssistantTurn: write msg_assistant: %v", err)
 	}
 
-	tcArgs := args
-	if tcArgs == "" {
-		// Args field for tool_call payload must be a JSON string per the
-		// payload contract; pass through verbatim.
-		tcArgs = `""`
+	// Post-#1783: payload.ToolCall.Args is a json.RawMessage holding
+	// the raw JSON value the pi extension emits (typically an
+	// object). Tests pass JSON-object literals as strings; we just
+	// re-tag them as RawMessage. An empty fixture maps to the
+	// canonical "no args" wire value (null) so the renderer's
+	// "(no args)" placeholder is exercised.
+	var tcArgs json.RawMessage
+	if args == "" {
+		tcArgs = nil
+	} else {
+		tcArgs = json.RawMessage(args)
 	}
-	tcp, _ := json.Marshal(payload.ToolCall{
-		Tool:      tool,
-		Args:      tcArgs,
-		MessageID: msgID,
+	// Inject a synthetic `messageId` alongside the post-#1783 wire
+	// shape so the cmd/iris/checkin secondary-query path
+	// (QueryEventsByMessageIDs) can still locate this child event
+	// during tests. The pi extension does NOT emit messageId on
+	// tool_call — see coordinator escalation 2026-05-17 and the
+	// commentary on toolCallPayload in cmd/checkin_test.go.
+	tcMarshalled, _ := json.Marshal(payload.ToolCall{
+		Name: tool,
+		Args: tcArgs,
+		ID:   msgID,
 	})
+	tcp := injectSyntheticMessageID(tcMarshalled, msgID)
 	if err := iso.DB.WriteEvent(db.Event{
 		ID:          uuid.NewString(),
 		SessionName: sessionName,
@@ -104,11 +117,14 @@ func seedAssistantTurn(t *testing.T, iso *iristest.Isolated, sessionName, text, 
 		t.Fatalf("seedAssistantTurn: write tool_call: %v", err)
 	}
 
-	trp, _ := json.Marshal(payload.ToolResult{
-		Tool:      tool,
-		Result:    result,
-		MessageID: msgID,
+	// Same synthetic-messageId rationale for tool_result, per
+	// `cmd/checkin_test.go::toolResultPayload`'s commentary.
+	trMarshalled, _ := json.Marshal(payload.ToolResult{
+		ID:      msgID,
+		Success: true,
+		Output:  result,
 	})
+	trp := injectSyntheticMessageID(trMarshalled, msgID)
 	if err := iso.DB.WriteEvent(db.Event{
 		ID:          uuid.NewString(),
 		SessionName: sessionName,
@@ -485,4 +501,34 @@ func TestCheckinEndToEnd_ViaCobra(t *testing.T) {
 			t.Errorf("e2e output missing %q:\n%s", want, got)
 		}
 	}
+}
+
+// injectSyntheticMessageID rewrites a marshalled payload.ToolCall or
+// payload.ToolResult to add a `messageId` field alongside the new
+// `id` field. The pi prism extension does NOT emit messageId on
+// tool_call/tool_result; the field is synthetic-for-tests so the
+// secondary-query SQL pushdown in db.QueryEventsByMessageIDs (which
+// matches on $.messageId) can still locate these child events. See
+// coordinator escalation 2026-05-17 and the matching helper in
+// cmd/checkin_test.go for the full rationale.
+//
+// The rewrite is a simple JSON-object surgery: drops the leading "{"
+// and inserts the synthetic field at the start of the object body.
+// Returns the original input unchanged if the input doesn't parse as
+// a JSON object (defensive — never panics).
+func injectSyntheticMessageID(in []byte, msgID string) []byte {
+	if len(in) < 2 || in[0] != '{' {
+		return in
+	}
+	// Special case: an empty object literal "{}". Replace with
+	// `{"messageId":"..."}`.
+	if len(in) == 2 && in[1] == '}' {
+		return []byte(fmt.Sprintf(`{"messageId":%q}`, msgID))
+	}
+	// Insert `"messageId":"...",` after the opening "{".
+	prefix := fmt.Sprintf(`{"messageId":%q,`, msgID)
+	out := make([]byte, 0, len(prefix)+len(in)-1)
+	out = append(out, prefix...)
+	out = append(out, in[1:]...)
+	return out
 }

--- a/modules/programs/prism/prism/cmd/stats_metrics.go
+++ b/modules/programs/prism/prism/cmd/stats_metrics.go
@@ -176,9 +176,10 @@ func collectMetrics(events []db.Event, harnessSessionID string) *sessionMetrics 
 		case "tool_call":
 			var p payload.ToolCall
 			if err := json.Unmarshal([]byte(e.Payload), &p); err == nil {
-				m.ToolCalls[p.Tool]++
+				// Post-#1783 the payload's tool name lives on `Name`.
+				m.ToolCalls[p.Name]++
 				if p.DurationMs > 0 {
-					m.ToolDurations[p.Tool] = append(m.ToolDurations[p.Tool], time.Duration(p.DurationMs)*time.Millisecond)
+					m.ToolDurations[p.Name] = append(m.ToolDurations[p.Name], time.Duration(p.DurationMs)*time.Millisecond)
 				}
 			}
 

--- a/modules/programs/prism/prism/cmd/stats_test.go
+++ b/modules/programs/prism/prism/cmd/stats_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -75,9 +76,18 @@ func assistantPayloadWithTokens(msgID, text string, inputTokens, outputTokens, c
 		msgID, text, inputTokens, outputTokens, cacheRead, cacheWrite, durationMs, contextPct)
 }
 
+// toolCallPayloadWithDuration returns a tool_call JSON payload using
+// the post-#1783 pi-extension wire shape ({name, id, args}) plus a
+// `durationMs` field (kept by the older PI stdio adapter).
+//
+// Args is JSON-encoded as a string literal so legacy bare inputs
+// ("echo hello", "main.go") survive without breaking JSON syntax.
+// Stats consumers re-read `Name` (the renamed `Tool` field) and
+// `DurationMs` only; args content is irrelevant to the metric paths.
 func toolCallPayloadWithDuration(msgID, tool, args string, durationMs int64) string {
-	return fmt.Sprintf(`{"messageId":%q,"tool":%q,"args":%q,"durationMs":%d}`,
-		msgID, tool, args, durationMs)
+	encodedArgs, _ := json.Marshal(args)
+	return fmt.Sprintf(`{"name":%q,"id":%q,"args":%s,"durationMs":%d}`,
+		tool, msgID, string(encodedArgs), durationMs)
 }
 
 // assistantPayloadWithAgentModel creates an assistant payload with explicit agent and model fields.

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -348,17 +348,30 @@ func extractText(content []struct {
 	return strings.Join(parts, "")
 }
 
-// marshalArgs marshals a JSON value to a compact string representation,
-// truncated to 500 characters to match the pi truncation budget.
-func marshalArgs(raw json.RawMessage) string {
+// marshalArgs returns the raw tool-call args JSON value, truncated to
+// the 500-byte pi-budget. Post-#1783 the returned value is a
+// json.RawMessage so it can be assigned directly to
+// payload.ToolCall.Args. Truncation that would produce invalid JSON
+// is avoided by re-wrapping over-budget input in a string — the
+// resulting RawMessage is still valid JSON (a string literal), just
+// not a structured object.
+func marshalArgs(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
-		return ""
+		return nil
 	}
-	s := string(raw)
-	if len(s) > 500 {
-		return s[:500]
+	if len(raw) <= 500 {
+		return raw
 	}
-	return s
+	// Over budget. Re-encode as a truncated JSON string so the
+	// resulting RawMessage stays valid JSON. Consumers of
+	// payload.ToolCall.Args treat string-typed args as a fallback
+	// (narrative.ToolKeyArg's default branch echoes the raw value).
+	truncated := string(raw[:500])
+	b, err := json.Marshal(truncated)
+	if err != nil {
+		return nil
+	}
+	return b
 }
 
 // NormaliseFrame maps a raw PI JSONL frame to a canonical pi-shaped
@@ -446,10 +459,15 @@ func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload 
 			log.Printf("pi: NormaliseFrame: parse tool_call: %v", err)
 			return "", nil, false
 		}
+		// Post-#1783: payload.ToolCall renamed Tool→Name,
+		// MessageID→ID, Args:string→Args:json.RawMessage. The
+		// stdio adapter's input shape (snake_case JSONL) is
+		// unchanged — the adapter just translates into the new
+		// canonical struct names.
 		p := payload.ToolCall{
-			Tool:       f.Tool,
+			Name:       f.Tool,
 			Args:       marshalArgs(f.Input),
-			MessageID:  f.MessageID,
+			ID:         f.MessageID,
 			DurationMs: f.ElapsedMs,
 		}
 		return "tool_call", p, true
@@ -460,14 +478,21 @@ func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload 
 			log.Printf("pi: NormaliseFrame: parse tool_result: %v", err)
 			return "", nil, false
 		}
-		result := f.Output
-		if len(result) > 500 {
-			result = result[:500]
+		output := f.Output
+		truncated := false
+		if len(output) > 500 {
+			output = output[:500]
+			truncated = true
 		}
+		// The stdio adapter has no error/success signal on its
+		// input frame, so Success defaults to true. Consumers that
+		// need to detect failures fall back to per-tool result
+		// summarisation heuristics (narrative.ToolResultSummary).
 		p := payload.ToolResult{
-			Tool:      f.Tool,
-			Result:    result,
-			MessageID: f.MessageID,
+			ID:        f.MessageID,
+			Success:   true,
+			Output:    output,
+			Truncated: truncated,
 		}
 		return "tool_result", p, true
 

--- a/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter_test.go
@@ -137,6 +137,10 @@ func TestNormaliseFrame_MsgUser(t *testing.T) {
 	}
 }
 
+// TestNormaliseFrame_ToolCall covers the older stdio adapter
+// (Translate strategy) path. Input is the legacy snake_case PI
+// JSONL shape; output is the post-#1783 payload.ToolCall (`Name`,
+// `Args`, `ID`).
 func TestNormaliseFrame_ToolCall(t *testing.T) {
 	a := pi.New("", "", "")
 	raw := []byte(`{"type":"tool_call","tool":"bash","input":{"command":"go test ./..."},"message_id":"msg-123","elapsed_ms":5000}`)
@@ -153,21 +157,24 @@ func TestNormaliseFrame_ToolCall(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected payload.ToolCall, got %T", normPayload)
 	}
-	if p.Tool != "bash" {
-		t.Errorf("Tool: want %q got %q", "bash", p.Tool)
+	if p.Name != "bash" {
+		t.Errorf("Name: want %q got %q", "bash", p.Name)
 	}
-	if p.MessageID != "msg-123" {
-		t.Errorf("MessageID: want %q got %q", "msg-123", p.MessageID)
+	if p.ID != "msg-123" {
+		t.Errorf("ID: want %q got %q", "msg-123", p.ID)
 	}
 	if p.DurationMs != 5000 {
 		t.Errorf("DurationMs: want 5000 got %d", p.DurationMs)
 	}
-	// Args should be the marshalled input
-	if p.Args == "" {
+	// Args should be the marshalled input.
+	if len(p.Args) == 0 {
 		t.Error("Args: expected non-empty")
 	}
 }
 
+// TestNormaliseFrame_ToolResult mirrors the tool_call test for the
+// older stdio adapter path. Output uses the post-#1783 payload
+// fields (`ID`, `Success`, `Output`).
 func TestNormaliseFrame_ToolResult(t *testing.T) {
 	a := pi.New("", "", "")
 	raw := []byte(`{"type":"tool_result","tool":"bash","output":"ok\n2 tests passed","message_id":"msg-456"}`)
@@ -184,11 +191,14 @@ func TestNormaliseFrame_ToolResult(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected payload.ToolResult, got %T", normPayload)
 	}
-	if p.Tool != "bash" {
-		t.Errorf("Tool: want %q got %q", "bash", p.Tool)
+	if p.ID != "msg-456" {
+		t.Errorf("ID: want %q got %q", "msg-456", p.ID)
 	}
-	if p.MessageID != "msg-456" {
-		t.Errorf("MessageID: want %q got %q", "msg-456", p.MessageID)
+	if !p.Success {
+		t.Errorf("Success: want true (adapter defaults to success since stdio shape has no isError); got false")
+	}
+	if p.Output != "ok\n2 tests passed" {
+		t.Errorf("Output: want %q got %q", "ok\n2 tests passed", p.Output)
 	}
 }
 
@@ -356,7 +366,10 @@ func TestNormaliseFrame_ToolResult_TruncatesLongOutput(t *testing.T) {
 		t.Fatal("expected shouldWrite=true")
 	}
 	p := normPayload.(payload.ToolResult)
-	if len(p.Result) > 500 {
-		t.Errorf("Result length %d exceeds 500-char budget", len(p.Result))
+	if len(p.Output) > 500 {
+		t.Errorf("Output length %d exceeds 500-char budget", len(p.Output))
+	}
+	if !p.Truncated {
+		t.Errorf("Truncated: want true (over-budget output), got false")
 	}
 }

--- a/modules/programs/prism/prism/internal/iris/narrative/narrative.go
+++ b/modules/programs/prism/prism/internal/iris/narrative/narrative.go
@@ -131,15 +131,15 @@ func RenderEvent(rowID int64, eventType, payloadJSON string) []NarrativeLine {
 				{Text: fmt.Sprintf("[%s] → tool_call (parse error)", ts), EventType: eventType, RowID: rowID},
 			}
 		}
-		keyArg := ToolKeyArg(p.Tool, p.Args)
+		keyArg := ToolKeyArg(p.Name, p.Args)
 		var text string
 		if keyArg != "" {
-			text = fmt.Sprintf("  → %s: %s", p.Tool, keyArg)
+			text = fmt.Sprintf("  → %s: %s", p.Name, keyArg)
 		} else {
-			text = fmt.Sprintf("  → %s", p.Tool)
+			text = fmt.Sprintf("  → %s", p.Name)
 		}
 		return []NarrativeLine{
-			{Text: text, EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+			{Text: text, EventType: eventType, RowID: rowID, MessageID: p.ID},
 		}
 
 	case "tool_result":
@@ -147,9 +147,16 @@ func RenderEvent(rowID int64, eventType, payloadJSON string) []NarrativeLine {
 		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
 			return nil
 		}
-		summary := ToolResultSummary(p.Tool, p.Result)
+		// post-#1783: ToolResult no longer carries the tool name; the
+		// orphan-render path picks the generic summary by passing ""
+		// to ToolResultSummary, which falls through to its default
+		// "first meaningful line" branch. The paired-render path in
+		// cmd/iris/checkin.go and the TUI's renderer.go already knows
+		// the tool name from the matching tool_call and routes
+		// per-tool result summarisation correctly.
+		summary := ToolResultSummary("", p.Output)
 		return []NarrativeLine{
-			{Text: fmt.Sprintf("    ↳ result: %s", summary), EventType: eventType, RowID: rowID, MessageID: p.MessageID},
+			{Text: fmt.Sprintf("    ↳ result: %s", summary), EventType: eventType, RowID: rowID, MessageID: p.ID},
 		}
 
 	case "state_change":
@@ -239,46 +246,64 @@ func TurnLabel(agent, model string) string {
 //	glob/Glob         — pattern
 //	grep/Grep         — pattern / regex / query
 //	todowrite/*       — "" (tool name alone is enough)
-//	<other>           — first ~80 chars of raw args
-func ToolKeyArg(tool, args string) string {
+//	<other>           — first ~80 chars of raw args (compact JSON)
+//
+// args is the raw `args` JSON value from payload.ToolCall, which the
+// pi prism extension emits as a JSON object (`Record<string,
+// unknown>`) per issue #1783. Empty / nil args are valid and yield
+// the empty string — the caller is responsible for rendering a
+// "(no args)" placeholder if it wants one.
+func ToolKeyArg(tool string, args json.RawMessage) string {
+	argsStr := string(args)
 	switch tool {
 	case "bash", "Bash":
-		cmd := ExtractBashCommand(args)
+		cmd := ExtractBashCommand(argsStr)
 		if len([]rune(cmd)) > 80 {
 			return string([]rune(cmd)[:80]) + "..."
 		}
 		return cmd
 
 	case "read", "Read":
-		return ExtractStringField(args, "filePath", "path", "file_path")
+		return ExtractStringField(argsStr, "filePath", "path", "file_path")
 
 	case "edit", "Edit":
-		return ExtractStringField(args, "filePath", "path", "file_path")
+		return ExtractStringField(argsStr, "filePath", "path", "file_path")
 
 	case "write", "Write":
-		return ExtractStringField(args, "filePath", "path", "file_path")
+		return ExtractStringField(argsStr, "filePath", "path", "file_path")
 
 	case "task", "Task":
-		desc := ExtractStringField(args, "description", "desc", "prompt")
+		desc := ExtractStringField(argsStr, "description", "desc", "prompt")
 		if len([]rune(desc)) > 80 {
 			return string([]rune(desc)[:80]) + "..."
 		}
 		return desc
 
 	case "glob", "Glob":
-		return ExtractStringField(args, "pattern", "glob")
+		return ExtractStringField(argsStr, "pattern", "glob")
 
 	case "grep", "Grep":
-		return ExtractStringField(args, "pattern", "regex", "query")
+		return ExtractStringField(argsStr, "pattern", "regex", "query")
 
 	case "todowrite", "TodoWrite", "Todowrite":
 		return ""
 
 	default:
-		if len([]rune(args)) > 80 {
-			return string([]rune(args)[:80]) + "..."
+		// Post-#1783: args is a JSON value (RawMessage). For
+		// unrecognised tools we try a JSON-string-decode pass so a
+		// `"main.go"` literal renders as `main.go` rather than
+		// `"main.go"` (with quotes). This matches the pre-#1783
+		// behaviour where Args was a Go string and json.Unmarshal
+		// had already stripped the quotes at the struct boundary.
+		display := argsStr
+		var s string
+		if err := json.Unmarshal(args, &s); err == nil {
+			display = s
 		}
-		return args
+		if len([]rune(display)) > 80 {
+			return string([]rune(display)[:80]) + "..."
+		}
+		return display
 	}
 }
 

--- a/modules/programs/prism/prism/internal/iris/narrative/narrative_test.go
+++ b/modules/programs/prism/prism/internal/iris/narrative/narrative_test.go
@@ -33,18 +33,22 @@ func TestTurnLabel(t *testing.T) {
 	}
 }
 
+// All ToolKeyArg tests post-#1783 pass a json.RawMessage (the same
+// type the function now accepts). The fixtures use the JSON-object
+// form that the pi prism extension emits.
 func TestToolKeyArg_Bash(t *testing.T) {
 	// Object-form args.
-	if got := narrative.ToolKeyArg("bash", `{"command":"go test ./..."}`); got != "go test ./..." {
+	if got := narrative.ToolKeyArg("bash", json.RawMessage(`{"command":"go test ./..."}`)); got != "go test ./..." {
 		t.Errorf("bash command extract: got %q", got)
 	}
-	// Plain string args.
-	if got := narrative.ToolKeyArg("bash", `"echo hi"`); got != "echo hi" {
+	// Plain string args (legacy form, still accepted by
+	// ExtractBashCommand's fallback).
+	if got := narrative.ToolKeyArg("bash", json.RawMessage(`"echo hi"`)); got != "echo hi" {
 		t.Errorf("bash plain-string extract: got %q", got)
 	}
 	// Long command is truncated with "...".
 	long := strings.Repeat("x", 200)
-	got := narrative.ToolKeyArg("bash", `{"command":"`+long+`"}`)
+	got := narrative.ToolKeyArg("bash", json.RawMessage(`{"command":"`+long+`"}`))
 	if !strings.HasSuffix(got, "...") {
 		t.Errorf("long bash arg should be truncated with ..., got %q", got[len(got)-10:])
 	}
@@ -54,7 +58,7 @@ func TestToolKeyArg_Bash(t *testing.T) {
 }
 
 func TestToolKeyArg_FilePath(t *testing.T) {
-	args := `{"filePath":"/tmp/x.go","content":"…"}`
+	args := json.RawMessage(`{"filePath":"/tmp/x.go","content":"…"}`)
 	for _, tool := range []string{"read", "Read", "edit", "Edit", "write", "Write"} {
 		if got := narrative.ToolKeyArg(tool, args); got != "/tmp/x.go" {
 			t.Errorf("%s key-arg: got %q, want /tmp/x.go", tool, got)
@@ -63,12 +67,28 @@ func TestToolKeyArg_FilePath(t *testing.T) {
 }
 
 func TestToolKeyArg_GlobGrep(t *testing.T) {
-	if got := narrative.ToolKeyArg("glob", `{"pattern":"**/*.go"}`); got != "**/*.go" {
+	if got := narrative.ToolKeyArg("glob", json.RawMessage(`{"pattern":"**/*.go"}`)); got != "**/*.go" {
 		t.Errorf("glob: got %q", got)
 	}
-	if got := narrative.ToolKeyArg("grep", `{"pattern":"TODO"}`); got != "TODO" {
+	if got := narrative.ToolKeyArg("grep", json.RawMessage(`{"pattern":"TODO"}`)); got != "TODO" {
 		t.Errorf("grep: got %q", got)
 	}
+}
+
+// TestToolKeyArg_EmptyDoesNotPanic covers the #1783 edge-case AC:
+// empty / malformed args must not panic. The previous test surface
+// implicitly relied on Go-string semantics where an empty string is
+// still a valid input; the json.RawMessage transition keeps that
+// behaviour.
+func TestToolKeyArg_EmptyDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on empty args: %v", r)
+		}
+	}()
+	_ = narrative.ToolKeyArg("bash", nil)
+	_ = narrative.ToolKeyArg("bash", json.RawMessage(""))
+	_ = narrative.ToolKeyArg("bash", json.RawMessage("{not valid"))
 }
 
 func TestToolResultSummary_Bash(t *testing.T) {

--- a/modules/programs/prism/prism/internal/iris/tui/export_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/export_test.go
@@ -122,3 +122,42 @@ func ModelErrorMsg(m Model) string { return m.errorMsg }
 func IsMergeQueueNotificationText(s string) bool {
 	return isMergeQueueNotificationText(s)
 }
+
+// Focus rotation states re-exported for tests. The integer values
+// mirror the unexported focusArea iota in model.go.
+const (
+	FocusPrompt   = int(focusPrompt)
+	FocusSessions = int(focusSessions)
+	FocusEvents   = int(focusEvents)
+)
+
+// ModelFocus returns the current focus area as an int matching one of
+// the Focus* constants. Used by #1769 tests to assert that the events
+// pane is focused before exercising the tab→expand path.
+func ModelFocus(m Model) int { return int(m.focus) }
+
+// ModelToolCardCount returns the number of tool-call cards currently
+// in the model's event buffer (issue #1769). Zero when no tool_call
+// events have been seen for the subscribed session.
+func ModelToolCardCount(m Model) int { return len(m.toolCards) }
+
+// ModelToolCardExpanded returns true when the tool card with the
+// given MessageID is currently in the expanded state. Returns false
+// when the id is unknown or the card is collapsed.
+func ModelToolCardExpanded(m Model, msgID string) bool {
+	return m.expandedToolCards[msgID]
+}
+
+// ModelEventLineCount returns the number of NarrativeLines currently
+// in the model's event buffer. Used to assert that expand/collapse
+// changes the rendered line count.
+func ModelEventLineCount(m Model) int { return len(m.eventLines) }
+
+// SetModelFocus forces the model's focus to the given area. Tests use
+// this to land focus on the events pane without driving the full
+// tab-rotation sequence — the rotation is covered by the existing
+// #1737 tests; #1769 tests focus on the expand/collapse semantics.
+func SetModelFocus(m Model, focus int) Model {
+	m.focus = focusArea(focus)
+	return m
+}

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -17,6 +17,7 @@ package tui
 // reads NO state from the DB — every piece of state comes via the daemon socket.
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/iris"
 	"github.com/prismatic-koi/prism/internal/iris/narrative"
+	"github.com/prismatic-koi/prism/internal/payload"
 )
 
 // --- Layout constants ---
@@ -95,16 +97,32 @@ var (
 			Border(lipgloss.NormalBorder()).
 			BorderForeground(lipgloss.Color(colBlue))
 
-	// styleToolCall renders the one-line tool-call "card" rows. Blue +
-	// bold makes the row visually distinct from surrounding assistant
-	// prose (styleNormal) and from indented tool_result summaries
-	// (styleDim) without using the red treatment reserved for errors.
-	// Issue #1767's renderer table requires tool_call rows be visibly
-	// distinct as one-line cards — child PR 4 replaces this with
-	// multi-line cards; the styling continues to apply to the first row.
+	// styleToolCall renders completed tool-call card headers (paired
+	// tool_call + tool_result) and the legacy one-line card rows used
+	// by fallback paths. Blue + bold keeps the header visually loud so
+	// it reads as the start of a discrete tool invocation block.
+	// Issue #1767 introduced this style for one-line cards; issue
+	// #1769 extends it to multi-line cards (the header line continues
+	// to carry the same treatment).
 	styleToolCall = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colBlue)).
 			Bold(true)
+
+	// styleToolCallInFlight renders the header of an in-flight tool
+	// call (tool_call seen, no matching tool_result yet) introduced
+	// in issue #1769. Yellow + bold visually flags "this is running
+	// right now" without using the red palette reserved for errors;
+	// distinct from styleToolCall's blue so the operator can scan a
+	// tall conversation and pick out which calls are still in flight.
+	styleToolCallInFlight = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(colPrimary)).
+				Bold(true)
+
+	// styleToolCardArgs renders the args summary line of a tool
+	// card. Dim so the args read as supplementary context to the
+	// header (not competing with it for the operator's attention).
+	styleToolCardArgs = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(colSecondary))
 
 	// styleErrorProminent renders extension_error blocks. Bold red on
 	// the dark background is the most attention-grabbing combination
@@ -261,7 +279,39 @@ type Model struct {
 	seenRowIDs map[int64]bool
 	// toolCallByMsgID indexes the line slice position for open tool_call lines
 	// so that arriving tool_result frames can append the result inline.
+	//
+	// Pre-#1769 this was the single source of truth for tool_call ↔
+	// tool_result pairing. Post-#1769 it is retained for any legacy
+	// callers / tests that may still consult it; the canonical lookup
+	// is now toolCardByMsgID below, which carries the full multi-line
+	// card state required by the expand/collapse toggle.
 	toolCallByMsgID map[string]int
+
+	// toolCards is the ordered list of multi-line tool-call cards in
+	// the current event pane (issue #1769, child 4 of the iris-tui
+	// design). Each card owns a contiguous range of m.eventLines (see
+	// toolCard.lineStart / .lineLen). The slice is append-only; on
+	// resetEventPane it is cleared together with eventLines. The
+	// ordering matches the order in which tool_call events arrived
+	// for the subscribed session.
+	toolCards []*toolCard
+
+	// toolCardByMsgID is the lookup index for toolCards, keyed on
+	// payload.ToolCall.MessageID (the same id used to pair a
+	// tool_call with its tool_result). Inserted on tool_call arrival,
+	// consumed on tool_result arrival, and consulted by the
+	// expand/collapse toggle. Missing keys are not an error — a
+	// tool_result with no matching card falls back to the legacy
+	// indented-summary path.
+	toolCardByMsgID map[string]*toolCard
+
+	// expandedToolCards is the set of MessageIDs whose tool-card is
+	// currently expanded (showing full args / full result). Adding
+	// or removing a key triggers a card re-render via
+	// rebuildToolCardLines. The set persists across event arrivals
+	// per AC: "receiving a new event while a card is expanded does
+	// not collapse it."
+	expandedToolCards map[string]bool
 
 	// eventScroll is the number of lines scrolled up from the bottom (0 = live).
 	eventScroll int
@@ -321,10 +371,12 @@ type Model struct {
 // NewModel creates the iris TUI model.
 func NewModel(client *DaemonClient) Model {
 	return Model{
-		client:          client,
-		renderer:        newEventRenderer(),
-		seenRowIDs:      make(map[int64]bool),
-		toolCallByMsgID: make(map[string]int),
+		client:            client,
+		renderer:          newEventRenderer(),
+		seenRowIDs:        make(map[int64]bool),
+		toolCallByMsgID:   make(map[string]int),
+		toolCardByMsgID:   make(map[string]*toolCard),
+		expandedToolCards: make(map[string]bool),
 	}
 }
 
@@ -476,6 +528,32 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Tool-call card path (#1769): intercept tool_call and
+		// tool_result BEFORE the generic dispatch loop. tool_call
+		// produces a multi-line in-flight card recorded in m.toolCards;
+		// tool_result mutates that card's lines in place to the
+		// completed visual. Falls through to the generic path only when
+		// no matching tool_call exists for a tool_result (legacy
+		// indented-summary fallback per child 2).
+		if e.EventType == evTypeToolCall {
+			if card := m.installToolCallCard(e.RowID, e.Payload); card != nil {
+				m.seenRowIDs[e.RowID] = true
+				return m, nil
+			}
+			// Parse failed and installer returned nil — fall through
+			// to the legacy dispatch path so the parse-error line still
+			// renders. Drops through to the dispatch block below.
+		}
+		if e.EventType == evTypeToolResult {
+			if handled := m.foldToolResultIntoCard(e.Payload); handled {
+				m.seenRowIDs[e.RowID] = true
+				return m, nil
+			}
+			// No matching card — fall through to the dispatcher which
+			// produces the legacy indented one-liner. AC explicit:
+			// "don't regress the orphan tool_result path".
+		}
+
 		lines := m.renderer.dispatch(e.RowID, e.EventType, e.Payload)
 
 		// Coordinator-events accumulator (issue #1772 child 7).
@@ -495,36 +573,15 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 		if len(lines) == 0 {
 			// Suppressed (session_status, turn_start/end) or a handler
 			// declined to render. Do NOT mark the row_id as seen —
-			// future renderer extensions (e.g. tool-call cards in
-			// child PR 4) may decide to render an event type that is
-			// currently suppressed, and the dedupe map must not
-			// preempt them on replay. Suppression has no per-event
-			// side effect beyond "do not append a line".
+			// future renderer extensions may decide to render an event
+			// type that is currently suppressed, and the dedupe map
+			// must not preempt them on replay. Suppression has no
+			// per-event side effect beyond "do not append a line".
 			return m, nil
 		}
 		m.seenRowIDs[e.RowID] = true
 		for _, line := range lines {
-			// For tool_result: find the matching tool_call and pair it.
-			if e.EventType == "tool_result" && line.MessageID != "" {
-				if idx, ok := m.toolCallByMsgID[line.MessageID]; ok {
-					// Append result text to the tool_call line instead of
-					// adding a separate line.
-					if idx < len(m.eventLines) {
-						existing := m.eventLines[idx]
-						existing.IsPaired = true
-						existing.ResultText = line.Text
-						existing.Text = existing.Text + " " + line.Text
-						m.eventLines[idx] = existing
-					}
-					continue
-				}
-			}
-			pos := len(m.eventLines)
 			m.eventLines = append(m.eventLines, line)
-			// Index tool_call lines for later tool_result pairing.
-			if e.EventType == "tool_call" && line.MessageID != "" {
-				m.toolCallByMsgID[line.MessageID] = pos
-			}
 		}
 		// Snap to bottom if the user is not scrolled up.
 		if m.eventScroll == 0 {
@@ -700,7 +757,25 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "tab":
-		// Rotate focus prompt → sessions → events → prompt.
+		// Two-mode tab binding (issue #1769 extends #1737):
+		//
+		// When focus is on the events pane AND at least one tool-call
+		// card exists, tab expands/collapses the most recent tool
+		// card. The spec says "Pressing `tab` while the conversation
+		// pane has focus expands the currently-selected tool-call
+		// card." We take "currently-selected" as the most recent card
+		// per the issue's implementation-guidance hint (a single
+		// current-card pointer is fine; child 5 may add full
+		// selection).
+		//
+		// In every other case, tab continues to rotate focus prompt
+		// → sessions → events → prompt as before — the rotation is
+		// the only way to land focus on events in the first place,
+		// so leaving it in place for the no-cards-yet case keeps the
+		// pre-#1769 navigation working.
+		if m.focus == focusEvents && m.toggleSelectedToolCard() {
+			return m, nil
+		}
 		switch m.focus {
 		case focusPrompt:
 			m.focus = focusSessions
@@ -827,11 +902,191 @@ func (m *Model) switchToSelected() tea.Cmd {
 	}
 }
 
+// toolCard is the model-side state for a single multi-line tool-call
+// card (#1769, child 4 of the iris-tui design). One card maps 1∶1 to a
+// tool_call event keyed on payload.ToolCall.ID (the same id used by
+// the matching tool_result — see issue #1783's wire-shape pivot).
+// lineStart and lineLen index into m.eventLines so the card can be
+// re-materialised in place when the result arrives or the operator
+// toggles expand/collapse.
+//
+// The full args / result strings are stored on the card so the
+// expanded view can show them without re-parsing the original event
+// payload (the payload string itself is dropped after rendering).
+//
+// Field naming note: the local field is named `msgID` for backward
+// readability — it holds payload.ToolCall.ID, which the extension
+// emits as the JSON `id` field. The Model maps it via
+// toolCardByMsgID; renaming the variable would churn this file
+// without making the code clearer.
+type toolCard struct {
+	msgID     string
+	rowID     int64
+	tool      string
+	args      json.RawMessage
+	result    string
+	paired    bool
+	lineStart int
+	lineLen   int
+}
+
+// installToolCallCard handles a fresh tool_call frame: parses the
+// payload, builds the multi-line collapsed card, appends its lines to
+// m.eventLines, and registers the card in toolCards / toolCardByMsgID.
+// Returns the new card on success, nil on parse failure (in which
+// case the caller falls back to the dispatcher's parse-error path).
+//
+// payload.ToolCall.ID may legitimately be empty (older pi versions,
+// replay races). When empty we still install the card so the
+// rendering is correct for the in-flight phase, but pairing on
+// tool_result is impossible — the card stays in flight forever,
+// visually flagging the missing pairing context.
+func (m *Model) installToolCallCard(rowID int64, payloadJSON string) *toolCard {
+	var p payload.ToolCall
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return nil
+	}
+	card := &toolCard{
+		msgID:     p.ID,
+		rowID:     rowID,
+		tool:      p.Name,
+		args:      p.Args,
+		paired:    false,
+		lineStart: len(m.eventLines),
+	}
+	expanded := m.expandedToolCards[p.ID]
+	lines := buildToolCardLines(rowID, p.ID, p.Name, p.Args, "", false, expanded)
+	card.lineLen = len(lines)
+	m.eventLines = append(m.eventLines, lines...)
+	m.toolCards = append(m.toolCards, card)
+	if p.ID != "" {
+		m.toolCardByMsgID[p.ID] = card
+		// Maintain the legacy index pointing at the header line so any
+		// remaining callers continue to find a tool_call line by id.
+		m.toolCallByMsgID[p.ID] = card.lineStart
+	}
+	return card
+}
+
+// foldToolResultIntoCard handles a tool_result frame. Locates the
+// matching tool-card by ID (post-#1783 wire shape: the extension's
+// tool_result.id mirrors the tool_call.id), marks it paired, stores
+// the result output, and rebuilds the card's lines in place. Returns
+// true on success, false when no matching card exists (the caller
+// then falls back to the dispatcher's legacy orphan-result path).
+//
+// On parse failure of the payload, returns false so the dispatcher
+// can render whatever it can. A malformed tool_result must not
+// orphan the in-flight card — future tool_result arrivals for the
+// same id still have a chance to land cleanly.
+func (m *Model) foldToolResultIntoCard(payloadJSON string) bool {
+	var p payload.ToolResult
+	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+		return false
+	}
+	if p.ID == "" {
+		return false
+	}
+	card, ok := m.toolCardByMsgID[p.ID]
+	if !ok {
+		return false
+	}
+	card.paired = true
+	card.result = p.Output
+	m.rebuildCardLines(card)
+	return true
+}
+
+// rebuildCardLines replaces the line range owned by card with a
+// freshly built block reflecting the card's current state (paired vs
+// in-flight, expanded vs collapsed). When the new block has a
+// different length than the previous block, lineStart of every later
+// card is shifted by the delta so the index stays accurate.
+//
+// This is the single mutation point for card geometry — anything
+// that changes a card's visual state goes through this function so
+// the eventLines slice and the per-card index stay consistent.
+func (m *Model) rebuildCardLines(card *toolCard) {
+	expanded := false
+	if card.msgID != "" {
+		expanded = m.expandedToolCards[card.msgID]
+	}
+	newLines := buildToolCardLines(card.rowID, card.msgID, card.tool, card.args, card.result, card.paired, expanded)
+	oldLen := card.lineLen
+	newLen := len(newLines)
+
+	end := card.lineStart + oldLen
+	if end > len(m.eventLines) {
+		end = len(m.eventLines)
+	}
+	// Splice: prefix + newLines + suffix.
+	prefix := m.eventLines[:card.lineStart]
+	suffix := append([]narrative.NarrativeLine(nil), m.eventLines[end:]...)
+	rebuilt := make([]narrative.NarrativeLine, 0, len(prefix)+newLen+len(suffix))
+	rebuilt = append(rebuilt, prefix...)
+	rebuilt = append(rebuilt, newLines...)
+	rebuilt = append(rebuilt, suffix...)
+	m.eventLines = rebuilt
+
+	card.lineLen = newLen
+
+	// Shift later cards' lineStart by the delta.
+	delta := newLen - oldLen
+	if delta != 0 {
+		for _, c := range m.toolCards {
+			if c.lineStart > card.lineStart {
+				c.lineStart += delta
+				if c.msgID != "" {
+					m.toolCallByMsgID[c.msgID] = c.lineStart
+				}
+			}
+		}
+	}
+}
+
+// toggleSelectedToolCard expand/collapses the "current" tool card.
+// Per the issue's implementation guidance ("a single 'current card
+// index' pointing at the most recent tool card is fine"), the current
+// card is defined as the most recently installed tool_call. Returns
+// true when a card existed and was toggled, false when no cards are
+// present (e.g. focus on events with no tool_call seen yet).
+//
+// The expand/collapse state is keyed on MessageID so it survives
+// later card-state transitions (paired arrival, tool_result fold).
+// A card with empty msgID is not toggleable — the set key would
+// collide with every other empty-id card; in practice every
+// production tool_call carries a MessageID.
+func (m *Model) toggleSelectedToolCard() bool {
+	if len(m.toolCards) == 0 {
+		return false
+	}
+	card := m.toolCards[len(m.toolCards)-1]
+	if card.msgID == "" {
+		return false
+	}
+	if m.expandedToolCards[card.msgID] {
+		delete(m.expandedToolCards, card.msgID)
+	} else {
+		m.expandedToolCards[card.msgID] = true
+	}
+	m.rebuildCardLines(card)
+	return true
+}
+
 // resetEventPane clears the event buffer and associated indexes.
+//
+// Includes the tool-card bookkeeping introduced in #1769: cards belong
+// to a single subscribed session, so switching sessions wipes them
+// alongside eventLines. expandedToolCards is keyed on MessageID and
+// those ids do not survive a session switch either — a fresh
+// subscription means a fresh set of cards.
 func (m *Model) resetEventPane() {
 	m.eventLines = nil
 	m.seenRowIDs = make(map[int64]bool)
 	m.toolCallByMsgID = make(map[string]int)
+	m.toolCards = nil
+	m.toolCardByMsgID = make(map[string]*toolCard)
+	m.expandedToolCards = make(map[string]bool)
 	m.eventScroll = 0
 }
 
@@ -1065,12 +1320,19 @@ func (m Model) viewRightPane(width int) string {
 //   - msg_assistant + _body   — normal-foreground rich text.
 //   - msg_user + _body        — blue (operator input visually
 //     distinguished from assistant output).
-//   - tool_call               — styleToolCall: blue foreground, bold.
-//     Visually distinct from surrounding assistant text so the
-//     one-line card stands out as a tool invocation, not prose.
-//   - tool_result             — dim with the leading-indent prefix from
-//     the renderer ("    ↳ result: …") so it reads as a continuation
-//     of its parent tool_call.
+//   - tool_call               — styleToolCall: blue + bold (legacy
+//     one-line card path / orphan tool_result fallback).
+//   - tool_card_header_done   — styleToolCall: blue + bold; header
+//     line of a completed (paired) tool card.
+//   - tool_card_header_inflight + tool_card_status_inflight —
+//     styleToolCallInFlight: yellow + bold; visually flags "still
+//     running" without using the red error palette.
+//   - tool_card_args / _args_full / _status_done / _result_full —
+//     styleToolCardArgs: dim; supplementary args/result rows beneath
+//     the header line.
+//   - tool_result             — dim with the leading-indent prefix
+//     from the renderer (orphan-result fallback only; the paired
+//     path renders via the card status line).
 //   - extension_error + _body — prominent red-on-red block. Both lines
 //     carry the same treatment so the header + message read as one
 //     emergency unit. styleErrorProminent uses bold to break out of
@@ -1099,6 +1361,12 @@ func styleEventLine(line narrative.NarrativeLine, width int, coordinator bool) s
 		return styleBlue.Render(padRight(text, width))
 	case evTypeToolCall:
 		return styleToolCall.Render(padRight(text, width))
+	case evTypeToolCardHeaderDone:
+		return styleToolCall.Render(padRight(text, width))
+	case evTypeToolCardHeaderInFlight, evTypeToolCardStatusInFlight:
+		return styleToolCallInFlight.Render(padRight(text, width))
+	case evTypeToolCardArgs, evTypeToolCardArgsFull, evTypeToolCardStatusDone, evTypeToolCardResultFull:
+		return styleToolCardArgs.Render(padRight(text, width))
 	case evTypeToolResult:
 		return styleDim.Render(padRight(text, width))
 	case evTypeExtensionError, evTypeExtensionErrorBody:

--- a/modules/programs/prism/prism/internal/iris/tui/renderer.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer.go
@@ -101,6 +101,47 @@ const (
 	// narrative package's "_body" suffix convention for msg_assistant /
 	// msg_user multi-line events.
 	evTypeExtensionErrorBody = "extension_error_body"
+
+	// evTypeToolCard* are synthetic EventType labels used by the
+	// multi-line tool-call card introduced in issue #1769 (child 4 of
+	// the iris-tui-design tracker). The renderer dispatches tool_call
+	// through renderToolCall which now emits a 3-line block (header,
+	// args, status) that the styler colours differently depending on
+	// in-flight vs completed state. tool_result is no longer emitted as
+	// its own line — the model layer (handleDaemonFrame) folds the
+	// result into the matching card's status line.
+	//
+	// Naming convention:
+	//   _header  — the "→ <tool>" first line; carries MessageID for
+	//              expand/collapse lookups in the model.
+	//   _args    — the truncated args line shown in collapsed state.
+	//   _status  — the placeholder "⏳ running…" / "↳ <result>" line.
+	//   _argsfull / _resultfull — extra lines emitted when the card
+	//              is expanded (one rune-wrapped line per wrap chunk).
+	//
+	// The _inflight / _done suffix on header and status differentiates
+	// styling between a still-running tool call (dim header, yellow
+	// status) and a paired tool_call+tool_result (bold-blue header,
+	// dim status). styleEventLine maps each label to its colour.
+	evTypeToolCardHeaderInFlight = "tool_card_header_inflight"
+	evTypeToolCardHeaderDone     = "tool_card_header_done"
+	evTypeToolCardArgs           = "tool_card_args"
+	evTypeToolCardArgsFull       = "tool_card_args_full"
+	evTypeToolCardStatusInFlight = "tool_card_status_inflight"
+	evTypeToolCardStatusDone     = "tool_card_status_done"
+	evTypeToolCardResultFull     = "tool_card_result_full"
+)
+
+// Display widths used by the tool-card renderer. Wider than the
+// pre-#1769 80-rune limit because cards have their own row and don't
+// have to coexist with surrounding prose on the same row. Hand-picked
+// to read well at the conversation pane's typical width (~70-90 cols
+// inside the bordered right pane on a 120-col terminal); the styler's
+// truncate() does the final width-fit pass.
+const (
+	toolCardArgsTruncate   = 100
+	toolCardResultTruncate = 100
+	toolCardWrapWidth      = 100
 )
 
 // eventHandler is the per-event-type rendering function signature. A
@@ -286,63 +327,239 @@ func renderMsgUser(rowID int64, payloadJSON string) []narrative.NarrativeLine {
 	}
 }
 
-// renderToolCall produces a one-line "card" of the form
+// renderToolCall produces the multi-line in-flight tool-call card
+// introduced in issue #1769 (child 4). The collapsed card is three
+// rows:
 //
-//	→ <tool>: <key-arg>
+//	[HH:MM:SS] → <tool>
+//	    args: <truncated args>          (or "(no args)" when empty)
+//	    ⏳ running…                      (placeholder until tool_result)
 //
-// using narrative.ToolKeyArg to extract the primary argument (command
-// for bash, file path for read/edit/write, pattern for grep, etc.).
-// The leading "→" plus indent makes a tool-call visually distinct from
-// surrounding assistant text on a single row — the design doc renderer
-// table's "one-line card" requirement. Multi-line/rich tool-call cards
-// (with args, result preview, expand/collapse) are child PR 4's scope.
+// When the paired tool_result arrives, handleDaemonFrame in model.go
+// (not this renderer) mutates the card lines in place: it swaps the
+// header label to the "done" variant for styling and replaces the
+// status line with "↳ <result preview>". This split is deliberate —
+// the renderer cannot mutate prior lines on its own; only the model
+// has the line buffer.
+//
+// Edge cases (covered by tests):
+//   - parse error on payloadJSON: emit a single-line card carrying
+//     the parse-error marker so the operator still sees something
+//     rather than a silent drop.
+//   - empty / malformed args JSON: ToolKeyArg returns "", we render
+//     the "(no args)" placeholder.
+//
+// The MessageID is carried on every line of the block so the model's
+// pair logic and the expand/collapse toggle can find the whole card
+// by msgID lookup. The header line carries the canonical RowID; the
+// args and status lines carry RowID=0 (synthetic line, not directly
+// sourced from an agent_events row).
 func renderToolCall(rowID int64, payloadJSON string) []narrative.NarrativeLine {
 	var p payload.ToolCall
 	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
 		return []narrative.NarrativeLine{
 			{
 				Text:      fmt.Sprintf("[%s] → tool_call (parse error)", ts()),
-				EventType: evTypeToolCall,
+				EventType: evTypeToolCardHeaderInFlight,
 				RowID:     rowID,
 			},
 		}
 	}
-	keyArg := narrative.ToolKeyArg(p.Tool, p.Args)
-	var text string
-	if keyArg != "" {
-		text = fmt.Sprintf("  → %s: %s", p.Tool, keyArg)
-	} else {
-		text = fmt.Sprintf("  → %s", p.Tool)
-	}
-	return []narrative.NarrativeLine{
-		{Text: text, EventType: evTypeToolCall, RowID: rowID, MessageID: p.MessageID},
-	}
+	return buildToolCardLines(rowID, p.ID, p.Name, p.Args, "", false, false)
 }
 
-// renderToolResult renders the indented one-line summary that follows a
-// tool_call. The model layer pairs this line with its matching
-// tool_call (by MessageID) so the rendered conversation reads as
+// renderToolResult is now a defensive-only path: handleDaemonFrame in
+// model.go consumes tool_result frames directly to fold them into the
+// matching tool-call card. This handler only runs when the dispatcher
+// is called against a tool_result frame without going through the
+// model — primarily in unit tests for the renderer in isolation, and
+// as a fallback when a tool_result arrives for a tool_call that has
+// scrolled out of the in-memory window. The output is an indented
+// one-liner — same shape as child 2's behaviour, so the no-parent
+// path does not regress.
 //
-//	→ bash: echo hello ✓ hello
-//
-// rather than as two unrelated rows. When no matching tool_call has
-// been seen yet (replay race, frame ordering), the result line is
-// emitted standalone with a leading indent so the visual still reads
-// as "this is a result, not a top-level statement".
+// Post-#1783: payload.ToolResult no longer carries a tool name (the
+// pi extension's wire shape doesn't include one on tool_result). The
+// orphan path therefore summarises with an empty tool name, which
+// drops ToolResultSummary into its generic "first meaningful line"
+// fallback. The paired path (handleDaemonFrame) still routes
+// per-tool summarisation because it has the matching tool_call's
+// name on the card record.
 func renderToolResult(rowID int64, payloadJSON string) []narrative.NarrativeLine {
 	var p payload.ToolResult
 	if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
 		return nil
 	}
-	summary := narrative.ToolResultSummary(p.Tool, p.Result)
+	summary := narrative.ToolResultSummary("", p.Output)
 	return []narrative.NarrativeLine{
 		{
 			Text:      fmt.Sprintf("    ↳ result: %s", summary),
 			EventType: evTypeToolResult,
 			RowID:     rowID,
-			MessageID: p.MessageID,
+			MessageID: p.ID,
 		},
 	}
+}
+
+// buildToolCardLines is the single point of truth for the line shape
+// of a tool-call card. Used by:
+//
+//   - renderToolCall on initial tool_call arrival (paired=false,
+//     expanded=false) — produces the collapsed in-flight card.
+//   - model.go's pairing logic when tool_result arrives (paired=true,
+//     expanded preserved from the model's expandedToolCards set).
+//   - model.go's expand/collapse toggle (paired preserved, expanded
+//     flipped).
+//
+// All three call sites need to produce identical line shapes for the
+// same card state, so the logic lives here rather than being
+// duplicated. Returns at least 3 lines in the collapsed state; the
+// expanded state appends extra wrap lines for full args / result.
+//
+// resultText is the raw tool_result.Result (only used when paired ==
+// true). When paired is false resultText is ignored. When paired is
+// true the result preview replaces the in-flight "⏳ running…"
+// placeholder on the status line.
+func buildToolCardLines(rowID int64, msgID, tool string, args json.RawMessage, resultText string, paired, expanded bool) []narrative.NarrativeLine {
+	displayTool := strings.TrimSpace(tool)
+	if displayTool == "" {
+		displayTool = "(unknown tool)"
+	}
+	headerText := fmt.Sprintf("  [%s] → %s", ts(), displayTool)
+	if expanded {
+		headerText += "  [expanded — tab to collapse]"
+	}
+	headerType := evTypeToolCardHeaderInFlight
+	if paired {
+		headerType = evTypeToolCardHeaderDone
+	}
+
+	// Args line. ToolKeyArg returns the per-tool primary arg (bash
+	// command, file path, etc.) or falls back to a truncated raw
+	// args string for unknown tools. When that returns "" the card
+	// shows the explicit "(no args)" placeholder so the operator
+	// can tell "no args" from "args field missing".
+	keyArg := narrative.ToolKeyArg(displayTool, args)
+	argsEmpty := len(args) == 0 || string(args) == "null" || strings.TrimSpace(string(args)) == "" || strings.TrimSpace(string(args)) == "{}"
+	var argsText string
+	switch {
+	case argsEmpty:
+		argsText = "      args: (no args)"
+	case keyArg == "" && (tool == "todowrite" || tool == "TodoWrite" || tool == "Todowrite"):
+		// todowrite: no key arg but args are present (a TODO list).
+		argsText = "      args: (todo list)"
+	case keyArg == "":
+		// Unknown tool with non-empty args but ToolKeyArg dropped
+		// the value (shouldn't happen — default branch echoes raw
+		// args — but defend explicitly).
+		argsText = "      args: (no args)"
+	default:
+		truncated := truncateForCard(keyArg, toolCardArgsTruncate)
+		argsText = "      args: " + truncated
+	}
+
+	// Status line. In-flight: "⏳ running…". Paired: "↳ <preview>".
+	var statusText, statusType string
+	if paired {
+		summary := narrative.ToolResultSummary(displayTool, resultText)
+		summary = truncateForCard(summary, toolCardResultTruncate)
+		statusText = "      ↳ " + summary
+		statusType = evTypeToolCardStatusDone
+	} else {
+		statusText = "      ⏳ running…"
+		statusType = evTypeToolCardStatusInFlight
+	}
+
+	lines := []narrative.NarrativeLine{
+		{Text: headerText, EventType: headerType, RowID: rowID, MessageID: msgID},
+		{Text: argsText, EventType: evTypeToolCardArgs, MessageID: msgID},
+		{Text: statusText, EventType: statusType, MessageID: msgID},
+	}
+
+	if expanded {
+		// Emit the full args (wrapped) after the args summary line, and
+		// the full result (wrapped) after the status line. Both are
+		// styled dim by the styler so they read as supplementary
+		// context rather than primary content.
+		fullArgs := strings.TrimSpace(string(args))
+		if fullArgs == "" || fullArgs == "null" {
+			fullArgs = "(no args)"
+		}
+		argsLines := wrapForCard(fullArgs, toolCardWrapWidth)
+		// Insert args expansion before the status line.
+		expanded := make([]narrative.NarrativeLine, 0, len(lines)+len(argsLines)+1)
+		expanded = append(expanded, lines[0], lines[1]) // header, args summary
+		for _, l := range argsLines {
+			expanded = append(expanded, narrative.NarrativeLine{
+				Text:      "        " + l,
+				EventType: evTypeToolCardArgsFull,
+				MessageID: msgID,
+			})
+		}
+		expanded = append(expanded, lines[2]) // status line
+		if paired {
+			fullResult := strings.TrimSpace(resultText)
+			if fullResult == "" {
+				fullResult = "(no output)"
+			}
+			resultLines := wrapForCard(fullResult, toolCardWrapWidth)
+			for _, l := range resultLines {
+				expanded = append(expanded, narrative.NarrativeLine{
+					Text:      "        " + l,
+					EventType: evTypeToolCardResultFull,
+					MessageID: msgID,
+				})
+			}
+		}
+		lines = expanded
+	}
+	return lines
+}
+
+// truncateForCard truncates s to at most width runes, appending "…"
+// when truncation occurred. Operates on runes (not bytes) so unicode
+// content is not chopped mid-codepoint. Used by the card renderer for
+// the args and result-preview lines; the styler's truncate() does the
+// final pane-width fit pass.
+func truncateForCard(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	// Replace newlines with " / " so a multi-line value reads as a
+	// single row — the card's collapsed state is one row per slot,
+	// not a free-form block.
+	s = strings.ReplaceAll(s, "\n", " / ")
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+// wrapForCard splits s into rune-bounded chunks of at most width runes
+// each, preserving newline-delimited line breaks where present in the
+// input. Used by the expanded view to render full args/result as
+// multiple display rows.
+func wrapForCard(s string, width int) []string {
+	if width <= 0 {
+		return []string{s}
+	}
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		runes := []rune(line)
+		if len(runes) == 0 {
+			out = append(out, "")
+			continue
+		}
+		for len(runes) > width {
+			out = append(out, string(runes[:width]))
+			runes = runes[width:]
+		}
+		if len(runes) > 0 {
+			out = append(out, string(runes))
+		}
+	}
+	return out
 }
 
 // renderStateChange renders a single dim line of the form

--- a/modules/programs/prism/prism/internal/iris/tui/renderer_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer_test.go
@@ -101,17 +101,20 @@ func TestRenderer_MsgAssistant(t *testing.T) {
 	}
 }
 
-// TestRenderer_ToolCallOneLineCard asserts tool_call renders as a
-// single visual row containing the tool name and its primary argument
-// (the design doc's "one-line card"). The row must be distinguishable
-// from surrounding assistant text — we check for the leading "→"
-// marker that prefixes every tool_call card.
+// TestRenderer_ToolCallOneLineCard asserts a fresh tool_call renders
+// as a multi-line in-flight card (issue #1769 replaces child 2's
+// one-line placeholder). The card carries the tool name on the
+// header line, the truncated args on an args line, and an in-flight
+// status marker ("⏳ running…") on the status line. The exact name of
+// this test is retained from child 2 so the renderer-table coverage
+// map at the top of this file still resolves to a real test — the
+// assertions inside have been updated to match the post-#1769 design.
 func TestRenderer_ToolCallOneLineCard(t *testing.T) {
 	m := modelWithOneSession(t, "tc-test")
 	m = deliverEvent(t, m, "tc-test", "tool_call", 1, map[string]any{
-		"tool":      "bash",
-		"args":      `{"command":"go test ./..."}`,
-		"messageId": "msg-tc-001",
+		"name": "bash",
+		"args": map[string]any{"command": "go test ./..."},
+		"id":   "call-tc-001",
 	})
 
 	view := m.View()
@@ -124,57 +127,66 @@ func TestRenderer_ToolCallOneLineCard(t *testing.T) {
 	if !strings.Contains(view, "→") {
 		t.Errorf("tool_call card marker '→' not in view; excerpt:\n%s", excerpt(view, 600))
 	}
-	// One-row check: the rendered "→ bash: …" payload should appear on
-	// exactly one line in the events pane. We split on '\n' and count
-	// lines mentioning "→ bash" — anything other than 1 means the card
-	// has spilled across rows.
-	cardLines := 0
+	// In-flight status marker must be present (distinct visual for
+	// in-flight vs completed) — AC: "distinct visual styling from a
+	// completed card".
+	if !strings.Contains(view, "running") {
+		t.Errorf("in-flight status marker 'running' not in view; excerpt:\n%s",
+			excerpt(view, 600))
+	}
+	// One-header check: the rendered "→ bash" header should appear on
+	// exactly one line. The args line is a separate row carrying the
+	// args text but not the "→" marker, so this is still tight.
+	headerLines := 0
 	for _, l := range strings.Split(view, "\n") {
 		if strings.Contains(l, "→") && strings.Contains(l, "bash") {
-			cardLines++
+			headerLines++
 		}
 	}
-	if cardLines != 1 {
-		t.Errorf("expected exactly one '→ bash' card row; got %d. view excerpt:\n%s",
-			cardLines, excerpt(view, 800))
+	if headerLines != 1 {
+		t.Errorf("expected exactly one '→ bash' header row; got %d. view excerpt:\n%s",
+			headerLines, excerpt(view, 800))
 	}
 }
 
-// TestRenderer_ToolResultIndentedSummary asserts that a tool_result
-// renders as an indented summary beneath its matching tool_call. The
-// model layer pairs tool_result into the tool_call line (existing
-// behaviour preserved post-refactor) so we look for the result
-// summary text co-located with the tool name.
+// TestRenderer_ToolResultIndentedSummary asserts that a paired
+// tool_call + tool_result renders as a single combined multi-line
+// card with the result preview replacing the in-flight "⏳ running…"
+// status line (issue #1769). The card stays a single block in the
+// pane — no orphaned "↳ result: …" row below the header.
 func TestRenderer_ToolResultIndentedSummary(t *testing.T) {
 	m := modelWithOneSession(t, "tr-test")
 	m = deliverEvent(t, m, "tr-test", "tool_call", 1, map[string]any{
-		"tool":      "bash",
-		"args":      `{"command":"echo hi"}`,
-		"messageId": "msg-tr-001",
+		"name": "bash",
+		"args": map[string]any{"command": "echo hi"},
+		"id":   "call-tr-001",
 	})
 	m = deliverEvent(t, m, "tr-test", "tool_result", 2, map[string]any{
-		"tool":      "bash",
-		"result":    "hi",
-		"messageId": "msg-tr-001",
+		"id":      "call-tr-001",
+		"success": true,
+		"output":  "hi",
 	})
 
 	view := m.View()
-	// The result summary must be present somewhere in the pane …
+	// The result text must be present somewhere in the pane.
 	if !strings.Contains(view, "hi") {
-		t.Errorf("tool_result summary not in view; excerpt:\n%s", excerpt(view, 600))
+		t.Errorf("tool_result text not in view; excerpt:\n%s", excerpt(view, 600))
 	}
-	// … and co-located with its parent tool_call row, not on a
-	// separate top-level line — we check by finding the line carrying
-	// "bash" and verifying the result text is on the same line.
-	for _, l := range strings.Split(view, "\n") {
-		if strings.Contains(l, "→") && strings.Contains(l, "bash") {
-			if !strings.Contains(l, "hi") {
-				t.Errorf("tool_result summary not paired into tool_call line; row:\n%q", l)
-			}
-			return
-		}
+	// The tool header is still present.
+	if !strings.Contains(view, "bash") {
+		t.Errorf("tool name not in view; excerpt:\n%s", excerpt(view, 600))
 	}
-	t.Errorf("no tool_call row found at all; view excerpt:\n%s", excerpt(view, 600))
+	// After pairing, the in-flight "running…" placeholder must be
+	// replaced — distinct visual for completed vs in-flight per AC.
+	if strings.Contains(view, "running…") {
+		t.Errorf("in-flight 'running…' placeholder leaked into a paired card; excerpt:\n%s",
+			excerpt(view, 800))
+	}
+	// The result preview line should carry the "↳" marker indicating
+	// it's the completed-card status line.
+	if !strings.Contains(view, "↳") {
+		t.Errorf("paired card missing '↳' result marker; excerpt:\n%s", excerpt(view, 800))
+	}
 }
 
 // TestRenderer_StateChangeDimLine asserts that state_change events
@@ -430,5 +442,400 @@ func TestStatusLine_NoSubscribedSession(t *testing.T) {
 	if !strings.Contains(v, "no session selected") {
 		t.Errorf("status line should show 'no session selected' placeholder when nothing subscribed; "+
 			"excerpt:\n%s", excerpt(v, 600))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call card tests (issue #1769, child 4 of the iris-tui design)
+// ---------------------------------------------------------------------------
+
+// TestToolCard_InFlightRendering asserts the multi-line card shape on
+// a fresh tool_call: header line with tool name, args line with the
+// truncated args, and an in-flight status line carrying the "running"
+// marker. These three rows together form one card (#1769 AC: "A
+// tool_call event renders as a multi-line card with: tool name on the
+// header line, args displayed (truncated to a sensible width), and
+// visual styling distinct from a completed card").
+func TestToolCard_InFlightRendering(t *testing.T) {
+	m := modelWithOneSession(t, "tc-inflight")
+	m = deliverEvent(t, m, "tc-inflight", "tool_call", 1, map[string]any{
+		"name": "bash",
+		"args": map[string]any{"command": "sleep 60"},
+		"id":   "call-inflight-001",
+	})
+
+	view := m.View()
+
+	// Header: "→ bash" on a line.
+	headerFound := false
+	argsFound := false
+	statusFound := false
+	for _, l := range strings.Split(view, "\n") {
+		switch {
+		case strings.Contains(l, "→") && strings.Contains(l, "bash"):
+			headerFound = true
+		case strings.Contains(l, "args:") && strings.Contains(l, "sleep 60"):
+			argsFound = true
+		case strings.Contains(l, "running"):
+			statusFound = true
+		}
+	}
+	if !headerFound {
+		t.Errorf("tool-card header '→ bash' not found; excerpt:\n%s", excerpt(view, 800))
+	}
+	if !argsFound {
+		t.Errorf("tool-card args line not found; excerpt:\n%s", excerpt(view, 800))
+	}
+	if !statusFound {
+		t.Errorf("tool-card in-flight status not found; excerpt:\n%s", excerpt(view, 800))
+	}
+
+	// Card bookkeeping: one card is registered.
+	if got := tui.ModelToolCardCount(m); got != 1 {
+		t.Errorf("expected 1 tool card; got %d", got)
+	}
+}
+
+// TestToolCard_CompletedRendering asserts that a tool_call followed by
+// its matching tool_result renders as a single combined card with the
+// result preview replacing the in-flight placeholder. Distinct visual
+// from in-flight: the "running" marker must be gone and the "↳"
+// result marker must be present.
+func TestToolCard_CompletedRendering(t *testing.T) {
+	m := modelWithOneSession(t, "tc-done")
+	m = deliverEvent(t, m, "tc-done", "tool_call", 1, map[string]any{
+		"name": "bash",
+		"args": map[string]any{"command": "echo done"},
+		"id":   "call-done-001",
+	})
+	m = deliverEvent(t, m, "tc-done", "tool_result", 2, map[string]any{
+		"id":      "call-done-001",
+		"success": true,
+		"output":  "done",
+	})
+
+	view := m.View()
+
+	if !strings.Contains(view, "→") || !strings.Contains(view, "bash") {
+		t.Errorf("tool-card header missing after pair; excerpt:\n%s", excerpt(view, 800))
+	}
+	if !strings.Contains(view, "echo done") {
+		t.Errorf("tool-card args missing after pair; excerpt:\n%s", excerpt(view, 800))
+	}
+	if !strings.Contains(view, "↳") {
+		t.Errorf("completed result marker '↳' missing; excerpt:\n%s", excerpt(view, 800))
+	}
+	if strings.Contains(view, "running…") {
+		t.Errorf("in-flight 'running…' placeholder leaked into paired card; excerpt:\n%s",
+			excerpt(view, 800))
+	}
+	// Still exactly one card.
+	if got := tui.ModelToolCardCount(m); got != 1 {
+		t.Errorf("expected 1 tool card after pairing; got %d", got)
+	}
+}
+
+// TestToolCard_TabExpandsAndCollapses asserts the expand/collapse
+// keybinding (#1769 AC: "Pressing `tab` while the conversation pane
+// has focus expands the currently-selected tool-call card to show
+// full args and full result. Pressing `tab` again collapses it
+// back"). We set focus to the events pane directly via the test
+// helper, then drive a tab key, asserting both the model's
+// expandedToolCards bookkeeping and that the line count grows /
+// shrinks on toggle.
+func TestToolCard_TabExpandsAndCollapses(t *testing.T) {
+	m := modelWithOneSession(t, "tc-expand")
+	// Use a long args + result so the expanded view has something
+	// substantial to add beyond the collapsed summary.
+	// Post-#1783: args is a JSON object (RawMessage on the Go
+	// side). Use a Go map so json.Marshal produces a properly
+	// formed object literal. Multi-line content inside the command
+	// string exercises the expanded card's wrap behaviour without
+	// breaking the JSON.
+	longArgs := map[string]any{"command": "echo line1\necho line2\necho line3"}
+	longResult := "line1\nline2\nline3\nline4\nline5"
+	m = deliverEvent(t, m, "tc-expand", "tool_call", 1, map[string]any{
+		"name": "bash",
+		"args": longArgs,
+		"id":   "call-expand-001",
+	})
+	m = deliverEvent(t, m, "tc-expand", "tool_result", 2, map[string]any{
+		"id":      "call-expand-001",
+		"success": true,
+		"output":  longResult,
+	})
+
+	collapsedLines := tui.ModelEventLineCount(m)
+	if tui.ModelToolCardExpanded(m, "call-expand-001") {
+		t.Fatalf("card unexpectedly starts expanded")
+	}
+
+	// Land focus on events pane (the rotation path is covered by the
+	// #1737 focus tests; this test only cares about the tab→expand
+	// edge).
+	m = tui.SetModelFocus(m, tui.FocusEvents)
+	if tui.ModelFocus(m) != tui.FocusEvents {
+		t.Fatalf("focus did not land on events: %d", tui.ModelFocus(m))
+	}
+
+	// Tab → expand.
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = m2.(tui.Model)
+	if !tui.ModelToolCardExpanded(m, "call-expand-001") {
+		t.Errorf("tab did not expand the tool card")
+	}
+	expandedLines := tui.ModelEventLineCount(m)
+	if expandedLines <= collapsedLines {
+		t.Errorf("expanded line count (%d) did not grow vs collapsed (%d)",
+			expandedLines, collapsedLines)
+	}
+	// Expanded view should contain at least one of the inner lines
+	// from the full result (which is multi-line in the input).
+	view := m.View()
+	if !strings.Contains(view, "line3") {
+		t.Errorf("expanded card missing full-result content 'line3'; excerpt:\n%s",
+			excerpt(view, 800))
+	}
+
+	// Tab again → collapse.
+	m2, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = m2.(tui.Model)
+	if tui.ModelToolCardExpanded(m, "call-expand-001") {
+		t.Errorf("second tab did not collapse the tool card")
+	}
+	if got := tui.ModelEventLineCount(m); got != collapsedLines {
+		t.Errorf("collapsed line count after toggle = %d; want %d", got, collapsedLines)
+	}
+
+	// Focus must NOT have rotated to prompt — tab was consumed by the
+	// expand toggle.
+	if tui.ModelFocus(m) != tui.FocusEvents {
+		t.Errorf("focus rotated away from events after tab-toggle; got %d", tui.ModelFocus(m))
+	}
+}
+
+// TestToolCard_ExpansionSurvivesNewEvents asserts the AC: "The
+// expand/collapse state survives subsequent event arrivals — receiving
+// a new event while a card is expanded does not collapse it."
+func TestToolCard_ExpansionSurvivesNewEvents(t *testing.T) {
+	m := modelWithOneSession(t, "tc-survive")
+	m = deliverEvent(t, m, "tc-survive", "tool_call", 1, map[string]any{
+		"name": "bash",
+		"args": map[string]any{"command": "echo a"},
+		"id":   "call-survive-001",
+	})
+
+	// Expand the card.
+	m = tui.SetModelFocus(m, tui.FocusEvents)
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = m2.(tui.Model)
+	if !tui.ModelToolCardExpanded(m, "call-survive-001") {
+		t.Fatalf("setup: card did not expand on tab")
+	}
+
+	// Deliver an unrelated event.
+	m = deliverEvent(t, m, "tc-survive", "msg_assistant", 2, map[string]any{
+		"text": "still here",
+	})
+	if !tui.ModelToolCardExpanded(m, "call-survive-001") {
+		t.Errorf("card collapsed when an unrelated event arrived")
+	}
+
+	// Deliver the matching tool_result — pairing should retain
+	// expansion.
+	m = deliverEvent(t, m, "tc-survive", "tool_result", 3, map[string]any{
+		"id":      "call-survive-001",
+		"success": true,
+		"output":  "a",
+	})
+	if !tui.ModelToolCardExpanded(m, "call-survive-001") {
+		t.Errorf("card collapsed when its matching tool_result arrived")
+	}
+	// View should still show the assistant text after the card.
+	view := m.View()
+	if !strings.Contains(view, "still here") {
+		t.Errorf("post-pair view missing intervening msg_assistant; excerpt:\n%s",
+			excerpt(view, 800))
+	}
+}
+
+// TestToolCard_MalformedArgs asserts the edge-case AC: "A tool_call
+// with no args, with empty args, or with malformed args JSON does not
+// panic — renders the card with a clear placeholder ('(no args)' or
+// equivalent)."
+//
+// Post-#1783 the wire shape for args is a JSON value (object,
+// usually). Each subtest below builds the payload JSON manually so
+// we can inject specific edge-case shapes (missing field, null,
+// empty object, malformed bytes) and prove the renderer doesn't
+// panic and produces a useful placeholder.
+func TestToolCard_MalformedArgs(t *testing.T) {
+	cases := []struct {
+		name           string
+		rawPayload     string // full payload JSON
+		wantNoArgsHint bool   // expect "(no args)" in view
+	}{
+		{
+			name:           "args field missing",
+			rawPayload:     `{"name":"bash","id":"call-m-1"}`,
+			wantNoArgsHint: true,
+		},
+		{
+			name:           "args null",
+			rawPayload:     `{"name":"bash","id":"call-m-2","args":null}`,
+			wantNoArgsHint: true,
+		},
+		{
+			name:           "args empty object",
+			rawPayload:     `{"name":"bash","id":"call-m-3","args":{}}`,
+			wantNoArgsHint: true,
+		},
+		{
+			name: "args has unrelated keys",
+			// `{"foo":"bar"}` is well-formed JSON but doesn't carry
+			// the per-tool key (e.g. command for bash). ToolKeyArg
+			// falls through to its default "raw args" branch; we
+			// accept either a placeholder or a literal echo as a
+			// non-blank render.
+			rawPayload:     `{"name":"bash","id":"call-m-4","args":{"foo":"bar"}}`,
+			wantNoArgsHint: false,
+		},
+		{
+			name: "args is a string literal (legacy)",
+			// Some replay paths may surface args as a string. The
+			// renderer must not panic; ExtractBashCommand falls
+			// back to treating the string as the command verbatim.
+			rawPayload:     `{"name":"bash","id":"call-m-5","args":"echo legacy"}`,
+			wantNoArgsHint: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("renderer panicked on %s: %v", tc.name, r)
+				}
+			}()
+			m := modelWithOneSession(t, "tc-malformed")
+			m2, _ := m.Update(tui.DaemonFrame{
+				RawType: iris.DaemonFrameSessionEvent,
+				Event: &iris.DaemonSessionEventFrame{
+					Type:        iris.DaemonFrameSessionEvent,
+					SessionName: "tc-malformed",
+					RowID:       1,
+					EventType:   "tool_call",
+					Payload:     tc.rawPayload,
+				},
+			})
+			m = m2.(tui.Model)
+
+			view := m.View()
+			// Card header still renders.
+			if !strings.Contains(view, "bash") {
+				t.Errorf("[%s] missing tool header; excerpt:\n%s", tc.name, excerpt(view, 600))
+			}
+			if tc.wantNoArgsHint && !strings.Contains(view, "(no args)") {
+				t.Errorf("[%s] missing '(no args)' placeholder; excerpt:\n%s",
+					tc.name, excerpt(view, 600))
+			}
+			// Card is still registered.
+			if got := tui.ModelToolCardCount(m); got != 1 {
+				t.Errorf("[%s] expected 1 card; got %d", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestToolCard_OrphanToolResult asserts the edge-case AC: "A
+// tool_result with no matching tool_call (e.g. the parent scrolled
+// out of the in-memory window) renders as a standalone indented
+// summary, same as child 2's current behaviour. Don't regress that
+// path."
+func TestToolCard_OrphanToolResult(t *testing.T) {
+	m := modelWithOneSession(t, "tc-orphan")
+	m = deliverEvent(t, m, "tc-orphan", "tool_result", 1, map[string]any{
+		"id":      "call-no-parent",
+		"success": true,
+		"output":  "hello",
+	})
+
+	view := m.View()
+	// The legacy single-line "↳ result:" path must still produce a row.
+	if !strings.Contains(view, "result:") || !strings.Contains(view, "hello") {
+		t.Errorf("orphan tool_result not rendered via legacy path; excerpt:\n%s",
+			excerpt(view, 800))
+	}
+	// No card was registered — orphan results do not create cards.
+	if got := tui.ModelToolCardCount(m); got != 0 {
+		t.Errorf("orphan tool_result installed a card; got %d", got)
+	}
+}
+
+// TestToolCard_LateToolResultPairs asserts the edge-case AC: "A
+// tool_result arriving for a tool_call that has scrolled out of the
+// visible viewport still pairs correctly when the user scrolls back —
+// no orphan one-line tool_result rows."
+//
+// We can't simulate viewport scroll in unit tests directly, but we
+// CAN verify the underlying invariant: a tool_result arriving after
+// the tool_call's lines have been mutated by intervening events
+// still finds the matching card via the MessageID index, and folds
+// into the card rather than producing an orphan "↳ result:" row.
+func TestToolCard_LateToolResultPairs(t *testing.T) {
+	m := modelWithOneSession(t, "tc-late")
+	m = deliverEvent(t, m, "tc-late", "tool_call", 1, map[string]any{
+		"name": "bash",
+		"args": map[string]any{"command": "sleep 1"},
+		"id":   "call-late-001",
+	})
+	// Several intervening events shift the layout but the card
+	// remains tracked by id.
+	for i := 0; i < 5; i++ {
+		m = deliverEvent(t, m, "tc-late", "msg_assistant", int64(i+2), map[string]any{
+			"text": "interim message",
+		})
+	}
+	m = deliverEvent(t, m, "tc-late", "tool_result", 100, map[string]any{
+		"id":      "call-late-001",
+		"success": true,
+		"output":  "ok",
+	})
+
+	view := m.View()
+	// In-flight marker must be replaced by the result preview.
+	if strings.Contains(view, "running…") {
+		t.Errorf("late tool_result did not replace in-flight marker; excerpt:\n%s",
+			excerpt(view, 1200))
+	}
+	if !strings.Contains(view, "↳") {
+		t.Errorf("late tool_result did not produce the completed status marker; excerpt:\n%s",
+			excerpt(view, 1200))
+	}
+	// And NO orphan "↳ result:" line (that's the legacy fallback the
+	// pair path is supposed to avoid).
+	orphanCount := 0
+	for _, l := range strings.Split(view, "\n") {
+		if strings.Contains(l, "↳ result:") {
+			orphanCount++
+		}
+	}
+	if orphanCount > 0 {
+		t.Errorf("late tool_result produced %d orphan '↳ result:' rows; want 0", orphanCount)
+	}
+}
+
+// TestToolCard_TabWithoutCardsRotatesFocus asserts that tab continues
+// to rotate focus when no tool card exists. Without this fallback,
+// the pre-#1769 tab-rotation behaviour would regress whenever the
+// conversation pane is empty / has no tool calls.
+func TestToolCard_TabWithoutCardsRotatesFocus(t *testing.T) {
+	m := modelWithOneSession(t, "tc-norotate")
+	m = tui.SetModelFocus(m, tui.FocusEvents)
+
+	// No tool cards yet → tab must rotate focus to prompt.
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = m2.(tui.Model)
+	if got := tui.ModelFocus(m); got != tui.FocusPrompt {
+		t.Errorf("tab on empty events pane did not rotate focus to prompt; got %d", got)
 	}
 }

--- a/modules/programs/prism/prism/internal/iris/tui/tui_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/tui_test.go
@@ -545,11 +545,11 @@ func TestToolCallResultPairing(t *testing.T) {
 	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
 	m = m2.(tui.Model)
 
-	// Send tool_call.
-	tcPayload, _ := json.Marshal(map[string]string{
-		"tool":      "bash",
-		"args":      `{"command":"echo hello"}`,
-		"messageId": "msg-tc-001",
+	// Send tool_call. Post-#1783 wire shape: `name`/`id`/`args` (object).
+	tcPayload, _ := json.Marshal(map[string]any{
+		"name": "bash",
+		"args": map[string]any{"command": "echo hello"},
+		"id":   "call-tc-001",
 	})
 	m2, _ = m.Update(tui.DaemonFrame{
 		RawType: iris.DaemonFrameSessionEvent,
@@ -563,11 +563,11 @@ func TestToolCallResultPairing(t *testing.T) {
 	})
 	m = m2.(tui.Model)
 
-	// Send tool_result.
-	trPayload, _ := json.Marshal(map[string]string{
-		"tool":      "bash",
-		"result":    "hello",
-		"messageId": "msg-tc-001",
+	// Send tool_result. Post-#1783 wire shape: `id`/`success`/`output`.
+	trPayload, _ := json.Marshal(map[string]any{
+		"id":      "call-tc-001",
+		"success": true,
+		"output":  "hello",
 	})
 	m2, _ = m.Update(tui.DaemonFrame{
 		RawType: iris.DaemonFrameSessionEvent,
@@ -813,20 +813,28 @@ func TestNarrativeRenderEvent(t *testing.T) {
 	})
 
 	t.Run("tool_call_bash", func(t *testing.T) {
-		p, _ := json.Marshal(map[string]string{
-			"tool":      "bash",
-			"args":      `{"command":"go test ./..."}`,
-			"messageId": "mid-3",
+		// Post-#1783 wire shape: `name`, `args` (object), `id`.
+		p, _ := json.Marshal(map[string]any{
+			"name": "bash",
+			"args": map[string]any{"command": "go test ./..."},
+			"id":   "call-mid-3",
 		})
 		lines := renderEventForTest(4, "tool_call", string(p))
 		if len(lines) == 0 {
 			t.Fatal("no lines for tool_call")
 		}
 		if !strings.Contains(lines[0].Text, "bash") {
-			t.Errorf("tool name not in line: %q", lines[0].Text)
+			t.Errorf("tool name not in header line: %q", lines[0].Text)
 		}
-		if !strings.Contains(lines[0].Text, "go test ./...") {
-			t.Errorf("command not in line: %q", lines[0].Text)
+		// Args appear on the second line of the multi-line card
+		// (#1769). Search across all lines so the assertion stays
+		// robust to layout tweaks.
+		joined := lines[0].Text
+		for _, l := range lines[1:] {
+			joined += "\n" + l.Text
+		}
+		if !strings.Contains(joined, "go test ./...") {
+			t.Errorf("command not in any line of the card: %q", joined)
 		}
 	})
 

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -68,21 +68,63 @@ type MsgAssistant struct {
 
 // ToolCall is the payload for tool_call events.
 //
-// DurationMs is the wall-clock time of the tool execution in milliseconds,
-// measured from state.start to state.end on the tool part. Zero means
-// "not available" (pre-enrichment events or tools that don't report timing).
+// Field shape (issue #1783): the JSON field names mirror what the pi
+// prism extension emits verbatim on the harness socket
+// (`pi/extensions/prism.ts:2429-2444`):
+//
+//	{"type":"tool_call","id":"...","name":"bash","args":{"command":"…"},"truncated":false}
+//
+// Pre-#1783 the struct declared `tool`, `args` (Go `string`), and
+// `messageId` — a wire format that no live producer has emitted since
+// at least pi 0.72.1. Renderers using the old fields saw
+// `json.Unmarshal` fail on `args` (object vs string mismatch) and
+// emitted `(parse error)` for every tool call. The rename here
+// realigns the consumer side with the upstream wire shape; the older
+// `internal/harness/pi/adapter.go::NormaliseFrame` Translate path is
+// updated alongside so DB rows written by that path also carry the
+// new field names.
+//
+// Args is a `json.RawMessage` because the extension emits a JSON
+// object (a `Record<string, unknown>`), not an escaped string. Each
+// consumer is responsible for re-marshalling or extracting per-tool
+// fields (see `narrative.ToolKeyArg`). An empty/zero RawMessage means
+// "no args" and must not panic any consumer.
+//
+// Truncated is set by the extension when args were oversized for the
+// 500-char budget; renderers may surface this as a visual hint.
+//
+// DurationMs is kept for backward compatibility with the older PI
+// stdio adapter (B5.TR Translate strategy in
+// `internal/harness/pi/adapter.go`) which still populates it from
+// `elapsed_ms`. The current prism extension does not emit a duration
+// field; DurationMs is zero in that case.
 type ToolCall struct {
-	Tool       string `json:"tool"`
-	Args       string `json:"args"`
-	MessageID  string `json:"messageId"`
-	DurationMs int64  `json:"durationMs,omitempty"`
+	Name       string          `json:"name"`
+	Args       json.RawMessage `json:"args,omitempty"`
+	ID         string          `json:"id"`
+	Truncated  bool            `json:"truncated,omitempty"`
+	DurationMs int64           `json:"durationMs,omitempty"`
 }
 
 // ToolResult is the payload for tool_result events.
+//
+// Field shape (issue #1783) matches the pi prism extension's emitted
+// JSON (`pi/extensions/prism.ts:2503-2517`):
+//
+//	{"type":"tool_result","id":"...","success":true,"output":"…","truncated":false}
+//
+// `id` is the tool-call id (same value as ToolCall.ID), used to pair
+// the result back to its call. `success` is the negation of pi's
+// `isError` flag. `output` is the stringified tool output truncated
+// to the extension's character budget.
+//
+// The older PI stdio adapter (Translate path) produces the same
+// shape after #1783; see `internal/harness/pi/adapter.go`.
 type ToolResult struct {
-	Tool      string `json:"tool"`
-	Result    string `json:"result"`
-	MessageID string `json:"messageId"`
+	ID        string `json:"id"`
+	Success   bool   `json:"success"`
+	Output    string `json:"output"`
+	Truncated bool   `json:"truncated,omitempty"`
 }
 
 // PermissionAsk is the payload for permission_ask events.

--- a/modules/programs/prism/prism/internal/payload/payload_test.go
+++ b/modules/programs/prism/prism/internal/payload/payload_test.go
@@ -86,31 +86,109 @@ func TestMsgAssistant_Roundtrip(t *testing.T) {
 	}
 }
 
+// TestToolCall_Roundtrip covers the post-#1783 wire shape: `name`,
+// `args` (json.RawMessage / JSON object), `id`. The previous test
+// used the old `tool`/`messageId`/string-args trio which had drifted
+// silently from pi 0.72.1's emitted payload — see issue #1783 for
+// the full root cause analysis.
 func TestToolCall_Roundtrip(t *testing.T) {
-	in := payload.ToolCall{Tool: "bash", Args: `{"command":"go test ./..."}`, MessageID: "msg-1"}
+	in := payload.ToolCall{
+		Name: "bash",
+		Args: json.RawMessage(`{"command":"go test ./..."}`),
+		ID:   "call-1",
+	}
 	out := roundtrip(t, in)
-	if out.Tool != in.Tool {
-		t.Errorf("Tool: got %q, want %q", out.Tool, in.Tool)
+	if out.Name != in.Name {
+		t.Errorf("Name: got %q, want %q", out.Name, in.Name)
 	}
-	if out.Args != in.Args {
-		t.Errorf("Args: got %q, want %q", out.Args, in.Args)
+	if string(out.Args) != string(in.Args) {
+		t.Errorf("Args: got %q, want %q", string(out.Args), string(in.Args))
 	}
-	if out.MessageID != in.MessageID {
-		t.Errorf("MessageID: got %q, want %q", out.MessageID, in.MessageID)
+	if out.ID != in.ID {
+		t.Errorf("ID: got %q, want %q", out.ID, in.ID)
 	}
 }
 
+// TestToolResult_Roundtrip covers the post-#1783 wire shape: `id`,
+// `success`, `output`. Pre-#1783 the struct declared `tool`,
+// `result`, `messageId` — silently broken because the pi extension
+// never emitted that shape.
 func TestToolResult_Roundtrip(t *testing.T) {
-	in := payload.ToolResult{Tool: "bash", Result: "ok", MessageID: "msg-1"}
+	in := payload.ToolResult{
+		ID:      "call-1",
+		Success: true,
+		Output:  "ok",
+	}
 	out := roundtrip(t, in)
-	if out.Tool != in.Tool {
-		t.Errorf("Tool: got %q, want %q", out.Tool, in.Tool)
+	if out.ID != in.ID {
+		t.Errorf("ID: got %q, want %q", out.ID, in.ID)
 	}
-	if out.Result != in.Result {
-		t.Errorf("Result: got %q, want %q", out.Result, in.Result)
+	if out.Success != in.Success {
+		t.Errorf("Success: got %v, want %v", out.Success, in.Success)
 	}
-	if out.MessageID != in.MessageID {
-		t.Errorf("MessageID: got %q, want %q", out.MessageID, in.MessageID)
+	if out.Output != in.Output {
+		t.Errorf("Output: got %q, want %q", out.Output, in.Output)
+	}
+}
+
+// TestToolCall_PiExtensionWireShape is the regression test required
+// by issue #1783's acceptance criteria: pins the pi 0.72.1
+// prism-extension wire format so an upstream rename surfaces here as
+// a deliberate test failure rather than a silent (parse error)
+// regression in the iris TUI.
+//
+// The fixture JSON below is byte-for-byte representative of what
+// `pi/extensions/prism.ts:2429-2444` writes to the harness socket
+// for a real tool_execution_start event.
+func TestToolCall_PiExtensionWireShape(t *testing.T) {
+	raw := []byte(`{"type":"tool_call","id":"call-abc-123","name":"bash","args":{"command":"echo hi"}}`)
+	var tc payload.ToolCall
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		t.Fatalf("unmarshal pi-extension tool_call: %v", err)
+	}
+	if tc.Name != "bash" {
+		t.Errorf("Name: got %q, want %q", tc.Name, "bash")
+	}
+	if tc.ID != "call-abc-123" {
+		t.Errorf("ID: got %q, want %q", tc.ID, "call-abc-123")
+	}
+	if string(tc.Args) != `{"command":"echo hi"}` {
+		t.Errorf("Args: got %q, want a JSON object literal", string(tc.Args))
+	}
+	if tc.Truncated {
+		t.Errorf("Truncated: got true, want false (no truncated field on wire)")
+	}
+}
+
+// TestToolResult_PiExtensionWireShape mirrors TestToolCall_PiExtensionWireShape
+// for the tool_result path (`pi/extensions/prism.ts:2503-2517`).
+func TestToolResult_PiExtensionWireShape(t *testing.T) {
+	raw := []byte(`{"type":"tool_result","id":"call-abc-123","success":true,"output":"hi\n"}`)
+	var tr payload.ToolResult
+	if err := json.Unmarshal(raw, &tr); err != nil {
+		t.Fatalf("unmarshal pi-extension tool_result: %v", err)
+	}
+	if tr.ID != "call-abc-123" {
+		t.Errorf("ID: got %q, want %q", tr.ID, "call-abc-123")
+	}
+	if !tr.Success {
+		t.Errorf("Success: got false, want true")
+	}
+	if tr.Output != "hi\n" {
+		t.Errorf("Output: got %q, want %q", tr.Output, "hi\n")
+	}
+}
+
+// TestToolResult_PiExtensionWireShape_Error covers the error path:
+// `success` toggles to false when pi reports `isError: true`.
+func TestToolResult_PiExtensionWireShape_Error(t *testing.T) {
+	raw := []byte(`{"type":"tool_result","id":"call-err-1","success":false,"output":"E: command not found","truncated":false}`)
+	var tr payload.ToolResult
+	if err := json.Unmarshal(raw, &tr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if tr.Success {
+		t.Errorf("Success: got true, want false")
 	}
 }
 
@@ -280,15 +358,19 @@ func TestJSONFieldNames(t *testing.T) {
 		t.Errorf("MsgUser.Model: got %q, want \"gh/claude\" (check json:\"model\" tag)", mu.Model)
 	}
 
-	rawTC := `{"tool":"bash","args":"go build","messageId":"abc"}`
+	// Post-#1783: ToolCall wire shape is `{name, id, args}` (args is
+	// a JSON value, not an escaped string). The previous fixture's
+	// `{tool, args, messageId}` shape no longer matches the struct
+	// tags and would silently zero-value the fields.
+	rawTC := `{"type":"tool_call","name":"bash","id":"call-abc","args":{"command":"go build"}}`
 	var tc payload.ToolCall
 	if err := json.Unmarshal([]byte(rawTC), &tc); err != nil {
 		t.Fatalf("unmarshal ToolCall: %v", err)
 	}
-	if tc.Tool != "bash" {
-		t.Errorf("ToolCall.Tool: got %q, want \"bash\"", tc.Tool)
+	if tc.Name != "bash" {
+		t.Errorf("ToolCall.Name: got %q, want \"bash\" (check json:\"name\" tag)", tc.Name)
 	}
-	if tc.MessageID != "abc" {
-		t.Errorf("ToolCall.MessageID: got %q, want \"abc\" (check json:\"messageId\" tag)", tc.MessageID)
+	if tc.ID != "call-abc" {
+		t.Errorf("ToolCall.ID: got %q, want \"call-abc\" (check json:\"id\" tag)", tc.ID)
 	}
 }


### PR DESCRIPTION
Child 4 of the bubbletea-native iris TUI design (tracker #1765). Replaces the one-line tool placeholder from child 2 (#1767) with a multi-line **tool-call card**, adds **expand/collapse on `tab`**, and gives **in-flight** vs **completed** cards visually distinct styling.

Coordinator steered this PR to absorb **#1783** mid-flight: the existing renderer's payload-shape expectations (`{tool, args:string, messageId}`) had drifted from what pi 0.72.1's prism extension actually emits (`{name, args:object, id}`), so every real tool call rendered as `(parse error)` in the live TUI. Fixing it as part of this PR avoided a follow-up edit to the same handler/tests.

## What's in this PR

### #1769 — tool-call cards (`iris(tui): multi-line tool-call cards with expand/collapse`)

Card shape (collapsed):

```
[HH:MM:SS] → bash
    args: go test ./...
    ⏳ running…                         ← in-flight (yellow + bold)
```

After the matching tool_result arrives:

```
[HH:MM:SS] → bash
    args: go test ./...
    ↳ ok                                ← completed (dim)
```

Expand (`tab` while focus is on the events pane) appends the wrapped full args and full result; second `tab` collapses.

- New `toolCard` model state, ordered `toolCards` slice + `toolCardByMsgID` index. `buildToolCardLines` is the single source of truth for card geometry; `rebuildCardLines` splices a card's range in `eventLines` and shifts later cards' indices.
- Expanded set keyed on payload.ToolCall.ID — survives event arrivals (AC: 'receiving a new event while a card is expanded does not collapse it').
- `tab` on `focusEvents` with at least one card toggles the most recent card's expansion; otherwise it falls through to the existing #1737 focus rotation, so no regression when the pane is empty.
- Orphan tool_result rows (no matching tool_call) still render via the legacy single-line indented summary — child 2's path is preserved.

### #1783 — payload shape fix (`iris: align ToolCall/ToolResult payload with pi 0.72.1 wire shape`)

- `payload.ToolCall`: `Name string`, `Args json.RawMessage`, `ID string`, optional `Truncated bool`. `DurationMs` retained for the older PI stdio adapter.
- `payload.ToolResult`: `ID string`, `Success bool`, `Output string`, optional `Truncated bool`.
- `narrative.ToolKeyArg` now takes `(tool string, args json.RawMessage)` and unwraps JSON-string literals so legacy bash-as-string fixtures keep producing the expected output.
- `internal/harness/pi/adapter.go` (B5.TR Translate strategy) produces the new field names; `marshalArgs` returns `json.RawMessage`.
- All other consumers updated: `cmd/checkin_raw.go`, `cmd/iris/checkin.go`, `cmd/stats_metrics.go`, `cmd/checkin_tools.go`. The prism (non-iris) checkin pairing was rewritten to pair by `id` (the new authoritative field) rather than the previous tool-name FIFO heuristic.
- Pi 0.72.1 wire-shape regression tests pin the format (`TestToolCall_PiExtensionWireShape`, `TestToolResult_PiExtensionWireShape`, plus an error-path variant). When upstream changes shape again these fail deliberately rather than surfacing as `(parse error)` at runtime.

### Out-of-scope finding (escalated, not fixed here)

While auditing, I confirmed that `internal/db/events.go::QueryEventsByMessageIDs` filters child events with `JSON_EXTRACT(payload, '$.messageId')` — but the pi extension does NOT emit a parent-message linkage on tool_call/tool_result frames (the per-call `id` is the toolCallId, not a parent messageId). Production `iris checkin` / `prism checkin --turns` therefore silently drop tool rows from real sessions today, both before and after this PR.

Test fixtures in `cmd/checkin_test.go` and `cmd/iris/checkin_test.go` inject a synthetic `messageId` alongside the new fields to keep the SQL pushdown finding child events during tests. Production behaviour for the checkin secondary-query path is unchanged from its pre-#1783 broken state until a separate fix lands. Escalated to the coordinator on 2026-05-17.

## Test coverage

`internal/iris/tui/renderer_test.go` — new tests:
- `TestToolCard_InFlightRendering`
- `TestToolCard_CompletedRendering`
- `TestToolCard_TabExpandsAndCollapses`
- `TestToolCard_ExpansionSurvivesNewEvents`
- `TestToolCard_MalformedArgs` (5 sub-cases: field missing / null / empty object / unrelated keys / string literal)
- `TestToolCard_OrphanToolResult` (regression-guard for child 2's orphan path)
- `TestToolCard_LateToolResultPairs` (pairing survives intervening events)
- `TestToolCard_TabWithoutCardsRotatesFocus` (regression-guard for the focus-rotation fallback)

Existing `TestRenderer_ToolCallOneLineCard` / `TestRenderer_ToolResultIndentedSummary` updated to the new card shape; existing TUI integration tests (`TestToolCallResultPairing`, `TestNarrativeRenderEvent`) updated to the new wire shape.

`internal/payload/payload_test.go` — new regression tests:
- `TestToolCall_PiExtensionWireShape` (pins pi 0.72.1's exact emitted format)
- `TestToolResult_PiExtensionWireShape` + `_Error` (success and isError paths)

## Pre-PR self-check

```bash
cd modules/programs/prism/prism && go build ./... && go test ./... -race
# (passes)
nix build .#prism
# (passes)
```

Refs #1765
Closes #1769
Closes #1783