### PR TITLE
Disable pseudotiling in Hyprland dwindle configuration

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -178,7 +178,6 @@ in
                 ];
               };
               dwindle = {
-                pseudotile = "yes";
                 preserve_split = "yes";
                 force_split = 2;
               };


### PR DESCRIPTION
Removed the pseudotile setting from the Hyprland dwindle layout configuration. It was removed in 0.55.1