### PR TITLE
iris(tui): conversation pane viewport, scrollback, lazy-load history (#1770)

### DIFF
--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -7509,3 +7509,112 @@ func TestUpsertStatusSeedRootAgentName_PreservesHarness(t *testing.T) {
 		t.Errorf("harness = %q after empty-harness upsert; want %q", got, "pi")
 	}
 }
+
+// TestQuerySessionEventsBeforeRowID covers the paged-history query that
+// backs the iris TUI's lazy-load scrollback (issue #1770 child 5). The
+// query must:
+//
+//   - return up to `limit` rows in ASC rowid order
+//   - filter by session_name
+//   - use rowid < beforeRowID when beforeRowID > 0
+//   - return the most recent `limit` rows when beforeRowID == 0
+//   - return an empty slice (not an error) when no rows match
+func TestQuerySessionEventsBeforeRowID(t *testing.T) {
+	d := openTestDB(t)
+
+	// Write 10 events for two different sessions interleaved, so the
+	// per-session filter has to actually do work.
+	now := time.Now()
+	for i := 0; i < 10; i++ {
+		e := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: "repo@main",
+			Repo:        "repo",
+			Worktree:    "/wt/main",
+			Type:        "state_change",
+			Payload:     `{"i":` + fmt.Sprintf("%d", i) + `}`,
+			CreatedAt:   now.Add(time.Duration(i) * time.Second),
+		}
+		if _, err := d.WriteEventReturningRowID(e); err != nil {
+			t.Fatalf("WriteEventReturningRowID main[%d]: %v", i, err)
+		}
+		// Intersperse other-session rows that the query must ignore.
+		other := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: "repo@other",
+			Repo:        "repo",
+			Worktree:    "/wt/other",
+			Type:        "state_change",
+			Payload:     `{"other":` + fmt.Sprintf("%d", i) + `}`,
+			CreatedAt:   now.Add(time.Duration(i) * time.Second),
+		}
+		if _, err := d.WriteEventReturningRowID(other); err != nil {
+			t.Fatalf("WriteEventReturningRowID other[%d]: %v", i, err)
+		}
+	}
+
+	// beforeRowID == 0 should return the most recent `limit` rows.
+	tail, err := d.QuerySessionEventsBeforeRowID("repo@main", 0, 3)
+	if err != nil {
+		t.Fatalf("QuerySessionEventsBeforeRowID(tail): %v", err)
+	}
+	if len(tail) != 3 {
+		t.Fatalf("tail len = %d, want 3", len(tail))
+	}
+	// ASC ordering by rowid; payload encodes the original insertion index.
+	wantPayloads := []string{`{"i":7}`, `{"i":8}`, `{"i":9}`}
+	for i, er := range tail {
+		if er.Event.Payload != wantPayloads[i] {
+			t.Errorf("tail[%d].Payload = %q, want %q", i, er.Event.Payload, wantPayloads[i])
+		}
+		if er.Event.SessionName != "repo@main" {
+			t.Errorf("tail[%d].SessionName = %q, want repo@main (cross-session leak?)", i, er.Event.SessionName)
+		}
+	}
+
+	// Now page backwards: take the rowid of the first row in `tail`
+	// and ask for everything strictly before it.
+	beforeRowID := tail[0].RowID
+	older, err := d.QuerySessionEventsBeforeRowID("repo@main", beforeRowID, 100)
+	if err != nil {
+		t.Fatalf("QuerySessionEventsBeforeRowID(older): %v", err)
+	}
+	if len(older) != 7 {
+		t.Fatalf("older len = %d, want 7 (10 total minus 3 in tail)", len(older))
+	}
+	// ASC ordering; payloads i=0..6.
+	for i, er := range older {
+		want := `{"i":` + fmt.Sprintf("%d", i) + `}`
+		if er.Event.Payload != want {
+			t.Errorf("older[%d].Payload = %q, want %q", i, er.Event.Payload, want)
+		}
+	}
+
+	// Paging past the head: ask for everything before the very first row.
+	headRowID := older[0].RowID
+	none, err := d.QuerySessionEventsBeforeRowID("repo@main", headRowID, 10)
+	if err != nil {
+		t.Fatalf("QuerySessionEventsBeforeRowID(none): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("none len = %d, want 0 (paged past head of history)", len(none))
+	}
+
+	// limit == 0 short-circuits to an empty result.
+	zero, err := d.QuerySessionEventsBeforeRowID("repo@main", 0, 0)
+	if err != nil {
+		t.Fatalf("QuerySessionEventsBeforeRowID(zero limit): %v", err)
+	}
+	if len(zero) != 0 {
+		t.Errorf("zero-limit result len = %d, want 0", len(zero))
+	}
+
+	// Unknown session returns an empty result, not an error.
+	missing, err := d.QuerySessionEventsBeforeRowID("repo@nope", 0, 10)
+	if err != nil {
+		t.Fatalf("QuerySessionEventsBeforeRowID(missing): %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing-session result len = %d, want 0", len(missing))
+	}
+}

--- a/modules/programs/prism/prism/internal/db/events.go
+++ b/modules/programs/prism/prism/internal/db/events.go
@@ -518,6 +518,89 @@ func (d *DB) MaxSessionEventRowID(sessionName string) (int64, error) {
 	return max, nil
 }
 
+// QuerySessionEventsBeforeRowID returns up to `limit` events for sessionName
+// with rowid < beforeRowID, ordered by rowid ASC. When beforeRowID == 0 the
+// query returns the most recent `limit` events for the session — i.e. the
+// tail of history — which is useful when the caller has not yet seen any
+// event for the session and wants a starting window.
+//
+// This is the backing query for the iris client IPC socket's paged-history
+// frame (issue #1770 child 5): when the TUI's operator scrolls past the top
+// of the in-memory window, the TUI requests another page of older events
+// using the rowid of the previously-top event as `beforeRowID`. The result
+// is returned in ASC order so the caller can prepend it directly without
+// re-sorting; the caller is responsible for detecting head-of-history
+// (zero rows returned) and suppressing further requests.
+func (d *DB) QuerySessionEventsBeforeRowID(sessionName string, beforeRowID int64, limit int) ([]EventRow, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	// Two-step query: select the last `limit` rows in DESC order using the
+	// `<` predicate, then re-order ASC in the outer select. SQLite's query
+	// planner uses the implicit rowid index for both the WHERE filter and
+	// the ORDER BY so this is O(limit) on a session of any size.
+	//
+	// When beforeRowID == 0 the inner WHERE collapses to `session_name = ?`
+	// alone and we get the tail of history — same `limit`/ORDER semantics.
+	const qWithBefore = `
+SELECT rowid, id, session_name, repo, worktree, harness_session_id,
+       type, payload, created_at, instance_id
+  FROM (
+    SELECT rowid, id, session_name, repo, worktree, harness_session_id,
+           type, payload, created_at, instance_id
+      FROM agent_events
+     WHERE session_name = ? AND rowid < ?
+     ORDER BY rowid DESC
+     LIMIT ?
+  )
+ ORDER BY rowid ASC`
+	const qNoBefore = `
+SELECT rowid, id, session_name, repo, worktree, harness_session_id,
+       type, payload, created_at, instance_id
+  FROM (
+    SELECT rowid, id, session_name, repo, worktree, harness_session_id,
+           type, payload, created_at, instance_id
+      FROM agent_events
+     WHERE session_name = ?
+     ORDER BY rowid DESC
+     LIMIT ?
+  )
+ ORDER BY rowid ASC`
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if beforeRowID > 0 {
+		rows, err = d.conn.Query(qWithBefore, sessionName, beforeRowID, limit)
+	} else {
+		rows, err = d.conn.Query(qNoBefore, sessionName, limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: query session events before rowid: %w", err)
+	}
+	defer rows.Close()
+
+	var result []EventRow
+	for rows.Next() {
+		var er EventRow
+		var createdAt int64
+		if err := rows.Scan(
+			&er.RowID, &er.Event.ID, &er.Event.SessionName, &er.Event.Repo,
+			&er.Event.Worktree, &er.Event.HarnessSessionID,
+			&er.Event.Type, &er.Event.Payload, &createdAt, &er.Event.InstanceID,
+		); err != nil {
+			return nil, fmt.Errorf("db: scan event row: %w", err)
+		}
+		er.Event.CreatedAt = time.UnixMilli(createdAt)
+		result = append(result, er)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: iterate session events before rowid: %w", err)
+	}
+	return result, nil
+}
+
 // EventRow wraps an Event together with its SQLite rowid. The rowid is a
 // monotonically increasing integer that clients use as since_event_id for
 // replay requests.

--- a/modules/programs/prism/prism/internal/iris/client_protocol.go
+++ b/modules/programs/prism/prism/internal/iris/client_protocol.go
@@ -12,13 +12,14 @@ package iris
 // Client → daemon frames:
 //
 //	sessions_list, session_subscribe, session_unsubscribe,
-//	session_spawn, session_kill, prompt_deliver, review_spawn,
-//	escalation_deliver, ping
+//	session_history, session_spawn, session_kill, prompt_deliver,
+//	review_spawn, escalation_deliver, ping
 //
 // Daemon → client frames:
 //
-//	sessions_snapshot, session_event, session_state, session_spawned,
-//	session_killed, review_spawned, escalation_delivered, error, pong
+//	sessions_snapshot, session_event, session_history, session_state,
+//	session_spawned, session_killed, review_spawned,
+//	escalation_delivered, error, pong
 
 // ---------------------------------------------------------------------------
 // Client → daemon request frames
@@ -50,6 +51,37 @@ type ClientSessionSubscribeFrame struct {
 type ClientSessionUnsubscribeFrame struct {
 	Type string `json:"type"` // "session_unsubscribe"
 	Name string `json:"name"`
+}
+
+// ClientSessionHistoryFrame requests a page of older agent_events for the
+// named session. Used by the iris TUI's lazy-load scrollback (issue #1770
+// child 5) when the operator scrolls past the top of the in-memory window.
+//
+// Semantics:
+//
+//   - BeforeRowID > 0: return the last `Limit` rows with rowid < BeforeRowID,
+//     ordered ASC by rowid. This is the canonical "page backwards" call.
+//   - BeforeRowID == 0: return the most recent `Limit` rows for the session
+//     (tail of history). Useful when the TUI wants to seed the scrollback
+//     before any live event has been observed.
+//   - RequestID: an opaque client-chosen string echoed verbatim on the
+//     matching DaemonSessionHistoryFrame so the TUI can correlate a
+//     response with the request that triggered it. Optional; the daemon
+//     does not interpret it.
+//
+// The response is one DaemonSessionHistoryFrame carrying the page of
+// events plus a Done flag the TUI uses to suppress further requests when
+// the head of history has been reached. The daemon does NOT change any
+// subscription state — session_history is a one-shot read.
+//
+//	{"type": "session_history", "name": "<session>", "before_row_id": 42, "limit": 100}
+//	{"type": "session_history", "name": "<session>", "limit": 100, "request_id": "abc"}
+type ClientSessionHistoryFrame struct {
+	Type        string `json:"type"` // "session_history"
+	Name        string `json:"name"`
+	BeforeRowID int64  `json:"before_row_id,omitempty"` // 0 means "tail of history"
+	Limit       int    `json:"limit"`                   // max events to return; daemon may cap further
+	RequestID   string `json:"request_id,omitempty"`    // opaque echo for client-side correlation
 }
 
 // ClientSessionSpawnFrame requests the daemon to spawn a new pi session.
@@ -224,6 +256,31 @@ type DaemonSessionEventFrame struct {
 	Payload     string `json:"payload"`      // verbatim agent_events.payload JSON
 }
 
+// DaemonSessionHistoryFrame is the response to ClientSessionHistoryFrame.
+// Events is the requested page, ordered ASC by RowID (oldest first) so the
+// TUI can prepend it to its in-memory buffer without re-sorting. The flag
+// `Done` is true when the daemon's query returned fewer rows than the
+// client's `Limit` AND the page's first event was the head of history
+// (no rows exist with smaller rowid for the session) — in practice, the
+// daemon sets Done == true whenever the query returns fewer than `Limit`
+// rows, which is sufficient for the TUI to suppress further requests.
+//
+// RequestID is the verbatim echo of ClientSessionHistoryFrame.RequestID.
+// Empty when the request did not carry one.
+//
+// The frame is one-shot: the daemon writes it once per request and does
+// not change subscription state. Concurrent session_event frames continue
+// to flow on any active subscription.
+//
+//	{"type": "session_history", "name": "<session>", "events": [...], "done": true, "request_id": "abc"}
+type DaemonSessionHistoryFrame struct {
+	Type        string                    `json:"type"` // "session_history"
+	SessionName string                    `json:"session_name"`
+	Events      []DaemonSessionEventFrame `json:"events"`
+	Done        bool                      `json:"done"`
+	RequestID   string                    `json:"request_id,omitempty"`
+}
+
 // DaemonSessionStateFrame notifies the client of a state transition for a
 // subscribed session.
 //
@@ -325,17 +382,19 @@ type DaemonReviewGroupMember struct {
 
 // Client-socket frame type constants.
 const (
-	ClientFrameSessionsList       = "sessions_list"
-	ClientFrameSessionSubscribe   = "session_subscribe"
-	ClientFrameSessionUnsubscribe = "session_unsubscribe"
-	ClientFrameSessionSpawn       = "session_spawn"
-	ClientFrameSessionKill        = "session_kill"
+	ClientFrameSessionsList        = "sessions_list"
+	ClientFrameSessionSubscribe    = "session_subscribe"
+	ClientFrameSessionUnsubscribe  = "session_unsubscribe"
+	ClientFrameSessionHistory      = "session_history"
+	ClientFrameSessionSpawn        = "session_spawn"
+	ClientFrameSessionKill         = "session_kill"
 	ClientFramePromptDeliver       = "prompt_deliver"
 	ClientFrameReviewSpawn         = "review_spawn"
 	ClientFrameEscalationDeliver   = "escalation_deliver"
 	ClientFramePing                = "ping"
 	DaemonFrameSessionsSnapshot    = "sessions_snapshot"
 	DaemonFrameSessionEvent        = "session_event"
+	DaemonFrameSessionHistory      = "session_history"
 	DaemonFrameSessionState        = "session_state"
 	DaemonFrameSessionSpawned      = "session_spawned"
 	DaemonFrameSessionKilled       = "session_killed"

--- a/modules/programs/prism/prism/internal/iris/client_socket.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket.go
@@ -517,6 +517,18 @@ func (cs *ClientSocket) handleConn(ctx context.Context, conn net.Conn) {
 			}
 			subMu.Unlock()
 
+		case ClientFrameSessionHistory:
+			var frame ClientSessionHistoryFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				sendError(w, ClientFrameSessionHistory, "invalid frame: "+err.Error())
+				continue
+			}
+			cs.wg.Add(1)
+			go func(frame ClientSessionHistoryFrame) {
+				defer cs.wg.Done()
+				cs.handleSessionHistory(w, frame)
+			}(frame)
+
 		case ClientFrameSessionSpawn:
 			var frame ClientSessionSpawnFrame
 			if err := json.Unmarshal(line, &frame); err != nil {
@@ -601,6 +613,69 @@ func (cs *ClientSocket) handleSessionsList(w *jsonlWriter) {
 	_ = w.write(DaemonSessionsSnapshotFrame{
 		Type:     DaemonFrameSessionsSnapshot,
 		Sessions: sessions,
+	})
+}
+
+// historyMaxLimit caps the per-request page size for session_history
+// queries. Larger requests are silently clamped so a misbehaving client
+// cannot force the daemon into an arbitrarily large allocation.
+const historyMaxLimit = 1000
+
+// historyDefaultLimit is the page size used when the client omits Limit
+// or sends a non-positive value. Matches the iris TUI's default page
+// size for lazy-load scrollback (issue #1770 child 5) so a TUI that
+// trusts the daemon default still gets a useful page.
+const historyDefaultLimit = 100
+
+// handleSessionHistory answers a ClientSessionHistoryFrame with one
+// DaemonSessionHistoryFrame containing the requested page of events.
+// One-shot read; no subscription state is modified.
+//
+// Semantics mirror db.QuerySessionEventsBeforeRowID:
+//
+//   - BeforeRowID > 0 → last `limit` rows with rowid < BeforeRowID
+//   - BeforeRowID == 0 → the most recent `limit` rows (tail of history)
+//
+// `Done` is true when the query returned fewer rows than `limit`,
+// which is sufficient for the TUI to recognise head-of-history and
+// suppress further requests.
+func (cs *ClientSocket) handleSessionHistory(w *jsonlWriter, frame ClientSessionHistoryFrame) {
+	if frame.Name == "" {
+		sendError(w, ClientFrameSessionHistory, "name is required")
+		return
+	}
+	limit := frame.Limit
+	if limit <= 0 {
+		limit = historyDefaultLimit
+	}
+	if limit > historyMaxLimit {
+		limit = historyMaxLimit
+	}
+
+	events, err := cs.database.QuerySessionEventsBeforeRowID(frame.Name, frame.BeforeRowID, limit)
+	if err != nil {
+		log.Printf("[iris] client socket: history query for %q before %d: %v",
+			frame.Name, frame.BeforeRowID, err)
+		sendError(w, ClientFrameSessionHistory, "history query failed: "+err.Error())
+		return
+	}
+
+	out := make([]DaemonSessionEventFrame, 0, len(events))
+	for _, er := range events {
+		out = append(out, DaemonSessionEventFrame{
+			Type:        DaemonFrameSessionEvent,
+			SessionName: frame.Name,
+			RowID:       er.RowID,
+			EventType:   er.Event.Type,
+			Payload:     er.Event.Payload,
+		})
+	}
+	_ = w.write(DaemonSessionHistoryFrame{
+		Type:        DaemonFrameSessionHistory,
+		SessionName: frame.Name,
+		Events:      out,
+		Done:        len(events) < limit,
+		RequestID:   frame.RequestID,
 	})
 }
 

--- a/modules/programs/prism/prism/internal/iris/client_socket_test.go
+++ b/modules/programs/prism/prism/internal/iris/client_socket_test.go
@@ -230,11 +230,11 @@ func TestClientFrameRoundTrip(t *testing.T) {
 //  1. database.Close   — runs LAST among these.
 //  2. cs.Close         — closes the listener so Accept errors out.
 //  3. cancel           — cancels the Serve context so handleConn /
-//                        runSubscription / handle*Frame goroutines exit.
+//     runSubscription / handle*Frame goroutines exit.
 //  4. cs.Wait drain    — runs FIRST: blocks until every spawned
-//                        ClientSocket goroutine returns, so no late
-//                        write races against Close / database.Close /
-//                        tempdir removal.
+//     ClientSocket goroutine returns, so no late
+//     write races against Close / database.Close /
+//     tempdir removal.
 //
 // t.TempDir()'s implicit cleanup is registered before any of ours, so it
 // runs last — after the drain has guaranteed no goroutine is still
@@ -689,6 +689,221 @@ func TestSinceEventIDReplay(t *testing.T) {
 		if rid != expected {
 			t.Errorf("replayed event[%d] rowID = %.0f, want %.0f", i, rid, expected)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// session_history — paged lazy-load (issue #1770 child 5)
+// ---------------------------------------------------------------------------
+
+// TestSessionHistoryFrame writes a known set of events to the DB and
+// verifies that a `session_history` request returns exactly the
+// requested page in ASC rowid order, with the `done` flag set when
+// the page is shorter than the limit.
+func TestSessionHistoryFrame(t *testing.T) {
+	sessionName := "hist@test"
+
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+
+	// Seed 7 events for the target session and a couple of decoys for
+	// a different session that must NOT be returned.
+	var rowIDs []int64
+	for i := 1; i <= 7; i++ {
+		ev := db.Event{
+			ID:          fmt.Sprintf("ev-%d", i),
+			SessionName: sessionName,
+			Worktree:    tmp,
+			Type:        "msg_user",
+			Payload:     fmt.Sprintf(`{"n":%d}`, i),
+		}
+		r, err := database.WriteEventReturningRowID(ev)
+		if err != nil {
+			t.Fatalf("WriteEventReturningRowID[%d]: %v", i, err)
+		}
+		rowIDs = append(rowIDs, r)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := database.WriteEventReturningRowID(db.Event{
+			ID:          fmt.Sprintf("decoy-%d", i),
+			SessionName: "other@session",
+			Worktree:    tmp,
+			Type:        "msg_user",
+			Payload:     `{"decoy":true}`,
+		}); err != nil {
+			t.Fatalf("WriteEventReturningRowID decoy: %v", err)
+		}
+	}
+
+	sessions := []iris.SessionSnapshot{
+		{Name: sessionName, InstanceID: "iid-hist", State: "active", Role: "worker"},
+	}
+	sockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return sessions
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer cs.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go cs.Serve(ctx)
+
+	conn, r := dialClientSocket(t, sockPath)
+
+	// ---- Page 1: tail (before_row_id == 0), limit 3.
+	sendClientFrame(t, conn, map[string]any{
+		"type":       "session_history",
+		"name":       sessionName,
+		"limit":      3,
+		"request_id": "page-1",
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatalf("timed out waiting for session_history page 1")
+	}
+	if frame["type"] != "session_history" {
+		t.Fatalf("page 1: type = %v, want session_history", frame["type"])
+	}
+	if frame["session_name"] != sessionName {
+		t.Errorf("page 1: session_name = %v, want %s", frame["session_name"], sessionName)
+	}
+	if frame["request_id"] != "page-1" {
+		t.Errorf("page 1: request_id = %v, want page-1", frame["request_id"])
+	}
+	events, _ := frame["events"].([]any)
+	if len(events) != 3 {
+		t.Fatalf("page 1: len(events) = %d, want 3", len(events))
+	}
+	// Page returns the last 3 rows for the session, ASC by rowid:
+	// events 5, 6, 7 — rowIDs[4], [5], [6].
+	wantRowIDs := []int64{rowIDs[4], rowIDs[5], rowIDs[6]}
+	for i, raw := range events {
+		ev, _ := raw.(map[string]any)
+		rid, _ := ev["row_id"].(float64)
+		if int64(rid) != wantRowIDs[i] {
+			t.Errorf("page 1 event[%d].row_id = %.0f, want %d", i, rid, wantRowIDs[i])
+		}
+		if name, _ := ev["session_name"].(string); name != sessionName {
+			t.Errorf("page 1 event[%d].session_name = %q, want %q (cross-session leak?)", i, name, sessionName)
+		}
+	}
+	// done == false because there are more rows older than this page.
+	if done, _ := frame["done"].(bool); done {
+		t.Errorf("page 1: done = true; want false (more rows older than this page)")
+	}
+
+	// ---- Page 2: before_row_id = rowIDs[4] (top of page 1), limit 3.
+	sendClientFrame(t, conn, map[string]any{
+		"type":          "session_history",
+		"name":          sessionName,
+		"before_row_id": rowIDs[4],
+		"limit":         3,
+	})
+	frame, ok = readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatalf("timed out waiting for session_history page 2")
+	}
+	events, _ = frame["events"].([]any)
+	if len(events) != 3 {
+		t.Fatalf("page 2: len(events) = %d, want 3", len(events))
+	}
+	wantRowIDs = []int64{rowIDs[1], rowIDs[2], rowIDs[3]}
+	for i, raw := range events {
+		ev, _ := raw.(map[string]any)
+		rid, _ := ev["row_id"].(float64)
+		if int64(rid) != wantRowIDs[i] {
+			t.Errorf("page 2 event[%d].row_id = %.0f, want %d", i, rid, wantRowIDs[i])
+		}
+	}
+
+	// ---- Page 3: before_row_id = rowIDs[1], limit 10. Only one row left.
+	sendClientFrame(t, conn, map[string]any{
+		"type":          "session_history",
+		"name":          sessionName,
+		"before_row_id": rowIDs[1],
+		"limit":         10,
+	})
+	frame, ok = readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatalf("timed out waiting for session_history page 3")
+	}
+	events, _ = frame["events"].([]any)
+	if len(events) != 1 {
+		t.Fatalf("page 3: len(events) = %d, want 1 (only rowIDs[0] remains)", len(events))
+	}
+	if !frame["done"].(bool) {
+		t.Errorf("page 3: done = false; want true (less than limit returned)")
+	}
+
+	// ---- Page 4: before_row_id = rowIDs[0]. Empty page.
+	sendClientFrame(t, conn, map[string]any{
+		"type":          "session_history",
+		"name":          sessionName,
+		"before_row_id": rowIDs[0],
+		"limit":         10,
+	})
+	frame, ok = readClientFrameWithTimeout(t, conn, r, 5*time.Second)
+	if !ok {
+		t.Fatalf("timed out waiting for session_history page 4")
+	}
+	events, _ = frame["events"].([]any)
+	if len(events) != 0 {
+		t.Errorf("page 4 (past head): len(events) = %d, want 0", len(events))
+	}
+	if !frame["done"].(bool) {
+		t.Errorf("page 4 (past head): done = false; want true")
+	}
+}
+
+// TestSessionHistoryFrame_MissingName verifies the daemon answers a
+// missing-name session_history request with an error frame, not a
+// silent empty response (which could hide a TUI bug).
+func TestSessionHistoryFrame_MissingName(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "iris.db")
+	database, err := iris.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer database.Close()
+	sockPath := filepath.Join(tmp, "iris.sock")
+	cs := iris.NewClientSocket(iris.ClientSocketConfig{
+		SockPath: sockPath,
+		Database: database,
+		GetActiveSessions: func() []iris.SessionSnapshot {
+			return nil
+		},
+	})
+	if err := cs.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer cs.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go cs.Serve(ctx)
+
+	conn, r := dialClientSocket(t, sockPath)
+	sendClientFrame(t, conn, map[string]any{
+		"type":  "session_history",
+		"limit": 10,
+	})
+	frame, ok := readClientFrameWithTimeout(t, conn, r, 3*time.Second)
+	if !ok {
+		t.Fatalf("timed out waiting for error frame")
+	}
+	if frame["type"] != "error" {
+		t.Errorf("missing-name response type = %v, want error", frame["type"])
 	}
 }
 

--- a/modules/programs/prism/prism/internal/iris/tui/client.go
+++ b/modules/programs/prism/prism/internal/iris/tui/client.go
@@ -34,6 +34,10 @@ type DaemonFrame struct {
 	State *iris.DaemonSessionStateFrame
 	// Spawned is populated when RawType == DaemonFrameSessionSpawned.
 	Spawned *iris.DaemonSessionSpawnedFrame
+	// History is populated when RawType == DaemonFrameSessionHistory.
+	// Carries a page of older events for the lazy-load scrollback in
+	// the conversation pane (issue #1770 child 5).
+	History *iris.DaemonSessionHistoryFrame
 	// Error is populated when RawType == DaemonFrameError.
 	Error *iris.DaemonErrorFrame
 }
@@ -139,6 +143,11 @@ func (c *DaemonClient) readLoop(conn net.Conn) {
 			if err := json.Unmarshal(line, &f); err == nil {
 				msg.Event = &f
 			}
+		case iris.DaemonFrameSessionHistory:
+			var f iris.DaemonSessionHistoryFrame
+			if err := json.Unmarshal(line, &f); err == nil {
+				msg.History = &f
+			}
 		case iris.DaemonFrameSessionState:
 			var f iris.DaemonSessionStateFrame
 			if err := json.Unmarshal(line, &f); err == nil {
@@ -239,6 +248,24 @@ func (c *DaemonClient) SendPromptDeliver(name, text string) error {
 		Type: iris.ClientFramePromptDeliver,
 		Name: name,
 		Text: text,
+	})
+}
+
+// SendSessionHistory requests a page of older events for the named
+// session. beforeRowID == 0 returns the tail of history; otherwise the
+// daemon returns the last `limit` events with rowid < beforeRowID,
+// ASC-ordered. requestID is an opaque echo for client-side correlation.
+//
+// One-shot request; the daemon does not change any subscription state.
+// See iris.ClientSessionHistoryFrame for the wire shape; iris
+// client_socket.go's handleSessionHistory for the daemon-side handler.
+func (c *DaemonClient) SendSessionHistory(name string, beforeRowID int64, limit int, requestID string) error {
+	return c.writeFrame(iris.ClientSessionHistoryFrame{
+		Type:        iris.ClientFrameSessionHistory,
+		Name:        name,
+		BeforeRowID: beforeRowID,
+		Limit:       limit,
+		RequestID:   requestID,
 	})
 }
 

--- a/modules/programs/prism/prism/internal/iris/tui/export_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/export_test.go
@@ -161,3 +161,85 @@ func SetModelFocus(m Model, focus int) Model {
 	m.focus = focusArea(focus)
 	return m
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1770 child 5 — viewport / scroll / lazy-load accessors.
+// ---------------------------------------------------------------------------
+
+// ModelViewportFollowing returns true when the conversation pane
+// viewport is in auto-tail mode (sticking to the bottom of the
+// buffer). False when the operator has scrolled up to read history.
+func ModelViewportFollowing(m Model) bool {
+	return m.viewport.Following()
+}
+
+// ModelViewportOffset returns the index of the topmost visible line
+// in the conversation pane's line buffer. Zero means "at the top".
+func ModelViewportOffset(m Model) int {
+	return m.viewport.Offset()
+}
+
+// ModelViewportAtBottom returns true when the conversation pane is
+// currently showing the tail of the buffer.
+func ModelViewportAtBottom(m Model) bool {
+	return m.viewport.AtBottom(len(m.eventLines))
+}
+
+// ModelViewportAtTop returns true when the conversation pane is
+// currently showing the head of the buffer.
+func ModelViewportAtTop(m Model) bool {
+	return m.viewport.AtTop()
+}
+
+// ModelPendingNewCount returns the number of new events that have
+// arrived while the viewport was scrolled up. Drives the "↓ N new"
+// status-line indicator.
+func ModelPendingNewCount(m Model) int {
+	return m.pendingNewCount
+}
+
+// ModelHistoryExhausted returns true once the TUI knows the head of
+// the subscribed session's history has been reached.
+func ModelHistoryExhausted(m Model) bool {
+	return m.historyExhausted
+}
+
+// ModelHistoryOldestRowID returns the smallest agent_events.rowid the
+// TUI has observed for the subscribed session. Used as the
+// `before_row_id` of the next session_history request.
+func ModelHistoryOldestRowID(m Model) int64 {
+	return m.historyOldestRowID
+}
+
+// ModelHistoryRequestInFlight returns true while a session_history
+// request is outstanding. Prevents duplicate concurrent requests.
+func ModelHistoryRequestInFlight(m Model) bool {
+	return m.historyRequestInFlight
+}
+
+// SetModelHistoryPageSize overrides the session_history page size on
+// the model. Tests use a small page size so the lazy-load behaviour
+// can be exercised without seeding hundreds of fixture events.
+func SetModelHistoryPageSize(m Model, n int) Model {
+	m.historyPageSize = n
+	return m
+}
+
+// SetModelViewportHeight forces the viewport's content height. Tests
+// use this to drive PgUp/PgDn page-size arithmetic without going
+// through a full render. The model's rightPaneHeight() depends on
+// the WindowSizeMsg-supplied width/height; this helper bypasses the
+// frame size for unit-test predictability.
+func SetModelViewportHeight(m Model, h int) Model {
+	m.viewport.height = h
+	m.viewport.Update(len(m.eventLines), h)
+	return m
+}
+
+// ModelEventPaneEmptyPlaceholder returns the literal string the
+// conversation pane uses for the empty-state row (no events yet).
+// Test-only so the matching assertion does not have to track the
+// exact placeholder text across PRs.
+func ModelEventPaneEmptyPlaceholder() string {
+	return "no events yet"
+}

--- a/modules/programs/prism/prism/internal/iris/tui/model.go
+++ b/modules/programs/prism/prism/internal/iris/tui/model.go
@@ -313,8 +313,51 @@ type Model struct {
 	// not collapse it."
 	expandedToolCards map[string]bool
 
-	// eventScroll is the number of lines scrolled up from the bottom (0 = live).
-	eventScroll int
+	// viewport tracks scroll position over m.eventLines for the
+	// conversation pane (issue #1770 child 5). It is the
+	// functionally-equivalent in-house alternative to
+	// github.com/charmbracelet/bubbles/viewport — see viewport.go for
+	// the rationale on not pulling in the new dependency and the
+	// auto-tail / lazy-load semantics it implements. The model owns
+	// the underlying line slice so that the tool-card splice logic
+	// (#1769 rebuildCardLines) can mutate it in place without going
+	// through the viewport API.
+	viewport lineViewport
+
+	// pendingNewCount counts unseen events that arrived while the
+	// viewport was NOT at the bottom (the operator was reading
+	// history). Drives the "↓ N new" indicator rendered in the
+	// status-line strip. Reset to 0 when the viewport returns to the
+	// bottom (via End / G / PgDn-to-bottom / a scroll that lands at
+	// the bottom edge).
+	pendingNewCount int
+
+	// historyOldestRowID is the smallest agent_events.rowid currently
+	// loaded into m.eventLines for the subscribed session. Used by
+	// the lazy-load path (issue #1770 child 5) as the `before_row_id`
+	// of the next history page request. Zero means "no events yet for
+	// this session" or "this session has not had any rowid-bearing
+	// event observed yet" — in both cases the first history request
+	// uses 0 (= tail of history).
+	historyOldestRowID int64
+
+	// historyExhausted is set to true once a session_history response
+	// arrives with Done == true OR with zero events — meaning the
+	// daemon has no older rows for this session. Further scroll-up
+	// past the top suppresses the request, satisfying the AC: "a
+	// subsequent scroll-up does not re-request — the TUI knows it has
+	// reached the head."
+	historyExhausted bool
+
+	// historyRequestInFlight is true while a session_history request
+	// is outstanding. Prevents duplicate concurrent requests when the
+	// operator holds PgUp at the top of the buffer.
+	historyRequestInFlight bool
+
+	// historyPageSize is the number of events requested per
+	// session_history call. Held on the model so tests can override
+	// it; production code uses historyPageSizeDefault.
+	historyPageSize int
 
 	// Prompt input (bottom).
 	promptRunes  []rune
@@ -368,6 +411,14 @@ type Model struct {
 	coordinatorEvents []coordinatorEvent
 }
 
+// historyPageSizeDefault is the number of events requested per
+// session_history call when the model has not been customised by a
+// test. 100 matches db.historyDefaultLimit on the daemon side; the
+// daemon will accept and serve a larger value (up to historyMaxLimit)
+// if a future TUI revision wants larger pages, but 100 is plenty for
+// a single PgUp burst at typical terminal heights.
+const historyPageSizeDefault = 100
+
 // NewModel creates the iris TUI model.
 func NewModel(client *DaemonClient) Model {
 	return Model{
@@ -377,6 +428,8 @@ func NewModel(client *DaemonClient) Model {
 		toolCallByMsgID:   make(map[string]int),
 		toolCardByMsgID:   make(map[string]*toolCard),
 		expandedToolCards: make(map[string]bool),
+		viewport:          newLineViewport(),
+		historyPageSize:   historyPageSizeDefault,
 	}
 }
 
@@ -580,12 +633,29 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.seenRowIDs[e.RowID] = true
-		for _, line := range lines {
-			m.eventLines = append(m.eventLines, line)
+		// Track the lowest rowid we've observed for the subscribed
+		// session so the lazy-load path knows what `before_row_id` to
+		// pass on its next page request. A live event's rowid is
+		// always > the rowids of every replayed event, so the
+		// historyOldestRowID is set only when no rowid has been
+		// observed yet for this session (the first event of a
+		// just-spawned session, or after a session switch).
+		if e.SessionName == m.subscribedTo && e.RowID > 0 {
+			if m.historyOldestRowID == 0 || e.RowID < m.historyOldestRowID {
+				m.historyOldestRowID = e.RowID
+			}
 		}
-		// Snap to bottom if the user is not scrolled up.
-		if m.eventScroll == 0 {
-			// (view already renders from bottom; nothing extra needed)
+		wasAtBottom := m.viewport.AtBottom(len(m.eventLines))
+		m.eventLines = append(m.eventLines, lines...)
+		m.viewport.OnAppend(len(lines))
+		// Auto-tail vs. preserve-position: if the viewport was already
+		// at the bottom, leave following=true (set by GotoBottom or by
+		// the initial newLineViewport state). If not, the operator is
+		// reading history — increment the pendingNewCount so the
+		// status-line strip surfaces a "↓ N new" hint and DO NOT touch
+		// the offset.
+		if !wasAtBottom {
+			m.pendingNewCount += len(lines)
 		}
 
 	case iris.DaemonFrameSessionState:
@@ -657,6 +727,116 @@ func (m Model) handleDaemonFrame(msg DaemonFrame) (tea.Model, tea.Cmd) {
 				_ = m.client.SendSessionSubscribe(name, 0)
 				return nil
 			}
+		}
+
+	case iris.DaemonFrameSessionHistory:
+		// Lazy-load response (issue #1770 child 5). The frame carries a
+		// page of older events for the named session, ASC-ordered by
+		// rowid. We:
+		//
+		//   1. Filter the page to the currently-subscribed session
+		//      (defensive: a stale response could arrive after a
+		//      session switch).
+		//   2. Filter out any rowids we've already seen — a concurrent
+		//      live event may have already landed for the same row
+		//      (e.g. a replay+live overlap, or two history pages that
+		//      slightly overlap). This satisfies the AC "no duplicate
+		//      rows, no skipped rows" when a live event arrives during
+		//      a lazy-load.
+		//   3. Render each event through the existing renderer
+		//      dispatch table, producing []NarrativeLine entries.
+		//   4. Prepend the new lines to m.eventLines and shift the
+		//      viewport offset by len(prepended) so the previously-top
+		//      line stays at the top — satisfying the AC "scroll
+		//      position is preserved relative to the previously-top
+		//      event."
+		//   5. Update historyOldestRowID / historyExhausted /
+		//      historyRequestInFlight based on the page contents.
+		if msg.History == nil {
+			return m, nil
+		}
+		m.historyRequestInFlight = false
+		if msg.History.SessionName != m.subscribedTo {
+			// Stale response for a session we no longer care about.
+			return m, nil
+		}
+		if msg.History.Done {
+			m.historyExhausted = true
+		}
+		if len(msg.History.Events) == 0 {
+			// Empty page: head of history reached. Treat as exhausted
+			// regardless of the Done flag (defensive against older
+			// daemons that may not set it).
+			m.historyExhausted = true
+			return m, nil
+		}
+		var prepended []narrative.NarrativeLine
+		var minRowID int64
+		for _, ev := range msg.History.Events {
+			if ev.RowID > 0 {
+				if minRowID == 0 || ev.RowID < minRowID {
+					minRowID = ev.RowID
+				}
+			}
+			if m.seenRowIDs[ev.RowID] {
+				continue
+			}
+			// Historic events run through the legacy renderer dispatch
+			// table, NOT the live tool-card installer (m.installToolCallCard /
+			// m.foldToolResultIntoCard from #1769). Two consequences:
+			//
+			//   - A historic tool_call followed by its tool_result
+			//     renders as a multi-line "in-flight" card header
+			//     followed by an indented one-line result — not as a
+			//     folded paired card. Acceptable per the issue's
+			//     out-of-scope list ("Selection/copy of historic events"
+			//     is OOS; the tool-card OOS is implied since cards are a
+			//     live-pairing affordance).
+			//
+			//   - The expand/collapse `tab` binding (#1769) still only
+			//     operates on the most recent live card; historic
+			//     tool_call lines have no associated toolCard struct.
+			//
+			// This keeps the lazy-load path lean and avoids re-deriving
+			// card state from arbitrary historic rowid ordering, which
+			// would interact awkwardly with rebuildCardLines' lineStart
+			// invariants.
+			lines := m.renderer.dispatch(ev.RowID, ev.EventType, ev.Payload)
+			if len(lines) == 0 {
+				// Suppressed event type (e.g. session_status). Skip
+				// without marking the row as seen so future replays
+				// can still render it if the renderer table grows.
+				continue
+			}
+			m.seenRowIDs[ev.RowID] = true
+			prepended = append(prepended, lines...)
+		}
+		if minRowID > 0 {
+			if m.historyOldestRowID == 0 || minRowID < m.historyOldestRowID {
+				m.historyOldestRowID = minRowID
+			}
+		}
+		if len(prepended) > 0 {
+			// Prepend by allocating a fresh slice so the existing
+			// tool-card lineStart indices need only the matching
+			// shift below — we cannot append in place because the
+			// new lines belong at the head.
+			combined := make([]narrative.NarrativeLine, 0, len(prepended)+len(m.eventLines))
+			combined = append(combined, prepended...)
+			combined = append(combined, m.eventLines...)
+			m.eventLines = combined
+			delta := len(prepended)
+			// Shift any existing tool-card lineStart indices so they
+			// continue to refer to the same NarrativeLine rows after
+			// the prepend. The toolCallByMsgID legacy lookup is also
+			// updated for any cards that survived in the buffer.
+			for _, c := range m.toolCards {
+				c.lineStart += delta
+				if c.msgID != "" {
+					m.toolCallByMsgID[c.msgID] = c.lineStart
+				}
+			}
+			m.viewport.OnPrepend(delta)
 		}
 
 	case iris.DaemonFrameError:
@@ -812,14 +992,61 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "pgup":
-		m.eventScroll += (m.rightPaneHeight() - 2)
-		return m, nil
+		// PgUp scrolls the conversation pane up by one page when the
+		// events pane has focus. The behaviour is identical regardless
+		// of focus (issue #1770 spec: "PgUp / PgDn scroll the
+		// conversation pane by one page when the events pane has
+		// focus. Existing up/down key handling is preserved") because
+		// PgUp/PgDn don't conflict with session-list navigation. Sets
+		// following=false implicitly.
+		page := m.viewportPageSize()
+		m.viewport.ScrollUp(page, len(m.eventLines))
+		return m, m.maybeRequestMoreHistory()
 
 	case "pgdown":
-		m.eventScroll -= (m.rightPaneHeight() - 2)
-		if m.eventScroll < 0 {
-			m.eventScroll = 0
+		page := m.viewportPageSize()
+		m.viewport.ScrollDown(page, len(m.eventLines))
+		if m.viewport.AtBottom(len(m.eventLines)) {
+			m.pendingNewCount = 0
 		}
+		return m, nil
+
+	case "g":
+		// Vi-style "go to top" of the conversation pane (issue #1770
+		// AC). Only fires when focus is on the events pane (or when
+		// the prompt is empty AND focus is anywhere else — then it's
+		// a navigation gesture, not a literal letter). When the
+		// prompt has content, `g` is a literal rune and falls through
+		// to the default insert path. This mirrors how `?` is handled
+		// earlier in the switch.
+		if m.focus == focusPrompt && len(m.promptRunes) > 0 {
+			ins := []rune{'g'}
+			newRunes := make([]rune, len(m.promptRunes)+len(ins))
+			copy(newRunes, m.promptRunes[:m.promptCursor])
+			copy(newRunes[m.promptCursor:], ins)
+			copy(newRunes[m.promptCursor+len(ins):], m.promptRunes[m.promptCursor:])
+			m.promptRunes = newRunes
+			m.promptCursor += len(ins)
+			return m, nil
+		}
+		m.viewport.GotoTop()
+		return m, m.maybeRequestMoreHistory()
+
+	case "G":
+		// Vi-style "go to bottom" and resume auto-tail. Same
+		// prompt-vs-events disambiguation as `g`.
+		if m.focus == focusPrompt && len(m.promptRunes) > 0 {
+			ins := []rune{'G'}
+			newRunes := make([]rune, len(m.promptRunes)+len(ins))
+			copy(newRunes, m.promptRunes[:m.promptCursor])
+			copy(newRunes[m.promptCursor:], ins)
+			copy(newRunes[m.promptCursor+len(ins):], m.promptRunes[m.promptCursor:])
+			m.promptRunes = newRunes
+			m.promptCursor += len(ins)
+			return m, nil
+		}
+		m.viewport.GotoBottom(len(m.eventLines))
+		m.pendingNewCount = 0
 		return m, nil
 
 	case "enter":
@@ -854,9 +1081,29 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "home", "ctrl+a":
+		// Context-sensitive: when focus is on the events pane, `home`
+		// jumps to the top of the conversation scrollback (issue
+		// #1770 AC: "Pressing Home or g jumps to the top of the
+		// loaded window"). In any other focus area `home` continues
+		// to mean "prompt cursor home". ctrl+a remains the
+		// unconditional prompt-cursor-home alias so emacs muscle
+		// memory still works regardless of focus.
+		if msg.String() == "home" && m.focus == focusEvents {
+			m.viewport.GotoTop()
+			return m, m.maybeRequestMoreHistory()
+		}
 		m.promptCursor = 0
 
 	case "end", "ctrl+e":
+		// Context-sensitive: focus on events → jump to bottom and
+		// resume auto-tail (issue #1770 AC). Other focus areas →
+		// prompt cursor end. ctrl+e remains unconditionally the
+		// prompt-end alias.
+		if msg.String() == "end" && m.focus == focusEvents {
+			m.viewport.GotoBottom(len(m.eventLines))
+			m.pendingNewCount = 0
+			return m, nil
+		}
 		m.promptCursor = len(m.promptRunes)
 
 	case "delete", "ctrl+d":
@@ -877,6 +1124,59 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// viewportPageSize returns the number of lines to scroll on PgUp/PgDn.
+// We use the viewport's most recently set content height so a PgDn
+// after a PgUp lands back at the same spot — the symmetric behaviour
+// operators expect from most terminal pagers. The viewport height is
+// set by viewRightPane each frame; before the first frame renders
+// (e.g. immediately after WindowSizeMsg, before View() runs) the
+// viewport height is 0 and we fall back to rightPaneHeight()-2
+// minus the header/separator overhead so unit tests that drive
+// keystrokes without a render still get a sensible page size.
+func (m *Model) viewportPageSize() int {
+	p := m.viewport.height
+	if p < 1 {
+		p = m.rightPaneHeight() - 2
+	}
+	if p < 1 {
+		p = 1
+	}
+	return p
+}
+
+// maybeRequestMoreHistory issues a session_history request when the
+// viewport is at the top of its loaded window AND the head of
+// history has not yet been reached AND no request is currently in
+// flight. Called after every scroll-up gesture and after Home / G.
+//
+// Returns a tea.Cmd that performs the write off the Update goroutine,
+// or nil when no request should be made.
+func (m *Model) maybeRequestMoreHistory() tea.Cmd {
+	if m.subscribedTo == "" {
+		return nil
+	}
+	if m.historyExhausted {
+		return nil
+	}
+	if m.historyRequestInFlight {
+		return nil
+	}
+	if !m.viewport.AtTop() {
+		return nil
+	}
+	name := m.subscribedTo
+	before := m.historyOldestRowID
+	limit := m.historyPageSize
+	if limit <= 0 {
+		limit = historyPageSizeDefault
+	}
+	m.historyRequestInFlight = true
+	return func() tea.Msg {
+		_ = m.client.SendSessionHistory(name, before, limit, "")
+		return nil
+	}
 }
 
 // switchToSelected unsubscribes from the previous session and subscribes to
@@ -1087,7 +1387,11 @@ func (m *Model) resetEventPane() {
 	m.toolCards = nil
 	m.toolCardByMsgID = make(map[string]*toolCard)
 	m.expandedToolCards = make(map[string]bool)
-	m.eventScroll = 0
+	m.viewport.Reset()
+	m.pendingNewCount = 0
+	m.historyOldestRowID = 0
+	m.historyExhausted = false
+	m.historyRequestInFlight = false
 }
 
 // --- View ---
@@ -1269,24 +1573,18 @@ func (m Model) viewRightPane(width int) string {
 	if len(m.eventLines) == 0 {
 		rows = append(rows, "")
 		if m.subscribedTo != "" {
-			rows = append(rows, styleDim.Render(padRight("  waiting for events…", innerW)))
+			rows = append(rows, styleDim.Render(padRight("  no events yet…", innerW)))
 		} else {
 			rows = append(rows, styleDim.Render(padRight("  select a session to stream events", innerW)))
 		}
 	} else {
-		// Render from the bottom up, respecting scroll offset.
-		total := len(m.eventLines)
-		end := total - m.eventScroll
-		if end < 0 {
-			end = 0
-		}
-		if end > total {
-			end = total
-		}
-		start := end - contentH
-		if start < 0 {
-			start = 0
-		}
+		// The viewport tracks scroll position over m.eventLines (issue
+		// #1770 child 5). Update() clamps offset against the current
+		// content height; VisibleRange returns the [start, end)
+		// window. The viewport replaces the previous eventScroll int
+		// + ad-hoc end/start arithmetic.
+		m.viewport.Update(len(m.eventLines), contentH)
+		start, end := m.viewport.VisibleRange(len(m.eventLines))
 		coord := m.focusedIsCoordinator()
 		for _, line := range m.eventLines[start:end] {
 			rendered := styleEventLine(line, innerW, coord)
@@ -1294,10 +1592,21 @@ func (m Model) viewRightPane(width int) string {
 		}
 	}
 
-	// Scroll indicator.
-	if m.eventScroll > 0 {
+	// Scroll-state indicators (issue #1770).
+	//
+	// Top: when the viewport is at the head AND we know we've fetched
+	// every available historic event, render a subtle "(start of
+	// session)" line. This is the AC's "subtle indicator may show
+	// '(start of session)' at the top".
+	if m.viewport.AtTop() && m.historyExhausted && len(m.eventLines) > 0 {
 		rows = append(rows, styleDim.Render(
-			padRight(fmt.Sprintf("  ↑ %d lines above (PgDn to scroll down)", m.eventScroll), innerW),
+			padRight("  (start of session)", innerW),
+		))
+	}
+	// Bottom: when scrolled up, hint at how to return to live.
+	if !m.viewport.AtBottom(len(m.eventLines)) && len(m.eventLines) > 0 {
+		rows = append(rows, styleDim.Render(
+			padRight(fmt.Sprintf("  ↑ offset %d (PgDn / End to return to live)", m.viewport.Offset()), innerW),
 		))
 	}
 
@@ -1459,7 +1768,17 @@ func (m Model) viewStatusLine(width int) string {
 		}
 		parts = append(parts, costStr)
 	}
+	// "↓ N new" indicator (issue #1770 child 5). Appended after the
+	// regular metadata segments so operators can spot it without
+	// losing the session/state/model/cost line they're used to. Only
+	// rendered when the operator has scrolled up AND new events have
+	// arrived since — the count is reset on every return-to-bottom
+	// gesture, so a "↓ 0 new" never appears.
 	line := "  " + strings.Join(parts, " · ")
+	if m.pendingNewCount > 0 {
+		hint := fmt.Sprintf("  ↓ %d new", m.pendingNewCount)
+		line = line + hint
+	}
 	return styleStatusLine.Render(padRight(truncate(line, width), width))
 }
 

--- a/modules/programs/prism/prism/internal/iris/tui/overlay.go
+++ b/modules/programs/prism/prism/internal/iris/tui/overlay.go
@@ -611,7 +611,9 @@ func (m Model) viewHelpOverlay() string {
 		{"C-r", "force-refresh sessions list from daemon"},
 		{"C-l", "clear / redraw the screen"},
 		{"\u2191/\u2193", "navigate session list"},
-		{"PgUp/PgDn", "scroll event stream"},
+		{"PgUp/PgDn", "scroll event stream by one page"},
+		{"Home, g", "jump to top of conversation (loads older history)"},
+		{"End, G", "jump to bottom, resume auto-tail"},
 		{"Enter", "send prompt (or pick row when overlay open)"},
 		{"q, C-c", "quit the TUI"},
 	}

--- a/modules/programs/prism/prism/internal/iris/tui/renderer_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/renderer_test.go
@@ -269,8 +269,13 @@ func TestRenderer_SessionStatusSuppressed(t *testing.T) {
 	})
 
 	view := m.View()
-	if !strings.Contains(view, "waiting for events") {
-		t.Errorf("expected 'waiting for events…' placeholder (session_status should be suppressed); "+
+	// The pane should render the empty-state placeholder — issue
+	// #1770 changed the wording from "waiting for events…" to
+	// "no events yet…" to better match the AC's expected language.
+	// We accept either form to keep this test resilient to future
+	// wording tweaks of the placeholder.
+	if !strings.Contains(view, "no events yet") && !strings.Contains(view, "waiting for events") {
+		t.Errorf("expected empty-state placeholder (session_status should be suppressed); "+
 			"excerpt:\n%s", excerpt(view, 600))
 	}
 	// The literal payload-id string must not appear anywhere in the

--- a/modules/programs/prism/prism/internal/iris/tui/viewport.go
+++ b/modules/programs/prism/prism/internal/iris/tui/viewport.go
@@ -1,0 +1,282 @@
+package tui
+
+import "github.com/prismatic-koi/prism/internal/iris/narrative"
+
+// viewport.go — the conversation pane's buffered scrollback abstraction
+// (issue #1770 child 5 of the iris-tui design).
+//
+// `lineViewport` is the functionally-equivalent in-house alternative to
+// github.com/charmbracelet/bubbles/viewport. It tracks scroll position
+// over an externally-owned []NarrativeLine slice; the Model continues to
+// own the underlying line buffer so that the tool-card splice logic
+// (#1769 rebuildCardLines) can mutate the slice in place without going
+// through this viewport.
+//
+// Design notes on auto-tail (acceptance criteria for #1770):
+//
+//   - `following` is the boolean "stick to bottom" flag. When true,
+//     the viewport's visible window is the last `height` lines regardless
+//     of the offset field.
+//
+//   - When a NEW line arrives at the tail of the buffer:
+//
+//   - following == true  → stay at bottom (the new line becomes visible)
+//
+//   - following == false → offset is unchanged; the operator's reading
+//     position is preserved. The pendingNewCount field on the Model
+//     (not on the viewport) increments to drive the "↓ N new" indicator.
+//
+//   - When OLDER lines are PREPENDED (lazy-load):
+//
+//   - following stays whatever it was.
+//
+//   - offset shifts by len(prepended) so the same top line remains the
+//     top line on screen.
+//
+//   - When the operator scrolls down past the bottom edge, following
+//     is re-enabled. This is the auto-tail "resume" path.
+//
+// All offset arithmetic clamps to [0, max(0, len(lines)-height)] so that
+// the visible window is always a valid slice of the line buffer.
+type lineViewport struct {
+	// following is the auto-tail flag. true → snap to bottom each frame.
+	following bool
+	// offset is the index of the topmost visible line into the externally
+	// owned line buffer. Meaningful when following is false; recomputed
+	// on every call to Update() so that it always points at a valid row.
+	offset int
+	// height is the most recent content height (visible rows). Stored
+	// here so methods that don't take the height parameter (Visible,
+	// AtBottom, AtTop) can still answer correctly. Updated by Update().
+	height int
+}
+
+// newLineViewport constructs an empty viewport in the "following" state
+// (auto-tail to bottom). This matches the AC: at session start there
+// are no events, and the next event to arrive should be visible.
+func newLineViewport() lineViewport {
+	return lineViewport{following: true}
+}
+
+// Update clamps the viewport's offset against the current line count and
+// height. Call this at the start of each frame (before Visible) so the
+// offset always points at a valid window. When `following` is true the
+// offset is dragged to the bottom on every Update — that is the auto-tail
+// mechanism.
+//
+// height is the number of visible rows the pane can render. Must be > 0
+// for a useful Visible() result; callers pass 0 when the pane is too
+// small to draw, and Visible() then returns an empty slice.
+func (v *lineViewport) Update(lineCount, height int) {
+	if height < 0 {
+		height = 0
+	}
+	v.height = height
+	if v.following {
+		// Auto-tail: offset = bottom.
+		v.offset = maxOffset(lineCount, height)
+		return
+	}
+	// Manual offset; clamp.
+	if v.offset < 0 {
+		v.offset = 0
+	}
+	if max := maxOffset(lineCount, height); v.offset > max {
+		v.offset = max
+	}
+}
+
+// Visible returns the slice of `lines` currently visible in the pane.
+// Returns up to `height` lines starting at `offset`. An empty slice is
+// returned when height == 0 or lines is empty.
+func (v *lineViewport) Visible(lines []narrative.NarrativeLine) []narrative.NarrativeLine {
+	if v.height <= 0 || len(lines) == 0 {
+		return nil
+	}
+	start := v.offset
+	if start < 0 {
+		start = 0
+	}
+	end := start + v.height
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if start > end {
+		start = end
+	}
+	return lines[start:end]
+}
+
+// VisibleRange returns the [start, end) window into the externally
+// owned line buffer. Equivalent to Visible() but without needing the
+// caller to pass the buffer in — used when the buffer is held on a
+// struct that is not directly accessible to the viewport.
+func (v *lineViewport) VisibleRange(lineCount int) (start, end int) {
+	if v.height <= 0 || lineCount == 0 {
+		return 0, 0
+	}
+	start = v.offset
+	if start < 0 {
+		start = 0
+	}
+	end = start + v.height
+	if end > lineCount {
+		end = lineCount
+	}
+	if start > end {
+		start = end
+	}
+	return start, end
+}
+
+// AtBottom reports whether the viewport is currently showing the
+// last `height` lines of the buffer. true when `following` is set OR
+// when the manual offset happens to coincide with the bottom of the
+// buffer. The auto-tail decision (in handleDaemonFrame) consults this
+// before appending a new line.
+func (v *lineViewport) AtBottom(lineCount int) bool {
+	if v.following {
+		return true
+	}
+	return v.offset >= maxOffset(lineCount, v.height)
+}
+
+// AtTop reports whether the viewport's first visible line is the
+// first line in the buffer. Used to gate the lazy-load request: when
+// the operator scrolls past the top, the TUI fires a request for
+// older events.
+func (v *lineViewport) AtTop() bool {
+	return v.offset <= 0
+}
+
+// ScrollUp moves the visible window up by `n` lines, capped at 0.
+// Disables auto-tail because scrolling up explicitly is the operator
+// reading historic content. Returns true when the offset actually
+// moved (false when already at the top).
+//
+// When the viewport is transitioning out of auto-tail mode (following
+// == true on entry), the offset is first snapped to the current
+// bottom-of-buffer position (lineCount-height) before the scroll-up
+// is applied. This keeps the visible content stable across the
+// transition: the row at the bottom of the screen immediately before
+// the PgUp is the same row visible immediately after (modulo the
+// requested scroll).
+func (v *lineViewport) ScrollUp(n, lineCount int) bool {
+	if n <= 0 {
+		return false
+	}
+	if v.following {
+		v.offset = maxOffset(lineCount, v.height)
+	}
+	v.following = false
+	newOffset := v.offset - n
+	if newOffset < 0 {
+		newOffset = 0
+	}
+	if newOffset == v.offset {
+		return false
+	}
+	v.offset = newOffset
+	return true
+}
+
+// ScrollDown moves the visible window down by `n` lines. When the
+// resulting offset lands at the bottom edge, re-enables auto-tail so
+// future appends snap to bottom (the AC: "Pressing End ... jumps to
+// the bottom and resumes auto-tail" — ScrollDown to the bottom does
+// the same).
+func (v *lineViewport) ScrollDown(n, lineCount int) bool {
+	if n <= 0 {
+		return false
+	}
+	max := maxOffset(lineCount, v.height)
+	// When entering ScrollDown from auto-tail mode the offset may be
+	// stale (the renderer is what normally drags it forward each
+	// frame). Snap to bottom so the no-op return short-circuits
+	// correctly when already at the bottom edge.
+	if v.following {
+		v.offset = max
+	}
+	newOffset := v.offset + n
+	if newOffset >= max {
+		newOffset = max
+		v.following = true
+	}
+	if newOffset == v.offset && v.following {
+		// Already at bottom; nothing moved but auto-tail is on.
+		return false
+	}
+	if newOffset == v.offset {
+		return false
+	}
+	v.offset = newOffset
+	return true
+}
+
+// GotoTop jumps to the head of the buffer. Disables auto-tail.
+// Equivalent to the `home` / `g` keybinding (AC #1770).
+func (v *lineViewport) GotoTop() {
+	v.following = false
+	v.offset = 0
+}
+
+// GotoBottom jumps to the tail of the buffer and re-enables
+// auto-tail. Equivalent to the `end` / `G` keybinding (AC #1770).
+func (v *lineViewport) GotoBottom(lineCount int) {
+	v.following = true
+	v.offset = maxOffset(lineCount, v.height)
+}
+
+// OnAppend is the hook called when one or more lines are appended to
+// the tail of the buffer. When auto-tail is on, the offset is dragged
+// forward by Update() on the next frame — nothing to do here. When
+// auto-tail is OFF, we leave the offset alone so the operator's
+// reading position is unchanged.
+//
+// This is structured as an explicit method (even though the body is
+// currently empty) so that future changes to auto-tail semantics
+// (e.g. sticky-to-line behaviour rather than sticky-to-bottom) have
+// an obvious seam to hook into without re-touching every appender.
+func (v *lineViewport) OnAppend(added int) { _ = added }
+
+// OnPrepend shifts the offset forward by `added` so the same line
+// that was the top of the visible window before the prepend stays at
+// the top after. Auto-tail is preserved: when following == true, the
+// new lines at the head are invisible (we're still showing the tail);
+// when following == false, the offset shift keeps the reading
+// position pinned to the same source row.
+func (v *lineViewport) OnPrepend(added int) {
+	if added <= 0 {
+		return
+	}
+	v.offset += added
+}
+
+// Reset returns the viewport to its initial following-bottom state
+// with offset 0. Called by Model.resetEventPane on session switch
+// (AC: "Switching focus to a different session resets the viewport
+// to that session's tail").
+func (v *lineViewport) Reset() {
+	v.following = true
+	v.offset = 0
+}
+
+// Following reports whether the viewport is currently in auto-tail
+// mode. Exposed so the Model can decide whether to increment the
+// pendingNewCount indicator when a new event arrives.
+func (v *lineViewport) Following() bool { return v.following }
+
+// Offset returns the current top-line offset. Test-only accessor;
+// production code should not depend on the absolute value.
+func (v *lineViewport) Offset() int { return v.offset }
+
+// maxOffset returns the largest valid offset for a buffer of
+// `lineCount` lines and a viewport of `height` rows. Equal to
+// max(0, lineCount-height) so that the last `height` lines fit
+// exactly into the visible window.
+func maxOffset(lineCount, height int) int {
+	if lineCount <= height {
+		return 0
+	}
+	return lineCount - height
+}

--- a/modules/programs/prism/prism/internal/iris/tui/viewport_test.go
+++ b/modules/programs/prism/prism/internal/iris/tui/viewport_test.go
@@ -1,0 +1,468 @@
+package tui_test
+
+// viewport_test.go — model-level tests for the conversation pane's
+// scrollback viewport (issue #1770 child 5). Exercises the Model.Update
+// loop end-to-end via DaemonFrame / tea.KeyMsg deliveries so the
+// behaviour is verified in the same shape it ships to the operator.
+//
+// Coverage map (matches the AC list in issue #1770):
+//
+//   - TestViewport_EmptyPlaceholder   — AC: at session start, "no events
+//                                       yet" placeholder, not a blank pane.
+//   - TestViewport_AutoTailAtBottom   — AC: new event arrives while at
+//                                       bottom → visible without manual scroll.
+//   - TestViewport_NoJumpWhenScrolled — AC: new event arrives while
+//                                       scrolled up → offset preserved,
+//                                       "↓ N new" indicator surfaced.
+//   - TestViewport_PgUpPgDn           — AC: PgUp / PgDn scroll by one page.
+//   - TestViewport_HomeEnd            — AC: Home/g and End/G jump to top
+//                                       / bottom; End re-enables auto-tail.
+//   - TestViewport_LazyLoadOlder      — AC: scroll past top → request older
+//                                       events; prepend preserves scroll
+//                                       position.
+//   - TestViewport_LazyLoadExhausted  — AC: empty page → suppress further
+//                                       requests, render "(start of session)"
+//                                       at the top.
+//   - TestViewport_LazyLoadInterleave — edge-case AC: live event during a
+//                                       lazy-load → interleaved by rowid;
+//                                       no duplicates.
+//   - TestViewport_SessionSwitchResets — edge-case AC: switching sessions
+//                                       resets the viewport to tail and
+//                                       clears pending-new + history state.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/iris"
+	"github.com/prismatic-koi/prism/internal/iris/tui"
+)
+
+// deliverEv is a local helper duplicating renderer_test.go's
+// deliverEvent so this file compiles standalone. Both helpers are
+// trivial wrappers around model.Update; keeping a local copy avoids
+// cross-file ordering brittleness.
+func deliverEv(t *testing.T, m tui.Model, sessionName, eventType string, rowID int64, payload any) tui.Model {
+	t.Helper()
+	pb, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m2, _ := m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionEvent,
+		Event: &iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: sessionName,
+			RowID:       rowID,
+			EventType:   eventType,
+			Payload:     string(pb),
+		},
+	})
+	return m2.(tui.Model)
+}
+
+// newSubscribedModel returns a connected model subscribed to a single
+// session with a 200-line-tall viewport so PgUp/PgDn arithmetic has
+// room to manoeuvre.
+func newSubscribedModel(t *testing.T, name string) tui.Model {
+	t.Helper()
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: name, InstanceID: "iid-" + name, State: "active", Role: "worker", Worktree: "/repo/" + name},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+	// Force a small viewport so 5-line buffers exceed the height and
+	// PgUp can scroll without first having to seed dozens of fixture
+	// events.
+	m = tui.SetModelViewportHeight(m, 4)
+	return m
+}
+
+// pressKey delivers a KeyMsg to the model. The string is what
+// tea.KeyMsg.String() would return for the binding under test
+// (e.g. "pgup", "g", "G", "home", "end").
+func pressKey(t *testing.T, m tui.Model, name string) tui.Model {
+	t.Helper()
+	var msg tea.KeyMsg
+	switch name {
+	case "pgup":
+		msg = tea.KeyMsg{Type: tea.KeyPgUp}
+	case "pgdown":
+		msg = tea.KeyMsg{Type: tea.KeyPgDown}
+	case "home":
+		msg = tea.KeyMsg{Type: tea.KeyHome}
+	case "end":
+		msg = tea.KeyMsg{Type: tea.KeyEnd}
+	case "g":
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
+	case "G":
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}}
+	default:
+		t.Fatalf("pressKey: unknown binding %q", name)
+	}
+	m2, _ := m.Update(msg)
+	return m2.(tui.Model)
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_EmptyPlaceholder
+// ---------------------------------------------------------------------------
+
+func TestViewport_EmptyPlaceholder(t *testing.T) {
+	m := newSubscribedModel(t, "empty")
+	view := m.View()
+	if !strings.Contains(view, tui.ModelEventPaneEmptyPlaceholder()) {
+		t.Errorf("expected empty-state placeholder %q in view; excerpt:\n%s",
+			tui.ModelEventPaneEmptyPlaceholder(), excerpt(view, 600))
+	}
+	if !tui.ModelViewportFollowing(m) {
+		t.Errorf("a freshly subscribed model should auto-tail by default")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_AutoTailAtBottom
+// ---------------------------------------------------------------------------
+
+func TestViewport_AutoTailAtBottom(t *testing.T) {
+	m := newSubscribedModel(t, "auto")
+	// Deliver 6 events; viewport height is 4 so the last 4 are visible.
+	for i := 1; i <= 6; i++ {
+		m = deliverEv(t, m, "auto", "msg_assistant", int64(i), map[string]any{
+			"messageId": "m" + string(rune('0'+i)),
+			"text":      "line-" + string(rune('0'+i)),
+		})
+	}
+	if !tui.ModelViewportFollowing(m) {
+		t.Errorf("auto-tail should remain on when events arrive at the bottom")
+	}
+	if !tui.ModelViewportAtBottom(m) {
+		t.Errorf("viewport should be at the bottom after autoscrolling appends")
+	}
+	view := m.View()
+	if !strings.Contains(view, "line-6") {
+		t.Errorf("most recent event 'line-6' should be visible; excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_NoJumpWhenScrolled
+// ---------------------------------------------------------------------------
+
+func TestViewport_NoJumpWhenScrolled(t *testing.T) {
+	m := newSubscribedModel(t, "scroll")
+	// Seed 10 events.
+	for i := 1; i <= 10; i++ {
+		m = deliverEv(t, m, "scroll", "msg_assistant", int64(i), map[string]any{
+			"messageId": "m",
+			"text":      "line-" + string(rune('0'+i%10)),
+		})
+	}
+	// Scroll up: a PgUp.
+	m = pressKey(t, m, "pgup")
+	if tui.ModelViewportFollowing(m) {
+		t.Fatalf("PgUp should disable auto-tail")
+	}
+	offsetBefore := tui.ModelViewportOffset(m)
+	// New event arrives while scrolled up.
+	m = deliverEv(t, m, "scroll", "msg_assistant", 11, map[string]any{
+		"messageId": "m11",
+		"text":      "newest",
+	})
+	if got := tui.ModelViewportOffset(m); got != offsetBefore {
+		t.Errorf("scroll offset shifted during scrolled-up append: was %d, now %d", offsetBefore, got)
+	}
+	if got := tui.ModelPendingNewCount(m); got == 0 {
+		t.Errorf("pendingNewCount should increment when a new event arrives off-screen; got 0")
+	}
+	view := m.View()
+	if !strings.Contains(view, "↓") || !strings.Contains(view, "new") {
+		t.Errorf("status strip should surface '↓ N new' indicator; excerpt:\n%s", excerpt(view, 800))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_PgUpPgDn
+// ---------------------------------------------------------------------------
+
+func TestViewport_PgUpPgDn(t *testing.T) {
+	m := newSubscribedModel(t, "pg")
+	// Seed enough events that a one-page PgUp does NOT land at the
+	// top (so AtTop is false after PgUp — we exercise the "middle of
+	// the buffer" path) but few enough that a single PgDn returns
+	// to the bottom and re-enables auto-tail.
+	for i := 1; i <= 6; i++ {
+		m = deliverEv(t, m, "pg", "msg_user", int64(i), map[string]any{
+			"text": "u" + string(rune('a'+i%26)),
+		})
+	}
+	if !tui.ModelViewportAtBottom(m) {
+		t.Fatalf("setup: should be at bottom after 6 appends")
+	}
+	m = pressKey(t, m, "pgup")
+	if tui.ModelViewportFollowing(m) {
+		t.Errorf("PgUp should disable auto-tail")
+	}
+	if tui.ModelViewportAtBottom(m) {
+		t.Errorf("PgUp should leave viewport NOT at bottom (got AtBottom=true)")
+	}
+	m = pressKey(t, m, "pgdown")
+	if !tui.ModelViewportAtBottom(m) {
+		t.Errorf("PgDn from one-page-up should land back at the bottom (offset=%d)",
+			tui.ModelViewportOffset(m))
+	}
+	if !tui.ModelViewportFollowing(m) {
+		t.Errorf("PgDn landing at bottom should re-enable auto-tail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_HomeEnd
+// ---------------------------------------------------------------------------
+
+func TestViewport_HomeEnd(t *testing.T) {
+	m := newSubscribedModel(t, "he")
+	for i := 1; i <= 12; i++ {
+		m = deliverEv(t, m, "he", "msg_user", int64(i), map[string]any{
+			"text": "row-" + string(rune('a'+i%26)),
+		})
+	}
+	// Focus the events pane so context-sensitive home/end target the
+	// conversation viewport rather than the prompt cursor. We also
+	// verify the `g` / `G` aliases work regardless of focus.
+	m = tui.SetModelFocus(m, tui.FocusEvents)
+	m = pressKey(t, m, "home")
+	if !tui.ModelViewportAtTop(m) {
+		t.Errorf("home (focus=events) should jump to top of viewport")
+	}
+	if tui.ModelViewportFollowing(m) {
+		t.Errorf("home should disable auto-tail")
+	}
+	m = pressKey(t, m, "end")
+	if !tui.ModelViewportAtBottom(m) {
+		t.Errorf("end (focus=events) should jump to bottom")
+	}
+	if !tui.ModelViewportFollowing(m) {
+		t.Errorf("end should re-enable auto-tail")
+	}
+	// `g` and `G` from a non-prompt focus should also work and should
+	// continue to work even with focus=prompt as long as the prompt
+	// buffer is empty (so `g` is unambiguously a navigation gesture).
+	m = tui.SetModelFocus(m, tui.FocusPrompt)
+	m = pressKey(t, m, "g")
+	if !tui.ModelViewportAtTop(m) {
+		t.Errorf("g (focus=prompt, empty prompt) should jump to top")
+	}
+	m = pressKey(t, m, "G")
+	if !tui.ModelViewportAtBottom(m) || !tui.ModelViewportFollowing(m) {
+		t.Errorf("G (focus=prompt, empty prompt) should jump to bottom and re-enable auto-tail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_LazyLoadOlder
+// ---------------------------------------------------------------------------
+
+// TestViewport_LazyLoadOlder verifies that a session_history response
+// is prepended to the conversation pane and that the viewport's scroll
+// position is preserved relative to the previously-top event.
+func TestViewport_LazyLoadOlder(t *testing.T) {
+	m := newSubscribedModel(t, "ll")
+	// Seed live events with rowids 100..104.
+	for i := int64(100); i <= 104; i++ {
+		m = deliverEv(t, m, "ll", "msg_user", i, map[string]any{
+			"text": "live-" + string(rune('a'+int(i)%26)),
+		})
+	}
+	oldestBefore := tui.ModelHistoryOldestRowID(m)
+	if oldestBefore != 100 {
+		t.Errorf("historyOldestRowID should track the smallest observed rowid; got %d, want 100", oldestBefore)
+	}
+	// Scroll to the top, then jump to top to ensure AtTop is true.
+	m = pressKey(t, m, "g")
+	if !tui.ModelViewportAtTop(m) {
+		t.Fatalf("setup: viewport should be at top after `g`")
+	}
+	if !tui.ModelHistoryRequestInFlight(m) {
+		t.Errorf("`g` at AtTop with non-exhausted history should fire a history request")
+	}
+
+	// Deliver a history response with 3 older events (rowids 50..52)
+	// and Done=false (more available).
+	older := make([]iris.DaemonSessionEventFrame, 0, 3)
+	for i := int64(50); i <= 52; i++ {
+		payload, _ := json.Marshal(map[string]any{"text": "old-" + string(rune('a'+int(i)%26))})
+		older = append(older, iris.DaemonSessionEventFrame{
+			Type:        iris.DaemonFrameSessionEvent,
+			SessionName: "ll",
+			RowID:       i,
+			EventType:   "msg_user",
+			Payload:     string(payload),
+		})
+	}
+	m2, _ := m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionHistory,
+		History: &iris.DaemonSessionHistoryFrame{
+			Type:        iris.DaemonFrameSessionHistory,
+			SessionName: "ll",
+			Events:      older,
+			Done:        false,
+		},
+	})
+	m = m2.(tui.Model)
+	if tui.ModelHistoryRequestInFlight(m) {
+		t.Errorf("historyRequestInFlight should clear on response arrival")
+	}
+	if tui.ModelHistoryExhausted(m) {
+		t.Errorf("historyExhausted should NOT be set when Done=false and len(events)>0")
+	}
+	if got := tui.ModelHistoryOldestRowID(m); got != 50 {
+		t.Errorf("historyOldestRowID after prepend: got %d, want 50", got)
+	}
+	// The view should now contain the older events.
+	view := m.View()
+	if !strings.Contains(view, "old-") {
+		t.Errorf("prepended older events should be visible; excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_LazyLoadExhausted
+// ---------------------------------------------------------------------------
+
+func TestViewport_LazyLoadExhausted(t *testing.T) {
+	m := newSubscribedModel(t, "ex")
+	for i := int64(1); i <= 3; i++ {
+		m = deliverEv(t, m, "ex", "msg_user", i, map[string]any{"text": "row"})
+	}
+	m = pressKey(t, m, "g") // request older
+	// Empty response.
+	m2, _ := m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionHistory,
+		History: &iris.DaemonSessionHistoryFrame{
+			Type:        iris.DaemonFrameSessionHistory,
+			SessionName: "ex",
+			Events:      nil,
+			Done:        true,
+		},
+	})
+	m = m2.(tui.Model)
+	if !tui.ModelHistoryExhausted(m) {
+		t.Errorf("empty/Done response should set historyExhausted=true")
+	}
+	// A subsequent scroll-up at the top must NOT re-request.
+	m = pressKey(t, m, "g")
+	if tui.ModelHistoryRequestInFlight(m) {
+		t.Errorf("scroll-up at head-of-history should NOT fire another request")
+	}
+	view := m.View()
+	if !strings.Contains(view, "(start of session)") {
+		t.Errorf("exhausted history at top should render '(start of session)'; excerpt:\n%s", excerpt(view, 600))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_LazyLoadInterleave — live event during lazy-load.
+// ---------------------------------------------------------------------------
+
+// TestViewport_LazyLoadInterleave covers the edge-case AC: "An
+// incoming event arriving DURING a lazy-load is interleaved correctly
+// by event timestamp / rowid — no duplicate rows, no skipped rows."
+func TestViewport_LazyLoadInterleave(t *testing.T) {
+	m := newSubscribedModel(t, "il")
+	// Seed live events with rowids 100..101.
+	for i := int64(100); i <= 101; i++ {
+		m = deliverEv(t, m, "il", "msg_user", i, map[string]any{
+			"text": "live-" + string(rune('a'+int(i)%26)),
+		})
+	}
+	// Operator triggers a lazy-load.
+	m = pressKey(t, m, "g")
+	// Before the history response arrives, a NEW live event lands.
+	m = deliverEv(t, m, "il", "msg_user", 102, map[string]any{
+		"text": "during-load",
+	})
+	// Now the history response arrives, containing an event with
+	// rowid 102 (a duplicate of the live event we just received —
+	// the daemon's response was sent before the live publish
+	// happened) plus a genuinely older event rowid 50.
+	dupPayload, _ := json.Marshal(map[string]any{"text": "during-load"})
+	oldPayload, _ := json.Marshal(map[string]any{"text": "very-old"})
+	m2, _ := m.Update(tui.DaemonFrame{
+		RawType: iris.DaemonFrameSessionHistory,
+		History: &iris.DaemonSessionHistoryFrame{
+			Type:        iris.DaemonFrameSessionHistory,
+			SessionName: "il",
+			Events: []iris.DaemonSessionEventFrame{
+				{Type: iris.DaemonFrameSessionEvent, SessionName: "il", RowID: 50, EventType: "msg_user", Payload: string(oldPayload)},
+				{Type: iris.DaemonFrameSessionEvent, SessionName: "il", RowID: 102, EventType: "msg_user", Payload: string(dupPayload)},
+			},
+			Done: false,
+		},
+	})
+	m = m2.(tui.Model)
+	view := m.View()
+	// "very-old" must appear exactly once.
+	if got := strings.Count(view, "very-old"); got != 1 {
+		t.Errorf("very-old should render exactly once; got %d, excerpt:\n%s", got, excerpt(view, 800))
+	}
+	// "during-load" must also appear exactly once — the duplicate
+	// rowid in the history response must NOT produce a second row.
+	if got := strings.Count(view, "during-load"); got != 1 {
+		t.Errorf("during-load should render exactly once (no duplicate from history overlap); got %d, excerpt:\n%s", got, excerpt(view, 800))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestViewport_SessionSwitchResets
+// ---------------------------------------------------------------------------
+
+func TestViewport_SessionSwitchResets(t *testing.T) {
+	m := newConnectedModel()
+	snap := iris.DaemonSessionsSnapshotFrame{
+		Type: iris.DaemonFrameSessionsSnapshot,
+		Sessions: []iris.SessionSnapshot{
+			{Name: "one", InstanceID: "iid-1", State: "active", Role: "worker"},
+			{Name: "two", InstanceID: "iid-2", State: "active", Role: "worker"},
+		},
+	}
+	m2, _ := m.Update(tui.DaemonFrame{RawType: iris.DaemonFrameSessionsSnapshot, Snapshot: &snap})
+	m = m2.(tui.Model)
+	m = tui.SetModelViewportHeight(m, 4)
+	// Build state on session "one": some events + scrolled-up
+	// pending-new count + a history-exhaustion marker.
+	for i := int64(1); i <= 8; i++ {
+		m = deliverEv(t, m, "one", "msg_user", i, map[string]any{"text": "x"})
+	}
+	m = pressKey(t, m, "pgup")
+	m = deliverEv(t, m, "one", "msg_user", 9, map[string]any{"text": "new-while-up"})
+	if tui.ModelPendingNewCount(m) == 0 {
+		t.Fatalf("setup: pendingNewCount should be > 0 before session switch")
+	}
+	// Switch to session "two" by moving cursor down + delivering a
+	// new snapshot is overkill; use the existing keybinding for
+	// session-list navigation.
+	down := tea.KeyMsg{Type: tea.KeyDown}
+	m2, _ = m.Update(down)
+	m = m2.(tui.Model)
+
+	if tui.ModelSubscribedTo(m) != "two" {
+		t.Fatalf("after `down` on session list, subscribedTo = %q, want two", tui.ModelSubscribedTo(m))
+	}
+	if tui.ModelPendingNewCount(m) != 0 {
+		t.Errorf("pendingNewCount should reset on session switch; got %d", tui.ModelPendingNewCount(m))
+	}
+	if tui.ModelHistoryExhausted(m) {
+		t.Errorf("historyExhausted should reset on session switch")
+	}
+	if !tui.ModelViewportFollowing(m) {
+		t.Errorf("viewport should be in auto-tail mode after session switch")
+	}
+}


### PR DESCRIPTION
Closes #1770
Refs #1765

Child 5 of the bubbletea-native iris TUI design tracker. Hard
dependency #1767 (renderer + visitor dispatch) merged; siblings
#1769 (tool-cards) and #1772 (coordinator affordances) merged.

## Scope

- Bubbletea **viewport-equivalent** scrollback abstraction for the
  conversation pane (right pane).
- **PgUp / PgDn** scroll history by one page.
- **Home / g** jump to top, **End / G** jump to bottom (resume
  auto-tail).
- **Auto-tail** to the latest when at the bottom; preserve scroll
  position when not at the bottom.
- **Lazy-load** older \`agent_events\` from the DB when the operator
  scrolls past the top of the in-memory window. Empty page →
  \`(start of session)\` indicator + suppressed further requests.
- **\"↓ N new\"** indicator in the status-line strip when new events
  arrive while scrolled up.

## Implementation choice — new daemon frame vs. re-subscribe

The AC said either approach is acceptable; I went with a **new
\`session_history\` daemon frame** rather than re-subscribing with a
lower \`since_event_id\`. Two reasons:

1. Re-subscribing replays a forward range from a rowid and would
   tear down + re-create the live subscription mid-fetch. The new
   frame is a one-shot read that doesn't disturb the live stream.
2. The response carries an explicit \`done\` flag which gives the
   TUI an unambiguous head-of-history signal — \`since_event_id\`
   replay has no such marker.

The frame:

\`\`\`
client → daemon: {\"type\":\"session_history\",\"name\":\"...\",\"before_row_id\":42,\"limit\":100,\"request_id\":\"...\"}
daemon → client: {\"type\":\"session_history\",\"session_name\":\"...\",\"events\":[…ASC by rowid…],\"done\":true,\"request_id\":\"...\"}
\`\`\`

Backed by a new \`db.QuerySessionEventsBeforeRowID\`. The TUI does
NOT import \`internal/db\` — \`TestNoDBImport\` continues to pass.

## In-house viewport (not \`bubbles/viewport\`)

The AC explicitly allows \"a functionally-equivalent buffered
scrollback abstraction\". Pulling in \`github.com/charmbracelet/bubbles\`
for one feature would mean a new vendored module + vendorHash bump
across the prism Go module. Instead, \`viewport.go\` provides a
focused 280-line type that tracks scroll position over the Model's
externally-owned \`[]NarrativeLine\` (so #1769's tool-card splice
logic continues to mutate the slice in place without going through
this viewport). Methods: \`ScrollUp/Down\`, \`GotoTop/Bottom\`,
\`AtTop/Bottom\`, \`OnAppend/OnPrepend\`, \`Reset\`, \`Following\`,
\`Update\` (per-frame offset clamp).

Auto-tail nuance: \`ScrollUp\` from \`following==true\` snaps the
offset to the current effective bottom *first*, then moves up by
the page size. Without this, a user pressing PgUp from auto-tail
mode would jump to the top of the buffer in one keystroke (because
the stored offset was 0 while following was true). The
ScrollUp-then-ScrollDown round-trip now lands in the same place,
matching every other terminal pager.

## Files

| file | role |
| --- | --- |
| \`internal/db/events.go\` | new \`QuerySessionEventsBeforeRowID\` |
| \`internal/db/db_test.go\` | unit test for the new query |
| \`internal/iris/client_protocol.go\` | new \`session_history\` request + response frames |
| \`internal/iris/client_socket.go\` | new \`handleSessionHistory\` |
| \`internal/iris/client_socket_test.go\` | round-trip tests for the new frame |
| \`internal/iris/tui/viewport.go\` | new viewport abstraction |
| \`internal/iris/tui/viewport_test.go\` | end-to-end Model.Update tests for all ACs |
| \`internal/iris/tui/client.go\` | \`SendSessionHistory\` + \`DaemonFrame.History\` |
| \`internal/iris/tui/model.go\` | viewport wiring, lazy-load logic, indicators, key handling |
| \`internal/iris/tui/overlay.go\` | help-overlay entries for the new bindings |
| \`internal/iris/tui/export_test.go\` | test-only accessors for the new model state |
| \`internal/iris/tui/renderer_test.go\` | placeholder text relaxed (\"no events yet\" or \"waiting for events\") |

## Pre-PR checks

\`\`\`
cd modules/programs/prism/prism
go build ./...       # clean
go test ./... -race  # all green
cd -
nix build .#prism    # clean
\`\`\`

\`TestNoDBImport\` continues to pass — no \`internal/db\` import was
added to the TUI package.

## Coordination

No overlap with #1787 (\`internal/db/events.go\` + \`cmd/checkin*.go\`):
my events.go change is an additive new function below their
\`MaxSessionEventRowID\`; no conflict at the file or function level.
\`client_protocol.go\` saw the new frame type added as a new
constant + new struct; no existing types touched.